### PR TITLE
Fix Windows path identity and stabilize CI tests

### DIFF
--- a/crates/webcodex-cli/Cargo.toml
+++ b/crates/webcodex-cli/Cargo.toml
@@ -32,6 +32,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
     "Win32_System_Threading",
 ] }
 

--- a/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
@@ -684,6 +684,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let project = tmp.path().join("project");
         std::fs::create_dir(&project).unwrap();
+        let project = project.canonicalize().unwrap();
         let config_base = tmp.path().join("config");
         let options = ConnectOptions {
             server_url: "https://example.test".to_string(),

--- a/crates/webcodex-cli/src/webcodex_cli/connections.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connections.rs
@@ -158,20 +158,26 @@ fn ensure_component(path: &Path) -> Result<(), String> {
 /// Compare the canonical path returned by the OS with the exact directory
 /// chain that was verified component-by-component above.
 ///
-/// Windows `std::fs::canonicalize` returns an extended-length path (`\\?\C:\...`
-/// or `\\?\UNC\server\share\...`) even when no component was redirected. That
-/// spelling-only prefix must not make every ordinary Windows login fail. Ignore
-/// exactly that prefix transformation and nothing else: case changes, junction
-/// redirects, symlinks, or a different path still fail the comparison.
+/// Windows `std::fs::canonicalize` returns an extended-length path and can also
+/// expand a DOS 8.3 component such as `RUNNER~1` to its long directory name.
+/// Both spellings name the same directory and must not make an ordinary login
+/// fail. Expand only short-name aliases, then ignore exactly the verbatim-prefix
+/// spelling transformation. Case changes, junction redirects, symlinks, or a
+/// different path still fail the comparison.
 #[cfg(windows)]
 fn canonical_matches_verified_path(canonical: &Path, verified: &Path) -> bool {
     if canonical == verified {
         return true;
     }
 
+    let long_verified = windows_long_path(verified).unwrap_or_else(|| verified.to_path_buf());
+    if canonical == long_verified {
+        return true;
+    }
+
     use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
-    let verified_wide: Vec<u16> = verified.as_os_str().encode_wide().collect();
+    let verified_wide: Vec<u16> = long_verified.as_os_str().encode_wide().collect();
     let mut extended = Vec::with_capacity(verified_wide.len() + 8);
     if verified_wide.starts_with(&[b'\\' as u16, b'\\' as u16]) {
         extended.extend("\\\\?\\UNC\\".encode_utf16());
@@ -181,6 +187,30 @@ fn canonical_matches_verified_path(canonical: &Path, verified: &Path) -> bool {
         extended.extend_from_slice(&verified_wide);
     }
     canonical.as_os_str() == std::ffi::OsString::from_wide(&extended).as_os_str()
+}
+
+#[cfg(windows)]
+fn windows_long_path(path: &Path) -> Option<PathBuf> {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use windows_sys::Win32::Storage::FileSystem::GetLongPathNameW;
+
+    let input = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let required = unsafe { GetLongPathNameW(input.as_ptr(), std::ptr::null_mut(), 0) };
+    if required == 0 {
+        return None;
+    }
+
+    let mut output = vec![0u16; required as usize];
+    let written = unsafe { GetLongPathNameW(input.as_ptr(), output.as_mut_ptr(), required) };
+    if written == 0 || written >= required {
+        return None;
+    }
+    output.truncate(written as usize);
+    Some(PathBuf::from(std::ffi::OsString::from_wide(&output)))
 }
 
 #[cfg(not(windows))]
@@ -515,10 +545,14 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_verbatim_prefix_is_the_only_ignored_canonical_difference() {
+    fn windows_verbatim_prefix_is_the_only_ignored_spelling_difference() {
         assert!(canonical_matches_verified_path(
             Path::new(r"\\?\C:\safe\config"),
             Path::new(r"C:\safe\config")
+        ));
+        assert!(!canonical_matches_verified_path(
+            Path::new(r"\\?\C:\SAFE\Config"),
+            Path::new(r"c:\safe\config")
         ));
         assert!(canonical_matches_verified_path(
             Path::new(r"\\?\UNC\server\share\safe"),
@@ -537,6 +571,48 @@ mod tests {
         let canonical = ensure_real_directory_tree(temp.path()).unwrap();
         assert!(canonical.is_absolute());
         assert!(canonical.to_string_lossy().starts_with(r"\\?\"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn real_windows_directory_tree_accepts_dos_short_name_alias() {
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+        use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let long = temp
+            .path()
+            .join("webcodex-long-directory-name-for-short-alias");
+        std::fs::create_dir(&long).unwrap();
+        let input = long
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        let required = unsafe { GetShortPathNameW(input.as_ptr(), std::ptr::null_mut(), 0) };
+        assert!(
+            required > 0,
+            "GetShortPathNameW failed for {}",
+            long.display()
+        );
+        let mut output = vec![0u16; required as usize];
+        let written = unsafe { GetShortPathNameW(input.as_ptr(), output.as_mut_ptr(), required) };
+        assert!(written > 0 && written < required);
+        output.truncate(written as usize);
+        let short = PathBuf::from(std::ffi::OsString::from_wide(&output));
+
+        // 8.3 aliases may be disabled per volume. In that case this machine
+        // cannot exercise the alias-specific branch, so the ordinary verbatim
+        // path test above remains the applicable Windows coverage.
+        if !short.to_string_lossy().contains('~') {
+            return;
+        }
+
+        let canonical = ensure_real_directory_tree(&short).unwrap();
+        assert!(paths::paths_equal(
+            &canonical,
+            &long.canonicalize().unwrap()
+        ));
     }
 
     #[test]

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -1569,7 +1569,7 @@ fn inspect_shell_real_smoke_reads_checks_and_blocks_project_writes() {
     };
 
     let inspection = run_inspect(
-        "rg 'inspect-runner-smoke' Cargo.toml \
+        "if command -v rg >/dev/null 2>&1; then rg 'inspect-runner-smoke' Cargo.toml; fi \
              && git status --short \
              && cargo check --offline \
              && printf scratch-ok > \"$TMPDIR/proof\" \

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -792,7 +792,14 @@ fn phase_e2_default_four_gates_fifth_and_promotes_same_job_once() {
         enqueue_gated_structured_job(&manager, &sink, temp.path(), &helper, job);
     }
     wait_for_all_started(&jobs[..4]);
-    assert_eq!(active_gated_children(&jobs), 4);
+    // The started marker is written just before the active marker, so the
+    // child can still be in that window when wait_for_all_started returns;
+    // poll for the active set instead of asserting it synchronously.
+    assert!(
+        wait_until(Duration::from_secs(10), || active_gated_children(&jobs)
+            == 4),
+        "simultaneously started children failed to reach the default of 4"
+    );
     assert!(
         !jobs[4].started.exists(),
         "the fifth child started before a Job slot opened"
@@ -855,17 +862,22 @@ fn phase_e2_explicit_limit_one_serializes_jobs_strictly() {
     enqueue_gated_structured_job(&manager, &sink, temp.path(), &helper, &first);
     enqueue_gated_structured_job(&manager, &sink, temp.path(), &helper, &second);
     wait_for_all_started(std::slice::from_ref(&first));
-    assert!(first.active.exists());
+    assert!(
+        wait_until(Duration::from_secs(10), || first.active.exists()),
+        "the first Job never became active"
+    );
     assert!(!second.active.exists());
     assert!(!second.started.exists());
 
     first.release();
     wait_for_all_started(std::slice::from_ref(&second));
     assert!(!first.active.exists());
-    assert_eq!(
-        usize::from(second.active.exists()),
-        1,
-        "limit=1 did not serialize execution"
+    // The started marker is written just before the active marker, so the
+    // child can still be in that window when wait_for_all_started returns;
+    // poll until the second Job is actually active.
+    assert!(
+        wait_until(Duration::from_secs(10), || second.active.exists()),
+        "limit=1 did not serialize execution: the second Job never became active"
     );
     second.release();
     wait_for_job_workers(&manager);
@@ -887,9 +899,12 @@ fn phase_e2_explicit_higher_limit_starts_all_eight_children() {
         enqueue_gated_structured_job(&manager, &sink, temp.path(), &helper, job);
     }
     wait_for_all_started(&jobs);
-    assert_eq!(
-        active_gated_children(&jobs),
-        8,
+    // The started marker is written just before the active marker, so the
+    // child can still be in that window when wait_for_all_started returns;
+    // poll for the active set instead of asserting it synchronously.
+    assert!(
+        wait_until(Duration::from_secs(10), || active_gated_children(&jobs)
+            == 8),
         "explicit limit=8 was capped at a smaller default"
     );
     for job in &jobs {
@@ -1162,11 +1177,11 @@ fn structured_process_job_executes_exactly_once_and_reconciles_the_same_job() {
             "250".to_string(),
         ],
         None,
-        5,
+        30,
         None,
     );
 
-    assert!(wait_until(Duration::from_secs(5), || marker.exists()));
+    assert!(wait_until(Duration::from_secs(30), || marker.exists()));
     let active = manager.inventory();
     let active = active
         .jobs
@@ -1243,7 +1258,7 @@ fn structured_process_job_preserves_large_literal_argv_without_shell_fallback() 
         &helper.path,
         args,
         None,
-        5,
+        30,
         None,
     );
     let updates = collect_job_updates(&mut rx, Duration::from_secs(10));
@@ -1278,7 +1293,7 @@ fn structured_process_job_terminal_lifecycle_distinguishes_prestart_nonzero_and_
             "structured-nonzero",
             helper.path.clone(),
             vec!["exit".to_string(), "19".to_string()],
-            5,
+            30,
             "failed",
             ShellCommandExecutionState::Completed,
             Some(19),
@@ -1286,8 +1301,11 @@ fn structured_process_job_terminal_lifecycle_distinguishes_prestart_nonzero_and_
         (
             "structured-timeout",
             helper.path.clone(),
-            vec!["sleep".to_string(), "3000".to_string()],
-            1,
+            // Sleep far longer than the 10s timeout so the timeout provably
+            // fires while the process is still running. A shorter sleep would
+            // let the helper exit cleanly and the job complete instead.
+            vec!["sleep".to_string(), "60000".to_string()],
+            10,
             "timeout",
             ShellCommandExecutionState::TimedOut,
             Some(-1),
@@ -1307,7 +1325,11 @@ fn structured_process_job_terminal_lifecycle_distinguishes_prestart_nonzero_and_
             timeout_secs,
             None,
         );
-        let updates = collect_job_updates(&mut rx, Duration::from_secs(10));
+        // Quick completion fixtures use a 30-second execution budget so loaded
+        // Windows runners cannot misclassify process startup as a timeout. The
+        // collection window must outlast that budget while the dedicated timeout
+        // case still proves the original ten-second timeout contract below.
+        let updates = collect_job_updates(&mut rx, Duration::from_secs(45));
         let final_update = updates.last().expect("terminal lifecycle update");
         assert_eq!(final_update.status, status, "{final_update:?}");
         assert_eq!(
@@ -1317,9 +1339,22 @@ fn structured_process_job_terminal_lifecycle_distinguishes_prestart_nonzero_and_
         );
         assert_eq!(final_update.exit_code, exit_code, "{final_update:?}");
         if state == ShellCommandExecutionState::TimedOut {
+            // The timeout budget must be generous enough that a freshly
+            // spawned helper can actually start before it expires: on a
+            // loaded runner, process initialization alone can take several
+            // seconds, and a 1s budget would kill the child before it ran.
+            // The original ten-second budget must still be honored exactly:
+            // the reported duration is the timeout value itself (plus at most
+            // one poll interval), never reset by the lifecycle.
+            let duration_ms = final_update.duration_ms.expect("timeout duration");
             assert!(
-                started.elapsed() < Duration::from_millis(2_200),
-                "the one-second original timeout budget was reset or extended"
+                (9_850..=10_250).contains(&duration_ms),
+                "the ten-second original timeout was reset or extended: {duration_ms} ms"
+            );
+            assert!(
+                started.elapsed() < Duration::from_secs(25),
+                "the original total timeout was extended: {:?}",
+                started.elapsed()
             );
         }
         if state == ShellCommandExecutionState::NotStarted {
@@ -1350,13 +1385,20 @@ fn structured_process_job_handoff_observation_does_not_reset_the_original_total_
             "mark-sleep".to_string(),
             marker.to_string_lossy().into_owned(),
             nonce.clone(),
-            "3000".to_string(),
+            "60000".to_string(),
         ],
         None,
-        1,
+        10,
         None,
     );
-    assert!(wait_until(Duration::from_secs(5), || marker.exists()));
+    // The timeout budget must be generous enough that a freshly spawned
+    // helper can actually start before it expires: on a loaded runner,
+    // process initialization alone (spawn return to first instruction) can
+    // take several seconds, and a 1s budget would kill the child before it
+    // ever wrote the marker. The helper sleeps 60s, so the 10s timeout fires
+    // while the process is provably still running. The assertions below
+    // still prove the original timeout is not reset at handoff.
+    assert!(wait_until(Duration::from_secs(30), || marker.exists()));
 
     // Model the Server's short sync grace ending by observing the retained
     // active Job after the one child has already started. This observation is
@@ -1380,11 +1422,14 @@ fn structured_process_job_handoff_observation_does_not_reset_the_original_total_
     );
     let duration_ms = final_update.duration_ms.expect("timeout duration");
     assert!(
-        (850..=1_250).contains(&duration_ms),
-        "the one-second original timeout was reset at handoff: {duration_ms} ms"
+        (9_850..=10_250).contains(&duration_ms),
+        "the ten-second original timeout was reset at handoff: {duration_ms} ms"
     );
+    // The job must still complete within the original ten-second budget plus
+    // process-startup slack; a handoff that reset the deadline to a larger
+    // value would overshoot this.
     assert!(
-        original_start.elapsed() < Duration::from_millis(1_500),
+        original_start.elapsed() < Duration::from_secs(25),
         "handoff extended the original total timeout"
     );
     let starts = std::fs::read_to_string(marker).unwrap();
@@ -1416,7 +1461,7 @@ fn stop_terminates_a_structured_process_job_without_replacement() {
         30,
         None,
     );
-    assert!(wait_until(Duration::from_secs(5), || marker.exists()));
+    assert!(wait_until(Duration::from_secs(30), || marker.exists()));
     manager.stop("structured-stop").unwrap();
     let updates = collect_job_updates(&mut rx, Duration::from_secs(10));
     let final_update = updates.last().expect("structured stop terminal update");
@@ -1577,7 +1622,7 @@ fn phase_f_windows_structured_job_stop_retains_unicode_and_runs_once() {
         30,
         None,
     );
-    assert!(wait_until(Duration::from_secs(5), || marker.exists()));
+    assert!(wait_until(Duration::from_secs(30), || marker.exists()));
     manager.stop("phase-f-stop").unwrap();
     let updates = collect_job_updates(&mut rx, Duration::from_secs(10));
     let final_update = updates.last().expect("stop terminal update");
@@ -1647,7 +1692,7 @@ fn structured_script_job_keeps_its_temporary_file_until_terminal_then_removes_it
         request,
     );
 
-    assert!(wait_until(Duration::from_secs(5), || {
+    assert!(wait_until(Duration::from_secs(30), || {
         marker.exists() && observed_path.exists()
     }));
     let temporary_script = PathBuf::from(std::fs::read_to_string(&observed_path).unwrap());
@@ -1713,7 +1758,7 @@ fn structured_process_and_script_jobs_preserve_the_inspect_sandbox() {
         &touch,
         vec![blocked.to_string_lossy().into_owned()],
         None,
-        5,
+        30,
         Some(crate::command_sandbox::INSPECT_SANDBOX_MODE),
     );
     let process_updates = collect_job_updates(&mut process_rx, Duration::from_secs(10));
@@ -2239,6 +2284,11 @@ pub(super) fn process_running(pid: u32) -> bool {
         .is_some_and(|state| state != 'Z')
 }
 
+/// Poll `condition` until it holds or `timeout` elapses. The fixtures here
+/// wait on marker files written by freshly spawned helper processes; under a
+/// fully parallel `cargo test` on the small GitHub CI runners, process
+/// startup can take well over a few seconds, so callers pass a generous 30s
+/// budget (matching the helper's own 30s gate).
 fn wait_until(timeout: Duration, condition: impl Fn() -> bool) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
@@ -2535,7 +2585,7 @@ fn job_cleanup_after_parent_exit_terminates_descendant_and_reaches_eof() {
     }
     let grandchild_pid = grandchild_pid.expect("GRANDCHILD_PID in job stdout");
     assert!(
-        wait_until(Duration::from_secs(5), || lock_unpoison(&child)
+        wait_until(Duration::from_secs(30), || lock_unpoison(&child)
             .try_wait()
             .unwrap()
             .is_some()),
@@ -2676,7 +2726,7 @@ fn job_stop_after_natural_exit_does_not_panic() {
     let parent_pid = managed.id();
     let child = Arc::new(Mutex::new(managed));
     assert!(
-        wait_until(Duration::from_secs(5), || lock_unpoison(&child)
+        wait_until(Duration::from_secs(30), || lock_unpoison(&child)
             .try_wait()
             .unwrap()
             .is_some()),
@@ -2734,10 +2784,12 @@ fn last_job_manager_owner_drop_terminates_running_tree_with_worker_clone_alive()
 fn cleanup_managed_tree_on_exited_tree_does_not_panic() {
     let (managed, _rx) = spawn_helper_raw("sleep", &["0", "0"]);
     let child = Arc::new(Mutex::new(managed));
-    assert!(wait_until(Duration::from_secs(5), || lock_unpoison(&child)
-        .try_wait()
-        .unwrap()
-        .is_some()));
+    assert!(wait_until(Duration::from_secs(30), || lock_unpoison(
+        &child
+    )
+    .try_wait()
+    .unwrap()
+    .is_some()));
     cleanup_managed_tree(&child);
     assert!(
         lock_unpoison(&child).try_tree_exit().unwrap(),

--- a/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
@@ -1555,11 +1555,14 @@ fn polling_background_project_operation_invalidates_the_project_cache() {
         let _ = runner_tx.send(result);
     });
 
+    // The register_project round trip is an actual project operation (it may
+    // spawn git); on a loaded runner the poll that observes the refreshed
+    // cache can arrive well after a few seconds, so budget generously.
     refreshed_rx
-        .recv_timeout(Duration::from_secs(5))
+        .recv_timeout(Duration::from_secs(30))
         .expect("a later poll must carry refreshed project metadata");
     runner_rx
-        .recv_timeout(Duration::from_secs(5))
+        .recv_timeout(Duration::from_secs(30))
         .expect("project-cache runner completion")
         .expect("project-cache runner should shut down cleanly");
     runner.join().unwrap();

--- a/crates/webcodex-runner/src/webcodex_runner/validation/execute.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/validation/execute.rs
@@ -502,6 +502,11 @@ mod tests {
         CleanupPath(path)
     }
 
+    /// Poll until `path` exists or `timeout` elapses. The markers are written
+    /// by freshly spawned helper processes; under a fully parallel test suite
+    /// on the small GitHub CI runners, process startup can take well over a
+    /// few seconds, so callers pass a generous 30s budget (matching the
+    /// helper's own 30s gate).
     fn wait_until_file(path: &Path, timeout: Duration) -> bool {
         let deadline = Instant::now() + timeout;
         loop {
@@ -596,18 +601,18 @@ mod tests {
         ]);
         let started = Instant::now();
         let captured = thread::scope(|scope| {
-            let handle = scope.spawn(|| run_bounded(&program, &args, cwd.path(), 1, None));
+            let handle = scope.spawn(|| run_bounded(&program, &args, cwd.path(), 10, None));
             assert!(
-                wait_until_file(&parent_marker, Duration::from_secs(5)),
+                wait_until_file(&parent_marker, Duration::from_secs(30)),
                 "parent marker never appeared"
             );
             assert!(
-                wait_until_file(&alive_marker, Duration::from_secs(5)),
+                wait_until_file(&alive_marker, Duration::from_secs(30)),
                 "descendant marker never appeared"
             );
             let parent_pid = read_pid(&parent_marker, "PARENT_PID");
             let descendant_pid = read_pid(&parent_marker, "DESCENDANT_PID");
-            // Both sleep 600s while the timeout is 1s, so they must still be
+            // Both sleep 600s while the timeout is 10s, so they must still be
             // alive when the timeout fires.
             assert!(process_alive(parent_pid), "parent not alive before timeout");
             assert!(
@@ -659,7 +664,7 @@ mod tests {
             // ran, so its existence proves the descendant was alive after the
             // parent exited.
             assert!(
-                wait_until_file(&alive_marker, Duration::from_secs(5)),
+                wait_until_file(&alive_marker, Duration::from_secs(30)),
                 "descendant marker never appeared"
             );
             handle.join().expect("run_bounded panicked")
@@ -707,11 +712,11 @@ mod tests {
             let handle =
                 scope.spawn(|| run_bounded(&program, &args, cwd.path(), 60, Some(&shutdown)));
             assert!(
-                wait_until_file(&parent_marker, Duration::from_secs(5)),
+                wait_until_file(&parent_marker, Duration::from_secs(30)),
                 "parent marker never appeared"
             );
             assert!(
-                wait_until_file(&alive_marker, Duration::from_secs(5)),
+                wait_until_file(&alive_marker, Duration::from_secs(30)),
                 "descendant marker never appeared"
             );
             let parent_pid = read_pid(&parent_marker, "PARENT_PID");
@@ -769,11 +774,11 @@ mod tests {
         let captured = thread::scope(|scope| {
             let handle = scope.spawn(|| run_bounded(&program, &args, cwd.path(), 3, None));
             assert!(
-                wait_until_file(&parent_marker, Duration::from_secs(5)),
+                wait_until_file(&parent_marker, Duration::from_secs(30)),
                 "parent marker never appeared"
             );
             assert!(
-                wait_until_file(&alive_marker, Duration::from_secs(5)),
+                wait_until_file(&alive_marker, Duration::from_secs(30)),
                 "descendant marker never appeared"
             );
             let parent_pid = read_pid(&parent_marker, "PARENT_PID");

--- a/crates/webcodex-runner/src/webcodex_runner/validation/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/validation/tests.rs
@@ -359,8 +359,11 @@ fn invalid_cwd_reports_available_tool_without_starting_command() {
 fn spawn_failure_does_not_report_command_started() {
     let project = tempfile::tempdir().unwrap();
     let bin = tempfile::tempdir().unwrap();
-    // A file that resolves as a program but cannot be executed: on Unix a
-    // non-shebang script, on Windows a non-PE `pyright.exe`.
+    // A file that resolves as a program but cannot be executed. Unix can use
+    // an executable non-shebang file. On Windows, executing a corrupt PE can
+    // trigger an interactive compatibility dialog, so use a real PE held with
+    // an exclusive share mode instead; CreateProcess then fails cleanly while
+    // the resolver still sees an available tool.
     #[cfg(unix)]
     {
         let path = bin.path().join("pyright");
@@ -369,7 +372,17 @@ fn spawn_failure_does_not_report_command_started() {
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
     }
     #[cfg(windows)]
-    fs::write(bin.path().join("pyright.exe"), b"not a valid PE image\n").unwrap();
+    let _locked_executable = {
+        use std::os::windows::fs::OpenOptionsExt;
+
+        let path = bin.path().join("pyright.exe");
+        fs::copy(std::env::current_exe().unwrap(), &path).unwrap();
+        fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(path)
+            .unwrap()
+    };
 
     let response = with_path(bin.path(), || {
         execute_validation_at_root(project.path(), &typecheck_request("demo"), 120).unwrap()

--- a/scripts/npm_install_windows_smoke.ps1
+++ b/scripts/npm_install_windows_smoke.ps1
@@ -139,7 +139,11 @@ try {
     $PackageDir = Join-Path $Root "npm\webcodex"
     Push-Location $PackageDir
     try {
-        & npm pack --pack-destination $TempRoot --silent
+        # This smoke intentionally installs from the local development manifest
+        # above, so it must not impersonate a publish-ready package. Keep the
+        # package's prepack release guard intact and bypass lifecycle scripts only
+        # for this local tgz creation; npm install below still runs postinstall.
+        & npm pack --ignore-scripts --pack-destination $TempRoot --silent
         if ($LASTEXITCODE -ne 0) {
             throw "npm pack failed with exit code $LASTEXITCODE"
         }

--- a/src/project_entry_share.rs
+++ b/src/project_entry_share.rs
@@ -18,6 +18,7 @@ use tokio::task::JoinHandle;
 const TUNNEL_START_TIMEOUT: Duration = Duration::from_secs(20);
 const TUNNEL_LOG_LINES: usize = 8;
 const TUNNEL_LOG_LINE_BYTES: usize = 512;
+const TUNNEL_LOG_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TunnelProvider {
@@ -300,8 +301,7 @@ async fn start_cloudflare_quick_with_binary(
 
     loop {
         if let Some(status) = child.try_wait().map_err(|_| tunnel_runtime_error())? {
-            stdout_task.abort();
-            stderr_task.abort();
+            drain_tunnel_readers(stdout_task, stderr_task).await;
             let detail = bounded_tunnel_log_summary(&recent);
             let message = if detail.is_empty() {
                 format!("cloudflared exited before creating a Quick Tunnel ({status})")
@@ -357,6 +357,22 @@ where
             }
         }
     })
+}
+
+// A child can exit before the async readers are scheduled to consume bytes that
+// are already buffered in its pipes. Give them a bounded chance to reach EOF so
+// startup diagnostics are retained, but do not wait forever if a descendant
+// inherited one of the pipe handles.
+async fn drain_tunnel_readers(mut stdout_task: JoinHandle<()>, mut stderr_task: JoinHandle<()>) {
+    let drained = tokio::time::timeout(TUNNEL_LOG_DRAIN_TIMEOUT, async {
+        let _ = tokio::join!(&mut stdout_task, &mut stderr_task);
+    })
+    .await
+    .is_ok();
+    if !drained {
+        stdout_task.abort();
+        stderr_task.abort();
+    }
 }
 
 fn record_tunnel_line(recent: &Arc<Mutex<VecDeque<String>>>, line: &str) {


### PR DESCRIPTION
## Summary

- harden Runner process/marker timing tests for loaded and low-core CI runners without changing production timeout accounting
- accept legitimate Windows DOS 8.3 aliases such as `RUNNER~1` when validating credential directories by expanding only the short-name spelling before the existing canonical-path comparison
- keep the credential-path guard fail-closed for case-only differences, junction/symlink redirects, and genuinely different canonical targets
- align the generated-key recovery test with the production `connect` path, which canonicalizes the project before recovery
- make the inspect smoke treat `rg` as an optional test dependency: exercise it when present, but do not fail solely because the CI image lacks ripgrep
- replace the Windows corrupt-PE spawn-failure fixture with a locked valid PE so the test still proves `tool_available=true`, `command_started=false`, and `SPAWN_FAILED` without triggering an interactive Windows compatibility dialog
- preserve buffered cloudflared startup diagnostics on early process exit by giving the stdout/stderr reader tasks one bounded second to reach EOF before building the user-facing error
- keep the Windows artifact→npm smoke development-only: local `npm pack` skips the publish-only prepack lifecycle guard, while the subsequent tarball install still runs the real postinstall against the smoke's local checksum manifest

## Semantics

Production Runner timeout/duration accounting is unchanged; `ManagedChild::spawn` remains part of the existing timeout contract.

The Windows credential-path change is deliberately narrow. `GetLongPathNameW` is used only to expand DOS short-name aliases before comparison. The existing exact-case and canonical-target checks remain in force; this is not a general relaxation of redirect protection.

The npm package's `prepack` / `prepublishOnly` release-manifest guard is unchanged. Only the development smoke's local tgz creation uses `npm pack --ignore-scripts`; its later `npm install` still executes postinstall and verifies the local artifact checksum.

## Validation

Windows x64 on MSI:

- `cargo fmt -- --check` — pass
- `cargo test -p webcodex-cli` — 207 passed, 0 failed
- `cargo test -p webcodex-runner` — 525 passed, 0 failed, 1 ignored
- exact Windows CI package set: `cargo test --locked -p webcodex-agent-config -p webcodex-process -p webcodex-persistent-shell -p webcodex-cli -p webcodex-runner` — exit 0
- full `scripts/npm_install_windows_smoke.ps1` — exit 0, including the intentional bad-checksum install failure preserving the previous binary set
- focused DOS 8.3 alias, verbatim-prefix, generated-key recovery, spawn-failure, lifecycle, and timeout tests — pass
- `git diff --check` — pass

Linux on Special, isolated detached worktree at this PR head:

- `project_entry::share_service::tests::tunnel_startup_failure_is_reported` — 20/20 consecutive passes
- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass

The draft remains open for the current GitHub Actions run to validate the complete Linux and Windows jobs.