### PR TITLE
Automate exact-source release readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,13 @@ jobs:
           bash scripts/workspace_boundary_check.sh
       - name: Test release verification tooling
         run: |
-          python3 -m unittest scripts.tests.test_verify_public_release scripts.tests.test_collect_release_bundle
-          python3 -m py_compile scripts/verify_public_release.py scripts/collect_release_bundle.py scripts/release_operator.py
+          python3 -m unittest scripts.tests.test_verify_public_release scripts.tests.test_collect_release_bundle scripts.tests.test_release_readiness scripts.tests.test_check_markdown_links
+          python3 -m py_compile scripts/verify_public_release.py scripts/collect_release_bundle.py scripts/release_readiness.py scripts/release_operator.py scripts/check_markdown_links.py
           python3 scripts/release_operator.py --help >/dev/null
           python3 scripts/release_operator.py collect --help >/dev/null
+          python3 scripts/release_operator.py readiness-start --help >/dev/null
+          python3 scripts/release_operator.py readiness-status --help >/dev/null
+          python3 scripts/check_markdown_links.py
           bash -n scripts/npm_package_smoke.sh scripts/tests/test_npm_package_smoke_existing_binaries.sh
           bash scripts/npm_package_smoke.sh --help >/dev/null
           bash scripts/tests/test_npm_package_smoke_existing_binaries.sh

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,131 @@
+name: Release readiness
+
+run-name: Release readiness ${{ inputs.request_id }} ${{ inputs.source_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact 40-character main commit to validate before tagging
+        required: true
+        type: string
+      request_id:
+        description: Operator-generated correlation id (rr_<24 lowercase hex>)
+        required: true
+        type: string
+
+# This workflow validates one exact main commit before an immutable release tag is
+# created. It never builds release candidates, writes repository contents, publishes,
+# tags, or deploys.
+permissions:
+  contents: read
+
+concurrency:
+  group: release-readiness-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Fence exact reviewed main source
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          INPUT_REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Release readiness must be dispatched from the main workflow definition." >&2
+            exit 1
+          fi
+          if [[ ! "$INPUT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "source_sha must be exactly 40 lowercase hexadecimal characters." >&2
+            exit 1
+          fi
+          if [[ ! "$INPUT_REQUEST_ID" =~ ^rr_[0-9a-f]{24}$ ]]; then
+            echo "request_id must match rr_<24 lowercase hex>." >&2
+            exit 1
+          fi
+          if [ "$GITHUB_SHA" != "$INPUT_SOURCE_SHA" ]; then
+            echo "main moved before readiness dispatch: requested=$INPUT_SOURCE_SHA run=$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ inputs.source_sha }}
+
+      - name: Verify exact clean checkout
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$INPUT_SOURCE_SHA"
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Run canonical release check
+        run: bash scripts/release_check.sh
+
+      - name: Run full workspace suite
+        run: cargo test --locked --workspace -- --nocapture
+
+      - name: Validate frontend source and committed build
+        run: |
+          npm ci --prefix frontend
+          npm --prefix frontend run typecheck
+          npm --prefix frontend test
+          npm --prefix frontend run check:dist
+
+      - name: Run WebSocket zero-config E2E
+        run: bash scripts/e2e_zero_config_ws.sh
+
+      - name: Run polling zero-config E2E
+        env:
+          E2E_TRANSPORT: polling
+        run: bash scripts/e2e_zero_config_ws.sh
+
+      - name: Run coding-loop eval compare
+        env:
+          EVAL_MODE: compare
+        run: bash scripts/eval_coding_loop.sh
+
+      - name: Require final source cleanliness
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+      - name: Record readiness summary
+        if: ${{ success() }}
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          INPUT_REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          {
+            echo "### Release readiness passed"
+            echo "- source: \`$INPUT_SOURCE_SHA\`"
+            echo "- request: \`$INPUT_REQUEST_ID\`"
+            echo "- candidate binaries produced: no"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -8,31 +8,29 @@ Do not create tags, push commits, publish npm packages, create GitHub Releases, 
 
 ## 1. Source Validation
 
-Run:
+After the release-prep PR is squash-merged, select the exact `origin/main` commit that would be tagged. Final pre-tag validation is a reviewed GitHub Actions workflow, not a sequence of hand-run release-host commands:
 
 ```bash
-cargo fmt --check
-cargo check --workspace --all-targets
-cargo test --workspace -- --nocapture
-git diff --check
-git status --short --branch
+python3 scripts/release_operator.py readiness-start \
+  --source-sha <MAIN_COMMIT> \
+  --state-file <STATE_FILE>
+
+python3 scripts/release_operator.py readiness-status \
+  --state-file <STATE_FILE> \
+  --wait-secs 3600
 ```
 
-For documentation-only release readiness work, the full test suite may be deferred, but the deferral must be reported.
+`readiness-start` first requires GitHub `main` to equal `<MAIN_COMMIT>`, writes a mode-0600 operator-local correlation state before dispatch, and dispatches `.github/workflows/release-readiness.yml` from `main`. The workflow itself requires its `github.sha` to equal the requested source, checks out that exact commit with no persisted credential, and never tags, publishes, deploys, or produces release candidate binaries.
+
+If dispatch delivery becomes uncertain or the run is not resolved before the short start timeout, **do not create a second state file and do not redispatch**. Continue with `readiness-status` on the original state; its unique request id recovers the exact workflow run when present. Only terminal `success` (operator exit 0) satisfies the pre-tag gate. A nonterminal/unresolved status is not release approval.
+
+The readiness workflow runs the canonical `scripts/release_check.sh`, the locked full workspace suite, frontend typecheck/tests/committed-build check, WebSocket and polling zero-config E2E, and coding-loop compare eval. `release_check.sh` includes formatting, workspace all-target check, focused metadata/schema/OpenAPI/MCP tests, release-tooling self-tests, Markdown local-link validation, and static current-contract/leakage guards.
+
+For focused diagnosis outside the final workflow, the underlying commands remain available, but a local pass does not replace the exact-source readiness run.
 
 ## 2. Focused Runtime Tests
 
-Run focused lanes when touching runtime metadata, schemas, OpenAPI, MCP, session, handoff, validation, or coding-task behavior:
-
-```bash
-cargo test -p webcodex --lib metadata -- --nocapture
-cargo test -p webcodex --lib schema -- --nocapture
-cargo test -p webcodex --lib openapi -- --nocapture
-cargo test -p webcodex --lib mcp -- --nocapture
-cargo test -p webcodex --lib validation -- --nocapture
-cargo test -p webcodex --lib handoff -- --nocapture
-cargo test -p webcodex --lib coding_task -- --nocapture
-```
+During implementation/review, run focused lanes when touching runtime metadata, schemas, OpenAPI, MCP, session, handoff, validation, or coding-task behavior. The final release-readiness run does **not** repeat every focused lane after the full workspace suite: `release_check.sh` already records metadata/schema/OpenAPI/MCP evidence, and the locked full workspace suite covers validation/handoff/coding-task tests. Re-run an individual lane only to diagnose a failure or when a review explicitly requires separate evidence.
 
 ## 3. Product Documentation Check
 
@@ -47,7 +45,7 @@ Confirm the user-facing docs tell one story:
 - The release PR / GitHub Release notes read like external release notes and include highlights, compatibility or breaking changes, known limitations, upgrade notes, and validation. Do not restore per-version release-note files as a second documentation source.
 - Roadmap stays short and does not promise a full IDE replacement, autonomous ops, arbitrary computer use, or universal client compatibility.
 
-Run a markdown local link check and report markdown file count, local link count, and missing local link count.
+Run `python3 scripts/check_markdown_links.py` (also included in `release_check.sh`) and require zero missing repository-local links. Product narrative and allowed legacy-term matches remain review judgments in the release-prep PR; the readiness workflow automates only deterministic checks.
 
 ## 4. Legacy Surface Guard
 
@@ -63,24 +61,18 @@ Do not allow docs that ask users to configure server-side project onboarding, im
 
 ## 5. E2E Smoke
 
-Run both supported zero-config transports against a safe local test project:
+The exact-source release-readiness workflow runs both supported zero-config transports against disposable local fixtures:
 
 ```bash
 bash scripts/e2e_zero_config_ws.sh
 E2E_TRANSPORT=polling bash scripts/e2e_zero_config_ws.sh
 ```
 
-These smokes must not target a production repository. Any write checks must stay within disposable probe files or a temporary project.
+These commands remain useful for diagnosis, but do not rerun them manually after a successful readiness workflow merely to duplicate evidence. They must never target a production repository; any write checks stay within disposable probe files or a temporary project.
 
 ## 6. Eval Harness
 
-Run the coding-loop comparison:
-
-```bash
-EVAL_MODE=compare bash scripts/eval_coding_loop.sh
-```
-
-The eval harness measures scripted WebCodex tool-call mechanics. It is not a full model-behavior evaluation.
+The exact-source release-readiness workflow runs `EVAL_MODE=compare bash scripts/eval_coding_loop.sh`. Run it separately only for focused diagnosis. The eval harness measures scripted WebCodex tool-call mechanics; it is not a full model-behavior evaluation.
 
 ## 7. Security And Leakage Checks
 
@@ -111,7 +103,7 @@ For every new binary and npm release, choose one candidate `<VERSION>` first and
 ## 9. Release Sequence
 
 1. Select a new `<VERSION>` that does not already exist as a Git tag, GitHub Release, or npm package version. Put version bumps, release notes, platform docs, packaging changes, and release tests in **one release-prep PR** and squash-merge it into `main`.
-2. On the release control host, fast-forward to `origin/main`, require a clean worktree, run the source/release gates, and only after explicit operator authorization create the immutable annotated `v<VERSION>` tag. Never move that tag afterward.
+2. Resolve the exact merged `origin/main` commit and run `release_operator.py readiness-start` with a fresh durable state file, then `readiness-status --wait-secs 3600` on that same state. Require terminal success for the exact source before explicit operator authorization creates the immutable annotated `v<VERSION>` tag. If readiness dispatch/observation is uncertain, recover from the same state instead of blind redispatch. Never move the release tag afterward.
 3. Dispatch the reviewed release-build workflow for the exact tag. Require all five native targets (`linux-x64`, `linux-arm64`, `darwin-arm64`, `win32-x64`, `win32-arm64`) plus the final `assemble` job to succeed in one recorded workflow run. Native jobs remain authoritative for executable version/build identity, architecture, Windows npm artifact smoke, and the Linux `GLIBC_* <= 2.17` / `DT_NEEDED` gates.
 4. Collect only that run's `<ARCHIVE_STEM>-bundle` with `scripts/release_operator.py collect`, passing the recorded run id, exact tag commit, and tag. The collector must finish successfully before publication; its output directory is the retained candidate bundle. Create a draft GitHub Release and upload the five exact archives plus `SHA256SUMS`; download those draft assets once and verify SHA-256 against the retained bundle bytes.
 5. From a clean detached worktree at the immutable tag, run `scripts/stage_npm_release.sh --manifest <BUNDLE_DIR>/manifest.json --output-dir <STAGE_DIR>`. Extract the retained `linux-x64` archive and run `scripts/npm_package_smoke.sh --package-dir <STAGE_DIR>/npm-package --binary-dir <EXTRACTED_LINUX_X64_DIR>` so npm publication smoke reuses the CI bytes without recompilation.

--- a/docs/agent/release-process.md
+++ b/docs/agent/release-process.md
@@ -71,16 +71,18 @@ results (if any), and any deferred checks.
 ## 3. Operator checklist pointer
 
 Before tagging or publishing, follow sections in
-[`RELEASE_CHECKLIST.md`](../RELEASE_CHECKLIST.md):
+[`RELEASE_CHECKLIST.md`](../RELEASE_CHECKLIST.md). The final executable pre-tag gate is
+`.github/workflows/release-readiness.yml`, dispatched through
+`scripts/release_operator.py readiness-start` for one exact merged `main` SHA and
+observed through the same durable state with `readiness-status`. It runs the canonical
+release check, locked full workspace suite, frontend checks, both zero-config E2E
+transports, and the coding-loop compare eval without producing release candidates.
+Product-documentation consistency and allowed legacy-term matches remain part of the
+release-prep review rather than being guessed by an automated semantic checker.
 
-1. Source validation (fmt, check, full suite when required)
-2. Focused runtime tests for touched domains
-3. Product documentation consistency
-4. Legacy surface guard
-5. Remaining checklist items in that document
-
-The normal release topology deliberately separates roles: GitHub Actions builds and
-assembles the one same-run native candidate bundle; the release control host collects
+The normal release topology deliberately separates roles: GitHub Actions first validates
+the exact pre-tag source in the readiness workflow, then after the immutable tag builds
+and assembles the one same-run native candidate bundle; the release control host collects
 that exact bundle with `scripts/release_operator.py collect` (locked run id, source SHA,
 and tag; GitHub artifact REST download, no `gh run download`) and performs privileged
 GitHub/npm publication from the verified bytes; one well-connected Linux host may run

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Fail closed on missing repository-local links in tracked Markdown files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+
+LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(([^)\n]+)\)")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+
+
+@dataclass(frozen=True)
+class MissingLink:
+    markdown_path: str
+    line: int
+    target: str
+    reason: str
+
+
+def _tracked_markdown(root: Path) -> list[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z", "*.md"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError("could not list tracked Markdown files") from exc
+    paths = []
+    for raw in result.stdout.split(b"\0"):
+        if not raw:
+            continue
+        try:
+            relative = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise RuntimeError("tracked Markdown path is not UTF-8") from exc
+        paths.append(root / relative)
+    return sorted(paths)
+
+
+def _extract_destination(raw: str) -> str | None:
+    value = raw.strip()
+    if not value:
+        return None
+    if value.startswith("<"):
+        end = value.find(">", 1)
+        if end < 0:
+            return value
+        return value[1:end].strip()
+    # This repository does not use title-bearing local links. Splitting here still
+    # handles the common Markdown form `(path "title")` conservatively.
+    return value.split(maxsplit=1)[0]
+
+
+def _is_external_or_anchor(target: str) -> bool:
+    return (
+        not target
+        or target.startswith("#")
+        or target.startswith("//")
+        or target.startswith("/")
+        or bool(SCHEME_RE.match(target))
+    )
+
+
+def check_markdown_links(root: Path, markdown_paths: list[Path]) -> tuple[int, list[MissingLink]]:
+    repo_root = root.resolve()
+    checked_links = 0
+    missing: list[MissingLink] = []
+    for path in markdown_paths:
+        try:
+            relative_path = path.resolve().relative_to(repo_root).as_posix()
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            raise RuntimeError(f"could not read tracked Markdown file: {path}") from exc
+
+        fence: str | None = None
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            fence_match = FENCE_RE.match(line)
+            if fence_match:
+                marker = fence_match.group(1)
+                marker_char = marker[0]
+                if fence is None:
+                    fence = marker_char
+                elif fence == marker_char:
+                    fence = None
+                continue
+            if fence is not None:
+                continue
+
+            for match in LINK_RE.finditer(line):
+                destination = _extract_destination(match.group(1))
+                if destination is None or _is_external_or_anchor(destination):
+                    continue
+                checked_links += 1
+                decoded = urllib.parse.unquote(destination)
+                path_part = decoded.split("#", 1)[0].split("?", 1)[0]
+                if not path_part:
+                    continue
+                candidate = (path.parent / path_part).resolve()
+                try:
+                    candidate.relative_to(repo_root)
+                except ValueError:
+                    missing.append(
+                        MissingLink(relative_path, line_number, destination, "escapes repository root")
+                    )
+                    continue
+                if not candidate.exists():
+                    missing.append(MissingLink(relative_path, line_number, destination, "target missing"))
+    return checked_links, missing
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check tracked Markdown repository-local links.")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = args.root.resolve()
+    try:
+        markdown = _tracked_markdown(root)
+        checked_links, missing = check_markdown_links(root, markdown)
+    except RuntimeError as exc:
+        print(f"markdown link check failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        f"Markdown local links: files={len(markdown)} local_links={checked_links} missing={len(missing)}"
+    )
+    for item in missing:
+        print(
+            f"{item.markdown_path}:{item.line}: {item.target!r}: {item.reason}",
+            file=sys.stderr,
+        )
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -23,8 +23,10 @@ set -euo pipefail
 #  11. static: no python runtime helper regressions
 #  12. static: no sensitive files tracked or staged by git
 #
-# Manual final acceptance steps live in docs/RELEASE_CHECKLIST.md:
-#   - cargo test --workspace -- --nocapture
+# Final pre-tag acceptance is orchestrated by .github/workflows/release-readiness.yml:
+#   - this canonical release_check.sh
+#   - cargo test --locked --workspace -- --nocapture
+#   - frontend typecheck/test/committed-build check
 #   - bash scripts/e2e_zero_config_ws.sh
 #   - E2E_TRANSPORT=polling bash scripts/e2e_zero_config_ws.sh
 #   - EVAL_MODE=compare bash scripts/eval_coding_loop.sh
@@ -157,10 +159,13 @@ done
 # Stage 9: release verification tooling self-tests
 # ----------------------------------------------------------------------------
 stage_start "release verification tooling self-tests"
-if python3 -m unittest scripts.tests.test_verify_public_release scripts.tests.test_collect_release_bundle \
-    && python3 -m py_compile scripts/verify_public_release.py scripts/collect_release_bundle.py scripts/release_operator.py \
+if python3 -m unittest scripts.tests.test_verify_public_release scripts.tests.test_collect_release_bundle scripts.tests.test_release_readiness scripts.tests.test_check_markdown_links \
+    && python3 -m py_compile scripts/verify_public_release.py scripts/collect_release_bundle.py scripts/release_readiness.py scripts/release_operator.py scripts/check_markdown_links.py \
     && python3 scripts/release_operator.py --help >/dev/null \
     && python3 scripts/release_operator.py collect --help >/dev/null \
+    && python3 scripts/release_operator.py readiness-start --help >/dev/null \
+    && python3 scripts/release_operator.py readiness-status --help >/dev/null \
+    && python3 scripts/check_markdown_links.py \
     && bash scripts/tests/test_npm_package_smoke_existing_binaries.sh; then
     ok "release verification tooling self-tests"
 else
@@ -256,6 +261,6 @@ fi
 # ----------------------------------------------------------------------------
 printf '\n[release] ===== all stages passed =====\n'
 ok "workspace boundaries, fmt, check --all-targets, focused metadata/schema/openapi/mcp tests, bash syntax, release tooling self-tests, harness contracts, static checks"
-log "manual final acceptance: full suite, E2E websocket/polling, and eval compare (see docs/RELEASE_CHECKLIST.md)"
+log "final pre-tag acceptance: dispatch the exact-source release-readiness workflow (see docs/RELEASE_CHECKLIST.md)"
 log "release readiness gate PASSED"
 exit 0

--- a/scripts/release_operator.py
+++ b/scripts/release_operator.py
@@ -10,9 +10,11 @@ from pathlib import Path
 
 if __package__:
     from . import collect_release_bundle as collector
+    from . import release_readiness as readiness
 else:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     import collect_release_bundle as collector
+    import release_readiness as readiness
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -30,27 +32,73 @@ def build_parser() -> argparse.ArgumentParser:
     collect.add_argument("--output-dir", type=Path, required=True)
     collect.add_argument("--repo", default=collector.DEFAULT_REPO)
     collect.add_argument("--timeout", type=float, default=120.0)
+    readiness_start = subparsers.add_parser(
+        "readiness-start",
+        help="dispatch exact-main pre-tag readiness and record durable correlation state",
+    )
+    readiness_start.add_argument("--source-sha", required=True)
+    readiness_start.add_argument("--state-file", type=Path, required=True)
+    readiness_start.add_argument("--repo", default=collector.DEFAULT_REPO)
+    readiness_start.add_argument("--timeout", type=float, default=30.0)
+    readiness_start.add_argument("--resolve-secs", type=int, default=60)
+
+    readiness_status = subparsers.add_parser(
+        "readiness-status",
+        help="recover/observe the exact readiness run recorded in a durable state file",
+    )
+    readiness_status.add_argument("--state-file", type=Path, required=True)
+    readiness_status.add_argument("--timeout", type=float, default=30.0)
+    readiness_status.add_argument("--wait-secs", type=int, default=0)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    if args.command != "collect":
-        raise AssertionError(f"unhandled release operator command: {args.command}")
-    try:
-        summary = collector.collect_bundle(
-            repo=args.repo,
-            run_id=args.run_id,
-            expected_source_sha=args.source_sha,
-            expected_tag=args.tag,
-            output_dir=args.output_dir,
-            timeout=args.timeout,
-        )
-    except collector.CollectionError as exc:
-        print(f"release operator collect failed: {exc}", file=sys.stderr)
-        return 1
-    print(json.dumps(summary, indent=2, sort_keys=True))
-    return 0
+    if args.command == "collect":
+        try:
+            summary = collector.collect_bundle(
+                repo=args.repo,
+                run_id=args.run_id,
+                expected_source_sha=args.source_sha,
+                expected_tag=args.tag,
+                output_dir=args.output_dir,
+                timeout=args.timeout,
+            )
+        except collector.CollectionError as exc:
+            print(f"release operator collect failed: {exc}", file=sys.stderr)
+            return 1
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "readiness-start":
+        try:
+            summary, exit_code = readiness.start_readiness(
+                repo=args.repo,
+                source_sha=args.source_sha,
+                state_file=args.state_file,
+                timeout=args.timeout,
+                resolve_secs=args.resolve_secs,
+            )
+        except (collector.CollectionError, readiness.ReadinessError) as exc:
+            print(f"release operator readiness-start failed: {exc}", file=sys.stderr)
+            return 1
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return exit_code
+
+    if args.command == "readiness-status":
+        try:
+            summary, exit_code = readiness.status_readiness(
+                state_file=args.state_file,
+                timeout=args.timeout,
+                wait_secs=args.wait_secs,
+            )
+        except (collector.CollectionError, readiness.ReadinessError) as exc:
+            print(f"release operator readiness-status failed: {exc}", file=sys.stderr)
+            return 1
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return exit_code
+
+    raise AssertionError(f"unhandled release operator command: {args.command}")
 
 
 if __name__ == "__main__":

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Dispatch and observe one exact-source WebCodex release-readiness workflow run."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import tempfile
+import time
+import urllib.error
+from pathlib import Path
+
+if __package__:
+    from . import collect_release_bundle as collector
+else:
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import collect_release_bundle as collector
+
+READINESS_WORKFLOW_FILE = "release-readiness.yml"
+READINESS_WORKFLOW_PATH = f".github/workflows/{READINESS_WORKFLOW_FILE}"
+STATE_SCHEMA_VERSION = 1
+REQUEST_ID_RE = re.compile(r"^rr_[0-9a-f]{24}$")
+MAX_STATE_BYTES = 64 * 1024
+MAX_RUN_LIST = 100
+
+
+class ReadinessError(RuntimeError):
+    pass
+
+
+class DispatchRejected(ReadinessError):
+    pass
+
+
+class DispatchOutcomeUnknown(ReadinessError):
+    pass
+
+
+def _run_name(request_id: str, source_sha: str) -> str:
+    return f"Release readiness {request_id} {source_sha}"
+
+
+def _validate_request_id(value: str) -> str:
+    request_id = value.strip()
+    if not REQUEST_ID_RE.fullmatch(request_id):
+        raise ReadinessError("invalid release-readiness request id")
+    return request_id
+
+
+def _validate_state_path_for_create(path: Path) -> Path:
+    result = path.absolute()
+    if result.exists() or result.is_symlink():
+        raise ReadinessError(f"readiness state file already exists: {result}")
+    result.parent.mkdir(parents=True, exist_ok=True)
+    return result
+
+
+def _write_state(path: Path, state: dict) -> None:
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(state, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(payload) > MAX_STATE_BYTES:
+        raise ReadinessError("readiness state exceeds its size bound")
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=parent)
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.is_symlink():
+            raise ReadinessError(f"refusing to replace readiness state symlink: {path}")
+        os.replace(temp_path, path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _load_state(path: Path) -> dict:
+    state_path = path.absolute()
+    if state_path.is_symlink() or not state_path.is_file():
+        raise ReadinessError(f"readiness state file is missing or unsafe: {state_path}")
+    try:
+        size = state_path.stat().st_size
+        if size <= 0 or size > MAX_STATE_BYTES:
+            raise ReadinessError("readiness state file is outside its size bound")
+        value = json.loads(state_path.read_text(encoding="utf-8"))
+    except ReadinessError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReadinessError("could not read readiness state file") from exc
+    if not isinstance(value, dict):
+        raise ReadinessError("readiness state must be a JSON object")
+    required = {
+        "schema_version",
+        "kind",
+        "repo",
+        "source_sha",
+        "workflow_file",
+        "workflow_path",
+        "request_id",
+        "run_name",
+        "dispatch_state",
+        "created_at",
+        "run_id",
+        "run_head_sha",
+        "source_matches",
+        "run_url",
+        "run_status",
+        "run_conclusion",
+        "last_observed_at",
+    }
+    if set(value) != required:
+        raise ReadinessError("readiness state fields do not match the supported schema")
+    if value.get("schema_version") != STATE_SCHEMA_VERSION or value.get("kind") != "release-readiness":
+        raise ReadinessError("unsupported readiness state schema")
+    source_sha = collector.normalize_source_sha(str(value.get("source_sha", "")))
+    request_id = _validate_request_id(str(value.get("request_id", "")))
+    if value.get("workflow_file") != READINESS_WORKFLOW_FILE or value.get("workflow_path") != READINESS_WORKFLOW_PATH:
+        raise ReadinessError("readiness state references an unexpected workflow")
+    if value.get("run_name") != _run_name(request_id, source_sha):
+        raise ReadinessError("readiness state run name is inconsistent")
+    if not isinstance(value.get("repo"), str):
+        raise ReadinessError("readiness state repository is invalid")
+    if not isinstance(value.get("created_at"), int) or value["created_at"] <= 0:
+        raise ReadinessError("readiness state created_at is invalid")
+    run_id = value.get("run_id")
+    if run_id is not None and (not isinstance(run_id, int) or run_id <= 0):
+        raise ReadinessError("readiness state run id is invalid")
+    run_head_sha = value.get("run_head_sha")
+    if run_head_sha is not None:
+        try:
+            collector.normalize_source_sha(str(run_head_sha))
+        except collector.CollectionError as exc:
+            raise ReadinessError("readiness state run head SHA is invalid") from exc
+    source_matches = value.get("source_matches")
+    if source_matches is not None and not isinstance(source_matches, bool):
+        raise ReadinessError("readiness state source_matches is invalid")
+    run_url = value.get("run_url")
+    if run_url is not None and not isinstance(run_url, str):
+        raise ReadinessError("readiness state run URL is invalid")
+    run_status = value.get("run_status")
+    if run_status is not None and not isinstance(run_status, str):
+        raise ReadinessError("readiness state run status is invalid")
+    run_conclusion = value.get("run_conclusion")
+    if run_conclusion is not None and not isinstance(run_conclusion, str):
+        raise ReadinessError("readiness state run conclusion is invalid")
+    last_observed_at = value.get("last_observed_at")
+    if last_observed_at is not None and (not isinstance(last_observed_at, int) or last_observed_at <= 0):
+        raise ReadinessError("readiness state last_observed_at is invalid")
+    return value
+
+
+def _main_sha(client: collector.GitHubClient) -> str:
+    payload = client.fetch_json("/branches/main")
+    commit = payload.get("commit")
+    if not isinstance(commit, dict):
+        raise ReadinessError("GitHub main branch response is malformed")
+    try:
+        return collector.normalize_source_sha(str(commit.get("sha", "")))
+    except collector.CollectionError as exc:
+        raise ReadinessError("GitHub main branch SHA is invalid") from exc
+
+
+def _post_dispatch(client: collector.GitHubClient, source_sha: str, request_id: str) -> None:
+    url = client.api_url(f"/actions/workflows/{READINESS_WORKFLOW_FILE}/dispatches")
+    data = json.dumps(
+        {
+            "ref": "main",
+            "inputs": {"source_sha": source_sha, "request_id": request_id},
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    request = client._request(url)
+    request.data = data
+    request.method = "POST"
+    request.add_header("Content-Type", "application/json")
+    try:
+        with client.opener.open(request, timeout=client.timeout) as response:
+            status = getattr(response, "status", response.getcode())
+            body = response.read(1)
+    except urllib.error.HTTPError as exc:
+        if 400 <= exc.code < 500:
+            raise DispatchRejected(f"GitHub rejected release-readiness dispatch with HTTP {exc.code}") from exc
+        raise DispatchOutcomeUnknown(
+            f"GitHub release-readiness dispatch outcome is unknown after HTTP {exc.code}; do not redispatch"
+        ) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise DispatchOutcomeUnknown(
+            "GitHub release-readiness dispatch outcome is unknown after transport failure; do not redispatch"
+        ) from exc
+    if status != 204 or body:
+        raise DispatchOutcomeUnknown(
+            f"GitHub release-readiness dispatch returned unexpected HTTP {status}; do not redispatch"
+        )
+
+
+def _run_identity_matches(run: dict, state: dict) -> bool:
+    return (
+        run.get("path") == READINESS_WORKFLOW_PATH
+        and run.get("event") == "workflow_dispatch"
+        and run.get("head_branch") == "main"
+        and run.get("display_title") == state["run_name"]
+    )
+
+
+def select_readiness_run(payload: dict, state: dict) -> dict | None:
+    runs = payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise ReadinessError("GitHub readiness run listing is malformed")
+    if len(runs) > MAX_RUN_LIST:
+        raise ReadinessError("GitHub readiness run listing exceeds its bound")
+    matches = [run for run in runs if isinstance(run, dict) and _run_identity_matches(run, state)]
+    if len(matches) > 1:
+        raise ReadinessError("multiple GitHub readiness runs match one request id")
+    if not matches:
+        return None
+    run = matches[0]
+    run_id = run.get("id")
+    if not isinstance(run_id, int) or run_id <= 0:
+        raise ReadinessError("GitHub readiness run id is invalid")
+    if not isinstance(run.get("html_url"), str):
+        raise ReadinessError("GitHub readiness run URL is invalid")
+    return run
+
+
+def _list_runs(client: collector.GitHubClient) -> dict:
+    return client.fetch_json(
+        f"/actions/workflows/{READINESS_WORKFLOW_FILE}/runs?event=workflow_dispatch&branch=main&per_page={MAX_RUN_LIST}"
+    )
+
+
+def _apply_run_snapshot(state: dict, run: dict) -> None:
+    if not _run_identity_matches(run, state):
+        raise ReadinessError("GitHub readiness run no longer matches durable request identity")
+    run_id = run.get("id")
+    if not isinstance(run_id, int) or run_id <= 0:
+        raise ReadinessError("GitHub readiness run id is invalid")
+    bound_run_id = state.get("run_id")
+    if bound_run_id is not None and bound_run_id != run_id:
+        raise ReadinessError("GitHub readiness run id changed after durable binding")
+    try:
+        run_head_sha = collector.normalize_source_sha(str(run.get("head_sha", "")))
+    except collector.CollectionError as exc:
+        raise ReadinessError("GitHub readiness run head SHA is invalid") from exc
+    status = run.get("status")
+    conclusion = run.get("conclusion")
+    if not isinstance(status, str):
+        raise ReadinessError("GitHub readiness run status is invalid")
+    if conclusion is not None and not isinstance(conclusion, str):
+        raise ReadinessError("GitHub readiness run conclusion is invalid")
+    run_url = run.get("html_url")
+    if not isinstance(run_url, str) or not run_url.startswith("https://github.com/"):
+        raise ReadinessError("GitHub readiness run URL is invalid")
+    state["run_id"] = run_id
+    state["run_head_sha"] = run_head_sha
+    state["source_matches"] = run_head_sha == state["source_sha"]
+    state["run_url"] = run_url
+    state["run_status"] = status
+    state["run_conclusion"] = conclusion
+    state["last_observed_at"] = int(time.time())
+    state["dispatch_state"] = "completed" if status == "completed" else "resolved"
+
+
+def _recover_run(client: collector.GitHubClient, state: dict) -> dict | None:
+    run = select_readiness_run(_list_runs(client), state)
+    if run is not None:
+        _apply_run_snapshot(state, run)
+    return run
+
+
+def _get_bound_run(client: collector.GitHubClient, state: dict) -> dict | None:
+    run_id = state.get("run_id")
+    if run_id is None:
+        return _recover_run(client, state)
+    run = client.fetch_json(f"/actions/runs/{run_id}")
+    _apply_run_snapshot(state, run)
+    return run
+
+
+def start_readiness(
+    *,
+    repo: str,
+    source_sha: str,
+    state_file: Path,
+    timeout: float,
+    resolve_secs: int,
+) -> tuple[dict, int]:
+    source = collector.normalize_source_sha(source_sha)
+    if resolve_secs < 0 or resolve_secs > 120:
+        raise ReadinessError("resolve_secs must be within 0..120")
+    state_path = _validate_state_path_for_create(state_file)
+    client = collector.GitHubClient(repo, collector.resolve_github_token(), timeout)
+    main_sha = _main_sha(client)
+    if main_sha != source:
+        raise ReadinessError(f"main source fence failed: expected={source} current={main_sha}")
+
+    request_id = f"rr_{secrets.token_hex(12)}"
+    now = int(time.time())
+    state = {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "kind": "release-readiness",
+        "repo": repo,
+        "source_sha": source,
+        "workflow_file": READINESS_WORKFLOW_FILE,
+        "workflow_path": READINESS_WORKFLOW_PATH,
+        "request_id": request_id,
+        "run_name": _run_name(request_id, source),
+        "dispatch_state": "prepared",
+        "created_at": now,
+        "run_id": None,
+        "run_head_sha": None,
+        "source_matches": None,
+        "run_url": None,
+        "run_status": None,
+        "run_conclusion": None,
+        "last_observed_at": None,
+    }
+    _write_state(state_path, state)
+
+    try:
+        _post_dispatch(client, source, request_id)
+    except DispatchRejected:
+        state["dispatch_state"] = "rejected"
+        _write_state(state_path, state)
+        raise
+    except DispatchOutcomeUnknown:
+        state["dispatch_state"] = "unknown"
+        _write_state(state_path, state)
+        raise
+
+    state["dispatch_state"] = "dispatched"
+    _write_state(state_path, state)
+    deadline = time.monotonic() + resolve_secs
+    while True:
+        run = _recover_run(client, state)
+        if run is not None:
+            _write_state(state_path, state)
+            return state, 0 if state["source_matches"] is True else 1
+        if time.monotonic() >= deadline:
+            state["dispatch_state"] = "dispatched_unresolved"
+            state["last_observed_at"] = int(time.time())
+            _write_state(state_path, state)
+            return state, 2
+        time.sleep(2)
+
+
+def status_readiness(*, state_file: Path, timeout: float, wait_secs: int) -> tuple[dict, int]:
+    if wait_secs < 0 or wait_secs > 3600:
+        raise ReadinessError("wait_secs must be within 0..3600")
+    state_path = state_file.absolute()
+    state = _load_state(state_path)
+    if state["dispatch_state"] == "rejected":
+        raise ReadinessError("release-readiness dispatch was rejected; create a new state only after fixing the cause")
+    client = collector.GitHubClient(state["repo"], collector.resolve_github_token(), timeout)
+    deadline = time.monotonic() + wait_secs
+    while True:
+        run = _get_bound_run(client, state)
+        _write_state(state_path, state)
+        if run is not None and state["source_matches"] is False:
+            return state, 1
+        if run is not None and state["run_status"] == "completed":
+            return state, 0 if state["run_conclusion"] == "success" else 1
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return state, 2
+        time.sleep(min(10, max(0.1, remaining)))

--- a/scripts/tests/test_check_markdown_links.py
+++ b/scripts/tests/test_check_markdown_links.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_markdown_links as checker
+
+
+class MarkdownLinkTests(unittest.TestCase):
+    def test_local_links_exist_and_external_or_fenced_links_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "docs").mkdir()
+            (root / "docs" / "other.md").write_text("ok\n", encoding="utf-8")
+            source = root / "README.md"
+            source.write_text(
+                "[local](docs/other.md#section)\n"
+                "[web](https://example.com/x)\n"
+                "[anchor](#local)\n"
+                "```markdown\n[example](missing.md)\n```\n",
+                encoding="utf-8",
+            )
+            count, missing = checker.check_markdown_links(root, [source, root / "docs" / "other.md"])
+            self.assertEqual(count, 1)
+            self.assertEqual(missing, [])
+
+    def test_missing_and_escape_are_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source = root / "README.md"
+            source.write_text("[missing](nope.md)\n[escape](../outside.md)\n", encoding="utf-8")
+            count, missing = checker.check_markdown_links(root, [source])
+            self.assertEqual(count, 2)
+            self.assertEqual([item.reason for item in missing], ["target missing", "escapes repository root"])
+
+    def test_percent_encoded_local_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a b.md").write_text("ok\n", encoding="utf-8")
+            source = root / "README.md"
+            source.write_text("[encoded](a%20b.md)\n", encoding="utf-8")
+            count, missing = checker.check_markdown_links(root, [source])
+            self.assertEqual(count, 1)
+            self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_readiness.py
+++ b/scripts/tests/test_release_readiness.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+
+from scripts import collect_release_bundle as collector
+from scripts import release_readiness as readiness
+
+
+SOURCE = "a" * 40
+REQUEST = "rr_" + "b" * 24
+
+
+def _state() -> dict:
+    return {
+        "schema_version": readiness.STATE_SCHEMA_VERSION,
+        "kind": "release-readiness",
+        "repo": collector.DEFAULT_REPO,
+        "source_sha": SOURCE,
+        "workflow_file": readiness.READINESS_WORKFLOW_FILE,
+        "workflow_path": readiness.READINESS_WORKFLOW_PATH,
+        "request_id": REQUEST,
+        "run_name": readiness._run_name(REQUEST, SOURCE),
+        "dispatch_state": "dispatched",
+        "created_at": 1234567890,
+        "run_id": None,
+        "run_head_sha": None,
+        "source_matches": None,
+        "run_url": None,
+        "run_status": None,
+        "run_conclusion": None,
+        "last_observed_at": None,
+    }
+
+
+def _run(run_id: int = 123) -> dict:
+    return {
+        "id": run_id,
+        "path": readiness.READINESS_WORKFLOW_PATH,
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": SOURCE,
+        "display_title": readiness._run_name(REQUEST, SOURCE),
+        "html_url": f"https://github.com/yyjeqhc/webcodex/actions/runs/{run_id}",
+        "status": "in_progress",
+        "conclusion": None,
+    }
+
+
+class ReadinessSelectionTests(unittest.TestCase):
+    def test_selects_exact_request_source_and_workflow(self) -> None:
+        payload = {"workflow_runs": [_run(), dict(_run(456), display_title="other")]}
+        selected = readiness.select_readiness_run(payload, _state())
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["id"], 123)
+
+    def test_duplicate_exact_runs_fail_closed(self) -> None:
+        payload = {"workflow_runs": [_run(1), _run(2)]}
+        with self.assertRaises(readiness.ReadinessError):
+            readiness.select_readiness_run(payload, _state())
+
+    def test_wrong_run_head_still_resolves_by_request_identity(self) -> None:
+        payload = {"workflow_runs": [dict(_run(), head_sha="c" * 40)]}
+        selected = readiness.select_readiness_run(payload, _state())
+        self.assertIsNotNone(selected)
+        state = _state()
+        assert selected is not None
+        readiness._apply_run_snapshot(state, selected)
+        self.assertFalse(state["source_matches"])
+        self.assertEqual(state["run_head_sha"], "c" * 40)
+
+
+class SnapshotFenceTests(unittest.TestCase):
+    def test_bound_run_id_cannot_change(self) -> None:
+        state = _state()
+        state["run_id"] = 123
+        with self.assertRaises(readiness.ReadinessError):
+            readiness._apply_run_snapshot(state, _run(456))
+
+    def test_terminal_snapshot_records_conclusion(self) -> None:
+        state = _state()
+        run = dict(_run(), status="completed", conclusion="success")
+        readiness._apply_run_snapshot(state, run)
+        self.assertEqual(state["dispatch_state"], "completed")
+        self.assertEqual(state["run_status"], "completed")
+        self.assertEqual(state["run_conclusion"], "success")
+        self.assertTrue(state["source_matches"])
+        self.assertEqual(state["run_head_sha"], SOURCE)
+
+
+class ReadinessStateTests(unittest.TestCase):
+    def test_state_round_trip_and_symlink_rejection(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            state_path = root / "readiness.json"
+            readiness._write_state(state_path, _state())
+            loaded = readiness._load_state(state_path)
+            self.assertEqual(loaded["request_id"], REQUEST)
+            state_path.unlink()
+            target = root / "target.json"
+            target.write_text("{}\n", encoding="utf-8")
+            state_path.symlink_to(target)
+            with self.assertRaises(readiness.ReadinessError):
+                readiness._load_state(state_path)
+
+
+class _Response:
+    status = 204
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, _size=-1):
+        return b""
+
+    def getcode(self):
+        return self.status
+
+
+class _Opener:
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def open(self, request, timeout):
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+class DispatchClassificationTests(unittest.TestCase):
+    def test_resolved_wrong_source_is_never_a_successful_gate(self) -> None:
+        state = _state()
+        readiness._apply_run_snapshot(state, dict(_run(), head_sha="c" * 40))
+        self.assertFalse(state["source_matches"])
+
+    def _client(self):
+        return collector.GitHubClient(collector.DEFAULT_REPO, "fake-token", 5)
+
+    def test_204_is_accepted(self) -> None:
+        client = self._client()
+        client.opener = _Opener(_Response())
+        readiness._post_dispatch(client, SOURCE, REQUEST)
+
+    def test_4xx_is_definite_rejection(self) -> None:
+        client = self._client()
+        error = urllib.error.HTTPError("https://api.github.test", 422, "bad", {}, None)
+        client.opener = _Opener(error)
+        with self.assertRaises(readiness.DispatchRejected):
+            readiness._post_dispatch(client, SOURCE, REQUEST)
+
+    def test_transport_failure_is_outcome_unknown(self) -> None:
+        client = self._client()
+        client.opener = _Opener(urllib.error.URLError("lost"))
+        with self.assertRaises(readiness.DispatchOutcomeUnknown):
+            readiness._post_dispatch(client, SOURCE, REQUEST)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `.github/workflows/release-readiness.yml` as the reviewed exact-source pre-tag gate
- run the canonical release check, locked full workspace suite, frontend validation, WebSocket + polling zero-config E2E, and coding-loop compare eval in one cached Ubuntu job
- add `release_operator.py readiness-start` / `readiness-status` with a mode-0600 durable correlation state, exact `main` source fencing, unique request identity, fixed run-id binding, and explicit nonterminal/failure exit codes
- fail closed on dispatch uncertainty: the state is written before POST and the operator never automatically redispatches; the same request id/state recovers a delivered run
- handle the main-moved race explicitly: a run is recovered by its unique request identity even when its actual head differs, records `source_matches=false`, and can never satisfy the readiness gate
- add a deterministic tracked-Markdown local-link checker and wire all new release tooling tests into CI / `release_check.sh`
- update release docs so terminal readiness success is required before explicit tag authorization; readiness does not tag, publish, deploy, or produce release candidate binaries

## Validation

- `python3 -m unittest scripts.tests.test_release_readiness scripts.tests.test_check_markdown_links scripts.tests.test_collect_release_bundle scripts.tests.test_verify_public_release` — 27 tests passed
- `python3 scripts/check_markdown_links.py` — 36 tracked Markdown files / 232 repository-local links / 0 missing
- `bash scripts/release_check.sh` — all stages passed after final hardening
- `git diff --check`
- staged file-set and credential-pattern checks passed

The release-build workflow remains the only producer of release candidate binaries. After this PR is merged, the new readiness workflow must be exercised once end-to-end against the exact merged `main` SHA through `readiness-start` + the same durable state + `readiness-status`; that acceptance will not create a tag or publish/deploy anything.