### PR TITLE
Fix release preflight GitHub identity lookup

### DIFF
--- a/scripts/collect_release_bundle.py
+++ b/scripts/collect_release_bundle.py
@@ -131,8 +131,7 @@ class GitHubClient:
             },
         )
 
-    def fetch_json(self, suffix: str) -> dict:
-        url = self.api_url(suffix)
+    def _fetch_json_url(self, url: str) -> dict:
         try:
             with self.opener.open(self._request(url), timeout=self.timeout) as response:
                 length = _content_length(response.headers)
@@ -154,6 +153,12 @@ class GitHubClient:
         if not isinstance(value, dict):
             raise CollectionError(f"GitHub API returned a non-object: {url}")
         return value
+
+    def fetch_json(self, suffix: str) -> dict:
+        return self._fetch_json_url(self.api_url(suffix))
+
+    def fetch_authenticated_user(self) -> dict:
+        return self._fetch_json_url("https://api.github.com/user")
 
     def download_artifact_zip(
         self,

--- a/scripts/release_publication.py
+++ b/scripts/release_publication.py
@@ -206,7 +206,7 @@ def preflight_release(
     if npm_metadata is not None:
         raise PublicationError(f"npm package version already exists: {PACKAGE}@{release_version}")
 
-    github_user = client.fetch_json("/user").get("login")
+    github_user = client.fetch_authenticated_user().get("login")
     if not isinstance(github_user, str) or not github_user:
         raise PublicationError("GitHub publication identity is unavailable")
     npm_user = _run_capture(

--- a/scripts/tests/test_release_publication.py
+++ b/scripts/tests/test_release_publication.py
@@ -109,10 +109,50 @@ def _write_bundle(root: Path) -> dict:
     return release_build
 
 
+class _JsonResponse:
+    headers: dict[str, str] = {}
+
+    def __init__(self, payload: dict):
+        self.payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, _size=-1):
+        return self.payload
+
+
+class _RecordingOpener:
+    def __init__(self, payload: dict):
+        self.payload = payload
+        self.requests = []
+
+    def open(self, request, timeout):
+        self.requests.append((request, timeout))
+        return _JsonResponse(self.payload)
+
+
+class GitHubClientIdentityTests(unittest.TestCase):
+    def test_authenticated_user_uses_global_api_endpoint(self) -> None:
+        client = collector.GitHubClient(collector.DEFAULT_REPO, "fake-token", 5)
+        opener = _RecordingOpener({"login": "publisher"})
+        client.opener = opener
+
+        self.assertEqual(client.fetch_authenticated_user(), {"login": "publisher"})
+        self.assertEqual(client.api_url("/branches/main"), f"https://api.github.com/repos/{collector.DEFAULT_REPO}/branches/main")
+        self.assertEqual(len(opener.requests), 1)
+        request, timeout = opener.requests[0]
+        self.assertEqual(request.full_url, "https://api.github.com/user")
+        self.assertEqual(timeout, 5)
+
+
 class PreflightTests(unittest.TestCase):
     def test_preflight_requires_exact_versions_and_unused_namespaces(self) -> None:
         client = mock.Mock()
-        client.fetch_json.side_effect = lambda suffix: {"login": "publisher"} if suffix == "/user" else {}
+        client.fetch_authenticated_user.return_value = {"login": "publisher"}
         with mock.patch.object(publication, "_require_exact_clean_root"), mock.patch.object(
             publication, "_package_versions", return_value=(VERSION, VERSION)
         ), mock.patch.object(publication.collector, "resolve_github_token", return_value="fake"), mock.patch.object(
@@ -140,6 +180,7 @@ class PreflightTests(unittest.TestCase):
             ["npm", "whoami", "--registry", publication.NPM_REGISTRY], timeout=5
         )
         self.assertEqual(optional_json.call_count, 2)
+        client.fetch_authenticated_user.assert_called_once_with()
 
     def test_preflight_rejects_existing_local_tag(self) -> None:
         client = mock.Mock()


### PR DESCRIPTION
## Release blocker

A real `release_operator.py preflight` run for v0.3.8 failed because the authenticated-user lookup called `GitHubClient.fetch_json("/user")`. That client is intentionally repository-scoped, so the request became `/repos/yyjeqhc/webcodex/user` and returned 404.

## Fix

- keep repository-scoped `fetch_json()` behavior unchanged
- add a narrow `fetch_authenticated_user()` that uses the fixed global `https://api.github.com/user` endpoint while reusing the existing auth request and bounded JSON handling
- update release preflight to use that method
- add a concrete `GitHubClient` regression that records the actual request URL and verifies repo-scoped URLs remain unchanged

## Validation

- release tooling focused tests: 31 passed
- real OE authenticated-user probe through the fixed method resolves `yyjeqhc`
- canonical `bash scripts/release_check.sh`: all stages passed, including 40 release verification tooling self-tests

This PR changes no release version, tag, artifact, package namespace, or publication state.