### PR TITLE
Retire legacy ignored import fixtures

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,7 +15,7 @@ tests with different cost profiles sharing the same default lane.
 | fast unit | Pure parsing, validation, helpers, local state machines, small fixtures. | No network, no global env mutation, no long sleeps. | `cargo test -p webcodex --lib tool_call` |
 | contract/schema | Keep metadata, registry, MCP `tools/list`, OpenAPI, and runtime tool names synchronized. | No external network; in-process services are preferred. | `cargo test -p webcodex --lib metadata`; `cargo test -p webcodex --lib mcp`; `cargo test -p webcodex --lib openapi` |
 | local integration | Exercise HTTP handlers, runtime dispatch, sessions, local agent registry, temp dirs, loopback listeners, and database fixtures. | Loopback only, isolated temp dirs, bounded waits, no shared mutable state without a lock. | `cargo test -p webcodex --lib runtime_http -- --nocapture`; `cargo test -p webcodex --lib session -- --nocapture` |
-| slow/manual ignored | Valuable coverage that is local but slow, serial, large-input, or global-state-sensitive. | Explicit operator opt-in; often `--ignored` and `--test-threads=1`. | `cargo test -p webcodex --lib import_http -- --ignored --nocapture --test-threads=1` |
+| slow/manual ignored | Valuable coverage that is local but slow, serial, large-input, or global-state-sensitive. | Explicit operator opt-in; often `--ignored` and `--test-threads=1`. | Run the specific ignored test/filter documented by its subsystem. |
 | e2e/deployment smoke | Prove that binaries, local services, GPT Actions schema, MCP, artifact transfer, and an agent can work together. | Temporary local services and loopback ports; real deployment only when explicitly requested. | `bash scripts/e2e_zero_config_ws.sh`; `bash scripts/smoke_deployment.sh`; `bash scripts/smoke_artifact_transfer.sh` |
 | reconnect continuity | Runner disconnect/reconnect layer independence, stale-not-ready observations, server-restart durable Session plus exact binding restoration, lost-job terminal semantics, meaningful-activity scoping, and version-mismatch diagnostics. | In-process fixtures, no external network. | `cargo test -p webcodex --lib reconnect` |
 | trusted smoke | Disposable git fixture full chain (start → edit → failing shell validation → fix → pass → git review → finish) asserting zero approval interruptions under `trusted_agent` authority, resolved failure evidence, dirty-worktree advisory-only, and bounded payloads; prints baseline counters. | Temp git fixture, no external network. | `cargo test -p webcodex --lib trusted_smoke` |
@@ -44,8 +44,8 @@ The lanes above define test semantics; workflows decide when to run them.
 - Exact-source release acceptance is separate from ordinary pull-request CI.
   Follow [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md) and
   `.github/workflows/release-readiness.yml`.
-- Slow/manual and real-process lanes remain explicit targeted evidence unless a
-  workflow names them. Do not infer that one lane ran merely because another CI
+- Slow/manual and real-process lanes remain explicit targeted evidence unless
+  a workflow names them. Do not infer that one lane ran merely because another CI
   job passed.
 
 ## Default Test Principles
@@ -76,47 +76,13 @@ The lanes above define test semantics; workflows decide when to run them.
 - Ignored tests are not dead tests. Each ignored test should have a reason and a
   documented lane for running it intentionally.
 
-## Current `import_http` Inventory
+## `import_http` Coverage
 
