### PR TITLE
feat: add temporary local MCP sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,21 @@ Server and Agent, creates a separate temporary Project Connector credential,
 and exposes `/mcp` through the Quick Tunnel. WebCodex does not silently install
 system packages. The printed HTTPS URL and Bearer credential are valid only for
 that share session; Ctrl-C stops the runtime and tunnel and removes the temporary
-credential. Use `webcodex share --tunnel none` for local-only debugging. Quick
-Tunnels are for development and testing, not stable production deployment.
+credential.
+
+In ChatGPT Developer Mode, create a custom app with the printed `/mcp` URL. If
+your workspace offers **Access token/API key** authentication, choose it, paste
+the temporary Bearer credential, and run **Scan Tools**. ChatGPT UI labels and
+availability can vary by workspace and rollout. Treat this credential as live
+coding access: anyone who has it can modify this project and run commands allowed
+by the share runtime while the session is active. Keep it private and stop
+sharing when finished.
+
+Use `webcodex share --tunnel none` for local-only debugging. Quick Tunnels are
+for development and testing, not stable production deployment. If Quick Tunnel
+startup fails and `~/.cloudflared/config.yaml` already exists, Cloudflare does
+not currently support Quick Tunnels with that default config present; use a
+separate Quick Tunnel environment or temporarily move the file out of the way.
 
 See [AI Onboarding](docs/AI_ONBOARDING.md) for managed accounts, custom servers,
 and other connection paths.
@@ -169,8 +182,10 @@ services and advanced overrides.
 ## Client access
 
 - **ChatGPT over MCP:** create a Developer Mode custom app that points to the
-  Server `/mcp` endpoint. OAuth is supported for managed and self-hosted HTTPS
-  Servers; the setup below shows the current ChatGPT flow.
+  Server `/mcp` endpoint. For `webcodex share`, choose **Access token/API key**
+  when that option is available and paste the temporary Bearer credential.
+  Managed and self-hosted HTTPS Servers can use OAuth; the setup below shows
+  that long-lived ChatGPT flow.
 - **Other MCP clients:** use the Server `/mcp` endpoint with the credential
   produced by the selected setup flow. See [MCP](docs/MCP.md).
 - **GPT Actions:** OpenAPI-based GPT Actions remain available as an alternative

--- a/README.md
+++ b/README.md
@@ -49,6 +49,38 @@ profile shown by the first run:
 webcodex agent start --profile <profile>
 ```
 
+### Temporary local sharing
+
+If you do not have a hosted Server and only need temporary access to the current
+computer, use `webcodex share`. The default path uses a Cloudflare Quick Tunnel,
+which does not require a Cloudflare account.
+
+Install `cloudflared` first if needed. These commands follow Cloudflare's
+[official installation instructions](https://developers.cloudflare.com/tunnel/downloads/):
+
+```bash
+# macOS
+brew install cloudflared
+
+# Debian / Ubuntu: one copy-paste command using Cloudflare's official APT repository
+sudo mkdir -p --mode=0755 /usr/share/keyrings && curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null && echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list >/dev/null && sudo apt-get update && sudo apt-get install -y cloudflared
+```
+
+Then share the current project:
+
+```bash
+cd /path/to/your/repository
+webcodex share
+```
+
+`share` performs the idempotent project setup when needed, starts the local
+Server and Agent, creates a separate temporary Project Connector credential,
+and exposes `/mcp` through the Quick Tunnel. WebCodex does not silently install
+system packages. The printed HTTPS URL and Bearer credential are valid only for
+that share session; Ctrl-C stops the runtime and tunnel and removes the temporary
+credential. Use `webcodex share --tunnel none` for local-only debugging. Quick
+Tunnels are for development and testing, not stable production deployment.
+
 See [AI Onboarding](docs/AI_ONBOARDING.md) for managed accounts, custom servers,
 and other connection paths.
 
@@ -89,10 +121,11 @@ travel through the connection.
 
 | Goal | Recommended path |
 | --- | --- |
-| Connect one project immediately | Use the hosted quick start with `webcodex connect`. |
+| Connect one project through the hosted service | Use `webcodex connect <server>`. Only the Runner runs locally. |
+| Temporarily expose the current local project to ChatGPT/MCP | Use `webcodex share`; it starts local Server + Agent and a temporary Quick Tunnel. |
+| Keep everything local without public access | Use `webcodex setup` + `webcodex run` (or `webcodex share --tunnel none` for share debugging). |
+| Run a stable long-lived deployment | Self-host the Server with a stable HTTPS domain/tunnel, service management, and OAuth as needed. |
 | Use managed users, device enrollment, revocation, and audit | Use `webcodex login` and the managed deployment flow. |
-| Control the Server and data yourself | Deploy the Server with Docker Compose or systemd. |
-| Keep everything on one machine | Follow the loopback setup in the Quick Start guide. |
 
 ## Self-host the Server with Docker
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,6 +47,37 @@ Git。关闭终端不会停止 Runner；机器重启后，重新运行同一条 
 webcodex agent start --profile <profile>
 ```
 
+### 临时分享本地项目
+
+如果没有 hosted Server，只想临时把当前电脑上的项目接给 ChatGPT 或其他 MCP
+client，可以直接使用 `webcodex share`。默认路径使用 Cloudflare Quick Tunnel，
+不要求 Cloudflare 账号。
+
+如果尚未安装 `cloudflared`，可以直接使用 Cloudflare
+[官方安装说明](https://developers.cloudflare.com/tunnel/downloads/)中的命令：
+
+```bash
+# macOS
+brew install cloudflared
+
+# Debian / Ubuntu：把 Cloudflare 官方 APT 安装步骤合并成一条可直接复制的命令
+sudo mkdir -p --mode=0755 /usr/share/keyrings && curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null && echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list >/dev/null && sudo apt-get update && sudo apt-get install -y cloudflared
+```
+
+安装后直接分享当前项目：
+
+```bash
+cd /path/to/your/repository
+webcodex share
+```
+
+`share` 会在需要时执行幂等 project setup，启动本地 Server + Agent，创建一把独立的
+临时 Project Connector credential，并通过 Quick Tunnel 暴露 `/mcp`。WebCodex
+不会静默安装系统软件包。输出的 HTTPS URL 和 Bearer credential 只对本次 share
+session 有效；Ctrl-C 会停止 runtime 与 tunnel，并删除临时 credential。
+`webcodex share --tunnel none` 可用于纯本地 debug。Quick Tunnel 面向开发/测试，
+不适合作为长期生产部署。
+
 Managed account、自定义 Server 和其他接入方式见
 [AI 接入指南](docs/AI_ONBOARDING.zh-CN.md)。
 
@@ -84,10 +115,11 @@ Runner 机器完成。仓库和本地工具链留在 Runner 主机上，连接�
 
 | 目标 | 推荐方式 |
 | --- | --- |
-| 立即接入一个本地项目 | 使用 hosted `webcodex connect`。 |
+| 通过 hosted 服务接入一个项目 | 使用 `webcodex connect <server>`，本地只运行 Runner。 |
+| 临时把当前本地项目接给 ChatGPT/MCP client | 使用 `webcodex share`，启动本地 Server + Agent 与临时 Quick Tunnel。 |
+| 保持纯本地、不开放公网 | 使用 `webcodex setup` + `webcodex run`（share 调试也可用 `--tunnel none`）。 |
+| 长期稳定部署 | 自托管 Server，并配置 stable HTTPS domain/tunnel、service 与按需 OAuth。 |
 | 需要用户、设备 enrollment、撤销和审计 | 使用 managed `webcodex login` 流程。 |
-| 完全控制 Server 与数据 | 使用 Docker Compose 或 systemd 自托管。 |
-| 所有组件只在一台机器运行 | 使用快速开始文档中的 loopback 方式。 |
 
 ## 使用 Docker 自托管 Server
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,8 +75,18 @@ webcodex share
 临时 Project Connector credential，并通过 Quick Tunnel 暴露 `/mcp`。WebCodex
 不会静默安装系统软件包。输出的 HTTPS URL 和 Bearer credential 只对本次 share
 session 有效；Ctrl-C 会停止 runtime 与 tunnel，并删除临时 credential。
+
+在 ChatGPT Developer Mode 中，用输出的 `/mcp` URL 创建自定义 app。如果当前
+workspace 提供 **访问令牌/API 密钥** 认证方式，选择它并粘贴本次临时 Bearer
+credential，然后执行 **Scan Tools / 扫描工具**。ChatGPT 的 UI 文案和可用范围可能
+随 workspace 与 rollout 变化。这把 credential 代表实时 coding 权限：在 share
+session 存活期间，持有它的人可以修改当前项目并执行 share runtime 允许的命令。
+请保持私密，并在使用完成后停止分享。
+
 `webcodex share --tunnel none` 可用于纯本地 debug。Quick Tunnel 面向开发/测试，
-不适合作为长期生产部署。
+不适合作为长期生产部署。如果机器上已经存在 `~/.cloudflared/config.yaml` 且 Quick
+Tunnel 启动失败，需要注意 Cloudflare 当前不支持在该默认配置文件存在时使用 Quick
+Tunnel；请使用独立的 Quick Tunnel 环境，或临时移开该文件。
 
 Managed account、自定义 Server 和其他接入方式见
 [AI 接入指南](docs/AI_ONBOARDING.zh-CN.md)。
@@ -161,8 +171,9 @@ System service 与高级覆盖参数见
 ## 接入客户端
 
 - **ChatGPT MCP：** 在 Developer Mode 中创建自定义 app，指向 Server 的 `/mcp`
-  endpoint。Managed 或自托管 HTTPS Server 可以使用 OAuth；下面给出当前 ChatGPT
-  的实际配置流程。
+  endpoint。使用 `webcodex share` 时，如果当前 workspace 提供 **访问令牌/API 密钥**，
+  选择它并粘贴本次临时 Bearer credential。Managed 或自托管 HTTPS Server 可以使用
+  OAuth；下面给出长期接入时的 ChatGPT OAuth 配置流程。
 - **其他 MCP client：** 使用 Server 的 `/mcp` endpoint 和当前接入流程生成的
   credential。详见 [MCP](docs/MCP.zh-CN.md)。
 - **GPT Actions：** 基于 OpenAPI 的 GPT Actions 仍作为另一种接入方式保留。

--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -310,7 +310,7 @@ where
             stdout: build_info::version_output("webcodex"),
             stderr: String::new(),
         },
