### PR TITLE
feat: complete MCP 2026 stateless tools core

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -54,6 +54,31 @@ never the persistent project Connector credential. Production enrollment,
 scoped user tokens, and OAuth are described in [AUTH_MODEL.md](AUTH_MODEL.md),
 [DEPLOYMENT.md](DEPLOYMENT.md), and [OAUTH2_SMOKE_TEST.md](OAUTH2_SMOKE_TEST.md).
 
+## Protocol Compatibility
+
+WebCodex serves the existing tools surface over two MCP protocol eras:
+
+- **MCP 2026-07-28 stateless tools core:** clients may start with `server/discover`
+  and then call `tools/list` and `tools/call` directly. Every request is
+  self-describing; WebCodex validates the 2026 protocol metadata and standard
+  `MCP-Protocol-Version`, `Mcp-Method`, and, for named requests, `Mcp-Name`
+  headers. It does not mint, consume, or echo `Mcp-Session-Id` on this path.
+- **MCP 2025-06-18 compatibility:** legacy clients continue to use
+  `initialize` / `notifications/initialized` and may retain the server-issued
+  `Mcp-Session-Id`. This path is kept for existing clients and is not silently
+  converted into the 2026 lifecycle.
+
+Both paths expose the same selected WebCodex tool surface and authorization
+rules. MCP transport state is not WebCodex application state: durable work is
+identified by explicit WebCodex handles such as `task_id`, Workflow Session IDs,
+and Job IDs.
+
+This is deliberately **2026 tools-core support**, not an implementation claim
+for every MCP 2026 extension. WebCodex does not currently advertise MCP
+resources, prompts, Tasks, Apps, MRTR, subscriptions, or other optional 2026
+extensions. Unsupported modern methods return the standard method-not-found
+response after transport metadata has been validated.
+
 ## Model Surface Selection
 
 MCP exposes one model surface selected at server startup:
@@ -96,13 +121,15 @@ task_cancel
 task_finish
 ```
 
-The same chat window continues the configured repository automatically.
-`task_start` resolves one context for that window and project without
-duplicating it; each follow-up instruction is appended to the active durable
-task.
-Switching repository connections keeps their histories isolated, and returning
-to a previous connection restores its prior task. Compatible MCP clients retain
-the protocol session automatically; users do not pass it in prompts.
+The Connector context already binds the configured repository. With legacy
+2025-06-18 clients, a retained MCP protocol session can also bind a chat window
+to its active durable task, so repeated `task_start` calls from that window can
+reuse the same task. With 2026-07-28 clients, transport requests are stateless:
+WebCodex deliberately ignores `Mcp-Session-Id`, does not derive a hidden window
+from the credential, and `task_start` returns an explicit durable `task_id`.
+Keep that handle in client/model context and use `task_resume(task_id)` when the
+application needs to restore task context explicitly. Switching repository
+connections keeps task histories isolated.
 
 The Connector context already binds the project. Start with `task_start`; do
 not call `list_projects`, `runtime_status`, `tool_manifest`, `start_session`,
@@ -114,8 +141,8 @@ applicable repository rules, and project manifests. Unchanged context is
 reused; only changed slices are reported as refreshed. If a bounded scan cannot
 prove a slice complete, the response marks it partial/unknown and includes a
 compact warning instead of claiming reuse. `task_list` and `task_resume` are
-explicit recovery tools for a client that lost its MCP transport session, not
-steps in the ordinary loop.
+explicit recovery tools when a client no longer has the application-level task
+context; they are not prerequisites for every ordinary tool call.
 
 On `local_coding`, MCP `tools/list` contains exactly the focused coding tool
 set, in this order:

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -51,6 +51,28 @@ enrollment、scoped user token 和 OAuth 见
 [DEPLOYMENT.zh-CN.md](DEPLOYMENT.zh-CN.md) 与
 [OAUTH2_SMOKE_TEST.md](OAUTH2_SMOKE_TEST.md)。
 
+## 协议兼容性
+
+WebCodex 通过两代 MCP 协议提供同一套已选择的 tools surface：
+
+- **MCP 2026-07-28 stateless tools core：** client 可以先调用 `server/discover`，
+  随后直接调用 `tools/list` 和 `tools/call`。每个请求都自描述；WebCodex
+  会校验 2026 protocol metadata，以及标准的 `MCP-Protocol-Version`、
+  `Mcp-Method`，并对带名称的请求校验 `Mcp-Name`。这条路径不会创建、消费或
+  回传 `Mcp-Session-Id`。
+- **MCP 2025-06-18 compatibility：** 旧 client 继续使用 `initialize` /
+  `notifications/initialized`，并可以保留 server 签发的 `Mcp-Session-Id`。
+  这条路径为现有 client 保留，不会静默切换成 2026 lifecycle。
+
+两条路径暴露相同的 WebCodex tool surface 与授权规则。MCP transport state 不等于
+WebCodex application state；持久工作应由显式 WebCodex handle 标识，例如
+`task_id`、Workflow Session ID 和 Job ID。
+
+这里刻意定义为 **2026 tools-core support**，不代表已经实现 MCP 2026 的全部
+extension。WebCodex 当前不发布 MCP resources、prompts、Tasks、Apps、MRTR、
+subscriptions 或其它可选 2026 extension。现代 client 调用未实现的方法时，
+WebCodex 会先完成 transport metadata 校验，再返回标准 method-not-found。
+
 ## Model surface 选择
 
 MCP 在 server 启动时选择一个 model surface：
@@ -91,10 +113,13 @@ task_cancel
 task_finish
 ```
 
-同一个聊天窗口会自动继续已配置仓库的工作。`task_start` 会为该窗口和项目解析
-唯一上下文，不创建无意义的重复任务；每条后续指令都会追加到当前持久任务。
-切换仓库连接时各仓库历史保持隔离，切回此前连接时恢复原任务。兼容的 MCP
-client 会自动保留协议 session，用户不需要在 prompt 中传入它。
+Connector context 已经绑定当前配置的仓库。对于 legacy 2025-06-18 client，
+保留的 MCP protocol session 还可以把聊天窗口绑定到当前持久任务，因此同一窗口
+重复调用 `task_start` 时可以复用任务。对于 2026-07-28 client，transport request
+是 stateless 的：WebCodex 会明确忽略 `Mcp-Session-Id`，不会从 credential 推断
+隐藏 window；`task_start` 会返回显式的持久 `task_id`。client/model 应保留这个
+handle；需要重新恢复 task context 时使用 `task_resume(task_id)`。切换仓库连接时
+各仓库的 task history 仍然彼此隔离。
 
 Connector context 已绑定项目。直接从 `task_start` 开始；不要调用
 `list_projects`、`runtime_status`、`tool_manifest`、`start_session` 或
