### PR TITLE
Fix Windows project text search

### DIFF
--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -7664,6 +7664,88 @@ fn dispatch_request_run_shell_sends_result_over_sink() {
 }
 
 #[test]
+fn dispatch_request_internal_search_uses_posix_runtime_not_configured_shell_parser() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cfg = test_config(tmp.path().join("config/projects.d"));
+    // The generated search program is POSIX shell. It must not inherit an
+    // arbitrary configured shell parser (PowerShell is the Windows production
+    // case); use a guaranteed-failing program here to prove the bypass.
+    cfg.shell.program = if cfg!(windows) {
+        "powershell".to_string()
+    } else {
+        "/bin/false".to_string()
+    };
+    let jobs = JobManager::new(max_concurrent_jobs(&cfg));
+    let pdir = projects_dir(&cfg).unwrap();
+    let hot = runtime_config(&cfg);
+    let persistent_shells = webcodex_runner::PersistentShellManager::new(
+        &cfg.shell,
+        webcodex_runner::SshConnectionPool::default(),
+    );
+    let (sink, mut rx) = ws_sink("ws-client");
+    let marker = r#"{"webcodex_search":{"backend":"grep","feature_unavailable":false}}"#;
+    let request = ShellAgentShellRequest {
+        request_id: "req-internal-search".to_string(),
+        client_id: "ws-client".to_string(),
+        kind: "run_shell".to_string(),
+        job_id: None,
+        cwd: Some(tmp.path().to_string_lossy().to_string()),
+        path: None,
+        content: None,
+        max_bytes: None,
+        expected_sha256: None,
+        expected_prefix: None,
+        start_line: None,
+        end_line: None,
+        create_dirs: false,
+        command: format!(
+            "{}\nprintf '%s\\n' '{}'\n",
+            shell_protocol::EXTERNAL_SEARCH_REQUEST_PREFIX,
+            marker
+        ),
+        process: None,
+        script: None,
+        stdin: Some("{}".to_string()),
+        timeout_secs: if cfg!(windows) { 30 } else { 10 },
+        requested_by: "tester".to_string(),
+        created_at: 0,
+        validation: None,
+        lsp: None,
+        sandbox: None,
+        job_context: None,
+        persistent_shell: None,
+    };
+
+    assert!(dispatch_request(
+        &sink,
+        &hot.snapshot(),
+        &hot,
+        &jobs,
+        &persistent_shells,
+        &pdir,
+        &webcodex_runner::LspSupervisor::default(),
+        request,
+    )
+    .unwrap());
+    match rx.try_recv().expect("internal search result") {
+        AgentEnvelope::Result { payload } => {
+            assert_eq!(payload.result.exit_code, Some(0));
+            assert!(payload
+                .result
+                .stdout
+                .as_deref()
+                .unwrap_or_default()
+                .contains("webcodex_search"));
+            assert_eq!(
+                payload.command_execution_state,
+                Some(ShellCommandExecutionState::Completed)
+            );
+        }
+        other => panic!("expected result, got {:?}", other.kind()),
+    }
+}
+
+#[test]
 fn dispatch_request_run_shell_rejects_oversized_wire_command_before_start() {
     let tmp = tempfile::tempdir().unwrap();
     let cfg = test_config(tmp.path().join("config/projects.d"));

--- a/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
@@ -5,7 +5,9 @@ use super::validation::{handle_validation_request, is_validation_request_kind};
 use super::{
     handle_computer_request, handle_project_lifecycle_op,
     handle_project_op_with_temporary_projects_root, handle_resolve_or_register_project,
-    is_computer_request_kind, run_process_with_profiles_in_sandbox_and_execution_state,
+    is_computer_request_kind,
+    run_internal_search_script_with_profiles_in_sandbox_and_execution_state,
+    run_process_with_profiles_in_sandbox_and_execution_state,
     run_script_with_profiles_in_sandbox_and_execution_state,
     run_shell_with_profiles_in_sandbox_and_execution_state, run_ssh_shell_with_execution_state,
     AgentSink, CommandResult, HotAgentConfig, PersistentShellManager, ReloadableAgentConfig,
@@ -13,12 +15,68 @@ use super::{
 };
 use crate::shell_protocol::{
     validate_process_argv, validate_raw_shell_wire_command, validate_script_request,
-    ShellAgentShellRequest, ShellProcessArgv, ShellScriptPayload, PROCESS_CWD_MAX_BYTES,
-    PROCESS_STDIN_MAX_BYTES, STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS,
+    ShellAgentShellRequest, ShellProcessArgv, ShellScriptPayload, EXTERNAL_SEARCH_REQUEST_PREFIX,
+    PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES,
+    STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS,
 };
 use crate::{handle_file_request, is_file_request_kind, JobManager, PendingJobStart};
 use std::path::Path;
 use std::sync::atomic::Ordering;
+
+fn internal_search_script(command: &str) -> Option<&str> {
+    let rest = command.strip_prefix(EXTERNAL_SEARCH_REQUEST_PREFIX)?;
+    let script = rest.strip_prefix('\n')?;
+    (!script.is_empty()).then_some(script)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_native_shell_or_internal_search(
+    config: &HotAgentConfig,
+    runtime: &ReloadableAgentConfig,
+    jobs: &JobManager,
+    projects_dir: &Path,
+    request: &ShellAgentShellRequest,
+) -> ShellCommandResult {
+    if request.command.lines().next() == Some(EXTERNAL_SEARCH_REQUEST_PREFIX) {
+        let Some(script) = internal_search_script(&request.command) else {
+            return ShellCommandResult::not_started(CommandResult {
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: Some(0),
+                error: Some(
+                    "invalid_internal_search_request: generated search script is missing; command was not started"
+                        .to_string(),
+                ),
+            });
+        };
+        return run_internal_search_script_with_profiles_in_sandbox_and_execution_state(
+            config.generation,
+            &config.policy,
+            &config.shell,
+            projects_dir,
+            &jobs.prepared_profiles,
+            request.cwd.as_deref(),
+            script,
+            request.timeout_secs,
+            Some(runtime.shutdown_flag()),
+            request.sandbox.as_deref(),
+        );
+    }
+    run_shell_with_profiles_in_sandbox_and_execution_state(
+        config.generation,
+        &config.policy,
+        &config.shell,
+        projects_dir,
+        &jobs.prepared_profiles,
+        request.cwd.as_deref(),
+        &request.command,
+        request.stdin.as_deref(),
+        request.timeout_secs,
+        Some(runtime.shutdown_flag()),
+        request.sandbox.as_deref(),
+    )
+}
 
 /// Execute a single agent request (shell/file/job/lsp/validation) and send the
 /// result over the active transport. This is the shared dispatch path used by
@@ -263,19 +321,8 @@ pub(crate) fn dispatch_request(
                     .submit_result_with_metadata(request_id, result, config, runtime)
                     .map(|_| true);
             }
-            let result = run_shell_with_profiles_in_sandbox_and_execution_state(
-                config.generation,
-                policy,
-                shell,
-                projects_dir,
-                &jobs.prepared_profiles,
-                request.cwd.as_deref(),
-                &request.command,
-                request.stdin.as_deref(),
-                request.timeout_secs,
-                Some(runtime.shutdown_flag()),
-                request.sandbox.as_deref(),
-            );
+            let result =
+                run_native_shell_or_internal_search(config, runtime, jobs, projects_dir, &request);
             external_tools.complete_native_fallback(fallback, &result.result);
             return sink
                 .submit_shell_result_with_metadata(request_id, result, config, runtime)
@@ -395,18 +442,12 @@ pub(crate) fn dispatch_request(
                         "ssh_session_required: an SSH resource requires a Workflow Session id; command was not started".to_string(),
                     ),
                 }),
-                (None, _) => run_shell_with_profiles_in_sandbox_and_execution_state(
-                    config.generation,
-                    policy,
-                    shell,
+                (None, _) => run_native_shell_or_internal_search(
+                    config,
+                    runtime,
+                    jobs,
                     projects_dir,
-                    &jobs.prepared_profiles,
-                    request.cwd.as_deref(),
-                    &request.command,
-                    request.stdin.as_deref(),
-                    request.timeout_secs,
-                    Some(runtime.shutdown_flag()),
-                    request.sandbox.as_deref(),
+                    &request,
                 ),
             };
             sink.submit_shell_result_with_metadata(request_id, result, config, runtime)

--- a/crates/webcodex-runner/src/webcodex_runner/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/mod.rs
@@ -67,6 +67,7 @@ pub(crate) use projects::{
 pub(crate) use shell::{
     configured_prepared_shell_job_command, configured_shell_job_command,
     configured_validation_job_command, cwd_allowed, resolve_prepared_shell_profile,
+    run_internal_search_script_with_profiles_in_sandbox_and_execution_state,
     run_process_with_profiles_in_sandbox_and_execution_state,
     run_process_with_profiles_in_sandbox_and_execution_state_with_start_hook,
     run_script_with_profiles_in_sandbox_and_execution_state,

--- a/crates/webcodex-runner/src/webcodex_runner/shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell.rs
@@ -1719,6 +1719,188 @@ pub(crate) fn run_process_with_profiles_in_sandbox_and_execution_state_with_star
 }
 
 #[allow(clippy::too_many_arguments)]
+pub(crate) fn run_internal_search_script_with_profiles_in_sandbox_and_execution_state(
+    generation: u64,
+    policy: &AgentPolicy,
+    shell: &ShellConfig,
+    projects_dir: &Path,
+    cache: &PreparedShellProfileCache,
+    cwd: Option<&str>,
+    script: &str,
+    timeout_secs: u64,
+    stop_requested: Option<&AtomicBool>,
+    sandbox: Option<&str>,
+) -> ShellCommandResult {
+    #[cfg(not(windows))]
+    {
+        let payload = ShellScriptPayload {
+            language: ShellScriptLanguage::Sh,
+            script: script.to_string(),
+            args: Vec::new(),
+        };
+        return run_script_with_profiles_in_sandbox_and_execution_state(
+            generation,
+            policy,
+            shell,
+            projects_dir,
+            cache,
+            cwd,
+            &payload,
+            None,
+            timeout_secs,
+            stop_requested,
+            sandbox,
+        );
+    }
+
+    #[cfg(windows)]
+    {
+        // The native search program is a Runner-generated POSIX script. Do not
+        // hand it to the configured PowerShell parser, and do not materialize a
+        // Windows script-file path for an unrelated Bash runtime to interpret.
+        // Native Windows Bash launchers map the process cwd; `bash -s` consumes
+        // the generated script bytes directly from stdin.
+        if !policy.allow_raw_shell {
+            return ShellCommandResult::not_started(CommandResult {
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: Some(0),
+                error: Some(
+                    "internal search script execution is disabled by local agent policy".into(),
+                ),
+            });
+        }
+        if script.is_empty() {
+            return ShellCommandResult::not_started(CommandResult {
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: Some(0),
+                error: Some("internal search script is empty; command was not started".into()),
+            });
+        }
+        let cwd_path = cwd
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")));
+        if let Err(error) = cwd_allowed(policy, &cwd_path) {
+            return ShellCommandResult::not_started(CommandResult {
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: Some(0),
+                error: Some(error),
+            });
+        }
+        let timeout_secs = timeout_secs.min(policy.max_timeout_secs).max(1);
+        let start = Instant::now();
+        let inspect_scratch = match sandbox {
+            None => None,
+            Some(crate::command_sandbox::INSPECT_SANDBOX_MODE) => {
+                match crate::command_sandbox::InspectScratch::create() {
+                    Ok(scratch) => Some(scratch),
+                    Err(error) => {
+                        return ShellCommandResult::not_started(CommandResult {
+                            exit_code: None,
+                            stdout: None,
+                            stderr: None,
+                            duration_ms: Some(start.elapsed().as_millis() as u64),
+                            error: Some(format!("inspect sandbox unavailable: {error}")),
+                        })
+                    }
+                }
+            }
+            Some(other) => {
+                return ShellCommandResult::not_started(CommandResult {
+                    exit_code: None,
+                    stdout: None,
+                    stderr: None,
+                    duration_ms: Some(start.elapsed().as_millis() as u64),
+                    error: Some(format!("unknown sandbox mode '{other}'")),
+                })
+            }
+        };
+        let profile = if inspect_scratch.is_none() {
+            match resolve_prepared_shell_profile(
+                generation,
+                shell,
+                projects_dir,
+                &cwd_path,
+                cwd.is_some(),
+                cache,
+                stop_requested,
+            ) {
+                Ok(profile) => profile,
+                Err(error) => {
+                    return ShellCommandResult::not_started(CommandResult {
+                        exit_code: None,
+                        stdout: None,
+                        stderr: None,
+                        duration_ms: Some(start.elapsed().as_millis() as u64),
+                        error: Some(error),
+                    })
+                }
+            }
+        } else {
+            None
+        };
+        let interpreter = match configured_script_interpreter(
+            shell,
+            profile.as_deref(),
+            ShellScriptLanguage::Bash,
+        ) {
+            Ok(interpreter) => interpreter,
+            Err(error) => {
+                return ShellCommandResult::not_started(CommandResult {
+                    exit_code: None,
+                    stdout: None,
+                    stderr: None,
+                    duration_ms: Some(start.elapsed().as_millis() as u64),
+                    error: Some(error),
+                })
+            }
+        };
+        let mut command = Command::new(interpreter);
+        command.arg("-s");
+        match profile.as_deref() {
+            Some(profile) => apply_env_snapshot(&mut command, &profile.env_snapshot),
+            None => {
+                if let Err(error) = apply_shell_environment(&mut command, shell) {
+                    return ShellCommandResult::not_started(CommandResult {
+                        exit_code: None,
+                        stdout: None,
+                        stderr: None,
+                        duration_ms: Some(start.elapsed().as_millis() as u64),
+                        error: Some(error),
+                    });
+                }
+            }
+        }
+        // WSL/Git-Bash interop may expose a host ripgrep binary as `rg.exe`
+        // rather than `rg`. Keep the existing search script and its rg-first
+        // semantics unchanged by providing a process-local function only when
+        // no native `rg` command is already visible. Relative project paths are
+        // preserved across the Windows/Bash cwd mapping.
+        let script = format!(
+            "if ! command -v rg >/dev/null 2>&1 && command -v rg.exe >/dev/null 2>&1; then rg() {{ command rg.exe --path-separator / \"$@\"; }}; fi\n{script}"
+        );
+
+        execute_configured_command(
+            policy,
+            command,
+            &cwd_path,
+            Some(&script),
+            timeout_secs,
+            stop_requested,
+            inspect_scratch.as_ref(),
+            start,
+            "failed to spawn internal search interpreter",
+            None,
+        )
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_script_with_profiles_in_sandbox_and_execution_state(
     generation: u64,
     policy: &AgentPolicy,

--- a/src/tool_runtime/files.rs
+++ b/src/tool_runtime/files.rs
@@ -1402,8 +1402,8 @@ fn parse_search_line_record(line: &str) -> Option<SearchLineRecord> {
 
 /// Return the byte offset immediately after the leading trusted backend marker,
 /// when present. The command always emits this marker outside the bounded search
-/// payload. Parser-only tests and legacy/transport-truncated responses may omit
-/// it, in which case the whole stdout string is treated as payload.
+/// payload. Low-level parser helpers still tolerate markerless input, but the
+/// public search result path rejects it before parsing.
 fn search_payload_start(stdout: &str) -> usize {
     let Some(newline) = stdout.find('\n') else {
         return 0;
@@ -5167,7 +5167,7 @@ mod tests {
         let result = search_project_text_output(
             "demo",
             &options,
-            "src/main.rs:42:fn main() {}\n",
+            "{\"webcodex_search\":{\"backend\":\"rg\"}}\nsrc/main.rs:42:fn main() {}\n",
             Some(0),
             "",
         );
@@ -5184,7 +5184,7 @@ mod tests {
 
     #[test]
     fn parse_search_context_matches_returns_context_line_numbers() {
-        let stdout = "src/lib.rs\x001-one\nsrc/lib.rs\x002-two\nsrc/lib.rs\x003:needle\nsrc/lib.rs\x004-four\nsrc/lib.rs\x005-five\n";
+        let stdout = "{\"webcodex_search\":{\"backend\":\"rg\"}}\nsrc/lib.rs\x001-one\nsrc/lib.rs\x002-two\nsrc/lib.rs\x003:needle\nsrc/lib.rs\x004-four\nsrc/lib.rs\x005-five\n";
         let options = SearchOptions::normalize(SearchRequest {
             pattern: "needle".to_string(),
             path: None,
@@ -5238,7 +5238,7 @@ mod tests {
             timeout_secs: None,
         })
         .unwrap();
-        let stdout = "src/a.rs:1:needle one\nsrc/b.rs:2:needle tw";
+        let stdout = "{\"webcodex_search\":{\"backend\":\"rg\"}}\nsrc/a.rs:1:needle one\nsrc/b.rs:2:needle tw";
         let result = search_project_text_output("demo", &options, stdout, Some(0), "");
         let matches = result.output["matches"].as_array().unwrap();
 
@@ -5265,7 +5265,7 @@ mod tests {
             timeout_secs: None,
         })
         .unwrap();
-        let stdout = "src/a.rs:1:needle one\n";
+        let stdout = "{\"webcodex_search\":{\"backend\":\"rg\"}}\nsrc/a.rs:1:needle one\n";
         let result = search_project_text_output("demo", &options, stdout, Some(0), "");
         assert!(result.success);
         assert_eq!(result.output["matches"].as_array().unwrap().len(), 1);
@@ -5377,7 +5377,7 @@ mod tests {
             timeout_secs: None,
         })
         .unwrap();
-        let stdout = "src/a.rs:1:one\nsrc/b.rs:2:two\nsrc/c.rs:3:three\n";
+        let stdout = "{\"webcodex_search\":{\"backend\":\"rg\"}}\nsrc/a.rs:1:one\nsrc/b.rs:2:two\nsrc/c.rs:3:three\n";
         let result = search_project_text_output("demo", &options, stdout, Some(141), "");
         assert!(result.success, "{:?}", result.error);
         assert_eq!(result.output["matches"].as_array().unwrap().len(), 2);
@@ -5577,7 +5577,7 @@ mod tests {
             timeout_secs: None,
         })
         .unwrap();
-        let stdout = "src/a.rs:1:needle\n";
+        let stdout = "{\"webcodex_search\":{\"backend\":\"rg\"}}\nsrc/a.rs:1:needle\n";
         let result = search_project_text_output("demo", &options, stdout, Some(2), "");
         assert!(!result.success);
         assert_eq!(result.output["code"], "search_execution_failed");
@@ -5600,6 +5600,7 @@ mod tests {
         // Absolute path, parent traversal, and a temp-file path must be
         // dropped; only the trusted relative record survives.
         let stdout = concat!(
+            "{\"webcodex_search\":{\"backend\":\"rg\"}}\n",
             "/tmp/webcodex-x:1:secret\n",
             "src/../../etc/passwd:1:secret\n",
             "src/a.rs:1:needle\n",
@@ -5666,7 +5667,9 @@ mod tests {
         .unwrap();
 
         for marker in transport_truncation_markers() {
-            let stdout = format!("{marker}src/a.rs:1:needle one\nsrc/b.rs:2:needle two\n");
+            let stdout = format!(
+                "{marker}{{\"webcodex_search\":{{\"backend\":\"rg\"}}}}\nsrc/a.rs:1:needle one\nsrc/b.rs:2:needle two\n"
+            );
             let result = search_project_text_output("demo", &options, &stdout, Some(0), "");
             assert!(result.success, "marker {marker:?}: {:?}", result.error);
             assert_eq!(result.output["truncated"], true, "marker {marker:?}");
@@ -5700,7 +5703,9 @@ mod tests {
         .unwrap();
 
         for marker in transport_truncation_markers() {
-            let stdout = format!("{marker}src/a.rs\nsrc/b.rs\n");
+            let stdout = format!(
+                "{marker}{{\"webcodex_search\":{{\"backend\":\"rg\"}}}}\nsrc/a.rs\nsrc/b.rs\n"
+            );
             let result = search_project_text_output("demo", &options, &stdout, Some(0), "");
             assert!(result.success, "marker {marker:?}: {:?}", result.error);
             assert_eq!(result.output["truncated"], true, "marker {marker:?}");
@@ -5738,7 +5743,9 @@ mod tests {
         .unwrap();
 
         for marker in transport_truncation_markers() {
-            let stdout = format!("{marker}src/a.rs:2\nsrc/b.rs:3\n");
+            let stdout = format!(
+                "{marker}{{\"webcodex_search\":{{\"backend\":\"rg\"}}}}\nsrc/a.rs:2\nsrc/b.rs:3\n"
+            );
             let result = search_project_text_output("demo", &options, &stdout, Some(0), "");
             assert!(result.success, "marker {marker:?}: {:?}", result.error);
             assert_eq!(result.output["truncated"], true, "marker {marker:?}");
@@ -5775,6 +5782,7 @@ mod tests {
         })
         .unwrap();
         let stdout = concat!(
+            "{\"webcodex_search\":{\"backend\":\"rg\"}}\n",
             "src/a.rs:1:needle one\n",
             "[output truncated]\n",
             "src/b.rs:2:needle two\n",

--- a/src/tool_runtime/files.rs
+++ b/src/tool_runtime/files.rs
@@ -1300,6 +1300,7 @@ struct SearchResult {
 struct SearchBackendStatus {
     backend: String,
     feature_unavailable: bool,
+    marker_present: bool,
 }
 
 fn parse_search_backend_status(stdout: &str) -> SearchBackendStatus {
@@ -1318,11 +1319,13 @@ fn parse_search_backend_status(stdout: &str) -> SearchBackendStatus {
                     .get("feature_unavailable")
                     .and_then(Value::as_bool)
                     .unwrap_or(false),
+                marker_present: true,
             })
         })
         .unwrap_or_else(|| SearchBackendStatus {
             backend: "grep".to_string(),
             feature_unavailable: false,
+            marker_present: false,
         })
 }
 
@@ -1673,6 +1676,24 @@ pub(crate) fn search_project_text_output_with_agent_error(
     agent_error: Option<&str>,
 ) -> ToolResult {
     let backend_status = parse_search_backend_status(stdout);
+    // Every canonical native or external-provider success path emits a trusted
+    // backend identity marker before search records. Missing identity is therefore
+    // an execution/protocol failure regardless of incidental stdout/stderr noise;
+    // accepting markerless output could turn a shell/parser failure into a false
+    // search result (observed with PowerShell on Windows).
+    if !backend_status.marker_present {
+        let message = "search_project_text backend did not emit its identity marker";
+        return ToolResult::err_with_output(
+            message,
+            json!({
+                "code": "search_execution_failed",
+                "backend": Value::Null,
+                "result_mode": options.result_mode.as_str(),
+                "effective_timeout_secs": options.timeout_secs,
+                "message": message,
+            }),
+        );
+    }
     if backend_status.feature_unavailable {
         let message = "ripgrep is required for the requested search_project_text features; grep fallback supports only basic matches requests";
         return ToolResult::err_with_output(

--- a/src/tool_runtime/helpers.rs
+++ b/src/tool_runtime/helpers.rs
@@ -882,7 +882,10 @@ pub(crate) fn validate_project_relative_path(path: &str) -> Result<(), String> {
         return Ok(());
     }
     let p = Path::new(path);
-    if p.is_absolute() {
+    if p.has_root()
+        || p.components()
+            .any(|component| matches!(component, std::path::Component::Prefix(_)))
+    {
         return Err("path must be project-relative".to_string());
     }
     if p.components()

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -1351,7 +1351,7 @@ fn validate_project_relative_path_rejects_absolute_and_parent_traversal() {
 
 #[test]
 fn parse_search_matches_is_bounded_and_strips_dot_slash() {
-    let stdout = "./src/main.rs:10:fn main() {}\n./src/lib.rs:3:pub fn x()\n./src/a:1:1\n";
+    let stdout = "{\"webcodex_search\":{\"backend\":\"rg\"}}\n./src/main.rs:10:fn main() {}\n./src/lib.rs:3:pub fn x()\n./src/a:1:1\n";
     let options = SearchOptions::normalize(SearchRequest {
         limit: Some(2),
         ..raw_search_request()
@@ -1372,7 +1372,7 @@ fn parse_search_matches_is_bounded_and_strips_dot_slash() {
 #[test]
 fn parse_search_matches_skips_lines_without_line_number() {
     // Binary file matches or malformed lines are skipped, not counted.
-    let stdout = "binary:file\nsrc/main.rs:5:hit\n";
+    let stdout = "{\"webcodex_search\":{\"backend\":\"rg\"}}\nbinary:file\nsrc/main.rs:5:hit\n";
     let options = SearchOptions::normalize(SearchRequest {
         limit: Some(10),
         ..raw_search_request()

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -1817,6 +1817,26 @@ fn search_backend_exit_codes_map_to_results() {
     }
 }
 
+#[test]
+fn search_markerless_output_cannot_be_reported_as_a_search_result() {
+    let options = SearchOptions::normalize(raw_search_request()).unwrap();
+    for (stdout, exit_code, stderr) in [
+        (
+            "",
+            Some(1),
+            "PowerShell parser rejected the generated POSIX search script",
+        ),
+        ("src/lib.rs:1:startup noise\n", Some(0), ""),
+        ("src/lib.rs:1:partial output\n", Some(1), ""),
+    ] {
+        let result = search_project_text_output("demo", &options, stdout, exit_code, stderr);
+        assert!(!result.success, "stdout={stdout:?} exit_code={exit_code:?}");
+        assert_search_output_keys_are_declared(&result.output);
+        assert_eq!(result.output["code"], "search_execution_failed");
+        assert!(result.output["backend"].is_null());
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn search_command_preserves_rg_exit_2_despite_head() {

--- a/src/tool_runtime/tests/support/agent.rs
+++ b/src/tool_runtime/tests/support/agent.rs
@@ -4,7 +4,7 @@ use crate::shell_client::ShellClientRegistry;
 use crate::shell_protocol::{
     AgentPolicySummary, ShellAgentPollRequest, ShellAgentProjectSummary, ShellAgentResultRequest,
     ShellAgentShellRequest, ShellClientCapabilities, ShellClientRegisterRequest,
-    ShellProfileSummaryEntry,
+    ShellProfileSummaryEntry, EXTERNAL_SEARCH_REQUEST_PREFIX,
 };
 use crate::tool_runtime::{RuntimeInfo, ToolCall, ToolResult, ToolRuntime};
 use crate::workspace_checkpoint::{create_workspace_checkpoint, restore_workspace_checkpoint};
@@ -100,12 +100,33 @@ pub(in crate::tool_runtime::tests) fn run_agent_shell_request_locally(
     if req.kind == "file_project_overview" {
         return run_agent_project_overview_request_locally(req);
     }
-    let mut command = std::process::Command::new("sh");
-    command.arg("-c").arg(&req.command);
+    let internal_search = req
+        .command
+        .strip_prefix(EXTERNAL_SEARCH_REQUEST_PREFIX)
+        .and_then(|rest| rest.strip_prefix('\n'));
+    let (mut command, stdin_payload) = if let Some(script) = internal_search {
+        #[cfg(windows)]
+        let mut command = std::process::Command::new("bash.exe");
+        #[cfg(not(windows))]
+        let mut command = std::process::Command::new("sh");
+        command.arg("-s");
+        let script = if cfg!(windows) {
+            format!(
+                "if ! command -v rg >/dev/null 2>&1 && command -v rg.exe >/dev/null 2>&1; then rg() {{ command rg.exe --path-separator / \"$@\"; }}; fi\n{script}"
+            )
+        } else {
+            script.to_string()
+        };
+        (command, Some(script))
+    } else {
+        let mut command = std::process::Command::new("sh");
+        command.arg("-c").arg(&req.command);
+        (command, req.stdin.clone())
+    };
     if let Some(cwd) = req.cwd.as_deref() {
         command.current_dir(cwd);
     }
-    if req.stdin.is_some() {
+    if stdin_payload.is_some() {
         command.stdin(std::process::Stdio::piped());
     }
     let mut child = command
@@ -113,7 +134,7 @@ pub(in crate::tool_runtime::tests) fn run_agent_shell_request_locally(
         .stderr(std::process::Stdio::piped())
         .spawn()
         .expect("spawn agent shell request");
-    if let Some(stdin) = req.stdin.as_deref() {
+    if let Some(stdin) = stdin_payload.as_deref() {
         use std::io::Write;
         let write_result = child
             .stdin


### PR DESCRIPTION
## Summary

- route WebCodex-generated POSIX search programs through a dedicated internal search runtime instead of the configured Windows PowerShell parser
- execute Windows internal search with WSL `bash -s` over stdin and bridge host `rg.exe` with `/` path separators
- require an explicit search backend identity marker so parser/interpreter failures cannot be reported as valid empty or partial search results
- reject rooted-without-drive Windows paths in project-relative validation

## Review hardening

Independent review tightened the backend marker contract: every canonical native or external-provider success path emits `webcodex_search`, so any markerless output now fails closed, including non-empty stdout with empty stderr.

## Validation

- Linux `cargo test 'search_project_text' -p webcodex`: 31 passed
- Linux `cargo test 'search' -p webcodex-runner`: 4 passed
- `cargo check --all-targets -p webcodex-runner`: passed
- `cargo check --all-targets -p webcodex`: passed
- `cargo fmt -- --check`: passed
- `git diff --check`: passed

Windows-native validation for the same implementation before rebase passed the focused search suite; the implementation is also carried by the reviewed Windows parity branch.