### PR TITLE
Stabilize V1 CI and clean maintenance warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 These are the always-on rules for ordinary repository work. Read only the linked sections needed for the current task. A deeper `AGENTS.md` governs its directory.
 
+## V1 maintenance mode
+
+The V1 formal product surface is feature-frozen by default: ordinary V1 work should prefer correctness, CI reliability, warning/Clippy hygiene, and test quality over new features. Explicitly experimental surfaces may continue only when the task asks for them. Do not weaken safety, credential, process-tree, transport, durability, or boundedness contracts while cleaning up.
+
 ## 1. Verify and preserve
 
 - Work only in the repository, worktree, and external target authorized by the user.

--- a/crates/webcodex-cli/src/webcodex_cli/connect/process.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/process.rs
@@ -1178,9 +1178,12 @@ mod tests {
         std::fs::create_dir(&bounded).unwrap();
         write_lines(&local_runner_log_path(&bounded), 100, 120, true);
         let archive = local_runner_log_archive_path(&bounded, 1);
+        // The archive content is replaced wholesale below (set_len to 2x the
+        // read cap, then a fresh log), so truncation is the intended contract.
         let mut large = OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .open(&archive)
             .unwrap();
         large

--- a/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
@@ -465,6 +465,8 @@ pub(super) fn atomic_write(path: &Path, content: &[u8], secret: bool) -> Result<
     result
 }
 
