### PR TITLE
Improve audit stats coverage and caller attribution

### DIFF
--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -580,8 +580,10 @@ not “what is the coding task ledger for this repo work?”.
 
 - Group HTTP Action / REST audit events under one audit session
 - Persist action audit records (endpoints, status, durations, redacted summaries)
+- Snapshot non-secret caller attribution at event write time: canonical credential
+  kind, optional stable user id, and OAuth-only client id
 - Idle open-session reuse and explicit close for operator audit views
-- Aggregate stats for read-only audit APIs
+- Aggregate stats for read-only audit APIs, with explicit bounded-scan coverage
 
 ### Identity
 
@@ -590,6 +592,8 @@ not “what is the coding task ledger for this repo work?”.
 | ID form | UUID string (or client-supplied id via headers/query), **not** `wc_sess_*` |
 | Request affinity | Headers `x-action-session-id` / `x-webcodex-session-id`, or query `action_session_id` |
 | Default creation | Server may create a new UUID when no open recent session is reused |
+| Durable caller attribution | `principal_kind`, optional `principal_user_id`, OAuth-only `oauth_client_id`; legacy rows remain `NULL` and are never inferred from target project or session |
+| Stats exposure | `/api/audit/stats` aggregates credential kinds and OAuth client usage; ordinary `/api/audit/session` event views do not expose principal/user/client attribution fields |
 
 ### Storage and ownership
 
@@ -606,8 +610,12 @@ not “what is the coding task ledger for this repo work?”.
    from headers/query.
 2. `get_or_create_active_session` attaches the event to an existing open session
    (explicit id, or recent idle-open session) or creates a new one.
-3. Events are written to SQLite; session aggregate counters update.
+3. Events are written to SQLite; session aggregate counters update. Caller
+   attribution is snapshotted from the authenticated request context before the
+   write and never reconstructed later from execution targets.
 4. Operator APIs list sessions, fetch one session with events, or compute stats.
+   Stats report scanned/available event coverage and fail on database read errors
+   instead of silently presenting a partial aggregate as complete.
 5. Sessions may be closed (`status = closed`); idle open sessions time out for
    reuse purposes (`ACTION_SESSION_IDLE_TIMEOUT_SECS`).
 
@@ -708,7 +716,8 @@ renamed without an explicit compatibility migration:
 ### JSON / type shapes (illustrative)
 
 - Audit session records (`session_id`, `status`, counters, timestamps, …)
-- Audit event views and stats aggregates
+- Audit event views (without principal attribution fields) and stats aggregates,
+  including coverage plus credential-kind/OAuth-client usage summaries
 - Workflow tool fields: `session_id`, `recording_session_id`, session mode
   values such as `normal` / `inspect` / `read_only`
 - Error kinds such as `unknown_session_id`

