### PR TITLE
Stabilize release readiness E2E startup

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -96,11 +96,21 @@ jobs:
           npm --prefix frontend test
           npm --prefix frontend run check:dist
 
+      - name: Build E2E runtime fixtures
+        run: |
+          cargo build --locked -p webcodex --bin webcodex-server
+          cargo build --locked -p webcodex-runner --bin webcodex-runner
+
       - name: Run WebSocket zero-config E2E
+        env:
+          E2E_SERVER_BIN: ${{ github.workspace }}/target/debug/webcodex-server
+          E2E_RUNNER_BIN: ${{ github.workspace }}/target/debug/webcodex-runner
         run: bash scripts/e2e_zero_config_ws.sh
 
       - name: Run polling zero-config E2E
         env:
+          E2E_SERVER_BIN: ${{ github.workspace }}/target/debug/webcodex-server
+          E2E_RUNNER_BIN: ${{ github.workspace }}/target/debug/webcodex-runner
           E2E_TRANSPORT: polling
         run: bash scripts/e2e_zero_config_ws.sh
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -61,7 +61,9 @@ Do not allow docs that ask users to configure server-side project onboarding, im
 
 ## 5. E2E Smoke
 
-The exact-source release-readiness workflow runs both supported zero-config transports against disposable local fixtures:
+The exact-source release-readiness workflow builds dedicated debug `webcodex-server` / `webcodex-runner` test fixtures once, then runs both supported zero-config transports against disposable local fixtures through the E2E script's existing-binary overrides. These binaries are never uploaded or treated as release candidates; `.github/workflows/release-build.yml` remains the only candidate producer.
+
+The underlying smoke commands remain:
 
 ```bash
 bash scripts/e2e_zero_config_ws.sh

--- a/scripts/e2e_zero_config_ws.sh
+++ b/scripts/e2e_zero_config_ws.sh
@@ -35,8 +35,10 @@ set -euo pipefail
 #   E2E_KEEPALIVE_WAIT_SECS
 #                       seconds to idle before the keepalive-online recheck
 #                       (default: 2; raise to ~35 to span a real ping/pong)
-#   E2E_SKIP_RUN        if set to "1", skip `cargo run` and only syntax-check
-#   CARGO_BIN           cargo binary (default: cargo)
+#   E2E_SKIP_RUN        if set to "1", skip execution and only syntax-check
+#   E2E_SERVER_BIN      existing webcodex-server executable; skips server `cargo run`
+#   E2E_RUNNER_BIN      existing webcodex-runner executable; skips runner `cargo run`
+#   CARGO_BIN           cargo binary (default: cargo; used when an override is absent)
 #
 # Exit codes:
 #   0  all smoke checks passed
@@ -49,6 +51,8 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_DIR"
 
 CARGO_BIN="${CARGO_BIN:-cargo}"
+SERVER_BIN="${E2E_SERVER_BIN:-}"
+RUNNER_BIN="${E2E_RUNNER_BIN:-}"
 TOKEN="${E2E_TOKEN:-e2e-smoke-token}"
 CLIENT_ID="${E2E_CLIENT_ID:-e2e-agent}"
 PROJECT_ID="${E2E_PROJECT_ID:-smoke-proj}"
@@ -243,7 +247,7 @@ cleanup() {
         sleep 1
         kill -9 "$SERVER_PID" 2>/dev/null || true
     fi
-    # Wait briefly for the cargo parent processes to tear down children.
+    # Wait briefly for the launched runtime processes to tear down children.
     sleep 1
 }
 
@@ -269,6 +273,31 @@ fi
 if [ "${E2E_SKIP_RUN:-0}" = "1" ]; then
     log "E2E_SKIP_RUN=1: skipping execution (syntax-only)"
     exit 0
+fi
+
+validate_binary_override() {
+    local label="$1"
+    local value="$2"
+    if [ -z "$value" ]; then
+        return 0
+    fi
+    case "$value" in
+        *$'\n'*|*$'\r'*)
+            echo "[e2e] $label contains a newline" >&2
+            exit 2
+            ;;
+    esac
+    if [ ! -f "$value" ] || [ ! -x "$value" ]; then
+        echo "[e2e] $label is not an executable regular file: $value" >&2
+        exit 2
+    fi
+}
+
+validate_binary_override "E2E_SERVER_BIN" "$SERVER_BIN"
+validate_binary_override "E2E_RUNNER_BIN" "$RUNNER_BIN"
+if { [ -z "$SERVER_BIN" ] || [ -z "$RUNNER_BIN" ]; } && ! command -v "$CARGO_BIN" >/dev/null 2>&1; then
+    echo "[e2e] cargo is required when an existing runtime binary override is absent" >&2
+    exit 2
 fi
 
 # ----------------------------------------------------------------------------
@@ -341,14 +370,25 @@ log "runtime project id: $RUNTIME_PROJECT_ID"
 # 3. Start the server
 # ----------------------------------------------------------------------------
 
-log "starting server (cargo run -p webcodex --bin webcodex-server)"
-WEBCODEX_ADDR="127.0.0.1:${PORT}" \
-WEBCODEX_DATA="$DATA_DIR" \
-WEBCODEX_TOKEN="$TOKEN" \
-CODEX_DEFAULT_TIMEOUT_SECS="30" \
-CODEX_APPROVAL_MODE="full-auto" \
-RUST_LOG="info" \
-"$CARGO_BIN" run --quiet -p webcodex --bin webcodex-server >"$SERVER_LOG" 2>&1 &
+if [ -n "$SERVER_BIN" ]; then
+    log "starting server (existing binary: $SERVER_BIN)"
+    WEBCODEX_ADDR="127.0.0.1:${PORT}" \
+    WEBCODEX_DATA="$DATA_DIR" \
+    WEBCODEX_TOKEN="$TOKEN" \
+    CODEX_DEFAULT_TIMEOUT_SECS="30" \
+    CODEX_APPROVAL_MODE="full-auto" \
+    RUST_LOG="info" \
+    "$SERVER_BIN" >"$SERVER_LOG" 2>&1 &
+else
+    log "starting server (cargo run -p webcodex --bin webcodex-server)"
+    WEBCODEX_ADDR="127.0.0.1:${PORT}" \
+    WEBCODEX_DATA="$DATA_DIR" \
+    WEBCODEX_TOKEN="$TOKEN" \
+    CODEX_DEFAULT_TIMEOUT_SECS="30" \
+    CODEX_APPROVAL_MODE="full-auto" \
+    RUST_LOG="info" \
+    "$CARGO_BIN" run --quiet -p webcodex --bin webcodex-server >"$SERVER_LOG" 2>&1 &
+fi
 SERVER_PID=$!
 
 if ! wait_for_port "$PORT" 40; then
@@ -362,8 +402,13 @@ pass "server listening on $PORT"
 # 4. Start the agent
 # ----------------------------------------------------------------------------
 
-log "starting agent (cargo run -p webcodex-runner --bin webcodex-runner, transport=$TRANSPORT)"
-"$CARGO_BIN" run --quiet -p webcodex-runner --bin webcodex-runner -- --config "$AGENT_TOML" >"$AGENT_LOG" 2>&1 &
+if [ -n "$RUNNER_BIN" ]; then
+    log "starting agent (existing binary: $RUNNER_BIN, transport=$TRANSPORT)"
+    "$RUNNER_BIN" --config "$AGENT_TOML" >"$AGENT_LOG" 2>&1 &
+else
+    log "starting agent (cargo run -p webcodex-runner --bin webcodex-runner, transport=$TRANSPORT)"
+    "$CARGO_BIN" run --quiet -p webcodex-runner --bin webcodex-runner -- --config "$AGENT_TOML" >"$AGENT_LOG" 2>&1 &
+fi
 AGENT_PID=$!
 
 # Wait for the agent to register by polling runtime_status for the client.


### PR DESCRIPTION
## Summary

- add optional `E2E_SERVER_BIN` / `E2E_RUNNER_BIN` overrides to the zero-config E2E harness while preserving the existing `cargo run` defaults
- make release-readiness explicitly build debug server/runner test fixtures once, then execute those exact fixtures for WebSocket and polling E2E
- keep these debug fixtures local to the readiness job: they are never uploaded, packaged, or treated as release candidates; `release-build.yml` remains the only candidate producer
- document the fixture boundary in the release checklist

## Why

The first real post-merge readiness run (`31803955811`, exact main `4aa0e03cc63b1fc0723a6e6df87789ae924c0b4e`) correctly passed source fencing, release_check, full workspace tests, and frontend checks, but failed at WebSocket E2E before any assertion because cold-runner `cargo run -p webcodex --bin webcodex-server` did not finish linking/listening within the harness's fixed 40s startup budget.

This removes the accidental warm-build assumption rather than increasing the startup timeout.

## Validation

- `bash -n scripts/e2e_zero_config_ws.sh`
- `cargo build --locked -p webcodex --bin webcodex-server`
- `cargo build --locked -p webcodex-runner --bin webcodex-runner`
- existing-binary WebSocket E2E: 111 passed / 0 failed / 17s
- existing-binary polling E2E: 111 passed / 0 failed / 56s
- `bash scripts/release_check.sh` — all stages passed
- `git diff --check`

After merge, the exact-source readiness workflow will be dispatched once for the new main using a new durable readiness state. The failed prior state/run remains failure evidence and will not be reused or overwritten.