### PR TITLE
V1 maintenance phases 3 and 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "base64",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-admin"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "reqwest 0.12.28",
  "serde_json",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-agent-config"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "toml",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "fs2",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-persistent-shell"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "libc",
  "tempfile",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-process"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "libc",
  "tempfile",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-runner"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64",
  "chrono",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-sandbox"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "landlock",
  "tempfile",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-workspace"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ cargo build --release --workspace --bins
 export PATH="$PWD/target/release:$PATH"
 ```
 
+## Acknowledgements
+
+Thanks to the [LINUX DO](https://linux.do/) community for its welcoming space
+for technical discussion and support for open-source sharing.
+
 ## License
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,6 +137,10 @@ cargo build --release --workspace --bins
 export PATH="$PWD/target/release:$PATH"
 ```
 
+## 鸣谢
+
+感谢 [LINUX DO](https://linux.do/) 社区提供的交流氛围与开源推广支持。
+
 ## License
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE).

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -180,6 +180,10 @@ async fn ops_rejects_agent_token_from_env_file_without_leaking_it() {
     assert!(!error.contains(secret));
 }
 
+// `WEBCODEX_TOKEN` from the process env is the tested product behavior: it
+// must stay set (and serialized against other env-mutating tests) for the
+// whole async operation, so the env lock is held across the awaits by contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn ops_rejects_agent_token_from_process_env_without_leaking_it() {
     let _guard = env_test_guard();

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/env.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/env.rs
@@ -346,6 +346,10 @@ async fn agent_token_create_local_does_not_send_plaintext_token_to_server() {
     handle.join().unwrap();
 }
 
+// `WEBCODEX_ACCOUNT_CREDENTIAL` is the tested product behavior: it must stay
+// set (and serialized against other env-mutating tests) for the whole async
+// operation, so the env lock is held across the awaits by contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn agent_token_create_local_prefers_admin_token_over_default_account_credential() {
     let _guard = env_test_guard();
@@ -387,6 +391,10 @@ async fn agent_token_create_local_prefers_admin_token_over_default_account_crede
     handle.join().unwrap();
 }
 
+// `WEBCODEX_ACCOUNT_CREDENTIAL` is the tested product behavior: it must stay
+// set (and serialized against other env-mutating tests) for the whole async
+// operation, so the env lock is held across the awaits by contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn agent_token_create_local_uses_default_account_credential() {
     let _guard = env_test_guard();
@@ -492,6 +500,10 @@ fn server_http_proxy_validation_and_flag_conflict_are_fail_closed() {
     ));
 }
 
+// The ambient HTTP_PROXY/NO_PROXY env is the tested product behavior: it must
+// stay stable (and serialized against other env-mutating tests) for the whole
+// async operation, so the env lock is held across the awaits by contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn default_server_http_uses_ambient_http_proxy() {
     let _guard = env_test_guard();
@@ -529,6 +541,10 @@ async fn default_server_http_uses_ambient_http_proxy() {
     handle.join().unwrap();
 }
 
+// The ambient HTTP_PROXY/NO_PROXY env is the tested product behavior: it must
+// stay stable (and serialized against other env-mutating tests) for the whole
+// async operation, so the env lock is held across the awaits by contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn ambient_no_proxy_bypasses_system_proxy() {
     let _guard = env_test_guard();
@@ -565,6 +581,11 @@ async fn ambient_no_proxy_bypasses_system_proxy() {
     handle.join().unwrap();
 }
 
+// The ambient HTTP_PROXY/NO_PROXY env is part of the tested product behavior:
+// it must stay stable (and serialized against other env-mutating tests) for
+// the whole async operation, so the env lock is held across the awaits by
+// contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn explicit_proxy_overrides_ambient_system_proxy() {
     let _guard = env_test_guard();
@@ -606,6 +627,11 @@ async fn explicit_proxy_overrides_ambient_system_proxy() {
     handle.join().unwrap();
 }
 
+// The ambient HTTP_PROXY/NO_PROXY env is part of the tested product behavior:
+// it must stay stable (and serialized against other env-mutating tests) for
+// the whole async operation, so the env lock is held across the awaits by
+// contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn no_system_proxy_forces_direct_connection() {
     let _guard = env_test_guard();
@@ -646,6 +672,10 @@ async fn no_system_proxy_forces_direct_connection() {
     handle.join().unwrap();
 }
 
+// The ambient HTTP_PROXY env is part of the tested product behavior: it must
+// stay stable (and serialized against other env-mutating tests) for the whole
+// async operation, so the env lock is held across the awaits by contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "current_thread")]
 async fn authenticated_explicit_proxy_request_redacts_bearer_from_error() {
     let _guard = env_test_guard();

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -124,23 +124,29 @@ impl Drop for JobManagerOwnerLifetime {
     }
 }
 
