### PR TITLE
Add Windows UIA Computer parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4921,6 +4921,7 @@ dependencies = [
  "webcodex-sandbox",
  "webcodex-workspace",
  "webpki-roots 0.26.11",
+ "windows",
  "windows-sys 0.61.2",
  "xcap",
  "xml",

--- a/crates/webcodex-runner/Cargo.toml
+++ b/crates/webcodex-runner/Cargo.toml
@@ -45,6 +45,11 @@ objc2-core-foundation = "0.3.2"
 objc2-core-graphics = "0.3.2"
 
 [target.'cfg(windows)'.dependencies]
+windows = { version = "0.62.2", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_UI_Accessibility",
+] }
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Globalization",

--- a/crates/webcodex-runner/Cargo.toml
+++ b/crates/webcodex-runner/Cargo.toml
@@ -49,6 +49,7 @@ windows = { version = "0.62.2", features = [
     "Win32_Foundation",
     "Win32_System_Com",
     "Win32_UI_Accessibility",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",

--- a/crates/webcodex-runner/Cargo.toml
+++ b/crates/webcodex-runner/Cargo.toml
@@ -48,6 +48,7 @@ objc2-core-graphics = "0.3.2"
 windows = { version = "0.62.2", features = [
     "Win32_Foundation",
     "Win32_System_Com",
+    "Win32_System_Ole",
     "Win32_UI_Accessibility",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -1883,9 +1883,9 @@ fn agent_register_capabilities(cfg: &AgentConfig) -> ShellClientCapabilities {
     // Closed key input is a separate effect/wire capability. It is currently
     // implemented only by the macOS Runner and is never implied by control.
     capabilities.computer_key_input = cfg!(target_os = "macos");
-    // Exact window activation is a separate effect/wire capability. Old macOS
-    // Runners that only advertise computer_control must fail closed.
-    capabilities.computer_window_activate = cfg!(target_os = "macos");
+    // Exact window activation is a separate effect/wire capability. It is
+    // independently advertised by native macOS and Windows implementations.
+    capabilities.computer_window_activate = cfg!(any(target_os = "macos", windows));
     // Bounded Accessibility text input is a separate rolling-upgrade fence;
     // older macOS Runners with computer_control must not be treated as capable.
     capabilities.computer_text_input = cfg!(target_os = "macos");

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -1868,12 +1868,12 @@ fn agent_register_capabilities(cfg: &AgentConfig) -> ShellClientCapabilities {
     // old Runners that support only whole-window snapshots fail closed.
     capabilities.computer_snapshot_region = cfg!(any(target_os = "macos", windows));
     // Accessibility inspection is a separate read-only semantic capability.
-    // It is currently implemented only by the macOS Runner and never implies
-    // future computer-control authority.
-    capabilities.computer_accessibility_observe = cfg!(target_os = "macos");
+    // macOS AX and Windows UI Automation share the same model-facing tree;
+    // observation authority never implies computer-control authority.
+    capabilities.computer_accessibility_observe = cfg!(any(target_os = "macos", windows));
     // Normalized element-state observation is a separate rolling-upgrade wire
-    // capability and is currently implemented only on macOS.
-    capabilities.computer_element_state = cfg!(target_os = "macos");
+    // capability implemented by the same native read-only backends.
+    capabilities.computer_element_state = cfg!(any(target_os = "macos", windows));
     // Accessibility control is independently fenced and currently implemented
     // only by the macOS Runner; observation authority never implies it.
     capabilities.computer_control = cfg!(target_os = "macos");

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -1887,8 +1887,8 @@ fn agent_register_capabilities(cfg: &AgentConfig) -> ShellClientCapabilities {
     // independently advertised by native macOS and Windows implementations.
     capabilities.computer_window_activate = cfg!(any(target_os = "macos", windows));
     // Bounded Accessibility text input is a separate rolling-upgrade fence;
-    // older macOS Runners with computer_control must not be treated as capable.
-    capabilities.computer_text_input = cfg!(target_os = "macos");
+    // older native Runners with computer_control must not be treated as capable.
+    capabilities.computer_text_input = cfg!(any(target_os = "macos", windows));
     capabilities.job_state_reconciliation = !disable_job_state_reconciliation_for_test();
 
     // New agents always advertise read-only LSP navigation. Older agents omit

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -1874,9 +1874,9 @@ fn agent_register_capabilities(cfg: &AgentConfig) -> ShellClientCapabilities {
     // Normalized element-state observation is a separate rolling-upgrade wire
     // capability implemented by the same native read-only backends.
     capabilities.computer_element_state = cfg!(any(target_os = "macos", windows));
-    // Accessibility control is independently fenced and currently implemented
-    // only by the macOS Runner; observation authority never implies it.
-    capabilities.computer_control = cfg!(target_os = "macos");
+    // Accessibility control is independently fenced and implemented by the
+    // native macOS AX and Windows UI Automation backends.
+    capabilities.computer_control = cfg!(any(target_os = "macos", windows));
     // Semantic AX scroll-to-visible is independently fenced for rolling upgrades;
     // existing computer_control support never implies it.
     capabilities.computer_scroll_to_element = cfg!(target_os = "macos");

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -6952,8 +6952,8 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
     );
     assert_eq!(
         caps.computer_window_activate,
-        cfg!(target_os = "macos"),
-        "computer window activation is independently advertised only by the macOS native implementation"
+        cfg!(any(target_os = "macos", windows)),
+        "computer window activation is independently advertised only by native macOS/Windows implementations"
     );
     assert_eq!(
         caps.computer_text_input,

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -6957,8 +6957,8 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
     );
     assert_eq!(
         caps.computer_text_input,
-        cfg!(target_os = "macos"),
-        "computer text input is independently advertised only by the macOS native implementation"
+        cfg!(any(target_os = "macos", windows)),
+        "computer text input is independently advertised only by native macOS/Windows implementations"
     );
     assert_eq!(
         caps.sandbox_inspect_commands,

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -6937,8 +6937,8 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
     );
     assert_eq!(
         caps.computer_control,
-        cfg!(target_os = "macos"),
-        "computer control is independently advertised only by the macOS native implementation"
+        cfg!(any(target_os = "macos", windows)),
+        "computer control is independently advertised only by native macOS/Windows implementations"
     );
     assert_eq!(
         caps.computer_scroll_to_element,

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -6927,13 +6927,13 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
     );
     assert_eq!(
         caps.computer_accessibility_observe,
-        cfg!(target_os = "macos"),
-        "computer accessibility observation is advertised only by the macOS native implementation"
+        cfg!(any(target_os = "macos", windows)),
+        "computer accessibility observation is advertised only by native AX/UIA implementations"
     );
     assert_eq!(
         caps.computer_element_state,
-        cfg!(target_os = "macos"),
-        "computer element state is independently advertised only by the macOS native implementation"
+        cfg!(any(target_os = "macos", windows)),
+        "computer element state is independently advertised only by native AX/UIA implementations"
     );
     assert_eq!(
         caps.computer_control,

--- a/crates/webcodex-runner/src/webcodex_runner/computer.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/computer.rs
@@ -2250,6 +2250,7 @@ mod platform {
                 UIA_TreeItemControlTypeId, UIA_ValuePatternId, UIA_WindowControlTypeId,
                 UIA_CONTROLTYPE_ID, UIA_E_ELEMENTNOTAVAILABLE, UIA_E_NOTSUPPORTED, UIA_PATTERN_ID,
             },
+            UI::WindowsAndMessaging::{GetForegroundWindow, IsIconic, ShowWindowAsync, SW_RESTORE},
         },
     };
     #[cfg(windows)]
@@ -3252,7 +3253,7 @@ mod platform {
     }
 
     #[cfg(windows)]
-    fn win_hwnd(native_id: u32) -> Result<WinHwnd, String> {
+    pub(super) fn win_hwnd(native_id: u32) -> Result<WinHwnd, String> {
         let hwnd = WinHwnd(native_id as i32 as isize as *mut std::ffi::c_void);
         if hwnd.0.is_null() {
             Err("stale_surface: window handle is invalid".to_string())
@@ -4052,14 +4053,92 @@ mod platform {
     }
 
     #[cfg(windows)]
-    pub(super) fn activate_window(
-        _surface_id: &str,
-        _surface: &SurfaceRecord,
-    ) -> Result<Value, String> {
-        Err(
-            "unsupported_platform: computer window activation is unavailable on this platform"
-                .to_string(),
+    pub(super) fn windows_window_activation_attempt_error(operation: &str) -> String {
+        format!(
+            "outcome_unknown: {operation} did not establish the exact foreground-window postcondition after the native activation attempt"
         )
+    }
+
+    #[cfg(windows)]
+    pub(super) fn activate_window(
+        surface_id: &str,
+        surface: &SurfaceRecord,
+    ) -> Result<Value, String> {
+        // Resolve the exact xcap identity immediately before the first native
+        // effect. This never falls back to an application name, PID, or title.
+        let _window = resolve_surface_window(surface)?;
+        let hwnd = win_hwnd(surface.native_id)?;
+        let already_foreground = unsafe { GetForegroundWindow() == hwnd };
+        let minimized = unsafe { IsIconic(hwnd).as_bool() };
+        if already_foreground && !minimized {
+            return Ok(json!({
+                "platform": "windows",
+                "surface_id": surface_id,
+                "success": true,
+            }));
+        }
+
+        // Obtain the exact UIA root before the first effect. This revalidates
+        // the same HWND/PID lineage used by read-only Windows observation.
+        let context = UiaContext::new()?;
+        let root = exact_uia_window(&context, surface)?;
+        context.deadline.ensure_remaining()?;
+        let control_type = unsafe { root.CurrentControlType() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentControlType", &error))?;
+        if control_type != UIA_WindowControlTypeId {
+            return Err(
+                "control_failed: exact Windows UIA root is not an activatable Window control"
+                    .to_string(),
+            );
+        }
+        let mut prior_effect = false;
+        if minimized {
+            // Restoring a foreign UI thread must not synchronously wait on a
+            // stalled target. Queue the exact restore request asynchronously,
+            // then observe only the local window-state predicate for a bounded
+            // interval before proceeding.
+            let restore_expires_at = Instant::now() + Duration::from_secs(2);
+            let _ = unsafe { ShowWindowAsync(hwnd, SW_RESTORE) };
+            prior_effect = true;
+            while unsafe { IsIconic(hwnd).as_bool() } {
+                if let Err(error) = context.deadline.ensure_remaining() {
+                    return Err(windows_window_activation_attempt_error(&error));
+                }
+                if Instant::now() >= restore_expires_at {
+                    return Err(windows_window_activation_attempt_error(
+                        "ShowWindowAsync(SW_RESTORE) timeout",
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+
+        // A background Runner is normally denied by SetForegroundWindow.
+        // UI Automation's exact SetFocus is the native automation primitive;
+        // once attempted, any error or mismatched postcondition is uncertain.
+        if let Err(error) = context.deadline.ensure_remaining() {
+            if prior_effect {
+                return Err(windows_window_activation_attempt_error(&error));
+            }
+            return Err(error);
+        }
+        if let Err(error) = unsafe { root.SetFocus() } {
+            return Err(windows_window_activation_attempt_error(&format!(
+                "IUIAutomationElement::SetFocus HRESULT(0x{:08X})",
+                error.code().0 as u32
+            )));
+        }
+        if unsafe { GetForegroundWindow() != hwnd } {
+            return Err(windows_window_activation_attempt_error(
+                "IUIAutomationElement::SetFocus postcondition",
+            ));
+        }
+
+        Ok(json!({
+            "platform": "windows",
+            "surface_id": surface_id,
+            "success": true,
+        }))
     }
 
     #[cfg(windows)]
@@ -4499,6 +4578,7 @@ mod windows_uia_tests {
         UIA_ButtonControlTypeId, UIA_CheckBoxControlTypeId, UIA_DocumentControlTypeId,
         UIA_EditControlTypeId, UIA_HyperlinkControlTypeId, UIA_WindowControlTypeId,
     };
+    use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
 
     fn surface_record(candidate: PlatformWindow) -> SurfaceRecord {
         SurfaceRecord {
@@ -4537,6 +4617,74 @@ mod windows_uia_tests {
         assert_eq!(
             platform::uia_control_role(UIA_CheckBoxControlTypeId),
             "AXCheckBox"
+        );
+    }
+
+    #[test]
+    fn computer_windows_window_activation_attempt_failure_is_unknown() {
+        let error =
+            platform::windows_window_activation_attempt_error("IUIAutomationElement::SetFocus");
+        assert!(error.starts_with("outcome_unknown:"), "{error}");
+    }
+
+    #[test]
+    #[ignore = "requires an interactive Windows desktop with two observable UIA-backed windows; leaves the activated test window foreground"]
+    fn computer_windows_window_activation_live_smoke() {
+        let candidates = platform::list_windows(MAX_WINDOWS).expect("list live Windows windows");
+        let foreground = unsafe { GetForegroundWindow() };
+        let original_native_id = candidates
+            .iter()
+            .find(|candidate| platform::win_hwnd(candidate.native_id).ok() == Some(foreground))
+            .map(|candidate| candidate.native_id)
+            .expect("current foreground window must have an exact xcap surface");
+        let mut failures = Vec::new();
+
+        for candidate in candidates {
+            if candidate.native_id == original_native_id {
+                continue;
+            }
+            let target_hwnd = match platform::win_hwnd(candidate.native_id) {
+                Ok(hwnd) if hwnd != foreground => hwnd,
+                _ => continue,
+            };
+            let target_record = surface_record(candidate);
+            match platform::accessibility_tree(
+                "surface_windows_activation_probe",
+                &target_record,
+                1,
+                8,
+            ) {
+                Ok(tree)
+                    if tree.output["nodes"]
+                        .as_array()
+                        .and_then(|nodes| nodes.first())
+                        .and_then(|node| node["role"].as_str())
+                        == Some("AXWindow") => {}
+                Ok(_) => continue,
+                Err(error)
+                    if error.starts_with("stale_surface:")
+                        || error.starts_with("accessibility_failed:") =>
+                {
+                    if failures.len() < 8 {
+                        failures.push(error);
+                    }
+                    continue;
+                }
+                Err(error) => panic!("unexpected Windows activation preflight error: {error}"),
+            }
+
+            let output =
+                platform::activate_window("surface_windows_activation_live", &target_record)
+                    .expect("activate one exact Windows UIA-backed surface");
+            assert_eq!(output["platform"], "windows");
+            assert_eq!(output["surface_id"], "surface_windows_activation_live");
+            assert_eq!(output["success"], true);
+            assert_eq!(unsafe { GetForegroundWindow() }, target_hwnd);
+            return;
+        }
+
+        panic!(
+            "no alternate exact UIA-backed Windows surface was available; failures={failures:?}"
         );
     }
 

--- a/crates/webcodex-runner/src/webcodex_runner/computer.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/computer.rs
@@ -183,7 +183,7 @@ impl ComputerAction {
         }
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", windows))]
     fn as_str(self) -> &'static str {
         match self {
             Self::Press => "press",
@@ -2235,20 +2235,21 @@ mod platform {
                 COINIT_MULTITHREADED,
             },
             UI::Accessibility::{
-                CUIAutomation8, IUIAutomation2, IUIAutomationElement, IUIAutomationTreeWalker,
-                IUIAutomationValuePattern, UIA_ButtonControlTypeId, UIA_CheckBoxControlTypeId,
-                UIA_ComboBoxControlTypeId, UIA_CustomControlTypeId, UIA_DataGridControlTypeId,
-                UIA_DataItemControlTypeId, UIA_DocumentControlTypeId, UIA_EditControlTypeId,
-                UIA_GroupControlTypeId, UIA_HeaderControlTypeId, UIA_HeaderItemControlTypeId,
-                UIA_HyperlinkControlTypeId, UIA_ListControlTypeId, UIA_ListItemControlTypeId,
-                UIA_MenuControlTypeId, UIA_MenuItemControlTypeId, UIA_PaneControlTypeId,
-                UIA_ProgressBarControlTypeId, UIA_RadioButtonControlTypeId,
-                UIA_ScrollBarControlTypeId, UIA_SeparatorControlTypeId, UIA_SliderControlTypeId,
-                UIA_SpinnerControlTypeId, UIA_StatusBarControlTypeId, UIA_TabControlTypeId,
-                UIA_TabItemControlTypeId, UIA_TableControlTypeId, UIA_TextControlTypeId,
-                UIA_ToolBarControlTypeId, UIA_ToolTipControlTypeId, UIA_TreeControlTypeId,
-                UIA_TreeItemControlTypeId, UIA_ValuePatternId, UIA_WindowControlTypeId,
-                UIA_CONTROLTYPE_ID, UIA_E_ELEMENTNOTAVAILABLE, UIA_E_NOTSUPPORTED, UIA_PATTERN_ID,
+                CUIAutomation8, IUIAutomation2, IUIAutomationElement, IUIAutomationInvokePattern,
+                IUIAutomationTreeWalker, IUIAutomationValuePattern, UIA_ButtonControlTypeId,
+                UIA_CheckBoxControlTypeId, UIA_ComboBoxControlTypeId, UIA_CustomControlTypeId,
+                UIA_DataGridControlTypeId, UIA_DataItemControlTypeId, UIA_DocumentControlTypeId,
+                UIA_EditControlTypeId, UIA_GroupControlTypeId, UIA_HeaderControlTypeId,
+                UIA_HeaderItemControlTypeId, UIA_HyperlinkControlTypeId, UIA_InvokePatternId,
+                UIA_ListControlTypeId, UIA_ListItemControlTypeId, UIA_MenuControlTypeId,
+                UIA_MenuItemControlTypeId, UIA_PaneControlTypeId, UIA_ProgressBarControlTypeId,
+                UIA_RadioButtonControlTypeId, UIA_ScrollBarControlTypeId,
+                UIA_SeparatorControlTypeId, UIA_SliderControlTypeId, UIA_SpinnerControlTypeId,
+                UIA_StatusBarControlTypeId, UIA_TabControlTypeId, UIA_TabItemControlTypeId,
+                UIA_TableControlTypeId, UIA_TextControlTypeId, UIA_ToolBarControlTypeId,
+                UIA_ToolTipControlTypeId, UIA_TreeControlTypeId, UIA_TreeItemControlTypeId,
+                UIA_ValuePatternId, UIA_WindowControlTypeId, UIA_CONTROLTYPE_ID,
+                UIA_E_ELEMENTNOTAVAILABLE, UIA_E_NOTSUPPORTED, UIA_PATTERN_ID,
             },
             UI::WindowsAndMessaging::{GetForegroundWindow, IsIconic, ShowWindowAsync, SW_RESTORE},
         },
@@ -3079,6 +3080,25 @@ mod platform {
     }
 
     #[cfg(windows)]
+    fn uia_element_has_exact_focus(
+        context: &UiaContext,
+        element: &IUIAutomationElement,
+    ) -> Result<bool, String> {
+        context.deadline.ensure_remaining()?;
+        let Some(focused) = optional_uia_element(
+            unsafe { context.automation.GetFocusedElement() },
+            "IUIAutomation::GetFocusedElement",
+        )?
+        else {
+            return Ok(false);
+        };
+        context.deadline.ensure_remaining()?;
+        unsafe { context.automation.CompareElements(element, &focused) }
+            .map(|same| same.as_bool())
+            .map_err(|error| uia_error("IUIAutomation::CompareElements", &error))
+    }
+
+    #[cfg(windows)]
     fn uia_string(
         result: windows::core::Result<windows::core::BSTR>,
         operation: &str,
@@ -3155,6 +3175,11 @@ mod platform {
         };
         role.map(str::to_string)
             .unwrap_or_else(|| format!("UIAControlType({})", control_type.0))
+    }
+
+    #[cfg(windows)]
+    pub(super) fn uia_semantic_focus_role(role: &str) -> bool {
+        role == "AXTextField"
     }
 
     #[cfg(windows)]
@@ -4024,15 +4049,37 @@ mod platform {
         let enabled = unsafe { current.CurrentIsEnabled() }
             .map_err(|error| uia_error("IUIAutomationElement::CurrentIsEnabled", &error))?
             .as_bool();
-        context.deadline.ensure_remaining()?;
-        let focused = unsafe { current.CurrentHasKeyboardFocus() }
-            .map_err(|error| uia_error("IUIAutomationElement::CurrentHasKeyboardFocus", &error))?
-            .as_bool();
+        let focused = uia_element_has_exact_focus(&context, &current)?;
         let protected = element.contains_protected_content();
         let value_empty = if !protected && is_supported_text_input_fingerprint(target) {
             uia_text_value(&context, &current)?.map(|value| value.is_empty())
         } else {
             None
+        };
+        let can_press = if protected || !enabled {
+            false
+        } else {
+            optional_uia_pattern::<IUIAutomationInvokePattern>(
+                &context,
+                &current,
+                UIA_InvokePatternId,
+            )?
+            .is_some()
+        };
+        let can_focus = if protected || !enabled || !uia_semantic_focus_role(&target.role) {
+            false
+        } else {
+            let hwnd = win_hwnd(surface.native_id)?;
+            if unsafe { GetForegroundWindow() != hwnd } {
+                false
+            } else {
+                context.deadline.ensure_remaining()?;
+                unsafe { current.CurrentIsKeyboardFocusable() }
+                    .map_err(|error| {
+                        uia_error("IUIAutomationElement::CurrentIsKeyboardFocusable", &error)
+                    })?
+                    .as_bool()
+            }
         };
 
         Ok(json!({
@@ -4044,10 +4091,9 @@ mod platform {
             "focused": focused,
             "protected": protected,
             "value_empty": value_empty,
-            // W1 is read-only. Do not overstate WebCodex mutation affordances
-            // before the corresponding Windows effect capabilities exist.
-            "can_press": false,
-            "can_focus": false,
+            "can_press": can_press,
+            "can_focus": can_focus,
+            // W3 still does not widen Windows text mutation authority.
             "can_input_text": false,
         }))
     }
@@ -4056,6 +4102,13 @@ mod platform {
     pub(super) fn windows_window_activation_attempt_error(operation: &str) -> String {
         format!(
             "outcome_unknown: {operation} did not establish the exact foreground-window postcondition after the native activation attempt"
+        )
+    }
+
+    #[cfg(windows)]
+    pub(super) fn windows_control_attempt_error(operation: &str) -> String {
+        format!(
+            "outcome_unknown: {operation} returned after the exact Windows UI Automation control effect was attempted"
         )
     }
 
@@ -4143,13 +4196,122 @@ mod platform {
 
     #[cfg(windows)]
     pub(super) fn control(
-        _surface_id: &str,
-        _element_id: &str,
-        _surface: &SurfaceRecord,
-        _element: &ElementRecord,
-        _action: ComputerAction,
+        surface_id: &str,
+        element_id: &str,
+        surface: &SurfaceRecord,
+        element: &ElementRecord,
+        action: ComputerAction,
     ) -> Result<Value, String> {
-        Err("unsupported_platform: computer control is unavailable on this platform".to_string())
+        let target = element.target_fingerprint().ok_or_else(|| {
+            "stale_element: UIA element correlation lineage is incomplete".to_string()
+        })?;
+        if element.contains_protected_content() {
+            return Err(
+                "permission_denied: Windows UI Automation protected content cannot be controlled"
+                    .to_string(),
+            );
+        }
+        if !target.has_positive_evidence() {
+            return Err(
+                "stale_element: UIA element lacks positive correlation evidence for control"
+                    .to_string(),
+            );
+        }
+
+        let context = UiaContext::new()?;
+        let current = resolve_uia_element(&context, surface, element)?;
+        context.deadline.ensure_remaining()?;
+        let enabled = unsafe { current.CurrentIsEnabled() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentIsEnabled", &error))?
+            .as_bool();
+        if !enabled {
+            return Err("control_failed: UI Automation element is disabled".to_string());
+        }
+
+        match action {
+            ComputerAction::Press => {
+                let pattern = optional_uia_pattern::<IUIAutomationInvokePattern>(
+                    &context,
+                    &current,
+                    UIA_InvokePatternId,
+                )?
+                .ok_or_else(|| {
+                    "control_failed: UI Automation element does not support InvokePattern"
+                        .to_string()
+                })?;
+                context.deadline.ensure_remaining()?;
+                if let Err(error) = unsafe { pattern.Invoke() } {
+                    return Err(windows_control_attempt_error(&format!(
+                        "IUIAutomationInvokePattern::Invoke HRESULT(0x{:08X})",
+                        error.code().0 as u32
+                    )));
+                }
+            }
+            ComputerAction::Focus => {
+                if !uia_semantic_focus_role(&target.role) {
+                    return Err(
+                        "control_failed: UI Automation element role is outside the bounded semantic focus set"
+                            .to_string(),
+                    );
+                }
+                let hwnd = win_hwnd(surface.native_id)?;
+                if unsafe { GetForegroundWindow() != hwnd } {
+                    return Err(
+                        "control_failed: exact Windows surface must already be foreground before element focus"
+                            .to_string(),
+                    );
+                }
+                context.deadline.ensure_remaining()?;
+                let focusable = unsafe { current.CurrentIsKeyboardFocusable() }
+                    .map_err(|error| {
+                        uia_error("IUIAutomationElement::CurrentIsKeyboardFocusable", &error)
+                    })?
+                    .as_bool();
+                if !focusable {
+                    return Err(
+                        "control_failed: UI Automation element is not keyboard-focusable"
+                            .to_string(),
+                    );
+                }
+                let already_focused = uia_element_has_exact_focus(&context, &current)?;
+                if !already_focused {
+                    context.deadline.ensure_remaining()?;
+                    if let Err(error) = unsafe { current.SetFocus() } {
+                        return Err(windows_control_attempt_error(&format!(
+                            "IUIAutomationElement::SetFocus HRESULT(0x{:08X})",
+                            error.code().0 as u32
+                        )));
+                    }
+                    let focus_expires_at = Instant::now() + Duration::from_secs(1);
+                    loop {
+                        if let Err(error) = context.deadline.ensure_remaining() {
+                            return Err(windows_control_attempt_error(&error));
+                        }
+                        let focused = match uia_element_has_exact_focus(&context, &current) {
+                            Ok(focused) => focused,
+                            Err(error) => return Err(windows_control_attempt_error(&error)),
+                        };
+                        if focused {
+                            break;
+                        }
+                        if Instant::now() >= focus_expires_at {
+                            return Err(windows_control_attempt_error(
+                                "IUIAutomationElement::SetFocus postcondition timeout",
+                            ));
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                }
+            }
+        }
+
+        Ok(json!({
+            "platform": "windows",
+            "surface_id": surface_id,
+            "element_id": element_id,
+            "action": action.as_str(),
+            "success": true,
+        }))
     }
 
     #[cfg(windows)]
@@ -4574,6 +4736,8 @@ mod platform {
 #[cfg(all(test, windows))]
 mod windows_uia_tests {
     use super::*;
+    use std::process::{Child, Command, Stdio};
+    use std::thread;
     use windows::Win32::UI::Accessibility::{
         UIA_ButtonControlTypeId, UIA_CheckBoxControlTypeId, UIA_DocumentControlTypeId,
         UIA_EditControlTypeId, UIA_HyperlinkControlTypeId, UIA_WindowControlTypeId,
@@ -4589,6 +4753,69 @@ mod windows_uia_tests {
             title: bounded_text(&candidate.title),
             width: candidate.width,
             height: candidate.height,
+        }
+    }
+
+    const WINDOWS_CONTROL_FIXTURE_TITLE: &str = "WebCodex Windows UIA Control Smoke";
+
+    struct WindowsControlFixture {
+        child: Child,
+    }
+
+    impl WindowsControlFixture {
+        fn start() -> Self {
+            let script = r#"
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+[System.Windows.Forms.Application]::EnableVisualStyles()
+$form = New-Object System.Windows.Forms.Form
+$form.Text = 'WebCodex Windows UIA Control Smoke'
+$form.StartPosition = 'Manual'
+$form.Location = New-Object System.Drawing.Point(120, 120)
+$form.Size = New-Object System.Drawing.Size(520, 260)
+$input = New-Object System.Windows.Forms.TextBox
+$input.Name = 'SmokeInput'
+$input.AccessibleName = 'Smoke input'
+$input.Location = New-Object System.Drawing.Point(24, 44)
+$input.Size = New-Object System.Drawing.Size(280, 28)
+$button = New-Object System.Windows.Forms.Button
+$button.Name = 'SmokePress'
+$button.Text = 'Smoke press'
+$button.Location = New-Object System.Drawing.Point(24, 96)
+$button.Size = New-Object System.Drawing.Size(140, 32)
+$status = New-Object System.Windows.Forms.Label
+$status.Name = 'SmokeStatus'
+$status.Text = 'ready'
+$status.Location = New-Object System.Drawing.Point(24, 148)
+$status.Size = New-Object System.Drawing.Size(140, 24)
+$button.Add_Click({ param($sender, $eventArgs) $sender.Text = 'clicked' })
+$form.Controls.Add($input)
+$form.Controls.Add($button)
+$form.Controls.Add($status)
+[System.Windows.Forms.Application]::Run($form)
+"#;
+            let child = Command::new("powershell.exe")
+                .args([
+                    "-NoProfile",
+                    "-STA",
+                    "-WindowStyle",
+                    "Hidden",
+                    "-Command",
+                    script,
+                ])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("launch private WinForms control fixture");
+            Self { child }
+        }
+    }
+
+    impl Drop for WindowsControlFixture {
+        fn drop(&mut self) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
         }
     }
 
@@ -4618,12 +4845,22 @@ mod windows_uia_tests {
             platform::uia_control_role(UIA_CheckBoxControlTypeId),
             "AXCheckBox"
         );
+        assert!(platform::uia_semantic_focus_role("AXTextField"));
+        assert!(!platform::uia_semantic_focus_role("AXTextArea"));
+        assert!(!platform::uia_semantic_focus_role("AXButton"));
+        assert!(!platform::uia_semantic_focus_role("AXWindow"));
     }
 
     #[test]
     fn computer_windows_window_activation_attempt_failure_is_unknown() {
         let error =
             platform::windows_window_activation_attempt_error("IUIAutomationElement::SetFocus");
+        assert!(error.starts_with("outcome_unknown:"), "{error}");
+    }
+
+    #[test]
+    fn computer_windows_control_attempt_failure_is_unknown() {
+        let error = platform::windows_control_attempt_error("IUIAutomationInvokePattern::Invoke");
         assert!(error.starts_with("outcome_unknown:"), "{error}");
     }
 
@@ -4689,6 +4926,118 @@ mod windows_uia_tests {
     }
 
     #[test]
+    #[ignore = "requires an interactive Windows desktop; creates and closes a private WinForms control fixture"]
+    fn computer_windows_control_fixture_live_smoke() {
+        let mut fixture = WindowsControlFixture::start();
+        let candidate = (0..500)
+            .find_map(|_| {
+                if let Some(status) = fixture
+                    .child
+                    .try_wait()
+                    .expect("query private WinForms fixture process")
+                {
+                    panic!("private WinForms fixture exited before discovery: {status}");
+                }
+                let candidate = platform::list_windows(4096)
+                    .expect("list Windows windows for control fixture")
+                    .into_iter()
+                    .find(|candidate| candidate.title == WINDOWS_CONTROL_FIXTURE_TITLE);
+                if candidate.is_none() {
+                    thread::sleep(Duration::from_millis(20));
+                }
+                candidate
+            })
+            .expect("discover private WinForms control fixture");
+        let record = surface_record(candidate);
+        let activation =
+            platform::activate_window("surface_windows_control_fixture_activate", &record)
+                .expect("activate private WinForms control fixture");
+        assert_eq!(activation["success"], true);
+
+        let candidate = platform::list_windows(4096)
+            .expect("re-list Windows windows after fixture activation")
+            .into_iter()
+            .find(|candidate| candidate.title == WINDOWS_CONTROL_FIXTURE_TITLE)
+            .expect("re-observe private WinForms control fixture");
+        let record = surface_record(candidate);
+        let surface_id = "surface_windows_control_fixture";
+        let tree = platform::accessibility_tree(surface_id, &record, 4, 64)
+            .expect("read private WinForms control fixture UIA tree");
+        let (edit_id, edit) = tree
+            .elements
+            .iter()
+            .find(|(_, element)| {
+                element.target_fingerprint().is_some_and(|fingerprint| {
+                    fingerprint.role == "AXTextField"
+                        && fingerprint.has_positive_evidence()
+                        && !fingerprint.protected
+                })
+            })
+            .expect("fixture exposes a positively correlated UIA edit");
+        let (button_id, button) = tree
+            .elements
+            .iter()
+            .find(|(_, element)| {
+                element.target_fingerprint().is_some_and(|fingerprint| {
+                    fingerprint.role == "AXButton"
+                        && fingerprint.has_positive_evidence()
+                        && !fingerprint.protected
+                })
+            })
+            .expect("fixture exposes a positively correlated UIA button");
+
+        let edit_state = platform::element_state(surface_id, edit_id, 1, &record, edit)
+            .expect("read private edit state");
+        assert_eq!(edit_state["can_focus"], true);
+        assert_eq!(edit_state["can_input_text"], false);
+        let focused = platform::control(surface_id, edit_id, &record, edit, ComputerAction::Focus)
+            .expect("focus private UIA edit");
+        assert_eq!(focused["platform"], "windows");
+        assert_eq!(focused["action"], "focus");
+        assert_eq!(focused["success"], true);
+        let focused_state = platform::element_state(surface_id, edit_id, 1, &record, edit)
+            .expect("re-read private edit state");
+        assert_eq!(focused_state["focused"], true);
+
+        let button_state = platform::element_state(surface_id, button_id, 1, &record, button)
+            .expect("read private button state");
+        assert_eq!(button_state["can_press"], true);
+        let pressed = platform::control(
+            surface_id,
+            button_id,
+            &record,
+            button,
+            ComputerAction::Press,
+        )
+        .expect("invoke private UIA button");
+        assert_eq!(pressed["platform"], "windows");
+        assert_eq!(pressed["action"], "press");
+        assert_eq!(pressed["success"], true);
+        let click_deadline = Instant::now() + Duration::from_secs(1);
+        let mut clicked = false;
+        while Instant::now() < click_deadline {
+            let after_press = platform::accessibility_tree(
+                "surface_windows_control_fixture_after_press",
+                &record,
+                4,
+                64,
+            )
+            .expect("re-observe private WinForms fixture after InvokePattern");
+            clicked = after_press.output["nodes"]
+                .as_array()
+                .is_some_and(|nodes| nodes.iter().any(|node| node["title"] == "clicked"));
+            if clicked {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            clicked,
+            "UIA InvokePattern did not update the private fixture"
+        );
+    }
+
+    #[test]
     #[ignore = "requires an interactive Windows desktop with at least one UIA-accessible window"]
     fn computer_windows_uia_live_smoke() {
         let status = platform::accessibility_status().expect("initialize Windows UI Automation");
@@ -4729,8 +5078,8 @@ mod windows_uia_tests {
                             assert_eq!(state["platform"], "windows");
                             assert_eq!(state["surface_id"], "surface_windows_live");
                             assert_eq!(state["element_id"], element_id.as_str());
-                            assert_eq!(state["can_press"], false);
-                            assert_eq!(state["can_focus"], false);
+                            assert!(state["can_press"].is_boolean());
+                            assert!(state["can_focus"].is_boolean());
                             assert_eq!(state["can_input_text"], false);
                             return;
                         }

--- a/crates/webcodex-runner/src/webcodex_runner/computer.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/computer.rs
@@ -2190,15 +2190,14 @@ mod tests {
 #[cfg(any(target_os = "macos", windows))]
 mod platform {
     use super::{
-        bounded_text, ensure_raw_capture_bound, AccessibilityTreeResult, ComputerAction,
-        ElementRecord, PlatformWindow, SurfaceRecord,
+        bounded_text, ensure_raw_capture_bound, validate_input_text, AccessibilityTreeResult,
+        ComputerAction, ElementRecord, PlatformWindow, SurfaceRecord,
     };
     #[cfg(target_os = "macos")]
     use super::{
         ensure_correlated_fingerprint, is_secure_text_fingerprint, select_exact_ax_window_index,
-        validate_element_state_target, validate_input_text, validate_key_input,
-        validate_key_modifiers, validate_text_input_preflight, validate_text_input_target,
-        AxObservationDeadline,
+        validate_element_state_target, validate_key_input, validate_key_modifiers,
+        validate_text_input_preflight, validate_text_input_target, AxObservationDeadline,
     };
     #[cfg(any(target_os = "macos", windows))]
     use super::{is_supported_text_input_fingerprint, ElementFingerprint};
@@ -3183,6 +3182,11 @@ mod platform {
     }
 
     #[cfg(windows)]
+    pub(super) fn uia_semantic_text_input_role(role: &str) -> bool {
+        role == "AXTextField"
+    }
+
+    #[cfg(windows)]
     fn uia_fingerprint(
         context: &UiaContext,
         element: &IUIAutomationElement,
@@ -3231,24 +3235,46 @@ mod platform {
     }
 
     #[cfg(windows)]
-    fn uia_text_value(
+    fn uia_text_pattern(
         context: &UiaContext,
         element: &IUIAutomationElement,
-    ) -> Result<Option<String>, String> {
-        let Some(pattern) = optional_uia_pattern::<IUIAutomationValuePattern>(
-            context,
-            element,
-            UIA_ValuePatternId,
-        )?
-        else {
-            return Ok(None);
-        };
+    ) -> Result<Option<IUIAutomationValuePattern>, String> {
+        optional_uia_pattern::<IUIAutomationValuePattern>(context, element, UIA_ValuePatternId)
+    }
+
+    #[cfg(windows)]
+    fn uia_value_pattern_current_value(
+        context: &UiaContext,
+        pattern: &IUIAutomationValuePattern,
+    ) -> Result<String, String> {
         context.deadline.ensure_remaining()?;
         uia_string(
             unsafe { pattern.CurrentValue() },
             "IUIAutomationValuePattern::CurrentValue",
         )
-        .map(|value| value.or_else(|| Some(String::new())))
+        .map(|value| value.unwrap_or_default())
+    }
+
+    #[cfg(windows)]
+    fn uia_value_pattern_writable(
+        context: &UiaContext,
+        pattern: &IUIAutomationValuePattern,
+    ) -> Result<bool, String> {
+        context.deadline.ensure_remaining()?;
+        unsafe { pattern.CurrentIsReadOnly() }
+            .map(|read_only| !read_only.as_bool())
+            .map_err(|error| uia_error("IUIAutomationValuePattern::CurrentIsReadOnly", &error))
+    }
+
+    #[cfg(windows)]
+    fn uia_text_value(
+        context: &UiaContext,
+        element: &IUIAutomationElement,
+    ) -> Result<Option<String>, String> {
+        let Some(pattern) = uia_text_pattern(context, element)? else {
+            return Ok(None);
+        };
+        uia_value_pattern_current_value(context, &pattern).map(Some)
     }
 
     #[cfg(windows)]
@@ -4051,11 +4077,21 @@ mod platform {
             .as_bool();
         let focused = uia_element_has_exact_focus(&context, &current)?;
         let protected = element.contains_protected_content();
-        let value_empty = if !protected && is_supported_text_input_fingerprint(target) {
-            uia_text_value(&context, &current)?.map(|value| value.is_empty())
-        } else {
-            None
-        };
+        let (value_empty, value_writable) =
+            if !protected && is_supported_text_input_fingerprint(target) {
+                match uia_text_pattern(&context, &current)? {
+                    Some(pattern) => {
+                        let value = uia_value_pattern_current_value(&context, &pattern)?;
+                        let writable = uia_value_pattern_writable(&context, &pattern)?;
+                        (Some(value.is_empty()), writable)
+                    }
+                    None => (None, false),
+                }
+            } else {
+                (None, false)
+            };
+        let hwnd = win_hwnd(surface.native_id)?;
+        let surface_foreground = unsafe { GetForegroundWindow() == hwnd };
         let can_press = if protected || !enabled {
             false
         } else {
@@ -4066,21 +4102,27 @@ mod platform {
             )?
             .is_some()
         };
-        let can_focus = if protected || !enabled || !uia_semantic_focus_role(&target.role) {
+        let can_focus = if protected
+            || !enabled
+            || !surface_foreground
+            || !uia_semantic_focus_role(&target.role)
+        {
             false
         } else {
-            let hwnd = win_hwnd(surface.native_id)?;
-            if unsafe { GetForegroundWindow() != hwnd } {
-                false
-            } else {
-                context.deadline.ensure_remaining()?;
-                unsafe { current.CurrentIsKeyboardFocusable() }
-                    .map_err(|error| {
-                        uia_error("IUIAutomationElement::CurrentIsKeyboardFocusable", &error)
-                    })?
-                    .as_bool()
-            }
+            context.deadline.ensure_remaining()?;
+            unsafe { current.CurrentIsKeyboardFocusable() }
+                .map_err(|error| {
+                    uia_error("IUIAutomationElement::CurrentIsKeyboardFocusable", &error)
+                })?
+                .as_bool()
         };
+        let can_input_text = !protected
+            && enabled
+            && surface_foreground
+            && focused
+            && uia_semantic_text_input_role(&target.role)
+            && value_writable
+            && value_empty == Some(true);
 
         Ok(json!({
             "platform": "windows",
@@ -4093,8 +4135,7 @@ mod platform {
             "value_empty": value_empty,
             "can_press": can_press,
             "can_focus": can_focus,
-            // W3 still does not widen Windows text mutation authority.
-            "can_input_text": false,
+            "can_input_text": can_input_text,
         }))
     }
 
@@ -4109,6 +4150,13 @@ mod platform {
     pub(super) fn windows_control_attempt_error(operation: &str) -> String {
         format!(
             "outcome_unknown: {operation} returned after the exact Windows UI Automation control effect was attempted"
+        )
+    }
+
+    #[cfg(windows)]
+    pub(super) fn windows_text_input_attempt_error(operation: &str) -> String {
+        format!(
+            "outcome_unknown: {operation} returned after the exact Windows UI Automation text write was attempted"
         )
     }
 
@@ -4336,13 +4384,91 @@ mod platform {
 
     #[cfg(windows)]
     pub(super) fn input_text(
-        _surface_id: &str,
-        _element_id: &str,
-        _surface: &SurfaceRecord,
-        _element: &ElementRecord,
-        _text: &str,
+        surface_id: &str,
+        element_id: &str,
+        surface: &SurfaceRecord,
+        element: &ElementRecord,
+        text: &str,
     ) -> Result<Value, String> {
-        Err("unsupported_platform: computer text input is unavailable on this platform".to_string())
+        let text_bytes = validate_input_text(text)?;
+        let target = element.target_fingerprint().ok_or_else(|| {
+            "stale_element: UIA element correlation lineage is incomplete".to_string()
+        })?;
+        if element.contains_protected_content() {
+            return Err(
+                "permission_denied: Windows UI Automation protected content cannot receive text input"
+                    .to_string(),
+            );
+        }
+        if !target.has_positive_evidence() {
+            return Err(
+                "stale_element: UIA element lacks positive correlation evidence for text input"
+                    .to_string(),
+            );
+        }
+        if !uia_semantic_text_input_role(&target.role) {
+            return Err(
+                "input_failed: UI Automation element is outside the bounded Windows text-entry role set"
+                    .to_string(),
+            );
+        }
+
+        let context = UiaContext::new()?;
+        let current = resolve_uia_element(&context, surface, element)?;
+        context.deadline.ensure_remaining()?;
+        let enabled = unsafe { current.CurrentIsEnabled() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentIsEnabled", &error))?
+            .as_bool();
+        if !enabled {
+            return Err("input_failed: UI Automation text element is disabled".to_string());
+        }
+        let pattern = uia_text_pattern(&context, &current)?.ok_or_else(|| {
+            "input_failed: UI Automation text element does not expose ValuePattern".to_string()
+        })?;
+        if !uia_value_pattern_writable(&context, &pattern)? {
+            return Err("input_failed: UI Automation ValuePattern is read-only".to_string());
+        }
+
+        let hwnd = win_hwnd(surface.native_id)?;
+        if unsafe { GetForegroundWindow() != hwnd } {
+            return Err(
+                "input_failed: exact Windows surface must already be foreground before text input"
+                    .to_string(),
+            );
+        }
+        if !uia_element_has_exact_focus(&context, &current)? {
+            return Err(
+                "input_failed: exact Windows text element must already have keyboard focus"
+                    .to_string(),
+            );
+        }
+
+        // Keep emptiness as the final state read before the native write. The
+        // value never leaves the Runner; only the empty/non-empty affordance is
+        // exposed through element_state.
+        let current_value = uia_value_pattern_current_value(&context, &pattern)?;
+        if !current_value.is_empty() {
+            return Err(
+                "input_failed: UI Automation ValuePattern must be empty before bounded text input; observe and reconcile before retrying"
+                    .to_string(),
+            );
+        }
+
+        let value = windows::core::BSTR::from(text);
+        context.deadline.ensure_remaining()?;
+        if let Err(error) = unsafe { pattern.SetValue(&value) } {
+            return Err(windows_text_input_attempt_error(&format!(
+                "IUIAutomationValuePattern::SetValue HRESULT(0x{:08X})",
+                error.code().0 as u32
+            )));
+        }
+        Ok(json!({
+            "platform": "windows",
+            "surface_id": surface_id,
+            "element_id": element_id,
+            "text_bytes": text_bytes,
+            "success": true,
+        }))
     }
 
     #[cfg(windows)]
@@ -4847,6 +4973,8 @@ $form.Controls.Add($status)
         );
         assert!(platform::uia_semantic_focus_role("AXTextField"));
         assert!(!platform::uia_semantic_focus_role("AXTextArea"));
+        assert!(platform::uia_semantic_text_input_role("AXTextField"));
+        assert!(!platform::uia_semantic_text_input_role("AXTextArea"));
         assert!(!platform::uia_semantic_focus_role("AXButton"));
         assert!(!platform::uia_semantic_focus_role("AXWindow"));
     }
@@ -4861,6 +4989,13 @@ $form.Controls.Add($status)
     #[test]
     fn computer_windows_control_attempt_failure_is_unknown() {
         let error = platform::windows_control_attempt_error("IUIAutomationInvokePattern::Invoke");
+        assert!(error.starts_with("outcome_unknown:"), "{error}");
+    }
+
+    #[test]
+    fn computer_windows_text_input_attempt_failure_is_unknown() {
+        let error =
+            platform::windows_text_input_attempt_error("IUIAutomationValuePattern::SetValue");
         assert!(error.starts_with("outcome_unknown:"), "{error}");
     }
 
@@ -4989,7 +5124,7 @@ $form.Controls.Add($status)
         let edit_state = platform::element_state(surface_id, edit_id, 1, &record, edit)
             .expect("read private edit state");
         assert_eq!(edit_state["can_focus"], true);
-        assert_eq!(edit_state["can_input_text"], false);
+        assert_eq!(edit_state["value_empty"], true);
         let focused = platform::control(surface_id, edit_id, &record, edit, ComputerAction::Focus)
             .expect("focus private UIA edit");
         assert_eq!(focused["platform"], "windows");
@@ -4998,6 +5133,26 @@ $form.Controls.Add($status)
         let focused_state = platform::element_state(surface_id, edit_id, 1, &record, edit)
             .expect("re-read private edit state");
         assert_eq!(focused_state["focused"], true);
+        assert_eq!(focused_state["value_empty"], true);
+        assert_eq!(focused_state["can_input_text"], true);
+
+        let text = "webcodex computer smoke";
+        let input = platform::input_text(surface_id, edit_id, &record, edit, text)
+            .expect("write bounded text through private UIA ValuePattern");
+        assert_eq!(input["platform"], "windows");
+        assert_eq!(input["surface_id"], surface_id);
+        assert_eq!(input["element_id"], edit_id.as_str());
+        assert_eq!(input["text_bytes"], text.len());
+        assert_eq!(input["success"], true);
+
+        let after_input = platform::element_state(surface_id, edit_id, 1, &record, edit)
+            .expect("re-read private edit state after bounded text input");
+        assert_eq!(after_input["focused"], true);
+        assert_eq!(after_input["value_empty"], false);
+        assert_eq!(after_input["can_input_text"], false);
+        let second = platform::input_text(surface_id, edit_id, &record, edit, "again")
+            .expect_err("bounded Windows text input must not overwrite a non-empty field");
+        assert!(second.starts_with("input_failed:"), "{second}");
 
         let button_state = platform::element_state(surface_id, button_id, 1, &record, button)
             .expect("read private button state");
@@ -5080,7 +5235,7 @@ $form.Controls.Add($status)
                             assert_eq!(state["element_id"], element_id.as_str());
                             assert!(state["can_press"].is_boolean());
                             assert!(state["can_focus"].is_boolean());
-                            assert_eq!(state["can_input_text"], false);
+                            assert!(state["can_input_text"].is_boolean());
                             return;
                         }
                         Err(error) => {

--- a/crates/webcodex-runner/src/webcodex_runner/computer.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/computer.rs
@@ -158,7 +158,7 @@ fn select_exact_ax_window_index(
 struct SurfaceRecord {
     #[cfg_attr(not(any(target_os = "macos", windows)), allow(dead_code))]
     native_id: u32,
-    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    #[cfg_attr(not(any(target_os = "macos", windows)), allow(dead_code))]
     pid: u32,
     #[cfg_attr(not(any(target_os = "macos", windows)), allow(dead_code))]
     identity_hash: [u8; 32],
@@ -204,7 +204,7 @@ struct ElementFingerprint {
 }
 
 impl ElementFingerprint {
-    #[cfg(any(test, target_os = "macos"))]
+    #[cfg(any(test, target_os = "macos", windows))]
     fn has_positive_evidence(&self) -> bool {
         [
             self.identifier.as_deref(),
@@ -226,14 +226,14 @@ struct ElementRecord {
 }
 
 impl ElementRecord {
-    #[cfg(any(test, target_os = "macos"))]
+    #[cfg(any(test, target_os = "macos", windows))]
     fn target_fingerprint(&self) -> Option<&ElementFingerprint> {
         (self.lineage.len() == self.path.len() + 1)
             .then(|| self.lineage.last())
             .flatten()
     }
 
-    #[cfg(any(test, target_os = "macos"))]
+    #[cfg(any(test, target_os = "macos", windows))]
     fn contains_protected_content(&self) -> bool {
         self.lineage.iter().any(|fingerprint| fingerprint.protected)
     }
@@ -256,7 +256,7 @@ fn is_secure_text_fingerprint(fingerprint: &ElementFingerprint) -> bool {
             .is_some_and(|subrole| subrole.contains("Secure"))
 }
 
-#[cfg(any(test, target_os = "macos"))]
+#[cfg(any(test, target_os = "macos", windows))]
 fn is_supported_text_input_fingerprint(fingerprint: &ElementFingerprint) -> bool {
     match fingerprint.role.as_str() {
         "AXTextField" => matches!(fingerprint.subrole.as_deref(), None | Some("AXSearchField")),
@@ -2195,12 +2195,13 @@ mod platform {
     };
     #[cfg(target_os = "macos")]
     use super::{
-        ensure_correlated_fingerprint, is_secure_text_fingerprint,
-        is_supported_text_input_fingerprint, select_exact_ax_window_index,
+        ensure_correlated_fingerprint, is_secure_text_fingerprint, select_exact_ax_window_index,
         validate_element_state_target, validate_input_text, validate_key_input,
         validate_key_modifiers, validate_text_input_preflight, validate_text_input_target,
-        AxObservationDeadline, ElementFingerprint,
+        AxObservationDeadline,
     };
+    #[cfg(any(target_os = "macos", windows))]
+    use super::{is_supported_text_input_fingerprint, ElementFingerprint};
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};
     use xcap::Window;
@@ -2215,16 +2216,45 @@ mod platform {
     };
     #[cfg(target_os = "macos")]
     use objc2_core_graphics::{CGEvent, CGEventFlags, CGKeyCode, CGPreflightPostEventAccess};
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", windows))]
     use std::collections::VecDeque;
     #[cfg(target_os = "macos")]
     use std::ptr::NonNull;
-    #[cfg(target_os = "macos")]
+    #[cfg(windows)]
+    use std::time::{Duration, Instant};
+    #[cfg(any(target_os = "macos", windows))]
     use uuid::Uuid;
 
     #[cfg(windows)]
+    use windows::{
+        core::{IUnknown, Interface},
+        Win32::{
+            Foundation::{E_NOINTERFACE, E_POINTER, HWND as WinHwnd, RPC_E_CHANGED_MODE},
+            System::Com::{
+                CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+                COINIT_MULTITHREADED,
+            },
+            UI::Accessibility::{
+                CUIAutomation8, IUIAutomation2, IUIAutomationElement, IUIAutomationTreeWalker,
+                IUIAutomationValuePattern, UIA_ButtonControlTypeId, UIA_CheckBoxControlTypeId,
+                UIA_ComboBoxControlTypeId, UIA_CustomControlTypeId, UIA_DataGridControlTypeId,
+                UIA_DataItemControlTypeId, UIA_DocumentControlTypeId, UIA_EditControlTypeId,
+                UIA_GroupControlTypeId, UIA_HeaderControlTypeId, UIA_HeaderItemControlTypeId,
+                UIA_HyperlinkControlTypeId, UIA_ListControlTypeId, UIA_ListItemControlTypeId,
+                UIA_MenuControlTypeId, UIA_MenuItemControlTypeId, UIA_PaneControlTypeId,
+                UIA_ProgressBarControlTypeId, UIA_RadioButtonControlTypeId,
+                UIA_ScrollBarControlTypeId, UIA_SeparatorControlTypeId, UIA_SliderControlTypeId,
+                UIA_SpinnerControlTypeId, UIA_StatusBarControlTypeId, UIA_TabControlTypeId,
+                UIA_TabItemControlTypeId, UIA_TableControlTypeId, UIA_TextControlTypeId,
+                UIA_ToolBarControlTypeId, UIA_ToolTipControlTypeId, UIA_TreeControlTypeId,
+                UIA_TreeItemControlTypeId, UIA_ValuePatternId, UIA_WindowControlTypeId,
+                UIA_CONTROLTYPE_ID, UIA_E_ELEMENTNOTAVAILABLE, UIA_E_NOTSUPPORTED, UIA_PATTERN_ID,
+            },
+        },
+    };
+    #[cfg(windows)]
     use windows_sys::Win32::{
-        Foundation::HWND,
+        Foundation::HWND as SysHwnd,
         Graphics::Gdi::{
             BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
             GetCurrentObject, GetDIBits, GetObjectW, GetWindowDC, ReleaseDC, SelectObject, BITMAP,
@@ -2814,7 +2844,7 @@ mod platform {
             .map_err(|_| "stale_element: AX child path resolved to a non-element value".to_string())
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", windows))]
     fn resolve_surface_window(surface: &SurfaceRecord) -> Result<Window, String> {
         let window = Window::all()
             .map_err(map_error)?
@@ -2893,11 +2923,410 @@ mod platform {
     }
 
     #[cfg(windows)]
-    pub(super) fn accessibility_status() -> Result<Value, String> {
-        Err(
-            "unsupported_platform: computer accessibility observation is unavailable on this platform"
-                .to_string(),
+    const UIA_CONNECTION_TIMEOUT_MS: u32 = 2_000;
+    #[cfg(windows)]
+    const UIA_TRANSACTION_TIMEOUT_MS: u32 = 2_000;
+    #[cfg(windows)]
+    const UIA_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(10);
+    #[cfg(windows)]
+    const UIA_OBSERVATION_TIMEOUT_ERROR: &str =
+        "accessibility_failed: Windows UI Automation observation deadline exceeded";
+
+    #[cfg(windows)]
+    struct UiaObservationDeadline {
+        expires_at: Instant,
+    }
+
+    #[cfg(windows)]
+    impl UiaObservationDeadline {
+        fn new() -> Self {
+            Self {
+                expires_at: Instant::now() + UIA_OBSERVATION_TIMEOUT,
+            }
+        }
+
+        fn ensure_remaining(&self) -> Result<(), String> {
+            self.expires_at
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .map(|_| ())
+                .ok_or_else(|| UIA_OBSERVATION_TIMEOUT_ERROR.to_string())
+        }
+    }
+
+    #[cfg(windows)]
+    struct ComInitialization {
+        uninitialize: bool,
+    }
+
+    #[cfg(windows)]
+    impl ComInitialization {
+        fn new() -> Result<Self, String> {
+            let result = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+            if result.is_ok() {
+                Ok(Self { uninitialize: true })
+            } else if result == RPC_E_CHANGED_MODE {
+                // The Runner thread is already initialized in another apartment.
+                // UI Automation supports either apartment; do not uninitialize an
+                // apartment established by another subsystem.
+                Ok(Self {
+                    uninitialize: false,
+                })
+            } else {
+                Err(format!(
+                    "accessibility_failed: CoInitializeEx failed with HRESULT(0x{:08X})",
+                    result.0 as u32
+                ))
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    impl Drop for ComInitialization {
+        fn drop(&mut self) {
+            if self.uninitialize {
+                unsafe { CoUninitialize() };
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    struct UiaContext {
+        // COM interfaces must be released before the matching CoUninitialize.
+        // Rust drops struct fields in declaration order, so keep the guard last.
+        automation: IUIAutomation2,
+        walker: IUIAutomationTreeWalker,
+        deadline: UiaObservationDeadline,
+        _com: ComInitialization,
+    }
+
+    #[cfg(windows)]
+    impl UiaContext {
+        fn new() -> Result<Self, String> {
+            let com = ComInitialization::new()?;
+            let automation: IUIAutomation2 = unsafe {
+                CoCreateInstance(&CUIAutomation8, None::<&IUnknown>, CLSCTX_INPROC_SERVER)
+            }
+            .map_err(|error| uia_error("CoCreateInstance(CUIAutomation8)", &error))?;
+            unsafe { automation.SetConnectionTimeout(UIA_CONNECTION_TIMEOUT_MS) }
+                .map_err(|error| uia_error("IUIAutomation2::SetConnectionTimeout", &error))?;
+            unsafe { automation.SetTransactionTimeout(UIA_TRANSACTION_TIMEOUT_MS) }
+                .map_err(|error| uia_error("IUIAutomation2::SetTransactionTimeout", &error))?;
+            let walker = unsafe { automation.ControlViewWalker() }
+                .map_err(|error| uia_error("IUIAutomation::ControlViewWalker", &error))?;
+            Ok(Self {
+                automation,
+                walker,
+                deadline: UiaObservationDeadline::new(),
+                _com: com,
+            })
+        }
+    }
+
+    #[cfg(windows)]
+    fn uia_error(operation: &str, error: &windows::core::Error) -> String {
+        format!(
+            "accessibility_failed: {operation} failed with HRESULT(0x{:08X})",
+            error.code().0 as u32
         )
+    }
+
+    #[cfg(windows)]
+    fn uia_error_code(error: &windows::core::Error) -> u32 {
+        error.code().0 as u32
+    }
+
+    #[cfg(windows)]
+    fn optional_uia_element(
+        result: windows::core::Result<IUIAutomationElement>,
+        operation: &str,
+    ) -> Result<Option<IUIAutomationElement>, String> {
+        match result {
+            Ok(element) => Ok(Some(element)),
+            // UIA tree-walker APIs use S_OK + a null interface for end-of-list.
+            // windows-rs represents that nullable success as Error::empty() (S_OK).
+            Err(error) if error.code().is_ok() || error.code() == E_POINTER => Ok(None),
+            Err(error) => Err(uia_error(operation, &error)),
+        }
+    }
+
+    #[cfg(windows)]
+    fn optional_uia_pattern<T: Interface>(
+        context: &UiaContext,
+        element: &IUIAutomationElement,
+        pattern: UIA_PATTERN_ID,
+    ) -> Result<Option<T>, String> {
+        context.deadline.ensure_remaining()?;
+        match unsafe { element.GetCurrentPatternAs::<T>(pattern) } {
+            Ok(pattern) => Ok(Some(pattern)),
+            Err(error)
+                if error.code().is_ok()
+                    || error.code() == E_NOINTERFACE
+                    || error.code() == E_POINTER
+                    || uia_error_code(&error) == UIA_E_NOTSUPPORTED =>
+            {
+                Ok(None)
+            }
+            Err(error) if uia_error_code(&error) == UIA_E_ELEMENTNOTAVAILABLE => {
+                Err("stale_element: UI Automation element is no longer available".to_string())
+            }
+            Err(error) => Err(uia_error(
+                "IUIAutomationElement::GetCurrentPatternAs",
+                &error,
+            )),
+        }
+    }
+
+    #[cfg(windows)]
+    fn uia_string(
+        result: windows::core::Result<windows::core::BSTR>,
+        operation: &str,
+    ) -> Result<Option<String>, String> {
+        let value = result.map_err(|error| uia_error(operation, &error))?;
+        let value = bounded_text(&value.to_string());
+        Ok((!value.is_empty()).then_some(value))
+    }
+
+    #[cfg(windows)]
+    pub(super) fn uia_control_role(control_type: UIA_CONTROLTYPE_ID) -> String {
+        let role = if control_type == UIA_WindowControlTypeId {
+            Some("AXWindow")
+        } else if control_type == UIA_ButtonControlTypeId {
+            Some("AXButton")
+        } else if control_type == UIA_EditControlTypeId {
+            Some("AXTextField")
+        } else if control_type == UIA_DocumentControlTypeId {
+            Some("AXTextArea")
+        } else if control_type == UIA_HyperlinkControlTypeId {
+            Some("AXLink")
+        } else if control_type == UIA_CheckBoxControlTypeId {
+            Some("AXCheckBox")
+        } else if control_type == UIA_RadioButtonControlTypeId {
+            Some("AXRadioButton")
+        } else if control_type == UIA_ComboBoxControlTypeId {
+            Some("AXComboBox")
+        } else if control_type == UIA_ListControlTypeId {
+            Some("AXList")
+        } else if control_type == UIA_ListItemControlTypeId
+            || control_type == UIA_TreeItemControlTypeId
+            || control_type == UIA_DataItemControlTypeId
+        {
+            Some("AXRow")
+        } else if control_type == UIA_MenuControlTypeId {
+            Some("AXMenu")
+        } else if control_type == UIA_MenuItemControlTypeId {
+            Some("AXMenuItem")
+        } else if control_type == UIA_TreeControlTypeId {
+            Some("AXOutline")
+        } else if control_type == UIA_TabControlTypeId {
+            Some("AXTabGroup")
+        } else if control_type == UIA_TabItemControlTypeId {
+            Some("AXRadioButton")
+        } else if control_type == UIA_TextControlTypeId {
+            Some("AXStaticText")
+        } else if control_type == UIA_TableControlTypeId
+            || control_type == UIA_DataGridControlTypeId
+        {
+            Some("AXTable")
+        } else if control_type == UIA_ToolBarControlTypeId {
+            Some("AXToolbar")
+        } else if control_type == UIA_ScrollBarControlTypeId {
+            Some("AXScrollBar")
+        } else if control_type == UIA_SliderControlTypeId {
+            Some("AXSlider")
+        } else if control_type == UIA_SpinnerControlTypeId {
+            Some("AXIncrementor")
+        } else if control_type == UIA_ProgressBarControlTypeId {
+            Some("AXProgressIndicator")
+        } else if control_type == UIA_HeaderItemControlTypeId {
+            Some("AXColumn")
+        } else if control_type == UIA_PaneControlTypeId
+            || control_type == UIA_GroupControlTypeId
+            || control_type == UIA_CustomControlTypeId
+            || control_type == UIA_HeaderControlTypeId
+            || control_type == UIA_StatusBarControlTypeId
+            || control_type == UIA_SeparatorControlTypeId
+            || control_type == UIA_ToolTipControlTypeId
+        {
+            Some("AXGroup")
+        } else {
+            None
+        };
+        role.map(str::to_string)
+            .unwrap_or_else(|| format!("UIAControlType({})", control_type.0))
+    }
+
+    #[cfg(windows)]
+    fn uia_fingerprint(
+        context: &UiaContext,
+        element: &IUIAutomationElement,
+        inherited_protected: bool,
+    ) -> Result<ElementFingerprint, String> {
+        context.deadline.ensure_remaining()?;
+        let control_type = unsafe { element.CurrentControlType() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentControlType", &error))?;
+        context.deadline.ensure_remaining()?;
+        let is_password = unsafe { element.CurrentIsPassword() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentIsPassword", &error))?
+            .as_bool();
+        let protected = inherited_protected || is_password;
+        context.deadline.ensure_remaining()?;
+        let identifier = uia_string(
+            unsafe { element.CurrentAutomationId() },
+            "IUIAutomationElement::CurrentAutomationId",
+        )?;
+        let title = if protected {
+            None
+        } else {
+            context.deadline.ensure_remaining()?;
+            uia_string(
+                unsafe { element.CurrentName() },
+                "IUIAutomationElement::CurrentName",
+            )?
+        };
+        let description = if protected {
+            None
+        } else {
+            context.deadline.ensure_remaining()?;
+            uia_string(
+                unsafe { element.CurrentHelpText() },
+                "IUIAutomationElement::CurrentHelpText",
+            )?
+        };
+        Ok(ElementFingerprint {
+            role: uia_control_role(control_type),
+            subrole: None,
+            identifier,
+            title,
+            description,
+            placeholder: None,
+            protected,
+        })
+    }
+
+    #[cfg(windows)]
+    fn uia_text_value(
+        context: &UiaContext,
+        element: &IUIAutomationElement,
+    ) -> Result<Option<String>, String> {
+        let Some(pattern) = optional_uia_pattern::<IUIAutomationValuePattern>(
+            context,
+            element,
+            UIA_ValuePatternId,
+        )?
+        else {
+            return Ok(None);
+        };
+        context.deadline.ensure_remaining()?;
+        uia_string(
+            unsafe { pattern.CurrentValue() },
+            "IUIAutomationValuePattern::CurrentValue",
+        )
+        .map(|value| value.or_else(|| Some(String::new())))
+    }
+
+    #[cfg(windows)]
+    fn uia_children(
+        context: &UiaContext,
+        element: &IUIAutomationElement,
+        limit: usize,
+    ) -> Result<(Vec<IUIAutomationElement>, bool), String> {
+        let mut output = Vec::with_capacity(limit.min(32));
+        context.deadline.ensure_remaining()?;
+        let mut current = optional_uia_element(
+            unsafe { context.walker.GetFirstChildElement(element) },
+            "IUIAutomationTreeWalker::GetFirstChildElement",
+        )?;
+        while let Some(element) = current {
+            if output.len() >= limit {
+                return Ok((output, true));
+            }
+            context.deadline.ensure_remaining()?;
+            current = optional_uia_element(
+                unsafe { context.walker.GetNextSiblingElement(&element) },
+                "IUIAutomationTreeWalker::GetNextSiblingElement",
+            )?;
+            output.push(element);
+        }
+        Ok((output, false))
+    }
+
+    #[cfg(windows)]
+    fn win_hwnd(native_id: u32) -> Result<WinHwnd, String> {
+        let hwnd = WinHwnd(native_id as i32 as isize as *mut std::ffi::c_void);
+        if hwnd.0.is_null() {
+            Err("stale_surface: window handle is invalid".to_string())
+        } else {
+            Ok(hwnd)
+        }
+    }
+
+    #[cfg(windows)]
+    fn exact_uia_window(
+        context: &UiaContext,
+        surface: &SurfaceRecord,
+    ) -> Result<IUIAutomationElement, String> {
+        let _window = resolve_surface_window(surface)?;
+        let hwnd = win_hwnd(surface.native_id)?;
+        context.deadline.ensure_remaining()?;
+        let root = unsafe { context.automation.ElementFromHandle(hwnd) }
+            .map_err(|error| uia_error("IUIAutomation::ElementFromHandle", &error))?;
+        context.deadline.ensure_remaining()?;
+        let current_hwnd = unsafe { root.CurrentNativeWindowHandle() }.map_err(|error| {
+            uia_error("IUIAutomationElement::CurrentNativeWindowHandle", &error)
+        })?;
+        context.deadline.ensure_remaining()?;
+        let current_pid = unsafe { root.CurrentProcessId() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentProcessId", &error))?;
+        let current_pid = u32::try_from(current_pid)
+            .map_err(|_| "stale_surface: UI Automation process id is invalid".to_string())?;
+        if current_hwnd != hwnd || current_pid != surface.pid {
+            return Err(
+                "stale_surface: UI Automation root no longer matches the observed HWND/PID"
+                    .to_string(),
+            );
+        }
+        Ok(root)
+    }
+
+    #[cfg(windows)]
+    fn resolve_uia_element(
+        context: &UiaContext,
+        surface: &SurfaceRecord,
+        element: &ElementRecord,
+    ) -> Result<IUIAutomationElement, String> {
+        if element.lineage.len() != element.path.len() + 1 {
+            return Err("stale_element: UIA element correlation lineage is incomplete".to_string());
+        }
+        let mut current = exact_uia_window(context, surface)?;
+        let current_root = uia_fingerprint(context, &current, false)?;
+        if current_root != element.lineage[0] {
+            return Err("stale_element: UIA root identity changed since observation".to_string());
+        }
+        for (depth, &index) in element.path.iter().enumerate() {
+            let (children, has_more) = uia_children(context, &current, index + 1)?;
+            if children.len() <= index {
+                return Err("stale_element: UIA child path no longer exists".to_string());
+            }
+            if has_more && index >= super::MAX_ACCESSIBILITY_NODES {
+                return Err("stale_element: UIA child path exceeds bounded correlation".to_string());
+            }
+            current = children[index].clone();
+            let current_fingerprint =
+                uia_fingerprint(context, &current, element.lineage[depth].protected)?;
+            if current_fingerprint != element.lineage[depth + 1] {
+                return Err(
+                    "stale_element: UIA element lineage changed since observation".to_string(),
+                );
+            }
+        }
+        Ok(current)
+    }
+
+    #[cfg(windows)]
+    pub(super) fn accessibility_status() -> Result<Value, String> {
+        let _context = UiaContext::new()?;
+        Ok(json!({"platform": "windows", "trusted": true}))
     }
 
     #[cfg(target_os = "macos")]
@@ -3441,29 +3870,185 @@ mod platform {
 
     #[cfg(windows)]
     pub(super) fn accessibility_tree(
-        _surface_id: &str,
-        _surface: &SurfaceRecord,
-        _max_depth: usize,
-        _max_nodes: usize,
+        surface_id: &str,
+        surface: &SurfaceRecord,
+        max_depth: usize,
+        max_nodes: usize,
     ) -> Result<AccessibilityTreeResult, String> {
-        Err(
-            "unsupported_platform: computer accessibility observation is unavailable on this platform"
-                .to_string(),
-        )
+        let context = UiaContext::new()?;
+        let root = exact_uia_window(&context, surface)?;
+        let mut queue = VecDeque::from([(
+            root,
+            None::<String>,
+            0usize,
+            Vec::<usize>::new(),
+            Vec::<ElementFingerprint>::new(),
+            false,
+        )]);
+        let mut nodes = Vec::with_capacity(max_nodes.min(64));
+        let mut elements = Vec::with_capacity(max_nodes.min(64));
+        let mut truncated = false;
+
+        while let Some((
+            current,
+            parent_element_id,
+            depth,
+            path,
+            mut lineage,
+            inherited_protected,
+        )) = queue.pop_front()
+        {
+            if nodes.len() >= max_nodes {
+                truncated = true;
+                break;
+            }
+
+            let element_id = format!("element_{}", Uuid::new_v4().simple());
+            let fingerprint = uia_fingerprint(&context, &current, inherited_protected)?;
+            let role = fingerprint.role.clone();
+            let subrole = fingerprint.subrole.clone();
+            let title = fingerprint.title.clone();
+            let description = fingerprint.description.clone();
+            let placeholder = fingerprint.placeholder.clone();
+            let protected = fingerprint.protected;
+            let value = if protected || !is_supported_text_input_fingerprint(&fingerprint) {
+                None
+            } else {
+                uia_text_value(&context, &current)?
+            };
+            context.deadline.ensure_remaining()?;
+            let enabled = unsafe { current.CurrentIsEnabled() }
+                .map_err(|error| uia_error("IUIAutomationElement::CurrentIsEnabled", &error))?
+                .as_bool();
+            context.deadline.ensure_remaining()?;
+            let focused = unsafe { current.CurrentHasKeyboardFocus() }
+                .map_err(|error| {
+                    uia_error("IUIAutomationElement::CurrentHasKeyboardFocus", &error)
+                })?
+                .as_bool();
+            lineage.push(fingerprint);
+
+            let reserved = nodes.len() + queue.len() + 1;
+            let remaining = max_nodes.saturating_sub(reserved);
+            let inspect_limit = if depth < max_depth {
+                remaining.saturating_add(1).max(1)
+            } else {
+                1
+            };
+            let (children, has_more_children) = uia_children(&context, &current, inspect_limit)?;
+            let child_count = children.len() + usize::from(has_more_children);
+
+            if depth < max_depth {
+                if children.len() > remaining || has_more_children {
+                    truncated = true;
+                }
+                for (index, child) in children.into_iter().take(remaining).enumerate() {
+                    let mut child_path = path.clone();
+                    child_path.push(index);
+                    queue.push_back((
+                        child,
+                        Some(element_id.clone()),
+                        depth + 1,
+                        child_path,
+                        lineage.clone(),
+                        protected,
+                    ));
+                }
+            } else if child_count > 0 {
+                truncated = true;
+            }
+
+            elements.push((
+                element_id.clone(),
+                ElementRecord {
+                    surface_id: surface_id.to_string(),
+                    path,
+                    lineage,
+                },
+            ));
+            nodes.push(json!({
+                "element_id": element_id,
+                "parent_element_id": parent_element_id,
+                "depth": depth,
+                "role": role,
+                "subrole": subrole,
+                "title": title,
+                "description": description,
+                "value": value,
+                "placeholder": placeholder,
+                "enabled": enabled,
+                "focused": focused,
+                "child_count": child_count,
+            }));
+        }
+
+        if !queue.is_empty() {
+            truncated = true;
+        }
+        let node_count = nodes.len();
+        Ok(AccessibilityTreeResult {
+            output: json!({
+                "platform": "windows",
+                "surface_id": surface_id,
+                "nodes": nodes,
+                "node_count": node_count,
+                "truncated": truncated,
+                "max_depth": max_depth,
+                "max_nodes": max_nodes,
+            }),
+            elements,
+        })
     }
 
     #[cfg(windows)]
     pub(super) fn element_state(
-        _surface_id: &str,
-        _element_id: &str,
-        _observation_generation: u32,
-        _surface: &SurfaceRecord,
-        _element: &ElementRecord,
+        surface_id: &str,
+        element_id: &str,
+        observation_generation: u32,
+        surface: &SurfaceRecord,
+        element: &ElementRecord,
     ) -> Result<Value, String> {
-        Err(
-            "unsupported_platform: computer element state is unavailable on this platform"
-                .to_string(),
-        )
+        let target = element.target_fingerprint().ok_or_else(|| {
+            "stale_element: UIA element correlation lineage is incomplete".to_string()
+        })?;
+        if !target.has_positive_evidence() {
+            return Err(
+                "stale_element: UIA element lacks positive correlation evidence for state"
+                    .to_string(),
+            );
+        }
+        let context = UiaContext::new()?;
+        let current = resolve_uia_element(&context, surface, element)?;
+        context.deadline.ensure_remaining()?;
+        let enabled = unsafe { current.CurrentIsEnabled() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentIsEnabled", &error))?
+            .as_bool();
+        context.deadline.ensure_remaining()?;
+        let focused = unsafe { current.CurrentHasKeyboardFocus() }
+            .map_err(|error| uia_error("IUIAutomationElement::CurrentHasKeyboardFocus", &error))?
+            .as_bool();
+        let protected = element.contains_protected_content();
+        let value_empty = if !protected && is_supported_text_input_fingerprint(target) {
+            uia_text_value(&context, &current)?.map(|value| value.is_empty())
+        } else {
+            None
+        };
+
+        Ok(json!({
+            "platform": "windows",
+            "surface_id": surface_id,
+            "element_id": element_id,
+            "observation_generation": observation_generation,
+            "enabled": enabled,
+            "focused": focused,
+            "protected": protected,
+            "value_empty": value_empty,
+            // W1 is read-only. Do not overstate WebCodex mutation affordances
+            // before the corresponding Windows effect capabilities exist.
+            "can_press": false,
+            "can_focus": false,
+            "can_input_text": false,
+        }))
     }
 
     #[cfg(windows)]
@@ -3529,13 +4114,13 @@ mod platform {
 
     #[cfg(windows)]
     struct WindowDc {
-        hwnd: HWND,
+        hwnd: SysHwnd,
         hdc: HDC,
     }
 
     #[cfg(windows)]
     impl WindowDc {
-        fn acquire(hwnd: HWND) -> Result<Self, String> {
+        fn acquire(hwnd: SysHwnd) -> Result<Self, String> {
             let hdc = unsafe { GetWindowDC(hwnd) };
             if hdc.is_null() {
                 Err(win32_capture_error("GetWindowDC"))
@@ -3668,7 +4253,7 @@ mod platform {
             super::native_capture_dimension(output_width, "window width")?,
             super::native_capture_dimension(output_height, "window height")?,
         )?;
-        let hwnd = native_id as i32 as isize as HWND;
+        let hwnd = native_id as i32 as isize as SysHwnd;
         if hwnd.is_null() {
             return Err("capture_failed: window handle is invalid".to_string());
         }
@@ -3901,8 +4486,125 @@ mod platform {
         }
         #[cfg(windows)]
         {
+            ensure_platform_capture_bound(&window, width, height)?;
             capture_window_gdi(surface.native_id, width, height)
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_uia_tests {
+    use super::*;
+    use windows::Win32::UI::Accessibility::{
+        UIA_ButtonControlTypeId, UIA_CheckBoxControlTypeId, UIA_DocumentControlTypeId,
+        UIA_EditControlTypeId, UIA_HyperlinkControlTypeId, UIA_WindowControlTypeId,
+    };
+
+    fn surface_record(candidate: PlatformWindow) -> SurfaceRecord {
+        SurfaceRecord {
+            native_id: candidate.native_id,
+            pid: candidate.pid,
+            identity_hash: candidate.identity_hash,
+            application: bounded_text(&candidate.application),
+            title: bounded_text(&candidate.title),
+            width: candidate.width,
+            height: candidate.height,
+        }
+    }
+
+    #[test]
+    fn computer_windows_uia_control_types_use_existing_semantic_roles() {
+        assert_eq!(
+            platform::uia_control_role(UIA_WindowControlTypeId),
+            "AXWindow"
+        );
+        assert_eq!(
+            platform::uia_control_role(UIA_ButtonControlTypeId),
+            "AXButton"
+        );
+        assert_eq!(
+            platform::uia_control_role(UIA_EditControlTypeId),
+            "AXTextField"
+        );
+        assert_eq!(
+            platform::uia_control_role(UIA_DocumentControlTypeId),
+            "AXTextArea"
+        );
+        assert_eq!(
+            platform::uia_control_role(UIA_HyperlinkControlTypeId),
+            "AXLink"
+        );
+        assert_eq!(
+            platform::uia_control_role(UIA_CheckBoxControlTypeId),
+            "AXCheckBox"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an interactive Windows desktop with at least one UIA-accessible window"]
+    fn computer_windows_uia_live_smoke() {
+        let status = platform::accessibility_status().expect("initialize Windows UI Automation");
+        assert_eq!(status["platform"], "windows");
+        assert_eq!(status["trusted"], true);
+
+        let candidates = platform::list_windows(MAX_WINDOWS).expect("list live Windows windows");
+        let mut failures = Vec::new();
+        for candidate in candidates {
+            let record = surface_record(candidate);
+            match platform::accessibility_tree("surface_windows_live", &record, 3, 64) {
+                Ok(tree) => {
+                    assert_eq!(tree.output["platform"], "windows");
+                    assert_eq!(tree.output["surface_id"], "surface_windows_live");
+                    assert!(tree.output["node_count"].as_u64().unwrap_or(0) > 0);
+                    assert!(!tree.elements.is_empty());
+                    let Some((element_id, element)) = tree.elements.iter().find(|(_, element)| {
+                        element
+                            .target_fingerprint()
+                            .is_some_and(ElementFingerprint::has_positive_evidence)
+                    }) else {
+                        if failures.len() < 8 {
+                            failures.push(
+                                "accessibility_failed: live UIA tree had no positively correlated element"
+                                    .to_string(),
+                            );
+                        }
+                        continue;
+                    };
+                    match platform::element_state(
+                        "surface_windows_live",
+                        element_id,
+                        1,
+                        &record,
+                        element,
+                    ) {
+                        Ok(state) => {
+                            assert_eq!(state["platform"], "windows");
+                            assert_eq!(state["surface_id"], "surface_windows_live");
+                            assert_eq!(state["element_id"], element_id.as_str());
+                            assert_eq!(state["can_press"], false);
+                            assert_eq!(state["can_focus"], false);
+                            assert_eq!(state["can_input_text"], false);
+                            return;
+                        }
+                        Err(error) => {
+                            if failures.len() < 8 && !failures.contains(&error) {
+                                failures.push(error);
+                            }
+                            continue;
+                        }
+                    }
+                }
+                Err(error) => {
+                    if failures.len() < 8 && !failures.contains(&error) {
+                        failures.push(error);
+                    }
+                    continue;
+                }
+            }
+        }
+        panic!(
+            "no bounded observable window exposed a Windows UIA Control View root; errors={failures:?}"
+        );
     }
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/computer.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/computer.rs
@@ -201,6 +201,8 @@ struct ElementFingerprint {
     description: Option<String>,
     placeholder: Option<String>,
     protected: bool,
+    #[cfg(windows)]
+    native_runtime_id: Vec<i32>,
 }
 
 impl ElementFingerprint {
@@ -1334,6 +1336,8 @@ mod element_registry_tests {
             subrole: None,
             identifier: None,
             title: Some(label.to_string()),
+            #[cfg(windows)]
+            native_runtime_id: Vec::new(),
             description: None,
             placeholder: None,
             protected: false,
@@ -2217,13 +2221,21 @@ mod platform {
     use objc2_core_graphics::{CGEvent, CGEventFlags, CGKeyCode, CGPreflightPostEventAccess};
     #[cfg(any(target_os = "macos", windows))]
     use std::collections::VecDeque;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", windows))]
     use std::ptr::NonNull;
     #[cfg(windows)]
     use std::time::{Duration, Instant};
     #[cfg(any(target_os = "macos", windows))]
     use uuid::Uuid;
 
+    #[cfg(windows)]
+    use windows::Win32::System::{
+        Com::SAFEARRAY,
+        Ole::{
+            SafeArrayDestroy, SafeArrayGetDim, SafeArrayGetElement, SafeArrayGetElemsize,
+            SafeArrayGetLBound, SafeArrayGetUBound,
+        },
+    };
     #[cfg(windows)]
     use windows::{
         core::{IUnknown, Interface},
@@ -2932,6 +2944,8 @@ mod platform {
     #[cfg(windows)]
     const UIA_OBSERVATION_TIMEOUT_ERROR: &str =
         "accessibility_failed: Windows UI Automation observation deadline exceeded";
+    #[cfg(windows)]
+    const MAX_UIA_RUNTIME_ID_ELEMENTS: usize = 64;
 
     #[cfg(windows)]
     struct UiaObservationDeadline {
@@ -3021,6 +3035,31 @@ mod platform {
                 deadline: UiaObservationDeadline::new(),
                 _com: com,
             })
+        }
+    }
+
+    #[cfg(windows)]
+    struct OwnedSafeArray(NonNull<SAFEARRAY>);
+
+    #[cfg(windows)]
+    impl OwnedSafeArray {
+        fn new(array: *mut SAFEARRAY) -> Result<Self, String> {
+            NonNull::new(array)
+                .map(Self)
+                .ok_or_else(|| "stale_element: UI Automation runtime id is missing".to_string())
+        }
+
+        fn as_ptr(&self) -> *mut SAFEARRAY {
+            self.0.as_ptr()
+        }
+    }
+
+    #[cfg(windows)]
+    impl Drop for OwnedSafeArray {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = SafeArrayDestroy(self.as_ptr());
+            }
         }
     }
 
@@ -3187,6 +3226,65 @@ mod platform {
     }
 
     #[cfg(windows)]
+    fn uia_runtime_id(
+        context: &UiaContext,
+        element: &IUIAutomationElement,
+    ) -> Result<Vec<i32>, String> {
+        context.deadline.ensure_remaining()?;
+        let array = unsafe { element.GetRuntimeId() }.map_err(|error| {
+            if uia_error_code(&error) == UIA_E_ELEMENTNOTAVAILABLE {
+                "stale_element: UI Automation element is no longer available".to_string()
+            } else {
+                uia_error("IUIAutomationElement::GetRuntimeId", &error)
+            }
+        })?;
+        let array = OwnedSafeArray::new(array)?;
+        if unsafe { SafeArrayGetDim(array.as_ptr()) } != 1
+            || unsafe { SafeArrayGetElemsize(array.as_ptr()) } != std::mem::size_of::<i32>() as u32
+        {
+            return Err(
+                "stale_element: UI Automation runtime id has an invalid SAFEARRAY shape"
+                    .to_string(),
+            );
+        }
+        let lower = unsafe { SafeArrayGetLBound(array.as_ptr(), 1) }
+            .map_err(|error| uia_error("SafeArrayGetLBound(runtime id)", &error))?;
+        let upper = unsafe { SafeArrayGetUBound(array.as_ptr(), 1) }
+            .map_err(|error| uia_error("SafeArrayGetUBound(runtime id)", &error))?;
+        let length = upper
+            .checked_sub(lower)
+            .and_then(|span| span.checked_add(1))
+            .and_then(|length| usize::try_from(length).ok())
+            .filter(|length| (1..=MAX_UIA_RUNTIME_ID_ELEMENTS).contains(length))
+            .ok_or_else(|| {
+                "stale_element: UI Automation runtime id length is invalid or exceeds the bound"
+                    .to_string()
+            })?;
+        let mut runtime_id = Vec::with_capacity(length);
+        for offset in 0..length {
+            context.deadline.ensure_remaining()?;
+            let index = lower
+                .checked_add(i32::try_from(offset).map_err(|_| {
+                    "stale_element: UI Automation runtime id index exceeds the bound".to_string()
+                })?)
+                .ok_or_else(|| {
+                    "stale_element: UI Automation runtime id index overflow".to_string()
+                })?;
+            let mut value = 0i32;
+            unsafe {
+                SafeArrayGetElement(
+                    array.as_ptr(),
+                    &index,
+                    (&mut value as *mut i32).cast::<std::ffi::c_void>(),
+                )
+            }
+            .map_err(|error| uia_error("SafeArrayGetElement(runtime id)", &error))?;
+            runtime_id.push(value);
+        }
+        Ok(runtime_id)
+    }
+
+    #[cfg(windows)]
     fn uia_fingerprint(
         context: &UiaContext,
         element: &IUIAutomationElement,
@@ -3200,6 +3298,7 @@ mod platform {
             .map_err(|error| uia_error("IUIAutomationElement::CurrentIsPassword", &error))?
             .as_bool();
         let protected = inherited_protected || is_password;
+        let native_runtime_id = uia_runtime_id(context, element)?;
         context.deadline.ensure_remaining()?;
         let identifier = uia_string(
             unsafe { element.CurrentAutomationId() },
@@ -3225,6 +3324,7 @@ mod platform {
         };
         Ok(ElementFingerprint {
             role: uia_control_role(control_type),
+            native_runtime_id,
             subrole: None,
             identifier,
             title,
@@ -4898,7 +4998,7 @@ $form = New-Object System.Windows.Forms.Form
 $form.Text = 'WebCodex Windows UIA Control Smoke'
 $form.StartPosition = 'Manual'
 $form.Location = New-Object System.Drawing.Point(120, 120)
-$form.Size = New-Object System.Drawing.Size(520, 260)
+$form.Size = New-Object System.Drawing.Size(700, 300)
 $input = New-Object System.Windows.Forms.TextBox
 $input.Name = 'SmokeInput'
 $input.AccessibleName = 'Smoke input'
@@ -4914,10 +5014,65 @@ $status.Name = 'SmokeStatus'
 $status.Text = 'ready'
 $status.Location = New-Object System.Drawing.Point(24, 148)
 $status.Size = New-Object System.Drawing.Size(140, 24)
+$script:twinPrimary = New-Object System.Windows.Forms.Button
+$script:twinPrimary.Name = 'TwinAction'
+$script:twinPrimary.Text = 'Twin action'
+$script:twinPrimary.AccessibleName = 'Twin action'
+$script:twinPrimary.Location = New-Object System.Drawing.Point(210, 96)
+$script:twinPrimary.Size = New-Object System.Drawing.Size(120, 32)
+$script:twinPrimary.TabIndex = 10
+$script:twinPrimary.Add_Click({ param($sender, $eventArgs) $sender.Text = 'wrong target invoked' })
+$script:twinSecondary = New-Object System.Windows.Forms.Button
+$script:twinSecondary.Name = 'TwinAction'
+$script:twinSecondary.Text = 'Twin action'
+$script:twinSecondary.AccessibleName = 'Twin action'
+$script:twinSecondary.Location = New-Object System.Drawing.Point(350, 96)
+$script:twinSecondary.Size = New-Object System.Drawing.Size(120, 32)
+$script:twinSecondary.TabIndex = 11
+$script:twinSecondary.Add_Click({ param($sender, $eventArgs) $sender.Text = 'wrong target invoked' })
+$replaceTwins = New-Object System.Windows.Forms.Button
+$replaceTwins.Name = 'ReplaceTwins'
+$replaceTwins.Text = 'Replace twins'
+$replaceTwins.AccessibleName = 'Replace twins'
+$replaceTwins.Location = New-Object System.Drawing.Point(210, 148)
+$replaceTwins.Size = New-Object System.Drawing.Size(140, 32)
+$replaceTwins.TabIndex = 12
+$replaceTwins.Add_Click({
+    param($sender, $eventArgs)
+    $primaryIndex = $form.Controls.GetChildIndex($script:twinPrimary)
+    $secondaryIndex = $form.Controls.GetChildIndex($script:twinSecondary)
+    $form.Controls.Remove($script:twinPrimary)
+    $form.Controls.Remove($script:twinSecondary)
+    $script:twinPrimary.Dispose()
+    $script:twinSecondary.Dispose()
+    $script:twinPrimary = New-Object System.Windows.Forms.Button
+    $script:twinPrimary.Name = 'TwinAction'
+    $script:twinPrimary.Text = 'Twin action'
+    $script:twinPrimary.AccessibleName = 'Twin action'
+    $script:twinPrimary.Location = New-Object System.Drawing.Point(210, 96)
+    $script:twinPrimary.Size = New-Object System.Drawing.Size(120, 32)
+    $script:twinPrimary.TabIndex = 10
+    $script:twinPrimary.Add_Click({ param($replacementSender, $replacementEventArgs) $replacementSender.Text = 'wrong target invoked' })
+    $script:twinSecondary = New-Object System.Windows.Forms.Button
+    $script:twinSecondary.Name = 'TwinAction'
+    $script:twinSecondary.Text = 'Twin action'
+    $script:twinSecondary.AccessibleName = 'Twin action'
+    $script:twinSecondary.Location = New-Object System.Drawing.Point(350, 96)
+    $script:twinSecondary.Size = New-Object System.Drawing.Size(120, 32)
+    $script:twinSecondary.TabIndex = 11
+    $script:twinSecondary.Add_Click({ param($replacementSender, $replacementEventArgs) $replacementSender.Text = 'wrong target invoked' })
+    $form.Controls.Add($script:twinPrimary)
+    $form.Controls.Add($script:twinSecondary)
+    $form.Controls.SetChildIndex($script:twinPrimary, $primaryIndex)
+    $form.Controls.SetChildIndex($script:twinSecondary, $secondaryIndex)
+})
 $button.Add_Click({ param($sender, $eventArgs) $sender.Text = 'clicked' })
 $form.Controls.Add($input)
 $form.Controls.Add($button)
 $form.Controls.Add($status)
+$form.Controls.Add($script:twinPrimary)
+$form.Controls.Add($script:twinSecondary)
+$form.Controls.Add($replaceTwins)
 [System.Windows.Forms.Application]::Run($form)
 "#;
             let child = Command::new("powershell.exe")
@@ -5189,6 +5344,139 @@ $form.Controls.Add($status)
         assert!(
             clicked,
             "UIA InvokePattern did not update the private fixture"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an interactive Windows desktop; creates and replaces indistinguishable private WinForms controls"]
+    fn computer_windows_uia_stale_identity_rejects_indistinguishable_replacement_live() {
+        let mut fixture = WindowsControlFixture::start();
+        let candidate = (0..500)
+            .find_map(|_| {
+                if let Some(status) = fixture
+                    .child
+                    .try_wait()
+                    .expect("query private WinForms fixture process")
+                {
+                    panic!("private WinForms fixture exited before discovery: {status}");
+                }
+                let candidate = platform::list_windows(4096)
+                    .expect("list Windows windows for identity fixture")
+                    .into_iter()
+                    .find(|candidate| candidate.title == WINDOWS_CONTROL_FIXTURE_TITLE);
+                if candidate.is_none() {
+                    thread::sleep(Duration::from_millis(20));
+                }
+                candidate
+            })
+            .expect("discover private WinForms identity fixture");
+        let record = surface_record(candidate);
+        platform::activate_window("surface_windows_identity_fixture_activate", &record)
+            .expect("activate private WinForms identity fixture");
+
+        let candidate = platform::list_windows(4096)
+            .expect("re-list Windows windows after identity fixture activation")
+            .into_iter()
+            .find(|candidate| candidate.title == WINDOWS_CONTROL_FIXTURE_TITLE)
+            .expect("re-observe private WinForms identity fixture");
+        let record = surface_record(candidate);
+        let surface_id = "surface_windows_identity_fixture";
+        let tree = platform::accessibility_tree(surface_id, &record, 4, 96)
+            .expect("read private WinForms identity fixture UIA tree");
+        let twins = tree
+            .elements
+            .iter()
+            .filter(|(_, element)| {
+                element.target_fingerprint().is_some_and(|fingerprint| {
+                    fingerprint.role == "AXButton"
+                        && fingerprint.identifier.as_deref() == Some("TwinAction")
+                        && fingerprint.title.as_deref() == Some("Twin action")
+                })
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            twins.len(),
+            2,
+            "fixture must expose two indistinguishable twins"
+        );
+        let (old_twin_id, old_twin) = twins[0];
+        let old_twin_id = old_twin_id.clone();
+        let old_twin = old_twin.clone();
+        let old_target = old_twin
+            .target_fingerprint()
+            .expect("old twin has complete lineage")
+            .clone();
+        let (replace_id, replace) = tree
+            .elements
+            .iter()
+            .find(|(_, element)| {
+                element.target_fingerprint().is_some_and(|fingerprint| {
+                    fingerprint.role == "AXButton"
+                        && fingerprint.identifier.as_deref() == Some("ReplaceTwins")
+                })
+            })
+            .expect("fixture exposes the replace-twins trigger");
+        platform::control(
+            surface_id,
+            replace_id,
+            &record,
+            replace,
+            ComputerAction::Press,
+        )
+        .expect("replace both indistinguishable twins through the private fixture");
+
+        let replacement_deadline = Instant::now() + Duration::from_secs(1);
+        let mut replacement_observed = false;
+        while Instant::now() < replacement_deadline {
+            let refreshed = platform::accessibility_tree(surface_id, &record, 4, 96)
+                .expect("re-observe private fixture after twin replacement");
+            replacement_observed = refreshed.elements.iter().any(|(_, element)| {
+                if element.path != old_twin.path {
+                    return false;
+                }
+                element.target_fingerprint().is_some_and(|fingerprint| {
+                    fingerprint.role == old_target.role
+                        && fingerprint.subrole == old_target.subrole
+                        && fingerprint.identifier == old_target.identifier
+                        && fingerprint.title == old_target.title
+                        && fingerprint.description == old_target.description
+                        && fingerprint.placeholder == old_target.placeholder
+                        && fingerprint.protected == old_target.protected
+                        && fingerprint.native_runtime_id != old_target.native_runtime_id
+                })
+            });
+            if replacement_observed {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            replacement_observed,
+            "replacement must preserve the old semantic path while changing native UIA identity"
+        );
+
+        let stale_state = platform::element_state(surface_id, &old_twin_id, 1, &record, &old_twin)
+            .expect_err("old element state handle must not retarget the replacement twin");
+        assert!(stale_state.starts_with("stale_element:"), "{stale_state}");
+        let stale_control = platform::control(
+            surface_id,
+            &old_twin_id,
+            &record,
+            &old_twin,
+            ComputerAction::Press,
+        )
+        .expect_err("old effect handle must fail before invoking the replacement twin");
+        assert!(
+            stale_control.starts_with("stale_element:"),
+            "{stale_control}"
+        );
+        let after = platform::accessibility_tree(surface_id, &record, 4, 96)
+            .expect("re-observe fixture after rejected stale control");
+        assert!(
+            after.output["nodes"].as_array().is_some_and(|nodes| nodes
+                .iter()
+                .all(|node| node["title"] != "wrong target invoked")),
+            "stale control must not invoke either indistinguishable replacement"
         );
     }
 

--- a/docs/AUTH_MODEL.md
+++ b/docs/AUTH_MODEL.md
@@ -238,7 +238,12 @@ from `list_agents`.
 `computer_activate_window` may activate/raise only an exact previously observed
 `surface_id`; it cannot select or launch an application by name, PID, bundle,
 executable, path, or command. `computer_control` remains deliberately closed to
-native macOS Accessibility press and focus actions. `computer_scroll_to_element`
+native macOS Accessibility or Windows UI Automation press and focus actions. On
+Windows, press is only UIA `InvokePattern`; the first Windows focus slice is
+closed to an exact normalized `AXTextField` on an already-foreground surface and
+uses only exact-element `SetFocus`, with `GetFocusedElement`/`CompareElements`
+read-back. Unsupported roles, protected or disabled targets, and background-
+surface focus targets fail closed before the effect. `computer_scroll_to_element`
 is a separate semantic effect that revalidates one exact observed element and
 uses native AX scroll-to-visible only when that element supports it; callers do
 not supply wheel deltas, direction, distance, or coordinates. `computer_key_input`

--- a/docs/AUTH_MODEL.md
+++ b/docs/AUTH_MODEL.md
@@ -251,8 +251,8 @@ is a separate closed effect for Enter, Escape, Tab, arrows, paging/home/end plus
 bounded modifiers. The exact `surface_id` must still be the frontmost focused
 window, and the Runner does not focus or activate it implicitly. Ordinary text,
 arbitrary characters/keycodes, repeat counts, or held-key state are not accepted.
-`computer_input_text` writes bounded text through native AXValue only to an already
-focused, enabled when known, empty, non-secure, unprotected supported text element.
+`computer_input_text` writes bounded text through native AXValue or Windows UIA ValuePattern only to an already
+focused, enabled, writable, empty, non-secure, unprotected supported text element; Windows also requires the exact surface to already be foreground.
 There is no coordinate-click, generic wheel, open-ended key input, dragging,
 clipboard, app-launch, AppleScript, shell, paste, or implicit-focus fallback in this contract. A
 lost response after an effect may have been dispatched is reported as an

--- a/docs/COMPUTER_USE.md
+++ b/docs/COMPUTER_USE.md
@@ -127,6 +127,12 @@ Windows reuses the existing `computer_control(surface_id, element_id, action)` c
 
 `computer_element_state` now derives `can_press` from live `InvokePattern` support and exposes Windows `can_focus=true` only for an enabled, unprotected, keyboard-focusable `AXTextField` on the exact foreground surface; Windows `can_input_text` remains false until the separate text-input parity slice. Focus state/read-back uses `IUIAutomation::GetFocusedElement` plus `CompareElements` against the exact re-resolved element rather than trusting a provider-local focus flag. Protected or disabled targets, background-surface focus, roles outside the bounded focus set, and missing patterns fail closed before an effect. Once `Invoke` or `SetFocus` has been attempted, native failure, deadline loss, or a failed bounded exact-focus read-back is `outcome_unknown`; callers must re-observe before considering another effect.
 
+### Windows UIA parity W4 — bounded text input
+
+Windows reuses `computer_input_text(surface_id, element_id, text)` and its independent `computer_text_input` capability. The first Windows mutation slice remains closed to an exact normalized `AXTextField`: the exact surface must already be foreground, the exact re-resolved element must already hold UIA keyboard focus, and the target must be enabled, unprotected/non-password, positively correlated, expose a writable `ValuePattern`, and have an empty current value. Caller text keeps the existing non-empty, NUL-free, 2048-byte UTF-8 bound and is passed verbatim only to `IUIAutomationValuePattern::SetValue`. There is no implicit activation/focus, key event, paste, clipboard, script, shell, coordinate, or generic automation fallback.
+
+`computer_element_state.can_input_text` reflects the same writable/foreground/focused/empty predicate; the current value itself never leaves the Runner. Emptiness is re-read immediately before `SetValue`, so a non-empty field fails closed instead of being overwritten. Once `SetValue` has been attempted, any native HRESULT failure is `outcome_unknown`; callers must re-observe the exact element before considering another write. Successful responses contain only bounded metadata such as `text_bytes`, never caller text or field contents.
+
 ## Next capability sequence
 
 After the near-term slices are dogfooded, the expected order is:

--- a/docs/COMPUTER_USE.md
+++ b/docs/COMPUTER_USE.md
@@ -121,6 +121,12 @@ Immediately before the effect the Runner revalidates the xcap surface identity, 
 
 A background Runner is normally denied by `SetForegroundWindow`, which was confirmed during Windows live dogfood, so W2 does not pretend that API provides parity and does not bypass the policy with `AttachThreadInput`, synthetic Alt/key input, app/PID selection, or generic automation fallback. Exact UIA focus is the native automation path. Shared post-dispatch delivery fencing remains authoritative when the Runner response itself is lost.
 
+### Windows UIA parity W3 — semantic press and focus
+
+Windows reuses the existing `computer_control(surface_id, element_id, action)` contract for the same closed `press|focus` vocabulary. `press` requires the exact re-resolved UIA element to expose `InvokePattern` and calls only `IUIAutomationInvokePattern::Invoke`. The first bounded Windows `focus` slice is narrower: the exact surface must already be foreground and the exact element must normalize to `AXTextField`, be enabled, unprotected, and keyboard-focusable before `IUIAutomationElement::SetFocus` is attempted. Buttons and other controls are not treated as reliable exact-focus targets merely because a provider reports keyboard-focusability; their semantic action remains `press` when `InvokePattern` is available. Focus never activates a background window implicitly. No Windows-specific model tool, LegacyIAccessible fallback, coordinate click, `SendInput`, script, shell, or generic action path is added.
+
+`computer_element_state` now derives `can_press` from live `InvokePattern` support and exposes Windows `can_focus=true` only for an enabled, unprotected, keyboard-focusable `AXTextField` on the exact foreground surface; Windows `can_input_text` remains false until the separate text-input parity slice. Focus state/read-back uses `IUIAutomation::GetFocusedElement` plus `CompareElements` against the exact re-resolved element rather than trusting a provider-local focus flag. Protected or disabled targets, background-surface focus, roles outside the bounded focus set, and missing patterns fail closed before an effect. Once `Invoke` or `SetFocus` has been attempted, native failure, deadline loss, or a failed bounded exact-focus read-back is `outcome_unknown`; callers must re-observe before considering another effect.
+
 ## Next capability sequence
 
 After the near-term slices are dogfooded, the expected order is:

--- a/docs/COMPUTER_USE.md
+++ b/docs/COMPUTER_USE.md
@@ -105,6 +105,14 @@ On macOS the Runner revalidates the exact surface through the existing native wi
 
 The effect keeps the existing Computer delivery fence: definite non-dispatch is `not_started`; possible dispatch, lost response, partial key-pair delivery, or inconsistent success metadata is `outcome_unknown` and requires UI re-observation before retry. There is no clipboard, paste, AppleScript, shell, pointer, or global-key fallback.
 
+### Windows UIA parity W1 — read-only semantic observation
+
+The first Windows parity slice extends the existing read-only `computer_accessibility_status`, `computer_accessibility_tree`, `computer_find_elements`, and `computer_element_state` model surface to Windows UI Automation. It does not add `windows_*` tools or grant any Windows Computer effect capability.
+
+The Windows Runner revalidates the exact xcap-observed HWND/PID before obtaining the UIA root, walks the UIA Control View with the same depth/node bounds, and registers the same ephemeral `element_id` plus observation-generation lineage used by macOS. The native client uses `CUIAutomation8` / `IUIAutomation2` with bounded connection/transaction timeouts plus a top-level observation deadline, so a stalled provider does not turn node bounds into an unbounded call. UIA control types are projected into the existing semantic role vocabulary where a stable equivalent exists. Password/protected elements suppress value observation.
+
+`computer_find_elements` remains a Control-side adapter over the canonical bounded tree, so Windows support adds no finder-specific Runner protocol. `computer_element_state` re-resolves the exact UIA lineage before returning normalized state. W1 deliberately reports all mutation `can_*` affordances false because the corresponding Windows effect capabilities remain independently unavailable until later parity slices.
+
 ## Next capability sequence
 
 After the near-term slices are dogfooded, the expected order is:

--- a/docs/COMPUTER_USE.md
+++ b/docs/COMPUTER_USE.md
@@ -113,6 +113,14 @@ The Windows Runner revalidates the exact xcap-observed HWND/PID before obtaining
 
 `computer_find_elements` remains a Control-side adapter over the canonical bounded tree, so Windows support adds no finder-specific Runner protocol. `computer_element_state` re-resolves the exact UIA lineage before returning normalized state. W1 deliberately reports all mutation `can_*` affordances false because the corresponding Windows effect capabilities remain independently unavailable until later parity slices.
 
+### Windows UIA parity W2 — exact window activation
+
+Windows reuses the existing `computer_activate_window` effect and its independent `computer_window_activate` capability. The caller supplies only an exact previously observed `surface_id`; there is no app-name, PID, title, executable-path, command, or fallback target.
+
+Immediately before the effect the Runner revalidates the xcap surface identity, exact native HWND/PID, and UIA root. Non-Window UIA roots fail closed before any effect. An already-foreground non-minimized window is a no-op success. A minimized exact window is restored with `ShowWindowAsync(SW_RESTORE)` plus a bounded local-state wait so a stalled foreign UI thread cannot block the Runner; then the exact UIA Window root receives `IUIAutomationElement::SetFocus`. Success still requires `GetForegroundWindow()` to equal the exact HWND. Once either restore or UIA focus has been attempted, any native error, timeout, or mismatched foreground postcondition is `outcome_unknown` and requires fresh observation before any retry.
+
+A background Runner is normally denied by `SetForegroundWindow`, which was confirmed during Windows live dogfood, so W2 does not pretend that API provides parity and does not bypass the policy with `AttachThreadInput`, synthetic Alt/key input, app/PID selection, or generic automation fallback. Exact UIA focus is the native automation path. Shared post-dispatch delivery fencing remains authoritative when the Runner response itself is lost.
+
 ## Next capability sequence
 
 After the near-term slices are dogfooded, the expected order is:

--- a/src/tool_runtime/computer_tools.rs
+++ b/src/tool_runtime/computer_tools.rs
@@ -1204,6 +1204,7 @@ fn filter_accessibility_tree(
     enabled: Option<bool>,
     limit: usize,
 ) -> ToolResult {
+    let platform = tree.get("platform").cloned().unwrap_or(Value::Null);
     let nodes = match tree.get("nodes").and_then(Value::as_array) {
         Some(nodes) => nodes,
         None => {
@@ -1249,7 +1250,7 @@ fn filter_accessibility_tree(
     }
     let count = elements.len();
     ToolResult::ok(json!({
-        "platform": "macos",
+        "platform": platform,
         "surface_id": expected_surface_id,
         "observation_generation": observation_generation,
         "elements": elements,
@@ -1449,6 +1450,10 @@ fn validate_window_list(output: Value, limit: usize) -> ToolResult {
     ToolResult::ok(output)
 }
 
+fn is_native_accessibility_platform(value: Option<&str>) -> bool {
+    matches!(value, Some("macos" | "windows"))
+}
+
 fn validate_accessibility_status(output: Value) -> ToolResult {
     let object = match output.as_object() {
         Some(object) => object,
@@ -1462,7 +1467,7 @@ fn validate_accessibility_status(output: Value) -> ToolResult {
     if object
         .keys()
         .any(|key| !matches!(key.as_str(), "platform" | "trusted"))
-        || output.get("platform").and_then(Value::as_str) != Some("macos")
+        || !is_native_accessibility_platform(output.get("platform").and_then(Value::as_str))
         || output.get("trusted").and_then(Value::as_bool).is_none()
     {
         return computer_error(
@@ -1606,7 +1611,7 @@ fn validate_accessibility_tree(
             "Accessibility tree fields are inconsistent",
         );
     }
-    if output.get("platform").and_then(Value::as_str) != Some("macos")
+    if !is_native_accessibility_platform(output.get("platform").and_then(Value::as_str))
         || output.get("surface_id").and_then(Value::as_str) != Some(expected_surface_id)
         || output.get("max_depth").and_then(Value::as_u64) != Some(max_depth as u64)
         || output.get("max_nodes").and_then(Value::as_u64) != Some(max_nodes as u64)
@@ -1680,7 +1685,7 @@ fn validate_computer_element_state(
     };
     if object.len() != allowed.len()
         || object.keys().any(|key| !allowed.contains(&key.as_str()))
-        || output.get("platform").and_then(Value::as_str) != Some("macos")
+        || !is_native_accessibility_platform(output.get("platform").and_then(Value::as_str))
         || output.get("surface_id").and_then(Value::as_str) != Some(expected_surface_id)
         || output.get("element_id").and_then(Value::as_str) != Some(expected_element_id)
         || !output
@@ -2147,6 +2152,52 @@ mod tests {
     fn computer_accessibility_tree_validator_accepts_bounded_parent_first_tree() {
         let result = validate_accessibility_tree(accessibility_tree(), "surface_test", 2, 8);
         assert!(result.success, "{:?}", result.output);
+    }
+
+    #[test]
+    fn computer_accessibility_read_validators_accept_windows_platform() {
+        let status = validate_accessibility_status(json!({
+            "platform": "windows",
+            "trusted": true
+        }));
+        assert!(status.success, "{:?}", status.output);
+
+        let mut tree = accessibility_tree();
+        tree["platform"] = json!("windows");
+        let validated = validate_accessibility_tree(tree.clone(), "surface_test", 2, 8);
+        assert!(validated.success, "{:?}", validated.output);
+
+        let found = filter_accessibility_tree(
+            tree,
+            "surface_test",
+            Some("AXButton"),
+            None,
+            None,
+            None,
+            None,
+            4,
+        );
+        assert!(found.success, "{:?}", found.output);
+        assert_eq!(found.output["platform"], "windows");
+
+        let state = validate_computer_element_state(
+            json!({
+                "platform": "windows",
+                "surface_id": "surface_test",
+                "element_id": "element_child",
+                "observation_generation": 7,
+                "enabled": true,
+                "focused": false,
+                "protected": false,
+                "value_empty": true,
+                "can_press": false,
+                "can_focus": false,
+                "can_input_text": false
+            }),
+            "surface_test",
+            "element_child",
+        );
+        assert!(state.success, "{:?}", state.output);
     }
 
     #[test]

--- a/src/tool_runtime/computer_tools.rs
+++ b/src/tool_runtime/computer_tools.rs
@@ -1723,6 +1723,10 @@ fn validate_computer_element_state(
     ToolResult::ok(output)
 }
 
+fn is_native_window_activation_platform(value: Option<&str>) -> bool {
+    matches!(value, Some("macos" | "windows"))
+}
+
 fn validate_computer_activate_window(output: Value, expected_surface_id: &str) -> ToolResult {
     let object = match output.as_object() {
         Some(object) => object,
@@ -1736,7 +1740,7 @@ fn validate_computer_activate_window(output: Value, expected_surface_id: &str) -
     let allowed = ["platform", "surface_id", "success"];
     if object.len() != allowed.len()
         || object.keys().any(|key| !allowed.contains(&key.as_str()))
-        || output.get("platform").and_then(Value::as_str) != Some("macos")
+        || !is_native_window_activation_platform(output.get("platform").and_then(Value::as_str))
         || output.get("surface_id").and_then(Value::as_str) != Some(expected_surface_id)
         || output.get("success").and_then(Value::as_bool) != Some(true)
     {
@@ -2362,6 +2366,26 @@ mod tests {
             "surface_test",
         );
         assert!(valid.success, "{:?}", valid.output);
+
+        let windows = validate_computer_activate_window(
+            json!({
+                "platform": "windows",
+                "surface_id": "surface_test",
+                "success": true
+            }),
+            "surface_test",
+        );
+        assert!(windows.success, "{:?}", windows.output);
+
+        let wrong_platform = validate_computer_activate_window(
+            json!({
+                "platform": "linux",
+                "surface_id": "surface_test",
+                "success": true
+            }),
+            "surface_test",
+        );
+        assert!(!wrong_platform.success);
 
         let invalid = validate_computer_activate_window(
             json!({

--- a/src/tool_runtime/computer_tools.rs
+++ b/src/tool_runtime/computer_tools.rs
@@ -1770,7 +1770,7 @@ fn validate_computer_control(
     let allowed = ["platform", "surface_id", "element_id", "action", "success"];
     if object.len() != allowed.len()
         || object.keys().any(|key| !allowed.contains(&key.as_str()))
-        || output.get("platform").and_then(Value::as_str) != Some("macos")
+        || !is_native_window_activation_platform(output.get("platform").and_then(Value::as_str))
         || output.get("surface_id").and_then(Value::as_str) != Some(expected_surface_id)
         || output.get("element_id").and_then(Value::as_str) != Some(expected_element_id)
         || output.get("action").and_then(Value::as_str) != Some(expected_action)
@@ -2423,6 +2423,20 @@ mod tests {
             "focus",
         );
         assert!(result.success, "{:?}", result.output);
+
+        let windows = validate_computer_control(
+            json!({
+                "platform": "windows",
+                "surface_id": "surface_test",
+                "element_id": "element_child",
+                "action": "press",
+                "success": true
+            }),
+            "surface_test",
+            "element_child",
+            "press",
+        );
+        assert!(windows.success, "{:?}", windows.output);
     }
 
     #[test]

--- a/src/tool_runtime/computer_tools.rs
+++ b/src/tool_runtime/computer_tools.rs
@@ -1870,7 +1870,7 @@ fn validate_computer_input_text(
     ];
     if object.len() != allowed.len()
         || object.keys().any(|key| !allowed.contains(&key.as_str()))
-        || output.get("platform").and_then(Value::as_str) != Some("macos")
+        || !is_native_window_activation_platform(output.get("platform").and_then(Value::as_str))
         || output.get("surface_id").and_then(Value::as_str) != Some(expected_surface_id)
         || output.get("element_id").and_then(Value::as_str) != Some(expected_element_id)
         || output.get("text_bytes").and_then(Value::as_u64) != Some(expected_text_bytes as u64)
@@ -2592,6 +2592,20 @@ mod tests {
             "你好🙂".len(),
         );
         assert!(valid.success, "{:?}", valid.output);
+
+        let windows = validate_computer_input_text(
+            json!({
+                "platform": "windows",
+                "surface_id": "surface_test",
+                "element_id": "element_child",
+                "text_bytes": 5,
+                "success": true
+            }),
+            "surface_test",
+            "element_child",
+            5,
+        );
+        assert!(windows.success, "{:?}", windows.output);
 
         let invalid = validate_computer_input_text(
             json!({

--- a/src/tool_runtime/registry/output_schemas/computer.rs
+++ b/src/tool_runtime/registry/output_schemas/computer.rs
@@ -127,11 +127,17 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("truncated", json!({"type": "boolean"})),
         ])),
         "computer_accessibility_status" => Some(wrapped_output_schema(vec![
-            ("platform", json!({"type": "string", "enum": ["macos"]})),
+            (
+                "platform",
+                json!({"type": "string", "enum": ["macos", "windows"]}),
+            ),
             ("trusted", json!({"type": "boolean"})),
         ])),
         "computer_accessibility_tree" => Some(wrapped_output_schema(vec![
-            ("platform", json!({"type": "string", "enum": ["macos"]})),
+            (
+                "platform",
+                json!({"type": "string", "enum": ["macos", "windows"]}),
+            ),
             (
                 "surface_id",
                 json!({"type": "string", "minLength": 1, "maxLength": 128}),
@@ -159,7 +165,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
         ])),
         "computer_find_elements" => Some(wrapped_output_schema(vec![
-            ("platform", json!({"type": "string", "enum": ["macos"]})),
+            (
+                "platform",
+                json!({"type": "string", "enum": ["macos", "windows"]}),
+            ),
             (
                 "surface_id",
                 json!({"type": "string", "minLength": 1, "maxLength": 128}),
@@ -183,7 +192,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("truncated", json!({"type": "boolean"})),
         ])),
         "computer_element_state" => Some(wrapped_output_schema(vec![
-            ("platform", json!({"type": "string", "enum": ["macos"]})),
+            (
+                "platform",
+                json!({"type": "string", "enum": ["macos", "windows"]}),
+            ),
             (
                 "surface_id",
                 json!({"type": "string", "minLength": 1, "maxLength": 128}),

--- a/src/tool_runtime/registry/output_schemas/computer.rs
+++ b/src/tool_runtime/registry/output_schemas/computer.rs
@@ -284,7 +284,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("success", json!({"type": "boolean", "const": true})),
         ])),
         "computer_input_text" => Some(wrapped_output_schema(vec![
-            ("platform", json!({"type": "string", "enum": ["macos"]})),
+            (
+                "platform",
+                json!({"type": "string", "enum": ["macos", "windows"]}),
+            ),
             (
                 "surface_id",
                 json!({"type": "string", "minLength": 1, "maxLength": 128}),

--- a/src/tool_runtime/registry/output_schemas/computer.rs
+++ b/src/tool_runtime/registry/output_schemas/computer.rs
@@ -237,7 +237,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("success", json!({"type": "boolean", "const": true})),
         ])),
         "computer_control" => Some(wrapped_output_schema(vec![
-            ("platform", json!({"type": "string", "enum": ["macos"]})),
+            (
+                "platform",
+                json!({"type": "string", "enum": ["macos", "windows"]}),
+            ),
             (
                 "surface_id",
                 json!({"type": "string", "minLength": 1, "maxLength": 128}),

--- a/src/tool_runtime/registry/output_schemas/computer.rs
+++ b/src/tool_runtime/registry/output_schemas/computer.rs
@@ -226,7 +226,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("can_input_text", json!({"type": "boolean"})),
         ])),
         "computer_activate_window" => Some(wrapped_output_schema(vec![
-            ("platform", json!({"type": "string", "enum": ["macos"]})),
+            (
+                "platform",
+                json!({"type": "string", "enum": ["macos", "windows"]}),
+            ),
             (
                 "surface_id",
                 json!({"type": "string", "minLength": 1, "maxLength": 128}),

--- a/src/tool_runtime/registry/tool_specs/computer.rs
+++ b/src/tool_runtime/registry/tool_specs/computer.rs
@@ -48,7 +48,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "computer_control",
-            "Perform native macOS Accessibility press or focus on an exact reusable element_id. Stale or mismatched targets fail closed; no AppleScript or shell fallback. If delivery may have occurred but the response is lost, outcome is unknown; observe current UI state before retrying.",
+            "Perform native macOS Accessibility or Windows UI Automation press/focus on an exact reusable element_id. Stale, protected, disabled, or unsupported targets fail closed. There is no script, shell, coordinate, or generic fallback; uncertain post-dispatch outcomes require re-observation.",
             computer_control_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/registry/tool_specs/computer.rs
+++ b/src/tool_runtime/registry/tool_specs/computer.rs
@@ -43,7 +43,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "computer_activate_window",
-            "Activate and raise one exact previously observed macOS window surface. The tool accepts no app name, PID, path, bundle, command, or fallback target. Stale surfaces fail closed; if delivery may have occurred but the response is lost, observe current UI state before retrying.",
+            "Activate and raise one exact previously observed macOS or Windows window surface. The tool accepts no app name, PID, path, bundle, command, or fallback target. Stale surfaces fail closed; if delivery may have occurred but the response is lost, observe current UI state before retrying.",
             computer_activate_window_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/registry/tool_specs/computer.rs
+++ b/src/tool_runtime/registry/tool_specs/computer.rs
@@ -23,22 +23,22 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "computer_accessibility_status",
-            "Read the exact Runner's macOS Accessibility trust status without prompting or changing system permission state.",
+            "Read the exact Runner's native accessibility availability/trust status without prompting or changing system permission state. Supports macOS Accessibility and Windows UI Automation.",
             computer_accessibility_status_input_schema(),
         ),
         tool_spec(
             "computer_accessibility_tree",
-            "Inspect an exact macOS window as a bounded read-only Accessibility tree. element_id values are ephemeral process-local handles for computer_control; this tool performs no control action and has no AppleScript or shell fallback.",
+            "Inspect an exact macOS or Windows window as a bounded read-only native accessibility tree. element_id values are ephemeral process-local handles; this tool performs no control action and has no shell or platform-script fallback.",
             computer_accessibility_tree_input_schema(),
         ),
         tool_spec(
             "computer_find_elements",
-            "Find bounded semantic elements on an exact macOS window without parsing the full Accessibility tree. Requires at least one role, subrole, label, focused, or enabled filter. Matching is deterministic and read-only; returned element_id values are fresh ephemeral handles.",
+            "Find bounded semantic elements on an exact macOS or Windows window without parsing the full native accessibility tree. Requires at least one role, subrole, label, focused, or enabled filter. Matching is deterministic and read-only; returned element_id values are fresh ephemeral handles.",
             computer_find_elements_input_schema(),
         ),
         tool_spec(
             "computer_element_state",
-            "Revalidate one exact ephemeral macOS Accessibility element and return normalized read-only affordances plus observation generation. Never returns the element value; protected or secure targets suppress value_empty. Reacquire stale handles with computer_find_elements.",
+            "Revalidate one exact ephemeral native accessibility element and return normalized read-only affordances plus observation generation. Supports macOS AX and Windows UIA; never returns the element value, and protected or secure targets suppress value_empty. Reacquire stale handles with computer_find_elements.",
             computer_element_state_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/registry/tool_specs/computer.rs
+++ b/src/tool_runtime/registry/tool_specs/computer.rs
@@ -38,7 +38,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "computer_element_state",
-            "Revalidate one exact ephemeral native accessibility element and return normalized read-only affordances plus observation generation. Supports macOS AX and Windows UIA; never returns the element value, and protected or secure targets suppress value_empty. Reacquire stale handles with computer_find_elements.",
+            "Revalidate an exact ephemeral accessibility element and return normalized read-only affordances plus observation generation. Supports macOS AX and Windows UIA; never returns element values. Protected or secure targets suppress value_empty. Reacquire stale handles with computer_find_elements.",
             computer_element_state_input_schema(),
         ),
         tool_spec(
@@ -63,7 +63,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "computer_input_text",
-            "Write bounded text verbatim with native macOS AXValue or Windows UI Automation ValuePattern to an exact reusable element_id. Target must already be focused, non-secure, unprotected, supported, enabled, writable, and empty; Windows also requires the exact surface to already be foreground. No focus, activation, paste, synthetic-key, or send fallback. If outcome is unknown, observe UI state before retrying.",
+            "Write bounded text via macOS AXValue or Windows UIA ValuePattern to an exact element_id. Target must be focused, non-secure, unprotected, supported, enabled, writable, and empty; Windows must be foreground. No focus/activation, paste, key, or send fallback. Re-observe unknown outcomes.",
             computer_input_text_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/registry/tool_specs/computer.rs
+++ b/src/tool_runtime/registry/tool_specs/computer.rs
@@ -63,7 +63,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "computer_input_text",
-            "Write bounded text verbatim with native macOS AXValue to an exact reusable element_id. Target must already be focused, non-secure, unprotected, supported, enabled when known, and empty. No focus, paste, synthetic-key, or send fallback. If outcome is unknown, observe UI state before retrying.",
+            "Write bounded text verbatim with native macOS AXValue or Windows UI Automation ValuePattern to an exact reusable element_id. Target must already be focused, non-secure, unprotected, supported, enabled, writable, and empty; Windows also requires the exact surface to already be foreground. No focus, activation, paste, synthetic-key, or send fallback. If outcome is unknown, observe UI state before retrying.",
             computer_input_text_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/tests/schema/migration.rs
+++ b/src/tool_runtime/tests/schema/migration.rs
@@ -242,6 +242,7 @@ fn tool_definition_runtime_tool_policy_inventory_is_stable() {
         ),
         ("list_projects", "project", "none"),
         ("register_project", "project", "none"),
+        ("unregister_project", "project", "none"),
         ("create_project", "project", "none"),
         ("list_agents", "runtime", "none"),
         ("runtime_status", "runtime", "none"),

--- a/src/tool_runtime/tests/tool_call.rs
+++ b/src/tool_runtime/tests/tool_call.rs
@@ -433,14 +433,22 @@ fn from_tool_name_error_includes_tool_name() {
 fn tool_call_project_accessor_covers_project_tool_specs() {
     for spec in registered_tool_specs() {
         let args = sample_tool_args(&spec.name);
-        let expected_project = if spec.name == "start_session" {
-            // start_session project is task association metadata, not an
-            // execution target exposed by the project accessor.
-            None
-        } else {
-            args.get("project")
+        let expected_project = match spec.name.as_str() {
+            "start_session" => {
+                // start_session project is task association metadata, not an
+                // execution target exposed by the project accessor.
+                None
+            }
+            "unregister_project" => {
+                // unregister_project carries an exact lifecycle target, but it
+                // must bypass generic project pre-resolution so a terminal
+                // already_unregistered outcome remains representable.
+                None
+            }
+            _ => args
+                .get("project")
                 .and_then(Value::as_str)
-                .map(str::to_string)
+                .map(str::to_string),
         };
         let call = ToolCall::from_tool_name(&spec.name, args)
             .unwrap_or_else(|e| panic!("{} should deserialize: {}", spec.name, e));


### PR DESCRIPTION
## Summary

- add bounded Windows UIA element observation using exact observed surface/lineage correlation
- add exact-window foreground activation and semantic AXButton/AXTextField control parity
- add bounded Windows text input through UIA `ValuePattern::SetValue` with no key, paste, clipboard, coordinate, LegacyIAccessible, shell, or script fallback
- keep stale/protected/read-only/non-empty/background/not-focused cases fail-closed before the native attempt; post-attempt native failure remains `outcome_unknown`

## Integration

This branch is rebuilt directly on post-#57 `main` and contains only the four reviewed Windows parity commits. The Windows project-search correctness fix is inherited from `main`, not duplicated in this PR.

## Validation

- Windows Runner Computer suite: 37 passed / 0 failed / 3 ignored
- Windows Server `computer_input_text`: 3 passed / 0 failed
- private WinForms production-path smoke: 1 passed / 0 failed
- `cargo fmt -- --check`: passed
- `git diff --check origin/main...HEAD`: passed

The private WinForms fixture exercises observation, activation, focus, bounded text input, fresh state, second-write rejection, and button invocation without touching real user applications.