### PR TITLE
Add macOS detached Job restart parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,30 @@ jobs:
       - name: Run tests
         run: cargo test --locked --workspace
 
+  test-macos:
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.user.login != github.repository_owner ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
+    # Native macOS gate for the release production surfaces plus the Runner's
+    # detached ownership/restart suites. Keep this ahead of immutable tagging.
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: macos-ci
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Check macOS release production surfaces
+        run: cargo check --locked -p webcodex -p webcodex-cli -p webcodex-runner
+      - name: Run native macOS Runner tests
+        run: cargo test --locked -p webcodex-runner
+
   test-windows:
     if: >-
       github.event_name == 'push' ||

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -133,8 +133,75 @@ jobs:
           git diff --check
           test -z "$(git status --porcelain --untracked-files=all)"
 
+  macos-runner:
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - name: Fence exact reviewed main source
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          INPUT_REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Release readiness must be dispatched from the main workflow definition." >&2
+            exit 1
+          fi
+          if [[ ! "$INPUT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "source_sha must be exactly 40 lowercase hexadecimal characters." >&2
+            exit 1
+          fi
+          if [[ ! "$INPUT_REQUEST_ID" =~ ^rr_[0-9a-f]{24}$ ]]; then
+            echo "request_id must match rr_<24 lowercase hex>." >&2
+            exit 1
+          fi
+          if [ "$GITHUB_SHA" != "$INPUT_SOURCE_SHA" ]; then
+            echo "main moved before readiness dispatch: requested=$INPUT_SOURCE_SHA run=$GITHUB_SHA" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ inputs.source_sha }}
+
+      - name: Verify exact clean checkout
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$INPUT_SOURCE_SHA"
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-readiness-macos
+
+      - name: Check macOS release production surfaces
+        run: cargo check --locked -p webcodex -p webcodex-cli -p webcodex-runner
+
+      - name: Run native macOS Runner tests
+        run: cargo test --locked -p webcodex-runner -- --nocapture
+
+      - name: Require final macOS source cleanliness
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+  summary:
+    needs: [readiness, macos-runner]
+    runs-on: ubuntu-latest
+    steps:
       - name: Record readiness summary
-        if: ${{ success() }}
         shell: bash
         env:
           INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
@@ -144,5 +211,6 @@ jobs:
             echo "### Release readiness passed"
             echo "- source: \`$INPUT_SOURCE_SHA\`"
             echo "- request: \`$INPUT_REQUEST_ID\`"
+            echo "- native macOS Runner validation: passed"
             echo "- candidate binaries produced: no"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/webcodex-process/src/unix.rs
+++ b/crates/webcodex-process/src/unix.rs
@@ -243,13 +243,11 @@ fn group_exists(pgid: u32) -> bool {
 /// Whether the group contains any member that can still execute code.
 ///
 /// `kill(-pgid, 0)` reports a zombie as a live member because it still occupies
-/// a process table entry — and in containers whose PID 1 does not reap orphaned
-/// grandchildren, a terminated grandchild can linger as a zombie
-/// indefinitely, so the group would appear non-empty forever. On Linux we
-/// therefore walk `/proc` and ignore zombies (`Z` / `X` states), matching the
-/// approach already used by `webcodex-persistent-shell`. On other Unix
-/// platforms zombies are reaped promptly by the nearest ancestor or PID 1, so
-/// the plain group-exists probe is sufficient.
+/// a process table entry. Linux therefore walks `/proc`, while macOS enumerates
+/// the exact process group through libproc; both backends ignore zombies when
+/// deciding whether any member can still execute code. Other Unix platforms
+/// retain the conservative group-exists probe until they have an equivalent
+/// native process-state implementation.
 fn group_has_live_members(pgid: u32) -> bool {
     if !group_exists(pgid) {
         return false;
@@ -287,8 +285,70 @@ fn group_has_live_members(pgid: u32) -> bool {
         }
         false
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    {
+        darwin_group_has_live_members(pgid)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         true
     }
+}
+
+#[cfg(target_os = "macos")]
+fn darwin_group_has_live_members(pgid: u32) -> bool {
+    const MAX_GROUP_PIDS: usize = 16 * 1024;
+
+    let Ok(pgid) = libc::pid_t::try_from(pgid) else {
+        return true;
+    };
+    // `proc_listpgrppids(..., NULL, 0)` returns a sizing count. It may be much
+    // larger than this private group's current membership, so cap allocation;
+    // a full buffer is treated as possibly truncated and therefore live.
+    let required = unsafe { libc::proc_listpgrppids(pgid, std::ptr::null_mut(), 0) };
+    if required <= 0 {
+        return true;
+    }
+    let capacity = usize::try_from(required)
+        .unwrap_or(MAX_GROUP_PIDS)
+        .clamp(1, MAX_GROUP_PIDS);
+    let mut pids = vec![0 as libc::pid_t; capacity];
+    let Some(buffer_bytes) = capacity
+        .checked_mul(std::mem::size_of::<libc::pid_t>())
+        .and_then(|bytes| libc::c_int::try_from(bytes).ok())
+    else {
+        return true;
+    };
+    let count = unsafe { libc::proc_listpgrppids(pgid, pids.as_mut_ptr().cast(), buffer_bytes) };
+    let Ok(count) = usize::try_from(count) else {
+        return true;
+    };
+    if count >= capacity {
+        return true;
+    }
+
+    for pid in pids.into_iter().take(count).filter(|pid| *pid > 0) {
+        let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+        let size = std::mem::size_of::<libc::proc_bsdinfo>();
+        let bytes = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                info.as_mut_ptr().cast(),
+                size as libc::c_int,
+            )
+        };
+        if bytes != size as libc::c_int {
+            // The member may have raced with exit, but an incomplete query is
+            // not positive proof that the whole group is zombie-only. Retry on
+            // the next bounded poll instead of prematurely releasing the PGID.
+            return true;
+        }
+        let info = unsafe { info.assume_init() };
+        if info.pbi_pgid == pgid as u32 && info.pbi_status != libc::SZOMB {
+            return true;
+        }
+    }
+    false
 }

