### PR TITLE
release: record v0.3.2 artifact checksums

### DIFF
--- a/docs/RELEASE_NOTES_v0.3.2.md
+++ b/docs/RELEASE_NOTES_v0.3.2.md
@@ -90,6 +90,14 @@ The planned binary artifacts are:
 - `webcodex-v0.3.2-linux-arm64.tar.gz`
 - `webcodex-v0.3.2-darwin-arm64.tar.gz`
 
+SHA-256 checksums of the exact uploaded release assets:
+
+```text
+ee6fd40d26524dd3d4ad76b2fdb31a626d0321703b55414ff66b7962b4ec3aaa  webcodex-v0.3.2-linux-x64.tar.gz
+bb582960d6ab0b6001514997e4fa23adcbabf355c878abd6c790ac83e4c13aab  webcodex-v0.3.2-linux-arm64.tar.gz
+56bfc43cb1dce0ede9810f81a4eb0a25d5e991fb729db6154b16cca35cfb8533  webcodex-v0.3.2-darwin-arm64.tar.gz
+```
+
 Each artifact must contain `webcodex`, `webcodex-server`, and
 `webcodex-runner` built from the exact immutable `v0.3.2` tag. The npm package
 must not be published until the exact uploaded bytes have been recorded in the

--- a/docs/RELEASE_NOTES_v0.3.2.zh-CN.md
+++ b/docs/RELEASE_NOTES_v0.3.2.zh-CN.md
@@ -80,6 +80,14 @@ GHCR 或 Docker Hub 是独立的 release operation，不是 source 或 binary re
 - `webcodex-v0.3.2-linux-arm64.tar.gz`
 - `webcodex-v0.3.2-darwin-arm64.tar.gz`
 
+实际上传 release assets 的 SHA-256：
+
+```text
+ee6fd40d26524dd3d4ad76b2fdb31a626d0321703b55414ff66b7962b4ec3aaa  webcodex-v0.3.2-linux-x64.tar.gz
+bb582960d6ab0b6001514997e4fa23adcbabf355c878abd6c790ac83e4c13aab  webcodex-v0.3.2-linux-arm64.tar.gz
+56bfc43cb1dce0ede9810f81a4eb0a25d5e991fb729db6154b16cca35cfb8533  webcodex-v0.3.2-darwin-arm64.tar.gz
+```
+
 每个 artifact 都必须包含从不可变 `v0.3.2` tag 构建的 `webcodex`、
 `webcodex-server` 和 `webcodex-runner`。只有实际上传 bytes 的真实 SHA-256 已写入
 release manifest 后，才能发布 npm package。

--- a/npm/webcodex/manifest.json
+++ b/npm/webcodex/manifest.json
@@ -4,15 +4,15 @@
   "artifacts": {
     "linux-x64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.2/webcodex-v0.3.2-linux-x64.tar.gz",
-      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+      "sha256": "ee6fd40d26524dd3d4ad76b2fdb31a626d0321703b55414ff66b7962b4ec3aaa"
     },
     "linux-arm64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.2/webcodex-v0.3.2-linux-arm64.tar.gz",
-      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+      "sha256": "bb582960d6ab0b6001514997e4fa23adcbabf355c878abd6c790ac83e4c13aab"
     },
     "darwin-arm64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.2/webcodex-v0.3.2-darwin-arm64.tar.gz",
-      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+      "sha256": "56bfc43cb1dce0ede9810f81a4eb0a25d5e991fb729db6154b16cca35cfb8533"
     }
   }
 }


### PR DESCRIPTION
## Summary

- record SHA-256 values of the exact bytes downloaded back from the draft v0.3.2 GitHub Release
- add the same checksums to the English and Chinese release notes
- keep the immutable `v0.3.2` tag fixed at `e900c1f27332af2d96ecf2a57664e84a215c08b3`

## Artifact checksums

```text
ee6fd40d26524dd3d4ad76b2fdb31a626d0321703b55414ff66b7962b4ec3aaa  webcodex-v0.3.2-linux-x64.tar.gz
bb582960d6ab0b6001514997e4fa23adcbabf355c878abd6c790ac83e4c13aab  webcodex-v0.3.2-linux-arm64.tar.gz
56bfc43cb1dce0ede9810f81a4eb0a25d5e991fb729db6154b16cca35cfb8533  webcodex-v0.3.2-darwin-arm64.tar.gz
```

## Validation

- downloaded all three assets back from the draft GitHub Release
- `sha256sum -c`: all three passed
- `node npm/webcodex/test/release-manifest-check.js`
- `npm --prefix npm/webcodex test`
- `bash scripts/npm_package_smoke.sh`
- release-note local links: 0 missing
- `git diff --check`
- local and remote `v0.3.2` still resolve to the immutable tagged commit
