### PR TITLE
fix(cli): support safe non-root Runner services

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ export PATH="$PWD/target/release:$PATH"
 
 See [docs/BUILD_INSTALL.md](docs/BUILD_INSTALL.md) for installation details.
 
+The npm install location and the systemd service scope are separate choices.
+An ordinary user can install the package in a user-owned npm prefix, log in
+without `sudo`, and run a persistent Runner as a user service:
+
+```bash
+webcodex login https://your-domain.example --code <wc_pair_...> \
+  --allowed-root "$HOME/git"
+webcodex agent install --scope user \
+  --config <login-reported-agent-config>
+webcodex agent status --scope user \
+  --config <login-reported-agent-config>
+```
+
+User services use `systemctl --user`, require no root privileges, and store
+their unit under `$XDG_CONFIG_HOME/systemd/user` (or
+`$HOME/.config/systemd/user`). Non-root users default to this scope. See the
+[build/install guide](docs/BUILD_INSTALL.md#runner-service-scopes) for the
+administrator-managed system scope and its non-root Runner requirement.
+
 ## Hosted Quick Start
 
 The lowest-cost path uses the official hosted Server and one background Runner
@@ -180,6 +199,15 @@ Actions → Import from URL), with copy buttons. Authentication stays the
 Project Credential from setup — the console never displays it. Set
 `WEBCODEX_PUBLIC_URL` when the advertised schema should pin a fixed public
 address.