+/// A Job start accepted by `enqueue` and waiting for a slot: the immutable
+/// inputs the start pipeline consumes once capacity is available.
+///
+/// The sink is deliberately not part of this unit. `enqueue` installs it on
+/// the manager and reports admission failures through it, but the queued
+/// entry and every downstream start path communicate through the installed
+/// sink (`current_sink`); a sink carried here would be dead weight for every
+/// consumer of the queue.
+#[derive(Debug, Clone)]
+struct PendingJobStart {
+    generation: u64,
+    policy: AgentPolicy,
+    shell: ShellConfig,
+    ssh: SshConfig,
+    projects_dir: PathBuf,
+    request: ShellAgentShellRequest,
+}
+
 #[derive(Debug, Clone)]
 struct JobManager {
     max_concurrent: usize,
     jobs: Arc<Mutex<HashMap<String, RunningJob>>>,
-    queued: Arc<
-        Mutex<
-            VecDeque<(
-                AgentSink,
-                u64,
-                AgentPolicy,
-                ShellConfig,
-                SshConfig,
-                PathBuf,
-                ShellAgentShellRequest,
-            )>,
-        >,
-    >,
+    queued: Arc<Mutex<VecDeque<PendingJobStart>>>,
     prepared_profiles: PreparedShellProfileCache,
     ssh_pool: SshConnectionPool,
     lifecycle: Arc<Mutex<()>>,
@@ -2933,26 +2939,17 @@ impl JobManager {
         self.fail_job(request, "runner is shutting down".to_string(), None);
     }
 
-    fn enqueue(
-        &self,
-        sink: AgentSink,
-        generation: u64,
-        policy: AgentPolicy,
-        shell: ShellConfig,
-        ssh: SshConfig,
-        projects_dir: PathBuf,
-        request: ShellAgentShellRequest,
-    ) {
-        let Some(job_id) = request.job_id.clone() else {
+    fn enqueue(&self, sink: AgentSink, start: PendingJobStart) {
+        let Some(job_id) = start.request.job_id.clone() else {
             return;
         };
-        let Some(context) = request.job_context.clone() else {
-            let command_execution_state = structured_prestart_lifecycle(&request);
+        let Some(context) = start.request.job_context.clone() else {
+            let command_execution_state = structured_prestart_lifecycle(&start.request);
             let _ = sink.send_job_update(&ShellAgentJobUpdateRequest {
                 client_id: sink.client_id().to_string(),
                 agent_instance_id: sink.agent_instance_id().to_string(),
                 job_id,
-                request_id: Some(request.request_id),
+                request_id: Some(start.request.request_id),
                 update_seq: Some(1),
                 status: "failed".to_string(),
                 stdout_chunk: None,
@@ -2969,13 +2966,14 @@ impl JobManager {
             });
             return;
         };
-        if let Err(error) = validate_runner_job_context(&context, &request, sink.client_id()) {
-            let command_execution_state = structured_prestart_lifecycle(&request);
+        if let Err(error) = validate_runner_job_context(&context, &start.request, sink.client_id())
+        {
+            let command_execution_state = structured_prestart_lifecycle(&start.request);
             let _ = sink.send_job_update(&ShellAgentJobUpdateRequest {
                 client_id: sink.client_id().to_string(),
                 agent_instance_id: sink.agent_instance_id().to_string(),
                 job_id,
-                request_id: Some(request.request_id),
+                request_id: Some(start.request.request_id),
                 update_seq: Some(1),
                 status: "failed".to_string(),
                 stdout_chunk: None,
@@ -3036,21 +3034,21 @@ impl JobManager {
                     agent_instance_id,
                     snapshot: ShellJobSnapshot {
                         job_id: job_id.clone(),
-                        request_id: request.request_id.clone(),
+                        request_id: start.request.request_id.clone(),
                         status: if terminal {
                             "failed".to_string()
                         } else {
                             "agent_queued".to_string()
                         },
                         update_seq: u64::from(terminal),
-                        created_at: request.created_at,
+                        created_at: start.request.created_at,
                         started_at: None,
                         ended_at: terminal.then_some(now),
                         exit_code: None,
                         duration_ms: terminal.then_some(0),
                         error: immediate_failure.clone(),
                         command_execution_state: terminal
-                            .then(|| structured_prestart_lifecycle(&request))
+                            .then(|| structured_prestart_lifecycle(&start.request))
                             .flatten(),
                         context,
                         stdout: ShellJobStreamSnapshot::default(),
@@ -3064,15 +3062,7 @@ impl JobManager {
             );
             drop(jobs);
             if queue_locally {
-                lock_unpoison(&self.queued).push_back((
-                    sink.clone(),
-                    generation,
-                    policy.clone(),
-                    shell.clone(),
-                    ssh.clone(),
-                    projects_dir.clone(),
-                    request.clone(),
-                ));
+                lock_unpoison(&self.queued).push_back(start.clone());
             }
             (queue_locally, immediate_failure)
         };
@@ -3092,30 +3082,29 @@ impl JobManager {
         if queue_locally {
             return;
         }
-        self.start_now(sink, generation, policy, shell, ssh, projects_dir, request);
+        self.start_now(start);
     }
 
-    fn start_now(
-        &self,
-        sink: AgentSink,
-        generation: u64,
-        policy: AgentPolicy,
-        shell: ShellConfig,
-        ssh: SshConfig,
-        projects_dir: PathBuf,
-        request: ShellAgentShellRequest,
-    ) {
+    fn start_now(&self, start: PendingJobStart) {
         if self.shutting_down.load(Ordering::SeqCst) {
-            self.shutdown_rejection(&request);
+            self.shutdown_rejection(&start.request);
             return;
         }
         if matches!(
-            request.kind.as_str(),
+            start.request.kind.as_str(),
             "start_process_job" | "start_script_job"
         ) {
+            let PendingJobStart {
+                generation,
+                policy,
+                shell,
+                projects_dir,
+                request,
+                ..
+            } = start;
             self.start_structured_job(generation, policy, shell, projects_dir, request);
         } else {
-            self.start_shell_job(sink, generation, policy, shell, ssh, projects_dir, request);
+            self.start_shell_job(start);
         }
     }
 
@@ -3134,13 +3123,11 @@ impl JobManager {
                 let mut jobs = lock_unpoison(&self.jobs);
                 let mut queued = lock_unpoison(&self.queued);
                 let mut selected = None;
-                for (idx, (_, _, _policy, _shell, _ssh, _projects_dir, request)) in
-                    queued.iter().enumerate()
-                {
+                for (idx, queued_start) in queued.iter().enumerate() {
                     let reserved = jobs
                         .values()
                         .filter(|job| {
-                            job.client_id == request.client_id
+                            job.client_id == queued_start.request.client_id
                                 && job.slot_reserved
                                 && runner_job_is_active(&job.snapshot.status)
                         })
@@ -3151,7 +3138,7 @@ impl JobManager {
                     }
                 }
                 if let Some(idx) = selected {
-                    if let Some(job_id) = queued[idx].6.job_id.as_deref() {
+                    if let Some(job_id) = queued[idx].request.job_id.as_deref() {
                         if let Some(job) = jobs.get_mut(job_id) {
                             job.slot_reserved = true;
                         }
@@ -3161,10 +3148,10 @@ impl JobManager {
                     None
                 }
             };
-            let Some((sink, generation, policy, shell, ssh, projects_dir, request)) = next else {
+            let Some(start) = next else {
                 return;
             };
-            self.start_now(sink, generation, policy, shell, ssh, projects_dir, request);
+            self.start_now(start);
         }
     }
 
@@ -3292,16 +3279,15 @@ impl JobManager {
         });
     }
 
-    fn start_shell_job(
-        &self,
-        _sink: AgentSink,
-        generation: u64,
-        policy: AgentPolicy,
-        shell: ShellConfig,
-        ssh: SshConfig,
-        projects_dir: PathBuf,
-        request: ShellAgentShellRequest,
-    ) {
+    fn start_shell_job(&self, start: PendingJobStart) {
+        let PendingJobStart {
+            generation,
+            policy,
+            shell,
+            ssh,
+            projects_dir,
+            request,
+        } = start;
         let Some(job_id) = request.job_id.clone() else {
             return;
         };
@@ -4136,16 +4122,15 @@ impl JobManager {
             let mut queued = lock_unpoison(&self.queued);
             if let Some(pos) = queued
                 .iter()
-                .position(|(_, _, _, _, _, _, request)| request.job_id.as_deref() == Some(job_id))
+                .position(|queued_start| queued_start.request.job_id.as_deref() == Some(job_id))
             {
                 queued.remove(pos)
             } else {
                 None
             }
         };
-        if let Some((_sink, _generation, _policy, _shell, _ssh, _projects_dir, request)) =
-            queued_job
-        {
+        if let Some(queued_start) = queued_job {
+            let PendingJobStart { request, .. } = queued_start;
             self.update_and_send(
                 job_id,
                 RunnerJobDelta {

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -1719,6 +1719,9 @@ server_url = "http://127.0.0.1:8000"
 token = "test-token"
 client_id = "agent-1"
 
+[policy]
+allow_cwd_anywhere = true
+
 [shell]
 dialect = "powershell"
 
@@ -1743,6 +1746,9 @@ args = ["-c"]
 server_url = "http://127.0.0.1:8000"
 token = "test-token"
 client_id = "agent-1"
+
+[policy]
+allow_cwd_anywhere = true
 
 [shell]
 dialect = "cmd"

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -6340,12 +6340,14 @@ fn job_manager_stop_all_clears_queue_and_requests_running_stop() {
 
     jobs.enqueue(
         sink,
-        1,
-        cfg.policy.clone(),
-        cfg.shell.clone(),
-        cfg.ssh.clone(),
-        projects_dir(&cfg).unwrap(),
-        request,
+        PendingJobStart {
+            generation: 1,
+            policy: cfg.policy.clone(),
+            shell: cfg.shell.clone(),
+            ssh: cfg.ssh.clone(),
+            projects_dir: projects_dir(&cfg).unwrap(),
+            request,
+        },
     );
     match rx.try_recv().expect("queued status was sent") {
         AgentEnvelope::JobUpdate { payload } => {
@@ -6370,12 +6372,14 @@ fn job_manager_stop_all_clears_queue_and_requests_running_stop() {
     let (rejected_sink, mut rejected_rx) = ws_sink("ws-client");
     jobs.enqueue(
         rejected_sink,
-        1,
-        cfg.policy.clone(),
-        cfg.shell.clone(),
-        cfg.ssh.clone(),
-        projects_dir(&cfg).unwrap(),
-        rejected_request,
+        PendingJobStart {
+            generation: 1,
+            policy: cfg.policy.clone(),
+            shell: cfg.shell.clone(),
+            ssh: cfg.ssh.clone(),
+            projects_dir: projects_dir(&cfg).unwrap(),
+            request: rejected_request,
+        },
     );
     assert!(jobs.queued.lock().unwrap().is_empty());
     let rejected = (0..2)

--- a/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
@@ -15,7 +15,7 @@ use crate::shell_protocol::{
     ShellScriptPayload, PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES,
     STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS,
 };
-use crate::{handle_file_request, is_file_request_kind, JobManager};
+use crate::{handle_file_request, is_file_request_kind, JobManager, PendingJobStart};
 use std::path::Path;
 use std::sync::atomic::Ordering;
 
@@ -245,12 +245,14 @@ pub(crate) fn dispatch_request(
         "start_job" | "start_validation_job" | "start_process_job" | "start_script_job" => {
             jobs.enqueue(
                 sink.clone(),
-                config.generation,
-                policy.clone(),
-                shell.clone(),
-                config.ssh.clone(),
-                projects_dir.to_path_buf(),
-                request,
+                PendingJobStart {
+                    generation: config.generation,
+                    policy: policy.clone(),
+                    shell: shell.clone(),
+                    ssh: config.ssh.clone(),
+                    projects_dir: projects_dir.to_path_buf(),
+                    request,
+                },
             );
             Ok(true)
         }

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -663,33 +663,35 @@ fn enqueue_structured_process_job(
     let context = structured_process_context(cwd, args.len(), stdin.is_some());
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
-        },
-        ShellConfig::default(),
-        SshConfig::default(),
-        cwd.join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": format!("request-{job_id}"),
-            "client_id": "structured-agent",
-            "kind": "start_process_job",
-            "job_id": job_id,
-            "cwd": cwd,
-            "command": "",
-            "process": {
-                "executable": executable,
-                "args": args,
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
             },
-            "stdin": stdin,
-            "timeout_secs": timeout_secs,
-            "requested_by": "test",
-            "created_at": chrono::Utc::now().timestamp(),
-            "sandbox": sandbox,
-            "job_context": context,
-        }))
-        .unwrap(),
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: cwd.join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": format!("request-{job_id}"),
+                "client_id": "structured-agent",
+                "kind": "start_process_job",
+                "job_id": job_id,
+                "cwd": cwd,
+                "command": "",
+                "process": {
+                    "executable": executable,
+                    "args": args,
+                },
+                "stdin": stdin,
+                "timeout_secs": timeout_secs,
+                "requested_by": "test",
+                "created_at": chrono::Utc::now().timestamp(),
+                "sandbox": sandbox,
+                "job_context": context,
+            }))
+            .unwrap(),
+        },
     );
 }
 
@@ -1061,7 +1063,7 @@ fn phase_e2_stopped_queued_job_never_executes_after_slot_release() {
     assert!(!stopped.active.exists());
     assert!(lock_unpoison(&manager.queued)
         .iter()
-        .all(|entry| entry.6.job_id.as_deref() != Some(stopped.job_id.as_str())));
+        .all(|entry| entry.request.job_id.as_deref() != Some(stopped.job_id.as_str())));
 }
 
 #[cfg(unix)]
@@ -1100,27 +1102,29 @@ fn phase_e2_validation_job_shares_the_same_job_manager_slot_limit() {
     shell.path_prepend.push(bin);
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell,
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "request-validation-shared-slot",
+                "client_id": "structured-agent",
+                "kind": "start_validation_job",
+                "job_id": "validation-shared-slot",
+                "cwd": temp.path(),
+                "command": serde_json::to_string(&steps).unwrap(),
+                "timeout_secs": 20,
+                "requested_by": "test",
+                "created_at": chrono::Utc::now().timestamp(),
+                "job_context": test_job_context(temp.path(), vec!["check".to_string()]),
+            }))
+            .unwrap(),
         },
-        shell,
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": "request-validation-shared-slot",
-            "client_id": "structured-agent",
-            "kind": "start_validation_job",
-            "job_id": "validation-shared-slot",
-            "cwd": temp.path(),
-            "command": serde_json::to_string(&steps).unwrap(),
-            "timeout_secs": 20,
-            "requested_by": "test",
-            "created_at": chrono::Utc::now().timestamp(),
-            "job_context": test_job_context(temp.path(), vec!["check".to_string()]),
-        }))
-        .unwrap(),
     );
     assert!(!validation_marker.exists());
     assert_eq!(
@@ -1527,27 +1531,29 @@ fn phase_f_windows_shell_job_stream_reconstructs_split_utf8_and_oem() {
     let marker_arg = marker.to_string_lossy().replace('\'', "''");
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "request-phase-f-stream",
+                "client_id": "structured-agent",
+                "kind": "start_job",
+                "job_id": "phase-f-stream",
+                "cwd": temp.path(),
+                "command": format!("& '{helper}' windows-utf8-split-output '{marker_arg}'"),
+                "timeout_secs": 10,
+                "requested_by": "test",
+                "created_at": chrono::Utc::now().timestamp(),
+                "job_context": test_job_context(temp.path(), Vec::new()),
+            }))
+            .unwrap(),
         },
-        ShellConfig::default(),
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": "request-phase-f-stream",
-            "client_id": "structured-agent",
-            "kind": "start_job",
-            "job_id": "phase-f-stream",
-            "cwd": temp.path(),
-            "command": format!("& '{helper}' windows-utf8-split-output '{marker_arg}'"),
-            "timeout_secs": 10,
-            "requested_by": "test",
-            "created_at": chrono::Utc::now().timestamp(),
-            "job_context": test_job_context(temp.path(), Vec::new()),
-        }))
-        .unwrap(),
     );
     let updates = collect_job_updates(&mut rx, Duration::from_secs(10));
     let final_update = updates.last().expect("stream Job terminal update");
@@ -1566,29 +1572,31 @@ fn phase_f_windows_shell_job_stream_reconstructs_split_utf8_and_oem() {
     let marker_arg = oem_marker.to_string_lossy().replace('\'', "''");
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "request-phase-f-oem-stream",
+                "client_id": "structured-agent",
+                "kind": "start_job",
+                "job_id": "phase-f-oem-stream",
+                "cwd": temp.path(),
+                "command": format!(
+                    "& '{helper}' windows-oem-split-output '{expected_arg}' '{marker_arg}'"
+                ),
+                "timeout_secs": 10,
+                "requested_by": "test",
+                "created_at": chrono::Utc::now().timestamp(),
+                "job_context": test_job_context(temp.path(), Vec::new()),
+            }))
+            .unwrap(),
         },
