### PR TITLE
release: publish v0.3.3 artifact checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ toolchains installed on the machine that owns the project.
 
 ## Quick start
 
-Supported package platforms are Linux x64, Linux arm64, and macOS arm64. The
+Supported package platforms are Linux x64, Linux arm64, macOS arm64, and Windows x64. The
 npm installer requires Node.js 18 or newer.
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@ WebCodex 把 ChatGPT、Claude 和其他 MCP 客户端连接到你的本地仓库
 
 ## 三步开始
 
-当前 package 支持 Linux x64、Linux arm64 和 macOS arm64；npm installer 需要
+当前 package 支持 Linux x64、Linux arm64、macOS arm64 和 Windows x64；npm installer 需要
 Node.js 18 或更新版本。
 
 ```bash

--- a/docs/RELEASE_NOTES_v0.3.3.md
+++ b/docs/RELEASE_NOTES_v0.3.3.md
@@ -66,18 +66,21 @@ clients. Clients that cache tool schemas should refresh them after upgrading.
 
 ## Binary packaging
 
-The planned release artifacts are:
+The v0.3.3 release artifacts are:
 
 - `webcodex-v0.3.3-linux-x64.tar.gz`
 - `webcodex-v0.3.3-linux-arm64.tar.gz`
 - `webcodex-v0.3.3-darwin-arm64.tar.gz`
 - `webcodex-v0.3.3-win32-x64.tar.gz`
 
-Each artifact must contain `webcodex`, `webcodex-server`, and
-`webcodex-runner` built natively from the exact immutable `v0.3.3` tag. Real
-SHA-256 checksums are recorded only after the exact release assets have been
-built and verified; the npm package must not be published before those checksums
-replace the release-manifest placeholders.
+Each artifact was built natively from the exact immutable `v0.3.3` tag and
+contains the three runtime binaries (`.exe` on Windows). The SHA-256 values of
+the exact upload candidates are:
+
+- `linux-x64`: `9b41648a2ca22a2919a47fd52db8a2e9c88b605b8afc9f378929922d3227ffa4`
+- `linux-arm64`: `305eeca72321cca19632cecf9780dcb60a6719291e9ca76bb48a8b00924fb88c`
+- `darwin-arm64`: `bd2ad416d21115248a0473afb186048151de7b407bbfd8eff6f1bb60d09429eb`
+- `win32-x64`: `de44975c7abe5e3947bb486b2fe9172840dcbe3faec07633d8512b72efb790c2`
 
 ## Known limitations
 

--- a/docs/RELEASE_NOTES_v0.3.3.zh-CN.md
+++ b/docs/RELEASE_NOTES_v0.3.3.zh-CN.md
@@ -59,17 +59,20 @@ MCP 2025-06-18 initialize/session 行为继续保留。缓存 tool schema 的 cl
 
 ## Binary 打包
 
-计划发布的 artifacts：
+v0.3.3 release artifacts：
 
 - `webcodex-v0.3.3-linux-x64.tar.gz`
 - `webcodex-v0.3.3-linux-arm64.tar.gz`
 - `webcodex-v0.3.3-darwin-arm64.tar.gz`
 - `webcodex-v0.3.3-win32-x64.tar.gz`
 
-每个 artifact 都必须在对应 native release host 上从同一个不可变 `v0.3.3` tag
-构建，并包含 `webcodex`、`webcodex-server` 和 `webcodex-runner`。真实 SHA-256
-只会在 exact release assets 完成构建和验证后写入；在这些 checksum 替换 release
-manifest placeholder 之前，不得发布 npm package。
+四个 artifact 都已在对应 native release host 上从同一个不可变 `v0.3.3` tag 构建，
+并包含三项 runtime binary（Windows 为 `.exe`）。exact upload candidates 的 SHA-256：
+
+- `linux-x64`: `9b41648a2ca22a2919a47fd52db8a2e9c88b605b8afc9f378929922d3227ffa4`
+- `linux-arm64`: `305eeca72321cca19632cecf9780dcb60a6719291e9ca76bb48a8b00924fb88c`
+- `darwin-arm64`: `bd2ad416d21115248a0473afb186048151de7b407bbfd8eff6f1bb60d09429eb`
+- `win32-x64`: `de44975c7abe5e3947bb486b2fe9172840dcbe3faec07633d8512b72efb790c2`
 
 ## 已知限制
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -11,7 +11,7 @@ platforms.
 
 ### Install and connect
 
-Supported platforms are Linux x64, Linux arm64, and macOS arm64. Node.js 18 or
+Supported platforms are Linux x64, Linux arm64, macOS arm64, and Windows x64. Node.js 18 or
 newer is required by the installer wrapper.
 
 ```bash
@@ -59,7 +59,7 @@ WebCodex 让 ChatGPT、Claude 和其他 MCP client 成为连接到你自己仓�
 
 ### 安装与接入
 
-支持 Linux x64、Linux arm64 和 macOS arm64；installer wrapper 需要 Node.js 18
+支持 Linux x64、Linux arm64、macOS arm64 和 Windows x64；installer wrapper 需要 Node.js 18
 或更新版本。
 
 ```bash

--- a/npm/webcodex/manifest.json
+++ b/npm/webcodex/manifest.json
@@ -4,19 +4,19 @@
   "artifacts": {
     "linux-x64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.3/webcodex-v0.3.3-linux-x64.tar.gz",
-      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+      "sha256": "9b41648a2ca22a2919a47fd52db8a2e9c88b605b8afc9f378929922d3227ffa4"
     },
     "linux-arm64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.3/webcodex-v0.3.3-linux-arm64.tar.gz",
-      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+      "sha256": "305eeca72321cca19632cecf9780dcb60a6719291e9ca76bb48a8b00924fb88c"
     },
     "darwin-arm64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.3/webcodex-v0.3.3-darwin-arm64.tar.gz",
-      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+      "sha256": "bd2ad416d21115248a0473afb186048151de7b407bbfd8eff6f1bb60d09429eb"
     },
     "win32-x64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.3/webcodex-v0.3.3-win32-x64.tar.gz",
-      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+      "sha256": "de44975c7abe5e3947bb486b2fe9172840dcbe3faec07633d8512b72efb790c2"
     }
   }
 }


### PR DESCRIPTION
## Summary

Record the exact native v0.3.3 release artifact checksums after building all four platforms from the immutable `v0.3.3` tag, and update the published platform lists to include Windows x64.

Artifacts were built natively on Special (Linux x64), Orb (Linux arm64), Mini (macOS arm64), and MSI (Windows x64). The tag remains fixed at `777c558bec2e520a69458202307a4422261977d2`.

## SHA-256

- linux-x64: `9b41648a2ca22a2919a47fd52db8a2e9c88b605b8afc9f378929922d3227ffa4`
- linux-arm64: `305eeca72321cca19632cecf9780dcb60a6719291e9ca76bb48a8b00924fb88c`
- darwin-arm64: `bd2ad416d21115248a0473afb186048151de7b407bbfd8eff6f1bb60d09429eb`
- win32-x64: `de44975c7abe5e3947bb486b2fe9172840dcbe3faec07633d8512b72efb790c2`

## Validation

- exact archive SHA-256 rechecked on OE — PASS
- archive contents — exactly three runtime binaries per platform
- release manifest publish check — PASS
- `npm --prefix npm/webcodex test` — PASS
- Markdown local links — 74 files / 437 local links / 0 missing
- `git diff --check` — PASS
- Windows native distribution smoke — PASS
- Windows native npm test — PASS

`manifest.example.json` intentionally keeps placeholder checksums as the publish-gate negative fixture.
