### PR TITLE
Make guarded text edits CRLF-aware

### DIFF
--- a/crates/webcodex-core/src/apply_edits_shared.rs
+++ b/crates/webcodex-core/src/apply_edits_shared.rs
@@ -6,6 +6,76 @@
 //! have. Do not add main-crate-only imports here.
 
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+/// Line-ending convention of one existing text file. Mixed LF/CRLF and bare
+/// carriage returns are rejected because edit matching must not guess how to
+/// rewrite an ambiguous file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyTextLineEnding {
+    None,
+    Lf,
+    Crlf,
+}
+
+/// Detect one unambiguous existing-file line-ending convention.
+pub fn detect_apply_text_line_ending(text: &str) -> Result<ApplyTextLineEnding, &'static str> {
+    let bytes = text.as_bytes();
+    let mut saw_lf = false;
+    let mut saw_crlf = false;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\r' => {
+                if bytes.get(index + 1) != Some(&b'\n') {
+                    return Err("file contains unsupported bare CR line endings");
+                }
+                saw_crlf = true;
+                index += 2;
+            }
+            b'\n' => {
+                saw_lf = true;
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+    match (saw_lf, saw_crlf) {
+        (true, true) => Err("file contains mixed LF and CRLF line endings"),
+        (true, false) => Ok(ApplyTextLineEnding::Lf),
+        (false, true) => Ok(ApplyTextLineEnding::Crlf),
+        (false, false) => Ok(ApplyTextLineEnding::None),
+    }
+}
+
+/// Canonicalize LF/CRLF edit text to LF for exact matching. Bare CR remains a
+/// hard error; no other whitespace or textual normalization is performed.
+pub fn canonicalize_apply_text_line_endings<'a>(
+    text: &'a str,
+    line_ending: ApplyTextLineEnding,
+) -> Result<Cow<'a, str>, &'static str> {
+    let bytes = text.as_bytes();
+    if !bytes.contains(&b'\r') {
+        return Ok(Cow::Borrowed(text));
+    }
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte == b'\r' && bytes.get(index + 1) != Some(&b'\n') {
+            return Err("edit text contains unsupported bare CR line endings");
+        }
+    }
+    if line_ending == ApplyTextLineEnding::None {
+        return Ok(Cow::Borrowed(text));
+    }
+    Ok(Cow::Owned(text.replace("\r\n", "\n")))
+}
+
+/// Restore canonical LF content to the original existing-file convention.
+pub fn restore_apply_text_line_endings(text: String, line_ending: ApplyTextLineEnding) -> String {
+    match line_ending {
+        ApplyTextLineEnding::Crlf => text.replace('\n', "\r\n"),
+        ApplyTextLineEnding::None | ApplyTextLineEnding::Lf => text,
+    }
+}
 
 /// Kind of atomic text edit performed by `apply_text_edits`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]

--- a/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
+++ b/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
@@ -345,6 +345,160 @@ fn file_apply_text_edits_insert_before_after_and_delete_exact() {
 }
 
 #[test]
