### PR TITLE
Add always-on PR contract CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,14 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Check schema and metadata contracts
         run: |
-          cargo test --locked -p webcodex --lib openapi_operation_ids_are_minimal
-          cargo test --locked -p webcodex --lib openapi_all_local_refs_resolve
-          cargo test --locked -p webcodex --lib explicit_resume_openapi_metadata_is_distinct_from_session_recording
-          cargo test --locked -p webcodex --lib mcp_tools_list_returns_same_names_as_runtime
-          cargo test --locked -p webcodex --lib mcp_tools_list_parity_with_rest_tools_list
-          cargo test --locked -p webcodex --lib explicit_resume_mcp_schema_and_metadata_are_exposed
-          cargo test --locked -p webcodex --lib http_project_connector_lists_and_dispatches_only_canonical_capabilities
+          cargo test --locked -p webcodex --lib -- \
+            openapi_operation_ids_are_minimal \
+            openapi_all_local_refs_resolve \
+            explicit_resume_openapi_metadata_is_distinct_from_session_recording \
+            mcp_tools_list_returns_same_names_as_runtime \
+            mcp_tools_list_parity_with_rest_tools_list \
+            explicit_resume_mcp_schema_and_metadata_are_exposed \
+            http_project_connector_lists_and_dispatches_only_canonical_capabilities
 
   test:
     # External PRs run automatically (subject to GitHub's normal fork approval

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  contract:
+    # Every PR gets this cheap contract lane, including owner-authored PRs that
+    # have not opted into the heavier `run-ci` jobs below. Keep it limited to
+    # deterministic, in-process/static checks so feedback stays fast.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+      - name: Check frontend contracts
+        run: |
+          npm --prefix frontend run typecheck
+          npm --prefix frontend test
+          npm --prefix frontend run check:dist
+      - name: Verify workspace boundaries
+        run: |
+          bash scripts/workspace_boundary_check.sh --self-test
+          bash scripts/workspace_boundary_check.sh
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Check schema and metadata contracts
+        run: |
+          cargo test --locked -p webcodex --lib openapi_operation_ids_are_minimal
+          cargo test --locked -p webcodex --lib openapi_all_local_refs_resolve
+          cargo test --locked -p webcodex --lib explicit_resume_openapi_metadata_is_distinct_from_session_recording
+          cargo test --locked -p webcodex --lib mcp_tools_list_returns_same_names_as_runtime
+          cargo test --locked -p webcodex --lib mcp_tools_list_parity_with_rest_tools_list
+          cargo test --locked -p webcodex --lib explicit_resume_mcp_schema_and_metadata_are_exposed
+          cargo test --locked -p webcodex --lib http_project_connector_lists_and_dispatches_only_canonical_capabilities
+
   test:
     # External PRs run automatically (subject to GitHub's normal fork approval
     # protections). PRs authored by the repository owner are intentionally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: linux-ci
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -75,6 +77,8 @@ jobs:
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: linux-ci
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,6 +25,16 @@ tests with different cost profiles sharing the same default lane.
 | real-process job recovery failure/compat harness | Cover the failure and compatibility paths the happy-path reconciliation harness omits, using `WEBCODEX_JOB_RECOVERY_GRACE_SECS=10` (clamped, above the 5s floor) so the deadline is bounded without waiting the 120s default. Scenario C: kill the runner only (server stays up), let the job enter `recovering`, and assert the non-request-triggered recovery-timeout sweep transitions it to `lost` with `runner_recovery_deadline_exceeded`, `ended_at` set once, one list record, stop-on-lost stable, and the command never re-executes. Scenario D: instance B replaces instance A (same client_id, new `agent_instance_id`); A's job becomes `lost` with `runner_instance_replaced`, B starts its own new job, A's late update is rejected, first `ended_at`/reason preserved. Scenario E: a legacy runner registered with `WEBCODEX_RUNNER_DISABLE_JOB_STATE_RECONCILIATION=1` (no capability, no inventory) dispatches a job and, on disconnect, deterministically fences it to `lost` with `legacy_runner_disconnected` (never `recovering`); after a server restart the lost job has no durable record and a same-client new instance cannot revive it. Scenario F: a long job across three server restarts keeps the same `job_id`, runs the command once, keeps `last_update_seq`/log cursors non-regressing and markers non-duplicating, and reaches a terminal `stopped` that survives a third restart with `ended_at` unchanged by terminal inventory replay. | Local processes, temp dirs/ports/tokens, and a temp project; no production services or QUIC certs. | `bash scripts/e2e_job_recovery_failures_ws.sh` |
 | security auth matrix | Cover OAuth, scope policy, shared-key behavior, token classes, read-only session guards, and denied mutations. | No external identity provider by default; use local fixtures and synthetic tokens. | `cargo test -p webcodex --lib oauth -- --nocapture`; `cargo test -p webcodex --lib scope -- --nocapture`; `cargo test -p webcodex --lib metadata -- --nocapture` |
 
+PR CI maps the `contract/schema` intent to the always-on `contract` job in
+`.github/workflows/ci.yml`. That job runs on every configured PR workflow run
+without requiring the `run-ci` label and stays limited to workspace/static boundaries,
+frontend type/test/dist checks, formatting, and focused registry/OpenAPI/MCP
+schema and metadata parity tests. The heavier Linux workspace and native Windows
+jobs keep their existing owner-PR `run-ci` opt-in and still run automatically on
+`main`; they retain full workspace, release-tooling, and native Windows coverage.
+Real-process/restart harnesses and exact-source release readiness remain in their
+existing explicit or release-specific lanes.
+
 Iteration 9 execution/reporting changes use the existing domain lanes rather
 than a new test suite:
 


### PR DESCRIPTION
## Summary

- add an always-on `contract` job for configured pull-request workflow events, independent of the owner-only `run-ci` opt-in
- keep the lane limited to cheap/high-signal frontend, workspace-boundary, formatting, OpenAPI, MCP, registry, and connector contract checks
- run the seven Rust contract filters through one libtest invocation so the focused lane builds the test binary once instead of once per filter
- share the Linux Rust cache identity between the contract and heavy Linux jobs so `main` CI can seed warm PR contract builds
- preserve the existing heavy Linux workspace, native Windows, release-tooling, exact-source release readiness, and real-process coverage semantics
- document how the PR contract lane maps to the existing testing strategy

## Validation

- `actionlint .github/workflows/ci.yml`
- frontend typecheck + 55 tests + committed dist check
- workspace boundary self-test + boundary check
- `cargo fmt --all -- --check`
- one combined Rust contract invocation: 7 passed, 0 failed, 2523 filtered out
- `git diff --check`
- independent review of trigger/`run-ci`/heavy-lane preservation and selected contract coverage
- live owner-authored PR run without `run-ci`: `contract` starts while heavy Linux/Windows jobs are skipped

Closes #61