### PR TITLE
sessions: reduce persistence memory usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.29", features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 rusqlite = { version = "0.32", features = ["bundled"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_urlencoded = "0.7"
 uuid = { version = "1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio-tungstenite = { version = "0.29", features = ["connect", "rustls-tls-webpk
 futures-util = "0.3"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 serde_urlencoded = "0.7"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"

--- a/src/tool_runtime/sessions/messages.rs
+++ b/src/tool_runtime/sessions/messages.rs
@@ -4,8 +4,9 @@
 
 use super::model::{
     ListSessionMessagesFilter, PostSessionMessageInput, SessionDiscussionSummary, SessionInboxHint,
-    SessionMessage, SessionMessageError,
+    SessionMessage, SessionMessageError, DEFAULT_MESSAGE_LIST_LIMIT, MAX_MESSAGE_LIST_LIMIT,
 };
+use super::query::{build_discussion_summary, build_inbox_hint};
 use super::store::SessionStore;
 
 impl SessionStore {
@@ -26,8 +27,22 @@ impl SessionStore {
         session_id: &str,
         filter: ListSessionMessagesFilter,
     ) -> Result<Vec<SessionMessage>, SessionMessageError> {
-        let mut inner = self.inner.lock().expect("session store mutex poisoned");
-        inner.list_messages(session_id, filter)
+        self.with_record_for_query(session_id, |record, _| {
+            let limit = filter
+                .limit
+                .unwrap_or(DEFAULT_MESSAGE_LIST_LIMIT)
+                .clamp(0, MAX_MESSAGE_LIST_LIMIT);
+            record
+                .messages
+                .iter()
+                .filter(|message| filter.kind.is_none_or(|kind| message.kind == kind))
+                .filter(|message| filter.status.is_none_or(|status| message.status == status))
+                .rev()
+                .take(limit)
+                .map(|message| message.as_ref().clone())
+                .collect()
+        })
+        .ok_or(SessionMessageError::UnknownSession)
     }
 
     pub(crate) fn resolve_message(
@@ -49,12 +64,17 @@ impl SessionStore {
         session_id: &str,
         limit: Option<usize>,
     ) -> Result<SessionDiscussionSummary, SessionMessageError> {
-        let mut inner = self.inner.lock().expect("session store mutex poisoned");
-        inner.discussion_summary(session_id, limit)
+        self.with_record_for_query(session_id, |record, _| {
+            let limit = limit
+                .unwrap_or(DEFAULT_MESSAGE_LIST_LIMIT)
+                .clamp(0, MAX_MESSAGE_LIST_LIMIT);
+            build_discussion_summary(record, limit)
+        })
+        .ok_or(SessionMessageError::UnknownSession)
     }
 
     pub(crate) fn inbox_hint(&self, session_id: &str) -> Option<SessionInboxHint> {
-        let mut inner = self.inner.lock().expect("session store mutex poisoned");
-        inner.inbox_hint(session_id)
+        self.with_record_for_query(session_id, |record, _| build_inbox_hint(record))
+            .flatten()
     }
 }

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -5,7 +5,7 @@ use super::super::project_instructions::{
 };
 use super::super::tool_inputs::{ExecutionShell, SessionMode};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{value::RawValue, Value};
 use sha2::{Digest, Sha256};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -234,7 +234,7 @@ impl CurrentSessionKey {
 /// - Create always yields [`SessionLifecycle::Active`].
 /// - Explicit `close_session` may transition `Active → Closed`.
 /// - `Closed → Active` is not allowed (no reopen in this phase).
-/// - `Archived` is reserved for Phase 3+ and is never produced yet.
+/// - `Archived` is a reserved wire state and is never produced by the store.
 ///
 /// LRU eviction remains capacity management, not a lifecycle transition.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
@@ -244,7 +244,7 @@ pub(crate) enum SessionLifecycle {
     Active,
     /// Explicitly closed; query remains allowed, mutations are denied.
     Closed,
-    /// Reserved — Phase 3+. Not produced yet; treated like Closed for denial.
+    /// Reserved wire state. Not produced; treated like Closed for denial.
     Archived,
 }
 
@@ -305,6 +305,79 @@ pub(super) struct SessionRecord {
     pub(super) events_observed: u64,
     pub(super) messages: VecDeque<Arc<SessionMessage>>,
     pub(super) project_instructions: Option<ProjectInstructionsSnapshot>,
+}
+
+/// Internal residency state is deliberately orthogonal to business lifecycle.
+/// Active sessions stay hot; historical closed sessions may keep only one
+/// compact, immutable durable JSON object plus the small metadata required for
+/// lifecycle/authorization checks and LRU bookkeeping.
+#[derive(Debug)]
+pub(super) enum StoredSession {
+    Hot(SessionRecord),
+    Cold(ColdSessionRecord),
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ColdSessionRecord {
+    pub(super) session_id: String,
+    pub(super) project: Option<String>,
+    pub(super) mode: SessionMode,
+    pub(super) guards: SessionGuards,
+    pub(super) lifecycle: SessionLifecycle,
+    pub(super) updated_at: i64,
+    pub(super) project_instructions: Option<ProjectInstructionsSummarySnapshot>,
+    pub(super) raw: Arc<RawValue>,
+}
+
+impl StoredSession {
+    pub(super) fn session_id(&self) -> &str {
+        match self {
+            Self::Hot(record) => &record.session_id,
+            Self::Cold(record) => &record.session_id,
+        }
+    }
+
+    pub(super) fn project(&self) -> Option<&str> {
+        match self {
+            Self::Hot(record) => record.project.as_deref(),
+            Self::Cold(record) => record.project.as_deref(),
+        }
+    }
+
+    pub(super) fn lifecycle(&self) -> SessionLifecycle {
+        match self {
+            Self::Hot(record) => record.lifecycle,
+            Self::Cold(record) => record.lifecycle,
+        }
+    }
+
+    pub(super) fn mode_guards(&self) -> (SessionMode, SessionGuards) {
+        match self {
+            Self::Hot(record) => (record.mode, record.guards),
+            Self::Cold(record) => (record.mode, record.guards),
+        }
+    }
+
+    pub(super) fn updated_at(&self) -> i64 {
+        match self {
+            Self::Hot(record) => record.updated_at,
+            Self::Cold(record) => record.updated_at,
+        }
+    }
+
+    pub(super) fn hot(&self) -> Option<&SessionRecord> {
+        match self {
+            Self::Hot(record) => Some(record),
+            Self::Cold(_) => None,
+        }
+    }
+
+    pub(super) fn hot_mut(&mut self) -> Option<&mut SessionRecord> {
+        match self {
+            Self::Hot(record) => Some(record),
+            Self::Cold(_) => None,
+        }
+    }
 }
 
 /// Options for creating a new session. Using a struct keeps the
@@ -447,12 +520,29 @@ pub(crate) struct SessionStoreStatus {
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct PersistedSessionLedger {
     pub(super) version: u32,
-    pub(super) sessions: Vec<PersistedSessionRecord>,
+    pub(super) sessions: Vec<PersistedSessionSnapshot>,
     /// Additive v1 field. Old ledgers omit it and deserialize to an empty map.
     /// The lossy wrapper prevents one malformed binding entry from rejecting
     /// otherwise valid Workflow Session records and events.
     #[serde(default)]
     pub(super) durable_current_bindings: PersistedCurrentBindings,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(super) enum PersistedSessionSnapshot {
+    Hot(PersistedSessionRecord),
+    Cold(Arc<RawValue>),
+}
+
+impl PersistedSessionSnapshot {
+    #[cfg(test)]
+    pub(super) fn hot(&self) -> Option<&PersistedSessionRecord> {
+        match self {
+            Self::Hot(record) => Some(record),
+            Self::Cold(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Instant;
 
 pub(crate) const SESSION_ID_PREFIX: &str = "wc_sess_";
@@ -295,14 +296,14 @@ pub(super) struct SessionRecord {
     pub(super) lifecycle: SessionLifecycle,
     pub(super) created_at: i64,
     pub(super) updated_at: i64,
-    pub(super) events: VecDeque<SessionEvent>,
+    pub(super) events: VecDeque<Arc<SessionEvent>>,
     /// Cumulative number of events ever appended to this session ledger,
     /// including events the per-session event cap has since evicted. This is
     /// the source of truth for "did the durable ledger ever hold more events
     /// than are retained now". The persisted counterpart carries the additive
     /// serde default; the in-memory record is always constructed explicitly.
     pub(super) events_observed: u64,
-    pub(super) messages: VecDeque<SessionMessage>,
+    pub(super) messages: VecDeque<Arc<SessionMessage>>,
     pub(super) project_instructions: Option<ProjectInstructionsSnapshot>,
 }
 
@@ -524,8 +525,8 @@ pub(super) struct PersistedSessionRecord {
     pub(super) lifecycle: SessionLifecycle,
     pub(super) created_at: i64,
     pub(super) updated_at: i64,
-    pub(super) events: Vec<SessionEvent>,
-    pub(super) messages: Vec<SessionMessage>,
+    pub(super) events: Vec<Arc<SessionEvent>>,
+    pub(super) messages: Vec<Arc<SessionMessage>>,
     /// Additive v1 field. Cumulative number of events ever appended, including
     /// those the per-session event cap has evicted. Older ledgers omit it and
     /// deserialize to 0; the restore path treats 0 as "retain exactly the

--- a/src/tool_runtime/sessions/persistence.rs
+++ b/src/tool_runtime/sessions/persistence.rs
@@ -1,7 +1,7 @@
 //! JSON session ledger load/save, sanitize-on-restore, and atomic writes.
 use std::collections::{HashMap, VecDeque};
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use super::events::{
@@ -264,8 +264,15 @@ pub(super) fn write_ledger_atomic(
         ".{file_name}.tmp-{}",
         uuid::Uuid::new_v4().simple()
     ));
-    let data = serde_json::to_vec_pretty(ledger).map_err(io::Error::other)?;
-    if let Err(err) = fs::write(&tmp_path, data).and_then(|_| fs::rename(&tmp_path, path)) {
+    let result = (|| {
+        let file = fs::File::create(&tmp_path)?;
+        let mut writer = io::BufWriter::new(file);
+        serde_json::to_writer(&mut writer, ledger).map_err(io::Error::other)?;
+        writer.flush()?;
+        drop(writer);
+        fs::rename(&tmp_path, path)
+    })();
+    if let Err(err) = result {
         let _ = fs::remove_file(&tmp_path);
         return Err(err);
     }

--- a/src/tool_runtime/sessions/persistence.rs
+++ b/src/tool_runtime/sessions/persistence.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use super::events::{
     exploration_tool_kind, is_valid_session_id, sanitize_failure_expectation_result,
@@ -28,6 +29,20 @@ impl PersistedSessionRecord {
             .messages
             .len()
             .saturating_sub(DEFAULT_MAX_MESSAGES_PER_SESSION);
+        let events: Vec<_> = record.events.iter().skip(event_skip).cloned().collect();
+        let messages: Vec<_> = record.messages.iter().skip(message_skip).cloned().collect();
+        debug_assert!(record
+            .events
+            .iter()
+            .skip(event_skip)
+            .zip(&events)
+            .all(|(record, snapshot)| Arc::ptr_eq(record, snapshot)));
+        debug_assert!(record
+            .messages
+            .iter()
+            .skip(message_skip)
+            .zip(&messages)
+            .all(|(record, snapshot)| Arc::ptr_eq(record, snapshot)));
         Self {
             session_id: record.session_id.clone(),
             project: record.project.clone(),
@@ -38,8 +53,8 @@ impl PersistedSessionRecord {
             lifecycle: record.lifecycle,
             created_at: record.created_at,
             updated_at: record.updated_at,
-            events: record.events.iter().skip(event_skip).cloned().collect(),
-            messages: record.messages.iter().skip(message_skip).cloned().collect(),
+            events,
+            messages,
             events_observed: record.events_observed,
         }
     }
@@ -49,20 +64,24 @@ impl PersistedSessionRecord {
         if !is_valid_session_id(&session_id) {
             return None;
         }
-        let events: VecDeque<SessionEvent> = self
+        let events: VecDeque<Arc<SessionEvent>> = self
             .events
             .into_iter()
+            .map(|event| Arc::try_unwrap(event).unwrap_or_else(|event| (*event).clone()))
             .filter_map(|event| sanitize_persisted_event(event, &session_id))
+            .map(Arc::new)
             .rev()
             .take(max_events_per_session)
             .collect::<Vec<_>>()
             .into_iter()
             .rev()
             .collect();
-        let messages: VecDeque<SessionMessage> = self
+        let messages: VecDeque<Arc<SessionMessage>> = self
             .messages
             .into_iter()
+            .map(|message| Arc::try_unwrap(message).unwrap_or_else(|message| (*message).clone()))
             .filter_map(|message| sanitize_persisted_message(message, &session_id))
+            .map(Arc::new)
             .rev()
             .take(DEFAULT_MAX_MESSAGES_PER_SESSION)
             .collect::<Vec<_>>()

--- a/src/tool_runtime/sessions/persistence.rs
+++ b/src/tool_runtime/sessions/persistence.rs
@@ -5,22 +5,33 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use serde::Deserialize;
+
+use super::super::project_instructions::ProjectInstructionsSummarySnapshot;
 use super::events::{
     exploration_tool_kind, is_valid_session_id, sanitize_failure_expectation_result,
     sanitize_observed_paths, sanitize_persisted_validation_output_summary,
     sanitize_persistent_shell_event_evidence, session_input_summary_for_tool,
 };
 use super::model::{
-    DurableCurrentBinding, PersistedSessionLedger, PersistedSessionRecord, SessionEvent,
-    SessionGuards, SessionLifecycle, SessionMessage, SessionRecord,
-    DEFAULT_MAX_MESSAGES_PER_SESSION, EVENT_ID_PREFIX, MAX_CODING_INSTRUCTION_CHARS,
-    MAX_INPUT_ARRAY_ITEMS, MAX_MESSAGE_CHARS, MAX_MESSAGE_RESOLUTION_CHARS, MESSAGE_ID_PREFIX,
-    SESSION_LEDGER_VERSION,
+    ColdSessionRecord, DurableCurrentBinding, PersistedCurrentBindings, PersistedSessionLedger,
+    PersistedSessionRecord, SessionEvent, SessionGuards, SessionLifecycle, SessionMessage,
+    SessionRecord, StoredSession, DEFAULT_MAX_MESSAGES_PER_SESSION, EVENT_ID_PREFIX,
+    MAX_CODING_INSTRUCTION_CHARS, MAX_INPUT_ARRAY_ITEMS, MAX_MESSAGE_CHARS,
+    MAX_MESSAGE_RESOLUTION_CHARS, MESSAGE_ID_PREFIX, SESSION_LEDGER_VERSION,
 };
 use super::query::validate_message_tags;
 use super::util::{
     bound_chars, bound_event_error_summary, bound_summary_string, redact_and_bound_instruction,
 };
+
+#[derive(Deserialize)]
+struct LoadedSessionLedger {
+    version: u32,
+    sessions: Vec<PersistedSessionRecord>,
+    #[serde(default)]
+    durable_current_bindings: PersistedCurrentBindings,
+}
 
 impl PersistedSessionRecord {
     pub(super) fn from_record(record: &SessionRecord, max_events_per_session: usize) -> Self {
@@ -57,6 +68,31 @@ impl PersistedSessionRecord {
             messages,
             events_observed: record.events_observed,
         }
+    }
+
+    pub(super) fn still_matches_record(&self, record: &SessionRecord) -> bool {
+        self.session_id == record.session_id
+            && self.project == record.project
+            && self.title == record.title
+            && self.mode == record.mode
+            && self.guards == record.guards
+            && self.execution_context == record.execution_context
+            && self.lifecycle == record.lifecycle
+            && self.created_at == record.created_at
+            && self.updated_at == record.updated_at
+            && self.events_observed == record.events_observed
+            && self.events.len() == record.events.len()
+            && self.messages.len() == record.messages.len()
+            && self
+                .events
+                .iter()
+                .zip(&record.events)
+                .all(|(snapshot, live)| Arc::ptr_eq(snapshot, live))
+            && self
+                .messages
+                .iter()
+                .zip(&record.messages)
+                .all(|(snapshot, live)| Arc::ptr_eq(snapshot, live))
     }
 
     pub(super) fn into_record(self, max_events_per_session: usize) -> Option<SessionRecord> {
@@ -118,8 +154,47 @@ impl PersistedSessionRecord {
     }
 }
 
+pub(super) fn cold_session_from_record(
+    record: &SessionRecord,
+    max_events_per_session: usize,
+) -> Result<ColdSessionRecord, serde_json::Error> {
+    debug_assert!(!record.lifecycle.allows_mutation());
+    let project_instructions = record
+        .project_instructions
+        .as_ref()
+        .map(|snapshot| snapshot.to_summary());
+    let persisted = PersistedSessionRecord::from_record(record, max_events_per_session);
+    cold_session_from_persisted(&persisted, project_instructions)
+}
+
+pub(super) fn cold_session_from_persisted(
+    persisted: &PersistedSessionRecord,
+    project_instructions: Option<ProjectInstructionsSummarySnapshot>,
+) -> Result<ColdSessionRecord, serde_json::Error> {
+    let raw = Arc::from(serde_json::value::to_raw_value(persisted)?);
+    Ok(ColdSessionRecord {
+        session_id: persisted.session_id.clone(),
+        project: persisted.project.clone(),
+        mode: persisted.mode,
+        guards: persisted.guards,
+        lifecycle: persisted.lifecycle,
+        updated_at: persisted.updated_at,
+        project_instructions,
+        raw,
+    })
+}
+
+pub(super) fn materialize_cold_session(
+    record: &ColdSessionRecord,
+    max_events_per_session: usize,
+) -> Option<SessionRecord> {
+    serde_json::from_str::<PersistedSessionRecord>(record.raw.get())
+        .ok()?
+        .into_record(max_events_per_session)
+}
+
 pub(super) struct RestoredSessionLedger {
-    pub(super) sessions: HashMap<String, SessionRecord>,
+    pub(super) sessions: HashMap<String, StoredSession>,
     pub(super) durable_current_bindings: HashMap<String, DurableCurrentBinding>,
     pub(super) lru: VecDeque<String>,
     pub(super) restored_sessions: usize,
@@ -159,7 +234,7 @@ pub(super) fn load_persisted_ledger(
             return RestoredSessionLedger::empty(Some(error));
         }
     };
-    let ledger = match serde_json::from_str::<PersistedSessionLedger>(&content) {
+    let ledger = match serde_json::from_str::<LoadedSessionLedger>(&content) {
         Ok(ledger) => ledger,
         Err(err) => {
             let error = bound_summary_string(&format!(
@@ -178,20 +253,34 @@ pub(super) fn load_persisted_ledger(
         return RestoredSessionLedger::empty(Some(error));
     }
     let mut discarded_binding_count = ledger.durable_current_bindings.malformed_count;
-    let mut records: Vec<SessionRecord> = ledger
+    let mut records: Vec<StoredSession> = ledger
         .sessions
         .into_iter()
         .filter_map(|record| record.into_record(max_events_per_session))
+        .map(|record| {
+            if record.lifecycle.allows_mutation() {
+                StoredSession::Hot(record)
+            } else {
+                match cold_session_from_record(&record, max_events_per_session) {
+                    Ok(cold) => StoredSession::Cold(cold),
+                    Err(err) => {
+                        tracing::warn!("session cold restore serialization failed: {err}");
+                        StoredSession::Hot(record)
+                    }
+                }
+            }
+        })
         .collect();
-    records.sort_by_key(|record| record.updated_at);
+    records.sort_by_key(StoredSession::updated_at);
     while records.len() > max_sessions {
         records.remove(0);
     }
     let mut sessions = HashMap::new();
     let mut lru = VecDeque::new();
     for record in records {
-        lru.push_back(record.session_id.clone());
-        sessions.insert(record.session_id.clone(), record);
+        let session_id = record.session_id().to_string();
+        lru.push_back(session_id.clone());
+        sessions.insert(session_id, record);
     }
     let restored_sessions = sessions.len();
 
@@ -205,7 +294,7 @@ pub(super) fn load_persisted_ledger(
         if !is_lower_hex_sha256(&binding.binding_key_sha256)
             || !is_valid_session_id(session_id)
             || binding.updated_at < 0
-            || session.lifecycle != SessionLifecycle::Active
+            || session.lifecycle() != SessionLifecycle::Active
         {
             discarded_binding_count = discarded_binding_count.saturating_add(1);
             continue;

--- a/src/tool_runtime/sessions/query.rs
+++ b/src/tool_runtime/sessions/query.rs
@@ -161,7 +161,7 @@ pub(super) fn take_recent_kind(
         .filter(|message| message.kind == kind)
         .filter(|message| status.is_none_or(|status| message.status == status))
         .take(limit)
-        .cloned()
+        .map(|message| message.as_ref().clone())
         .map(bound_message_for_summary)
         .collect()
 }

--- a/src/tool_runtime/sessions/store.rs
+++ b/src/tool_runtime/sessions/store.rs
@@ -653,7 +653,7 @@ impl SessionStore {
                             record.project_instructions = Some(project_instructions);
                         }
                     }
-                    record.events.push_back(event);
+                    record.events.push_back(Arc::new(event));
                     record.events_observed = record.events_observed.saturating_add(1);
                     while record.events.len() > max_events {
                         record.events.pop_front();
@@ -716,7 +716,7 @@ impl SessionStore {
                     created_at: now,
                     updated_at: now,
                     messages: VecDeque::new(),
-                    events: VecDeque::from([event]),
+                    events: VecDeque::from([Arc::new(event)]),
                     events_observed: 1,
                     project_instructions: request.project_instructions,
                 };
@@ -877,7 +877,7 @@ impl SessionStore {
                 .expect("validated Session disappeared under store lock");
             record.execution_context = execution_context;
             record.updated_at = now;
-            record.events.push_back(event);
+            record.events.push_back(Arc::new(event));
             record.events_observed = record.events_observed.saturating_add(1);
             while record.events.len() > max_events {
                 record.events.pop_front();
@@ -1592,7 +1592,7 @@ impl SessionStoreInner {
                         .expect("session present after lifecycle read");
                     record.lifecycle = SessionLifecycle::Closed;
                     record.updated_at = now;
-                    record.events.push_back(event);
+                    record.events.push_back(Arc::new(event));
                     record.events_observed = record.events_observed.saturating_add(1);
                     while record.events.len() > max_events {
                         record.events.pop_front();
@@ -1779,7 +1779,7 @@ impl SessionStoreInner {
             resolution: None,
         };
         record.updated_at = now;
-        record.messages.push_back(message.clone());
+        record.messages.push_back(Arc::new(message.clone()));
         while record.messages.len() > DEFAULT_MAX_MESSAGES_PER_SESSION {
             record.messages.pop_front();
         }
@@ -1806,7 +1806,7 @@ impl SessionStoreInner {
             .filter(|message| filter.status.is_none_or(|status| message.status == status))
             .rev()
             .take(limit)
-            .cloned()
+            .map(|message| message.as_ref().clone())
             .collect())
     }
 
@@ -1834,6 +1834,7 @@ impl SessionStoreInner {
         else {
             return Err(SessionMessageError::UnknownMessage);
         };
+        let message = Arc::make_mut(message);
         let resolution = match resolution {
             Some(value) => Some(validate_resolution_text(value)?),
             None => None,
@@ -1877,7 +1878,7 @@ impl SessionStoreInner {
         let max_events_per_session = self.max_events_per_session;
         if let Some(record) = self.sessions.get_mut(&event.session_id) {
             record.updated_at = now_ts();
-            record.events.push_back(event);
+            record.events.push_back(Arc::new(event));
             record.events_observed = record.events_observed.saturating_add(1);
             while record.events.len() > max_events_per_session {
                 record.events.pop_front();
@@ -1906,7 +1907,7 @@ impl SessionStoreInner {
             .rev()
             .find(|event| event.event_id == event_id)
         {
-            event.permission = Some(permission);
+            Arc::make_mut(event).permission = Some(permission);
             true
         } else {
             false
@@ -1929,7 +1930,7 @@ impl SessionStoreInner {
         else {
             return false;
         };
-        event.persistent_shell = Some(evidence);
+        Arc::make_mut(event).persistent_shell = Some(evidence);
         record.updated_at = now_ts();
         true
     }
@@ -2037,6 +2038,7 @@ impl SessionStoreInner {
         let finished_events: Vec<&SessionEvent> = record
             .events
             .iter()
+            .map(Arc::as_ref)
             .filter(|event| event.kind == "tool_call_finished")
             .collect();
         let counts = SessionCounts {
@@ -2078,7 +2080,12 @@ impl SessionStoreInner {
         let observed_total = record.events_observed.max(retained_total as u64) as usize;
         // The returned window is further sliced by the requested `limit`.
         let skip = retained_total.saturating_sub(limit);
-        let events: Vec<SessionEvent> = record.events.iter().skip(skip).cloned().collect();
+        let events: Vec<SessionEvent> = record
+            .events
+            .iter()
+            .skip(skip)
+            .map(|event| event.as_ref().clone())
+            .collect();
         let events_returned = events.len();
         // Truncated when the durable ledger ever held more events than we are
         // returning: either the per-session cap evicted older events, or the

--- a/src/tool_runtime/sessions/store.rs
+++ b/src/tool_runtime/sessions/store.rs
@@ -19,25 +19,25 @@ use super::events::{
     validation_output_summary_for_tool_result, SessionToolClassification,
 };
 use super::model::{
-    CodingSessionError, CodingSessionOutcome, CodingSessionRequest, CurrentSessionKey,
-    DurableCurrentBinding, ListSessionMessagesFilter, PersistedCurrentBinding,
-    PersistedCurrentBindings, PersistedSessionLedger, PersistedSessionRecord,
+    CodingSessionError, CodingSessionOutcome, CodingSessionRequest, ColdSessionRecord,
+    CurrentSessionKey, DurableCurrentBinding, PersistedCurrentBinding, PersistedCurrentBindings,
+    PersistedSessionLedger, PersistedSessionRecord, PersistedSessionSnapshot,
     PersistentShellEventEvidence, PostSessionMessageInput, SessionCloseError, SessionCloseOutcome,
-    SessionCounts, SessionCreateOptions, SessionDiscussionSummary, SessionEvent,
-    SessionExecutionContext, SessionExecutionContextUpdateError,
-    SessionExecutionContextUpdateOutcome, SessionGuardDenial, SessionGuards, SessionInboxHint,
-    SessionLifecycle, SessionLifecycleDenial, SessionMessage, SessionMessageError,
+    SessionCounts, SessionCreateOptions, SessionEvent, SessionExecutionContext,
+    SessionExecutionContextUpdateError, SessionExecutionContextUpdateOutcome, SessionGuardDenial,
+    SessionGuards, SessionLifecycle, SessionLifecycleDenial, SessionMessage, SessionMessageError,
     SessionMessageStatus, SessionRecord, SessionStoreStatus, SessionSummary, SessionTransport,
-    ToolCallRecorderMetadata, ToolCallStart, DEFAULT_MAX_EVENTS_PER_SESSION,
-    DEFAULT_MAX_MESSAGES_PER_SESSION, DEFAULT_MAX_SESSIONS, DEFAULT_MESSAGE_LIST_LIMIT,
-    DEFAULT_SUMMARY_LIMIT, DURABLE_CURRENT_BINDINGS_PER_SESSION, EVENT_ID_PREFIX,
-    MAX_CODING_INSTRUCTION_CHARS, MAX_MESSAGE_LIST_LIMIT, MAX_SUMMARY_LIMIT, MESSAGE_ID_PREFIX,
-    SESSION_ID_PREFIX, SESSION_LEDGER_VERSION,
+    StoredSession, ToolCallRecorderMetadata, ToolCallStart, DEFAULT_MAX_EVENTS_PER_SESSION,
+    DEFAULT_MAX_MESSAGES_PER_SESSION, DEFAULT_MAX_SESSIONS, DEFAULT_SUMMARY_LIMIT,
+    DURABLE_CURRENT_BINDINGS_PER_SESSION, EVENT_ID_PREFIX, MAX_CODING_INSTRUCTION_CHARS,
+    MAX_SUMMARY_LIMIT, MESSAGE_ID_PREFIX, SESSION_ID_PREFIX, SESSION_LEDGER_VERSION,
 };
-use super::persistence::{load_persisted_ledger, write_ledger_atomic};
+use super::persistence::{
+    cold_session_from_persisted, load_persisted_ledger, materialize_cold_session,
+    write_ledger_atomic,
+};
 use super::query::{
-    build_discussion_summary, build_inbox_hint, build_messages_summary, validate_message_tags,
-    validate_message_text, validate_resolution_text,
+    build_messages_summary, validate_message_tags, validate_message_text, validate_resolution_text,
 };
 use super::util::{
     bound_event_error_summary, bound_summary_string, now_ts, redact_and_bound_instruction,
@@ -259,7 +259,7 @@ fn ledger_writer_loop(
 #[derive(Debug)]
 pub(super) struct SessionStoreInner {
     /// Durable workflow sessions. Mutated only via the helpers below.
-    sessions: HashMap<String, SessionRecord>,
+    sessions: HashMap<String, StoredSession>,
     /// Fast process-local cache of the exact binding tuple.
     current_sessions: HashMap<CurrentSessionKey, String>,
     /// Durable projection keyed only by the domain-separated SHA-256 of the
@@ -302,7 +302,7 @@ impl SessionStore {
         let max_durable_bindings = max_durable_bindings(max_sessions);
         Self {
             inner: Arc::new(Mutex::new(SessionStoreInner {
-                sessions: HashMap::new(),
+                sessions: HashMap::<String, StoredSession>::new(),
                 current_sessions: HashMap::new(),
                 durable_current_bindings: HashMap::new(),
                 lru: VecDeque::new(),
@@ -409,8 +409,8 @@ impl SessionStore {
             .sessions
             .values()
             .filter(|record| {
-                record.lifecycle == SessionLifecycle::Active
-                    && project.is_none_or(|project| record.project.as_deref() == Some(project))
+                record.lifecycle() == SessionLifecycle::Active
+                    && project.is_none_or(|project| record.project() == Some(project))
             })
             .count()
     }
@@ -422,6 +422,26 @@ impl SessionStore {
             .expect("session store mutex poisoned")
             .current_sessions
             .len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hot_payload_entry_count_for_test(&self, session_id: &str) -> Option<usize> {
+        self.inner
+            .lock()
+            .expect("session store mutex poisoned")
+            .sessions
+            .get(session_id)?
+            .hot()
+            .map(|record| record.events.len() + record.messages.len())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cold_payload_bytes_for_test(&self, session_id: &str) -> Option<usize> {
+        let inner = self.inner.lock().expect("session store mutex poisoned");
+        match inner.sessions.get(session_id)? {
+            StoredSession::Hot(_) => None,
+            StoredSession::Cold(record) => Some(record.raw.get().len()),
+        }
     }
 
     /// Thin convenience wrapper — creation always goes through
@@ -540,19 +560,20 @@ impl SessionStore {
         let outcome = {
             let mut inner = self.inner.lock().expect("session store mutex poisoned");
             let reusable_session_id = if let Some(session_id) = explicit_resume_session_id {
-                let Some(record) = inner.sessions.get(&session_id) else {
+                let Some(stored) = inner.sessions.get(&session_id) else {
                     return Err(CodingSessionError::UnknownResumeSession { session_id });
                 };
-                if !record.lifecycle.allows_mutation() {
+                let lifecycle = stored.lifecycle();
+                if !lifecycle.allows_mutation() {
                     return Err(CodingSessionError::ResumeSessionNotActive {
                         session_id,
-                        lifecycle: record.lifecycle,
+                        lifecycle,
                     });
                 }
-                if record.project.as_deref() != Some(request.project.as_str()) {
+                if stored.project() != Some(request.project.as_str()) {
                     return Err(CodingSessionError::ResumeProjectMismatch {
                         session_id,
-                        session_project: record.project.clone(),
+                        session_project: stored.project().map(str::to_string),
                         request_project: request.project.clone(),
                     });
                 }
@@ -570,7 +591,8 @@ impl SessionStore {
                     let record = inner
                         .sessions
                         .get(&session_id)
-                        .expect("reusable session disappeared under store lock");
+                        .and_then(StoredSession::hot)
+                        .expect("active reusable session must stay hot");
                     (record.mode, record.guards, record.execution_context.clone())
                 };
                 // Repeating a mode preserves any stricter explicit guard from
@@ -637,7 +659,8 @@ impl SessionStore {
                     let record = inner
                         .sessions
                         .get_mut(&session_id)
-                        .expect("reusable session disappeared before commit");
+                        .and_then(StoredSession::hot_mut)
+                        .expect("active reusable session must stay hot before commit");
                     record.mode = request.mode;
                     record.guards = next_guards;
                     record.execution_context = next_execution_context;
@@ -761,9 +784,66 @@ impl SessionStore {
     }
 
     pub(crate) fn summary(&self, session_id: &str, limit: Option<usize>) -> Option<SessionSummary> {
+        self.with_record_for_query(session_id, |record, cold| {
+            summarize_record(record, limit, cold)
+        })
+    }
+
+    pub(super) fn with_record_for_query<T>(
+        &self,
+        session_id: &str,
+        query: impl FnOnce(&SessionRecord, Option<&ColdSessionRecord>) -> T,
+    ) -> Option<T> {
+        let (cold, max_events_per_session) = {
+            let mut inner = self.inner.lock().expect("session store mutex poisoned");
+            inner.touch(session_id);
+            let max_events_per_session = inner.max_events_per_session;
+            let stored = inner.sessions.get(session_id)?;
+            match stored {
+                StoredSession::Hot(record) => return Some(query(record, None)),
+                StoredSession::Cold(record) => (record.clone(), max_events_per_session),
+            }
+        };
+        let record = materialize_cold_session(&cold, max_events_per_session)?;
+        Some(query(&record, Some(&cold)))
+    }
+
+    fn coldify_closed_session(&self, session_id: &str) {
+        let (snapshot, project_instructions) = {
+            let inner = self.inner.lock().expect("session store mutex poisoned");
+            let Some(StoredSession::Hot(record)) = inner.sessions.get(session_id) else {
+                return;
+            };
+            if record.lifecycle.allows_mutation() {
+                return;
+            }
+            (
+                PersistedSessionRecord::from_record(record, inner.max_events_per_session),
+                record
+                    .project_instructions
+                    .as_ref()
+                    .map(|instructions| instructions.to_summary()),
+            )
+        };
+        let cold = match cold_session_from_persisted(&snapshot, project_instructions) {
+            Ok(cold) => cold,
+            Err(err) => {
+                tracing::warn!("session cold serialization failed: {err}");
+                return;
+            }
+        };
         let mut inner = self.inner.lock().expect("session store mutex poisoned");
-        inner.touch(session_id);
-        inner.summary(session_id, limit)
+        let Some(stored) = inner.sessions.get_mut(session_id) else {
+            return;
+        };
+        let Some(record) = stored.hot() else {
+            return;
+        };
+        if !snapshot.still_matches_record(record) {
+            return;
+        }
+        debug_assert!(!cold.lifecycle.allows_mutation());
+        *stored = StoredSession::Cold(cold);
     }
 
     pub(crate) fn contains_session(&self, session_id: &str) -> bool {
@@ -789,7 +869,7 @@ impl SessionStore {
         resolved_project: &str,
     ) -> Option<SessionExecutionContext> {
         let inner = self.inner.lock().expect("session store mutex poisoned");
-        let record = inner.sessions.get(session_id)?;
+        let record = inner.sessions.get(session_id)?.hot()?;
         (record.lifecycle.allows_mutation() && record.project.as_deref() == Some(resolved_project))
             .then(|| record.execution_context.clone())
     }
@@ -818,10 +898,17 @@ impl SessionStore {
         if session_id.is_empty() || !is_valid_session_id(session_id) {
             return Err(SessionCloseError::UnknownSession);
         }
-        let outcome = {
+        let committed = {
             let mut inner = self.inner.lock().expect("session store mutex poisoned");
             inner.close_session(session_id)?
         };
+        let outcome = committed.unwrap_or_else(|| SessionCloseOutcome {
+            summary: self
+                .summary(session_id, Some(DEFAULT_SUMMARY_LIMIT))
+                .expect("known cold closed session must materialize for summary"),
+            already_closed: true,
+        });
+        self.coldify_closed_session(session_id);
         self.persist_after_mutation();
         Ok(outcome)
     }
@@ -841,21 +928,22 @@ impl SessionStore {
         }
         let outcome = {
             let mut inner = self.inner.lock().expect("session store mutex poisoned");
-            let (lifecycle, project, previous_execution_context) = inner
+            let stored = inner
                 .sessions
                 .get(session_id)
-                .map(|record| {
-                    (
-                        record.lifecycle,
-                        record.project.clone(),
-                        record.execution_context.clone(),
-                    )
-                })
                 .ok_or(SessionExecutionContextUpdateError::UnknownSession)?;
+            let lifecycle = stored.lifecycle();
             if !lifecycle.allows_mutation() {
                 return Err(SessionExecutionContextUpdateError::SessionNotActive { lifecycle });
             }
-            let project = project.ok_or(SessionExecutionContextUpdateError::SessionHasNoProject)?;
+            let record = stored
+                .hot()
+                .expect("active execution-context session must stay hot");
+            let project = record
+                .project
+                .clone()
+                .ok_or(SessionExecutionContextUpdateError::SessionHasNoProject)?;
+            let previous_execution_context = record.execution_context.clone();
             let execution_context = execution_context
                 .validated()
                 .map_err(SessionExecutionContextUpdateError::InvalidExecutionContext)?;
@@ -874,7 +962,8 @@ impl SessionStore {
             let record = inner
                 .sessions
                 .get_mut(session_id)
-                .expect("validated Session disappeared under store lock");
+                .and_then(StoredSession::hot_mut)
+                .expect("validated active Session must stay hot under store lock");
             record.execution_context = execution_context;
             record.updated_at = now;
             record.events.push_back(Arc::new(event));
@@ -1089,10 +1178,7 @@ impl SessionStore {
         permission: PermissionDecision,
     ) {
         start.permission = Some(permission.clone());
-        let persisted = {
-            let mut inner = self.inner.lock().expect("session store mutex poisoned");
-            inner.set_event_permission(&start.session_id, &start.event_id, permission)
-        };
+        let persisted = self.set_event_permission(&start.session_id, &start.event_id, permission);
         if persisted {
             self.persist_after_mutation();
         }
@@ -1125,10 +1211,7 @@ impl SessionStore {
         let Some(evidence) = evidence else {
             return;
         };
-        let persisted = {
-            let mut inner = self.inner.lock().expect("session store mutex poisoned");
-            inner.set_session_close_persistent_shell_evidence(session_id, evidence)
-        };
+        let persisted = self.set_session_close_persistent_shell_evidence(session_id, evidence);
         if persisted {
             self.persist_after_mutation();
         }
@@ -1256,13 +1339,202 @@ impl SessionStore {
 
     /// Sole entry for appending a session ledger event.
     fn push_event(&self, event: SessionEvent) {
-        let persisted = {
+        let session_id = event.session_id.clone();
+        let mut event = Some(event);
+        let (cold, hot_closed) = {
             let mut inner = self.inner.lock().expect("session store mutex poisoned");
-            inner.push_event(event)
+            let max_events_per_session = inner.max_events_per_session;
+            let Some(stored) = inner.sessions.get_mut(&session_id) else {
+                return;
+            };
+            match stored {
+                StoredSession::Hot(record) => {
+                    record.updated_at = now_ts();
+                    record.events.push_back(Arc::new(event.take().unwrap()));
+                    record.events_observed = record.events_observed.saturating_add(1);
+                    while record.events.len() > max_events_per_session {
+                        record.events.pop_front();
+                    }
+                    let hot_closed = !record.lifecycle.allows_mutation();
+                    inner.touch(&session_id);
+                    (None, hot_closed)
+                }
+                StoredSession::Cold(record) => (Some(record.clone()), false),
+            }
+        };
+        let persisted = match cold {
+            Some(cold) => {
+                let event = event.as_ref().expect("cold append keeps source event");
+                self.rewrite_cold_record(&session_id, cold, true, |record, max_events| {
+                    record.updated_at = now_ts();
+                    record.events.push_back(Arc::new(event.clone()));
+                    record.events_observed = record.events_observed.saturating_add(1);
+                    while record.events.len() > max_events {
+                        record.events.pop_front();
+                    }
+                    true
+                })
+            }
+            None => true,
         };
         if persisted {
+            if hot_closed {
+                self.coldify_closed_session(&session_id);
+            }
             self.persist_after_mutation();
         }
+    }
+
+    fn max_events_per_session(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("session store mutex poisoned")
+            .max_events_per_session
+    }
+
+    fn rewrite_cold_record(
+        &self,
+        session_id: &str,
+        mut cold: ColdSessionRecord,
+        touch: bool,
+        mutate: impl Fn(&mut SessionRecord, usize) -> bool,
+    ) -> bool {
+        let max_events_per_session = self.max_events_per_session();
+        loop {
+            let Some(mut record) = materialize_cold_session(&cold, max_events_per_session) else {
+                tracing::warn!(session_id, "cold session materialization failed");
+                return false;
+            };
+            if !mutate(&mut record, max_events_per_session) {
+                return false;
+            }
+            let persisted = PersistedSessionRecord::from_record(&record, max_events_per_session);
+            let next =
+                match cold_session_from_persisted(&persisted, cold.project_instructions.clone()) {
+                    Ok(next) => next,
+                    Err(err) => {
+                        tracing::warn!(
+                            session_id,
+                            "cold session rewrite serialization failed: {err}"
+                        );
+                        return false;
+                    }
+                };
+            let mut inner = self.inner.lock().expect("session store mutex poisoned");
+            let Some(stored) = inner.sessions.get_mut(session_id) else {
+                return false;
+            };
+            match stored {
+                StoredSession::Cold(current) if Arc::ptr_eq(&current.raw, &cold.raw) => {
+                    *stored = StoredSession::Cold(next);
+                    if touch {
+                        inner.touch(session_id);
+                    }
+                    return true;
+                }
+                StoredSession::Cold(current) => {
+                    cold = current.clone();
+                }
+                StoredSession::Hot(_) => return false,
+            }
+        }
+    }
+
+    fn set_event_permission(
+        &self,
+        session_id: &str,
+        event_id: &str,
+        permission: PermissionDecision,
+    ) -> bool {
+        let mut permission = Some(permission);
+        let (cold, hot_closed, found) = {
+            let mut inner = self.inner.lock().expect("session store mutex poisoned");
+            let Some(stored) = inner.sessions.get_mut(session_id) else {
+                return false;
+            };
+            match stored {
+                StoredSession::Hot(record) => {
+                    let found = record
+                        .events
+                        .iter_mut()
+                        .rev()
+                        .find(|event| event.event_id == event_id)
+                        .map(|event| {
+                            Arc::make_mut(event).permission = Some(permission.take().unwrap());
+                        })
+                        .is_some();
+                    (None, !record.lifecycle.allows_mutation(), found)
+                }
+                StoredSession::Cold(record) => (Some(record.clone()), false, true),
+            }
+        };
+        let found = match cold {
+            Some(cold) => self.rewrite_cold_record(session_id, cold, false, |record, _| {
+                let Some(event) = record
+                    .events
+                    .iter_mut()
+                    .rev()
+                    .find(|event| event.event_id == event_id)
+                else {
+                    return false;
+                };
+                Arc::make_mut(event).permission = Some(permission.as_ref().unwrap().clone());
+                true
+            }),
+            None => found,
+        };
+        if found && hot_closed {
+            self.coldify_closed_session(session_id);
+        }
+        found
+    }
+
+    fn set_session_close_persistent_shell_evidence(
+        &self,
+        session_id: &str,
+        evidence: PersistentShellEventEvidence,
+    ) -> bool {
+        let mut evidence = Some(evidence);
+        let (cold, hot_closed, found) = {
+            let mut inner = self.inner.lock().expect("session store mutex poisoned");
+            let Some(stored) = inner.sessions.get_mut(session_id) else {
+                return false;
+            };
+            match stored {
+                StoredSession::Hot(record) => {
+                    let found = if let Some(event) = record.events.iter_mut().rev().find(|event| {
+                        event.kind == "session_closed" && event.tool_name == "close_session"
+                    }) {
+                        Arc::make_mut(event).persistent_shell = Some(evidence.take().unwrap());
+                        true
+                    } else {
+                        false
+                    };
+                    if found {
+                        record.updated_at = now_ts();
+                    }
+                    (None, !record.lifecycle.allows_mutation(), found)
+                }
+                StoredSession::Cold(record) => (Some(record.clone()), false, true),
+            }
+        };
+        let found = match cold {
+            Some(cold) => self.rewrite_cold_record(session_id, cold, false, |record, _| {
+                let Some(event) = record.events.iter_mut().rev().find(|event| {
+                    event.kind == "session_closed" && event.tool_name == "close_session"
+                }) else {
+                    return false;
+                };
+                Arc::make_mut(event).persistent_shell = Some(evidence.as_ref().unwrap().clone());
+                record.updated_at = now_ts();
+                true
+            }),
+            None => found,
+        };
+        if found && hot_closed {
+            self.coldify_closed_session(session_id);
+        }
+        found
     }
 
     pub(super) fn persist_after_mutation(&self) {
@@ -1545,13 +1817,97 @@ fn session_execution_context_updated_event(
     }
 }
 
+fn summarize_record(
+    record: &SessionRecord,
+    limit: Option<usize>,
+    cold: Option<&ColdSessionRecord>,
+) -> SessionSummary {
+    let limit = limit
+        .unwrap_or(DEFAULT_SUMMARY_LIMIT)
+        .clamp(0, MAX_SUMMARY_LIMIT);
+    let finished_events: Vec<&SessionEvent> = record
+        .events
+        .iter()
+        .map(Arc::as_ref)
+        .filter(|event| event.kind == "tool_call_finished")
+        .collect();
+    let counts = SessionCounts {
+        tool_calls: finished_events.len(),
+        succeeded: finished_events
+            .iter()
+            .filter(|event| event.status.as_deref() == Some("succeeded"))
+            .count(),
+        failed: finished_events
+            .iter()
+            .filter(|event| event.status.as_deref() == Some("failed"))
+            .count(),
+        read_like: finished_events
+            .iter()
+            .filter(|event| event.read_like)
+            .count(),
+        write_like: finished_events
+            .iter()
+            .filter(|event| event.write_like)
+            .count(),
+        shell_like: finished_events
+            .iter()
+            .filter(|event| event.shell_like)
+            .count(),
+        git_like: finished_events
+            .iter()
+            .filter(|event| event.git_like)
+            .count(),
+        change_summary_like: finished_events
+            .iter()
+            .filter(|event| event.change_summary_like)
+            .count(),
+    };
+    let retained_total = record.events.len();
+    let observed_total = record.events_observed.max(retained_total as u64) as usize;
+    let skip = retained_total.saturating_sub(limit);
+    let events: Vec<SessionEvent> = record
+        .events
+        .iter()
+        .skip(skip)
+        .map(|event| event.as_ref().clone())
+        .collect();
+    let events_returned = events.len();
+    let project_instructions = match cold {
+        Some(cold) => cold.project_instructions.clone(),
+        None => record
+            .project_instructions
+            .as_ref()
+            .map(|snapshot| snapshot.to_summary()),
+    };
+    SessionSummary {
+        session_id: record.session_id.clone(),
+        project: record.project.clone(),
+        title: record.title.clone(),
+        mode: record.mode,
+        guards: record.guards,
+        execution_context: record.execution_context.clone(),
+        lifecycle: record.lifecycle,
+        created_at: record.created_at,
+        updated_at: record.updated_at,
+        counts,
+        events,
+        events_total: observed_total,
+        events_returned,
+        events_truncated: observed_total > events_returned,
+        first_retained_sequence: observed_total.saturating_sub(events_returned),
+        project_instructions,
+        messages: build_messages_summary(record),
+    }
+}
+
 impl SessionStoreInner {
     // --- create / lifecycle ---
 
     /// Sole map-insert path for a newly created session.
     pub(super) fn insert_session(&mut self, record: SessionRecord) -> SessionSummary {
         let session_id = record.session_id.clone();
-        self.sessions.insert(session_id.clone(), record);
+        self.sessions
+            .insert(session_id.clone(), StoredSession::Hot(record));
         self.touch(&session_id);
         self.enforce_session_bound();
         self.summary(&session_id, Some(DEFAULT_SUMMARY_LIMIT))
@@ -1562,34 +1918,35 @@ impl SessionStoreInner {
     pub(super) fn close_session(
         &mut self,
         session_id: &str,
-    ) -> Result<SessionCloseOutcome, SessionCloseError> {
+    ) -> Result<Option<SessionCloseOutcome>, SessionCloseError> {
         self.touch(session_id);
         let lifecycle = self
             .sessions
             .get(session_id)
-            .map(|record| record.lifecycle)
+            .map(StoredSession::lifecycle)
             .ok_or(SessionCloseError::UnknownSession)?;
         match lifecycle {
             SessionLifecycle::Closed | SessionLifecycle::Archived => {
                 self.remove_bindings_for_session(session_id);
-                let summary = self
-                    .summary(session_id, Some(DEFAULT_SUMMARY_LIMIT))
-                    .expect("known closed session must summarize");
-                Ok(SessionCloseOutcome {
-                    summary,
+                let Some(record) = self.sessions.get(session_id).and_then(StoredSession::hot)
+                else {
+                    return Ok(None);
+                };
+                Ok(Some(SessionCloseOutcome {
+                    summary: summarize_record(record, Some(DEFAULT_SUMMARY_LIMIT), None),
                     already_closed: true,
-                })
+                }))
             }
             SessionLifecycle::Active => {
                 let now = now_ts();
-                // Soft-stop system event: only the Active → Closed transition.
                 let event = session_closed_system_event(session_id, now);
                 let max_events = self.max_events_per_session;
                 {
                     let record = self
                         .sessions
                         .get_mut(session_id)
-                        .expect("session present after lifecycle read");
+                        .and_then(StoredSession::hot_mut)
+                        .expect("active session must stay hot through close commit");
                     record.lifecycle = SessionLifecycle::Closed;
                     record.updated_at = now;
                     record.events.push_back(Arc::new(event));
@@ -1599,13 +1956,15 @@ impl SessionStoreInner {
                     }
                 }
                 self.remove_bindings_for_session(session_id);
-                let summary = self
-                    .summary(session_id, Some(DEFAULT_SUMMARY_LIMIT))
-                    .expect("just-closed session must summarize");
-                Ok(SessionCloseOutcome {
-                    summary,
+                let record = self
+                    .sessions
+                    .get(session_id)
+                    .and_then(StoredSession::hot)
+                    .expect("just-closed session remains hot until outer coldification");
+                Ok(Some(SessionCloseOutcome {
+                    summary: summarize_record(record, Some(DEFAULT_SUMMARY_LIMIT), None),
                     already_closed: false,
-                })
+                }))
             }
         }
     }
@@ -1619,8 +1978,8 @@ impl SessionStoreInner {
     ) -> Option<SessionSummary> {
         let session_id = session_id.trim();
         let record = self.sessions.get(session_id)?;
-        if !record.lifecycle.allows_mutation()
-            || record.project.as_deref() != Some(key.resolved_project.as_str())
+        if !record.lifecycle().allows_mutation()
+            || record.project() != Some(key.resolved_project.as_str())
         {
             return None;
         }
@@ -1708,7 +2067,7 @@ impl SessionStoreInner {
 
     fn binding_session_is_reusable(&self, session_id: &str, project: &str) -> bool {
         self.sessions.get(session_id).is_some_and(|record| {
-            record.lifecycle.allows_mutation() && record.project.as_deref() == Some(project)
+            record.lifecycle().allows_mutation() && record.project() == Some(project)
         })
     }
 
@@ -1745,14 +2104,16 @@ impl SessionStoreInner {
         input: PostSessionMessageInput,
     ) -> Result<SessionMessage, SessionMessageError> {
         self.touch(&input.session_id);
-        let Some(record) = self.sessions.get_mut(&input.session_id) else {
+        let Some(stored) = self.sessions.get_mut(&input.session_id) else {
             return Err(SessionMessageError::UnknownSession);
         };
-        if !record.lifecycle.allows_mutation() {
-            return Err(SessionMessageError::SessionClosed {
-                lifecycle: record.lifecycle,
-            });
+        let lifecycle = stored.lifecycle();
+        if !lifecycle.allows_mutation() {
+            return Err(SessionMessageError::SessionClosed { lifecycle });
         }
+        let record = stored
+            .hot_mut()
+            .expect("active session message mutation must stay hot");
         let message = validate_message_text(input.message)?;
         let tags = validate_message_tags(input.tags)?;
         if let Some(reply_to) = input.reply_to.as_deref() {
@@ -1786,30 +2147,6 @@ impl SessionStoreInner {
         Ok(message)
     }
 
-    pub(super) fn list_messages(
-        &mut self,
-        session_id: &str,
-        filter: ListSessionMessagesFilter,
-    ) -> Result<Vec<SessionMessage>, SessionMessageError> {
-        self.touch(session_id);
-        let Some(record) = self.sessions.get(session_id) else {
-            return Err(SessionMessageError::UnknownSession);
-        };
-        let limit = filter
-            .limit
-            .unwrap_or(DEFAULT_MESSAGE_LIST_LIMIT)
-            .clamp(0, MAX_MESSAGE_LIST_LIMIT);
-        Ok(record
-            .messages
-            .iter()
-            .filter(|message| filter.kind.is_none_or(|kind| message.kind == kind))
-            .filter(|message| filter.status.is_none_or(|status| message.status == status))
-            .rev()
-            .take(limit)
-            .map(|message| message.as_ref().clone())
-            .collect())
-    }
-
     /// Resolve an open message. Already-resolved messages stay resolved
     /// (status is not reopened); an optional new resolution text may update.
     pub(super) fn resolve_message(
@@ -1819,14 +2156,16 @@ impl SessionStoreInner {
         resolution: Option<String>,
     ) -> Result<SessionMessage, SessionMessageError> {
         self.touch(session_id);
-        let Some(record) = self.sessions.get_mut(session_id) else {
+        let Some(stored) = self.sessions.get_mut(session_id) else {
             return Err(SessionMessageError::UnknownSession);
         };
-        if !record.lifecycle.allows_mutation() {
-            return Err(SessionMessageError::SessionClosed {
-                lifecycle: record.lifecycle,
-            });
+        let lifecycle = stored.lifecycle();
+        if !lifecycle.allows_mutation() {
+            return Err(SessionMessageError::SessionClosed { lifecycle });
         }
+        let record = stored
+            .hot_mut()
+            .expect("active session message mutation must stay hot");
         let Some(message) = record
             .messages
             .iter_mut()
@@ -1850,91 +2189,6 @@ impl SessionStoreInner {
         Ok(message.clone())
     }
 
-    pub(super) fn discussion_summary(
-        &mut self,
-        session_id: &str,
-        limit: Option<usize>,
-    ) -> Result<SessionDiscussionSummary, SessionMessageError> {
-        self.touch(session_id);
-        let Some(record) = self.sessions.get(session_id) else {
-            return Err(SessionMessageError::UnknownSession);
-        };
-        let limit = limit
-            .unwrap_or(DEFAULT_MESSAGE_LIST_LIMIT)
-            .clamp(0, MAX_MESSAGE_LIST_LIMIT);
-        Ok(build_discussion_summary(record, limit))
-    }
-
-    pub(super) fn inbox_hint(&mut self, session_id: &str) -> Option<SessionInboxHint> {
-        self.touch(session_id);
-        let record = self.sessions.get(session_id)?;
-        build_inbox_hint(record)
-    }
-
-    // --- events ---
-
-    /// Sole path that appends to `SessionRecord.events`.
-    pub(super) fn push_event(&mut self, event: SessionEvent) -> bool {
-        let max_events_per_session = self.max_events_per_session;
-        if let Some(record) = self.sessions.get_mut(&event.session_id) {
-            record.updated_at = now_ts();
-            record.events.push_back(Arc::new(event));
-            record.events_observed = record.events_observed.saturating_add(1);
-            while record.events.len() > max_events_per_session {
-                record.events.pop_front();
-            }
-            let session_id = record.session_id.clone();
-            self.touch(&session_id);
-            true
-        } else {
-            // Unknown / already-evicted session: do not recreate.
-            false
-        }
-    }
-
-    pub(super) fn set_event_permission(
-        &mut self,
-        session_id: &str,
-        event_id: &str,
-        permission: PermissionDecision,
-    ) -> bool {
-        let Some(record) = self.sessions.get_mut(session_id) else {
-            return false;
-        };
-        if let Some(event) = record
-            .events
-            .iter_mut()
-            .rev()
-            .find(|event| event.event_id == event_id)
-        {
-            Arc::make_mut(event).permission = Some(permission);
-            true
-        } else {
-            false
-        }
-    }
-
-    pub(super) fn set_session_close_persistent_shell_evidence(
-        &mut self,
-        session_id: &str,
-        evidence: PersistentShellEventEvidence,
-    ) -> bool {
-        let Some(record) = self.sessions.get_mut(session_id) else {
-            return false;
-        };
-        let Some(event) = record
-            .events
-            .iter_mut()
-            .rev()
-            .find(|event| event.kind == "session_closed" && event.tool_name == "close_session")
-        else {
-            return false;
-        };
-        Arc::make_mut(event).persistent_shell = Some(evidence);
-        record.updated_at = now_ts();
-        true
-    }
-
     // --- reads / housekeeping ---
 
     pub(super) fn contains_session(&self, session_id: &str) -> bool {
@@ -1944,17 +2198,17 @@ impl SessionStoreInner {
     pub(super) fn session_project(&self, session_id: &str) -> Option<Option<String>> {
         self.sessions
             .get(session_id)
-            .map(|record| record.project.clone())
+            .map(|record| record.project().map(str::to_string))
     }
 
     pub(super) fn guard_state(&self, session_id: &str) -> Option<(SessionMode, SessionGuards)> {
         self.sessions
             .get(session_id)
-            .map(|record| (record.mode, record.guards))
+            .map(StoredSession::mode_guards)
     }
 
     pub(super) fn lifecycle_state(&self, session_id: &str) -> Option<SessionLifecycle> {
-        self.sessions.get(session_id).map(|record| record.lifecycle)
+        self.sessions.get(session_id).map(StoredSession::lifecycle)
     }
 
     fn to_persisted_ledger(&self) -> PersistedSessionLedger {
@@ -1962,7 +2216,14 @@ impl SessionStoreInner {
             .lru
             .iter()
             .filter_map(|session_id| self.sessions.get(session_id))
-            .map(|record| PersistedSessionRecord::from_record(record, self.max_events_per_session))
+            .map(|record| match record {
+                StoredSession::Hot(record) => PersistedSessionSnapshot::Hot(
+                    PersistedSessionRecord::from_record(record, self.max_events_per_session),
+                ),
+                StoredSession::Cold(record) => {
+                    PersistedSessionSnapshot::Cold(Arc::clone(&record.raw))
+                }
+            })
             .collect();
         let mut durable_current_bindings: Vec<PersistedCurrentBinding> = self
             .durable_current_bindings
@@ -1970,7 +2231,7 @@ impl SessionStoreInner {
             .filter(|(_, binding)| {
                 self.sessions
                     .get(&binding.session_id)
-                    .is_some_and(|session| session.lifecycle.allows_mutation())
+                    .is_some_and(|session| session.lifecycle().allows_mutation())
             })
             .map(|(binding_key_sha256, binding)| PersistedCurrentBinding {
                 binding_key_sha256: binding_key_sha256.clone(),
@@ -2031,93 +2292,7 @@ impl SessionStoreInner {
     }
 
     pub(super) fn summary(&self, session_id: &str, limit: Option<usize>) -> Option<SessionSummary> {
-        let record = self.sessions.get(session_id)?;
-        let limit = limit
-            .unwrap_or(DEFAULT_SUMMARY_LIMIT)
-            .clamp(0, MAX_SUMMARY_LIMIT);
-        let finished_events: Vec<&SessionEvent> = record
-            .events
-            .iter()
-            .map(Arc::as_ref)
-            .filter(|event| event.kind == "tool_call_finished")
-            .collect();
-        let counts = SessionCounts {
-            tool_calls: finished_events.len(),
-            succeeded: finished_events
-                .iter()
-                .filter(|event| event.status.as_deref() == Some("succeeded"))
-                .count(),
-            failed: finished_events
-                .iter()
-                .filter(|event| event.status.as_deref() == Some("failed"))
-                .count(),
-            read_like: finished_events
-                .iter()
-                .filter(|event| event.read_like)
-                .count(),
-            write_like: finished_events
-                .iter()
-                .filter(|event| event.write_like)
-                .count(),
-            shell_like: finished_events
-                .iter()
-                .filter(|event| event.shell_like)
-                .count(),
-            git_like: finished_events
-                .iter()
-                .filter(|event| event.git_like)
-                .count(),
-            change_summary_like: finished_events
-                .iter()
-                .filter(|event| event.change_summary_like)
-                .count(),
-        };
-        // The retained ledger is the per-session-capped tail `record.events`.
-        // `events_observed` counts every event ever appended, including those
-        // the per-session cap evicted; it is the durable source of truth for
-        // "did this session ever hold more events than are retained now".
-        let retained_total = record.events.len();
-        let observed_total = record.events_observed.max(retained_total as u64) as usize;
-        // The returned window is further sliced by the requested `limit`.
-        let skip = retained_total.saturating_sub(limit);
-        let events: Vec<SessionEvent> = record
-            .events
-            .iter()
-            .skip(skip)
-            .map(|event| event.as_ref().clone())
-            .collect();
-        let events_returned = events.len();
-        // Truncated when the durable ledger ever held more events than we are
-        // returning: either the per-session cap evicted older events, or the
-        // requested limit sliced a shorter tail than the retained ledger.
-        let events_truncated = observed_total > events_returned;
-        // Absolute sequence of the first returned event within the durable
-        // ledger's observed event stream. Older evicted events occupy sequences
-        // before this; a read-only projection must not mistake the retained tail
-        // for the session start when this is non-zero.
-        let first_retained_sequence = observed_total.saturating_sub(events_returned);
-        let project_instructions = record
-            .project_instructions
-            .as_ref()
-            .map(|snapshot| snapshot.to_summary());
-        Some(SessionSummary {
-            session_id: record.session_id.clone(),
-            project: record.project.clone(),
-            title: record.title.clone(),
-            mode: record.mode,
-            guards: record.guards,
-            execution_context: record.execution_context.clone(),
-            lifecycle: record.lifecycle,
-            created_at: record.created_at,
-            updated_at: record.updated_at,
-            counts,
-            events,
-            events_total: observed_total,
-            events_returned,
-            events_truncated,
-            first_retained_sequence,
-            project_instructions,
-            messages: build_messages_summary(record),
-        })
+        let record = self.sessions.get(session_id)?.hot()?;
+        Some(summarize_record(record, limit, None))
     }
 }

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -1485,6 +1485,88 @@ fn corrupted_ledger_does_not_panic() {
 }
 
 #[test]
+fn persistence_snapshot_shares_payload_and_stays_stable_across_message_cow() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger = tmp.path().join("sessions.json");
+    let store = persistent_store(ledger.clone());
+    let session = store.start_session(None, Some("shared snapshot".to_string()));
+    assert!(store
+        .record_tool_call_started(
+            Some(&session.session_id),
+            SessionTransport::Api,
+            "read_file",
+            &json!({
+                "project": "demo",
+                "path": "src/lib.rs",
+                "query": "snapshot payload"
+            }),
+        )
+        .is_some());
+    let message = post_message(
+        &store,
+        &session.session_id,
+        SessionMessageKind::Todo,
+        "snapshot message payload",
+    );
+    store.flush_persistence();
+
+    let (snapshot_ready_tx, snapshot_ready_rx) = std::sync::mpsc::channel();
+    let (allow_old_write_tx, allow_old_write_rx) = std::sync::mpsc::channel();
+    let snapshot_session_id = session.session_id.clone();
+    let delayed_store = store.clone();
+    let delayed_write = std::thread::spawn(move || {
+        delayed_store.persist_after_mutation_with(|path, ledger| {
+            let snapshot = ledger
+                .sessions
+                .iter()
+                .find(|record| record.session_id == snapshot_session_id)
+                .unwrap();
+            let event = snapshot.events.last().unwrap();
+            let message = snapshot.messages.last().unwrap();
+            assert_eq!(std::sync::Arc::strong_count(event), 2);
+            assert_eq!(std::sync::Arc::strong_count(message), 2);
+            assert_eq!(message.status, SessionMessageStatus::Open);
+
+            snapshot_ready_tx.send(()).unwrap();
+            allow_old_write_rx.recv().unwrap();
+
+            assert_eq!(std::sync::Arc::strong_count(message), 1);
+            assert_eq!(message.status, SessionMessageStatus::Open);
+            assert_eq!(message.resolution, None);
+            write_ledger_atomic(path, ledger)
+        });
+    });
+    snapshot_ready_rx.recv().unwrap();
+
+    let resolved = store
+        .resolve_message(
+            &session.session_id,
+            &message.message_id,
+            Some("resolved after snapshot".to_string()),
+        )
+        .unwrap();
+    assert_eq!(resolved.status, SessionMessageStatus::Resolved);
+    assert_eq!(
+        resolved.resolution.as_deref(),
+        Some("resolved after snapshot")
+    );
+
+    allow_old_write_tx.send(()).unwrap();
+    delayed_write.join().unwrap();
+
+    let restored = flush_and_restore(&store, ledger);
+    let messages = restored
+        .list_messages(&session.session_id, ListSessionMessagesFilter::default())
+        .unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].status, SessionMessageStatus::Resolved);
+    assert_eq!(
+        messages[0].resolution.as_deref(),
+        Some("resolved after snapshot")
+    );
+}
+
+#[test]
 fn concurrent_persistence_reloads_current_snapshot_before_write() {
     let tmp = tempfile::tempdir().unwrap();
     let ledger = tmp.path().join("sessions.json");

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -1519,6 +1519,7 @@ fn persistence_snapshot_shares_payload_and_stays_stable_across_message_cow() {
             let snapshot = ledger
                 .sessions
                 .iter()
+                .filter_map(|snapshot| snapshot.hot())
                 .find(|record| record.session_id == snapshot_session_id)
                 .unwrap();
             let event = snapshot.events.last().unwrap();
@@ -2552,7 +2553,10 @@ fn persisted_session_record_serde_defaults_missing_lifecycle() {
     let ledger: PersistedSessionLedger = serde_json::from_str(&ledger_json).unwrap();
     assert_eq!(ledger.version, SESSION_LEDGER_VERSION);
     assert_eq!(ledger.sessions.len(), 1);
-    assert_eq!(ledger.sessions[0].lifecycle, SessionLifecycle::Active);
+    assert_eq!(
+        ledger.sessions[0].hot().unwrap().lifecycle,
+        SessionLifecycle::Active
+    );
     assert!(ledger.durable_current_bindings.records.is_empty());
     assert_eq!(ledger.durable_current_bindings.malformed_count, 0);
 }
@@ -2601,6 +2605,266 @@ fn active_to_closed_succeeds_and_emits_session_closed_event() {
     assert_eq!(closed_events.len(), 1);
     assert_eq!(closed_events[0].tool_name, "close_session");
     assert_eq!(closed_events[0].status.as_deref(), Some("succeeded"));
+}
+
+#[test]
+fn closed_session_coldifies_payload_and_queries_without_reheating() {
+    let store = SessionStore::default();
+    let session = store.start_session(None, Some("cold history".to_string()));
+    post_message(
+        &store,
+        &session.session_id,
+        SessionMessageKind::Todo,
+        "retained closed message",
+    );
+    let start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "read_file",
+        &json!({"project": "demo", "path": "src/lib.rs"}),
+    );
+    store.record_tool_call_finished(start, true, &json!({"content": "retained"}), None, None);
+    assert!(store
+        .hot_payload_entry_count_for_test(&session.session_id)
+        .is_some_and(|entries| entries > 0));
+
+    let outcome = store.close_session(&session.session_id).unwrap();
+    assert!(!outcome.already_closed);
+    assert_eq!(
+        store.hot_payload_entry_count_for_test(&session.session_id),
+        None
+    );
+    assert!(store
+        .cold_payload_bytes_for_test(&session.session_id)
+        .is_some_and(|bytes| bytes > 0));
+
+    let other = store.start_session(None, Some("other cold history".to_string()));
+    store.close_session(&other.session_id).unwrap();
+    assert!(store
+        .cold_payload_bytes_for_test(&other.session_id)
+        .is_some());
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    assert_eq!(summary.lifecycle, SessionLifecycle::Closed);
+    assert!(summary
+        .events
+        .iter()
+        .any(|event| event.kind == "session_closed"));
+    let messages = store
+        .list_messages(&session.session_id, ListSessionMessagesFilter::default())
+        .unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].message, "retained closed message");
+    assert_eq!(
+        store.hot_payload_entry_count_for_test(&session.session_id),
+        None,
+        "cold queries must not install a hot SessionRecord"
+    );
+    assert_eq!(
+        store.hot_payload_entry_count_for_test(&other.session_id),
+        None,
+        "querying one cold Session must not heat another historical Session"
+    );
+
+    let query_start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "session_summary",
+        &json!({"session_id": session.session_id.clone()}),
+    );
+    store.record_tool_call_finished(query_start, true, &json!({"success": true}), None, None);
+    assert_eq!(
+        store.hot_payload_entry_count_for_test(&session.session_id),
+        None,
+        "closed recorder events must rewrite the cold payload in place"
+    );
+
+    let repeated = store.close_session(&session.session_id).unwrap();
+    assert!(repeated.already_closed);
+    let summary = store.summary(&session.session_id, Some(100)).unwrap();
+    assert_eq!(
+        summary
+            .events
+            .iter()
+            .filter(|event| event.kind == "session_closed")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn close_cleanup_evidence_rewrites_cold_payload_without_reheating() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger = tmp.path().join("sessions.json");
+    let store = persistent_store(ledger.clone());
+    let session = store.start_session(None, Some("cold close evidence".to_string()));
+    store.close_session(&session.session_id).unwrap();
+    assert!(store
+        .cold_payload_bytes_for_test(&session.session_id)
+        .is_some());
+
+    store.record_session_close_persistent_shell_evidence(
+        &session.session_id,
+        "wc_shell_cold_close",
+        "closed",
+        "completed",
+        None,
+        false,
+    );
+    assert_eq!(
+        store.hot_payload_entry_count_for_test(&session.session_id),
+        None
+    );
+
+    let restored = flush_and_restore(&store, ledger);
+    assert!(restored
+        .cold_payload_bytes_for_test(&session.session_id)
+        .is_some());
+    let summary = restored.summary(&session.session_id, Some(50)).unwrap();
+    let evidence = summary
+        .events
+        .iter()
+        .find(|event| event.kind == "session_closed")
+        .and_then(|event| event.persistent_shell.as_ref())
+        .expect("close cleanup evidence must survive cold persistence");
+    assert_eq!(evidence.shell_id.as_deref(), Some("wc_shell_cold_close"));
+    assert_eq!(evidence.shell_state.as_deref(), Some("closed"));
+    assert_eq!(evidence.execution_state.as_deref(), Some("completed"));
+}
+
+#[test]
+fn closed_cold_round_trip_preserves_evidence_and_active_stays_hot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger = tmp.path().join("sessions.json");
+    let store = SessionStore::with_persistence(&ledger, 10, 20);
+    let closed = store.start_session(Some("proj".to_string()), Some("historical".to_string()));
+    post_message(
+        &store,
+        &closed.session_id,
+        SessionMessageKind::Note,
+        "durable historical message",
+    );
+    let start = store.record_tool_call_started(
+        Some(&closed.session_id),
+        SessionTransport::Api,
+        "read_file",
+        &json!({"project": "proj", "path": "history.rs"}),
+    );
+    store.record_tool_call_finished(
+        start,
+        true,
+        &json!({"content": "history evidence"}),
+        None,
+        None,
+    );
+    store.close_session(&closed.session_id).unwrap();
+
+    let active = store.start_session(Some("proj".to_string()), Some("active".to_string()));
+    post_message(
+        &store,
+        &active.session_id,
+        SessionMessageKind::Progress,
+        "active message",
+    );
+    assert_eq!(
+        store.hot_payload_entry_count_for_test(&closed.session_id),
+        None
+    );
+    assert!(store
+        .hot_payload_entry_count_for_test(&active.session_id)
+        .is_some());
+    assert_eq!(store.cold_payload_bytes_for_test(&active.session_id), None);
+
+    let before_summary = store.summary(&closed.session_id, Some(100)).unwrap();
+    let before_messages = store
+        .list_messages(&closed.session_id, ListSessionMessagesFilter::default())
+        .unwrap();
+    store.flush_persistence();
+    let raw = std::fs::read_to_string(&ledger).unwrap();
+    let ledger_value: Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(ledger_value["version"], SESSION_LEDGER_VERSION);
+    let closed_json = ledger_value["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["session_id"] == closed.session_id)
+        .unwrap();
+    assert_eq!(closed_json["lifecycle"], "closed");
+    assert!(closed_json["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|message| message["message"] == "durable historical message"));
+
+    drop(store);
+    let restored = SessionStore::with_persistence(&ledger, 10, 20);
+    assert_eq!(
+        restored.hot_payload_entry_count_for_test(&closed.session_id),
+        None,
+        "restored closed session must not keep the parsed event/message graph"
+    );
+    assert!(restored
+        .cold_payload_bytes_for_test(&closed.session_id)
+        .is_some_and(|bytes| bytes > 0));
+    assert!(restored
+        .hot_payload_entry_count_for_test(&active.session_id)
+        .is_some());
+    assert_eq!(
+        restored.cold_payload_bytes_for_test(&active.session_id),
+        None
+    );
+
+    let after_summary = restored.summary(&closed.session_id, Some(100)).unwrap();
+    let after_messages = restored
+        .list_messages(&closed.session_id, ListSessionMessagesFilter::default())
+        .unwrap();
+    assert_eq!(
+        serde_json::to_value(&after_summary).unwrap(),
+        serde_json::to_value(&before_summary).unwrap()
+    );
+    assert_eq!(after_messages.len(), before_messages.len());
+    assert_eq!(after_messages[0].message, before_messages[0].message);
+    assert_eq!(after_summary.lifecycle, SessionLifecycle::Closed);
+    assert_eq!(
+        restored.hot_payload_entry_count_for_test(&closed.session_id),
+        None,
+        "restart query must materialize only a temporary target record"
+    );
+    assert_eq!(
+        restored
+            .summary(&active.session_id, Some(10))
+            .unwrap()
+            .lifecycle,
+        SessionLifecycle::Active
+    );
+}
+
+#[test]
+fn cold_session_query_touch_preserves_lru_capacity_order() {
+    let store = SessionStore::new(2, 10);
+    let first = store.start_session(None, Some("cold survivor".to_string()));
+    store.close_session(&first.session_id).unwrap();
+    let second = store.start_session(None, Some("old active".to_string()));
+
+    assert!(store
+        .cold_payload_bytes_for_test(&first.session_id)
+        .is_some());
+    store.summary(&first.session_id, Some(10)).unwrap();
+    let third = store.start_session(None, Some("new active".to_string()));
+
+    assert!(store.contains_session(&first.session_id));
+    assert!(!store.contains_session(&second.session_id));
+    assert!(store.contains_session(&third.session_id));
+    assert_eq!(
+        store.lifecycle_state(&first.session_id),
+        Some(SessionLifecycle::Closed)
+    );
+    assert!(store
+        .cold_payload_bytes_for_test(&first.session_id)
+        .is_some());
+    assert!(store
+        .hot_payload_entry_count_for_test(&third.session_id)
+        .is_some());
 }
 
 #[test]

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -5,8 +5,9 @@ use super::events::{
     session_input_summary_for_tool, SessionToolClassification,
 };
 use super::model::{
-    PersistedSessionLedger, PersistedSessionRecord, SessionLifecycle, MAX_OBSERVED_PATHS_PER_EVENT,
-    MAX_VALIDATION_EXCERPT_CHARS, MESSAGE_ID_PREFIX, SESSION_ID_PREFIX, SESSION_LEDGER_VERSION,
+    PersistedCurrentBindings, PersistedSessionLedger, PersistedSessionRecord, SessionLifecycle,
+    MAX_OBSERVED_PATHS_PER_EVENT, MAX_VALIDATION_EXCERPT_CHARS, MESSAGE_ID_PREFIX,
+    SESSION_ID_PREFIX, SESSION_LEDGER_VERSION,
 };
 use super::persistence::write_ledger_atomic;
 use super::*;
@@ -468,7 +469,13 @@ fn session_store_persists_and_restores_basic_session() {
         Some("persistent work".to_string()),
     );
 
-    let restored = flush_and_restore(&store, ledger);
+    store.flush_persistence();
+    let raw = std::fs::read_to_string(&ledger).unwrap();
+    assert!(
+        !raw.contains('\n'),
+        "production ledger should use compact JSON"
+    );
+    let restored = SessionStore::with_persistence(ledger, 10, 10);
     let status = restored.status();
     assert_eq!(status.persistence, "enabled");
     assert_eq!(status.restored_sessions, 1);
@@ -481,6 +488,36 @@ fn session_store_persists_and_restores_basic_session() {
     assert_eq!(
         summary.execution_context,
         SessionExecutionContext::default()
+    );
+}
+
+#[test]
+fn write_ledger_atomic_cleans_up_temp_file_when_rename_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger_path = tmp.path().join("sessions.json");
+    std::fs::create_dir(&ledger_path).unwrap();
+    let ledger = PersistedSessionLedger {
+        version: SESSION_LEDGER_VERSION,
+        sessions: Vec::new(),
+        durable_current_bindings: PersistedCurrentBindings::default(),
+    };
+
+    let err = write_ledger_atomic(&ledger_path, &ledger).unwrap_err();
+    assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
+
+    let temp_files: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".sessions.json.tmp-")
+        })
+        .collect();
+    assert!(
+        temp_files.is_empty(),
+        "failed write left a temporary ledger"
     );
 }
 


### PR DESCRIPTION
## Summary

Reduce `webcodex-server` Session persistence memory usage across the three concrete contributors identified in #15:

- stream compact JSON directly to the atomic temporary ledger file instead of materializing a full pretty-JSON `Vec<u8>`
- share immutable event/message payloads with `Arc` so persistence snapshots do not deep-clone the retained Session payload graph
- cold-store closed Session history in a compact serialized representation and materialize one Session on demand for reads, while keeping active Sessions hot

The existing background-writer generation/locking contract, atomic temp-file + rename behavior, Session recovery semantics, retention bounds, and query behavior are preserved.

Closes #15.

## Local memory smoke

Measured locally on Linux with release builds, comparing baseline `9c7ae467fe8f` against this branch. The synthetic ledger matches the production-scale characteristics from #15 without using production data:

- 9.094 MiB `sessions.json`
- 100 retained Sessions
- 5,539 retained events
- 34 active / 66 closed
- three interleaved runs per build; values below are medians
- each run verified that a known closed Session restored with the expected lifecycle and retained event count before sampling

| Metric | baseline | this branch | change |
| --- | ---: | ---: | ---: |
| Empty RSS | 24.32 MiB | 24.25 MiB | ~same |
| Populated steady RSS | 48.29 MiB | 45.81 MiB | -5.1% |
| Populated steady PSS | 46.08 MiB | 43.49 MiB | -5.6% |
| Startup high-water RSS | 48.29 MiB | 45.81 MiB | -5.1% |
| Persistence rewrite peak RSS | 84.43 MiB | 45.94 MiB | -45.6% |
| Post-rewrite RSS | 72.36 MiB | 45.94 MiB | -36.5% |
| Post-rewrite PSS | 70.14 MiB | 43.68 MiB | -37.7% |

The persistence transient above steady state dropped from about **+36.14 MiB** to about **+0.125 MiB**.

An all-active control using the same 100-Session ledger showed the `Arc` representation has a small hot-state cost, while converting 66 Sessions to closed/cold state reduced this branch by about **3.36 MiB RSS / 3.41 MiB PSS**. After subtracting the empty-server baseline, populated ledger residency was about **10% lower**.

The compact writer also reduced the rewritten ledger size in this fixture from 12,597,540 bytes to 10,286,156 bytes (-18.3%).

No live deployment or production Session data was used for these measurements.

## Validation

Focused validation performed during the three commits includes:

- session persistence/restore and compact-ledger regressions
- atomic rename-failure temp-file cleanup
- persistence snapshot sharing and mutation-isolation regressions
- closed/cold Session query, recovery, mutation rejection, ordering/retention, and persistence concurrency regressions
- affected Rust formatting and package checks
- focused race/concurrency coverage where the Session persistence ownership model changed
- `git diff --check`

The final branch was also exercised through the release-build memory smoke described above.

## Scope

This intentionally does not introduce SQLite, an append-only journal, or another incremental persistence framework. Startup restore still parses the bounded retained ledger, but the realistic smoke did not show a startup RSS peak above the final populated resident set, so there is no measurement-driven reason to expand the persistence architecture in this PR.