### PR TITLE
runner: harden polling and websocket proxy transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ toolchains installed on the machine that owns the project.
 Supported package platforms are Linux x64, Linux arm64, macOS arm64, and Windows x64. The
 npm installer requires Node.js 18 or newer.
 
+Pick the path that matches how you want to run WebCodex:
+
+| Goal | Start here |
+| --- | --- |
+| Use an existing hosted Server | Install WebCodex, then run `webcodex connect <server>` in the repository. |
+| Temporarily expose one local project | Run `webcodex share`; it starts a local Server + Runner and a Cloudflare Quick Tunnel. |
+| Run your own long-lived Server | Deploy the server-only Docker/Compose stack, put a stable HTTPS domain or named tunnel in front of it, then enroll each repository machine as a Runner. |
+
+### Hosted Server: connect one project
+
 ```bash
 npm install -g @yyjeqhc/webcodex
 cd /path/to/your/repository
@@ -130,15 +140,21 @@ the actual work on the machine that owns the repository. Repositories and local
 toolchains stay on that Runner host; only the requested tool inputs and results
 travel through the connection.
 
-## Choose a setup
+## Long-lived self-hosting
 
-| Goal | Recommended path |
-| --- | --- |
-| Connect one project through the hosted service | Use `webcodex connect <server>`. Only the Runner runs locally. |
-| Temporarily expose the current local project to ChatGPT/MCP | Use `webcodex share`; it starts local Server + Agent and a temporary Quick Tunnel. |
-| Keep everything local without public access | Use `webcodex setup` + `webcodex run` (or `webcodex share --tunnel none` for share debugging). |
-| Run a stable long-lived deployment | Self-host the Server with a stable HTTPS domain/tunnel, service management, and OAuth as needed. |
-| Use managed users, device enrollment, revocation, and audit | Use `webcodex login` and the managed deployment flow. |
+A durable personal deployment keeps the Server separate from the machines that own your
+repositories:
+
+1. Deploy the server-only Docker/Compose stack on an always-on Linux host.
+2. Publish it through a stable HTTPS hostname. Nginx is supported; a named Cloudflare Tunnel
+   or another durable reverse tunnel can also route the hostname to the loopback Server.
+   Cloudflare Quick Tunnel (`trycloudflare.com`) is only for temporary development/testing.
+3. Create a short-lived pairing code on the Server.
+4. On each workstation/server that owns repositories, run `webcodex login`, then install its
+   generated Runner profile as a user service.
+
+This gives ChatGPT/MCP one stable `/mcp` endpoint while files, Git state, compilers, and other
+local toolchains stay on the Runner machines.
 
 ## Self-host the Server with Docker
 
@@ -178,6 +194,12 @@ webcodex agent status --scope user \
 
 See [Build and Install](docs/BUILD_INSTALL.md#runner-service-scopes) for system
 services and advanced overrides.
+
+If a Runner host needs an outbound HTTP proxy, make the proxy variables available to the
+Runner process/service. WebSocket honors `HTTPS_PROXY` / `HTTP_PROXY`, `ALL_PROXY`, and
+`NO_PROXY` (including lowercase forms); the supported proxy transport is HTTP `CONNECT`.
+See [Agent transports](docs/AGENT_TRANSPORTS.md) for precedence, limitations, and fallback
+behavior.
 
 ## Client access
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,10 +20,20 @@ WebCodex 把 ChatGPT、Claude 和其他 MCP 客户端连接到你的本地仓库
 | --- | --- |
 | ![MCP 会话](docs/assets/mcp-1.png) | ![WebCodex console](docs/assets/gpt-action-1.png) |
 
-## 三步开始
+## 快速开始
 
 当前 package 支持 Linux x64、Linux arm64、macOS arm64 和 Windows x64；npm installer 需要
 Node.js 18 或更新版本。
+
+先按实际部署方式选择入口：
+
+| 目标 | 从这里开始 |
+| --- | --- |
+| 使用已有 hosted Server | 安装 WebCodex，然后在仓库中运行 `webcodex connect <server>`。 |
+| 临时把一个本地项目接给 ChatGPT/MCP | 使用 `webcodex share`，自动启动本地 Server + Runner 与 Cloudflare Quick Tunnel。 |
+| 长期运行自己的 Server | 部署 server-only Docker/Compose，在前面配置 stable HTTPS domain 或 named tunnel，再把每台持有仓库的机器 enrollment 为 Runner。 |
+
+### Hosted Server：接入一个项目
 
 ```bash
 npm install -g @yyjeqhc/webcodex
@@ -121,15 +131,20 @@ Server 负责连接、凭据和工具请求协调；真正的文件、Git 和命
 Runner 机器完成。仓库和本地工具链留在 Runner 主机上，连接中只传输当前工具调用
 所需的输入与结果。
 
-## 选择接入方式
+## 长期自托管
 
-| 目标 | 推荐方式 |
-| --- | --- |
-| 通过 hosted 服务接入一个项目 | 使用 `webcodex connect <server>`，本地只运行 Runner。 |
-| 临时把当前本地项目接给 ChatGPT/MCP client | 使用 `webcodex share`，启动本地 Server + Agent 与临时 Quick Tunnel。 |
-| 保持纯本地、不开放公网 | 使用 `webcodex setup` + `webcodex run`（share 调试也可用 `--tunnel none`）。 |
-| 长期稳定部署 | 自托管 Server，并配置 stable HTTPS domain/tunnel、service 与按需 OAuth。 |
-| 需要用户、设备 enrollment、撤销和审计 | 使用 managed `webcodex login` 流程。 |
+稳定的个人部署应把 Server 与真正持有仓库的机器分开：
+
+1. 在常在线 Linux 主机上部署 server-only Docker/Compose。
+2. 为 Server 提供稳定 HTTPS hostname。可以使用 Nginx，也可以使用 named Cloudflare
+   Tunnel 或其他长期 reverse tunnel，把公网 hostname 转发到 loopback Server。
+   `trycloudflare.com` Quick Tunnel 只用于临时开发/测试。
+3. 在 Server 上创建短期 pairing code。
+4. 在每台真正持有仓库的工作站/服务器上运行 `webcodex login`，再把生成的 Runner
+   profile 安装成 user service。
+
+这样 ChatGPT/MCP 只需要一个稳定 `/mcp` endpoint，而仓库、Git 状态、编译器和本地
+工具链都继续留在各 Runner 机器上。
 
 ## 使用 Docker 自托管 Server
 
