### PR TITLE
fix(shell): raise bounded raw command limit

### DIFF
--- a/crates/webcodex-core/src/shell_protocol.rs
+++ b/crates/webcodex-core/src/shell_protocol.rs
@@ -45,6 +45,37 @@ fn default_transport_polling() -> String {
 
 /// Protocol version announced by current `webcodex-runner` polling builds.
 pub const AGENT_PROTOCOL_VERSION_POLLING_V1: &str = "polling-v1";
+/// Model/user-authored raw shell command ceiling. Raw shell remains a bounded
+/// escape hatch; larger program text belongs in `run_script`, while large
+/// literal data belongs in stdin/files/artifacts.
+pub const RAW_SHELL_COMMAND_MAX_BYTES: usize = 16_000;
+
+/// Internal Control -> Runner raw-shell command envelope. This is deliberately
+/// larger than the authored-command ceiling because an explicit `sh`/`bash`
+/// request is transported through the existing POSIX single-quote wrapper.
+/// In the worst case every authored byte is a single quote, expanding a
+/// 16,000-byte command to about 64 KiB. This transport bound is not a model
+/// input allowance.
+pub const RAW_SHELL_WIRE_MAX_BYTES: usize = 64 * 1024;
+
+/// Validate the internal raw-shell request envelope accepted by Control and
+/// revalidated by the Runner. Model-facing authored commands use the smaller
+/// `RAW_SHELL_COMMAND_MAX_BYTES` bound before any explicit-shell wrapper is
+/// constructed.
+pub fn validate_raw_shell_wire_command(command: &str) -> Result<(), String> {
+    if command.trim().is_empty() {
+        return Err("command cannot be empty".to_string());
+    }
+    if command.len() > RAW_SHELL_WIRE_MAX_BYTES {
+        return Err(format!(
+            "command is too long for the Runner wire envelope; maximum is {RAW_SHELL_WIRE_MAX_BYTES} bytes"
+        ));
+    }
+    if command.contains('\0') {
+        return Err("command cannot contain NUL bytes".to_string());
+    }
+    Ok(())
+}
 pub const VALIDATION_STEP_SPAWN_FAILED_CODE: &str = "validation_step_spawn_failed";
 pub const VALIDATION_TOOL_UNAVAILABLE_CODE: &str = "validation_tool_unavailable";
 /// The step ran, but the executor lost the ability to reap it — `waitpid`

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2743,6 +2743,9 @@ fn validate_runner_job_context(
     }) {
         return Err("job recovery context shell is invalid".to_string());
     }
+    if request.kind == "start_job" {
+        shell_protocol::validate_raw_shell_wire_command(&request.command)?;
+    }
     let validation_context = request.kind == "start_validation_job";
     if (validation_context && !(1..=3).contains(&context.validation_steps.len()))
         || (!validation_context && !context.validation_steps.is_empty())

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -7409,6 +7409,77 @@ fn dispatch_request_run_shell_sends_result_over_sink() {
 }
 
 #[test]