+fn file_apply_text_edits_crlf_accepts_lf_edits_and_preserves_crlf() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let file = tmp.path().join("target.txt");
+    std::fs::write(&file, b"one\r\ntwo\r\nthree\r\nfour\r\nfive\r\n").unwrap();
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_text_edits_request(
+            tmp.path(),
+            "target.txt",
+            serde_json::json!({
+                "edits": [
+                    {"kind": "replace_exact", "old_text": "one\n", "new_text": "ONE\n"},
+                    {"kind": "insert_after", "anchor_text": "two\n", "new_text": "AFTER-TWO\n"},
+                    {"kind": "delete_exact", "old_text": "three\n"},
+                    {"kind": "insert_before", "anchor_text": "four\n", "new_text": "BEFORE-FOUR\n"}
+                ]
+            }),
+        ),
+    ));
+
+    assert_eq!(out["changed"], true);
+    assert_eq!(
+        std::fs::read(&file).unwrap(),
+        b"ONE\r\ntwo\r\nAFTER-TWO\r\nBEFORE-FOUR\r\nfour\r\nfive\r\n"
+    );
+}
+
+#[test]
+fn file_apply_text_edits_lf_accepts_crlf_edits_and_preserves_lf() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let file = tmp.path().join("target.txt");
+    std::fs::write(&file, b"one\ntwo\nthree\nfour\nfive\n").unwrap();
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_text_edits_request(
+            tmp.path(),
+            "target.txt",
+            serde_json::json!({
+                "edits": [
+                    {"kind": "replace_exact", "old_text": "one\r\n", "new_text": "ONE\r\n"},
+                    {"kind": "insert_after", "anchor_text": "two\r\n", "new_text": "AFTER-TWO\r\n"},
+                    {"kind": "delete_exact", "old_text": "three\r\n"},
+                    {"kind": "insert_before", "anchor_text": "four\r\n", "new_text": "BEFORE-FOUR\r\n"}
+                ]
+            }),
+        ),
+    ));
+
+    assert_eq!(out["changed"], true);
+    assert_eq!(
+        std::fs::read(&file).unwrap(),
+        b"ONE\ntwo\nAFTER-TWO\nBEFORE-FOUR\nfour\nfive\n"
+    );
+}
+
+#[test]
+fn file_apply_text_edits_mixed_line_endings_abort_entire_batch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let first = tmp.path().join("first.txt");
+    let mixed = tmp.path().join("mixed.txt");
+    std::fs::write(&first, b"alpha\r\n").unwrap();
+    std::fs::write(&mixed, b"beta\r\ngamma\n").unwrap();
+    let hash = |path: &Path| sha256_hex_bytes(&std::fs::read(path).unwrap());
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_text_edits_request(
+            tmp.path(),
+            "first.txt",
+            serde_json::json!({
+                "changes": [
+                    {
+                        "kind": "edit",
+                        "path": "first.txt",
+                        "expected_sha256": hash(&first),
+                        "edits": [{"kind": "replace_exact", "old_text": "alpha\n", "new_text": "ALPHA\n"}]
+                    },
+                    {
+                        "kind": "edit",
+                        "path": "mixed.txt",
+                        "expected_sha256": hash(&mixed),
+                        "edits": [{"kind": "replace_exact", "old_text": "beta\n", "new_text": "BETA\n"}]
+                    }
+                ]
+            }),
+        ),
+    ));
+
+    assert_eq!(out["error_kind"], "edit_conflict");
+    assert_eq!(out["change_index"], 1);
+    assert!(out["error"].as_str().unwrap().contains("mixed LF and CRLF"));
+    assert_eq!(std::fs::read(&first).unwrap(), b"alpha\r\n");
+    assert_eq!(std::fs::read(&mixed).unwrap(), b"beta\r\ngamma\n");
+}
+
+#[test]
+fn file_apply_text_edits_line_ending_normalization_is_not_fuzzy_matching() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let file = tmp.path().join("target.txt");
+    std::fs::write(&file, b"alpha beta\r\n").unwrap();
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_text_edits_request(
+            tmp.path(),
+            "target.txt",
+            serde_json::json!({
+                "edits": [
+                    {"kind": "replace_exact", "old_text": "alpha  beta\n", "new_text": "x\n"}
+                ]
+            }),
+        ),
+    ));
+
+    assert_eq!(out["error_kind"], "edit_conflict");
+    assert!(out["error"]
+        .as_str()
+        .unwrap()
+        .contains("match text was not found"));
+    assert_eq!(std::fs::read(&file).unwrap(), b"alpha beta\r\n");
+}
+
+#[test]
+fn file_apply_text_edits_rejects_bare_cr_replacement_without_file_line_endings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let file = tmp.path().join("target.txt");
+    std::fs::write(&file, b"one").unwrap();
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_text_edits_request(
+            tmp.path(),
+            "target.txt",
+            serde_json::json!({
+                "edits": [
+                    {"kind": "replace_exact", "old_text": "one", "new_text": "ONE\r"}
+                ]
+            }),
+        ),
+    ));
+
+    assert_eq!(out["error_kind"], "edit_conflict");
+    assert!(out["error"].as_str().unwrap().contains("bare CR"));
+    assert_eq!(std::fs::read(&file).unwrap(), b"one");
+}
+
+#[test]
 fn file_apply_text_edits_rejects_overlapping_edits() {
     let tmp = tempfile::tempdir().unwrap();
     let policy = project_policy(tmp.path());

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -264,7 +264,8 @@ const APPLY_TEXT_EDITS_MAX_FILE_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 // shared verbatim with the host write path via `apply_edits_shared`. Aliases
 // keep this module's existing `Agent*` / `APPLY_TEXT_EDITS_MAX_*` names.
 use crate::apply_edits_shared::{
-    is_sensitive_edit_path, ApplyFileChangeInput as AgentFileChange,
+    canonicalize_apply_text_line_endings, detect_apply_text_line_ending, is_sensitive_edit_path,
+    restore_apply_text_line_endings, ApplyFileChangeInput as AgentFileChange,
     ApplyFileChangeKind as AgentFileChangeKind, ApplyTextEditInput as AgentTextEdit,
     ApplyTextEditKind as AgentTextEditKind, MAX_APPLY_FILE_CHANGES as APPLY_TEXT_EDITS_MAX_CHANGES,
     MAX_APPLY_TEXT_EDITS as APPLY_TEXT_EDITS_MAX_EDITS,
@@ -313,6 +314,11 @@ fn edit_plan(
             ),
         ));
     }