@@ -104,8 +129,8 @@ executor reference 或 workflow session。
 复用前，WebCodex 会比较仓库实际路径、分支与 HEAD、工作区、适用的仓库规则及
 项目 manifest。未变化的上下文直接复用，只把变化部分标为已刷新。如果有界扫描
 无法证明某个 slice 完整，response 会把它标记为 partial/unknown 并返回紧凑
-warning，不会声称已经复用。`task_list` 和 `task_resume` 只用于 client 丢失 MCP
-transport session 后的显式恢复，不是普通工作流的前置步骤。
+warning，不会声称已经复用。`task_list` 和 `task_resume` 用于 client 已经没有
+application-level task context 时的显式恢复，不是每次普通 tool call 的前置步骤。
 
 在 `local_coding` 上，MCP `tools/list` 恰好包含如下聚焦 coding 工具集，且顺序
 严格一致：

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -456,19 +456,7 @@ pub(crate) fn json_error(status: StatusCode, msg: impl Into<String>) -> Json<ser
     }))
 }
 
-pub(crate) fn require_json_same_origin(
-    req: &Request,
-) -> Result<(), (u16, &'static str, &'static str)> {
-    if !req
-        .content_type()
-        .is_some_and(|content_type| content_type.essence_str() == "application/json")
-    {
-        return Err((
-            415,
-            "unsupported_media_type",
-            "Content-Type must be application/json",
-        ));
-    }
+pub(crate) fn require_same_origin(req: &Request) -> Result<(), (u16, &'static str, &'static str)> {
     if let Some(origin) = req
         .headers()
         .get("origin")
@@ -486,6 +474,23 @@ pub(crate) fn require_json_same_origin(
                 "cross-origin requests are not allowed",
             ));
         }
+    }
+    Ok(())
+}
+
+pub(crate) fn require_json_same_origin(
+    req: &Request,
+) -> Result<(), (u16, &'static str, &'static str)> {
+    require_same_origin(req)?;
+    if !req
+        .content_type()
+        .is_some_and(|content_type| content_type.essence_str() == "application/json")
+    {
+        return Err((
+            415,
+            "unsupported_media_type",
+            "Content-Type must be application/json",
+        ));
     }
     Ok(())
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -77,7 +77,7 @@ pub(crate) use middleware::{
     allow_query_token_for_path, bearer_or_allowed_query_token, bearer_token, enforce_token_surface,
     get_config, get_db, is_account_control_path, is_agent_transport_path, json_error,
     oauth_insufficient_scope_body, oauth_insufficient_scope_challenge,
-    render_oauth_insufficient_scope, require_json_same_origin, AuthMiddleware,
+    render_oauth_insufficient_scope, require_json_same_origin, require_same_origin, AuthMiddleware,
     ACCOUNT_CONTROL_PATHS, AGENT_TRANSPORT_PATHS,
 };
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -126,6 +126,20 @@ fn request_client_capabilities(params: &Value) -> Option<&Value> {
         .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
 }
 
+fn request_client_info_is_valid(params: &Value) -> bool {
+    let Some(meta) = params.get("_meta").and_then(Value::as_object) else {
+        return true;
+    };
+    let Some(client_info) = meta.get("io.modelcontextprotocol/clientInfo") else {
+        return true;
+    };
+    let Some(client_info) = client_info.as_object() else {
+        return false;
+    };
+    client_info.get("name").is_some_and(Value::is_string)
+        && client_info.get("version").is_some_and(Value::is_string)
+}
+
 fn request_header<'a>(req: &'a Request, name: &str) -> Option<&'a str> {
     req.headers()
         .get(name)
