### PR TITLE
Fix MCP OAuth scope discovery

### DIFF
--- a/docs/AUTH_MODEL.md
+++ b/docs/AUTH_MODEL.md
@@ -168,9 +168,9 @@ access tokens. OAuth credentials have their own roles:
   stored.
 - **access token** (`wc_oat_*`) — issued after consent, delegated from the
   authorizing user's scopes.
-- **refresh token** — `offline_access` is advertised as a protocol-level
-  refresh-token scope; it grants no extra WebCodex permission and should not be
-  added to the client's `allowed_scopes`.
+- **refresh token** — authorization-server metadata advertises `offline_access`
+  as a protocol-level refresh-token scope; it grants no extra WebCodex permission
+  and should not be added to the client's `allowed_scopes`.
 
 The server supports the authorization-code grant, token revocation, and OAuth
 metadata. Dynamic client registration, OIDC, JWKS/JWT ID tokens, and the
@@ -184,6 +184,13 @@ complete allow-list with `POST /api/oauth/clients/update_scopes`. A real change
 atomically revokes that client's existing access tokens, refresh tokens, and
 outstanding authorization codes, so the client must complete OAuth authorization
 again before using the new scope set.
+
+The MCP Protected Resource Metadata intentionally omits `scopes_supported`
+because pre-registered clients can have different delegation ceilings. An MCP
+client can therefore omit the authorization request's `scope`; WebCodex then
+defaults to that client's registered `allowed_scopes`. OAuth Authorization Server
+Metadata continues to advertise server-level capabilities such as
+`account:manage` and `offline_access`.
 
 ## Scope enforcement and credential surfaces
 

