### PR TITLE
Unify bearer scope enforcement

### DIFF
--- a/docs/AUTH_MODEL.md
+++ b/docs/AUTH_MODEL.md
@@ -85,6 +85,11 @@ A shared key is not an admin credential, not a managed user identity, and not
 production IAM. It has no independent per-device revocation: rotate the shared
 secret for the whole group, or use managed credentials.
 
+Its default principal carries `runtime:read`, `project:read`, `project:write`,
+`job:run`, and the bounded Agent-transport scopes `agent:register`, `agent:poll`,
+`agent:result`, and `agent:job_update`. It does not carry Computer, account
+management, or admin scopes.
+
 `WEBCODEX_SHARED_KEY_ENABLED=true` enables direct Bearer shared-key fallback on
 an ordinary server. Managed `wc_*` values and empty/whitespace Bearer values
 never fall back to shared-key mode. `WEBCODEX_OAUTH2_SHARED_KEY_BRIDGE` is a
@@ -171,6 +176,35 @@ The server supports the authorization-code grant, token revocation, and OAuth
 metadata. Dynamic client registration, OIDC, JWKS/JWT ID tokens, and the
 device-code flow are not implemented. OAuth setup steps are in
 [Deployment](DEPLOYMENT.md#oauth2).
+
+## Scope enforcement and credential surfaces
+
+WebCodex treats scope permission and credential identity as separate checks.
+For ordinary runtime principals, a declared runtime/project/job/Computer scope is
+enforced from the authenticated `AuthContext` whether the caller arrived through
+a PAT, OAuth access token, direct shared key, or open-anonymous mode.
+Bootstrap/admin remains the explicit superuser exception. Credential-specific
+capabilities keep their own narrower authorization layer: Runner tokens remain
+Agent-transport-only, account credentials remain account-control-only, OAuth
+access tokens cannot use Agent transport, and project credentials remain bounded
+to the Connector/project surface and its operation-level authorization.
+
+`account:manage` remains a delegated OAuth/account-credential permission, while
+first-party PAT account self-service keeps the existing handler-level identity
+and role checks rather than requiring that scope merely to manage the PAT's own
+account resources.
+
+The direct shared-key profile uses the default scopes listed above; it does not
+implicitly gain `computer:read`, `computer:control`, `account:manage`, or
+`admin`. Consequently, a Computer tool
+cannot be reached merely because the caller used a direct shared key. Unknown
+authenticated routes and runtime tools fail closed for ordinary principals until
+a scope policy is declared; bootstrap retains setup/superuser compatibility.
+
+Scope-denial wire formatting remains credential-aware. OAuth access tokens use
+the OAuth `insufficient_scope` response and `WWW-Authenticate` challenge. Other
+Bearer principals receive a normal WebCodex `403` without being represented as
+an OAuth error. This changes only response framing, not the required scope.
 
 ## Computer observation and control authorization
 

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -78,6 +78,36 @@ pub(crate) fn render_oauth_insufficient_scope(
     res.render(Json(oauth_insufficient_scope_body(description)));
 }
 
+pub(crate) fn scope_forbidden_body(
+    auth: Option<&AuthContext>,
+    description: impl Into<String>,
+) -> serde_json::Value {
+    let description = description.into();
+    if auth.is_some_and(AuthContext::is_oauth_token) {
+        oauth_insufficient_scope_body(description)
+    } else {
+        serde_json::json!({
+            "status": StatusCode::FORBIDDEN.as_u16(),
+            "error": description,
+        })
+    }
+}
+
+pub(crate) fn render_scope_forbidden(
+    res: &mut Response,
+    auth: Option<&AuthContext>,
+    required_scope: Option<&str>,
+    description: impl Into<String>,
+) {
+    let description = description.into();
+    if auth.is_some_and(AuthContext::is_oauth_token) {
+        render_oauth_insufficient_scope(res, required_scope, description);
+        return;
+    }
+    res.status_code(StatusCode::FORBIDDEN);
+    res.render(Json(scope_forbidden_body(auth, description)));
+}
+
 pub(crate) fn bearer_or_allowed_query_token(req: &Request) -> Option<String> {
     bearer_token(req).or_else(|| {
         if allow_query_token_for_path(req.uri().path()) {
@@ -291,7 +321,7 @@ impl Handler for AuthMiddleware {
                 }
                 if allow_anonymous_enabled() {
                     // Explicit --open: anonymous callers get a non-admin open
-                    // context. Surface restrictions still apply.
+                    // context. Surface restrictions and declared scopes still apply.
                     let ctx = open_anonymous_context();
                     if let Err((status, msg)) = enforce_request_surface(
                         project_connector_enabled(depot),
@@ -299,6 +329,13 @@ impl Handler for AuthMiddleware {
                         req.uri().path(),
                     ) {
                         reject(res, ctrl, status, msg);
+                        return;
+                    }
+                    if let Err((scope, description)) =
+                        scopes::enforce_route_scope(&ctx, req.method().as_str(), req.uri().path())
+                    {
+                        render_scope_forbidden(res, Some(&ctx), scope, description);
+                        ctrl.skip_rest();
                         return;
                     }
                     depot.inject(ctx);
@@ -326,6 +363,9 @@ impl Handler for AuthMiddleware {
                     reject(res, ctrl, status, msg);
                     return;
                 }
+                // Project credentials are a specialized Connector capability.
+                // Their exact surface and operation authorization stay owned by
+                // the project Connector instead of the ordinary route registry.
                 depot.inject(ctx);
                 ctrl.call_next(req, depot, res).await;
                 return;
@@ -335,6 +375,8 @@ impl Handler for AuthMiddleware {
                     reject(res, ctrl, status, msg);
                     return;
                 }
+                // Project Agent Tokens remain governed by the exact Agent
+                // transport surface and its agent:* scope checks.
                 depot.inject(ctx);
                 ctrl.call_next(req, depot, res).await;
                 return;
@@ -369,9 +411,9 @@ impl Handler for AuthMiddleware {
                     return;
                 }
                 if let Err((scope, description)) =
-                    scopes::enforce_oauth_route_scope(&ctx, req.method().as_str(), req.uri().path())
+                    scopes::enforce_route_scope(&ctx, req.method().as_str(), req.uri().path())
                 {
-                    render_oauth_insufficient_scope(res, scope, description);
+                    render_scope_forbidden(res, Some(&ctx), scope, description);
                     ctrl.skip_rest();
                     return;
                 }
@@ -400,12 +442,10 @@ impl Handler for AuthMiddleware {
                         reject(res, ctrl, status, msg);
                         return;
                     }
-                    if let Err((scope, description)) = scopes::enforce_oauth_route_scope(
-                        &ctx,
-                        req.method().as_str(),
-                        req.uri().path(),
-                    ) {
-                        render_oauth_insufficient_scope(res, scope, description);
+                    if let Err((scope, description)) =
+                        scopes::enforce_route_scope(&ctx, req.method().as_str(), req.uri().path())
+                    {
+                        render_scope_forbidden(res, Some(&ctx), scope, description);
                         ctrl.skip_rest();
                         return;
                     }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -78,9 +78,9 @@ pub(crate) use middleware::{
     is_agent_transport_path, ACCOUNT_CONTROL_PATHS, AGENT_TRANSPORT_PATHS,
 };
 pub(crate) use middleware::{
-    bearer_token, get_config, get_db, json_error, oauth_insufficient_scope_body,
-    oauth_insufficient_scope_challenge, render_oauth_insufficient_scope, require_json_same_origin,
-    require_same_origin, AuthMiddleware,
+    bearer_token, get_config, get_db, json_error, oauth_insufficient_scope_challenge,
+    render_scope_forbidden, require_json_same_origin, require_same_origin, scope_forbidden_body,
+    AuthMiddleware,
 };
 
 pub(crate) use pat::{

--- a/src/auth/scopes.rs
+++ b/src/auth/scopes.rs
@@ -1,8 +1,8 @@
 //! Scope definitions and validation for the WebCodex auth system.
 //!
-//! Scopes are string-based permissions attached to tokens. Bootstrap auth is
-//! treated as holding every scope. PAT (personal API token) and future OAuth2
-//! tokens carry an explicit set of granted scopes.
+//! Scopes are string-based permissions carried by authenticated principals.
+//! Bootstrap auth is treated as holding every scope; managed tokens, delegated
+//! OAuth access tokens, and lightweight contexts carry explicit granted scopes.
 
 use std::collections::HashSet;
 
@@ -123,8 +123,11 @@ pub(crate) fn scopes_to_string(scopes: &[String]) -> String {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// OAuth delegated scope policy
+// Authenticated route/tool scope policy
 // ---------------------------------------------------------------------------
+// The OAuth-prefixed type/function names below are retained for compatibility
+// with the existing policy registry. Enforcement is principal-neutral; OAuth
+// remains special only for delegated-scope issuance and wire error framing.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OAuthRouteScopePolicy {
@@ -285,36 +288,73 @@ pub(crate) fn required_oauth_scope_for_path_method(
     }
 }
 
-pub(crate) fn enforce_oauth_route_scope(
+fn pat_account_manage_compatibility_route(method: &str, path: &str) -> bool {
+    matches!(
+        (method, path),
+        ("POST", "/api/users/create")
+            | ("POST", "/api/users/list")
+            | ("POST", "/api/users/me")
+            | ("POST", "/api/tokens/create")
+            | ("POST", "/api/tokens/register_hash")
+            | ("POST", "/api/tokens/list")
+            | ("POST", "/api/tokens/revoke")
+            | ("POST", "/api/agent-tokens/create")
+            | ("POST", "/api/agent-tokens/register_hash")
+            | ("POST", "/api/agent-tokens/list")
+            | ("POST", "/api/agent-tokens/revoke")
+            | ("POST", "/api/pairing/create")
+    )
+}
+
+pub(crate) fn enforce_route_scope(
     ctx: &AuthContext,
     method: &str,
     path: &str,
 ) -> Result<(), (Option<&'static str>, String)> {
-    if !ctx.is_oauth_token() {
-        return Ok(());
-    }
-
     match oauth_route_scope_policy_for_path_method(method, path) {
         OAuthRouteScopePolicy::Public | OAuthRouteScopePolicy::BodyAware(_) => Ok(()),
         OAuthRouteScopePolicy::Require(scope) => {
-            if ctx.has_scope(scope) {
+            // A narrow set of account-management routes predates delegated
+            // scopes and already enforces admin/self or admin-only identity in
+            // its handler. Preserve PAT compatibility only for those exact
+            // routes; other account:manage surfaces (notably global audit
+            // reads) must carry the scope explicitly.
+            let first_party_pat_account_route = scope == SCOPE_ACCOUNT_MANAGE
+                && matches!(ctx.kind, super::context::AuthKind::ApiToken)
+                && pat_account_manage_compatibility_route(method, path);
+            if first_party_pat_account_route || ctx.has_scope(scope) {
                 Ok(())
             } else {
                 Err((Some(scope), format!("missing required scope: {}", scope)))
             }
         }
-        OAuthRouteScopePolicy::FirstPartyOnly => Err((
-            None,
-            "OAuth2 access tokens cannot call first-party-only routes".to_string(),
-        )),
-        OAuthRouteScopePolicy::AgentSurface => Err((
-            None,
-            "OAuth2 access tokens cannot call agent transport routes".to_string(),
-        )),
-        OAuthRouteScopePolicy::Unknown => Err((
-            None,
-            "OAuth2 access tokens cannot call unknown authenticated routes".to_string(),
-        )),
+        OAuthRouteScopePolicy::FirstPartyOnly => {
+            if matches!(
+                ctx.kind,
+                super::context::AuthKind::Bootstrap | super::context::AuthKind::ApiToken
+            ) {
+                Ok(())
+            } else {
+                Err((
+                    None,
+                    "route requires a first-party bootstrap or personal API token".to_string(),
+                ))
+            }
+        }
+        // Agent transport identity and exact agent:* scopes are enforced by the
+        // dedicated surface gate and transport handlers. Do not reinterpret
+        // those credentials as ordinary runtime principals here.
+        OAuthRouteScopePolicy::AgentSurface => Ok(()),
+        OAuthRouteScopePolicy::Unknown => {
+            if ctx.is_bootstrap() {
+                Ok(())
+            } else {
+                Err((
+                    None,
+                    "authenticated route has no declared scope policy".to_string(),
+                ))
+            }
+        }
     }
 }
 
@@ -465,6 +505,94 @@ mod tests {
                 required_oauth_scope_for_path_method(method, path),
                 Some(scope),
                 "{method} {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn route_scope_enforcement_is_principal_neutral() {
+        let mut pat = AuthContext::new(super::super::context::AuthKind::ApiToken);
+        pat.scopes = vec![SCOPE_RUNTIME_READ.to_string()];
+        let mut oauth = AuthContext::new(super::super::context::AuthKind::OAuth2Token);
+        oauth.scopes = vec![SCOPE_RUNTIME_READ.to_string()];
+        let shared = crate::auth::shared_key_context("scope-matrix");
+        let bootstrap = crate::auth::bootstrap_context();
+
+        for (label, auth) in [("pat", &pat), ("oauth", &oauth), ("shared", &shared)] {
+            assert!(
+                enforce_route_scope(auth, "POST", "/api/runtime/status").is_ok(),
+                "{label} should honor runtime:read"
+            );
+        }
+        for (label, auth) in [("pat", &pat), ("oauth", &oauth)] {
+            assert_eq!(
+                enforce_route_scope(auth, "POST", "/api/projects/read_file"),
+                Err((
+                    Some(SCOPE_PROJECT_READ),
+                    "missing required scope: project:read".to_string()
+                )),
+                "{label} must not bypass missing project:read"
+            );
+        }
+        assert!(
+            enforce_route_scope(&shared, "POST", "/api/projects/read_file").is_ok(),
+            "direct shared key should use its declared project:read scope"
+        );
+        assert!(
+            enforce_route_scope(&pat, "POST", "/api/oauth/clients/list").is_ok(),
+            "PAT remains an allowed first-party identity"
+        );
+        assert!(
+            enforce_route_scope(&oauth, "POST", "/api/oauth/clients/list").is_err(),
+            "OAuth delegation cannot become first-party client management"
+        );
+        assert!(
+            enforce_route_scope(&shared, "POST", "/api/future/authenticated-route").is_err(),
+            "ordinary principals must fail closed on undeclared routes"
+        );
+        assert!(
+            enforce_route_scope(&bootstrap, "POST", "/api/future/authenticated-route").is_ok(),
+            "bootstrap keeps explicit superuser compatibility"
+        );
+    }
+
+    #[test]
+    fn pat_account_manage_compatibility_is_route_bounded() {
+        let mut pat = AuthContext::new(super::super::context::AuthKind::ApiToken);
+        pat.scopes = vec![SCOPE_RUNTIME_READ.to_string()];
+
+        for path in [
+            "/api/users/create",
+            "/api/users/list",
+            "/api/users/me",
+            "/api/tokens/create",
+            "/api/tokens/register_hash",
+            "/api/tokens/list",
+            "/api/tokens/revoke",
+            "/api/agent-tokens/create",
+            "/api/agent-tokens/register_hash",
+            "/api/agent-tokens/list",
+            "/api/agent-tokens/revoke",
+            "/api/pairing/create",
+        ] {
+            assert!(
+                enforce_route_scope(&pat, "POST", path).is_ok(),
+                "legacy PAT account compatibility should remain on {path}"
+            );
+        }
+
+        for path in [
+            "/api/audit/sessions",
+            "/api/audit/session",
+            "/api/audit/stats",
+        ] {
+            assert_eq!(
+                enforce_route_scope(&pat, "POST", path),
+                Err((
+                    Some(SCOPE_ACCOUNT_MANAGE),
+                    "missing required scope: account:manage".to_string()
+                )),
+                "PAT audit access must require account:manage on {path}"
             );
         }
     }

--- a/src/auth/tests.rs
+++ b/src/auth/tests.rs
@@ -150,7 +150,11 @@ fn gate_mint_agent_token(
 }
 
 /// Create a user token for `username` via the DB layer directly.
-fn gate_mint_user_token(db: &crate::Database, user: &crate::models::UserRecord) -> String {
+fn gate_mint_user_token_with_scopes(
+    db: &crate::Database,
+    user: &crate::models::UserRecord,
+    scopes: &str,
+) -> String {
     let plaintext = generate_api_token();
     let prefix = token_prefix(&plaintext);
     let hash = hash_token(&plaintext);
@@ -163,13 +167,17 @@ fn gate_mint_user_token(db: &crate::Database, user: &crate::models::UserRecord) 
         created_at: now,
         last_used_at: None,
         revoked_at: None,
-        scopes: "runtime:read project:read project:write job:run".to_string(),
+        scopes: scopes.to_string(),
         expires_at: None,
         kind: crate::models::TOKEN_KIND_USER.to_string(),
         allowed_client_id: None,
     };
     db.insert_api_key(&record, &hash).unwrap();
     plaintext
+}
+
+fn gate_mint_user_token(db: &crate::Database, user: &crate::models::UserRecord) -> String {
+    gate_mint_user_token_with_scopes(db, user, "runtime:read project:read project:write job:run")
 }
 
 fn gate_mint_account_credential(db: &crate::Database, user: &crate::models::UserRecord) -> String {
@@ -287,6 +295,8 @@ fn gate_router(config: Arc<crate::Config>, db: Arc<crate::Database>) -> Router {
                 .push(Router::with_path("projects/run_job").post(echo_ok))
                 .push(Router::with_path("jobs/list").post(echo_ok))
                 .push(Router::with_path("audit/sessions").post(echo_ok))
+                .push(Router::with_path("audit/session").post(echo_ok))
+                .push(Router::with_path("audit/stats").post(echo_ok))
                 .push(Router::with_path("users/me").post(echo_ok))
                 .push(Router::with_path("users/list").post(echo_ok))
                 .push(Router::with_path("tokens/list").post(echo_ok))
@@ -1939,21 +1949,123 @@ async fn managed_oauth2_token_with_account_manage_can_call_users_me() {
 }
 
 #[tokio::test]
-async fn api_token_still_works_on_representative_routes() {
+async fn api_token_obeys_declared_scope_and_unknown_route_policy() {
     let config = gate_test_config(Some("secret"));
     let (_tmp, db) = gate_test_db();
     let user = gate_seed_user(&db, "alice");
     let user_token = gate_mint_user_token(&db, &user);
+    let runtime_only_token = gate_mint_user_token_with_scopes(&db, &user, SCOPE_RUNTIME_READ);
     let service = Service::new(gate_router(config, db));
+
     for path in [
         "/api/runtime/status",
         "/api/projects/read_file",
         "/api/projects/run_job",
-        "/api/users/me",
-        "/api/future/authenticated-route",
     ] {
         let (status, body) = gate_send(&service, path, Some(&user_token)).await;
         assert_eq!(status, StatusCode::OK, "{} body: {:?}", path, body);
+    }
+
+    let (status, body) = gate_send(
+        &service,
+        "/api/projects/read_file",
+        Some(&runtime_only_token),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "body: {body:?}");
+    assert_ne!(body["error"], "insufficient_scope");
+    assert!(body["error"]
+        .as_str()
+        .unwrap_or("")
+        .contains(SCOPE_PROJECT_READ));
+
+    let (status, body) = gate_send(&service, "/api/users/me", Some(&runtime_only_token)).await;
+    assert_eq!(status, StatusCode::OK, "PAT self-service body: {body:?}");
+
+    let (status, body) = gate_send(
+        &service,
+        "/api/future/authenticated-route",
+        Some(&runtime_only_token),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "body: {body:?}");
+    assert!(body["error"]
+        .as_str()
+        .unwrap_or("")
+        .contains("no declared scope policy"));
+}
+
+#[tokio::test]
+async fn api_token_without_account_manage_cannot_read_audit_routes() {
+    let config = gate_test_config(Some("secret"));
+    let (_tmp, db) = gate_test_db();
+    let user = gate_seed_user(&db, "alice");
+    let runtime_only_token = gate_mint_user_token_with_scopes(&db, &user, SCOPE_RUNTIME_READ);
+    let service = Service::new(gate_router(config, db));
+
+    for path in [
+        "/api/audit/sessions",
+        "/api/audit/session",
+        "/api/audit/stats",
+    ] {
+        let mut resp = TestClient::post(format!("http://localhost{path}"))
+            .bearer_auth(&runtime_only_token)
+            .send(&service)
+            .await;
+        assert_eq!(gate_status(&resp), StatusCode::FORBIDDEN, "path: {path}");
+        assert!(
+            !resp.headers.contains_key("www-authenticate"),
+            "PAT scope denial must not use OAuth challenge framing on {path}"
+        );
+        let body = resp.take_json::<serde_json::Value>().await.unwrap();
+        assert_ne!(body["error"], "insufficient_scope", "path: {path}");
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains(SCOPE_ACCOUNT_MANAGE),
+            "path: {path}, body: {body:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn managed_oauth2_without_account_manage_gets_audit_scope_challenge() {
+    let config = gate_test_config_oauth2(Some("secret"));
+    let (_tmp, db) = gate_test_db();
+    let user = gate_seed_user(&db, "alice");
+    let (client, _secret) = gate_seed_oauth_client(&db, &user, "Audit Scope App");
+    let (_at, token) = gate_seed_oauth_access_token(&db, &client, &user, SCOPE_RUNTIME_READ);
+    let service = Service::new(gate_router(config, db));
+
+    for path in [
+        "/api/audit/sessions",
+        "/api/audit/session",
+        "/api/audit/stats",
+    ] {
+        let mut resp = TestClient::post(format!("http://localhost{path}"))
+            .bearer_auth(&token)
+            .send(&service)
+            .await;
+        assert_eq!(gate_status(&resp), StatusCode::FORBIDDEN, "path: {path}");
+        let challenge = resp
+            .headers
+            .get("www-authenticate")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            challenge.contains("error=\"insufficient_scope\""),
+            "OAuth audit scope denial must use insufficient_scope on {path}: {challenge}"
+        );
+        let body = resp.take_json::<serde_json::Value>().await.unwrap();
+        assert_eq!(body["error"], "insufficient_scope", "path: {path}");
+        assert!(
+            body["error_description"]
+                .as_str()
+                .unwrap_or("")
+                .contains(SCOPE_ACCOUNT_MANAGE),
+            "path: {path}, body: {body:?}"
+        );
     }
 }
 
@@ -2116,6 +2228,21 @@ async fn auth_middleware_direct_shared_key_and_oauth_bridge_flags_are_independen
         "direct shared-key fallback should not require OAuth bridge: {:?}",
         body
     );
+    let mut resp = TestClient::post("http://localhost/api/future/authenticated-route")
+        .bearer_auth("my-key")
+        .send(&service)
+        .await;
+    assert_eq!(gate_status(&resp), StatusCode::FORBIDDEN);
+    assert!(
+        !resp.headers.contains_key("www-authenticate"),
+        "direct shared-key denial must not emit an OAuth insufficient_scope challenge"
+    );
+    let body = resp.take_json::<serde_json::Value>().await.unwrap();
+    assert_ne!(body["error"], "insufficient_scope");
+    assert!(body["error"]
+        .as_str()
+        .unwrap_or("")
+        .contains("no declared scope policy"));
 }
 
 #[tokio::test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1343,9 +1343,7 @@ async fn mcp_artifact_export_resource_read_with_gate_timeout(
     read_timeout: Duration,
 ) -> Result<Value, McpArtifactExportReadError> {
     let record = mcp_artifact_export_lookup(uri, auth)?;
-    if auth.is_some_and(|auth| auth.is_oauth_token())
-        && !auth.is_some_and(|auth| auth.has_scope(crate::auth::SCOPE_PROJECT_READ))
-    {
+    if auth.is_some_and(|auth| !auth.has_scope(crate::auth::SCOPE_PROJECT_READ)) {
         return Err(McpArtifactExportReadError::Forbidden {
             required_scope: Some(crate::auth::SCOPE_PROJECT_READ),
             description: format!(
@@ -1742,9 +1740,11 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
             let estimated = estimate_json_bytes(&body);
             guard.response_serialized(403, estimated, Some(false), None, "forbidden");
             res.status_code(StatusCode::FORBIDDEN);
-            let challenge = crate::auth::oauth_insufficient_scope_challenge(required_scope);
-            if let Ok(val) = salvo::http::HeaderValue::from_str(&challenge) {
-                res.headers_mut().insert("www-authenticate", val);
+            if auth.as_ref().is_some_and(AuthContext::is_oauth_token) {
+                let challenge = crate::auth::oauth_insufficient_scope_challenge(required_scope);
+                if let Ok(val) = salvo::http::HeaderValue::from_str(&challenge) {
+                    res.headers_mut().insert("www-authenticate", val);
+                }
             }
             res.render(Json(body));
             guard.handler_returned(403, estimated, Some(false), None, "forbidden");
@@ -1795,7 +1795,6 @@ async fn handle_mcp_request_with_lifecycle(
     window: Option<&crate::client_window::ClientWindow>,
     mut lifecycle: Option<&mut ToolRequestLifecycle>,
 ) -> McpOutcome {
-    let is_oauth2 = auth.is_some_and(|ctx| ctx.is_oauth_token());
     let stateless_2026 = protocol_era == McpProtocolEra::Stateless2026;
     let artifact_export_resource_read = stateless_2026
         && request.method == "resources/read"
@@ -1808,7 +1807,7 @@ async fn handle_mcp_request_with_lifecycle(
         && model_surface_supports_computer_app(runtime.model_surface())
         && request_supports_mcp_apps(&request.params);
 
-    if is_oauth2
+    if auth.is_some()
         && (matches!(
             request.method.as_str(),
             "server/discover" | "tools/list" | "resources/list"
@@ -1819,12 +1818,12 @@ async fn handle_mcp_request_with_lifecycle(
                     "initialize" | "ping" | "notifications/initialized"
                 )))
     {
-        if let Some(outcome) = require_mcp_oauth_scope(auth, crate::auth::SCOPE_RUNTIME_READ) {
+        if let Some(outcome) = require_mcp_scope(auth, crate::auth::SCOPE_RUNTIME_READ) {
             return outcome;
         }
     }
 
-    if is_oauth2
+    if auth.is_some_and(|auth| !auth.is_bootstrap())
         && !stateless_2026
         && !matches!(
             request.method.as_str(),
@@ -1836,7 +1835,11 @@ async fn handle_mcp_request_with_lifecycle(
                 | "notifications/initialized"
         )
     {
-        return oauth_forbidden(None, "OAuth2 access tokens cannot call unknown MCP methods");
+        return scope_forbidden(
+            auth,
+            None,
+            "authenticated caller cannot call unknown MCP methods",
+        );
     }
 
     // A JSON-RPC request without an `id` member is a notification. Per the
@@ -1953,7 +1956,7 @@ async fn handle_mcp_request_with_lifecycle(
                     Err(McpArtifactExportReadError::Forbidden {
                         required_scope,
                         description,
-                    }) => return oauth_forbidden(required_scope, description),
+                    }) => return scope_forbidden(auth, required_scope, description),
                     Err(McpArtifactExportReadError::Unavailable) => {
                         return McpOutcome::BadRequest(rpc_error(
                             id,
@@ -2103,7 +2106,7 @@ async fn handle_mcp_request_with_lifecycle(
                         .and_then(Value::as_str)
                         .unwrap_or("connector credential lacks the required scope")
                         .to_string();
-                    return oauth_forbidden(Some(required_scope), description);
+                    return scope_forbidden(auth, Some(required_scope), description);
                 }
                 if outcome.protocol_error {
                     if let Some(lc) = lifecycle.as_deref() {
@@ -2166,7 +2169,7 @@ async fn handle_mcp_request_with_lifecycle(
                         lc.dispatch_failed("forbidden");
                         lc.dispatch_finished(false, Some(false), "forbidden");
                     }
-                    return oauth_forbidden(required_scope, description);
+                    return scope_forbidden(auth, required_scope, description);
                 }
                 Some(ToolCallErrorStatus::InvalidArguments { message }) => {
                     if let Some(lc) = lifecycle.as_deref() {
@@ -2466,12 +2469,13 @@ fn log_mcp_host_file_import_trust_decision(
     );
 }
 
-fn require_mcp_oauth_scope(auth: Option<&AuthContext>, scope: &'static str) -> Option<McpOutcome> {
+fn require_mcp_scope(auth: Option<&AuthContext>, scope: &'static str) -> Option<McpOutcome> {
     let auth = auth?;
-    if !auth.is_oauth_token() || auth.has_scope(scope) {
+    if auth.has_scope(scope) {
         return None;
     }
-    Some(oauth_forbidden(
+    Some(scope_forbidden(
+        Some(auth),
         Some(scope),
         format!("missing required scope: {}", scope),
     ))
@@ -2486,12 +2490,13 @@ fn strip_reserved_session_id(arguments: &mut Value) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-fn oauth_forbidden(
+fn scope_forbidden(
+    auth: Option<&AuthContext>,
     required_scope: Option<&'static str>,
     description: impl Into<String>,
 ) -> McpOutcome {
     McpOutcome::Forbidden {
-        body: crate::auth::oauth_insufficient_scope_body(description),
+        body: crate::auth::scope_forbidden_body(auth, description),
         required_scope,
     }
 }

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -2486,7 +2486,10 @@ fn mcp_export_api_auth(api_key_id: &str, username: &str) -> crate::auth::AuthCon
     auth.username = Some(username.to_string());
     auth.api_key_id = Some(api_key_id.to_string());
     auth.token_kind = Some("user".to_string());
-    auth.scopes = vec![crate::auth::SCOPE_PROJECT_READ.to_string()];
+    auth.scopes = vec![
+        crate::auth::SCOPE_RUNTIME_READ.to_string(),
+        crate::auth::SCOPE_PROJECT_READ.to_string(),
+    ];
     auth
 }
 
@@ -6030,6 +6033,35 @@ fn assert_mcp_oauth_scope_rejected(
             body
         );
         assert!(challenge.contains(scope), "challenge: {}", challenge);
+    }
+}
+
+#[tokio::test]
+async fn pat_mcp_tools_list_requires_runtime_read_without_oauth_framing() {
+    let runtime = test_runtime();
+    let mut auth = mcp_export_api_auth("pat-project-read-only", "alice");
+    auth.scopes = vec![crate::auth::SCOPE_PROJECT_READ.to_string()];
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc("tools/list", Some(json!(41)), json!({})),
+        Some(&auth),
+    )
+    .await;
+
+    match outcome {
+        McpOutcome::Forbidden {
+            body,
+            required_scope,
+        } => {
+            assert_eq!(required_scope, Some(crate::auth::SCOPE_RUNTIME_READ));
+            assert_eq!(body["status"], StatusCode::FORBIDDEN.as_u16());
+            assert_ne!(body["error"], "insufficient_scope");
+            assert!(body["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains(crate::auth::SCOPE_RUNTIME_READ));
+        }
+        other => panic!("PAT without runtime:read must fail closed, got {other:?}"),
     }
 }
 

--- a/src/runtime_http.rs
+++ b/src/runtime_http.rs
@@ -260,9 +260,9 @@ pub async fn tools_call(req: &mut Request, depot: &mut Depot, res: &mut Response
         }) => {
             guard.dispatch_failed("insufficient_scope");
             guard.dispatch_finished(false, Some(false), "insufficient_scope");
-            // oauth insufficient-scope body is rendered by helper; size not measured.
+            // Scope-denial body is rendered by the credential-aware helper; size not measured.
             guard.response_serialized(403, None, Some(false), Some(false), "insufficient_scope");
-            crate::auth::render_oauth_insufficient_scope(res, required_scope, description);
+            crate::auth::render_scope_forbidden(res, auth.as_ref(), required_scope, description);
             guard.handler_returned(403, None, Some(false), Some(false), "insufficient_scope");
         }
         Some(ToolCallErrorStatus::InvalidArguments { message }) => {

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -227,20 +227,18 @@ fn resolve_project_source(
 }
 
 fn registration_scope_denied(auth: Option<&AuthContext>, operation: &str) -> Option<ToolResult> {
-    auth.is_some_and(|auth| {
-        auth.is_oauth_token() && !auth.has_scope(crate::auth::SCOPE_PROJECT_WRITE)
-    })
-    .then(|| {
-        ToolResult::err_with_output(
-            format!("{operation} requires project:write"),
-            json!({
-                "error_kind": "insufficient_scope",
-                "failure_kind": "insufficient_scope",
-                "required_scope": crate::auth::SCOPE_PROJECT_WRITE,
-                "state_changed": false,
-            }),
-        )
-    })
+    auth.is_some_and(|auth| !auth.has_scope(crate::auth::SCOPE_PROJECT_WRITE))
+        .then(|| {
+            ToolResult::err_with_output(
+                format!("{operation} requires project:write"),
+                json!({
+                    "error_kind": "insufficient_scope",
+                    "failure_kind": "insufficient_scope",
+                    "required_scope": crate::auth::SCOPE_PROJECT_WRITE,
+                    "state_changed": false,
+                }),
+            )
+        })
 }
 
 fn attach_permission(
@@ -741,9 +739,8 @@ impl ToolRuntime {
             append_workspace_warnings(&workspace_payload_from_git_summary(&git), &mut warnings);
         }
         let binding_available = bind_current && continuity_key.is_some();
-        let write_scope_verified = auth.is_none_or(|auth| {
-            !auth.is_oauth_token() || auth.has_scope(crate::auth::SCOPE_PROJECT_WRITE)
-        });
+        let write_scope_verified =
+            auth.is_none_or(|auth| auth.has_scope(crate::auth::SCOPE_PROJECT_WRITE));
         let session_outcome = match self.sessions.ensure_coding_session(
             sessions::CodingSessionRequest {
                 key: continuity_key.clone(),

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -44,9 +44,9 @@ pub(crate) struct ToolCallContext<'a> {
     pub(crate) session_id: Option<&'a str>,
     pub(crate) auth: Option<&'a AuthContext>,
     pub(crate) window: Option<&'a crate::client_window::ClientWindow>,
-    /// REST already recorded OAuth scope denials with session metadata before
-    /// this facade existed. MCP rejected scope denials before `_session_id`
-    /// became recorder metadata. Keep both adapter-visible behaviors stable.
+    /// REST records scope denials with session metadata. MCP rejects scope
+    /// denials before `_session_id` becomes recorder metadata. Keep both
+    /// adapter-visible behaviors stable.
     pub(crate) record_oauth_scope_denials: bool,
     /// Server-derived provenance for ChatGPT host file references. Raw tool
     /// arguments cannot set this value.
@@ -78,16 +78,13 @@ pub(crate) struct ToolCallOutcome {
     pub(crate) project: Option<String>,
 }
 
-pub(crate) fn check_oauth_runtime_tool_scope(
+pub(crate) fn check_runtime_tool_scope(
     auth: Option<&AuthContext>,
     tool_name: &str,
 ) -> Result<(), ToolCallErrorStatus> {
     let Some(auth) = auth else {
         return Ok(());
     };
-    if !auth.is_oauth_token() {
-        return Ok(());
-    }
 
     match crate::auth::scopes::oauth_scope_policy_for_runtime_tool(tool_name) {
         OAuthToolScopePolicy::Require(scope) => {
@@ -100,14 +97,30 @@ pub(crate) fn check_oauth_runtime_tool_scope(
                 })
             }
         }
-        OAuthToolScopePolicy::FirstPartyOnly => Err(ToolCallErrorStatus::InsufficientScope {
-            required_scope: None,
-            description: "OAuth2 access tokens cannot call first-party-only tools".to_string(),
-        }),
-        OAuthToolScopePolicy::Unknown => Err(ToolCallErrorStatus::InsufficientScope {
-            required_scope: None,
-            description: "OAuth2 access tokens cannot call unknown runtime tools".to_string(),
-        }),
+        OAuthToolScopePolicy::FirstPartyOnly => {
+            if matches!(
+                auth.kind,
+                crate::auth::AuthKind::Bootstrap | crate::auth::AuthKind::ApiToken
+            ) {
+                Ok(())
+            } else {
+                Err(ToolCallErrorStatus::InsufficientScope {
+                    required_scope: None,
+                    description: "tool requires a first-party bootstrap or personal API token"
+                        .to_string(),
+                })
+            }
+        }
+        OAuthToolScopePolicy::Unknown => {
+            if auth.is_bootstrap() {
+                Ok(())
+            } else {
+                Err(ToolCallErrorStatus::InsufficientScope {
+                    required_scope: None,
+                    description: "runtime tool has no declared scope policy".to_string(),
+                })
+            }
+        }
     }
 }
 
@@ -332,9 +345,7 @@ impl ToolRuntime {
         }
 
         if !context.record_oauth_scope_denials {
-            if let Err(error_status) =
-                check_oauth_runtime_tool_scope(context.auth, &request.tool_name)
-            {
+            if let Err(error_status) = check_runtime_tool_scope(context.auth, &request.tool_name) {
                 return ToolCallOutcome {
                     success: false,
                     result: None,
@@ -356,9 +367,7 @@ impl ToolRuntime {
         );
 
         if context.record_oauth_scope_denials {
-            if let Err(error_status) =
-                check_oauth_runtime_tool_scope(context.auth, &request.tool_name)
-            {
+            if let Err(error_status) = check_runtime_tool_scope(context.auth, &request.tool_name) {
                 let error_message = match &error_status {
                     ToolCallErrorStatus::InsufficientScope { description, .. } => {
                         description.as_str()
@@ -648,10 +657,10 @@ mod tests {
     }
 
     #[test]
-    fn computer_tools_require_independent_oauth_scope() {
+    fn computer_tools_require_independent_scope() {
         let denied = oauth(&["runtime:read", "project:read"]);
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&denied), "computer_snapshot"),
+            check_runtime_tool_scope(Some(&denied), "computer_snapshot"),
             Err(ToolCallErrorStatus::InsufficientScope {
                 required_scope: Some(crate::auth::SCOPE_COMPUTER_READ),
                 description: "missing required scope: computer:read".to_string(),
@@ -659,15 +668,15 @@ mod tests {
         );
         let allowed = oauth(&["computer:read"]);
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&allowed), "computer_list_windows"),
+            check_runtime_tool_scope(Some(&allowed), "computer_list_windows"),
             Ok(())
         );
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&allowed), "computer_list_targets"),
+            check_runtime_tool_scope(Some(&allowed), "computer_list_targets"),
             Ok(())
         );
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&allowed), "list_agents"),
+            check_runtime_tool_scope(Some(&allowed), "list_agents"),
             Err(ToolCallErrorStatus::InsufficientScope {
                 required_scope: Some(crate::auth::SCOPE_RUNTIME_READ),
                 description: "missing required scope: runtime:read".to_string(),
@@ -676,17 +685,17 @@ mod tests {
     }
 
     #[test]
-    fn computer_control_requires_its_own_oauth_scope() {
+    fn computer_control_requires_its_own_scope() {
         let observe_only = oauth(&["computer:read"]);
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&observe_only), "computer_control"),
+            check_runtime_tool_scope(Some(&observe_only), "computer_control"),
             Err(ToolCallErrorStatus::InsufficientScope {
                 required_scope: Some(crate::auth::SCOPE_COMPUTER_CONTROL),
                 description: "missing required scope: computer:control".to_string(),
             })
         );
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&observe_only), "computer_input_text"),
+            check_runtime_tool_scope(Some(&observe_only), "computer_input_text"),
             Err(ToolCallErrorStatus::InsufficientScope {
                 required_scope: Some(crate::auth::SCOPE_COMPUTER_CONTROL),
                 description: "missing required scope: computer:control".to_string(),
@@ -694,17 +703,44 @@ mod tests {
         );
         let control = oauth(&["computer:control"]);
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&control), "computer_control"),
+            check_runtime_tool_scope(Some(&control), "computer_control"),
             Ok(())
         );
         assert_eq!(
-            check_oauth_runtime_tool_scope(Some(&control), "computer_input_text"),
+            check_runtime_tool_scope(Some(&control), "computer_input_text"),
             Ok(())
         );
     }
 
+    #[test]
+    fn tool_scope_enforcement_applies_to_pat_and_direct_shared_key() {
+        let mut pat = AuthContext::new(crate::auth::AuthKind::ApiToken);
+        pat.scopes = vec![crate::auth::SCOPE_RUNTIME_READ.to_string()];
+        assert_eq!(
+            check_runtime_tool_scope(Some(&pat), "read_file"),
+            Err(ToolCallErrorStatus::InsufficientScope {
+                required_scope: Some(crate::auth::SCOPE_PROJECT_READ),
+                description: "missing required scope: project:read".to_string(),
+            })
+        );
+        assert_eq!(
+            check_runtime_tool_scope(Some(&pat), "runtime_status"),
+            Ok(())
+        );
+
+        let shared = crate::auth::shared_key_context("kernel-scope-matrix");
+        assert_eq!(check_runtime_tool_scope(Some(&shared), "read_file"), Ok(()));
+        assert_eq!(
+            check_runtime_tool_scope(Some(&shared), "computer_snapshot"),
+            Err(ToolCallErrorStatus::InsufficientScope {
+                required_scope: Some(crate::auth::SCOPE_COMPUTER_READ),
+                description: "missing required scope: computer:read".to_string(),
+            })
+        );
+    }
+
     #[tokio::test]
-    async fn tool_kernel_rejects_missing_oauth_scope() {
+    async fn tool_kernel_rejects_missing_scope() {
         let runtime = test_runtime();
         let auth = oauth(&["runtime:read"]);
         let outcome = runtime

--- a/src/tool_runtime/tests/schema.rs
+++ b/src/tool_runtime/tests/schema.rs
@@ -1,5 +1,34 @@
 //! Schema tests for tool_runtime.
 
+macro_rules! assert_schema_fields {
+    (
+        $properties:expr,
+        $context:expr,
+        present: [$($present:expr),* $(,)?]
+        $(, absent: [$($absent:expr),* $(,)?])?
+        $(,)?
+    ) => {{
+        let properties = $properties;
+        let context = $context;
+        $(
+            assert!(
+                properties.contains_key($present),
+                "{context}: missing schema field {}",
+                $present
+            );
+        )*
+        $(
+            $(
+                assert!(
+                    !properties.contains_key($absent),
+                    "{context}: unexpected schema field {}",
+                    $absent
+                );
+            )*
+        )?
+    }};
+}
+
 mod annotations;
 mod artifacts;
 mod consistency;

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -5,35 +5,33 @@ fn list_tools_schema_exposes_bounded_discovery_fields() {
     let specs = registered_tool_specs();
     let spec = spec_named(&specs, "list_tools");
     let props = spec.input_schema["properties"].as_object().unwrap();
-    for field in ["category", "features", "summary_only", "limit"] {
-        assert!(
-            props.contains_key(field),
-            "list_tools input schema must expose {field}"
-        );
-    }
+    assert_schema_fields!(
+        props,
+        "list_tools input schema",
+        present: ["category", "features", "summary_only", "limit"]
+    );
     assert!(spec.input_schema["required"].as_array().unwrap().is_empty());
     let output = spec.output_schema["properties"]["output"]["properties"]
         .as_object()
         .unwrap();
-    for field in [
-        "category",
-        "features",
-        "limit",
-        "returned_count",
-        "total_count",
-        "filtered_count",
-        "limit_applied",
-        "requested_limit",
-        "truncation_reason",
-        "truncated",
-        "categories",
-        "recommended_flows",
-    ] {
-        assert!(
-            output.contains_key(field),
-            "list_tools output schema must expose {field}"
-        );
-    }
+    assert_schema_fields!(
+        output,
+        "list_tools output schema",
+        present: [
+            "category",
+            "features",
+            "limit",
+            "returned_count",
+            "total_count",
+            "filtered_count",
+            "limit_applied",
+            "requested_limit",
+            "truncation_reason",
+            "truncated",
+            "categories",
+            "recommended_flows",
+        ]
+    );
 }
 
 #[test]
@@ -41,47 +39,45 @@ fn tool_manifest_schema_exposes_compact_discovery_fields() {
     let specs = registered_tool_specs();
     let spec = spec_named(&specs, "tool_manifest");
     let props = spec.input_schema["properties"].as_object().unwrap();
-    for field in [
-        "category",
-        "intent",
-        "include_recommended_flows",
-        "include_risk_summary",
-    ] {
-        assert!(
-            props.contains_key(field),
-            "tool_manifest input schema must expose {field}"
-        );
-    }
+    assert_schema_fields!(
+        props,
+        "tool_manifest input schema",
+        present: [
+            "category",
+            "intent",
+            "include_recommended_flows",
+            "include_risk_summary",
+        ]
+    );
     let output = spec.output_schema["properties"]["output"]["properties"]
         .as_object()
         .unwrap();
-    for field in [
-        "schema_version",
-        "count",
-        "tool_count",
-        "filtered_count",
-        "category",
-        "intent",
-        "available_intents",
-        "filtered",
-        "categories_requested",
-        "limit",
-        "returned_count",
-        "total_count",
-        "limit_applied",
-        "requested_limit",
-        "truncation_reason",
-        "truncated",
-        "categories",
-        "tools",
-        "risk_summary",
-        "recommended_flows",
-    ] {
-        assert!(
-            output.contains_key(field),
-            "tool_manifest output schema must expose {field}"
-        );
-    }
+    assert_schema_fields!(
+        output,
+        "tool_manifest output schema",
+        present: [
+            "schema_version",
+            "count",
+            "tool_count",
+            "filtered_count",
+            "category",
+            "intent",
+            "available_intents",
+            "filtered",
+            "categories_requested",
+            "limit",
+            "returned_count",
+            "total_count",
+            "limit_applied",
+            "requested_limit",
+            "truncation_reason",
+            "truncated",
+            "categories",
+            "tools",
+            "risk_summary",
+            "recommended_flows",
+        ]
+    );
 }
 
 #[test]

--- a/src/tool_runtime/tests/schema/specs.rs
+++ b/src/tool_runtime/tests/schema/specs.rs
@@ -123,14 +123,11 @@ fn search_project_text_schema_declares_bounded_advanced_inputs() {
         .expect("search_project_text spec");
     let properties = search.input_schema["properties"].as_object().unwrap();
 
-    for field in [
-        "include_globs",
-        "exclude_globs",
-        "result_mode",
-        "timeout_secs",
-    ] {
-        assert!(properties.contains_key(field), "missing {field}");
-    }
+    assert_schema_fields!(
+        properties,
+        "search_project_text input schema",
+        present: ["include_globs", "exclude_globs", "result_mode", "timeout_secs"]
+    );
     for field in ["include_globs", "exclude_globs"] {
         assert_eq!(properties[field]["type"], "array");
         assert_eq!(properties[field]["maxItems"], 32);
@@ -221,24 +218,21 @@ fn run_process_schema_is_small_bounded_and_has_no_shell_or_environment_input() {
         spec.input_schema["required"],
         json!(["project", "executable"])
     );
-    for field in [
-        "project",
-        "executable",
-        "args",
-        "cwd",
-        "stdin",
-        "timeout_secs",
-        "purpose",
-        "session_id",
-    ] {
-        assert!(properties.contains_key(field), "missing {field}");
-    }
-    for forbidden in ["shell", "env", "environment"] {
-        assert!(
-            !properties.contains_key(forbidden),
-            "run_process must not expose {forbidden}"
-        );
-    }
+    assert_schema_fields!(
+        properties,
+        "run_process input schema",
+        present: [
+            "project",
+            "executable",
+            "args",
+            "cwd",
+            "stdin",
+            "timeout_secs",
+            "purpose",
+            "session_id",
+        ],
+        absent: ["shell", "env", "environment"]
+    );
     assert_eq!(properties["executable"]["minLength"], 1);
     assert_eq!(properties["executable"]["maxLength"], 1024);
     assert_eq!(properties["args"]["type"], "array");
@@ -272,38 +266,35 @@ fn run_script_schema_is_typed_bounded_and_hides_execution_infrastructure() {
         spec.input_schema["required"],
         json!(["project", "language", "script"])
     );
-    for field in [
-        "project",
-        "language",
-        "script",
-        "args",
-        "stdin",
-        "cwd",
-        "timeout_secs",
-        "purpose",
-        "session_id",
-    ] {
-        assert!(properties.contains_key(field), "missing {field}");
-    }
-    for forbidden in [
-        "command",
-        "executable",
-        "interpreter",
-        "interpreter_path",
-        "interpreter_args",
-        "shell",
-        "env",
-        "environment",
-        "temp_file",
-        "profile",
-        "pty",
-        "allow_cross_project_session",
-    ] {
-        assert!(
-            !properties.contains_key(forbidden),
-            "run_script must not expose {forbidden}"
-        );
-    }
+    assert_schema_fields!(
+        properties,
+        "run_script input schema",
+        present: [
+            "project",
+            "language",
+            "script",
+            "args",
+            "stdin",
+            "cwd",
+            "timeout_secs",
+            "purpose",
+            "session_id",
+        ],
+        absent: [
+            "command",
+            "executable",
+            "interpreter",
+            "interpreter_path",
+            "interpreter_args",
+            "shell",
+            "env",
+            "environment",
+            "temp_file",
+            "profile",
+            "pty",
+            "allow_cross_project_session",
+        ]
+    );
     assert_eq!(
         properties["language"]["enum"],
         json!(["sh", "bash", "powershell"])

--- a/src/tool_runtime/tests/schema/spot_checks.rs
+++ b/src/tool_runtime/tests/schema/spot_checks.rs
@@ -7,15 +7,19 @@ fn tool_specs_git_log_schema() {
     let required = required_fields(spec);
     assert_eq!(required, vec!["project".to_string()]);
     let props = spec.input_schema["properties"].as_object().unwrap();
-    for field in ["project", "limit", "skip", "session_id"] {
-        assert!(props.contains_key(field), "missing {}", field);
-    }
+    assert_schema_fields!(
+        props,
+        "git_log input schema",
+        present: ["project", "limit", "skip", "session_id"]
+    );
     let output_props = spec.output_schema["properties"]["output"]["properties"]
         .as_object()
         .unwrap();
-    for field in ["project", "limit", "skip", "count", "truncated", "commits"] {
-        assert!(output_props.contains_key(field), "missing {}", field);
-    }
+    assert_schema_fields!(
+        output_props,
+        "git_log output schema",
+        present: ["project", "limit", "skip", "count", "truncated", "commits"]
+    );
     assert!(spec.description.chars().count() <= 300);
 }
 
@@ -26,35 +30,39 @@ fn tool_specs_show_changes_schema() {
     let required = required_fields(spec);
     assert_eq!(required, vec!["project".to_string()]);
     let props = spec.input_schema["properties"].as_object().unwrap();
-    for field in [
-        "project",
-        "session_id",
-        "include_diff",
-        "max_hunks",
-        "max_hunk_lines",
-        "session_event_limit",
-    ] {
-        assert!(props.contains_key(field), "missing {}", field);
-    }
+    assert_schema_fields!(
+        props,
+        "show_changes input schema",
+        present: [
+            "project",
+            "session_id",
+            "include_diff",
+            "max_hunks",
+            "max_hunk_lines",
+            "session_event_limit",
+        ]
+    );
     let output_props = spec.output_schema["properties"]["output"]["properties"]
         .as_object()
         .unwrap();
-    for field in [
-        "project",
-        "branch",
-        "head",
-        "clean",
-        "counts",
-        "files",
-        "diff_stat",
-        "untracked_previews",
-        "untracked_previews_truncated",
-        "warnings",
-        "suggested_next_actions",
-        "session",
-    ] {
-        assert!(output_props.contains_key(field), "missing {}", field);
-    }
+    assert_schema_fields!(
+        output_props,
+        "show_changes output schema",
+        present: [
+            "project",
+            "branch",
+            "head",
+            "clean",
+            "counts",
+            "files",
+            "diff_stat",
+            "untracked_previews",
+            "untracked_previews_truncated",
+            "warnings",
+            "suggested_next_actions",
+            "session",
+        ]
+    );
     assert!(spec.description.chars().count() <= 300);
 }
 
@@ -69,48 +77,33 @@ fn tool_specs_structured_validation_schema_and_output() {
             .as_object()
             .unwrap()
             .contains_key("cwd"));
-        for field in [
-            "exit_code",
-            "duration_ms",
-            "stdout_tail",
-            "stderr_tail",
-            "passed",
-        ] {
-            assert!(
-                spec.output_schema["properties"]["output"]["properties"]
-                    .as_object()
-                    .unwrap()
-                    .contains_key(field),
-                "{} missing output field {}",
-                name,
-                field
-            );
-        }
+        let output_props = spec.output_schema["properties"]["output"]["properties"]
+            .as_object()
+            .unwrap();
+        assert_schema_fields!(
+            output_props,
+            format!("{name} output schema"),
+            present: ["exit_code", "duration_ms", "stdout_tail", "stderr_tail", "passed"]
+        );
     }
     let go_props = spec_named(&specs, "go_test").input_schema["properties"]
         .as_object()
         .unwrap();
-    for field in ["project", "cwd", "timeout_secs", "session_id"] {
-        assert!(
-            go_props.contains_key(field),
-            "go_test missing input {field}"
-        );
-    }
-    for field in [
-        "filter",
-        "package",
-        "features",
-        "all_targets",
-        "all_features",
-        "no_default_features",
-        "no_run",
-        "env",
-    ] {
-        assert!(
-            !go_props.contains_key(field),
-            "go_test must not expose {field}"
-        );
-    }
+    assert_schema_fields!(
+        go_props,
+        "go_test input schema",
+        present: ["project", "cwd", "timeout_secs", "session_id"],
+        absent: [
+            "filter",
+            "package",
+            "features",
+            "all_targets",
+            "all_features",
+            "no_default_features",
+            "no_run",
+            "env",
+        ]
+    );
 }
 
 #[test]

--- a/src/tool_runtime/tool_definition.rs
+++ b/src/tool_runtime/tool_definition.rs
@@ -305,55 +305,29 @@ const fn def(
     }
 }
 
-const fn captures_validation_output(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            captures_validation_output: true,
-            ..definition.policy
-        },
-        ..definition
-    }
+macro_rules! bool_policy_modifier {
+    ($function:ident, $field:ident) => {
+        const fn $function(definition: ToolDefinition) -> ToolDefinition {
+            ToolDefinition {
+                policy: ToolDefinitionPolicy {
+                    $field: true,
+                    ..definition.policy
+                },
+                ..definition
+            }
+        }
+    };
 }
 
-const fn change_summary_like(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            change_summary_like: true,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
+bool_policy_modifier!(captures_validation_output, captures_validation_output);
 
-const fn current_session_control(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            current_session_control: true,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
+bool_policy_modifier!(change_summary_like, change_summary_like);
 
-const fn git_like(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            git_like: true,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
+bool_policy_modifier!(current_session_control, current_session_control);
 
-const fn creates_or_binds_session(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            creates_or_binds_session: true,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
+bool_policy_modifier!(git_like, git_like);
+
+bool_policy_modifier!(creates_or_binds_session, creates_or_binds_session);
 
 const fn extra_accepted_flattened_args(
     definition: ToolDefinition,
@@ -381,35 +355,17 @@ const fn permission_risk(
     }
 }
 
-const fn requires_artifact_upload_path_binding(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            requires_artifact_upload_path_binding: true,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
+bool_policy_modifier!(
+    requires_artifact_upload_path_binding,
+    requires_artifact_upload_path_binding
+);
 
-const fn unit_arguments(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            unit_arguments: true,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
+bool_policy_modifier!(unit_arguments, unit_arguments);
 
-const fn requires_explicit_business_session(definition: ToolDefinition) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            requires_explicit_business_session: true,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
+bool_policy_modifier!(
+    requires_explicit_business_session,
+    requires_explicit_business_session
+);
 
 use ToolPathHint::None as NoPath;
 use ToolRisk::ReadOnly;


### PR DESCRIPTION
## Summary

- reduce ToolDefinition/test policy boilerplate without changing authoritative tool metadata semantics
- unify runtime/project/job/Computer scope enforcement across PATs, OAuth access tokens, direct shared keys, and open principals through `AuthContext::has_scope()`
- keep credential-specific authorization surfaces separate for Agent/Runner tokens, Project Credentials, Account Credentials, and trusted OAuth-client provenance
- preserve first-party PAT account self-service only on an explicit handler-guarded route allowlist; global audit APIs still require `account:manage`
- preserve credential-aware denial framing: OAuth uses `insufficient_scope` plus `WWW-Authenticate`, while non-OAuth bearer principals receive ordinary 403 responses
- remove implicit Computer access from direct shared keys and fail closed on undeclared authenticated routes/tools

## Validation

- final amended HEAD: focused route/PAT/OAuth/Tool-kernel/MCP authorization regressions passed
- independent review on `5028668c`: 9 focused authorization test cases passed, 0 failed
- `cargo fmt -- --check` passed during final implementation validation
- `git diff --check main...HEAD` passed

The unrelated untracked `docs/agent/testing-metadata-schema-scoping.md` file is not part of this PR.