### PR TITLE
test: stabilize validation observation handoff

### DIFF
--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -2394,9 +2394,31 @@ mod tests {
         .await;
     assert!(observed.success, "{:?}", observed.error);
     assert_eq!(observed.output["items"][0]["success"], true);
+    assert_eq!(observed.output["wake_reason"], "immediate");
+    let baseline_observation = crate::job_observation::JobObservationToken::parse_bound(
+        &observation_token,
+        crate::job_observation::JobObservationExecutor::Local,
+        &hidden_job_id,
+    )
+    .unwrap();
+    let observed_output = &observed.output["items"][0]["output"];
+    let current_observation_token = observed_output["observation_token"]
+        .as_str()
+        .expect("local validation observed token");
+    let current_observation = crate::job_observation::JobObservationToken::parse_bound(
+        current_observation_token,
+        crate::job_observation::JobObservationExecutor::Local,
+        &hidden_job_id,
+    )
+    .unwrap();
+    assert_eq!(current_observation.epoch, baseline_observation.epoch);
+    assert!(
+        current_observation.revision >= baseline_observation.revision,
+        "local Job observation revision must not move backwards"
+    );
     assert_eq!(
-        observed.output["items"][0]["output"]["observation_token"],
-        observation_token
+        observed_output["changed"].as_bool(),
+        Some(current_observation.revision != baseline_observation.revision)
     );
 
     let status = wait_for_local_job_terminal(&runtime, &hidden_job_id).await;


### PR DESCRIPTION
## Summary

Fix the release-gate flake exposed while preparing v0.3.7.

The local validation handoff test previously required the immediate `observe_jobs` snapshot to return exactly the same observation token produced by the handoff. That is stronger than the runtime contract: the local Job may legitimately advance between handoff and the next immediate read, in which case the returned token revision advances and `changed=true`.

This changes only the test assertion. It now verifies the actual observation contract:

- the snapshot is immediate
- the token remains bound to the same local Job and epoch
- the observation revision never moves backwards
- `changed` exactly reflects whether the revision advanced

No product/runtime behavior is changed.

## Release context

During the v0.3.7 OE release gate, the full workspace suite passed, but the subsequent focused `validation` lane hit this race once (`handoff token ...:1`, immediate observed token `...:2`). The same test had passed in the full suite, confirming the old exact-token assertion was scheduling-sensitive.

## Validation

- `cargo fmt -- --check` — pass
- exact `local_long_test_hides_then_hands_off_once_with_structured_terminal` — 5/5 consecutive passes
- `cargo test -p webcodex --lib validation -- --nocapture` — 180 passed, 0 failed
- `git diff --check` — pass

This is a release-blocker test fix for v0.3.7. No tag or publication has been created yet.