+fn dispatch_request_run_shell_rejects_oversized_wire_command_before_start() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = test_config(tmp.path().join("config/projects.d"));
+    let jobs = JobManager::new(max_concurrent_jobs(&cfg));
+    let pdir = projects_dir(&cfg).unwrap();
+    let hot = runtime_config(&cfg);
+    let persistent_shells = webcodex_runner::PersistentShellManager::new(
+        &cfg.shell,
+        webcodex_runner::SshConnectionPool::default(),
+    );
+    let (sink, mut rx) = ws_sink("ws-client");
+    let request = ShellAgentShellRequest {
+        request_id: "req-oversized-shell".to_string(),
+        client_id: "ws-client".to_string(),
+        kind: "run_shell".to_string(),
+        job_id: None,
+        cwd: Some(tmp.path().to_string_lossy().to_string()),
+        path: None,
+        content: None,
+        max_bytes: None,
+        expected_sha256: None,
+        expected_prefix: None,
+        start_line: None,
+        end_line: None,
+        create_dirs: false,
+        command: "x".repeat(shell_protocol::RAW_SHELL_WIRE_MAX_BYTES + 1),
+        process: None,
+        script: None,
+        stdin: None,
+        timeout_secs: 10,
+        requested_by: "tester".to_string(),
+        created_at: 0,
+        validation: None,
+        lsp: None,
+        sandbox: None,
+        job_context: None,
+        persistent_shell: None,
+    };
+
+    assert!(dispatch_request(
+        &sink,
+        &hot.snapshot(),
+        &hot,
+        &jobs,
+        &persistent_shells,
+        &pdir,
+        &webcodex_runner::LspSupervisor::default(),
+        request,
+    )
+    .unwrap());
+    let env = rx.try_recv().expect("rejection envelope was sent");
+    match env {
+        AgentEnvelope::Result { payload } => {
+            assert_eq!(payload.result.request_id, "req-oversized-shell");
+            assert_eq!(payload.result.exit_code, None);
+            assert_eq!(
+                payload.command_execution_state,
+                Some(ShellCommandExecutionState::NotStarted)
+            );
+            assert!(payload
+                .result
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("invalid_raw_shell_request"));
+        }
+        other => panic!("expected result, got {:?}", other.kind()),
+    }
+}
+
+#[test]
 fn dispatch_request_structured_process_uses_typed_argv_and_never_shell_fallback() {
     let tmp = tempfile::tempdir().unwrap();
     let helper = tmp.path().join(format!(

--- a/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
@@ -12,9 +12,9 @@ use super::{
     ShellCommandResult, SubmitResultError,
 };
 use crate::shell_protocol::{
-    validate_process_argv, validate_script_request, ShellAgentShellRequest, ShellProcessArgv,
-    ShellScriptPayload, PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES,
-    STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS,
+    validate_process_argv, validate_raw_shell_wire_command, validate_script_request,
+    ShellAgentShellRequest, ShellProcessArgv, ShellScriptPayload, PROCESS_CWD_MAX_BYTES,
+    PROCESS_STDIN_MAX_BYTES, STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS,
 };
 use crate::{handle_file_request, is_file_request_kind, JobManager, PendingJobStart};
 use std::path::Path;
@@ -200,6 +200,23 @@ pub(crate) fn dispatch_request(
         }
         return submitted.map(|_| true);
     }
+    if request.kind == "run_shell" {
+        if let Err(error) = validate_raw_shell_wire_command(&request.command) {
+            let result = ShellCommandResult::not_started(CommandResult {
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: Some(0),
+                error: Some(format!(
+                    "invalid_raw_shell_request: {error}; command was not started"
+                )),
+            });
+            return sink
+                .submit_shell_result_with_metadata(request.request_id, result, config, runtime)
+                .map(|_| true);
+        }
+    }
+
     // Inspect requests must stay on the native execution path where Landlock
     // is applied in pre_exec. External providers are not an equivalent local
     // filesystem write boundary.

--- a/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
@@ -9,6 +9,7 @@ use super::shell::{base_shell_env, cwd_allowed, shell_quote};
 use super::ssh::SshConnectionPool;
 use crate::shell_protocol::{
     PersistentShellRequest, PersistentShellResult, ShellAgentShellRequest,
+    RAW_SHELL_COMMAND_MAX_BYTES,
 };
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -22,7 +23,6 @@ const EXECUTOR_AGENT: &str = "agent";
 #[cfg(unix)]
 const EXECUTOR_SSH: &str = "ssh";
 const TERMINAL_RECORDS: usize = 128;
-const MAX_COMMAND_BYTES: usize = 8_000;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PersistentShellManager {
@@ -311,12 +311,12 @@ impl PersistentShellManager {
                 )
             }
         };
-        if command.len() > MAX_COMMAND_BYTES {
+        if command.len() > RAW_SHELL_COMMAND_MAX_BYTES {
             return summary_error_result_from_status(
                 &self.processes,
                 operation,
                 "persistent_shell_invalid_command",
-                format!("command exceeds the {MAX_COMMAND_BYTES}-byte Runner limit"),
+                format!("command exceeds the {RAW_SHELL_COMMAND_MAX_BYTES}-byte Runner limit"),
             );
         }
         let timeout_secs = operation.timeout_secs.unwrap_or(30);
@@ -485,11 +485,11 @@ impl PersistentShellManager {
                 )
             }
         };
