### PR TITLE
Write portable Windows release checksums

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -489,7 +489,8 @@ jobs:
             Move-Item -LiteralPath $canonicalArchive -Destination $archive
           }
           $hash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-          "$hash  $(Split-Path -Leaf $archive)" | Set-Content -LiteralPath "$archive.sha256" -Encoding ascii
+          $checksumLine = "$hash  $(Split-Path -Leaf $archive)`n"
+          [System.IO.File]::WriteAllText("$archive.sha256", $checksumLine, [System.Text.Encoding]::ASCII)
 
       - name: Upload Windows candidate
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- write Windows release-build `.sha256` files with an explicit LF terminator instead of PowerShell's platform-default CRLF
- keep the checksum content and artifact naming unchanged

## Root cause

The first five-target verification run (`31577851826`) built all platforms successfully, but downloading the artifacts on macOS exposed that Windows checksum files ended with CRLF. `shasum -c` then interpreted the archive name as ending in `\r`, so the checksum file was not portable to the OE/mini verification path.

## Validation

- `git diff --check` — pass
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-build.yml` — pass
- PowerShell `WriteAllText(..., ASCII)` probe on MSI — emitted LF with no CR

This changes only checksum-file serialization. It does not publish, create a GitHub Release, move a tag, or change the formal release provenance gates.