-        ShellConfig::default(),
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": "request-phase-f-oem-stream",
-            "client_id": "structured-agent",
-            "kind": "start_job",
-            "job_id": "phase-f-oem-stream",
-            "cwd": temp.path(),
-            "command": format!(
-                "& '{helper}' windows-oem-split-output '{expected_arg}' '{marker_arg}'"
-            ),
-            "timeout_secs": 10,
-            "requested_by": "test",
-            "created_at": chrono::Utc::now().timestamp(),
-            "job_context": test_job_context(temp.path(), Vec::new()),
-        }))
-        .unwrap(),
     );
     let updates = collect_job_updates(&mut rx, Duration::from_secs(10));
     let final_update = updates.last().expect("OEM stream Job terminal update");
@@ -1682,15 +1690,17 @@ fn structured_script_job_keeps_its_temporary_file_until_terminal_then_removes_it
     assert_eq!(request.script.as_ref().unwrap().script, script);
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request,
         },
-        ShellConfig::default(),
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        request,
     );
 
     assert!(wait_until(Duration::from_secs(30), || {
@@ -1783,33 +1793,35 @@ fn structured_process_and_script_jobs_preserve_the_inspect_sandbox() {
     let script_manager = JobManager::new(1);
     script_manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
-        },
-        ShellConfig::default(),
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": "request-inspect-structured-script",
-            "client_id": "structured-agent",
-            "kind": "start_script_job",
-            "job_id": "inspect-structured-script",
-            "cwd": project,
-            "command": "",
-            "script": {
-                "language": "sh",
-                "script": script,
-                "args": [],
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
             },
-            "timeout_secs": 5,
-            "requested_by": "test",
-            "created_at": chrono::Utc::now().timestamp(),
-            "sandbox": crate::command_sandbox::INSPECT_SANDBOX_MODE,
-            "job_context": context,
-        }))
-        .unwrap(),
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "request-inspect-structured-script",
+                "client_id": "structured-agent",
+                "kind": "start_script_job",
+                "job_id": "inspect-structured-script",
+                "cwd": project,
+                "command": "",
+                "script": {
+                    "language": "sh",
+                    "script": script,
+                    "args": [],
+                },
+                "timeout_secs": 5,
+                "requested_by": "test",
+                "created_at": chrono::Utc::now().timestamp(),
+                "sandbox": crate::command_sandbox::INSPECT_SANDBOX_MODE,
+                "job_context": context,
+            }))
+            .unwrap(),
+        },
     );
     let script_updates = collect_job_updates(&mut script_rx, Duration::from_secs(10));
     let script_final = script_updates.last().unwrap();
@@ -1890,28 +1902,30 @@ fn inspect_job_manager_path_landlocks_commands_and_descendants() {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "inspect-job-request",
+                "client_id": "inspect-agent",
+                "kind": "start_job",
+                "job_id": "inspect-job",
+                "cwd": project,
+                "command": "set -eu; cat tracked.txt; printf ok > \"$TMPDIR/proof\"; test \"$(cat \"$TMPDIR/proof\")\" = ok; ! touch created.txt; ! truncate -s 0 tracked.txt; ! sh -c 'printf child > child.txt'",
+                "timeout_secs": 30,
+                "requested_by": "test",
+                "created_at": 1,
+                "sandbox": crate::command_sandbox::INSPECT_SANDBOX_MODE,
+                "job_context": test_job_context(&project, Vec::new())
+            }))
+            .unwrap(),
         },
-        ShellConfig::default(),
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": "inspect-job-request",
-            "client_id": "inspect-agent",
-            "kind": "start_job",
-            "job_id": "inspect-job",
-            "cwd": project,
-            "command": "set -eu; cat tracked.txt; printf ok > \"$TMPDIR/proof\"; test \"$(cat \"$TMPDIR/proof\")\" = ok; ! touch created.txt; ! truncate -s 0 tracked.txt; ! sh -c 'printf child > child.txt'",
-            "timeout_secs": 30,
-            "requested_by": "test",
-            "created_at": 1,
-            "sandbox": crate::command_sandbox::INSPECT_SANDBOX_MODE,
-            "job_context": test_job_context(&project, Vec::new())
-        }))
-        .unwrap(),
     );
 
     let updates = collect_job_updates(&mut rx, Duration::from_secs(30));
