### PR TITLE
Stabilize Runner concurrency and lifecycle CI

### DIFF
--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -1268,6 +1268,11 @@ impl PersistentShellManager {
         let mut closed = 0;
         for entry in entries {
             self.refresh_exit(&entry);
+            let should_attempt_close = lock_unpoison(&entry.state).is_active()
+                && lock_unpoison(&entry.last_activity_instant).elapsed() >= idle;
+            if !should_attempt_close {
+                continue;
+            }
             if entry
                 .busy
                 .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)

--- a/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
@@ -249,6 +249,15 @@ fn concurrent_document_refresh_uses_one_monotonic_version() {
         handle.join().unwrap().unwrap();
     }
 
+    assert!(
+        wait_until(Duration::from_secs(5), || {
+            fs::read_to_string(&fixture.marker)
+                .unwrap_or_default()
+                .lines()
+                .any(|line| line.starts_with("didChange:"))
+        }),
+        "fake LSP server never observed the document change"
+    );
     let marker = fs::read_to_string(&fixture.marker).unwrap();
     assert_eq!(
         marker

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -2554,10 +2554,32 @@ mod git_lifecycle_tests {
         ok == 1 && exit_code == 259 // 259 == STILL_ACTIVE
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn process_alive(pid: u32) -> bool {
+        // `kill(pid, 0)` also succeeds for zombies, while ManagedChild's Linux
+        // tree-liveness contract deliberately treats zombies as unable to run.
+        // Use /proc to align this test probe with that contract, but fall back
+        // conservatively if procfs cannot be read or parsed.
         // SAFETY: signal 0 is an existence probe; the pid comes from our own
         // test helper.
+        if (unsafe { libc::kill(pid as i32, 0) }) != 0 {
+            return false;
+        }
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            return true;
+        };
+        let Some((_, rest)) = stat.rsplit_once(')') else {
+            return true;
+        };
+        let state = rest.split_whitespace().next().unwrap_or("");
+        state != "Z" && state != "X"
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn process_alive(pid: u32) -> bool {
+        // SAFETY: signal 0 is an existence probe; the pid comes from our own
+        // test helper. Non-Linux Unix test hosts reap orphaned descendants
+        // promptly, so a successful probe represents a live process here.
         (unsafe { libc::kill(pid as i32, 0) }) == 0
     }
 


### PR DESCRIPTION
## Summary

- avoid acquiring the persistent-shell `busy` flag during idle sweeps when the shell has not reached its idle timeout
- make the concurrent LSP document-refresh test wait for the fake server to observe the already-sent `didChange` before asserting the exact marker count/version
- make Linux Git lifecycle tests treat zombie descendants consistently with `ManagedChild` tree-liveness semantics instead of using `kill(pid, 0)` as a live-code probe

## Why

The original PR #27 CI failure exposed a real persistent-shell race: `status()`/idle maintenance could transiently claim `busy` on an active non-idle shell and make a concurrent `exec()` fail with `shell_busy`.

After that production fix, CI exposed two independent test-observation races. The LSP client notification is written and flushed before `prepare_document` returns, but the fake server may not have appended its marker yet. On Linux, `kill(pid, 0)` can still report an exited zombie as existing even though `ManagedChild` deliberately treats zombies as unable to execute and therefore not live tree members.

This PR keeps the behavioral assertions: one `didOpen`, one version-2 `didChange`, bounded shutdown, and no executable descendant after cleanup. It removes only scheduler/reaping timing assumptions.

## Validation

- `cargo fmt --all -- --check` — pass
- `cargo check -p webcodex-persistent-shell` — pass
- `cargo test -p webcodex-persistent-shell` — 17/17 pass
- affected Runner tests repeated 20x on Linux — pass
- `cargo test -p webcodex-runner` on Special — 560 passed, 0 failed, 2 ignored
- `git diff --check` — pass
- GitHub Actions run `31575830092` — Linux and Windows both success

Scope is intentionally CI/concurrency stabilization. If subsequent runs expose another clearly scheduler-dependent test, it will be fixed narrowly here rather than weakening production contracts or assertions.