--- a/docs/AUTH_MODEL.zh-CN.md
+++ b/docs/AUTH_MODEL.zh-CN.md
@@ -137,8 +137,9 @@ code。只把该 code 传给要接入的客户端；客户端用 `webcodex login
 - **client id** —— 标识 OAuth client（`wc_client_...`）。
 - **client secret** —— client 创建时只返回一次；服务端只存其 hash。
 - **access token**（`wc_oat_*`）—— 同意后签发，委派自授权用户的 scopes。
-- **refresh token** —— `offline_access` 作为协议级 refresh-token scope 发布；
-  它不授予额外 WebCodex 权限，不应写进 client 的 `allowed_scopes`。
+- **refresh token** —— Authorization Server Metadata 会把 `offline_access` 作为协议级
+  refresh-token scope 发布；它不授予额外 WebCodex 权限，不应写进 client 的
+  `allowed_scopes`。
 
 Server 支持 authorization-code grant、token 撤销与 OAuth metadata。动态 client
 注册、OIDC、JWKS/JWT ID token 与 device-code 流程未实现。OAuth 设置步骤见
@@ -150,6 +151,11 @@ operator 可以通过 `POST /api/oauth/clients/update_scopes` 显式替换 activ
 完整 allowlist。allowlist 真正变化时，Server 会在同一事务里撤销该 client 现有的
 access token、refresh token 与尚存 authorization code，因此 client 必须重新完成
 OAuth 授权，才能使用新的 scope 集合。
+
+MCP Protected Resource Metadata 会明确省略 `scopes_supported`，因为不同的预注册 client
+可能具有不同的委派权限上限。MCP client 因此可以在授权请求中省略 `scope`；WebCodex
+随后会默认采用该 client 已注册的 `allowed_scopes`。OAuth Authorization Server Metadata
+仍会发布 `account:manage`、`offline_access` 等 server-level capability。
 
 ## `client_id`
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -98,7 +98,10 @@ WebCodex advertises PKCE `S256`; Grok can use PKCE together with
 `client_secret_post`. Do not select `none (PKCE only)` for a WebCodex OAuth
 client that has a client secret. `offline_access` is a protocol-level scope for
 refresh tokens and is intentionally not stored in the OAuth client's
-`allowed_scopes` permission list.
+`allowed_scopes` permission list. The MCP Protected Resource Metadata omits
+`scopes_supported` because pre-registered clients can have different scope
+ceilings. General-purpose MCP clients can therefore omit `scope` and let WebCodex
+default the authorization request to that client's registered `allowed_scopes`.
 
 When the WebCodex authorization page opens, sign in with a current user PAT
 (`wc_pat_*`) for the user whose authority Grok should receive. A Runner token

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -91,7 +91,10 @@ curl -fsS -X POST https://your-domain.example/api/oauth/clients/create \
 WebCodex 会公布 PKCE `S256`；Grok 可以同时使用 PKCE 与
 `client_secret_post`。对于已经注册 client secret 的 WebCodex OAuth client，不要选
 `none (PKCE only)`。`offline_access` 是用于 refresh token 的协议级 scope，不会写进
-OAuth client 的 `allowed_scopes` 权限列表。
+OAuth client 的 `allowed_scopes` 权限列表。MCP Protected Resource Metadata 会省略
+`scopes_supported`，因为不同的预注册 client 可能有不同的 scope 上限。通用 MCP 客户端
+因此可以省略 `scope`，由 WebCodex 把授权请求默认到该 client 已注册的
+`allowed_scopes`。
 
 打开 WebCodex Authorization 页面后，用希望 Grok 代表的用户当前有效 PAT
 （`wc_pat_*`）登录。Runner token（`wc_agent_*`）不是用户登录 token。最终签发的

--- a/src/oauth_http/metadata.rs
+++ b/src/oauth_http/metadata.rs
@@ -32,7 +32,6 @@ pub(crate) async fn oauth_metadata(depot: &mut Depot, res: &mut Response) {
         "resource": resource,
         "authorization_servers": [issuer],
         "bearer_methods_supported": ["header"],
-        "scopes_supported": oauth_discovery_scopes_supported(),
         "resource_name": "WebCodex",
     });
 

--- a/src/oauth_http/scope_registry.rs
+++ b/src/oauth_http/scope_registry.rs
@@ -28,8 +28,9 @@ pub(crate) fn oauth_scopes_supported() -> &'static [&'static str] {
     OAUTH_SCOPES_SUPPORTED
 }
 
-/// Return scopes advertised through OAuth discovery. This includes WebCodex
-/// permission scopes plus protocol-level capabilities such as `offline_access`.
+/// Return scopes advertised through OAuth authorization-server discovery. This
+/// includes WebCodex permission scopes plus protocol capabilities such as
+/// `offline_access`.
 pub(crate) fn oauth_discovery_scopes_supported() -> Vec<&'static str> {
     let mut scopes = oauth_scopes_supported().to_vec();
     scopes.push(OAUTH_OFFLINE_ACCESS_SCOPE);

--- a/src/oauth_http/tests/authorize.rs
+++ b/src/oauth_http/tests/authorize.rs
@@ -928,6 +928,34 @@ async fn authorize_code_contains_user_client_redirect_scope_pkce_metadata() {
 }
 
 #[tokio::test]
+async fn authorize_omitted_scope_defaults_to_client_allowed_scopes() {
+    let config = test_config(oauth2_enabled());
+    let (_tmp, db) = test_db();
+    let user = seed_user(&db, "alice");
+    let token = seed_user_token(&db, &user);
+    let client = seed_client_with_redirects_and_scopes(
+        &db,
+        &user,
+        "https://example.com/callback",
+        "project:read runtime:read",
+    );
+    let service = Service::new(build_router(config, db.clone()));
+    let url = authorize_url(&[
+        ("response_type", "code"),
+        ("client_id", &client.client_id),
+        ("redirect_uri", "https://example.com/callback"),
+        ("state", "state-1"),
+        ("code_challenge", "challenge-1"),
+        ("code_challenge_method", "S256"),
+    ]);
+
+    let (_resp, _location, _parsed, code) = authorize_success(&service, &db, &url, &token).await;
+    let record = auth_code_by_plaintext(&db, &code);
+
+    assert_eq!(record.scopes, "runtime:read project:read");
+}
+
+#[tokio::test]
 async fn authorize_success_redirect_appends_with_ampersand_when_redirect_uri_has_query() {
     let config = test_config(oauth2_enabled());
     let (_tmp, db) = test_db();

--- a/src/oauth_http/tests/metadata.rs
+++ b/src/oauth_http/tests/metadata.rs
@@ -57,17 +57,9 @@ async fn oauth_protected_resource_metadata_fields() {
     assert_eq!(methods.len(), 1);
     assert_eq!(methods[0], "header");
 
-    // scopes_supported is a non-empty array
-    let scopes = body["scopes_supported"].as_array().unwrap();
-    assert!(!scopes.is_empty(), "scopes_supported should be non-empty");
-    // Must contain at least runtime:read
     assert!(
-        scopes.iter().any(|s| s == "runtime:read"),
-        "scopes_supported should contain runtime:read"
-    );
-    assert!(
-        scopes.iter().any(|s| s == "offline_access"),
-        "discovery should advertise offline_access when refresh tokens are supported"
+        body.get("scopes_supported").is_none(),
+        "MCP resource metadata must let the registered client define its scope ceiling"
     );
 
     // resource_name
@@ -260,9 +252,7 @@ async fn openid_configuration_not_exposed() {
 }
 
 #[tokio::test]
-async fn oauth_protected_resource_metadata_scopes_exclude_agent() {
-    // Agent scopes must not appear in scopes_supported because OAuth2
-    // tokens are rejected on agent transport surfaces.
+async fn oauth_protected_resource_metadata_omits_scopes_supported() {
     let config = test_config(oauth2_enabled());
     let (_tmp, db) = test_db();
     let service = Service::new(build_router(config, db));
@@ -271,18 +261,5 @@ async fn oauth_protected_resource_metadata_scopes_exclude_agent() {
         .await;
     assert_eq!(resp.status_code, Some(StatusCode::OK));
     let body: serde_json::Value = resp.take_json().await.unwrap();
-    let scopes = body["scopes_supported"].as_array().unwrap();
-    for scope in scopes {
-        let s = scope.as_str().unwrap();
-        assert!(
-            !s.starts_with("agent:"),
-            "agent scope '{}' must not appear in scopes_supported",
-            s
-        );
-    }
-    // admin is a bootstrap scope, not for OAuth2 delegation
-    assert!(
-        !scopes.iter().any(|s| s == "admin"),
-        "admin scope must not appear in scopes_supported"
-    );
+    assert!(body.get("scopes_supported").is_none());
 }


### PR DESCRIPTION
## Summary
- omit `scopes_supported` from MCP Protected Resource Metadata so pre-registered clients with different delegation ceilings do not request permissions outside their own allowlist
- keep Authorization Server Metadata advertising the full server-supported OAuth scope set, including `account:manage` and protocol-level `offline_access`
- preserve the existing authorize behavior where an omitted `scope` defaults to the registered client's allowed WebCodex scopes
- document the distinction in English and Chinese OAuth/MCP docs

## Why
MCP clients can use Protected Resource Metadata for initial scope selection when the `WWW-Authenticate` challenge does not provide a scope. Advertising the server-wide scope set there can make a client request scopes that its pre-registered OAuth client is not allowed to delegate, which WebCodex correctly rejects as `invalid_scope`. Omitting the optional resource-level `scopes_supported` avoids imposing one global scope set across clients with different ceilings.

## Validation
- `cargo fmt -- --check`
- `cargo test 'oauth_protected_resource_metadata' -p webcodex` — 5 passed
- `cargo test 'oauth_authorization_server_metadata' -p webcodex` — 4 passed
- `cargo test 'normalize_oauth_scopes_defaults_to_client_global_intersection' -p webcodex` — 1 passed
- `cargo test 'authorize_omitted_scope_defaults_to_client_allowed_scopes' -p webcodex` — 1 passed
- `git diff --check`

No deployment or release performed.