@@ -1992,35 +2006,37 @@ fn run_fail_fast_validation_job(attempt: usize) -> FailFastAttempt {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            // These tests run jobs in a temp dir; the boundary itself is
-            // covered separately, and AgentPolicy::default() is fail-closed.
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                // These tests run jobs in a temp dir; the boundary itself is
+                // covered separately, and AgentPolicy::default() is fail-closed.
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell,
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": format!("validation-request-{attempt}"),
+                "client_id": "validation-agent",
+                "kind": "start_validation_job",
+                "job_id": format!("validation-job-{attempt}"),
+                "cwd": temp.path(),
+                "command": serde_json::to_string(&steps).unwrap(),
+                // Two `sh` one-liners. A timeout here would mean a hang, not a busy
+                // machine, which is the point of the gap between this and the
+                // collector deadline below.
+                "timeout_secs": 60,
+                "requested_by": "test",
+                "created_at": 1,
+                "job_context": test_job_context(
+                    temp.path(),
+                    steps.iter().map(|step| step.name.clone()).collect(),
+                )
+            }))
+            .unwrap(),
         },
-        shell,
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": format!("validation-request-{attempt}"),
-            "client_id": "validation-agent",
-            "kind": "start_validation_job",
-            "job_id": format!("validation-job-{attempt}"),
-            "cwd": temp.path(),
-            "command": serde_json::to_string(&steps).unwrap(),
-            // Two `sh` one-liners. A timeout here would mean a hang, not a busy
-            // machine, which is the point of the gap between this and the
-            // collector deadline below.
-            "timeout_secs": 60,
-            "requested_by": "test",
-            "created_at": 1,
-            "job_context": test_job_context(
-                temp.path(),
-                steps.iter().map(|step| step.name.clone()).collect(),
-            )
-        }))
-        .unwrap(),
     );
     let updates = collect_job_updates(&mut rx, Duration::from_secs(120));
     FailFastAttempt {
@@ -2129,34 +2145,36 @@ fn validation_spawn_failure_is_infrastructure_without_failed_assertion() {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            // These tests run jobs in a temp dir; the boundary itself is
-            // covered separately, and AgentPolicy::default() is fail-closed.
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                // These tests run jobs in a temp dir; the boundary itself is
+                // covered separately, and AgentPolicy::default() is fail-closed.
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell,
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "spawn-failure-request",
+                "client_id": "validation-agent",
+                "kind": "start_validation_job",
+                "job_id": "spawn-failure-job",
+                "cwd": temp.path(),
+                "command": serde_json::to_string(&[ShellJobValidationStep {
+                    name: "check".into(),
+                    program: "cargo".into(),
+                    args: vec!["check".into(), "--all-targets".into()],
+                env: Vec::new(),
+                }]).unwrap(),
+                "timeout_secs": 10,
+                "requested_by": "test",
+                "created_at": 1,
+                "job_context": test_job_context(temp.path(), vec!["check".to_string()])
+            }))
+            .unwrap(),
         },
-        shell,
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": "spawn-failure-request",
-            "client_id": "validation-agent",
-            "kind": "start_validation_job",
-            "job_id": "spawn-failure-job",
-            "cwd": temp.path(),
-            "command": serde_json::to_string(&[ShellJobValidationStep {
-                name: "check".into(),
-                program: "cargo".into(),
-                args: vec!["check".into(), "--all-targets".into()],
-            env: Vec::new(),
-            }]).unwrap(),
-            "timeout_secs": 10,
-            "requested_by": "test",
-            "created_at": 1,
-            "job_context": test_job_context(temp.path(), vec!["check".to_string()])
-        }))
-        .unwrap(),
     );
     let update = (0..100)
         .find_map(|_| {
@@ -2862,27 +2880,29 @@ fn job_timeout_terminates_the_whole_tree() {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        1,
-        AgentPolicy {
-            allow_cwd_anywhere: true,
-            ..AgentPolicy::default()
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                ..AgentPolicy::default()
+            },
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "timeout-request",
+                "client_id": "timeout-agent",
+                "kind": "start_job",
+                "job_id": "timeout-job",
+                "cwd": temp.path(),
+                "command": command,
+                "timeout_secs": 1,
+                "requested_by": "test",
+                "created_at": 1,
+                "job_context": test_job_context(temp.path(), Vec::new())
+            }))
+            .unwrap(),
         },
-        ShellConfig::default(),
-        SshConfig::default(),
-        temp.path().join("projects.d"),
-        serde_json::from_value(json!({
-            "request_id": "timeout-request",
-            "client_id": "timeout-agent",
-            "kind": "start_job",
-            "job_id": "timeout-job",
-            "cwd": temp.path(),
-            "command": command,
-            "timeout_secs": 1,
-            "requested_by": "test",
-            "created_at": 1,
-            "job_context": test_job_context(temp.path(), Vec::new())
-        }))
-        .unwrap(),
     );
 
     let updates = collect_job_updates(&mut rx, Duration::from_secs(20));

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -1438,12 +1438,14 @@ mod tests {
         };
         manager.enqueue(
             sink.clone(),
-            11,
-            AgentPolicy::default(),
-            crate::webcodex_runner::ShellConfig::default(),
-            config.clone(),
-            PathBuf::new(),
-            ssh_job_request("ssh-job-complete", "tmp", "printf job-ok"),
+            crate::PendingJobStart {
+                generation: 11,
+                policy: AgentPolicy::default(),
+                shell: crate::webcodex_runner::ShellConfig::default(),
+                ssh: config.clone(),
+                projects_dir: PathBuf::new(),
+                request: ssh_job_request("ssh-job-complete", "tmp", "printf job-ok"),
+            },
         );
         let completed = wait_for_job_update(&mut rx, "ssh-job-complete", |update| update.finished);
         assert_eq!(completed.status, "completed", "{completed:?}");
