### PR TITLE
fix: provision ripgrep for release readiness E2E

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -83,6 +83,13 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
+      # search_project_texts advanced result modes intentionally require ripgrep;
+      # do not rely on the mutable hosted-runner image to provide it implicitly.
+      - name: Install E2E search dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y ripgrep
+
       - name: Run canonical release check
         run: bash scripts/release_check.sh
 


### PR DESCRIPTION
## Summary

- provision `ripgrep` explicitly in the release-readiness Ubuntu job
- keep the product's fail-closed `search_backend_feature_unavailable` behavior unchanged
- avoid relying on mutable hosted-runner image contents for the advanced `search_project_texts` E2E modes

## Failure evidence

Readiness run `31808642743` reached the WebSocket zero-config E2E and failed at `MCP tools/call(search_project_texts) contract mismatch`: the basic `matches` query used the grep fallback successfully, while the `files_with_matches` query correctly returned `search_backend_feature_unavailable` because `ripgrep` was unavailable.

## Validation plan

- normal PR CI on Ubuntu and Windows
- after merge, dispatch a fresh exact-source release-readiness state from the new `main`; do not reuse or rerun the failed readiness state