### PR TITLE
Prepare WebCodex v0.3.9 release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing annotated release tag (v0.3.8) or verification tag (release-build-test-*)
+        description: Existing annotated release tag (v0.3.9) or verification tag (release-build-test-*)
         required: true
         type: string
       request_id:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "base64",
@@ -4818,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-admin"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "reqwest 0.12.28",
  "serde_json",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-agent-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "toml 0.8.23",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "fs2",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-persistent-shell"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "libc",
  "tempfile",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-process"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "libc",
  "tempfile",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-runner"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64",
  "chrono",
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-sandbox"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "landlock",
  "tempfile",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-workspace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/npm/webcodex/manifest.example.json
+++ b/npm/webcodex/manifest.example.json
@@ -1,25 +1,25 @@
 {
-  "version": "0.3.8",
+  "version": "0.3.9",
   "binaries": ["webcodex", "webcodex-server", "webcodex-runner"],
   "artifacts": {
     "linux-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-linux-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-linux-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "linux-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-linux-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-linux-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "darwin-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-darwin-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-darwin-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "win32-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-win32-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-win32-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "win32-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-win32-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-win32-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     }
   }

--- a/npm/webcodex/package.json
+++ b/npm/webcodex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yyjeqhc/webcodex",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Thin npm installer/wrapper for WebCodex native binaries.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/npm/webcodex/test/self-test.js
+++ b/npm/webcodex/test/self-test.js
@@ -209,7 +209,7 @@ async function expectInstallFailure(action, destination, tempRoot, pattern) {
 }
 
 async function main() {
-  assert.strictEqual(packageJson.version, "0.3.8");
+  assert.strictEqual(packageJson.version, "0.3.9");
   assert.deepStrictEqual(packageJson.bin, { webcodex: "bin/webcodex.js" });
   assert.deepStrictEqual(install.RUNTIME_BINARIES, ["webcodex", "webcodex-server", "webcodex-runner"]);
   assert.deepStrictEqual(install.SUPPORTED_PLATFORM_KEYS, ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"]);


### PR DESCRIPTION
## Summary

Prepare WebCodex `v0.3.9` as the replacement release after the immutable `v0.3.8` candidate build exposed the macOS detached-Job lifecycle gap. The `v0.3.8` tag remains untouched and was never published as a GitHub Release or npm version.

This PR only synchronizes release metadata from `0.3.8` to `0.3.9`; product/runtime fixes are already reviewed and merged on `main` through PR #101.

## Release highlights

- full detached Job ownership-handoff and Runner-restart recovery parity across Linux, macOS, and Windows
- Darwin PID-reuse fencing using native process birth identity plus lifetime-lock identity
- Darwin-correct process-group liveness/termination that does not treat zombie-only groups as executable trees
- native macOS PR CI and exact-source pre-tag release-readiness coverage, closing the validation gap that allowed the failed `v0.3.8` native build
- all other changes intended for the aborted `v0.3.8` release remain included in this replacement release

## Compatibility / upgrade notes

- No published `v0.3.8` GitHub Release or npm package needs migration; `v0.3.9` is the next publishable version.
- Existing Linux and Windows detached Job semantics are preserved; macOS now advertises and implements the same restart-recovery capability.
- The failed `v0.3.8` annotated tag is retained as immutable release audit evidence and is not reused or moved.

## Release metadata

- workspace package version: `0.3.9`
- local WebCodex `Cargo.lock` package versions: `0.3.9` only; no third-party dependency drift
- npm package / manifest example / self-test: `0.3.9`
- release-build input example: `v0.3.9`

## Focused validation

- `cargo check --all-targets -p webcodex` — passed
- `npm test --prefix npm/webcodex` — passed
- release publication/readiness/collector tooling tests — 31 passed
- Markdown local links — 42 files / 260 links / 0 missing
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

No merge, tag, release-readiness dispatch, GitHub Release publication, npm publication, or deployment is part of this PR.