### PR TITLE
test(npm): make cross-platform path assertions target-aware

### DIFF
--- a/npm/webcodex/test/self-test.js
+++ b/npm/webcodex/test/self-test.js
@@ -230,11 +230,11 @@ async function main() {
   assert.throws(() => install.platformKey("sunos", "x64"), /Unsupported/);
   assert.strictEqual(
     wrapper.nativePath({ packageRoot: "/tmp/package", platform: "linux" }),
-    path.normalize("/tmp/package/vendor/bin/webcodex")
+    path.posix.normalize("/tmp/package/vendor/bin/webcodex")
   );
   assert.strictEqual(
     wrapper.nativePath({ packageRoot: "C:\\package", platform: "win32" }),
-    path.normalize("C:\\package\\vendor\\bin\\webcodex.exe")
+    path.win32.normalize("C:\\package\\vendor\\bin\\webcodex.exe")
   );
 
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "webcodex-npm-test-"));


### PR DESCRIPTION
## Summary

Fix the v0.3.3 npm self-test so explicit target-platform path assertions use target path semantics on both Linux and Windows.

The production wrapper already correctly uses `path.posix` / `path.win32` according to the requested target platform. The remaining test expectation used host `path.normalize`, which made the Linux-target assertion fail when the test suite ran natively on Windows.

## Validation

- `npm --prefix npm/webcodex test` — PASS on OE/Linux
- `git diff --check` — PASS
- Windows distribution smoke itself already passed before this assertion was reached; native Windows npm test will be rerun after merge.

This is a post-tag test-only fix. The immutable `v0.3.3` tag remains at `777c558bec2e520a69458202307a4422261977d2` and is not moved.
