### PR TITLE
Document manual multi-window collaboration and clarify Session defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Release guidance: [`docs/agent/release-process.md`](docs/agent/release-process.m
 
 - Public runtime and API surfaces: [`docs/agent/openapi-guidelines.md`](docs/agent/openapi-guidelines.md).
 - Workflow Sessions: [`docs/agent/session-model.md`](docs/agent/session-model.md).
+- Manual multi-window collaboration: [`docs/agent/manual-window-collaboration.md`](docs/agent/manual-window-collaboration.md).
 - Authority boundaries: [`docs/agent/permission-model.md`](docs/agent/permission-model.md).
 - Architecture decisions: [`docs/agent/architecture-decisions.md`](docs/agent/architecture-decisions.md).
 

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -66,8 +66,12 @@ bounded `answer` with `reply_to=<todo_id>` and resolves that exact todo.
 
 The first version is intentionally manual. There is no automatic claim, worker
 scheduler, shared transcript, or implicit cross-Session authority. Assign one
-worker per todo. Do not concurrently mutate the same worktree from multiple
-windows; prefer read-only workers or explicitly isolated worktrees/projects.
+worker per todo. Prefer read-oriented workers when windows share a worktree, and
+explicitly isolated worktrees/projects when independent concurrent writes are
+intentional. A `read_only` request or Session mode is useful operating context,
+not authoritative proof of what happened for the worker's whole lifetime. The
+worker should accurately report material operations or deviations, while the
+coordinator relies on recorded tool/effect evidence and current workspace state.
 Return conclusions, load-bearing evidence, and result paths instead of injecting
 the worker transcript into the coordinator.
 

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -56,6 +56,24 @@ whether the change is acceptable.
 The role names belong in the instruction text. Do not look for a role parameter
 on `start_coding_task` or `work_on_project`.
 
+## Manual multi-window collaboration
+
+For a bounded independent subtask, keep the coordinator and worker in **separate**
+Workflow Sessions. The coordinator posts a `todo` to its own Session; the worker
+starts a fresh Session, reads the coordinator's `session_handoff_summary` plus the
+relevant open todo, performs the subtask under the worker Session, then posts a
+bounded `answer` with `reply_to=<todo_id>` and resolves that exact todo.
+
+The first version is intentionally manual. There is no automatic claim, worker
+scheduler, shared transcript, or implicit cross-Session authority. Assign one
+worker per todo. Do not concurrently mutate the same worktree from multiple
+windows; prefer read-only workers or explicitly isolated worktrees/projects.
+Return conclusions, load-bearing evidence, and result paths instead of injecting
+the worker transcript into the coordinator.
+
+See [Manual Multi-Window Collaboration](agent/manual-window-collaboration.md) for
+the detailed protocol and the dogfood gates for any future convenience primitive.
+
 ## Habits that make the workflow reliable
 
 **Reuse validation identity after a fix.** When a structured validation uses

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -58,9 +58,12 @@ Workflow Session。coordinator 在自己的 Session 中发布 `todo`；worker �
 resolve 精确的 todo。
 
 第一版故意保持手动：没有自动 claim、worker scheduler、共享 transcript，也没有隐式的
-跨 Session authority。一个 todo 由人工分配给一个 worker。不要让多个窗口并发修改同一
-worktree；优先使用 read-only worker，或显式隔离的 worktree/project。worker 应回传结论、
-关键 evidence 与 result path，而不是把长 transcript 注入 coordinator。
+跨 Session authority。一个 todo 由人工分配给一个 worker。多个窗口共享 worktree 时优先
+让 worker 以读为主；确实需要独立并发写时优先隔离 worktree/project。`read_only` 请求或
+Session mode 是有用的执行姿态与 guard context，但不是 worker 整个生命周期实际行为的
+权威证明。worker 应如实回报 mutation、shell/process、validation、external effect 等重要
+操作或偏离预期的行为；coordinator 以记录下来的 tool/effect evidence 与当前 workspace
+状态为准。回传结论、关键 evidence 与 result path，而不是把长 transcript 注入 coordinator。
 
 详细协议与后续 convenience primitive 的 dogfood gate 见
 [Manual Multi-Window Collaboration](agent/manual-window-collaboration.md)。

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -49,6 +49,22 @@ guidance。沿现有架构实现 <任务>，运行聚焦的 structured validatio
 role 名称应写在 instruction 文本中，不要在 `start_coding_task` 或 `work_on_project` 上寻找
 role 参数。
 
+## 手动多窗口协作
+
+需要把一个有界独立子任务交给另一个窗口时，coordinator 与 worker 应保持**不同的**
+Workflow Session。coordinator 在自己的 Session 中发布 `todo`；worker 新建独立 Session，
+读取 coordinator 的 `session_handoff_summary` 与对应 open todo，在自己的 Session 下完成
+子任务，然后向 coordinator Session 发布带 `reply_to=<todo_id>` 的有界 `answer`，最后
+resolve 精确的 todo。
+
+第一版故意保持手动：没有自动 claim、worker scheduler、共享 transcript，也没有隐式的
+跨 Session authority。一个 todo 由人工分配给一个 worker。不要让多个窗口并发修改同一
+worktree；优先使用 read-only worker，或显式隔离的 worktree/project。worker 应回传结论、
+关键 evidence 与 result path，而不是把长 transcript 注入 coordinator。
+
+详细协议与后续 convenience primitive 的 dogfood gate 见
+[Manual Multi-Window Collaboration](agent/manual-window-collaboration.md)。
+
 ## 已被 dogfood 证明重要的习惯
 
 **修复后复用 validation identity。** structured validation 使用 `assertion_name` 时，同一个

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -41,5 +41,6 @@
 - [Job reliability and Runner concurrency](agent/job-reliability-and-concurrency.md) — Control restart recovery, observation semantics, shared Job capacity, and tool-description requirements
 - [Authority model](agent/permission-model.md)
 - [Session model](agent/session-model.md)
+- [Manual multi-window collaboration](agent/manual-window-collaboration.md) — coordinator/worker handoff through existing Workflow Session message primitives
 - [OpenAPI guidelines](agent/openapi-guidelines.md)
 - [Release process](agent/release-process.md)

--- a/docs/INDEX.zh-CN.md
+++ b/docs/INDEX.zh-CN.md
@@ -39,5 +39,6 @@
 - [Job 可靠性与 Runner 并发](agent/job-reliability-and-concurrency.md) —— Control 重启恢复、observation 语义、共享 Job 容量与工具描述要求
 - [权限模型](agent/permission-model.md)
 - [会话模型](agent/session-model.md)
+- [手动多窗口协作](agent/manual-window-collaboration.md) —— 使用现有 Workflow Session message primitive 做 coordinator/worker handoff
 - [OpenAPI 指南](agent/openapi-guidelines.md)
 - [发布流程](agent/release-process.md)

--- a/docs/agent/manual-window-collaboration.md
+++ b/docs/agent/manual-window-collaboration.md
@@ -10,12 +10,12 @@ The first version is manual:
 
 - a human opens the additional window or agent;
 - coordinator and worker keep separate Workflow Sessions;
-- the coordinator Session owns the durable todo and receives the bounded result;
+- the coordinator Session owns the ledger-backed todo and receives the bounded result;
 - the worker Session owns the worker's tool/evidence history;
 - the worker reads a bounded coordinator handoff instead of inheriting the coordinator transcript;
 - no primitive in this workflow grants filesystem authority, task ownership, or a concurrency lease.
 
-Do not use this protocol as permission to concurrently mutate the same worktree from multiple windows. Prefer read-only workers. If a worker must modify files concurrently, give it an explicitly isolated worktree/project rather than relying on message state for filesystem coordination.
+The message board does not coordinate filesystem concurrency. Prefer read-oriented workers when several windows share one worktree, and use an explicitly isolated worktree/project when independent concurrent writes are intentional. A worker may still change course when its available authority and later task state allow it; any mutation or other material deviation from the requested posture must be reported, and the coordinator must re-observe current state before consequential follow-up.
 
 ## Canonical flow
 
@@ -24,7 +24,7 @@ Assume the coordinator has Session `C` and the worker will create Session `W`.
 1. **Coordinator posts one bounded todo to `C`.** Use `post_session_message(kind="todo")`. The todo should contain the objective, narrow scope, important prohibitions, and expected result shape. Include a result path only when the worker is explicitly expected to produce an isolated document or artifact.
 2. **Open the worker as a fresh Session.** The worker should normally start a new Workflow Session `W`; do not resume `C` merely to delegate work. Separate Sessions keep the worker's tool history and reasoning context independent.
 3. **Worker reads the coordinator handoff.** Call `session_handoff_summary(session_id=C, ...)`, then inspect the relevant open todo with `list_session_messages(session_id=C, kind="todo", status="open")` or the bounded discussion summary. The handoff is continuity evidence, not transcript replay.
-4. **Worker performs the subtask under `W`.** Use `W` for project reads, validation, or other worker-local evidence. The worker must obey the same project, authority, guard, and tool contracts as any other Session; the coordinator todo does not widen them.
+4. **Worker performs the subtask under `W`.** Use `W` for project reads, validation, mutation, or other worker-local evidence as the task actually requires. The coordinator todo does not widen project authority. A requested `read_only` posture or current Session guard is useful intent/safety context, but it is not authoritative proof that no later write occurred or that the Session could never change mode; actual tool/effect evidence and the worker's report remain the basis for handoff.
 5. **Worker posts a bounded answer back to `C`.** Use `post_session_message(kind="answer", reply_to=<todo_id>)`. Return the conclusion, load-bearing evidence, and any explicit result path. When useful, include the worker Session id in the answer because Session messages do not currently carry a first-class author-Session field.
 6. **Resolve the exact todo.** After the answer has been successfully recorded in the coordinator Session, call `resolve_session_message(session_id=C, message_id=<todo_id>, ...)`. Resolution means the coordination item was handled; it is not an implementation acceptance verdict.
 7. **Coordinator consumes only the bounded result.** The coordinator should use the answer, referenced artifact/document, and its own source revalidation. It should not import the worker's long transcript into its context.
@@ -54,11 +54,11 @@ A useful todo is small and explicit. Prefer fields expressed in ordinary prose:
 - goal;
 - allowed scope;
 - prohibited actions;
-- whether the worker is read-only;
+- the requested worker posture, such as read-oriented or write-capable, while recognizing that this is intent rather than completion truth;
 - expected output: conclusion, findings, evidence, or an isolated result path;
 - relevant commit/path identifiers when they are stable enough to be useful.
 
-Do not put credentials, bearer tokens, private keys, secret values, or sensitive connection details in Session messages. The message board is durable task state, not a secret transport.
+Do not put credentials, bearer tokens, private keys, secret values, or sensitive connection details in Session messages. The message board is ledger-backed task state, not a secret transport. Message mutations are recorded in the in-memory Session state and queued to the existing persistence path; a successful tool return does not by itself promise synchronous disk flush.
 
 ## Correlation and completion
 
@@ -68,14 +68,16 @@ There is no atomic claim in the first version. Manually assign one worker per to
 
 Completion is currently two explicit metadata operations: post the answer, then resolve the todo. This is acceptable while the workflow is still low-volume and manual. If repeated use shows that this pair is a persistent source of mistakes or boilerplate, prefer one narrow `complete_session_message`-style convenience over a general collaboration framework.
 
-## Worktree and result safety
+## Worktree, evidence, and result safety
 
-The Session message board is not a filesystem lock.
+The Session message board is not a filesystem lock, and a task label such as `read_only` is not authoritative outcome truth.
 
-- Do not let coordinator and worker concurrently edit the same worktree.
-- Read-only review/analysis workers are the default safe parallel use case.
-- Concurrent write workers require explicit isolation at the worktree/project layer.
+- Read-oriented review/analysis workers are the lowest-conflict parallel use case when several windows share one worktree.
+- If independent concurrent writes are intended, prefer explicit isolation at the worktree/project layer; if a worker writes in a shared worktree anyway, it must report that fact and the coordinator must re-observe the resulting state rather than relying on the original todo.
+- Session mode and guards describe effective state at a point in the workflow. They can be changed only through normal accepted Session/tool paths and never widen underlying project authority, but they should not be treated as proof that a worker remained read-only for its entire lifetime.
+- Worker results should explicitly report material operations and deviations: mutations, shell/process execution, validation, external effects, or anything else that changes how the coordinator should interpret the result.
 - A result path is only a reference. The coordinator must re-read/revalidate current source or artifact state before a consequential follow-up.
+- Recorded tool/effect evidence and current workspace state are stronger evidence of what happened than the worker's requested posture alone; the worker's bounded report should accurately summarize that evidence rather than conceal or normalize deviations.
 - Worker completion does not make `finish_coding_task` or any other advisory projection authoritative completion truth.
 
 ## What this deliberately does not build
@@ -93,8 +95,12 @@ Do not add any of the following merely to make the first manual workflow look mo
 
 Each would add a new correctness or ownership model. Introduce one only for a demonstrated repeated problem that existing Session/message primitives cannot handle cleanly.
 
-## Initial dogfood result
+## Dogfood results
 
-The first protocol dogfood on 2026-08-16 exercised the intended sequence against the existing runtime: coordinator todo -> fresh worker Session -> bounded handoff -> open-todo read -> independent read-only inspection -> answer with `reply_to` -> explicit todo resolution. It used two independent Workflow Sessions in one host interaction; it did not validate the ergonomics of physically opening and switching between separate ChatGPT UI windows.
+The first protocol dogfood on 2026-08-16 exercised the intended sequence against the existing runtime: coordinator todo -> fresh worker Session -> bounded handoff -> open-todo read -> independent inspection -> answer with `reply_to` -> explicit todo resolution. It used two independent Workflow Sessions in one host interaction.
 
-The existing primitives were sufficient for the protocol flow. Two minor friction points were observed: answer and resolution are separate calls, and worker Session identity must be carried explicitly in the bounded answer when useful. Neither blocked the workflow, so this phase adds documentation rather than a new runtime primitive. Real multi-window dogfood remains the next source of evidence for UI/operator friction.
+A second dogfood used a physically separate ChatGPT window. The coordinator supplied only the coordinator Session/todo identifiers; after the worker finished, the coordinator recovered the result entirely from the board. The answer correlated to the exact todo, the todo was resolved, the worker Session id was discoverable from the bounded answer, and direct inspection of that independent worker ledger showed read/search activity with no write-like or shell-like project operations during the task.
+
+That run also showed why `read_only` should remain an intent/guard concept rather than completion truth: the worker followed a read-only instruction while its Session remained in normal mode. This was not a correctness problem because the recorded operation history accurately showed what actually happened. Future workers may use `read_only` mode when useful, or later change effective Session posture through normal accepted paths; coordinator acceptance should remain based on actual recorded operations, current state, and an accurate bounded worker report.
+
+The existing primitives were sufficient. Minor friction remains: answer and resolution are separate calls, and worker Session identity must be carried explicitly in the bounded answer when useful. Neither currently justifies a new runtime primitive, claim/lease system, or worker scheduler.

--- a/docs/agent/manual-window-collaboration.md
+++ b/docs/agent/manual-window-collaboration.md
@@ -1,0 +1,100 @@
+# Manual Multi-Window Collaboration
+
+This document defines the first supported pattern for manually splitting one coding task across multiple ChatGPT windows or agents. It deliberately reuses the existing Workflow Session handoff and message-board primitives. It is not a scheduler, worker pool, claim service, or shared-transcript design.
+
+## Scope
+
+Use this pattern when a coordinator wants an independent worker to perform a bounded subtask such as analysis, review, investigation, or a clearly isolated deliverable.
+
+The first version is manual:
+
+- a human opens the additional window or agent;
+- coordinator and worker keep separate Workflow Sessions;
+- the coordinator Session owns the durable todo and receives the bounded result;
+- the worker Session owns the worker's tool/evidence history;
+- the worker reads a bounded coordinator handoff instead of inheriting the coordinator transcript;
+- no primitive in this workflow grants filesystem authority, task ownership, or a concurrency lease.
+
+Do not use this protocol as permission to concurrently mutate the same worktree from multiple windows. Prefer read-only workers. If a worker must modify files concurrently, give it an explicitly isolated worktree/project rather than relying on message state for filesystem coordination.
+
+## Canonical flow
+
+Assume the coordinator has Session `C` and the worker will create Session `W`.
+
+1. **Coordinator posts one bounded todo to `C`.** Use `post_session_message(kind="todo")`. The todo should contain the objective, narrow scope, important prohibitions, and expected result shape. Include a result path only when the worker is explicitly expected to produce an isolated document or artifact.
+2. **Open the worker as a fresh Session.** The worker should normally start a new Workflow Session `W`; do not resume `C` merely to delegate work. Separate Sessions keep the worker's tool history and reasoning context independent.
+3. **Worker reads the coordinator handoff.** Call `session_handoff_summary(session_id=C, ...)`, then inspect the relevant open todo with `list_session_messages(session_id=C, kind="todo", status="open")` or the bounded discussion summary. The handoff is continuity evidence, not transcript replay.
+4. **Worker performs the subtask under `W`.** Use `W` for project reads, validation, or other worker-local evidence. The worker must obey the same project, authority, guard, and tool contracts as any other Session; the coordinator todo does not widen them.
+5. **Worker posts a bounded answer back to `C`.** Use `post_session_message(kind="answer", reply_to=<todo_id>)`. Return the conclusion, load-bearing evidence, and any explicit result path. When useful, include the worker Session id in the answer because Session messages do not currently carry a first-class author-Session field.
+6. **Resolve the exact todo.** After the answer has been successfully recorded in the coordinator Session, call `resolve_session_message(session_id=C, message_id=<todo_id>, ...)`. Resolution means the coordination item was handled; it is not an implementation acceptance verdict.
+7. **Coordinator consumes only the bounded result.** The coordinator should use the answer, referenced artifact/document, and its own source revalidation. It should not import the worker's long transcript into its context.
+8. **Close the worker Session when appropriate.** A completed one-shot worker can be closed explicitly. The coordinator Session remains independent.
+
+A compact mental model is:
+
+```text
+coordinator C
+  -> post todo
+  -> human opens worker
+worker W
+  -> read handoff(C)
+  -> read open todo(C)
+  -> perform bounded work under W
+  -> post answer(C, reply_to=todo)
+  -> resolve todo(C)
+coordinator C
+  -> consume bounded answer/evidence/result path
+  -> revalidate current source before consequential follow-up
+```
+
+## Todo contents
+
+A useful todo is small and explicit. Prefer fields expressed in ordinary prose:
+
+- goal;
+- allowed scope;
+- prohibited actions;
+- whether the worker is read-only;
+- expected output: conclusion, findings, evidence, or an isolated result path;
+- relevant commit/path identifiers when they are stable enough to be useful.
+
+Do not put credentials, bearer tokens, private keys, secret values, or sensitive connection details in Session messages. The message board is durable task state, not a secret transport.
+
+## Correlation and completion
+
+`reply_to` is the correlation mechanism between an answer and the coordinator todo. It does not claim the todo, grant authority, or prove that only one worker acted on it.
+
+There is no atomic claim in the first version. Manually assign one worker per todo. If several independent workers are desired, create distinct todos. Add an atomic claim primitive only after real dogfood shows workers racing for the same todo often enough that manual assignment is unreliable.
+
+Completion is currently two explicit metadata operations: post the answer, then resolve the todo. This is acceptable while the workflow is still low-volume and manual. If repeated use shows that this pair is a persistent source of mistakes or boilerplate, prefer one narrow `complete_session_message`-style convenience over a general collaboration framework.
+
+## Worktree and result safety
+
+The Session message board is not a filesystem lock.
+
+- Do not let coordinator and worker concurrently edit the same worktree.
+- Read-only review/analysis workers are the default safe parallel use case.
+- Concurrent write workers require explicit isolation at the worktree/project layer.
+- A result path is only a reference. The coordinator must re-read/revalidate current source or artifact state before a consequential follow-up.
+- Worker completion does not make `finish_coding_task` or any other advisory projection authoritative completion truth.
+
+## What this deliberately does not build
+
+Do not add any of the following merely to make the first manual workflow look more automatic:
+
+- automatic worker spawning;
+- scheduler or worker pool;
+- generic WorkItem/lease framework;
+- automatic todo claim;
+- shared multi-window transcript;
+- implicit cross-Session authority;
+- concurrent same-worktree edit orchestration;
+- automatic injection of worker history into the coordinator.
+
+Each would add a new correctness or ownership model. Introduce one only for a demonstrated repeated problem that existing Session/message primitives cannot handle cleanly.
+
+## Initial dogfood result
+
+The first protocol dogfood on 2026-08-16 exercised the intended sequence against the existing runtime: coordinator todo -> fresh worker Session -> bounded handoff -> open-todo read -> independent read-only inspection -> answer with `reply_to` -> explicit todo resolution. It used two independent Workflow Sessions in one host interaction; it did not validate the ergonomics of physically opening and switching between separate ChatGPT UI windows.
+
+The existing primitives were sufficient for the protocol flow. Two minor friction points were observed: answer and resolution are separate calls, and worker Session identity must be carried explicitly in the bounded answer when useful. Neither blocked the workflow, so this phase adds documentation rather than a new runtime primitive. Real multi-window dogfood remains the next source of evidence for UI/operator friction.

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -96,10 +96,11 @@ handoff, and finish can reason about the same unit of work.
 | Durability | JSON-oriented session ledger (bounded events/messages per session) |
 | Current-session binding | In-memory exact-key cache plus a bounded durable projection in the same JSON ledger; isolated by client window, principal, transport, resolved project, and canonical repository-root hash |
 
-### Persistent execution context
+### Persistent execution defaults
 
-An existing registered-project-bound Workflow Session may persist this
-strongly typed execution context:
+An existing registered-project-bound Workflow Session may persist a closed set
+of strongly typed execution defaults. The wire/type name remains
+`SessionExecutionContext` for compatibility:
 
 ```text
 SessionExecutionContext {
@@ -109,11 +110,12 @@ SessionExecutionContext {
 }
 ```
 
-It is not an arbitrary context bag. It cannot contain environment variables,
-credentials, SSH host/configuration, keys, passwords, SSH state, shell input,
-connection data, or custom options. `resource` is only a safe named resource
-configured on the Runner that owns the Session project. It is persisted as a
-name, never as an SSH transport or authentication material.
+These fields are execution defaults, not arbitrary model context. They cannot
+contain environment variables, credentials, SSH host/configuration, keys,
+passwords, SSH state, shell input, connection data, or custom options.
+`resource` is only a safe named resource configured on the Runner that owns the
+Session project. It is persisted as a name, never as an SSH transport or
+authentication material.
 
 Without `resource`, `default_cwd` is validated and normalized as a
 project-relative path: absolute paths, URI forms, control characters, and
@@ -128,7 +130,7 @@ unenterable cwd explicitly.
 when creating a Session; on automatic continuation or explicit resume,
 omitting `execution_context` preserves the stored value, while an explicit
 object commits with the instruction/capability/binding update under the
-in-memory store lock. An explicit `{}` clears both defaults.
+in-memory store lock. An explicit `{}` clears all execution defaults.
 `update_session_context` requires a project input that the caller may access and
 that resolves exactly to the explicit known active Session project. It never
 uses current-session fallback, never creates an unknown Session, rejects closed,
@@ -138,11 +140,26 @@ ledger is then queued to the existing background writer. Persistence failures
 are reported through existing status and logs, and success does not mean a
 synchronous disk flush or promise rollback on a later writer failure.
 
-`run_shell`, `run_job`, and `open_session_shell` inherit these defaults.
+Inheritance is intentionally closed and per field:
+
+| Tool | `default_cwd` | `default_shell` | named `resource` |
+|---|---|---|---|
+| `run_process` | inherited when `cwd` is omitted | not applicable | unsupported; fails before process start |
+| `run_script` | inherited when `cwd` is omitted | not applicable | unsupported; fails before script start |
+| `run_shell` | inherited when `cwd` is omitted | inherited when `shell` is omitted | routes this call through the named SSH resource |
+| `run_job` | inherited when `cwd` is omitted | inherited when `shell` is omitted | routes this Job through the named SSH resource |
+| `open_session_shell` | inherited when `cwd` is omitted | inherited when `shell` is omitted | opens the persistent shell through the named SSH resource |
+
+Structured Cargo/Go tools (`cargo_fmt`, `cargo_check`, `cargo_test`, `go_test`)
+do not inherit `default_cwd` or `default_shell`; a named `resource` is also
+rejected for those tools rather
+than silently falling back to the Runner-host project. File, Git, LSP, and
+checkpoint tools do not inherit any execution default.
+
 `run_shell` and `run_job` remain independent-process tools. When an SSH
-resource is selected, only those two tools execute remotely; file, Git, LSP,
-checkpoint, and persistent-shell tools remain bound to the registered project
-host. Remote cwd precedence for one-shot SSH commands is:
+resource is selected, `run_shell`, `run_job`, and a newly opened
+`open_session_shell` execute through that remote resource. Remote cwd
+precedence for one-shot SSH commands is:
 
 ```text
 per-call cwd
@@ -191,20 +208,25 @@ close_session_shell
 ```
 
 Opening creates one real long-lived `sh` or `bash` process, at most one active
-shell per Workflow Session. For an `agent:<client>:<project>` it is owned by
-that project's Runner process. The process manager also has a Server-owned
-executor branch for a hosting surface that supplies a Server-local project,
-although the current built-in public project registry advertises Agent projects
-only. It never executes through
-`execution_context.resource`: an SSH resource is rejected with
-`persistent_shell_ssh_resource_unsupported` rather than falling back locally.
-`inspect` and `read_only` Sessions cannot open or execute a persistent shell.
+shell per Workflow Session. For an `agent:<client>:<project>` the Runner owns
+and controls the shell. Without `execution_context.resource`, it runs against
+the registered project host. With a named resource, the Runner opens a remote
+persistent shell through that SSH resource; this requires the Runner's SSH and
+SSH-persistent-shell capabilities and never silently falls back locally. The
+process manager also has a Server-owned executor branch for a hosting surface
+that supplies a Server-local project, although the current built-in public
+project registry advertises Agent projects only. `inspect` and `read_only`
+Sessions cannot open or execute a persistent shell.
 
-Open resolution is explicit `cwd`/`shell`, then the exact Session's
-`default_cwd`/`default_shell`, then the project/Runner defaults. Profile
+Local open resolution is explicit `cwd`/`shell`, then the exact Session's
+`default_cwd`/`default_shell`, then the project/Runner defaults. For an SSH
+persistent shell, cwd precedence is explicit open `cwd`, Session `default_cwd`,
+the named resource's default cwd, then the remote login default; the selected
+Session `default_shell` is also inherited when `shell` is omitted. Profile
 environment and initialization run once at open. Later commands retain the
 same process's cwd, exports, unset state, umask, functions, and ordinary shell
-variables. Updating Session execution context never moves, restarts, or
+variables. The shell record retains the execution location selected at open, so
+updating Session execution defaults never redirects, moves, restarts, or
 changes an already-open shell; close and reopen it to apply new defaults.
 `run_shell` and `run_job` never reuse this process.
 

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -515,6 +515,10 @@ Session with `session_handoff_summary(session_id=...)`. Explicit
 the same active Session and continues to obey the existing identity,
 lifecycle, project, guard, and binding rules.
 
+For deliberate coordinator/worker delegation across separate windows, keep the
+Sessions independent and use the existing handoff plus message-board primitives;
+see [Manual Multi-Window Collaboration](manual-window-collaboration.md).
+
 ### Invariants (must)
 
 These are also summarized in `AGENTS.md` §7, **Sessions**:

--- a/src/connector_runtime/execution_tests.rs
+++ b/src/connector_runtime/execution_tests.rs
@@ -2717,7 +2717,10 @@ async fn transient_check_status_recovers_within_grace() {
 
 #[tokio::test]
 async fn check_transport_failure_becomes_unknown_only_after_grace() {
-    let fixture = fixture_configured(5, |service| service.with_monitor_timing(80, 5)).await;
+    // Grace must comfortably exceed scheduler starvation under full-suite
+    // parallelism so the test can observe the degraded active state before the
+    // monitor legitimately finishes the execution as unknown.
+    let fixture = fixture_configured(5, |service| service.with_monitor_timing(2_000, 5)).await;
     let arguments = checks(&fixture, "transport-grace-1", &["test"]);
     let connector = fixture.connector.clone();
     let owner = fixture.owner.clone();
@@ -2742,18 +2745,28 @@ async fn check_transport_failure_becomes_unknown_only_after_grace() {
         .registry
         .reconcile_disconnect("hosted", "instance")
         .await;
-    tokio::time::sleep(Duration::from_millis(30)).await;
-    let degraded = fixture
-        .connector
-        .db
-        .connector_execution(execution_id)
-        .unwrap();
+    // The degraded observation is asynchronous. Poll for the recorded failure
+    // instead of assuming a fixed sleep lands inside the grace window.
+    let mut observed = None;
+    for _ in 0..400 {
+        let current = fixture
+            .connector
+            .db
+            .connector_execution(execution_id)
+            .unwrap();
+        if current.status_failure_code.as_deref() == Some("executor_status_unavailable") {
+            observed = Some(current);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    let degraded = observed.expect("monitor never recorded the executor transport failure");
     assert!(degraded.is_active());
     assert_eq!(
         degraded.status_failure_code.as_deref(),
         Some("executor_status_unavailable")
     );
-    for _ in 0..100 {
+    for _ in 0..600 {
         let current = fixture
             .connector
             .db

--- a/src/tool_runtime/registry/input_schemas/coding.rs
+++ b/src/tool_runtime/registry/input_schemas/coding.rs
@@ -41,7 +41,7 @@ pub(crate) fn start_coding_task_input_schema() -> Value {
                 "description": "Optional task guard for the created session. Defaults to false unless mode=read_only."
             },
             "execution_context": session_execution_context_schema(
-                "Optional complete Workflow Session execution defaults. On creation this becomes the initial context. On continuation or explicit resume, omission preserves the existing context while an explicit object replaces it atomically; `{}` clears both defaults."
+                "Optional complete Workflow Session execution defaults. On creation this becomes the initial context. On continuation or explicit resume, omission preserves the existing context while an explicit object replaces it atomically; `{}` clears all execution defaults."
             ),
             "detail": {
                 "type": "string",

--- a/src/tool_runtime/registry/input_schemas/jobs.rs
+++ b/src/tool_runtime/registry/input_schemas/jobs.rs
@@ -270,7 +270,7 @@ pub(crate) fn open_session_shell_input_schema() -> Value {
         (
             "cwd",
             "string",
-            "Optional project-relative initial cwd. Omission uses the Session execution context and then the project default.",
+            "Optional initial cwd. Without a named Session SSH resource it is project-relative; with one it is a remote path. Omission uses the Session default, then the project or SSH-resource default.",
             false,
         ),
         (

--- a/src/tool_runtime/registry/input_schemas/sessions.rs
+++ b/src/tool_runtime/registry/input_schemas/sessions.rs
@@ -51,19 +51,19 @@ pub(crate) fn session_execution_context_schema(description: &str) -> Value {
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 4096,
-                "description": "Optional cwd inherited by Session-aware shell execution. Without resource it is project-relative; with a named SSH resource it is a remote path verified by the remote shell instead of the Runner project-root policy."
+                "description": "Optional cwd inherited when omitted by run_process, run_script, run_shell, run_job, and open_session_shell. Without resource it is project-relative. With a named SSH resource it is a remote-path default for run_shell, run_job, and open_session_shell; run_process/run_script reject that resource before start."
             },
             "default_shell": {
                 "type": "string",
                 "enum": ["sh", "bash"],
-                "description": "Optional explicit shell dialect inherited by Session-aware shell execution."
+                "description": "Optional explicit shell dialect inherited when omitted by run_shell, run_job, and open_session_shell. It does not affect run_process or run_script."
             },
             "resource": {
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 80,
                 "pattern": "^[A-Za-z0-9_.-]+$",
-                "description": "Optional named SSH resource configured only on the Runner that owns this Session project. It changes Session-aware shell execution location only and never contains host, SSH configuration, key, password, or connection data."
+                "description": "Optional named SSH resource configured only on the Runner that owns this Session project. It routes run_shell, run_job, and open_session_shell remotely; run_process, run_script, and structured Cargo/Go tools reject it before execution. It never contains host, SSH configuration, key, password, or connection data."
             }
         }
     })

--- a/src/tool_runtime/registry/input_schemas/sessions.rs
+++ b/src/tool_runtime/registry/input_schemas/sessions.rs
@@ -51,19 +51,19 @@ pub(crate) fn session_execution_context_schema(description: &str) -> Value {
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 4096,
-                "description": "Optional cwd inherited when omitted by run_process, run_script, run_shell, run_job, and open_session_shell. Without resource it is project-relative. With a named SSH resource it is a remote-path default for run_shell, run_job, and open_session_shell; run_process/run_script reject that resource before start."
+                "description": "Optional working-directory default for the closed set of Session-aware execution tools. Without resource it is project-relative. With a named SSH resource it becomes a remote-path default only for remote-capable shell execution; local structured process/script execution rejects that resource before start."
             },
             "default_shell": {
                 "type": "string",
                 "enum": ["sh", "bash"],
-                "description": "Optional explicit shell dialect inherited when omitted by run_shell, run_job, and open_session_shell. It does not affect run_process or run_script."
+                "description": "Optional explicit shell dialect inherited by Session-aware shell execution when the per-call shell is omitted. It does not affect structured process or script execution."
             },
             "resource": {
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 80,
                 "pattern": "^[A-Za-z0-9_.-]+$",
-                "description": "Optional named SSH resource configured only on the Runner that owns this Session project. It routes run_shell, run_job, and open_session_shell remotely; run_process, run_script, and structured Cargo/Go tools reject it before execution. It never contains host, SSH configuration, key, password, or connection data."
+                "description": "Optional named SSH resource configured only on the Runner that owns this Session project. It routes supported one-shot, background, and persistent shell execution remotely; structured process/script and Cargo/Go validation reject it before execution. It never contains host, SSH configuration, key, password, or connection data."
             }
         }
     })

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -55,8 +55,8 @@ pub(crate) const TOOL_CALL_EXPECTATION_METADATA_FIELDS: &[&str] = &[
     TOOL_ASSERTION_NAME_FIELD,
 ];
 
-/// Durable defaults inherited by shell-like tools attached to a
-/// project-scoped Workflow Session.
+/// Durable execution defaults inherited by a closed set of execution tools
+/// attached to a project-scoped Workflow Session.
 ///
 /// This intentionally contains no environment, credential, connection, or
 /// arbitrary option bag. `resource` is only a named Runner-local SSH resource;
@@ -69,7 +69,8 @@ pub(crate) struct SessionExecutionContext {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) default_shell: Option<ExecutionShell>,
     /// Optional named SSH resource on the Runner that owns this Session's
-    /// project. It changes only `run_shell` and `run_job` execution location.
+    /// project. It changes `run_shell`, `run_job`, and newly opened
+    /// `open_session_shell` execution location.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) resource: Option<String>,
 }
@@ -443,7 +444,7 @@ pub(crate) struct CodingSessionRequest {
     pub(crate) mode: SessionMode,
     pub(crate) guards: SessionGuards,
     /// `None` preserves an existing Session value during continuation.
-    /// `Some({})` explicitly clears both defaults.
+    /// `Some({})` explicitly clears all execution defaults.
     pub(crate) execution_context: Option<SessionExecutionContext>,
     pub(crate) project_instructions: Option<ProjectInstructionsSnapshot>,
     pub(crate) transport: SessionTransport,

--- a/src/tool_runtime/sessions/store.rs
+++ b/src/tool_runtime/sessions/store.rs
@@ -990,7 +990,7 @@ impl SessionStore {
 
     /// Replace the complete execution context and append one safe metadata
     /// event together under the in-memory store lock. Persistent stores then
-    /// queue the JSON ledger to the background writer. `{}` clears both defaults.
+    /// queue the JSON ledger to the background writer. `{}` clears all execution defaults.
     pub(crate) fn update_execution_context(
         &self,
         session_id: &str,

--- a/src/tool_runtime/tests/sessions_guards.rs
+++ b/src/tool_runtime/tests/sessions_guards.rs
@@ -534,73 +534,56 @@ async fn read_only_current_session_guard_blocks_write_before_enqueue() {
 }
 
 #[tokio::test]
-async fn start_session_defaults_to_normal_without_guards() {
-    let runtime = test_runtime();
-    let result = runtime
-        .dispatch(ToolCall::from_tool_name("start_session", json!({})).unwrap())
-        .await;
+async fn start_session_mode_effective_guards_matrix() {
+    for (case, input, expected_mode, deny_write_tools, deny_shell_tools) in [
+        (
+            "normal defaults",
+            json!({}),
+            SessionMode::Normal,
+            false,
+            false,
+        ),
+        (
+            "read_only fixed profile overrides caller shell guard",
+            json!({"mode": "read_only", "deny_shell_tools": false}),
+            SessionMode::ReadOnly,
+            true,
+            true,
+        ),
+        (
+            "inspect fixed profile overrides caller guards",
+            json!({
+                "mode": "inspect",
+                "deny_write_tools": false,
+                "deny_shell_tools": true
+            }),
+            SessionMode::Inspect,
+            true,
+            false,
+        ),
+    ] {
+        let runtime = test_runtime();
+        let result = runtime
+            .dispatch(ToolCall::from_tool_name("start_session", input).unwrap())
+            .await;
 
-    assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["mode"], "normal");
-    assert_eq!(result.output["guards"]["deny_write_tools"], false);
-    assert_eq!(result.output["guards"]["deny_shell_tools"], false);
-    let session_id = result.output["session_id"].as_str().unwrap();
-    let summary = runtime.sessions.summary(session_id, None).unwrap();
-    assert_eq!(summary.mode, SessionMode::Normal);
-    assert!(!summary.guards.deny_write_tools);
-    assert!(!summary.guards.deny_shell_tools);
-}
+        assert!(result.success, "{case}: {:?}", result.error);
+        assert_eq!(result.output["mode"], expected_mode.as_str(), "{case}");
+        assert_eq!(
+            result.output["guards"]["deny_write_tools"], deny_write_tools,
+            "{case}"
+        );
+        assert_eq!(
+            result.output["guards"]["deny_shell_tools"], deny_shell_tools,
+            "{case}"
+        );
 
-#[tokio::test]
-async fn start_session_read_only_enables_write_and_shell_guards() {
-    let runtime = test_runtime();
-    let result = runtime
-        .dispatch(
-            ToolCall::from_tool_name(
-                "start_session",
-                json!({"mode": "read_only", "deny_shell_tools": false}),
-            )
-            .unwrap(),
-        )
-        .await;
-
-    assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["mode"], "read_only");
-    assert_eq!(result.output["guards"]["deny_write_tools"], true);
-    assert_eq!(result.output["guards"]["deny_shell_tools"], true);
-    let session_id = result.output["session_id"].as_str().unwrap();
-    let summary = runtime.sessions.summary(session_id, None).unwrap();
-    assert_eq!(summary.mode, SessionMode::ReadOnly);
-    assert!(summary.guards.deny_write_tools);
-    assert!(summary.guards.deny_shell_tools);
-}
-
-#[tokio::test]
-async fn start_session_inspect_enables_write_guard_but_keeps_shell_enabled() {
-    let runtime = test_runtime();
-    let result = runtime
-        .dispatch(
-            ToolCall::from_tool_name(
-                "start_session",
-                json!({
-                    "mode": "inspect",
-                    "deny_write_tools": false,
-                    "deny_shell_tools": true
-                }),
-            )
-            .unwrap(),
-        )
-        .await;
-
-    assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["mode"], "inspect");
-    assert_eq!(result.output["guards"]["deny_write_tools"], true);
-    assert_eq!(result.output["guards"]["deny_shell_tools"], false);
-    let session_id = result.output["session_id"].as_str().unwrap();
-    let summary = runtime.sessions.summary(session_id, None).unwrap();
-    assert_eq!(summary.mode, SessionMode::Inspect);
-    assert!(summary.guards.deny_write_tools);
-    assert!(!summary.guards.deny_shell_tools);
+        let session_id = result.output["session_id"].as_str().unwrap();
+        let summary = runtime.sessions.summary(session_id, None).unwrap();
+        assert_eq!(summary.mode, expected_mode, "{case}");
+        assert_eq!(summary.guards.deny_write_tools, deny_write_tools, "{case}");
+        assert_eq!(summary.guards.deny_shell_tools, deny_shell_tools, "{case}");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- define the first manual coordinator/worker multi-window workflow using existing Workflow Session handoff and message-board primitives
- record protocol and physical separate-ChatGPT-window dogfood, keeping worker results bounded and correlated with `reply_to`
- treat `read_only` as requested posture/current guard context rather than authoritative lifetime outcome truth; coordinator acceptance relies on recorded tool/effect evidence and current workspace state
- document shared-worktree conflict guidance without introducing claim, lease, scheduler, worker-pool, or shared-transcript machinery
- clarify `SessionExecutionContext` as a closed set of execution defaults and document the exact cwd/shell/resource inheritance matrix
- correct existing documentation/schema drift: named SSH resources already support newly opened persistent Session shells, while structured process/script and Cargo/Go paths remain fail-closed where unsupported
- consolidate the duplicated `start_session` normal/inspect/read-only effective-guard tests into one table-driven matrix while preserving the separate enforcement tests

## Validation

- `cargo fmt -- --check`
- `cargo test 'start_session_mode_effective_guards_matrix'` — 1 passed
- `cargo test 'ssh_persistent_shell_enqueues_with_bound_resource_and_routes_by_record'` — 1 passed
- `git diff --check`
- independent review of the Session documentation/schema contract against current runtime behavior
- remote PR branch tree compared byte-for-byte with the reviewed local integration tree (`git diff --exit-code HEAD origin/docs/manual-window-collaboration`)

No new runtime collaboration primitive is introduced, and no deployment or release is required for this change.