### PR TITLE
CLI: add explicit HTTP proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1078,9 +1088,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2289,7 +2301,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.21.1",
  "log",
@@ -2310,7 +2322,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -2583,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2867,6 +2879,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3797,6 +3830,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ webcodex agent status --scope user \
 See [Build and Install](docs/BUILD_INSTALL.md#runner-service-scopes) for system
 services and advanced overrides.
 
+WebCodex CLI requests to a WebCodex Server follow reqwest's standard proxy environment by
+default, including `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` (plus the
+corresponding forms reqwest supports). Use `--proxy http://HOST:PORT` to override that
+selection for the current CLI invocation, or `--no-system-proxy` to ignore proxy environment
+and connect directly. These flags affect CLI HTTP requests only. In particular,
+`webcodex connect` does not persist or inject them into the Runner configuration.
+
 If a Runner host needs an outbound HTTP proxy, make the proxy variables available to the
 Runner process/service. WebSocket honors `HTTPS_PROXY` / `HTTP_PROXY`, `ALL_PROXY`, and
 `NO_PROXY` (including lowercase forms); the supported proxy transport is HTTP `CONNECT`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -182,6 +182,12 @@ webcodex agent status --scope user \
 System service 与高级覆盖参数见
 [构建与安装](docs/BUILD_INSTALL.zh-CN.md#runner-service-scope)。
 
+WebCodex CLI 访问 WebCodex Server 时，默认遵循 reqwest 的标准代理环境变量，包括
+`HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 和 `NO_PROXY`（以及 reqwest 支持的对应形式）。
+`--proxy http://HOST:PORT` 会仅为本次 CLI invocation 显式覆盖该选择；
+`--no-system-proxy` 则忽略代理环境变量并强制直连。这两个 flag 只影响 CLI HTTP 请求。
+特别是 `webcodex connect` 不会把它们持久化或注入 Runner 配置。
+
 如果 Runner 所在网络需要出站 HTTP proxy，应把代理环境变量传给 Runner process/service。
 WebSocket 会遵循 `HTTPS_PROXY` / `HTTP_PROXY`、`ALL_PROXY` 与 `NO_PROXY`
 （也支持对应小写变量）；当前支持的代理传输是 HTTP `CONNECT`。变量优先级、限制和

--- a/crates/webcodex-admin/Cargo.toml
+++ b/crates/webcodex-admin/Cargo.toml
@@ -5,7 +5,7 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "system-proxy"] }
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/webcodex-admin/src/commands.rs
+++ b/crates/webcodex-admin/src/commands.rs
@@ -1,6 +1,6 @@
 use super::output::{format_error, sanitize};
 use super::{
-    AdminCliCommand, AdminCliRequest, AdminOptions, AgentTokenCreateArgs,
+    build_server_http_client, AdminCliCommand, AdminCliRequest, AdminOptions, AgentTokenCreateArgs,
     AgentTokenRegisterHashArgs, CreateUserArgs, RevokeTokenArgs, TokenCreateArgs,
     TokenRegisterHashArgs, UsernameArgs,
 };
@@ -73,6 +73,8 @@ pub fn usage() -> &'static str {
       webcodex agent-tokens list --server-url URL [--token TOKEN|--token-file PATH] --username USER\n\
       webcodex agent-tokens revoke --server-url URL [--token TOKEN|--token-file PATH] --username USER --token-id ID\n\n\
     Token fallback: WEBCODEX_TOKEN\n\
+    Proxy: standard HTTP_PROXY/HTTPS_PROXY/ALL_PROXY/NO_PROXY environment by default;\n\
+           --proxy http://HOST:PORT overrides it, --no-system-proxy forces direct.\n\
     Output: JSON\n"
 }
 
@@ -133,6 +135,14 @@ fn parse_common_flag(
             opts.token_file = Some(PathBuf::from(p.value(flag)?));
             Ok(true)
         }
