### PR TITLE
Harden PowerShell runtime smoke timeout

### DIFF
--- a/crates/webcodex-runner/src/webcodex_runner/shell_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell_tests.rs
@@ -1113,7 +1113,9 @@ fn powershell_runtime_executes_from_file_when_available() {
             args: vec!["two words".to_string()],
         },
         None,
-        10,
+        // This smoke validates external PowerShell file execution, not timeout
+        // behavior. Allow cold pwsh startup under a loaded CI runner.
+        30,
         None,
         None,
     );


### PR DESCRIPTION
## Release-readiness failure

Exact-source release-readiness run `32151509099` for v0.3.8 failed in the full workspace suite with one Runner failure:

`webcodex_runner::shell::runner_lifecycle_tests::powershell_runtime_executes_from_file_when_available`

The test's external `pwsh` process hit its 10-second runtime deadline under the loaded GitHub runner. Runner result was otherwise 692 passed / 1 failed / 3 ignored.

## Fix

- increase only this test's external PowerShell smoke deadline from 10s to 30s
- document that the smoke verifies `.ps1` file execution/argv semantics, while timeout behavior is covered by separate tests
- no production runtime timeout or process semantics change

## Validation

- `cargo fmt --check`: passed
- focused Runner test: 1 passed on OE (OE has no pwsh, so the test follows its existing availability skip path)
- `git diff --check`: passed

This PR should run with the `run-ci` label so GitHub's pwsh-equipped Linux runner exercises the actual external interpreter path before a new release-readiness source is selected.