### PR TITLE
release: prepare v0.3.7

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing annotated release tag (v0.3.6) or verification tag (release-build-test-*)
+        description: Existing annotated release tag (v0.3.7) or verification tag (release-build-test-*)
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "base64",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-admin"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "reqwest 0.12.28",
  "serde_json",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-agent-config"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "serde",
  "toml",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "fs2",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-persistent-shell"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "libc",
  "tempfile",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-process"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "libc",
  "tempfile",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-runner"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "base64",
  "chrono",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-sandbox"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "landlock",
  "tempfile",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-workspace"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/npm/webcodex/manifest.example.json
+++ b/npm/webcodex/manifest.example.json
@@ -1,25 +1,25 @@
 {
-  "version": "0.3.6",
+  "version": "0.3.7",
   "binaries": ["webcodex", "webcodex-server", "webcodex-runner"],
   "artifacts": {
     "linux-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-linux-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.7/webcodex-v0.3.7-linux-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "linux-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-linux-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.7/webcodex-v0.3.7-linux-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "darwin-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-darwin-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.7/webcodex-v0.3.7-darwin-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "win32-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-win32-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.7/webcodex-v0.3.7-win32-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "win32-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.6/webcodex-v0.3.6-win32-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.7/webcodex-v0.3.7-win32-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     }
   }

--- a/npm/webcodex/package.json
+++ b/npm/webcodex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yyjeqhc/webcodex",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Thin npm installer/wrapper for WebCodex native binaries.",
   "license": "Apache-2.0",
   "bin": {

--- a/npm/webcodex/test/self-test.js
+++ b/npm/webcodex/test/self-test.js
@@ -209,7 +209,7 @@ async function expectInstallFailure(action, destination, tempRoot, pattern) {
 }
 
 async function main() {
-  assert.strictEqual(packageJson.version, "0.3.6");
+  assert.strictEqual(packageJson.version, "0.3.7");
   assert.deepStrictEqual(packageJson.bin, { webcodex: "bin/webcodex.js" });
   assert.deepStrictEqual(install.RUNTIME_BINARIES, ["webcodex", "webcodex-server", "webcodex-runner"]);
   assert.deepStrictEqual(install.SUPPORTED_PLATFORM_KEYS, ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"]);


### PR DESCRIPTION
## Summary

Prepare WebCodex v0.3.7 from the current mainline after #35 and #36.

This PR only advances canonical release metadata from `0.3.6` to `0.3.7`:

- Cargo workspace version and all local WebCodex `Cargo.lock` package entries
- `@yyjeqhc/webcodex` package version
- five-platform example release manifest URLs
- npm version self-test
- release-build workflow example tag

No tag, GitHub Release, npm publication, or deployment is performed by this PR.

## Proposed v0.3.7 release notes

WebCodex 0.3.7 is a V1 reliability and orchestration release focused on safer hosted project lifecycle, more durable Job behavior, bounded coding/validation tooling, and clearer MCP setup.

### Highlights

- **Hosted project disconnect.** `webcodex disconnect` is the exact inverse of hosted `webcodex connect`: live project unregister uses Runner-side structured lifecycle fencing, preserves the source repository and `.git`, and fails closed on uncertain outcomes rather than blindly retrying or deleting local registration state.
- **Managed Runner authorization hardening.** Ordinary project unregister now enforces the managed Runner owner boundary before project visibility and active-Job fencing; cross-owner regression coverage verifies a foreign principal cannot unregister another user's Runner/project.
- **Job reliability under backpressure.** Promoted Job output capture is decoupled from transport backpressure while retained output remains bounded and terminal state reconciliation stays durable.
- **Bounded coding tools.** Batch project-text search retries only transient dropped read-only Agent requests under the existing shared deadline/concurrency slot; `git_diff_hunks` gains source-fenced bounded continuation.
- **Focused Go validation.** Structured Go validation supports a bounded list of project-relative package patterns while continuing to use machine-readable `go test -json` evidence and rejecting arbitrary flags, environment overrides, shell control, and caller-selected executables.
- **Workflow and closeout evidence.** The documented coding workflow separates bootstrap/session continuity from behavioral guidance and authority, while closeout evidence distinguishes historical failures from currently actionable unexpected failures without discarding raw history.
- **Operator dogfood.** The Windows Runner deployment helper is hardened around exact-process replacement, rollback, and interactive Scheduled Task behavior.
- **MCP/OAuth setup.** Grok Custom MCP Connector OAuth configuration is documented, including authorization-code flow, PKCE S256, `client_secret_post`, redirect URI registration, scopes, and common failure modes.

### Compatibility and upgrade notes

There is no intentional breaking protocol change. New Runner/tool capabilities remain capability-fenced and fail closed when a peer does not support them.

`webcodex disconnect` requires a Server and Runner that implement structured project unregister. A newer CLI pointed at an older Server can therefore fail closed with an uncertain/unsupported unregister result; upgrade the Server and Runner together before relying on the new lifecycle command. A same-version local Server + hosted Runner + CLI `connect -> disconnect` smoke completed successfully and verified that the Server inventory entry disappeared, the hosted Runner stopped, the local registration was removed, and the repository plus `.git` remained intact.

### Known limitations

- macOS x64 is still not a published native artifact.
- The npm wrapper requires Node.js 18+ independently of native binary compatibility.
- `webcodex disconnect` manages hosted registrations created by `webcodex connect`; it is not a generic user-facing cleanup command for arbitrary pre-existing `agent_registered` projects.

## Release-prep validation

Preflight:

- `v0.3.7` Git tag absent
- GitHub Release `v0.3.7` absent
- `@yyjeqhc/webcodex@0.3.7` absent from npm

Focused checks on this branch:

- canonical Cargo/npm/manifest version references agree on `0.3.7`
- `cargo fmt -- --check` — pass
- `cargo check --all-targets` — pass
- `npm --prefix npm/webcodex test` — pass
- `node --check npm/webcodex/install.js` — pass
- `node --check npm/webcodex/test/self-test.js` — pass
- `git diff --check` — pass

The preceding V1 feature PR #36 completed its Linux and Windows CI successfully before merge. This release-prep PR should still pass its own required CI before merge.

## Release boundary

This PR does **not** create `v0.3.7`, publish a GitHub Release or npm package, deploy any runtime, or merge itself. Those remain post-review release steps from the immutable merged release commit.