### PR TITLE
release: prepare v0.3.6

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -396,11 +396,13 @@ jobs:
             rust_target: x86_64-pc-windows-msvc
             processor_architecture: AMD64
             pe_machine: "8664"
+            node_architecture: x64
           - platform: win32-arm64
             runner: windows-11-arm
             rust_target: aarch64-pc-windows-msvc
             processor_architecture: ARM64
             pe_machine: "AA64"
+            node_architecture: arm64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     env:
@@ -423,6 +425,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.rust_target }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          architecture: ${{ matrix.node_architecture }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: release-${{ matrix.platform }}
@@ -491,6 +497,18 @@ jobs:
           $hash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
           $checksumLine = "$hash  $(Split-Path -Leaf $archive)`n"
           [System.IO.File]::WriteAllText("$archive.sha256", $checksumLine, [System.Text.Encoding]::ASCII)
+
+      - name: Smoke native Windows artifact through npm installer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $binDir = Join-Path "target" (Join-Path $env:RUST_TARGET "release")
+          & .\scripts\npm_install_windows_smoke.ps1 `
+            -BinDir $binDir `
+            -Platform $env:WEBCODEX_RELEASE_PLATFORM
+          if ($LASTEXITCODE -ne 0) {
+            throw "native Windows npm smoke failed with exit code $LASTEXITCODE"
+          }
 
       - name: Upload Windows candidate
         uses: actions/upload-artifact@v4

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -42,7 +42,7 @@ Confirm the user-facing docs tell one story:
 - Architecture starts with client/server/agent/codebase, security-boundary, and runtime-module diagrams before Rust module notes.
 - MCP and GPT Actions both say they call the same WebCodex ToolRuntime.
 - Security explains what the model can and cannot do, project access, agent trust boundary, shell/job risk, token handling, session/audit evidence, and revocation.
-- Release Notes read like external release notes and include highlights, breaking changes, known limitations, upgrade notes, validation, and next steps.
+- The release PR / GitHub Release notes read like external release notes and include highlights, compatibility or breaking changes, known limitations, upgrade notes, and validation. Do not restore per-version release-note files as a second documentation source.
 - Roadmap stays short and does not promise a full IDE replacement, autonomous ops, arbitrary computer use, or universal client compatibility.
 
 Run a markdown local link check and report markdown file count, local link count, and missing local link count.
@@ -95,11 +95,11 @@ For every new binary and npm release, choose one candidate `<VERSION>` first and
 
 - `Cargo.toml`, every local WebCodex workspace entry in `Cargo.lock`, `npm/webcodex/package.json`, `manifest.example.json`, and the npm self-tests must agree on `<VERSION>` before tagging.
 - `npm/webcodex/manifest.json` is generated release metadata and is intentionally not tracked. Do not commit real checksums or create a post-tag checksum-only PR.
-- Build the four published platforms (`linux-x64`, `linux-arm64`, `darwin-arm64`, `win32-x64`) on their native release hosts from the exact `v<VERSION>` tag. Do not rebuild an artifact on an intermediate packaging machine or substitute a cross-compiled artifact for native validation.
-- For `linux-x64`, build on the dedicated compatibility release builder whose userspace baseline is glibc 2.17. Before packaging, inspect all three ELF binaries with `readelf` and fail the release if any required `GLIBC_*` symbol version exceeds 2.17. This glibc floor currently applies only to `linux-x64`; `linux-arm64` keeps its native-host compatibility until its release builder is migrated separately.
+- Build the five published platforms (`linux-x64`, `linux-arm64`, `darwin-arm64`, `win32-x64`, `win32-arm64`) natively from the exact `v<VERSION>` tag through the reviewed release-build workflow. Do not rebuild an artifact on an intermediate packaging machine or substitute a cross-compiled artifact for native validation.
+- For both `linux-x64` and `linux-arm64`, build in the native-architecture manylinux2014 userspace used by the release-build workflow. Before packaging, inspect all three ELF binaries with `readelf` and fail the release if any required `GLIBC_*` symbol version exceeds 2.17 or an unexpected host-specific `DT_NEEDED` dependency appears. The published Linux x64 and arm64 artifacts therefore share the glibc 2.17 floor.
 - Pin one `WEBCODEX_BUILT_AT` value for the release. Every final `webcodex`, `webcodex-server`, and `webcodex-runner` binary must report `<VERSION>`, the same concrete tag commit, `dirty=false`, and the shared `built_at`.
 - Windows packaging must use `scripts/package_release_artifact.ps1` in its default provenance-checked mode. `-AllowDevelopmentBuild` is for local/CI smoke only and its output must never be uploaded.
-- The release control host is where the final archives are collected. Collect all four final archives there, then run `scripts/prepare_release_metadata.py` to validate archive contents and generate `manifest.json` plus `SHA256SUMS` from the exact bytes.
+- The release control host is where the final archives are collected. Collect all five final archives there, then run `scripts/prepare_release_metadata.py` to validate archive contents and generate `manifest.json` plus `SHA256SUMS` from the exact bytes.
 - Create the npm publication tree with `scripts/stage_npm_release.sh`. Its default mode requires a clean source worktree at exactly `v<VERSION>` and overlays the generated manifest without modifying Git. `--allow-development` is never valid for publication.
 - Run `WEBCODEX_NPM_PACKAGE_DIR=<STAGE_DIR>/npm-package bash scripts/npm_package_smoke.sh` before npm publication. The smoke must validate the generated manifest, package contents, temporary installation, wrapper, and all three binaries.
 - Upload `SHA256SUMS` with the native archives to the GitHub Release. Re-download uploaded assets to the release control host and verify their checksums before making the release public.
@@ -109,11 +109,11 @@ For every new binary and npm release, choose one candidate `<VERSION>` first and
 
 1. Select a new `<VERSION>` that does not already exist as a Git tag, GitHub Release, or npm package version. Put version bumps, release notes, platform docs, packaging changes, and release tests in **one release-prep PR** and squash-merge it into `main`.
 2. On the release control host, fast-forward to `origin/main`, require a clean worktree, run the source/release gates, and only after explicit operator authorization create the immutable annotated `v<VERSION>` tag. Never move that tag afterward.
-3. Build the four native artifacts from that exact tag on their native release hosts (`linux-x64` glibc 2.17 baseline, `linux-arm64`, `darwin-arm64`, `win32-x64`). Verify version/build identity on each host, enforce the Linux x64 `GLIBC_* <= 2.17` gate, and transfer the final archives back to the release control host.
-4. On the release control host, run `scripts/prepare_release_metadata.py --version <VERSION> --artifact-dir <ARTIFACT_DIR> --output-dir <METADATA_DIR>`. Create a draft GitHub Release and upload the four archives plus `SHA256SUMS`; download them again and verify SHA-256 against the local exact bytes.
+3. Dispatch the reviewed release-build workflow for the exact tag and collect the five native artifacts (`linux-x64`, `linux-arm64`, `darwin-arm64`, `win32-x64`, `win32-arm64`). Verify version/build identity and native architecture for every target, enforce the `GLIBC_* <= 2.17` plus `DT_NEEDED` gates for both Linux targets, and transfer the exact candidate archives to the release control host.
+4. On the release control host, run `scripts/prepare_release_metadata.py --version <VERSION> --artifact-dir <ARTIFACT_DIR> --output-dir <METADATA_DIR>`. Create a draft GitHub Release and upload the five archives plus `SHA256SUMS`; download them again and verify SHA-256 against the local exact bytes.
 5. From a clean detached worktree at the immutable tag, run `scripts/stage_npm_release.sh --manifest <METADATA_DIR>/manifest.json --output-dir <STAGE_DIR>`, then run the npm package smoke against `<STAGE_DIR>/npm-package`.
 6. Make the GitHub Release public and verify every generated manifest URL is reachable. From the release control host only, publish npm from the staged package (`npm publish --access public`) and verify the requested version/dist-tag in the registry.
-7. Run public npm install acceptance on Linux x64 and Windows x64 when network routing permits, then fast-forward the four build-host source repositories to current `main` and clean temporary worktrees/bundles/pre-smoke artifacts.
+7. Run public npm install acceptance on Linux x64, Windows x64, and native Windows arm64 when a suitable runner and network path are available. Then fast-forward any persistent release-control/build-host source checkouts used outside GitHub Actions to current `main` and clean temporary worktrees/bundles/pre-smoke artifacts.
 
 ## 10. Post-Deployment Acceptance Smoke
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -11,8 +11,8 @@ platforms.
 
 ### Install and connect
 
-Supported platforms are Linux x64, Linux arm64, macOS arm64, and Windows x64. Node.js 18 or
-newer is required by the installer wrapper.
+Supported platforms are Linux x64, Linux arm64, macOS arm64, Windows x64, and native Windows
+arm64. Node.js 18 or newer is required by the installer wrapper.
 
 ```bash
 npm install -g @yyjeqhc/webcodex
@@ -59,8 +59,8 @@ WebCodex 让 ChatGPT、Claude 和其他 MCP client 成为连接到你自己仓�
 
 ### 安装与接入
 
-支持 Linux x64、Linux arm64、macOS arm64 和 Windows x64；installer wrapper 需要 Node.js 18
-或更新版本。
+支持 Linux x64、Linux arm64、macOS arm64、Windows x64 和原生 Windows arm64；installer
+wrapper 需要 Node.js 18 或更新版本。
 
 ```bash
 npm install -g @yyjeqhc/webcodex

--- a/npm/webcodex/install.js
+++ b/npm/webcodex/install.js
@@ -22,7 +22,7 @@ const RUNTIME_BINARIES = Object.freeze(["webcodex", "webcodex-server", "webcodex
 const PLATFORM_KEYS = Object.freeze({
   linux: Object.freeze({ x64: "linux-x64", arm64: "linux-arm64" }),
   darwin: Object.freeze({ x64: "darwin-x64", arm64: "darwin-arm64" }),
-  win32: Object.freeze({ x64: "win32-x64" })
+  win32: Object.freeze({ x64: "win32-x64", arm64: "win32-arm64" })
 });
 const SUPPORTED_PLATFORM_KEYS = Object.freeze(
   Object.values(PLATFORM_KEYS).flatMap((architectures) => Object.values(architectures))

--- a/npm/webcodex/manifest.example.json
+++ b/npm/webcodex/manifest.example.json
@@ -17,6 +17,10 @@
     "win32-x64": {
       "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-win32-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
+    },
+    "win32-arm64": {
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-win32-arm64.tar.gz",
+      "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     }
   }
 }

--- a/npm/webcodex/test/release-manifest-check-self-test.js
+++ b/npm/webcodex/test/release-manifest-check-self-test.js
@@ -43,15 +43,15 @@ function main() {
   assert.strictEqual(validateReleaseManifest(linuxOnly), true);
   assert.strictEqual(validateReleaseManifest(validFixture()), true);
 
-  // win32-x64 is a producible release platform: its URL shape and a
-  // placeholder-free checksum must validate like any other platform. The
-  // published manifest only gains a real win32-x64 entry once a Windows-host
-  // built artifact and its checksum exist.
-  assert.strictEqual(
-    expectedArtifactUrl(packageJson.version, "win32-x64"),
-    `https://github.com/yyjeqhc/webcodex/releases/download/v${packageJson.version}/webcodex-v${packageJson.version}-win32-x64.tar.gz`
-  );
-  assert.strictEqual(validateReleaseManifest(validFixture(["win32-x64"])), true);
+  // Both Windows architectures are native release platforms: their URL shapes
+  // and placeholder-free checksums must validate like any other platform.
+  for (const platform of ["win32-x64", "win32-arm64"]) {
+    assert.strictEqual(
+      expectedArtifactUrl(packageJson.version, platform),
+      `https://github.com/yyjeqhc/webcodex/releases/download/v${packageJson.version}/webcodex-v${packageJson.version}-${platform}.tar.gz`
+    );
+    assert.strictEqual(validateReleaseManifest(validFixture([platform])), true);
+  }
 
   assertInvalid({ version: packageJson.version, binaries: EXPECTED_BINARIES, artifacts: {} }, /at least one artifact/);
 

--- a/npm/webcodex/test/self-test.js
+++ b/npm/webcodex/test/self-test.js
@@ -212,7 +212,7 @@ async function main() {
   assert.strictEqual(packageJson.version, "0.3.6");
   assert.deepStrictEqual(packageJson.bin, { webcodex: "bin/webcodex.js" });
   assert.deepStrictEqual(install.RUNTIME_BINARIES, ["webcodex", "webcodex-server", "webcodex-runner"]);
-  assert.deepStrictEqual(install.SUPPORTED_PLATFORM_KEYS, ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"]);
+  assert.deepStrictEqual(install.SUPPORTED_PLATFORM_KEYS, ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"]);
   assert.strictEqual(install.MAX_MANIFEST_BYTES, 1024 * 1024);
   assert.strictEqual(install.MAX_ARTIFACT_BYTES, 128 * 1024 * 1024);
   assert.strictEqual(install.MAX_UNCOMPRESSED_BYTES, 256 * 1024 * 1024);
@@ -231,6 +231,7 @@ async function main() {
 
   assert.strictEqual(install.platformKey("linux", "x64"), "linux-x64");
   assert.strictEqual(install.platformKey("darwin", "arm64"), "darwin-arm64");
+  assert.strictEqual(install.platformKey("win32", "arm64"), "win32-arm64");
   assert.throws(() => install.platformKey("sunos", "x64"), /Unsupported/);
   assert.strictEqual(
     wrapper.nativePath({ packageRoot: "/tmp/package", platform: "linux" }),

--- a/scripts/npm_install_windows_smoke.ps1
+++ b/scripts/npm_install_windows_smoke.ps1
@@ -22,18 +22,31 @@
 #
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File scripts\npm_install_windows_smoke.ps1
-#   powershell -ExecutionPolicy Bypass -File scripts\npm_install_windows_smoke.ps1 -BinDir E:\webcodex\target\release
+#   powershell -ExecutionPolicy Bypass -File scripts\npm_install_windows_smoke.ps1 -BinDir E:\webcodex\target\release -Platform win32-x64
 [CmdletBinding()]
 param(
     # Directory containing webcodex.exe / webcodex-server.exe / webcodex-runner.exe.
     # Defaults to the debug build, which this script builds first.
-    [string]$BinDir
+    [string]$BinDir,
+    # Native Windows release platform exercised by this host.
+    [string]$Platform
 )
 
 $ErrorActionPreference = "Stop"
 
 $Root = Split-Path -Parent $PSScriptRoot
 $Version = (Get-Content -LiteralPath (Join-Path $Root "npm\webcodex\package.json") -Raw | ConvertFrom-Json).version
+if (-not $Platform) {
+    $Platform = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "win32-arm64" } else { "win32-x64" }
+}
+if ($Platform -notin @("win32-x64", "win32-arm64")) {
+    throw "invalid Windows smoke platform '$Platform'"
+}
+$ExpectedNodeArch = if ($Platform -eq "win32-arm64") { "arm64" } else { "x64" }
+$NodeArch = (& node -p "process.arch").Trim()
+if ($LASTEXITCODE -ne 0 -or $NodeArch -ne $ExpectedNodeArch) {
+    throw "native npm smoke requires Node $ExpectedNodeArch for $Platform; got '$NodeArch'"
+}
 
 # ---------------------------------------------------------------------------
 # 0. Build the three Windows binaries unless an explicit BIN_DIR was given.
@@ -77,7 +90,7 @@ try {
     # -----------------------------------------------------------------------
     Write-Host "creating Windows release artifact..."
     $artifactOutput = & (Join-Path $PSScriptRoot "package_release_artifact.ps1") `
-        -BinDir $BinDir -OutDir $ArtifactOut -AllowDevelopmentBuild
+        -BinDir $BinDir -OutDir $ArtifactOut -Platform $Platform -AllowDevelopmentBuild
     if ($LASTEXITCODE -ne 0) {
         throw "package_release_artifact.ps1 failed with exit code $LASTEXITCODE"
     }
@@ -90,7 +103,7 @@ try {
     if ($sha256 -notmatch '^[a-f0-9]{64}$') {
         throw "packaging did not report a SHA-256: $shaLine"
     }
-    $ExpectedArchiveName = "webcodex-v$Version-win32-x64.tar.gz"
+    $ExpectedArchiveName = "webcodex-v$Version-$Platform.tar.gz"
     if ((Split-Path -Leaf $Archive) -ne $ExpectedArchiveName) {
         throw "unexpected artifact name: $(Split-Path -Leaf $Archive) (expected $ExpectedArchiveName)"
     }
@@ -115,15 +128,15 @@ try {
     # -----------------------------------------------------------------------
     # 3. Local manifest with the actual SHA-256.
     # -----------------------------------------------------------------------
+    $artifacts = [ordered]@{}
+    $artifacts[$Platform] = [ordered]@{
+        url = [System.Uri]::new($Archive).AbsoluteUri
+        sha256 = $sha256
+    }
     $manifest = [ordered]@{
         version = $Version
         binaries = @("webcodex", "webcodex-server", "webcodex-runner")
-        artifacts = [ordered]@{
-            "win32-x64" = [ordered]@{
-                url = [System.Uri]::new($Archive).AbsoluteUri
-                sha256 = $sha256
-            }
-        }
+        artifacts = $artifacts
     }
     # BOM-less UTF-8: install.js parses the manifest with JSON.parse, which
     # rejects a leading byte-order mark.
@@ -205,15 +218,15 @@ try {
     # -----------------------------------------------------------------------
     # 6. An install failure must not break the previous binary set.
     # -----------------------------------------------------------------------
+    $badArtifacts = [ordered]@{}
+    $badArtifacts[$Platform] = [ordered]@{
+        url = [System.Uri]::new($Archive).AbsoluteUri
+        sha256 = "0" * 64
+    }
     $badManifest = [ordered]@{
         version = $Version
         binaries = @("webcodex", "webcodex-server", "webcodex-runner")
-        artifacts = [ordered]@{
-            "win32-x64" = [ordered]@{
-                url = [System.Uri]::new($Archive).AbsoluteUri
-                sha256 = "0" * 64
-            }
-        }
+        artifacts = $badArtifacts
     }
     $BadManifestPath = Join-Path $TempRoot "bad-manifest.json"
     [System.IO.File]::WriteAllText(
@@ -248,7 +261,7 @@ try {
         throw "installer left staging/temp files behind: $($leftovers + $stagingLeftovers -join '; ')"
     }
 
-    Write-Host "Windows artifact -> npm install smoke passed"
+    Write-Host "Windows artifact -> npm install smoke passed for $Platform"
     Write-Host "  artifact:  $Archive"
     Write-Host "  sha256:    $sha256"
     Write-Host "  installed: $VendorBin"

--- a/scripts/prepare_release_metadata.py
+++ b/scripts/prepare_release_metadata.py
@@ -11,7 +11,7 @@ import tarfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-PLATFORMS = ("linux-x64", "linux-arm64", "darwin-arm64", "win32-x64")
+PLATFORMS = ("linux-x64", "linux-arm64", "darwin-arm64", "win32-x64", "win32-arm64")
 BINARIES = ("webcodex", "webcodex-server", "webcodex-runner")
 
 
@@ -28,7 +28,7 @@ def archive_filename(version: str, platform: str) -> str:
 
 
 def expected_members(platform: str) -> set[str]:
-    suffix = ".exe" if platform == "win32-x64" else ""
+    suffix = ".exe" if platform in {"win32-x64", "win32-arm64"} else ""
     return {f"{name}{suffix}" for name in BINARIES}
 
 


### PR DESCRIPTION
## Summary

Prepare WebCodex v0.3.6 for release from the current post-#33 mainline.

The canonical Cargo/npm version is already `0.3.6` from #32. This PR closes the remaining distribution gap by making native Windows ARM64 a first-class artifact in the main npm package and by aligning release metadata, validation, and operator documentation with the existing five-target release-build workflow.

### Native Windows ARM64

- map `win32-arm64` hosts to a distinct `win32-arm64` artifact rather than the x64 artifact
- add `win32-arm64` to the generated release metadata and example manifest
- extend npm manifest/platform tests for the native ARM64 artifact
- generalize the existing Windows artifact -> npm install smoke across x64 and ARM64
- run that smoke in both native Windows release-build matrix jobs using an explicitly matching Node architecture

The five published native artifacts are now:

- `linux-x64`
- `linux-arm64`
- `darwin-arm64`
- `win32-x64`
- `win32-arm64`

### Release contract alignment

- update `prepare_release_metadata.py` to require and validate all five final archives
- align the release checklist with the reviewed five-target GitHub Actions candidate-build workflow
- document that both native Linux targets use the manylinux2014/glibc 2.17 userspace and enforce the existing `GLIBC_* <= 2.17` plus `DT_NEEDED` gates
- keep publication separate on the release control host: candidate workflow -> exact archive collection -> generated manifest/checksums -> npm staging/smoke -> draft asset verification -> publication
- preserve the #31 documentation consolidation: release notes live in this release PR / eventual GitHub Release body rather than restoring per-version release-note files

## Proposed v0.3.6 release notes

WebCodex 0.3.6 adds bounded semantic code inspection and structured Go test evidence, expands the native release matrix to Windows ARM64, and rolls up the reliability and release-pipeline work completed since 0.3.5.

### Highlights

- **Bounded semantic code inspection.** #33 adds typed call hierarchy / `code_impact` on the existing multi-language LSP bridge, with project-relative output, external/private location filtering, explicit capability negotiation, bounded depth/fanout/call-site/result budgets, and one shared operation deadline.
- **Structured Go validation evidence.** Go test recipes use `go test -json ./...` and derive bounded pass/fail/skip counts plus failed-test identities from the machine-readable stream rather than arbitrary stderr heuristics.
- **Native Windows ARM64 distribution.** The main npm package selects the native `win32-arm64` artifact directly; x64 emulation is no longer the release path for ARM64 hosts.
- **Five-target release builds.** Native candidate builds cover Linux x64/ARM64, macOS ARM64, and Windows x64/ARM64. Both Linux targets enforce the glibc 2.17 and dynamic-dependency gates.
- **CLI HTTP proxy controls.** #23 added explicit credential-free HTTP proxy override and `--no-system-proxy` while preserving Runner proxy semantics.
- **Runtime reliability.** #24 fixed UTF-8 output-tail truncation panics; #28 hardened persistent-shell/LSP/process lifecycle concurrency; #32 bounded queued-job start inputs and completed the 0.3.6 metadata version transition.

There is no intentional breaking protocol change. New semantic/validation capabilities are negotiated explicitly and fail closed on older Runners.

Known distribution limits remain: macOS x64 is not a published native artifact, and the npm wrapper requires Node.js 18+ independently of native binary compatibility.

## Draft #22 disposition

This supersedes #22 rather than rebasing/merging its stale branch.

The old draft's `win32-arm64 -> win32-x64` emulation mapping is intentionally not carried forward because the native Windows ARM64 build path is now repeatedly verified in the five-target release workflow. The bounded rename/cleanup retry from #22 is also not copied preemptively: its observed `EPERM` arose after executing x64 binaries through ARM64 emulation, which this native path removes. If the new native ARM64 npm smoke reproduces a Windows file-busy failure, that retry can be reintroduced based on current evidence.

## Evidence and validation

Preflight:

- current release base includes merged #33 (`2ca25bda`)
- `v0.3.6` Git tag absent
- GitHub Release `v0.3.6` absent
- `@yyjeqhc/webcodex@0.3.6` absent from npm
- two recent five-target release-build verification runs succeeded; the latest completed native `win32-arm64` build/PE validation and uploaded an ARM64 candidate artifact

Focused release-prep checks:

- `npm --prefix npm/webcodex test` — pass
- `node --check npm/webcodex/install.js` — pass
- `node --check npm/webcodex/test/self-test.js` — pass
- `python3 -m py_compile scripts/prepare_release_metadata.py` — pass
- five-platform synthetic archive -> `prepare_release_metadata.py` smoke — pass; manifest and `SHA256SUMS` contain all five targets
- Markdown local links — 33 files / 210 local links / 0 missing
- `git diff --check` / staged diff check — pass

`actionlint` and PowerShell are not installed on the Special development container, so the modified workflow and generalized PowerShell smoke are left to the PR's GitHub/Windows CI rather than installing new local tooling solely for this prep.

## Release boundary

This PR does **not** create `v0.3.6`, publish a GitHub Release or npm package, deploy any runtime, or merge itself. Those remain post-review release steps from the immutable merged release commit.