+// On non-Unix the body is a no-op, so the `path` parameter is unused there.
+#[cfg_attr(not(unix), allow(unused_variables))]
 pub(super) fn protect_secret_file(path: &Path) -> Result<(), String> {
     #[cfg(unix)]
     {

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -1518,6 +1518,7 @@ mod tests {
     // --- verified parent directory -------------------------------------------
 
     /// Nothing a login writes may appear in a directory outside the base.
+    #[cfg(unix)]
     fn assert_no_credentials_in(dir: &Path) {
         let mut offenders = Vec::new();
         for entry in std::fs::read_dir(dir).unwrap() {

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -63,7 +63,8 @@ mod shell_command_tests {
     }
 }
 
-#[cfg(test)]
+// Only the Unix systemd service tests consume this re-export.
+#[cfg(all(test, unix))]
 pub(crate) use agent_service::render_agent_systemd_unit;
 pub(crate) use agent_service::{run_agent_install_service, run_agent_service, run_agent_status};
 pub(crate) use connect::{

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -46,23 +46,6 @@ pub(crate) fn shell_command(args: &[String]) -> String {
         .join(" ")
 }
 
-#[cfg(test)]
-mod shell_command_tests {
-    use super::shell_quote_arg;
-
-    #[test]
-    fn shell_quote_arg_handles_shell_metacharacters() {
-        assert_eq!(shell_quote_arg("webcodex-runner"), "webcodex-runner");
-        assert_eq!(shell_quote_arg("/tmp/agent.toml"), "/tmp/agent.toml");
-        assert_eq!(shell_quote_arg(""), "''");
-        assert_eq!(shell_quote_arg("path with spaces"), "'path with spaces'");
-        assert_eq!(shell_quote_arg("it's"), "'it'\\''s'");
-        assert_eq!(shell_quote_arg("$HOME"), "'$HOME'");
-        assert_eq!(shell_quote_arg("`id`"), "'`id`'");
-        assert_eq!(shell_quote_arg("one;two"), "'one;two'");
-    }
-}
-
 // Only the Unix systemd service tests consume this re-export.
 #[cfg(all(test, unix))]
 pub(crate) use agent_service::render_agent_systemd_unit;
@@ -136,3 +119,20 @@ pub(crate) use usage::{
     pairing_create_usage, pairing_usage, server_init_usage, server_install_service_usage,
     server_status_usage, server_usage, status_usage, usage,
 };
+
+#[cfg(test)]
+mod shell_command_tests {
+    use super::shell_quote_arg;
+
+    #[test]
+    fn shell_quote_arg_handles_shell_metacharacters() {
+        assert_eq!(shell_quote_arg("webcodex-runner"), "webcodex-runner");
+        assert_eq!(shell_quote_arg("/tmp/agent.toml"), "/tmp/agent.toml");
+        assert_eq!(shell_quote_arg(""), "''");
+        assert_eq!(shell_quote_arg("path with spaces"), "'path with spaces'");
+        assert_eq!(shell_quote_arg("it's"), "'it'\\''s'");
+        assert_eq!(shell_quote_arg("$HOME"), "'$HOME'");
+        assert_eq!(shell_quote_arg("`id`"), "'`id`'");
+        assert_eq!(shell_quote_arg("one;two"), "'one;two'");
+    }
+}

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -1,3 +1,5 @@
+// Every test in this module is Unix-only; the glob import is only needed there.
+#[cfg(unix)]
 use super::super::support::*;
 
 /// Unix-only: systemd service unit semantics with Unix absolute-path

--- a/crates/webcodex-cli/src/webcodex_cli/tests/support.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/support.rs
@@ -4,12 +4,16 @@ pub(super) use crate::webcodex_cli::test_support::{
 };
 pub(super) use crate::webcodex_cli::{
     client_output_dir_for_profile, compare_build_commits, format_error_body, is_effective_root,
-    parse_env_content_value, render_agent_systemd_unit, render_build_metadata_block,
-    resolve_account_credential, runtime_build_metadata, server_status_revision_check, token_prefix,
-    RevisionComparison, CLIENT_PROFILE_ERROR,
+    parse_env_content_value, render_build_metadata_block, resolve_account_credential,
+    runtime_build_metadata, server_status_revision_check, token_prefix, RevisionComparison,
+    CLIENT_PROFILE_ERROR,
 };
+// Only the Unix systemd service tests consume these re-exports.
+#[cfg(unix)]
+pub(super) use crate::webcodex_cli::render_agent_systemd_unit;
 pub(super) use crate::*;
 pub(super) use serde_json::{json, Value};
+#[cfg(unix)]
 pub(super) use std::ffi::OsString;
 pub(super) use std::io::{Read, Write};
 pub(super) use std::net::TcpListener;

--- a/crates/webcodex-process/src/bin/process_tree_helper.rs
+++ b/crates/webcodex-process/src/bin/process_tree_helper.rs
@@ -74,6 +74,11 @@ fn spawn_grandchild(args: &[String]) {
     cmd.stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
+    // The grandchild must survive this process: `spawn-grandchild` exits
+    // immediately so tests can verify process-tree termination (Job Object /
+    // process group) reaches the orphaned grandchild. Waiting for it here
+    // would change the test contract.
+    #[allow(clippy::zombie_processes)]
     let child = cmd.spawn().expect("spawn grandchild");
     println!("GRANDCHILD_PID={}", child.id());
     std::io::stdout().flush().expect("flush stdout");

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -57,9 +57,9 @@ use webcodex_runner::{
     default_websocket_connect_timeout_secs, effective_transport, handle_project_op,
     load_agent_project_summaries_from_dir, non_empty_token, parse_agent_project_toml,
     quic_client_bind_addr_for, resolve_quic_config, resolve_quic_server_addrs, run_shell,
-    run_shell_with_profiles, run_shell_with_profiles_in_sandbox, server_url_to_ws,
-    sha256_hex_bytes, validate_project_path_policy, websocket_session, AgentRuntimeState,
-    ShellProfileConfig, CLIENT_PROFILE_ERROR, DEFAULT_MAX_CONCURRENT_JOBS, WS_OUTGOING_CAPACITY,
+    run_shell_with_profiles, server_url_to_ws, sha256_hex_bytes, validate_project_path_policy,
+    websocket_session, AgentRuntimeState, ShellProfileConfig, CLIENT_PROFILE_ERROR,
+    DEFAULT_MAX_CONCURRENT_JOBS, WS_OUTGOING_CAPACITY,
 };
 use webcodex_runner::{
     client_profile_agent_config, configured_prepared_shell_job_command,

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::webcodex_runner::config::validate_shell_config;
+#[cfg(target_os = "linux")]
+use crate::webcodex_runner::run_shell_with_profiles_in_sandbox;
 use crate::webcodex_runner::{
     handle_project_lifecycle_op, handle_project_op_with_temporary_projects_root,
     handle_resolve_or_register_project,

--- a/crates/webcodex-runner/src/webcodex_runner/config.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/config.rs
@@ -329,6 +329,10 @@ impl HotAgentConfig {
 
 pub(crate) struct ReloadableAgentConfig {
     startup: AgentConfig,
+    /// Config file path used by `reload()`. Config reload is a Unix feature
+    /// (Windows marks reload as unsupported and never stores the path), but
+    /// the reload logic is exercised by cross-platform tests.
+    #[cfg(any(unix, test))]
     path: PathBuf,
     current: RwLock<Arc<HotAgentConfig>>,
     external_routers: Mutex<Vec<Weak<ExternalToolRouter>>>,
@@ -342,10 +346,13 @@ impl ReloadableAgentConfig {
             status.last_reload_result = "unsupported".to_string();
             status.last_reload_error_code = Some("reload_unsupported".to_string());
         }
+        #[cfg(not(any(unix, test)))]
+        let _ = &path;
         let current = Arc::new(HotAgentConfig::new(1, &startup, status));
         let external_routers = vec![Arc::downgrade(&current.external_tools)];
         Self {
             startup,
+            #[cfg(any(unix, test))]
             path,
             current: RwLock::new(current),
             external_routers: Mutex::new(external_routers),
@@ -376,6 +383,7 @@ impl ReloadableAgentConfig {
         self.startup.temporary_projects_root.as_deref()
     }
 
+    #[cfg(any(unix, test))]
     pub(crate) fn is_stopping(&self) -> bool {
         self.stopping.load(Ordering::SeqCst)
     }
@@ -387,6 +395,7 @@ impl ReloadableAgentConfig {
         live
     }
 
+    #[cfg(any(unix, test))]
     pub(crate) fn reload(&self) -> AgentConfigReloadStatus {
         if self.is_stopping() {
             return self.snapshot().reload_status();
@@ -441,6 +450,7 @@ impl ReloadableAgentConfig {
     }
 }
 
+#[cfg(any(unix, test))]
 fn reload_error_code(error: &str) -> &'static str {
     if error.starts_with("failed to read config") {
         "config_read_failed"
@@ -453,6 +463,7 @@ fn reload_error_code(error: &str) -> &'static str {
     }
 }
 
+#[cfg(any(unix, test))]
 pub(crate) fn restart_required_fields(
     startup: &AgentConfig,
     candidate: &AgentConfig,

--- a/crates/webcodex-runner/src/webcodex_runner/external_tools.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/external_tools.rs
@@ -169,6 +169,7 @@ impl ExternalToolRouter {
         )
     }
 
+    #[cfg(any(unix, test))]
     pub(crate) fn configuration_status_changed(&self) {
         self.metadata_revision.fetch_add(1, Ordering::SeqCst);
     }
@@ -1140,7 +1141,7 @@ impl McpConnection {
         self.alive.load(Ordering::SeqCst)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     fn request(
         &self,
         method: &str,

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -610,6 +610,7 @@ fn structured_process_context(
     context
 }
 
+#[cfg(unix)]
 fn structured_script_context(
     cwd: &Path,
     language: shell_protocol::ShellScriptLanguage,

--- a/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
@@ -807,6 +807,10 @@ fn lsp_initialize_pre_exit_with_stderr_surfaces_component_missing_diagnostic() {
     assert_eq!(fixture.starts(), 2);
 }
 
+/// The rustup proxy shim and toolchain layout are Unix-only; the whole test
+/// is skipped on Windows rather than exiting early from a `#[cfg(not(unix))]`
+/// block (which left the remainder of the body unreachable there).
+#[cfg(unix)]
 #[test]
 fn lsp_rustup_proxy_without_component_is_not_available() {
     let _serial = super::super::serialize_fake_lsp_test();
@@ -824,18 +828,12 @@ fn lsp_rustup_proxy_without_component_is_not_available() {
     // Mimic cargo-bin rustup shims: rust-analyzer -> rustup.
     let rustup_bin = bin.join("rustup");
     fs::write(&rustup_bin, b"#!/bin/sh\nexit 1\n").unwrap();
-    #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let mut perms = fs::metadata(&rustup_bin).unwrap().permissions();
         perms.set_mode(0o755);
         fs::set_permissions(&rustup_bin, perms).unwrap();
         std::os::unix::fs::symlink("rustup", bin.join("rust-analyzer")).unwrap();
-    }
-    #[cfg(not(unix))]
-    {
-        // Non-unix CI: skip symlink-specific assertion.
-        return;
     }
 
     let command = LspCommand::new(bin.join("rust-analyzer"));

--- a/crates/webcodex-runner/src/webcodex_runner/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/mod.rs
@@ -73,7 +73,11 @@ pub(crate) use shell::{
     PreparedShellProfileCache,
 };
 #[cfg(test)]
-pub(crate) use shell::{run_shell, run_shell_with_profiles, run_shell_with_profiles_in_sandbox};
+pub(crate) use shell::{run_shell, run_shell_with_profiles};
+// Only the Linux inspect-sandbox smoke test consumes the sandboxed profile
+// runner directly; keep the re-export gated to its consumer.
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) use shell::run_shell_with_profiles_in_sandbox;
 pub(crate) use ssh::{is_transport_failure, run_ssh_shell_with_execution_state, SshConnectionPool};
 #[cfg(test)]
 pub(crate) use transport::{

--- a/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
@@ -617,7 +617,7 @@ impl PersistentShellManager {
         self.processes.close_all(reason)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) fn active_count(&self) -> usize {
         self.processes.active_count()
     }

--- a/crates/webcodex-runner/src/webcodex_runner/shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell.rs
@@ -380,7 +380,7 @@ fn resolve_process_program(
         } else {
             program.to_string()
         };
-        return match super::util::resolve_program_in_path(&resolved_input, &path) {
+        match super::util::resolve_program_in_path(&resolved_input, &path) {
             Some(super::util::ResolvedProgram::Native(path)) => Ok(path.into_os_string()),
             Some(super::util::ResolvedProgram::Batch(_)) => Err(
                 "unsupported_executable_type: Windows .cmd/.bat files require shell/script semantics and cannot preserve run_process native argv; use run_shell as the current explicit escape hatch"
@@ -389,7 +389,7 @@ fn resolve_process_program(
             None => Err(format!(
                 "structured process executable is unavailable or has an unsupported Windows extension: {program}"
             )),
-        };
+        }
     }
     #[cfg(not(windows))]
     {
@@ -3587,9 +3587,7 @@ done
         assert_eq!(command.get_program(), native.as_os_str());
         assert_eq!(
             command.get_args().collect::<Vec<_>>(),
-            args.iter()
-                .map(|argument| OsStr::new(argument))
-                .collect::<Vec<_>>()
+            args.iter().map(OsStr::new).collect::<Vec<_>>()
         );
 
         let marker = temp.path().join("batch-started");

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -637,15 +637,18 @@ fn close_control_socket(connection: &SshConnection) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
-    if status.is_ok_and(|status| status.success()) {
-        return;
+    if !status.is_ok_and(|status| status.success()) {
+        release_control_master_after_failed_exit(connection);
     }
-    // `-O exit` is the normal path. Some OpenSSH builds can reject the
-    // control request after a transport-side failure even though the master
-    // is still alive. The socket lives in our private 0700 directory, so a
-    // successful `-O check` identifies only the master that this pool created.
-    // Release it conservatively instead of leaking an orphaned local client.
-    #[cfg(unix)]
+}
+
+/// `-O exit` is the normal path. Some OpenSSH builds can reject the control
+/// request after a transport-side failure even though the master is still
+/// alive. The socket lives in our private 0700 directory, so a successful
+/// `-O check` identifies only the master that this pool created. Release it
+/// conservatively instead of leaking an orphaned local client.
+#[cfg(unix)]
+fn release_control_master_after_failed_exit(connection: &SshConnection) {
     if let Some(pid) = control_master_pid(connection) {
         // SAFETY: `pid` came from the authenticated control socket located in
         // this pool's private directory. SIGTERM affects only that SSH master.
@@ -653,6 +656,11 @@ fn close_control_socket(connection: &SshConnection) {
             let _ = libc::kill(pid, libc::SIGTERM);
         }
     }
+}
+
+#[cfg(not(unix))]
+fn release_control_master_after_failed_exit(_connection: &SshConnection) {
+    // Windows never has an `-O check`-derived master pid to release.
 }
 
 #[cfg(unix)]

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -291,19 +291,19 @@ impl SshConnectionPool {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) fn connection_count(&self) -> usize {
         lock_unpoison(&self.state).entries.len()
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) fn with_test_config(config_path: PathBuf) -> Self {
         let pool = Self::default();
         lock_unpoison(&pool.state).test_config_path = Some(config_path);
         pool
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) fn control_path_for(
         &self,
         generation: u64,
@@ -406,7 +406,7 @@ impl Drop for SshConnectionPool {
 }
 
 /// Execute a short remote shell command through a Session-bound SSH resource.
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(crate) fn run_ssh_shell(
     pool: &SshConnectionPool,
     generation: u64,
@@ -747,6 +747,8 @@ fn is_safe_session_id(value: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
+// On non-Unix the body is a no-op, so the `command` parameter is unused there.
+#[cfg_attr(not(unix), allow(unused_variables))]
 fn configure_private_process_group(command: &mut Command) {
     #[cfg(unix)]
     {

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -2716,15 +2716,9 @@ fn first_nonempty_env_value_with<F>(names: &[&str], get_env: &mut F) -> Option<s
 where
     F: FnMut(&str) -> Option<std::ffi::OsString>,
 {
-    names.iter().find_map(|name| {
-        get_env(name).and_then(|value| {
-            if value.as_os_str().is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        })
-    })
+    names
+        .iter()
+        .find_map(|name| get_env(name).filter(|value| !value.as_os_str().is_empty()))
 }
 
 fn split_no_proxy_host_port(entry: &str) -> (&str, Option<u16>) {

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -219,6 +219,7 @@ impl AgentRuntimeState {
         }
     }
 
+    #[cfg(any(unix, test))]
     fn register_reload_thread(&self, handle: std::thread::JoinHandle<()>) {
         self.reload_threads.register(handle);
     }

--- a/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use crate::shell_protocol::{
     ShellAgentShellRequest, ShellClientCapabilities, AGENT_PROTOCOL_VERSION_WEBSOCKET_V1,
 };
+#[cfg(unix)]
 use crate::POLLING_DISPATCH_MAX_IN_FLIGHT;
 use futures_util::{SinkExt, StreamExt};
 use std::io::{Read, Write};
@@ -416,6 +417,7 @@ enum ScriptStep {
         body: &'static str,
     },
     PollDeliver(&'static str),
+    #[cfg(unix)]
     PollDeliverRequest(ShellAgentShellRequest),
     PollEmpty,
     PollResponse {
@@ -444,12 +446,13 @@ impl ScriptStep {
                 "/api/shell/agent/register"
             }
             Self::PollDeliver(_)
-            | Self::PollDeliverRequest(_)
             | Self::PollEmpty
             | Self::PollResponse { .. }
             | Self::PollTypedResponse { .. }
             | Self::PollOversized { .. }
             | Self::PollClose => "/api/shell/agent/poll",
+            #[cfg(unix)]
+            Self::PollDeliverRequest(_) => "/api/shell/agent/poll",
             Self::Result { .. } => "/api/shell/agent/result",
         }
     }
@@ -568,6 +571,7 @@ fn sync_file_request(request_id: &str) -> ShellAgentShellRequest {
     }
 }
 
+#[cfg(unix)]
 fn polling_shell_request(request_id: &str, cwd: &Path, command: String) -> ShellAgentShellRequest {
     ShellAgentShellRequest {
         request_id: request_id.to_string(),
@@ -598,6 +602,7 @@ fn polling_shell_request(request_id: &str, cwd: &Path, command: String) -> Shell
     }
 }
 
+#[cfg(unix)]
 fn polling_job_request(
     request_id: &str,
     job_id: &str,
@@ -611,6 +616,7 @@ fn polling_job_request(
     request
 }
 
+#[cfg(unix)]
 fn polling_persistent_shell_request(
     request_id: &str,
     action: &str,
@@ -671,6 +677,7 @@ fn result_success_response() -> ConcurrentHttpResponse {
     ConcurrentHttpResponse::json(r#"{"success":true}"#)
 }
 
+#[cfg(unix)]
 fn job_update_success_response() -> ConcurrentHttpResponse {
     ConcurrentHttpResponse::json(r#"{"success":true,"job":null,"error":null}"#)
 }
@@ -775,6 +782,7 @@ fn start_scripted_agent_server(steps: Vec<ScriptStep>) -> ScriptedServer {
                     );
                     write_http_response(&mut stream, "200 OK", "application/json", &body);
                 }
+                #[cfg(unix)]
                 ScriptStep::PollDeliverRequest(request) => {
                     assert_eq!(path, "/api/shell/agent/poll", "expected poll, got {path}");
                     let request_json = serde_json::to_string(&request).unwrap();

--- a/crates/webcodex-runner/src/webcodex_runner/util.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/util.rs
@@ -17,16 +17,20 @@ pub(crate) enum ResolvedProgram {
     /// Native executable (`.exe`, `.com`, or an extensionless PE image).
     Native(PathBuf),
     /// Batch script (`.cmd` / `.bat`), which requires shell/script semantics.
+    /// Only Windows resolution can produce batch scripts.
+    #[cfg(windows)]
     Batch(PathBuf),
 }
 
 impl ResolvedProgram {
+    #[cfg(windows)]
     pub(crate) fn path(&self) -> &Path {
         match self {
             ResolvedProgram::Native(path) | ResolvedProgram::Batch(path) => path,
         }
     }
 
+    #[cfg(all(test, windows))]
     pub(crate) fn is_batch(&self) -> bool {
         matches!(self, ResolvedProgram::Batch(_))
     }

--- a/crates/webcodex-runner/src/webcodex_runner/util.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/util.rs
@@ -386,7 +386,7 @@ mod tests {
         let executable = spaced.join("probe.exe");
         std::fs::write(&executable, pe_bytes()).unwrap();
         assert_eq!(
-            resolve_program_in_path(&executable.to_string_lossy(), &OsStr::new("")),
+            resolve_program_in_path(&executable.to_string_lossy(), OsStr::new("")),
             Some(ResolvedProgram::Native(executable))
         );
     }
@@ -397,7 +397,7 @@ mod tests {
         let script = temp.path().join("run.cmd");
         std::fs::write(&script, b"@echo off\r\n").unwrap();
         assert_eq!(
-            resolve_program_in_path(&script.to_string_lossy(), &OsStr::new("")),
+            resolve_program_in_path(&script.to_string_lossy(), OsStr::new("")),
             Some(ResolvedProgram::Batch(script))
         );
     }
@@ -543,7 +543,7 @@ mod tests {
         std::fs::create_dir_all(script.parent().unwrap()).unwrap();
         std::fs::write(&script, b"@echo off\r\n").unwrap();
         assert_eq!(
-            resolve_program_in_path(&script.to_string_lossy(), &OsStr::new("")),
+            resolve_program_in_path(&script.to_string_lossy(), OsStr::new("")),
             Some(ResolvedProgram::Batch(script))
         );
     }

--- a/crates/webcodex-runner/src/webcodex_runner/validation/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/validation/tests.rs
@@ -110,7 +110,7 @@ fn write_fake_pyright(bin_dir: &std::path::Path, spec: &FakePyrightSpec) -> Path
         // classic batch sleep; `timeout.exe` needs stdin in pipelines).
         let mut script = String::from("@echo off\r\nchcp 65001 >nul\r\n");
         if spec.delay_ms > 0 {
-            let seconds = (spec.delay_ms + 999) / 1000;
+            let seconds = spec.delay_ms.div_ceil(1000);
             script.push_str(&format!("ping -n {} 127.0.0.1 >nul\r\n", seconds + 1));
         }
         script.push_str("type \"%~dp0pyright.stdout\"\r\n");

--- a/crates/webcodex-workspace/src/project_context.rs
+++ b/crates/webcodex-workspace/src/project_context.rs
@@ -24,6 +24,20 @@ pub const MAX_TRACKED_DIFF_BYTES: usize = 2 * 1024 * 1024;
 pub const MAX_MANIFEST_CANDIDATES: usize = 128;
 pub const MAX_CONTEXT_SCAN_ENTRIES: usize = 100_000;
 pub const MAX_CONTEXT_SCAN_ELAPSED: Duration = Duration::from_secs(3);
+
+/// Compile-time invariants for the bounded-context budgets above: they must
+/// stay positive and ordered, so any future edit that violates the budgets is
+/// caught at build time instead of at runtime.
+const _: () = {
+    assert!(MAX_UNTRACKED_FILE_COUNT > 0);
+    assert!(MAX_BYTES_PER_UNTRACKED_FILE > 0);
+    assert!(MAX_TOTAL_UNTRACKED_BYTES >= MAX_BYTES_PER_UNTRACKED_FILE);
+    assert!(MAX_TRACKED_DIFF_BYTES > 0);
+    assert!(MAX_MANIFEST_CANDIDATES > 0);
+    assert!(MAX_CONTEXT_SCAN_ENTRIES >= MAX_MANIFEST_CANDIDATES);
+    assert!(MAX_CONTEXT_SCAN_ELAPSED.as_nanos() > 0);
+};
+
 const MAX_GIT_STATUS_BYTES: usize = 1024 * 1024;
 const MAX_GIT_LIST_BYTES: usize = 1024 * 1024;
 const MAX_GIT_IDENTITY_BYTES: usize = 4096;
@@ -1552,16 +1566,5 @@ mod tests {
             .manifests
             .iter()
             .all(|file| file.hash_kind == "full"));
-    }
-
-    #[test]
-    fn production_context_budgets_are_positive_and_ordered() {
-        assert!(MAX_UNTRACKED_FILE_COUNT > 0);
-        assert!(MAX_BYTES_PER_UNTRACKED_FILE > 0);
-        assert!(MAX_TOTAL_UNTRACKED_BYTES >= MAX_BYTES_PER_UNTRACKED_FILE);
-        assert!(MAX_TRACKED_DIFF_BYTES > 0);
-        assert!(MAX_MANIFEST_CANDIDATES > 0);
-        assert!(MAX_CONTEXT_SCAN_ENTRIES >= MAX_MANIFEST_CANDIDATES);
-        assert!(!MAX_CONTEXT_SCAN_ELAPSED.is_zero());
     }
 }

--- a/npm/webcodex/test/self-test.js
+++ b/npm/webcodex/test/self-test.js
@@ -337,7 +337,12 @@ async function main() {
         () => install.installFromManifest(manifestPath, testOptions({
           destinationDir: downloaded,
           tempDir: tmp,
-          artifactDownload: { firstByteTimeoutMs: 40, inactivityTimeoutMs: 40, totalTimeoutMs: 150 }
+          // This case exercises the inactivity (stall) path specifically: the
+          // server sends one byte and then never finishes. The first-byte
+          // budget must be comfortably larger than the loopback response
+          // latency, otherwise a loaded CI can trip the first-byte timer
+          // ("timed out waiting for a response") before the stall is observed.
+          artifactDownload: { firstByteTimeoutMs: 5000, inactivityTimeoutMs: 40, totalTimeoutMs: 10000 }
         })),
         downloaded, tmp, /Artifact download stalled before completion/
       );

--- a/src/connector_runtime/execution/monitor.rs
+++ b/src/connector_runtime/execution/monitor.rs
@@ -351,6 +351,26 @@ fn workspace_provenance_mismatch_detail(
     )
 }
 
+fn validation_protocol_failure_code(error: &str) -> Option<&'static str> {
+    let code = error
+        .strip_prefix("executor protocol violation: ")?
+        .split(':')
+        .next()?;
+    match code {
+        "validation_progress_missing" => Some("validation_progress_missing"),
+        "validation_progress_unexpected" => Some("validation_progress_unexpected"),
+        "validation_progress_incomplete" => Some("validation_progress_incomplete"),
+        "validation_progress_invalid" => Some("validation_progress_invalid"),
+        "validation_plan_invalid" => Some("validation_plan_invalid"),
+        _ => Some("validation_progress_invalid"),
+    }
+}
+
+fn executor_failure_code(error: &str) -> Option<&'static str> {
+    crate::shell_protocol::validation_infrastructure_failure_code(error)
+        .or_else(|| validation_protocol_failure_code(error))
+}
+
 #[cfg(test)]
 mod provenance_tests {
     use super::workspace_provenance_mismatch_detail;
@@ -373,24 +393,4 @@ mod provenance_tests {
         );
         assert!(!tracked.contains(".gitignore"), "{tracked}");
     }
-}
-
-fn validation_protocol_failure_code(error: &str) -> Option<&'static str> {
-    let code = error
-        .strip_prefix("executor protocol violation: ")?
-        .split(':')
-        .next()?;
-    match code {
-        "validation_progress_missing" => Some("validation_progress_missing"),
-        "validation_progress_unexpected" => Some("validation_progress_unexpected"),
-        "validation_progress_incomplete" => Some("validation_progress_incomplete"),
-        "validation_progress_invalid" => Some("validation_progress_invalid"),
-        "validation_plan_invalid" => Some("validation_plan_invalid"),
-        _ => Some("validation_progress_invalid"),
-    }
-}
-
-fn executor_failure_code(error: &str) -> Option<&'static str> {
-    crate::shell_protocol::validation_infrastructure_failure_code(error)
-        .or_else(|| validation_protocol_failure_code(error))
 }

--- a/src/tool_runtime/helpers.rs
+++ b/src/tool_runtime/helpers.rs
@@ -1152,6 +1152,9 @@ pub(crate) fn read_lines_from_text(
 
 #[cfg(test)]
 mod tests {
+    // Every test in this module is Unix-only, so the glob import is only
+    // needed there.
+    #[cfg(unix)]
     use super::*;
 
     /// Regression guard for the local-command infinite hang: a shell that exits

--- a/src/tool_runtime/permissions/tests.rs
+++ b/src/tool_runtime/permissions/tests.rs
@@ -152,7 +152,7 @@ fn hard_security_rules_are_not_bypassed_by_authority_mode() {
         "failure_kind": "policy_rejected",
     });
     assert!(is_hard_denied_output(&hard, None));
-    let filtered = Some(decision).filter(|_| !is_hard_denied_output(&hard, None));
+    let filtered = (!is_hard_denied_output(&hard, None)).then_some(decision);
     assert!(
         filtered.is_none(),
         "hard deny must suppress permission attach even under trusted_agent"

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -2509,10 +2509,13 @@ async fn job_log_wait_rejects_invalid_wait_secs_before_execution() {
 #[test]
 fn local_noop_observation_does_not_rewrite_file() {
     let (_temp, record, initial) = make_local_record("job-noop");
+    #[cfg(unix)]
     let path = record.dir.join("observation.json");
+    #[cfg(unix)]
     let before = fs::metadata(&path).unwrap();
     let first = record.observe().unwrap();
     let second = record.observe().unwrap();
+    #[cfg(unix)]
     let after = fs::metadata(&path).unwrap();
     assert_eq!(initial, first);
     assert_eq!(first, second);

--- a/src/tool_runtime/validation_parser.rs
+++ b/src/tool_runtime/validation_parser.rs
@@ -338,7 +338,8 @@ fn parse_diagnostic_header_for_severity(line: &str, severity: &'static str) -> O
     let rest = line.strip_prefix(severity)?;
     let (code, message) = if let Some(message) = rest.strip_prefix(':') {
         (None, message)
-    } else if let Some(rest) = rest.strip_prefix('[') {
+    } else {
+        let rest = rest.strip_prefix('[')?;
         let Some((code, after_code)) = rest.split_once(']') else {
             return Some(HeaderParse::Invalid);
         };
@@ -349,8 +350,6 @@ fn parse_diagnostic_header_for_severity(line: &str, severity: &'static str) -> O
             return Some(HeaderParse::Invalid);
         }
         (Some(code.to_string()), message)
-    } else {
-        return None;
     };
     let message = sanitize_bounded_value(message, MAX_DIAGNOSTIC_MESSAGE_CHARS);
     match message {


### PR DESCRIPTION
## Summary

- make the npm installer stall self-test deterministic without changing production timeout semantics
- eliminate ordinary Rust compiler warnings on Windows and Linux through targeted cfg/dead-code cleanup
- remove low-risk Clippy noise while preserving intentional process-tree and platform behavior
- document the V1 maintenance / feature-freeze policy in `AGENTS.md`

## Why

V1 is entering maintenance mode. This PR establishes a green, warning-free compiler baseline and removes mechanical lint noise before later test-harness and architecture cleanup.

## Validation

- Windows: `cargo fmt --all -- --check`
- Windows: `cargo check --workspace --all-targets --all-features` with 0 rustc warnings
- Windows focused Rust suites covering Runner, CLI, workspace/process, validation/permissions
- `npm --prefix npm/webcodex test` repeated successfully after the timeout-test fix
- Linux/spe: matching source content, `cargo fmt --all -- --check`, `cargo check --workspace --all-targets --all-features` with 0 warnings, focused Rust suites
- Clippy mechanical/idiomatic diagnostics reduced without broad lint suppression
- `git diff --check`

No new V1 product feature is added.