-`src/runtime_http/tests/import_http_tests.rs` currently contains four ignored
-`import_http` tests:
-
-- `import_http_does_not_follow_302_redirect`
-- `import_http_rejects_content_length_over_limit`
-- `import_http_rejects_chunked_body_after_limit_without_content_length`
-- `import_http_success_uses_source_name_fallback_for_missing_target`
-
-These tests do not access the external internet. They use a loopback mock HTTP
-server, rewrite the import download base URL, create temporary project roots,
-and in one success case drive asynchronous agent completion. They remain
-ignored because they combine several local-integration risks:
-
-- a global download URL override that must be reset,
-- a serial import test lock that protects the test body but still makes the lane
-  unsuitable for high-parallel default runs,
-- raw loopback listener setup and spawned async server tasks,
-- large body coverage around `MAX_IMPORT_FILE_BYTES`,
-- polling with short sleeps while waiting for agent requests,
-- temp-dir project roots and artifact writes.
-
-This coverage is useful and should be preserved. The current default behavior is
-to keep it out of the fast and contract/schema lanes until the fixture can be
-made deterministic enough for a serial local integration lane.
-
-## Path To A Serial Local Integration Lane
-
-The next structural step is to run the four `import_http` ignored tests under a
-named serial local integration lane without changing their assertions:
-
-1. Keep the tests local-only and run them with `--test-threads=1`.
-2. Replace the global URL rewrite with a fixture-scoped guard or downloader
-   injection, if the runtime boundary allows it.
-3. Replace sleep polling for agent completion with a bounded notification or a
-   helper that fails with a clear timeout.
-4. Keep the mock HTTP server on `127.0.0.1:0` and make task shutdown explicit.
-5. Promote the lane from manual to scheduled or path-filtered CI only after the
-   inventory shows no unguarded env mutation, leaked global state, or unbounded
-   waits.
+Conversation-import tests use bounded loopback fixtures in the ordinary local-integration
+surface. Legacy ignored HTTP fixtures for redirect and download-size limits were retired
+after equivalent boundary coverage moved to the current MCP import path; source-name
+fallback is covered directly at the import-name helper. Keep new coverage on the current
+transport/runtime path instead of preserving duplicate historical fixtures.
 
 Run the current heuristic inventory with:
 
@@ -139,13 +105,11 @@ Recent structure work moved large test groups out of production roots:
   `crates/webcodex-cli/src/webcodex_cli/tests/*`.
 - CLI help smoke coverage lives with the CLI test modules and covers common
   help entry points, so new command help should extend that smoke coverage.
-- Runtime HTTP tests live under `src/runtime_http/tests/*`; the only currently
-  ignored tests tracked by the inventory are the four `import_http` tests listed
-  above.
+- Runtime HTTP tests live under `src/runtime_http/tests/*`; historical ignored
+  import fixtures should not be retained once equivalent current-path coverage exists.
 - Tool runtime tests live under `src/tool_runtime/tests/*` by domain.
 
 Do not add large ordinary test blocks to production facade files when one of
 these `tests/` module trees already exists. Exact full-suite pass counts should
-come from a fresh `cargo test -p webcodex --lib` run; recent full-suite scale is
-roughly 1.7k passing tests plus the four ignored `import_http` tests, but this
-document should not be treated as the source of truth for exact counts.
+come from a fresh `cargo test -p webcodex --lib` run; this document should not be
+treated as the source of truth for exact counts.

--- a/src/runtime_http/import_http.rs
+++ b/src/runtime_http/import_http.rs
@@ -8,9 +8,7 @@ use salvo::prelude::*;
 use serde::Deserialize;
 
 #[cfg(test)]
-pub(super) use crate::tool_runtime::conversation_import::{
-    set_import_test_download_base_url, MAX_IMPORT_FILE_BYTES,
-};
+pub(super) use crate::tool_runtime::conversation_import::set_import_test_download_base_url;
 
 #[derive(Debug, Deserialize)]
 struct ImportConversationFilesRequest {

--- a/src/runtime_http/tests/import_http_tests.rs
+++ b/src/runtime_http/tests/import_http_tests.rs
@@ -1,4 +1,4 @@
-use super::super::import_http::{set_import_test_download_base_url, MAX_IMPORT_FILE_BYTES};
+use super::super::import_http::set_import_test_download_base_url;
 use crate::tool_runtime::files::{
     MAX_PROJECT_ARTIFACT_UPLOAD_BYTES, MAX_PROJECT_ARTIFACT_UPLOAD_CHUNK_BYTES,
 };
@@ -9,8 +9,17 @@ use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Duration;
 
+const IMPORT_TEST_AGENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const IMPORT_TEST_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+const IMPORT_TEST_SERVER_IO_TIMEOUT: Duration = Duration::from_secs(30);
+
 async fn lock_import_http_test() -> tokio::sync::MutexGuard<'static, ()> {
-    crate::tool_runtime::conversation_import::lock_import_test_network().await
+    tokio::time::timeout(
+        IMPORT_TEST_LOCK_TIMEOUT,
+        crate::tool_runtime::conversation_import::lock_import_test_network(),
+    )
+    .await
+    .expect("timed out waiting for import test network lock")
 }
 
 struct ImportDownloadBaseUrlGuard;