+
+WebCodex currently integrates with ChatGPT as an OpenAPI-based **Custom GPT
+Action** (also called GPT Actions); it is not claiming to be a published
+ChatGPT plugin. The current ChatGPT/Codex plugin directory contains installable
+bundles that may combine apps, skills, connectors, and MCP servers, while an
+app, a Custom GPT, and an Action are different layers. See OpenAI's
+[GPT Actions introduction](https://developers.openai.com/api/docs/actions/introduction),
+[plugin documentation](https://learn.chatgpt.com/docs/plugins), and the
+[WebCodex GPT Actions guide](docs/GPT_ACTIONS.md).
 
 ## Long-Running Self-Hosting
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,6 +68,23 @@ export PATH="$PWD/target/release:$PATH"
 
 安装细节见 [docs/BUILD_INSTALL.zh-CN.md](docs/BUILD_INSTALL.zh-CN.md)。
 
+npm 安装位置与 systemd service scope 是两件事。普通用户可以把 package 安装到
+自己拥有的 npm prefix，不使用 `sudo` 登录，并把常驻 Runner 安装为用户 service：
+
+```bash
+webcodex login https://your-domain.example --code <wc_pair_...> \
+  --allowed-root "$HOME/git"
+webcodex agent install --scope user \
+  --config <login 输出的 agent config 路径>
+webcodex agent status --scope user \
+  --config <login 输出的 agent config 路径>
+```
+
+user service 使用 `systemctl --user`，不需要 root 权限，unit 位于
+`$XDG_CONFIG_HOME/systemd/user`（未设置时为 `$HOME/.config/systemd/user`）。
+非 root 用户省略 scope 时默认使用 user scope。管理员管理的 system scope 及其
+非 root Runner 要求见[构建与安装指南](docs/BUILD_INSTALL.zh-CN.md#runner-service-scope)。
+
 ## Hosted 最快接入
 
 最低成本路径使用官方托管 Server，只在持有代码的机器上运行一个后台 Runner。
@@ -162,6 +179,14 @@ cloudflared tunnel --url http://127.0.0.1:8080
 要导入的 schema URL，均带复制按钮。认证始终使用 setup 生成的 Project
 Credential——console 永远不会显示它。需要在 schema 里固定公网地址时设置
 `WEBCODEX_PUBLIC_URL`。
+
+WebCodex 当前通过 OpenAPI **Custom GPT Action**（也称 GPT Actions）接入
+ChatGPT；本文不声称 WebCodex 已发布为 ChatGPT 官方插件。当前 ChatGPT/Codex 的
+插件目录提供可安装的 bundle，可组合 app、skill、connector 和 MCP server；app、
+Custom GPT、Action 又是不同层次。参见 OpenAI 的
+[GPT Actions 介绍](https://developers.openai.com/api/docs/actions/introduction)、
+[插件文档](https://learn.chatgpt.com/docs/plugins)以及
+[WebCodex GPT Actions 指南](docs/GPT_ACTIONS.zh-CN.md)。
 
 ## 长期自托管
 

--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -32,24 +32,25 @@ use agent_init::{
 };
 use webcodex_cli::ops::ops_exit_code;
 use webcodex_cli::{
-    agent_init_usage, agent_install_service_usage, agent_status_usage, agent_usage,
-    base_dir_or_default, client_enroll_usage, client_profile_agent_config,
-    client_profile_agent_token_file, client_profile_projects_dir, client_profile_service_file,
-    client_profile_state_dir, client_profile_user_token_file, client_usage, connect_usage,
+    agent_config_for_scope, agent_init_usage, agent_install_service_usage,
+    agent_service_file_for_scope, agent_status_usage, agent_usage, base_dir_or_default,
+    client_enroll_usage, client_profile_agent_config, client_profile_agent_token_file_for_scope,
+    client_profile_projects_dir, client_profile_state_dir,
+    client_profile_user_token_file_for_scope, client_usage, connect_usage, current_user_home,
     default_client_output_dir_for_profile, default_device_name, default_server_paths,
-    discover_internal_binary, login_usage, logout_usage, ops_agents_usage, ops_projects_usage,
-    ops_smoke_preflight_usage, ops_status_usage, ops_usage, pairing_create_usage, pairing_usage,
-    render_token_generate, run_agent_install_service, run_agent_service, run_agent_status,
-    run_agent_token_create_local, run_client_enroll, run_connect, run_hosted_log_writer,
-    run_internal_binary, run_login, run_logout, run_ops_command, run_pairing_create,
-    run_server_init, run_server_install_service, run_server_service, run_server_status,
-    run_setup_single_user, run_status, run_token_create_local, server_init_usage,
-    server_install_service_usage, server_status_usage, server_usage, status_usage, usage,
-    validate_client_profile, write_connect_result, write_secret_file, write_text_file,
-    ConnectOptions, LoginOptions, LogoutOptions, OpsCommand, OpsCommonOptions,
+    discover_internal_binary, is_effective_root, login_usage, logout_usage, ops_agents_usage,
+    ops_projects_usage, ops_smoke_preflight_usage, ops_status_usage, ops_usage,
+    pairing_create_usage, pairing_usage, render_token_generate, run_agent_install_service,
+    run_agent_service, run_agent_status, run_agent_token_create_local, run_client_enroll,
+    run_connect, run_hosted_log_writer, run_internal_binary, run_login, run_logout,
+    run_ops_command, run_pairing_create, run_server_init, run_server_install_service,
+    run_server_service, run_server_status, run_setup_single_user, run_status,
+    run_token_create_local, server_init_usage, server_install_service_usage, server_status_usage,
+    server_usage, status_usage, system_user_home, system_user_is_root, usage,
+    validate_client_profile, validate_service_file_scope, write_connect_result, write_secret_file,
+    write_text_file, ConnectOptions, LoginOptions, LogoutOptions, OpsCommand, OpsCommonOptions,
     OpsSmokePreflightOptions, ServerStatusOptions, ServiceControl, StatusOptions,
-    AGENT_SERVICE_FILE, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE,
-    SERVER_SERVICE_UNIT,
+    AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT,
 };
 const SETUP_GPT_SCOPES: &[&str] = &["runtime:read", "project:read", "project:write", "job:run"];
 const SETUP_AGENT_SCOPES: &[&str] = &[
@@ -58,6 +59,37 @@ const SETUP_AGENT_SCOPES: &[&str] = &[
     "agent:result",
     "agent:job_update",
 ];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceScope {
+    User,
+    System,
+}
+
+impl ServiceScope {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "user" => Ok(Self::User),
+            "system" => Ok(Self::System),
+            _ => Err("--scope must be 'user' or 'system'".to_string()),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::System => "system",
+        }
+    }
+}
+
+fn default_agent_service_scope(effective_root: bool) -> ServiceScope {
+    if effective_root {
+        ServiceScope::System
+    } else {
+        ServiceScope::User
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CliAction {
@@ -191,12 +223,15 @@ struct ServerInstallServiceOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AgentInstallServiceOptions {
+    scope: ServiceScope,
     config: PathBuf,
     bin: PathBuf,
     service_file: PathBuf,
     user: Option<String>,
     group: Option<String>,
     working_directory: PathBuf,
+    root_runner: bool,
+    allow_root_runner: bool,
     overwrite: bool,
     dry_run: bool,
     output_stdout: bool,
@@ -225,6 +260,7 @@ enum ServiceActionKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ServiceActionOptions {
+    scope: ServiceScope,
     service_file: PathBuf,
     unit: String,
     kind: ServiceActionKind,
@@ -239,6 +275,7 @@ struct LocalProfileOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AgentStatusOptions {
+    scope: ServiceScope,
     config: PathBuf,
     service_file: PathBuf,
     local_state_dir: Option<PathBuf>,
@@ -850,10 +887,10 @@ fn parse_agent_subcommand(args: &[String]) -> CliAction {
             "init" => agent_init_usage(),
             "install" => agent_install_service_usage(),
             "run" => "Usage: webcodex agent run [--profile NAME|--config PATH]\n\nRun webcodex-runner directly in the foreground.\n",
-            "start" | "stop" | "restart" => "Usage: webcodex agent <start|stop|restart> [--profile NAME]\n\nWith a profile created by `webcodex connect`, manage its user-level background Runner. Other profiles use the installed systemd service.\n",
+            "start" | "stop" | "restart" => "Usage: webcodex agent <start|stop|restart> [--profile NAME] [--scope user|system] [--service-file PATH]\n\nWith a profile created by `webcodex connect`, omitting --scope manages its user-level background Runner. An explicit scope manages the matching systemd service.\n",
             "status" => agent_status_usage(),
-            "logs" => "Usage: webcodex agent logs [--profile NAME] [--lines N] [--since VALUE] [--follow]\n",
-            "uninstall" => "Usage: webcodex agent uninstall [--profile NAME] --confirm\n",
+            "logs" => "Usage: webcodex agent logs [--profile NAME] [--scope user|system] [--service-file PATH] [--lines N] [--since VALUE] [--follow]\n",
+            "uninstall" => "Usage: webcodex agent uninstall [--profile NAME] [--scope user|system] [--service-file PATH] --confirm\n",
             "install-service" => "`webcodex agent install-service` was removed; use `webcodex agent install`.\n",
             _ => agent_usage(),
         };
@@ -1279,6 +1316,7 @@ fn parse_server_service_action(
     args: &[String],
 ) -> Result<ServiceActionOptions, String> {
     Ok(ServiceActionOptions {
+        scope: ServiceScope::System,
         service_file: PathBuf::from(SERVER_SERVICE_FILE),
         unit: SERVER_SERVICE_UNIT.to_string(),
         kind: parse_service_kind(command, args)?,
@@ -1291,36 +1329,51 @@ fn parse_agent_service_action(
     args: &[String],
 ) -> Result<ServiceActionOptions, String> {
     let mut profile: Option<String> = None;
+    let mut scope: Option<ServiceScope> = None;
+    let mut service_file: Option<PathBuf> = None;
     let mut remaining = Vec::new();
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
-        if arg == "--profile" {
-            profile = Some(next_value(&mut iter, arg)?);
-        } else {
-            remaining.push(arg.clone());
+        match arg.as_str() {
+            "--profile" => profile = Some(next_value(&mut iter, arg)?),
+            "--scope" => {
+                if scope.is_some() {
+                    return Err("--scope may be specified only once".to_string());
+                }
+                scope = Some(ServiceScope::parse(&next_value(&mut iter, arg)?)?);
+            }
+            "--service-file" => service_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
+            _ => remaining.push(arg.clone()),
         }
     }
+    let scope_explicit = scope.is_some();
+    let scope = scope.unwrap_or_else(|| default_agent_service_scope(is_effective_root()));
     let profile = profile
         .as_deref()
         .map(validate_client_profile)
         .transpose()?;
-    let service_file = profile
-        .as_deref()
-        .map(client_profile_service_file)
-        .unwrap_or_else(|| PathBuf::from(AGENT_SERVICE_FILE));
+    let service_file = service_file
+        .map(Ok)
+        .unwrap_or_else(|| agent_service_file_for_scope(scope, profile.as_deref()))?;
+    validate_service_file_scope(scope, &service_file)?;
     let unit = service_file
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or(AGENT_SERVICE_UNIT)
         .to_string();
     Ok(ServiceActionOptions {
+        scope,
         service_file,
         unit,
         kind: parse_service_kind(command, &remaining)?,
-        local_profile: profile.as_deref().map(|profile| LocalProfileOptions {
-            config: client_profile_agent_config(profile),
-            state_dir: client_profile_state_dir(profile),
-        }),
+        local_profile: if scope_explicit {
+            None
+        } else {
+            profile.as_deref().map(|profile| LocalProfileOptions {
+                config: client_profile_agent_config(profile),
+                state_dir: client_profile_state_dir(profile),
+            })
+        },
     })
 }
 
@@ -1366,13 +1419,22 @@ fn parse_server_init(args: &[String]) -> Result<ServerInitOptions, String> {
 }
 
 fn parse_agent_install_service(args: &[String]) -> Result<AgentInstallServiceOptions, String> {
+    parse_agent_install_service_with_identity(args, is_effective_root())
+}
+
+fn parse_agent_install_service_with_identity(
+    args: &[String],
+    effective_root: bool,
+) -> Result<AgentInstallServiceOptions, String> {
     let mut profile: Option<String> = None;
+    let mut scope: Option<ServiceScope> = None;
     let mut config: Option<PathBuf> = None;
     let mut bin: Option<PathBuf> = None;
     let mut service_file: Option<PathBuf> = None;
-    let mut working_directory = PathBuf::from("/root");
+    let mut working_directory: Option<PathBuf> = None;
     let mut user = None;
     let mut group = None;
+    let mut allow_root_runner = false;
     let mut overwrite = false;
     let mut dry_run = false;
     let mut output_stdout = false;
@@ -1382,12 +1444,21 @@ fn parse_agent_install_service(args: &[String]) -> Result<AgentInstallServiceOpt
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--profile" => profile = Some(next_value(&mut iter, arg)?),
+            "--scope" => {
+                if scope.is_some() {
+                    return Err("--scope may be specified only once".to_string());
+                }
+                scope = Some(ServiceScope::parse(&next_value(&mut iter, arg)?)?);
+            }
             "--config" => config = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--bin" => bin = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--service-file" => service_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
-            "--working-directory" => working_directory = PathBuf::from(next_value(&mut iter, arg)?),
+            "--working-directory" => {
+                working_directory = Some(PathBuf::from(next_value(&mut iter, arg)?))
+            }
             "--user" => user = Some(next_value(&mut iter, arg)?),
             "--group" => group = Some(next_value(&mut iter, arg)?),
+            "--allow-root-runner" => allow_root_runner = true,
             "--overwrite" => overwrite = true,
             "--dry-run" => dry_run = true,
             "--no-start" => no_start = true,
@@ -1406,18 +1477,14 @@ fn parse_agent_install_service(args: &[String]) -> Result<AgentInstallServiceOpt
         .as_deref()
         .map(validate_client_profile)
         .transpose()?;
-    let config = config.unwrap_or_else(|| {
-        profile
-            .as_deref()
-            .map(client_profile_agent_config)
-            .unwrap_or_else(|| PathBuf::from("/etc/webcodex/agent.toml"))
-    });
-    let service_file = service_file.unwrap_or_else(|| {
-        profile
-            .as_deref()
-            .map(client_profile_service_file)
-            .unwrap_or_else(|| PathBuf::from("/etc/systemd/system/webcodex-runner.service"))
-    });
+    let scope = scope.unwrap_or_else(|| default_agent_service_scope(effective_root));
+    let config = config
+        .map(Ok)
+        .unwrap_or_else(|| agent_config_for_scope(scope, profile.as_deref()))?;
+    let service_file = service_file
+        .map(Ok)
+        .unwrap_or_else(|| agent_service_file_for_scope(scope, profile.as_deref()))?;
+    validate_service_file_scope(scope, &service_file)?;
     let bin = match bin.or_else(|| discover_internal_binary("webcodex-runner")) {
         Some(path) => path,
         None => {
@@ -1435,16 +1502,70 @@ fn parse_agent_install_service(args: &[String]) -> Result<AgentInstallServiceOpt
     if service_file.as_os_str().is_empty() {
         return Err("--service-file cannot be empty".to_string());
     }
+    let root_runner = match scope {
+        ServiceScope::User => effective_root,
+        ServiceScope::System => user.as_deref().is_none_or(system_user_is_root),
+    };
+    match scope {
+        ServiceScope::User => {
+            if user.is_some() || group.is_some() {
+                return Err(
+                    "--user and --group are valid only with --scope system; user services run as the current user"
+                        .to_string(),
+                );
+            }
+        }
+        ServiceScope::System if !root_runner && user.is_none() => {
+            return Err("--scope system requires an explicit non-root --user".to_string());
+        }
+        ServiceScope::System => {}
+    }
+    if root_runner && !allow_root_runner {
+        return Err(
+            "refusing to install a Runner that would run as root; pass a non-root --user with --scope system, or explicitly opt in with --allow-root-runner"
+                .to_string(),
+        );
+    }
+    if !root_runner && allow_root_runner {
+        return Err(
+            "--allow-root-runner is only valid when the selected Runner would run as root"
+                .to_string(),
+        );
+    }
+    let working_directory = match working_directory {
+        Some(path) => path,
+        None if scope == ServiceScope::User => current_user_home()?,
+        None => {
+            let selected_user = user.as_deref().unwrap_or("root");
+            system_user_home(selected_user).ok_or_else(|| {
+                format!(
+                    "could not determine the home directory for system Runner user '{selected_user}'; pass --working-directory explicitly"
+                )
+            })?
+        }
+    };
     if working_directory.as_os_str().is_empty() {
         return Err("--working-directory cannot be empty".to_string());
     }
+    if !working_directory.is_absolute() {
+        return Err("--working-directory must be an absolute path".to_string());
+    }
+    if !root_runner && working_directory.starts_with("/root") {
+        return Err(
+            "a non-root Runner cannot use /root as its WorkingDirectory; use that user's home or another accessible directory"
+                .to_string(),
+        );
+    }
     Ok(AgentInstallServiceOptions {
+        scope,
         config,
         bin,
         service_file,
         user,
         group,
         working_directory,
+        root_runner,
+        allow_root_runner,
         overwrite,
         dry_run,
         output_stdout,
@@ -1455,10 +1576,13 @@ fn parse_agent_install_service(args: &[String]) -> Result<AgentInstallServiceOpt
 
 fn parse_agent_status(args: &[String]) -> Result<AgentStatusOptions, String> {
     let mut profile: Option<String> = None;
+    let mut scope: Option<ServiceScope> = None;
     let mut config: Option<PathBuf> = None;
+    let mut service_file: Option<PathBuf> = None;
     let mut opts = AgentStatusOptions {
+        scope: ServiceScope::System,
         config: PathBuf::new(),
-        service_file: PathBuf::from("/etc/systemd/system/webcodex-runner.service"),
+        service_file: PathBuf::new(),
         local_state_dir: None,
         server_url: None,
         user_token_file: None,
@@ -1469,7 +1593,14 @@ fn parse_agent_status(args: &[String]) -> Result<AgentStatusOptions, String> {
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--profile" => profile = Some(next_value(&mut iter, arg)?),
+            "--scope" => {
+                if scope.is_some() {
+                    return Err("--scope may be specified only once".to_string());
+                }
+                scope = Some(ServiceScope::parse(&next_value(&mut iter, arg)?)?);
+            }
             "--config" => config = Some(PathBuf::from(next_value(&mut iter, arg)?)),
+            "--service-file" => service_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--server-url" => opts.server_url = Some(next_value(&mut iter, arg)?),
             "--user-token-file" => {
                 opts.user_token_file = Some(PathBuf::from(next_value(&mut iter, arg)?))
@@ -1481,22 +1612,31 @@ fn parse_agent_status(args: &[String]) -> Result<AgentStatusOptions, String> {
             _ => return Err(format!("unknown agent status flag: {}", arg)),
         }
     }
-    if let Some(profile) = profile
+    let scope_explicit = scope.is_some();
+    let scope = scope.unwrap_or_else(|| default_agent_service_scope(is_effective_root()));
+    opts.scope = scope;
+    let profile = profile
         .as_deref()
         .map(validate_client_profile)
-        .transpose()?
-    {
-        opts.config = config.unwrap_or_else(|| client_profile_agent_config(&profile));
-        opts.service_file = client_profile_service_file(&profile);
-        opts.local_state_dir = Some(client_profile_state_dir(&profile));
-        opts.user_token_file = opts
-            .user_token_file
-            .or_else(|| Some(client_profile_user_token_file(&profile)));
-        opts.agent_token_file = opts
-            .agent_token_file
-            .or_else(|| Some(client_profile_agent_token_file(&profile)));
-    } else {
-        opts.config = config.unwrap_or_else(|| PathBuf::from("/etc/webcodex/agent.toml"));
+        .transpose()?;
+    opts.config = config
+        .map(Ok)
+        .unwrap_or_else(|| agent_config_for_scope(scope, profile.as_deref()))?;
+    opts.service_file = service_file
+        .map(Ok)
+        .unwrap_or_else(|| agent_service_file_for_scope(scope, profile.as_deref()))?;
+    validate_service_file_scope(scope, &opts.service_file)?;
+    if let Some(profile) = profile {
+        if !scope_explicit {
+            opts.local_state_dir = Some(client_profile_state_dir(&profile));
+        }
+        if opts.user_token_file.is_none() {
+            opts.user_token_file = Some(client_profile_user_token_file_for_scope(scope, &profile)?);
+        }
+        if opts.agent_token_file.is_none() {
+            opts.agent_token_file =
+                Some(client_profile_agent_token_file_for_scope(scope, &profile)?);
+        }
     }
     if opts.config.as_os_str().is_empty() {
         return Err("--config cannot be empty".to_string());

--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -34,8 +34,9 @@ use webcodex_cli::ops::ops_exit_code;
 use webcodex_cli::{
     agent_config_for_scope, agent_init_usage, agent_install_service_usage,
     agent_service_file_for_scope, agent_status_usage, agent_usage, base_dir_or_default,
-    client_enroll_usage, client_profile_agent_config, client_profile_agent_token_file_for_scope,
-    client_profile_projects_dir, client_profile_state_dir,
+    client_enroll_usage, client_profile_agent_config, client_profile_agent_token_file,
+    client_profile_agent_token_file_for_scope, client_profile_projects_dir,
+    client_profile_state_dir, client_profile_user_token_file,
     client_profile_user_token_file_for_scope, client_usage, connect_usage, current_user_home,
     default_client_output_dir_for_profile, default_device_name, default_server_paths,
     discover_internal_binary, is_effective_root, login_usage, logout_usage, ops_agents_usage,
@@ -1575,6 +1576,13 @@ fn parse_agent_install_service_with_identity(
 }
 
 fn parse_agent_status(args: &[String]) -> Result<AgentStatusOptions, String> {
+    parse_agent_status_with_identity(args, is_effective_root())
+}
+
+fn parse_agent_status_with_identity(
+    args: &[String],
+    effective_root: bool,
+) -> Result<AgentStatusOptions, String> {
     let mut profile: Option<String> = None;
     let mut scope: Option<ServiceScope> = None;
     let mut config: Option<PathBuf> = None;
@@ -1613,15 +1621,17 @@ fn parse_agent_status(args: &[String]) -> Result<AgentStatusOptions, String> {
         }
     }
     let scope_explicit = scope.is_some();
-    let scope = scope.unwrap_or_else(|| default_agent_service_scope(is_effective_root()));
+    let scope = scope.unwrap_or_else(|| default_agent_service_scope(effective_root));
     opts.scope = scope;
     let profile = profile
         .as_deref()
         .map(validate_client_profile)
         .transpose()?;
-    opts.config = config
-        .map(Ok)
-        .unwrap_or_else(|| agent_config_for_scope(scope, profile.as_deref()))?;
+    opts.config = match (config, profile.as_deref(), scope_explicit) {
+        (Some(config), _, _) => config,
+        (None, Some(profile), false) => client_profile_agent_config(profile),
+        (None, profile, _) => agent_config_for_scope(scope, profile)?,
+    };
     opts.service_file = service_file
         .map(Ok)
         .unwrap_or_else(|| agent_service_file_for_scope(scope, profile.as_deref()))?;
@@ -1631,11 +1641,18 @@ fn parse_agent_status(args: &[String]) -> Result<AgentStatusOptions, String> {
             opts.local_state_dir = Some(client_profile_state_dir(&profile));
         }
         if opts.user_token_file.is_none() {
-            opts.user_token_file = Some(client_profile_user_token_file_for_scope(scope, &profile)?);
+            opts.user_token_file = Some(if scope_explicit {
+                client_profile_user_token_file_for_scope(scope, &profile)?
+            } else {
+                client_profile_user_token_file(&profile)
+            });
         }
         if opts.agent_token_file.is_none() {
-            opts.agent_token_file =
-                Some(client_profile_agent_token_file_for_scope(scope, &profile)?);
+            opts.agent_token_file = Some(if scope_explicit {
+                client_profile_agent_token_file_for_scope(scope, &profile)?
+            } else {
+                client_profile_agent_token_file(&profile)
+            });
         }
     }
     if opts.config.as_os_str().is_empty() {

--- a/crates/webcodex-cli/src/webcodex_cli/agent_service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/agent_service.rs
@@ -4,19 +4,37 @@ use std::path::{Path, PathBuf};
 
 use super::http::{fetch_runtime_status, http_post_json_status, HttpStatusSummary};
 use super::{
-    control_service, encode_exec_argument, encode_exec_path_argument, encode_exec_program,
-    encode_unit_path_value, install_unit, local_runner_profile_marker, local_runner_state_summary,
-    query_systemd_service_status, read_optional_token, run_local_runner_logs,
-    run_local_runner_service, run_logs, service_unit_name, uninstall_unit,
-    validate_systemd_identity, LocalRunnerServiceAction, AGENT_SERVICE_UNIT,
+    control_service_for_scope, encode_exec_argument, encode_exec_path_argument,
+    encode_exec_program, encode_unit_path_value, ensure_service_file_parent,
+    install_unit_for_scope, local_runner_profile_marker, local_runner_state_summary,
+    query_systemd_service_status_for_scope, read_optional_token, read_optional_user_api_token,
+    run_local_runner_logs, run_local_runner_service, run_logs_for_scope, service_unit_name,
+    uninstall_unit_for_scope, validate_systemd_identity, LocalRunnerServiceAction,
+    AGENT_SERVICE_UNIT,
 };
 use crate::{
     AgentInstallServiceOptions, AgentStatusOptions, ServiceActionKind, ServiceActionOptions,
+    ServiceScope,
 };
 
 pub(crate) fn render_agent_systemd_unit(
     opts: &AgentInstallServiceOptions,
 ) -> Result<String, String> {
+    match opts.scope {
+        ServiceScope::User if opts.user.is_some() || opts.group.is_some() => {
+            return Err(
+                "user service units cannot contain User= or Group=; they run as the current user"
+                    .to_string(),
+            );
+        }
+        _ if opts.root_runner && !opts.allow_root_runner => {
+            return Err(
+                "refusing to render a Runner that would run as root without --allow-root-runner"
+                    .to_string(),
+            );
+        }
+        _ => {}
+    }
     let binary = encode_exec_program("ExecStart", &opts.bin)?;
     let config_flag = encode_exec_argument("ExecStart option", "--config")?;
     let config = encode_exec_path_argument("ExecStart --config", &opts.config)?;
@@ -30,11 +48,18 @@ pub(crate) fn render_agent_systemd_unit(
     }
 
     let mut unit = String::new();
+    if opts.root_runner {
+        unit.push_str(
+            "# WARNING: --allow-root-runner was explicitly accepted; project commands run as root.\n",
+        );
+    }
     unit.push_str("[Unit]\n");
     unit.push_str("Description=WebCodex Runner\n");
-    unit.push_str("After=network-online.target\n");
-    unit.push_str("Wants=network-online.target\n\n");
-    unit.push_str("[Service]\n");
+    if opts.scope == ServiceScope::System {
+        unit.push_str("After=network-online.target\n");
+        unit.push_str("Wants=network-online.target\n");
+    }
+    unit.push_str("\n[Service]\n");
     unit.push_str("Type=simple\n");
     unit.push_str(&format!("ExecStart={exec_start}\n"));
     unit.push_str("ExecReload=/bin/kill -HUP $MAINPID\n");
@@ -44,14 +69,19 @@ pub(crate) fn render_agent_systemd_unit(
     unit.push_str("StandardError=journal\n");
     unit.push_str("Environment=RUST_LOG=info\n");
     unit.push_str(&format!("WorkingDirectory={working_directory}\n"));
-    if let Some(user) = &opts.user {
-        unit.push_str(&format!("User={user}\n"));
-    }
-    if let Some(group) = &opts.group {
-        unit.push_str(&format!("Group={group}\n"));
+    if opts.scope == ServiceScope::System {
+        if let Some(user) = &opts.user {
+            unit.push_str(&format!("User={user}\n"));
+        }
+        if let Some(group) = &opts.group {
+            unit.push_str(&format!("Group={group}\n"));
+        }
     }
     unit.push_str("\n[Install]\n");
-    unit.push_str("WantedBy=multi-user.target\n");
+    unit.push_str(match opts.scope {
+        ServiceScope::User => "WantedBy=default.target\n",
+        ServiceScope::System => "WantedBy=multi-user.target\n",
+    });
     Ok(unit)
 }
 
@@ -67,6 +97,8 @@ pub(crate) fn run_agent_install_service(
                 "config": opts.config.to_string_lossy(),
                 "bin": opts.bin.to_string_lossy(),
                 "unit_name": unit,
+                "scope": opts.scope.as_str(),
+                "root_runner": opts.root_runner,
                 "dry_run": true,
                 "systemd_called": false,
                 "unit": rendered,
@@ -75,7 +107,11 @@ pub(crate) fn run_agent_install_service(
         }
         return Ok(rendered);
     }
-    let result = install_unit(
+    if opts.scope == ServiceScope::User {
+        ensure_service_file_parent(&opts.service_file)?;
+    }
+    let result = install_unit_for_scope(
+        opts.scope,
         &opts.service_file,
         &unit,
         &rendered,
@@ -88,18 +124,27 @@ pub(crate) fn run_agent_install_service(
             "config": opts.config.to_string_lossy(),
             "bin": opts.bin.to_string_lossy(),
             "unit": result.unit,
+            "scope": opts.scope.as_str(),
+            "root_runner": opts.root_runner,
             "enabled": true,
             "started": result.started,
         }))
         .map_err(|e| e.to_string());
     }
+    let warning = if opts.root_runner {
+        "\nWARNING: explicit --allow-root-runner accepted; this Runner executes project commands as root.\n"
+    } else {
+        ""
+    };
     Ok(format!(
-        "Agent service installed.\n\n  service file: {}\n  unit:         {}\n  config:       {}\n  binary:       {}\n  enabled:      yes\n  started:      {}\n",
+        "Agent service installed.\n\n  scope:        {}\n  service file: {}\n  unit:         {}\n  config:       {}\n  binary:       {}\n  enabled:      yes\n  started:      {}\n{}",
+        opts.scope.as_str(),
         opts.service_file.display(),
         result.unit,
         opts.config.display(),
         opts.bin.display(),
-        if result.started { "yes" } else { "no (--no-start)" }
+        if result.started { "yes" } else { "no (--no-start)" },
+        warning,
     ))
 }
 
@@ -136,7 +181,7 @@ pub(crate) fn run_agent_service(opts: ServiceActionOptions) -> Result<String, St
     }
     match opts.kind {
         ServiceActionKind::Control(control) => {
-            control_service(&opts.unit, control)?;
+            control_service_for_scope(opts.scope, &opts.unit, control)?;
             Ok(format!(
                 "Agent service {} completed for {}.\n",
                 control.as_str(),
@@ -147,12 +192,12 @@ pub(crate) fn run_agent_service(opts: ServiceActionOptions) -> Result<String, St
             lines,
             since,
             follow,
-        } => run_logs(&opts.unit, lines, since.as_deref(), follow),
+        } => run_logs_for_scope(opts.scope, &opts.unit, lines, since.as_deref(), follow),
         ServiceActionKind::Uninstall { confirm } => {
             if !confirm {
                 return Err("agent uninstall requires --confirm; no changes were made".to_string());
             }
-            let result = uninstall_unit(&opts.service_file, &opts.unit)?;
+            let result = uninstall_unit_for_scope(opts.scope, &opts.service_file, &opts.unit)?;
             Ok(format!(
                 "Agent service {}. Agent config, tokens, profile data and binaries were not deleted.\n",
                 if result.removed { "uninstalled" } else { "was already absent" }
@@ -257,7 +302,7 @@ fn runtime_client_online(output: &Value, client_id: &str) -> Option<bool> {
 
 pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String, String> {
     let service_unit = service_unit_name(&opts.service_file, AGENT_SERVICE_UNIT);
-    let systemd = query_systemd_service_status(&service_unit);
+    let systemd = query_systemd_service_status_for_scope(opts.scope, &service_unit);
     let metadata = read_agent_config_metadata(&opts.config)?;
     let local = opts
         .local_state_dir
@@ -280,7 +325,7 @@ pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String,
         }
         Some(key.to_string())
     } else {
-        read_optional_token(&opts.user_token_file, "--user-token-file")?
+        read_optional_user_api_token(&opts.user_token_file, "--user-token-file")?
     };
     let agent_token = if local.is_some() {
         None
@@ -333,6 +378,7 @@ pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String,
         let summary = json!({
             "service": {
                 "mode": if local.is_some() { "hosted_local" } else { "systemd" },
+                "scope": if local.is_some() { Value::Null } else { json!(opts.scope.as_str()) },
                 "unit": service_unit,
                 "active": local.as_ref().map(|state| json!(state.running)).unwrap_or_else(|| json!(systemd.active)),
                 "enabled": local.as_ref().map(|state| json!(state.managed)).unwrap_or_else(|| json!(systemd.enabled)),
@@ -393,6 +439,10 @@ pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String,
             local.log_path.display()
         ));
     } else {
+        out.push_str(&format!(
+            "  service scope:        {}\n",
+            opts.scope.as_str()
+        ));
         out.push_str(&format!("  service unit:         {service_unit}\n"));
         out.push_str(&format!("  service active:       {}\n", systemd.active));
         out.push_str(&format!("  service enabled:      {}\n", systemd.enabled));

--- a/crates/webcodex-cli/src/webcodex_cli/agent_service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/agent_service.rs
@@ -302,14 +302,16 @@ fn runtime_client_online(output: &Value, client_id: &str) -> Option<bool> {
 
 pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String, String> {
     let service_unit = service_unit_name(&opts.service_file, AGENT_SERVICE_UNIT);
-    let systemd = query_systemd_service_status_for_scope(opts.scope, &service_unit);
-    let metadata = read_agent_config_metadata(&opts.config)?;
     let local = opts
         .local_state_dir
         .as_ref()
         .filter(|dir| local_runner_profile_marker(dir).is_file())
         .map(|dir| local_runner_state_summary(dir))
         .transpose()?;
+    let systemd = local
+        .is_none()
+        .then(|| query_systemd_service_status_for_scope(opts.scope, &service_unit));
+    let metadata = read_agent_config_metadata(&opts.config)?;
     let effective_server_url = opts.server_url.clone().or_else(|| {
         let url = metadata.server_url.trim().to_string();
         if url.is_empty() {
@@ -380,8 +382,8 @@ pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String,
                 "mode": if local.is_some() { "hosted_local" } else { "systemd" },
                 "scope": if local.is_some() { Value::Null } else { json!(opts.scope.as_str()) },
                 "unit": service_unit,
-                "active": local.as_ref().map(|state| json!(state.running)).unwrap_or_else(|| json!(systemd.active)),
-                "enabled": local.as_ref().map(|state| json!(state.managed)).unwrap_or_else(|| json!(systemd.enabled)),
+                "active": local.as_ref().map(|state| json!(state.running)).unwrap_or_else(|| json!(systemd.as_ref().expect("systemd status exists outside hosted mode").active)),
+                "enabled": local.as_ref().map(|state| json!(state.managed)).unwrap_or_else(|| json!(systemd.as_ref().expect("systemd status exists outside hosted mode").enabled)),
                 "pid": local.as_ref().and_then(|state| state.pid),
                 "logs": local.as_ref().map(|state| state.log_path.to_string_lossy().to_string()),
             },
@@ -439,6 +441,9 @@ pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String,
             local.log_path.display()
         ));
     } else {
+        let systemd = systemd
+            .as_ref()
+            .expect("systemd status exists outside hosted mode");
         out.push_str(&format!(
             "  service scope:        {}\n",
             opts.scope.as_str()

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -23,7 +23,7 @@ use super::connections::{
     list_connections, resolve_connection_parent, user_slug, Connection, ConnectionPaths,
     INTERNAL_DIR_PREFIX,
 };
-use super::{shell_command, validate_user_api_token};
+use super::{is_effective_root, shell_command, validate_user_api_token};
 
 /// Device name reported to the server. The hostname is what a person would call
 /// this machine; `--device` overrides it.
@@ -545,11 +545,14 @@ pub(crate) fn stage_connection(
     write_descriptor(&paths, server_url, &identity.username, device, now)
 }
 
+const ROOT_AGENT_INSTALL_REASON: &str = "login ran as root; no safe systemd installation argv can be generated without explicitly selecting a non-root Runner user and validating access to the agent config, working directory, projects directory, and allowed roots";
+
 pub(crate) fn render_login_result(
     paths: &ConnectionPaths,
     server_url: &str,
     username: &str,
     device: &str,
+    effective_root: bool,
     json: bool,
     print_mcp_config: bool,
 ) -> Result<String, String> {
@@ -558,22 +561,30 @@ pub(crate) fn render_login_result(
         "--config".to_string(),
         paths.agent_config.to_string_lossy().into_owned(),
     ];
-    let agent_install_argv = vec![
-        "webcodex".to_string(),
-        "agent".to_string(),
-        "install".to_string(),
-        "--scope".to_string(),
-        "user".to_string(),
-        "--config".to_string(),
-        paths.agent_config.to_string_lossy().into_owned(),
-    ];
+    let agent_install_argv = if effective_root {
+        None
+    } else {
+        Some(vec![
+            "webcodex".to_string(),
+            "agent".to_string(),
+            "install".to_string(),
+            "--scope".to_string(),
+            "user".to_string(),
+            "--config".to_string(),
+            paths.agent_config.to_string_lossy().into_owned(),
+        ])
+    };
     let foreground_command = shell_command(&foreground_argv);
-    let agent_install_command = shell_command(&agent_install_argv);
+    let agent_install_command = agent_install_argv.as_ref().map(|argv| shell_command(argv));
 
     // JSON output carries only safe metadata; never a full token. The
     // `--print-mcp-config` path is text-only and mutually exclusive with `--json`
     // (enforced at parse time), so the two cannot both apply here.
     if json {
+        let mut next_steps = vec![foreground_command.clone()];
+        if let Some(command) = &agent_install_command {
+            next_steps.push(command.clone());
+        }
         let summary = serde_json::json!({
             "server_url": server_url,
             "username": username,
@@ -587,8 +598,10 @@ pub(crate) fn render_login_result(
                 "agent_config_token": "Runner/Agent transport only",
             },
             "foreground_argv": &foreground_argv,
+            "agent_install_available": agent_install_argv.is_some(),
             "agent_install_argv": &agent_install_argv,
-            "next_steps": [&foreground_command, &agent_install_command],
+            "agent_install_reason": effective_root.then_some(ROOT_AGENT_INSTALL_REASON),
+            "next_steps": next_steps,
         });
         return serde_json::to_string_pretty(&summary).map_err(|error| error.to_string());
     }
@@ -613,17 +626,27 @@ pub(crate) fn render_login_result(
         ));
     }
 
+    let service_guidance = match agent_install_command {
+        Some(command) => format!(
+            "Or install it as a non-root user service (run as the same ordinary user):\n  {command}\n"
+        ),
+        None => "No safe systemd installation command was generated because login ran as root.\n\
+                 Recommended: have the ordinary local user who will run the Runner execute `webcodex login`, then install the user service as that same user.\n\
+                 Advanced system service deployment requires an administrator to explicitly select a non-root account with `--scope system --user`, verify that account can read the agent config and access the working directory, and ensure the config, projects directory, and allowed roots have suitable permissions.\n"
+            .to_string(),
+    };
+
     Ok(format!(
         "Logged in to {server_url} as {username} ({device}).\n\n  \
          MCP endpoint: {server_url}/mcp\n  \
          user token file: {} (GPT Actions, MCP, and REST/project APIs)\n  \
          agent config:   {} (contains Runner/Agent transport credentials only)\n\n\
          Start the agent in the foreground:\n  {}\n\n\
-         Or install it as a non-root user service (run as the same ordinary user):\n  {}\n",
+         {}",
         paths.user_token.display(),
         paths.agent_config.display(),
         foreground_command,
-        agent_install_command,
+        service_guidance,
     ))
 }
 
@@ -808,6 +831,7 @@ pub(crate) async fn redeem_pairing_code(
 
 /// Log this device into a server.
 pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
+    let effective_root = is_effective_root();
     // Reject a URL we could not turn into an identity *before* spending the
     // one-time code on it, and settle the directory it would be stored under
     // for the same reason: a symlinked base is better found now than after the
@@ -843,6 +867,7 @@ pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
             &server_url,
             &identity.username,
             &device,
+            effective_root,
             opts.json,
             opts.print_mcp_config,
         ),
@@ -1987,6 +2012,7 @@ mod tests {
             "laptop",
             false,
             false,
+            false,
         )
         .unwrap();
         assert!(text.contains("https://api.example.com/mcp"), "{text}");
@@ -2014,6 +2040,10 @@ mod tests {
             )),
             "{text}"
         );
+        assert!(
+            text.contains("same ordinary user"),
+            "non-root guidance was not explicit: {text}"
+        );
         assert!(!text.contains(USER_TOKEN), "default text leaked a token");
         assert!(!text.contains(AGENT_TOKEN), "default text leaked a token");
 
@@ -2022,6 +2052,7 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            false,
             true,
             false,
         )
@@ -2061,6 +2092,7 @@ mod tests {
             "laptop",
             false,
             false,
+            false,
         )
         .unwrap();
         assert!(text.contains(&shell_command(&foreground_argv)), "{text}");
@@ -2071,6 +2103,7 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            false,
             true,
             false,
         )
@@ -2078,6 +2111,8 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&json_text).unwrap();
         assert_eq!(value["foreground_argv"], serde_json::json!(foreground_argv));
         assert_eq!(value["agent_install_argv"], serde_json::json!(install_argv));
+        assert_eq!(value["agent_install_available"], serde_json::json!(true));
+        assert!(value["agent_install_reason"].is_null());
         assert_eq!(
             value["next_steps"][0].as_str().unwrap(),
             shell_command(&foreground_argv)
@@ -2088,6 +2123,113 @@ mod tests {
         );
         assert!(!json_text.contains(USER_TOKEN));
         assert!(!json_text.contains(AGENT_TOKEN));
+
+        let recommended_argv: Vec<String> =
+            serde_json::from_value(value["agent_install_argv"].clone()).unwrap();
+        let parser_env = tempfile::TempDir::new().unwrap();
+        std::fs::write(parser_env.path().join("webcodex-runner"), "").unwrap();
+        #[cfg(windows)]
+        std::fs::write(parser_env.path().join("webcodex-runner.exe"), "").unwrap();
+        let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
+        let old_home = std::env::var_os("HOME");
+        let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let old_path = std::env::var_os("PATH");
+        std::env::set_var("HOME", parser_env.path());
+        std::env::set_var("XDG_CONFIG_HOME", parser_env.path());
+        std::env::set_var("PATH", parser_env.path());
+        let parsed =
+            crate::parse_agent_install_service_with_identity(&recommended_argv[3..], false);
+        if let Some(value) = old_home {
+            std::env::set_var("HOME", value);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(value) = old_xdg {
+            std::env::set_var("XDG_CONFIG_HOME", value);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        if let Some(value) = old_path {
+            std::env::set_var("PATH", value);
+        } else {
+            std::env::remove_var("PATH");
+        }
+        assert!(
+            parsed.is_ok(),
+            "non-root recommendation was rejected by the install parser: {parsed:?}"
+        );
+    }
+
+    #[test]
+    fn render_login_result_omits_invalid_root_service_guidance() {
+        let paths = ConnectionPaths::new(PathBuf::from("/tmp/root-login"));
+        let foreground_argv = vec![
+            "webcodex-runner".to_string(),
+            "--config".to_string(),
+            paths.agent_config.to_string_lossy().into_owned(),
+        ];
+
+        let text = render_login_result(
+            &paths,
+            "https://api.example.com",
+            "alice",
+            "laptop",
+            true,
+            false,
+            false,
+        )
+        .unwrap();
+        assert!(
+            !text.contains("webcodex agent install --scope user"),
+            "{text}"
+        );
+        assert!(!text.contains("--allow-root-runner"), "{text}");
+        assert!(text.contains("login ran as root"), "{text}");
+        assert!(
+            text.contains("ordinary local user who will run the Runner"),
+            "{text}"
+        );
+        assert!(
+            text.contains("install the user service as that same user"),
+            "{text}"
+        );
+        assert!(
+            text.contains("Advanced system service deployment"),
+            "{text}"
+        );
+        assert!(text.contains("--scope system --user"), "{text}");
+        assert!(text.contains("read the agent config"), "{text}");
+        assert!(text.contains("working directory"), "{text}");
+        assert!(text.contains("projects directory"), "{text}");
+        assert!(text.contains("allowed roots"), "{text}");
+        assert!(!text.contains(USER_TOKEN), "root text leaked a token");
+        assert!(!text.contains(AGENT_TOKEN), "root text leaked a token");
+
+        let json_text = render_login_result(
+            &paths,
+            "https://api.example.com",
+            "alice",
+            "laptop",
+            true,
+            true,
+            false,
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_text).unwrap();
+        assert_eq!(value["agent_install_available"], serde_json::json!(false));
+        assert!(value["agent_install_argv"].is_null());
+        let reason = value["agent_install_reason"].as_str().unwrap();
+        assert!(reason.contains("login ran as root"), "{reason}");
+        assert!(reason.contains("non-root Runner user"), "{reason}");
+        assert!(!reason.contains("--allow-root-runner"), "{reason}");
+        assert_eq!(value["foreground_argv"], serde_json::json!(foreground_argv));
+        assert_eq!(
+            value["next_steps"],
+            serde_json::json!([shell_command(&foreground_argv)])
+        );
+        assert!(!json_text.contains("webcodex agent install --scope user"));
+        assert!(!json_text.contains(USER_TOKEN), "root json leaked a token");
+        assert!(!json_text.contains(AGENT_TOKEN), "root json leaked a token");
     }
 
     #[test]
@@ -2101,6 +2243,7 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            false,
             false,
             true,
         )
@@ -2128,6 +2271,7 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            false,
             false,
             true,
         )

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -23,7 +23,7 @@ use super::connections::{
     list_connections, resolve_connection_parent, user_slug, Connection, ConnectionPaths,
     INTERNAL_DIR_PREFIX,
 };
-use super::shell_command;
+use super::{shell_command, validate_user_api_token};
 
 /// Device name reported to the server. The hostname is what a person would call
 /// this machine; `--device` overrides it.
@@ -562,6 +562,8 @@ pub(crate) fn render_login_result(
         "webcodex".to_string(),
         "agent".to_string(),
         "install".to_string(),
+        "--scope".to_string(),
+        "user".to_string(),
         "--config".to_string(),
         paths.agent_config.to_string_lossy().into_owned(),
     ];
@@ -580,6 +582,10 @@ pub(crate) fn render_login_result(
             "dir": paths.dir.to_string_lossy(),
             "user_token_file": paths.user_token.to_string_lossy(),
             "agent_config": paths.agent_config.to_string_lossy(),
+            "credential_usage": {
+                "webcodex-user-token": "GPT Actions, MCP, and REST/project APIs",
+                "agent_config_token": "Runner/Agent transport only",
+            },
             "foreground_argv": &foreground_argv,
             "agent_install_argv": &agent_install_argv,
             "next_steps": [&foreground_command, &agent_install_command],
@@ -597,6 +603,7 @@ pub(crate) fn render_login_result(
             })?
             .trim()
             .to_string();
+        validate_user_api_token(&token)?;
         return Ok(format!(
             "Sensitive HTTP MCP connection details\n\
              ======================================\n\
@@ -609,10 +616,10 @@ pub(crate) fn render_login_result(
     Ok(format!(
         "Logged in to {server_url} as {username} ({device}).\n\n  \
          MCP endpoint: {server_url}/mcp\n  \
-         user token file: {}\n  \
-         agent config:   {}\n\n\
+         user token file: {} (GPT Actions, MCP, and REST/project APIs)\n  \
+         agent config:   {} (contains Runner/Agent transport credentials only)\n\n\
          Start the agent in the foreground:\n  {}\n\n\
-         Or install it as a service:\n  {}\n",
+         Or install it as a non-root user service (run as the same ordinary user):\n  {}\n",
         paths.user_token.display(),
         paths.agent_config.display(),
         foreground_command,
@@ -1993,8 +2000,16 @@ mod tests {
         );
         assert!(text.contains("webcodex-runner --config"), "{text}");
         assert!(
+            text.contains("GPT Actions, MCP, and REST/project APIs"),
+            "{text}"
+        );
+        assert!(
+            text.contains("Runner/Agent transport credentials only"),
+            "{text}"
+        );
+        assert!(
             text.contains(&format!(
-                "webcodex agent install --config {}",
+                "webcodex agent install --scope user --config {}",
                 paths.agent_config.display()
             )),
             "{text}"
@@ -2012,6 +2027,7 @@ mod tests {
         )
         .unwrap();
         assert!(json.contains("mcp_url"), "{json}");
+        assert!(json.contains("credential_usage"), "{json}");
         assert!(
             json.contains(&paths.user_token.display().to_string()),
             "{json}"
@@ -2032,6 +2048,8 @@ mod tests {
             "webcodex".to_string(),
             "agent".to_string(),
             "install".to_string(),
+            "--scope".to_string(),
+            "user".to_string(),
             "--config".to_string(),
             paths.agent_config.to_string_lossy().into_owned(),
         ];
@@ -2096,6 +2114,27 @@ mod tests {
             text.contains(&format!("Authorization: Bearer {USER_TOKEN}")),
             "{text}"
         );
+    }
+
+    #[test]
+    fn print_mcp_config_rejects_an_agent_token_in_the_user_token_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let paths = ConnectionPaths::new(temp.path().join("connection"));
+        std::fs::create_dir_all(&paths.dir).unwrap();
+        let secret = "wc_agent_do_not_echo_login_0123456789";
+        std::fs::write(&paths.user_token, format!("{secret}\n")).unwrap();
+        let error = render_login_result(
+            &paths,
+            "https://api.example.com",
+            "alice",
+            "laptop",
+            false,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.contains("Agent transport token"), "{error}");
+        assert!(error.contains("webcodex-user-token"), "{error}");
+        assert!(!error.contains(secret));
     }
 
     #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -546,6 +546,7 @@ pub(crate) fn stage_connection(
 }
 
 const ROOT_AGENT_INSTALL_REASON: &str = "login ran as root; no safe systemd installation argv can be generated without explicitly selecting a non-root Runner user and validating access to the agent config, working directory, projects directory, and allowed roots";
+const ROOT_FOREGROUND_REASON: &str = "login ran as root; no foreground Runner argv is emitted because it would execute project commands as root";
 
 pub(crate) fn render_login_result(
     paths: &ConnectionPaths,
@@ -556,11 +557,13 @@ pub(crate) fn render_login_result(
     json: bool,
     print_mcp_config: bool,
 ) -> Result<String, String> {
-    let foreground_argv = vec![
-        "webcodex-runner".to_string(),
-        "--config".to_string(),
-        paths.agent_config.to_string_lossy().into_owned(),
-    ];
+    let foreground_argv = (!effective_root).then(|| {
+        vec![
+            "webcodex-runner".to_string(),
+            "--config".to_string(),
+            paths.agent_config.to_string_lossy().into_owned(),
+        ]
+    });
     let agent_install_argv = if effective_root {
         None
     } else {
@@ -574,14 +577,17 @@ pub(crate) fn render_login_result(
             paths.agent_config.to_string_lossy().into_owned(),
         ])
     };
-    let foreground_command = shell_command(&foreground_argv);
+    let foreground_command = foreground_argv.as_ref().map(|argv| shell_command(argv));
     let agent_install_command = agent_install_argv.as_ref().map(|argv| shell_command(argv));
 
     // JSON output carries only safe metadata; never a full token. The
     // `--print-mcp-config` path is text-only and mutually exclusive with `--json`
     // (enforced at parse time), so the two cannot both apply here.
     if json {
-        let mut next_steps = vec![foreground_command.clone()];
+        let mut next_steps = Vec::new();
+        if let Some(command) = &foreground_command {
+            next_steps.push(command.clone());
+        }
         if let Some(command) = &agent_install_command {
             next_steps.push(command.clone());
         }
@@ -597,7 +603,9 @@ pub(crate) fn render_login_result(
                 "webcodex-user-token": "GPT Actions, MCP, and REST/project APIs",
                 "agent_config_token": "Runner/Agent transport only",
             },
+            "foreground_available": foreground_argv.is_some(),
             "foreground_argv": &foreground_argv,
+            "foreground_reason": effective_root.then_some(ROOT_FOREGROUND_REASON),
             "agent_install_available": agent_install_argv.is_some(),
             "agent_install_argv": &agent_install_argv,
             "agent_install_reason": effective_root.then_some(ROOT_AGENT_INSTALL_REASON),
@@ -626,14 +634,16 @@ pub(crate) fn render_login_result(
         ));
     }
 
-    let service_guidance = match agent_install_command {
-        Some(command) => format!(
-            "Or install it as a non-root user service (run as the same ordinary user):\n  {command}\n"
+    let next_step_guidance = match (foreground_command, agent_install_command) {
+        (Some(foreground_command), Some(command)) => format!(
+            "Start the agent in the foreground:\n  {foreground_command}\n\n\
+             Or install it as a non-root user service (run as the same ordinary user):\n  {command}\n"
         ),
-        None => "No safe systemd installation command was generated because login ran as root.\n\
-                 Recommended: have the ordinary local user who will run the Runner execute `webcodex login`, then install the user service as that same user.\n\
-                 Advanced system service deployment requires an administrator to explicitly select a non-root account with `--scope system --user`, verify that account can read the agent config and access the working directory, and ensure the config, projects directory, and allowed roots have suitable permissions.\n"
+        (None, None) => "Login ran as root, so no command to start a root Runner is recommended.\n\
+                        Recommended: have the ordinary local user who will run the Runner use a fresh pairing code to execute `webcodex login`, then install the user service as that same user.\n\
+                        Advanced system service deployment requires an administrator to explicitly select a non-root account with `--scope system --user`, verify that account can read the agent config and access the working directory, and ensure the config, projects directory, and allowed roots have suitable permissions.\n"
             .to_string(),
+        _ => return Err("inconsistent login Runner guidance state".to_string()),
     };
 
     Ok(format!(
@@ -641,12 +651,10 @@ pub(crate) fn render_login_result(
          MCP endpoint: {server_url}/mcp\n  \
          user token file: {} (GPT Actions, MCP, and REST/project APIs)\n  \
          agent config:   {} (contains Runner/Agent transport credentials only)\n\n\
-         Start the agent in the foreground:\n  {}\n\n\
          {}",
         paths.user_token.display(),
         paths.agent_config.display(),
-        foreground_command,
-        service_guidance,
+        next_step_guidance,
     ))
 }
 
@@ -2109,7 +2117,9 @@ mod tests {
         )
         .unwrap();
         let value: serde_json::Value = serde_json::from_str(&json_text).unwrap();
+        assert_eq!(value["foreground_available"], serde_json::json!(true));
         assert_eq!(value["foreground_argv"], serde_json::json!(foreground_argv));
+        assert!(value["foreground_reason"].is_null());
         assert_eq!(value["agent_install_argv"], serde_json::json!(install_argv));
         assert_eq!(value["agent_install_available"], serde_json::json!(true));
         assert!(value["agent_install_reason"].is_null());
@@ -2184,11 +2194,17 @@ mod tests {
             "{text}"
         );
         assert!(!text.contains("--allow-root-runner"), "{text}");
-        assert!(text.contains("login ran as root"), "{text}");
+        assert!(
+            !text.contains("Start the agent in the foreground"),
+            "{text}"
+        );
+        assert!(!text.contains(&shell_command(&foreground_argv)), "{text}");
+        assert!(text.contains("Login ran as root"), "{text}");
         assert!(
             text.contains("ordinary local user who will run the Runner"),
             "{text}"
         );
+        assert!(text.contains("fresh pairing code"), "{text}");
         assert!(
             text.contains("install the user service as that same user"),
             "{text}"
@@ -2222,11 +2238,13 @@ mod tests {
         assert!(reason.contains("login ran as root"), "{reason}");
         assert!(reason.contains("non-root Runner user"), "{reason}");
         assert!(!reason.contains("--allow-root-runner"), "{reason}");
-        assert_eq!(value["foreground_argv"], serde_json::json!(foreground_argv));
-        assert_eq!(
-            value["next_steps"],
-            serde_json::json!([shell_command(&foreground_argv)])
-        );
+        assert_eq!(value["foreground_available"], serde_json::json!(false));
+        assert!(value["foreground_argv"].is_null());
+        let foreground_reason = value["foreground_reason"].as_str().unwrap();
+        assert!(foreground_reason.contains("login ran as root"));
+        assert!(foreground_reason.contains("project commands as root"));
+        assert_eq!(value["next_steps"], serde_json::json!([]));
+        assert!(!json_text.contains("--allow-root-runner"));
         assert!(!json_text.contains("webcodex agent install --scope user"));
         assert!(!json_text.contains(USER_TOKEN), "root json leaked a token");
         assert!(!json_text.contains(AGENT_TOKEN), "root json leaked a token");

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -71,7 +71,6 @@ pub(crate) use connect::{
     run_local_runner_logs, run_local_runner_service, write_connect_result, ConnectOptions,
     LocalRunnerServiceAction,
 };
-#[cfg(test)]
 pub(crate) use env::is_effective_root;
 #[cfg(test)]
 pub(crate) use env::parse_env_content_value;
@@ -98,27 +97,30 @@ pub(crate) use output::{
 #[cfg(test)]
 pub(crate) use pairing::{ensure_enroll_outputs_available, resolve_pairing_create_token};
 pub(crate) use pairing::{run_client_enroll, run_pairing_create};
+pub(crate) use profiles::{
+    agent_config_for_scope, agent_service_file_for_scope, client_profile_agent_config,
+    client_profile_agent_token_file_for_scope, client_profile_projects_dir,
+    client_profile_state_dir, client_profile_user_token_file_for_scope, current_user_home,
+    default_client_output_dir_for_profile, validate_client_profile, validate_service_file_scope,
+};
 #[cfg(test)]
 pub(crate) use profiles::{client_output_dir_for_profile, CLIENT_PROFILE_ERROR};
-pub(crate) use profiles::{
-    client_profile_agent_config, client_profile_agent_token_file, client_profile_projects_dir,
-    client_profile_service_file, client_profile_state_dir, client_profile_user_token_file,
-    default_client_output_dir_for_profile, validate_client_profile,
-};
 pub(crate) use server::{
     run_server_init, run_server_install_service, run_server_service, run_server_status,
     ServerStatusOptions,
 };
 pub(crate) use service::{
-    control_service, encode_exec_argument, encode_exec_path_argument, encode_exec_program,
-    encode_unit_path_value, install_unit, query_systemd_service_status, query_systemd_status,
-    run_internal_binary, run_logs, service_unit_name, uninstall_unit, validate_systemd_identity,
-    ServiceControl, AGENT_SERVICE_FILE, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE,
-    SERVER_SERVICE_UNIT,
+    control_service, control_service_for_scope, encode_exec_argument, encode_exec_path_argument,
+    encode_exec_program, encode_unit_path_value, ensure_service_file_parent, install_unit,
+    install_unit_for_scope, query_systemd_service_status_for_scope, query_systemd_status,
+    run_internal_binary, run_logs, run_logs_for_scope, service_unit_name, uninstall_unit,
+    uninstall_unit_for_scope, validate_systemd_identity, ServiceControl, AGENT_SERVICE_UNIT,
+    DEFAULT_LOG_LINES, SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT,
 };
 pub(crate) use setup::run_setup_single_user;
 pub(crate) use system::{
-    discover_internal_binary, read_optional_token, write_secret_file, write_text_file,
+    discover_internal_binary, read_optional_token, read_optional_user_api_token, system_user_home,
+    system_user_is_root, validate_user_api_token, write_secret_file, write_text_file,
 };
 #[cfg(test)]
 pub(crate) use token_commands::resolve_account_credential;

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -99,8 +99,9 @@ pub(crate) use pairing::{ensure_enroll_outputs_available, resolve_pairing_create
 pub(crate) use pairing::{run_client_enroll, run_pairing_create};
 pub(crate) use profiles::{
     agent_config_for_scope, agent_service_file_for_scope, client_profile_agent_config,
-    client_profile_agent_token_file_for_scope, client_profile_projects_dir,
-    client_profile_state_dir, client_profile_user_token_file_for_scope, current_user_home,
+    client_profile_agent_token_file, client_profile_agent_token_file_for_scope,
+    client_profile_projects_dir, client_profile_state_dir, client_profile_user_token_file,
+    client_profile_user_token_file_for_scope, current_user_home,
     default_client_output_dir_for_profile, validate_client_profile, validate_service_file_scope,
 };
 #[cfg(test)]

--- a/crates/webcodex-cli/src/webcodex_cli/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/ops.rs
@@ -1,7 +1,9 @@
 use serde_json::{json, Value};
 use std::path::PathBuf;
 
-use super::{http_post_json_status, read_env_file_value, read_optional_token};
+use super::{
+    http_post_json_status, read_env_file_value, read_optional_token, validate_user_api_token,
+};
 
 const DEFAULT_EXPECTED_TOOL_COUNT: u64 = 66;
 
@@ -283,15 +285,18 @@ fn resolve_ops_token(opts: &OpsCommonOptions) -> Result<Option<String>, String> 
         if token.is_empty() {
             return Err("--token cannot be empty".to_string());
         }
+        validate_user_api_token(&token)?;
         return Ok(Some(token));
     }
     if let Some(token) = read_optional_token(&opts.token_file, "--token-file")? {
+        validate_user_api_token(&token)?;
         return Ok(Some(token));
     }
     if let Some(path) = &opts.env_file {
         if let Some(token) = read_env_file_value(path, "WEBCODEX_TOKEN")? {
             let token = token.trim().to_string();
             if !token.is_empty() {
+                validate_user_api_token(&token)?;
                 return Ok(Some(token));
             }
         }
@@ -299,6 +304,7 @@ fn resolve_ops_token(opts: &OpsCommonOptions) -> Result<Option<String>, String> 
     if let Ok(token) = std::env::var("WEBCODEX_TOKEN") {
         let token = token.trim().to_string();
         if !token.is_empty() {
+            validate_user_api_token(&token)?;
             return Ok(Some(token));
         }
     }

--- a/crates/webcodex-cli/src/webcodex_cli/pairing.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/pairing.rs
@@ -256,6 +256,10 @@ pub(crate) async fn run_client_enroll(opts: ClientEnrollOptions) -> Result<Strin
                 "start webcodex-runner with the generated agent.toml",
                 "configure GPT Actions with the user-token file"
             ],
+            "credential_usage": {
+                "webcodex-user-token": "GPT Actions, MCP, and REST/project APIs",
+                "webcodex-runner-token": "Runner/Agent transport only"
+            }
         });
         serde_json::to_string_pretty(&summary).map_err(|e| e.to_string())
     } else {
@@ -277,6 +281,9 @@ pub(crate) async fn run_client_enroll(opts: ClientEnrollOptions) -> Result<Strin
             "  agent config:      {}\n",
             opts.agent_config.display()
         ));
+        out.push_str("\nCredential usage:\n");
+        out.push_str("  - webcodex-user-token: GPT Actions, MCP, and REST/project APIs\n");
+        out.push_str("  - webcodex-runner-token: Runner/Agent transport only\n");
         out.push_str("\nNext steps:\n");
         let foreground_command = shell_command(&[
             "webcodex-runner".to_string(),

--- a/crates/webcodex-cli/src/webcodex_cli/profiles.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/profiles.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use super::env::is_effective_root;
+use crate::ServiceScope;
 
 pub(crate) const CLIENT_PROFILE_ERROR: &str =
     "--profile must be a safe path component using only ASCII letters, digits, '.', '_' or '-'";
@@ -17,6 +18,126 @@ pub(crate) fn default_client_base_dir() -> PathBuf {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("."));
         home.join(".config/webcodex")
+    }
+}
+
+pub(crate) fn current_user_home() -> Result<PathBuf, String> {
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is required to derive user service paths".to_string())?;
+    if !home.is_absolute() {
+        return Err("HOME must be an absolute path to derive user service paths".to_string());
+    }
+    Ok(home)
+}
+
+pub(crate) fn user_config_home() -> Result<PathBuf, String> {
+    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty())
+    {
+        let config_home = PathBuf::from(config_home);
+        if !config_home.is_absolute() {
+            return Err(
+                "XDG_CONFIG_HOME must be an absolute path to derive user service paths".to_string(),
+            );
+        }
+        return Ok(config_home);
+    }
+    Ok(current_user_home()?.join(".config"))
+}
+
+pub(crate) fn client_base_dir_for_scope(scope: ServiceScope) -> Result<PathBuf, String> {
+    match scope {
+        ServiceScope::User => Ok(user_config_home()?.join("webcodex")),
+        ServiceScope::System => Ok(PathBuf::from("/etc/webcodex")),
+    }
+}
+
+pub(crate) fn agent_config_for_scope(
+    scope: ServiceScope,
+    profile: Option<&str>,
+) -> Result<PathBuf, String> {
+    let base = client_base_dir_for_scope(scope)?;
+    Ok(match profile {
+        Some(profile) => client_output_dir_for_profile(&base, profile).join("agent.toml"),
+        None => base.join("agent.toml"),
+    })
+}
+
+pub(crate) fn client_profile_user_token_file_for_scope(
+    scope: ServiceScope,
+    profile: &str,
+) -> Result<PathBuf, String> {
+    Ok(
+        client_output_dir_for_profile(&client_base_dir_for_scope(scope)?, profile)
+            .join("webcodex-user-token"),
+    )
+}
+
+pub(crate) fn client_profile_agent_token_file_for_scope(
+    scope: ServiceScope,
+    profile: &str,
+) -> Result<PathBuf, String> {
+    Ok(
+        client_output_dir_for_profile(&client_base_dir_for_scope(scope)?, profile)
+            .join("webcodex-runner-token"),
+    )
+}
+
+pub(crate) fn user_systemd_unit_dir() -> Result<PathBuf, String> {
+    Ok(user_config_home()?.join("systemd/user"))
+}
+
+pub(crate) fn agent_service_file_for_scope(
+    scope: ServiceScope,
+    profile: Option<&str>,
+) -> Result<PathBuf, String> {
+    let name = match profile {
+        Some(profile) => format!("webcodex-runner-{profile}.service"),
+        None => "webcodex-runner.service".to_string(),
+    };
+    let directory = match scope {
+        ServiceScope::User => user_systemd_unit_dir()?,
+        ServiceScope::System => PathBuf::from("/etc/systemd/system"),
+    };
+    Ok(directory.join(name))
+}
+
+pub(crate) fn validate_service_file_scope(
+    scope: ServiceScope,
+    service_file: &Path,
+) -> Result<(), String> {
+    if !service_file.is_absolute() {
+        return Err("--service-file must be an absolute path".to_string());
+    }
+    let components = service_file
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    if components.iter().any(|component| *component == "..") {
+        return Err("--service-file cannot contain '..' path components".to_string());
+    }
+    let is_user_unit_path = components
+        .windows(2)
+        .any(|pair| pair == ["systemd", "user"]);
+    let is_system_unit_path = service_file.starts_with("/etc")
+        || service_file.starts_with("/usr/lib/systemd/system")
+        || service_file.starts_with("/usr/local/lib/systemd/system")
+        || service_file.starts_with("/lib/systemd/system")
+        || service_file.starts_with("/run/systemd/system")
+        || components
+            .windows(2)
+            .any(|pair| pair == ["systemd", "system"]);
+    match scope {
+        ServiceScope::User if is_system_unit_path => Err(format!(
+            "user scope cannot write a system unit path: {}",
+            service_file.display()
+        )),
+        ServiceScope::System if is_user_unit_path => Err(format!(
+            "system scope cannot write a user unit path: {}",
+            service_file.display()
+        )),
+        _ => Ok(()),
     }
 }
 
@@ -74,19 +195,4 @@ pub(crate) fn client_profile_agent_config(profile: &str) -> PathBuf {
 
 pub(crate) fn client_profile_projects_dir(profile: &str) -> PathBuf {
     client_profile_dir(profile).join("projects.d")
-}
-
-pub(crate) fn client_profile_user_token_file(profile: &str) -> PathBuf {
-    client_profile_dir(profile).join("webcodex-user-token")
-}
-
-pub(crate) fn client_profile_agent_token_file(profile: &str) -> PathBuf {
-    client_profile_dir(profile).join("webcodex-runner-token")
-}
-
-pub(crate) fn client_profile_service_file(profile: &str) -> PathBuf {
-    PathBuf::from(format!(
-        "/etc/systemd/system/webcodex-runner-{}.service",
-        profile
-    ))
 }

--- a/crates/webcodex-cli/src/webcodex_cli/profiles.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/profiles.rs
@@ -196,3 +196,11 @@ pub(crate) fn client_profile_agent_config(profile: &str) -> PathBuf {
 pub(crate) fn client_profile_projects_dir(profile: &str) -> PathBuf {
     client_profile_dir(profile).join("projects.d")
 }
+
+pub(crate) fn client_profile_user_token_file(profile: &str) -> PathBuf {
+    client_profile_dir(profile).join("webcodex-user-token")
+}
+
+pub(crate) fn client_profile_agent_token_file(profile: &str) -> PathBuf {
+    client_profile_dir(profile).join("webcodex-runner-token")
+}

--- a/crates/webcodex-cli/src/webcodex_cli/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/service.rs
@@ -3,10 +3,10 @@ use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::system::discover_named_binary_absolute;
+use crate::ServiceScope;
 
 pub(crate) const SERVER_SERVICE_FILE: &str = "/etc/systemd/system/webcodex.service";
 pub(crate) const SERVER_SERVICE_UNIT: &str = "webcodex.service";
-pub(crate) const AGENT_SERVICE_FILE: &str = "/etc/systemd/system/webcodex-runner.service";
 pub(crate) const AGENT_SERVICE_UNIT: &str = "webcodex-runner.service";
 pub(crate) const DEFAULT_LOG_LINES: u32 = 200;
 
@@ -240,6 +240,32 @@ fn systemctl_invocation(
     }
 }
 
+fn invocation_for_scope(scope: ServiceScope, invocation: &ProcessInvocation) -> ProcessInvocation {
+    let mut invocation = invocation.clone();
+    if scope == ServiceScope::User {
+        invocation.args.insert(0, "--user".to_string());
+        invocation.operation = invocation
+            .operation
+            .replacen("systemctl", "systemctl --user", 1);
+        invocation.operation = invocation
+            .operation
+            .replacen("journalctl", "journalctl --user", 1);
+    }
+    invocation
+}
+
+struct ScopedProcessExecutor<'a, E> {
+    inner: &'a mut E,
+    scope: ServiceScope,
+}
+
+impl<E: ProcessExecutor> ProcessExecutor for ScopedProcessExecutor<'_, E> {
+    fn execute(&mut self, invocation: &ProcessInvocation) -> Result<ProcessOutput, String> {
+        self.inner
+            .execute(&invocation_for_scope(self.scope, invocation))
+    }
+}
+
 pub(crate) fn plan_install(systemctl: &Path, unit: &str, no_start: bool) -> Vec<ProcessInvocation> {
     let mut enable_args = vec!["enable".to_string()];
     if !no_start {
@@ -266,6 +292,19 @@ pub(crate) fn plan_install(systemctl: &Path, unit: &str, no_start: bool) -> Vec<
             Some(unit),
         ),
     ]
+}
+
+#[cfg(test)]
+pub(crate) fn plan_install_for_scope(
+    scope: ServiceScope,
+    systemctl: &Path,
+    unit: &str,
+    no_start: bool,
+) -> Vec<ProcessInvocation> {
+    plan_install(systemctl, unit, no_start)
+        .iter()
+        .map(|invocation| invocation_for_scope(scope, invocation))
+        .collect()
 }
 
 pub(crate) fn plan_control(
@@ -295,6 +334,19 @@ pub(crate) fn plan_control(
     plan
 }
 
+#[cfg(test)]
+pub(crate) fn plan_control_for_scope(
+    scope: ServiceScope,
+    systemctl: &Path,
+    unit: &str,
+    control: ServiceControl,
+) -> Vec<ProcessInvocation> {
+    plan_control(systemctl, unit, control)
+        .iter()
+        .map(|invocation| invocation_for_scope(scope, invocation))
+        .collect()
+}
+
 pub(crate) fn plan_uninstall_before_remove(systemctl: &Path, unit: &str) -> Vec<ProcessInvocation> {
     vec![
         systemctl_invocation(
@@ -312,6 +364,18 @@ pub(crate) fn plan_uninstall_before_remove(systemctl: &Path, unit: &str) -> Vec<
     ]
 }
 
+#[cfg(test)]
+pub(crate) fn plan_uninstall_before_remove_for_scope(
+    scope: ServiceScope,
+    systemctl: &Path,
+    unit: &str,
+) -> Vec<ProcessInvocation> {
+    plan_uninstall_before_remove(systemctl, unit)
+        .iter()
+        .map(|invocation| invocation_for_scope(scope, invocation))
+        .collect()
+}
+
 pub(crate) fn plan_uninstall_after_remove(systemctl: &Path, unit: &str) -> Vec<ProcessInvocation> {
     vec![
         systemctl_invocation(
@@ -327,6 +391,18 @@ pub(crate) fn plan_uninstall_after_remove(systemctl: &Path, unit: &str) -> Vec<P
             Some(unit),
         ),
     ]
+}
+
+#[cfg(test)]
+pub(crate) fn plan_uninstall_after_remove_for_scope(
+    scope: ServiceScope,
+    systemctl: &Path,
+    unit: &str,
+) -> Vec<ProcessInvocation> {
+    plan_uninstall_after_remove(systemctl, unit)
+        .iter()
+        .map(|invocation| invocation_for_scope(scope, invocation))
+        .collect()
 }
 
 pub(crate) fn journalctl_invocation(
@@ -357,6 +433,39 @@ pub(crate) fn journalctl_invocation(
         unit: Some(unit.to_string()),
         inherit_stdio: follow,
     }
+}
+
+#[cfg(test)]
+pub(crate) fn journalctl_invocation_for_scope(
+    scope: ServiceScope,
+    journalctl: &Path,
+    unit: &str,
+    lines: u32,
+    since: Option<&str>,
+    follow: bool,
+) -> ProcessInvocation {
+    invocation_for_scope(
+        scope,
+        &journalctl_invocation(journalctl, unit, lines, since, follow),
+    )
+}
+
+pub(crate) fn ensure_service_file_parent(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| format!("{} must have a parent directory", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    let metadata = std::fs::symlink_metadata(parent)
+        .map_err(|error| format!("failed to inspect {}: {error}", parent.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(format!(
+            "refusing to use non-directory or symlinked service unit directory: {}",
+            parent.display()
+        ));
+    }
+    Ok(())
 }
 
 fn failure_detail(output: &ProcessOutput) -> String {
@@ -861,6 +970,31 @@ pub(crate) fn install_unit_with_executor<E: ProcessExecutor>(
     })
 }
 
+pub(crate) fn install_unit_with_executor_for_scope<E: ProcessExecutor>(
+    scope: ServiceScope,
+    executor: &mut E,
+    systemctl: &Path,
+    service_file: &Path,
+    unit: &str,
+    content: &str,
+    overwrite: bool,
+    no_start: bool,
+) -> Result<InstallUnitResult, String> {
+    let mut executor = ScopedProcessExecutor {
+        inner: executor,
+        scope,
+    };
+    install_unit_with_executor(
+        &mut executor,
+        systemctl,
+        service_file,
+        unit,
+        content,
+        overwrite,
+        no_start,
+    )
+}
+
 pub(crate) fn control_service_with_executor<E: ProcessExecutor>(
     executor: &mut E,
     systemctl: &Path,
@@ -868,6 +1002,20 @@ pub(crate) fn control_service_with_executor<E: ProcessExecutor>(
     control: ServiceControl,
 ) -> Result<(), String> {
     execute_plan(executor, &plan_control(systemctl, unit, control))
+}
+
+pub(crate) fn control_service_with_executor_for_scope<E: ProcessExecutor>(
+    scope: ServiceScope,
+    executor: &mut E,
+    systemctl: &Path,
+    unit: &str,
+    control: ServiceControl,
+) -> Result<(), String> {
+    let mut executor = ScopedProcessExecutor {
+        inner: executor,
+        scope,
+    };
+    control_service_with_executor(&mut executor, systemctl, unit, control)
 }
 
 fn missing_unit_failure(output: &ProcessOutput) -> bool {
@@ -930,6 +1078,20 @@ pub(crate) fn uninstall_unit_with_executor<E: ProcessExecutor>(
     })
 }
 
+pub(crate) fn uninstall_unit_with_executor_for_scope<E: ProcessExecutor>(
+    scope: ServiceScope,
+    executor: &mut E,
+    systemctl: &Path,
+    service_file: &Path,
+    unit: &str,
+) -> Result<UninstallUnitResult, String> {
+    let mut executor = ScopedProcessExecutor {
+        inner: executor,
+        scope,
+    };
+    uninstall_unit_with_executor(&mut executor, systemctl, service_file, unit)
+}
+
 pub(crate) fn run_logs_with_executor<E: ProcessExecutor>(
     executor: &mut E,
     journalctl: &Path,
@@ -941,6 +1103,22 @@ pub(crate) fn run_logs_with_executor<E: ProcessExecutor>(
     let invocation = journalctl_invocation(journalctl, unit, lines, since, follow);
     let output = execute_required(executor, &invocation)?;
     Ok(output.stdout)
+}
+
+pub(crate) fn run_logs_with_executor_for_scope<E: ProcessExecutor>(
+    scope: ServiceScope,
+    executor: &mut E,
+    journalctl: &Path,
+    unit: &str,
+    lines: u32,
+    since: Option<&str>,
+    follow: bool,
+) -> Result<String, String> {
+    let mut executor = ScopedProcessExecutor {
+        inner: executor,
+        scope,
+    };
+    run_logs_with_executor(&mut executor, journalctl, unit, lines, since, follow)
 }
 
 pub(crate) fn install_unit(
@@ -964,10 +1142,43 @@ pub(crate) fn install_unit(
     )
 }
 
+pub(crate) fn install_unit_for_scope(
+    scope: ServiceScope,
+    service_file: &Path,
+    unit: &str,
+    content: &str,
+    overwrite: bool,
+    no_start: bool,
+) -> Result<InstallUnitResult, String> {
+    preflight_unit_path(service_file, overwrite)?;
+    let systemctl = systemctl_path()?;
+    let mut executor = RealProcessExecutor;
+    install_unit_with_executor_for_scope(
+        scope,
+        &mut executor,
+        &systemctl,
+        service_file,
+        unit,
+        content,
+        overwrite,
+        no_start,
+    )
+}
+
 pub(crate) fn control_service(unit: &str, control: ServiceControl) -> Result<(), String> {
     let systemctl = systemctl_path()?;
     let mut executor = RealProcessExecutor;
     control_service_with_executor(&mut executor, &systemctl, unit, control)
+}
+
+pub(crate) fn control_service_for_scope(
+    scope: ServiceScope,
+    unit: &str,
+    control: ServiceControl,
+) -> Result<(), String> {
+    let systemctl = systemctl_path()?;
+    let mut executor = RealProcessExecutor;
+    control_service_with_executor_for_scope(scope, &mut executor, &systemctl, unit, control)
 }
 
 pub(crate) fn uninstall_unit(
@@ -979,6 +1190,16 @@ pub(crate) fn uninstall_unit(
     uninstall_unit_with_executor(&mut executor, &systemctl, service_file, unit)
 }
 
+pub(crate) fn uninstall_unit_for_scope(
+    scope: ServiceScope,
+    service_file: &Path,
+    unit: &str,
+) -> Result<UninstallUnitResult, String> {
+    let systemctl = systemctl_path()?;
+    let mut executor = RealProcessExecutor;
+    uninstall_unit_with_executor_for_scope(scope, &mut executor, &systemctl, service_file, unit)
+}
+
 pub(crate) fn run_logs(
     unit: &str,
     lines: u32,
@@ -988,6 +1209,26 @@ pub(crate) fn run_logs(
     let journalctl = journalctl_path()?;
     let mut executor = RealProcessExecutor;
     run_logs_with_executor(&mut executor, &journalctl, unit, lines, since, follow)
+}
+
+pub(crate) fn run_logs_for_scope(
+    scope: ServiceScope,
+    unit: &str,
+    lines: u32,
+    since: Option<&str>,
+    follow: bool,
+) -> Result<String, String> {
+    let journalctl = journalctl_path()?;
+    let mut executor = RealProcessExecutor;
+    run_logs_with_executor_for_scope(
+        scope,
+        &mut executor,
+        &journalctl,
+        unit,
+        lines,
+        since,
+        follow,
+    )
 }
 
 pub(crate) fn run_internal_binary(path: &Path, args: &[String]) -> Result<i32, String> {
@@ -1025,6 +1266,27 @@ pub(crate) fn query_systemd_service_status(service_name: &str) -> SystemdStatus 
     }
 }
 
+pub(crate) fn query_systemd_service_status_for_scope(
+    scope: ServiceScope,
+    service_name: &str,
+) -> SystemdStatus {
+    let Ok(systemctl) = systemctl_path() else {
+        return SystemdStatus {
+            active: "unknown".to_string(),
+            enabled: "unknown".to_string(),
+        };
+    };
+    let mut executor = RealProcessExecutor;
+    let mut executor = ScopedProcessExecutor {
+        inner: &mut executor,
+        scope,
+    };
+    SystemdStatus {
+        active: query_status_output(&mut executor, &systemctl, service_name, "is-active"),
+        enabled: query_status_output(&mut executor, &systemctl, service_name, "is-enabled"),
+    }
+}
+
 pub(crate) fn query_systemd_status() -> SystemdStatus {
     query_systemd_service_status(SERVER_SERVICE_UNIT)
 }
@@ -1048,6 +1310,87 @@ mod tests {
             no_start[2].args,
             ["is-enabled", "--quiet", AGENT_SERVICE_UNIT]
         );
+    }
+
+    #[test]
+    fn user_scope_covers_install_status_control_logs_and_uninstall_manager_args() {
+        let systemctl = Path::new("/usr/bin/systemctl");
+        let journalctl = Path::new("/usr/bin/journalctl");
+        let unit = "webcodex-runner-work.service";
+
+        for invocation in plan_install_for_scope(ServiceScope::User, systemctl, unit, false) {
+            assert_eq!(invocation.args.first().map(String::as_str), Some("--user"));
+        }
+        for control in [
+            ServiceControl::Start,
+            ServiceControl::Stop,
+            ServiceControl::Restart,
+        ] {
+            for invocation in plan_control_for_scope(ServiceScope::User, systemctl, unit, control) {
+                assert_eq!(invocation.args.first().map(String::as_str), Some("--user"));
+            }
+        }
+        for invocation in
+            plan_uninstall_before_remove_for_scope(ServiceScope::User, systemctl, unit)
+                .into_iter()
+                .chain(plan_uninstall_after_remove_for_scope(
+                    ServiceScope::User,
+                    systemctl,
+                    unit,
+                ))
+        {
+            assert_eq!(invocation.args.first().map(String::as_str), Some("--user"));
+        }
+        let logs =
+            journalctl_invocation_for_scope(ServiceScope::User, journalctl, unit, 50, None, false);
+        assert_eq!(logs.args.first().map(String::as_str), Some("--user"));
+
+        let mut executor = FakeExecutor::with_outputs(vec![status("active")]);
+        let mut scoped = ScopedProcessExecutor {
+            inner: &mut executor,
+            scope: ServiceScope::User,
+        };
+        assert_eq!(
+            query_status_output(&mut scoped, systemctl, unit, "is-active"),
+            "active"
+        );
+        assert_eq!(executor.calls, [["--user", "is-active", unit]]);
+    }
+
+    #[test]
+    fn system_scope_never_adds_user_manager_flags() {
+        let systemctl = Path::new("/usr/bin/systemctl");
+        let unit = "webcodex-runner.service";
+        for invocation in plan_install_for_scope(ServiceScope::System, systemctl, unit, false)
+            .into_iter()
+            .chain(plan_control_for_scope(
+                ServiceScope::System,
+                systemctl,
+                unit,
+                ServiceControl::Restart,
+            ))
+            .chain(plan_uninstall_before_remove_for_scope(
+                ServiceScope::System,
+                systemctl,
+                unit,
+            ))
+            .chain(plan_uninstall_after_remove_for_scope(
+                ServiceScope::System,
+                systemctl,
+                unit,
+            ))
+        {
+            assert_ne!(invocation.args.first().map(String::as_str), Some("--user"));
+        }
+        let logs = journalctl_invocation_for_scope(
+            ServiceScope::System,
+            Path::new("/usr/bin/journalctl"),
+            unit,
+            50,
+            None,
+            false,
+        );
+        assert_ne!(logs.args.first().map(String::as_str), Some("--user"));
     }
 
     #[test]
@@ -1350,6 +1693,33 @@ mod tests {
         ] {
             assert!(validate_systemd_identity("User", value).is_err());
         }
+    }
+
+    #[test]
+    fn user_unit_parent_is_created_without_touching_systemd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let service_file = tmp.path().join("xdg/systemd/user/webcodex-runner.service");
+        ensure_service_file_parent(&service_file).unwrap();
+        assert!(service_file.parent().unwrap().is_dir());
+        assert!(!service_file.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_unit_parent_rejects_a_symlinked_final_directory() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        let linked = tmp.path().join("user");
+        symlink(&target, &linked).unwrap();
+        let error =
+            ensure_service_file_parent(&linked.join("webcodex-runner.service")).unwrap_err();
+        assert!(
+            error.contains("symlinked service unit directory"),
+            "{error}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/webcodex-cli/src/webcodex_cli/system.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/system.rs
@@ -104,6 +104,85 @@ pub(crate) fn discover_named_binary_absolute(name: &str) -> Option<PathBuf> {
     None
 }
 
+#[cfg(unix)]
+pub(crate) fn system_user_home(user: &str) -> Option<PathBuf> {
+    use std::ffi::{CStr, CString, OsString};
+    use std::os::unix::ffi::OsStringExt;
+
+    let user = CString::new(user).ok()?;
+    let initial_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    let size = if initial_size > 0 {
+        usize::try_from(initial_size).ok()?.clamp(1024, 1024 * 1024)
+    } else {
+        16 * 1024
+    };
+    let mut buffer = vec![0_u8; size];
+    let mut record = std::mem::MaybeUninit::<libc::passwd>::uninit();
+    let mut result = std::ptr::null_mut();
+    let status = unsafe {
+        libc::getpwnam_r(
+            user.as_ptr(),
+            record.as_mut_ptr(),
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        )
+    };
+    if status != 0 || result.is_null() {
+        return None;
+    }
+    let record = unsafe { record.assume_init() };
+    if record.pw_dir.is_null() {
+        return None;
+    }
+    let bytes = unsafe { CStr::from_ptr(record.pw_dir) }.to_bytes().to_vec();
+    let path = PathBuf::from(OsString::from_vec(bytes));
+    path.is_absolute().then_some(path)
+}
+
+#[cfg(unix)]
+pub(crate) fn system_user_is_root(user: &str) -> bool {
+    use std::ffi::CString;
+
+    if user == "root" || user.parse::<u32>().is_ok_and(|uid| uid == 0) {
+        return true;
+    }
+    let Ok(user) = CString::new(user) else {
+        return false;
+    };
+    let initial_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    let size = if initial_size > 0 {
+        usize::try_from(initial_size)
+            .unwrap_or(16 * 1024)
+            .clamp(1024, 1024 * 1024)
+    } else {
+        16 * 1024
+    };
+    let mut buffer = vec![0_u8; size];
+    let mut record = std::mem::MaybeUninit::<libc::passwd>::uninit();
+    let mut result = std::ptr::null_mut();
+    let status = unsafe {
+        libc::getpwnam_r(
+            user.as_ptr(),
+            record.as_mut_ptr(),
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        )
+    };
+    status == 0 && !result.is_null() && unsafe { record.assume_init().pw_uid == 0 }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn system_user_home(_user: &str) -> Option<PathBuf> {
+    None
+}
+
+#[cfg(not(unix))]
+pub(crate) fn system_user_is_root(user: &str) -> bool {
+    user == "root" || user.parse::<u32>().is_ok_and(|uid| uid == 0)
+}
+
 /// Write `content` to `path` with 0600 permissions on Unix, creating parent
 /// directories as needed. Used for one-time plaintext token files.
 pub(crate) fn write_secret_file(path: &Path, content: &str) -> Result<(), String> {
@@ -153,4 +232,52 @@ pub(crate) fn read_optional_token(
         return Err(format!("{} {} is empty", label, path.display()));
     }
     Ok(Some(token))
+}
+
+pub(crate) fn validate_user_api_token(token: &str) -> Result<(), String> {
+    if token.trim().starts_with("wc_agent_") {
+        return Err(
+            "This is an Agent transport token and cannot be used for project/runtime APIs. Use the generated webcodex-user-token instead."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn read_optional_user_api_token(
+    path: &Option<PathBuf>,
+    label: &str,
+) -> Result<Option<String>, String> {
+    let token = read_optional_token(path, label)?;
+    if let Some(token) = token.as_deref() {
+        validate_user_api_token(token)?;
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_api_token_validation_rejects_agent_tokens_without_echoing_them() {
+        let token = "wc_agent_do_not_echo_0123456789";
+        let error = validate_user_api_token(token).unwrap_err();
+        assert!(error.contains("Agent transport token"));
+        assert!(error.contains("webcodex-user-token"));
+        assert!(!error.contains(token));
+    }
+
+    #[test]
+    fn user_api_token_validation_accepts_user_tokens() {
+        validate_user_api_token("wc_pat_user_api_token_0123456789").unwrap();
+        validate_user_api_token("shared-key-without-managed-prefix").unwrap();
+    }
+
+    #[test]
+    fn root_system_identities_include_numeric_zero() {
+        assert!(system_user_is_root("root"));
+        assert!(system_user_is_root("0"));
+        assert!(system_user_is_root("000"));
+    }
 }

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -166,6 +166,40 @@ fn ops_parser_errors_do_not_leak_token_value() {
 }
 
 #[tokio::test]
+async fn ops_rejects_agent_token_from_env_file_without_leaking_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("webcodex.env");
+    let secret = "wc_agent_do_not_echo_ops_env_file_0123456789";
+    std::fs::write(&env_file, format!("WEBCODEX_TOKEN={secret}\n")).unwrap();
+    let mut opts = ops_common_opts("http://127.0.0.1:1".to_string());
+    opts.env_file = Some(env_file);
+
+    let error = run_ops_command(OpsCommand::Status(opts)).await.unwrap_err();
+    assert!(error.contains("Agent transport token"), "{error}");
+    assert!(error.contains("webcodex-user-token"), "{error}");
+    assert!(!error.contains(secret));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn ops_rejects_agent_token_from_process_env_without_leaking_it() {
+    let _guard = admin_cli::TEST_ENV_LOCK.lock().unwrap();
+    let previous = std::env::var_os("WEBCODEX_TOKEN");
+    let secret = "wc_agent_do_not_echo_ops_process_env_0123456789";
+    std::env::set_var("WEBCODEX_TOKEN", secret);
+    let opts = ops_common_opts("http://127.0.0.1:1".to_string());
+    let error = run_ops_command(OpsCommand::Status(opts)).await.unwrap_err();
+    if let Some(value) = previous {
+        std::env::set_var("WEBCODEX_TOKEN", value);
+    } else {
+        std::env::remove_var("WEBCODEX_TOKEN");
+    }
+
+    assert!(error.contains("Agent transport token"), "{error}");
+    assert!(error.contains("webcodex-user-token"), "{error}");
+    assert!(!error.contains(secret));
+}
+
+#[tokio::test]
 async fn ops_status_http_401_reports_auth_required_not_runtime_unreachable() {
     let output = run_ops_with_routes(
         OpsCommand::Status(ops_common_opts(String::new())),

--- a/crates/webcodex-cli/src/webcodex_cli/tests/profiles.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/profiles.rs
@@ -641,6 +641,46 @@ fn explicit_scope_selects_systemd_while_omitted_scope_preserves_hosted_profile()
 }
 
 #[test]
+fn omitted_scope_hosted_status_keeps_xdg_profile_paths_for_root() {
+    let _guard = admin_cli::TEST_ENV_LOCK.lock().unwrap();
+    let old_home = std::env::var_os("HOME");
+    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", "/root");
+    std::env::set_var("XDG_CONFIG_HOME", "/tmp/hosted-xdg");
+
+    let opts = parse_agent_status_with_identity(&args(&["--profile", "hosted"]), true).unwrap();
+    assert_eq!(opts.scope, ServiceScope::System);
+    assert_eq!(
+        opts.config,
+        PathBuf::from("/tmp/hosted-xdg/webcodex/clients/hosted/agent.toml")
+    );
+    assert_eq!(
+        opts.user_token_file,
+        Some(PathBuf::from(
+            "/tmp/hosted-xdg/webcodex/clients/hosted/webcodex-user-token"
+        ))
+    );
+    assert_eq!(
+        opts.agent_token_file,
+        Some(PathBuf::from(
+            "/tmp/hosted-xdg/webcodex/clients/hosted/webcodex-runner-token"
+        ))
+    );
+    assert!(opts.local_state_dir.is_some());
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    if let Some(value) = old_xdg {
+        std::env::set_var("XDG_CONFIG_HOME", value);
+    } else {
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+}
+
+#[test]
 fn every_agent_service_action_accepts_scope_and_service_file() {
     let service_file = "/home/alice/.config/systemd/user/webcodex-runner-work.service";
     for command in ["start", "stop", "restart"] {

--- a/crates/webcodex-cli/src/webcodex_cli/tests/profiles.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/profiles.rs
@@ -258,17 +258,25 @@ fn agent_init_rejects_unsafe_profile() {
 
 #[test]
 fn agent_status_profile_derives_config_and_token_paths() {
-    let opts = parse_agent_status(&args(&["--profile", "special"])).unwrap();
-    assert_eq!(opts.config, client_profile_agent_config("special"));
-    assert_eq!(opts.service_file, client_profile_service_file("special"));
+    let opts = parse_agent_status(&args(&["--profile", "special", "--scope", "system"])).unwrap();
+    assert_eq!(opts.scope, ServiceScope::System);
+    assert_eq!(
+        opts.config,
+        agent_config_for_scope(ServiceScope::System, Some("special")).unwrap()
+    );
+    assert_eq!(
+        opts.service_file,
+        agent_service_file_for_scope(ServiceScope::System, Some("special")).unwrap()
+    );
     assert_eq!(
         opts.user_token_file,
-        Some(client_profile_user_token_file("special"))
+        Some(client_profile_user_token_file_for_scope(ServiceScope::System, "special").unwrap())
     );
     assert_eq!(
         opts.agent_token_file,
-        Some(client_profile_agent_token_file("special"))
+        Some(client_profile_agent_token_file_for_scope(ServiceScope::System, "special").unwrap())
     );
+    assert!(opts.local_state_dir.is_none());
 }
 
 #[test]
@@ -276,6 +284,8 @@ fn agent_status_explicit_paths_win_and_no_profile_keeps_legacy_default() {
     let opts = parse_agent_status(&args(&[
         "--profile",
         "special",
+        "--scope",
+        "system",
         "--config",
         "/tmp/agent.toml",
         "--user-token-file",
@@ -291,7 +301,7 @@ fn agent_status_explicit_paths_win_and_no_profile_keeps_legacy_default() {
         Some(PathBuf::from("/tmp/agent-token"))
     );
 
-    let legacy = parse_agent_status(&args(&[])).unwrap();
+    let legacy = parse_agent_status(&args(&["--scope", "system"])).unwrap();
     assert_eq!(legacy.config, PathBuf::from("/etc/webcodex/agent.toml"));
     assert_eq!(
         legacy.service_file,
@@ -306,13 +316,25 @@ fn agent_install_service_profile_derives_config_and_service_file() {
     let opts = parse_agent_install_service(&args(&[
         "--profile",
         "special",
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
+        "--working-directory",
+        "/srv/webcodex",
         "--bin",
         "/opt/webcodex/bin/webcodex-runner",
         "--dry-run",
     ]))
     .unwrap();
-    assert_eq!(opts.config, client_profile_agent_config("special"));
-    assert_eq!(opts.service_file, client_profile_service_file("special"));
+    assert_eq!(
+        opts.config,
+        agent_config_for_scope(ServiceScope::System, Some("special")).unwrap()
+    );
+    assert_eq!(
+        opts.service_file,
+        agent_service_file_for_scope(ServiceScope::System, Some("special")).unwrap()
+    );
     let unit = render_agent_systemd_unit(&opts).unwrap();
     assert!(unit.contains(
         "ExecStart=\"/opt/webcodex/bin/webcodex-runner\" \"--config\" \"/etc/webcodex/clients/special/agent.toml\""
@@ -324,6 +346,12 @@ fn agent_install_service_explicit_paths_win_and_rejects_unsafe_profile() {
     let opts = parse_agent_install_service(&args(&[
         "--profile",
         "special",
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
+        "--working-directory",
+        "/srv/webcodex",
         "--config",
         "/tmp/agent.toml",
         "--service-file",
@@ -341,9 +369,321 @@ fn agent_install_service_explicit_paths_win_and_rejects_unsafe_profile() {
     let err = parse_agent_install_service(&args(&[
         "--profile",
         "../x",
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
+        "--working-directory",
+        "/srv/webcodex",
         "--bin",
         "/opt/webcodex/bin/webcodex-runner",
     ]))
     .unwrap_err();
     assert_eq!(err, CLIENT_PROFILE_ERROR);
+}
+
+#[test]
+fn agent_service_scope_parsing_defaults_and_paths_are_deterministic() {
+    let _guard = admin_cli::TEST_ENV_LOCK.lock().unwrap();
+    let old_home = std::env::var_os("HOME");
+    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", "/home/alice");
+    std::env::set_var("XDG_CONFIG_HOME", "/tmp/alice-config");
+
+    let user = parse_agent_install_service_with_identity(
+        &args(&["--bin", "/opt/webcodex/bin/webcodex-runner", "--dry-run"]),
+        false,
+    )
+    .unwrap();
+    assert_eq!(user.scope, ServiceScope::User);
+    assert_eq!(
+        user.config,
+        PathBuf::from("/tmp/alice-config/webcodex/agent.toml")
+    );
+    assert_eq!(
+        user.service_file,
+        PathBuf::from("/tmp/alice-config/systemd/user/webcodex-runner.service")
+    );
+    assert_eq!(user.working_directory, PathBuf::from("/home/alice"));
+    assert!(!user.root_runner);
+
+    let root_error = parse_agent_install_service_with_identity(
+        &args(&["--bin", "/opt/webcodex/bin/webcodex-runner", "--dry-run"]),
+        true,
+    )
+    .unwrap_err();
+    assert!(root_error.contains("would run as root"), "{root_error}");
+
+    let root = parse_agent_install_service_with_identity(
+        &args(&[
+            "--bin",
+            "/opt/webcodex/bin/webcodex-runner",
+            "--allow-root-runner",
+            "--dry-run",
+        ]),
+        true,
+    )
+    .unwrap();
+    assert_eq!(root.scope, ServiceScope::System);
+    assert_eq!(root.config, PathBuf::from("/etc/webcodex/agent.toml"));
+    assert_eq!(
+        root.service_file,
+        PathBuf::from("/etc/systemd/system/webcodex-runner.service")
+    );
+    assert!(root.root_runner);
+
+    let root_user_error = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "user",
+            "--bin",
+            "/opt/webcodex/bin/webcodex-runner",
+        ]),
+        true,
+    )
+    .unwrap_err();
+    assert!(
+        root_user_error.contains("would run as root"),
+        "{root_user_error}"
+    );
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    if let Some(value) = old_xdg {
+        std::env::set_var("XDG_CONFIG_HOME", value);
+    } else {
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+}
+
+#[test]
+fn user_scope_falls_back_to_home_and_profile_paths() {
+    let _guard = admin_cli::TEST_ENV_LOCK.lock().unwrap();
+    let old_home = std::env::var_os("HOME");
+    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", "/home/bob");
+    std::env::remove_var("XDG_CONFIG_HOME");
+
+    let opts = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "user",
+            "--profile",
+            "work",
+            "--bin",
+            "/opt/webcodex/bin/webcodex-runner",
+            "--dry-run",
+        ]),
+        false,
+    )
+    .unwrap();
+    assert_eq!(
+        opts.config,
+        PathBuf::from("/home/bob/.config/webcodex/clients/work/agent.toml")
+    );
+    assert_eq!(
+        opts.service_file,
+        PathBuf::from("/home/bob/.config/systemd/user/webcodex-runner-work.service")
+    );
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    if let Some(value) = old_xdg {
+        std::env::set_var("XDG_CONFIG_HOME", value);
+    } else {
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+}
+
+#[test]
+fn agent_service_scope_rejects_invalid_and_conflicting_flags() {
+    let bin = "/opt/webcodex/bin/webcodex-runner";
+    let invalid = parse_agent_install_service_with_identity(
+        &args(&["--scope", "session", "--bin", bin]),
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(invalid, "--scope must be 'user' or 'system'");
+
+    for flags in [
+        vec!["--scope", "user", "--user", "alice"],
+        vec!["--scope", "user", "--group", "alice"],
+    ] {
+        let mut values = flags;
+        values.extend(["--bin", bin]);
+        let error = parse_agent_install_service_with_identity(&args(&values), false).unwrap_err();
+        assert!(error.contains("valid only with --scope system"), "{error}");
+    }
+
+    let system_root = parse_agent_install_service_with_identity(
+        &args(&["--scope", "system", "--bin", bin]),
+        false,
+    )
+    .unwrap_err();
+    assert!(system_root.contains("would run as root"), "{system_root}");
+
+    let unnecessary_opt_in = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "system",
+            "--user",
+            "alice",
+            "--working-directory",
+            "/home/alice",
+            "--allow-root-runner",
+            "--bin",
+            bin,
+        ]),
+        false,
+    )
+    .unwrap_err();
+    assert!(
+        unnecessary_opt_in.contains("only valid"),
+        "{unnecessary_opt_in}"
+    );
+}
+
+#[test]
+fn explicit_service_paths_override_defaults_but_wrong_scope_paths_are_rejected() {
+    let user = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "user",
+            "--config",
+            "/tmp/custom-agent.toml",
+            "--service-file",
+            "/tmp/webcodex-runner-custom.service",
+            "--working-directory",
+            "/tmp",
+            "--bin",
+            "/opt/webcodex/bin/webcodex-runner",
+        ]),
+        false,
+    )
+    .unwrap();
+    assert_eq!(user.config, PathBuf::from("/tmp/custom-agent.toml"));
+    assert_eq!(
+        user.service_file,
+        PathBuf::from("/tmp/webcodex-runner-custom.service")
+    );
+
+    let error = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "user",
+            "--service-file",
+            "/etc/systemd/system/webcodex-runner.service",
+            "--bin",
+            "/opt/webcodex/bin/webcodex-runner",
+        ]),
+        false,
+    )
+    .unwrap_err();
+    assert!(error.contains("user scope cannot write"), "{error}");
+
+    let error = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "user",
+            "--service-file",
+            "/etc/webcodex-runner.service",
+            "--bin",
+            "/opt/webcodex/bin/webcodex-runner",
+        ]),
+        false,
+    )
+    .unwrap_err();
+    assert!(error.contains("user scope cannot write"), "{error}");
+
+    let error = parse_agent_service_action(
+        "start",
+        &args(&[
+            "--scope",
+            "system",
+            "--service-file",
+            "/home/alice/.config/systemd/user/webcodex-runner.service",
+        ]),
+    )
+    .unwrap_err();
+    assert!(error.contains("system scope cannot write"), "{error}");
+
+    let error = parse_agent_service_action(
+        "start",
+        &args(&[
+            "--scope",
+            "user",
+            "--service-file",
+            "/home/alice/.config/systemd/user/../../../../etc/systemd/system/webcodex-runner.service",
+        ]),
+    )
+    .unwrap_err();
+    assert!(error.contains("cannot contain '..'"), "{error}");
+}
+
+#[test]
+fn explicit_scope_selects_systemd_while_omitted_scope_preserves_hosted_profile() {
+    let implicit = parse_agent_service_action("start", &args(&["--profile", "hosted"])).unwrap();
+    assert!(implicit.local_profile.is_some());
+
+    let explicit = parse_agent_service_action(
+        "start",
+        &args(&["--profile", "hosted", "--scope", "system"]),
+    )
+    .unwrap();
+    assert_eq!(explicit.scope, ServiceScope::System);
+    assert!(explicit.local_profile.is_none());
+}
+
+#[test]
+fn every_agent_service_action_accepts_scope_and_service_file() {
+    let service_file = "/home/alice/.config/systemd/user/webcodex-runner-work.service";
+    for command in ["start", "stop", "restart"] {
+        let parsed = parse_agent_service_action(
+            command,
+            &args(&["--scope", "user", "--service-file", service_file]),
+        )
+        .unwrap();
+        assert_eq!(parsed.scope, ServiceScope::User);
+        assert_eq!(parsed.service_file, PathBuf::from(service_file));
+        assert_eq!(parsed.unit, "webcodex-runner-work.service");
+    }
+
+    let logs = parse_agent_service_action(
+        "logs",
+        &args(&[
+            "--scope",
+            "user",
+            "--service-file",
+            service_file,
+            "--lines",
+            "25",
+        ]),
+    )
+    .unwrap();
+    assert!(matches!(
+        logs.kind,
+        ServiceActionKind::Logs { lines: 25, .. }
+    ));
+
+    let uninstall = parse_agent_service_action(
+        "uninstall",
+        &args(&[
+            "--scope",
+            "user",
+            "--service-file",
+            service_file,
+            "--confirm",
+        ]),
+    )
+    .unwrap();
+    assert!(matches!(
+        uninstall.kind,
+        ServiceActionKind::Uninstall { confirm: true }
+    ));
 }

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -23,8 +23,58 @@ fn install_service_generates_expected_unit_without_tokens() {
     assert!(unit.contains("WorkingDirectory=/var/lib/webcodex\n"));
     assert!(unit.contains("User=webcodex\n"));
     assert!(unit.contains("Group=webcodex\n"));
+    assert!(unit.contains("WantedBy=multi-user.target\n"));
     assert!(!unit.contains("WEBCODEX_TOKEN"));
     assert!(!unit.contains("wc_boot_"));
+}
+
+#[test]
+fn user_agent_unit_uses_user_target_without_identity_directives_or_root_workdir() {
+    let opts = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "user",
+            "--config",
+            "/home/alice/.config/webcodex/agent.toml",
+            "--service-file",
+            "/home/alice/.config/systemd/user/webcodex-runner.service",
+            "--bin",
+            "/home/alice/.local/bin/webcodex-runner",
+            "--working-directory",
+            "/home/alice",
+            "--dry-run",
+        ]),
+        false,
+    )
+    .unwrap();
+    let unit = run_agent_install_service(opts).unwrap();
+    assert!(unit.contains("WantedBy=default.target\n"));
+    assert!(!unit.contains("network-online.target"));
+    assert!(unit.contains("WorkingDirectory=/home/alice\n"));
+    assert!(!unit.contains("WorkingDirectory=/root\n"));
+    assert!(!unit.contains("\nUser="));
+    assert!(!unit.contains("\nGroup="));
+}
+
+#[test]
+fn explicitly_allowed_root_runner_is_visibly_marked() {
+    let opts = parse_agent_install_service_with_identity(
+        &args(&[
+            "--scope",
+            "system",
+            "--bin",
+            "/opt/webcodex/bin/webcodex-runner",
+            "--working-directory",
+            "/root",
+            "--allow-root-runner",
+            "--dry-run",
+        ]),
+        true,
+    )
+    .unwrap();
+    let unit = run_agent_install_service(opts).unwrap();
+    assert!(unit.contains("WARNING: --allow-root-runner was explicitly accepted"));
+    assert!(unit.contains("WorkingDirectory=/root\n"));
 }
 
 #[test]
@@ -74,12 +124,14 @@ fn agent_install_service_generates_expected_unit_without_tokens() {
     let config = tmp.path().join("agent.toml");
     std::fs::write(&config, "token = \"agent_secret_should_not_print\"\n").unwrap();
     let opts = parse_agent_install_service(&args(&[
+        "--scope",
+        "system",
         "--config",
         config.to_str().unwrap(),
         "--bin",
         "/opt/webcodex/bin/webcodex-runner",
         "--working-directory",
-        "/root",
+        "/srv/webcodex",
         "--user",
         "webcodex",
         "--group",
@@ -89,6 +141,8 @@ fn agent_install_service_generates_expected_unit_without_tokens() {
     .unwrap();
     let unit = run_agent_install_service(opts).unwrap();
     assert!(unit.contains("[Unit]\nDescription=WebCodex Runner\n"));
+    assert!(unit.contains("After=network-online.target\n"));
+    assert!(unit.contains("Wants=network-online.target\n"));
     assert!(unit.contains(&format!(
         "ExecStart=\"/opt/webcodex/bin/webcodex-runner\" \"--config\" \"{}\"\n",
         config.display()
@@ -99,7 +153,7 @@ fn agent_install_service_generates_expected_unit_without_tokens() {
     assert!(unit.contains("StandardOutput=journal\n"));
     assert!(unit.contains("StandardError=journal\n"));
     assert!(unit.contains("Environment=RUST_LOG=info\n"));
-    assert!(unit.contains("WorkingDirectory=/root\n"));
+    assert!(unit.contains("WorkingDirectory=/srv/webcodex\n"));
     assert!(unit.contains("User=webcodex\n"));
     assert!(unit.contains("Group=webcodex\n"));
     assert!(!unit.contains("agent_secret_should_not_print"));
@@ -113,6 +167,12 @@ fn agent_install_service_refuses_overwrite_unless_requested() {
     let service_file = tmp.path().join("webcodex-runner.service");
     std::fs::write(&service_file, "old").unwrap();
     let opts = parse_agent_install_service(&args(&[
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
+        "--working-directory",
+        "/srv/webcodex",
         "--config",
         "/etc/webcodex/agent.toml",
         "--bin",
@@ -128,6 +188,12 @@ fn agent_install_service_refuses_overwrite_unless_requested() {
 #[test]
 fn agent_install_service_dry_run_and_output_work_without_systemd() {
     let dry = parse_agent_install_service(&args(&[
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
+        "--working-directory",
+        "/srv/webcodex",
         "--config",
         "/etc/webcodex/agent.toml",
         "--bin",
@@ -140,6 +206,12 @@ fn agent_install_service_dry_run_and_output_work_without_systemd() {
     ));
 
     let out = parse_agent_install_service(&args(&[
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
+        "--working-directory",
+        "/srv/webcodex",
         "--config",
         "/etc/webcodex/agent.toml",
         "--bin",
@@ -269,6 +341,10 @@ fn generated_server_and_agent_units_pass_systemd_analyze_verify() {
     let config = tmp.path().join("agent.toml");
     std::fs::write(&config, "server_url = \"http://127.0.0.1\"\n").unwrap();
     let agent = parse_agent_install_service(&args(&[
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
         "--bin",
         runner_bin.to_str().unwrap(),
         "--config",
@@ -318,6 +394,10 @@ fn special_supported_paths_pass_systemd_analyze_verify() {
     verify_systemd_unit(&server_unit, "webcodex-special.service");
 
     let agent = parse_agent_install_service(&args(&[
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
         "--bin",
         runner_bin.to_str().unwrap(),
         "--config",
@@ -347,6 +427,12 @@ fn executable_program_rejects_quote_and_backslash_in_dry_run() {
 #[test]
 fn agent_output_mode_rejects_invalid_unit_fields() {
     let opts = parse_agent_install_service(&args(&[
+        "--scope",
+        "system",
+        "--user",
+        "webcodex",
+        "--working-directory",
+        "/srv/webcodex",
         "--config",
         "/etc/webcodex/agent.toml\nEnvironment=BAD=1",
         "--bin",
@@ -386,8 +472,14 @@ allowed_roots = ["/srv/projects"]
         ),
     )
     .unwrap();
-    let opts =
-        parse_agent_status(&args(&["--config", config.to_str().unwrap(), "--json"])).unwrap();
+    let opts = parse_agent_status(&args(&[
+        "--scope",
+        "system",
+        "--config",
+        config.to_str().unwrap(),
+        "--json",
+    ]))
+    .unwrap();
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -409,6 +501,45 @@ allowed_roots = ["/srv/projects"]
     assert_eq!(json["config"]["allowed_roots"]["count"], 1);
     assert!(json.get("token").is_none());
     assert!(json["config"].get("token").is_none());
+}
+
+#[test]
+fn agent_status_rejects_agent_token_in_user_runtime_token_file_without_leaking_it() {
+    let _guard = admin_cli::TEST_ENV_LOCK.lock().unwrap();
+    let old_path = std::env::var_os("PATH");
+    std::env::set_var("PATH", "");
+    let tmp = tempfile::tempdir().unwrap();
+    let config = tmp.path().join("agent.toml");
+    std::fs::write(
+        &config,
+        "server_url = \"https://example.test\"\nclient_id = \"alice\"\n",
+    )
+    .unwrap();
+    let token_file = tmp.path().join("webcodex-user-token");
+    let secret = "wc_agent_do_not_echo_status_0123456789";
+    std::fs::write(&token_file, format!("{secret}\n")).unwrap();
+    let opts = parse_agent_status(&args(&[
+        "--scope",
+        "system",
+        "--config",
+        config.to_str().unwrap(),
+        "--user-token-file",
+        token_file.to_str().unwrap(),
+    ]))
+    .unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let error = runtime.block_on(run_agent_status(opts)).unwrap_err();
+    if let Some(path) = old_path {
+        std::env::set_var("PATH", path);
+    } else {
+        std::env::remove_var("PATH");
+    }
+    assert!(error.contains("Agent transport token"), "{error}");
+    assert!(error.contains("webcodex-user-token"), "{error}");
+    assert!(!error.contains(secret));
 }
 
 #[tokio::test]
@@ -462,6 +593,8 @@ transport = "websocket"
     std::fs::write(&user_token_file, "pat_online_secret_1234567890\n").unwrap();
     std::fs::write(&agent_token_file, "agent_boundary_secret_1234567890\n").unwrap();
     let opts = parse_agent_status(&args(&[
+        "--scope",
+        "system",
         "--config",
         config.to_str().unwrap(),
         "--server-url",

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -542,6 +542,77 @@ fn agent_status_rejects_agent_token_in_user_runtime_token_file_without_leaking_i
     assert!(!error.contains(secret));
 }
 
+#[cfg(unix)]
+#[test]
+fn hosted_profile_status_uses_xdg_config_and_never_invokes_systemctl() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = admin_cli::TEST_ENV_LOCK.lock().unwrap();
+    let old_home = std::env::var_os("HOME");
+    let old_xdg_config = std::env::var_os("XDG_CONFIG_HOME");
+    let old_xdg_state = std::env::var_os("XDG_STATE_HOME");
+    let old_path = std::env::var_os("PATH");
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let config_home = tmp.path().join("config");
+    let state_home = tmp.path().join("state");
+    let profile_config = config_home.join("webcodex/clients/hosted/agent.toml");
+    let profile_state = state_home.join("webcodex/clients/hosted");
+    let fake_bin = tmp.path().join("bin");
+    let systemctl_called = tmp.path().join("systemctl-called");
+    std::fs::create_dir_all(profile_config.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(&profile_state).unwrap();
+    std::fs::create_dir_all(&fake_bin).unwrap();
+    std::fs::write(
+        &profile_config,
+        format!(
+            "server_url = \"\"\ntoken = \"hosted-shared-key\"\nclient_id = \"hosted\"\nprojects_dir = {:?}\n",
+            profile_config.parent().unwrap().join("projects.d")
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        crate::webcodex_cli::local_runner_profile_marker(&profile_state),
+        "profile = \"hosted\"\n",
+    )
+    .unwrap();
+    let fake_systemctl = fake_bin.join("systemctl");
+    std::fs::write(
+        &fake_systemctl,
+        format!("#!/bin/sh\n: > {:?}\n", systemctl_called),
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_systemctl, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    std::env::set_var("HOME", &home);
+    std::env::set_var("XDG_CONFIG_HOME", &config_home);
+    std::env::set_var("XDG_STATE_HOME", &state_home);
+    std::env::set_var("PATH", &fake_bin);
+    let opts = parse_agent_status_with_identity(&args(&["--profile", "hosted"]), true).unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let output = runtime.block_on(run_agent_status(opts));
+
+    for (name, value) in [
+        ("HOME", old_home),
+        ("XDG_CONFIG_HOME", old_xdg_config),
+        ("XDG_STATE_HOME", old_xdg_state),
+        ("PATH", old_path),
+    ] {
+        if let Some(value) = value {
+            std::env::set_var(name, value);
+        } else {
+            std::env::remove_var(name);
+        }
+    }
+
+    let output = output.unwrap();
+    assert!(output.contains("runner mode:          hosted local process"));
+    assert!(!systemctl_called.exists());
+}
+
 #[tokio::test]
 async fn agent_status_detects_current_client_online_and_agent_boundary() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
@@ -170,6 +170,9 @@ fn webcodex_cli_agent_help_mentions_new_subcommands() {
             assert_eq!(code, 0);
             assert!(stdout.contains("--config PATH"));
             assert!(stdout.contains("--bin PATH"));
+            assert!(stdout.contains("--scope user|system"));
+            assert!(stdout.contains("--allow-root-runner"));
+            assert!(stdout.contains("default: user for non-root"));
             assert!(stdout.contains("Tokens are never inlined"));
         }
         other => panic!("expected help exit, got {other:?}"),
@@ -179,6 +182,8 @@ fn webcodex_cli_agent_help_mentions_new_subcommands() {
             assert_eq!(code, 0);
             assert!(stdout.contains("--user-token-file PATH"));
             assert!(stdout.contains("--agent-token-file PATH"));
+            assert!(stdout.contains("--scope user|system"));
+            assert!(stdout.contains("--service-file PATH"));
             assert!(stdout.contains("no tokens"));
         }
         other => panic!("expected help exit, got {other:?}"),

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -267,6 +267,8 @@ Commands:\n\
   status      Check Runner lifecycle, safe config metadata, and connectivity\n\
   logs        Read hosted Runner logs or the installed service journal\n\
   uninstall   Remove only the systemd unit; requires --confirm\n\n\
+Service commands accept --scope user|system. Non-root users default to user; root defaults to system.\n\
+Profiles created by `connect` keep their detached-process behavior when --scope is omitted.\n\n\
 `webcodex run` is the current-project runtime coordinator. `webcodex agent run` directly executes the standalone Runner.\n"
 }
 pub(crate) fn agent_init_usage() -> &'static str {
@@ -297,36 +299,43 @@ pub(crate) fn agent_install_service_usage() -> &'static str {
     "Usage: webcodex agent install [--profile NAME] [--config PATH] [OPTIONS]\n\n\
 Options:\n\
   --profile NAME             Profile for config and unit defaults\n\
+  --scope user|system        Service manager scope [default: user for non-root; system for root]\n\
   --config PATH              Agent config path\n\
   --bin PATH                 webcodex-runner path; sibling then absolute PATH by default\n\
   --service-file PATH        Unit path [default: webcodex-runner[-<profile>].service]\n\
-  --working-directory PATH   WorkingDirectory=\n\
-  --user USER                Optional systemd User=\n\
-  --group GROUP              Optional systemd Group=\n\
+  --working-directory PATH   WorkingDirectory= [default: selected user's home]\n\
+  --user USER                Required non-root system service user\n\
+  --group GROUP              Optional system service Group=\n\
+  --allow-root-runner        Explicitly allow project commands to run as root\n\
   --overwrite                Replace an existing unit\n\
   --no-start                 Enable without starting immediately\n\
   --dry-run                  Render only; never call systemctl\n\
   --output -                 Render only; never call systemctl\n\
   --json                     Print machine-readable output\n\
   -h, --help                 Print help and exit\n\n\
+User scope uses systemctl --user, the XDG user unit directory, default.target,\n\
+and never writes User= or Group=. System scope uses /etc/systemd/system,\n\
+multi-user.target, and requires --user unless --allow-root-runner is explicit.\n\
 The unit runs webcodex-runner --config <config>. Tokens are never inlined.\n"
 }
 pub(crate) fn agent_status_usage() -> &'static str {
     "Usage: webcodex agent status [OPTIONS]\n\n\
      Options:\n\
        --profile NAME             Client config profile for config/token defaults\n\
-       --config PATH              Agent config path [default: /etc/webcodex/agent.toml, or profile agent.toml]\n\
+       --scope user|system        Service manager scope [default: user for non-root; system for root]\n\
+       --config PATH              Agent config path [default: scope-specific agent.toml]\n\
+       --service-file PATH        Override the scope-specific systemd unit path\n\
        --server-url URL           Override server URL for runtime checks\n\
        --user-token-file PATH     Read user API token for /api/runtime/status\n\
        --agent-token-file PATH    Read agent token for boundary check\n\
        --json                     Print a machine-readable summary\n\
        -h, --help                 Print help and exit\n\n\
-     With --profile, missing config and token paths are derived under\n\
-     /etc/webcodex/clients/<profile> for root or\n\
-     ~/.config/webcodex/clients/<profile> for non-root users. Explicit path\n\
-     flags override profile-derived defaults. Profiles created by `connect`\n\
-     report their user-level background process, PID, and log path instead of\n\
-     systemd state. Status prints safe metadata only:\n\
+     User scope derives config under $XDG_CONFIG_HOME/webcodex (or\n\
+     $HOME/.config/webcodex) and units under $XDG_CONFIG_HOME/systemd/user\n\
+     (or $HOME/.config/systemd/user). System scope uses /etc/webcodex and\n\
+     /etc/systemd/system. Explicit path flags override profile-derived defaults.\n\
+     Profiles created by `connect` report their detached process when --scope\n\
+     is omitted; an explicit scope checks systemd instead. Status prints safe metadata only:\n\
      no tokens, Authorization headers, full agent.toml, env files, or secrets.\n"
 }
 

--- a/docs/AGENT_PROTOCOL.md
+++ b/docs/AGENT_PROTOCOL.md
@@ -12,7 +12,7 @@ Managed agents use agent tokens created during client enrollment (`webcodex logi
 webcodex login URL --code CODE
 ```
 
-The server/admin side creates the temporary code with `webcodex pairing create`. The agent token is returned to the client during login and written into the generated `agent.toml`; do not copy agent token files from the server. For binary deployments, install the client-side service with `webcodex agent install --config <path>` and inspect it with `webcodex agent status`.
+The server/admin side creates the temporary code with `webcodex pairing create`. The agent token is returned to the client during login and written into the generated `agent.toml`; do not copy agent token files from the server. For normal binary deployments, install the client-side service as the ordinary Runner account with `webcodex agent install --scope user --config <path>` and inspect it with `webcodex agent status --scope user`.
 
 On a Server with `WEBCODEX_SHARED_KEY_ENABLED=true`, the hosted quick-start is
 the other supported mode: a Runner may present the exact same direct,

--- a/docs/AGENT_PROTOCOL.zh-CN.md
+++ b/docs/AGENT_PROTOCOL.zh-CN.md
@@ -12,7 +12,7 @@ Managed Agent 应使用 client enrollment 期间创建的 agent tokens（`webcod
 webcodex login URL --code CODE
 ```
 
-Server/admin 侧用 `webcodex pairing create` 创建临时代码。Agent token 在 login 期间返回给 client，并写入生成的 `agent.toml`；不要从 server 复制 agent token files。二进制部署时，使用 `webcodex agent install --config <path>` 安装 client-side service，并用 `webcodex agent status` 检查。
+Server/admin 侧用 `webcodex pairing create` 创建临时代码。Agent token 在 login 期间返回给 client，并写入生成的 `agent.toml`；不要从 server 复制 agent token files。普通二进制部署应由 Runner 的普通账户使用 `webcodex agent install --scope user --config <path>` 安装 client-side service，并用 `webcodex agent status --scope user` 检查。
 
 当 Server 开启 `WEBCODEX_SHARED_KEY_ENABLED=true` 时，hosted quick-start 是另一种受支持
 模式：Runner 可以提交与 MCP 完全相同的 direct、非 `wc_` shared key。Server 与

--- a/docs/AUTH_MODEL.md
+++ b/docs/AUTH_MODEL.md
@@ -12,8 +12,8 @@ WebCodex separates bootstrap administration, account onboarding, runtime API acc
 | Project Credential | setup-generated Connector + Agent | exact access to one private project grant | other projects/admin/general quick start |
 | shared key | agent + GPT/MCP quick start | shared-key group onboarding | production IAM/admin |
 | `wc_acct_xxx` | user CLI | create local PAT/agent token | GPT/MCP/agent |
-| `wc_pat_xxx` | GPT Action/MCP/API | runtime tools | agent connection |
-| `wc_agent_xxx` | `webcodex-runner` | connect agent to server | GPT/MCP/runtime API |
+| `wc_pat_xxx` (`webcodex-user-token`) | GPT Action/MCP/API | runtime and project APIs | agent connection |
+| `wc_agent_xxx` (`webcodex-runner-token`) | `webcodex-runner` | Agent transport only | GPT/MCP/runtime/project API |
 
 ## `WEBCODEX_TOKEN`
 
@@ -132,6 +132,12 @@ Scope the PAT to the workflow. For example, a GPT Action that inspects and edits
 `wc_agent_xxx` is an agent token generated locally by the user. The server stores only its hash and binds the token to `allowed_client_id`.
 
 Use `wc_agent_xxx` only for `webcodex-runner` connectivity. It cannot call runtime, project, tool, MCP, or account endpoints.
+
+The managed login writes the user credential to `webcodex-user-token` and the
+Runner credential into `agent.toml` (with a companion
+`webcodex-runner-token`). Selecting a `wc_agent_*` value for a user/runtime CLI
+token is diagnosed locally where possible and remains a server-side 403. The
+diagnostic never grants broader authority or prints the complete token.
 
 ## `client_id`
 

--- a/docs/AUTH_MODEL.zh-CN.md
+++ b/docs/AUTH_MODEL.zh-CN.md
@@ -12,8 +12,8 @@ WebCodex 把 bootstrap administration、account onboarding、runtime API access 
 | Project Credential | setup 生成的 Connector + Agent | 精确访问一个 private project grant | 其他项目/admin/普通 quick start |
 | shared key | agent + GPT/MCP quick start | shared-key group onboarding | production IAM/admin |
 | `wc_acct_xxx` | user CLI | 创建本地 PAT/agent token | GPT/MCP/agent |
-| `wc_pat_xxx` | GPT Action/MCP/API | runtime tools | agent connection |
-| `wc_agent_xxx` | `webcodex-runner` | 连接 agent 到 server | GPT/MCP/runtime API |
+| `wc_pat_xxx`（`webcodex-user-token`） | GPT Action/MCP/API | runtime 和 project API | agent connection |
+| `wc_agent_xxx`（`webcodex-runner-token`） | `webcodex-runner` | 仅 Agent transport | GPT/MCP/runtime/project API |
 
 ## `WEBCODEX_TOKEN`
 
@@ -113,6 +113,11 @@ key。Hosted quick-start 应通过 `webcodex connect` 使用非 `wc_` key；mana
 `wc_agent_xxx` 是用户本地生成的 agent token。server 只保存它的 hash，并把 token 绑定到 `allowed_client_id`。
 
 `wc_agent_xxx` 只能用于 `webcodex-runner` connectivity。它不能调用 runtime、project、tool、MCP 或 account endpoints。
+
+managed login 会把 user credential 写入 `webcodex-user-token`，把 Runner
+credential 写入 `agent.toml`（并带 companion `webcodex-runner-token`）。在
+user/runtime CLI token 位置选择 `wc_agent_*` 时，CLI 会尽可能先给出本地诊断，
+server 端仍保持 403。该诊断不会扩大权限，也不会打印完整 token。
 
 ## `client_id`
 

--- a/docs/BUILD_INSTALL.md
+++ b/docs/BUILD_INSTALL.md
@@ -58,7 +58,8 @@ The examples in this guide were checked against the current help output from `we
 | Client enrollment (primary) | `webcodex login <server-url> --code <pairing-code>` |
 | Client enrollment (advanced) | `webcodex client enroll --server-url ... --pairing-code ... --client-id ...` |
 | Agent foreground run | `webcodex-runner --profile ...` |
-| Agent service | `webcodex agent install --profile ... --bin ...` |
+| Runner user service | `webcodex agent install --scope user --profile ... --bin ...` |
+| Runner system service | `sudo webcodex agent install --scope system --user ... --working-directory ...` |
 
 The account-management command uses `users create` and `--server-url`; local token creation commands use `--server`. That difference comes from the current CLI surface and is intentionally reflected in the examples.
 
@@ -145,29 +146,84 @@ Client:
 7. Exchange the pairing code over HTTPS and write client-side credentials/config:
 
 ```bash
-sudo webcodex login https://your-domain.example --code <wc_pair_...> \
-  --allowed-root /home/friend/git
+webcodex login https://your-domain.example --code <wc_pair_...> \
+  --allowed-root "$HOME/git"
 ```
 
 Login derives a unique device name automatically (hostname + local suffix), redeems the pairing code, writes the `wc_pat_*` user token to `webcodex-user-token`, and stores the `wc_agent_*` agent token inside the generated `agent.toml`; both files use `0600` permissions on Unix. `/etc/webcodex/webcodex.env` is server-side only. For an explicit client id or a custom output directory, the advanced `webcodex client enroll` flow still works with its existing flags.
 
-8. Install and start the agent service, then validate. Login prints the exact
-   `webcodex agent install --config <agent-config-path>` command for the config
-   it wrote; it is the equivalent of the profile-based form below. The agent
-   config path is the one login reported (for example under
-   `/etc/webcodex/<server>/<user>/agent.toml` as root):
+8. As that same ordinary user, install and start the Runner user service, then
+   validate. Login prints the exact config path and a `--scope user` install
+   command. `agent install` performs the user-manager daemon reload and
+   enable/start operation itself:
 
 ```bash
-sudo webcodex agent install --config /path/to/login/wrote/agent.toml --overwrite
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner
-webcodex agent status --server-url https://your-domain.example
+webcodex agent install --scope user \
+  --config /path/to/login/wrote/agent.toml
+webcodex agent status --scope user \
+  --config /path/to/login/wrote/agent.toml \
+  --server-url https://your-domain.example
 webcodex ops status \
   --server-url https://your-domain.example \
   --token-file /path/to/login/wrote/webcodex-user-token
 ```
 
-GPT Actions should use the generated client-side user-token file. GPT Actions require a public HTTPS URL; WebCodex CLI does not automate reverse proxies or tunnels.
+GPT Actions, MCP, and ordinary REST/project APIs use the generated client-side
+`webcodex-user-token`. The Agent token stored in `agent.toml` is Runner
+transport-only. GPT Actions require a public HTTPS URL; WebCodex CLI does not
+automate reverse proxies or tunnels.
+
+## Runner service scopes
+
+The npm package can be installed in an ordinary user's npm environment. Its
+install location does not select the systemd service scope.
+
+`--scope user` uses `systemctl --user`, writes the unit to
+`$XDG_CONFIG_HOME/systemd/user` (or `$HOME/.config/systemd/user`), stores
+default WebCodex config under `$XDG_CONFIG_HOME/webcodex` (or
+`$HOME/.config/webcodex`), uses `default.target`, and runs without `User=` or
+`Group=`. It requires no `sudo`. Use the same scope for every lifecycle
+command:
+
+```bash
+webcodex agent install --scope user --profile workstation
+webcodex agent status --scope user --profile workstation
+webcodex agent restart --scope user --profile workstation
+webcodex agent logs --scope user --profile workstation --lines 100
+webcodex agent uninstall --scope user --profile workstation --confirm
+```
+
+An enabled user unit starts when that account's user manager starts. It does not
+by itself guarantee that the Runner starts at boot before the first login or
+remains after the last logout. If unattended boot persistence is required, an
+administrator may explicitly run `sudo loginctl enable-linger <runner-user>`
+after reviewing the long-lived service authority granted to that account.
+WebCodex does not change lingering automatically.
+
+Non-root callers default to user scope. Root callers default to system scope,
+but a system Runner may not run as root without explicit opt-in. The normal
+administrator-managed installation names a non-root account and a matching
+working directory; `--group` is optional:
+
+```bash
+sudo webcodex agent install \
+  --scope system \
+  --profile workstation \
+  --user <runner-user> \
+  --working-directory /home/<runner-user> \
+  --config /etc/webcodex/clients/workstation/agent.toml
+sudo webcodex agent status --scope system --profile workstation
+```
+
+System scope uses `/etc/systemd/system`, `systemctl`, and
+`multi-user.target`. It does not create users, change sudoers, migrate files,
+or overwrite an existing unit unless `--overwrite` is explicit. Running
+project commands as root is strongly discouraged and is accepted only with
+`--allow-root-runner`, which prints and embeds a prominent warning. Explicit
+`--config` and `--working-directory` values override the defaults and must be
+readable or usable by the selected service account. An explicit
+`--service-file` must belong to the selected manager scope; reuse the same
+`--scope` and `--service-file` for status, control, logs, and uninstall.
 
 Compatibility commands still work, but should not be the first choice in new docs:
 
@@ -180,7 +236,8 @@ webcodex setup single-user
 
 ## Agent config
 
-Client enroll writes `agent.toml`. For a systemd service, use `webcodex agent install`; for a foreground test, run:
+Client enroll writes `agent.toml`. For the normal user service, use
+`webcodex agent install --scope user`; for a foreground test, run:
 
 ```bash
 webcodex-runner --profile workstation
@@ -235,13 +292,16 @@ The example above is a narrowing example, not the default.
 
 ## Auth reminders
 
-Use:
+Use a user token such as the generated `webcodex-user-token` (`wc_pat_*`):
 
 ```text
 Authorization: Bearer <token>
 ```
 
 for REST, polling, MCP, and GPT Actions.
+
+Use `webcodex-runner-token` (`wc_agent_*`) only through the Runner config for
+Agent transport. It is intentionally rejected by project/runtime APIs.
 
 `?token=` is allowed only for `/api/agents/ws` WebSocket handshake compatibility.
 

--- a/docs/BUILD_INSTALL.zh-CN.md
+++ b/docs/BUILD_INSTALL.zh-CN.md
@@ -57,7 +57,8 @@ binary、npm 命令、systemd unit 与 QUIC ALPN（`webcodex-runner/1`）统一�
 | 客户端 enrollment（主入口） | `webcodex login <server-url> --code <pairing-code>` |
 | 客户端 enrollment（高级） | `webcodex client enroll --server-url ... --pairing-code ... --client-id ...` |
 | 前台运行 agent | `webcodex-runner --profile ...` |
-| 安装 agent service | `webcodex agent install --profile ... --bin ...` |
+| 安装 Runner user service | `webcodex agent install --scope user --profile ... --bin ...` |
+| 安装 Runner system service | `sudo webcodex agent install --scope system --user ... --working-directory ...` |
 
 账户管理命令使用 `users create` 和 `--server-url`；本地 token 创建命令使用 `--server`。这是当前 CLI surface 的实际差异，示例中会按这个差异书写。
 
@@ -144,29 +145,82 @@ Client：
 7. 通过 HTTPS 交换 pairing code，并写入 client-side credentials/config：
 
 ```bash
-sudo webcodex login https://your-domain.example --code <wc_pair_...> \
-  --allowed-root /home/friend/git
+webcodex login https://your-domain.example --code <wc_pair_...> \
+  --allowed-root "$HOME/git"
 ```
 
 `login` 会自动生成唯一设备名（hostname + 本地后缀），兑换 pairing code，把 `wc_pat_*` user token 写入 `webcodex-user-token`，并把 `wc_agent_*` agent token 存入生成的 `agent.toml`；两个文件在 Unix 上均使用 `0600` 权限。`/etc/webcodex/webcodex.env` 只属于 server 侧。如需显式 client id 或自定义输出目录，高级的 `webcodex client enroll` 流程仍支持原有参数。
 
-8. 安装并启动 agent service，然后验证：
+8. 仍由同一个普通用户安装并启动 Runner user service，然后验证。`login` 会打印
+   确切 config 路径和带 `--scope user` 的安装命令。`agent install` 会自行完成 user
+   manager 的 daemon reload 和 enable/start：
 
 ```bash
-sudo webcodex agent install --config /path/to/login/wrote/agent.toml --overwrite
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner
-webcodex agent status --server-url https://your-domain.example
+webcodex agent install --scope user \
+  --config /path/to/login/wrote/agent.toml
+webcodex agent status --scope user \
+  --config /path/to/login/wrote/agent.toml \
+  --server-url https://your-domain.example
 webcodex ops status \
   --server-url https://your-domain.example \
   --token-file /path/to/login/wrote/webcodex-user-token
 ```
 
-GPT Actions 应使用生成的 client-side user-token file。GPT Actions 需要 public HTTPS URL；WebCodex CLI 不会自动配置 reverse proxies 或 tunnels。
+GPT Actions、MCP 和普通 REST/project API 使用生成的 client-side
+`webcodex-user-token`。`agent.toml` 中的 Agent token 只用于 Runner transport。
+GPT Actions 需要 public HTTPS URL；WebCodex CLI 不会自动配置 reverse proxy 或
+tunnel。
+
+## Runner service scope
+
+npm package 可以安装在普通用户自己的 npm 环境中；npm 安装位置不会选择 systemd
+service scope。
+
+`--scope user` 使用 `systemctl --user`，unit 写入
+`$XDG_CONFIG_HOME/systemd/user`（未设置时为 `$HOME/.config/systemd/user`），默认
+WebCodex config 位于 `$XDG_CONFIG_HOME/webcodex`（未设置时为
+`$HOME/.config/webcodex`），使用 `default.target`，且不生成 `User=` 或 `Group=`。
+全程不需要 `sudo`。所有 lifecycle 命令必须使用同一 scope：
+
+```bash
+webcodex agent install --scope user --profile workstation
+webcodex agent status --scope user --profile workstation
+webcodex agent restart --scope user --profile workstation
+webcodex agent logs --scope user --profile workstation --lines 100
+webcodex agent uninstall --scope user --profile workstation --confirm
+```
+
+启用后的 user unit 会在该账户的 user manager 启动时启动，但这并不自动保证 Runner
+能在首次登录前随系统启动，或在最后一次注销后继续运行。若确实需要无人值守的开机
+常驻，管理员应先评估该账户长期运行 service 的权限，再显式执行
+`sudo loginctl enable-linger <runner-user>`。WebCodex 不会自动修改 linger 设置。
+
+非 root 调用者默认使用 user scope。root 调用者默认使用 system scope，但 system
+Runner 不得在没有显式确认时以 root 运行。正常的管理员安装应指定非 root 账户和
+匹配的 working directory；`--group` 可选：
+
+```bash
+sudo webcodex agent install \
+  --scope system \
+  --profile workstation \
+  --user <runner-user> \
+  --working-directory /home/<runner-user> \
+  --config /etc/webcodex/clients/workstation/agent.toml
+sudo webcodex agent status --scope system --profile workstation
+```
+
+system scope 使用 `/etc/systemd/system`、`systemctl` 和 `multi-user.target`。它
+不会创建用户、修改 sudoers、迁移文件，也不会在没有 `--overwrite` 时覆盖已有
+unit。强烈不建议以 root 执行项目命令；只有显式传入 `--allow-root-runner` 才会
+接受，并输出且写入醒目警告。显式 `--config` 和 `--working-directory` 会覆盖
+默认值，并且所选 service account 必须能够读取或使用它们；显式
+`--service-file` 必须属于所选 manager scope。status、control、logs 和 uninstall
+也要复用同一 `--scope` 与 `--service-file`。
 
 ## Agent config
 
-`login` / `client enroll` 会写入 `agent.toml`。systemd service 使用 `webcodex agent install --config <path>`；前台测试可运行：
+`login` / `client enroll` 会写入 `agent.toml`。普通 user service 使用
+`webcodex agent install --scope user --config <path>`；前台测试可运行：
 
 ```bash
 webcodex-runner --config /path/to/login/wrote/agent.toml
@@ -207,13 +261,17 @@ webcodex ops status \
 
 ## Auth reminders
 
-REST、polling、MCP 和 GPT Actions 使用：
+REST、polling、MCP 和 GPT Actions 使用 user token，例如生成的
+`webcodex-user-token`（`wc_pat_*`）：
 
 ```text
 Authorization: Bearer <token>
 ```
 
 `?token=` 只允许用于 `/api/agents/ws` WebSocket handshake 兼容场景。
+
+`webcodex-runner-token`（`wc_agent_*`）只应通过 Runner config 用于 Agent
+transport；project/runtime API 会按设计拒绝它。
 
 ## systemd PATH reminder
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -172,14 +172,19 @@ Server/admin:
 Client:
 
 8. Install the public `webcodex` CLI and the `webcodex-runner` binary.
-9. Run `webcodex login <server-url> --code <code>` (advanced: `webcodex client enroll`).
-10. Run `webcodex agent install --config <login-reported-agent-config>`.
-11. Run `sudo systemctl daemon-reload`.
-12. Run `sudo systemctl enable --now webcodex-runner`.
-13. Run `webcodex agent status`.
-14. Run `webcodex ops status --strict`.
+9. As the ordinary account that will run project commands, run
+   `webcodex login <server-url> --code <code>` (advanced:
+   `webcodex client enroll`). Do not use `sudo`.
+10. Run `webcodex agent install --scope user --config <login-reported-agent-config>`.
+11. Run `webcodex agent status --scope user --config <login-reported-agent-config>`.
+12. Run `webcodex ops status --strict`.
 
-`/etc/webcodex/webcodex.env` is server-side only. Client-side files live under a profile directory such as `/etc/webcodex/clients/workstation/agent.toml`, `/etc/webcodex/clients/workstation/webcodex-user-token`, `/etc/webcodex/clients/workstation/webcodex-runner-token`, and `/etc/webcodex/clients/workstation/projects.d` when multiple users or clients share one machine.
+`agent install` reloads, enables, and starts the selected service manager. The
+ordinary path therefore needs neither `sudo` nor separate `systemctl`
+commands. `/etc/webcodex/webcodex.env` is server-side only. An ordinary user's
+client files default to `$XDG_CONFIG_HOME/webcodex` (or
+`$HOME/.config/webcodex`); system-scope profiles can instead live under
+`/etc/webcodex` when an administrator deliberately provisions them.
 
 ## Account credential onboarding flow
 
@@ -214,27 +219,26 @@ Client/friend side:
 
 ```bash
 webcodex login https://your-domain.example --code <wc_pair_...> \
-  --allowed-root /home/friend/git
+  --allowed-root "$HOME/git"
 
-webcodex agent install --config /etc/webcodex/https_your-domain.example/friendname/agent.toml \
-  --overwrite
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner
+webcodex agent install --scope user \
+  --config "$HOME/.config/webcodex/https_your-domain.example/friendname/agent.toml"
+webcodex agent status --scope user \
+  --config "$HOME/.config/webcodex/https_your-domain.example/friendname/agent.toml"
 
 webcodex ops status \
   --server-url https://your-domain.example \
-  --token-file /etc/webcodex/https_your-domain.example/friendname/webcodex-user-token \
+  --token-file "$HOME/.config/webcodex/https_your-domain.example/friendname/webcodex-user-token" \
   --strict
 ```
 
 `webcodex login` is the client/friend-side entry: it derives a unique device
 name, redeems the pairing code, and writes the client-side `webcodex-user-token`
-and an `agent.toml` under `<dir>/<server>/<user>/` (root: `/etc/webcodex/...`,
-user: `~/.config/webcodex/...`). Login prints the exact agent config path and
-the `webcodex agent install --config <path>` command to use. GPT Actions should
-use the client-side `webcodex-user-token`; the generated agent config uses the
-client-side agent token for `webcodex-runner`. Do not copy `WEBCODEX_TOKEN`,
+and an `agent.toml` below the user's WebCodex config directory. Login prints
+the exact agent config path and a `webcodex agent install --scope user
+--config <path>` command. GPT Actions, MCP, and ordinary REST/project APIs use
+the client-side `webcodex-user-token`; the generated agent config uses the
+client-side `webcodex-runner-token` only for Agent transport. Do not copy `WEBCODEX_TOKEN`,
 `wc_pat_*`, `wc_agent_*`, complete env files, or complete `agent.toml` files
 between machines. Each friend should use a unique `username`; the device name is
 made unique automatically. The advanced `webcodex client enroll` flow is still
@@ -315,18 +319,56 @@ Keep WebCodex listening on `127.0.0.1:8080` behind the proxy. The QUIC agent tra
 
 ## Agent configuration
 
-Client enroll generates the agent config. Install a systemd unit with:
+Client enroll generates the agent config. For the normal non-root installation,
+install a user unit with:
 
 ```bash
-sudo webcodex agent install \
+webcodex agent install \
+  --scope user \
   --profile workstation \
   --bin /opt/webcodex/bin/webcodex-runner
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner-workstation
 webcodex agent status \
+  --scope user \
   --profile workstation \
   --server-url https://your-domain.example
 ```
+
+The npm install location and systemd scope are independent. User scope uses
+`systemctl --user`, stores units under `$XDG_CONFIG_HOME/systemd/user` (or
+`$HOME/.config/systemd/user`), uses `default.target`, omits `User=`/`Group=`,
+and needs no administrator privileges. Non-root callers default to user scope.
+Use the same scope for install, status, start, stop, restart, logs, and
+uninstall.
+
+An enabled user unit follows the lifetime of that account's user manager. It
+does not by itself guarantee startup before the first login or continued
+operation after the last logout. For unattended boot persistence, an
+administrator may explicitly enable lingering with
+`sudo loginctl enable-linger <runner-user>` after reviewing the resulting
+long-lived service authority. WebCodex never changes lingering automatically.
+
+For an administrator-managed service, system scope uses
+`/etc/systemd/system`, `systemctl`, and `multi-user.target`. It normally
+requires a named non-root user and a working directory that account can use:
+
+```bash
+sudo webcodex agent install \
+  --scope system \
+  --profile workstation \
+  --user <runner-user> \
+  --working-directory /home/<runner-user> \
+  --config /etc/webcodex/clients/workstation/agent.toml
+sudo webcodex agent status --scope system --profile workstation
+```
+
+`--group` is optional. WebCodex does not create a system user, change sudoers,
+or migrate permissions. A root Runner is refused unless the administrator
+also supplies `--allow-root-runner`; this discouraged exception prints and
+embeds a prominent warning. Explicit config and working-directory overrides
+remain available, but the selected service account must be able to read or use
+them. An explicit service-file must match the selected manager scope: user
+scope rejects system unit paths and system scope rejects user-unit paths.
+Existing units are never silently overwritten.
 
 For a foreground test, start the agent with:
 
@@ -410,8 +452,10 @@ when its long-lived process opens; later commands use that process state.
 Neither path sources `.bashrc`/`.profile` by default. See
 [SHELL_PROFILES.md](SHELL_PROFILES.md) for Rust/Cargo, Python venv, Conda
 examples, resolution rules, and safety boundaries. After editing `agent.toml`,
-`sudo systemctl reload webcodex-runner` atomically applies policy, shell,
-SSH-resource, and tool-provider settings to new requests. An already-open
+reload the matching manager (`systemctl --user reload webcodex-runner` for
+user scope, or `sudo systemctl reload webcodex-runner` for system scope). This
+atomically applies policy, shell, SSH-resource, and tool-provider settings to
+new requests. An already-open
 persistent shell is not silently restarted or moved; current policy is still
 rechecked before later exec/status operations, while close remains available
 for cleanup; close/reopen applies new defaults. Identity, server/auth,
@@ -425,13 +469,18 @@ documented in
 
 ## Authentication and transport
 
-Ordinary REST, polling, MCP, and GPT Actions calls must use:
+Ordinary REST, polling, MCP, and GPT Actions calls must use the generated
+`webcodex-user-token` (`wc_pat_*`):
 
 ```text
 Authorization: Bearer <token>
 ```
 
 `?token=` is allowed only for `/api/agents/ws` WebSocket handshake compatibility. Do not use query-string tokens for polling, REST, MCP, or GPT Actions.
+
+The `webcodex-runner-token` (`wc_agent_*`) is accepted only by Agent transport
+endpoints. Using it on a project/runtime endpoint remains a 403; do not work
+around that boundary.
 
 For agents, prefer `transport = "auto"` with QUIC configured. WebSocket and polling remain supported fallbacks for constrained networks.
 
@@ -444,6 +493,10 @@ https://your-domain.example/openapi.json
 ```
 
 Configure GPT Actions authentication as HTTP Bearer/API key in the `Authorization` header.
+
+This is an OpenAPI Custom GPT Action integration, not a claim that WebCodex is
+published in the ChatGPT plugin directory. Plugins, apps, Custom GPTs, and GPT
+Actions are distinct layers; see [GPT_ACTIONS.md](GPT_ACTIONS.md).
 
 The OpenAPI GPT Actions management surface intentionally excludes users, API tokens, agent tokens, pairing/enrollment, setup, doctor, npm, server management, and audit endpoints. Use `webcodex` for those tasks.
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -166,14 +166,18 @@ Server/admin：
 Client：
 
 8. 安装公开 `webcodex` CLI 和 `webcodex-runner` binary。
-9. 运行 `webcodex login <server-url> --code <code>`（高级替代：`webcodex client enroll`）。
-10. 运行 `webcodex agent install --config <login 报告的 agent config 路径>`。
-11. 运行 `sudo systemctl daemon-reload`。
-12. 运行 `sudo systemctl enable --now webcodex-runner`。
-13. 运行 `webcodex agent status`。
-14. 运行 `webcodex ops status --strict`。
+9. 由实际运行项目命令的普通账户执行
+   `webcodex login <server-url> --code <code>`（高级替代：
+   `webcodex client enroll`），不要使用 `sudo`。
+10. 运行 `webcodex agent install --scope user --config <login 报告的 agent config 路径>`。
+11. 运行 `webcodex agent status --scope user --config <login 报告的 agent config 路径>`。
+12. 运行 `webcodex ops status --strict`。
 
-`/etc/webcodex/webcodex.env` 只属于 server 侧。多用户或多个 client 共享一台机器时，client 侧文件应放在 profile 目录下，例如 `/etc/webcodex/clients/workstation/agent.toml`、`/etc/webcodex/clients/workstation/webcodex-user-token`、`/etc/webcodex/clients/workstation/webcodex-runner-token` 和 `/etc/webcodex/clients/workstation/projects.d`。
+`agent install` 会自行对所选 service manager 执行 reload、enable 和 start；普通
+流程不需要 `sudo`，也不需要另行调用 `systemctl`。
+`/etc/webcodex/webcodex.env` 只属于 server 侧。普通用户的 client files 默认位于
+`$XDG_CONFIG_HOME/webcodex`（未设置时为 `$HOME/.config/webcodex`）；管理员有意
+配置 system scope 时，profile 可以放在 `/etc/webcodex` 下。
 
 ## 账户凭据开通流程
 
@@ -208,21 +212,28 @@ Client/friend 侧：
 
 ```bash
 webcodex login https://your-domain.example --code <wc_pair_...> \
-  --allowed-root /home/friend/git
+  --allowed-root "$HOME/git"
 
-webcodex agent install --config /etc/webcodex/https_your-domain.example/friendname/agent.toml \
-  --overwrite
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner
+webcodex agent install --scope user \
+  --config "$HOME/.config/webcodex/https_your-domain.example/friendname/agent.toml"
+webcodex agent status --scope user \
+  --config "$HOME/.config/webcodex/https_your-domain.example/friendname/agent.toml"
 
 webcodex ops status \
   --server-url https://your-domain.example \
-  --token-file /etc/webcodex/https_your-domain.example/friendname/webcodex-user-token \
+  --token-file "$HOME/.config/webcodex/https_your-domain.example/friendname/webcodex-user-token" \
   --strict
 ```
 
-`webcodex login` 是 client/friend 侧入口：自动生成唯一设备名、兑换 pairing code，并在 `<dir>/<server>/<user>/`（root：`/etc/webcodex/...`，普通用户：`~/.config/webcodex/...`）下写入 client 侧 `webcodex-user-token` 和 `agent.toml`。login 会打印确切的 agent config 路径和要使用的 `webcodex agent install --config <path>` 命令。GPT Actions 应使用 client 侧的 `webcodex-user-token`；生成的 agent config 使用 client 侧 agent token 连接 `webcodex-runner`。不要在机器之间复制 `WEBCODEX_TOKEN`、`wc_pat_*`、`wc_agent_*`、完整 env files 或完整 `agent.toml` files。每个 friend 都应使用唯一的 `username`；设备名会自动唯一。如需显式 client id 或自定义输出目录，高级的 `webcodex client enroll` 流程仍可用。
+`webcodex login` 是 client/friend 侧入口：自动生成唯一设备名、兑换 pairing code，
+并在用户 WebCodex config 目录下写入 client 侧 `webcodex-user-token` 和
+`agent.toml`。login 会打印确切 config 路径和
+`webcodex agent install --scope user --config <path>` 命令。GPT Actions、MCP 和普通
+REST/project API 使用 client 侧 `webcodex-user-token`；生成的 agent config 只把
+`webcodex-runner-token` 用于 Agent transport。不要在机器之间复制
+`WEBCODEX_TOKEN`、`wc_pat_*`、`wc_agent_*`、完整 env files 或完整
+`agent.toml` files。每个 friend 都应使用唯一的 `username`；设备名会自动唯一。
+如需显式 client id 或自定义输出目录，高级的 `webcodex client enroll` 流程仍可用。
 
 ## Runtime console
 
@@ -297,14 +308,45 @@ server {
 
 ## Agent 配置
 
-`login` / `client enroll` 会生成 agent config。使用下面命令安装 systemd unit（`login` 会打印确切的 config 路径）：
+`login` / `client enroll` 会生成 agent config。普通非 root 安装使用 user unit
+（`login` 会打印确切的 config 路径）：
 
 ```bash
-sudo webcodex agent install --config /etc/webcodex/https_your-domain.example/friendname/agent.toml
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner
-webcodex agent status --server-url https://your-domain.example
+webcodex agent install --scope user --profile workstation
+webcodex agent status --scope user --profile workstation \
+  --server-url https://your-domain.example
 ```
+
+npm 安装位置与 systemd scope 相互独立。user scope 使用 `systemctl --user`，unit
+位于 `$XDG_CONFIG_HOME/systemd/user`（未设置时为
+`$HOME/.config/systemd/user`），使用 `default.target`，不生成 `User=` 或
+`Group=`，也不需要管理员权限。非 root 调用者默认使用 user scope。install、
+status、start、stop、restart、logs 和 uninstall 必须使用同一 scope。
+
+启用后的 user unit 跟随该账户的 user manager 生命周期；这并不自动保证它能在首次
+登录前启动，或在最后一次注销后继续运行。若需要无人值守的开机常驻，管理员应先
+评估该账户长期运行 service 的权限，再显式执行
+`sudo loginctl enable-linger <runner-user>`。WebCodex 不会自动修改 linger 设置。
+
+管理员管理的 service 使用 system scope：`/etc/systemd/system`、`systemctl` 和
+`multi-user.target`。正常安装应指定非 root 用户及其可用的 working directory：
+
+```bash
+sudo webcodex agent install \
+  --scope system \
+  --profile workstation \
+  --user <runner-user> \
+  --working-directory /home/<runner-user> \
+  --config /etc/webcodex/clients/workstation/agent.toml
+sudo webcodex agent status --scope system --profile workstation
+```
+
+`--group` 可选。WebCodex 不创建系统用户、不修改 sudoers，也不迁移权限。只有
+管理员同时传入 `--allow-root-runner` 时才允许 root Runner；这个不推荐的例外会
+输出并写入醒目警告。显式 config 和 working-directory override 仍然可用，但
+所选 service account 必须能够读取或使用它们。显式 service-file 必须匹配所选
+manager scope：user scope 拒绝 system unit path，system scope 拒绝 user-unit
+path；已有 unit 不会被静默覆盖。
 
 前台测试可直接启动 agent：
 
@@ -369,8 +411,10 @@ Python venv、Conda 示例、解析规则和安全边界见
 [SHELL_PROFILES.md](SHELL_PROFILES.md)。修改配置不会静默移动、重启或改变已打开
 Shell；需要显式 close/reopen 才应用新默认值。当前 policy 会在后续 exec/status
 操作前重检，而 close 仍可用于清理。
-修改 `agent.toml` 后，`sudo systemctl reload webcodex-runner` 会把新的 policy、
-shell、SSH resource 和 tool-provider generation 应用于后续请求；已打开的
+修改 `agent.toml` 后，应 reload 匹配的 manager（user scope 使用
+`systemctl --user reload webcodex-runner`，system scope 使用
+`sudo systemctl reload webcodex-runner`）。这会把新的 policy、shell、SSH
+resource 和 tool-provider generation 应用于后续请求；已打开的
 persistent shell 仍保持原进程状态。无效 reload 保留当前 generation，
 `projects.d` 继续独立刷新。
 
@@ -378,13 +422,17 @@ persistent shell 仍保持原进程状态。无效 reload 保留当前 generatio
 
 ## Authentication and transport
 
-普通 REST、polling、MCP 和 GPT Actions 调用必须使用：
+普通 REST、polling、MCP 和 GPT Actions 必须使用生成的
+`webcodex-user-token`（`wc_pat_*`）：
 
 ```text
 Authorization: Bearer <token>
 ```
 
 `?token=` 只允许用于 `/api/agents/ws` WebSocket handshake 兼容场景。不要把 query-string token 用在 polling、REST、MCP 或 GPT Actions。
+
+`webcodex-runner-token`（`wc_agent_*`）只允许访问 Agent transport endpoints；
+project/runtime endpoint 仍会返回 403，不要绕过这条边界。
 
 Agent 推荐配置 QUIC 并使用 `transport = "auto"`。WebSocket 和 polling 继续作为受限网络下的 fallback。
 
@@ -397,6 +445,10 @@ https://your-domain.example/openapi.json
 ```
 
 在 GPT Actions 中把认证配置为 HTTP Bearer/API key，并放在 `Authorization` header。
+
+这里指基于 OpenAPI 的 Custom GPT Action 接入，并不声称 WebCodex 已发布到 ChatGPT
+插件目录。plugin、app、Custom GPT 和 GPT Action 属于不同层次，详见
+[GPT_ACTIONS.zh-CN.md](GPT_ACTIONS.zh-CN.md)。
 
 OpenAPI GPT Actions 管理面有意排除 users、API tokens、agent tokens、pairing/enrollment、setup、doctor、npm、server management 和 audit endpoints。这些任务请使用 `webcodex`。
 

--- a/docs/DOCKER_DEPLOYMENT.zh-CN.md
+++ b/docs/DOCKER_DEPLOYMENT.zh-CN.md
@@ -151,21 +151,23 @@ npm install -g @yyjeqhc/webcodex
 使用配对码登录，并限制允许访问的代码根目录：
 
 ```bash
-sudo webcodex login https://webcodex.example.com \
+webcodex login https://webcodex.example.com \
   --code '<wc_pair_...>' \
-  --allowed-root /home/your-user/git
+  --allowed-root "$HOME/git"
 ```
 
 按照 `login` 输出的实际配置路径安装 Runner 服务：
 
 ```bash
-sudo webcodex agent install \
-  --config /path/reported/by/login/agent.toml \
-  --overwrite
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner
+webcodex agent install --scope user \
+  --config /path/reported/by/login/agent.toml
+webcodex agent status --scope user \
+  --config /path/reported/by/login/agent.toml
 ```
+
+普通用户的 npm 安装和 user systemd service 都不需要 `sudo`。若管理员有意使用
+system scope，请改用 `--scope system --user <runner-user>
+--working-directory /home/<runner-user>`；不要让 Runner 静默以 root 运行。
 
 因此，公网服务器只负责协调；源代码、Git 凭据和项目工具链都留在代码机器。
 

--- a/docs/E2E_VALIDATION.md
+++ b/docs/E2E_VALIDATION.md
@@ -66,8 +66,8 @@ webcodex server install
 webcodex server status
 webcodex pairing create --server-url URL --username alice
 webcodex login URL --code CODE --allowed-root /home/alice/git
-webcodex agent install --config PATH_FROM_LOGIN
-webcodex agent status --server-url URL
+webcodex agent install --scope user --config PATH_FROM_LOGIN
+webcodex agent status --scope user --config PATH_FROM_LOGIN --server-url URL
 webcodex ops status --strict --server-url URL --token-file PATH
 ```
 

--- a/docs/E2E_VALIDATION.zh-CN.md
+++ b/docs/E2E_VALIDATION.zh-CN.md
@@ -65,8 +65,8 @@ webcodex server install
 webcodex server status
 webcodex pairing create --server-url URL --username alice
 webcodex login URL --code CODE --allowed-root /home/alice/git
-webcodex agent install --config PATH_FROM_LOGIN
-webcodex agent status --server-url URL
+webcodex agent install --scope user --config PATH_FROM_LOGIN
+webcodex agent status --scope user --config PATH_FROM_LOGIN --server-url URL
 webcodex ops status --strict --server-url URL --token-file PATH
 ```
 

--- a/docs/GPT_ACTIONS.md
+++ b/docs/GPT_ACTIONS.md
@@ -5,6 +5,16 @@
 Use GPT Actions when a Custom GPT should call the project-bound WebCodex
 Connector. Use MCP when the client supports MCP directly.
 
+## Product terminology
+
+WebCodex currently provides an OpenAPI-based **Custom GPT Action** integration.
+It is not described here as a published ChatGPT plugin. In current OpenAI
+terminology, a plugin is an installable bundle in the ChatGPT/Codex plugin
+directory and can contain apps, skills, connectors, or MCP servers; an app, a
+Custom GPT, and an Action are distinct layers. See OpenAI's
+[GPT Actions introduction](https://developers.openai.com/api/docs/actions/introduction)
+and [plugin documentation](https://learn.chatgpt.com/docs/plugins).
+
 ## Schema
 
 Import:
@@ -17,8 +27,13 @@ ChatGPT requires public HTTPS. `webcodex setup` intentionally creates only a
 loopback project runtime; ingress and production authentication are operator
 responsibilities described in [DEPLOYMENT.md](DEPLOYMENT.md).
 
-Configure Bearer/API-key authentication with a scoped runtime credential. Do
-not paste bootstrap/admin, account, or Agent credentials into a GPT.
+Configure API-key authentication as an HTTP Bearer credential. In a managed
+login, select the generated `webcodex-user-token` (`wc_pat_*`); it is for GPT
+Actions, MCP, and ordinary REST/project APIs. `webcodex-runner-token`
+(`wc_agent_*`) is an Agent transport credential and is accepted only by Agent
+transport endpoints. Do not paste it, a bootstrap/admin token, or an account
+credential into a GPT. The server continues to return 403 when an Agent token
+is used on a project/runtime endpoint.
 
 ## Canonical Hosted Operations
 
@@ -156,6 +171,10 @@ webcodex task accept <task-id>
 This keeps the acceptance authority local even when the model is hosted.
 
 ## Common Errors
+
+- An authentication error after copying a `wc_agent_*` value means the wrong
+  credential type was selected. Use the generated `webcodex-user-token`
+  instead; never paste complete token values into logs or bug reports.
 
 - `project_not_configured`: run `webcodex setup`.
 - `project_registration_invalid` / `project_credential_invalid`: resolve the

--- a/docs/GPT_ACTIONS.zh-CN.md
+++ b/docs/GPT_ACTIONS.zh-CN.md
@@ -5,6 +5,15 @@
 Custom GPT 需要调用 project-bound WebCodex Connector 时使用 GPT Actions；
 client 直接支持 MCP 时优先 MCP。
 
+## 产品术语
+
+WebCodex 当前提供的是基于 OpenAPI 的 **Custom GPT Action** 接入。本文不把它
+描述为已经发布到 ChatGPT 插件目录的正式插件。按 OpenAI 当前术语，plugin 是
+ChatGPT/Codex 插件目录中的可安装 bundle，可以包含 app、skill、connector 或 MCP
+server；app、Custom GPT 和 Action 则是不同层次。参见 OpenAI 的
+[GPT Actions 介绍](https://developers.openai.com/api/docs/actions/introduction)和
+[插件文档](https://learn.chatgpt.com/docs/plugins)。
+
 ## Schema
 
 导入：
@@ -17,8 +26,12 @@ ChatGPT 要求公网 HTTPS。`webcodex setup` 有意只创建 loopback project r
 ingress 和 production authentication 由 operator 负责，见
 [DEPLOYMENT.zh-CN.md](DEPLOYMENT.zh-CN.md)。
 
-Bearer/API-key authentication 使用 scoped runtime credential。不要把
-bootstrap/admin、account 或 Agent credential 粘贴进 GPT。
+API-key 认证配置为 HTTP Bearer credential。Managed login 应选择生成的
+`webcodex-user-token`（`wc_pat_*`）；它用于 GPT Actions、MCP 和普通
+REST/project API。`webcodex-runner-token`（`wc_agent_*`）是 Agent transport
+credential，只能访问 Agent transport endpoints。不要把它、bootstrap/admin
+token 或 account credential 粘贴进 GPT。Agent token 调用 project/runtime
+endpoint 时，server 仍会返回 403。
 
 ## Canonical hosted operations
 
@@ -128,6 +141,9 @@ webcodex task accept <task-id>
 即使模型托管在远端，accept authority 仍留在本机。
 
 ## 常见错误
+
+- 复制 `wc_agent_*` 后出现认证错误，说明选错了 credential type。请改用生成的
+  `webcodex-user-token`；日志和 issue 中都不要粘贴完整 token。
 
 - `project_not_configured`：运行 `webcodex setup`。
 - `project_registration_invalid` / `project_credential_invalid`：解决报告的

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -213,7 +213,8 @@ clients on one machine.
 
 ### Profile-based config (advanced)
 
-Each client or user profile gets its own directory under `/etc/webcodex/clients/`:
+This example is an administrator-managed system-scope profile under
+`/etc/webcodex/clients/`:
 
 ```text
 /etc/webcodex/clients/<profile>/agent.toml
@@ -231,20 +232,25 @@ Enroll a client with a profile:
   --client-id workstation \
   --display-name "Workstation" \
   --profile workstation \
-  --allowed-root /root/git
+  --allowed-root /home/<runner-user>/git
 ```
 
 Install a profile-specific agent service:
 
 ```bash
 "$CLI" agent install \
+  --scope system \
   --profile workstation \
+  --user <runner-user> \
+  --working-directory /home/<runner-user> \
   --bin /opt/webcodex/bin/webcodex-runner \
   --overwrite
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex-runner-workstation
 ```
+
+Run that install command with administrator privileges. It reloads, enables,
+and starts the system manager itself. A normal ordinary-user installation
+instead uses the user's WebCodex config directory plus `--scope user` and does
+not need `sudo`.
 
 ### Legacy flat paths (not recommended)
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -135,9 +135,16 @@ For a hosted `connect` profile, use the profile-specific status and log path
 shown above. For a systemd-managed deployment, check the agent service and its
 connection details:
 
+Use the same scope that installed the service:
+
 ```bash
-systemctl status webcodex-runner
-journalctl -u webcodex-runner
+# Ordinary user service
+webcodex agent status --scope user
+webcodex agent logs --scope user --lines 100
+
+# Administrator-managed system service
+sudo webcodex agent status --scope system
+sudo webcodex agent logs --scope system --lines 100
 ```
 
 Also verify the server URL, local token files, and agent `allowed_roots`. Missing or empty `allowed_roots` defaults to `$HOME`; explicit `allowed_roots` replaces that default.
@@ -168,8 +175,9 @@ new service and check `journalctl -u webcodex` for startup or auth errors.
 Run `runtime_status` or `listAgents`, then check the agent host:
 
 ```bash
-systemctl status webcodex-runner
-journalctl -u webcodex-runner
+webcodex agent status --scope user
+webcodex agent logs --scope user --lines 100
+# Use `sudo ... --scope system` for an administrator-managed system service.
 ```
 
 Confirm the agent server URL, token file, service user, and `allowed_roots`.
@@ -177,10 +185,28 @@ Confirm the agent server URL, token file, service user, and `allowed_roots`.
 ### Wrong token type
 
 In the hosted quick-start, MCP and Runner use the same non-`wc_` shared key.
-In managed mode, GPT Actions and MCP use a `wc_pat_*`, while `wc_agent_*` is
-only for `webcodex-runner`.
+In managed mode, GPT Actions, MCP, and ordinary REST/project APIs use
+`webcodex-user-token` (`wc_pat_*`), while `webcodex-runner-token`
+(`wc_agent_*`) is only for Runner/Agent transport. A 403 after putting a
+`wc_agent_*` value in `--token` or `--token-file` is the expected security
+boundary: select the generated `webcodex-user-token` instead. Recent CLI
+commands also diagnose this mismatch without printing the complete token.
 `WEBCODEX_TOKEN` is bootstrap/admin-oriented and should not be copied into GPT
 Actions, MCP, or agent config.
+
+### Runner service is visible in one command but missing in another
+
+Pass the same `--scope` to install, status, start, stop, restart, logs, and
+uninstall. User scope invokes `systemctl --user` and `journalctl --user` and
+uses `$XDG_CONFIG_HOME/systemd/user` (or `$HOME/.config/systemd/user`). System
+scope invokes the system manager and uses `/etc/systemd/system`.
+
+Non-root callers default to user scope. Root callers default to system scope,
+but installation still requires a non-root `--user`; an intentional root
+Runner additionally requires `--allow-root-runner` and is discouraged. If a
+custom `--service-file` was used during install, pass that same absolute path
+and scope to later commands. WebCodex does not silently migrate or overwrite a
+unit in the other scope.
 
 ### Non-git smoke workspace cannot run `git_status`
 

--- a/docs/TROUBLESHOOTING.zh-CN.md
+++ b/docs/TROUBLESHOOTING.zh-CN.md
@@ -125,9 +125,16 @@ sudo ln -s /opt/webcodex/bin/webcodex /usr/local/bin/webcodex
 Hosted `connect` profile 使用上面的 profile-specific status 和日志路径。
 systemd-managed deployment 则检查 agent service 和连接详情：
 
+使用安装 service 时选择的同一 scope：
+
 ```bash
-systemctl status webcodex-runner
-journalctl -u webcodex-runner
+# 普通 user service
+webcodex agent status --scope user
+webcodex agent logs --scope user --lines 100
+
+# 管理员管理的 system service
+sudo webcodex agent status --scope system
+sudo webcodex agent logs --scope system --lines 100
 ```
 
 同时确认 server URL、本地 token files 和 agent `allowed_roots`。缺失或为空的 `allowed_roots` 默认使用 `$HOME`；显式 `allowed_roots` 会覆盖该默认值。
@@ -158,8 +165,9 @@ schema；artifact upload tools 应继续作为 runtime-only tools 通过
 先运行 `runtime_status` 或 `listAgents`，再在 agent host 上检查：
 
 ```bash
-systemctl status webcodex-runner
-journalctl -u webcodex-runner
+webcodex agent status --scope user
+webcodex agent logs --scope user --lines 100
+# 管理员管理的 system service 使用 `sudo ... --scope system`。
 ```
 
 确认 agent server URL、token file、service user 和 `allowed_roots`。
@@ -167,9 +175,26 @@ journalctl -u webcodex-runner
 ### Token type 错误
 
 Hosted quick-start 中，MCP 与 Runner 使用同一个非 `wc_` shared key。Managed
-mode 中，GPT Actions 和 MCP 使用 `wc_pat_*`，`wc_agent_*` 只给
-`webcodex-runner` 使用。`WEBCODEX_TOKEN` 面向 bootstrap/admin，
+mode 中，GPT Actions、MCP 和普通 REST/project API 使用
+`webcodex-user-token`（`wc_pat_*`）；`webcodex-runner-token`
+（`wc_agent_*`）只给 Runner/Agent transport 使用。把 `wc_agent_*` 放入
+`--token` 或 `--token-file` 后得到 403，正是预期安全边界；应改用生成的
+`webcodex-user-token`。新版 CLI 也会在不打印完整 token 的前提下诊断这个错误。
+`WEBCODEX_TOKEN` 面向 bootstrap/admin，
 不应复制到 GPT Actions、MCP 或 agent config。
+
+### 一条命令能看到 Runner service，另一条却看不到
+
+install、status、start、stop、restart、logs 和 uninstall 必须传入相同的
+`--scope`。user scope 调用 `systemctl --user` / `journalctl --user`，并使用
+`$XDG_CONFIG_HOME/systemd/user`（未设置时为 `$HOME/.config/systemd/user`）；
+system scope 调用 system manager，并使用 `/etc/systemd/system`。
+
+非 root 调用者默认使用 user scope。root 调用者默认使用 system scope，但安装时
+仍需提供非 root `--user`；有意使用 root Runner 还必须传
+`--allow-root-runner`，且不推荐这样做。install 时若使用了自定义
+`--service-file`，后续命令也要传同一 absolute path 与 scope。WebCodex 不会静默
+迁移或覆盖另一 scope 的 unit。
 
 ### 非 git smoke workspace 不能运行 `git_status`
 


### PR DESCRIPTION
## Summary

- add consistent user/system service scopes for Runner lifecycle commands
- default non-root callers to user services and require an explicit non-root account for system services
- require `--allow-root-runner` before intentionally running project commands as root
- separate Runner transport tokens from user/runtime API tokens with local, non-leaking diagnostics
- preserve hosted profile and detached Runner behavior
- avoid unsafe root login guidance in both text and JSON output
- update English and Chinese authentication, deployment, operations, and GPT Actions/plugin documentation

## Safety

- user scope uses XDG/HOME paths, `systemctl --user`, `journalctl --user`, and `default.target`
- system scope rejects implicit root execution
- install preserves atomic writes, symlink rejection, overwrite preflight, and rollback behavior
- Server 403 behavior and Agent transport authorization boundaries remain unchanged
- WebCodex does not modify linger settings

## Validation

- `cargo fmt -- --check`
- `cargo check --all-targets -p webcodex-cli`
- `cargo test --all-targets -p webcodex-cli` — 243 passed
- `cargo test --all-targets` — 2151 passed, 4 ignored
- `bash scripts/e2e_hosted_connect.sh` — PASS
- diff whitespace, conflict marker, worktree, and process checks

Closes #2