-        "status" | "doctor" | "run" | "task" => CliAction::Project(args),
+        "status" | "doctor" | "run" | "share" | "task" => CliAction::Project(args),
         "setup" if args.get(1).map(String::as_str) != Some("single-user") => {
             CliAction::Project(args)
         }

--- a/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
@@ -44,6 +44,10 @@ fn project_doctor_and_hosted_connect_dispatch() {
         CliAction::Project(args) if args == ["doctor"]
     ));
     assert!(matches!(
+        cli_action(["share", "--tunnel", "none"]),
+        CliAction::Project(args) if args == ["share", "--tunnel", "none"]
+    ));
+    assert!(matches!(
         cli_action(["connect", "https://example.test", "--key", "shared-secret"]),
         CliAction::Connect(_)
     ));
@@ -125,6 +129,7 @@ fn unified_project_and_auth_commands_dispatch() {
         &["doctor", "--help"][..],
         &["task", "--help"][..],
         &["run", "--help"][..],
+        &["share", "--help"][..],
     ] {
         assert!(matches!(
             cli_action(args.iter().copied()),

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -5,7 +5,8 @@ Project:\n\
   setup                         Configure the current Git project\n\
   doctor                        Diagnose project readiness\n\
   status                        Show concise project coding readiness\n\
-  run                           Run the current project runtime and local Agent\n\n\
+  run                           Run the current project runtime and local Agent\n\
+  share                         Temporarily share the local project over HTTPS\n\n\
 Account (quick start):\n\
   connect                       Connect a local project to a hosted Server\n\
   login                         Log this device into a server (one-time pairing code)\n\

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -13,15 +13,23 @@ Local clients can use:
 http://127.0.0.1:<configured-port>/mcp
 ```
 
-Hosted clients require an operator-managed HTTPS endpoint:
+Hosted clients need HTTPS. There are three paths:
+
+- **Hosted:** `webcodex connect <server>` uses an existing hosted Server; only the Runner runs locally.
+- **Local Share:** `webcodex share` starts the local Server + Agent and a Cloudflare Quick Tunnel, then prints a temporary HTTPS `/mcp` URL and a separate temporary Bearer credential. Ctrl-C revokes that access by stopping the runtime/tunnel and removing the temporary share state. The URL can change every run. Use `--tunnel none` only for local testing/debugging.
+- **Self-hosted:** use a stable HTTPS domain/tunnel, durable service management, and OAuth or scoped credentials for long-lived operation.
+
+Cloudflare Quick Tunnel is intended for development/testing, not production.
+For stable self-hosted access, an endpoint looks like:
 
 ```text
 https://your-domain.example/mcp
 ```
 
-Use either a scoped Bearer credential or OAuth issued for runtime/project
-access. Do not use or expose bootstrap/admin, account, or Agent credentials.
-Prefer the client secret store; never commit a token.
+Do not use or expose bootstrap/admin, account, Agent, or the persistent
+project-first Connector credential as a public sharing secret. `share` creates
+and prints its own temporary Connector credential. Prefer the client secret
+store; never commit a token.
 
 For ChatGPT Developer Mode, point the custom app at the public HTTPS `/mcp`
 endpoint and use a user-defined/custom OAuth client. WebCodex currently supports
@@ -32,9 +40,11 @@ WebCodex API permission, so do not put it in the OAuth client's
 `allowed_scopes` list. Dynamic client registration is not currently required or
 implemented by WebCodex.
 
-Canonical setup does not print credential values or secret paths, create a
-tunnel, or expose a public port. Production enrollment, scoped user tokens, and
-OAuth are described in [AUTH_MODEL.md](AUTH_MODEL.md),
+Canonical `webcodex setup` still does not print credential values or secret
+paths, create a tunnel, or expose a public port. `webcodex share` is the
+explicit temporary exception: it prints only its session-scoped credential,
+never the persistent project Connector credential. Production enrollment,
+scoped user tokens, and OAuth are described in [AUTH_MODEL.md](AUTH_MODEL.md),
 [DEPLOYMENT.md](DEPLOYMENT.md), and [OAUTH2_SMOKE_TEST.md](OAUTH2_SMOKE_TEST.md).
 
 ## Model Surface Selection
@@ -410,7 +420,7 @@ No project discovery or runtime identifier belongs in this prompt.
 | `project_credential_invalid` | The private Project Credential is missing, unsafe, malformed, or mismatched | Restore both matching private files or explicitly recreate the profile |
 | `project_credential_rejected` | The reachable server rejected the configured Project Credential | Restore the server-matching credential; do not treat this as Agent offline |
 | `workspace_unavailable` | The configured Git workspace is unavailable | Restore the workspace, then run doctor |
-| `server_unreachable` | The project runtime is unavailable | Run `webcodex agent start` |
+| `server_unreachable` | The project runtime is unavailable | Run `webcodex run` for local project-first mode |
 | `agent_offline` | The local Agent is not ready | Run `webcodex doctor` |
 | `required_capability_unavailable` | The Agent lacks a coding capability | Upgrade all binaries |
 | `structured_validation_unavailable` | The Agent cannot run structured checks | Upgrade all binaries |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -28,17 +28,24 @@ https://your-domain.example/mcp
 
 Do not use or expose bootstrap/admin, account, Agent, or the persistent
 project-first Connector credential as a public sharing secret. `share` creates
-and prints its own temporary Connector credential. Prefer the client secret
-store; never commit a token.
+and prints its own temporary Connector credential. That credential authorizes
+project modification and allowed command execution for the shared project while
+the session is active, so keep it private and never commit it.
 
-For ChatGPT Developer Mode, point the custom app at the public HTTPS `/mcp`
-endpoint and use a user-defined/custom OAuth client. WebCodex currently supports
-PKCE S256 plus `client_secret_post`; register the exact ChatGPT callback URL as a
-redirect URI. The OAuth discovery metadata advertises `offline_access` for
-refresh-token continuity. `offline_access` is protocol-level and does not add a
-WebCodex API permission, so do not put it in the OAuth client's
-`allowed_scopes` list. Dynamic client registration is not currently required or
-implemented by WebCodex.
+For a temporary `webcodex share` connection in ChatGPT Developer Mode, point the
+custom app at the printed public HTTPS `/mcp` URL. If the authentication menu
+offers **Access token/API key**, choose it, paste the temporary Bearer
+credential, and run **Scan Tools**. ChatGPT UI labels and availability can vary
+by workspace and rollout.
+
+For a managed or self-hosted HTTPS Server with OAuth enabled, use a
+user-defined/custom OAuth client instead. WebCodex currently supports PKCE S256
+plus `client_secret_post`; register the exact ChatGPT callback URL as a redirect
+URI. The OAuth discovery metadata advertises `offline_access` for refresh-token
+continuity. `offline_access` is protocol-level and does not add a WebCodex API
+permission, so do not put it in the OAuth client's `allowed_scopes` list.
+Dynamic client registration is not currently required or implemented by
+WebCodex.
 
 Canonical `webcodex setup` still does not print credential values or secret
 paths, create a tunnel, or expose a public port. `webcodex share` is the

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -13,15 +13,22 @@ client 能连接 project-bound WebCodex endpoint 时使用 MCP。先完成
 http://127.0.0.1:<configured-port>/mcp
 ```
 
-Hosted client 需要 operator 管理的 HTTPS endpoint：
+Hosted client 需要 HTTPS，目前有三条用户路径：
+
+- **Hosted：** `webcodex connect <server>` 使用现有 hosted Server，本地只运行 Runner。
+- **Local Share：** `webcodex share` 启动本地 Server + Agent 与 Cloudflare Quick Tunnel，并输出临时 HTTPS `/mcp` URL 和一把独立的临时 Bearer credential。Ctrl-C 会停止 runtime/tunnel 并删除临时 share state，因此访问随之失效；URL 每次运行都可能变化。`--tunnel none` 仅用于本地测试/debug。
+- **Self-hosted：** 长期运行时使用 stable HTTPS domain/tunnel、durable service 管理，以及 OAuth 或 scoped credential。
+
+Cloudflare Quick Tunnel 面向开发/测试，不是 production 部署方案。稳定自托管 endpoint
+通常形如：
 
 ```text
 https://your-domain.example/mcp
 ```
 
-runtime/project access 可以使用 scoped Bearer credential 或 OAuth。不要使用或暴露
-bootstrap/admin、account 或 Agent credential。优先使用 client secret store，
-不要提交 token。
+不要把 bootstrap/admin、account、Agent credential，或 project-first setup 的长期
+Connector credential 当成公网分享 secret。`share` 会创建并只打印本次 session 的
+临时 Connector credential。优先使用 client secret store，不要提交 token。
 
 ChatGPT Developer Mode 应指向公网 HTTPS `/mcp` endpoint，并选择用户自定义的
 OAuth client。WebCodex 当前支持 PKCE S256 与 `client_secret_post`；需要把 ChatGPT
@@ -30,8 +37,10 @@ OAuth client。WebCodex 当前支持 PKCE S256 与 `client_secret_post`；需要
 WebCodex API 权限，因此不要把它写入 OAuth client 的 `allowed_scopes`。WebCodex
 当前不要求、也未实现 Dynamic Client Registration。
 
-Canonical setup 不打印 credential value 或 secret path，不创建 tunnel，也不开放
-公网端口。production enrollment、scoped user token 和 OAuth 见
+Canonical `webcodex setup` 仍然不打印 credential value 或 secret path、不创建
+tunnel，也不开放公网端口。`webcodex share` 是显式的临时例外：它只打印本次
+session-scoped credential，绝不打印长期 project Connector credential。production
+enrollment、scoped user token 和 OAuth 见
 [AUTH_MODEL.zh-CN.md](AUTH_MODEL.zh-CN.md)、
 [DEPLOYMENT.zh-CN.md](DEPLOYMENT.zh-CN.md) 与
 [OAUTH2_SMOKE_TEST.md](OAUTH2_SMOKE_TEST.md)。
@@ -320,7 +329,7 @@ prompt 中不需要 project discovery 或 runtime identifier。
 | `project_credential_invalid` | private Project Credential 缺失、权限不安全、格式错误或两份不匹配 | 恢复两份匹配 private file，或显式重建 profile |
 | `project_credential_rejected` | 可达 server 拒绝已配置 Project Credential | 恢复与 server 匹配的 credential；不得折叠为 Agent offline |
 | `workspace_unavailable` | 配置的 Git workspace 不可用 | 恢复 workspace 后运行 doctor |
-| `server_unreachable` | project runtime 不可用 | `webcodex agent start` |
+| `server_unreachable` | project runtime 不可用 | 本地 project-first 模式运行 `webcodex run` |
 | `agent_offline` | 本地 Agent 未 ready | `webcodex doctor` |
 | `required_capability_unavailable` | Agent 缺少 coding capability | 升级全部 binaries |
 | `structured_validation_unavailable` | Agent 不能运行 structured checks | 升级全部 binaries |

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -28,14 +28,20 @@ https://your-domain.example/mcp
 
 不要把 bootstrap/admin、account、Agent credential，或 project-first setup 的长期
 Connector credential 当成公网分享 secret。`share` 会创建并只打印本次 session 的
-临时 Connector credential。优先使用 client secret store，不要提交 token。
+临时 Connector credential。该 credential 在 session 存活期间允许对当前项目进行
+修改并执行 share runtime 允许的命令，因此必须保持私密，也不要提交到 Git。
 
-ChatGPT Developer Mode 应指向公网 HTTPS `/mcp` endpoint，并选择用户自定义的
-OAuth client。WebCodex 当前支持 PKCE S256 与 `client_secret_post`；需要把 ChatGPT
-显示的 callback URL 原样注册为 redirect URI。OAuth discovery 会发布
-`offline_access` 以支持 refresh token 连续性；它是协议级 scope，不会增加任何
-WebCodex API 权限，因此不要把它写入 OAuth client 的 `allowed_scopes`。WebCodex
-当前不要求、也未实现 Dynamic Client Registration。
+临时使用 `webcodex share` 接入 ChatGPT Developer Mode 时，用命令输出的公网 HTTPS
+`/mcp` URL 创建自定义 app。如果认证菜单提供 **访问令牌/API 密钥**，选择它并粘贴
+本次临时 Bearer credential，然后执行 **Scan Tools / 扫描工具**。ChatGPT 的 UI
+文案和可用范围可能随 workspace 与 rollout 变化。
+
+对于已经启用 OAuth 的 managed / 自托管 HTTPS Server，则使用用户自定义 OAuth
+client。WebCodex 当前支持 PKCE S256 与 `client_secret_post`；需要把 ChatGPT 显示的
+callback URL 原样注册为 redirect URI。OAuth discovery 会发布 `offline_access` 以
+支持 refresh token 连续性；它是协议级 scope，不会增加任何 WebCodex API 权限，
+因此不要把它写入 OAuth client 的 `allowed_scopes`。WebCodex 当前不要求、也未实现
+Dynamic Client Registration。
 
 Canonical `webcodex setup` 仍然不打印 credential value 或 secret path、不创建
 tunnel，也不开放公网端口。`webcodex share` 是显式的临时例外：它只打印本次

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -12,6 +12,7 @@ workflow session, executor reference, or internal config path.
   `webcodex-runner`).
 - Git available on `PATH`.
 - A Git project you can safely inspect and edit.
+- For the default `webcodex share` path only: `cloudflared` installed and available on `PATH`. If it is missing, install it from [Cloudflare's official downloads](https://developers.cloudflare.com/tunnel/downloads/); WebCodex does not silently install system packages.
 
 Install the packaged Linux x64 or macOS arm64 build:
 
@@ -57,12 +58,12 @@ missing, setup repairs only that component. If an existing field conflicts with
 the current Git root or profile, setup stops and names the conflicting field;
 it never overwrites the existing configuration.
 
-The Connector credential file and the Agent configuration contain the same
-secret and map to one stable, non-secret project grant identity. Both files are
+The persistent Connector credential and the Agent Token are separate secrets
+that map to the same stable, non-secret project grant identity. Their files are
 owner-only private state; plaintext is not written to the database. Runtime
-verification hashes the candidate and compares it in constant time. This path
-is separate from ordinary shared-key quick start: unknown Bearer values are
-rejected in project mode.
+verification hashes credential candidates and compares them in constant time.
+This path is separate from ordinary shared-key quick start: unknown Bearer
+values are rejected in project mode.
 
 Setup never rotates a surviving credential silently. If the credential is
 lost, restore both matching private files. If it is unrecoverable, stop the
@@ -81,7 +82,7 @@ action` with:
 
 ```text
 Next:
-  webcodex agent start
+  webcodex run
 ```
 
 Each finding has a stable `name`, `status`, `code`, `summary`, and
@@ -90,13 +91,13 @@ Each finding has a stable `name`, `status`, `code`, `summary`, and
 ## 3. Start the Local Runtime
 
 ```bash
-webcodex agent start
+webcodex run
 ```
 
-This explicit foreground action starts the project-bound loopback server and
+This canonical foreground action starts the project-bound loopback Server and
 local Agent. It does not install a service. Leave the terminal open; Ctrl-C
 stops both processes. Loopback does not bypass authentication: only the exact
-configured Project Credential can reach this project's Connector and Agent.
+configured Project Credential can reach this project's Connector.
 
 In another terminal, from the same project:
 
@@ -125,11 +126,47 @@ repository switches project context, and returning restores that repository's
 prior work. `task_list` and `task_resume` are only needed for explicit recovery
 when the client can no longer present its transport window identity.
 
-Hosted ChatGPT cannot reach a loopback address. An operator must provide an
-approved HTTPS endpoint and authentication without changing the project
-binding. See [DEPLOYMENT.md](DEPLOYMENT.md), [MCP.md](MCP.md), or
-[GPT_ACTIONS.md](GPT_ACTIONS.md). Setup deliberately does not create a tunnel
-or expose a port.
+### Install `cloudflared` for temporary sharing
+
+The default `webcodex share` path uses Cloudflare Quick Tunnel. Install
+`cloudflared` with Cloudflare's official package path if it is not already on
+`PATH`:
+
+```bash
+# macOS
+brew install cloudflared
+
+# Debian / Ubuntu: one copy-paste command using Cloudflare's official APT repository
+sudo mkdir -p --mode=0755 /usr/share/keyrings && curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null && echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list >/dev/null && sudo apt-get update && sudo apt-get install -y cloudflared
+```
+
+See Cloudflare's [official downloads and installation instructions](https://developers.cloudflare.com/tunnel/downloads/) for other platforms.
+WebCodex never silently installs system packages or elevates privileges.
+
+Hosted ChatGPT cannot reach a loopback address. For temporary development or
+testing access from a hosted MCP client, stop `webcodex run` and run:
+
+```bash
+webcodex share
+```
+
+`share` reuses the same project-first setup and local runtime, but starts a
+Cloudflare Quick Tunnel and a separate temporary Connector credential. It
+prints a temporary `https://*.trycloudflare.com/mcp` URL and Bearer token; both
+stop being usable when the command exits. `webcodex share --tunnel none` starts
+the same share runtime without a public tunnel for local debugging. Quick
+Tunnels are not a production deployment mechanism.
+
+If Quick Tunnel startup fails and this machine already has a Cloudflare Tunnel
+configuration at `~/.cloudflared/config.yaml`, note that Cloudflare Quick Tunnels
+do not support that configuration file. Use a separate Quick Tunnel environment
+(or temporarily move that config out of the way), or use `--tunnel none` for
+local-only debugging.
+
+For a stable long-lived endpoint, use a stable HTTPS domain/tunnel, service
+management, and OAuth or another production authentication path. See
+[DEPLOYMENT.md](DEPLOYMENT.md), [MCP.md](MCP.md), or
+[GPT_ACTIONS.md](GPT_ACTIONS.md).
 
 ## 5. Run the Golden Coding Path
 
@@ -260,8 +297,8 @@ Common stable codes:
 | `project_registration_invalid` | Existing state conflicts or is incomplete | Resolve the named field, then rerun setup |
 | `project_credential_invalid` | Private credential state is missing, unreadable, unsafe, malformed, or mismatched | Restore both matching private files or explicitly recreate the profile |
 | `project_credential_rejected` | The server rejected the locally configured credential | Restore the matching credential; do not treat this as Agent offline |
-| `server_unreachable` | The loopback runtime cannot be reached | `webcodex agent start`, or inspect doctor |
-| `agent_offline` | Server is reachable but the local Agent is unavailable | `webcodex agent start` |
+| `server_unreachable` | The loopback runtime cannot be reached | `webcodex run`, or inspect doctor |
+| `agent_offline` | Server is reachable but the local Agent is unavailable | `webcodex run` |
 | `required_capability_unavailable` | The installed Agent is too old/incomplete | Upgrade all WebCodex binaries |
 | `structured_validation_unavailable` | The Agent lacks structured validation | Upgrade all WebCodex binaries |
 | `workspace_unavailable` | Git or the configured project path is unavailable | Restore the path/Git workspace |
@@ -294,7 +331,7 @@ you cannot judge a command you cannot see. That has a consequence:
 - To turn previews off entirely:
 
   ```bash
-  WEBCODEX_ACTIVITY_COMMAND_PREVIEW=0 webcodex agent start
+  WEBCODEX_ACTIVITY_COMMAND_PREVIEW=0 webcodex run
   ```
 
   The tool, paths, and outcome are still recorded; only the command text is

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -153,9 +153,17 @@ webcodex share
 `share` reuses the same project-first setup and local runtime, but starts a
 Cloudflare Quick Tunnel and a separate temporary Connector credential. It
 prints a temporary `https://*.trycloudflare.com/mcp` URL and Bearer token; both
-stop being usable when the command exits. `webcodex share --tunnel none` starts
-the same share runtime without a public tunnel for local debugging. Quick
-Tunnels are not a production deployment mechanism.
+stop being usable when the command exits.
+
+For ChatGPT Developer Mode, create a custom app with that `/mcp` URL. If the
+authentication menu offers **Access token/API key**, choose it, paste the
+printed temporary Bearer credential, and run **Scan Tools**. Anyone who has that
+credential can modify this project and run commands allowed by the share runtime
+while the session is active, so keep it private.
+
+`webcodex share --tunnel none` starts the same share runtime without a public
+tunnel for local debugging. Quick Tunnels are not a production deployment
+mechanism.
 
 If Quick Tunnel startup fails and this machine already has a Cloudflare Tunnel
 configuration at `~/.cloudflared/config.yaml`, note that Cloudflare Quick Tunnels

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -145,6 +145,12 @@ webcodex share
 `share` 复用同一套 project-first setup 和 local runtime，但会启动 Cloudflare Quick
 Tunnel，并为本次 session 创建一把独立的临时 Connector credential。命令会输出
 临时 `https://*.trycloudflare.com/mcp` URL 和 Bearer token；命令退出后两者都失效。
+
+在 ChatGPT Developer Mode 中，用这个 `/mcp` URL 创建自定义 app。如果认证菜单提供
+**访问令牌/API 密钥**，选择它并粘贴命令输出的临时 Bearer credential，然后执行
+**Scan Tools / 扫描工具**。在 session 存活期间，任何拿到这把 credential 的人都可以
+修改当前项目并执行 share runtime 允许的命令，因此必须保持私密。
+
 `webcodex share --tunnel none` 可在不创建公网 tunnel 的情况下启动同一 share
 runtime，便于本地 debug。Quick Tunnel 不是 production 部署方式。
 

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -12,6 +12,7 @@ reference 或内部 config path。
   `webcodex-runner`；
 - `PATH` 中有 Git；
 - 一个可以安全查看和修改的 Git 项目。
+- 仅默认 `webcodex share` 路径需要：已安装 `cloudflared`，并可从 `PATH` 找到。若缺失，请从 [Cloudflare 官方下载页](https://developers.cloudflare.com/tunnel/downloads/)安装；WebCodex 不会静默安装系统软件包。
 
 安装 Linux x64 或 macOS arm64 package：
 
@@ -55,10 +56,11 @@ webcodex setup
 第二次返回 `already configured`。若一个生成组件缺失，只修复该组件。若已有字段
 与当前 Git root/profile 冲突，setup 会指出字段并停止，不覆盖现有配置。
 
-Connector credential file 与 Agent config 保存同一个 secret，并映射到同一个稳定、
-非秘密的 project grant identity。两个文件都属于 owner-only private state；数据库
-不保存明文。runtime 会 hash candidate 并使用 constant-time comparison。这条路径
-独立于普通 shared-key quick start：project mode 会拒绝任意未知 Bearer value。
+长期 Connector credential 与 Agent Token 是两把独立 secret，并映射到同一个稳定、
+非秘密的 project grant identity。对应文件都属于 owner-only private state；数据库
+不保存明文。runtime 会 hash credential candidate 并使用 constant-time comparison。
+这条路径独立于普通 shared-key quick start：project mode 会拒绝任意未知 Bearer
+value。
 
 Setup 不会静默轮换仍存在的 credential。credential 丢失时应恢复两份匹配的 private
 file；若无法恢复，先停止 runtime，明确退役整个 private project-state profile，再
@@ -75,7 +77,7 @@ Doctor 完全只读。Agent 尚未启动时，预期 verdict 是 `Needs action`�
 
 ```text
 Next:
-  webcodex agent start
+  webcodex run
 ```
 
 每条 finding 都有稳定 `name`、`status`、`code`、`summary` 和 `next_action`。
@@ -84,12 +86,13 @@ Next:
 ## 3. 启动本地 runtime
 
 ```bash
-webcodex agent start
+webcodex run
 ```
 
-这是显式 foreground action，会启动绑定当前项目的 loopback server 和本地 Agent；
-不会安装 system service。保持该终端运行，Ctrl-C 会停止两个进程。Loopback 不构成
-认证豁免；只有 setup 配置的精确 Project Credential 能访问该项目 Connector/Agent。
+这是 canonical foreground action，会启动绑定当前项目的 loopback Server 和本地
+Agent；不会安装 system service。保持该终端运行，Ctrl-C 会停止两个进程。
+Loopback 不构成认证豁免；只有 setup 配置的精确 Project Credential 能访问该项目
+Connector。
 
 在同一项目的另一个终端运行：
 
@@ -116,10 +119,43 @@ task_start
 之后切回会恢复该仓库之前的工作。只有 client 无法继续提供 transport 窗口身份
 时，才需要用 `task_list` 和 `task_resume` 做显式恢复。
 
-ChatGPT hosted client 无法访问 loopback address。operator 必须提供批准的 HTTPS
-endpoint 和认证，同时保持 project binding 不变。见
-[DEPLOYMENT.zh-CN.md](DEPLOYMENT.zh-CN.md)、[MCP.zh-CN.md](MCP.zh-CN.md) 或
-[GPT_ACTIONS.zh-CN.md](GPT_ACTIONS.zh-CN.md)。Setup 不创建 tunnel，也不暴露端口。
+### 为临时分享安装 `cloudflared`
+
+默认 `webcodex share` 使用 Cloudflare Quick Tunnel。如果 `PATH` 中还没有
+`cloudflared`，可以使用 Cloudflare 官方 package 安装方式：
+
+```bash
+# macOS
+brew install cloudflared
+
+# Debian / Ubuntu：把 Cloudflare 官方 APT 安装步骤合并成一条可直接复制的命令
+sudo mkdir -p --mode=0755 /usr/share/keyrings && curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null && echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list >/dev/null && sudo apt-get update && sudo apt-get install -y cloudflared
+```
+
+其他平台见 Cloudflare [官方下载与安装说明](https://developers.cloudflare.com/tunnel/downloads/)。
+WebCodex 不会静默安装系统软件包，也不会自行提升权限。
+
+ChatGPT hosted client 无法访问 loopback address。如果只是开发/测试期间临时让
+hosted MCP client 访问当前项目，先停止 `webcodex run`，然后执行：
+
+```bash
+webcodex share
+```
+
+`share` 复用同一套 project-first setup 和 local runtime，但会启动 Cloudflare Quick
+Tunnel，并为本次 session 创建一把独立的临时 Connector credential。命令会输出
+临时 `https://*.trycloudflare.com/mcp` URL 和 Bearer token；命令退出后两者都失效。
+`webcodex share --tunnel none` 可在不创建公网 tunnel 的情况下启动同一 share
+runtime，便于本地 debug。Quick Tunnel 不是 production 部署方式。
+
+如果 Quick Tunnel 启动失败，并且机器上已经存在
+`~/.cloudflared/config.yaml`，需要注意 Cloudflare Quick Tunnel 不支持该配置文件。
+可以为 Quick Tunnel 使用独立环境（或临时移开该配置），也可以使用 `--tunnel none`
+进行纯本地 debug。
+
+需要长期稳定 endpoint 时，应使用 stable HTTPS domain/tunnel、service 管理以及
+OAuth 或其他生产认证方案。见 [DEPLOYMENT.zh-CN.md](DEPLOYMENT.zh-CN.md)、
+[MCP.zh-CN.md](MCP.zh-CN.md) 或 [GPT_ACTIONS.zh-CN.md](GPT_ACTIONS.zh-CN.md)。
 
 ## 5. 运行 golden coding path
 
@@ -236,8 +272,8 @@ webcodex doctor
 | `project_registration_invalid` | 现有 state 冲突或不完整 | 解决指出的字段后重新 setup |
 | `project_credential_invalid` | private credential 缺失、不可读、权限不安全、格式错误或两份不匹配 | 恢复两份匹配的 private file，或显式重建 profile |
 | `project_credential_rejected` | server 拒绝本地配置的 credential | 恢复匹配 credential；不得折叠成 Agent offline |
-| `server_unreachable` | loopback runtime 不可达 | `webcodex agent start` 或查看 doctor |
-| `agent_offline` | server 可达但本地 Agent 不可用 | `webcodex agent start` |
+| `server_unreachable` | loopback runtime 不可达 | `webcodex run` 或查看 doctor |
+| `agent_offline` | server 可达但本地 Agent 不可用 | `webcodex run` |
 | `required_capability_unavailable` | Agent 太旧或不完整 | 升级全部 WebCodex binaries |
 | `structured_validation_unavailable` | Agent 缺少 structured validation | 升级全部 WebCodex binaries |
 | `workspace_unavailable` | Git 或配置的项目路径不可用 | 恢复 path/Git workspace |
@@ -266,7 +302,7 @@ webcodex doctor
 - 需要完全关闭预览时：
 
   ```bash
-  WEBCODEX_ACTIVITY_COMMAND_PREVIEW=0 webcodex agent start
+  WEBCODEX_ACTIVITY_COMMAND_PREVIEW=0 webcodex run
   ```
 
   关闭后仍会记录工具名、路径和结果，只是命令文本存为空。

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -6,6 +6,8 @@
 
 #[path = "project_entry_setup.rs"]
 mod setup_service;
+#[path = "project_entry_share.rs"]
+mod share_service;
 
 use setup_service::{
     create_private_dir, local_readiness, read_private_value, read_project_agent_token,
@@ -14,6 +16,9 @@ use setup_service::{
     validate_profile, ProjectConfig,
 };
 pub(crate) use setup_service::{resolve_local_task_state, setup};
+#[cfg(test)]
+pub(crate) use share_service::TunnelProvider;
+pub(crate) use share_service::{parse_share_options, share, ShareCommandOptions};
 
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
@@ -177,7 +182,7 @@ pub(crate) fn parse_options(
             "--root" => options.root = PathBuf::from(value(&mut index)?),
             "--profile" => options.profile = value(&mut index)?,
             "--state-dir" => options.state_dir = Some(PathBuf::from(value(&mut index)?)),
-            "--json" if command != "run" => options.json = true,
+            "--json" if !matches!(command, "run" | "share") => options.json = true,
             "--console-assets-dir" if command == "run" => {
                 let directory = PathBuf::from(value(&mut index)?);
                 if !directory.is_absolute() {
@@ -201,11 +206,14 @@ pub(crate) fn usage() -> &'static str {
        webcodex doctor [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
        webcodex status [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
        webcodex run [--root PATH] [--profile NAME] [--state-dir PATH]\n\
-                              [--console-assets-dir ABSOLUTE_PATH]\n\n\
+                              [--console-assets-dir ABSOLUTE_PATH]\n\
+       webcodex share [--root PATH] [--profile NAME] [--state-dir PATH]\n\
+                     [--tunnel cloudflare|none]\n\n\
 Run setup in a local Git project. It writes private WebCodex state outside the\n\
 checkout and never starts services, modifies Git content, or opens a network\n\
 port. `run` is the explicit foreground runtime step. Its optional\n\
-`--console-assets-dir` enables loopback-only development assets for that run.\n"
+`--console-assets-dir` enables loopback-only development assets for that run.\n\
+`share` starts the same local runtime with a temporary Connector credential.\n"
 }
 
 pub(crate) fn readiness_with_probe(
@@ -472,6 +480,14 @@ pub(crate) async fn collect_readiness(options: &ProjectCommandOptions) -> Projec
         Ok(key) => key,
         Err(_) => return readiness_with_probe(options, RemoteProbe::Unreachable),
     };
+    collect_readiness_from_remote(options, &config, &key).await
+}
+
+async fn collect_readiness_from_remote(
+    options: &ProjectCommandOptions,
+    config: &ProjectConfig,
+    key: &str,
+) -> ProjectReadiness {
     let url = format!("{}/api/connector/readiness", config.server_url());
     let response = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(1))
@@ -584,20 +600,59 @@ pub(crate) fn render_error(error: &ProductError, json: bool) -> String {
     }
 }
 
-pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), ProductError> {
-    let console_assets_dir = resolve_console_assets_directory(options)?;
-    let readiness = readiness_with_probe(options, RemoteProbe::Unreachable);
-    if readiness
-        .findings
-        .iter()
-        .any(|finding| finding.code == "project_not_configured")
-    {
-        return Err(ProductError::new(
-            "project_not_configured",
-            "the current project has not been set up",
-            Some("Run webcodex setup."),
-        ));
+#[derive(Debug, Clone)]
+pub(super) struct LocalRuntimeOptions {
+    pub(super) public_url: Option<String>,
+    pub(super) connector_credential_file: Option<PathBuf>,
+    pub(super) port_conflict_action: &'static str,
+}
+
+impl Default for LocalRuntimeOptions {
+    fn default() -> Self {
+        Self {
+            public_url: None,
+            connector_credential_file: None,
+            port_conflict_action: "Stop the conflicting process, then run webcodex run.",
+        }
     }
+}
+
+pub(super) struct LocalRuntimeHandle {
+    pub(super) project_name: String,
+    pub(super) local_url: String,
+    pub(super) public_url: String,
+    pub(super) console_assets_dir: Option<PathBuf>,
+    server: Child,
+    agent: Child,
+}
+
+impl LocalRuntimeHandle {
+    pub(super) async fn wait_for_exit(&mut self) -> Result<(), ProductError> {
+        tokio::select! {
+            status = self.server.wait() => Err(ProductError::new(
+                "server_unreachable",
+                format!("WebCodex stopped unexpectedly ({:?})", status.ok()),
+                Some("Run webcodex doctor."),
+            )),
+            status = self.agent.wait() => Err(ProductError::new(
+                "agent_offline",
+                format!("the local Agent stopped unexpectedly ({:?})", status.ok()),
+                Some("Run webcodex doctor."),
+            )),
+        }
+    }
+
+    pub(super) async fn stop(&mut self) {
+        let _ = self.agent.start_kill();
+        let _ = self.server.start_kill();
+        let _ = self.agent.wait().await;
+        let _ = self.server.wait().await;
+    }
+}
+
+fn configured_project(
+    options: &ProjectCommandOptions,
+) -> Result<(ProjectConfig, setup_service::ProjectPaths), ProductError> {
     let (expected, paths) = ProjectConfig::resolve(options)?;
     let config = read_toml_optional::<ProjectConfig>(&paths.config)?.ok_or_else(|| {
         ProductError::new(
@@ -609,13 +664,30 @@ pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), P
     validate_product_config(&expected, &config)?;
     validate_existing_agent(&config, &paths)?;
     validate_existing_registration(&config, &paths)?;
-    if TcpListener::bind(("127.0.0.1", config.port)).is_err() {
+    Ok((config, paths))
+}
+
+pub(super) fn ensure_local_runtime_port_available(
+    port: u16,
+    port_conflict_action: &'static str,
+) -> Result<(), ProductError> {
+    if TcpListener::bind(("127.0.0.1", port)).is_err() {
         return Err(ProductError::new(
             "server_unreachable",
             "the configured loopback port is already in use",
-            Some("Stop the conflicting process, then run webcodex run."),
+            Some(port_conflict_action),
         ));
     }
+    Ok(())
+}
+
+pub(super) async fn start_local_runtime(
+    options: &ProjectCommandOptions,
+    runtime_options: LocalRuntimeOptions,
+) -> Result<LocalRuntimeHandle, ProductError> {
+    let console_assets_dir = resolve_console_assets_directory(options)?;
+    let (config, paths) = configured_project(options)?;
+    ensure_local_runtime_port_available(config.port, runtime_options.port_conflict_action)?;
     let agent_binary = locate_agent_binary().ok_or_else(|| {
         ProductError::new(
             "required_capability_unavailable",
@@ -624,21 +696,27 @@ pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), P
         )
     })?;
     let bootstrap = read_private_value(&paths.bootstrap_key)?;
-    let connector_key = read_project_credential(&paths.connector_key)?;
+    let credential_file = runtime_options
+        .connector_credential_file
+        .unwrap_or_else(|| paths.connector_key.clone());
+    let connector_key = read_project_credential(&credential_file)?;
     let _agent_token = read_project_agent_token(&paths.agent_token)?;
     validate_agent_authentication(&config, &paths)?;
-    let server_binary = std::env::current_exe().map_err(|error| {
+    let server_binary = locate_companion_binary("webcodex-server").ok_or_else(|| {
         ProductError::new(
             "required_capability_unavailable",
-            format!("cannot locate the WebCodex executable: {error}"),
-            Some("Reinstall WebCodex, then retry."),
+            "the WebCodex Server executable is unavailable",
+            Some("Install all WebCodex binaries, then run webcodex doctor."),
         )
     })?;
+    let local_url = config.server_url();
+    let public_url = runtime_options
+        .public_url
+        .unwrap_or_else(|| local_url.clone());
     let server_log = open_log(&paths.logs.join("server.log"))?;
     let server_error = server_log.try_clone().map_err(io_error)?;
     let mut server_command = Command::new(server_binary);
     server_command
-        .arg("serve")
         .current_dir(&paths.state)
         .env_remove("WEBCODEX_ENV_FILE")
         .env("WEBCODEX_ADDR", format!("127.0.0.1:{}", config.port))
@@ -646,7 +724,7 @@ pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), P
         .env("WEBCODEX_TOKEN", bootstrap)
         .env("WEBCODEX_SHARED_KEY_ENABLED", "false")
         .env("WEBCODEX_ALLOW_ANONYMOUS", "false")
-        .env("WEBCODEX_PUBLIC_URL", config.server_url())
+        .env("WEBCODEX_PUBLIC_URL", &public_url)
         .env("WEBCODEX_OAUTH2_ENABLED", "false")
         .env("WEBCODEX_QUIC_ENABLED", "false")
         .env("WEBCODEX_CONNECTOR_SURFACE", "task-v1")
@@ -654,7 +732,7 @@ pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), P
             "WEBCODEX_CONNECTOR_PROJECT_GRANT_ID",
             config.project_grant_id(&paths),
         )
-        .env("WEBCODEX_PROJECT_CREDENTIAL_FILE", &paths.connector_key)
+        .env("WEBCODEX_PROJECT_CREDENTIAL_FILE", &credential_file)
         .env("WEBCODEX_PROJECT_AGENT_TOKEN_FILE", &paths.agent_token)
         .env("WEBCODEX_CONNECTOR_PROJECT_ID", &config.logical_project_id)
         .env("WEBCODEX_CONNECTOR_PROJECT_NAME", &config.project_name)
@@ -679,7 +757,7 @@ pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), P
             Some("Run webcodex doctor."),
         )
     })?;
-    wait_for_server(&mut server, &config.server_url(), &connector_key).await?;
+    wait_for_server(&mut server, &local_url, &connector_key).await?;
 
     let agent_log = open_log(&paths.logs.join("agent.log"))?;
     let agent_error = agent_log.try_clone().map_err(io_error)?;
@@ -700,36 +778,41 @@ pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), P
                 Some("Run webcodex doctor."),
             )
         })?;
-    wait_for_ready(&mut server, &mut agent, options).await?;
+    wait_for_ready(&mut server, &mut agent, options, &config, &connector_key).await?;
+    Ok(LocalRuntimeHandle {
+        project_name: config.project_name,
+        local_url,
+        public_url,
+        console_assets_dir,
+        server,
+        agent,
+    })
+}
+
+pub(crate) async fn start_agent(options: &ProjectCommandOptions) -> Result<(), ProductError> {
+    let mut runtime = start_local_runtime(options, LocalRuntimeOptions::default()).await?;
     let mut started = format!(
         "Project: {}\nConnection: connected at {}\nConsole: {}/console\nConsole assets: {}",
-        config.project_name,
-        config.server_url(),
-        config.server_url(),
-        if console_assets_dir.is_some() {
+        runtime.project_name,
+        runtime.local_url,
+        runtime.local_url,
+        if runtime.console_assets_dir.is_some() {
             "local development"
         } else {
             "embedded"
         }
     );
-    if let Some(directory) = &console_assets_dir {
+    if let Some(directory) = &runtime.console_assets_dir {
         started.push_str(&format!("\nAssets directory: {}", directory.display()));
     }
     started.push_str("\nAgent: online\nCoding access: ready\n\nPress Ctrl-C to stop.");
     println!("{started}");
-    tokio::select! {
+    let outcome = tokio::select! {
         _ = tokio::signal::ctrl_c() => Ok(()),
-        status = server.wait() => Err(ProductError::new(
-            "server_unreachable",
-            format!("WebCodex stopped unexpectedly ({:?})", status.ok()),
-            Some("Run webcodex doctor."),
-        )),
-        status = agent.wait() => Err(ProductError::new(
-            "agent_offline",
-            format!("the local Agent stopped unexpectedly ({:?})", status.ok()),
-            Some("Run webcodex doctor."),
-        )),
-    }
+        result = runtime.wait_for_exit() => result,
+    };
+    runtime.stop().await;
+    outcome
 }
 
 fn resolve_console_assets_directory(
@@ -790,13 +873,17 @@ fn locate_agent_binary() -> Option<PathBuf> {
             return Some(path);
         }
     }
+    locate_companion_binary("webcodex-runner")
+}
+
+fn locate_companion_binary(name: &str) -> Option<PathBuf> {
     let current = std::env::current_exe().ok()?;
     let parent = current.parent()?;
     for candidate in [
-        parent.join(executable_name("webcodex-runner")),
+        parent.join(executable_name(name)),
         parent
             .parent()
-            .map(|path| path.join(executable_name("webcodex-runner")))
+            .map(|path| path.join(executable_name(name)))
             .unwrap_or_default(),
     ] {
         if candidate.is_file() {
@@ -805,11 +892,11 @@ fn locate_agent_binary() -> Option<PathBuf> {
     }
     let path = std::env::var_os("PATH")?;
     std::env::split_paths(&path)
-        .map(|directory| directory.join(executable_name("webcodex-runner")))
+        .map(|directory| directory.join(executable_name(name)))
         .find(|candidate| candidate.is_file())
 }
 
-fn executable_name(name: &str) -> String {
+pub(super) fn executable_name(name: &str) -> String {
     if cfg!(windows) {
         format!("{name}.exe")
     } else {
@@ -896,6 +983,8 @@ async fn wait_for_ready(
     server: &mut Child,
     agent: &mut Child,
     options: &ProjectCommandOptions,
+    config: &ProjectConfig,
+    connector_key: &str,
 ) -> Result<(), ProductError> {
     let deadline = Instant::now() + START_TIMEOUT;
     while Instant::now() < deadline {
@@ -913,7 +1002,10 @@ async fn wait_for_ready(
                 Some("Run webcodex doctor."),
             ));
         }
-        if collect_readiness(options).await.ready {
+        if collect_readiness_from_remote(options, config, connector_key)
+            .await
+            .ready
+        {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(150)).await;

--- a/src/project_entry_setup.rs
+++ b/src/project_entry_setup.rs
@@ -252,11 +252,7 @@ pub(crate) fn setup(options: &ProjectCommandOptions) -> Result<SetupReport, Prod
                 Some("Restore the existing authentication material or remove this incomplete profile, then run webcodex setup."),
             ));
         }
-        let value = format!(
-            "webcodex_{}{}",
-            Uuid::new_v4().simple(),
-            Uuid::new_v4().simple()
-        );
+        let value = generate_project_credential();
         write_new_private(&paths.connector_key, format!("{value}\n").as_bytes())?;
         changed.push("Connection".to_string());
     }
@@ -964,6 +960,14 @@ pub(super) fn read_toml_optional<T: for<'de> Deserialize<'de>>(
     }
 }
 
+pub(super) fn generate_project_credential() -> String {
+    format!(
+        "webcodex_{}{}",
+        Uuid::new_v4().simple(),
+        Uuid::new_v4().simple()
+    )
+}
+
 pub(super) fn read_private_value(path: &Path) -> Result<String, ProductError> {
     read_private_value_with_code(path, "project_registration_invalid")
 }
@@ -1030,7 +1034,7 @@ pub(super) fn create_private_dir(path: &Path) -> Result<(), ProductError> {
     Ok(())
 }
 
-fn write_new_private(path: &Path, content: &[u8]) -> Result<(), ProductError> {
+pub(super) fn write_new_private(path: &Path, content: &[u8]) -> Result<(), ProductError> {
     if let Some(parent) = path.parent() {
         create_private_dir(parent)?;
     }

--- a/src/project_entry_share.rs
+++ b/src/project_entry_share.rs
@@ -1,0 +1,621 @@
+use super::setup_service::{
+    create_private_dir, generate_project_credential, read_project_credential, write_new_private,
+};
+use super::{
+    configured_project, ensure_local_runtime_port_available, executable_name, parse_options, setup,
+    start_local_runtime, LocalRuntimeOptions, ProductError, ProjectCommandOptions,
+};
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+const TUNNEL_START_TIMEOUT: Duration = Duration::from_secs(20);
+const TUNNEL_LOG_LINES: usize = 8;
+const TUNNEL_LOG_LINE_BYTES: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TunnelProvider {
+    CloudflareQuick,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShareCommandOptions {
+    pub(crate) project: ProjectCommandOptions,
+    pub(crate) tunnel: TunnelProvider,
+}
+
+pub(crate) fn parse_share_options(args: &[String]) -> Result<ShareCommandOptions, String> {
+    let mut tunnel = TunnelProvider::CloudflareQuick;
+    let mut project_args = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--tunnel" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| "--tunnel requires a value".to_string())?;
+                tunnel = match value.as_str() {
+                    "cloudflare" => TunnelProvider::CloudflareQuick,
+                    "none" => TunnelProvider::None,
+                    _ => {
+                        return Err(format!(
+                            "unknown tunnel provider '{value}'; expected cloudflare or none"
+                        ))
+                    }
+                };
+            }
+            flag => project_args.push(flag.to_string()),
+        }
+        index += 1;
+    }
+    let project = parse_options(&project_args, "share")?;
+    Ok(ShareCommandOptions { project, tunnel })
+}
+
+struct ShareSession {
+    directory: PathBuf,
+    credential_file: PathBuf,
+    credential: String,
+}
+
+impl ShareSession {
+    fn create(state: &Path) -> Result<Self, ProductError> {
+        let share_root = state.join("share");
+        create_private_dir(&share_root)?;
+        let directory = share_root.join(uuid::Uuid::new_v4().simple().to_string());
+        let credential_file = directory.join("connector-key");
+        let result = (|| {
+            create_private_dir(&directory)?;
+            let credential = generate_project_credential();
+            write_new_private(&credential_file, format!("{credential}\n").as_bytes())?;
+            let credential = read_project_credential(&credential_file)?;
+            Ok(Self {
+                directory: directory.clone(),
+                credential_file,
+                credential,
+            })
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_dir_all(&directory);
+        }
+        result
+    }
+}
+
+impl Drop for ShareSession {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[derive(Debug)]
+struct CloudflareTunnel {
+    child: Child,
+    stdout_task: JoinHandle<()>,
+    stderr_task: JoinHandle<()>,
+}
+
+impl CloudflareTunnel {
+    async fn wait_for_exit(&mut self) -> Result<(), ProductError> {
+        let status = self
+            .child
+            .wait()
+            .await
+            .map_err(|_| tunnel_runtime_error())?;
+        Err(ProductError::new(
+            "tunnel_unavailable",
+            format!("Cloudflare Quick Tunnel stopped unexpectedly ({status})"),
+            Some("Check network connectivity and cloudflared, then retry webcodex share."),
+        ))
+    }
+
+    async fn stop(&mut self) {
+        let _ = self.child.start_kill();
+        let _ = self.child.wait().await;
+        self.stdout_task.abort();
+        self.stderr_task.abort();
+    }
+}
+
+impl Drop for CloudflareTunnel {
+    fn drop(&mut self) {
+        self.stdout_task.abort();
+        self.stderr_task.abort();
+    }
+}
+
+fn tunnel_runtime_error() -> ProductError {
+    ProductError::new(
+        "tunnel_unavailable",
+        "Cloudflare Quick Tunnel process could not be supervised",
+        Some("Check cloudflared installation and retry webcodex share."),
+    )
+}
+
+pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductError> {
+    setup(&options.project)?;
+    let (config, paths) = configured_project(&options.project)?;
+    ensure_local_runtime_port_available(
+        config.port,
+        "Stop the conflicting process, then retry webcodex share.",
+    )?;
+    let persistent_credential = read_project_credential(&paths.connector_key)?;
+    let session = ShareSession::create(&paths.state)?;
+    if session.credential == persistent_credential {
+        return Err(ProductError::new(
+            "project_credential_invalid",
+            "temporary share credential unexpectedly matched the persistent project credential",
+            Some("Retry webcodex share."),
+        ));
+    }
+
+    let local_url = config.server_url();
+    let (public_url, mut tunnel) = match options.tunnel {
+        TunnelProvider::CloudflareQuick => {
+            let binary = locate_cloudflared()?;
+            let (url, tunnel) =
+                start_cloudflare_quick_with_binary(&binary, &local_url, TUNNEL_START_TIMEOUT)
+                    .await?;
+            (url, Some(tunnel))
+        }
+        TunnelProvider::None => (local_url.clone(), None),
+    };
+
+    let mut runtime = start_local_runtime(
+        &options.project,
+        LocalRuntimeOptions {
+            public_url: Some(public_url.clone()),
+            connector_credential_file: Some(session.credential_file.clone()),
+            port_conflict_action: "Stop the conflicting process, then retry webcodex share.",
+        },
+    )
+    .await?;
+
+    println!(
+        "{}",
+        render_share_ready(
+            &runtime.project_name,
+            options.tunnel,
+            &runtime.public_url,
+            &session.credential,
+        )
+    );
+
+    let outcome = if let Some(tunnel) = tunnel.as_mut() {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => Ok(()),
+            result = runtime.wait_for_exit() => result,
+            result = tunnel.wait_for_exit() => result,
+        }
+    } else {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => Ok(()),
+            result = runtime.wait_for_exit() => result,
+        }
+    };
+
+    runtime.stop().await;
+    if let Some(tunnel) = tunnel.as_mut() {
+        tunnel.stop().await;
+    }
+    outcome
+}
+
+fn render_share_ready(
+    project_name: &str,
+    tunnel: TunnelProvider,
+    public_url: &str,
+    credential: &str,
+) -> String {
+    let tunnel_name = match tunnel {
+        TunnelProvider::CloudflareQuick => "Cloudflare Quick Tunnel",
+        TunnelProvider::None => "none (local only)",
+    };
+    let public_access = match tunnel {
+        TunnelProvider::CloudflareQuick => "temporary",
+        TunnelProvider::None => "local only",
+    };
+    let ready_message = match tunnel {
+        TunnelProvider::CloudflareQuick => "Ready for ChatGPT or another remote MCP client.",
+        TunnelProvider::None => "Ready for a local MCP client. No public tunnel is running.",
+    };
+    let lifetime_message = match tunnel {
+        TunnelProvider::CloudflareQuick => "This credential and tunneled URL are temporary.",
+        TunnelProvider::None => "This credential is temporary.",
+    };
+    format!(
+        "Project: {project_name}\nRuntime: local\nTunnel: {tunnel_name}\nPublic access: {public_access}\n\nMCP URL:\n  {}/mcp\n\nAuthentication:\n  Bearer token\n\nToken:\n  {credential}\n\n{ready_message}\n\n{lifetime_message}\nPress Ctrl-C to stop sharing.",
+        public_url.trim_end_matches('/')
+    )
+}
+
+fn locate_cloudflared() -> Result<PathBuf, ProductError> {
+    let override_bin = std::env::var_os("WEBCODEX_CLOUDFLARED_BIN").map(PathBuf::from);
+    require_cloudflared_from(override_bin.as_deref(), std::env::var_os("PATH").as_deref())
+}
+
+fn require_cloudflared_from(
+    override_bin: Option<&Path>,
+    path: Option<&std::ffi::OsStr>,
+) -> Result<PathBuf, ProductError> {
+    locate_cloudflared_from(override_bin, path).ok_or_else(|| {
+        ProductError::new(
+            "tunnel_unavailable",
+            "cloudflared was not found",
+            Some(
+                "Install cloudflared from Cloudflare's official downloads (https://developers.cloudflare.com/tunnel/downloads/), ensure it is on PATH, then retry; or use webcodex share --tunnel none for local-only debugging.",
+            ),
+        )
+    })
+}
+
+fn locate_cloudflared_from(
+    override_bin: Option<&Path>,
+    path: Option<&std::ffi::OsStr>,
+) -> Option<PathBuf> {
+    if let Some(binary) = override_bin {
+        return binary.is_file().then(|| binary.to_path_buf());
+    }
+    let path = path?;
+    std::env::split_paths(path)
+        .map(|directory| directory.join(executable_name("cloudflared")))
+        .find(|candidate| candidate.is_file())
+}
+
+async fn start_cloudflare_quick_with_binary(
+    binary: &Path,
+    local_url: &str,
+    timeout: Duration,
+) -> Result<(String, CloudflareTunnel), ProductError> {
+    let mut child = Command::new(binary)
+        .arg("tunnel")
+        .arg("--url")
+        .arg(local_url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|_| {
+            ProductError::new(
+                "tunnel_unavailable",
+                "cloudflared could not start",
+                Some("Check the cloudflared executable and retry webcodex share."),
+            )
+        })?;
+    let stdout = child.stdout.take().ok_or_else(tunnel_runtime_error)?;
+    let stderr = child.stderr.take().ok_or_else(tunnel_runtime_error)?;
+    let recent = Arc::new(Mutex::new(VecDeque::with_capacity(TUNNEL_LOG_LINES)));
+    let (url_tx, mut url_rx) = mpsc::channel(2);
+    let stdout_task = spawn_tunnel_reader(stdout, recent.clone(), url_tx.clone());
+    let stderr_task = spawn_tunnel_reader(stderr, recent.clone(), url_tx);
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if let Some(status) = child.try_wait().map_err(|_| tunnel_runtime_error())? {
+            stdout_task.abort();
+            stderr_task.abort();
+            let detail = bounded_tunnel_log_summary(&recent);
+            let message = if detail.is_empty() {
+                format!("cloudflared exited before creating a Quick Tunnel ({status})")
+            } else {
+                format!("cloudflared exited before creating a Quick Tunnel ({status}): {detail}")
+            };
+            return Err(ProductError::new(
+                "tunnel_unavailable",
+                message,
+                Some("Check cloudflared output and network connectivity, then retry."),
+            ));
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            stdout_task.abort();
+            stderr_task.abort();
+            return Err(ProductError::new(
+                "tunnel_unavailable",
+                "Cloudflare Quick Tunnel did not provide a public URL before the startup timeout",
+                Some("Check network connectivity and cloudflared, then retry."),
+            ));
+        }
+        let wait = (deadline - now).min(Duration::from_millis(100));
+        if let Ok(Some(url)) = tokio::time::timeout(wait, url_rx.recv()).await {
+            return Ok((
+                url,
+                CloudflareTunnel {
+                    child,
+                    stdout_task,
+                    stderr_task,
+                },
+            ));
+        }
+    }
+}
+
+fn spawn_tunnel_reader<R>(
+    reader: R,
+    recent: Arc<Mutex<VecDeque<String>>>,
+    url_tx: mpsc::Sender<String>,
+) -> JoinHandle<()>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(reader).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            record_tunnel_line(&recent, &line);
+            if let Some(url) = parse_quick_tunnel_url(&line) {
+                let _ = url_tx.try_send(url);
+            }
+        }
+    })
+}
+
+fn record_tunnel_line(recent: &Arc<Mutex<VecDeque<String>>>, line: &str) {
+    let mut line = line.to_string();
+    if line.len() > TUNNEL_LOG_LINE_BYTES {
+        let mut end = TUNNEL_LOG_LINE_BYTES;
+        while !line.is_char_boundary(end) {
+            end -= 1;
+        }
+        line.truncate(end);
+    }
+    if let Ok(mut lines) = recent.lock() {
+        if lines.len() == TUNNEL_LOG_LINES {
+            lines.pop_front();
+        }
+        lines.push_back(line);
+    }
+}
+
+fn bounded_tunnel_log_summary(recent: &Arc<Mutex<VecDeque<String>>>) -> String {
+    recent
+        .lock()
+        .map(|lines| lines.iter().cloned().collect::<Vec<_>>().join(" | "))
+        .unwrap_or_default()
+}
+
+fn parse_quick_tunnel_url(line: &str) -> Option<String> {
+    let start = line.find("https://")?;
+    let candidate = line[start..]
+        .split_whitespace()
+        .next()?
+        .trim_end_matches(|character: char| {
+            matches!(character, ',' | ';' | ')' | ']' | '}' | '"' | '\'')
+        });
+    let parsed = url::Url::parse(candidate).ok()?;
+    let host = parsed.host_str()?;
+    (parsed.scheme() == "https"
+        && host.ends_with(".trycloudflare.com")
+        && parsed.path() == "/"
+        && parsed.query().is_none()
+        && parsed.fragment().is_none())
+    .then(|| format!("https://{host}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn parses_cloudflare_quick_tunnel_url_from_bounded_log_line() {
+        assert_eq!(
+            parse_quick_tunnel_url(
+                "INF +--------------------------------------------------------------------------------------------+ https://bright-example.trycloudflare.com"
+            ),
+            Some("https://bright-example.trycloudflare.com".to_string())
+        );
+        assert_eq!(parse_quick_tunnel_url("https://example.com"), None);
+        assert_eq!(
+            parse_quick_tunnel_url("https://bad.trycloudflare.com/mcp"),
+            None
+        );
+    }
+
+    #[test]
+    fn missing_cloudflared_reports_actionable_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let error = require_cloudflared_from(Some(&temp.path().join("missing")), None).unwrap_err();
+        assert_eq!(error.code, "tunnel_unavailable");
+        assert!(error.message.contains("cloudflared was not found"));
+        let next_action = error.next_action.unwrap();
+        assert!(next_action.contains("https://developers.cloudflare.com/tunnel/downloads/"));
+        assert!(next_action.contains("--tunnel none"));
+    }
+
+    #[test]
+    fn share_cli_defaults_to_cloudflare_and_accepts_none() {
+        let default = parse_share_options(&[]).unwrap();
+        assert_eq!(default.tunnel, TunnelProvider::CloudflareQuick);
+        let explicit =
+            parse_share_options(&["--tunnel".to_string(), "cloudflare".to_string()]).unwrap();
+        assert_eq!(explicit.tunnel, TunnelProvider::CloudflareQuick);
+        let local = parse_share_options(&["--tunnel".to_string(), "none".to_string()]).unwrap();
+        assert_eq!(local.tunnel, TunnelProvider::None);
+        assert!(parse_share_options(&["--tunnel".to_string(), "unknown".to_string()]).is_err());
+    }
+
+    #[test]
+    fn share_output_contains_only_the_temporary_connector_credential() {
+        let persistent = "webcodex_persistent-never-print";
+        let temporary = "webcodex_temporary-print-once";
+        let output = render_share_ready(
+            "demo",
+            TunnelProvider::CloudflareQuick,
+            "https://demo.trycloudflare.com",
+            temporary,
+        );
+        assert!(output.contains(temporary));
+        assert!(!output.contains(persistent));
+        assert!(output.contains("https://demo.trycloudflare.com/mcp"));
+    }
+
+    #[test]
+    fn local_only_share_output_does_not_claim_remote_chatgpt_readiness() {
+        let output = render_share_ready(
+            "demo",
+            TunnelProvider::None,
+            "http://127.0.0.1:23456",
+            "webcodex_temporary-print-once",
+        );
+        assert!(output.contains("Ready for a local MCP client"));
+        assert!(output.contains("No public tunnel is running"));
+        assert!(!output.contains("Ready for ChatGPT"));
+        assert!(!output.contains("tunneled URL"));
+    }
+
+    #[test]
+    fn tunnel_log_truncation_preserves_utf8_boundaries() {
+        let recent = Arc::new(Mutex::new(VecDeque::new()));
+        let line = format!("{}界tail", "a".repeat(TUNNEL_LOG_LINE_BYTES - 1));
+        record_tunnel_line(&recent, &line);
+        let recorded = recent.lock().unwrap();
+        let line = recorded.back().unwrap();
+        assert!(line.len() <= TUNNEL_LOG_LINE_BYTES);
+        assert_eq!(line, &"a".repeat(TUNNEL_LOG_LINE_BYTES - 1));
+    }
+
+    #[test]
+    fn local_port_preflight_rejects_an_occupied_port() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let error = ensure_local_runtime_port_available(port, "stop conflict").unwrap_err();
+        assert_eq!(error.code, "server_unreachable");
+        assert!(error.message.contains("already in use"));
+    }
+
+    #[test]
+    fn temporary_share_credential_is_private_distinct_and_cleaned_up() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = temp.path().join("state");
+        create_private_dir(&state).unwrap();
+        let persistent = state.join("credentials/connector-key");
+        let persistent_value = generate_project_credential();
+        write_new_private(&persistent, format!("{persistent_value}\n").as_bytes()).unwrap();
+        let persistent_before = fs::read_to_string(&persistent).unwrap();
+        let session = ShareSession::create(&state).unwrap();
+        assert_ne!(session.credential, persistent_value);
+        assert_eq!(fs::read_to_string(&persistent).unwrap(), persistent_before);
+        assert_eq!(
+            crate::auth::read_protected_secret(&session.credential_file).unwrap(),
+            session.credential
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(state.join("share"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&session.directory)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&session.credential_file)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        let directory = session.directory.clone();
+        drop(session);
+        assert!(!directory.exists());
+        assert!(persistent.is_file());
+    }
+
+    #[cfg(unix)]
+    fn fake_cloudflared(script: &str) -> (tempfile::TempDir, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("cloudflared");
+        fs::write(&path, script).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        (temp, path)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tunnel_startup_failure_is_reported() {
+        let (_temp, binary) = fake_cloudflared("#!/bin/sh\necho startup-failed >&2\nexit 7\n");
+        let error = start_cloudflare_quick_with_binary(
+            &binary,
+            "http://127.0.0.1:23456",
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.code, "tunnel_unavailable");
+        assert!(error.message.contains("startup-failed"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tunnel_startup_timeout_kills_fake_process() {
+        let (_temp, binary) = fake_cloudflared("#!/bin/sh\nsleep 5\n");
+        let error = start_cloudflare_quick_with_binary(
+            &binary,
+            "http://127.0.0.1:23456",
+            Duration::from_millis(100),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.code, "tunnel_unavailable");
+        assert!(error.message.contains("startup timeout"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tunnel_stop_reaps_fake_process() {
+        let (_temp, binary) = fake_cloudflared(
+            "#!/bin/sh\necho https://cleanup-test.trycloudflare.com >&2\nsleep 5\n",
+        );
+        let (_url, mut tunnel) = start_cloudflare_quick_with_binary(
+            &binary,
+            "http://127.0.0.1:23456",
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        tunnel.stop().await;
+        assert!(tunnel.child.try_wait().unwrap().is_some());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tunnel_early_exit_after_url_is_supervised() {
+        let (_temp, binary) = fake_cloudflared(
+            "#!/bin/sh\necho https://short-lived.trycloudflare.com >&2\nsleep 0.1\nexit 9\n",
+        );
+        let (url, mut tunnel) = start_cloudflare_quick_with_binary(
+            &binary,
+            "http://127.0.0.1:23456",
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(url, "https://short-lived.trycloudflare.com");
+        let error = tunnel.wait_for_exit().await.unwrap_err();
+        assert_eq!(error.code, "tunnel_unavailable");
+        assert!(error.message.contains("stopped unexpectedly"));
+    }
+}

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -6,6 +6,7 @@ pub(crate) enum ProjectCliAction {
     Doctor(project_entry::ProjectCommandOptions),
     Status(project_entry::ProjectCommandOptions),
     Run(project_entry::ProjectCommandOptions),
+    Share(project_entry::ShareCommandOptions),
     Task(task_cli::TaskCliCommand),
     Exit {
         code: i32,
@@ -41,7 +42,7 @@ impl CliCommandOutput {
 
 pub fn is_project_command(args: &[String]) -> bool {
     match args.first().map(String::as_str) {
-        Some("setup" | "doctor" | "status" | "run" | "task") => true,
+        Some("setup" | "doctor" | "status" | "run" | "share" | "task") => true,
         _ => false,
     }
 }
@@ -63,7 +64,7 @@ where
         };
     };
 
-    if matches!(command, "setup" | "doctor" | "status" | "run") {
+    if matches!(command, "setup" | "doctor" | "status" | "run" | "share") {
         if args.len() == 2 && matches!(args[1].as_str(), "--help" | "-h") {
             return ProjectCliAction::Exit {
                 code: 0,
@@ -71,14 +72,19 @@ where
                 stderr: String::new(),
             };
         }
-        return match project_entry::parse_options(&args[1..], command) {
-            Ok(options) => match command {
+        let parsed = if command == "share" {
+            project_entry::parse_share_options(&args[1..]).map(ProjectCliAction::Share)
+        } else {
+            project_entry::parse_options(&args[1..], command).map(|options| match command {
                 "setup" => ProjectCliAction::Setup(options),
                 "doctor" => ProjectCliAction::Doctor(options),
                 "status" => ProjectCliAction::Status(options),
                 "run" => ProjectCliAction::Run(options),
                 _ => unreachable!(),
-            },
+            })
+        };
+        return match parsed {
+            Ok(action) => action,
             Err(error) => ProjectCliAction::Exit {
                 code: 2,
                 stdout: String::new(),
@@ -184,6 +190,13 @@ pub async fn run_project_command(args: Vec<String>) -> CliCommandOutput {
                 format!("{}\n", project_entry::render_error(&error, false)),
             ),
         },
+        ProjectCliAction::Share(options) => match project_entry::share(&options).await {
+            Ok(()) => CliCommandOutput::success(String::new()),
+            Err(error) => CliCommandOutput::failure(
+                1,
+                format!("{}\n", project_entry::render_error(&error, false)),
+            ),
+        },
         ProjectCliAction::Task(command) => match task_cli::run(command) {
             Ok(stdout) => CliCommandOutput::success(format!("{stdout}\n")),
             Err(stderr) => CliCommandOutput::failure(1, format!("{stderr}\n")),
@@ -221,6 +234,17 @@ mod tests {
         assert!(matches!(
             project_cli_action(["run", "--root", "."]),
             ProjectCliAction::Run(_)
+        ));
+        assert!(matches!(
+            project_cli_action(["share", "--root", "."]),
+            ProjectCliAction::Share(_)
+        ));
+        assert!(matches!(
+            project_cli_action(["share", "--tunnel", "none"]),
+            ProjectCliAction::Share(project_entry::ShareCommandOptions {
+                tunnel: project_entry::TunnelProvider::None,
+                ..
+            })
         ));
     }
 


### PR DESCRIPTION
## Summary

- add `webcodex share` as the temporary local-to-hosted MCP path
- default to Cloudflare Quick Tunnel with `--tunnel cloudflare`, plus `--tunnel none` for local-only debugging
- create a per-share temporary Connector credential while preserving the persistent project credential and Agent identity
- share the existing local Server + Agent runtime lifecycle and supervise tunnel/runtime shutdown together
- document the Hosted / Local Share / Self-hosted modes in English and Chinese, including Cloudflare official install commands
- launch the companion `webcodex-server` binary explicitly for project-local runtime startup

## Validation

- `cargo test -p webcodex-cli` — 243 passed
- `cargo test -p webcodex project_entry::tests` — 33 passed
- share-focused tests — 12 passed
- `cargo check -p webcodex -p webcodex-cli`
- `cargo fmt -- --check`
- real `webcodex run` regression smoke: MCP initialize, status/doctor readiness, Ctrl-C cleanup
- real `webcodex share --tunnel none` smoke through `task_start`
- real Cloudflare Quick Tunnel E2E from `special` to remote client on `oe`: GET `/mcp`, initialize, session identity, tools/list, task_start, graceful cleanup and tunnel invalidation

## Compatibility

Existing hosted `connect`, Server/Agent management, auth, token, ops, and project command dispatch remain covered by the full `webcodex-cli` suite. The existing `webcodex run` path was also exercised with a release binary after the local-runtime refactor.