@@ -1458,12 +1460,14 @@ mod tests {
 
         manager.enqueue(
             sink.clone(),
-            11,
-            AgentPolicy::default(),
-            crate::webcodex_runner::ShellConfig::default(),
-            config.clone(),
-            PathBuf::new(),
-            ssh_job_request("ssh-job-stop", "tmp", "sleep 30"),
+            crate::PendingJobStart {
+                generation: 11,
+                policy: AgentPolicy::default(),
+                shell: crate::webcodex_runner::ShellConfig::default(),
+                ssh: config.clone(),
+                projects_dir: PathBuf::new(),
+                request: ssh_job_request("ssh-job-stop", "tmp", "sleep 30"),
+            },
         );
         let running =
             wait_for_job_update(&mut rx, "ssh-job-stop", |update| update.status == "running");
@@ -1475,12 +1479,14 @@ mod tests {
 
         manager.enqueue(
             sink,
-            11,
-            AgentPolicy::default(),
-            crate::webcodex_runner::ShellConfig::default(),
-            config,
-            PathBuf::new(),
-            ssh_job_request("ssh-job-missing", "missing", "printf never-started"),
+            crate::PendingJobStart {
+                generation: 11,
+                policy: AgentPolicy::default(),
+                shell: crate::webcodex_runner::ShellConfig::default(),
+                ssh: config,
+                projects_dir: PathBuf::new(),
+                request: ssh_job_request("ssh-job-missing", "missing", "printf never-started"),
+            },
         );
         let missing = wait_for_job_update(&mut rx, "ssh-job-missing", |update| update.finished);
         assert_eq!(missing.status, "failed", "{missing:?}");

--- a/npm/webcodex/manifest.example.json
+++ b/npm/webcodex/manifest.example.json
@@ -1,21 +1,21 @@
 {
-  "version": "0.3.5",
+  "version": "0.3.6",
   "binaries": ["webcodex", "webcodex-server", "webcodex-runner"],
   "artifacts": {
     "linux-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.5/webcodex-v0.3.5-linux-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-linux-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "linux-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.5/webcodex-v0.3.5-linux-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-linux-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "darwin-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.5/webcodex-v0.3.5-darwin-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-darwin-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "win32-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.5/webcodex-v0.3.5-win32-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-win32-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     }
   }

--- a/npm/webcodex/package.json
+++ b/npm/webcodex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yyjeqhc/webcodex",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Thin npm installer/wrapper for WebCodex native binaries.",
   "license": "Apache-2.0",
   "bin": {

--- a/npm/webcodex/test/self-test.js
+++ b/npm/webcodex/test/self-test.js
@@ -209,7 +209,7 @@ async function expectInstallFailure(action, destination, tempRoot, pattern) {
 }
 
 async function main() {
-  assert.strictEqual(packageJson.version, "0.3.5");
+  assert.strictEqual(packageJson.version, "0.3.6");
   assert.deepStrictEqual(packageJson.bin, { webcodex: "bin/webcodex.js" });
   assert.deepStrictEqual(install.RUNTIME_BINARIES, ["webcodex", "webcodex-server", "webcodex-runner"]);
   assert.deepStrictEqual(install.SUPPORTED_PLATFORM_KEYS, ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"]);

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -332,8 +332,18 @@ fn mcp_stateless_result(mut result: Value, cacheable: bool) -> Value {
 }
 
 /// MCP tools/list payload for the immutable startup-selected model surface.
+///
+/// Env adapter: resolves the `WEBCODEX_MCP_COMPACT_SCHEMAS` switch and
+/// delegates to the pure renderer.
 fn mcp_tools_list_payload(model_surface: ModelSurface) -> Value {
-    let compact = crate::config::mcp_compact_schemas_enabled();
+    mcp_tools_list_payload_with_compact(model_surface, crate::config::mcp_compact_schemas_enabled())
+}
+
+/// Pure tools/list rendering with an explicit compact switch; no env access.
+/// Production resolves the switch from the env adapter above; tests pass an
+/// explicit bool so they never need process-global env. The schema shape is
+/// identical to the adapter path: `compact` only omits `outputSchema`.
+fn mcp_tools_list_payload_with_compact(model_surface: ModelSurface, compact: bool) -> Value {
     let specs = match model_surface {
         ModelSurface::CanonicalConnector => crate::connector_runtime::surface::capability_specs(),
         ModelSurface::LocalCoding => crate::model_surface::local_coding_tool_specs(),

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -7,54 +7,53 @@ use base64::{engine::general_purpose, Engine as _};
 use sha2::{Digest, Sha256};
 
 fn test_runtime() -> ToolRuntime {
-    let model_surface = crate::model_surface::resolve_model_surface(None)
-        .expect("test model surface configuration");
-    test_runtime_with_surface(model_surface)
+    test_runtime_with_surface(ModelSurface::LocalCoding)
 }
 
 fn test_runtime_with_surface(model_surface: ModelSurface) -> ToolRuntime {
     ToolRuntime::new_for_tests().with_model_surface(model_surface)
 }
 
-/// Lock the shared env lock and select the full operator runtime MCP surface
-/// for the duration of a test. Restores the env on drop. Used by tests whose
-/// assertions target the full operator surface, which is no longer the
-/// default (the default is `local_coding`).
-///
-/// The env var is set only AFTER the lock is acquired so a concurrently
-/// running test that holds the lock cannot clear it between the set and the
-/// lock; on drop the var is removed before the guard is released.
-fn full_operator_mcp_env() -> impl Drop {
-    struct Cleanup {
+/// Run one synchronous operation with a temporary model-surface env value.
+/// The previous value is restored while the shared env lock is still held,
+/// including during unwinding. Async request tests receive an already-built
+/// runtime so process-global env state never needs to span an await.
+fn with_model_surface_env<T>(value: Option<&str>, operation: impl FnOnce() -> T) -> T {
+    struct Restore {
+        previous: Option<std::ffi::OsString>,
         _guard: std::sync::MutexGuard<'static, ()>,
     }
-    impl Drop for Cleanup {
+
+    impl Drop for Restore {
         fn drop(&mut self) {
-            std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
+            match self.previous.as_ref() {
+                Some(previous) => {
+                    std::env::set_var(crate::model_surface::MCP_MODEL_SURFACE_ENV, previous)
+                }
+                None => std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV),
+            }
         }
     }
+
     let guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::set_var(
-        crate::model_surface::MCP_MODEL_SURFACE_ENV,
-        crate::model_surface::MCP_MODEL_SURFACE_FULL_OPERATOR_V1,
-    );
-    Cleanup { _guard: guard }
+    let previous = std::env::var_os(crate::model_surface::MCP_MODEL_SURFACE_ENV);
+    match value {
+        Some(value) => std::env::set_var(crate::model_surface::MCP_MODEL_SURFACE_ENV, value),
+        None => std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV),
+    }
+    let _restore = Restore {
+        previous,
+        _guard: guard,
+    };
+    operation()
 }
 
-/// Variant for callers that already hold `TEST_ENV_LOCK`: only sets/removes
-/// the surface env var.
-fn full_operator_mcp_env_locked() -> impl Drop {
-    struct SurfaceEnvCleanup;
-    impl Drop for SurfaceEnvCleanup {
-        fn drop(&mut self) {
-            std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
-        }
-    }
-    std::env::set_var(
-        crate::model_surface::MCP_MODEL_SURFACE_ENV,
-        crate::model_surface::MCP_MODEL_SURFACE_FULL_OPERATOR_V1,
-    );
-    SurfaceEnvCleanup
+fn test_runtime_from_model_surface_env(value: Option<&str>) -> ToolRuntime {
+    with_model_surface_env(value, || {
+        let model_surface = crate::model_surface::resolve_model_surface(None)
+            .expect("test model surface configuration");
+        test_runtime_with_surface(model_surface)
+    })
 }
 
 fn rpc(method: &str, id: Option<Value>, params: Value) -> JsonRpcRequest {
@@ -99,8 +98,7 @@ fn rpc_error_envelope_carries_code_and_message() {
 
 #[tokio::test]
 async fn mcp_initialize_returns_protocol_and_server_info() {
-    let _guard = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(
         &runtime,
         rpc("initialize", Some(Value::from(1)), json!({})),
@@ -184,6 +182,10 @@ async fn mcp_info_advertised_methods_match_dispatch() {
     }
 }
 
+// The compact switch is read per tools/list request, so `WEBCODEX_MCP_COMPACT_SCHEMAS`
+// must stay stable (and serialized against other env-mutating tests) for the whole
+// async body below. The full-operator surface is passed explicitly instead of via env.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn mcp_tools_list_returns_same_names_as_runtime() {
     // Name parity with the runtime registry must hold under both full and
@@ -191,8 +193,7 @@ async fn mcp_tools_list_returns_same_names_as_runtime() {
     // `mcp_tools_list_default_retains_output_schema` and
     // `mcp_tools_list_compact_omits_output_schema_only`.
     let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    let _full = full_operator_mcp_env_locked();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let runtime_names: Vec<String> = registered_tool_specs()
         .iter()
         .map(|s| s.name.clone())
@@ -223,11 +224,25 @@ async fn mcp_tools_list_returns_same_names_as_runtime() {
             names, runtime_names,
             "tools/list names must match runtime registry (compact={compact})"
         );
-        // Fields retained in both modes (compact only drops outputSchema).
+        // Exercise the real env adapter, not just the pure renderer: compact
+        // must change outputSchema shape while preserving the common fields.
         for tool in tools {
             assert!(tool["name"].is_string());
             assert!(tool["description"].is_string());
             assert!(tool["inputSchema"].is_object());
+            if compact {
+                assert!(
+                    tool.get("outputSchema").is_none(),
+                    "compact env adapter must omit outputSchema for {}",
+                    tool["name"]
+                );
+            } else {
+                assert!(
+                    tool["outputSchema"].is_object(),
+                    "default env adapter must retain outputSchema for {}",
+                    tool["name"]
+                );
+            }
         }
     }
     std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
@@ -235,8 +250,8 @@ async fn mcp_tools_list_returns_same_names_as_runtime() {
 
 #[test]
 fn mcp_tools_list_adds_image_mode_without_changing_generic_artifact_schema() {
-    let _guard = full_operator_mcp_env();
-    let payload = mcp_tools_list_payload(ModelSurface::FullOperatorRuntime);
+    // Explicit non-compact rendering: no env involvement, nothing to serialize.
+    let payload = mcp_tools_list_payload_with_compact(ModelSurface::FullOperatorRuntime, false);
     let mcp_tool = payload["tools"]
         .as_array()
         .unwrap()
@@ -298,8 +313,7 @@ fn ordinary_artifact_result_keeps_existing_text_and_structured_base64_shape() {
 async fn mcp_image_call_returns_native_image_for_remote_agent_project() {
     // read_project_artifact is an artifact tool outside the local_coding
     // surface; select the full operator surface for this call.
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let client_id = "mcp-vision-agent";
     let agent_instance_id = "inst-mcp-vision";
     let project_name = "remote-images";
@@ -468,9 +482,8 @@ async fn mcp_image_call_returns_native_image_for_remote_agent_project() {
 
 #[test]
 fn project_connector_tools_list_is_exact_canonical_surface() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
-    let payload = mcp_tools_list_payload(ModelSurface::CanonicalConnector);
+    // Explicit non-compact rendering: no env involvement.
+    let payload = mcp_tools_list_payload_with_compact(ModelSurface::CanonicalConnector, false);
     let tools = payload["tools"].as_array().expect("tools array");
     let names = tools
         .iter()
@@ -485,17 +498,13 @@ fn project_connector_tools_list_is_exact_canonical_surface() {
     assert!(!names.contains(&"start_session"));
 }
 
-#[tokio::test]
-async fn mcp_tools_list_default_retains_output_schema() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
-    let runtime = test_runtime();
-    let outcome =
-        handle_mcp_request(&runtime, rpc("tools/list", Some(json!(1)), json!({})), None).await;
-    let McpOutcome::Ok(value) = outcome else {
-        panic!("expected Ok");
-    };
-    let tools = value["result"]["tools"].as_array().expect("tools array");
+#[test]
+fn mcp_tools_list_default_retains_output_schema() {
+    // Pure renderer with the explicit default compact=false switch; the
+    // env-adapter path for the default is covered end-to-end by
+    // `mcp_tools_list_returns_same_names_as_runtime`.
+    let value = mcp_tools_list_payload_with_compact(ModelSurface::FullOperatorRuntime, false);
+    let tools = value["tools"].as_array().expect("tools array");
     assert!(!tools.is_empty());
     for tool in tools {
         assert!(tool["name"].is_string());
@@ -512,10 +521,8 @@ async fn mcp_tools_list_default_retains_output_schema() {
 
 #[test]
 fn explicit_resume_mcp_schema_and_metadata_are_exposed() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    let _full = full_operator_mcp_env_locked();
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
-    let payload = mcp_tools_list_payload(ModelSurface::FullOperatorRuntime);
+    // Explicit non-compact rendering: no env involvement.
+    let payload = mcp_tools_list_payload_with_compact(ModelSurface::FullOperatorRuntime, false);
     let tool = payload["tools"]
         .as_array()
         .unwrap()
@@ -539,18 +546,13 @@ fn explicit_resume_mcp_schema_and_metadata_are_exposed() {
         .contains("resume_session_id"));
 }
 
-#[tokio::test]
-async fn mcp_tools_list_compact_omits_output_schema_only() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::set_var("WEBCODEX_MCP_COMPACT_SCHEMAS", "true");
-    let runtime = test_runtime();
-    let outcome =
-        handle_mcp_request(&runtime, rpc("tools/list", Some(json!(2)), json!({})), None).await;
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
-    let McpOutcome::Ok(value) = outcome else {
-        panic!("expected Ok");
-    };
-    let tools = value["result"]["tools"].as_array().expect("tools array");
+#[test]
+fn mcp_tools_list_compact_omits_output_schema_only() {
+    // Pure renderer with the explicit compact=true switch; the env-adapter
+    // path for compact mode is covered end-to-end by
+    // `mcp_tools_list_returns_same_names_as_runtime`.
+    let value = mcp_tools_list_payload_with_compact(ModelSurface::FullOperatorRuntime, true);
+    let tools = value["tools"].as_array().expect("tools array");
     assert!(!tools.is_empty());
     for tool in tools {
         assert!(tool["name"].is_string(), "{tool:?}");
@@ -570,16 +572,19 @@ async fn mcp_tools_list_compact_omits_output_schema_only() {
     }
 }
 
-#[tokio::test]
-async fn mcp_tools_list_compact_is_smaller_than_full_serialized() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
-    let full = serde_json::to_vec(&mcp_tools_list_payload(ModelSurface::FullOperatorRuntime))
-        .expect("full serialize");
-    std::env::set_var("WEBCODEX_MCP_COMPACT_SCHEMAS", "true");
-    let compact = serde_json::to_vec(&mcp_tools_list_payload(ModelSurface::FullOperatorRuntime))
-        .expect("compact serialize");
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
+#[test]
+fn mcp_tools_list_compact_is_smaller_than_full_serialized() {
+    // Explicit compact switches on the pure renderer: no env involvement.
+    let full = serde_json::to_vec(&mcp_tools_list_payload_with_compact(
+        ModelSurface::FullOperatorRuntime,
+        false,
+    ))
+    .expect("full serialize");
+    let compact = serde_json::to_vec(&mcp_tools_list_payload_with_compact(
+        ModelSurface::FullOperatorRuntime,
+        true,
+    ))
+    .expect("compact serialize");
     assert!(
         compact.len() < full.len(),
         "compact={} full={}",
@@ -594,6 +599,10 @@ async fn mcp_tools_list_compact_is_smaller_than_full_serialized() {
     );
 }
 
+// The compact switch is the tested product behavior: `tools/call` must be
+// unaffected while `WEBCODEX_MCP_COMPACT_SCHEMAS` is set, so the env must stay
+// stable (and serialized against other env-mutating tests) for the whole call.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn mcp_tools_call_still_returns_structured_content_under_compact_flag() {
     let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
@@ -620,13 +629,10 @@ async fn mcp_tools_call_still_returns_structured_content_under_compact_flag() {
 
 #[tokio::test]
 async fn session_tools_exposed_in_registry_and_mcp() {
-    // tools/list outputSchema depends on WEBCODEX_MCP_COMPACT_SCHEMAS; take
-    // the shared env lock so parallel compact-schema tests cannot strip it.
-    // The session tools live on the full operator surface, not local_coding.
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    let _full = full_operator_mcp_env_locked();
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
-    let runtime = test_runtime();
+    // Session tools live on the full operator surface, not local_coding.
+    // Assertions cover names/descriptions/inputSchema only, which compact
+    // mode keeps, so no env or lock is needed.
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let specs = registered_tool_specs();
     let registry_names: Vec<&str> = specs.iter().map(|spec| spec.name.as_str()).collect();
     assert!(registry_names.contains(&"session_summary"));
@@ -1206,8 +1212,7 @@ async fn mcp_notifications_initialized_with_id_returns_result() {
 async fn mcp_tools_list_parity_with_rest_tools_list() {
     // MCP tools/list and REST /api/tools/list both expose the exact same
     // registry-backed tool names on the full operator surface.
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let mcp_outcome = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(8)), json!({})),
@@ -1272,10 +1277,9 @@ fn seed_oauth_access_token(
 async fn mcp_tools_call_writes_a_summary_action_audit_row() {
     // list_tools is a full-operator-only tool; select that surface so the
     // call dispatches and lands an action audit row.
-    let _full = full_operator_mcp_env();
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
-    let runtime = Arc::new(test_runtime());
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));
     let service = Service::new(build_test_router(config, db.clone(), runtime));
     let resp = TestClient::post("http://localhost/mcp")
         .bearer_auth("secret")
@@ -1289,24 +1293,29 @@ async fn mcp_tools_call_writes_a_summary_action_audit_row() {
         .await;
     assert_eq!(resp.status_code, Some(StatusCode::OK));
 
-    let conn = db.conn_for_tests();
-    let (endpoint, action, operation, status): (String, String, String, String) = conn
-        .query_row(
-            "SELECT endpoint, action_name, operation, status FROM action_events",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-        )
-        .unwrap();
+    // End the connection guard structurally inside the block: the awaited
+    // requests below must not overlap it.
+    let (endpoint, action, operation, status, summary) = {
+        let conn = db.conn_for_tests();
+        let (endpoint, action, operation, status): (String, String, String, String) = conn
+            .query_row(
+                "SELECT endpoint, action_name, operation, status FROM action_events",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        // Summary-level discipline: no tool output is persisted for MCP rows.
+        let summary: String = conn
+            .query_row("SELECT summary_json FROM action_events", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        (endpoint, action, operation, status, summary)
+    };
     assert_eq!(endpoint, "/mcp");
     assert_eq!(action, "toolsCall");
     assert_eq!(operation, "list_tools");
     assert_eq!(status, "success");
-    // Summary-level discipline: no tool output is persisted for MCP rows.
-    let summary: String = conn
-        .query_row("SELECT summary_json FROM action_events", [], |row| {
-            row.get(0)
-        })
-        .unwrap();
     assert!(
         !summary.contains("tools"),
         "summary must not embed output: {summary}"
@@ -1334,21 +1343,30 @@ async fn mcp_tools_call_writes_a_summary_action_audit_row() {
         .await;
     assert_eq!(resp.status_code, Some(StatusCode::ACCEPTED));
 
-    let count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM action_events", [], |row| row.get(0))
-        .unwrap();
+    let count: i64 = {
+        let conn = db.conn_for_tests();
+        conn.query_row("SELECT COUNT(*) FROM action_events", [], |row| row.get(0))
+            .unwrap()
+    };
     assert_eq!(count, 1);
 }
 
-fn oauth_mcp_service(scopes: &str) -> (tempfile::TempDir, Service, String) {
+fn oauth_mcp_service_with_surface(
+    scopes: &str,
+    model_surface: ModelSurface,
+) -> (tempfile::TempDir, Service, String) {
     let config = test_config_oauth2(Some("secret"));
     let (tmp, db) = test_db();
     let user = seed_user(&db, "alice");
     let client = seed_oauth_client(&db, &user);
     let token = seed_oauth_access_token(&db, &client, &user, scopes);
-    let runtime = Arc::new(test_runtime());
+    let runtime = Arc::new(test_runtime_with_surface(model_surface));
     let service = Service::new(build_test_router(config, db, runtime));
     (tmp, service, token)
+}
+
+fn oauth_mcp_service(scopes: &str) -> (tempfile::TempDir, Service, String) {
+    oauth_mcp_service_with_surface(scopes, ModelSurface::LocalCoding)
 }
 
 /// Build a minimal Router matching the production /mcp wiring: Config,
@@ -1442,10 +1460,9 @@ fn effective_status(resp: &Response) -> StatusCode {
 
 #[tokio::test]
 async fn http_mcp_initialize_success() {
-    let _full = full_operator_mcp_env();
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
-    let runtime = Arc::new(test_runtime());
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));
     let service = Service::new(build_test_router(config, db, runtime));
     let mut resp = TestClient::post("http://localhost/mcp")
         .bearer_auth("secret")
@@ -1479,6 +1496,10 @@ async fn http_mcp_initialize_success() {
     );
 }
 
+// The asserted outputSchema presence is the default (non-compact) product
+// behavior: `WEBCODEX_MCP_COMPACT_SCHEMAS` must stay unset (and serialized
+// against other env-mutating tests) for the whole HTTP request.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn http_mcp_tools_list_success() {
     // Default (non-compact) HTTP tools/list: full schema fields present.
@@ -1519,10 +1540,9 @@ async fn http_mcp_tools_list_success() {
 
 #[tokio::test]
 async fn http_mcp_2026_validates_headers_and_ignores_legacy_session_id() {
-    let _full = full_operator_mcp_env();
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
-    let runtime = Arc::new(test_runtime());
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));
     let service = Service::new(build_test_router(config, db, runtime));
     let params = mcp_2026_params(json!({}));
 
@@ -1714,10 +1734,9 @@ async fn http_mcp_2026_validates_headers_and_ignores_legacy_session_id() {
 
 #[tokio::test]
 async fn http_mcp_2026_tools_call_requires_matching_name_and_accepts_base64_sentinel() {
-    let _full = full_operator_mcp_env();
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
-    let runtime = Arc::new(test_runtime());
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));
     let service = Service::new(build_test_router(config, db, runtime));
     let params = mcp_2026_params(json!({"name": "list_projects", "arguments": {}}));
 
@@ -1945,10 +1964,8 @@ async fn http_mcp_2026_rejects_legacy_lifecycle_and_cross_origin_transport() {
 
 #[tokio::test]
 async fn http_project_connector_lists_and_dispatches_only_canonical_capabilities() {
-    // A Connector test must not observe a concurrent local_coding/full-operator
-    // test's WEBCODEX_MCP_MODEL_SURFACE value; hold the env lock and clear it.
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
+    // The runtime surface is explicit below and the request path never
+    // re-reads WEBCODEX_MCP_MODEL_SURFACE, so no env lock is needed.
     let config = test_config(Some("secret"));
     let (tmp, db) = test_db();
     let project = tmp.path().join("connector-project");
@@ -2220,8 +2237,8 @@ async fn http_project_connector_lists_and_dispatches_only_canonical_capabilities
 
 #[tokio::test]
 async fn http_project_connector_2026_uses_explicit_task_ids_without_transport_window_state() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
+    // The runtime surface is explicit below and the request path never
+    // re-reads WEBCODEX_MCP_MODEL_SURFACE, so no env lock is needed.
     let config = test_config(Some("secret"));
     let (tmp, db) = test_db();
     let project = tmp.path().join("connector-2026-project");
@@ -2695,8 +2712,8 @@ async fn oauth2_mcp_tool_call_requires_project_write_for_edit_tools() {
     // Edit tools require the project:write scope. Select the explicit full
     // operator surface so the scope gate (not the local_coding boundary)
     // decides this call.
-    let _full = full_operator_mcp_env();
-    let (_tmp, service, token) = oauth_mcp_service("project:write");
+    let (_tmp, service, token) =
+        oauth_mcp_service_with_surface("project:write", ModelSurface::FullOperatorRuntime);
     let (status, body, _) = oauth_mcp_request(
         &service,
         &token,
@@ -2713,7 +2730,8 @@ async fn oauth2_mcp_tool_call_requires_project_write_for_edit_tools() {
     .await;
     assert_ne!(status, StatusCode::FORBIDDEN, "body: {:?}", body);
 
-    let (_tmp, service, token) = oauth_mcp_service("project:read");
+    let (_tmp, service, token) =
+        oauth_mcp_service_with_surface("project:read", ModelSurface::FullOperatorRuntime);
     let (status, body, challenge) = oauth_mcp_request(
         &service,
         &token,
@@ -2766,8 +2784,10 @@ async fn oauth2_mcp_tool_call_requires_job_run_for_run_shell() {
 
 #[tokio::test]
 async fn oauth2_mcp_unknown_tool_fails_closed() {
-    let _full = full_operator_mcp_env();
-    let (_tmp, service, token) = oauth_mcp_service("runtime:read project:read");
+    let (_tmp, service, token) = oauth_mcp_service_with_surface(
+        "runtime:read project:read",
+        ModelSurface::FullOperatorRuntime,
+    );
     let (status, body, challenge) = oauth_mcp_request(
         &service,
         &token,
@@ -2825,10 +2845,9 @@ async fn http_mcp_notification_returns_accepted_with_empty_body() {
 
 #[tokio::test]
 async fn http_mcp_get_discovery_returns_metadata() {
-    let _full = full_operator_mcp_env();
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
-    let runtime = Arc::new(test_runtime());
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));
     let service = Service::new(build_test_router(config, db, runtime));
     let mut resp = TestClient::get("http://localhost/mcp")
         .bearer_auth("secret")
@@ -2877,8 +2896,7 @@ async fn http_mcp_get_discovery_returns_metadata() {
 
 #[tokio::test]
 async fn mcp_tools_list_includes_runtime_status() {
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(10)), json!({})),
@@ -2903,8 +2921,7 @@ async fn mcp_tools_list_includes_runtime_status() {
 
 #[tokio::test]
 async fn mcp_tools_list_exposes_coding_task_and_runtime_status_ux_flags() {
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(10)), json!({})),
@@ -3005,8 +3022,7 @@ async fn mcp_tools_list_exposes_coding_task_and_runtime_status_ux_flags() {
 async fn mcp_tools_list_includes_validate_patch() {
     // validate_patch is a patch preflight / dry-run tool exposed via MCP
     // tools/list (and a thin REST wrapper), but NOT via GPT Actions.
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(12)), json!({})),
@@ -3063,8 +3079,7 @@ async fn mcp_tools_list_includes_show_changes() {
 async fn mcp_tools_call_runtime_status_returns_content() {
     // runtime_status is not part of the local_coding surface; select the full
     // operator surface so the call reaches dispatch.
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(
         &runtime,
         rpc(
@@ -3126,8 +3141,7 @@ async fn mcp_tools_call_show_changes_returns_structured_tool_error() {
 
 #[tokio::test]
 async fn mcp_tools_list_includes_project_management_tools() {
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(99)), json!({})),
@@ -3158,10 +3172,9 @@ async fn mcp_tools_list_includes_project_management_tools() {
 
 #[tokio::test]
 async fn local_coding_tools_list_returns_exact_ordered_surface() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
-    std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
-    let runtime = test_runtime();
+    // Explicit local_coding surface; names are compact-invariant, so no env
+    // or lock is needed.
+    let runtime = test_runtime_with_surface(ModelSurface::LocalCoding);
     let outcome = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(60)), json!({})),
@@ -3219,9 +3232,9 @@ async fn local_coding_tools_list_returns_exact_ordered_surface() {
 
 #[tokio::test]
 async fn local_coding_default_initialize_and_discovery_report_local_coding() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
-    let runtime = test_runtime();
+    // Preserve the unset-env integration path, but confine process env state
+    // to synchronous runtime construction.
+    let runtime = test_runtime_from_model_surface_env(None);
     let outcome = handle_mcp_request(
         &runtime,
         rpc("initialize", Some(Value::from(61)), json!({})),
@@ -3240,9 +3253,8 @@ async fn local_coding_default_initialize_and_discovery_report_local_coding() {
 
 #[tokio::test]
 async fn local_coding_rejects_non_surface_tools_at_mcp_boundary() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
-    let runtime = test_runtime();
+    // Explicit local_coding surface: no env or lock needed.
+    let runtime = test_runtime_with_surface(ModelSurface::LocalCoding);
     for denied in [
         "start_coding_task",
         "register_project",
@@ -3287,9 +3299,8 @@ async fn local_coding_rejects_non_surface_tools_at_mcp_boundary() {
 
 #[tokio::test]
 async fn local_coding_allows_surface_tools_to_dispatch() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
-    let runtime = test_runtime();
+    // Explicit local_coding surface: no env or lock needed.
+    let runtime = test_runtime_with_surface(ModelSurface::LocalCoding);
     // list_projects and work_on_project resolve to the runtime registry; they
     // must reach dispatch (not be rejected at the MCP boundary).
     let outcome = handle_mcp_request(
@@ -3312,8 +3323,7 @@ async fn local_coding_allows_surface_tools_to_dispatch() {
 
 #[tokio::test]
 async fn full_operator_explicit_surface_lists_full_runtime_and_dispatches() {
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let listed = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(72)), json!({})),
@@ -3360,12 +3370,9 @@ async fn full_operator_explicit_surface_lists_full_runtime_and_dispatches() {
 
 #[tokio::test]
 async fn explicit_local_coding_v1_selects_local_coding() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::set_var(
-        crate::model_surface::MCP_MODEL_SURFACE_ENV,
+    let runtime = test_runtime_from_model_surface_env(Some(
         crate::model_surface::MCP_MODEL_SURFACE_LOCAL_CODING_V1,
-    );
-    let runtime = test_runtime();
+    ));
     let outcome = handle_mcp_request(
         &runtime,
         rpc("tools/list", Some(Value::from(74)), json!({})),
@@ -3386,13 +3393,13 @@ async fn explicit_local_coding_v1_selects_local_coding() {
         names,
         crate::tool_runtime::tool_definition::LOCAL_CODING_TOOL_NAMES
     );
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
 }
 
 #[tokio::test]
 async fn explicit_full_operator_v1_reports_full_operator_surface() {
-    let _full = full_operator_mcp_env();
-    let runtime = test_runtime();
+    let runtime = test_runtime_from_model_surface_env(Some(
+        crate::model_surface::MCP_MODEL_SURFACE_FULL_OPERATOR_V1,
+    ));
     let outcome = handle_mcp_request(
         &runtime,
         rpc("initialize", Some(Value::from(75)), json!({})),
@@ -3411,12 +3418,12 @@ async fn explicit_full_operator_v1_reports_full_operator_surface() {
 
 #[tokio::test]
 async fn selected_surface_is_immutable_after_environment_changes() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
-    let local = test_runtime();
-    std::env::set_var(
-        crate::model_surface::MCP_MODEL_SURFACE_ENV,
-        crate::model_surface::MCP_MODEL_SURFACE_FULL_OPERATOR_V1,
+    let local = test_runtime_from_model_surface_env(None);
+    // Prove the already-built runtime stays local_coding while the process env
+    // actively requests the opposite surface; restore it before any await.
+    with_model_surface_env(
+        Some(crate::model_surface::MCP_MODEL_SURFACE_FULL_OPERATOR_V1),
+        || assert_eq!(local.model_surface(), ModelSurface::LocalCoding),
     );
     for method in ["initialize", "tools/list"] {
         let outcome =
@@ -3460,10 +3467,9 @@ async fn selected_surface_is_immutable_after_environment_changes() {
     );
 
     let full = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
-    std::env::set_var(
-        crate::model_surface::MCP_MODEL_SURFACE_ENV,
-        "broken-after-startup",
-    );
+    with_model_surface_env(Some("broken-after-startup"), || {
+        assert_eq!(full.model_surface(), ModelSurface::FullOperatorRuntime);
+    });
     let listed =
         handle_mcp_request(&full, rpc("tools/list", Some(json!(82)), json!({})), None).await;
     let McpOutcome::Ok(value) = listed else {
@@ -3477,7 +3483,6 @@ async fn selected_surface_is_immutable_after_environment_changes() {
         full.runtime_status(None).await.output["model_surface"],
         crate::model_surface::MODEL_SURFACE_FULL_OPERATOR_RUNTIME
     );
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
 }
 
 #[tokio::test]

--- a/src/project_entry_tests.rs
+++ b/src/project_entry_tests.rs
@@ -1321,19 +1321,21 @@ async fn arbitrary_shared_key_cannot_access_project_connector() {
         .send(&fixture.service)
         .await;
 
-    let conn = fixture.db.conn_for_tests();
-    let task_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM wc_tasks", [], |row| row.get(0))
-        .unwrap();
-    let execution_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM wc_executions", [], |row| row.get(0))
-        .unwrap();
-    let binding_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM wc_connector_grants", [], |row| {
-            row.get(0)
-        })
-        .unwrap();
-    drop(conn);
+    // End the connection guard structurally inside the block so it is not
+    // held across the registry await below.
+    let (task_count, execution_count, binding_count) = {
+        let conn = fixture.db.conn_for_tests();
+        (
+            conn.query_row("SELECT COUNT(*) FROM wc_tasks", [], |row| row.get(0))
+                .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM wc_executions", [], |row| row.get(0))
+                .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM wc_connector_grants", [], |row| {
+                row.get(0)
+            })
+            .unwrap(),
+        )
+    };
     let pending = fixture
         .registry
         .get_client_view_for_auth(&fixture.client_id, Some(&fixture.agent_auth))
@@ -1432,24 +1434,25 @@ async fn connector_credential_cannot_cross_agent_auth_group() {
         responses.push(post_connector(&fixture, path, &wrong_project_credential, body).await);
     }
 
-    let conn = fixture.db.conn_for_tests();
-    let task_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM wc_tasks", [], |row| row.get(0))
-        .unwrap();
-    let execution_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM wc_executions", [], |row| row.get(0))
-        .unwrap();
-    let binding_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM wc_connector_grants", [], |row| {
-            row.get(0)
-        })
-        .unwrap();
-    let edit_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM wc_edit_operations", [], |row| {
-            row.get(0)
-        })
-        .unwrap();
-    drop(conn);
+    // End the connection guard structurally inside the block so it is not
+    // held across the registry await below.
+    let (task_count, execution_count, binding_count, edit_count) = {
+        let conn = fixture.db.conn_for_tests();
+        (
+            conn.query_row("SELECT COUNT(*) FROM wc_tasks", [], |row| row.get(0))
+                .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM wc_executions", [], |row| row.get(0))
+                .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM wc_connector_grants", [], |row| {
+                row.get(0)
+            })
+            .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM wc_edit_operations", [], |row| {
+                row.get(0)
+            })
+            .unwrap(),
+        )
+    };
     let agent = fixture
         .registry
         .get_client_view_for_auth(&fixture.client_id, Some(&fixture.agent_auth))

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1553,8 +1553,8 @@ async fn runtime_status_includes_build_metadata() {
 
 #[tokio::test]
 async fn runtime_status_defaults_to_local_coding_surface() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var(crate::model_surface::MCP_MODEL_SURFACE_ENV);
+    // ToolRuntime::new_for_tests defaults to local_coding; keep this as a real
+    // default-constructor check rather than overriding the value under test.
     let runtime = test_runtime();
     let result = runtime.dispatch(runtime_status_call()).await;
     assert!(result.success, "{:?}", result.error);


### PR DESCRIPTION
## Summary
- decouple phase-3 tests from process environment and global synchronization
- bound queued-job start inputs in `PendingJobStart` for phase 4
- make the Runner shell-dialect fixture independent of ambient `HOME`
- restore LINUX DO acknowledgements in the English and Chinese READMEs
- prepare canonical Cargo/npm release metadata for v0.3.6

## Validation
- `cargo fmt -- --check`
- `cargo check --all-targets`
- `cargo test --workspace -- --nocapture`
- `cargo test shell_config_dialect_field_parses_and_validates -p webcodex-runner`
- `npm test` in `npm/webcodex`
- Markdown local links: 34 files / 218 local links / 0 missing
- `git diff --check`