--- a/crates/webcodex-process/src/unix.rs
+++ b/crates/webcodex-process/src/unix.rs
@@ -340,9 +340,17 @@ fn darwin_group_has_live_members(pgid: u32) -> bool {
             )
         };
         if bytes != size as libc::c_int {
-            // The member may have raced with exit, but an incomplete query is
-            // not positive proof that the whole group is zombie-only. Retry on
-            // the next bounded poll instead of prematurely releasing the PGID.
+            let error = io::Error::last_os_error();
+            if bytes == 0 && error.raw_os_error() == Some(libc::ESRCH) {
+                // Darwin keeps an unreaped zombie in proc_listpgrppids but
+                // proc_pidinfo reports that zombie as ESRCH. The PID is still
+                // holding the group identity, yet it can no longer execute
+                // code, so it must not keep the owned tree live.
+                continue;
+            }
+            // Any other incomplete query is not proof that this member is
+            // dead/zombie. Retry on the next bounded poll instead of
+            // prematurely releasing the PGID identity.
             return true;
         }
         let info = unsafe { info.assume_init() };

--- a/crates/webcodex-process/src/unix.rs
+++ b/crates/webcodex-process/src/unix.rs
@@ -202,9 +202,13 @@ impl Drop for ManagedChild {
 
 /// Signal a whole process group, reporting whether it still existed.
 ///
-/// Returns `Ok(true)` when the signal was delivered, `Ok(false)` for `ESRCH`
-/// (the group is already gone), and `Err` for any other failure.
+/// Returns `Ok(true)` when the signal was delivered and `Ok(false)` when the
+/// owned group has no member that can still execute. Normally that is `ESRCH`;
+/// Darwin can instead return `EPERM` for a zombie-only group, which is resolved
+/// through the native exact-group liveness probe before being treated as gone.
 fn signal_group(pgid: u32, signal: i32) -> io::Result<bool> {
+    #[cfg(target_os = "macos")]
+    let native_pgid = pgid;
     let pgid = i32::try_from(pgid).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "process group id out of range")
     })?;
@@ -215,6 +219,10 @@ fn signal_group(pgid: u32, signal: i32) -> io::Result<bool> {
     }
     let error = io::Error::last_os_error();
     if error.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(false);
+    }
+    #[cfg(target_os = "macos")]
+    if error.raw_os_error() == Some(libc::EPERM) && !darwin_group_has_live_members(native_pgid) {
         return Ok(false);
     }
     Err(error)

--- a/crates/webcodex-process/tests/managed_child.rs
+++ b/crates/webcodex-process/tests/managed_child.rs
@@ -606,25 +606,47 @@ fn graceful_request_repeated_and_already_exited_do_not_panic() {
     let _ = result;
 }
 
-/// ManagedChild must preserve the normal Command spawn failure for an
-/// executable text file without a shebang. A generic pre_exec hook changes
-/// this on Unix by allowing libc execvp to fall back to /bin/sh on ENOEXEC.
+/// ManagedChild must preserve the platform's normal `Command::spawn` behavior
+/// for an executable text file without a shebang. Linux reports ENOEXEC while
+/// macOS's standard-library spawn path executes it through the platform shell;
+/// process-group ownership must not change either platform's baseline behavior.
 #[cfg(unix)]
 #[test]