--- a/src/action_audit_sessions.rs
+++ b/src/action_audit_sessions.rs
@@ -27,6 +27,18 @@ pub struct ActionSessionStats {
     pub shell_count: i64,
     pub changed_files_distinct_count: usize,
     pub job_ids_distinct_count: usize,
+    /// Number of events actually included in the aggregate.
+    pub events_scanned: usize,
+    /// Number of events present in the selected session scope before per-session caps.
+    pub events_available: usize,
+    /// Number of selected sessions included in the aggregate.
+    pub sessions_scanned: usize,
+    /// Selected sessions whose event history exceeded the bounded scan cap.
+    pub truncated_sessions: usize,
+    /// True when the aggregate does not cover every event in the selected sessions.
+    pub partial: bool,
+    /// True when bounded event caps caused the partial result.
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -406,6 +418,7 @@ pub fn compute_stats(events: &[ActionEventView]) -> ActionSessionStats {
     let mut by_status = BTreeMap::new();
     let mut changed_files = BTreeSet::new();
     let mut job_ids = BTreeSet::new();
+    let mut session_ids = BTreeSet::new();
     let mut edit_count = 0;
     let mut context_count = 0;
     let mut job_count = 0;
@@ -415,6 +428,7 @@ pub fn compute_stats(events: &[ActionEventView]) -> ActionSessionStats {
     let mut git_count = 0;
     let mut shell_count = 0;
     for event in events {
+        session_ids.insert(event.session_id.clone());
         *by_endpoint.entry(event.endpoint.clone()).or_insert(0) += 1;
         *by_status.entry(event.status.clone()).or_insert(0) += 1;
         if let Some(project) = &event.project {
@@ -473,6 +487,12 @@ pub fn compute_stats(events: &[ActionEventView]) -> ActionSessionStats {
         shell_count,
         changed_files_distinct_count: changed_files.len(),
         job_ids_distinct_count: job_ids.len(),
+        events_scanned: events.len(),
+        events_available: events.len(),
+        sessions_scanned: session_ids.len(),
+        truncated_sessions: 0,
+        partial: false,
+        truncated: false,
     }
 }
 

--- a/src/action_audit_sessions.rs
+++ b/src/action_audit_sessions.rs
@@ -10,6 +10,21 @@ pub const ACTION_SESSION_IDLE_TIMEOUT_SECS: i64 = 1800;
 const MAX_SUMMARY_TEXT: usize = 500;
 const MAX_PREVIEW_TEXT: usize = 120;
 
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ActionAttributionStats {
+    pub by_principal_kind: BTreeMap<String, i64>,
+    pub attributed_count: i64,
+    pub unattributed_count: i64,
+    pub by_oauth_client: Vec<OAuthClientActionStats>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OAuthClientActionStats {
+    pub client_id: String,
+    pub name: Option<String>,
+    pub count: i64,
+}
+
 /// Aggregate audit statistics over a set of decoded action events. Returned by
 /// the read-only `POST /api/audit/stats` endpoint.
 #[derive(Debug, Clone, Serialize)]
@@ -17,6 +32,7 @@ pub struct ActionSessionStats {
     pub by_endpoint: BTreeMap<String, i64>,
     pub by_project: BTreeMap<String, i64>,
     pub by_status: BTreeMap<String, i64>,
+    pub attribution: ActionAttributionStats,
     pub edit_count: i64,
     pub context_count: i64,
     pub job_count: i64,
@@ -412,6 +428,59 @@ pub fn decode_event(record: ActionEventRecord) -> ActionEventView {
     }
 }
 
+pub fn compute_attribution_stats(records: &[ActionEventRecord]) -> ActionAttributionStats {
+    let mut by_principal_kind = BTreeMap::new();
+    let mut oauth_client_counts = BTreeMap::new();
+    let mut attributed_count = 0i64;
+    let mut unattributed_count = 0i64;
+
+    for record in records {
+        if let Some(kind) = record
+            .principal_kind
+            .as_deref()
+            .map(str::trim)
+            .filter(|kind| !kind.is_empty())
+        {
+            *by_principal_kind.entry(kind.to_string()).or_insert(0) += 1;
+            attributed_count += 1;
+        } else {
+            unattributed_count += 1;
+        }
+        if let Some(client_id) = record
+            .oauth_client_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|client_id| !client_id.is_empty())
+        {
+            *oauth_client_counts
+                .entry(client_id.to_string())
+                .or_insert(0) += 1;
+        }
+    }
+
+    let mut by_oauth_client = oauth_client_counts
+        .into_iter()
+        .map(|(client_id, count)| OAuthClientActionStats {
+            client_id,
+            name: None,
+            count,
+        })
+        .collect::<Vec<_>>();
+    by_oauth_client.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.client_id.cmp(&right.client_id))
+    });
+
+    ActionAttributionStats {
+        by_principal_kind,
+        attributed_count,
+        unattributed_count,
+        by_oauth_client,
+    }
+}
+
 pub fn compute_stats(events: &[ActionEventView]) -> ActionSessionStats {
     let mut by_endpoint = BTreeMap::new();
     let mut by_project = BTreeMap::new();
@@ -477,6 +546,7 @@ pub fn compute_stats(events: &[ActionEventView]) -> ActionSessionStats {
         by_endpoint,
         by_project,
         by_status,
+        attribution: ActionAttributionStats::default(),
         edit_count,
         context_count,
         job_count,

--- a/src/audit_http/routes.rs
+++ b/src/audit_http/routes.rs
@@ -180,20 +180,14 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
                 return;
             }
         }
-        let available = match db.count_action_events(session_id) {
-            Ok(count) => count,
-            Err(e) => {
-                query_failed(res, &e.to_string());
-                return;
-            }
-        };
-        let raw = match db.list_action_events(session_id, STATS_SINGLE_SESSION_EVENTS) {
-            Ok(e) => e,
-            Err(e) => {
-                query_failed(res, &e.to_string());
-                return;
-            }
-        };
+        let (available, raw) =
+            match db.list_action_events_with_count(session_id, STATS_SINGLE_SESSION_EVENTS) {
+                Ok(snapshot) => snapshot,
+                Err(e) => {
+                    query_failed(res, &e.to_string());
+                    return;
+                }
+            };
         events_available = available;
         sessions_scanned = 1;
         truncated_sessions = usize::from(available > raw.len());
@@ -209,15 +203,10 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
         };
         sessions_scanned = sessions.len();
         for session in sessions {
-            let available = match db.count_action_events(&session.session_id) {
-                Ok(count) => count,
-                Err(e) => {
-                    query_failed(res, &e.to_string());
-                    return;
-                }
-            };
-            let raw = match db.list_action_events(&session.session_id, STATS_EVENTS_PER_SESSION) {
-                Ok(events) => events,
+            let (available, raw) = match db
+                .list_action_events_with_count(&session.session_id, STATS_EVENTS_PER_SESSION)
+            {
+                Ok(snapshot) => snapshot,
                 Err(e) => {
                     query_failed(res, &e.to_string());
                     return;

--- a/src/audit_http/routes.rs
+++ b/src/audit_http/routes.rs
@@ -135,9 +135,11 @@ struct AuditStatsRequest {
 ///
 /// Body: `{ "session_id"?: string, "limit"?: number }`.
 /// When `session_id` is supplied, stats cover that single session's events
-/// (capped internally). When omitted, stats cover the events of the `limit`
-/// most recent sessions (default 20, max 50; each session capped at 200
-/// events) to bound the scan. Returns the `ActionSessionStats` object.
+/// (capped internally) and return `404` for an unknown session. When omitted,
+/// stats cover the events of the `limit` most recent sessions (default 20,
+/// max 50; each session capped at 200 events) to bound the scan. Coverage fields
+/// report whether any selected session was truncated; database read failures
+/// fail the request rather than returning a silently partial aggregate.
 #[handler]
 pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let Some(db) = get_db(depot) else {
@@ -153,6 +155,9 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
     };
 
     let mut views: Vec<ActionEventView> = Vec::new();
+    let mut events_available = 0usize;
+    let sessions_scanned: usize;
+    let mut truncated_sessions = 0usize;
     let scoped = body
         .session_id
         .as_deref()
@@ -160,6 +165,24 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
         .filter(|s| !s.is_empty());
 
     if let Some(session_id) = scoped {
+        match db.get_action_session(session_id) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                not_found(res, "session not found");
+                return;
+            }
+            Err(e) => {
+                query_failed(res, &e.to_string());
+                return;
+            }
+        }
+        let available = match db.count_action_events(session_id) {
+            Ok(count) => count,
+            Err(e) => {
+                query_failed(res, &e.to_string());
+                return;
+            }
+        };
         let raw = match db.list_action_events(session_id, STATS_SINGLE_SESSION_EVENTS) {
             Ok(e) => e,
             Err(e) => {
@@ -167,6 +190,9 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
                 return;
             }
         };
+        events_available = available;
+        sessions_scanned = 1;
+        truncated_sessions = usize::from(available > raw.len());
         for record in raw {
             views.push(sanitize_event(decode_event(record)));
         }
@@ -179,19 +205,37 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
                 return;
             }
         };
+        sessions_scanned = sessions.len();
         for session in sessions {
-            let Ok(raw) = db.list_action_events(&session.session_id, STATS_EVENTS_PER_SESSION)
-            else {
-                // Skip a session whose events cannot be read rather than
-                // failing the whole aggregate.
-                continue;
+            let available = match db.count_action_events(&session.session_id) {
+                Ok(count) => count,
+                Err(e) => {
+                    query_failed(res, &e.to_string());
+                    return;
+                }
             };
+            let raw = match db.list_action_events(&session.session_id, STATS_EVENTS_PER_SESSION) {
+                Ok(events) => events,
+                Err(e) => {
+                    query_failed(res, &e.to_string());
+                    return;
+                }
+            };
+            events_available = events_available.saturating_add(available);
+            if available > raw.len() {
+                truncated_sessions = truncated_sessions.saturating_add(1);
+            }
             for record in raw {
                 views.push(sanitize_event(decode_event(record)));
             }
         }
     }
 
-    let stats = compute_stats(&views);
+    let mut stats = compute_stats(&views);
+    stats.events_available = events_available;
+    stats.sessions_scanned = sessions_scanned;
+    stats.truncated_sessions = truncated_sessions;
+    stats.truncated = truncated_sessions > 0;
+    stats.partial = stats.truncated;
     res.render(Json(stats));
 }

--- a/src/audit_http/routes.rs
+++ b/src/audit_http/routes.rs
@@ -1,5 +1,7 @@
 use super::responses::{bad_json, bad_request, no_db, not_found, query_failed, sanitize_event};
-use crate::action_audit_sessions::{compute_stats, decode_event, ActionEventView};
+use crate::action_audit_sessions::{
+    compute_attribution_stats, compute_stats, decode_event, ActionEventView,
+};
 use crate::get_db;
 use salvo::prelude::*;
 use serde::Deserialize;
@@ -139,7 +141,9 @@ struct AuditStatsRequest {
 /// stats cover the events of the `limit` most recent sessions (default 20,
 /// max 50; each session capped at 200 events) to bound the scan. Coverage fields
 /// report whether any selected session was truncated; database read failures
-/// fail the request rather than returning a silently partial aggregate.
+/// fail the request rather than returning a silently partial aggregate. Caller
+/// attribution is returned only as aggregate credential/client counts; stable
+/// user ids remain absent from this API.
 #[handler]
 pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let Some(db) = get_db(depot) else {
@@ -154,7 +158,7 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
         }
     };
 
-    let mut views: Vec<ActionEventView> = Vec::new();
+    let mut records = Vec::new();
     let mut events_available = 0usize;
     let sessions_scanned: usize;
     let mut truncated_sessions = 0usize;
@@ -193,9 +197,7 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
         events_available = available;
         sessions_scanned = 1;
         truncated_sessions = usize::from(available > raw.len());
-        for record in raw {
-            views.push(sanitize_event(decode_event(record)));
-        }
+        records.extend(raw);
     } else {
         let limit = clamp_limit(body.limit, DEFAULT_STATS_SESSIONS, MAX_STATS_SESSIONS);
         let sessions = match db.list_action_sessions(None, limit) {
@@ -225,13 +227,27 @@ pub async fn audit_stats(req: &mut Request, depot: &mut Depot, res: &mut Respons
             if available > raw.len() {
                 truncated_sessions = truncated_sessions.saturating_add(1);
             }
-            for record in raw {
-                views.push(sanitize_event(decode_event(record)));
-            }
+            records.extend(raw);
         }
     }
 
+    let mut attribution = compute_attribution_stats(&records);
+    for client in &mut attribution.by_oauth_client {
+        client.name = match db.get_oauth_client_name_by_client_id(&client.client_id) {
+            Ok(name) => name,
+            Err(e) => {
+                query_failed(res, &e.to_string());
+                return;
+            }
+        };
+    }
+    let views: Vec<ActionEventView> = records
+        .into_iter()
+        .map(decode_event)
+        .map(sanitize_event)
+        .collect();
     let mut stats = compute_stats(&views);
+    stats.attribution = attribution;
     stats.events_available = events_available;
     stats.sessions_scanned = sessions_scanned;
     stats.truncated_sessions = truncated_sessions;

--- a/src/audit_http/tests.rs
+++ b/src/audit_http/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::action_audit_sessions::{record_action_event, ActionAuditEventInput};
-use crate::test_support::{test_config, test_db};
+use crate::test_support::{seed_oauth_client_named, seed_user, test_config, test_db};
 use crate::Database;
 use salvo::prelude::{affix_state, Response, Router, StatusCode};
 use salvo::test::{ResponseExt, TestClient};
@@ -55,6 +55,41 @@ fn seed_event(
             changed_files: Vec::new(),
             ids: json!({}),
             summary,
+            request_bytes: None,
+            response_bytes: None,
+        },
+    );
+}
+
+fn seed_attributed_event(
+    db: &Arc<Database>,
+    session_id: &str,
+    principal_kind: Option<&str>,
+    principal_user_id: Option<&str>,
+    oauth_client_id: Option<&str>,
+) {
+    record_action_event(
+        db,
+        ActionAuditEventInput {
+            explicit_session_id: Some(session_id.to_string()),
+            session_title: None,
+            endpoint: "/api/runtime/status".to_string(),
+            action_name: "getRuntimeStatus".to_string(),
+            operation: Some("runtime_status".to_string()),
+            project: Some("demo".to_string()),
+            principal_kind: principal_kind.map(str::to_string),
+            principal_user_id: principal_user_id.map(str::to_string),
+            oauth_client_id: oauth_client_id.map(str::to_string),
+            status: "success".to_string(),
+            http_status: Some(200),
+            started_at: 1,
+            ended_at: 2,
+            duration_ms: 10,
+            error_summary: None,
+            warning_summary: None,
+            changed_files: Vec::new(),
+            ids: json!({}),
+            summary: json!({}),
             request_bytes: None,
             response_bytes: None,
         },
@@ -418,6 +453,73 @@ async fn http_audit_stats_reports_bounded_event_truncation() {
     assert_eq!(body["truncated_sessions"], 1);
     assert_eq!(body["partial"], true);
     assert_eq!(body["truncated"], true);
+}
+
+#[tokio::test]
+async fn http_audit_stats_aggregates_principal_and_oauth_client_usage() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let user = seed_user(&db, "audit-stats-alice");
+    let (client, _secret) = seed_oauth_client_named(&db, &user, "ChatGPT");
+
+    seed_attributed_event(&db, "stats-attribution", Some("user"), Some(&user.id), None);
+    for _ in 0..2 {
+        seed_attributed_event(
+            &db,
+            "stats-attribution",
+            Some("oauth2"),
+            Some(&user.id),
+            Some(&client.client_id),
+        );
+    }
+    seed_attributed_event(&db, "stats-attribution", None, None, None);
+    db.revoke_oauth_client(&client.id, 10).unwrap();
+
+    let service = Service::new(build_audit_router(config, db));
+    let mut resp = TestClient::post("http://localhost/api/audit/stats")
+        .bearer_auth("secret")
+        .json(&json!({ "session_id": "stats-attribution" }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::OK);
+    let body: Value = resp.take_json().await.unwrap();
+    let attribution = &body["attribution"];
+    assert_eq!(attribution["attributed_count"], 3);
+    assert_eq!(attribution["unattributed_count"], 1);
+    assert_eq!(attribution["by_principal_kind"]["user"], 1);
+    assert_eq!(attribution["by_principal_kind"]["oauth2"], 2);
+    let clients = attribution["by_oauth_client"].as_array().unwrap();
+    assert_eq!(clients.len(), 1);
+    assert_eq!(clients[0]["client_id"], client.client_id);
+    assert_eq!(clients[0]["name"], "ChatGPT");
+    assert_eq!(clients[0]["count"], 2);
+    assert!(!body.to_string().contains(&user.id));
+}
+
+#[tokio::test]
+async fn http_audit_session_keeps_principal_attribution_out_of_event_details() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    seed_attributed_event(
+        &db,
+        "private-attribution",
+        Some("oauth2"),
+        Some("user-private"),
+        Some("wc_client_public"),
+    );
+    let service = Service::new(build_audit_router(config, db));
+
+    let mut resp = TestClient::post("http://localhost/api/audit/session")
+        .bearer_auth("secret")
+        .json(&json!({ "session_id": "private-attribution" }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::OK);
+    let body: Value = resp.take_json().await.unwrap();
+    let event = &body["events"][0];
+    assert!(event.get("principal_kind").is_none());
+    assert!(event.get("principal_user_id").is_none());
+    assert!(event.get("oauth_client_id").is_none());
 }
 
 // =========================================================================

--- a/src/audit_http/tests.rs
+++ b/src/audit_http/tests.rs
@@ -326,6 +326,12 @@ async fn http_audit_stats_happy_path_scoped_to_session() {
     assert_eq!(body["by_status"]["failed"], 1);
     assert_eq!(body["job_count"], 1);
     assert_eq!(body["edit_count"], 1);
+    assert_eq!(body["events_scanned"], 2);
+    assert_eq!(body["events_available"], 2);
+    assert_eq!(body["sessions_scanned"], 1);
+    assert_eq!(body["truncated_sessions"], 0);
+    assert_eq!(body["partial"], false);
+    assert_eq!(body["truncated"], false);
 }
 
 #[tokio::test]
@@ -361,6 +367,57 @@ async fn http_audit_stats_global_over_recent_sessions() {
     assert_eq!(body["by_endpoint"]["/api/runtime/status"], 1);
     assert_eq!(body["git_count"], 1);
     assert_eq!(body["report_count"], 1);
+    assert_eq!(body["events_scanned"], 2);
+    assert_eq!(body["events_available"], 2);
+    assert_eq!(body["sessions_scanned"], 2);
+    assert_eq!(body["truncated_sessions"], 0);
+    assert_eq!(body["partial"], false);
+    assert_eq!(body["truncated"], false);
+}
+
+#[tokio::test]
+async fn http_audit_stats_unknown_session_is_not_found() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let service = Service::new(build_audit_router(config, db));
+
+    let resp = TestClient::post("http://localhost/api/audit/stats")
+        .bearer_auth("secret")
+        .json(&json!({ "session_id": "missing-stats-session" }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn http_audit_stats_reports_bounded_event_truncation() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    for _ in 0..201 {
+        seed_event(
+            &db,
+            "stats-truncated",
+            "/api/runtime/status",
+            "getRuntimeStatus",
+            "success",
+            json!({}),
+        );
+    }
+    let service = Service::new(build_audit_router(config, db));
+
+    let mut resp = TestClient::post("http://localhost/api/audit/stats")
+        .bearer_auth("secret")
+        .json(&json!({}))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::OK);
+    let body: Value = resp.take_json().await.unwrap();
+    assert_eq!(body["events_scanned"], 200);
+    assert_eq!(body["events_available"], 201);
+    assert_eq!(body["sessions_scanned"], 1);
+    assert_eq!(body["truncated_sessions"], 1);
+    assert_eq!(body["partial"], true);
+    assert_eq!(body["truncated"], true);
 }
 
 // =========================================================================

--- a/src/auth/context.rs
+++ b/src/auth/context.rs
@@ -148,3 +148,37 @@ impl AuthContext {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_kind_vocabulary_is_stable_for_durable_attribution() {
+        let cases = [
+            (AuthKind::Bootstrap, None, "bootstrap"),
+            (AuthKind::ApiToken, None, "api_token"),
+            (AuthKind::ApiToken, Some("user"), "user"),
+            (AuthKind::AgentToken, Some("agent"), "agent_token"),
+            (
+                AuthKind::AccountCredential,
+                Some("account"),
+                "account_credential",
+            ),
+            (AuthKind::OAuth2Token, Some("oauth2_shared_key"), "oauth2"),
+            (AuthKind::SharedKey, Some("shared-key"), "shared-key"),
+            (
+                AuthKind::ProjectCredential,
+                Some("project"),
+                "project-credential",
+            ),
+            (AuthKind::OpenAnonymous, Some("open"), "open"),
+        ];
+
+        for (kind, token_kind, expected) in cases {
+            let mut auth = AuthContext::new(kind);
+            auth.token_kind = token_kind.map(str::to_string);
+            assert_eq!(auth.principal_kind(), expected, "kind: {kind:?}");
+        }
+    }
+}

--- a/src/db/audit.rs
+++ b/src/db/audit.rs
@@ -1,6 +1,6 @@
 use super::Database;
 use crate::{ActionEventRecord, ActionSessionRecord};
-use rusqlite::params;
+use rusqlite::{params, Connection};
 
 impl Database {
     pub fn insert_action_session(&self, record: &ActionSessionRecord) -> anyhow::Result<()> {
@@ -194,29 +194,22 @@ impl Database {
         limit: usize,
     ) -> anyhow::Result<Vec<ActionEventRecord>> {
         let conn = self.conn.lock().unwrap();
-        let limit = limit.clamp(1, 500) as i64;
-        let mut stmt = conn.prepare(
-            "SELECT event_id, session_id, started_at, ended_at, duration_ms, endpoint,
-                    operation, action_name, project, principal_kind, principal_user_id,
-                    oauth_client_id, status, http_status, error_summary, warning_summary,
-                    changed_files_json, ids_json, summary_json, request_bytes, response_bytes
-             FROM action_events
-             WHERE session_id = ?1
-             ORDER BY started_at DESC
-             LIMIT ?2",
-        )?;
-        let rows = stmt.query_map(params![session_id, limit], row_to_action_event)?;
-        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+        list_action_events_on_conn(&conn, session_id, limit)
     }
 
-    pub fn count_action_events(&self, session_id: &str) -> anyhow::Result<usize> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM action_events WHERE session_id = ?1",
-            params![session_id],
-            |row| row.get(0),
-        )?;
-        Ok(usize::try_from(count).unwrap_or(usize::MAX))
+    /// Return the total event count and bounded newest rows from one SQLite read
+    /// transaction snapshot so coverage metadata cannot race a concurrent append.
+    pub fn list_action_events_with_count(
+        &self,
+        session_id: &str,
+        limit: usize,
+    ) -> anyhow::Result<(usize, Vec<ActionEventRecord>)> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let count = count_action_events_on_conn(&tx, session_id)?;
+        let events = list_action_events_on_conn(&tx, session_id, limit)?;
+        tx.commit()?;
+        Ok((count, events))
     }
 
     pub fn append_action_event_and_update_session(
@@ -296,6 +289,35 @@ impl Database {
     }
 }
 
+fn count_action_events_on_conn(conn: &Connection, session_id: &str) -> anyhow::Result<usize> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM action_events WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+    )?;
+    Ok(usize::try_from(count).unwrap_or(usize::MAX))
+}
+
+fn list_action_events_on_conn(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> anyhow::Result<Vec<ActionEventRecord>> {
+    let limit = limit.clamp(1, 500) as i64;
+    let mut stmt = conn.prepare(
+        "SELECT event_id, session_id, started_at, ended_at, duration_ms, endpoint,
+                operation, action_name, project, principal_kind, principal_user_id,
+                oauth_client_id, status, http_status, error_summary, warning_summary,
+                changed_files_json, ids_json, summary_json, request_bytes, response_bytes
+         FROM action_events
+         WHERE session_id = ?1
+         ORDER BY started_at DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![session_id, limit], row_to_action_event)?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
 fn row_to_action_session(row: &rusqlite::Row) -> rusqlite::Result<ActionSessionRecord> {
     Ok(ActionSessionRecord {
         session_id: row.get(0)?,
@@ -347,6 +369,72 @@ fn row_to_action_event(row: &rusqlite::Row) -> rusqlite::Result<ActionEventRecor
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn action_event_count_and_rows_share_one_snapshot_during_concurrent_append() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("snapshot.db");
+        let db_reader = Database::open(&path).unwrap();
+        {
+            let conn = db_reader.conn_for_tests();
+            conn.execute(
+                "INSERT INTO action_sessions (session_id, status, created_at, updated_at)
+                 VALUES ('snapshot-session', 'open', 1, 1)",
+                [],
+            )
+            .unwrap();
+            conn.execute_batch(
+                "WITH RECURSIVE seq(n) AS (
+                    SELECT 1
+                    UNION ALL
+                    SELECT n + 1 FROM seq WHERE n < 200
+                 )
+                 INSERT INTO action_events (
+                    event_id, session_id, started_at, ended_at, duration_ms, endpoint,
+                    action_name, status, changed_files_json, ids_json, summary_json
+                 )
+                 SELECT printf('event-%03d', n), 'snapshot-session', n, n, 0, '/mcp',
+                        'toolsCall', 'success', '[]', '{}', '{}'
+                 FROM seq;",
+            )
+            .unwrap();
+        }
+        let db_writer = Database::open(&path).unwrap();
+
+        let mut reader_conn = db_reader.conn_for_tests();
+        let read_tx = reader_conn.transaction().unwrap();
+        let available = count_action_events_on_conn(&read_tx, "snapshot-session").unwrap();
+        assert_eq!(available, 200);
+
+        db_writer
+            .conn_for_tests()
+            .execute(
+                "INSERT INTO action_events (
+                    event_id, session_id, started_at, ended_at, duration_ms, endpoint,
+                    action_name, status, changed_files_json, ids_json, summary_json
+                 ) VALUES (
+                    'event-201', 'snapshot-session', 201, 201, 0, '/mcp',
+                    'toolsCall', 'success', '[]', '{}', '{}'
+                 )",
+                [],
+            )
+            .unwrap();
+
+        let rows = list_action_events_on_conn(&read_tx, "snapshot-session", 200).unwrap();
+        assert_eq!(rows.len(), 200);
+        assert!(rows.iter().all(|event| event.event_id != "event-201"));
+        read_tx.commit().unwrap();
+
+        let committed_count: i64 = db_writer
+            .conn_for_tests()
+            .query_row(
+                "SELECT COUNT(*) FROM action_events WHERE session_id = 'snapshot-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(committed_count, 201);
+    }
 
     #[test]
     fn legacy_action_events_gain_nullable_caller_attribution() {

--- a/src/db/audit.rs
+++ b/src/db/audit.rs
@@ -209,6 +209,16 @@ impl Database {
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
+    pub fn count_action_events(&self, session_id: &str) -> anyhow::Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM action_events WHERE session_id = ?1",
+            params![session_id],
+            |row| row.get(0),
+        )?;
+        Ok(usize::try_from(count).unwrap_or(usize::MAX))
+    }
+
     pub fn append_action_event_and_update_session(
         &self,
         event: &ActionEventRecord,

--- a/src/db/oauth.rs
+++ b/src/db/oauth.rs
@@ -124,6 +124,21 @@ impl Database {
         }
     }
 
+    /// Resolve the non-secret display name for historical audit attribution.
+    /// Revoked clients remain resolvable so old usage keeps a stable label.
+    pub fn get_oauth_client_name_by_client_id(
+        &self,
+        client_id: &str,
+    ) -> anyhow::Result<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT name FROM oauth_clients WHERE client_id = ?1")?;
+        let mut rows = stmt.query_map(params![client_id], |row| row.get(0))?;
+        match rows.next() {
+            Some(name) => Ok(Some(name?)),
+            None => Ok(None),
+        }
+    }
+
     pub fn get_oauth_client_by_id(&self, id: &str) -> anyhow::Result<Option<OAuthClientRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(


### PR DESCRIPTION
## Summary
- make `/api/audit/stats` coverage explicit with scanned/available event counts, selected-session counts, and truncation metadata
- return `404` for unknown scoped audit sessions and fail on DB read errors instead of silently skipping partial data
- read each selected session's total count plus bounded event rows from one SQLite read-transaction snapshot, preventing concurrent appends from producing mixed coverage views
- aggregate durable caller attribution by credential kind and OAuth client without exposing stable user ids in audit responses
- preserve OAuth client display names for historical stats even after client revocation
- lock the durable `principal_kind` vocabulary with a focused regression and document the attribution/coverage contract

## Commits
1. `b8a41970` Make audit stats coverage explicit
2. `3d275e65` Add caller attribution to audit stats
3. `75575996` Lock durable audit principal kinds
4. `54a174c2` Keep audit stats coverage snapshot-consistent

## Privacy / compatibility
- ordinary `/api/audit/session` event views still do not expose `principal_kind`, `principal_user_id`, or `oauth_client_id`
- `/api/audit/stats` exposes only aggregate credential-kind counts and OAuth `{client_id, name, count}` entries; stable user ids are not returned
- legacy unattributed action events remain counted as `unattributed_count`; no historical identity is inferred or backfilled
- no schema migration or action-session isolation change is included

## Validation
- `cargo fmt -- --check`
- `cargo test -p webcodex action_event_count_and_rows_share_one_snapshot_during_concurrent_append` (1 passed; second WAL connection commits event 201 between count and row read while the read transaction remains on the 200-event snapshot)
- `cargo test -p webcodex audit_stats` (6 passed)
- `cargo test -p webcodex http_audit_session_keeps_principal_attribution_out_of_event_details` (1 passed)
- `cargo test -p webcodex principal_kind_vocabulary_is_stable_for_durable_attribution` (1 passed on the prior commit; taxonomy code unchanged by the blocker fix)
- `cargo check -p webcodex`
- `git diff --check`

No merge, deploy, or release is included.