@@ -46,13 +55,25 @@ async fn start_mock_http_server(responses: Vec<Vec<u8>>) -> MockHttpServer {
     let handle = tokio::spawn(async move {
         let mut responses = std::collections::VecDeque::from(responses);
         while let Some(response) = responses.pop_front() {
-            let Ok((mut stream, _)) = listener.accept().await else {
+            let Ok(Ok((mut stream, _))) =
+                tokio::time::timeout(IMPORT_TEST_SERVER_IO_TIMEOUT, listener.accept()).await
+            else {
                 return;
             };
             let mut buf = [0_u8; 4096];
-            let _ = stream.read(&mut buf).await;
-            let _ = stream.write_all(&response).await;
-            let _ = stream.shutdown().await;
+            if tokio::time::timeout(IMPORT_TEST_SERVER_IO_TIMEOUT, stream.read(&mut buf))
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if tokio::time::timeout(IMPORT_TEST_SERVER_IO_TIMEOUT, stream.write_all(&response))
+                .await
+                .is_err()
+            {
+                return;
+            }
+            let _ = tokio::time::timeout(IMPORT_TEST_SERVER_IO_TIMEOUT, stream.shutdown()).await;
         }
     });
     MockHttpServer {
@@ -94,20 +115,25 @@ async fn next_import_agent_request(
     registry: &crate::shell_client::ShellClientRegistry,
 ) -> crate::shell_protocol::ShellAgentShellRequest {
     use crate::shell_protocol::ShellAgentPollRequest;
-    loop {
-        if let Some(request) = registry
-            .poll(ShellAgentPollRequest {
-                client_id: "importer".to_string(),
-                agent_instance_id: "inst-import".to_string(),
-                projects: None,
-            })
-            .await
-            .unwrap()
-        {
-            return request;
+
+    tokio::time::timeout(IMPORT_TEST_AGENT_REQUEST_TIMEOUT, async {
+        loop {
+            if let Some(request) = registry
+                .poll(ShellAgentPollRequest {
+                    client_id: "importer".to_string(),
+                    agent_instance_id: "inst-import".to_string(),
+                    projects: None,
+                })
+                .await
+                .unwrap()
+            {
+                return request;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
-    }
+    })
+    .await
+    .expect("timed out waiting for import agent request")
 }
 
 async fn complete_import_artifact_uploads(
@@ -821,181 +847,4 @@ async fn import_http_rejects_non_openai_file_host() {
     );
     let body: Value = resp.take_json().await.unwrap();
     assert!(body["error"].as_str().unwrap().contains("OpenAI file host"));
-}
-
-// These ignored tests are a serial, loopback-only integration lane for import
-// downloader behavior. They remain manual/slow and are not part of default
-// runtime_http test execution.
-
-#[tokio::test]
-#[ignore]
-async fn import_http_does_not_follow_302_redirect() {
-    let _guard = lock_import_http_test().await;
-    let server = start_mock_http_server(vec![http_response(
-        "302 Found",
-        &[(
-            "Location",
-            "https://files.oaiusercontent.com/other.png".to_string(),
-        )],
-        b"",
-    )])
-    .await;
-    let _download_base = ImportDownloadBaseUrlGuard::set(server.base_url.clone());
-    let service = import_test_service_with_local_runtime().await;
-    let mut resp = TestClient::post("http://localhost/api/artifacts/import")
-        .bearer_auth("secret")
-        .json(&import_body(
-            "https://files.oaiusercontent.com/a.png",
-            "image/png",
-            "a.png",
-        ))
-        .send(&service)
-        .await;
-    assert_eq!(
-        super::effective_status(&resp),
-        salvo::http::StatusCode::BAD_REQUEST
-    );
-    let body: Value = resp.take_json().await.unwrap();
-    assert!(body["error"].as_str().unwrap().contains("HTTP 302"));
-}
-
-#[tokio::test]
-#[ignore]
-async fn import_http_rejects_content_length_over_limit() {
-    let _guard = lock_import_http_test().await;
-    let server = start_mock_http_server(vec![http_response(
-        "200 OK",
-        &[("Content-Length", (MAX_IMPORT_FILE_BYTES + 1).to_string())],
-        b"",
-    )])
-    .await;
-    let _download_base = ImportDownloadBaseUrlGuard::set(server.base_url.clone());
-    let service = import_test_service_with_local_runtime().await;
-    let mut resp = TestClient::post("http://localhost/api/artifacts/import")
-        .bearer_auth("secret")
-        .json(&import_body(
-            "https://files.oaiusercontent.com/a.png",
-            "image/png",
-            "a.png",
-        ))
-        .send(&service)
-        .await;
-    assert_eq!(
-        super::effective_status(&resp),
-        salvo::http::StatusCode::BAD_REQUEST
-    );
-    let body: Value = resp.take_json().await.unwrap();
-    assert!(body["error"].as_str().unwrap().contains("exceeds"));
-}
-
-#[tokio::test]
-#[ignore]
-async fn import_http_rejects_chunked_body_after_limit_without_content_length() {
-    let _guard = lock_import_http_test().await;
-    let body = vec![b'x'; MAX_IMPORT_FILE_BYTES + 1];
-    let server = start_mock_http_server(vec![http_response("200 OK", &[], &body)]).await;
-    let _download_base = ImportDownloadBaseUrlGuard::set(server.base_url.clone());
-    let tmp = tempfile::tempdir().unwrap();
-    let (runtime, registry) = super::register_import_agent_with_capabilities(
-        tmp.path(),
-        Some(crate::shell_protocol::ShellClientCapabilities {
-            file_write: true,
-            ..Default::default()
-        }),
-    )
-    .await;
-    let config = super::test_config(Some("secret"));
-    let (_db_tmp, db) = super::test_db();
-    let service = Service::new(super::build_projects_router(config, db, runtime));
-    let agent = tokio::spawn(complete_import_artifact_uploads(registry, 1));
-    let mut resp = TestClient::post("http://localhost/api/artifacts/import")
-        .bearer_auth("secret")
-        .json(&import_body(
-            "https://files.oaiusercontent.com/a.png",
-            "image/png",
-            "a.png",
-        ))
-        .send(&service)
-        .await;
-    let outcomes = tokio::time::timeout(Duration::from_secs(10), agent)
-        .await
-        .expect("over-limit upload abort fixture timed out")
-        .unwrap();
-    assert_eq!(outcomes.len(), 1);
-    assert!(outcomes[0].aborted);
-    assert!(!outcomes[0].finished);
-    assert!(!tmp.path().join("docs/assets/a.png").exists());
-    assert_eq!(
-        super::effective_status(&resp),
-        salvo::http::StatusCode::BAD_REQUEST
-    );
-    let body: Value = resp.take_json().await.unwrap();
-    assert!(body["error"].as_str().unwrap().contains("exceeds"));
-}
-
-#[tokio::test]
-#[ignore]
-async fn import_http_success_uses_source_name_fallback_for_missing_target() {
-    let _guard = lock_import_http_test().await;
-    let png = vec![0x89, b'P', b'N', b'G'];
-    let webp = b"RIFF\x00\x00\x00\x00WEBP".to_vec();
-    let server = start_mock_http_server(vec![
-        http_response("200 OK", &[("Content-Length", png.len().to_string())], &png),
-        http_response(
-            "200 OK",
-            &[("Content-Length", webp.len().to_string())],
-            &webp,
-        ),
-    ])
-    .await;
-    let _download_base = ImportDownloadBaseUrlGuard::set(server.base_url.clone());
-    let tmp = tempfile::tempdir().unwrap();
-    let (runtime, registry) = super::register_import_agent_with_capabilities(
-        tmp.path(),
-        Some(crate::shell_protocol::ShellClientCapabilities {
-            file_write: true,
-            ..Default::default()
-        }),
-    )
-    .await;
-    let config = super::test_config(Some("secret"));
-    let (_db_tmp, db) = super::test_db();
-    let service = Service::new(super::build_projects_router(config, db, runtime));
-    let agent = tokio::spawn(complete_import_artifact_uploads(registry, 2));
-    let mut resp = TestClient::post("http://localhost/api/artifacts/import")
-        .bearer_auth("secret")
-        .json(&json!({
-            "project":"agent:importer:demo",
-            "output_dir":"docs/assets",
-            "targets":["custom.png"],
-            "openaiFileIdRefs":[
-                {"name":"generated.png","id":"file_png","mime_type":"image/png","download_link":"https://files.oaiusercontent.com/generated.png"},
-                {"name":"fallback.webp","id":"file_webp","mime_type":"image/webp","download_link":"https://files.oaiusercontent.com/fallback.webp"}
-            ]
-        }))
-        .send(&service)
-        .await;
-    let outcomes = agent.await.unwrap();
-    assert_eq!(outcomes.len(), 2);
-    assert!(outcomes.iter().all(|outcome| outcome.finished));
-    assert_eq!(super::effective_status(&resp), salvo::http::StatusCode::OK);
-    let body: Value = resp.take_json().await.unwrap();
-    let imported = body["output"]["imported"].as_array().unwrap();
-    assert_eq!(imported.len(), 2);
-    assert_eq!(imported[0]["path"], "docs/assets/custom.png");
-    assert_eq!(imported[0]["bytes_written"], png.len());
-    assert_eq!(imported[0]["mime_type"], "image/png");
-    assert_eq!(imported[0]["sha256"].as_str().unwrap().len(), 64);
-    assert_eq!(imported[1]["path"], "docs/assets/fallback.webp");
-    assert_eq!(imported[1]["bytes_written"], webp.len());
-    assert_eq!(imported[1]["mime_type"], "image/webp");
-    assert_eq!(imported[1]["sha256"].as_str().unwrap().len(), 64);
-    assert_eq!(
-        std::fs::read(tmp.path().join("docs/assets/custom.png")).unwrap(),
-        png
-    );
-    assert_eq!(
-        std::fs::read(tmp.path().join("docs/assets/fallback.webp")).unwrap(),
-        webp
-    );
 }

--- a/src/tool_runtime/conversation_import.rs
+++ b/src/tool_runtime/conversation_import.rs
@@ -813,6 +813,20 @@ mod tests {
     }
 
     #[test]
+    fn default_import_leaf_uses_source_name_when_target_is_missing() {
+        let file_ref = OpenAiFileIdRef {
+            name: Some("fallback.webp".to_string()),
+            id: Some("file_webp".to_string()),
+            mime_type: Some("image/webp".to_string()),
+            download_link: "https://files.oaiusercontent.com/fallback.webp".to_string(),
+        };
+        assert_eq!(
+            default_import_leaf(&file_ref, 1, "image/webp"),
+            "fallback.webp"
+        );
+    }
+
+    #[test]
     fn trusted_mcp_ssrf_policy_rejects_non_public_ip_ranges() {
         for ip in [
             "127.0.0.1",


### PR DESCRIPTION
## Summary

- retire the four historical ignored `import_http` fixtures instead of adding a new CI lane for them
- keep current import test helpers bounded: the shared test-network lock, agent-request polling, and mock-server I/O now fail with explicit deadlines rather than waiting indefinitely
- cover source-name fallback directly with a small `default_import_leaf` unit test
- document that redirect refusal and declared/streamed download-size limits are now covered on the current MCP import path, including upload-abort cleanup for streamed over-limit data
- remove the stale testing-plan text that proposed promoting these old fixtures to a serial lane

## Why this supersedes the original lane proposal

Issue #60 was filed when these four ignored HTTP fixtures were the durable coverage for the downloader boundaries. The repository has since gained `oauth_mcp_file_import_trusted_download_guards_remain_bounded`, which covers redirect refusal, `Content-Length` overflow, streamed overflow, and abort cleanup on the current import path. Keeping a separate ignored-fixture CI lane would duplicate older transport-level coverage and add maintenance cost.

This PR therefore resolves the reliability problem by deleting the obsolete ignored tests while retaining bounded waits in the shared fixture code that is still used by ordinary import tests. Production import/download semantics are unchanged.

## Validation

- `cargo test --locked -p webcodex --lib import_http` — 9 passed, 0 ignored
- focused current-path coverage: `default_import_leaf_uses_source_name_when_target_is_missing` and `oauth_mcp_file_import_trusted_download_guards_remain_bounded` — 2 passed
- `bash scripts/test_inventory.sh` — ignored tests: none found
- `cargo fmt --all -- --check`
- `python3 scripts/check_markdown_links.py` — 260 local links, 0 missing
- `git diff --check`

Closes #60