+    let line_ending =
+        detect_apply_text_line_ending(original).map_err(|error| (0, "edit", error.to_string()))?;
+    let canonical_original = canonicalize_apply_text_line_endings(original, line_ending)
+        .map_err(|error| (0, "edit", error.to_string()))?;
+    let original = canonical_original.as_ref();
     let mut ops: Vec<(usize, usize, String, usize)> = Vec::with_capacity(edits.len());
     for (index, edit) in edits.iter().enumerate() {
         let kind = &edit.kind;
@@ -400,6 +406,12 @@ fn edit_plan(
         {
             return Err((index, kind.as_str(), "edit field is too large".to_string()));
         }
+        let needle = canonicalize_apply_text_line_endings(needle, line_ending)
+            .map_err(|error| (index, kind.as_str(), error.to_string()))?;
+        let replacement = canonicalize_apply_text_line_endings(&replacement, line_ending)
+            .map_err(|error| (index, kind.as_str(), error.to_string()))?
+            .into_owned();
+        let needle = needle.as_ref();
         let matches = original.matches(needle).count();
         if matches != 1 {
             return Err((
@@ -455,6 +467,7 @@ fn edit_plan(
         }));
     }
     replacement.push_str(&original[cursor..]);
+    let replacement = restore_apply_text_line_endings(replacement, line_ending);
     Ok((replacement, summaries))
 }
 

--- a/src/tool_runtime/files.rs
+++ b/src/tool_runtime/files.rs
@@ -64,6 +64,11 @@ pub(crate) use search::{
 pub(crate) use search::{SearchOptions, SearchRequest, DEFAULT_SEARCH_HEAD_ABSOLUTE_CANDIDATES};
 
 // Edit limits and the sensitive-path guard are shared with the agent binary.
+#[cfg(test)]
+pub(crate) use crate::apply_edits_shared::{
+    canonicalize_apply_text_line_endings, detect_apply_text_line_ending,
+    restore_apply_text_line_endings,
+};
 pub(crate) use crate::apply_edits_shared::{
     is_sensitive_edit_path, MAX_APPLY_FILE_CHANGES, MAX_APPLY_TEXT_EDITS,
     MAX_APPLY_TEXT_EDIT_FIELD_BYTES,

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -274,6 +274,13 @@ pub(crate) fn apply_text_edits_to_string(
         }
     }
 
+    let raw_original = original;
+    let line_ending =
+        detect_apply_text_line_ending(original).map_err(recoverable_write_rejection)?;
+    let canonical_original = canonicalize_apply_text_line_endings(original, line_ending)
+        .map_err(recoverable_write_rejection)?;
+    let original = canonical_original.as_ref();
+
     // Resolve each edit to a (start, end, replacement, index) op against the
     // original content. start/end are byte offsets; inserts are zero-width.
     let mut ops: Vec<(usize, usize, String, usize)> = Vec::with_capacity(edits.len());
@@ -327,6 +334,12 @@ pub(crate) fn apply_text_edits_to_string(
                 "replacement text cannot contain NUL bytes",
             ));
         }
+        let needle = canonicalize_apply_text_line_endings(needle, line_ending)
+            .map_err(|error| edit_match_error(index, kind, error))?;
+        let replacement = canonicalize_apply_text_line_endings(&replacement, line_ending)
+            .map_err(|error| edit_field_error(index, kind, error))?
+            .into_owned();
+        let needle = needle.as_ref();
         let matches = original.matches(needle).count();
         if matches == 0 {
             return Err(edit_match_error(index, kind, "match text was not found"));
@@ -400,9 +413,10 @@ pub(crate) fn apply_text_edits_to_string(
         }));
     }
     new_content.push_str(&original[cursor..]);
+    let new_content = restore_apply_text_line_endings(new_content, line_ending);
 
     let new_sha256 = sha256_hex_bytes(new_content.as_bytes());