@@ -168,9 +182,7 @@ fn unsupported_protocol_version(id: Option<Value>, requested: &str) -> Value {
 }
 
 fn inferred_protocol_era(request: &JsonRpcRequest) -> McpProtocolEra {
-    if request.method == "server/discover"
-        || request_protocol_version(&request.params) == Some(MCP_STATELESS_PROTOCOL_VERSION)
-    {
+    if request_protocol_version(&request.params) == Some(MCP_STATELESS_PROTOCOL_VERSION) {
         McpProtocolEra::Stateless2026
     } else {
         McpProtocolEra::Legacy
@@ -187,14 +199,24 @@ fn validate_http_protocol(
     let header_version = request_header(req, MCP_PROTOCOL_VERSION_HEADER);
     let body_version = request_protocol_version(&request.params);
 
-    for requested in [header_version, body_version].into_iter().flatten() {
-        if !MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
-            return Err(unsupported_protocol_version(id, requested));
+    if let (Some(header), Some(body)) = (header_version, body_version) {
+        if header != body {
+            return Err(header_mismatch(
+                id.clone(),
+                format!(
+                    "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} header value '{header}' does not match params._meta protocolVersion '{body}'"
+                ),
+            ));
         }
     }
 
-    let stateless = request.method == "server/discover"
-        || header_version == Some(MCP_STATELESS_PROTOCOL_VERSION)
+    for requested in [header_version, body_version].into_iter().flatten() {
+        if !MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
+            return Err(unsupported_protocol_version(id.clone(), requested));
+        }
+    }
+
+    let stateless = header_version == Some(MCP_STATELESS_PROTOCOL_VERSION)
         || body_version == Some(MCP_STATELESS_PROTOCOL_VERSION);
     if !stateless {
         return Ok(McpProtocolEra::Legacy);
@@ -216,14 +238,21 @@ fn validate_http_protocol(
             ),
         ));
     }
-    if request.id.is_some()
-        && !request_client_capabilities(&request.params).is_some_and(Value::is_object)
-    {
-        return Err(rpc_error(
-            id,
-            -32602,
-            "Invalid params: MCP 2026-07-28 requests require params._meta clientCapabilities",
-        ));
+    if request.id.is_some() {
+        if !request_client_capabilities(&request.params).is_some_and(Value::is_object) {
+            return Err(rpc_error(
+                id.clone(),
+                -32602,
+                "Invalid params: MCP 2026-07-28 requests require params._meta clientCapabilities",
+            ));
+        }
+        if !request_client_info_is_valid(&request.params) {
+            return Err(rpc_error(
+                id,
+                -32602,
+                "Invalid params: params._meta clientInfo must contain string name and version fields when present",
+            ));
+        }
     }
 
     match request_header(req, MCP_METHOD_HEADER) {
@@ -853,7 +882,12 @@ async fn handle_mcp_request_with_lifecycle(
         return McpOutcome::Notification;
     }
 
-    if request.jsonrpc.as_deref().unwrap_or("2.0") != "2.0" {
+    let jsonrpc_valid = if stateless_2026 {
+        request.jsonrpc.as_deref() == Some("2.0")
+    } else {
+        request.jsonrpc.as_deref().unwrap_or("2.0") == "2.0"
+    };
+    if !jsonrpc_valid {
         return McpOutcome::BadRequest(rpc_error(request.id, -32600, "jsonrpc must be '2.0'"));
     }
 
@@ -867,7 +901,7 @@ async fn handle_mcp_request_with_lifecycle(
         // requests. WebCodex supports the stateless tools path required by
         // modern clients while retaining its existing 2025-06-18
         // initialize/session lifecycle for legacy clients.
-        "server/discover" => rpc_result(
+        "server/discover" if stateless_2026 => rpc_result(
             id,
             json!({
                 "resultType": "complete",

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,6 +11,7 @@ use crate::tool_runtime::kernel::{
 };
 use crate::tool_runtime::tool_definition::LOCAL_CODING_TOOL_NAMES;
 use crate::tool_runtime::{registered_tool_specs, ToolResult, ToolRuntime, ToolSpec};
+use base64::engine::general_purpose;
 use salvo::prelude::*;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -18,6 +19,13 @@ use std::sync::Arc;
 
 const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 const MCP_STATELESS_PROTOCOL_VERSION: &str = "2026-07-28";
+const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+const MCP_METHOD_HEADER: &str = "mcp-method";
+const MCP_NAME_HEADER: &str = "mcp-name";
+const MCP_HEADER_MISMATCH: i64 = -32020;
+const MCP_UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
+const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &[MCP_STATELESS_PROTOCOL_VERSION, MCP_PROTOCOL_VERSION];
 
 /// Single source of truth for the JSON-RPC methods advertised by `GET /mcp`.
 /// Must match the dispatch arms in `handle_mcp_request_with_lifecycle`;
@@ -57,6 +65,12 @@ struct McpToolCallParams {
     pub name: String,
     #[serde(default)]
     pub arguments: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpProtocolEra {
+    Legacy,
+    Stateless2026,
 }
 
 fn runtime(depot: &Depot) -> Option<Arc<ToolRuntime>> {
@@ -99,12 +113,161 @@ fn project_from_tool_call_params(params: &Value) -> Option<String> {
     params["arguments"]["project"].as_str().map(str::to_string)
 }
 
-fn request_uses_stateless_protocol(params: &Value) -> bool {
+fn request_protocol_version(params: &Value) -> Option<&str> {
     params
         .get("_meta")
         .and_then(|meta| meta.get("io.modelcontextprotocol/protocolVersion"))
         .and_then(Value::as_str)
-        == Some(MCP_STATELESS_PROTOCOL_VERSION)
+}
+
+fn request_client_capabilities(params: &Value) -> Option<&Value> {
+    params
+        .get("_meta")
+        .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
+}
+
+fn request_header<'a>(req: &'a Request, name: &str) -> Option<&'a str> {
+    req.headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+}
+
+fn decode_mcp_name_header(value: &str) -> Result<String, ()> {
+    let Some(encoded) = value
+        .strip_prefix("=?base64?")
+        .and_then(|value| value.strip_suffix("?="))
+    else {
+        return Ok(value.to_string());
+    };
+    let bytes = base64::Engine::decode(&general_purpose::STANDARD, encoded).map_err(|_| ())?;
+    String::from_utf8(bytes).map_err(|_| ())
+}
+
+fn request_mcp_name(request: &JsonRpcRequest) -> Option<Option<&str>> {
+    match request.method.as_str() {
+        "tools/call" | "prompts/get" => Some(request.params.get("name").and_then(Value::as_str)),
+        "resources/read" => Some(request.params.get("uri").and_then(Value::as_str)),
+        _ => None,
+    }
+}
+
+fn header_mismatch(id: Option<Value>, message: impl Into<String>) -> Value {
+    rpc_error(id, MCP_HEADER_MISMATCH, message)
+}
+
+fn unsupported_protocol_version(id: Option<Value>, requested: &str) -> Value {
+    rpc_error_with_data(
+        id,
+        MCP_UNSUPPORTED_PROTOCOL_VERSION,
+        format!("Unsupported MCP protocol version: {requested}"),
+        json!({
+            "supported": MCP_SUPPORTED_PROTOCOL_VERSIONS,
+            "requested": requested,
+        }),
+    )
+}
+
+fn inferred_protocol_era(request: &JsonRpcRequest) -> McpProtocolEra {
+    if request.method == "server/discover"
+        || request_protocol_version(&request.params) == Some(MCP_STATELESS_PROTOCOL_VERSION)
+    {
+        McpProtocolEra::Stateless2026
+    } else {
+        McpProtocolEra::Legacy
+    }
+}
+
+/// Validate the HTTP-only request metadata introduced by MCP 2026-07-28.
+/// Requests with no modern markers retain the existing 2025-06-18 behavior.
+fn validate_http_protocol(
+    req: &Request,
+    request: &JsonRpcRequest,
+) -> Result<McpProtocolEra, Value> {
+    let id = request.id.clone();
+    let header_version = request_header(req, MCP_PROTOCOL_VERSION_HEADER);
+    let body_version = request_protocol_version(&request.params);
+
+    for requested in [header_version, body_version].into_iter().flatten() {
+        if !MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
+            return Err(unsupported_protocol_version(id, requested));
+        }
+    }
+
+    let stateless = request.method == "server/discover"
+        || header_version == Some(MCP_STATELESS_PROTOCOL_VERSION)
+        || body_version == Some(MCP_STATELESS_PROTOCOL_VERSION);
+    if !stateless {
+        return Ok(McpProtocolEra::Legacy);
+    }
+
+    if header_version != Some(MCP_STATELESS_PROTOCOL_VERSION) {
+        return Err(header_mismatch(
+            id,
+            format!(
+                "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} is required and must equal {MCP_STATELESS_PROTOCOL_VERSION}"
+            ),
+        ));
+    }
+    if body_version != Some(MCP_STATELESS_PROTOCOL_VERSION) {
+        return Err(header_mismatch(
+            id,
+            format!(
+                "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} does not match params._meta protocolVersion"
+            ),
+        ));
+    }
+    if request.id.is_some()
+        && !request_client_capabilities(&request.params).is_some_and(Value::is_object)
+    {
+        return Err(rpc_error(
+            id,
+            -32602,
+            "Invalid params: MCP 2026-07-28 requests require params._meta clientCapabilities",
+        ));
+    }
+
+    match request_header(req, MCP_METHOD_HEADER) {
+        Some(method) if method == request.method => {}
+        Some(method) => {
+            return Err(header_mismatch(
+                id,
+                format!(
+                    "Header mismatch: Mcp-Method header value '{method}' does not match body value '{}'",
+                    request.method
+                ),
+            ));
+        }
+        None => {
+            return Err(header_mismatch(
+                id,
+                "Header mismatch: required Mcp-Method header is missing or malformed",
+            ));
+        }
+    }
+
+    if let Some(body_name) = request_mcp_name(request) {
+        let header_name = request_header(req, MCP_NAME_HEADER)
+            .and_then(|value| decode_mcp_name_header(value).ok());
+        match (header_name.as_deref(), body_name) {
+            (Some(header), Some(body)) if header == body => {}
+            (Some(header), Some(body)) => {
+                return Err(header_mismatch(
+                    id,
+                    format!(
+                        "Header mismatch: Mcp-Name header value '{header}' does not match body value '{body}'"
+                    ),
+                ));
+            }
+            _ => {
+                return Err(header_mismatch(
+                    id,
+                    "Header mismatch: required Mcp-Name header is missing, malformed, or has no matching body value",
+                ));
+            }
+        }
+    }
+
+    Ok(McpProtocolEra::Stateless2026)
 }
 
 fn mcp_stateless_result(mut result: Value, cacheable: bool) -> Value {
@@ -295,6 +458,8 @@ enum McpOutcome {
     Ok(Value),
     /// A JSON-RPC protocol error. HTTP 400 with the error body.
     BadRequest(Value),
+    /// A modern MCP method is not implemented. HTTP 404 with JSON-RPC -32601.
+    NotFound(Value),
     /// A JSON-RPC notification (request without an `id` member). Per the
     /// JSON-RPC 2.0 and MCP specs the server MUST NOT reply with a
     /// JSON-RPC response body. The HTTP wrapper acknowledges with 202 and
@@ -309,7 +474,17 @@ enum McpOutcome {
 }
 
 #[handler]
-pub async fn mcp_info(depot: &mut Depot, res: &mut Response) {
+pub async fn mcp_info(req: &mut Request, depot: &mut Depot, res: &mut Response) {
+    if let Err((status, _, message)) = crate::auth::require_same_origin(req) {
+        let status = StatusCode::from_u16(status).unwrap_or(StatusCode::FORBIDDEN);
+        res.status_code(status);
+        res.render(json_error(status, message));
+        return;
+    }
+    if request_header(req, MCP_PROTOCOL_VERSION_HEADER) == Some(MCP_STATELESS_PROTOCOL_VERSION) {
+        res.status_code(StatusCode::METHOD_NOT_ALLOWED);
+        return;
+    }
     let auth_required = crate::auth::get_config(depot)
         .map(|c| c.is_auth_enabled())
         .unwrap_or(false);
@@ -357,6 +532,28 @@ pub async fn mcp_info(depot: &mut Depot, res: &mut Response) {
 pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let mut guard = ToolRequestLifecycle::new("mcp", new_trace_id(), "-", "POST /mcp", None);
     guard.received();
+
+    if let Err((status, _, message)) = crate::auth::require_json_same_origin(req) {
+        let status = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_REQUEST);
+        guard.parsed("http_validation_error");
+        guard.response_serialized(
+            status.as_u16(),
+            None,
+            Some(false),
+            None,
+            "http_validation_error",
+        );
+        res.status_code(status);
+        res.render(json_error(status, message));
+        guard.handler_returned(
+            status.as_u16(),
+            None,
+            Some(false),
+            None,
+            "http_validation_error",
+        );
+        return;
+    }
 
     let Some(runtime) = runtime(depot) else {
         // Size unknown without building the json_error body for measurement.
@@ -411,8 +608,28 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
         None
     };
     guard.set_tool_name(tool_name.clone());
+    let protocol_era = match validate_http_protocol(req, &request) {
+        Ok(protocol_era) => protocol_era,
+        Err(body) => {
+            guard.parsed("protocol_error");
+            let estimated = estimate_json_bytes(&body);
+            guard.response_serialized(400, estimated, Some(false), None, "protocol_error");
+            res.status_code(StatusCode::BAD_REQUEST);
+            res.render(Json(body));
+            guard.handler_returned(400, estimated, Some(false), None, "protocol_error");
+            return;
+        }
+    };
     guard.parsed("ok");
-    let window = crate::client_window::mcp_window(req, request.method == "initialize");
+    let window = match protocol_era {
+        McpProtocolEra::Legacy => {
+            crate::client_window::mcp_window(req, request.method == "initialize")
+        }
+        McpProtocolEra::Stateless2026 => crate::client_window::McpWindow {
+            identity: None,
+            issued_session_id: None,
+        },
+    };
 
     // Chat-window MCP tool calls must land in the action audit exactly like
     // the REST surface (they were previously invisible there). Summary-level
@@ -452,6 +669,7 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
             connector.as_deref(),
             request,
             auth.as_ref(),
+            protocol_era,
             window.identity.as_ref(),
             Some(&mut guard),
         ),
@@ -526,6 +744,18 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
             res.render(Json(body));
             guard.handler_returned(400, estimated, Some(false), None, "bad_request");
         }
+        McpOutcome::NotFound(body) => {
+            record_audit(
+                false,
+                StatusCode::NOT_FOUND,
+                body["error"]["message"].as_str().map(str::to_string),
+            );
+            let estimated = estimate_json_bytes(&body);
+            guard.response_serialized(404, estimated, Some(false), None, "not_found");
+            res.status_code(StatusCode::NOT_FOUND);
+            res.render(Json(body));
+            guard.handler_returned(404, estimated, Some(false), None, "not_found");
+        }
         McpOutcome::Forbidden {
             body,
             required_scope,
@@ -570,7 +800,8 @@ async fn handle_mcp_request(
     request: JsonRpcRequest,
     auth: Option<&AuthContext>,
 ) -> McpOutcome {
-    handle_mcp_request_with_lifecycle(runtime, None, request, auth, None, None).await
+    let protocol_era = inferred_protocol_era(&request);
+    handle_mcp_request_with_lifecycle(runtime, None, request, auth, protocol_era, None, None).await
 }
 
 async fn handle_mcp_request_with_lifecycle(
@@ -578,18 +809,20 @@ async fn handle_mcp_request_with_lifecycle(
     connector: Option<&ConnectorRuntime>,
     request: JsonRpcRequest,
     auth: Option<&AuthContext>,
+    protocol_era: McpProtocolEra,
     window: Option<&crate::client_window::ClientWindow>,
     mut lifecycle: Option<&mut ToolRequestLifecycle>,
 ) -> McpOutcome {
     let is_oauth2 = auth.is_some_and(|ctx| ctx.is_oauth_token());
-    let stateless_2026 =
-        request.method == "server/discover" || request_uses_stateless_protocol(&request.params);
+    let stateless_2026 = protocol_era == McpProtocolEra::Stateless2026;
 
     if is_oauth2
-        && matches!(
-            request.method.as_str(),
-            "server/discover" | "initialize" | "ping" | "tools/list" | "notifications/initialized"
-        )
+        && (matches!(request.method.as_str(), "server/discover" | "tools/list")
+            || (!stateless_2026
+                && matches!(
+                    request.method.as_str(),
+                    "initialize" | "ping" | "notifications/initialized"
+                )))
     {
         if let Some(outcome) = require_mcp_oauth_scope(auth, crate::auth::SCOPE_RUNTIME_READ) {
             return outcome;
@@ -597,6 +830,7 @@ async fn handle_mcp_request_with_lifecycle(
     }
 
     if is_oauth2
+        && !stateless_2026
         && !matches!(
             request.method.as_str(),
             "server/discover"
@@ -653,7 +887,7 @@ async fn handle_mcp_request_with_lifecycle(
                 }
             }),
         ),
-        "initialize" => rpc_result(
+        "initialize" if !stateless_2026 => rpc_result(
             id,
             json!({
                 "protocolVersion": MCP_PROTOCOL_VERSION,
@@ -669,14 +903,7 @@ async fn handle_mcp_request_with_lifecycle(
                 }
             }),
         ),
-        "ping" => rpc_result(
-            id,
-            if stateless_2026 {
-                mcp_stateless_result(json!({}), false)
-            } else {
-                json!({})
-            },
-        ),
+        "ping" if !stateless_2026 => rpc_result(id, json!({})),
         "tools/list" => {
             let result = mcp_tools_list_payload(runtime.model_surface());
             rpc_result(
@@ -727,7 +954,7 @@ async fn handle_mcp_request_with_lifecycle(
             }
             if runtime.model_surface() == ModelSurface::CanonicalConnector {
                 let connector = connector.expect("validated canonical Connector state");
-                if params.name == "task_start" && window.is_none() {
+                if !stateless_2026 && params.name == "task_start" && window.is_none() {
                     if let Some(lc) = lifecycle.as_deref() {
                         lc.dispatch_failed("window_identity_unavailable");
                         lc.dispatch_finished(false, Some(false), "window_identity_unavailable");
@@ -858,13 +1085,14 @@ async fn handle_mcp_request_with_lifecycle(
                 },
             )
         }
-        "notifications/initialized" => rpc_result(id, json!({})),
+        "notifications/initialized" if !stateless_2026 => rpc_result(id, json!({})),
         _ => {
-            return McpOutcome::BadRequest(rpc_error(
-                id,
-                -32601,
-                format!("Method not found: {}", request.method),
-            ));
+            let body = rpc_error(id, -32601, format!("Method not found: {}", request.method));
+            return if stateless_2026 {
+                McpOutcome::NotFound(body)
+            } else {
+                McpOutcome::BadRequest(body)
+            };
         }
     };
     McpOutcome::Ok(response)
@@ -915,6 +1143,23 @@ fn rpc_error(id: Option<Value>, code: i64, message: impl Into<String>) -> Value 
         "error": {
             "code": code,
             "message": message.into(),
+        }
+    })
+}
+
+fn rpc_error_with_data(
+    id: Option<Value>,
+    code: i64,
+    message: impl Into<String>,
+    data: Value,
+) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id.unwrap_or(Value::Null),
+        "error": {
+            "code": code,
+            "message": message.into(),
+            "data": data,
         }
     })
 }

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -66,6 +66,20 @@ fn rpc(method: &str, id: Option<Value>, params: Value) -> JsonRpcRequest {
     }
 }
 
+fn mcp_2026_params(mut params: Value) -> Value {
+    params
+        .as_object_mut()
+        .expect("MCP params must be an object")
+        .insert(
+            "_meta".to_string(),
+            json!({
+                "io.modelcontextprotocol/protocolVersion": MCP_STATELESS_PROTOCOL_VERSION,
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }),
+        );
+    params
+}
+
 #[test]
 fn rpc_result_envelope_is_valid() {
     let value = rpc_result(Some(Value::from(1)), json!({"ok": true}));
@@ -125,6 +139,21 @@ async fn mcp_ping_returns_empty_result() {
             assert!(value["result"].as_object().unwrap().is_empty());
         }
         other => panic!("expected Ok, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn mcp_2026_ping_is_removed() {
+    let runtime = test_runtime();
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc("ping", Some(Value::from(2002)), mcp_2026_params(json!({}))),
+        None,
+    )
+    .await;
+    match outcome {
+        McpOutcome::NotFound(value) => assert_eq!(value["error"]["code"], -32601),
+        other => panic!("modern ping must be method-not-found, got {other:?}"),
     }
 }
 
@@ -1468,6 +1497,368 @@ async fn http_mcp_tools_list_success() {
 }
 
 #[tokio::test]
+async fn http_mcp_2026_validates_headers_and_ignores_legacy_session_id() {
+    let _full = full_operator_mcp_env();
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime());
+    let service = Service::new(build_test_router(config, db, runtime));
+    let params = mcp_2026_params(json!({}));
+
+    let mut missing_headers = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 200,
+            "method": "tools/list",
+            "params": params.clone()
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&missing_headers), StatusCode::BAD_REQUEST);
+    let missing_body: Value = missing_headers.take_json().await.unwrap();
+    assert_eq!(missing_body["error"]["code"], MCP_HEADER_MISMATCH);
+
+    let mut ok = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/list", true)
+        .add_header(
+            crate::client_window::MCP_SESSION_HEADER,
+            "legacy-session-must-be-ignored",
+            true,
+        )
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 201,
+            "method": "tools/list",
+            "params": params.clone()
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&ok), StatusCode::OK);
+    assert!(ok
+        .headers
+        .get(crate::client_window::MCP_SESSION_HEADER)
+        .is_none());
+    let ok_body: Value = ok.take_json().await.unwrap();
+    assert_eq!(ok_body["result"]["resultType"], "complete");
+    assert_eq!(ok_body["result"]["cacheScope"], "private");
+
+    let mut method_mismatch = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "ping", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 202,
+            "method": "tools/list",
+            "params": params.clone()
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&method_mismatch), StatusCode::BAD_REQUEST);
+    let mismatch_body: Value = method_mismatch.take_json().await.unwrap();
+    assert_eq!(mismatch_body["error"]["code"], MCP_HEADER_MISMATCH);
+
+    let mut missing_capabilities = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/list", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2021,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": MCP_STATELESS_PROTOCOL_VERSION
+                }
+            }
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(
+        effective_status(&missing_capabilities),
+        StatusCode::BAD_REQUEST
+    );
+    let missing_capabilities_body: Value = missing_capabilities.take_json().await.unwrap();
+    assert_eq!(missing_capabilities_body["error"]["code"], -32602);
+
+    let unsupported_params = json!({
+        "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2099-01-01",
+            "io.modelcontextprotocol/clientCapabilities": {}
+        }
+    });
+    let mut unsupported = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(MCP_PROTOCOL_VERSION_HEADER, "2099-01-01", true)
+        .add_header(MCP_METHOD_HEADER, "tools/list", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 203,
+            "method": "tools/list",
+            "params": unsupported_params
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&unsupported), StatusCode::BAD_REQUEST);
+    let unsupported_body: Value = unsupported.take_json().await.unwrap();
+    assert_eq!(
+        unsupported_body["error"]["code"],
+        MCP_UNSUPPORTED_PROTOCOL_VERSION
+    );
+    assert_eq!(unsupported_body["error"]["data"]["requested"], "2099-01-01");
+    assert_eq!(
+        unsupported_body["error"]["data"]["supported"],
+        json!(MCP_SUPPORTED_PROTOCOL_VERSIONS)
+    );
+}
+
+#[tokio::test]
+async fn http_mcp_2026_tools_call_requires_matching_name_and_accepts_base64_sentinel() {
+    let _full = full_operator_mcp_env();
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime());
+    let service = Service::new(build_test_router(config, db, runtime));
+    let params = mcp_2026_params(json!({"name": "list_projects", "arguments": {}}));
+
+    let mut missing_name = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 204,
+            "method": "tools/call",
+            "params": params.clone()
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&missing_name), StatusCode::BAD_REQUEST);
+    let missing_name_body: Value = missing_name.take_json().await.unwrap();
+    assert_eq!(missing_name_body["error"]["code"], MCP_HEADER_MISMATCH);
+
+    let encoded = general_purpose::STANDARD.encode("list_projects");
+    let encoded = format!("=?base64?{encoded}?=");
+    let mut ok = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .add_header(MCP_NAME_HEADER, &encoded, true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 205,
+            "method": "tools/call",
+            "params": params
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&ok), StatusCode::OK);
+    let ok_body: Value = ok.take_json().await.unwrap();
+    assert_eq!(ok_body["result"]["resultType"], "complete");
+}
+
+#[tokio::test]
+async fn http_mcp_2026_unknown_method_is_404_jsonrpc_method_not_found() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime());
+    let service = Service::new(build_test_router(config, db, runtime));
+    let mut resp = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "resources/list", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 206,
+            "method": "resources/list",
+            "params": mcp_2026_params(json!({}))
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::NOT_FOUND);
+    let body: Value = resp.take_json().await.unwrap();
+    assert_eq!(body["error"]["code"], -32601);
+}
+
+#[tokio::test]
+async fn http_mcp_2026_validates_name_header_before_rejecting_unimplemented_named_method() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime());
+    let service = Service::new(build_test_router(config, db, runtime));
+    let params = mcp_2026_params(json!({"uri": "file:///demo.txt"}));
+
+    let mut missing_name = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "resources/read", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2061,
+            "method": "resources/read",
+            "params": params.clone()
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&missing_name), StatusCode::BAD_REQUEST);
+    let missing_body: Value = missing_name.take_json().await.unwrap();
+    assert_eq!(missing_body["error"]["code"], MCP_HEADER_MISMATCH);
+
+    let mut unsupported = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "resources/read", true)
+        .add_header(MCP_NAME_HEADER, "file:///demo.txt", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2062,
+            "method": "resources/read",
+            "params": params
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&unsupported), StatusCode::NOT_FOUND);
+    let unsupported_body: Value = unsupported.take_json().await.unwrap();
+    assert_eq!(unsupported_body["error"]["code"], -32601);
+}
+
+#[tokio::test]
+async fn http_mcp_2026_rejects_legacy_lifecycle_and_cross_origin_transport() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime());
+    let service = Service::new(build_test_router(config, db, runtime));
+
+    let mut initialize = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "initialize", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 207,
+            "method": "initialize",
+            "params": mcp_2026_params(json!({}))
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&initialize), StatusCode::NOT_FOUND);
+    let initialize_body: Value = initialize.take_json().await.unwrap();
+    assert_eq!(initialize_body["error"]["code"], -32601);
+
+    let cross_origin = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/list", true)
+        .add_header("origin", "https://attacker.example", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 208,
+            "method": "tools/list",
+            "params": mcp_2026_params(json!({}))
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&cross_origin), StatusCode::FORBIDDEN);
+
+    let legacy_cross_origin = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header("origin", "https://attacker.example", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2081,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(
+        effective_status(&legacy_cross_origin),
+        StatusCode::FORBIDDEN
+    );
+
+    let legacy_cross_origin_get = TestClient::get("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header("origin", "https://attacker.example", true)
+        .send(&service)
+        .await;
+    assert_eq!(
+        effective_status(&legacy_cross_origin_get),
+        StatusCode::FORBIDDEN
+    );
+
+    let modern_get = TestClient::get("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .send(&service)
+        .await;
+    assert_eq!(
+        effective_status(&modern_get),
+        StatusCode::METHOD_NOT_ALLOWED
+    );
+
+    let modern_delete = TestClient::delete("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .send(&service)
+        .await;
+    assert_eq!(
+        effective_status(&modern_delete),
+        StatusCode::METHOD_NOT_ALLOWED
+    );
+}
+
+#[tokio::test]
 async fn http_project_connector_lists_and_dispatches_only_canonical_capabilities() {
     // A Connector test must not observe a concurrent local_coding/full-operator
     // test's WEBCODEX_MCP_MODEL_SURFACE value; hold the env lock and clear it.
@@ -1743,6 +2134,124 @@ async fn http_project_connector_lists_and_dispatches_only_canonical_capabilities
 }
 
 #[tokio::test]
+async fn http_project_connector_2026_uses_explicit_task_ids_without_transport_window_state() {
+    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
+    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
+    let config = test_config(Some("secret"));
+    let (tmp, db) = test_db();
+    let project = tmp.path().join("connector-2026-project");
+    crate::connector_runtime::tests::init_repo(&project);
+    let user_token = "webcodex_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::CanonicalConnector));
+    let service = Service::new(build_connector_test_router(config, db, runtime, &project));
+
+    let start_params = |goal: &str| {
+        mcp_2026_params(json!({
+            "name": "task_start",
+            "arguments": { "goal": goal, "mode": "read_only" }
+        }))
+    };
+
+    let mut first = TestClient::post("http://localhost/mcp")
+        .bearer_auth(user_token)
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .add_header(MCP_NAME_HEADER, "task_start", true)
+        .add_header(
+            crate::client_window::MCP_SESSION_HEADER,
+            "legacy-session-must-not-bind-2026",
+            true,
+        )
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 220,
+            "method": "tools/call",
+            "params": start_params("inspect the stateless connector path")
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&first), StatusCode::OK);
+    assert!(first
+        .headers
+        .get(crate::client_window::MCP_SESSION_HEADER)
+        .is_none());
+    let first_body: Value = first.take_json().await.unwrap();
+    let first_task_id = first_body["result"]["structuredContent"]["task_id"]
+        .as_str()
+        .expect("2026 task_start must return task_id")
+        .to_string();
+    assert!(first_task_id.starts_with("wc_task_"));
+    assert_eq!(first_body["result"]["resultType"], "complete");
+
+    let mut second = TestClient::post("http://localhost/mcp")
+        .bearer_auth(user_token)
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .add_header(MCP_NAME_HEADER, "task_start", true)
+        .add_header(
+            crate::client_window::MCP_SESSION_HEADER,
+            "legacy-session-must-not-bind-2026",
+            true,
+        )
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 221,
+            "method": "tools/call",
+            "params": start_params("start independent stateless work")
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&second), StatusCode::OK);
+    let second_body: Value = second.take_json().await.unwrap();
+    let second_task_id = second_body["result"]["structuredContent"]["task_id"]
+        .as_str()
+        .expect("second 2026 task_start must return task_id");
+    assert_ne!(
+        second_task_id, first_task_id,
+        "2026 must not derive hidden continuity from Mcp-Session-Id"
+    );
+
+    let mut resumed = TestClient::post("http://localhost/mcp")
+        .bearer_auth(user_token)
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .add_header(MCP_NAME_HEADER, "task_resume", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 222,
+            "method": "tools/call",
+            "params": mcp_2026_params(json!({
+                "name": "task_resume",
+                "arguments": { "task_id": first_task_id }
+            }))
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resumed), StatusCode::OK);
+    let resumed_body: Value = resumed.take_json().await.unwrap();
+    assert_eq!(
+        resumed_body["result"]["structuredContent"]["task_id"],
+        first_task_id
+    );
+    assert_eq!(
+        resumed_body["result"]["structuredContent"]["data"]["continuity"]["window_rebound"],
+        false
+    );
+}
+
+#[tokio::test]
 async fn http_mcp_tools_call_list_projects_returns_mcp_content() {
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
@@ -1917,8 +2426,30 @@ async fn oauth_mcp_request(
     method: &str,
     params: Value,
 ) -> (StatusCode, Value, Option<String>) {
-    let mut resp = TestClient::post("http://localhost/mcp")
-        .bearer_auth(token)
+    let stateless_2026 = method == "server/discover"
+        || request_protocol_version(&params) == Some(MCP_STATELESS_PROTOCOL_VERSION);
+    let tool_name = (method == "tools/call")
+        .then(|| {
+            params
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .flatten();
+    let mut request = TestClient::post("http://localhost/mcp").bearer_auth(token);
+    if stateless_2026 {
+        request = request
+            .add_header(
+                MCP_PROTOCOL_VERSION_HEADER,
+                MCP_STATELESS_PROTOCOL_VERSION,
+                true,
+            )
+            .add_header(MCP_METHOD_HEADER, method, true);
+        if let Some(tool_name) = tool_name.as_deref() {
+            request = request.add_header(MCP_NAME_HEADER, tool_name, true);
+        }
+    }
+    let mut resp = request
         .json(&json!({
             "jsonrpc": "2.0",
             "id": 42,
@@ -2004,14 +2535,47 @@ async fn oauth2_mcp_server_discover_requires_runtime_read_and_advertises_both_ve
     assert_eq!(body["result"]["resultType"], "complete");
 
     let (_tmp, service, token) = oauth_mcp_service("project:read");
-    let (status, body, challenge) =
-        oauth_mcp_request(&service, &token, "server/discover", json!({})).await;
+    let (status, body, challenge) = oauth_mcp_request(
+        &service,
+        &token,
+        "server/discover",
+        mcp_2026_params(json!({})),
+    )
+    .await;
     assert_mcp_oauth_scope_rejected(
         status,
         &body,
         challenge.as_deref(),
         Some(crate::auth::SCOPE_RUNTIME_READ),
     );
+}
+
+#[tokio::test]
+async fn oauth2_mcp_unknown_method_keeps_legacy_fail_closed_but_modern_returns_404() {
+    let (_tmp, service, token) = oauth_mcp_service("runtime:read");
+
+    let (legacy_status, legacy_body, legacy_challenge) =
+        oauth_mcp_request(&service, &token, "resources/list", json!({})).await;
+    assert_mcp_oauth_scope_rejected(
+        legacy_status,
+        &legacy_body,
+        legacy_challenge.as_deref(),
+        None,
+    );
+
+    let (modern_status, modern_body, _) = oauth_mcp_request(
+        &service,
+        &token,
+        "resources/list",
+        mcp_2026_params(json!({})),
+    )
+    .await;
+    assert_eq!(
+        modern_status,
+        StatusCode::NOT_FOUND,
+        "body: {modern_body:?}"
+    );
+    assert_eq!(modern_body["error"]["code"], -32601);
 }
 
 #[tokio::test]

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -161,8 +161,12 @@ async fn mcp_2026_ping_is_removed() {
 async fn mcp_info_advertised_methods_match_dispatch() {
     let runtime = test_runtime();
     for method in MCP_INFO_METHODS {
-        let outcome =
-            handle_mcp_request(&runtime, rpc(method, Some(json!(1)), json!({})), None).await;
+        let params = if *method == "server/discover" {
+            mcp_2026_params(json!({}))
+        } else {
+            json!({})
+        };
+        let outcome = handle_mcp_request(&runtime, rpc(method, Some(json!(1)), params), None).await;
         assert!(
             !matches!(&outcome, McpOutcome::BadRequest(value) if value["error"]["code"] == -32601),
             "advertised method {method} must be dispatchable"
@@ -1034,6 +1038,21 @@ async fn mcp_server_discover_advertises_modern_and_legacy_protocols() {
 }
 
 #[tokio::test]
+async fn mcp_legacy_server_discover_is_method_not_found() {
+    let runtime = test_runtime();
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc("server/discover", Some(Value::from(61)), json!({})),
+        None,
+    )
+    .await;
+    match outcome {
+        McpOutcome::BadRequest(value) => assert_eq!(value["error"]["code"], -32601),
+        other => panic!("legacy server/discover must be method-not-found, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn mcp_stateless_tools_list_uses_2026_result_shape() {
     let runtime = test_runtime();
     let outcome = handle_mcp_request(
@@ -1595,6 +1614,70 @@ async fn http_mcp_2026_validates_headers_and_ignores_legacy_session_id() {
     );
     let missing_capabilities_body: Value = missing_capabilities.take_json().await.unwrap();
     assert_eq!(missing_capabilities_body["error"]["code"], -32602);
+
+    let mut version_mismatch = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(MCP_PROTOCOL_VERSION_HEADER, "2099-01-01", true)
+        .add_header(MCP_METHOD_HEADER, "tools/list", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2022,
+            "method": "tools/list",
+            "params": params.clone()
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&version_mismatch), StatusCode::BAD_REQUEST);
+    let version_mismatch_body: Value = version_mismatch.take_json().await.unwrap();
+    assert_eq!(version_mismatch_body["error"]["code"], MCP_HEADER_MISMATCH);
+
+    let mut malformed_client_info = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/list", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2023,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": MCP_STATELESS_PROTOCOL_VERSION,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                    "io.modelcontextprotocol/clientInfo": {"name": "missing-version"}
+                }
+            }
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(
+        effective_status(&malformed_client_info),
+        StatusCode::BAD_REQUEST
+    );
+    let malformed_client_info_body: Value = malformed_client_info.take_json().await.unwrap();
+    assert_eq!(malformed_client_info_body["error"]["code"], -32602);
+
+    let mut missing_jsonrpc = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/list", true)
+        .json(&json!({
+            "id": 2024,
+            "method": "tools/list",
+            "params": params.clone()
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&missing_jsonrpc), StatusCode::BAD_REQUEST);
+    let missing_jsonrpc_body: Value = missing_jsonrpc.take_json().await.unwrap();
+    assert_eq!(missing_jsonrpc_body["error"]["code"], -32600);
 
     let unsupported_params = json!({
         "_meta": {
@@ -2426,8 +2509,7 @@ async fn oauth_mcp_request(
     method: &str,
     params: Value,
 ) -> (StatusCode, Value, Option<String>) {
-    let stateless_2026 = method == "server/discover"
-        || request_protocol_version(&params) == Some(MCP_STATELESS_PROTOCOL_VERSION);
+    let stateless_2026 = request_protocol_version(&params) == Some(MCP_STATELESS_PROTOCOL_VERSION);
     let tool_name = (method == "tools/call")
         .then(|| {
             params


### PR DESCRIPTION
## Summary

Complete the MCP 2026-07-28 stateless tools core while preserving the existing 2025-06-18 lifecycle for legacy clients.

- enforce per-request 2026 protocol metadata and standard MCP HTTP headers
- return spec-defined HeaderMismatch / UnsupportedProtocolVersion errors
- expose `server/discover`, stateless `tools/list`, and `tools/call`
- remove legacy lifecycle/session behavior from the modern path, including `initialize`, `ping`, and `Mcp-Session-Id`
- keep the existing 2025-06-18 initialize/session path unchanged
- make the canonical Connector work statelessly through explicit `task_id` continuity
- validate Origin on MCP HTTP connections
- document dual-protocol behavior and explicitly defer optional 2026 extensions

This intentionally does not add MCP Tasks, Apps, MRTR, resources/prompts, subscriptions, or other optional extensions.

## Validation

- `cargo fmt -- --check`
- `cargo check --all-targets`
- `cargo test --all-targets` - 2165 passed, 0 failed, 4 ignored
- MCP tests - 74 passed
- `webcodex-cli` tests - 243 passed
- local `webcodex share --tunnel none` dual-stack E2E:
  - legacy `initialize` / session / `tools/list` / `task_start`
  - 2026 `server/discover` / `tools/list` / `task_start` / `task_resume` with no MCP session
- current ChatGPT custom MCP OAuth refresh:
  - `server/discover -> 200`
  - `tools/list -> 200`
  - no legacy `initialize`
  - tool refresh succeeded
