### PR TITLE
Use structured argv for Git path mutations

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -650,7 +650,7 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation_with_examples(
                     "gitRestorePaths",
                     "Restore tracked project paths",
-                    "Mutation with side effects. Runs `git restore -- <paths>` on selected tracked project-relative paths. Does not remove untracked files. Requires Bearer auth and the agent shell capability.",
+                    "Mutation with side effects. Runs `git restore -- <paths>` on selected tracked project-relative paths. Does not remove untracked files. Requires Bearer auth and the agent `structured_process_argv` capability.",
                     "GitRestorePathsRequest",
                     "ToolResult",
                     json!({
@@ -668,7 +668,7 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation_with_examples(
                     "discardUntrackedFiles",
                     "Discard untracked project files",
-                    "Mutation with side effects. Runs `git clean -f -- <paths>` only for selected project-relative untracked paths. Requires Bearer auth and the agent shell capability.",
+                    "Mutation with side effects. Runs `git clean -f -- <paths>` only for selected project-relative untracked paths. Requires Bearer auth and the agent `structured_process_argv` capability.",
                     "DiscardUntrackedRequest",
                     "ToolResult",
                     json!({

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -756,16 +756,14 @@ fn openapi_mutation_actions_describe_execution_risk_and_auth() {
             desc
         );
     }
-    // The patch/shell/cleanup/write mutations must also mention the agent
-    // shell capability. startProjectShellJob requires the async shell job
-    // capability (checked separately below), not the plain shell capability.
+    // Patch/shell/delete mutations still require the agent shell capability.
+    // Git path mutations use typed executable+argv dispatch and therefore
+    // require the distinct structured-process capability instead.
     for path in [
         "/api/projects/apply_patch",
         "/api/projects/apply_patch_checked",
         "/api/projects/run_shell",
         "/api/projects/delete_files",
-        "/api/projects/git_restore_paths",
-        "/api/projects/discard_untracked",
     ] {
         let desc = spec["paths"][path]["post"]["description"]
             .as_str()
@@ -773,6 +771,26 @@ fn openapi_mutation_actions_describe_execution_risk_and_auth() {
         assert!(
             desc.to_lowercase().contains("agent shell capability"),
             "{} description should mention the agent shell capability, got: {}",
+            path,
+            desc
+        );
+    }
+    for path in [
+        "/api/projects/git_restore_paths",
+        "/api/projects/discard_untracked",
+    ] {
+        let desc = spec["paths"][path]["post"]["description"]
+            .as_str()
+            .unwrap_or("");
+        assert!(
+            desc.contains("structured_process_argv"),
+            "{} description should mention structured_process_argv, got: {}",
+            path,
+            desc
+        );
+        assert!(
+            !desc.to_lowercase().contains("agent shell capability"),
+            "{} must not advertise the obsolete shell capability, got: {}",
             path,
             desc
         );

--- a/src/runtime_http/project_files.rs
+++ b/src/runtime_http/project_files.rs
@@ -343,7 +343,7 @@ pub async fn projects_delete_files(req: &mut Request, depot: &mut Depot, res: &m
 /// `POST /api/projects/git_restore_paths` — thin GPT Actions wrapper over
 /// `ToolCall::GitRestorePaths`. Mutation with side effects: runs
 /// `git restore -- <paths>` on selected tracked project-relative paths.
-/// Requires Bearer auth and the agent shell capability.
+/// Requires Bearer auth and the agent `structured_process_argv` capability.
 #[handler]
 pub async fn projects_git_restore_paths(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let audit = ActionAudit::start(
@@ -376,7 +376,7 @@ pub async fn projects_git_restore_paths(req: &mut Request, depot: &mut Depot, re
 /// `POST /api/projects/discard_untracked` — thin GPT Actions wrapper over
 /// `ToolCall::DiscardUntracked`. Mutation with side effects: runs
 /// `git clean -f -- <paths>` only for selected project-relative untracked
-/// paths. Requires Bearer auth and the agent shell capability.
+/// paths. Requires Bearer auth and the agent `structured_process_argv` capability.
 #[handler]
 pub async fn projects_discard_untracked(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let audit = ActionAudit::start(

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -479,11 +479,20 @@ impl ToolRuntime {
         self.delete_project_files_local(&proj, paths)
     }
 
+    /// Rolling-upgrade compatibility for Runner binaries that predate
+    /// `structured_file_delete`. This deliberately preserves the historical
+    /// POSIX `rm -f -- ...` path and is therefore not a new cross-platform
+    /// execution contract. Retirement condition: once the supported Runner
+    /// fleet requires `structured_file_delete`, remove this fallback and its
+    /// compatibility tests rather than extending shell quoting to new platforms.
     async fn delete_project_files_legacy_shell(
         &self,
         project: String,
         paths: Vec<String>,
     ) -> ToolResult {
+        // Admission reaches this path only while mixed-version Runner support is
+        // still required. Never retry here after a possibly-dispatched structured
+        // delete; that uncertainty is handled by the structured lifecycle path.
         let command = format!("rm -f -- {}", shell_join_paths(&paths));
         let result = self.run_shell(project, command, Some(30), None).await;
         if result.success {

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -8,8 +8,8 @@ use webcodex_workspace::file_read_normalize::MODEL_RESULT_ENVELOPE_RESERVE_BYTES
 use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
 
 use super::helpers::{
-    run_command_sync_bounded, shell_escape_simple, shell_join_paths,
-    validate_limited_cleanup_paths, validate_project_relative_path, LocalRunFailure,
+    run_command_sync_bounded, shell_escape_simple, validate_limited_cleanup_paths,
+    validate_project_relative_path, LocalRunFailure,
 };
 use super::tool_result::ToolResult;
 use super::ToolRuntime;
@@ -3016,8 +3016,11 @@ impl ToolRuntime {
             Ok(paths) => paths,
             Err(e) => return ToolResult::err(e),
         };
-        let command = format!("git restore -- {}", shell_join_paths(&paths));
-        let result = self.run_shell(project, command, Some(30), None).await;
+        let mut args = vec!["restore".to_string(), "--".to_string()];
+        args.extend(paths.iter().cloned());
+        let result = self
+            .run_internal_process_sync(project, "git".to_string(), args, 30)
+            .await;
         if result.success {
             ToolResult::ok(json!({
                 "restored_paths": paths,
@@ -3037,8 +3040,11 @@ impl ToolRuntime {
             Ok(paths) => paths,
             Err(e) => return ToolResult::err(e),
         };
-        let command = format!("git clean -f -- {}", shell_join_paths(&paths));
-        let result = self.run_shell(project, command, Some(30), None).await;
+        let mut args = vec!["clean".to_string(), "-f".to_string(), "--".to_string()];
+        args.extend(paths.iter().cloned());
+        let result = self
+            .run_internal_process_sync(project, "git".to_string(), args, 30)
+            .await;
         if result.success {
             ToolResult::ok(json!({
                 "discarded_untracked_paths": paths,

--- a/src/tool_runtime/process.rs
+++ b/src/tool_runtime/process.rs
@@ -329,6 +329,66 @@ impl ToolRuntime {
         session_id: Option<String>,
         auth: Option<&AuthContext>,
     ) -> ToolResult {
+        self.run_process_with_contract_mode(
+            project,
+            executable,
+            args,
+            stdin,
+            timeout_secs,
+            cwd,
+            purpose,
+            sandbox,
+            ssh_resource,
+            session_id,
+            auth,
+            true,
+        )
+        .await
+    }
+
+    /// Execute one server-owned fixed process synchronously without exposing the
+    /// model-facing structured-execution Job handoff. Effectful internal tools
+    /// must not report success while their fixed mutation is still running.
+    pub(super) async fn run_internal_process_sync(
+        &self,
+        project: String,
+        executable: String,
+        args: Vec<String>,
+        timeout_secs: u64,
+    ) -> ToolResult {
+        self.run_process_with_contract_mode(
+            project,
+            executable,
+            args,
+            None,
+            Some(timeout_secs),
+            None,
+            Some(ExecutionPurpose::Operation),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_process_with_contract_mode(
+        &self,
+        project: String,
+        executable: String,
+        args: Vec<String>,
+        stdin: Option<String>,
+        timeout_secs: Option<u64>,
+        cwd: Option<String>,
+        purpose: Option<ExecutionPurpose>,
+        sandbox: Option<&str>,
+        ssh_resource: Option<&str>,
+        session_id: Option<String>,
+        auth: Option<&AuthContext>,
+        allow_async_handoff: bool,
+    ) -> ToolResult {
         let budget = match StructuredExecutionBudget::resolve(timeout_secs) {
             Ok(budget) => budget,
             Err(error) => {
@@ -434,7 +494,8 @@ impl ToolRuntime {
                     return result;
                 }
             };
-            let async_handoff_available = capabilities.structured_execution_jobs
+            let async_handoff_available = allow_async_handoff
+                && capabilities.structured_execution_jobs
                 && (capabilities.async_jobs || capabilities.async_shell_jobs);
             if !async_handoff_available
                 && timeout > STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -172,6 +172,100 @@ async fn git_path_mutations_pass_shell_sensitive_paths_as_literal_argv() {
 }
 
 #[tokio::test]
+async fn git_path_mutation_capability_preflight_matches_structured_process_runtime() {
+    let runtime = runtime_with_agent_project("restore-structured-only");
+    register_agent(
+        &runtime,
+        "restore-structured-only",
+        None,
+        ShellClientCapabilities {
+            shell: false,
+            structured_process_argv: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id("restore-structured-only");
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            let bootstrap = auth_context(None, true);
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::GitRestorePaths {
+                        project,
+                        paths: vec!["safe.txt".to_string()],
+                        session_id: None,
+                    },
+                    Some(&bootstrap),
+                )
+                .await
+        }
+    });
+
+    let request = next_patch_agent_request(&runtime, "restore-structured-only")
+        .await
+        .expect("structured-process-only Runner should reach typed process dispatch");
+    assert_eq!(request.kind, "run_process");
+    assert!(request.command.is_empty());
+    let process = request.process.as_ref().expect("typed git restore process");
+    assert_eq!(process.executable, "git");
+    assert_eq!(
+        process.args,
+        ["restore", "--", "safe.txt"].map(str::to_string)
+    );
+    complete_patch_agent_request(
+        &runtime,
+        "restore-structured-only",
+        &request.request_id,
+        0,
+        "",
+        "",
+    )
+    .await;
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+
+    let runtime = runtime_with_agent_project("discard-shell-only");
+    register_agent(
+        &runtime,
+        "discard-shell-only",
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            git: true,
+            structured_process_argv: false,
+            ..Default::default()
+        },
+    )
+    .await;
+    let bootstrap = auth_context(None, true);
+    let result = runtime
+        .dispatch_with_auth(
+            ToolCall::DiscardUntracked {
+                project: agent_test_project_id("discard-shell-only"),
+                paths: vec!["safe.txt".to_string()],
+                session_id: None,
+            },
+            Some(&bootstrap),
+        )
+        .await;
+    assert!(!result.success);
+    assert_eq!(result.output["execution_state"], "not_started");
+    assert_eq!(result.output["command_started"], false);
+    assert_eq!(result.output["failure_kind"], "capability_unavailable");
+    let error = result.error.as_deref().unwrap_or_default();
+    assert!(error.contains("structured_process_argv"), "{error}");
+    assert!(error.contains("no shell fallback"), "{error}");
+    assert!(
+        next_patch_agent_request(&runtime, "discard-shell-only")
+            .await
+            .is_none(),
+        "capability preflight must reject before enqueue"
+    );
+}
+
+#[tokio::test]
 async fn git_restore_missing_structured_process_capability_is_definite_not_started() {
     let runtime = runtime_with_agent_project("restore-no-argv");
     register_agent(

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -12,6 +12,29 @@ use std::fs;
 use std::path::Path;
 use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
 
+async fn register_structured_git_agent_at_path(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project_id: &str,
+    root: &Path,
+) -> String {
+    let project_path = root.to_string_lossy().to_string();
+    register_agent_with_projects(
+        runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            git: true,
+            structured_process_argv: true,
+            ..Default::default()
+        },
+        vec![registered_project(project_id, &project_path)],
+    )
+    .await;
+    crate::tool_runtime::agent_project_runtime_id(client_id, project_id)
+}
+
 #[tokio::test]
 async fn git_restore_paths_restores_tracked_filename_containing_target() {
     let tmp = tempfile::tempdir().unwrap();
@@ -25,9 +48,13 @@ async fn git_restore_paths_restores_tracked_filename_containing_target() {
     fs::write(tmp.path().join("SMOKE_TARGET.txt"), "modified\n").unwrap();
 
     let runtime = test_runtime();
-    let project =
-        register_agent_project_at_path(&runtime, "restore-target-substring", "repo", tmp.path())
-            .await;
+    let project = register_structured_git_agent_at_path(
+        &runtime,
+        "restore-target-substring",
+        "repo",
+        tmp.path(),
+    )
+    .await;
     let restore = tokio::spawn({
         let runtime = runtime.clone();
         async move {
@@ -39,19 +66,257 @@ async fn git_restore_paths_restores_tracked_filename_containing_target() {
 
     let request = next_patch_agent_request(&runtime, "restore-target-substring")
         .await
-        .expect("git_restore_paths should enqueue an agent shell request");
-    assert_eq!(request.command, "git restore -- 'SMOKE_TARGET.txt'");
+        .expect("git_restore_paths should enqueue an agent process request");
+    assert_eq!(request.kind, "run_process");
+    assert!(request.command.is_empty());
+    let process = request.process.as_ref().expect("typed git restore process");
+    assert_eq!(process.executable, "git");
+    assert_eq!(
+        process.args,
+        ["restore", "--", "SMOKE_TARGET.txt"].map(str::to_string)
+    );
     complete_agent_request_by_running_locally(&runtime, "restore-target-substring", request).await;
 
     let result = restore.await.unwrap();
     assert!(result.success, "{:?}", result.error);
     assert_eq!(
-        fs::read_to_string(tmp.path().join("SMOKE_TARGET.txt")).unwrap(),
+        fs::read_to_string(tmp.path().join("SMOKE_TARGET.txt"))
+            .unwrap()
+            .replace("\r\n", "\n"),
         "original\n"
     );
     let (exit_code, stdout, stderr, _) = run_command_sync("git status --porcelain", tmp.path(), 30);
     assert_eq!(exit_code, 0, "git status failed: {stderr}");
     assert!(stdout.is_empty(), "worktree should be clean: {stdout}");
+}
+
+#[tokio::test]
+async fn git_path_mutations_pass_shell_sensitive_paths_as_literal_argv() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    let tracked = [
+        "space name.txt",
+        "quote'name.txt",
+        "amp&semi;.txt",
+        "dollar$(literal).txt",
+    ];
+    for path in tracked {
+        commit_file(tmp.path(), path, "original\n", &format!("track {path}"));
+        fs::write(tmp.path().join(path), "modified\n").unwrap();
+    }
+
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "literal-git-paths", "repo", tmp.path())
+            .await;
+    let restore_paths = tracked.map(str::to_string).to_vec();
+    let restore = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let restore_paths = restore_paths.clone();
+        async move { runtime.git_restore_paths(project, restore_paths).await }
+    });
+    let request = next_patch_agent_request(&runtime, "literal-git-paths")
+        .await
+        .expect("git restore should enqueue typed argv");
+    assert_eq!(request.kind, "run_process");
+    let process = request.process.as_ref().expect("typed git restore process");
+    assert_eq!(process.executable, "git");
+    let mut expected = vec!["restore".to_string(), "--".to_string()];
+    expected.extend(restore_paths.iter().cloned());
+    assert_eq!(process.args, expected);
+    complete_agent_request_by_running_locally(&runtime, "literal-git-paths", request).await;
+    assert!(restore.await.unwrap().success);
+    for path in tracked {
+        assert_eq!(
+            fs::read_to_string(tmp.path().join(path))
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "original\n"
+        );
+    }
+
+    let untracked = [
+        "untracked space.txt",
+        "untracked'quote.txt",
+        "untracked&semi;.txt",
+        "untracked$(literal).txt",
+    ];
+    for path in untracked {
+        fs::write(tmp.path().join(path), "remove me\n").unwrap();
+    }
+    let discard_paths = untracked.map(str::to_string).to_vec();
+    let discard = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let discard_paths = discard_paths.clone();
+        async move { runtime.discard_untracked(project, discard_paths).await }
+    });
+    let request = next_patch_agent_request(&runtime, "literal-git-paths")
+        .await
+        .expect("git clean should enqueue typed argv");
+    assert_eq!(request.kind, "run_process");
+    let process = request.process.as_ref().expect("typed git clean process");
+    assert_eq!(process.executable, "git");
+    let mut expected = vec!["clean".to_string(), "-f".to_string(), "--".to_string()];
+    expected.extend(discard_paths.iter().cloned());
+    assert_eq!(process.args, expected);
+    complete_agent_request_by_running_locally(&runtime, "literal-git-paths", request).await;
+    assert!(discard.await.unwrap().success);
+    for path in untracked {
+        assert!(
+            !tmp.path().join(path).exists(),
+            "{path} should be removed literally"
+        );
+    }
+}
+
+#[tokio::test]
+async fn git_restore_missing_structured_process_capability_is_definite_not_started() {
+    let runtime = runtime_with_agent_project("restore-no-argv");
+    register_agent(
+        &runtime,
+        "restore-no-argv",
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            git: true,
+            structured_process_argv: false,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let result = runtime
+        .git_restore_paths(
+            agent_test_project_id("restore-no-argv"),
+            vec!["safe.txt".to_string()],
+        )
+        .await;
+    assert!(!result.success);
+    assert_eq!(result.output["execution_state"], "not_started");
+    assert_eq!(result.output["failure_kind"], "capability_unavailable");
+    assert!(next_patch_agent_request(&runtime, "restore-no-argv")
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn git_restore_stays_sync_on_structured_job_capable_runner() {
+    let runtime = runtime_with_agent_project("restore-sync-job-capable");
+    register_agent(
+        &runtime,
+        "restore-sync-job-capable",
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            git: true,
+            jobs: true,
+            async_jobs: true,
+            structured_process_argv: true,
+            structured_execution_jobs: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id("restore-sync-job-capable");
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .git_restore_paths(project, vec!["safe.txt".to_string()])
+                .await
+        }
+    });
+
+    let request = next_patch_agent_request(&runtime, "restore-sync-job-capable")
+        .await
+        .expect("git restore should stay on the synchronous process path");
+    assert_eq!(request.kind, "run_process");
+    assert!(request.job_id.is_none());
+    assert!(request.command.is_empty());
+    let process = request.process.as_ref().expect("typed git restore process");
+    assert_eq!(process.executable, "git");
+    assert_eq!(
+        process.args,
+        ["restore", "--", "safe.txt"].map(str::to_string)
+    );
+    complete_patch_agent_request(
+        &runtime,
+        "restore-sync-job-capable",
+        &request.request_id,
+        0,
+        "",
+        "",
+    )
+    .await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["restored_paths"], json!(["safe.txt"]));
+    assert!(
+        next_patch_agent_request(&runtime, "restore-sync-job-capable")
+            .await
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn git_restore_replacement_after_dispatch_reports_outcome_unknown_without_retry() {
+    let runtime = runtime_with_agent_project("restore-uncertain");
+    register_agent(
+        &runtime,
+        "restore-uncertain",
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            git: true,
+            structured_process_argv: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id("restore-uncertain");
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .git_restore_paths(project, vec!["safe.txt".to_string()])
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, "restore-uncertain")
+        .await
+        .expect("git restore should dispatch once");
+    assert_eq!(request.kind, "run_process");
+
+    runtime
+        .shell_clients
+        .set_last_seen_for_test("restore-uncertain", chrono::Utc::now().timestamp() - 120)
+        .await;
+    register_agent_with_instance(
+        &runtime,
+        "restore-uncertain",
+        "inst-b",
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            git: true,
+            structured_process_argv: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let result = task.await.unwrap();
+    assert!(!result.success);
+    assert_eq!(result.output["execution_state"], "outcome_unknown");
+    assert_eq!(result.output["failure_kind"], "outcome_unknown");
+    let retry = next_agent_request_for_instance(&runtime, "restore-uncertain", "inst-b").await;
+    assert!(
+        retry.is_none(),
+        "uncertain mutation must not be retried: {retry:?}"
+    );
 }
 
 #[test]

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -411,12 +411,12 @@ fn required_agent_capability_matches_metadata_risk_table() {
         (
             "git_restore_paths",
             ToolRisk::ProjectWrite,
-            AgentCapability::Shell,
+            AgentCapability::StructuredProcess,
         ),
         (
             "discard_untracked",
             ToolRisk::ProjectWrite,
-            AgentCapability::Shell,
+            AgentCapability::StructuredProcess,
         ),
         // Read-only dry run, but implemented through the agent shell path.
         ("validate_patch", ToolRisk::ReadOnly, AgentCapability::Shell),

--- a/src/tool_runtime/tests/support/agent.rs
+++ b/src/tool_runtime/tests/support/agent.rs
@@ -102,6 +102,17 @@ pub(in crate::tool_runtime::tests) fn run_agent_shell_request_locally(
     if req.kind == "file_project_overview" {
         return run_agent_project_overview_request_locally(req);
     }
+    let structured_process = if req.kind == "run_process" {
+        assert!(req.command.is_empty());
+        assert!(req.script.is_none());
+        Some(
+            req.process
+                .as_ref()
+                .expect("run_process request must carry a typed process payload"),
+        )
+    } else {
+        None
+    };
     let internal_posix = if req.kind == "run_internal_posix_script" {
         let payload = req
             .script
@@ -122,7 +133,11 @@ pub(in crate::tool_runtime::tests) fn run_agent_shell_request_locally(
         .command
         .strip_prefix(EXTERNAL_SEARCH_REQUEST_PREFIX)
         .and_then(|rest| rest.strip_prefix('\n'));
-    let (mut command, stdin_payload) = if let Some(script) = internal_posix {
+    let (mut command, stdin_payload) = if let Some(process) = structured_process {
+        let mut command = std::process::Command::new(&process.executable);
+        command.args(&process.args);
+        (command, req.stdin.clone())
+    } else if let Some(script) = internal_posix {
         #[cfg(windows)]
         let mut command = std::process::Command::new("bash.exe");
         #[cfg(not(windows))]

--- a/src/tool_runtime/tool_definition/hygiene.rs
+++ b/src/tool_runtime/tool_definition/hygiene.rs
@@ -1,4 +1,4 @@
-use super::AgentCapability::{GitOrShell, Shell};
+use super::AgentCapability::{GitOrShell, Shell, StructuredProcess};
 use super::ToolVisibility::ModelVisible;
 use super::{def, git_like, ToolDefinition, TOOL_CATEGORY_CLEANUP};
 use crate::tool_runtime::metadata::{
@@ -39,7 +39,7 @@ pub(super) const CLEANUP_DEFINITIONS: &[ToolDefinition] = &[
         "git_restore_paths",
         ModelVisible,
         TOOL_CATEGORY_CLEANUP,
-        Some(Shell),
+        Some(StructuredProcess),
         TOOL_PROVIDER_AGENT,
         ProjectWrite,
         Some(PROJECT_WRITE),
@@ -52,7 +52,7 @@ pub(super) const CLEANUP_DEFINITIONS: &[ToolDefinition] = &[
         "discard_untracked",
         ModelVisible,
         TOOL_CATEGORY_CLEANUP,
-        Some(Shell),
+        Some(StructuredProcess),
         TOOL_PROVIDER_AGENT,
         ProjectWrite,
         Some(PROJECT_WRITE),


### PR DESCRIPTION
## Summary
- route internal `git restore` / `git clean` path mutations through typed executable+argv dispatch instead of shell-quoted command strings
- keep these effectful mutations synchronous while preserving `not_started` vs `outcome_unknown` lifecycle semantics and no blind retry after possible dispatch
- keep the legacy structured-file-delete rolling-upgrade fallback narrowly isolated and document its retirement condition
- add focused coverage for spaces, apostrophes, and shell metacharacters as literal Git argv items

## Independent review
Reviewed commit `ba0e5d1fe16b8a2a206ed21bbf6c64401e77aed1` against Issue #67 and the current runtime contracts. No blocking correctness, authorization, boundedness, or replay/uncertainty issues found.

## Validation
- `cargo test -p webcodex git_restore` — 4 passed
- `cargo test -p webcodex git_path_mutations_pass_shell_sensitive_paths_as_literal_argv` — 1 passed
- `cargo check -p webcodex` — passed
- `cargo fmt -- --check` — passed
- `git diff --check ba0e5d1f^ ba0e5d1f` — passed

Closes #67