-        if command.len() > MAX_COMMAND_BYTES {
+        if command.len() > RAW_SHELL_COMMAND_MAX_BYTES {
             return summary_error_result(
                 summary,
                 "persistent_shell_invalid_command",
-                format!("command exceeds the {MAX_COMMAND_BYTES}-byte Runner limit"),
+                format!("command exceeds the {RAW_SHELL_COMMAND_MAX_BYTES}-byte Runner limit"),
             );
         }
         let timeout_secs = operation.timeout_secs.unwrap_or(30);
@@ -1247,7 +1247,7 @@ mod tests {
             &request(
                 "exec",
                 "wc_shell_rejected_exec",
-                Some(&"x".repeat(MAX_COMMAND_BYTES + 1)),
+                Some(&"x".repeat(RAW_SHELL_COMMAND_MAX_BYTES + 1)),
             ),
         );
         assert_eq!(

--- a/crates/webcodex-runner/src/webcodex_runner/shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell.rs
@@ -2887,11 +2887,15 @@ mod runner_lifecycle_tests {
     }
 
     #[test]
-    fn structured_process_can_exceed_legacy_shell_command_limit() {
+    fn structured_process_preserves_large_literal_argv_without_shell_parsing() {
         let cwd = tempfile::tempdir().unwrap();
         let helper = process_argv_helper();
         let args = vec!["argv".to_string(), "a".repeat(4_500), "b".repeat(4_500)];
         assert!(args.iter().map(String::len).sum::<usize>() > 8_000);
+        assert!(
+            args.iter().map(String::len).sum::<usize>()
+                < crate::shell_protocol::PROCESS_ARGV_MAX_BYTES
+        );
 
         let result = run_direct_process(cwd.path(), &helper, &args, None, 10);
 

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -156,6 +156,18 @@ channel. The Runner may reuse the authenticated transport for the same
 Session/resource pair, but it does not preserve `cd`, exports, aliases,
 functions, umask, or shell-process state between commands.
 
+Raw shell text has one shared model-authored ceiling of 16,000 UTF-8 bytes for
+`run_shell`, raw `run_job`, and `session_shell_exec`. Larger shell program text
+belongs in `run_script`; large literal data belongs in stdin, files, or
+artifacts. Control may internally expand an explicit `sh`/`bash` command while
+POSIX-quoting it for the existing Runner wire, so the internal raw-shell wire
+envelope is separately capped at 64 KiB and revalidated by the Runner. That
+transport headroom is not an additional model-facing command allowance.
+A concrete OS/shell launch envelope may still be narrower (notably Windows
+`CreateProcess` after shell-specific wrapping); such a request remains a
+pre-start failure rather than weakening the authored bound or silently changing
+execution semantics. Large or quote-dense program text should use `run_script`.
+
 A missing Session leaves execution unchanged. A mismatched Session fails or,
 on an explicitly authorized cross-project escape path, executes without
 inheriting its context.

--- a/scripts/e2e_zero_config_ws.sh
+++ b/scripts/e2e_zero_config_ws.sh
@@ -1808,7 +1808,7 @@ log "---- patch chain hardening (large + check-failed) ----"
 pre_harden_status="$(api_post /api/projects/git_status "{\"project\":\"$RUNTIME_PROJECT_ID\"}")"
 pre_harden_porcelain="$(json_get "$pre_harden_status" output.stdout)"
 
-# A LARGE patch (well over the 8 KiB shell command limit) that creates a new
+# A LARGE patch (over the 16,000-byte authored raw shell command limit) that creates a new
 # file. It must still validate + apply because the patch travels over stdin,
 # not the command string.
 LARGE_APPLY_PATCH="$(python3 - <<'PY'
@@ -1823,10 +1823,10 @@ PY
 )"
 LARGE_APPLY_PATCH="${LARGE_APPLY_PATCH}"$'\n'
 lap_bytes="$(printf '%s' "$LARGE_APPLY_PATCH" | wc -c | tr -d ' ')"
-if [ "${lap_bytes:-0}" -gt 8000 ] 2>/dev/null; then
-    pass "LARGE_APPLY_PATCH is ${lap_bytes} bytes (> 8000 command limit)"
+if [ "${lap_bytes:-0}" -gt 16000 ] 2>/dev/null; then
+    pass "LARGE_APPLY_PATCH is ${lap_bytes} bytes (> 16000 authored command limit)"
 else
-    fail "LARGE_APPLY_PATCH must exceed the 8000-byte command limit (got ${lap_bytes} bytes)"
+    fail "LARGE_APPLY_PATCH must exceed the 16000-byte authored command limit (got ${lap_bytes} bytes)"
 fi
 lap_body="$(python3 -c 'import json,sys; print(json.dumps({"project": sys.argv[1], "patch": sys.argv[2]}))' "$RUNTIME_PROJECT_ID" "$LARGE_APPLY_PATCH")"
 body="$(api_post /api/projects/apply_patch_checked "$lap_body")"

--- a/src/shell_client/mod.rs
+++ b/src/shell_client/mod.rs
@@ -63,9 +63,7 @@ use state::ShellClientRegistryInner;
 pub(crate) use state::ShellJobVisibility;
 use validation::sha256_hex;
 #[cfg(test)]
-use validation::{
-    validate_file_request, validate_run_request, MAX_COMMAND_LEN, MAX_RUN_STDIN_BYTES,
-};
+use validation::{validate_file_request, validate_run_request, MAX_RUN_STDIN_BYTES};
 
 const MAX_OUTPUT_BYTES: usize = 256 * 1024;
 pub(crate) const CLIENT_ONLINE_WINDOW_SECS: i64 = 60;

--- a/src/shell_client/mod_tests.rs
+++ b/src/shell_client/mod_tests.rs
@@ -3544,12 +3544,30 @@ async fn registry_allows_quic_v1_stop_job_delivery_queueing() {
 }
 
 #[test]
+fn validate_run_request_uses_the_internal_raw_shell_wire_bound() {
+    let exact = ShellRunRequest {
+        client_id: "client-1".to_string(),
+        cwd: None,
+        command: "x".repeat(crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES),
+        stdin: None,
+        timeout_secs: 10,
+        wait_timeout_secs: 1,
+    };
+    validate_run_request(&exact).expect("wire-bound command accepted");
+
+    let mut oversized = exact;
+    oversized.command.push('x');
+    let error = validate_run_request(&oversized).unwrap_err();
+    assert!(error.contains("Runner wire envelope"), "{error}");
+}
+
+#[test]
 fn validate_run_request_allows_bounded_stdin_beyond_command_limit() {
     let body = ShellRunRequest {
         client_id: "client-1".to_string(),
         cwd: None,
         command: "cat >/dev/null".to_string(),
-        stdin: Some("x".repeat(MAX_COMMAND_LEN + 1024)),
+        stdin: Some("x".repeat(crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES + 1024)),
         timeout_secs: 10,
         wait_timeout_secs: 1,
     };

--- a/src/shell_client/requests.rs
+++ b/src/shell_client/requests.rs
@@ -7,14 +7,15 @@ use super::projects::{capability_enabled, ShellClientLookupError};
 use super::state::{PendingShellRequest, ShellClientRegistryInner};
 use super::validation::{
     validate_file_request, validate_id, validate_process_request, validate_run_request,
-    validate_script_enqueue_request, MAX_COMMAND_LEN,
+    validate_script_enqueue_request,
 };
 use super::{now_ts, ShellClientRegistry, CLIENT_ONLINE_WINDOW_SECS};
 use crate::lsp_bridge::{AgentLspPayload, AgentLspRequest, AGENT_LSP_REQUEST_KIND};
 use crate::shell_protocol::{
     shell_computer_request_payload_max_bytes, PersistentShellRequest, PersistentShellResult,
     ShellAgentShellRequest, ShellFileOpRequest, ShellJobContext, ShellProcessArgv, ShellRunRequest,
-    ShellRunResponse, ShellScriptPayload, SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ,
+    ShellRunResponse, ShellScriptPayload, RAW_SHELL_COMMAND_MAX_BYTES,
+    SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ,
     SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE,
     SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL, SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE,
     SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT, SHELL_CLIENT_CAPABILITY_FILE_READ,
@@ -796,10 +797,10 @@ impl ShellClientRegistry {
         if request
             .command
             .as_deref()
-            .is_some_and(|command| command.len() > MAX_COMMAND_LEN)
+            .is_some_and(|command| command.len() > RAW_SHELL_COMMAND_MAX_BYTES)
         {
             return Err(format!(
-                "persistent shell command too long (max {MAX_COMMAND_LEN} bytes)"
+                "persistent shell command too long (max {RAW_SHELL_COMMAND_MAX_BYTES} bytes)"
             ));
         }
         let request_id = next_request_id();

--- a/src/shell_client/validation.rs
+++ b/src/shell_client/validation.rs
@@ -1,7 +1,8 @@
 use crate::shell_protocol::{
-    validate_process_argv, validate_script_request, AgentConfigReloadStatus, ProviderCallSummary,
-    ShellAgentProjectSummary, ShellFileOpRequest, ShellProcessArgv, ShellRunRequest,
-    ShellScriptPayload, ToolProvidersStatus, PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES,
+    validate_process_argv, validate_raw_shell_wire_command, validate_script_request,
+    AgentConfigReloadStatus, ProviderCallSummary, ShellAgentProjectSummary, ShellFileOpRequest,
+    ShellProcessArgv, ShellRunRequest, ShellScriptPayload, ToolProvidersStatus,
+    PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES,
     STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS,
 };
 use sha2::{Digest, Sha256};
@@ -12,7 +13,6 @@ const MAX_CLIENT_FIELD_LEN: usize = 200;
 /// for future formats but bound it so a malicious peer cannot stash huge
 /// strings in the registry.
 const MAX_AGENT_INSTANCE_ID_LEN: usize = 128;
-pub(super) const MAX_COMMAND_LEN: usize = 8_000;
 const MAX_CWD_LEN: usize = 1_024;
 const MAX_FILE_PATH_LEN: usize = 2_048;
 const MAX_FILE_CONTENT_BYTES: usize = 512 * 1024;
@@ -451,19 +451,7 @@ pub(super) fn validate_file_request(body: &ShellFileOpRequest) -> Result<(), Str
 
 pub(super) fn validate_run_request(body: &ShellRunRequest) -> Result<(), String> {
     validate_id(&body.client_id, "client_id")?;
-    let command = body.command.trim();
-    if command.is_empty() {
-        return Err("command cannot be empty".to_string());
-    }
-    if body.command.len() > MAX_COMMAND_LEN {
-        return Err(format!(
-            "command is too long; maximum is {} bytes",
-            MAX_COMMAND_LEN
-        ));
-    }
-    if body.command.contains('\0') {
-        return Err("command cannot contain NUL bytes".to_string());
-    }
+    validate_raw_shell_wire_command(&body.command)?;
     if let Some(stdin) = &body.stdin {
         if stdin.len() > MAX_RUN_STDIN_BYTES {
             return Err(format!(

--- a/src/tool_runtime/helpers.rs
+++ b/src/tool_runtime/helpers.rs
@@ -1,4 +1,6 @@
-use crate::shell_protocol::{ShellScriptLanguage, ShellScriptPayload};
+use crate::shell_protocol::{
+    ShellScriptLanguage, ShellScriptPayload, RAW_SHELL_COMMAND_MAX_BYTES, RAW_SHELL_WIRE_MAX_BYTES,
+};
 use serde_json::json;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -889,6 +891,47 @@ pub(crate) fn validate_project_relative_path(path: &str) -> Result<(), String> {
         return Err("path cannot contain parent traversal".to_string());
     }
     Ok(())
+}
+
+pub(crate) fn validate_raw_shell_command_length(command: &str) -> Result<(), String> {
+    if command.len() > RAW_SHELL_COMMAND_MAX_BYTES {
+        return Err(format!(
+            "raw shell command exceeds the {RAW_SHELL_COMMAND_MAX_BYTES}-byte UTF-8 limit; use run_script for larger program text or stdin/files/artifacts for large data"
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn explicit_shell_dispatch_command(
+    command: &str,
+    shell: &str,
+) -> Result<String, String> {
+    validate_raw_shell_command_length(command)?;
+    let dispatched = format!("exec {shell} -c {}", shell_escape_simple(command));
+    if dispatched.len() > RAW_SHELL_WIRE_MAX_BYTES {
+        return Err(format!(
+            "explicit shell wrapper exceeds the {RAW_SHELL_WIRE_MAX_BYTES}-byte Runner wire limit; use run_script for large or quote-dense shell program text"
+        ));
+    }
+    Ok(dispatched)
+}
+
+#[cfg(test)]
+mod raw_shell_bound_tests {
+    use super::*;
+
+    #[test]
+    fn authored_raw_shell_bound_and_explicit_wrapper_headroom_are_consistent() {
+        let exact = "x".repeat(RAW_SHELL_COMMAND_MAX_BYTES);
+        validate_raw_shell_command_length(&exact).unwrap();
+        assert!(validate_raw_shell_command_length(&(exact + "x")).is_err());
+
+        let quote_dense = "'".repeat(RAW_SHELL_COMMAND_MAX_BYTES);
+        let dispatched = explicit_shell_dispatch_command(&quote_dense, "bash").unwrap();
+        assert!(dispatched.len() > RAW_SHELL_COMMAND_MAX_BYTES);
+        assert!(dispatched.len() <= RAW_SHELL_WIRE_MAX_BYTES);
+        assert!(dispatched.starts_with("exec bash -c "));
+    }
 }
 
 pub(crate) fn shell_escape_simple(s: &str) -> String {

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -2,9 +2,9 @@ use serde_json::{json, Value};
 use std::path::Path;
 
 use super::helpers::{
-    command_rejected_message, is_safe_job_id, normalize_local_status, project_relative_agent_cwd,
-    project_relative_cwd, resolve_agent_cwd, resolve_local_cwd, shell_escape_simple,
-    MAX_LOCAL_LOG_LINES,
+    command_rejected_message, explicit_shell_dispatch_command, is_safe_job_id,
+    normalize_local_status, project_relative_agent_cwd, project_relative_cwd, resolve_agent_cwd,
+    resolve_local_cwd, shell_escape_simple, validate_raw_shell_command_length, MAX_LOCAL_LOG_LINES,
 };
 use super::local_jobs::{
     retain_inspect_job_until_terminal, LocalJobKiller, LocalJobRecord, TerminateOutcome,
@@ -1186,6 +1186,12 @@ impl ToolRuntime {
         shell: Option<ExecutionShell>,
         ssh_resource: Option<&str>,
     ) -> ToolResult {
+        if let Err(error) = validate_raw_shell_command_length(&command) {
+            return ToolResult::err(command_rejected_message(
+                error,
+                "use run_script for larger shell program text or stdin/files/artifacts for large data.",
+            ));
+        }
         let resolved = match self.resolve_project_input_for_auth(&project, auth).await {
             Ok(resolved) => resolved,
             Err(e) => return ToolResult::err(command_rejected_message(
@@ -1263,15 +1269,17 @@ impl ToolRuntime {
             } else {
                 "configured"
             });
-            let dispatched_command = shell
-                .map(|shell| {
-                    format!(
-                        "exec {} -c {}",
-                        shell.as_str(),
-                        shell_escape_simple(&command)
-                    )
-                })
-                .unwrap_or_else(|| command.clone());
+            let dispatched_command =
+                match shell {
+                    Some(shell) => match explicit_shell_dispatch_command(&command, shell.as_str()) {
+                        Ok(command) => command,
+                        Err(error) => return ToolResult::err(command_rejected_message(
+                            error,
+                            "use run_script for large or quote-dense explicit-shell program text.",
+                        )),
+                    },
+                    None => command.clone(),
+                };
             match self
                 .shell_clients
                 .start_job_with_metadata_for_auth(

--- a/src/tool_runtime/registry/input_schemas/jobs.rs
+++ b/src/tool_runtime/registry/input_schemas/jobs.rs
@@ -4,8 +4,8 @@ use super::common::{object_schema, with_optional_session_id};
 use crate::shell_protocol::{
     PROCESS_ARG_MAX_BYTES, PROCESS_ARG_MAX_COUNT, PROCESS_CWD_MAX_BYTES,
     PROCESS_EXECUTABLE_MAX_BYTES, PROCESS_STDIN_MAX_BYTES, PROCESS_TIMEOUT_MAX_SECS,
-    SCRIPT_ARGV_MAX_BYTES, SCRIPT_ARG_MAX_BYTES, SCRIPT_ARG_MAX_COUNT, SCRIPT_CWD_MAX_BYTES,
-    SCRIPT_MAX_BYTES, SCRIPT_STDIN_MAX_BYTES, SCRIPT_TIMEOUT_MAX_SECS,
+    RAW_SHELL_COMMAND_MAX_BYTES, SCRIPT_ARGV_MAX_BYTES, SCRIPT_ARG_MAX_BYTES, SCRIPT_ARG_MAX_COUNT,
+    SCRIPT_CWD_MAX_BYTES, SCRIPT_MAX_BYTES, SCRIPT_STDIN_MAX_BYTES, SCRIPT_TIMEOUT_MAX_SECS,
 };
 
 pub(crate) fn run_process_input_schema() -> Value {
@@ -196,6 +196,10 @@ pub(crate) fn run_shell_input_schema() -> Value {
         "other"
     ]);
     schema["properties"]["shell"]["enum"] = json!(["sh", "bash"]);
+    schema["properties"]["command"]["maxLength"] = json!(RAW_SHELL_COMMAND_MAX_BYTES);
+    schema["properties"]["command"]["description"] = json!(format!(
+        "Shell command to run. At most {RAW_SHELL_COMMAND_MAX_BYTES} UTF-8 bytes; use run_script for larger program text and stdin/files/artifacts for large data."
+    ));
     schema["properties"]["timeout_secs"]["minimum"] = json!(1);
     schema["properties"]["timeout_secs"]["maximum"] = json!(120);
     schema["properties"]["timeout_secs"]["default"] = json!(60);
@@ -247,6 +251,10 @@ pub(crate) fn run_job_input_schema() -> Value {
         "other"
     ]);
     schema["properties"]["shell"]["enum"] = json!(["sh", "bash"]);
+    schema["properties"]["command"]["maxLength"] = json!(RAW_SHELL_COMMAND_MAX_BYTES);
+    schema["properties"]["command"]["description"] = json!(format!(
+        "Shell command to run asynchronously. At most {RAW_SHELL_COMMAND_MAX_BYTES} UTF-8 bytes; use run_script for larger program text and stdin/files/artifacts for large data."
+    ));
     schema
 }
 
@@ -308,7 +316,10 @@ pub(crate) fn session_shell_exec_input_schema() -> Value {
     schema["properties"]["timeout_secs"]["minimum"] = json!(1);
     schema["properties"]["timeout_secs"]["maximum"] = json!(3600);
     schema["properties"]["timeout_secs"]["default"] = json!(60);
-    schema["properties"]["command"]["maxLength"] = json!(8000);
+    schema["properties"]["command"]["maxLength"] = json!(RAW_SHELL_COMMAND_MAX_BYTES);
+    schema["properties"]["command"]["description"] = json!(format!(
+        "One command evaluated by the existing long-lived shell. At most {RAW_SHELL_COMMAND_MAX_BYTES} UTF-8 bytes."
+    ));
     schema["properties"]["purpose"]["enum"] = json!([
         "validation",
         "test",

--- a/src/tool_runtime/session_shell.rs
+++ b/src/tool_runtime/session_shell.rs
@@ -3,7 +3,9 @@ use super::helpers::{
 };
 use super::{ExecutionPurpose, ExecutionShell, ToolResult, ToolRuntime};
 use crate::projects::ProjectConfig;
-use crate::shell_protocol::{PersistentShellRequest, PersistentShellResult, ShellJobContext};
+use crate::shell_protocol::{
+    PersistentShellRequest, PersistentShellResult, ShellJobContext, RAW_SHELL_COMMAND_MAX_BYTES,
+};
 use serde_json::json;
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
@@ -21,7 +23,6 @@ const SERVER_MAX_PERSISTENT_SHELLS: usize = 64;
 const SERVER_MAX_TERMINAL_SHELLS: usize = 128;
 const LOCAL_IDLE_TIMEOUT_SECS: u64 = 30 * 60;
 const LOCAL_MAX_OUTPUT_BYTES: usize = 256 * 1024;
-const MAX_PERSISTENT_COMMAND_BYTES: usize = 8_000;
 
 #[derive(Debug, Clone)]
 struct SessionShellRecord {
@@ -670,10 +671,10 @@ impl ToolRuntime {
         };
         let runtime_project_id = resolved.resolved_id;
         let project_config = resolved.config;
-        if command.len() > MAX_PERSISTENT_COMMAND_BYTES {
+        if command.len() > RAW_SHELL_COMMAND_MAX_BYTES {
             return shell_tool_error(
                 "persistent_shell_invalid_command",
-                format!("command exceeds the {MAX_PERSISTENT_COMMAND_BYTES}-byte Server limit"),
+                format!("command exceeds the {RAW_SHELL_COMMAND_MAX_BYTES}-byte Server limit"),
                 Some(&shell_id),
             );
         }

--- a/src/tool_runtime/shell.rs
+++ b/src/tool_runtime/shell.rs
@@ -3,12 +3,12 @@ use std::time::Duration;
 
 use super::helpers::{
     bounded_tail, command_failed_message, command_outcome_unknown_message,
-    command_rejected_message, command_timeout_message, looks_like_command_timeout,
-    project_relative_agent_cwd, project_relative_cwd, resolve_agent_cwd, resolve_local_cwd,
-    resolve_sync_timeout_secs, run_command_sync_bounded_with_shell_and_sandbox,
-    shell_escape_simple, sync_timeout_out_of_range_result, LocalRunFailure,
-    COMMAND_STDIO_TAIL_CHARS, DEFAULT_RUN_SHELL_TIMEOUT_SECS, MAX_SYNC_TIMEOUT_SECS,
-    MIN_SYNC_TIMEOUT_SECS,
+    command_rejected_message, command_timeout_message, explicit_shell_dispatch_command,
+    looks_like_command_timeout, project_relative_agent_cwd, project_relative_cwd,
+    resolve_agent_cwd, resolve_local_cwd, resolve_sync_timeout_secs,
+    run_command_sync_bounded_with_shell_and_sandbox, sync_timeout_out_of_range_result,
+    validate_raw_shell_command_length, LocalRunFailure, COMMAND_STDIO_TAIL_CHARS,
+    DEFAULT_RUN_SHELL_TIMEOUT_SECS, MAX_SYNC_TIMEOUT_SECS, MIN_SYNC_TIMEOUT_SECS,
 };
 use super::tool_result::ToolResult;
 use super::{ExecutionPurpose, ExecutionShell, ToolRuntime};
@@ -420,6 +420,16 @@ impl ToolRuntime {
         ssh_resource: Option<&str>,
         ssh_session_id: Option<&str>,
     ) -> ToolResult {
+        if let Err(error) = validate_raw_shell_command_length(&command) {
+            return Self::run_shell_tool_failure_result(
+                command_rejected_message(
+                    error,
+                    "use run_script for larger shell program text or stdin/files/artifacts for large data.",
+                ),
+                "runtime_error",
+                ShellCommandExecutionState::NotStarted,
+            );
+        }
         let timeout = match resolve_sync_timeout_secs(timeout_secs, DEFAULT_RUN_SHELL_TIMEOUT_SECS)
         {
             Ok(timeout) => timeout,
@@ -522,15 +532,20 @@ impl ToolRuntime {
                     } else {
                         "configured"
                     });
-            let dispatched_command = shell
-                .map(|shell| {
-                    format!(
-                        "exec {} -c {}",
-                        shell.as_str(),
-                        shell_escape_simple(&command)
-                    )
-                })
-                .unwrap_or_else(|| command.clone());
+            let dispatched_command = match shell {
+                Some(shell) => match explicit_shell_dispatch_command(&command, shell.as_str()) {
+                    Ok(command) => command,
+                    Err(error) => return Self::run_shell_tool_failure_result(
+                        command_rejected_message(
+                            error,
+                            "use run_script for large or quote-dense explicit-shell program text.",
+                        ),
+                        "runtime_error",
+                        ShellCommandExecutionState::NotStarted,
+                    ),
+                },
+                None => command.clone(),
+            };
             let wait_timeout = timeout;
             let (request_id, rx) = match self
                 .shell_clients

--- a/src/tool_runtime/tests/dispatch.rs
+++ b/src/tool_runtime/tests/dispatch.rs
@@ -837,7 +837,10 @@ async fn apply_patch_checked_applies_large_patch_over_command_limit_via_stdin() 
     let patch = large_marker_patch("LARGE_CHECKED_PROBE.md", marker);
     // Prove the patch exceeds the agent shell command length limit; it must
     // still validate + apply because it travels over stdin, not the command.
-    assert!(patch.len() > 8_000, "patch must exceed command limit");
+    assert!(
+        patch.len() > crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES,
+        "patch must exceed authored raw shell command limit"
+    );
     assert!(patch.len() <= MAX_VALIDATE_PATCH_BYTES);
 
     let runtime_for_task = runtime.clone();

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -845,12 +845,12 @@ fn show_changes_command_is_read_only() {
     let without_diff = show_changes_command(false, 20, 80);
     let with_diff = show_changes_command(true, 20, 80);
     assert!(
-        without_diff.len() <= 8000,
+        without_diff.len() <= crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES,
         "include_diff=false command is {} bytes",
         without_diff.len()
     );
     assert!(
-        with_diff.len() <= 8000,
+        with_diff.len() <= crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES,
         "include_diff=true command is {} bytes",
         with_diff.len()
     );
@@ -3586,7 +3586,7 @@ async fn show_changes_runtime_rejects_stat_only_failure_for_both_diff_modes() {
             .await
             .expect("show_changes should enqueue a shell request");
         assert!(
-            req.command.len() <= 8000,
+            req.command.len() <= crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES,
             "command bytes={}",
             req.command.len()
         );

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -576,6 +576,47 @@ async fn run_shell_failure_reports_command_started_and_output_tail() {
 }
 
 #[tokio::test]
+async fn raw_shell_tools_reject_authored_command_above_shared_bound_before_project_resolution() {
+    let command = "x".repeat(crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES + 1);
+
+    let run_shell = test_runtime()
+        .run_shell(
+            "agent:missing:missing".to_string(),
+            command.clone(),
+            Some(30),
+            None,
+        )
+        .await;
+    assert!(!run_shell.success);
+    assert!(run_shell
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("raw shell command exceeds the 16000-byte UTF-8 limit"));
+    assert_eq!(run_shell.output["execution_state"], "not_started");
+    assert_eq!(run_shell.output["failure_kind"], "runtime_error");
+
+    let run_job = test_runtime()
+        .run_job_for_auth(
+            "agent:missing:missing".to_string(),
+            command,
+            None,
+            Some(30),
+            None,
+            Vec::new(),
+            None,
+            Some(&auth_context(None, true)),
+        )
+        .await;
+    assert!(!run_job.success);
+    assert!(run_job
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("raw shell command exceeds the 16000-byte UTF-8 limit"));
+}
+
+#[tokio::test]
 async fn run_shell_rejection_reports_not_started_and_no_files_modified() {
     let result = test_runtime()
         .run_shell(

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -915,7 +915,7 @@ async fn b2_process_runner_uses_direct_sync_and_rejects_durable_only_timeout() {
 }
 
 #[tokio::test]
-async fn run_process_allows_typed_argv_larger_than_legacy_shell_command_limit() {
+async fn run_process_preserves_large_typed_argv_without_shell_parsing() {
     let temp = tempfile::tempdir().unwrap();
     let runtime = test_runtime();
     let project = register_process_agent(&runtime, "process-large", temp.path(), true, false).await;
@@ -949,7 +949,6 @@ async fn run_process_allows_typed_argv_larger_than_legacy_shell_command_limit() 
     assert_eq!(request.command, "");
     let process = request.process.as_ref().unwrap();
     assert_eq!(process.args, large_args);
-    assert!(process.args.iter().map(String::len).sum::<usize>() > 8_000);
     complete_process_lifecycle(
         &runtime,
         "process-large",

--- a/src/tool_runtime/tests/schema/specs.rs
+++ b/src/tool_runtime/tests/schema/specs.rs
@@ -207,6 +207,25 @@ fn sync_validation_and_run_shell_timeout_schema_bounds() {
 }
 
 #[test]
+fn raw_shell_tools_expose_the_shared_authored_command_bound() {
+    let specs = registered_tool_specs();
+    for name in ["run_shell", "run_job", "session_shell_exec"] {
+        let spec = specs.iter().find(|spec| spec.name == name).expect(name);
+        let command = &spec.input_schema["properties"]["command"];
+        assert_eq!(
+            command["maxLength"],
+            crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES,
+            "{name}"
+        );
+        let description = command["description"].as_str().unwrap_or_default();
+        assert!(
+            description.contains("16000") || description.contains("16,000"),
+            "{name}: {description}"
+        );
+    }
+}
+
+#[test]
 fn run_process_schema_is_small_bounded_and_has_no_shell_or_environment_input() {
     let specs = registered_tool_specs();
     let spec = specs

--- a/src/tool_runtime/tests/support/files.rs
+++ b/src/tool_runtime/tests/support/files.rs
@@ -193,18 +193,18 @@ pub(in crate::tool_runtime::tests) fn marker_patch(filename: &str, marker: &str)
     )
 }
 
-/// A patch deliberately larger than the agent shell command limit
-/// (`MAX_COMMAND_LEN` = 8000 bytes) so tests can prove the patch still
-/// validates/applies via `stdin` rather than the command string.
+/// A patch deliberately larger than the model-authored raw shell command
+/// limit so tests can prove the patch still validates/applies via `stdin`
+/// rather than the command string.
 pub(in crate::tool_runtime::tests) fn large_marker_patch(filename: &str, marker: &str) -> String {
     let mut s = String::new();
     s.push_str(&format!(
         "diff --git a/{f} b/{f}\nnew file mode 100644\n--- /dev/null\n+++ b/{f}\n\
-             @@ -0,0 +1,200 @@\n",
+             @@ -0,0 +1,300 @@\n",
         f = filename,
     ));
     s.push_str(&format!("+{m}\n", m = marker));
-    for i in 0..199 {
+    for i in 0..299 {
         s.push_str(&format!("+line-{:04}-{}\n", i, "x".repeat(48)));
     }
     s


### PR DESCRIPTION
## Summary

- raise the model/user-authored raw shell command ceiling from the legacy ~8 KB limit to **16,000 UTF-8 bytes** across `run_shell`, raw `run_job`, and persistent Session shell execution
- keep a separate **64 KiB internal Control→Runner wire envelope** so explicit `sh`/`bash` quoting has bounded transport headroom without increasing model input authority
- revalidate the wire bound on Runner sync and async/Job paths before process start
- expose the authored command bound in tool schemas and document the intended escape hatches for larger programs/data

## Contract

The canonical model/user input contract is 16,000 UTF-8 bytes. The 64 KiB value is internal transport headroom only and is not a new model-facing command allowance.

Oversized authored commands and oversized wrapped wire commands fail closed before dispatch/process start. Existing output, stdin, timeout, Job lifecycle, and uncertainty semantics are unchanged.

Large program bodies should continue to use `run_script`; large data belongs in stdin, files, or artifacts rather than raw shell text.

Platform-specific launch envelopes may be narrower than the semantic 16 KB cap for pathological commands. In particular, this PR does not promise every 16 KB character distribution will spawn successfully through every Windows/configured-shell path; such launch failures remain pre-start failures.

JSON Schema `maxLength` cannot exactly express a UTF-8 byte limit for multibyte Unicode. The schema description states the byte contract, and runtime validation remains authoritative and fail-closed.

## Validation

Focused validation passed, including:

- `raw_shell_tools_reject_authored_command_above_shared_bound_before_project_resolution`
- `raw_shell_tools_expose_the_shared_authored_command_bound`
- `authored_raw_shell_bound_and_explicit_wrapper_headroom_are_consistent`
- `validate_run_request_uses_the_internal_raw_shell_wire_bound`
- Runner `dispatch_request_run_shell_rejects_oversized_wire_command_before_start`
- persistent-shell rejection/state regression
- large patch via stdin regression
- structured large argv regressions on Control and Runner
- affected package `cargo check` validation
- `cargo fmt -- --check`
- `git diff --check`

Independent review result: accepted with no follow-up required.