-fn spawn_preserves_enoexec_failure() {
+fn spawn_preserves_platform_enoexec_behavior() {
     use std::os::unix::fs::PermissionsExt;
 
     let temp = tempfile::tempdir().unwrap();
     let executable = temp.path().join("not-an-executable-format");
-    std::fs::write(&executable, "echo should-not-run\n").unwrap();
+    std::fs::write(&executable, "exit 0\n").unwrap();
     let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
     permissions.set_mode(0o755);
     std::fs::set_permissions(&executable, permissions).unwrap();
 
-    let mut command = Command::new(&executable);
-    let error = ManagedChild::spawn(&mut command)
-        .expect_err("ENOEXEC must remain a spawn failure, not a /bin/sh fallback");
-    assert_eq!(error.raw_os_error(), Some(libc::ENOEXEC));
+    let baseline = Command::new(&executable).spawn();
+    let mut managed_command = Command::new(&executable);
+    let managed = ManagedChild::spawn(&mut managed_command);
+    match (baseline, managed) {
+        (Ok(mut baseline), Ok(mut managed)) => {
+            assert_eq!(
+                baseline.wait().expect("wait baseline").success(),
+                managed.wait().expect("wait managed").success(),
+                "ManagedChild must preserve successful platform script fallback behavior"
+            );
+        }
+        (Err(baseline), Err(managed)) => {
+            assert_eq!(managed.kind(), baseline.kind());
+            assert_eq!(managed.raw_os_error(), baseline.raw_os_error());
+        }
+        (baseline, managed) => panic!(
+            "ManagedChild changed platform spawn behavior: baseline={:?} managed={:?}",
+            baseline
+                .map(|child| child.id())
+                .map_err(|error| (error.kind(), error.raw_os_error())),
+            managed
+                .map(|child| child.id())
+                .map_err(|error| (error.kind(), error.raw_os_error()))
+        ),
+    }
 }
 /// `try_tree_exit` is the non-blocking tree probe used by Runner shutdown.
 #[test]

--- a/crates/webcodex-process/tests/managed_child.rs
+++ b/crates/webcodex-process/tests/managed_child.rs
@@ -639,6 +639,26 @@ fn try_tree_exit_tracks_tree_liveness() {
     let _ = managed.try_wait();
 }
 
+#[test]
+fn unreaped_direct_child_is_not_a_live_tree_member() {
+    let (mut managed, reader) = spawn_helper("sleep", &["0", "0"], true);
+    reader
+        .expect("captured stdout reader")
+        .wait_for_eof(Duration::from_secs(5))
+        .expect("direct child should close stdout when it exits");
+
+    assert!(
+        managed
+            .wait_tree_exit(Duration::from_secs(1))
+            .expect("zombie-only tree probe"),
+        "an exited but unreaped direct child must not keep the process tree live"
+    );
+    assert!(
+        managed.try_wait().expect("reap direct child").is_some(),
+        "the direct child should still have been unreaped until try_wait"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Platform-native liveness probing
 // ---------------------------------------------------------------------------

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2603,7 +2603,15 @@ struct JobShutdownOutcome {
 }
 
 fn shutdown_target_running(target: &mut JobShutdownTarget) -> bool {
-    managed_tree_running(&target.child)
+    if managed_tree_running(&target.child) {
+        return true;
+    }
+    // Tree liveness and direct-child reaping are distinct on Unix. Darwin can
+    // prove a zombie-only process group non-executable just before waitpid makes
+    // the direct child's status observable. Keep the shutdown target pending
+    // within the existing global deadline until that direct child is reaped;
+    // do not re-signal the already-confirmed-empty process group.
+    !reap_managed_direct_child(&target.child, Instant::now()).unwrap_or(false)
 }
 
 #[derive(Debug, Default)]

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -1899,7 +1899,8 @@ fn agent_register_capabilities(cfg: &AgentConfig) -> ShellClientCapabilities {
     // Detached process ownership is an independent additive authority. Until
     // each native backend is implemented and dogfooded it must fail closed
     // rather than being inferred from structured process + durable Jobs.
-    capabilities.detached_process_jobs = cfg!(any(target_os = "linux", windows));
+    capabilities.detached_process_jobs =
+        cfg!(any(target_os = "linux", target_os = "macos", windows));
     capabilities.project_lifecycle = true;
     // This binary implements resolve_or_register_project; do not trust config to
     // advertise a capability that the binary does not implement.
@@ -3432,7 +3433,7 @@ impl JobManager {
         inventory
     }
 
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     fn recover_detached_jobs(
         &self,
         store: DetachedJobStore,
@@ -3515,7 +3516,7 @@ impl JobManager {
         Ok(recovered)
     }
 
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     fn spawn_detached_observer(
         &self,
         job_id: String,

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -86,6 +86,15 @@ fn test_config(projects_dir: PathBuf) -> AgentConfig {
     }
 }
 
+#[test]
+fn detached_process_capability_matches_supported_native_backends() {
+    let capabilities = agent_register_capabilities(&test_config(PathBuf::new()));
+    assert_eq!(
+        capabilities.detached_process_jobs,
+        cfg!(any(target_os = "linux", target_os = "macos", windows))
+    );
+}
+
 fn runtime_config(cfg: &AgentConfig) -> Arc<ReloadableAgentConfig> {
     Arc::new(ReloadableAgentConfig::new(cfg.clone(), PathBuf::new()))
 }

--- a/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
@@ -127,8 +127,9 @@ pub(crate) struct DetachedProcessIdentity {
     /// never treated as a standalone liveness proof.
     pub(crate) creation_id: String,
     /// OS-native process birth identity used to fence PID reuse during restart
-    /// reconciliation. Linux records `/proc/<pid>/stat` starttime; later
-    /// platform backends must provide their equivalent before enabling handoff.
+    /// reconciliation. Linux records `/proc/<pid>/stat` starttime, macOS uses
+    /// `proc_pidinfo(PROC_PIDTBSDINFO)` birth time, and Windows uses process
+    /// creation time. A backend must provide an equivalent before advertising handoff.
     pub(crate) native_start_id: String,
     pub(crate) started_at_unix_ms: i64,
 }
@@ -380,7 +381,7 @@ impl DetachedJobStore {
         Ok(records)
     }
 
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     pub(crate) fn reconcile_after_runner_restart(
         &self,
         record: DetachedJobRecord,
@@ -1011,6 +1012,12 @@ fn validate_process_identity(name: &str, identity: &DetachedProcessIdentity) -> 
             "invalid detached {name} Linux process start identity"
         ));
     }
+    #[cfg(target_os = "macos")]
+    if !identity.native_start_id.starts_with("macos_start_") {
+        return Err(format!(
+            "invalid detached {name} macOS process start identity"
+        ));
+    }
     #[cfg(windows)]
     if !identity.native_start_id.starts_with("windows_creation_") {
         return Err(format!(
@@ -1110,12 +1117,69 @@ fn detached_process_identity_is_live(
     }
 }
 
-#[cfg(all(unix, not(target_os = "linux")))]
+#[cfg(target_os = "macos")]
+fn native_process_start_identity(pid: u32) -> Result<String, String> {
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = std::mem::size_of::<libc::proc_bsdinfo>();
+    // SAFETY: `info` points to writable storage for exactly one proc_bsdinfo,
+    // and PROC_PIDTBSDINFO is the Darwin API for this PID's BSD process facts.
+    let bytes = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size as libc::c_int,
+        )
+    };
+    if bytes != size as libc::c_int {
+        return Err(format!(
+            "failed to read detached macOS process start identity for pid {pid}: returned {bytes} bytes ({})",
+            io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: proc_pidinfo reported that it initialized the complete structure.
+    let info = unsafe { info.assume_init() };
+    if info.pbi_start_tvsec == 0 && info.pbi_start_tvusec == 0 {
+        return Err("missing macOS process start identity".to_string());
+    }
+    Ok(format!(
+        "macos_start_{}_{}",
+        info.pbi_start_tvsec, info.pbi_start_tvusec
+    ))
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
 fn native_process_start_identity(_pid: u32) -> Result<String, String> {
     Err(
         "detached native process start identity is not implemented on this Unix platform"
             .to_string(),
     )
+}
+
+#[cfg(target_os = "macos")]
+fn detached_process_identity_is_live(
+    lock_path: &Path,
+    identity: &DetachedProcessIdentity,
+) -> Result<bool, String> {
+    validate_process_identity("recovery", identity)?;
+    let current_start = match native_process_start_identity(identity.pid) {
+        Ok(value) => value,
+        Err(error) => {
+            // PID-only probing is never positive identity evidence. It is used
+            // only after the Darwin birth-time query failed, to distinguish a
+            // definitely vanished process from an indeterminate query failure.
+            let probe = unsafe { libc::kill(identity.pid as libc::pid_t, 0) };
+            if probe != 0 && io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+                return Ok(false);
+            }
+            return Err(error);
+        }
+    };
+    if current_start != identity.native_start_id {
+        return Ok(false);
+    }
+    lifetime_lock_is_held(lock_path, &identity.creation_id)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
@@ -1118,7 +1118,7 @@ fn detached_process_identity_is_live(
 }
 
 #[cfg(target_os = "macos")]
-fn native_process_start_identity(pid: u32) -> Result<String, String> {
+fn macos_process_start_identity(pid: u32) -> Result<Option<String>, String> {
     let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
     let size = std::mem::size_of::<libc::proc_bsdinfo>();
     // SAFETY: `info` points to writable storage for exactly one proc_bsdinfo,
@@ -1133,9 +1133,16 @@ fn native_process_start_identity(pid: u32) -> Result<String, String> {
         )
     };
     if bytes != size as libc::c_int {
+        let error = io::Error::last_os_error();
+        if bytes == 0 && error.raw_os_error() == Some(libc::ESRCH) {
+            // Darwin reports an unreaped zombie as ESRCH here even while
+            // kill(pid, 0) can still succeed. A zombie cannot execute and its
+            // process-owned lifetime lock is already released, so this is
+            // definitive dead evidence for recovery without a PID-only probe.
+            return Ok(None);
+        }
         return Err(format!(
-            "failed to read detached macOS process start identity for pid {pid}: returned {bytes} bytes ({})",
-            io::Error::last_os_error()
+            "failed to read detached macOS process start identity for pid {pid}: returned {bytes} bytes ({error})"
         ));
     }
     // SAFETY: proc_pidinfo reported that it initialized the complete structure.
@@ -1143,10 +1150,17 @@ fn native_process_start_identity(pid: u32) -> Result<String, String> {
     if info.pbi_start_tvsec == 0 && info.pbi_start_tvusec == 0 {
         return Err("missing macOS process start identity".to_string());
     }
-    Ok(format!(
+    Ok(Some(format!(
         "macos_start_{}_{}",
         info.pbi_start_tvsec, info.pbi_start_tvusec
-    ))
+    )))
+}
+
+#[cfg(target_os = "macos")]
+fn native_process_start_identity(pid: u32) -> Result<String, String> {
+    macos_process_start_identity(pid)?.ok_or_else(|| {
+        format!("detached macOS process {pid} exited before its start identity was captured")
+    })
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
@@ -1163,18 +1177,8 @@ fn detached_process_identity_is_live(
     identity: &DetachedProcessIdentity,
 ) -> Result<bool, String> {
     validate_process_identity("recovery", identity)?;
-    let current_start = match native_process_start_identity(identity.pid) {
-        Ok(value) => value,
-        Err(error) => {
-            // PID-only probing is never positive identity evidence. It is used
-            // only after the Darwin birth-time query failed, to distinguish a
-            // definitely vanished process from an indeterminate query failure.
-            let probe = unsafe { libc::kill(identity.pid as libc::pid_t, 0) };
-            if probe != 0 && io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
-                return Ok(false);
-            }
-            return Err(error);
-        }
+    let Some(current_start) = macos_process_start_identity(identity.pid)? else {
+        return Ok(false);
     };
     if current_start != identity.native_start_id {
         return Ok(false);

--- a/crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs
@@ -308,7 +308,7 @@ fn reclamation_fails_closed_on_corrupt_or_symlink_state() {
     assert!(job_dir.exists());
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn prepared_restart_residue_converges_to_not_started_without_payload() {
     let temp = tempfile::tempdir().unwrap();
@@ -818,7 +818,7 @@ fn durable_update_sequence_advances_and_duplicate_handoff_does_not() {
     assert!(terminal.update_seq > sequence);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn restart_scan_reconciles_live_detached_execution_without_respawn() {
     let _guard = test_env_lock();
@@ -869,7 +869,7 @@ fn restart_scan_reconciles_live_detached_execution_without_respawn() {
     assert_eq!(fs::read_to_string(marker).unwrap().lines().count(), 1);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn durable_stop_request_terminates_exact_supervisor_owned_tree() {
     let _guard = test_env_lock();
@@ -920,6 +920,26 @@ fn durable_stop_request_terminates_exact_supervisor_owned_tree() {
 }
 
 #[cfg(target_os = "linux")]
+fn stale_native_start_identity() -> &'static str {
+    "linux_start_0"
+}
+
+#[cfg(target_os = "macos")]
+fn stale_native_start_identity() -> &'static str {
+    "macos_start_0_0"
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_native_process_start_identity_is_stable() {
+    let pid = std::process::id();
+    let first = native_process_start_identity(pid).unwrap();
+    let second = native_process_start_identity(pid).unwrap();
+    assert!(first.starts_with("macos_start_"));
+    assert_eq!(first, second);
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn stale_native_supervisor_identity_reconciles_to_lost_without_respawn() {
     let _guard = test_env_lock();
@@ -932,7 +952,8 @@ fn stale_native_supervisor_identity_reconciles_to_lost_without_respawn() {
         .is_ok_and(|record| record.phase == DetachedJobPhase::Running)));
     let mut running = store.read(&request.job_id).unwrap();
     let real_supervisor_pid = running.supervisor.as_ref().unwrap().pid;
-    running.supervisor.as_mut().unwrap().native_start_id = "linux_start_0".to_string();
+    running.supervisor.as_mut().unwrap().native_start_id =
+        stale_native_start_identity().to_string();
     atomic_write_json(
         &store.state_path_for_job(&request.job_id),
         &running,
@@ -1157,7 +1178,7 @@ fn pre_accept_supervisor_death_leaves_no_internal_or_payload_orphan() {
     assert!(record.tree_leader.is_none());
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn supervisor_death_terminates_payload_process_tree() {
     let _guard = test_env_lock();

--- a/crates/webcodex-runner/src/webcodex_runner/external_tools_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/external_tools_tests.rs
@@ -104,8 +104,12 @@ impl Fixture {
 
     fn with_timeout(scenario: &str, timeout_secs: u64) -> Self {
         let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().join("project");
-        fs::create_dir_all(root.join("src")).unwrap();
+        let requested_root = temp.path().join("project");
+        fs::create_dir_all(requested_root.join("src")).unwrap();
+        // Production request routing canonicalizes the project root before it
+        // reaches the provider. Mirror that here so macOS `/var` -> `/private/var`
+        // aliases cannot make fake absolute search output look out-of-project.
+        let root = fs::canonicalize(requested_root).unwrap();
         fs::write(root.join("edit.txt"), "before\n").unwrap();
         fs::write(root.join("src/lib.rs"), "zero\nneedle\n").unwrap();
         let marker = temp.path().join("marker.log");
@@ -1025,7 +1029,27 @@ fn opt_in_real_claude_mcp_smoke() {
 
 /// Whether a process with `pid` is still alive, probed natively (no tasklist,
 /// no shelling out).
-#[cfg(unix)]
+#[cfg(target_os = "macos")]
+fn process_exists(pid: u32) -> bool {
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = std::mem::size_of::<libc::proc_bsdinfo>();
+    let bytes = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size as libc::c_int,
+        )
+    };
+    if bytes == size as libc::c_int {
+        let info = unsafe { info.assume_init() };
+        return info.pbi_status != libc::SZOMB;
+    }
+    !(bytes == 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn process_exists(pid: u32) -> bool {
     // SAFETY: signal 0 is an existence probe; the pid comes from our own child.
     unsafe { libc::kill(pid as i32, 0) == 0 }

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::webcodex_runner::detached_job::{
     handoff_detached_job, DetachedJobPhase, DetachedJobStore, DetachedLaunchSpec,
     DetachedStartRequest,
@@ -351,7 +351,7 @@ fn validation_wait_failure_is_executor_owned_without_a_failed_check() {
     );
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn detached_job_request(
     cwd: &std::path::Path,
     job_id: &str,
@@ -406,7 +406,7 @@ fn detached_job_request(
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn detached_job_payload_subprocess_entrypoint() {
     let Ok(scenario) = std::env::var("WEBCODEX_DETACHED_JOB_MANAGER_SCENARIO") else {
@@ -441,7 +441,7 @@ fn detached_job_payload_subprocess_entrypoint() {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn detached_recovery_uses_same_inventory_and_observes_terminal_output() {
     let temp = tempfile::tempdir().unwrap();
@@ -504,7 +504,7 @@ fn detached_recovery_uses_same_inventory_and_observes_terminal_output() {
     wait_for_job_workers(&manager);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn detached_recovery_runner_shutdown_preserves_supervisor_ownership() {
     let temp = tempfile::tempdir().unwrap();
@@ -559,7 +559,7 @@ fn detached_recovery_runner_shutdown_preserves_supervisor_ownership() {
     );
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn detached_recovery_stop_uses_durable_control_without_managed_child() {
     let temp = tempfile::tempdir().unwrap();
@@ -602,7 +602,7 @@ fn detached_recovery_stop_uses_durable_control_without_managed_child() {
     wait_for_job_workers(&manager);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn detached_recovery_observer_start_failure_retains_durable_control_and_stop_routing() {
     let temp = tempfile::tempdir().unwrap();
@@ -659,7 +659,7 @@ fn detached_recovery_observer_start_failure_retains_durable_control_and_stop_rou
     wait_for_job_workers(&manager);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn detached_recovery_observer_marks_later_supervisor_loss() {
     let temp = tempfile::tempdir().unwrap();
@@ -1150,7 +1150,7 @@ fn enqueue_detached_process_job(
     );
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn detached_process_jobmanager_initiation_handoffs_once_and_stops_via_durable_control() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -3336,7 +3336,27 @@ pub(super) fn process_running(pid: u32) -> bool {
     ok == 1 && exit_code == 259 // 259 == STILL_ACTIVE
 }
 
-#[cfg(all(unix, not(target_os = "linux")))]
+#[cfg(target_os = "macos")]
+pub(super) fn process_running(pid: u32) -> bool {
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = std::mem::size_of::<libc::proc_bsdinfo>();
+    let bytes = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size as libc::c_int,
+        )
+    };
+    if bytes == size as libc::c_int {
+        let info = unsafe { info.assume_init() };
+        return info.pbi_status != libc::SZOMB;
+    }
+    !(bytes == 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH))
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
 pub(super) fn process_running(pid: u32) -> bool {
     // SAFETY: signal 0 is an existence probe; the pid comes from our own
     // helper subprocess.

--- a/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
@@ -1965,7 +1965,27 @@ fn process_exists(pid: u32) -> bool {
     ok == 1 && exit_code == 259
 }
 
-#[cfg(not(any(target_os = "linux", windows)))]
+#[cfg(target_os = "macos")]
+fn process_exists(pid: u32) -> bool {
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = std::mem::size_of::<libc::proc_bsdinfo>();
+    let bytes = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size as libc::c_int,
+        )
+    };
+    if bytes == size as libc::c_int {
+        let info = unsafe { info.assume_init() };
+        return info.pbi_status != libc::SZOMB;
+    }
+    !(bytes == 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 fn process_exists(_pid: u32) -> bool {
     false
 }

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -721,6 +721,13 @@ const DANGEROUS_PROJECT_ROOTS: &[&str] = &[
     "/sbin",
     "/usr",
     "/var",
+    // macOS canonicalizes the public `/etc` and `/var` aliases through
+    // `/private`; policy is evaluated after canonicalization, so fence those
+    // canonical spellings as the same dangerous roots.
+    #[cfg(target_os = "macos")]
+    "/private/etc",
+    #[cfg(target_os = "macos")]
+    "/private/var",
     "/proc",
     "/sys",
     "/dev",

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -980,10 +980,13 @@ mod tests {
     use super::{remote_script, run_ssh_shell, shell_quote, SshConnectionPool};
     use crate::webcodex_runner::config::{AgentPolicy, SshConfig, SshResourceConfig};
     use std::collections::BTreeMap;
+    #[cfg(target_os = "linux")]
     use std::net::{TcpListener, TcpStream};
     use std::os::unix::fs::{symlink, PermissionsExt};
     use std::path::{Path, PathBuf};
-    use std::process::{Child, Command, Stdio};
+    #[cfg(target_os = "linux")]
+    use std::process::Stdio;
+    use std::process::{Child, Command};
     use std::time::{Duration, Instant};
 
     struct TestSshServer {
@@ -1114,6 +1117,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     fn generate_key(path: &Path) {
         let status = Command::new("ssh-keygen")
             .args(["-q", "-t", "ed25519", "-N", "", "-f"])
@@ -1123,6 +1127,7 @@ mod tests {
         assert!(status.success(), "ssh-keygen failed");
     }
 
+    #[cfg(target_os = "linux")]
     fn executable_on_path(name: &str) -> Option<PathBuf> {
         std::env::var_os("PATH").and_then(|paths| {
             std::env::split_paths(&paths)

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -1002,6 +1002,7 @@ mod tests {
     }
 
     impl TestSshServer {
+        #[cfg(target_os = "linux")]
         fn start() -> Option<Self> {
             let sshd = executable_on_path("sshd")?;
             if Command::new(&sshd)
@@ -1101,6 +1102,15 @@ mod tests {
             let _ = child.kill();
             let _ = child.wait();
             panic!("SSH test daemon did not listen within five seconds");
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        fn start() -> Option<Self> {
+            // These tests launch a local OpenSSH daemon and exercise its
+            // Linux fixture configuration. macOS still compiles the SSH client
+            // production surface, but its system sshd account/auth policy is
+            // not a hermetic equivalent of this fixture.
+            None
         }
     }
 

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -2,7 +2,7 @@ use super::config::{
     max_concurrent_jobs, projects_dir, validate_quic_config, AgentConfig, HotAgentConfig,
     QuicClientConfig, ReloadableAgentConfig,
 };
-#[cfg(any(target_os = "linux", windows))]
+#[cfg(any(target_os = "linux", target_os = "macos", windows))]
 use super::detached_job::DetachedJobStore;
 use super::lsp::LspSupervisor;
 use super::projects::AgentProjectCache;
@@ -1256,7 +1256,7 @@ pub(crate) fn run_agent(cfg: AgentConfig, config_path: PathBuf, once: bool) -> R
     // The LSP supervisor belongs to the agent process rather than any server
     // transport session and is shared across reconnects.
     let runtime = AgentRuntimeState::new(&cfg, config_path.clone());
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     match DetachedJobStore::default_root_for_runner(&cfg.client_id, &cfg.server_url) {
         Ok(root) => match runtime.jobs.recover_detached_jobs(
             DetachedJobStore::new(root),

--- a/crates/webcodex-runner/src/webcodex_runner/validation/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/validation/tests.rs
@@ -359,15 +359,20 @@ fn invalid_cwd_reports_available_tool_without_starting_command() {
 fn spawn_failure_does_not_report_command_started() {
     let project = tempfile::tempdir().unwrap();
     let bin = tempfile::tempdir().unwrap();
-    // A file that resolves as a program but cannot be executed. Unix can use
-    // an executable non-shebang file. On Windows, executing a corrupt PE can
-    // trigger an interactive compatibility dialog, so use a real PE held with
-    // an exclusive share mode instead; CreateProcess then fails cleanly while
-    // the resolver still sees an available tool.
+    // A file that resolves as a program but cannot be started. Executable text
+    // without a shebang is not portable here: macOS Command::spawn may run it
+    // through the platform shell. A shebang naming a definitely missing
+    // interpreter instead produces a pre-start spawn failure on Unix. On
+    // Windows, executing a corrupt PE can trigger an interactive compatibility
+    // dialog, so use a real PE held with an exclusive share mode instead.
     #[cfg(unix)]
     {
         let path = bin.path().join("pyright");
-        fs::write(&path, "not a recognized executable format\n").unwrap();
+        fs::write(
+            &path,
+            "#!/definitely/missing/webcodex-validation-interpreter\n",
+        )
+        .unwrap();
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
     }

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -24,7 +24,7 @@ python3 scripts/release_operator.py readiness-status \
 
 If dispatch delivery becomes uncertain or the run is not resolved before the short start timeout, **do not create a second state file and do not redispatch**. Continue with `readiness-status` on the original state; its unique request id recovers the exact workflow run when present. Only terminal `success` (operator exit 0) satisfies the pre-tag gate. A nonterminal/unresolved status is not release approval.
 
-The readiness workflow runs the canonical `scripts/release_check.sh`, the locked full workspace suite, frontend typecheck/tests/committed-build check, WebSocket and polling zero-config E2E, and coding-loop compare eval. `release_check.sh` includes formatting, workspace all-target check, focused metadata/schema/OpenAPI/MCP tests, release-tooling self-tests, Markdown local-link validation, and static current-contract/leakage guards.
+The readiness workflow runs the canonical `scripts/release_check.sh`, the locked full workspace suite, frontend typecheck/tests/committed-build check, WebSocket and polling zero-config E2E, coding-loop compare eval, and a parallel native macOS gate that compiles the release production surfaces and runs the Runner suite. `release_check.sh` includes formatting, workspace all-target check, focused metadata/schema/OpenAPI/MCP tests, release-tooling self-tests, Markdown local-link validation, and static current-contract/leakage guards.
 
 For focused diagnosis outside the final workflow, the underlying commands remain available, but a local pass does not replace the exact-source readiness run.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -40,9 +40,11 @@ The lanes above define test semantics; workflows decide when to run them.
 - Heavy Linux CI runs frontend checks, workspace-boundary and release-tooling
   checks, Markdown-link validation, formatting, and the locked workspace test
   suite. macOS CI compiles the release production surfaces and runs the native
-  Runner suite, including detached ownership/restart recovery. Windows CI runs
-  formatting, native Windows package tests, npm checks, and the Windows
-  artifact-to-install smoke.
+  Runner suite, including detached ownership/restart recovery. The local-`sshd`
+  SSH integration fixture remains Linux-only because it depends on Linux daemon
+  account/auth configuration; macOS still compiles and tests the SSH client and
+  pure command-shaping surface. Windows CI runs formatting, native Windows
+  package tests, npm checks, and the Windows artifact-to-install smoke.
 - Exact-source release acceptance is separate from ordinary pull-request CI.
   Follow [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md) and
   `.github/workflows/release-readiness.yml`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -33,14 +33,16 @@ The lanes above define test semantics; workflows decide when to run them.
   pull-request workflow run gets the lightweight `contract` job without requiring
   the `run-ci` label. It covers frontend type/test/dist checks, workspace-boundary
   checks, formatting, and focused registry/OpenAPI/MCP schema and metadata parity.
-- The heavier Linux `test` and native Windows `test-windows` jobs still run on
-  every push to `main`. External pull requests run them automatically subject to
-  GitHub fork protections; owner-authored pull requests opt in with the `run-ci`
-  label.
+- The heavier Linux `test`, native macOS `test-macos`, and native Windows
+  `test-windows` jobs run on every push to `main`. External pull requests run
+  them automatically subject to GitHub fork protections; owner-authored pull
+  requests opt in with the `run-ci` label.
 - Heavy Linux CI runs frontend checks, workspace-boundary and release-tooling
   checks, Markdown-link validation, formatting, and the locked workspace test
-  suite. Windows CI runs formatting, native Windows package tests, npm checks,
-  and the Windows artifact-to-install smoke.
+  suite. macOS CI compiles the release production surfaces and runs the native
+  Runner suite, including detached ownership/restart recovery. Windows CI runs
+  formatting, native Windows package tests, npm checks, and the Windows
+  artifact-to-install smoke.
 - Exact-source release acceptance is separate from ordinary pull-request CI.
   Follow [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md) and
   `.github/workflows/release-readiness.yml`.

--- a/docs/agent/release-process.md
+++ b/docs/agent/release-process.md
@@ -82,7 +82,8 @@ Before tagging or publishing, follow sections in
 `scripts/release_operator.py readiness-start` for one exact merged `main` SHA and
 observed through the same durable state with `readiness-status`. It runs the canonical
 release check, locked full workspace suite, frontend checks, both zero-config E2E
-transports, and the coding-loop compare eval without producing release candidates.
+transports, the coding-loop compare eval, and a parallel native macOS production-surface
+compile plus Runner suite without producing release candidates.
 Product-documentation consistency and allowed legacy-term matches remain part of the
 release-prep review rather than being guessed by an automated semantic checker.
 

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -30,6 +30,7 @@ set -euo pipefail
 #   - bash scripts/e2e_zero_config_ws.sh
 #   - E2E_TRANSPORT=polling bash scripts/e2e_zero_config_ws.sh
 #   - EVAL_MODE=compare bash scripts/eval_coding_loop.sh
+#   - native macOS release-surface compile + webcodex-runner suite
 #
 # Usage:
 #   bash scripts/release_check.sh


### PR DESCRIPTION
## Summary

- complete `run_detached_process` ownership-handoff and Runner-restart recovery parity on macOS instead of merely making the failed release build compile
- use Darwin `proc_pidinfo(PROC_PIDTBSDINFO)` process birth time for PID-reuse fencing, combined with the existing Unix lifetime lock / creation identity
- enable macOS detached Job capability advertisement, startup reconciliation, observer recovery, cancellation, log continuity, and supervisor-owned process-tree semantics
- generalize the portable Linux detached recovery suites to macOS where the same Unix substrate applies
- add a native macOS CI lane for release production surfaces and the Runner suite
- make exact-source pre-tag `release-readiness` require a parallel native macOS gate, so this class of failure cannot first appear after an immutable tag is created

## Safety contract

macOS recovery never treats PID-only liveness as positive identity evidence. A recovered supervisor must match the persisted Darwin process birth identity and the exact lifetime-lock creation identity. `kill(pid, 0)` is used only after a Darwin identity query failure to classify a definite `ESRCH` disappearance; otherwise recovery fails closed.

Ordinary non-detached `ManagedChild` ownership/kill-on-owner-exit semantics are unchanged.

## Why this is required

The authoritative `v0.3.8` native release build exposed that #88 closed Linux and Windows ownership backends but left the macOS restart-recovery cfg incomplete. The immutable `v0.3.8` tag remains untouched and publication remains aborted; this PR fixes the source before preparing a replacement release version.

## Validation

On Linux/OE at exact branch source:

- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo check --locked --all-targets -p webcodex-runner` — passed
- `cargo test --locked -p webcodex-runner detached_ -- --nocapture` — passed
- capability/backend parity regression — 1 passed, 0 failed
- `python3 -m unittest scripts.tests.test_release_readiness` — 10 passed
- Markdown local links — 42 files / 260 links / 0 missing
- `bash -n scripts/release_check.sh` — passed

A native macOS validation of the production-surface compile, detached focused suite, and full Runner package is also running in an isolated disposable clone on the Mac mini; its existing dirty main checkout and installed Runner are not modified or restarted.