### PR TITLE
Remove redundant test coverage

### DIFF
--- a/crates/webcodex-runner/src/main_tests/file_read.rs
+++ b/crates/webcodex-runner/src/main_tests/file_read.rs
@@ -107,42 +107,6 @@ fn agent_file_read_range_reads_large_file_subset_under_max_bytes() {
 }
 
 #[test]
-fn agent_file_read_range_beyond_total_lines_returns_empty_content() {
-    let tmp = tempfile::tempdir().unwrap();
-    let policy = project_policy(tmp.path());
-    std::fs::write(tmp.path().join("short.txt"), "one\ntwo\nthree\n").unwrap();
-
-    let out = file_read_json(handle_file_request(
-        &policy,
-        &file_read_request(tmp.path(), "short.txt", Some(10), Some(12), Some(1024)),
-    ));
-
-    assert_eq!(out["format"], "webcodex.file_read_range.v1");
-    assert_eq!(out["content"], "");
-    assert_eq!(out["total_lines"], 3);
-    assert_eq!(out["start_line"], 10);
-    assert_eq!(out["limit"], 3);
-}
-
-#[test]
-fn agent_file_read_range_preserves_empty_selected_lines() {
-    let tmp = tempfile::tempdir().unwrap();
-    let policy = project_policy(tmp.path());
-    std::fs::write(tmp.path().join("blank.txt"), "\nsecond\nthird\n").unwrap();
-
-    let out = file_read_json(handle_file_request(
-        &policy,
-        &file_read_request(tmp.path(), "blank.txt", Some(1), Some(2), Some(1024)),
-    ));
-
-    assert_eq!(out["format"], "webcodex.file_read_range.v1");
-    assert_eq!(out["content"], "\nsecond");
-    assert_eq!(out["total_lines"], 3);
-    assert_eq!(out["start_line"], 1);
-    assert_eq!(out["limit"], 2);
-}
-
-#[test]
 fn agent_file_read_range_output_obeys_max_bytes() {
     let tmp = tempfile::tempdir().unwrap();
     let policy = project_policy(tmp.path());

--- a/crates/webcodex-runner/src/main_tests/file_read.rs
+++ b/crates/webcodex-runner/src/main_tests/file_read.rs
@@ -180,39 +180,6 @@ fn agent_file_read_precheck_distinguishes_missing_and_non_file() {
 }
 
 #[test]
-fn agent_file_read_range_large_file_small_range_uses_shared_core() {
-    let tmp = tempfile::tempdir().unwrap();
-    let policy = project_policy(tmp.path());
-    let line = "x".repeat(64);
-    let body = (0..300_000)
-        .map(|_| line.as_str())
-        .collect::<Vec<_>>()
-        .join("\n");
-    let expected_sha = sha256_hex_bytes(body.as_bytes());
-    std::fs::write(tmp.path().join("big.txt"), body).unwrap();
-
-    let out = file_read_json(handle_file_request(
-        &policy,
-        &file_read_request(
-            tmp.path(),
-            "big.txt",
-            Some(150_000),
-            Some(150_002),
-            Some(512 * 1024),
-        ),
-    ));
-    assert_eq!(out["format"], "webcodex.file_read_range.v1");
-    assert_eq!(
-        out["content"],
-        [line.as_str(), line.as_str(), line.as_str()].join("\n")
-    );
-    assert_eq!(out["total_lines"], 300_000);
-    assert_eq!(out["start_line"], 150_000);
-    assert_eq!(out["limit"], 3);
-    assert_eq!(out["sha256"], expected_sha);
-}
-
-#[test]
 fn agent_file_read_range_errors_never_include_absolute_path() {
     let tmp = tempfile::tempdir().unwrap();
     let policy = project_policy(tmp.path());

--- a/crates/webcodex-runner/src/webcodex_runner/external_tools_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/external_tools_tests.rs
@@ -489,39 +489,6 @@ fn fallback_and_failure_routes_record_bounded_last_call_evidence() {
 }
 
 #[test]
-fn search_falls_back_before_submission() {
-    let _serial = serialize_fake_mcp_test();
-    let fixture = Fixture::new("normal");
-    let mut unmapped_search = fixture.config.clone();
-    unmapped_search.mapping.remove("search_project_text");
-    let router = ExternalToolRouter::new(&ToolProvidersConfig {
-        strategy: ToolProviderStrategy::ClaudeCodeThenNative,
-        claude_code: unmapped_search,
-    });
-    let mut search = agent_request("run_shell", &fixture.root, ".", None);
-    search.command = EXTERNAL_SEARCH_REQUEST_PREFIX.to_string();
-    search.stdin = Some(search_request().to_string());
-    let ExternalRoute::NativeFallback(fallback) = router.route(&permissive_test_policy(), &search)
-    else {
-        panic!("unsubmitted search did not request Native fallback");
-    };
-    router.complete_native_fallback(
-        fallback,
-        &CommandResult {
-            exit_code: Some(0),
-            stdout: Some("native search".to_string()),
-            stderr: Some(String::new()),
-            duration_ms: Some(1),
-            error: None,
-        },
-    );
-    let call = router.status().claude_code.last_call.unwrap();
-    assert_eq!(call.selected_provider, "native");
-    assert!(call.fallback_used);
-    assert_eq!(call.write_state, None);
-}
-
-#[test]
 fn status_revisions_are_changed_only_and_registration_reads_latest_snapshot() {
     let _serial = serialize_fake_mcp_test();
     let fixture = Fixture::new("normal");

--- a/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
@@ -582,28 +582,6 @@ fn lsp_jsonrpc_replies_method_not_found_to_server_requests() {
 }
 
 #[test]
-fn lsp_request_timeout_removes_pending_request() {
-    let _serial = super::super::serialize_fake_lsp_test();
-    let fixture = Fixture::new("timeout");
-    let server = fixture
-        .supervisor
-        .server_for_test(&fixture.root, LspServerKind::RustAnalyzer)
-        .unwrap();
-    let error = fixture
-        .supervisor
-        .request_with_timeout(
-            &fixture.root,
-            LspServerKind::RustAnalyzer,
-            "fake/timeout",
-            json!({}),
-            Duration::from_millis(40),
-        )
-        .unwrap_err();
-    assert!(matches!(error, LspError::RequestTimeout { .. }));
-    assert_eq!(server.pending_count(), 0);
-}
-
-#[test]
 fn lsp_request_timeout_sends_cancel_request() {
     let _serial = super::super::serialize_fake_lsp_test();
     let fixture = Fixture::new("timeout_cancel");

--- a/src/db/task_kernel_tests.rs
+++ b/src/db/task_kernel_tests.rs
@@ -805,16 +805,6 @@ fn failed_claim_does_not_advance_the_watermark() {
 }
 
 #[test]
-fn an_empty_claim_leaves_the_watermark_alone() {
-    let (_temp, db) = database();
-    bind(&db, "user:one");
-    let task = start(&db, "user:one", "fix the parser");
-    assert!(claim(&db, &task).is_empty());
-    guide(&db, &task, "arrived later");
-    assert_eq!(claim(&db, &task).len(), 1);
-}
-
-#[test]
 fn read_state_reports_pending_and_claimed_guidance_without_consuming() {
     let (_temp, db) = database();
     bind(&db, "user:one");

--- a/src/mcp_tests/protocol.rs
+++ b/src/mcp_tests/protocol.rs
@@ -1,22 +1,5 @@
 use super::*;
 
-#[test]
-fn rpc_result_envelope_is_valid() {
-    let value = rpc_result(Some(Value::from(1)), json!({"ok": true}));
-    assert_eq!(value["jsonrpc"], "2.0");
-    assert_eq!(value["id"], 1);
-    assert_eq!(value["result"]["ok"], true);
-}
-
-#[test]
-fn rpc_error_envelope_carries_code_and_message() {
-    let value = rpc_error(Some(Value::from("a")), -32601, "missing");
-    assert_eq!(value["jsonrpc"], "2.0");
-    assert_eq!(value["id"], "a");
-    assert_eq!(value["error"]["code"], -32601);
-    assert_eq!(value["error"]["message"], "missing");
-}
-
 #[tokio::test]
 async fn mcp_initialize_returns_protocol_and_server_info() {
     let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);

--- a/src/mcp_tests/protocol.rs
+++ b/src/mcp_tests/protocol.rs
@@ -305,35 +305,3 @@ async fn mcp_notifications_initialized_with_id_returns_result() {
         other => panic!("expected Ok, got {:?}", other),
     }
 }
-
-#[tokio::test]
-async fn mcp_tools_list_parity_with_rest_tools_list() {
-    // MCP tools/list and REST /api/tools/list both expose the exact same
-    // registry-backed tool names on the full operator surface.
-    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
-    let mcp_outcome = handle_mcp_request(
-        &runtime,
-        rpc(
-            "tools/list",
-            Some(Value::from(8)),
-            mcp_2026_params(json!({})),
-        ),
-        None,
-    )
-    .await;
-    let mcp_value = match mcp_outcome {
-        McpOutcome::Ok(v) => v,
-        other => panic!("expected Ok, got {:?}", other),
-    };
-    let mcp_names: Vec<String> = mcp_value["result"]["tools"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|t| t["name"].as_str().unwrap().to_string())
-        .collect();
-    let rest_names: Vec<String> = registered_tool_specs()
-        .iter()
-        .map(|s| s.name.clone())
-        .collect();
-    assert_eq!(mcp_names, rest_names);
-}

--- a/src/mcp_tests/runtime_tools.rs
+++ b/src/mcp_tests/runtime_tools.rs
@@ -5,31 +5,6 @@ use super::*;
 // =========================================================================
 
 #[tokio::test]
-async fn mcp_tools_list_includes_runtime_status() {
-    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
-    let outcome = handle_mcp_request(
-        &runtime,
-        rpc("tools/list", Some(Value::from(10)), json!({})),
-        None,
-    )
-    .await;
-    let value = match outcome {
-        McpOutcome::Ok(v) => v,
-        other => panic!("expected Ok, got {:?}", other),
-    };
-    let tools = value["result"]["tools"].as_array().unwrap();
-    let names: Vec<String> = tools
-        .iter()
-        .map(|t| t["name"].as_str().unwrap().to_string())
-        .collect();
-    assert!(
-        names.iter().any(|n| n == "runtime_status"),
-        "MCP tools/list must include runtime_status: {:?}",
-        names
-    );
-}
-
-#[tokio::test]
 async fn mcp_tools_list_exposes_coding_task_and_runtime_status_ux_flags() {
     let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(

--- a/src/mcp_tests/runtime_tools.rs
+++ b/src/mcp_tests/runtime_tools.rs
@@ -166,63 +166,6 @@ async fn mcp_tools_list_exposes_coding_task_and_runtime_status_ux_flags() {
 }
 
 #[tokio::test]
-async fn mcp_tools_list_includes_validate_patch() {
-    // validate_patch is a patch preflight / dry-run tool exposed via MCP
-    // tools/list (and a thin REST wrapper), but NOT via GPT Actions.
-    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
-    let outcome = handle_mcp_request(
-        &runtime,
-        rpc("tools/list", Some(Value::from(12)), json!({})),
-        None,
-    )
-    .await;
-    let value = match outcome {
-        McpOutcome::Ok(v) => v,
-        other => panic!("expected Ok, got {:?}", other),
-    };
-    let tools = value["result"]["tools"].as_array().unwrap();
-    let names: Vec<String> = tools
-        .iter()
-        .map(|t| t["name"].as_str().unwrap().to_string())
-        .collect();
-    assert!(
-        names.iter().any(|n| n == "validate_patch"),
-        "MCP tools/list must include validate_patch: {:?}",
-        names
-    );
-}
-
-#[tokio::test]
-async fn mcp_tools_list_includes_show_changes() {
-    let runtime = test_runtime();
-    let outcome = handle_mcp_request(
-        &runtime,
-        rpc("tools/list", Some(Value::from(13)), json!({})),
-        None,
-    )
-    .await;
-    let value = match outcome {
-        McpOutcome::Ok(v) => v,
-        other => panic!("expected Ok, got {:?}", other),
-    };
-    let tools = value["result"]["tools"].as_array().unwrap();
-    let names: Vec<String> = tools
-        .iter()
-        .map(|t| t["name"].as_str().unwrap().to_string())
-        .collect();
-    assert!(
-        names.iter().any(|n| n == "show_changes"),
-        "MCP tools/list must include show_changes: {:?}",
-        names
-    );
-    assert!(
-        names.iter().any(|n| n == "git_log"),
-        "MCP tools/list must include git_log: {:?}",
-        names
-    );
-}
-
-#[tokio::test]
 async fn mcp_tools_call_runtime_status_returns_content() {
     // runtime_status is not part of the local_coding surface; select the full
     // operator surface so the call reaches dispatch.
@@ -283,37 +226,5 @@ async fn mcp_tools_call_show_changes_returns_structured_tool_error() {
     assert_eq!(
         value["result"]["structuredContent"]["output"]["error_kind"],
         "unknown_project"
-    );
-}
-
-#[tokio::test]
-async fn mcp_tools_list_includes_project_management_tools() {
-    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
-    let outcome = handle_mcp_request(
-        &runtime,
-        rpc("tools/list", Some(Value::from(99)), json!({})),
-        None,
-    )
-    .await;
-    let value = match outcome {
-        McpOutcome::Ok(v) => v,
-        other => panic!("expected Ok, got {:?}", other),
-    };
-    let tools = value["result"]["tools"].as_array().unwrap();
-    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
-    assert!(
-        names.contains(&"register_project"),
-        "MCP tools/list must include register_project: {:?}",
-        names
-    );
-    assert!(
-        names.contains(&"unregister_project"),
-        "MCP tools/list must include unregister_project: {:?}",
-        names
-    );
-    assert!(
-        names.contains(&"create_project"),
-        "MCP tools/list must include create_project: {:?}",
-        names
     );
 }

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -135,27 +135,6 @@ fn openapi_operation_ids_are_minimal() {
 }
 
 #[test]
-fn openapi_operations_have_consequential_flags() {
-    let spec = build_openapi_spec();
-    let paths = spec["paths"].as_object().unwrap();
-    let mut count = 0;
-    for methods in paths.values() {
-        for op in methods.as_object().unwrap().values() {
-            count += 1;
-            let operation_id = op["operationId"].as_str().unwrap();
-            assert!(
-                op.get("x-openai-isConsequential")
-                    .and_then(|v| v.as_bool())
-                    .is_some(),
-                "operation {} must have x-openai-isConsequential",
-                operation_id
-            );
-        }
-    }
-    assert_eq!(count, 25);
-}
-
-#[test]
 fn openapi_consequential_flags_match_operation_risk() {
     let spec = build_openapi_spec();
     let mut flags = std::collections::BTreeMap::new();
@@ -1424,28 +1403,6 @@ fn openapi_runtime_only_tools_do_not_get_dedicated_paths() {
             forbidden
         );
     }
-}
-
-#[test]
-fn openapi_operation_count_is_twenty_five_after_retiring_legacy_edits() {
-    // Phase 3 promoted 10 core runtime tools to dedicated GPT Actions,
-    // then later phases promoted run_job plus project onboarding actions.
-    // The single-purpose legacy edit tools are retired, while retained editing
-    // tools stay on the generic runtime surface. The current GPT Action count
-    // is 25 after removing legacy `/api/codex/*` routes.
-    // The surface must stay <= 30.
-    let spec = build_openapi_spec();
-    let count: usize = spec["paths"]
-        .as_object()
-        .unwrap()
-        .values()
-        .map(|m| m.as_object().unwrap().len())
-        .sum();
-    assert_eq!(
-        count, 25,
-        "GPT Actions schema must be 25 operations after retiring legacy edits"
-    );
-    assert!(count <= 30, "GPT Actions schema must stay <= 30 operations");
 }
 
 #[test]

--- a/src/project_entry_tests.rs
+++ b/src/project_entry_tests.rs
@@ -560,7 +560,6 @@ struct GoldenPathEvidence {
     accepted_output: String,
     accepted_content: String,
     execution_count: i64,
-    recipe_id: String,
 }
 
 async fn run_authenticated_golden_path(recipe: &str) -> GoldenPathEvidence {
@@ -846,10 +845,6 @@ async fn run_authenticated_golden_path(recipe: &str) -> GoldenPathEvidence {
         accepted_output,
         accepted_content,
         execution_count,
-        recipe_id: checked["data"]["execution"]["recipe"]["id"]
-            .as_str()
-            .unwrap()
-            .to_string(),
     }
 }
 
@@ -1028,20 +1023,6 @@ fn state_directory_rejects_symlink_that_resolves_into_checkout() {
 
     assert_eq!(error.code, "state_directory_unsafe");
     assert_no_project_state_artifacts(&root);
-}
-
-#[tokio::test]
-async fn checks_run_project_aware_golden_paths_cover_rust_node_python_and_go() {
-    for recipe in ["rust", "node", "python", "go"] {
-        let evidence = run_authenticated_golden_path(recipe).await;
-        assert_eq!(evidence.recipe_id, recipe);
-        assert!(evidence.accepted_output.contains("Accepted"));
-        assert_eq!(evidence.accepted_content, "accepted\n");
-        assert!(evidence
-            .agent_request_kinds
-            .iter()
-            .any(|kind| kind == "start_validation_job"));
-    }
 }
 
 #[test]

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -2085,22 +2085,6 @@ async fn oauth2_tools_call_unknown_tool_fails_closed() {
 }
 
 #[tokio::test]
-async fn api_token_tools_call_behavior_unchanged() {
-    let (_tmp, service) = phase2_service();
-    let mut resp = TestClient::post("http://localhost/api/tools/call")
-        .bearer_auth("secret")
-        .json(&json!({"tool": "definitely_not_a_tool"}))
-        .send(&service)
-        .await;
-    assert_eq!(effective_status(&resp), StatusCode::BAD_REQUEST);
-    let body: Value = resp.take_json().await.unwrap();
-    assert!(body["error"]
-        .as_str()
-        .unwrap_or("")
-        .contains("definitely_not_a_tool"));
-}
-
-#[tokio::test]
 async fn http_tools_list_includes_phase4_edit_tools() {
     let (_tmp, service) = phase2_service();
     let mut resp = TestClient::post("http://localhost/api/tools/list")

--- a/src/shell_client/mod_tests/file_validation.rs
+++ b/src/shell_client/mod_tests/file_validation.rs
@@ -1,15 +1,6 @@
 use super::*;
 
 #[test]
-fn validate_file_request_allows_read_with_start_and_end_line() {
-    let mut req = file_request("read");
-    req.start_line = Some(10);
-    req.end_line = Some(20);
-
-    validate_file_request(&req).unwrap();
-}
-
-#[test]
 fn validate_file_request_rejects_invalid_read_requests() {
     let cases: Vec<(&str, fn(&mut ShellFileOpRequest), &str)> = vec![
         (

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -2280,23 +2280,6 @@ fn show_changes_reports_conflicted_file() {
 }
 
 #[test]
-fn show_changes_include_diff_false_omits_hunks() {
-    let output = parse_show_changes_output(
-        "agent:oe:webcodex",
-        "## main\n M src/lib.rs",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
-        " src/lib.rs | 2 +-",
-        None,
-        20,
-        80,
-        Some(0),
-        "",
-    );
-    assert!(output.get("hunks").is_none());
-    assert!(output.get("hunk_count").is_none());
-}
-
-#[test]
 fn show_changes_include_diff_true_returns_bounded_hunks() {
     let diff = "\
 diff --git a/src/lib.rs b/src/lib.rs

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1201,19 +1201,6 @@ async fn agent_tool_allows_bootstrap_token_for_run_job() {
 }
 
 #[test]
-fn runtime_status_is_in_registered_tool_specs() {
-    let names: Vec<String> = registered_tool_specs()
-        .iter()
-        .map(|s| s.name.clone())
-        .collect();
-    assert!(
-        names.iter().any(|n| n == "runtime_status"),
-        "runtime_status must be in registered tool specs: {:?}",
-        names
-    );
-}
-
-#[test]
 fn runtime_status_input_schema_exposes_compact_flags() {
     let specs = registered_tool_specs();
     let spec = specs

--- a/src/tool_runtime/tests/schema/definitions.rs
+++ b/src/tool_runtime/tests/schema/definitions.rs
@@ -71,43 +71,6 @@ fn tool_definitions_cover_known_names_and_public_specs() {
 }
 
 #[test]
-fn model_visible_tool_definitions_have_public_tool_specs() {
-    use crate::tool_runtime::tool_definition::model_visible_tool_definitions;
-
-    let spec_names = registered_tool_specs()
-        .iter()
-        .map(|spec| spec.name.clone())
-        .collect::<BTreeSet<_>>();
-    for definition in model_visible_tool_definitions() {
-        assert!(
-            spec_names.contains(definition.name),
-            "{} is model-visible but missing a public ToolSpec row",
-            definition.name
-        );
-    }
-}
-
-#[test]
-fn public_tool_specs_are_model_visible_tool_definitions() {
-    use crate::tool_runtime::tool_definition::{
-        lookup_tool_definition, model_visible_tool_definitions,
-    };
-
-    let visible_definition_names = model_visible_tool_definitions()
-        .map(|definition| definition.name)
-        .collect::<BTreeSet<_>>();
-    for spec in registered_tool_specs() {
-        let definition = lookup_tool_definition(&spec.name)
-            .unwrap_or_else(|| panic!("{} public ToolSpec is missing ToolDefinition", spec.name));
-        assert!(
-            visible_definition_names.contains(definition.name),
-            "{} public ToolSpec must be model-visible in ToolDefinition",
-            spec.name
-        );
-    }
-}
-
-#[test]
 fn tool_definitions_drive_metadata_visibility_and_categories() {
     use crate::tool_runtime::metadata::lookup_tool_metadata;
     use crate::tool_runtime::tool_definition::tool_definitions;

--- a/src/tool_runtime/tests/schema/specs.rs
+++ b/src/tool_runtime/tests/schema/specs.rs
@@ -1,41 +1,6 @@
 use super::*;
 
 #[test]
-fn tool_specs_and_metadata_are_synchronized() {
-    let specs = registered_tool_specs();
-    let spec_names = specs
-        .iter()
-        .map(|spec| spec.name.as_str())
-        .collect::<BTreeSet<_>>();
-
-    for spec in &specs {
-        assert!(
-            crate::tool_runtime::metadata::lookup_tool_metadata(&spec.name).is_some(),
-            "{} missing metadata",
-            spec.name
-        );
-    }
-
-    for metadata in crate::tool_runtime::metadata::iter_tool_metadata() {
-        if metadata.name == "delete_files" {
-            // Legacy dedicated HTTP route metadata; not a public runtime
-            // ToolSpec name and intentionally not accepted by ToolCall.
-            continue;
-        }
-        if is_model_hidden_tool_name(metadata.name) {
-            // Hidden implemented tools keep parser/metadata coverage without
-            // being advertised through model-facing specs.
-            continue;
-        }
-        assert!(
-            spec_names.contains(metadata.name),
-            "{} metadata is not exposed by registry specs",
-            metadata.name
-        );
-    }
-}
-
-#[test]
 fn tool_specs_names_are_unique() {
     let specs = registered_tool_specs();
     let mut names = specs.iter().map(|s| s.name.clone()).collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

Remove redundant tests whose contracts are already owned by stronger or more focused canonical coverage.

- 17 commits, all test-only cleanup
- 14 changed files
- 486 deletions / 0 insertions
- no production source, CI configuration, timeout/retry behavior, fixtures, or runtime semantics changed

The branch is based directly on current `main` (`1ca37732af7bb970d2df155cff14148a88519eac`) and reviewed at `9aa0a67e179f3e9a141c56659c855dc96a041e73`.

## Coverage review

The removals were checked against retained canonical owners rather than accepted from green tests alone. Examples:

- runner file-range edge/large-file cases remain covered by the shared `webcodex-workspace` range core
- LSP timeout cleanup remains covered by the stronger timeout + cancel-request test
- external-tool fallback remains covered by the combined fallback/status evidence test
- MCP tool-list presence/parity remains covered by exact registry parity across legacy/stateless/compact surfaces
- show_changes `include_diff=false` remains covered through the real temporary-Git-repository path, including omitted hunk metadata
- HTTP unknown-tool behavior remains covered by the retained exact route/auth/error test
- ToolDefinition/ToolSpec/metadata synchronization remains owned by the exact model-visible definition/spec equality tests plus explicit legacy metadata fallback coverage
- MCP JSON-RPC envelopes and OpenAPI consequential/count invariants remain covered by broader protocol and exact-surface tests
- empty guidance-claim watermark behavior remains covered inside the sequential guidance delivery test
- Rust/Node/Python/Go validation recipe selection and argv remain covered by recipe-level table tests plus connector execution tests for Node/Python/Go; the full authenticated golden path remains as the Rust end-to-end representative

No reviewed deletion removed the sole owner of a contract.

## Validation

- `cargo fmt -- --check` — passed
- `git diff --check origin/main...HEAD` — passed
- `cargo test -p webcodex-runner` — **648 passed, 0 failed, 3 ignored**
- `cargo test -p webcodex` — **2568 passed, 0 failed**
- worktree clean before push

This PR should run the opt-in heavy CI via the `run-ci` label and auto-merge only after repository requirements pass.