@@ -167,6 +182,11 @@ webcodex agent status --scope user \
 
 System service 与高级覆盖参数见
 [构建与安装](docs/BUILD_INSTALL.zh-CN.md#runner-service-scope)。
+
+如果 Runner 所在网络需要出站 HTTP proxy，应把代理环境变量传给 Runner process/service。
+WebSocket 会遵循 `HTTPS_PROXY` / `HTTP_PROXY`、`ALL_PROXY` 与 `NO_PROXY`
+（也支持对应小写变量）；当前支持的代理传输是 HTTP `CONNECT`。变量优先级、限制和
+fallback 行为见 [Agent transport](docs/AGENT_TRANSPORTS.zh-CN.md)。
 
 ## 接入客户端
 

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -4223,6 +4223,7 @@ fn handle_one_poll(
     jobs: &JobManager,
     persistent_shells: &webcodex_runner::PersistentShellManager,
     project_cache: &mut AgentProjectCache,
+    poll_projects: Option<Vec<ShellAgentProjectSummary>>,
     agent_instance_id: &str,
     lsp: &webcodex_runner::LspSupervisor,
     shutdown: &Arc<AtomicBool>,
@@ -4247,7 +4248,7 @@ fn handle_one_poll(
         request: ShellAgentPollRequest {
             client_id: cfg.client_id.clone(),
             agent_instance_id: agent_instance_id.to_string(),
-            projects: Some(project_cache.get_with_shutdown(cfg, Some(shutdown.as_ref()))),
+            projects: poll_projects,
         },
         tool_providers: provider_update
             .as_ref()

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -696,6 +696,10 @@ impl AgentProjectCache {
         self.projects.clone()
     }
 
+    pub(crate) fn needs_refresh(&self) -> bool {
+        self.refreshed_at.is_none()
+    }
+
     pub(crate) fn invalidate(&mut self) {
         self.projects.clear();
         self.refreshed_at = None;

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -38,6 +38,9 @@ use std::time::{Duration, Instant};
 pub(crate) const WS_OUTGOING_CAPACITY: usize = 64;
 /// WebSocket ping interval.
 const WS_PING_INTERVAL: Duration = Duration::from_secs(30);
+/// HTTP CONNECT response headers are read one byte at a time so no tunneled
+/// WebSocket bytes can be over-read or lost before tungstenite takes ownership.
+const WS_PROXY_CONNECT_HEADER_MAX_BYTES: usize = 16 * 1024;
 /// Bounded reconnect backoff after a transport disconnect or transient error.
 const RECONNECT_BACKOFF_STEPS: [Duration; 5] = [
     Duration::from_secs(1),
@@ -80,6 +83,19 @@ const POLLING_RECOVERY_BACKOFF_STEPS: [Duration; 5] = [
     Duration::from_secs(5),
     Duration::from_secs(10),
 ];
+/// Empty successful polls back off independently from transient transport
+/// recovery. The configured poll interval remains the minimum; the built-in
+/// progression stops at 5 seconds so idle dispatch latency stays well below
+/// the Server's 30-second default synchronous tool wait.
+const POLLING_IDLE_BACKOFF_STEPS: [Duration; 3] = [
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+];
+/// Polling periodically refreshes the Server's project projection so external
+/// projects.d and Git metadata changes remain discoverable without attaching
+/// the full inventory to every poll.
+const POLLING_PROJECT_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 /// The current server contract keeps an active polling instance online for
 /// 60 seconds. Permit one lease window plus scheduling slack during deployment
 /// replacement, but do not let a real duplicate runner retry forever.
@@ -428,12 +444,17 @@ fn complete_polling_shutdown(runtime: &AgentRuntimeState) -> Result<(), String> 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AgentTransportError {
     Transient(String),
+    ProxyConfiguration(String),
     Fatal(String),
 }
 
 impl AgentTransportError {
     fn transient(message: impl Into<String>) -> Self {
         Self::Transient(message.into())
+    }
+
+    fn proxy_configuration(message: impl Into<String>) -> Self {
+        Self::ProxyConfiguration(message.into())
     }
 
     fn fatal(message: impl Into<String>) -> Self {
@@ -444,9 +465,15 @@ impl AgentTransportError {
         matches!(self, Self::Fatal(_))
     }
 
+    fn is_proxy_configuration(&self) -> bool {
+        matches!(self, Self::ProxyConfiguration(_))
+    }
+
     fn into_message(self) -> String {
         match self {
-            Self::Transient(message) | Self::Fatal(message) => message,
+            Self::Transient(message) | Self::ProxyConfiguration(message) | Self::Fatal(message) => {
+                message
+            }
         }
     }
 }
@@ -454,8 +481,16 @@ impl AgentTransportError {
 impl fmt::Display for AgentTransportError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Transient(message) | Self::Fatal(message) => f.write_str(message),
+            Self::Transient(message) | Self::ProxyConfiguration(message) | Self::Fatal(message) => {
+                f.write_str(message)
+            }
         }
+    }
+}
+
+impl From<String> for AgentTransportError {
+    fn from(message: String) -> Self {
+        classify_session_error(message)
     }
 }
 
@@ -1199,6 +1234,87 @@ pub(crate) fn auto_transport_plan(cfg: &AgentConfig) -> Vec<&'static str> {
 }
 
 #[derive(Debug, Clone)]
+struct PollingIdleBackoff {
+    initial: Duration,
+    next_step: usize,
+    first: bool,
+}
+
+impl PollingIdleBackoff {
+    fn new(initial: Duration) -> Self {
+        Self {
+            initial,
+            next_step: 0,
+            first: true,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.next_step = 0;
+        self.first = true;
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        if self.first {
+            self.first = false;
+            return self.initial;
+        }
+        while let Some(step) = POLLING_IDLE_BACKOFF_STEPS.get(self.next_step).copied() {
+            self.next_step += 1;
+            if step > self.initial {
+                return step;
+            }
+        }
+        self.initial.max(
+            *POLLING_IDLE_BACKOFF_STEPS
+                .last()
+                .expect("polling idle backoff is non-empty"),
+        )
+    }
+}
+
+fn polling_idle_delay(backoff: &mut PollingIdleBackoff, ran_request: bool) -> Option<Duration> {
+    if ran_request {
+        backoff.reset();
+        None
+    } else {
+        Some(backoff.next_delay())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PollingProjectRefresh {
+    last_sent_at: Instant,
+}
+
+impl PollingProjectRefresh {
+    fn new(now: Instant) -> Self {
+        Self { last_sent_at: now }
+    }
+
+    fn mark_sent(&mut self, now: Instant) {
+        self.last_sent_at = now;
+    }
+
+    fn should_refresh(&self, project_cache: &AgentProjectCache, now: Instant) -> bool {
+        project_cache.needs_refresh()
+            || now.saturating_duration_since(self.last_sent_at) >= POLLING_PROJECT_REFRESH_INTERVAL
+    }
+}
+
+fn polling_projects_for_poll(
+    refresh: &PollingProjectRefresh,
+    project_cache: &mut AgentProjectCache,
+    cfg: &AgentConfig,
+    shutdown: &AtomicBool,
+    now: Instant,
+) -> Option<Vec<ShellAgentProjectSummary>> {
+    refresh
+        .should_refresh(project_cache, now)
+        .then(|| project_cache.get_with_shutdown(cfg, Some(shutdown)))
+}
+
+#[derive(Debug, Clone)]
 struct RetryBackoff {
     attempts: usize,
     steps: &'static [Duration],
@@ -1317,7 +1433,7 @@ fn decide_stream_session(
     mode: StreamSupervisorMode,
     transport: StreamTransport,
     once: bool,
-    result: Result<AgentSessionExit, String>,
+    result: Result<AgentSessionExit, AgentTransportError>,
 ) -> StreamSessionDecision {
     match result {
         Ok(AgentSessionExit::Shutdown) => StreamSessionDecision::Complete { shutdown: true },
@@ -1326,8 +1442,14 @@ fn decide_stream_session(
             StreamSessionDecision::Complete { shutdown: false }
         }
         Ok(AgentSessionExit::TransportDisconnected) => StreamSessionDecision::Reconnect(None),
+        Err(error) if error.is_proxy_configuration() => {
+            if matches!(mode, StreamSupervisorMode::Strict(_)) {
+                StreamSessionDecision::Fatal(error.into_message())
+            } else {
+                StreamSessionDecision::TryNext(error)
+            }
+        }
         Err(error) => {
-            let error = classify_session_error(error);
             if error.is_fatal()
                 || matches!(mode, StreamSupervisorMode::Strict(_)) && once
                 || mode == StreamSupervisorMode::Auto
@@ -1365,14 +1487,14 @@ async fn run_stream_session(
     agent_instance_id: &str,
     once: bool,
     runtime: &AgentRuntimeState,
-) -> Result<AgentSessionExit, String> {
+) -> Result<AgentSessionExit, AgentTransportError> {
     match transport {
         StreamTransport::WebSocket => {
-            websocket_session(cfg, projects, agent_instance_id, runtime).await
+            websocket_session_classified(cfg, projects, agent_instance_id, runtime).await
         }
-        StreamTransport::Quic => {
-            quic_session(cfg, projects, agent_instance_id, once, runtime).await
-        }
+        StreamTransport::Quic => quic_session(cfg, projects, agent_instance_id, once, runtime)
+            .await
+            .map_err(classify_session_error),
     }
 }
 
@@ -1609,6 +1731,8 @@ fn run_polling_agent_with_shutdown(
         .map_err(|e| format!("failed to create http client: {}", e))?;
     let jobs = runtime.jobs.clone();
     let mut project_cache = AgentProjectCache::default();
+    let mut idle_backoff = PollingIdleBackoff::new(Duration::from_millis(cfg.poll_interval_ms));
+    let mut project_refresh = PollingProjectRefresh::new(Instant::now());
     let mut polling_dispatches = PollingDispatchSupervisor::new(
         Arc::clone(&runtime.background_threads),
         runtime.dispatches.clone(),
@@ -1662,6 +1786,8 @@ fn run_polling_agent_with_shutdown(
                     registered = true;
                     lease_conflict_started = None;
                     recovery_backoff.reset();
+                    idle_backoff.reset();
+                    project_refresh.mark_sent(Instant::now());
                     let sink = AgentSink::Http(HttpSendConfig {
                         client: client.clone(),
                         server_url: cfg.server_url.clone(),
@@ -1763,6 +1889,14 @@ fn run_polling_agent_with_shutdown(
                 &mut project_cache,
             );
         }
+        let poll_projects = polling_projects_for_poll(
+            &project_refresh,
+            &mut project_cache,
+            &cfg,
+            shutdown.as_ref(),
+            Instant::now(),
+        );
+        let sent_project_refresh = poll_projects.is_some();
         let mut poll_result = handle_one_poll(
             &client,
             &cfg,
@@ -1770,6 +1904,7 @@ fn run_polling_agent_with_shutdown(
             &jobs,
             &runtime.persistent_shells,
             &mut project_cache,
+            poll_projects,
             agent_instance_id,
             &runtime.lsp,
             &shutdown,
@@ -1784,9 +1919,13 @@ fn run_polling_agent_with_shutdown(
         }
         match poll_result {
             Ok(ran_request) => {
+                if sent_project_refresh {
+                    project_refresh.mark_sent(Instant::now());
+                }
                 recovery_backoff.reset();
                 lease_conflict_started = None;
                 if recovering {
+                    idle_backoff.reset();
                     eprintln!(
                         "webcodex-runner polling recovery succeeded phase=poll client_id={}",
                         concise_log_error(&cfg.client_id, &cfg.token)
@@ -1809,11 +1948,8 @@ fn run_polling_agent_with_shutdown(
                     }
                     return Ok(());
                 }
-                if !ran_request {
-                    if sleep_or_shutdown(
-                        Duration::from_millis(cfg.poll_interval_ms),
-                        shutdown.as_ref(),
-                    ) {
+                if let Some(delay) = polling_idle_delay(&mut idle_backoff, ran_request) {
+                    if sleep_or_shutdown(delay, shutdown.as_ref()) {
                         return complete_polling_after_shutdown(
                             runtime,
                             &mut polling_dispatches,
@@ -2569,6 +2705,338 @@ pub(crate) fn build_ws_request(
     Ok(request)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HttpProxyEndpoint {
+    host: String,
+    port: u16,
+}
+
+fn first_nonempty_env_value_with<F>(names: &[&str], get_env: &mut F) -> Option<std::ffi::OsString>
+where
+    F: FnMut(&str) -> Option<std::ffi::OsString>,
+{
+    names.iter().find_map(|name| {
+        get_env(name).and_then(|value| {
+            if value.as_os_str().is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        })
+    })
+}
+
+fn split_no_proxy_host_port(entry: &str) -> (&str, Option<u16>) {
+    if let Some(rest) = entry.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            let host = &rest[..end];
+            let suffix = &rest[end + 1..];
+            if suffix.is_empty() {
+                return (host, None);
+            }
+            if let Some(port) = suffix
+                .strip_prefix(':')
+                .and_then(|value| value.parse().ok())
+            {
+                return (host, Some(port));
+            }
+            return (entry, None);
+        }
+    }
+    if entry.bytes().filter(|byte| *byte == b':').count() == 1 {
+        if let Some((host, port)) = entry.rsplit_once(':') {
+            if let Ok(port) = port.parse::<u16>() {
+                return (host, Some(port));
+            }
+        }
+    }
+    (entry, None)
+}
+
+fn no_proxy_entry_matches(entry: &str, target_host: &str, target_port: u16) -> bool {
+    let entry = entry.trim();
+    if entry.is_empty() {
+        return false;
+    }
+    if entry == "*" {
+        return true;
+    }
+    let (pattern, port) = split_no_proxy_host_port(entry);
+    if port.is_some_and(|port| port != target_port) {
+        return false;
+    }
+    let pattern = pattern
+        .trim()
+        .trim_end_matches('.')
+        .strip_prefix("*.")
+        .unwrap_or(pattern.trim().trim_end_matches('.'))
+        .trim_start_matches('.');
+    if pattern.is_empty() {
+        return false;
+    }
+    let target_host = target_host.trim_end_matches('.');
+    if let Ok(pattern_ip) = pattern.parse::<std::net::IpAddr>() {
+        return target_host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|target_ip| target_ip == pattern_ip);
+    }
+    if pattern.eq_ignore_ascii_case("localhost") {
+        return target_host.eq_ignore_ascii_case("localhost");
+    }
+    let target = target_host.to_ascii_lowercase();
+    let pattern = pattern.to_ascii_lowercase();
+    target == pattern
+        || target
+            .strip_suffix(&pattern)
+            .is_some_and(|prefix| prefix.ends_with('.'))
+}
+
+fn no_proxy_matches(no_proxy: &str, target_host: &str, target_port: u16) -> bool {
+    no_proxy
+        .split(',')
+        .any(|entry| no_proxy_entry_matches(entry, target_host, target_port))
+}
+
+fn canonical_url_host(parsed: &url::Url) -> Option<String> {
+    match parsed.host()? {
+        url::Host::Domain(host) => (!host.is_empty()).then(|| host.to_string()),
+        url::Host::Ipv4(host) => Some(host.to_string()),
+        url::Host::Ipv6(host) => Some(host.to_string()),
+    }
+}
+
+fn parse_http_proxy_endpoint(raw: &str) -> Result<HttpProxyEndpoint, AgentTransportError> {
+    let parsed = url::Url::parse(raw.trim()).map_err(|_| {
+        AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy configuration is invalid",
+        )
+    })?;
+    if parsed.scheme() != "http" {
+        return Err(AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy scheme is unsupported",
+        ));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy authentication is unsupported",
+        ));
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() || !matches!(parsed.path(), "" | "/")
+    {
+        return Err(AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy URL options are unsupported",
+        ));
+    }
+    let host = canonical_url_host(&parsed).ok_or_else(|| {
+        AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy configuration is invalid",
+        )
+    })?;
+    let port = parsed.port_or_known_default().ok_or_else(|| {
+        AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy configuration is invalid",
+        )
+    })?;
+    Ok(HttpProxyEndpoint { host, port })
+}
+
+fn websocket_proxy_from_env_with<F>(
+    ws_url: &str,
+    mut get_env: F,
+) -> Result<Option<HttpProxyEndpoint>, AgentTransportError>
+where
+    F: FnMut(&str) -> Option<std::ffi::OsString>,
+{
+    let target = url::Url::parse(ws_url).map_err(|_| {
+        AgentTransportError::fatal("websocket connect failed: websocket target is invalid")
+    })?;
+    let proxy_names: &[&str] = match target.scheme() {
+        "wss" => &["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"],
+        "ws" => &["HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"],
+        _ => {
+            return Err(AgentTransportError::fatal(
+                "websocket connect failed: websocket target scheme is invalid",
+            ));
+        }
+    };
+    let Some(proxy_raw) = first_nonempty_env_value_with(proxy_names, &mut get_env) else {
+        return Ok(None);
+    };
+    let target_host = canonical_url_host(&target).ok_or_else(|| {
+        AgentTransportError::fatal("websocket connect failed: websocket target is invalid")
+    })?;
+    let target_port = target.port_or_known_default().ok_or_else(|| {
+        AgentTransportError::fatal("websocket connect failed: websocket target is invalid")
+    })?;
+    if let Some(no_proxy_raw) =
+        first_nonempty_env_value_with(&["NO_PROXY", "no_proxy"], &mut get_env)
+    {
+        let no_proxy = no_proxy_raw.into_string().map_err(|_| {
+            AgentTransportError::proxy_configuration(
+                "websocket connect failed: NO_PROXY configuration is invalid",
+            )
+        })?;
+        if no_proxy_matches(&no_proxy, &target_host, target_port) {
+            return Ok(None);
+        }
+    }
+    let proxy = proxy_raw.into_string().map_err(|_| {
+        AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy configuration is invalid",
+        )
+    })?;
+    parse_http_proxy_endpoint(&proxy).map(Some)
+}
+
+fn websocket_proxy_from_env(
+    ws_url: &str,
+) -> Result<Option<HttpProxyEndpoint>, AgentTransportError> {
+    websocket_proxy_from_env_with(ws_url, |name| std::env::var_os(name))
+}
+
+fn target_authority(host: &str, port: u16) -> String {
+    if host.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+fn websocket_target_endpoint(ws_url: &str) -> Result<(String, u16), AgentTransportError> {
+    let target = url::Url::parse(ws_url).map_err(|_| {
+        AgentTransportError::fatal("websocket connect failed: websocket target is invalid")
+    })?;
+    let host = canonical_url_host(&target).ok_or_else(|| {
+        AgentTransportError::fatal("websocket connect failed: websocket target is invalid")
+    })?;
+    let port = target.port_or_known_default().ok_or_else(|| {
+        AgentTransportError::fatal("websocket connect failed: websocket target is invalid")
+    })?;
+    Ok((host, port))
+}
+
+async fn http_proxy_connect_tunnel(
+    proxy: &HttpProxyEndpoint,
+    target_host: &str,
+    target_port: u16,
+) -> Result<tokio::net::TcpStream, AgentTransportError> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut stream = tokio::net::TcpStream::connect((proxy.host.as_str(), proxy.port))
+        .await
+        .map_err(|_| {
+            AgentTransportError::transient("websocket connect failed: proxy TCP connect failed")
+        })?;
+    let authority = target_authority(target_host, target_port);
+    let request = format!(
+        "CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\nConnection: keep-alive\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).await.map_err(|_| {
+        AgentTransportError::transient("websocket connect failed: proxy CONNECT write failed")
+    })?;
+
+    let mut headers = Vec::with_capacity(1024);
+    loop {
+        if headers.len() >= WS_PROXY_CONNECT_HEADER_MAX_BYTES {
+            return Err(AgentTransportError::transient(format!(
+                "websocket connect failed: proxy CONNECT response headers exceeded {} bytes",
+                WS_PROXY_CONNECT_HEADER_MAX_BYTES
+            )));
+        }
+        let mut byte = [0u8; 1];
+        let read = stream.read(&mut byte).await.map_err(|_| {
+            AgentTransportError::transient("websocket connect failed: proxy CONNECT read failed")
+        })?;
+        if read == 0 {
+            return Err(AgentTransportError::transient(
+                "websocket connect failed: proxy CONNECT response was malformed",
+            ));
+        }
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    let headers = std::str::from_utf8(&headers).map_err(|_| {
+        AgentTransportError::transient(
+            "websocket connect failed: proxy CONNECT response was malformed",
+        )
+    })?;
+    let status_line = headers.split("\r\n").next().ok_or_else(|| {
+        AgentTransportError::transient(
+            "websocket connect failed: proxy CONNECT response was malformed",
+        )
+    })?;
+    let mut parts = status_line.split_whitespace();
+    let version = parts
+        .next()
+        .filter(|version| version.starts_with("HTTP/"))
+        .ok_or_else(|| {
+            AgentTransportError::transient(
+                "websocket connect failed: proxy CONNECT response was malformed",
+            )
+        })?;
+    let _ = version;
+    let status = parts
+        .next()
+        .and_then(|status| status.parse::<u16>().ok())
+        .ok_or_else(|| {
+            AgentTransportError::transient(
+                "websocket connect failed: proxy CONNECT response was malformed",
+            )
+        })?;
+    if status == 407 {
+        return Err(AgentTransportError::proxy_configuration(
+            "websocket connect failed: proxy CONNECT returned HTTP 407",
+        ));
+    }
+    if !(200..300).contains(&status) {
+        return Err(AgentTransportError::transient(format!(
+            "websocket connect failed: proxy CONNECT returned HTTP {status}"
+        )));
+    }
+    Ok(stream)
+}
+
+async fn connect_websocket_request_with_proxy(
+    request: tokio_tungstenite::tungstenite::http::Request<()>,
+    ws_url: &str,
+    proxy: Option<&HttpProxyEndpoint>,
+    token: &str,
+) -> Result<RunnerWebSocket, AgentTransportError> {
+    let Some(proxy) = proxy else {
+        return tokio_tungstenite::connect_async(request)
+            .await
+            .map(|(stream, _)| stream)
+            .map_err(|error| {
+                classify_session_error(format!(
+                    "websocket connect failed: {}",
+                    concise_log_error(&error.to_string(), token)
+                ))
+            });
+    };
+    let (target_host, target_port) = websocket_target_endpoint(ws_url)?;
+    let stream = http_proxy_connect_tunnel(proxy, &target_host, target_port).await?;
+    tokio_tungstenite::client_async_tls_with_config(request, stream, None, None)
+        .await
+        .map(|(stream, _)| stream)
+        .map_err(|error| {
+            classify_session_error(format!(
+                "websocket connect failed: {}",
+                concise_log_error(&error.to_string(), token)
+            ))
+        })
+}
+
+async fn connect_websocket_request(
+    request: tokio_tungstenite::tungstenite::http::Request<()>,
+    ws_url: &str,
+    token: &str,
+) -> Result<RunnerWebSocket, AgentTransportError> {
+    let proxy = websocket_proxy_from_env(ws_url)?;
+    connect_websocket_request_with_proxy(request, ws_url, proxy.as_ref(), token).await
+}
+
 fn run_websocket_agent(
     cfg: AgentConfig,
     once: bool,
@@ -2587,12 +3055,24 @@ fn run_websocket_agent(
 
 /// One WebSocket connection lifecycle: connect, register, then serve requests
 /// until the socket closes or a fatal server error arrives.
+#[cfg(test)]
 pub(crate) async fn websocket_session(
     cfg: &AgentConfig,
     projects: Vec<ShellAgentProjectSummary>,
     agent_instance_id: &str,
     runtime: &AgentRuntimeState,
 ) -> Result<AgentSessionExit, String> {
+    websocket_session_classified(cfg, projects, agent_instance_id, runtime)
+        .await
+        .map_err(AgentTransportError::into_message)
+}
+
+async fn websocket_session_classified(
+    cfg: &AgentConfig,
+    projects: Vec<ShellAgentProjectSummary>,
+    agent_instance_id: &str,
+    runtime: &AgentRuntimeState,
+) -> Result<AgentSessionExit, AgentTransportError> {
     websocket_session_with_shutdown(
         cfg,
         projects,
@@ -2609,7 +3089,7 @@ async fn websocket_session_with_shutdown<F>(
     agent_instance_id: &str,
     runtime: &AgentRuntimeState,
     shutdown: F,
-) -> Result<AgentSessionExit, String>
+) -> Result<AgentSessionExit, AgentTransportError>
 where
     F: std::future::Future<Output = ()>,
 {
@@ -2622,21 +3102,19 @@ where
     let connect = tokio::select! {
         result = tokio::time::timeout(
             Duration::from_secs(cfg.websocket_connect_timeout_secs),
-            tokio_tungstenite::connect_async(request),
+            connect_websocket_request(request, &ws_url, &cfg.token),
         ) => result,
         _ = &mut shutdown => {
             runtime.request_shutdown_signal();
             return Ok(AgentSessionExit::Shutdown);
         }
     };
-    let (mut ws_stream, _resp) = connect
-        .map_err(|_| {
-            format!(
-                "websocket connect timed out after {}s",
-                cfg.websocket_connect_timeout_secs
-            )
-        })?
-        .map_err(|e| format!("websocket connect failed: {}", e))?;
+    let mut ws_stream = connect.map_err(|_| {
+        format!(
+            "websocket connect timed out after {}s",
+            cfg.websocket_connect_timeout_secs
+        )
+    })??;
 
     // Register over the socket. The prepared-profile cache is empty at
     // registration time (snapshots are prepared lazily on first use), so
@@ -2733,6 +3211,7 @@ where
         shutdown,
     )
     .await
+    .map_err(classify_session_error)
 }
 
 #[cfg(test)]

--- a/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
@@ -248,6 +248,22 @@ fn read_http_request(stream: &mut TcpStream) -> String {
     String::from_utf8_lossy(&buf).into_owned()
 }
 
+async fn read_async_http_headers(stream: &mut tokio::net::TcpStream) -> String {
+    use tokio::io::AsyncReadExt;
+
+    let mut bytes = Vec::new();
+    loop {
+        assert!(bytes.len() < 64 * 1024, "test HTTP header exceeded bound");
+        let mut byte = [0u8; 1];
+        let read = stream.read(&mut byte).await.unwrap();
+        assert!(read > 0, "peer closed before HTTP headers completed");
+        bytes.push(byte[0]);
+        if bytes.ends_with(b"\r\n\r\n") {
+            return String::from_utf8(bytes).unwrap();
+        }
+    }
+}
+
 fn request_path(request: &str) -> &str {
     request
         .lines()
@@ -1489,6 +1505,13 @@ fn polling_background_project_operation_invalidates_the_project_cache() {
             "/api/shell/agent/register" => register_success_response(),
             "/api/shell/agent/poll" => {
                 let payload: serde_json::Value = serde_json::from_str(body).unwrap();
+                let index = poll_count.fetch_add(1, Ordering::SeqCst);
+                if index == 0 {
+                    assert!(
+                        payload["projects"].is_null(),
+                        "ordinary poll immediately after register must omit projects"
+                    );
+                }
                 let refreshed = payload["projects"].as_array().is_some_and(|projects| {
                     projects.iter().any(|project| project["id"] == "e1-project")
                 });
@@ -1499,7 +1522,6 @@ fn polling_background_project_operation_invalidates_the_project_cache() {
                     let _ = refreshed_tx.send(());
                     runner_shutdown.store(true, Ordering::SeqCst);
                 }
-                let index = poll_count.fetch_add(1, Ordering::SeqCst);
                 poll_delivery_response((index == 0).then_some(&request))
             }
             "/api/shell/agent/result" => {
@@ -2906,6 +2928,42 @@ fn reconnect_backoff_is_bounded_exponential() {
 }
 
 #[test]
+fn polling_idle_backoff_progression_cap_and_request_reset() {
+    let mut backoff = PollingIdleBackoff::new(Duration::from_secs(1));
+    assert_eq!(
+        polling_idle_delay(&mut backoff, false),
+        Some(Duration::from_secs(1))
+    );
+    assert_eq!(
+        polling_idle_delay(&mut backoff, false),
+        Some(Duration::from_secs(2))
+    );
+    assert_eq!(
+        polling_idle_delay(&mut backoff, false),
+        Some(Duration::from_secs(5))
+    );
+    assert_eq!(
+        polling_idle_delay(&mut backoff, false),
+        Some(Duration::from_secs(5))
+    );
+
+    assert_eq!(polling_idle_delay(&mut backoff, true), None);
+    assert_eq!(
+        polling_idle_delay(&mut backoff, false),
+        Some(Duration::from_secs(1))
+    );
+
+    let mut custom = PollingIdleBackoff::new(Duration::from_secs(3));
+    assert_eq!(custom.next_delay(), Duration::from_secs(3));
+    assert_eq!(custom.next_delay(), Duration::from_secs(5));
+    assert_eq!(custom.next_delay(), Duration::from_secs(5));
+
+    let mut above_default_cap = PollingIdleBackoff::new(Duration::from_secs(60));
+    assert_eq!(above_default_cap.next_delay(), Duration::from_secs(60));
+    assert_eq!(above_default_cap.next_delay(), Duration::from_secs(60));
+}
+
+#[test]
 fn polling_recovery_backoff_is_bounded_and_resets() {
     let mut backoff = RetryBackoff::new(&POLLING_RECOVERY_BACKOFF_STEPS);
     assert_eq!(backoff.next_delay(), Duration::from_millis(500));
@@ -2938,6 +2996,10 @@ fn polling_lease_conflict_retry_has_a_finite_total_wait() {
 fn transport_error_classification_separates_transient_and_fatal() {
     let transient = classify_session_error("websocket connect failed: connection refused");
     assert!(!transient.is_fatal(), "{transient}");
+
+    let proxy_network =
+        AgentTransportError::transient("websocket connect failed: proxy TCP connect failed");
+    assert!(matches!(proxy_network, AgentTransportError::Transient(_)));
 
     let fatal = classify_session_error("register rejected by server: unauthorized");
     assert!(fatal.is_fatal(), "{fatal}");
@@ -2979,7 +3041,7 @@ fn stream_supervisor_once_semantics_are_explicit_and_shared() {
                 StreamSupervisorMode::Strict(transport),
                 transport,
                 true,
-                Err("connection refused".to_string()),
+                Err(classify_session_error("connection refused")),
             ),
             StreamSessionDecision::Fatal(error) if error == "connection refused"
         ));
@@ -2990,7 +3052,7 @@ fn stream_supervisor_once_semantics_are_explicit_and_shared() {
             StreamSupervisorMode::Auto,
             StreamTransport::Quic,
             true,
-            Err("connection refused".to_string()),
+            Err(classify_session_error("connection refused")),
         ),
         StreamSessionDecision::TryNext(AgentTransportError::Transient(error))
             if error == "connection refused"
@@ -3000,7 +3062,7 @@ fn stream_supervisor_once_semantics_are_explicit_and_shared() {
             StreamSupervisorMode::Auto,
             StreamTransport::WebSocket,
             true,
-            Err("connection refused".to_string()),
+            Err(classify_session_error("connection refused")),
         ),
         StreamSessionDecision::Fatal(error) if error == "connection refused"
     ));
@@ -3023,7 +3085,7 @@ fn stream_supervisor_reconnect_and_auto_fallback_semantics_are_shared() {
                 StreamSupervisorMode::Strict(transport),
                 transport,
                 false,
-                Err("connection refused".to_string()),
+                Err(classify_session_error("connection refused")),
             ),
             StreamSessionDecision::Reconnect(Some(AgentTransportError::Transient(error)))
                 if error == "connection refused"
@@ -3042,7 +3104,7 @@ fn stream_supervisor_reconnect_and_auto_fallback_semantics_are_shared() {
                 StreamSupervisorMode::Auto,
                 transport,
                 false,
-                Err("connection refused".to_string()),
+                Err(classify_session_error("connection refused")),
             ),
             StreamSessionDecision::TryNext(AgentTransportError::Transient(error))
                 if error == "connection refused"
@@ -3052,11 +3114,93 @@ fn stream_supervisor_reconnect_and_auto_fallback_semantics_are_shared() {
                 StreamSupervisorMode::Auto,
                 transport,
                 false,
-                Err("register rejected by server: unauthorized".to_string()),
+                Err(classify_session_error(
+                    "register rejected by server: unauthorized",
+                )),
             ),
             StreamSessionDecision::Fatal(error) if error.contains("register rejected")
         ));
     }
+}
+
+#[test]
+fn websocket_proxy_configuration_errors_are_mode_sensitive() {
+    let unsupported = parse_http_proxy_endpoint("socks5://proxy.test:1080")
+        .expect_err("unsupported proxy scheme must fail configuration");
+    assert!(matches!(
+        decide_stream_session(
+            StreamSupervisorMode::Strict(StreamTransport::WebSocket),
+            StreamTransport::WebSocket,
+            false,
+            Err(unsupported),
+        ),
+        StreamSessionDecision::Fatal(error) if error.contains("proxy scheme is unsupported")
+    ));
+
+    let auth = parse_http_proxy_endpoint("http://proxy-user:proxy-pass@proxy.test:8080")
+        .expect_err("proxy auth URL must fail configuration");
+    assert!(matches!(
+        decide_stream_session(
+            StreamSupervisorMode::Strict(StreamTransport::WebSocket),
+            StreamTransport::WebSocket,
+            false,
+            Err(auth),
+        ),
+        StreamSessionDecision::Fatal(error) if error.contains("proxy authentication is unsupported")
+    ));
+
+    let unsupported = parse_http_proxy_endpoint("socks5://proxy.test:1080")
+        .expect_err("unsupported proxy scheme must fail configuration");
+    assert!(matches!(
+        decide_stream_session(
+            StreamSupervisorMode::Auto,
+            StreamTransport::WebSocket,
+            false,
+            Err(unsupported),
+        ),
+        StreamSessionDecision::TryNext(AgentTransportError::ProxyConfiguration(error))
+            if error.contains("proxy scheme is unsupported")
+    ));
+
+    let proxy_auth_required = AgentTransportError::proxy_configuration(
+        "websocket connect failed: proxy CONNECT returned HTTP 407",
+    );
+    assert!(matches!(
+        decide_stream_session(
+            StreamSupervisorMode::Strict(StreamTransport::WebSocket),
+            StreamTransport::WebSocket,
+            false,
+            Err(proxy_auth_required),
+        ),
+        StreamSessionDecision::Fatal(error) if error.contains("HTTP 407")
+    ));
+
+    let proxy_auth_required = AgentTransportError::proxy_configuration(
+        "websocket connect failed: proxy CONNECT returned HTTP 407",
+    );
+    assert!(matches!(
+        decide_stream_session(
+            StreamSupervisorMode::Auto,
+            StreamTransport::WebSocket,
+            false,
+            Err(proxy_auth_required),
+        ),
+        StreamSessionDecision::TryNext(AgentTransportError::ProxyConfiguration(error))
+            if error.contains("HTTP 407")
+    ));
+
+    let network =
+        AgentTransportError::transient("websocket connect failed: proxy TCP connect failed");
+    assert!(matches!(
+        decide_stream_session(
+            StreamSupervisorMode::Strict(StreamTransport::WebSocket),
+            StreamTransport::WebSocket,
+            false,
+            Err(network),
+        ),
+        StreamSessionDecision::Reconnect(Some(AgentTransportError::Transient(error)))
+            if error.contains("proxy TCP connect failed")
+    ));
 }
 
 #[test]
@@ -3217,6 +3361,68 @@ fn polling_idle_empty_response_remains_successful_once() {
 }
 
 #[test]
+fn polling_register_sends_projects_and_ordinary_poll_omits_them() {
+    let server = start_scripted_agent_server(vec![ScriptStep::Register, ScriptStep::PollEmpty]);
+    run_polling_agent_against_scripted_server(&server, false)
+        .expect("empty polling turn should stop cleanly with scripted shutdown");
+    server.handle.join().unwrap();
+
+    let requests = server.requests.lock().unwrap();
+    let register: serde_json::Value = serde_json::from_str(&requests[0].1).unwrap();
+    let poll: serde_json::Value = serde_json::from_str(&requests[1].1).unwrap();
+    assert!(
+        register["projects"].is_array(),
+        "register must send full projects"
+    );
+    assert!(
+        poll["projects"].is_null(),
+        "ordinary poll must omit project refresh"
+    );
+}
+
+#[test]
+fn polling_project_refresh_is_periodic_and_invalidation_is_immediate() {
+    let temp = tempfile::tempdir().unwrap();
+    let cfg = polling_agent_config(
+        "http://127.0.0.1:1".to_string(),
+        temp.path().join("projects.d"),
+    );
+    let shutdown = AtomicBool::new(false);
+    let mut project_cache = AgentProjectCache::default();
+    let start = Instant::now();
+    let _ = project_cache.get_with_shutdown(&cfg, Some(&shutdown));
+    let mut refresh = PollingProjectRefresh::new(start);
+
+    assert!(polling_projects_for_poll(
+        &refresh,
+        &mut project_cache,
+        &cfg,
+        &shutdown,
+        start + POLLING_PROJECT_REFRESH_INTERVAL - Duration::from_millis(1),
+    )
+    .is_none());
+    assert!(polling_projects_for_poll(
+        &refresh,
+        &mut project_cache,
+        &cfg,
+        &shutdown,
+        start + POLLING_PROJECT_REFRESH_INTERVAL,
+    )
+    .is_some());
+
+    refresh.mark_sent(start + POLLING_PROJECT_REFRESH_INTERVAL);
+    project_cache.invalidate();
+    assert!(polling_projects_for_poll(
+        &refresh,
+        &mut project_cache,
+        &cfg,
+        &shutdown,
+        start + POLLING_PROJECT_REFRESH_INTERVAL + Duration::from_millis(1),
+    )
+    .is_some());
+}
+
+#[test]
 fn polling_shutdown_interrupts_retry_sleep() {
     let shutdown = Arc::new(AtomicBool::new(false));
     let trigger = Arc::clone(&shutdown);
@@ -3231,6 +3437,422 @@ fn polling_shutdown_interrupts_retry_sleep() {
         started.elapsed() < Duration::from_millis(500),
         "shutdown-aware polling sleep did not return promptly"
     );
+}
+
+#[test]
+fn websocket_proxy_env_precedence_and_no_proxy_bypass() {
+    use std::ffi::OsString;
+
+    let values = std::collections::HashMap::from([
+        (
+            "HTTPS_PROXY",
+            OsString::from("http://https-upper.test:8001"),
+        ),
+        (
+            "https_proxy",
+            OsString::from("http://https-lower.test:8002"),
+        ),
+        ("HTTP_PROXY", OsString::from("http://http-upper.test:8003")),
+        ("http_proxy", OsString::from("http://http-lower.test:8004")),
+        ("ALL_PROXY", OsString::from("http://all-upper.test:8005")),
+        ("all_proxy", OsString::from("http://all-lower.test:8006")),
+    ]);
+    let wss =
+        websocket_proxy_from_env_with("wss://example.test/ws", |name| values.get(name).cloned())
+            .unwrap()
+            .unwrap();
+    assert_eq!(wss.host, "https-upper.test");
+    assert_eq!(wss.port, 8001);
+    let ws =
+        websocket_proxy_from_env_with("ws://example.test/ws", |name| values.get(name).cloned())
+            .unwrap()
+            .unwrap();
+    assert_eq!(ws.host, "http-upper.test");
+    assert_eq!(ws.port, 8003);
+
+    let fallback_values = std::collections::HashMap::from([
+        (
+            "https_proxy",
+            OsString::from("http://https-lower-only.test:8101"),
+        ),
+        ("ALL_PROXY", OsString::from("http://all-fallback.test:8102")),
+    ]);
+    let wss = websocket_proxy_from_env_with("wss://example.test/ws", |name| {
+        fallback_values.get(name).cloned()
+    })
+    .unwrap()
+    .unwrap();
+    assert_eq!(wss.host, "https-lower-only.test");
+    assert_eq!(wss.port, 8101);
+
+    let all_only = std::collections::HashMap::from([(
+        "all_proxy",
+        OsString::from("http://all-lower-only.test:8103"),
+    )]);
+    let ws =
+        websocket_proxy_from_env_with("ws://example.test/ws", |name| all_only.get(name).cloned())
+            .unwrap()
+            .unwrap();
+    assert_eq!(ws.host, "all-lower-only.test");
+    assert_eq!(ws.port, 8103);
+
+    for (url, no_proxy, bypass) in [
+        ("ws://localhost/ws", "localhost", true),
+        ("ws://127.0.0.1/ws", "127.0.0.1", true),
+        ("wss://api.example.com/ws", "api.example.com", true),
+        ("wss://deep.example.com/ws", ".example.com", true),
+        (
+            "wss://api.example.com:8443/ws",
+            "api.example.com:8443",
+            true,
+        ),
+        ("wss://api.example.com/ws", "api.example.com:8443", false),
+        ("wss://anything.test/ws", "*", true),
+    ] {
+        let values = std::collections::HashMap::from([
+            ("HTTP_PROXY", OsString::from("http://proxy.test:8080")),
+            ("HTTPS_PROXY", OsString::from("http://proxy.test:8080")),
+            ("NO_PROXY", OsString::from(no_proxy)),
+        ]);
+        let selected =
+            websocket_proxy_from_env_with(url, |name| values.get(name).cloned()).unwrap();
+        assert_eq!(selected.is_none(), bypass, "url={url} no_proxy={no_proxy}");
+    }
+
+    let lower_no_proxy = std::collections::HashMap::from([
+        ("HTTP_PROXY", OsString::from("http://proxy.test:8080")),
+        ("no_proxy", OsString::from("localhost")),
+    ]);
+    assert!(websocket_proxy_from_env_with("ws://localhost/ws", |name| {
+        lower_no_proxy.get(name).cloned()
+    })
+    .unwrap()
+    .is_none());
+}
+
+#[test]
+fn websocket_proxy_ipv6_hosts_are_canonical() {
+    use std::ffi::OsString;
+
+    let proxy = parse_http_proxy_endpoint("http://[::1]:8080").unwrap();
+    assert_eq!(proxy.host, "::1");
+    assert_eq!(proxy.port, 8080);
+
+    let (target_host, target_port) =
+        websocket_target_endpoint("wss://[2001:db8::1]/api/agents/ws").unwrap();
+    assert_eq!(target_host, "2001:db8::1");
+    assert_eq!(target_port, 443);
+    let authority = target_authority(&target_host, target_port);
+    assert_eq!(authority, "[2001:db8::1]:443");
+    assert!(!authority.contains("[["), "{authority}");
+
+    let values = std::collections::HashMap::from([
+        ("HTTP_PROXY", OsString::from("http://proxy.test:8080")),
+        ("NO_PROXY", OsString::from("::1")),
+    ]);
+    assert!(
+        websocket_proxy_from_env_with("ws://[::1]/api/agents/ws", |name| {
+            values.get(name).cloned()
+        })
+        .unwrap()
+        .is_none()
+    );
+}
+
+#[test]
+fn websocket_proxy_invalid_configuration_is_sanitized() {
+    use std::ffi::OsString;
+
+    let proxy_secret = "PROXY_PASSWORD_DO_NOT_LEAK";
+    let query_secret = "PROXY_QUERY_DO_NOT_LEAK";
+    let raw = format!("http://proxy-user:{proxy_secret}@proxy.test:8080/?token={query_secret}");
+    let values = std::collections::HashMap::from([("HTTP_PROXY", OsString::from(raw))]);
+    let error =
+        websocket_proxy_from_env_with("ws://server.test/ws", |name| values.get(name).cloned())
+            .expect_err("credentialed proxy URL is intentionally unsupported");
+    assert!(matches!(error, AgentTransportError::ProxyConfiguration(_)));
+    let error = error.to_string();
+    assert!(
+        error.contains("proxy authentication is unsupported"),
+        "{error}"
+    );
+    assert!(!error.contains("proxy-user"), "{error}");
+    assert!(!error.contains(proxy_secret), "{error}");
+    assert!(!error.contains(query_secret), "{error}");
+}
+
+#[tokio::test]
+async fn websocket_http_proxy_connect_tunnels_websocket_handshake() {
+    use tokio::io::AsyncWriteExt;
+
+    let target_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target_listener.local_addr().unwrap();
+    let seen_auth = Arc::new(Mutex::new(None::<String>));
+    let server_seen_auth = Arc::clone(&seen_auth);
+    let target = tokio::spawn(async move {
+        let (stream, _) = target_listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_hdr_async(
+            stream,
+            move |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                  response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+            *server_seen_auth.lock().unwrap() = request
+                .headers()
+                .get(tokio_tungstenite::tungstenite::http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
+            Ok(response)
+        })
+        .await
+        .unwrap();
+        let _ = ws.send(WsMessage::Close(None)).await;
+    });
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy = tokio::spawn(async move {
+        let (mut downstream, _) = proxy_listener.accept().await.unwrap();
+        let connect = read_async_http_headers(&mut downstream).await;
+        let expected = format!("CONNECT {target_addr} HTTP/1.1");
+        assert!(connect.starts_with(&expected), "{connect}");
+        assert!(
+            !connect.to_ascii_lowercase().contains("authorization:"),
+            "{connect}"
+        );
+        assert!(!connect.contains("SERVER_TOKEN_DO_NOT_LEAK"), "{connect}");
+        let mut upstream = tokio::net::TcpStream::connect(target_addr).await.unwrap();
+        downstream
+            .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            .await
+            .unwrap();
+        let _ = tokio::io::copy_bidirectional(&mut downstream, &mut upstream).await;
+        connect
+    });
+
+    let token = "SERVER_TOKEN_DO_NOT_LEAK";
+    let ws_url = format!("ws://{target_addr}/api/agents/ws");
+    let request = build_ws_request(&ws_url, token).unwrap();
+    let endpoint = HttpProxyEndpoint {
+        host: "127.0.0.1".to_string(),
+        port: proxy_addr.port(),
+    };
+    let ws = tokio::time::timeout(
+        Duration::from_secs(5),
+        connect_websocket_request_with_proxy(request, &ws_url, Some(&endpoint), token),
+    )
+    .await
+    .expect("proxy websocket connect timed out")
+    .expect("proxy websocket connect failed");
+    drop(ws);
+
+    let connect = tokio::time::timeout(Duration::from_secs(5), proxy)
+        .await
+        .expect("proxy tunnel task did not finish")
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(5), target)
+        .await
+        .expect("target websocket task did not finish")
+        .unwrap();
+    assert!(connect.starts_with(&format!("CONNECT {target_addr} HTTP/1.1")));
+    assert_eq!(
+        seen_auth.lock().unwrap().as_deref(),
+        Some("Bearer SERVER_TOKEN_DO_NOT_LEAK")
+    );
+}
+
+#[tokio::test]
+async fn websocket_proxy_ipv6_target_connect_authority_has_single_brackets() {
+    use tokio::io::AsyncWriteExt;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let proxy = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let connect = read_async_http_headers(&mut stream).await;
+        assert!(
+            connect.starts_with("CONNECT [2001:db8::1]:443 HTTP/1.1"),
+            "{connect}"
+        );
+        assert!(!connect.contains("[[2001:db8::1]]"), "{connect}");
+        stream
+            .write_all(b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+        connect
+    });
+
+    let ws_url = "wss://[2001:db8::1]/api/agents/ws";
+    let request = build_ws_request(ws_url, "SERVER_TOKEN_DO_NOT_LEAK").unwrap();
+    let endpoint = HttpProxyEndpoint {
+        host: "127.0.0.1".to_string(),
+        port: addr.port(),
+    };
+    let error = connect_websocket_request_with_proxy(
+        request,
+        ws_url,
+        Some(&endpoint),
+        "SERVER_TOKEN_DO_NOT_LEAK",
+    )
+    .await
+    .expect_err("synthetic proxy must reject the IPv6 target");
+    let connect = proxy.await.unwrap();
+
+    assert!(connect.starts_with("CONNECT [2001:db8::1]:443 HTTP/1.1"));
+    assert!(
+        matches!(error, AgentTransportError::Transient(_)),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn websocket_wss_proxy_uses_connect_before_target_tls() {
+    use tokio::io::AsyncWriteExt;
+
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let server_token = "SERVER_TOKEN_DO_NOT_LEAK";
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy = tokio::spawn(async move {
+        let (mut stream, _) = proxy_listener.accept().await.unwrap();
+        let connect = read_async_http_headers(&mut stream).await;
+        assert!(
+            connect.starts_with("CONNECT server.test:443 HTTP/1.1"),
+            "{connect}"
+        );
+        assert!(
+            !connect.to_ascii_lowercase().contains("authorization:"),
+            "{connect}"
+        );
+        assert!(!connect.contains(server_token), "{connect}");
+        stream
+            .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            .await
+            .unwrap();
+        connect
+    });
+
+    let ws_url = "wss://server.test/api/agents/ws";
+    let request = build_ws_request(ws_url, server_token).unwrap();
+    let endpoint = HttpProxyEndpoint {
+        host: "127.0.0.1".to_string(),
+        port: proxy_addr.port(),
+    };
+    let error = tokio::time::timeout(
+        Duration::from_secs(5),
+        connect_websocket_request_with_proxy(request, ws_url, Some(&endpoint), server_token),
+    )
+    .await
+    .expect("wss proxy CONNECT test timed out")
+    .expect_err("the synthetic tunnel closes before target TLS can complete");
+    let connect = proxy.await.unwrap();
+
+    assert!(connect.starts_with("CONNECT server.test:443 HTTP/1.1"));
+    let error = error.to_string();
+    assert!(error.contains("websocket connect failed"), "{error}");
+    assert!(!error.contains(server_token), "{error}");
+}
+
+#[tokio::test]
+async fn websocket_proxy_network_failure_remains_transient() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let peer = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        drop(stream);
+    });
+    let endpoint = HttpProxyEndpoint {
+        host: "127.0.0.1".to_string(),
+        port: addr.port(),
+    };
+    let error = http_proxy_connect_tunnel(&endpoint, "server.test", 443)
+        .await
+        .expect_err("closed proxy connection must fail");
+    peer.await.unwrap();
+    assert!(
+        matches!(error, AgentTransportError::Transient(_)),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn websocket_proxy_connect_rejects_non_success_without_leaking_secrets() {
+    use tokio::io::AsyncWriteExt;
+
+    let proxy_secret = "PROXY_RESPONSE_SECRET_DO_NOT_LEAK";
+    let server_token = "SERVER_TOKEN_DO_NOT_LEAK";
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let proxy = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let connect = read_async_http_headers(&mut stream).await;
+        assert!(!connect.contains(server_token), "{connect}");
+        let response = format!(
+            "HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: {}\r\n\r\n{}",
+            proxy_secret.len(),
+            proxy_secret
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let ws_url = "ws://127.0.0.1:9/api/agents/ws";
+    let request = build_ws_request(ws_url, server_token).unwrap();
+    let endpoint = HttpProxyEndpoint {
+        host: "127.0.0.1".to_string(),
+        port: addr.port(),
+    };
+    let error = tokio::time::timeout(
+        Duration::from_secs(5),
+        connect_websocket_request_with_proxy(request, ws_url, Some(&endpoint), server_token),
+    )
+    .await
+    .expect("non-success CONNECT test timed out")
+    .expect_err("non-2xx CONNECT status must fail");
+    proxy.await.unwrap();
+    assert!(
+        matches!(&error, AgentTransportError::ProxyConfiguration(_)),
+        "{error}"
+    );
+    let error = error.to_string();
+    assert!(error.contains("HTTP 407"), "{error}");
+    assert!(!error.contains(proxy_secret), "{error}");
+    assert!(!error.contains(server_token), "{error}");
+}
+
+#[tokio::test]
+async fn websocket_proxy_connect_response_header_is_bounded_and_redacted() {
+    use tokio::io::AsyncWriteExt;
+
+    let proxy_secret = "PROXY_RESPONSE_SECRET_DO_NOT_LEAK";
+    let server_token = "SERVER_TOKEN_DO_NOT_LEAK";
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let proxy = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let connect = read_async_http_headers(&mut stream).await;
+        assert!(!connect.contains(server_token), "{connect}");
+        let mut response = format!("HTTP/1.1 200 OK\r\nX-Secret: {proxy_secret}\r\n").into_bytes();
+        response.extend(std::iter::repeat(b'x').take(WS_PROXY_CONNECT_HEADER_MAX_BYTES + 1024));
+        let _ = stream.write_all(&response).await;
+    });
+
+    let ws_url = "ws://127.0.0.1:9/api/agents/ws";
+    let request = build_ws_request(ws_url, server_token).unwrap();
+    let endpoint = HttpProxyEndpoint {
+        host: "127.0.0.1".to_string(),
+        port: addr.port(),
+    };
+    let error = tokio::time::timeout(
+        Duration::from_secs(5),
+        connect_websocket_request_with_proxy(request, ws_url, Some(&endpoint), server_token),
+    )
+    .await
+    .expect("bounded CONNECT response test timed out")
+    .expect_err("oversized CONNECT headers must fail");
+    proxy.await.unwrap();
+    let error = error.to_string();
+    assert!(error.contains("response headers exceeded"), "{error}");
+    assert!(!error.contains(proxy_secret), "{error}");
+    assert!(!error.contains(server_token), "{error}");
 }
 
 #[tokio::test]

--- a/docs/AGENT_TRANSPORTS.md
+++ b/docs/AGENT_TRANSPORTS.md
@@ -76,6 +76,8 @@ keepalive_interval_secs = 20
 
 `auto` attempts QUIC first when `[quic]` is present. If QUIC cannot connect, it tries WebSocket, then polling. When `[quic]` is absent, the agent logs that QUIC is not configured and starts with WebSocket. `websocket_connect_timeout_secs` bounds only the WebSocket connect attempt; timeout fallback to polling is normal in networks that block WebSocket.
 
+WebSocket connections honor proxy environment variables. `wss://` uses `HTTPS_PROXY` / `https_proxy` and then `ALL_PROXY` / `all_proxy`; `ws://` uses `HTTP_PROXY` / `http_proxy` and then `ALL_PROXY` / `all_proxy`. `NO_PROXY` / `no_proxy` bypasses the proxy for matching localhost, IP, hostname/domain suffix, host:port, or `*` entries. The current Runner supports `http://host:port` proxies through HTTP `CONNECT`; HTTPS proxies, SOCKS, and proxy authentication are not supported and fail closed rather than silently connecting directly. The WebSocket connect timeout covers proxy TCP connect, CONNECT, target TLS, and the WebSocket handshake. QUIC does not use these proxy settings.
+
 Use strict QUIC when you want connection failures to stay failures instead of falling back:
 
 ```toml

--- a/docs/AGENT_TRANSPORTS.zh-CN.md
+++ b/docs/AGENT_TRANSPORTS.zh-CN.md
@@ -72,6 +72,8 @@ keepalive_interval_secs = 20
 
 当 `[quic]` 存在时，`auto` 会先尝试 QUIC。如果 QUIC 连接失败，会尝试 WebSocket，然后 polling。
 
+WebSocket 连接会遵循代理环境变量。`wss://` 依次使用 `HTTPS_PROXY` / `https_proxy`、`ALL_PROXY` / `all_proxy`；`ws://` 依次使用 `HTTP_PROXY` / `http_proxy`、`ALL_PROXY` / `all_proxy`。`NO_PROXY` / `no_proxy` 可按 localhost、IP、hostname/domain suffix、host:port 或 `*` 绕过代理。当前 Runner 仅支持通过 HTTP `CONNECT` 使用 `http://host:port` proxy；不支持 HTTPS proxy、SOCKS 或 proxy authentication，遇到这些配置会 fail closed，不会偷偷 direct-connect。`websocket_connect_timeout_secs` 同时覆盖 proxy TCP connect、CONNECT、目标站 TLS 和 WebSocket handshake。QUIC 不使用这些 proxy 设置。
+
 如果希望连接失败保持失败、不要自动 fallback，可以使用 strict QUIC：
 
 ```toml

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -275,13 +275,21 @@ Use separate server/runtime instances for untrusted users.
 
 ## Public HTTPS URL
 
-GPT Actions require a public HTTPS URL. WebCodex CLI does not automate reverse proxy or tunnel setup, so configure one before importing `/openapi.json` into ChatGPT.
+Hosted MCP clients and GPT Actions require a public HTTPS URL. WebCodex CLI does not automate a long-lived reverse proxy or tunnel, so configure one before connecting a hosted client.
 
 Set the same public URL in the server env file:
 
 ```text
 WEBCODEX_PUBLIC_URL=https://your-domain.example
 ```
+
+For hosts where opening an inbound port is inconvenient, a durable Cloudflare Tunnel is also a
+valid front door: publish a stable hostname and route it to `http://127.0.0.1:8080`. Use a
+named/remotely managed production tunnel rather than the temporary `trycloudflare.com` Quick
+Tunnel. The same hostname must carry ordinary HTTPS requests and `/api/agents/ws`; Cloudflare
+supports WebSocket upgrades through its proxy. See the
+[Cloudflare Tunnel documentation](https://developers.cloudflare.com/tunnel/) for tunnel and DNS
+lifecycle management.
 
 Minimal Nginx example:
 
@@ -397,6 +405,12 @@ Important agent settings:
 | `transport` | Prefer `auto` with `[quic]` configured: QUIC first, then WebSocket, then polling. Use strict `quic`, `websocket`, or `polling` only when you want exactly one transport. |
 | `projects_dir` | Directory of project registry files. |
 | `temporary_projects_root` | Optional existing Runner-owned root for managed temporary projects; it is validated against the effective Runner path policy (and must be inside `allowed_roots` in narrowed deployments). |
+
+When the Runner needs an outbound HTTP proxy, set the proxy variables in the Runner's actual
+service environment, not only in an interactive shell. WebSocket uses `HTTPS_PROXY`/`https_proxy`
+for `wss://`, `HTTP_PROXY`/`http_proxy` for `ws://`, then `ALL_PROXY`/`all_proxy`; matching
+`NO_PROXY`/`no_proxy` bypasses it. Current support is an `http://host:port` proxy via CONNECT;
+see [AGENT_TRANSPORTS.md](AGENT_TRANSPORTS.md) for the exact boundary.
 | `[policy]` | Local execution boundary. |
 | `[shell]` | Optional shell profile definitions and bounded persistent-shell limits. |
 | `[ssh.resources.<name>]` | Optional named SSH target for Session-bound `run_shell` / `run_job`; contains only `host` (including a normal OpenSSH Host alias) and optional remote `default_cwd`. |

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -257,13 +257,20 @@ WebCodex runtime job API 面向可信单操作者部署。
 
 ## Public HTTPS URL
 
-GPT Actions 需要 public HTTPS URL。WebCodex CLI 不会自动配置 reverse proxy 或 tunnel，所以在把 `/openapi.json` 导入 ChatGPT 之前需要先配置好对外 HTTPS。
+Hosted MCP client 和 GPT Actions 都需要 public HTTPS URL。WebCodex CLI 不会自动配置长期 reverse proxy 或 tunnel，因此连接 hosted client 前需要先准备稳定的对外 HTTPS。
 
 在 server env 文件中设置同一个 public URL：
 
 ```text
 WEBCODEX_PUBLIC_URL=https://your-domain.example
 ```
+
+如果主机不方便开放入站端口，也可以使用长期 Cloudflare Tunnel 作为公网入口：发布
+stable hostname，并转发到 `http://127.0.0.1:8080`。长期部署应使用 named / remotely
+managed tunnel，而不是临时 `trycloudflare.com` Quick Tunnel。同一 hostname 需要同时
+承载普通 HTTPS 请求与 `/api/agents/ws`；Cloudflare proxy 支持 WebSocket upgrade。
+Tunnel 与 DNS 生命周期管理见
+[Cloudflare Tunnel 官方文档](https://developers.cloudflare.com/tunnel/)。
 
 最小 Nginx 示例：
 
@@ -368,6 +375,12 @@ webcodex-runner --profile workstation
 | `transport` | 推荐配置 `[quic]` 并使用 `auto`：先 QUIC，再 WebSocket，再 polling。只有明确需要单一 transport 时才使用 strict `quic`、`websocket` 或 `polling`。 |
 | `projects_dir` | 项目注册文件目录。 |
 | `temporary_projects_root` | 可选的、已存在的 Runner 托管临时项目根目录；它会按 effective Runner path policy 校验（收窄部署时必须位于 `allowed_roots` 内）。 |
+
+Runner 需要出站 HTTP proxy 时，应把代理变量配置到 Runner **实际 service environment**，
+而不是只写在交互 shell 中。WebSocket 对 `wss://` 使用 `HTTPS_PROXY`/`https_proxy`，
+对 `ws://` 使用 `HTTP_PROXY`/`http_proxy`，随后 fallback 到 `ALL_PROXY`/`all_proxy`；
+匹配 `NO_PROXY`/`no_proxy` 时绕过代理。当前支持 `http://host:port` + CONNECT，完整
+边界见 [AGENT_TRANSPORTS.zh-CN.md](AGENT_TRANSPORTS.zh-CN.md)。
 | `[policy]` | 本地执行边界。 |
 | `[shell]` | 可选 shell profile 定义和有界 persistent-shell 限额。 |
 

--- a/src/shell_client/mod_tests.rs
+++ b/src/shell_client/mod_tests.rs
@@ -1310,6 +1310,44 @@ async fn registry_poll_updates_projects() {
 }
 
 #[tokio::test]
+async fn registry_poll_without_projects_preserves_existing_projection() {
+    let registry = ShellClientRegistry::default();
+    registry
+        .register(ShellClientRegisterRequest {
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: None,
+            job_inventory: None,
+            client_id: "oe".to_string(),
+            agent_instance_id: "inst".to_string(),
+            display_name: None,
+            owner: Some("alice".to_string()),
+            hostname: None,
+            capabilities: None,
+            projects: Some(vec![project_summary("one", "/tmp/one")]),
+            agent_protocol_version: None,
+            policy: None,
+        })
+        .await
+        .unwrap();
+
+    let polled = registry
+        .poll(ShellAgentPollRequest {
+            client_id: "oe".to_string(),
+            agent_instance_id: "inst".to_string(),
+            projects: None,
+        })
+        .await
+        .unwrap();
+    assert!(polled.is_none());
+
+    let projects = registry.list_client_projects("oe").await.unwrap();
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].id, "one");
+    assert_eq!(projects[0].path, "/tmp/one");
+}
+
+#[tokio::test]
 async fn registry_project_owner_check_enforces_boundary() {
     let registry = ShellClientRegistry::default();
     registry


### PR DESCRIPTION
## Summary

- harden polling recovery, idle backoff, and project refresh behavior
- add bounded HTTP CONNECT proxy support for WebSocket transport with proxy env/NO_PROXY handling and secret-safe errors
- clarify long-lived self-hosted deployment and Runner proxy configuration

## Validation

- `cargo fmt -- --check`
- `cargo test -p webcodex-runner` — 558 passed, 2 ignored
- `cargo test -p webcodex registry_poll_without_projects_preserves_existing_projection`
- `git diff --check origin/main...HEAD`