-    let changed = new_content != original;
+    let changed = new_content != raw_original;
     let output = json!({
         "path": path,
         "dry_run": dry_run,

--- a/src/tool_runtime/tests/apply_text_edits.rs
+++ b/src/tool_runtime/tests/apply_text_edits.rs
@@ -193,6 +193,110 @@ fn apply_text_edits_rejects_overlapping_edits() {
     assert!(err.contains("overlap"));
 }
 
+#[test]
+fn apply_text_edits_crlf_accepts_lf_edits_and_preserves_crlf() {
+    let original = "one\r\ntwo\r\nthree\r\nfour\r\nfive\r\n";
+    let edits = vec![
+        text_edit(
+            ApplyTextEditKind::ReplaceExact,
+            Some("one\n"),
+            Some("ONE\n"),
+            None,
+        ),
+        text_edit(
+            ApplyTextEditKind::InsertAfter,
+            None,
+            Some("AFTER-TWO\n"),
+            Some("two\n"),
+        ),
+        text_edit(ApplyTextEditKind::DeleteExact, Some("three\n"), None, None),
+        text_edit(
+            ApplyTextEditKind::InsertBefore,
+            None,
+            Some("BEFORE-FOUR\n"),
+            Some("four\n"),
+        ),
+    ];
+    let real_sha = files::sha256_hex_bytes(original.as_bytes());
+    let (updated, out) =
+        files::apply_text_edits_to_string(original, "src/x.rs", &edits, Some(&real_sha), false)
+            .unwrap();
+
+    assert_eq!(
+        updated,
+        "ONE\r\ntwo\r\nAFTER-TWO\r\nBEFORE-FOUR\r\nfour\r\nfive\r\n"
+    );
+    assert!(!updated.replace("\r\n", "").contains('\n'));
+    assert_eq!(out["changed"], true);
+}
+
+#[test]
+fn apply_text_edits_lf_accepts_crlf_edits_and_preserves_lf() {
+    let original = "one\ntwo\nthree\nfour\nfive\n";
+    let edits = vec![
+        text_edit(
+            ApplyTextEditKind::ReplaceExact,
+            Some("one\r\n"),
+            Some("ONE\r\n"),
+            None,
+        ),
+        text_edit(
+            ApplyTextEditKind::InsertAfter,
+            None,
+            Some("AFTER-TWO\r\n"),
+            Some("two\r\n"),
+        ),
+        text_edit(
+            ApplyTextEditKind::DeleteExact,
+            Some("three\r\n"),
+            None,
+            None,
+        ),
+        text_edit(
+            ApplyTextEditKind::InsertBefore,
+            None,
+            Some("BEFORE-FOUR\r\n"),
+            Some("four\r\n"),
+        ),
+    ];
+    let (updated, _) =
+        files::apply_text_edits_to_string(original, "src/x.rs", &edits, None, false).unwrap();
+
+    assert_eq!(updated, "ONE\ntwo\nAFTER-TWO\nBEFORE-FOUR\nfour\nfive\n");
+    assert!(!updated.contains('\r'));
+}
+
+#[test]
+fn apply_text_edits_rejects_mixed_or_bare_cr_line_endings() {
+    for original in ["one\r\ntwo\n", "one\rtwo\r"] {
+        let edits = vec![text_edit(
+            ApplyTextEditKind::ReplaceExact,
+            Some("one\n"),
+            Some("ONE\n"),
+            None,
+        )];
+        let err = files::apply_text_edits_to_string(original, "src/x.rs", &edits, None, false)
+            .unwrap_err();
+        assert!(err.contains("line endings"), "{err}");
+        assert!(err.contains("No files were modified"), "{err}");
+    }
+}
+
+#[test]
+fn apply_text_edits_rejects_bare_cr_edit_text_without_file_line_endings() {
+    let original = "one";
+    let edits = vec![text_edit(
+        ApplyTextEditKind::ReplaceExact,
+        Some("one"),
+        Some("ONE\r"),
+        None,
+    )];
+    let err =
+        files::apply_text_edits_to_string(original, "src/x.rs", &edits, None, false).unwrap_err();
+    assert!(err.contains("bare CR"), "{err}");
+    assert!(err.contains("No files were modified"), "{err}");
+}
+
 #[tokio::test]
 async fn apply_text_edits_dry_run_does_not_write() {
     let runtime = runtime_with_agent_project("ate-dry");


### PR DESCRIPTION
## Summary

- make `apply_text_edits` treat LF and CRLF as the only newline-equivalent forms for exact guarded edits
- keep `expected_sha256` fenced against the real original file bytes before any newline normalization
- preserve the original file's LF/CRLF convention on writeback
- fail closed on mixed LF/CRLF files, bare CR, real textual mismatches, ambiguity, and overlap
- cover `replace_exact`, `insert_before`, `insert_after`, and `delete_exact` in both LF-authored→CRLF-file and CRLF-authored→LF-file directions
- preserve multi-file transactional zero-write behavior on preflight failure

No repository-wide `.gitattributes`/rustfmt line-ending policy change is included here.

## Independent review

Reviewed against local `main` at `1ca37732af7bb970d2df155cff14148a88519eac`.

Focused validation after review:

- `cargo test -p webcodex-runner file_apply_text_edits_` — 15 passed
- `cargo test -p webcodex apply_text_edits_` — 21 passed
- `cargo fmt -- --check` — pass
- `git diff --check 1ca37732af7bb970d2df155cff14148a88519eac..HEAD` — pass

After the branch was pushed, GitHub `main` advanced to `081a7bba7cef78b62b87a85f2cf72c2a53cf2cfb` via #89 (`Remove redundant test coverage`). That delta touches a disjoint set of test files; PR #90 currently reports mergeable=true, so no history rewrite/rebase was performed.

Closes #87.