+        "--proxy" => {
+            opts.server_http.proxy = Some(p.value(flag)?);
+            Ok(true)
+        }
+        "--no-system-proxy" => {
+            opts.server_http.no_system_proxy = true;
+            Ok(true)
+        }
         "--json" => {
             opts.json = true;
             Ok(true)
@@ -148,6 +158,7 @@ fn require_common(opts: &AdminOptions) -> Result<(), String> {
     if opts.token.is_some() && opts.token_file.is_some() {
         return Err("use only one of --token/--admin-token or --token-file".to_string());
     }
+    opts.server_http.validate()?;
     Ok(())
 }
 
@@ -463,6 +474,7 @@ pub fn build_admin_request(cmd: &AdminCliCommand) -> Result<AdminCliRequest, Str
     };
     Ok(AdminCliRequest {
         server_url: opts.server_url.trim_end_matches('/').to_string(),
+        server_http: opts.server_http.clone(),
         token: resolve_bearer_token(
             opts,
             matches!(
@@ -543,10 +555,7 @@ fn resolve_token(opts: &AdminOptions, env_key: &str) -> Result<String, String> {
 pub async fn run_admin_command(cmd: AdminCliCommand) -> Result<String, String> {
     let req = build_admin_request(&cmd)?;
     let url = format!("{}{}", req.server_url, req.path);
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+    let client = build_server_http_client(&req.server_http)?;
     let resp = client
         .post(url)
         .bearer_auth(&req.token)

--- a/crates/webcodex-admin/src/http.rs
+++ b/crates/webcodex-admin/src/http.rs
@@ -1,0 +1,80 @@
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ServerHttpOptions {
+    pub proxy: Option<String>,
+    pub no_system_proxy: bool,
+}
+
+fn proxy_validation_error() -> String {
+    "--proxy must be an http://host:port URL without credentials, path, query, or fragment"
+        .to_string()
+}
+
+fn authority_has_explicit_port(authority: &str) -> bool {
+    if authority.starts_with('[') {
+        let Some(close) = authority.find(']') else {
+            return false;
+        };
+        return authority[close + 1..]
+            .strip_prefix(':')
+            .is_some_and(|port| !port.is_empty());
+    }
+    authority
+        .rsplit_once(':')
+        .is_some_and(|(host, port)| !host.is_empty() && !host.contains(':') && !port.is_empty())
+}
+
+fn validate_http_proxy(proxy: &str) -> Result<(), String> {
+    if proxy.is_empty() {
+        return Err("--proxy cannot be empty".to_string());
+    }
+    if proxy.trim() != proxy {
+        return Err(proxy_validation_error());
+    }
+    let authority = proxy
+        .strip_prefix("http://")
+        .ok_or_else(proxy_validation_error)?;
+    if authority.is_empty()
+        || authority.contains('@')
+        || authority.contains('/')
+        || authority.contains('?')
+        || authority.contains('#')
+        || !authority_has_explicit_port(authority)
+    {
+        return Err(proxy_validation_error());
+    }
+    let parsed = reqwest::Url::parse(proxy).map_err(|_| proxy_validation_error())?;
+    if parsed.scheme() != "http"
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+    {
+        return Err(proxy_validation_error());
+    }
+    Ok(())
+}
+
+impl ServerHttpOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.proxy.is_some() && self.no_system_proxy {
+            return Err("--proxy and --no-system-proxy are mutually exclusive".to_string());
+        }
+        if let Some(proxy) = self.proxy.as_deref() {
+            validate_http_proxy(proxy)?;
+        }
+        Ok(())
+    }
+}
+
+pub fn build_server_http_client(options: &ServerHttpOptions) -> Result<reqwest::Client, String> {
+    options.validate()?;
+    let mut builder = reqwest::Client::builder();
+    if options.no_system_proxy {
+        builder = builder.no_proxy();
+    } else if let Some(proxy) = options.proxy.as_deref() {
+        let explicit = reqwest::Proxy::all(proxy).map_err(|_| proxy_validation_error())?;
+        builder = builder.no_proxy().proxy(explicit);
+    }
+    builder
+        .build()
+        .map_err(|_| "failed to build HTTP client".to_string())
+}

--- a/crates/webcodex-admin/src/lib.rs
+++ b/crates/webcodex-admin/src/lib.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 use std::path::PathBuf;
 
 mod commands;
+mod http;
 mod output;
 #[cfg(test)]
 mod tests;
@@ -9,6 +10,7 @@ mod tests;
 pub use commands::{
     build_admin_request, is_admin_group, parse_admin_cli, run_admin_command, usage,
 };
+pub use http::{build_server_http_client, ServerHttpOptions};
 
 /// Mutex serializing tests that mutate process-wide environment variables.
 /// It is exported because tests in both consuming packages use the same
@@ -32,6 +34,7 @@ pub enum AdminCliCommand {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct AdminOptions {
     pub server_url: String,
+    pub server_http: ServerHttpOptions,
     pub token: Option<String>,
     pub token_env: Option<String>,
     pub credential: Option<String>,
@@ -96,6 +99,7 @@ pub struct AgentTokenRegisterHashArgs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdminCliRequest {
     pub server_url: String,
+    pub server_http: ServerHttpOptions,
     pub token: String,
     pub path: &'static str,
     pub body: Value,

--- a/crates/webcodex-admin/src/tests.rs
+++ b/crates/webcodex-admin/src/tests.rs
@@ -350,6 +350,79 @@ fn non_json_error_reports_status_and_content_type_without_body() {
     assert!(!msg.contains("<html>"));
 }
 
+#[test]
+fn admin_proxy_controls_parse_and_validate() {
+    let req = request(&[
+        "users",
+        "list",
+        "--server-url",
+        "http://server.invalid",
+        "--proxy",
+        "http://proxy.example:80",
+        "--token",
+        "fake-admin",
+    ]);
+    assert_eq!(
+        req.server_http.proxy.as_deref(),
+        Some("http://proxy.example:80")
+    );
+    assert!(!req.server_http.no_system_proxy);
+
+    let error = parse_admin_cli(&args(&[
+        "users",
+        "list",
+        "--server-url",
+        "http://server.invalid",
+        "--proxy",
+        "http://127.0.0.1:7890",
+        "--no-system-proxy",
+        "--token",
+        "fake-admin",
+    ]))
+    .unwrap_err();
+    assert!(error.contains("mutually exclusive"));
+}
+
+#[tokio::test]
+async fn admin_request_routes_through_explicit_proxy() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let proxy_addr = listener.local_addr().unwrap();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 8192];
+        let n = stream.read(&mut buf).unwrap();
+        let request = String::from_utf8_lossy(&buf[..n]);
+        assert!(request.starts_with("POST http://server.invalid:9/api/users/list HTTP/1.1"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer fake-admin"));
+        let body = r#"{"success":true,"users":[]}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let proxy = format!("http://{proxy_addr}");
+    let cmd = parse_admin_cli(&args(&[
+        "users",
+        "list",
+        "--server-url",
+        "http://server.invalid:9",
+        "--proxy",
+        &proxy,
+        "--token",
+        "fake-admin",
+    ]))
+    .unwrap();
+    let output = run_admin_command(cmd).await.unwrap();
+    assert!(output.contains("\"users\": []"));
+    handle.join().unwrap();
+}
+
 #[tokio::test]
 async fn token_create_output_includes_plaintext_once_from_fake_server() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -377,6 +450,7 @@ async fn token_create_output_includes_plaintext_once_from_fake_server() {
         "create",
         "--server-url",
         &format!("http://{}", addr),
+        "--no-system-proxy",
         "--token",
         "fake-admin",
         "--username",

--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -25,7 +25,9 @@ use webcodex_admin as admin_cli;
 use webcodex_agent_config as agent_init;
 use webcodex_core::build_info;
 
-use admin_cli::{parse_admin_cli, run_admin_command, AdminCliCommand, AdminOptions};
+use admin_cli::{
+    parse_admin_cli, run_admin_command, AdminCliCommand, AdminOptions, ServerHttpOptions,
+};
 use agent_init::{
     run_agent_init, AgentInitOptions, DEFAULT_INIT_PROJECTS_DIR, DEFAULT_POLL_INTERVAL_MS,
     TRANSPORT_WEBSOCKET,
@@ -133,6 +135,7 @@ struct TokenGenerateOptions {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct TokenCreateLocalOptions {
     server_url: String,
+    server_http: ServerHttpOptions,
     username: String,
     credential: Option<String>,
     credential_env: Option<String>,
@@ -152,6 +155,7 @@ struct AgentTokenCreateLocalOptions {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct SetupSingleUserOptions {
     server_url: String,
+    server_http: ServerHttpOptions,
     token: Option<String>,
     token_file: Option<PathBuf>,
     username: String,
@@ -168,6 +172,7 @@ struct SetupSingleUserOptions {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct PairingCreateOptions {
     server_url: String,
+    server_http: ServerHttpOptions,
     env_file: Option<PathBuf>,
     token: Option<String>,
     token_file: Option<PathBuf>,
@@ -183,6 +188,7 @@ struct PairingCreateOptions {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ClientEnrollOptions {
     server_url: String,
+    server_http: ServerHttpOptions,
     pairing_code: String,
     client_id: String,
     display_name: Option<String>,
@@ -281,6 +287,7 @@ struct AgentStatusOptions {
     service_file: PathBuf,
     local_state_dir: Option<PathBuf>,
     server_url: Option<String>,
+    server_http: ServerHttpOptions,
     user_token_file: Option<PathBuf>,
     agent_token_file: Option<PathBuf>,
     json: bool,
@@ -366,6 +373,7 @@ fn parse_connect(args: &[String]) -> CliAction {
         };
     }
     let mut server_url = None;
+    let mut server_http = ServerHttpOptions::default();
     let mut key = None;
     let mut key_file = None;
     let mut project = PathBuf::from(".");
@@ -380,6 +388,11 @@ fn parse_connect(args: &[String]) -> CliAction {
             args.get(*index).cloned()
         };
         match arg.as_str() {
+            "--proxy" => match take(&mut index) {
+                Some(value) => server_http.proxy = Some(value),
+                None => return cli_parse_error("--proxy requires a value".to_string()),
+            },
+            "--no-system-proxy" => server_http.no_system_proxy = true,
             "--key" => match take(&mut index) {
                 Some(value) => key = Some(value),
                 None => return cli_parse_error("--key requires a value".to_string()),
@@ -416,6 +429,9 @@ fn parse_connect(args: &[String]) -> CliAction {
         }
         index += 1;
     }
+    if let Err(error) = server_http.validate() {
+        return cli_parse_error(error);
+    }
     if key.is_some() && key_file.is_some() {
         return cli_parse_error("--key and --key-file are mutually exclusive".to_string());
     }
@@ -432,6 +448,7 @@ fn parse_connect(args: &[String]) -> CliAction {
     }
     CliAction::Connect(ConnectOptions {
         server_url,
+        server_http,
         key,
         key_file,
         project,
@@ -478,6 +495,7 @@ fn parse_login(args: &[String]) -> CliAction {
         };
     }
     let mut server_url: Option<String> = None;
+    let mut server_http = ServerHttpOptions::default();
     let mut code: Option<String> = None;
     let mut device: Option<String> = None;
     let mut device_explicit = false;
@@ -495,6 +513,11 @@ fn parse_login(args: &[String]) -> CliAction {
             args.get(*index).cloned()
         };
         match arg.as_str() {
+            "--proxy" => match take(&mut index) {
+                Some(value) => server_http.proxy = Some(value),
+                None => return cli_parse_error("--proxy requires a value".to_string()),
+            },
+            "--no-system-proxy" => server_http.no_system_proxy = true,
             "--code" | "--pairing-code" => match take(&mut index) {
                 Some(value) => code = Some(value),
                 None => return cli_parse_error(format!("{arg} requires a value")),
@@ -533,6 +556,9 @@ fn parse_login(args: &[String]) -> CliAction {
         }
         index += 1;
     }
+    if let Err(error) = server_http.validate() {
+        return cli_parse_error(error);
+    }
     if json && print_mcp_config {
         return cli_parse_error(
             "--json and --print-mcp-config are mutually exclusive; --print-mcp-config emits a credential"
@@ -554,6 +580,7 @@ fn parse_login(args: &[String]) -> CliAction {
     };
     CliAction::Login(LoginOptions {
         server_url,
+        server_http,
         code,
         device: device.unwrap_or_else(default_device_name),
         device_explicit,
@@ -753,6 +780,8 @@ fn parse_agent_token_create_local(args: &[String]) -> Result<AgentTokenCreateLoc
     while let Some(flag) = p.next() {
         match flag.as_str() {
             "--server" | "--server-url" => opts.admin.server_url = p.value(&flag)?,
+            "--proxy" => opts.admin.server_http.proxy = Some(p.value(&flag)?),
+            "--no-system-proxy" => opts.admin.server_http.no_system_proxy = true,
             "--user" | "--username" => opts.username = p.value(&flag)?,
             "--client-id" => opts.client_id = p.value(&flag)?,
             "--credential" => opts.admin.credential = Some(p.value(&flag)?),
@@ -771,10 +800,11 @@ fn parse_agent_token_create_local(args: &[String]) -> Result<AgentTokenCreateLoc
                         .map(str::to_string),
                 );
             }
-            "-h" | "--help" => return Err("Usage: webcodex agent-token create-local --server URL --user USER --credential CRED --client-id ID [--name NAME] [--scopes S1,S2]".to_string()),
+            "-h" | "--help" => return Err("Usage: webcodex agent-token create-local --server URL --user USER --credential CRED --client-id ID [--proxy http://HOST:PORT|--no-system-proxy] [--name NAME] [--scopes S1,S2]".to_string()),
             _ => return Err(format!("unknown agent-token create-local flag: {}", flag)),
         }
     }
+    opts.admin.server_http.validate()?;
     if opts.admin.server_url.trim().is_empty() {
         return Err("--server is required".to_string());
     }
@@ -796,6 +826,8 @@ fn parse_token_create_local(args: &[String]) -> Result<TokenCreateLocalOptions, 
     while let Some(flag) = p.next() {
         match flag.as_str() {
             "--server" | "--server-url" => opts.server_url = p.value(&flag)?,
+            "--proxy" => opts.server_http.proxy = Some(p.value(&flag)?),
+            "--no-system-proxy" => opts.server_http.no_system_proxy = true,
             "--user" | "--username" => opts.username = p.value(&flag)?,
             "--credential" => opts.credential = Some(p.value(&flag)?),
             "--credential-env" => opts.credential_env = Some(p.value(&flag)?),
@@ -811,11 +843,12 @@ fn parse_token_create_local(args: &[String]) -> Result<TokenCreateLocalOptions, 
                 );
             }
             "-h" | "--help" => {
-                return Err("Usage: webcodex token create-local --server URL --user USER --credential CRED [--name NAME] [--scopes S1,S2]".to_string())
+                return Err("Usage: webcodex token create-local --server URL --user USER --credential CRED [--proxy http://HOST:PORT|--no-system-proxy] [--name NAME] [--scopes S1,S2]".to_string())
             }
             _ => return Err(format!("unknown token create-local flag: {}", flag)),
         }
     }
+    opts.server_http.validate()?;
     if opts.server_url.trim().is_empty() {
         return Err("--server is required".to_string());
     }
@@ -1099,6 +1132,7 @@ fn parse_ops_subcommand(args: &[String]) -> CliAction {
 fn default_ops_common_options() -> OpsCommonOptions {
     OpsCommonOptions {
         server_url: "http://127.0.0.1:8080".to_string(),
+        server_http: ServerHttpOptions::default(),
         env_file: None,
         token_file: None,
         token: None,
@@ -1113,6 +1147,8 @@ fn parse_ops_common(args: &[String], command: &str) -> Result<OpsCommonOptions, 
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--server-url" | "--url" => opts.server_url = next_value(&mut iter, arg)?,
+            "--proxy" => opts.server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => opts.server_http.no_system_proxy = true,
             "--env-file" => opts.env_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--token-file" => opts.token_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--token" => opts.token = Some(next_value(&mut iter, arg)?),
@@ -1125,6 +1161,7 @@ fn parse_ops_common(args: &[String], command: &str) -> Result<OpsCommonOptions, 
 }
 
 fn validate_ops_common(opts: &OpsCommonOptions) -> Result<OpsCommonOptions, String> {
+    opts.server_http.validate()?;
     if opts.server_url.trim().is_empty() {
         return Err("--server-url cannot be empty".to_string());
     }
@@ -1146,6 +1183,8 @@ fn parse_ops_smoke_preflight(args: &[String]) -> Result<OpsSmokePreflightOptions
         match arg.as_str() {
             "--project" => project = next_value(&mut iter, arg)?,
             "--server-url" | "--url" => common.server_url = next_value(&mut iter, arg)?,
+            "--proxy" => common.server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => common.server_http.no_system_proxy = true,
             "--env-file" => common.env_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--token-file" => common.token_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--token" => common.token = Some(next_value(&mut iter, arg)?),
@@ -1607,6 +1646,7 @@ fn parse_agent_status_with_identity(
         service_file: PathBuf::new(),
         local_state_dir: None,
         server_url: None,
+        server_http: ServerHttpOptions::default(),
         user_token_file: None,
         agent_token_file: None,
         json: false,
@@ -1624,6 +1664,8 @@ fn parse_agent_status_with_identity(
             "--config" => config = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--service-file" => service_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--server-url" => opts.server_url = Some(next_value(&mut iter, arg)?),
+            "--proxy" => opts.server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => opts.server_http.no_system_proxy = true,
             "--user-token-file" => {
                 opts.user_token_file = Some(PathBuf::from(next_value(&mut iter, arg)?))
             }
@@ -1634,6 +1676,7 @@ fn parse_agent_status_with_identity(
             _ => return Err(format!("unknown agent status flag: {}", arg)),
         }
     }
+    opts.server_http.validate()?;
     let scope_explicit = scope.is_some();
     let scope = scope.unwrap_or_else(|| default_agent_service_scope(effective_root));
     opts.scope = scope;
@@ -1751,6 +1794,7 @@ fn parse_server_install_service(args: &[String]) -> Result<ServerInstallServiceO
 fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
     let mut opts = ServerStatusOptions {
         url: "http://127.0.0.1:8080".to_string(),
+        server_http: ServerHttpOptions::default(),
         env_file: Some(default_server_paths()?.env_file),
         env_file_explicit: false,
         token_file: None,
@@ -1760,6 +1804,8 @@ fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--url" => opts.url = next_value(&mut iter, arg)?,
+            "--proxy" => opts.server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => opts.server_http.no_system_proxy = true,
             "--env-file" => {
                 opts.env_file = Some(PathBuf::from(next_value(&mut iter, arg)?));
                 opts.env_file_explicit = true;
@@ -1769,6 +1815,7 @@ fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
             _ => return Err(format!("unknown server status flag: {}", arg)),
         }
     }
+    opts.server_http.validate()?;
     if opts.url.trim().is_empty() {
         return Err("--url cannot be empty".to_string());
     }
@@ -1784,6 +1831,8 @@ fn parse_pairing_create(args: &[String]) -> Result<PairingCreateOptions, String>
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--server-url" => opts.server_url = next_value(&mut iter, arg)?,
+            "--proxy" => opts.server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => opts.server_http.no_system_proxy = true,
             "--env-file" => opts.env_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--token" => opts.token = Some(next_value(&mut iter, arg)?),
             "--token-file" => opts.token_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
@@ -1801,6 +1850,7 @@ fn parse_pairing_create(args: &[String]) -> Result<PairingCreateOptions, String>
             _ => return Err(format!("unknown pairing create flag: {}", arg)),
         }
     }
+    opts.server_http.validate()?;
     if opts.server_url.trim().is_empty() {
         return Err("--server-url is required".to_string());
     }
@@ -1821,6 +1871,7 @@ fn parse_pairing_create(args: &[String]) -> Result<PairingCreateOptions, String>
 
 fn parse_client_enroll(args: &[String]) -> Result<ClientEnrollOptions, String> {
     let mut server_url = String::new();
+    let mut server_http = ServerHttpOptions::default();
     let mut pairing_code = String::new();
     let mut client_id = String::new();
     let mut display_name = None;
@@ -1837,6 +1888,8 @@ fn parse_client_enroll(args: &[String]) -> Result<ClientEnrollOptions, String> {
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--server-url" => server_url = next_value(&mut iter, arg)?,
+            "--proxy" => server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => server_http.no_system_proxy = true,
             "--pairing-code" => pairing_code = next_value(&mut iter, arg)?,
             "--client-id" => client_id = next_value(&mut iter, arg)?,
             "--display-name" => display_name = Some(next_value(&mut iter, arg)?),
@@ -1854,6 +1907,7 @@ fn parse_client_enroll(args: &[String]) -> Result<ClientEnrollOptions, String> {
             _ => return Err(format!("unknown client enroll flag: {}", arg)),
         }
     }
+    server_http.validate()?;
     if server_url.trim().is_empty() {
         return Err("--server-url is required".to_string());
     }
@@ -1897,6 +1951,7 @@ fn parse_client_enroll(args: &[String]) -> Result<ClientEnrollOptions, String> {
     }
     Ok(ClientEnrollOptions {
         server_url,
+        server_http,
         pairing_code,
         client_id,
         display_name,
@@ -2027,6 +2082,7 @@ fn parse_setup_subcommand(args: &[String]) -> CliAction {
 fn parse_setup_single_user(args: &[String]) -> Result<SetupSingleUserOptions, String> {
     let mut opts = SetupSingleUserOptions {
         server_url: String::new(),
+        server_http: ServerHttpOptions::default(),
         token: None,
         token_file: None,
         username: String::new(),
@@ -2043,6 +2099,8 @@ fn parse_setup_single_user(args: &[String]) -> Result<SetupSingleUserOptions, St
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--server-url" => opts.server_url = next_value(&mut iter, arg)?,
+            "--proxy" => opts.server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => opts.server_http.no_system_proxy = true,
             "--token" => opts.token = Some(next_value(&mut iter, arg)?),
             "--token-file" => opts.token_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
             "--username" => opts.username = next_value(&mut iter, arg)?,
@@ -2058,6 +2116,7 @@ fn parse_setup_single_user(args: &[String]) -> Result<SetupSingleUserOptions, St
             _ => return Err(format!("unknown setup single-user flag: {}", arg)),
         }
     }
+    opts.server_http.validate()?;
     if opts.server_url.trim().is_empty() {
         return Err("--server-url is required".to_string());
     }

--- a/crates/webcodex-cli/src/webcodex_cli/agent_service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/agent_service.rs
@@ -340,7 +340,7 @@ pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String,
     if let (Some(server_url), Some(token)) =
         (effective_server_url.as_deref(), user_token.as_deref())
     {
-        let http = fetch_runtime_status(server_url, Some(token)).await?;
+        let http = fetch_runtime_status(server_url, &opts.server_http, Some(token)).await?;
         if let Some(output) = http.output.as_ref() {
             if !metadata.client_id.trim().is_empty() {
                 client_online = runtime_client_online(output, &metadata.client_id);
@@ -354,7 +354,14 @@ pub(crate) async fn run_agent_status(opts: AgentStatusOptions) -> Result<String,
     if let (Some(server_url), Some(token)) =
         (effective_server_url.as_deref(), agent_token.as_deref())
     {
-        match http_post_json_status(server_url, "/api/runtime/status", Some(token), json!({})).await
+        match http_post_json_status(
+            server_url,
+            &opts.server_http,
+            "/api/runtime/status",
+            Some(token),
+            json!({}),
+        )
+        .await
         {
             Ok((status, content_type, _)) if status == 401 || status == 403 => {
                 agent_boundary_status = Some("PASS");

--- a/crates/webcodex-cli/src/webcodex_cli/connect/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/mod.rs
@@ -149,7 +149,12 @@ pub(crate) async fn run_connect(opts: ConnectOptions) -> Result<ConnectResult, S
 
     // Fail before replacing a healthy profile when the destination cannot
     // authenticate this direct shared key at all.
-    preflight_shared_key(&canonical_server.url, &resolved_key.value).await?;
+    preflight_shared_key(
+        &canonical_server.url,
+        &opts.server_http,
+        &resolved_key.value,
+    )
+    .await?;
 
     let project_changed = if already_registered {
         false
@@ -187,6 +192,7 @@ pub(crate) async fn run_connect(opts: ConnectOptions) -> Result<ConnectResult, S
     })?;
     if let Err(error) = wait_for_connection(
         &canonical_server.url,
+        &opts.server_http,
         &resolved_key.value,
         &client_id,
         &runtime_project_id,

--- a/crates/webcodex-cli/src/webcodex_cli/connect/probe.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/probe.rs
@@ -1,13 +1,19 @@
 use serde_json::{json, Value as JsonValue};
 use std::path::Path;
 use std::time::{Duration, Instant};
+use webcodex_admin::ServerHttpOptions;
 
 use super::super::http::{fetch_runtime_status, post_json_authed, ApiCall};
 use super::process::local_runner_state_summary;
 
-pub(super) async fn preflight_shared_key(server_url: &str, key: &str) -> Result<(), String> {
+pub(super) async fn preflight_shared_key(
+    server_url: &str,
+    server_http: &ServerHttpOptions,
+    key: &str,
+) -> Result<(), String> {
     post_json_authed(ApiCall {
         server_url,
+        server_http,
         token: key,
         path: "/api/projects/list",
         body: json!({}),
@@ -57,6 +63,7 @@ pub(super) fn project_visible(
 
 pub(super) async fn wait_for_connection(
     server_url: &str,
+    server_http: &ServerHttpOptions,
     key: &str,
     client_id: &str,
     runtime_project_id: &str,
@@ -70,9 +77,10 @@ pub(super) async fn wait_for_connection(
         if !summary.running {
             return Err("Runner exited before it registered with the Server".to_string());
         }
-        let runtime = fetch_runtime_status(server_url, Some(key)).await;
+        let runtime = fetch_runtime_status(server_url, server_http, Some(key)).await;
         let projects = post_json_authed(ApiCall {
             server_url,
+            server_http,
             token: key,
             path: "/api/projects/list",
             body: json!({}),

--- a/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
@@ -6,6 +6,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use toml::{Table, Value as TomlValue};
+use webcodex_admin::ServerHttpOptions;
 
 use super::super::connections::{canonical_server_url, ensure_real_directory_tree};
 use super::super::profiles::{client_output_dir_for_profile, validate_client_profile};
@@ -16,6 +17,7 @@ const CONNECT_LOCK_FILE: &str = "connect.lock";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ConnectOptions {
     pub(crate) server_url: String,
+    pub(crate) server_http: ServerHttpOptions,
     pub(crate) key: Option<String>,
     pub(crate) key_file: Option<PathBuf>,
     pub(crate) project: PathBuf,
@@ -685,6 +687,7 @@ mod tests {
         let config_base = tmp.path().join("config");
         let options = ConnectOptions {
             server_url: "https://example.test".to_string(),
+            server_http: ServerHttpOptions::default(),
             key: None,
             key_file: None,
             project: project.clone(),

--- a/crates/webcodex-cli/src/webcodex_cli/http.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/http.rs
@@ -1,11 +1,13 @@
 use reqwest::header::CONTENT_TYPE;
 use serde_json::{json, Value};
+use webcodex_admin::{build_server_http_client, ServerHttpOptions};
 
 /// A single authenticated JSON POST against the server. Reuses
 /// `build_admin_request` to construct the path/body for known admin commands,
 /// but accepts arbitrary `(path, body)` so setup can issue its own calls.
 pub(crate) struct ApiCall<'a> {
     pub(crate) server_url: &'a str,
+    pub(crate) server_http: &'a ServerHttpOptions,
     pub(crate) token: &'a str,
     pub(crate) path: &'a str,
     pub(crate) body: Value,
@@ -13,17 +15,14 @@ pub(crate) struct ApiCall<'a> {
 
 pub(crate) async fn post_json_authed(call: ApiCall<'_>) -> Result<Value, String> {
     let url = format!("{}{}", call.server_url.trim_end_matches('/'), call.path);
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+    let client = build_server_http_client(call.server_http)?;
     let resp = client
         .post(url)
         .bearer_auth(call.token)
         .json(&call.body)
         .send()
         .await
-        .map_err(|e| format!("request failed: {}", e))?;
+        .map_err(|e| format!("request failed: {}", e).replace(call.token, "[redacted]"))?;
     let status = resp.status();
     let content_type = resp
         .headers()
@@ -36,7 +35,8 @@ pub(crate) async fn post_json_authed(call: ApiCall<'_>) -> Result<Value, String>
         .await
         .map_err(|e| format!("failed to read response: {}", e))?;
     if !status.is_success() {
-        return Err(format_error_body(status.as_u16(), &content_type, &text));
+        return Err(format_error_body(status.as_u16(), &content_type, &text)
+            .replace(call.token, "[redacted]"));
     }
     serde_json::from_str(&text).map_err(|e| {
         format!(
@@ -48,14 +48,12 @@ pub(crate) async fn post_json_authed(call: ApiCall<'_>) -> Result<Value, String>
 
 pub(crate) async fn post_json_unauthed(
     server_url: &str,
+    server_http: &ServerHttpOptions,
     path: &str,
     body: Value,
 ) -> Result<Value, String> {
     let url = format!("{}{}", server_url.trim_end_matches('/'), path);
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+    let client = build_server_http_client(server_http)?;
     let resp = client
         .post(url)
         .json(&body)
@@ -108,23 +106,21 @@ pub(crate) fn format_error_body(status: u16, content_type: &str, body: &str) -> 
 
 pub(crate) async fn http_post_json_status(
     server_url: &str,
+    server_http: &ServerHttpOptions,
     path: &str,
     token: Option<&str>,
     body: Value,
 ) -> Result<(u16, String, Option<Value>), String> {
     let url = format!("{}{}", server_url.trim_end_matches('/'), path);
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+    let client = build_server_http_client(server_http)?;
     let mut req = client.post(url).json(&body);
     if let Some(token) = token {
         req = req.bearer_auth(token);
     }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| format!("request failed: {}", e))?;
+    let resp = req.send().await.map_err(|e| {
+        let error = format!("request failed: {}", e);
+        token.map_or_else(|| error.clone(), |token| error.replace(token, "[redacted]"))
+    })?;
     let status = resp.status().as_u16();
     let content_type = resp
         .headers()
@@ -159,13 +155,11 @@ pub(crate) struct HttpStatusSummary {
 
 pub(crate) async fn fetch_runtime_status(
     url: &str,
+    server_http: &ServerHttpOptions,
     token: Option<&str>,
 ) -> Result<HttpStatusSummary, String> {
     let endpoint = format!("{}/api/runtime/status", url.trim_end_matches('/'));
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+    let client = build_server_http_client(server_http)?;
     let mut req = client.post(endpoint).json(&json!({}));
     if let Some(token) = token {
         req = req.bearer_auth(token);
@@ -173,11 +167,14 @@ pub(crate) async fn fetch_runtime_status(
     let resp = match req.send().await {
         Ok(resp) => resp,
         Err(e) => {
+            let error = format!("request failed: {}", e);
             return Ok(HttpStatusSummary {
                 reachable: false,
                 status_code: None,
                 content_type: None,
-                error: Some(format!("request failed: {}", e)),
+                error: Some(
+                    token.map_or_else(|| error.clone(), |token| error.replace(token, "[redacted]")),
+                ),
                 output: None,
             });
         }

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -17,6 +17,7 @@
 //! [`publish_connection`].
 
 use std::path::{Path, PathBuf};
+use webcodex_admin::ServerHttpOptions;
 
 use super::connections::{
     canonical_server_url, connections_for_server, default_base_dir, descriptor_toml,
@@ -287,6 +288,7 @@ pub(crate) fn resolve_device_name(base: &Path, opts: &LoginOptions) -> Result<St
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LoginOptions {
     pub(crate) server_url: String,
+    pub(crate) server_http: ServerHttpOptions,
     pub(crate) code: String,
     pub(crate) device: String,
     pub(crate) device_explicit: bool,
@@ -861,7 +863,9 @@ pub(crate) async fn redeem_pairing_code(
             .collect::<Vec<_>>());
     }
 
-    let value = super::http::post_json_unauthed(server_url, "/api/pairing/enroll", body).await?;
+    let value =
+        super::http::post_json_unauthed(server_url, &opts.server_http, "/api/pairing/enroll", body)
+            .await?;
     let field = |name: &str| -> Result<String, String> {
         value
             .get(name)
@@ -1021,6 +1025,7 @@ mod tests {
     fn login_opts(base: &Path, server_url: &str, overwrite: bool) -> LoginOptions {
         LoginOptions {
             server_url: server_url.to_string(),
+            server_http: ServerHttpOptions::default(),
             code: CODE.to_string(),
             device: "laptop".to_string(),
             device_explicit: false,
@@ -1949,6 +1954,10 @@ mod tests {
         let base = temp.path().join("config root");
         let opts = LoginOptions {
             server_url: format!("http://{address}"),
+            server_http: ServerHttpOptions {
+                proxy: None,
+                no_system_proxy: true,
+            },
             code: CODE.to_string(),
             device: "shared-host".to_string(),
             device_explicit: false,

--- a/crates/webcodex-cli/src/webcodex_cli/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/ops.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use webcodex_admin::ServerHttpOptions;
 
 use super::{
     http_post_json_status, read_env_file_value, read_optional_token, validate_user_api_token,
@@ -10,6 +11,7 @@ const DEFAULT_EXPECTED_TOOL_COUNT: u64 = 66;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OpsCommonOptions {
     pub(crate) server_url: String,
+    pub(crate) server_http: ServerHttpOptions,
     pub(crate) env_file: Option<PathBuf>,
     pub(crate) token_file: Option<PathBuf>,
     pub(crate) token: Option<String>,
@@ -105,6 +107,7 @@ pub(crate) async fn run_ops_command(command: OpsCommand) -> Result<OpsCommandOut
             let token = resolve_ops_token(&opts)?;
             let report = match fetch_ops_json_output(
                 &opts.server_url,
+                &opts.server_http,
                 "/api/runtime/status",
                 token.as_deref(),
                 json!({}),
@@ -125,6 +128,7 @@ pub(crate) async fn run_ops_command(command: OpsCommand) -> Result<OpsCommandOut
             let token = resolve_ops_token(&opts)?;
             let report = match fetch_ops_json_output(
                 &opts.server_url,
+                &opts.server_http,
                 "/api/runtime/status",
                 token.as_deref(),
                 json!({}),
@@ -143,21 +147,23 @@ pub(crate) async fn run_ops_command(command: OpsCommand) -> Result<OpsCommandOut
         }
         OpsCommand::Projects(opts) => {
             let token = resolve_ops_token(&opts)?;
-            let report = match fetch_projects(&opts.server_url, token.as_deref()).await {
-                Ok(projects) => ops_projects_report(&opts.server_url, Some(&projects)),
-                Err(failure) => ops_http_failure_report(
-                    &opts.server_url,
-                    "list_projects",
-                    failure,
-                    token.is_some(),
-                ),
-            };
+            let report =
+                match fetch_projects(&opts.server_url, &opts.server_http, token.as_deref()).await {
+                    Ok(projects) => ops_projects_report(&opts.server_url, Some(&projects)),
+                    Err(failure) => ops_http_failure_report(
+                        &opts.server_url,
+                        "list_projects",
+                        failure,
+                        token.is_some(),
+                    ),
+                };
             render_ops_command_output(report, opts.json, render_ops_projects)
         }
         OpsCommand::SmokePreflight(opts) => {
             let token = resolve_ops_token(&opts.common)?;
             let runtime_status = match fetch_ops_json_output(
                 &opts.common.server_url,
+                &opts.common.server_http,
                 "/api/runtime/status",
                 token.as_deref(),
                 json!({}),
@@ -179,7 +185,13 @@ pub(crate) async fn run_ops_command(command: OpsCommand) -> Result<OpsCommandOut
                     );
                 }
             };
-            let projects = match fetch_projects(&opts.common.server_url, token.as_deref()).await {
+            let projects = match fetch_projects(
+                &opts.common.server_url,
+                &opts.common.server_http,
+                token.as_deref(),
+            )
+            .await
+            {
                 Ok(projects) => projects,
                 Err(failure) => {
                     let report = ops_http_failure_report(
@@ -200,6 +212,7 @@ pub(crate) async fn run_ops_command(command: OpsCommand) -> Result<OpsCommandOut
             let (show_changes, hygiene) = if target_state.ready {
                 let show_changes = match call_runtime_tool(
                     &opts.common.server_url,
+                    &opts.common.server_http,
                     token.as_deref(),
                     "show_changes",
                     json!({"project": opts.project, "include_diff": false}),
@@ -223,6 +236,7 @@ pub(crate) async fn run_ops_command(command: OpsCommand) -> Result<OpsCommandOut
                 };
                 let hygiene = match call_runtime_tool(
                     &opts.common.server_url,
+                    &opts.common.server_http,
                     token.as_deref(),
                     "workspace_hygiene_check",
                     json!({"project": opts.project}),
@@ -383,11 +397,12 @@ impl OpsHttpFailure {
 
 async fn fetch_ops_json_output(
     server_url: &str,
+    server_http: &ServerHttpOptions,
     path: &str,
     token: Option<&str>,
     body: Value,
 ) -> Result<Value, OpsHttpFailure> {
-    match http_post_json_status(server_url, path, token, body).await {
+    match http_post_json_status(server_url, server_http, path, token, body).await {
         Ok((status, _content_type, Some(value))) if (200..300).contains(&status) => {
             Ok(output_payload(value))
         }
@@ -400,8 +415,19 @@ async fn fetch_ops_json_output(
     }
 }
 
-async fn fetch_projects(server_url: &str, token: Option<&str>) -> Result<Value, OpsHttpFailure> {
-    fetch_ops_json_output(server_url, "/api/projects/list", token, json!({})).await
+async fn fetch_projects(
+    server_url: &str,
+    server_http: &ServerHttpOptions,
+    token: Option<&str>,
+) -> Result<Value, OpsHttpFailure> {
+    fetch_ops_json_output(
+        server_url,
+        server_http,
+        "/api/projects/list",
+        token,
+        json!({}),
+    )
+    .await
 }
 
 fn ops_http_failure_report(
@@ -433,12 +459,14 @@ fn ops_http_failure_report(
 
 async fn call_runtime_tool(
     server_url: &str,
+    server_http: &ServerHttpOptions,
     token: Option<&str>,
     tool: &str,
     params: Value,
 ) -> Result<Option<Value>, OpsHttpFailure> {
     fetch_ops_json_output(
         server_url,
+        server_http,
         "/api/tools/call",
         token,
         json!({"tool": tool, "params": params}),

--- a/crates/webcodex-cli/src/webcodex_cli/pairing.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/pairing.rs
@@ -137,6 +137,7 @@ pub(crate) async fn run_pairing_create(opts: PairingCreateOptions) -> Result<Str
     }
     let value = post_json_authed(ApiCall {
         server_url: &opts.server_url,
+        server_http: &opts.server_http,
         token: &token,
         path: "/api/pairing/create",
         body,
@@ -184,7 +185,13 @@ pub(crate) async fn run_client_enroll(opts: ClientEnrollOptions) -> Result<Strin
             .map(|p| p.to_string_lossy().to_string())
             .collect::<Vec<_>>());
     }
-    let value = post_json_unauthed(&opts.server_url, "/api/pairing/enroll", body).await?;
+    let value = post_json_unauthed(
+        &opts.server_url,
+        &opts.server_http,
+        "/api/pairing/enroll",
+        body,
+    )
+    .await?;
     let user_token = value
         .get("user_token")
         .and_then(Value::as_str)

--- a/crates/webcodex-cli/src/webcodex_cli/server.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/server.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use webcodex_admin::ServerHttpOptions;
 
 use crate::{
     ServerInitOptions, ServerInstallServiceOptions, ServiceActionKind, ServiceActionOptions,
@@ -16,6 +17,7 @@ use super::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ServerStatusOptions {
     pub(crate) url: String,
+    pub(crate) server_http: ServerHttpOptions,
     pub(crate) env_file: Option<PathBuf>,
     pub(crate) env_file_explicit: bool,
     pub(crate) token_file: Option<PathBuf>,
@@ -225,7 +227,7 @@ fn resolve_status_token(opts: &ServerStatusOptions) -> Result<Option<String>, St
 pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<String, String> {
     let systemd = query_systemd_status();
     let token = resolve_status_token(&opts)?;
-    let http = fetch_runtime_status(&opts.url, token.as_deref()).await?;
+    let http = fetch_runtime_status(&opts.url, &opts.server_http, token.as_deref()).await?;
     let output = http.output.as_ref();
     let auth_enabled = output.and_then(|v| v.get("auth_enabled")).cloned();
     let configured_public_url = output

--- a/crates/webcodex-cli/src/webcodex_cli/setup.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/setup.rs
@@ -16,6 +16,7 @@ use super::{post_json_authed, resolve_token, token_prefix, ApiCall};
 pub(crate) async fn run_setup_single_user(opts: SetupSingleUserOptions) -> Result<String, String> {
     let admin_opts = AdminOptions {
         server_url: opts.server_url.clone(),
+        server_http: opts.server_http.clone(),
         token: opts.token.clone(),
         token_env: None,
         credential: None,
@@ -31,6 +32,7 @@ pub(crate) async fn run_setup_single_user(opts: SetupSingleUserOptions) -> Resul
     // bootstrap token (never printed).
     let call_opts = AdminOptions {
         server_url: opts.server_url.clone(),
+        server_http: opts.server_http.clone(),
         token: Some(bootstrap.clone()),
         token_env: None,
         credential: None,
@@ -49,6 +51,7 @@ pub(crate) async fn run_setup_single_user(opts: SetupSingleUserOptions) -> Resul
     }
     let user_result = post_json_authed(ApiCall {
         server_url: &server_url,
+        server_http: &opts.server_http,
         token: &bootstrap,
         path: "/api/users/create",
         body: user_body,
@@ -73,6 +76,7 @@ pub(crate) async fn run_setup_single_user(opts: SetupSingleUserOptions) -> Resul
         .map_err(|e| format!("internal: failed to build tokens create: {}", e))?;
     let gpt_resp = post_json_authed(ApiCall {
         server_url: &server_url,
+        server_http: &opts.server_http,
         token: &bootstrap,
         path: gpt_req.path,
         body: gpt_req.body,
@@ -98,6 +102,7 @@ pub(crate) async fn run_setup_single_user(opts: SetupSingleUserOptions) -> Resul
         .map_err(|e| format!("internal: failed to build agent-tokens create: {}", e))?;
     let agent_resp = post_json_authed(ApiCall {
         server_url: &server_url,
+        server_http: &opts.server_http,
         token: &bootstrap,
         path: agent_req.path,
         body: agent_req.body,

--- a/crates/webcodex-cli/src/webcodex_cli/tests/connect.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/connect.rs
@@ -84,6 +84,7 @@ async fn connect_rejects_invalid_url_and_missing_project_before_network_or_write
     let tmp = tempfile::tempdir().unwrap();
     let base = ConnectOptions {
         server_url: "ssh://example.test".to_string(),
+        server_http: ServerHttpOptions::default(),
         key: Some("shared-key".to_string()),
         key_file: None,
         project: tmp.path().join("missing"),

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -424,6 +424,7 @@ fn clean_hygiene_fixture() -> Value {
 fn ops_common_opts(server_url: String) -> OpsCommonOptions {
     OpsCommonOptions {
         server_url,
+        server_http: direct_server_http(),
         env_file: None,
         token_file: None,
         token: None,
@@ -537,6 +538,7 @@ fn smoke_preflight_opts(server_url: String, project: &str) -> OpsSmokePreflightO
     OpsSmokePreflightOptions {
         common: OpsCommonOptions {
             server_url,
+            server_http: direct_server_http(),
             env_file: None,
             token_file: None,
             token: Some("secret-smoke-token".to_string()),

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/env.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/env.rs
@@ -288,6 +288,7 @@ async fn token_create_local_does_not_send_plaintext_token_to_server() {
     let out = run_token_create_local(TokenCreateLocalOptions {
         server_url: format!("http://{}", addr),
         username: "alice".to_string(),
+        server_http: direct_server_http(),
         credential: Some("wc_acct_fake".to_string()),
         credential_env: None,
         name: Some("gpt-action".to_string()),
@@ -328,6 +329,7 @@ async fn agent_token_create_local_does_not_send_plaintext_token_to_server() {
     let out = run_agent_token_create_local(AgentTokenCreateLocalOptions {
         admin: AdminOptions {
             server_url: format!("http://{}", addr),
+            server_http: direct_server_http(),
             credential: Some("wc_acct_fake".to_string()),
             ..AdminOptions::default()
         },
@@ -370,6 +372,7 @@ async fn agent_token_create_local_prefers_admin_token_over_default_account_crede
     let out = run_agent_token_create_local(AgentTokenCreateLocalOptions {
         admin: AdminOptions {
             server_url: format!("http://{}", addr),
+            server_http: direct_server_http(),
             token: Some("fake-admin".to_string()),
             ..AdminOptions::default()
         },
@@ -410,6 +413,7 @@ async fn agent_token_create_local_uses_default_account_credential() {
     let out = run_agent_token_create_local(AgentTokenCreateLocalOptions {
         admin: AdminOptions {
             server_url: format!("http://{}", addr),
+            server_http: direct_server_http(),
             ..AdminOptions::default()
         },
         username: "alice".to_string(),
@@ -420,6 +424,270 @@ async fn agent_token_create_local_uses_default_account_credential() {
     .await
     .unwrap();
     assert_eq!(out.matches("wc_agent_").count(), 1);
+    handle.join().unwrap();
+}
+
+fn cleared_proxy_env() -> EnvGuard {
+    EnvGuard::new()
+        .remove("HTTP_PROXY")
+        .remove("HTTPS_PROXY")
+        .remove("ALL_PROXY")
+        .remove("NO_PROXY")
+        .remove("http_proxy")
+        .remove("https_proxy")
+        .remove("all_proxy")
+        .remove("no_proxy")
+}
+
+#[test]
+fn server_http_proxy_validation_and_flag_conflict_are_fail_closed() {
+    for proxy in [
+        "http://127.0.0.1:7890",
+        "http://proxy.example:80",
+        "http://[::1]:7890",
+    ] {
+        ServerHttpOptions {
+            proxy: Some(proxy.to_string()),
+            no_system_proxy: false,
+        }
+        .validate()
+        .unwrap();
+    }
+    for proxy in [
+        "",
+        "https://proxy.example:7890",
+        "socks5://proxy.example:7890",
+        "http://proxy.example",
+        "http://@127.0.0.1:7890",
+        "http://user@127.0.0.1:7890",
+        "http://user:password@127.0.0.1:7890",
+        "http://127.0.0.1:notaport",
+        "http://127.0.0.1:7890/path",
+        "http://127.0.0.1:7890?query=1",
+        "http://127.0.0.1:7890#fragment",
+    ] {
+        let error = ServerHttpOptions {
+            proxy: Some(proxy.to_string()),
+            no_system_proxy: false,
+        }
+        .validate()
+        .unwrap_err();
+        if !proxy.is_empty() {
+            assert!(!error.contains(proxy));
+        }
+        assert!(!error.contains("password"));
+    }
+
+    let action = cli_action(args(&[
+        "connect",
+        "http://server.invalid",
+        "--proxy",
+        "http://127.0.0.1:7890",
+        "--no-system-proxy",
+    ]));
+    assert!(matches!(
+        action,
+        CliAction::Exit { code: 2, ref stderr, .. }
+            if stderr.contains("--proxy and --no-system-proxy are mutually exclusive")
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn default_server_http_uses_ambient_http_proxy() {
+    let _guard = env_test_guard();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let proxy_addr = listener.local_addr().unwrap();
+    let proxy_url = format!("http://{proxy_addr}");
+    let _env = cleared_proxy_env()
+        .set("HTTP_PROXY", &proxy_url)
+        .set("NO_PROXY", "");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 8192];
+        let n = stream.read(&mut buf).unwrap();
+        let request = String::from_utf8_lossy(&buf[..n]);
+        assert!(request.starts_with("POST http://server.invalid:9/api/system-proxy HTTP/1.1"));
+        let body = r#"{"proxied":true}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let value = crate::webcodex_cli::post_json_unauthed(
+        "http://server.invalid:9",
+        &ServerHttpOptions::default(),
+        "/api/system-proxy",
+        json!({}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value["proxied"], true);
+    handle.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn ambient_no_proxy_bypasses_system_proxy() {
+    let _guard = env_test_guard();
+    let target = TcpListener::bind("127.0.0.1:0").unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let _env = cleared_proxy_env()
+        .set("HTTP_PROXY", "http://127.0.0.1:1")
+        .set("NO_PROXY", "127.0.0.1");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = target.accept().unwrap();
+        let mut buf = [0u8; 8192];
+        let n = stream.read(&mut buf).unwrap();
+        let request = String::from_utf8_lossy(&buf[..n]);
+        assert!(request.starts_with("POST /api/no-proxy-check HTTP/1.1"));
+        let body = r#"{"direct":true}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let value = crate::webcodex_cli::post_json_unauthed(
+        &format!("http://{target_addr}"),
+        &ServerHttpOptions::default(),
+        "/api/no-proxy-check",
+        json!({}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value["direct"], true);
+    handle.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn explicit_proxy_overrides_ambient_system_proxy() {
+    let _guard = env_test_guard();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let proxy_addr = listener.local_addr().unwrap();
+    let explicit_proxy = format!("http://{proxy_addr}");
+    let _env = cleared_proxy_env()
+        .set("HTTP_PROXY", "http://127.0.0.1:1")
+        .set("NO_PROXY", "");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 8192];
+        let n = stream.read(&mut buf).unwrap();
+        let request = String::from_utf8_lossy(&buf[..n]);
+        assert!(request.starts_with("POST http://server.invalid:9/api/explicit-proxy HTTP/1.1"));
+        let body = r#"{"explicit":true}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let options = ServerHttpOptions {
+        proxy: Some(explicit_proxy),
+        no_system_proxy: false,
+    };
+    let value = crate::webcodex_cli::post_json_unauthed(
+        "http://server.invalid:9",
+        &options,
+        "/api/explicit-proxy",
+        json!({}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value["explicit"], true);
+    handle.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn no_system_proxy_forces_direct_connection() {
+    let _guard = env_test_guard();
+    let target = TcpListener::bind("127.0.0.1:0").unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let _env = cleared_proxy_env()
+        .set("HTTP_PROXY", "http://127.0.0.1:1")
+        .set("NO_PROXY", "");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = target.accept().unwrap();
+        let mut buf = [0u8; 8192];
+        let n = stream.read(&mut buf).unwrap();
+        let request = String::from_utf8_lossy(&buf[..n]);
+        assert!(request.starts_with("POST /api/direct-check HTTP/1.1"));
+        let body = r#"{"direct":true}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let options = ServerHttpOptions {
+        proxy: None,
+        no_system_proxy: true,
+    };
+    let value = crate::webcodex_cli::post_json_unauthed(
+        &format!("http://{target_addr}"),
+        &options,
+        "/api/direct-check",
+        json!({}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value["direct"], true);
+    handle.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn authenticated_explicit_proxy_request_redacts_bearer_from_error() {
+    let _guard = env_test_guard();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let proxy_addr = listener.local_addr().unwrap();
+    let explicit_proxy = format!("http://{proxy_addr}");
+    let _env = cleared_proxy_env().set("HTTP_PROXY", "http://127.0.0.1:1");
+    let secret = "proxy-bearer-secret-do-not-leak";
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 8192];
+        let n = stream.read(&mut buf).unwrap();
+        let request = String::from_utf8_lossy(&buf[..n]);
+        assert!(request.starts_with("POST http://server.invalid:9/api/auth-check HTTP/1.1"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer proxy-bearer-secret-do-not-leak"));
+        let body = r#"{"error":"bad proxy-bearer-secret-do-not-leak"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 401 Unauthorized\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let options = ServerHttpOptions {
+        proxy: Some(explicit_proxy),
+        no_system_proxy: false,
+    };
+    let error = crate::webcodex_cli::post_json_authed(crate::webcodex_cli::ApiCall {
+        server_url: "http://server.invalid:9",
+        server_http: &options,
+        token: secret,
+        path: "/api/auth-check",
+        body: json!({}),
+    })
+    .await
+    .unwrap_err();
+    assert!(!error.contains(secret));
+    assert!(error.contains("[redacted]"));
     handle.join().unwrap();
 }
 

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
@@ -362,6 +362,7 @@ async fn setup_single_user_runs_expected_calls_and_writes_0600_files() {
     let tmp = tempfile::tempdir().unwrap();
     let opts = SetupSingleUserOptions {
         server_url: format!("http://{}", addr),
+        server_http: direct_server_http(),
         token: Some(bootstrap.clone()),
         token_file: None,
         username: "yyjeqhc".to_string(),
@@ -453,6 +454,7 @@ async fn setup_single_user_handles_user_already_exists() {
     let tmp = tempfile::tempdir().unwrap();
     let opts = SetupSingleUserOptions {
         server_url: format!("http://{}", addr),
+        server_http: direct_server_http(),
         token: Some(bootstrap.clone()),
         token_file: None,
         username: "yyjeqhc".to_string(),

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -684,6 +684,7 @@ transport = "websocket"
         config.to_str().unwrap(),
         "--server-url",
         &format!("http://{}", addr),
+        "--no-system-proxy",
         "--user-token-file",
         user_token_file.to_str().unwrap(),
         "--agent-token-file",

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
@@ -120,6 +120,7 @@ async fn server_status_parses_env_token_posts_and_does_not_print_token() {
     let opts = parse_server_status(&args(&[
         "--url",
         &format!("http://{}", addr),
+        "--no-system-proxy",
         "--env-file",
         env_file.to_str().unwrap(),
     ]))
@@ -167,6 +168,7 @@ async fn server_status_token_file_takes_priority_over_env_file() {
     let opts = parse_server_status(&args(&[
         "--url",
         &format!("http://{}", addr),
+        "--no-system-proxy",
         "--env-file",
         env_file.to_str().unwrap(),
         "--token-file",
@@ -200,6 +202,7 @@ async fn server_status_connection_failure_reports_unreachable_without_token() {
     let opts = parse_server_status(&args(&[
         "--url",
         &format!("http://{}", addr),
+        "--no-system-proxy",
         "--env-file",
         env_file.to_str().unwrap(),
     ]))
@@ -227,7 +230,12 @@ async fn server_status_non_json_error_reports_status_and_content_type_only() {
         )
         .unwrap();
     });
-    let opts = parse_server_status(&args(&["--url", &format!("http://{}", addr)])).unwrap();
+    let opts = parse_server_status(&args(&[
+        "--url",
+        &format!("http://{}", addr),
+        "--no-system-proxy",
+    ]))
+    .unwrap();
     let output = run_server_status(opts).await.unwrap();
     handle.join().unwrap();
     assert!(output.contains("HTTP reachable:        no"));

--- a/crates/webcodex-cli/src/webcodex_cli/tests/support.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/support.rs
@@ -15,3 +15,10 @@ pub(super) use std::io::{Read, Write};
 pub(super) use std::net::TcpListener;
 pub(super) use std::path::{Path, PathBuf};
 pub(super) use std::thread;
+
+pub(super) fn direct_server_http() -> ServerHttpOptions {
+    ServerHttpOptions {
+        proxy: None,
+        no_system_proxy: true,
+    }
+}

--- a/crates/webcodex-cli/src/webcodex_cli/token_commands.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/token_commands.rs
@@ -2,7 +2,7 @@ use reqwest::header::CONTENT_TYPE;
 use serde_json::json;
 
 use crate::{
-    admin_cli::{self, build_admin_request, AdminCliCommand},
+    admin_cli::{self, build_admin_request, build_server_http_client, AdminCliCommand},
     AgentTokenCreateLocalOptions, TokenCreateLocalOptions,
 };
 
@@ -67,10 +67,7 @@ pub(crate) async fn run_token_create_local(
         "{}/api/tokens/register_hash",
         opts.server_url.trim_end_matches('/')
     );
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+    let client = build_server_http_client(&opts.server_http)?;
     let resp = client
         .post(url)
         .bearer_auth(&credential)
@@ -129,10 +126,7 @@ pub(crate) async fn run_agent_token_create_local(
 
 async fn post_json_with_bearer(req: &admin_cli::AdminCliRequest) -> Result<(), String> {
     let url = format!("{}{}", req.server_url, req.path);
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+    let client = build_server_http_client(&req.server_http)?;
     let resp = client
         .post(url)
         .bearer_auth(&req.token)

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -42,6 +42,8 @@ Connect a local project to a hosted WebCodex Server with one shared key.\n\
 The command writes a reusable local profile, starts one background Runner,\n\
 and waits until the Runner and project are visible through the Server.\n\n\
 Options:\n\
+  --proxy http://HOST:PORT   Override standard proxy environment for CLI Server requests\n\
+  --no-system-proxy          Ignore proxy environment and connect directly\n\
   --key KEY                  Shared key (use --key-file to avoid shell history)\n\
   --key-file PATH            Read the shared key from a file\n\
   --project PATH             Local project directory [default: .]\n\
@@ -51,7 +53,8 @@ Options:\n\
   -h, --help                 Print help and exit\n\n\
 When neither --key nor --key-file is supplied, a strong key is generated and\n\
 printed once. Hosted shared keys must not start with wc_; managed credentials\n\
-use `webcodex login` instead.\n"
+use `webcodex login` instead. Proxy flags apply only to this command's Server\n\
+HTTP probes; Runner proxy configuration remains independent.\n"
 }
 
 pub(crate) fn pairing_usage() -> &'static str {
@@ -64,6 +67,8 @@ pub(crate) fn pairing_create_usage() -> &'static str {
     "Usage: webcodex pairing create --server-url URL --username USER [--client-id CLIENT_ID] [OPTIONS]\n\n\
      Options:\n\
        --server-url URL          WebCodex server URL\n\
+       --proxy http://HOST:PORT Explicit proxy override for this CLI request\n\
+       --no-system-proxy        Ignore proxy environment and connect directly\n\
        --env-file PATH           Read WEBCODEX_TOKEN from env file\n\
        --token-file PATH         Read bootstrap/admin bearer token from file\n\
        --token TOKEN             Bootstrap/admin bearer token (discouraged in shell history)\n\
@@ -102,6 +107,8 @@ pub(crate) fn client_enroll_usage() -> &'static str {
      and writes the same token files in one step.\n\n\
      Options:\n\
        --server-url URL              WebCodex server URL\n\
+       --proxy http://HOST:PORT     Explicit proxy override for this CLI request\n\
+       --no-system-proxy            Ignore proxy environment and connect directly\n\
        --pairing-code CODE           Temporary one-time pairing code\n\
        --client-id CLIENT_ID         Client id matching the pairing record\n\
        --display-name NAME           Optional agent display name\n\
@@ -131,6 +138,8 @@ pub(crate) fn ops_usage() -> &'static str {
      Common flags:\n\
        --server-url URL        WebCodex server URL [default: http://127.0.0.1:8080]\n\
        --url URL               Alias for --server-url\n\
+       --proxy http://HOST:PORT Explicit proxy override for Server requests\n\
+       --no-system-proxy       Ignore proxy environment and connect directly\n\
        --env-file PATH         Read WEBCODEX_TOKEN from env file\n\
        --token-file PATH       Read bearer token from file\n\
        --token TOKEN           Bearer token input; never printed\n\
@@ -146,6 +155,8 @@ pub(crate) fn ops_status_usage() -> &'static str {
      Options:\n\
        --server-url URL        WebCodex server URL [default: http://127.0.0.1:8080]\n\
        --url URL               Alias for --server-url\n\
+       --proxy http://HOST:PORT Explicit proxy override for Server requests\n\
+       --no-system-proxy       Ignore proxy environment and connect directly\n\
        --env-file PATH         Read WEBCODEX_TOKEN from env file\n\
        --token-file PATH       Read bearer token from file\n\
        --token TOKEN           Bearer token input; never printed\n\
@@ -160,6 +171,8 @@ pub(crate) fn ops_agents_usage() -> &'static str {
      Options:\n\
        --server-url URL        WebCodex server URL [default: http://127.0.0.1:8080]\n\
        --url URL               Alias for --server-url\n\
+       --proxy http://HOST:PORT Explicit proxy override for Server requests\n\
+       --no-system-proxy       Ignore proxy environment and connect directly\n\
        --env-file PATH         Read WEBCODEX_TOKEN from env file\n\
        --token-file PATH       Read bearer token from file\n\
        --token TOKEN           Bearer token input; never printed\n\
@@ -174,6 +187,8 @@ pub(crate) fn ops_projects_usage() -> &'static str {
      Options:\n\
        --server-url URL        WebCodex server URL [default: http://127.0.0.1:8080]\n\
        --url URL               Alias for --server-url\n\
+       --proxy http://HOST:PORT Explicit proxy override for Server requests\n\
+       --no-system-proxy       Ignore proxy environment and connect directly\n\
        --env-file PATH         Read WEBCODEX_TOKEN from env file\n\
        --token-file PATH       Read bearer token from file\n\
        --token TOKEN           Bearer token input; never printed\n\
@@ -189,6 +204,8 @@ pub(crate) fn ops_smoke_preflight_usage() -> &'static str {
        --project PROJECT_ID    Runtime project id to check\n\
        --server-url URL        WebCodex server URL [default: http://127.0.0.1:8080]\n\
        --url URL               Alias for --server-url\n\
+       --proxy http://HOST:PORT Explicit proxy override for Server requests\n\
+       --no-system-proxy       Ignore proxy environment and connect directly\n\
        --env-file PATH         Read WEBCODEX_TOKEN from env file\n\
        --token-file PATH       Read bearer token from file\n\
        --token TOKEN           Bearer token input; never printed\n\
@@ -248,6 +265,8 @@ pub(crate) fn server_status_usage() -> &'static str {
     "Usage: webcodex server status [OPTIONS]\n\n\
      Options:\n\
        --url URL              Runtime URL [default: http://127.0.0.1:8080]\n\
+       --proxy http://HOST:PORT Explicit proxy override for Server requests\n\
+       --no-system-proxy      Ignore proxy environment and connect directly\n\
        --env-file PATH        Read WEBCODEX_TOKEN from env file [default: root /etc/webcodex/webcodex.env; user ~/.config/webcodex/webcodex.env]\n\
        --token-file PATH      Read bearer token from file\n\
        --json                 Print a machine-readable summary\n\
@@ -327,6 +346,8 @@ pub(crate) fn agent_status_usage() -> &'static str {
        --config PATH              Agent config path [default: scope-specific agent.toml]\n\
        --service-file PATH        Override the scope-specific systemd unit path\n\
        --server-url URL           Override server URL for runtime checks\n\
+       --proxy http://HOST:PORT  Explicit proxy override for Server checks\n\
+       --no-system-proxy         Ignore proxy environment and connect directly\n\
        --user-token-file PATH     Read user API token for /api/runtime/status\n\
        --agent-token-file PATH    Read agent token for boundary check\n\
        --json                     Print a machine-readable summary\n\
@@ -347,6 +368,8 @@ pub(crate) fn login_usage() -> &'static str {
      primary way to connect a machine.\n\n\
      Options:\n\
      \x20\x20--code CODE          Pairing code from the server (required)\n\
+     \x20\x20--proxy http://HOST:PORT Explicit proxy override for this CLI request\n\
+     \x20\x20--no-system-proxy   Ignore proxy environment and connect directly\n\
      \x20\x20--device NAME        Name for this device [default: hostname + local suffix]\n\
      \x20\x20--allowed-root PATH  Repeatable project root the agent may touch\n\
      \x20\x20--transport NAME     websocket|polling|quic|auto [default: websocket]\n\

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -490,6 +490,7 @@ async fn collect_readiness_from_remote(
 ) -> ProjectReadiness {
     let url = format!("{}/api/connector/readiness", config.server_url());
     let response = reqwest::Client::builder()
+        .no_proxy()
         .connect_timeout(Duration::from_secs(1))
         .timeout(Duration::from_secs(3))
         .build()
@@ -946,6 +947,7 @@ async fn wait_for_server(
     key: &str,
 ) -> Result<(), ProductError> {
     let client = reqwest::Client::builder()
+        .no_proxy()
         .connect_timeout(Duration::from_secs(1))
         .timeout(Duration::from_secs(2))
         .build()

--- a/src/runtime_http/import_http.rs
+++ b/src/runtime_http/import_http.rs
@@ -191,6 +191,7 @@ pub async fn import_conversation_files_to_project(
     }
     let auth = depot.obtain::<crate::auth::AuthContext>().ok().cloned();
     let client = match reqwest::Client::builder()
+        .no_proxy()
         .timeout(Duration::from_secs(30))
         .redirect(reqwest::redirect::Policy::none())
         .build()


### PR DESCRIPTION
## Summary

Aligns WebCodex CLI Server HTTP behavior with conventional application proxy semantics.

CLI requests to a WebCodex Server now follow reqwest's standard system/environment proxy selection by default. `--proxy http://HOST:PORT` explicitly overrides that selection for the current CLI invocation, while `--no-system-proxy` disables ambient proxy settings and forces direct Server HTTP access.

The proxy controls are propagated across server-facing CLI, admin, token, status, connect, pairing/enrollment, setup, and ops paths. Proxy URLs are narrowly validated and credential-bearing/userinfo URLs are rejected without echoing secrets.

`webcodex connect --proxy` affects only CLI preflight/status probes; Runner proxy configuration remains unchanged and continues to use the existing Runner proxy environment behavior. Project-local loopback runtime/readiness requests and server-side outbound imports are intentionally kept direct rather than inheriting CLI proxy state.

## Semantics

- No proxy flag: follow reqwest's standard proxy environment/system behavior, including the supported `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` forms.
- `--proxy http://HOST:PORT`: explicitly route this CLI invocation's WebCodex Server HTTP requests through that proxy, overriding ambient proxy selection.
- `--no-system-proxy`: ignore ambient proxy configuration for this CLI invocation and connect directly.
- Supported explicit proxy form in this PR: `http://HOST:PORT`, including explicit port 80 and bracketed IPv6.
- Not included: proxy authentication, HTTPS/SOCKS explicit proxy URLs, persisted proxy configuration, or Runner configuration changes.

## Validation

- `cargo fmt -- --check`
- `cargo check -p webcodex-admin -p webcodex-cli`
- `cargo test -p webcodex-admin` — 18 passed
- `cargo test -p webcodex-cli` — 247 passed
- `git diff --check`

Focused coverage includes ambient-proxy behavior, direct opt-out with `--no-system-proxy`, real loopback proxy routing, authenticated requests through the proxy, admin routing, explicit `:80`, bracketed IPv6, malformed URL rejection, and credential-safe validation errors.