### PR TITLE
Reduce model-facing tool context

### DIFF
--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -20,6 +20,11 @@ selectors.
   instructions, `work_on_project(include_project_instructions=false)` omits their
   bodies from that bootstrap response. WebCodex still observes the instruction
   files and records current instruction metadata for the resulting Workflow Session.
+- When the caller's current model context already retains the built-in WebCodex
+  coding-workflow guidance, `work_on_project(include_workflow_guidance=false)`
+  omits that static `workflow` section from the response. This is projection-only:
+  it does not change Workflow Session state, authority, role selection, or execution
+  semantics.
 - `work_on_project` success output is sparse by default. Omitted default sections
   mean no Session execution defaults, ordinary existing-project resolution, the
   intentionally skipped repository overview, pass/non-blocking readiness, no

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -20,6 +20,13 @@ selectors.
   instructions, `work_on_project(include_project_instructions=false)` omits their
   bodies from that bootstrap response. WebCodex still observes the instruction
   files and records current instruction metadata for the resulting Workflow Session.
+- `work_on_project` success output is sparse by default. Omitted default sections
+  mean no Session execution defaults, ordinary existing-project resolution, the
+  intentionally skipped repository overview, pass/non-blocking readiness, no
+  noteworthy Jobs, or empty blockers/warnings. Instruction sources always keep
+  path/fingerprint identity; false/null/empty body-projection fields are omitted.
+  Positive warnings, blockers, truncation, non-default resolution, and noteworthy
+  Job state remain explicit.
 - Use `start_coding_task` when you need its advanced continuity controls, such
   as exact `resume_session_id` or deliberate `new_session=true` isolation.
 - Choose behavioral roles in the **task instruction**. For implementation work,

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -16,6 +16,10 @@ selectors.
 
 - Use `work_on_project` for the normal coding bootstrap. Its task `instruction`
   is the natural place to state what the agent should do.
+- When the caller's current model context already retains the applicable repository
+  instructions, `work_on_project(include_project_instructions=false)` omits their
+  bodies from that bootstrap response. WebCodex still observes the instruction
+  files and records current instruction metadata for the resulting Workflow Session.
 - Use `start_coding_task` when you need its advanced continuity controls, such
   as exact `resume_session_id` or deliberate `new_session=true` isolation.
 - Choose behavioral roles in the **task instruction**. For implementation work,

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -14,6 +14,10 @@ project-local instructions；它们不是 role selector。
 
 - 普通 coding bootstrap 优先用 `work_on_project`；它的 task `instruction` 正是描述模型
   应该做什么的自然位置。
+- 如果 caller 当前的模型上下文已经保留适用的 repository instructions，可使用
+  `work_on_project(include_project_instructions=false)` 省略本轮 bootstrap response 中的
+  instruction 正文。WebCodex 仍会观察这些文件，并为本次 bootstrap 对应的 Workflow
+  Session 记录当前的 instruction metadata。
 - 需要精确 `resume_session_id`、显式 `new_session=true` 隔离等高级 continuity 控制时，
   使用 `start_coding_task`。
 - behavioral role 由 **task instruction** 显式选择。实现任务明确写使用

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -18,6 +18,10 @@ project-local instructions；它们不是 role selector。
   `work_on_project(include_project_instructions=false)` 省略本轮 bootstrap response 中的
   instruction 正文。WebCodex 仍会观察这些文件，并为本次 bootstrap 对应的 Workflow
   Session 记录当前的 instruction metadata。
+- 如果 caller 当前模型上下文已经保留 WebCodex 内置 coding-workflow guidance，可使用
+  `work_on_project(include_workflow_guidance=false)` 省略 response 中静态的 `workflow`
+  section。这只控制 model-facing projection，不改变 Workflow Session state、authority、
+  role selection 或 execution semantics。
 - `work_on_project` 的成功输出默认采用 sparse projection。省略的默认 section 表示：没有
   Session execution defaults、普通已有 project 的解析没有特殊事件、repository overview
   按设计未请求、readiness 为 pass/non-blocking、没有值得报告的 Job，或 blockers/warnings

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -18,6 +18,12 @@ project-local instructions；它们不是 role selector。
   `work_on_project(include_project_instructions=false)` 省略本轮 bootstrap response 中的
   instruction 正文。WebCodex 仍会观察这些文件，并为本次 bootstrap 对应的 Workflow
   Session 记录当前的 instruction metadata。
+- `work_on_project` 的成功输出默认采用 sparse projection。省略的默认 section 表示：没有
+  Session execution defaults、普通已有 project 的解析没有特殊事件、repository overview
+  按设计未请求、readiness 为 pass/non-blocking、没有值得报告的 Job，或 blockers/warnings
+  为空。Instruction source 始终保留 path/fingerprint identity；false/null/empty 的正文投影
+  字段会省略。真实 warning、blocker、truncation、非默认 project resolution 和值得报告的
+  Job state 仍会显式返回。
 - 需要精确 `resume_session_id`、显式 `new_session=true` 隔离等高级 continuity 控制时，
   使用 `start_coding_task`。
 - behavioral role 由 **task instruction** 显式选择。实现任务明确写使用

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -71,9 +71,17 @@ async fn local_coding_tools_list_returns_exact_ordered_surface() {
         .expect("local_coding work_on_project");
     let schema = &work["inputSchema"];
     let props = schema["properties"].as_object().unwrap();
-    for field in ["project", "client_id", "path", "instruction", "session_id"] {
+    for field in [
+        "project",
+        "client_id",
+        "path",
+        "instruction",
+        "include_project_instructions",
+        "session_id",
+    ] {
         assert!(props.contains_key(field), "local_coding missing {field}");
     }
+    assert_eq!(props["include_project_instructions"]["default"], true);
     assert_eq!(schema["required"], json!(["instruction"]));
     assert_eq!(schema["additionalProperties"], false);
     assert!(schema.get("oneOf").is_none());

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -77,11 +77,13 @@ async fn local_coding_tools_list_returns_exact_ordered_surface() {
         "path",
         "instruction",
         "include_project_instructions",
+        "include_workflow_guidance",
         "session_id",
     ] {
         assert!(props.contains_key(field), "local_coding missing {field}");
     }
     assert_eq!(props["include_project_instructions"]["default"], true);
+    assert_eq!(props["include_workflow_guidance"]["default"], true);
     assert_eq!(schema["required"], json!(["instruction"]));
     assert_eq!(schema["additionalProperties"], false);
     assert!(schema.get("oneOf").is_none());

--- a/src/mcp_tests/runtime_tools.rs
+++ b/src/mcp_tests/runtime_tools.rs
@@ -72,11 +72,13 @@ async fn mcp_tools_list_exposes_coding_task_and_runtime_status_ux_flags() {
         "path",
         "instruction",
         "include_project_instructions",
+        "include_workflow_guidance",
         "session_id",
     ] {
         assert!(work_props.contains_key(field), "MCP schema missing {field}");
     }
     assert_eq!(work_props["include_project_instructions"]["default"], true);
+    assert_eq!(work_props["include_workflow_guidance"]["default"], true);
     assert_eq!(work_schema["required"], json!(["instruction"]));
     assert_eq!(work_schema["additionalProperties"], false);
     for keyword in [

--- a/src/mcp_tests/runtime_tools.rs
+++ b/src/mcp_tests/runtime_tools.rs
@@ -66,9 +66,17 @@ async fn mcp_tools_list_exposes_coding_task_and_runtime_status_ux_flags() {
         !work_props.contains_key("role"),
         "work_on_project must not grow a role wire field"
     );
-    for field in ["project", "client_id", "path", "instruction", "session_id"] {
+    for field in [
+        "project",
+        "client_id",
+        "path",
+        "instruction",
+        "include_project_instructions",
+        "session_id",
+    ] {
         assert!(work_props.contains_key(field), "MCP schema missing {field}");
     }
+    assert_eq!(work_props["include_project_instructions"]["default"], true);
     assert_eq!(work_schema["required"], json!(["instruction"]));
     assert_eq!(work_schema["additionalProperties"], false);
     for keyword in [

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -1542,6 +1542,19 @@ fn openapi_retained_edit_tools_remain_runtime_only() {
 }
 
 #[test]
+fn openapi_work_on_project_example_keeps_instruction_bodies_by_default() {
+    let spec = build_openapi_spec();
+    let example = &spec["paths"]["/api/tools/call"]["post"]["requestBody"]["content"]
+        ["application/json"]["examples"]["workOnAbsolutePath"]["value"];
+    assert_eq!(example["tool"], "work_on_project");
+    assert_eq!(example["instruction"], "Complete the development task");
+    assert!(
+        example.get("include_project_instructions").is_none(),
+        "the generic first-use work_on_project example must preserve the default instruction-body projection"
+    );
+}
+
+#[test]
 fn openapi_call_runtime_tool_examples_cover_alias_and_no_params() {
     // Phase 2: callRuntimeTool examples should demonstrate the arguments
     // alias and the argument-less (params omitted) shapes so a custom GPT

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -1542,8 +1542,15 @@ fn openapi_retained_edit_tools_remain_runtime_only() {
 }
 
 #[test]
-fn openapi_work_on_project_example_keeps_instruction_bodies_by_default() {
+fn openapi_work_on_project_example_keeps_first_use_projection_defaults() {
     let spec = build_openapi_spec();
+    let request_properties = spec["components"]["schemas"]["ToolCallRequest"]["properties"]
+        .as_object()
+        .expect("ToolCallRequest properties");
+    assert!(
+        request_properties.contains_key("include_workflow_guidance"),
+        "flattened OpenAPI ToolCallRequest must expose include_workflow_guidance"
+    );
     let example = &spec["paths"]["/api/tools/call"]["post"]["requestBody"]["content"]
         ["application/json"]["examples"]["workOnAbsolutePath"]["value"];
     assert_eq!(example["tool"], "work_on_project");
@@ -1551,6 +1558,10 @@ fn openapi_work_on_project_example_keeps_instruction_bodies_by_default() {
     assert!(
         example.get("include_project_instructions").is_none(),
         "the generic first-use work_on_project example must preserve the default instruction-body projection"
+    );
+    assert!(
+        example.get("include_workflow_guidance").is_none(),
+        "the generic first-use work_on_project example must preserve the default workflow-guidance projection"
     );
 }
 

--- a/src/runtime_http/tests/project_files_tests.rs
+++ b/src/runtime_http/tests/project_files_tests.rs
@@ -154,7 +154,7 @@ async fn dedicated_read_project_file_without_session_id_succeeds() {
     let body: Value = resp.take_json().await.unwrap();
     assert_eq!(body["success"], true);
     assert_eq!(body["output"]["text"], "hello");
-    assert_eq!(body["output"]["format"], "plain");
+    assert!(body["output"].get("format").is_none());
     assert!(body["output"].get("session_recorded").is_none());
 }
 

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -86,6 +86,7 @@ enum CodingProjectSource {
 struct CodingStartupOptions {
     detail: StartupDetail,
     include_repository_overview: bool,
+    include_project_instructions: bool,
 }
 
 impl CodingStartupOptions {
@@ -93,13 +94,15 @@ impl CodingStartupOptions {
         Self {
             detail,
             include_repository_overview: true,
+            include_project_instructions: true,
         }
     }
 
-    fn work_on_project() -> Self {
+    fn work_on_project(include_project_instructions: bool) -> Self {
         Self {
             detail: StartupDetail::Standard,
             include_repository_overview: false,
+            include_project_instructions,
         }
     }
 }
@@ -1106,6 +1109,7 @@ impl ToolRuntime {
             instructions: &project_instructions,
             previous_instructions,
             force_instruction_load,
+            include_project_instructions: startup.include_project_instructions,
             git: &git,
             semantic_navigation: &semantic_navigation,
             repository: &repository_overview,
@@ -1141,6 +1145,7 @@ impl ToolRuntime {
         path: Option<String>,
         instruction: String,
         session_id: Option<String>,
+        include_project_instructions: bool,
         auth: Option<&AuthContext>,
         transport: SessionTransport,
         window: Option<&crate::client_window::ClientWindow>,
@@ -1211,7 +1216,7 @@ impl ToolRuntime {
                 SessionMode::Normal,
                 false,
                 false,
-                CodingStartupOptions::work_on_project(),
+                CodingStartupOptions::work_on_project(include_project_instructions),
                 session_id.clone(),
                 false,
                 new_session,

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -1146,6 +1146,7 @@ impl ToolRuntime {
         instruction: String,
         session_id: Option<String>,
         include_project_instructions: bool,
+        include_workflow_guidance: bool,
         auth: Option<&AuthContext>,
         transport: SessionTransport,
         window: Option<&crate::client_window::ClientWindow>,
@@ -1241,7 +1242,11 @@ impl ToolRuntime {
         } else {
             project
         };
-        project_work_on_project_output(projected_project, result.output)
+        project_work_on_project_output_with_workflow(
+            projected_project,
+            result.output,
+            include_workflow_guidance,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2069,7 +2074,16 @@ fn is_default_work_on_project_repository(repository: &Value) -> bool {
 /// Convert a successful `start_coding_task` result into the compact
 /// `work_on_project` contract. The delegated call may already have changed
 /// Session state, so protocol drift fails closed with `state_changed=true`.
+#[cfg(test)]
 pub(crate) fn project_work_on_project_output(project: String, output: Value) -> ToolResult {
+    project_work_on_project_output_with_workflow(project, output, true)
+}
+
+pub(crate) fn project_work_on_project_output_with_workflow(
+    project: String,
+    output: Value,
+    include_workflow_guidance: bool,
+) -> ToolResult {
     let permission = output.get("permission").cloned();
     let Some(brief) = startup_brief_from_output(&output) else {
         return work_on_project_projection_failed(
@@ -2208,10 +2222,12 @@ pub(crate) fn project_work_on_project_output(project: String, output: Value) -> 
         "resolved_project": projection.project.resolved_id,
         "continuation": projection.session.continuation,
         "workspace": workspace,
-        "workflow": projection.workflow,
         "instructions": instructions,
         "semantic_navigation": semantic_navigation,
     }));
+    if include_workflow_guidance {
+        result.output["workflow"] = projection.workflow;
+    }
     if !project_resolution_is_default {
         result.output["project_resolution"] = json!(projection.project_resolution);
     }

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -1966,6 +1966,106 @@ struct WorkOnProjectStartupVerdictProjection {
     suggested_next_actions: Vec<String>,
 }
 
+fn sparse_work_on_project_instruction_source(
+    source: WorkOnProjectInstructionSourceProjection,
+) -> Value {
+    let WorkOnProjectInstructionSourceProjection {
+        path,
+        fingerprint,
+        truncated,
+        headings,
+        content,
+        read_more,
+    } = source;
+    let mut projected = json!({
+        "path": path,
+        "fingerprint": fingerprint,
+    });
+    if truncated {
+        projected["truncated"] = json!(true);
+    }
+    if let Some(content) = content.0 {
+        if !headings.is_empty() {
+            projected["headings"] = json!(headings);
+        }
+        projected["content"] = json!(content);
+    }
+    if let Some(read_more) = read_more.0 {
+        projected["read_more"] = json!(read_more);
+    }
+    projected
+}
+
+fn sparse_work_on_project_workspace(workspace: WorkOnProjectWorkspaceProjection) -> Value {
+    let WorkOnProjectWorkspaceProjection {
+        status,
+        git_available,
+        branch,
+        head,
+        clean,
+        conflicts,
+    } = workspace;
+    let status_unavailable = status == "unavailable";
+    let mut projected = json!({"status": status});
+    if git_available.0 == Some(false) {
+        projected["git_available"] = json!(false);
+    }
+    if let Some(branch) = branch.0 {
+        projected["branch"] = json!(branch);
+    }
+    if let Some(head) = head.0 {
+        projected["head"] = json!(head);
+    }
+    if status_unavailable {
+        if let Some(clean) = clean.0 {
+            projected["clean"] = json!(clean);
+        }
+    }
+    if conflicts > 0 {
+        projected["conflicts"] = json!(conflicts);
+    }
+    projected
+}
+
+fn sparse_work_on_project_jobs(jobs: WorkOnProjectJobsProjection) -> Option<Value> {
+    let mut projected = json!({});
+    for (key, count) in [
+        ("active_count", jobs.active_count),
+        ("blocking_active_count", jobs.blocking_active_count),
+        ("nonblocking_active_count", jobs.nonblocking_active_count),
+        ("recovering_count", jobs.recovering_count),
+        ("terminal_pending_count", jobs.terminal_pending_count),
+    ] {
+        if count > 0 {
+            projected[key] = json!(count);
+        }
+    }
+    if jobs.latest_status != "not_observed" {
+        projected["latest_status"] = json!(jobs.latest_status);
+    }
+    projected.as_object().filter(|object| !object.is_empty())?;
+    Some(projected)
+}
+
+fn is_default_work_on_project_resolution(
+    resolution: &ProjectResolutionMetadata,
+    resolved_project: &str,
+) -> bool {
+    resolution.source == "project"
+        && resolution.outcome == "resolved_existing_project"
+        && resolution.resolved_project == resolved_project
+        && !resolution.registered
+}
+
+fn is_default_work_on_project_repository(repository: &Value) -> bool {
+    repository.as_object().is_some_and(|object| {
+        object.len() == 2
+            && repository.get("status").and_then(Value::as_str) == Some("unavailable")
+            && repository.get("reason_code").and_then(Value::as_str)
+                == Some(REPOSITORY_OVERVIEW_NOT_REQUESTED_REASON)
+    })
+}
+
 /// Convert a successful `start_coding_task` result into the compact
 /// `work_on_project` contract. The delegated call may already have changed
 /// Session state, so protocol drift fails closed with `state_changed=true`.
@@ -2053,16 +2153,48 @@ pub(crate) fn project_work_on_project_output(project: String, output: Value) -> 
     } else {
         projection.startup_verdict.suggested_next_actions
     };
+    let generic_begin_action_only = suggested_next_actions.len() == 1
+        && suggested_next_actions[0] == "begin the requested coding task";
+    let project_resolution_is_default = is_default_work_on_project_resolution(
+        &projection.project_resolution,
+        &projection.project.resolved_id,
+    );
+    let repository_is_default = is_default_work_on_project_repository(&projection.repository);
+    let execution_context_is_empty = projection.session.execution_context.is_empty();
+    let jobs = sparse_work_on_project_jobs(projection.continuation.jobs);
+    let workspace = sparse_work_on_project_workspace(projection.workspace);
+
+    let WorkOnProjectInstructionsProjection {
+        status,
+        sources,
+        changed_sources,
+        content_included,
+        truncated,
+        total_chars,
+    } = projection.instructions;
     let mut instructions = json!({
-        "status": projection.instructions.status,
-        "sources": projection.instructions.sources,
-        "content_included": projection.instructions.content_included,
-        "truncated": projection.instructions.truncated,
-        "total_chars": projection.instructions.total_chars,
+        "status": status,
+        "sources": sources
+            .into_iter()
+            .map(sparse_work_on_project_instruction_source)
+            .collect::<Vec<_>>(),
     });
-    if let Some(changed_sources) = projection.instructions.changed_sources {
+    if changed_sources
+        .as_ref()
+        .is_some_and(|sources| !sources.is_empty())
+    {
         instructions["changed_sources"] = json!(changed_sources);
     }
+    if content_included {
+        instructions["content_included"] = json!(true);
+    }
+    if truncated {
+        instructions["truncated"] = json!(true);
+        if total_chars > 0 {
+            instructions["total_chars"] = json!(total_chars);
+        }
+    }
+
     let semantic_navigation = json!({
         "supported": projection.semantic_navigation.supported,
         "available": projection.semantic_navigation.available,
@@ -2074,39 +2206,39 @@ pub(crate) fn project_work_on_project_output(project: String, output: Value) -> 
         "session_id": projection.session.session_id,
         "project": project,
         "resolved_project": projection.project.resolved_id,
-        "project_resolution": projection.project_resolution,
         "continuation": projection.session.continuation,
-        "execution_context": projection.session.execution_context,
-        "readiness": {
-            "status": projection.startup_verdict.status,
-            "blocking": projection.startup_verdict.blocking,
-        },
-        "workspace": {
-            "status": projection.workspace.status,
-            "git_available": projection.workspace.git_available,
-            "branch": projection.workspace.branch,
-            "head": projection.workspace.head,
-            "clean": projection.workspace.clean,
-            "conflicts": projection.workspace.conflicts,
-        },
+        "workspace": workspace,
         "workflow": projection.workflow,
-        "repository": projection.repository,
         "instructions": instructions,
         "semantic_navigation": semantic_navigation,
-        "jobs": {
-            "active_count": projection.continuation.jobs.active_count,
-            "blocking_active_count": projection.continuation.jobs.blocking_active_count,
-            "nonblocking_active_count": projection.continuation.jobs.nonblocking_active_count,
-            "recovering_count": projection.continuation.jobs.recovering_count,
-            "terminal_pending_count": projection.continuation.jobs.terminal_pending_count,
-            "latest_status": projection.continuation.jobs.latest_status,
-        },
-        "blockers": projection.blockers,
-        "warnings": projection.warnings,
-        "suggested_next_actions": suggested_next_actions,
-        "deterministic": true,
-        "llm_summary": false,
     }));
+    if !project_resolution_is_default {
+        result.output["project_resolution"] = json!(projection.project_resolution);
+    }
+    if !execution_context_is_empty {
+        result.output["execution_context"] = json!(projection.session.execution_context);
+    }
+    if projection.startup_verdict.status != "pass" || projection.startup_verdict.blocking {
+        result.output["readiness"] = json!({
+            "status": projection.startup_verdict.status,
+            "blocking": projection.startup_verdict.blocking,
+        });
+    }
+    if !repository_is_default {
+        result.output["repository"] = projection.repository;
+    }
+    if let Some(jobs) = jobs {
+        result.output["jobs"] = jobs;
+    }
+    if !projection.blockers.is_empty() {
+        result.output["blockers"] = json!(projection.blockers);
+    }
+    if !projection.warnings.is_empty() {
+        result.output["warnings"] = json!(projection.warnings);
+    }
+    if !suggested_next_actions.is_empty() && !generic_begin_action_only {
+        result.output["suggested_next_actions"] = json!(suggested_next_actions);
+    }
     if let Some(permission) = permission {
         result.output["permission"] = permission;
     }

--- a/src/tool_runtime/coding_task_tools.rs
+++ b/src/tool_runtime/coding_task_tools.rs
@@ -53,6 +53,7 @@ impl ToolRuntime {
                 path,
                 instruction,
                 include_project_instructions,
+                include_workflow_guidance,
                 session_id,
             } => {
                 self.work_on_project(
@@ -62,6 +63,7 @@ impl ToolRuntime {
                     instruction,
                     session_id,
                     include_project_instructions,
+                    include_workflow_guidance,
                     auth,
                     transport,
                     window,

--- a/src/tool_runtime/coding_task_tools.rs
+++ b/src/tool_runtime/coding_task_tools.rs
@@ -52,6 +52,7 @@ impl ToolRuntime {
                 client_id,
                 path,
                 instruction,
+                include_project_instructions,
                 session_id,
             } => {
                 self.work_on_project(
@@ -60,6 +61,7 @@ impl ToolRuntime {
                     path,
                     instruction,
                     session_id,
+                    include_project_instructions,
                     auth,
                     transport,
                     window,

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -57,6 +57,75 @@ pub(super) fn decorate_structured_execution_prestart_denial(
     result.output = Value::Object(output);
 }
 
+/// Remove facts that are fully implied by a successful synchronous terminal
+/// structured execution, but only after the complete ToolResult has already
+/// been recorded into the Session ledger. Failure/uncertain/Job projections
+/// remain explicit because they participate in retry and reconciliation safety.
+fn sparsify_terminal_structured_execution_success(tool_name: &str, result: &mut ToolResult) {
+    if !matches!(tool_name, "run_process" | "run_script") || !result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object_mut() else {
+        return;
+    };
+    let terminal_success = output.get("execution_state").and_then(Value::as_str)
+        == Some("completed")
+        && output.get("command_started").and_then(Value::as_bool) == Some(true)
+        && output.get("command_completed").and_then(Value::as_bool) == Some(true)
+        && output.get("command_ok").and_then(Value::as_bool) == Some(true)
+        && output.get("promoted_to_job").and_then(Value::as_bool) == Some(false)
+        && output.get("terminal").and_then(Value::as_bool) == Some(true)
+        && output.get("job_id").map(Value::is_null).unwrap_or(true)
+        && output.get("job_status").map(Value::is_null).unwrap_or(true)
+        && output
+            .get("observation_token")
+            .map(Value::is_null)
+            .unwrap_or(true);
+    if !terminal_success {
+        return;
+    }
+
+    for key in [
+        "promoted_to_job",
+        "terminal",
+        "job_id",
+        "job_status",
+        "observation_token",
+        "effective_timeout_secs",
+        "sync_wait_secs",
+    ] {
+        output.remove(key);
+    }
+    if output
+        .get("async_handoff_available")
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        output.remove("async_handoff_available");
+    }
+    if output.get("failure_kind").is_some_and(Value::is_null) {
+        output.remove("failure_kind");
+    }
+    if output.get("tool_failure").and_then(Value::as_bool) == Some(false) {
+        output.remove("tool_failure");
+    }
+    for key in ["stdout_tail", "stderr_tail"] {
+        if output.get(key).and_then(Value::as_str) == Some("") {
+            output.remove(key);
+        }
+    }
+    for key in ["stdout_lines", "stderr_lines"] {
+        if output.get(key).and_then(Value::as_u64) == Some(0) {
+            output.remove(key);
+        }
+    }
+    for key in ["stdout_truncated", "stderr_truncated"] {
+        if output.get(key).and_then(Value::as_bool) == Some(false) {
+            output.remove(key);
+        }
+    }
+}
+
 /// Snapshot of the activity-relevant request facts, captured before the
 /// `ToolCall` is moved into execution.
 struct WorkspaceActivityContext {
@@ -630,6 +699,7 @@ impl ToolRuntime {
                 );
             }
         }
+        sparsify_terminal_structured_execution_success(tool_name, &mut result);
         result
     }
 

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -325,6 +325,149 @@ fn sparsify_complete_default_search_success(
     }
 }
 
+/// Remove range bookkeeping only when the returned text is provably the complete
+/// file. `sha256` and `total_lines` remain explicit freshness/content-shape
+/// evidence. Partial reads and every real continuation keep the canonical full
+/// range tuple. In a batch, the outer item path remains the navigation identity,
+/// so an identical inner path is redundant.
+fn sparsify_complete_file_read_output(
+    output: &mut serde_json::Map<String, Value>,
+    duplicate_outer_path: Option<&str>,
+) -> bool {
+    let format = output.get("format").and_then(Value::as_str);
+    let valid_format = matches!(format, Some("plain" | "numbered"));
+    let plain_format = format == Some("plain");
+    let Some(inner_path) = output.get("path").and_then(Value::as_str) else {
+        return false;
+    };
+    if duplicate_outer_path.is_some_and(|path| path != inner_path) {
+        return false;
+    }
+    let Some(total_lines) = output.get("total_lines").and_then(Value::as_u64) else {
+        return false;
+    };
+    let Some(returned_lines) = output.get("returned_lines").and_then(Value::as_u64) else {
+        return false;
+    };
+    let default_limit =
+        webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit as u64;
+    let end_line_matches = if total_lines == 0 {
+        output.get("end_line").is_some_and(Value::is_null)
+    } else {
+        output.get("end_line").and_then(Value::as_u64) == Some(total_lines)
+    };
+    let complete_file = output.get("text").and_then(Value::as_str).is_some()
+        && valid_format
+        && output
+            .get("sha256")
+            .and_then(Value::as_str)
+            .is_some_and(|sha| {
+                sha.len() == 64
+                    && sha
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            })
+        && output.get("start_line").and_then(Value::as_u64) == Some(1)
+        && output.get("limit").and_then(Value::as_u64) == Some(default_limit)
+        && returned_lines == total_lines
+        && returned_lines <= default_limit
+        && end_line_matches
+        && output.get("has_more").and_then(Value::as_bool) == Some(false)
+        && output.get("next_start_line").is_some_and(Value::is_null);
+    if !complete_file {
+        return false;
+    }
+
+    for key in [
+        "start_line",
+        "limit",
+        "returned_lines",
+        "end_line",
+        "has_more",
+        "next_start_line",
+    ] {
+        output.remove(key);
+    }
+    if plain_format {
+        output.remove("format");
+    }
+    if duplicate_outer_path.is_some() {
+        output.remove("path");
+    }
+    true
+}
+
+fn sparsify_complete_read_success(tool_name: &str, result: &mut ToolResult) {
+    if !result.success || !matches!(tool_name, "read_file" | "read_files") {
+        return;
+    }
+    let Some(output) = result.output.as_object_mut() else {
+        return;
+    };
+    if tool_name == "read_file" {
+        sparsify_complete_file_read_output(output, None);
+        return;
+    }
+
+    let complete_batch = output
+        .get("items")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            let item_count = items.len() as u64;
+            item_count > 0
+                && items.iter().all(|item| {
+                    item.get("success").and_then(Value::as_bool) == Some(true)
+                        && item.get("error").is_some_and(Value::is_null)
+                })
+                && output.get("requested_count").and_then(Value::as_u64) == Some(item_count)
+                && output.get("returned_count").and_then(Value::as_u64) == Some(item_count)
+                && output.get("succeeded_count").and_then(Value::as_u64) == Some(item_count)
+                && output.get("failed_count").and_then(Value::as_u64) == Some(0)
+                && output.get("output_truncated").and_then(Value::as_bool) == Some(false)
+                && output.get("next_index").is_some_and(Value::is_null)
+        });
+    let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
+        return;
+    };
+    let mut every_item_complete = complete_batch;
+    for item in items {
+        let Some(item) = item.as_object_mut() else {
+            every_item_complete = false;
+            continue;
+        };
+        if item.get("success").and_then(Value::as_bool) != Some(true)
+            || !item.get("error").is_some_and(Value::is_null)
+        {
+            every_item_complete = false;
+            continue;
+        }
+        let Some(outer_path) = item.get("path").and_then(Value::as_str).map(str::to_string) else {
+            every_item_complete = false;
+            continue;
+        };
+        let Some(read_output) = item.get_mut("output").and_then(Value::as_object_mut) else {
+            every_item_complete = false;
+            continue;
+        };
+        if !sparsify_complete_file_read_output(read_output, Some(&outer_path)) {
+            every_item_complete = false;
+        }
+    }
+    if every_item_complete {
+        for key in [
+            "project",
+            "requested_count",
+            "returned_count",
+            "succeeded_count",
+            "failed_count",
+            "output_truncated",
+            "next_index",
+        ] {
+            output.remove(key);
+        }
+    }
+}
+
 /// Snapshot of the activity-relevant request facts, captured before the
 /// `ToolCall` is moved into execution.
 struct WorkspaceActivityContext {
@@ -901,6 +1044,7 @@ impl ToolRuntime {
         }
         sparsify_terminal_structured_execution_success(tool_name, &mut result);
         sparsify_complete_default_search_success(&search_projection, &mut result);
+        sparsify_complete_read_success(tool_name, &mut result);
         result
     }
 
@@ -1068,6 +1212,64 @@ impl ToolRuntime {
             | ToolCall::GotoDefinition { .. }
             | ToolCall::FindReferences { .. }
             | ToolCall::CallHierarchy { .. }) => self.dispatch_lsp_tool(call).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod sparse_read_projection_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn complete_batch_item(outer_path: Option<&str>, inner_path: &str) -> Value {
+        let default_limit =
+            webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
+        let mut item = json!({
+            "index": 0,
+            "success": true,
+            "output": {
+                "text": "one",
+                "format": "plain",
+                "path": inner_path,
+                "sha256": "a".repeat(64),
+                "start_line": 1,
+                "limit": default_limit,
+                "total_lines": 1,
+                "returned_lines": 1,
+                "end_line": 1,
+                "has_more": false,
+                "next_start_line": null
+            },
+            "error": null
+        });
+        if let Some(path) = outer_path {
+            item["path"] = json!(path);
+        }
+        item
+    }
+
+    #[test]
+    fn sparse_read_batch_requires_exact_outer_path_identity() {
+        for item in [
+            complete_batch_item(None, "a.rs"),
+            complete_batch_item(Some("other.rs"), "a.rs"),
+        ] {
+            let mut result = ToolResult::ok(json!({
+                "project": "demo",
+                "requested_count": 1,
+                "returned_count": 1,
+                "succeeded_count": 1,
+                "failed_count": 0,
+                "items": [item],
+                "output_truncated": false,
+                "next_index": null
+            }));
+
+            sparsify_complete_read_success("read_files", &mut result);
+
+            assert_eq!(result.output["requested_count"], 1);
+            assert_eq!(result.output["items"][0]["output"]["path"], "a.rs");
+            assert_eq!(result.output["items"][0]["output"]["start_line"], 1);
         }
     }
 }

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -124,6 +124,22 @@ fn sparsify_terminal_structured_execution_success(tool_name: &str, result: &mut 
             output.remove(key);
         }
     }
+
+    let summary_key = match tool_name {
+        "run_process" => "process_summary",
+        "run_script" => "script_summary",
+        _ => unreachable!("structured execution sparsifier is tool-gated"),
+    };
+    let canonical_source =
+        output.get("execution_source").and_then(Value::as_str) == Some(tool_name);
+    let canonical_summary = output
+        .get(summary_key)
+        .and_then(Value::as_str)
+        .is_some_and(|summary| !summary.is_empty());
+    if canonical_source && canonical_summary {
+        output.remove(summary_key);
+        output.remove("execution_source");
+    }
 }
 
 enum SearchModelProjection {
@@ -1213,6 +1229,62 @@ impl ToolRuntime {
             | ToolCall::FindReferences { .. }
             | ToolCall::CallHierarchy { .. }) => self.dispatch_lsp_tool(call).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod structured_execution_sparse_projection_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn terminal_process_result(execution_source: &str) -> ToolResult {
+        ToolResult::ok(json!({
+            "duration_ms": 1,
+            "exit_code": 0,
+            "stdout_tail": "",
+            "stderr_tail": "",
+            "stdout_lines": 0,
+            "stderr_lines": 0,
+            "stdout_truncated": false,
+            "stderr_truncated": false,
+            "command_started": true,
+            "command_completed": true,
+            "command_ok": true,
+            "failure_kind": null,
+            "tool_failure": false,
+            "purpose": "diagnostic",
+            "process_summary": "tool --arg",
+            "cwd": ".",
+            "executor": "agent",
+            "execution_source": execution_source,
+            "execution_state": "completed",
+            "promoted_to_job": false,
+            "terminal": true,
+            "job_id": null,
+            "job_status": null,
+            "observation_token": null,
+            "effective_timeout_secs": 60,
+            "sync_wait_secs": 10,
+            "async_handoff_available": true
+        }))
+    }
+
+    #[test]
+    fn terminal_execution_only_omits_summary_and_source_for_exact_canonical_source() {
+        let mut canonical = terminal_process_result("run_process");
+        sparsify_terminal_structured_execution_success("run_process", &mut canonical);
+        assert!(canonical.output.get("process_summary").is_none());
+        assert!(canonical.output.get("execution_source").is_none());
+        assert_eq!(canonical.output["cwd"], ".");
+        assert_eq!(canonical.output["executor"], "agent");
+
+        let mut alternate = terminal_process_result("alternate_process_source");
+        sparsify_terminal_structured_execution_success("run_process", &mut alternate);
+        assert_eq!(alternate.output["process_summary"], "tool --arg");
+        assert_eq!(
+            alternate.output["execution_source"],
+            "alternate_process_source"
+        );
     }
 }
 

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -126,6 +126,205 @@ fn sparsify_terminal_structured_execution_success(tool_name: &str, result: &mut 
     }
 }
 
+enum SearchModelProjection {
+    None,
+    SingleDefault,
+    Batch { default_queries: Vec<bool> },
+}
+
+impl SearchModelProjection {
+    fn capture(call: &ToolCall) -> Self {
+        match call {
+            ToolCall::SearchProjectText {
+                result_mode,
+                timeout_secs,
+                context_before,
+                context_after,
+                ..
+            } if caller_uses_default_search_controls(
+                result_mode,
+                timeout_secs,
+                context_before,
+                context_after,
+            ) =>
+            {
+                Self::SingleDefault
+            }
+            ToolCall::SearchProjectTexts { queries, .. } => Self::Batch {
+                default_queries: queries
+                    .iter()
+                    .map(|query| {
+                        caller_uses_default_search_controls(
+                            &query.result_mode,
+                            &query.timeout_secs,
+                            &query.context_before,
+                            &query.context_after,
+                        )
+                    })
+                    .collect(),
+            },
+            _ => Self::None,
+        }
+    }
+}
+
+fn caller_uses_default_search_controls(
+    result_mode: &Option<super::SearchResultMode>,
+    timeout_secs: &Option<i64>,
+    context_before: &Option<usize>,
+    context_after: &Option<usize>,
+) -> bool {
+    result_mode
+        .as_ref()
+        .is_none_or(|mode| matches!(mode, super::SearchResultMode::Matches))
+        && timeout_secs
+            .as_ref()
+            .copied()
+            .unwrap_or(super::files::DEFAULT_SEARCH_TIMEOUT_SECS as i64)
+            == super::files::DEFAULT_SEARCH_TIMEOUT_SECS as i64
+        && context_before.as_ref().copied().unwrap_or(0) == 0
+        && context_after.as_ref().copied().unwrap_or(0) == 0
+}
+
+/// Project an ordinary complete default text search down to its actual records.
+/// Session/event extraction sees the complete result before this model-facing
+/// pass. Fallbacks, partial results, non-default modes, timeouts, and context
+/// requests stay explicit. Batch defaults may inherit a smaller remaining
+/// timeout from the shared outer deadline without making that derived value
+/// model-relevant.
+fn sparsify_complete_default_search_output(
+    output: &mut serde_json::Map<String, Value>,
+    allow_batch_deadline_reduction: bool,
+) -> bool {
+    let Some(matches_len) = output
+        .get("matches")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+    else {
+        return false;
+    };
+    let exit_code = output.get("exit_code").and_then(Value::as_i64);
+    let effective_timeout = output.get("effective_timeout_secs").and_then(Value::as_u64);
+    let default_timeout = if allow_batch_deadline_reduction {
+        effective_timeout.is_some_and(|timeout| {
+            (1..=super::files::DEFAULT_SEARCH_TIMEOUT_SECS).contains(&timeout)
+        })
+    } else {
+        effective_timeout == Some(super::files::DEFAULT_SEARCH_TIMEOUT_SECS)
+    };
+    let ordinary_complete = output.get("backend").and_then(Value::as_str) == Some("rg")
+        && output.get("result_mode").and_then(Value::as_str) == Some("matches")
+        && default_timeout
+        && output.get("context_before").and_then(Value::as_u64) == Some(0)
+        && output.get("context_after").and_then(Value::as_u64) == Some(0)
+        && output.get("truncated").and_then(Value::as_bool) == Some(false)
+        && output.get("truncation_reason").is_some_and(Value::is_null)
+        && matches!(exit_code, Some(0 | 1))
+        && output.get("count").and_then(Value::as_u64) == Some(matches_len as u64);
+    if !ordinary_complete {
+        return false;
+    }
+
+    for key in [
+        "project",
+        "pattern",
+        "backend",
+        "result_mode",
+        "effective_timeout_secs",
+        "exit_code",
+        "context_before",
+        "context_after",
+        "count",
+        "truncated",
+        "truncation_reason",
+    ] {
+        output.remove(key);
+    }
+    if output.get("path").and_then(Value::as_str) == Some(".") {
+        output.remove("path");
+    }
+    true
+}
+
+fn sparsify_complete_default_search_success(
+    projection: &SearchModelProjection,
+    result: &mut ToolResult,
+) {
+    if !result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object_mut() else {
+        return;
+    };
+    match projection {
+        SearchModelProjection::SingleDefault => {
+            sparsify_complete_default_search_output(output, false);
+        }
+        SearchModelProjection::Batch { default_queries } => {
+            let complete_batch =
+                output
+                    .get("items")
+                    .and_then(Value::as_array)
+                    .is_some_and(|items| {
+                        let item_count = items.len() as u64;
+                        item_count > 0
+                            && items.iter().all(|item| {
+                                item.get("success").and_then(Value::as_bool) == Some(true)
+                                    && item.get("error").is_some_and(Value::is_null)
+                            })
+                            && output.get("requested_count").and_then(Value::as_u64)
+                                == Some(item_count)
+                            && output.get("returned_count").and_then(Value::as_u64)
+                                == Some(item_count)
+                            && output.get("succeeded_count").and_then(Value::as_u64)
+                                == Some(item_count)
+                            && output.get("failed_count").and_then(Value::as_u64) == Some(0)
+                            && output.get("output_truncated").and_then(Value::as_bool)
+                                == Some(false)
+                            && output.get("next_index").is_some_and(Value::is_null)
+                    });
+            let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
+                return;
+            };
+            for item in items {
+                let Some(item) = item.as_object_mut() else {
+                    continue;
+                };
+                if item.get("success").and_then(Value::as_bool) != Some(true)
+                    || !item.get("error").is_some_and(Value::is_null)
+                {
+                    continue;
+                }
+                let Some(index) = item.get("index").and_then(Value::as_u64) else {
+                    continue;
+                };
+                if default_queries.get(index as usize).copied() != Some(true) {
+                    continue;
+                }
+                let Some(search_output) = item.get_mut("output").and_then(Value::as_object_mut)
+                else {
+                    continue;
+                };
+                sparsify_complete_default_search_output(search_output, true);
+            }
+            if complete_batch {
+                for key in [
+                    "project",
+                    "requested_count",
+                    "returned_count",
+                    "succeeded_count",
+                    "failed_count",
+                    "output_truncated",
+                    "next_index",
+                ] {
+                    output.remove(key);
+                }
+            }
+        }
+        SearchModelProjection::None => {}
+    }
+}
+
 /// Snapshot of the activity-relevant request facts, captured before the
 /// `ToolCall` is moved into execution.
 struct WorkspaceActivityContext {
@@ -627,6 +826,7 @@ impl ToolRuntime {
         }
         let activity_context =
             Self::capture_workspace_activity_context(&call, activity_project.as_deref());
+        let search_projection = SearchModelProjection::capture(&call);
         let tool_name = call.tool_name();
         let mut result = self
             .dispatch_authorized_inner(
@@ -700,6 +900,7 @@ impl ToolRuntime {
             }
         }
         sparsify_terminal_structured_execution_success(tool_name, &mut result);
+        sparsify_complete_default_search_success(&search_projection, &mut result);
         result
     }
 

--- a/src/tool_runtime/files.rs
+++ b/src/tool_runtime/files.rs
@@ -61,7 +61,10 @@ pub(crate) use search::{
     search_project_text_command_with_head_fallbacks, search_project_text_output,
     MAX_SEARCH_CONTEXT_LINES, MAX_SEARCH_GLOBS, MAX_SEARCH_GLOB_BYTES, SEARCH_OUTPUT_BYTE_BUDGET,
 };
-pub(crate) use search::{SearchOptions, SearchRequest, DEFAULT_SEARCH_HEAD_ABSOLUTE_CANDIDATES};
+pub(crate) use search::{
+    SearchOptions, SearchRequest, DEFAULT_SEARCH_HEAD_ABSOLUTE_CANDIDATES,
+    DEFAULT_SEARCH_TIMEOUT_SECS,
+};
 
 // Edit limits and the sensitive-path guard are shared with the agent binary.
 #[cfg(test)]

--- a/src/tool_runtime/files/search.rs
+++ b/src/tool_runtime/files/search.rs
@@ -71,7 +71,7 @@ const SEARCH_PROJECT_TEXT_RG_EXCLUDE_GLOBS: &[&str] = &[
 pub(crate) const MAX_SEARCH_CONTEXT_LINES: usize = 20;
 pub(crate) const MAX_SEARCH_GLOBS: usize = 32;
 pub(crate) const MAX_SEARCH_GLOB_BYTES: usize = 256;
-const DEFAULT_SEARCH_TIMEOUT_SECS: u64 = 30;
+pub(crate) const DEFAULT_SEARCH_TIMEOUT_SECS: u64 = 30;
 const MIN_SEARCH_TIMEOUT_SECS: i64 = 1;
 const MAX_SEARCH_TIMEOUT_SECS: i64 = 120;
 

--- a/src/tool_runtime/registry/input_schemas/coding.rs
+++ b/src/tool_runtime/registry/input_schemas/coding.rs
@@ -131,6 +131,11 @@ pub(crate) fn work_on_project_input_schema() -> Value {
                 "maxLength": 4000,
                 "description": "Required current user instruction. On a new task it becomes the root task title; when session_id is provided it is appended to the existing Workflow Session ledger and never overwrites the root title."
             },
+            "include_project_instructions": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this bootstrap response should include bounded project-instruction bodies such as AGENTS.md. Defaults to true. Set false when the caller's current model context already retains the applicable repository instructions. Instruction files are still observed for Workflow Session state and metadata; this flag controls only model-facing instruction-content projection."
+            },
             "session_id": {
                 "type": "string",
                 "pattern": "^wc_sess_[A-Za-z0-9_]+$",

--- a/src/tool_runtime/registry/input_schemas/coding.rs
+++ b/src/tool_runtime/registry/input_schemas/coding.rs
@@ -136,6 +136,11 @@ pub(crate) fn work_on_project_input_schema() -> Value {
                 "default": true,
                 "description": "Whether this bootstrap response should include bounded project-instruction bodies such as AGENTS.md. Defaults to true. Set false when the caller's current model context already retains the applicable repository instructions. Instruction files are still observed for Workflow Session state and metadata; this flag controls only model-facing instruction-content projection."
             },
+            "include_workflow_guidance": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this bootstrap response should include the static built-in WebCodex coding-workflow guidance. Defaults to true. Set false when the caller's current model context already retains that workflow guidance. This flag controls only model-facing workflow projection; it does not change Workflow Session state, authority, role selection, or execution semantics."
+            },
             "session_id": {
                 "type": "string",
                 "pattern": "^wc_sess_[A-Za-z0-9_]+$",

--- a/src/tool_runtime/registry/output_schemas/coding_tasks.rs
+++ b/src/tool_runtime/registry/output_schemas/coding_tasks.rs
@@ -1010,6 +1010,12 @@ fn semantic_navigation_schema() -> Value {
     })
 }
 
+fn work_on_project_instruction_source_schema() -> Value {
+    let mut schema = startup_instruction_source_schema();
+    schema["required"] = json!(["path", "fingerprint"]);
+    schema
+}
+
 /// Compact startup projection for `work_on_project`. Carries only the fields a
 /// coding model immediately needs after starting or continuing a task. It never
 /// returns the full runtime/connection/authority/binding/manifest diagnostics
@@ -1018,20 +1024,21 @@ fn semantic_navigation_schema() -> Value {
 fn work_on_project_output_schema() -> Value {
     let compact_workspace = json!({
         "type": "object",
+        "description": "Sparse workspace state. status is always present; null/default facts are omitted, branch/head are included when observed, git_available is emitted only when false, and conflicts only when non-zero.",
         "properties": {
             "status": {"type": "string", "enum": ["clean", "dirty", "blocked", "unavailable"]},
-            "git_available": nullable_schema("boolean", "Whether bounded Git inspection was available."),
+            "git_available": nullable_schema("boolean", "Emitted when bounded Git inspection is explicitly unavailable; omission means no exceptional Git-unavailable fact."),
             "branch": nullable_schema("string", "Current branch when observed."),
             "head": nullable_schema("string", "Current full HEAD commit when observed."),
-            "clean": nullable_schema("boolean", "Whether the worktree is clean when observed."),
-            "conflicts": {"type": "integer", "minimum": 0}
+            "clean": nullable_schema("boolean", "Legacy compatibility field; normal clean/dirty state is represented by status and may omit this field."),
+            "conflicts": {"type": "integer", "minimum": 1}
         },
-        "required": ["status", "git_available", "branch", "head", "clean", "conflicts"],
+        "required": ["status"],
         "additionalProperties": true
     });
     let compact_instructions = json!({
         "type": "object",
-        "description": "Compact project-local repository instruction projection, separate from the WebCodex built-in workflow.",
+        "description": "Compact project-local repository instruction projection, separate from the WebCodex built-in workflow. False/null/empty body-projection defaults are omitted.",
         "properties": {
             "status": {
                 "type": "string",
@@ -1040,8 +1047,8 @@ fn work_on_project_output_schema() -> Value {
             "sources": {
                 "type": "array",
                 "maxItems": 5,
-                "items": startup_instruction_source_schema(),
-                "description": "Fixed, ordered repository-rule sources."
+                "items": work_on_project_instruction_source_schema(),
+                "description": "Fixed, ordered repository-rule sources. path/fingerprint are always present; false/null/empty body-projection defaults are omitted."
             },
             "changed_sources": {
                 "type": "array",
@@ -1058,9 +1065,9 @@ fn work_on_project_output_schema() -> Value {
                     ]
                 }
             },
-            "content_included": {"type": "boolean"},
-            "truncated": {"type": "boolean"},
-            "total_chars": {"type": "integer", "minimum": 0, "maximum": 32768}
+            "content_included": {"type": "boolean", "description": "Emitted only when bounded instruction bodies are included; omission means false."},
+            "truncated": {"type": "boolean", "description": "Emitted only when true."},
+            "total_chars": {"type": "integer", "minimum": 1, "maximum": 32768, "description": "Emitted only with truncated=true to quantify the observed instruction extent."}
         },
         "required": ["status", "sources"],
         "additionalProperties": true
@@ -1093,22 +1100,16 @@ fn work_on_project_output_schema() -> Value {
     });
     let compact_jobs = json!({
         "type": "object",
+        "description": "Sparse noteworthy Job state. The whole object is omitted when all lifecycle counts are zero and no latest status was observed; inside the object zero counts and latest_status=not_observed are omitted.",
         "properties": {
-            "active_count": {"type": "integer", "minimum": 0},
-            "blocking_active_count": {"type": "integer", "minimum": 0},
-            "nonblocking_active_count": {"type": "integer", "minimum": 0},
-            "recovering_count": {"type": "integer", "minimum": 0},
-            "terminal_pending_count": {"type": "integer", "minimum": 0},
+            "active_count": {"type": "integer", "minimum": 1},
+            "blocking_active_count": {"type": "integer", "minimum": 1},
+            "nonblocking_active_count": {"type": "integer", "minimum": 1},
+            "recovering_count": {"type": "integer", "minimum": 1},
+            "terminal_pending_count": {"type": "integer", "minimum": 1},
             "latest_status": {"type": "string"}
         },
-        "required": [
-            "active_count",
-            "blocking_active_count",
-            "nonblocking_active_count",
-            "recovering_count",
-            "terminal_pending_count",
-            "latest_status"
-        ],
+        "minProperties": 1,
         "additionalProperties": true
     });
     let compact_repository = startup_repository_schema();
@@ -1127,7 +1128,11 @@ fn work_on_project_output_schema() -> Value {
         ),
         (
             "project_resolution",
-            project_resolution_schema(),
+            {
+                let mut schema = project_resolution_schema();
+                schema["description"] = json!("Non-default project-source resolution metadata. Omitted when an ordinary project input resolves to an existing registration without mutation.");
+                schema
+            },
         ),
         (
             "continuation",
@@ -1135,7 +1140,7 @@ fn work_on_project_output_schema() -> Value {
         ),
         (
             "execution_context",
-            session_execution_context_schema("Persistent execution defaults currently stored for this Workflow Session."),
+            session_execution_context_schema("Persistent execution defaults currently stored for this Workflow Session. Omitted when empty."),
         ),
         (
             "readiness",
@@ -1153,49 +1158,40 @@ fn work_on_project_output_schema() -> Value {
             "workspace",
             compact_workspace,
         ),
-        ("repository", compact_repository),
+        (
+            "repository",
+            {
+                let mut schema = compact_repository;
+                schema["description"] = json!("Unexpected or noteworthy repository-overview state. Omitted for work_on_project's normal intentional no-overview path.");
+                schema
+            },
+        ),
         ("workflow", startup_workflow_schema()),
         ("instructions", compact_instructions),
         ("semantic_navigation", compact_semantic_navigation),
         ("jobs", compact_jobs),
         (
             "blockers",
-            startup_issue_list_schema(true),
+            {
+                let mut schema = startup_issue_list_schema(true);
+                schema["description"] = json!("Blocking startup issues; omitted when empty.");
+                schema
+            },
         ),
         (
             "warnings",
-            startup_issue_list_schema(false),
+            {
+                let mut schema = startup_issue_list_schema(false);
+                schema["description"] = json!("Non-blocking startup warnings; omitted when empty. Deliberately disabled current-window binding is not a warning.");
+                schema
+            },
         ),
         (
             "suggested_next_actions",
-            array_schema(schema_type("string", "Short suggested action."), "Bounded suggested next actions."),
+            array_schema(schema_type("string", "Short suggested action."), "Bounded non-default suggested next actions. Omitted when there is nothing more informative than beginning the requested task."),
         ),
     ];
-    let mut schema = wrapped_output_schema(output_properties);
-    add_compact_work_metadata(&mut schema);
-    schema
-}
-
-fn add_compact_work_metadata(schema: &mut Value) {
-    let output = schema
-        .get_mut("properties")
-        .and_then(|properties| properties.get_mut("output"))
-        .and_then(|output| output.get_mut("properties"))
-        .expect("work_on_project output schema properties");
-    let output = output
-        .as_object_mut()
-        .expect("work_on_project output properties");
-    output.insert(
-        "deterministic".to_string(),
-        schema_type(
-            "boolean",
-            "True: the projection derives only from existing runtime state.",
-        ),
-    );
-    output.insert(
-        "llm_summary".to_string(),
-        schema_type("boolean", "Always false; never an LLM summary."),
-    );
+    wrapped_output_schema(output_properties)
 }
 
 fn review_evidence_schema(description: &str) -> Value {

--- a/src/tool_runtime/registry/output_schemas/coding_tasks.rs
+++ b/src/tool_runtime/registry/output_schemas/coding_tasks.rs
@@ -1166,7 +1166,14 @@ fn work_on_project_output_schema() -> Value {
                 schema
             },
         ),
-        ("workflow", startup_workflow_schema()),
+        (
+            "workflow",
+            {
+                let mut schema = startup_workflow_schema();
+                schema["description"] = json!("Static built-in WebCodex coding-workflow guidance. Omitted when work_on_project is called with include_workflow_guidance=false.");
+                schema
+            },
+        ),
         ("instructions", compact_instructions),
         ("semantic_navigation", compact_semantic_navigation),
         ("jobs", compact_jobs),

--- a/src/tool_runtime/registry/output_schemas/files.rs
+++ b/src/tool_runtime/registry/output_schemas/files.rs
@@ -393,12 +393,13 @@ fn search_project_texts_output_schema() -> Value {
 }
 
 fn read_file_output_schema() -> Value {
+    let default_limit = webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
     let success_properties = json!({
         "text": schema_type("string", "The single primary text representation: plain content or numbered text according to format."),
         "format": {
             "type": "string",
             "enum": ["plain", "numbered"],
-            "description": "Primary text format: plain or numbered."
+            "description": "Primary text format: plain or numbered. Complete default full-file model-facing success may omit plain; numbered remains explicit."
         },
         "path": schema_type("string", "Project-relative path."),
         "sha256": {
@@ -452,7 +453,7 @@ fn read_file_output_schema() -> Value {
         "session_hint": session_hint_schema(),
         "permission": permission_decision_schema()
     });
-    let success_output = json!({
+    let full_success_output = json!({
         "type": "object",
         "additionalProperties": false,
         "properties": success_properties.clone(),
@@ -460,6 +461,47 @@ fn read_file_output_schema() -> Value {
             "text", "format", "path", "sha256", "start_line", "limit",
             "total_lines", "returned_lines", "end_line", "has_more", "next_start_line"
         ]
+    });
+    let mut sparse_success_properties = success_properties
+        .as_object()
+        .expect("read_file success properties")
+        .clone();
+    for key in [
+        "start_line",
+        "limit",
+        "returned_lines",
+        "end_line",
+        "has_more",
+        "next_start_line",
+    ] {
+        sparse_success_properties.remove(key);
+    }
+    sparse_success_properties.insert(
+        "total_lines".to_string(),
+        json!({
+            "type": "integer",
+            "minimum": 0,
+            "maximum": default_limit,
+            "description": "Complete-file line count; sparse default reads cannot exceed the canonical default line limit."
+        }),
+    );
+    sparse_success_properties.insert(
+        "format".to_string(),
+        json!({
+            "type": "string",
+            "const": "numbered",
+            "description": "Present only when the complete full-file sparse projection contains numbered text; omission means plain."
+        }),
+    );
+    let sparse_success_output = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": sparse_success_properties,
+        "required": ["text", "path", "sha256", "total_lines"],
+        "description": "Sparse model-facing form for a provably complete default full-file read. Omitted range fields mean start_line=1, the canonical default limit, returned_lines=total_lines, and no continuation. sha256 and total_lines remain explicit."
+    });
+    let success_output = json!({
+        "anyOf": [full_success_output, sparse_success_output]
     });
     let read_failure_output = json!({
         "type": "object",
@@ -540,26 +582,70 @@ fn read_file_output_schema() -> Value {
 }
 
 fn read_files_output_schema() -> Value {
-    let read_success = json!({
+    let default_limit = webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
+    let read_success_properties = json!({
+        "text": schema_type("string", "The single primary text representation."),
+        "format": {"type": "string", "enum": ["plain", "numbered"]},
+        "path": schema_type("string", "Project-relative path; omitted from a sparse complete item when identical to the outer item path."),
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "start_line": {"type": "integer", "minimum": 1},
+        "limit": {"type": "integer", "minimum": 1, "maximum": 2000},
+        "total_lines": {"type": "integer", "minimum": 0},
+        "returned_lines": {"type": "integer", "minimum": 0, "maximum": 2000},
+        "end_line": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]},
+        "has_more": {"type": "boolean"},
+        "next_start_line": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]}
+    });
+    let read_success_full = json!({
         "type": "object",
         "additionalProperties": false,
-        "properties": {
-            "text": schema_type("string", "The single primary text representation."),
-            "format": {"type": "string", "enum": ["plain", "numbered"]},
-            "path": schema_type("string", "Project-relative path."),
-            "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
-            "start_line": {"type": "integer", "minimum": 1},
-            "limit": {"type": "integer", "minimum": 1, "maximum": 2000},
-            "total_lines": {"type": "integer", "minimum": 0},
-            "returned_lines": {"type": "integer", "minimum": 0, "maximum": 2000},
-            "end_line": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]},
-            "has_more": {"type": "boolean"},
-            "next_start_line": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]}
-        },
+        "properties": read_success_properties.clone(),
         "required": [
             "text", "format", "path", "sha256", "start_line", "limit",
             "total_lines", "returned_lines", "end_line", "has_more", "next_start_line"
         ]
+    });
+    let mut read_success_sparse_properties = read_success_properties
+        .as_object()
+        .expect("read_files success properties")
+        .clone();
+    for key in [
+        "path",
+        "start_line",
+        "limit",
+        "returned_lines",
+        "end_line",
+        "has_more",
+        "next_start_line",
+    ] {
+        read_success_sparse_properties.remove(key);
+    }
+    read_success_sparse_properties.insert(
+        "total_lines".to_string(),
+        json!({
+            "type": "integer",
+            "minimum": 0,
+            "maximum": default_limit,
+            "description": "Complete-file line count; sparse default reads cannot exceed the canonical default line limit."
+        }),
+    );
+    read_success_sparse_properties.insert(
+        "format".to_string(),
+        json!({
+            "type": "string",
+            "const": "numbered",
+            "description": "Present only for numbered complete default full-file sparse output; omission means plain."
+        }),
+    );
+    let read_success_sparse = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": read_success_sparse_properties,
+        "required": ["text", "sha256", "total_lines"],
+        "description": "Sparse model-facing item form for a provably complete default full-file read. The outer item path is the only navigation identity; inner path and range fields are omitted, and no continuation exists."
+    });
+    let read_success = json!({
+        "anyOf": [read_success_full, read_success_sparse.clone()]
     });
     let read_failure = json!({
         "type": "object",
@@ -596,7 +682,7 @@ fn read_files_output_schema() -> Value {
             "else": {"properties": {"output": read_failure, "error": {"type": "string"}}}
         }]
     });
-    let batch_output = json!({
+    let batch_output_full = json!({
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -618,6 +704,35 @@ fn read_files_output_schema() -> Value {
             "project", "requested_count", "returned_count", "succeeded_count",
             "failed_count", "items", "output_truncated", "next_index"
         ]
+    });
+    let sparse_complete_item = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "index": {"type": "integer", "minimum": 0, "maximum": 7},
+            "path": schema_type("string", "Project-relative input path."),
+            "success": {"type": "boolean", "const": true},
+            "output": read_success_sparse,
+            "error": {"type": "null"}
+        },
+        "required": ["index", "path", "success", "output", "error"]
+    });
+    let batch_output_sparse = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "items": {"type": "array", "minItems": 1, "maxItems": 8, "items": sparse_complete_item},
+            "session_recorded": schema_type("boolean", "True when this batch call was recorded."),
+            "session_id": schema_type("string", "Session id used for outer batch telemetry."),
+            "session_event_id": schema_type("string", "Session event id for the outer batch call."),
+            "session_hint": session_hint_schema(),
+            "permission": permission_decision_schema()
+        },
+        "required": ["items"],
+        "description": "Sparse model-facing batch form used only when every requested item succeeded as a complete default full-file read and the batch itself was not truncated. Omitted outer counts/defaults are therefore implied."
+    });
+    let batch_output = json!({
+        "anyOf": [batch_output_full, batch_output_sparse]
     });
     json!({
         "type": "object",

--- a/src/tool_runtime/registry/output_schemas/files.rs
+++ b/src/tool_runtime/registry/output_schemas/files.rs
@@ -108,17 +108,17 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
         "search_project_texts" => Some(search_project_texts_output_schema()),
         "search_project_text" => {
             Some(wrapped_output_schema(vec![
-            ("project", schema_type("string", "Resolved project id.")),
-            ("pattern", schema_type("string", "Search pattern.")),
+            ("project", schema_type("string", "Resolved project id; omitted as request echo in ordinary complete default rg/matches success.")),
+            ("pattern", schema_type("string", "Search pattern; omitted as request echo in ordinary complete default rg/matches success.")),
             (
                 "path",
-                schema_type("string", "Project-relative search root."),
+                schema_type("string", "Project-relative search root; omitted when it is the default project root in ordinary complete default rg/matches success."),
             ),
             (
                 "backend",
                 nullable_schema(
                     "string",
-                    "Search backend used: rg, grep, or native. Null/omitted when unknown (for example outer wait timeout before backend selection).",
+                    "Search backend used: rg, grep, or native. Omitted for ordinary complete default rg/matches success, or null/omitted when unknown (for example outer wait timeout before backend selection).",
                 ),
             ),
             (
@@ -126,12 +126,12 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 json!({
                     "type": "string",
                     "enum": ["matches", "files_with_matches", "count"],
-                    "description": "Effective result mode."
+                    "description": "Effective result mode; omitted when it is the default matches mode in ordinary complete rg success."
                 }),
             ),
             (
                 "effective_timeout_secs",
-                schema_type("integer", "Effective clamped timeout in seconds."),
+                schema_type("integer", "Effective clamped timeout in seconds; omitted when it is the default budget in ordinary complete rg/matches success."),
             ),
             (
                 "matches",
@@ -140,7 +140,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "Bounded search matches; present in matches mode.",
                 ),
             ),
-            ("count", schema_type("integer", "Returned match count.")),
+            ("count", schema_type("integer", "Returned match count; omitted in sparse default matches success because it equals matches.length.")),
             (
                 "files",
                 array_schema(
@@ -175,7 +175,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "truncated",
-                schema_type("boolean", "Whether more mode-specific records were available."),
+                schema_type("boolean", "Whether more mode-specific records were available; false is omitted in sparse default matches success."),
             ),
             (
                 "truncation_reason",
@@ -245,36 +245,50 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
 }
 
 fn search_project_texts_output_schema() -> Value {
-    let search_success = json!({
+    let search_success_properties = json!({
+        "path": schema_type("string", "Effective project-relative search root; omitted for the default project root in sparse complete matches success."),
+        "backend": nullable_schema("string", "Search backend: rg, grep, native, or null when unknown; omitted for ordinary complete default rg/matches success."),
+        "result_mode": {"type": "string", "enum": ["matches", "files_with_matches", "count"]},
+        "effective_timeout_secs": {"type": "integer", "minimum": 1, "maximum": 120},
+        "exit_code": nullable_schema("integer", "Search command exit code, when available."),
+        "context_before": {"type": "integer", "minimum": 0, "maximum": 20},
+        "context_after": {"type": "integer", "minimum": 0, "maximum": 20},
+        "matches": {"type": "array", "items": search_match_schema()},
+        "count": {"type": "integer", "minimum": 0},
+        "files": {"type": "array", "items": search_file_result_schema()},
+        "returned_file_count": {"type": "integer", "minimum": 0},
+        "returned_match_count": {"type": "integer", "minimum": 0},
+        "count_complete": {"type": "boolean"},
+        "total_matches": nullable_schema("integer", "Complete total in count mode; null when incomplete."),
+        "truncated": {"type": "boolean"},
+        "truncation_reason": {
+            "anyOf": [
+                {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport"]},
+                {"type": "null"}
+            ]
+        }
+    });
+    let search_success_full = json!({
         "type": "object",
         "additionalProperties": false,
-        "properties": {
-            "path": schema_type("string", "Effective project-relative search root."),
-            "backend": nullable_schema("string", "Search backend: rg, grep, native, or null when unknown."),
-            "result_mode": {"type": "string", "enum": ["matches", "files_with_matches", "count"]},
-            "effective_timeout_secs": {"type": "integer", "minimum": 1, "maximum": 120},
-            "exit_code": nullable_schema("integer", "Search command exit code, when available."),
-            "context_before": {"type": "integer", "minimum": 0, "maximum": 20},
-            "context_after": {"type": "integer", "minimum": 0, "maximum": 20},
-            "matches": {"type": "array", "items": search_match_schema()},
-            "count": {"type": "integer", "minimum": 0},
-            "files": {"type": "array", "items": search_file_result_schema()},
-            "returned_file_count": {"type": "integer", "minimum": 0},
-            "returned_match_count": {"type": "integer", "minimum": 0},
-            "count_complete": {"type": "boolean"},
-            "total_matches": nullable_schema("integer", "Complete total in count mode; null when incomplete."),
-            "truncated": {"type": "boolean"},
-            "truncation_reason": {
-                "anyOf": [
-                    {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport"]},
-                    {"type": "null"}
-                ]
-            }
-        },
+        "properties": search_success_properties.clone(),
         "required": [
             "path", "backend", "result_mode", "effective_timeout_secs", "exit_code",
             "context_before", "context_after", "truncated", "truncation_reason"
         ]
+    });
+    let search_success_sparse_matches = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "path": search_success_properties["path"].clone(),
+            "matches": search_success_properties["matches"].clone()
+        },
+        "required": ["matches"],
+        "description": "Sparse model-facing form for ordinary complete rg matches-mode success under the default timeout and zero context. Omitted metadata means the documented boring defaults."
+    });
+    let search_success = json!({
+        "anyOf": [search_success_full, search_success_sparse_matches]
     });
     let search_failure = json!({
         "type": "object",
@@ -309,7 +323,7 @@ fn search_project_texts_output_schema() -> Value {
             "else": {"properties": {"output": search_failure, "error": {"type": "string"}}}
         }]
     });
-    let batch_output = json!({
+    let batch_output_full = json!({
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -318,7 +332,7 @@ fn search_project_texts_output_schema() -> Value {
             "returned_count": {"type": "integer", "minimum": 0, "maximum": 8},
             "succeeded_count": {"type": "integer", "minimum": 0, "maximum": 8},
             "failed_count": {"type": "integer", "minimum": 0, "maximum": 8},
-            "items": {"type": "array", "maxItems": 8, "items": item_schema},
+            "items": {"type": "array", "maxItems": 8, "items": item_schema.clone()},
             "output_truncated": {"type": "boolean"},
             "next_index": {"anyOf": [{"type": "integer", "minimum": 0, "maximum": 7}, {"type": "null"}]},
             "session_recorded": schema_type("boolean", "True when this batch call was recorded."),
@@ -331,6 +345,35 @@ fn search_project_texts_output_schema() -> Value {
             "project", "requested_count", "returned_count", "succeeded_count",
             "failed_count", "items", "output_truncated", "next_index"
         ]
+    });
+    let sparse_success_item = json!({
+        "allOf": [
+            item_schema,
+            {
+                "properties": {
+                    "success": {"const": true},
+                    "error": {"type": "null"}
+                },
+                "required": ["success", "error"]
+            }
+        ]
+    });
+    let batch_output_sparse = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "items": {"type": "array", "minItems": 1, "maxItems": 8, "items": sparse_success_item},
+            "session_recorded": schema_type("boolean", "True when this batch call was recorded."),
+            "session_id": schema_type("string", "Session id used for outer batch telemetry."),
+            "session_event_id": schema_type("string", "Outer batch Session event id."),
+            "session_hint": session_hint_schema(),
+            "permission": permission_decision_schema()
+        },
+        "required": ["items"],
+        "description": "Sparse model-facing batch form used only when every returned query succeeded and the outer batch was complete. Omitted counts and continuation fields therefore mean all items succeeded and no outer truncation occurred."
+    });
+    let batch_output = json!({
+        "anyOf": [batch_output_full, batch_output_sparse]
     });
     json!({
         "type": "object",

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -51,6 +51,7 @@ fn structured_execution_lifecycle_constraints(execution_source: &str) -> Value {
                     {"required": ["terminal"]},
                     {"required": ["job_id"]},
                     {"required": ["job_status"]},
+                    {"required": ["observation_token"]},
                     {"required": ["effective_timeout_secs"]},
                     {"required": ["sync_wait_secs"]}
                 ]

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -52,8 +52,7 @@ fn structured_execution_lifecycle_constraints(execution_source: &str) -> Value {
                     {"required": ["job_id"]},
                     {"required": ["job_status"]},
                     {"required": ["effective_timeout_secs"]},
-                    {"required": ["sync_wait_secs"]},
-                    {"required": ["async_handoff_available"]}
+                    {"required": ["sync_wait_secs"]}
                 ]
             },
             "then": {
@@ -69,6 +68,41 @@ fn structured_execution_lifecycle_constraints(execution_source: &str) -> Value {
                     "command_started",
                     "command_completed"
                 ]
+            }
+        },
+        {
+            "if": {"required": ["async_handoff_available"]},
+            "then": {
+                "if": {
+                    "properties": {
+                        "async_handoff_available": {"const": false},
+                        "execution_state": {"const": "completed"},
+                        "command_started": {"const": true},
+                        "command_completed": {"const": true},
+                        "command_ok": {"const": true}
+                    },
+                    "required": [
+                        "async_handoff_available",
+                        "execution_state",
+                        "command_started",
+                        "command_completed",
+                        "command_ok"
+                    ]
+                },
+                "else": {
+                    "required": [
+                        "promoted_to_job",
+                        "terminal",
+                        "job_id",
+                        "job_status",
+                        "effective_timeout_secs",
+                        "sync_wait_secs",
+                        "async_handoff_available",
+                        "execution_state",
+                        "command_started",
+                        "command_completed"
+                    ]
+                }
             }
         },
         {
@@ -222,28 +256,28 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
             "promoted_to_job",
             schema_type(
                 "boolean",
-                "True only when the same original execution continues as a durable Job.",
+                "True only when the same original execution continues as a durable Job. Omitted from run_process/run_script model-facing output after ordinary synchronous terminal success.",
             ),
         ),
         (
             "terminal",
             schema_type(
                 "boolean",
-                "Whether a trustworthy terminal projection is available from this tool call.",
+                "Whether a trustworthy terminal projection is available from this tool call. Omitted when ordinary synchronous run_process/run_script success already implies terminal=true.",
             ),
         ),
         (
             "job_id",
             nullable_schema(
                 "string",
-                "Durable continuation Job id, or null when no Job was exposed.",
+                "Durable continuation Job id. Non-promoted terminal run_process/run_script success omits this field rather than returning null.",
             ),
         ),
         (
             "job_status",
             nullable_schema(
                 "string",
-                "Authoritative durable Job status, or null when no Job was exposed.",
+                "Authoritative durable Job status. Non-promoted terminal run_process/run_script success omits this field rather than returning null.",
             ),
         ),
         (
@@ -257,21 +291,21 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
             "effective_timeout_secs",
             schema_type(
                 "integer",
-                "Total execution budget in seconds, beginning with the one original execution.",
+                "Total execution budget in seconds, beginning with the one original execution. Omitted from ordinary synchronous terminal run_process/run_script success.",
             ),
         ),
         (
             "sync_wait_secs",
             schema_type(
                 "integer",
-                "Internal synchronous grace in seconds; this is not a second timeout budget.",
+                "Internal synchronous grace in seconds; this is not a second timeout budget. Omitted from ordinary synchronous terminal run_process/run_script success.",
             ),
         ),
         (
             "async_handoff_available",
             schema_type(
                 "boolean",
-                "Whether this Runner can continue typed structured execution as the same durable Job.",
+                "Whether this Runner can continue typed structured execution as the same durable Job. True is omitted after ordinary synchronous terminal run_process/run_script success; false remains explicit as a noteworthy capability limitation.",
             ),
         ),
     ]
@@ -507,27 +541,27 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
                 (
                     "stdout_tail",
-                    schema_type("string", "Bounded stdout tail."),
+                    schema_type("string", "Bounded stdout tail; omitted when empty on ordinary synchronous terminal success."),
                 ),
                 (
                     "stderr_tail",
-                    schema_type("string", "Bounded stderr tail."),
+                    schema_type("string", "Bounded stderr tail; omitted when empty on ordinary synchronous terminal success."),
                 ),
                 (
                     "stdout_lines",
-                    schema_type("integer", "Captured stdout line count."),
+                    schema_type("integer", "Captured stdout line count; omitted when zero on ordinary synchronous terminal success."),
                 ),
                 (
                     "stderr_lines",
-                    schema_type("integer", "Captured stderr line count."),
+                    schema_type("integer", "Captured stderr line count; omitted when zero on ordinary synchronous terminal success."),
                 ),
                 (
                     "stdout_truncated",
-                    schema_type("boolean", "Whether stdout_tail was truncated."),
+                    schema_type("boolean", "Whether stdout_tail was truncated; false is omitted on ordinary synchronous terminal success."),
                 ),
                 (
                     "stderr_truncated",
-                    schema_type("boolean", "Whether stderr_tail was truncated."),
+                    schema_type("boolean", "Whether stderr_tail was truncated; false is omitted on ordinary synchronous terminal success."),
                 ),
                 (
                     "command_started",
@@ -551,14 +585,14 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "failure_kind",
                     nullable_schema(
                         "string",
-                        "Structured failure kind such as command_exit_nonzero, timeout, outcome_unknown, capability_unavailable, unsupported_resource, unsupported_executable_type, spawn_failed, permission_denied, invalid_arguments, agent_offline, session_guard_denied, session_closed, or runtime_error.",
+                        "Structured failure kind such as command_exit_nonzero, timeout, outcome_unknown, capability_unavailable, unsupported_resource, unsupported_executable_type, spawn_failed, permission_denied, invalid_arguments, agent_offline, session_guard_denied, session_closed, or runtime_error. Omitted instead of null on ordinary synchronous terminal success.",
                     ),
                 ),
                 (
                     "tool_failure",
                     schema_type(
                         "boolean",
-                        "True for WebCodex tool/runtime failures; false for child exit status failures.",
+                        "True for WebCodex tool/runtime failures; false for child exit status failures. Omitted when false on ordinary synchronous terminal success.",
                     ),
                 ),
                 ("purpose", schema_type("string", "Declared execution purpose.")),
@@ -603,27 +637,27 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
                 (
                     "stdout_tail",
-                    schema_type("string", "Bounded stdout tail."),
+                    schema_type("string", "Bounded stdout tail; omitted when empty on ordinary synchronous terminal success."),
                 ),
                 (
                     "stderr_tail",
-                    schema_type("string", "Bounded stderr tail."),
+                    schema_type("string", "Bounded stderr tail; omitted when empty on ordinary synchronous terminal success."),
                 ),
                 (
                     "stdout_lines",
-                    schema_type("integer", "Captured stdout line count."),
+                    schema_type("integer", "Captured stdout line count; omitted when zero on ordinary synchronous terminal success."),
                 ),
                 (
                     "stderr_lines",
-                    schema_type("integer", "Captured stderr line count."),
+                    schema_type("integer", "Captured stderr line count; omitted when zero on ordinary synchronous terminal success."),
                 ),
                 (
                     "stdout_truncated",
-                    schema_type("boolean", "Whether stdout_tail was truncated."),
+                    schema_type("boolean", "Whether stdout_tail was truncated; false is omitted on ordinary synchronous terminal success."),
                 ),
                 (
                     "stderr_truncated",
-                    schema_type("boolean", "Whether stderr_tail was truncated."),
+                    schema_type("boolean", "Whether stderr_tail was truncated; false is omitted on ordinary synchronous terminal success."),
                 ),
                 (
                     "command_started",
@@ -650,14 +684,14 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "failure_kind",
                     nullable_schema(
                         "string",
-                        "Structured failure kind such as command_exit_nonzero, timeout, outcome_unknown, capability_unavailable, unsupported_resource, interpreter_unavailable, script_setup_failed, permission_denied, invalid_arguments, agent_offline, session_guard_denied, session_closed, or runtime_error.",
+                        "Structured failure kind such as command_exit_nonzero, timeout, outcome_unknown, capability_unavailable, unsupported_resource, interpreter_unavailable, script_setup_failed, permission_denied, invalid_arguments, agent_offline, session_guard_denied, session_closed, or runtime_error. Omitted instead of null on ordinary synchronous terminal success.",
                     ),
                 ),
                 (
                     "tool_failure",
                     schema_type(
                         "boolean",
-                        "True for WebCodex tool/runtime failures; false for interpreter exit status failures.",
+                        "True for WebCodex tool/runtime failures; false for interpreter exit status failures. Omitted when false on ordinary synchronous terminal success.",
                     ),
                 ),
                 ("purpose", schema_type("string", "Declared execution purpose.")),

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -601,7 +601,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "process_summary",
                     schema_type(
                         "string",
-                        "Bounded human-readable executable/argv summary; never execution input.",
+                        "Bounded human-readable executable/argv summary; never execution input. Omitted on ordinary synchronous terminal success when the canonical run_process source is implied by tool identity.",
                     ),
                 ),
                 (
@@ -611,7 +611,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ("executor", schema_type("string", "Executor type: local or agent.")),
                 (
                     "execution_source",
-                    schema_type("string", "Always run_process."),
+                    schema_type("string", "Canonical source is run_process. Omitted on ordinary synchronous terminal success only when the actual source is exactly canonical; any future schema-supported alternate source must remain explicit."),
                 ),
                 (
                     "execution_state",
@@ -700,7 +700,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "script_summary",
                     schema_type(
                         "string",
-                        "Bounded body-free language/byte/argument summary; never execution input.",
+                        "Bounded body-free language/byte/argument summary; never execution input. Omitted on ordinary synchronous terminal success when the canonical run_script source is implied by tool identity.",
                     ),
                 ),
                 (
@@ -714,7 +714,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ("executor", schema_type("string", "Executor type: local or agent.")),
                 (
                     "execution_source",
-                    schema_type("string", "Always run_script."),
+                    schema_type("string", "Canonical source is run_script. Omitted on ordinary synchronous terminal success only when the actual source is exactly canonical; any future schema-supported alternate source must remain explicit."),
                 ),
                 (
                     "execution_state",

--- a/src/tool_runtime/registry/tool_specs/coding_tasks.rs
+++ b/src/tool_runtime/registry/tool_specs/coding_tasks.rs
@@ -13,7 +13,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "work_on_project",
-            "Bootstrap coding work via project or Runner path; Git not required. Returns built-in workflow guidance and project-local instructions. Select implementation/review in the task instruction; guidance grants no authority.",
+            "Bootstrap coding work via project or Runner path; Git not required. Returns built-in workflow guidance by default plus project-local instructions. Select implementation/review in the task instruction; guidance grants no authority.",
             work_on_project_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/registry/tool_specs/coding_tasks.rs
+++ b/src/tool_runtime/registry/tool_specs/coding_tasks.rs
@@ -13,7 +13,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "work_on_project",
-            "Bootstrap coding work via project or Runner path; Git not required. Returns built-in workflow guidance by default plus project-local instructions. Select implementation/review in the task instruction; guidance grants no authority.",
+            "Bootstrap coding via project or Runner path; Git not required. Returns built-in workflow guidance plus project-local instructions. Select implementation/review in task instruction; guidance grants no authority.",
             work_on_project_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/startup_brief.rs
+++ b/src/tool_runtime/startup_brief.rs
@@ -107,6 +107,7 @@ pub(crate) struct StartupBriefInput<'a> {
     pub(crate) instructions: &'a ProjectInstructionsSnapshot,
     pub(crate) previous_instructions: Option<&'a ProjectInstructionsSummarySnapshot>,
     pub(crate) force_instruction_load: bool,
+    pub(crate) include_project_instructions: bool,
     pub(crate) git: &'a Value,
     pub(crate) semantic_navigation: &'a Value,
     pub(crate) repository: &'a Value,
@@ -124,7 +125,7 @@ pub(crate) fn build_startup_brief(input: StartupBriefInput<'_>) -> Value {
         input.instructions,
         input.previous_instructions,
         input.force_instruction_load,
-        !minimal,
+        !minimal && input.include_project_instructions,
         minimal,
     );
     let continuation = continuation_projection(
@@ -2088,6 +2089,7 @@ mod tests {
                 instructions: &instructions,
                 previous_instructions: None,
                 force_instruction_load: true,
+                include_project_instructions: true,
                 git: &git,
                 semantic_navigation: &semantic_navigation,
                 repository: &large_repository(),

--- a/src/tool_runtime/startup_brief.rs
+++ b/src/tool_runtime/startup_brief.rs
@@ -1049,7 +1049,7 @@ fn startup_issues(
     if workspace.get("git_available").and_then(Value::as_bool) == Some(false) {
         push_unique(&mut warnings, "git_unavailable");
     }
-    if !input.binding_available {
+    if !input.binding_available && input.binding_reason_code != Some("binding_disabled") {
         push_unique(&mut warnings, "current_binding_unavailable");
     }
     if instructions.get("status").and_then(Value::as_str) == Some("unavailable") {

--- a/src/tool_runtime/tests/coding_task_semantic_navigation.rs
+++ b/src/tool_runtime/tests/coding_task_semantic_navigation.rs
@@ -215,7 +215,7 @@ async fn coding_task_semantic_navigation_available_is_recommended_and_bounded() 
         .unwrap()
         .starts_with("wc_sess_"));
     assert_eq!(result.output["startup_verdict"]["status"], "warn");
-    assert!(result.output["warnings"]
+    assert!(!result.output["warnings"]
         .as_array()
         .unwrap()
         .iter()

--- a/src/tool_runtime/tests/explicit_resume.rs
+++ b/src/tool_runtime/tests/explicit_resume.rs
@@ -205,6 +205,11 @@ async fn explicit_resume_without_window_continues_unbound_and_preserves_root_tit
         resumed.output["session"]["explicit_session_id_required_for_continuity"],
         true
     );
+    assert!(resumed.output["startup_brief"]["warnings"]
+        .as_array()
+        .is_some_and(|warnings| warnings
+            .iter()
+            .any(|warning| warning == "current_binding_unavailable")));
     assert!(!serde_json::to_string(&resumed.output)
         .unwrap()
         .contains("current_session_unavailable"));

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -3150,7 +3150,6 @@ async fn search_project_text_include_and_exclude_globs_are_additive() {
         paths,
         vec!["docs/guide.md".to_string(), "src/lib.rs".to_string()]
     );
-    assert_eq!(result.output["result_mode"], "matches");
 }
 
 #[tokio::test]
@@ -3414,16 +3413,7 @@ async fn search_project_text_no_matches_returns_empty_matches() {
     let result = task.await.unwrap();
 
     assert!(result.success, "{:?}", result.error);
-    assert!(matches!(
-        result.output["backend"].as_str(),
-        Some("rg" | "grep")
-    ));
     assert_eq!(result.output["matches"], json!([]));
-    assert_eq!(result.output["count"], 0);
-    assert_eq!(result.output["truncated"], false);
-    assert_eq!(result.output["result_mode"], "matches");
-    assert_eq!(result.output["effective_timeout_secs"], 30);
-    assert_eq!(result.output["truncation_reason"], Value::Null);
 }
 
 #[tokio::test]
@@ -3480,9 +3470,8 @@ async fn search_project_text_excludes_sensitive_and_build_dirs() {
     let result = task.await.unwrap();
 
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["count"], 1);
+    assert_eq!(result.output["matches"].as_array().unwrap().len(), 1);
     assert_eq!(result.output["matches"][0]["path"], "src/lib.rs");
-    assert_eq!(result.output["truncated"], false);
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1390,6 +1390,7 @@ async fn tool_manifest_reports_accepted_flattened_args_without_schemas() {
         "path",
         "instruction",
         "include_project_instructions",
+        "include_workflow_guidance",
         "session_id",
         TOOL_CALL_RECORDING_SESSION_ID_FIELD,
     ] {

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1389,6 +1389,7 @@ async fn tool_manifest_reports_accepted_flattened_args_without_schemas() {
         "client_id",
         "path",
         "instruction",
+        "include_project_instructions",
         "session_id",
         TOOL_CALL_RECORDING_SESSION_ID_FIELD,
     ] {

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -849,11 +849,37 @@ async fn run_process_fast_terminal_jobs_project_back_without_visible_duplicates(
         assert_eq!(result.output["command_started"], true);
         assert_eq!(result.output["command_completed"], true);
         assert_eq!(result.output["exit_code"], exit_code);
-        assert_eq!(result.output["promoted_to_job"], false);
-        assert_eq!(result.output["terminal"], true);
-        assert!(result.output["job_id"].is_null());
-        assert!(result.output["job_status"].is_null());
-        assert_eq!(result.output["async_handoff_available"], true);
+        if expected_success {
+            assert_eq!(result.output["command_ok"], true);
+            for omitted in [
+                "promoted_to_job",
+                "terminal",
+                "job_id",
+                "job_status",
+                "observation_token",
+                "effective_timeout_secs",
+                "sync_wait_secs",
+                "async_handoff_available",
+                "failure_kind",
+                "tool_failure",
+                "stdout_truncated",
+                "stderr_truncated",
+            ] {
+                assert!(
+                    result.output.get(omitted).is_none(),
+                    "boring terminal success field {omitted} should be omitted: {}",
+                    result.output
+                );
+            }
+        } else {
+            assert_eq!(result.output["promoted_to_job"], false);
+            assert_eq!(result.output["terminal"], true);
+            assert!(result.output["job_id"].is_null());
+            assert!(result.output["job_status"].is_null());
+            assert_eq!(result.output["async_handoff_available"], true);
+            assert_eq!(result.output["failure_kind"], "command_exit_nonzero");
+            assert_eq!(result.output["tool_failure"], false);
+        }
         assert!(
             runtime
                 .shell_clients
@@ -867,6 +893,120 @@ async fn run_process_fast_terminal_jobs_project_back_without_visible_duplicates(
             "a fast terminal execution must not become a public duplicate"
         );
     }
+}
+
+#[tokio::test]
+async fn run_process_terminal_success_is_sparse_after_full_session_effect_recording() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = test_runtime().with_structured_execution_sync_wait(Duration::from_millis(250));
+    let project = register_process_job_agent(&runtime, "process-sparse-ledger", temp.path()).await;
+    let session = runtime.sessions.start_session(Some(project.clone()), None);
+    let session_id = session.session_id.clone();
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let session_id = session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(process_call(project, Some(session_id)), Some(&auth))
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, "process-sparse-ledger")
+        .await
+        .expect("hidden process Job should dispatch");
+    update_process_job(
+        &runtime,
+        "process-sparse-ledger",
+        &request,
+        "running",
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    update_process_job(
+        &runtime,
+        "process-sparse-ledger",
+        &request,
+        "completed",
+        Some(ShellCommandExecutionState::Completed),
+        Some(0),
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["execution_state"], "completed");
+    assert_eq!(result.output["command_started"], true);
+    assert_eq!(result.output["command_completed"], true);
+    assert_eq!(result.output["command_ok"], true);
+    assert_eq!(result.output["exit_code"], 0);
+    for omitted in [
+        "promoted_to_job",
+        "terminal",
+        "job_id",
+        "job_status",
+        "effective_timeout_secs",
+        "sync_wait_secs",
+        "async_handoff_available",
+        "failure_kind",
+        "tool_failure",
+        "stdout_tail",
+        "stderr_tail",
+        "stdout_lines",
+        "stderr_lines",
+        "stdout_truncated",
+        "stderr_truncated",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "model-facing boring success field {omitted} should be omitted: {}",
+            result.output
+        );
+    }
+
+    let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
+    assert!(
+        sparse_bytes <= 800,
+        "boring run_process success regressed above the model-facing context budget: {sparse_bytes} bytes"
+    );
+    eprintln!("run_process_sparse_terminal_success_bytes={sparse_bytes}");
+
+    let summary = runtime.sessions.summary(&session_id, Some(20)).unwrap();
+    let finished = summary
+        .events
+        .iter()
+        .rev()
+        .find(|event| event.kind == "tool_call_finished" && event.tool_name == "run_process")
+        .expect("recorded run_process completion");
+    assert_eq!(finished.exit_code, Some(0));
+    let effect = finished
+        .effect_evidence
+        .as_ref()
+        .expect("full lifecycle evidence must be recorded before model sparsification");
+    assert_eq!(effect.execution_state.as_deref(), Some("completed"));
+    assert_eq!(effect.command_started, Some(true));
+    assert_eq!(effect.command_completed, Some(true));
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("run_process");
+    let instance = json!({
+        "success": true,
+        "output": result.output,
+        "error": null,
+    });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| {
+            panic!("sparse terminal success must match run_process schema: {error}")
+        });
 }
 
 #[tokio::test]
@@ -932,8 +1072,8 @@ async fn run_process_fast_terminal_projection_does_not_silently_drop_retained_li
         Some(retained_stdout.as_str())
     );
     assert_eq!(result.output["stdout_lines"], 300);
-    assert_eq!(result.output["stdout_truncated"], false);
-    assert_eq!(result.output["promoted_to_job"], false);
+    assert!(result.output.get("stdout_truncated").is_none());
+    assert!(result.output.get("promoted_to_job").is_none());
     assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
 }
 
@@ -1390,8 +1530,35 @@ async fn b2_process_runner_uses_direct_sync_and_rejects_durable_only_timeout() {
     )
     .await;
     let direct = direct.await.unwrap();
-    assert_eq!(direct.output["promoted_to_job"], false);
+    assert!(direct.output.get("promoted_to_job").is_none());
     assert_eq!(direct.output["async_handoff_available"], false);
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("run_process");
+    let instance = json!({
+        "success": true,
+        "output": direct.output.clone(),
+        "error": null,
+    });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| {
+            panic!("B2 sparse terminal success must match run_process schema: {error}")
+        });
+    let mut malformed = direct.output.clone();
+    malformed["execution_state"] = json!("outcome_unknown");
+    malformed["command_completed"] = json!(false);
+    malformed["command_ok"] = json!(false);
+    let malformed_instance = json!({
+        "success": false,
+        "output": malformed,
+        "error": "transport outcome unknown",
+    });
+    assert!(
+        crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+            &malformed_instance,
+            &schema,
+        )
+        .is_err(),
+        "async_handoff_available=false must not weaken non-terminal continuation requirements"
+    );
 
     let rejected = runtime
         .dispatch_with_auth(

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -344,7 +344,13 @@ async fn run_process_enqueues_only_typed_argv_and_reports_completed_exit_codes()
         assert_eq!(result.output["command_started"], true);
         assert_eq!(result.output["command_completed"], true);
         assert_eq!(result.output["exit_code"], exit_code);
-        assert_eq!(result.output["execution_source"], "run_process");
+        if expected_success {
+            assert!(result.output.get("execution_source").is_none());
+            assert!(result.output.get("process_summary").is_none());
+        } else {
+            assert_eq!(result.output["execution_source"], "run_process");
+            assert!(result.output["process_summary"].as_str().is_some());
+        }
         assert_eq!(result.output["purpose"], "diagnostic");
     }
 }
@@ -966,6 +972,8 @@ async fn run_process_terminal_success_is_sparse_after_full_session_effect_record
         "stderr_lines",
         "stdout_truncated",
         "stderr_truncated",
+        "process_summary",
+        "execution_source",
     ] {
         assert!(
             result.output.get(omitted).is_none(),
@@ -974,9 +982,11 @@ async fn run_process_terminal_success_is_sparse_after_full_session_effect_record
         );
     }
 
+    assert!(result.output["cwd"].as_str().is_some());
+    assert!(result.output["executor"].as_str().is_some());
     let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
     assert!(
-        sparse_bytes <= 800,
+        sparse_bytes <= 620,
         "boring run_process success regressed above the model-facing context budget: {sparse_bytes} bytes"
     );
     eprintln!("run_process_sparse_terminal_success_bytes={sparse_bytes}");

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -194,6 +194,359 @@ async fn read_files_returns_ordered_normalized_successes_after_out_of_order_comp
 }
 
 #[tokio::test]
+async fn read_file_dispatch_complete_success_is_sparse_after_session_recording() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-sparse-single";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime
+        .sessions
+        .start_session(Some(project.clone()), Some("sparse read".to_string()));
+    let session_id = session.session_id.clone();
+    let auth = auth_context(None, true);
+    let content = "one\ntwo";
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let session_id = session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFile {
+                        project,
+                        path: "src/lib.rs".to_string(),
+                        session_id: Some(session_id),
+                        start_line: None,
+                        limit: None,
+                        with_line_numbers: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    assert_eq!(request.path.as_deref(), Some("src/lib.rs"));
+    complete_read(&runtime, client_id, &request, content).await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["text"], "one\ntwo");
+    assert_eq!(result.output["path"], "src/lib.rs");
+    assert_eq!(
+        result.output["sha256"],
+        format!("{:x}", Sha256::digest(content.as_bytes()))
+    );
+    assert_eq!(result.output["total_lines"], 2);
+    for omitted in [
+        "format",
+        "start_line",
+        "limit",
+        "returned_lines",
+        "end_line",
+        "has_more",
+        "next_start_line",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "complete full-file read field {omitted} should be omitted: {}",
+            result.output
+        );
+    }
+    let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
+    assert!(
+        sparse_bytes <= 400,
+        "complete sparse read_file regressed above model-facing budget: {sparse_bytes} bytes"
+    );
+    eprintln!("read_file_sparse_complete_bytes={sparse_bytes}");
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("read_file");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| panic!("sparse read_file success must match schema: {error}"));
+
+    let summary = runtime
+        .sessions
+        .summary(&session.session_id, Some(20))
+        .unwrap();
+    let finished = summary
+        .events
+        .iter()
+        .rev()
+        .find(|event| event.kind == "tool_call_finished" && event.tool_name == "read_file")
+        .expect("recorded read_file completion");
+    assert!(
+        finished
+            .observed_paths
+            .iter()
+            .any(|path| path == "src/lib.rs"),
+        "Session observation extraction must see the full read result before sparsification"
+    );
+}
+
+#[tokio::test]
+async fn read_file_dispatch_partial_success_keeps_full_range_cursor() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-partial-visible";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+    let content = "one\ntwo\nthree";
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFile {
+                        project,
+                        path: "src/lib.rs".to_string(),
+                        session_id: None,
+                        start_line: Some(2),
+                        limit: Some(1),
+                        with_line_numbers: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    complete_read(&runtime, client_id, &request, content).await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["text"], "two");
+    assert_eq!(result.output["format"], "plain");
+    assert_eq!(result.output["path"], "src/lib.rs");
+    assert_eq!(result.output["start_line"], 2);
+    assert_eq!(result.output["limit"], 1);
+    assert_eq!(result.output["total_lines"], 3);
+    assert_eq!(result.output["returned_lines"], 1);
+    assert_eq!(result.output["end_line"], 2);
+    assert_eq!(result.output["has_more"], true);
+    assert_eq!(result.output["next_start_line"], 3);
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("read_file");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| panic!("partial read_file success must match schema: {error}"));
+}
+
+#[tokio::test]
+async fn read_file_dispatch_complete_explicit_range_keeps_full_range_metadata() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-explicit-range-visible";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+    let content = "one\ntwo";
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFile {
+                        project,
+                        path: "src/lib.rs".to_string(),
+                        session_id: None,
+                        start_line: Some(1),
+                        limit: Some(2),
+                        with_line_numbers: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    complete_read(&runtime, client_id, &request, content).await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["text"], "one\ntwo");
+    assert_eq!(result.output["format"], "plain");
+    assert_eq!(result.output["path"], "src/lib.rs");
+    assert_eq!(result.output["start_line"], 1);
+    assert_eq!(result.output["limit"], 2);
+    assert_eq!(result.output["total_lines"], 2);
+    assert_eq!(result.output["returned_lines"], 2);
+    assert_eq!(result.output["end_line"], 2);
+    assert_eq!(result.output["has_more"], false);
+    assert!(result.output["next_start_line"].is_null());
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("read_file");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| {
+            panic!("explicit-range read_file success must match schema: {error}")
+        });
+}
+
+#[tokio::test]
+async fn read_files_dispatch_complete_batch_is_sparse_and_schema_valid() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-sparse-batch";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFiles {
+                        project,
+                        items: vec![
+                            item("src/lib.rs", None, None),
+                            item("src/main.rs", None, None),
+                        ],
+                        session_id: None,
+                        with_line_numbers: Some(true),
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let requests = [
+        next_read_request(&runtime, client_id).await,
+        next_read_request(&runtime, client_id).await,
+    ];
+    for request in &requests {
+        let content = match request.path.as_deref() {
+            Some("src/lib.rs") => "lib",
+            Some("src/main.rs") => "main",
+            other => panic!("unexpected batch read path: {other:?}"),
+        };
+        complete_read(&runtime, client_id, request, content).await;
+    }
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    for omitted in [
+        "project",
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "complete read_files batch field {omitted} should be omitted: {}",
+            result.output
+        );
+    }
+    let items = result.output["items"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    for item in items {
+        assert_eq!(item["success"], true);
+        assert!(item["error"].is_null());
+        assert_eq!(item["output"]["format"], "numbered");
+        assert!(item["output"].get("path").is_none());
+        assert!(item["output"]["sha256"].as_str().is_some());
+        assert_eq!(item["output"]["total_lines"], 1);
+        for omitted in [
+            "start_line",
+            "limit",
+            "returned_lines",
+            "end_line",
+            "has_more",
+            "next_start_line",
+        ] {
+            assert!(
+                item["output"].get(omitted).is_none(),
+                "complete batch item field {omitted} should be omitted: {item}"
+            );
+        }
+    }
+    let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
+    assert!(
+        sparse_bytes <= 600,
+        "complete two-file sparse batch regressed above model-facing budget: {sparse_bytes} bytes"
+    );
+    eprintln!("read_files_sparse_complete_bytes={sparse_bytes}");
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("read_files");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| panic!("sparse read_files batch must match schema: {error}"));
+}
+
+#[tokio::test]
+async fn read_files_dispatch_mixed_batch_keeps_outer_and_failure_semantics() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-sparse-mixed";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let expected_project = project.clone();
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFiles {
+                        project,
+                        items: vec![item("good.txt", None, None), item(".env", None, None)],
+                        session_id: None,
+                        with_line_numbers: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    assert_eq!(request.path.as_deref(), Some("good.txt"));
+    complete_read(&runtime, client_id, &request, "ok").await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["project"], expected_project);
+    assert_eq!(result.output["requested_count"], 2);
+    assert_eq!(result.output["returned_count"], 2);
+    assert_eq!(result.output["succeeded_count"], 1);
+    assert_eq!(result.output["failed_count"], 1);
+    assert_eq!(result.output["output_truncated"], false);
+    assert!(result.output["next_index"].is_null());
+
+    let items = result.output["items"].as_array().unwrap();
+    assert_eq!(items[0]["success"], true);
+    assert_eq!(items[0]["path"], "good.txt");
+    assert_eq!(items[0]["output"]["text"], "ok");
+    assert!(items[0]["output"].get("path").is_none());
+    assert!(items[0]["output"].get("format").is_none());
+    assert!(items[0]["output"].get("has_more").is_none());
+    assert_eq!(items[1]["success"], false);
+    assert_eq!(items[1]["path"], ".env");
+    assert_eq!(items[1]["output"]["error_kind"], "read_file_failed");
+    assert_eq!(items[1]["output"]["reason_code"], "sensitive_path");
+    assert_eq!(items[1]["output"]["state_changed"], false);
+    assert!(items[1]["error"].as_str().is_some());
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("read_files");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| panic!("mixed sparse/full read batch must match schema: {error}"));
+}
+
+#[tokio::test]
 async fn read_files_isolates_mixed_failures_without_leaking_absolute_paths() {
     let root = tempfile::tempdir().unwrap();
     let runtime = ToolRuntime::new_for_tests();

--- a/src/tool_runtime/tests/schema/outputs.rs
+++ b/src/tool_runtime/tests/schema/outputs.rs
@@ -287,6 +287,33 @@ fn key_tool_output_schemas_include_expected_fields() {
         .is_err(),
         "an execution-style run_process denial must include the canonical lifecycle tuple"
     );
+    for (tool_name, schema) in [
+        ("run_process", run_process_schema),
+        (
+            "run_script",
+            &spec_named(&specs, "run_script").output_schema,
+        ),
+    ] {
+        assert!(
+            crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+                &serde_json::json!({
+                    "success": true,
+                    "output": {
+                        "execution_state": "completed",
+                        "command_started": true,
+                        "command_completed": true,
+                        "command_ok": true,
+                        "exit_code": 0,
+                        "observation_token": "orphan-observation"
+                    },
+                    "error": null
+                }),
+                schema,
+            )
+            .is_err(),
+            "{tool_name} must reject an observation_token without the full continuation tuple"
+        );
+    }
     let process_started_description =
         output_schema_property(&specs, "run_process", "command_started")["description"]
             .as_str()

--- a/src/tool_runtime/tests/schema/outputs.rs
+++ b/src/tool_runtime/tests/schema/outputs.rs
@@ -1394,6 +1394,71 @@ fn read_file_output_schema_matches_real_results_and_strict_tool_payloads() {
             <= success["output"]["limit"].as_u64().unwrap()
     );
 
+    let sparse = serde_json::to_value(crate::tool_runtime::tool_result::ToolResult::ok(json!({
+        "text": "hello",
+        "path": "src/lib.rs",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "total_lines": 1
+    })))
+    .unwrap();
+    validate(&sparse).unwrap();
+    let mut sparse_numbered = sparse.clone();
+    sparse_numbered["output"]["format"] = json!("numbered");
+    validate(&sparse_numbered).unwrap();
+
+    let mut sparse_plain = sparse.clone();
+    sparse_plain["output"]["format"] = json!("plain");
+    assert!(
+        validate(&sparse_plain).is_err(),
+        "complete sparse plain output must omit redundant format"
+    );
+    let default_limit = webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
+    let mut sparse_over_default_limit = sparse.clone();
+    sparse_over_default_limit["output"]["total_lines"] = json!(default_limit + 1);
+    assert!(
+        validate(&sparse_over_default_limit).is_err(),
+        "complete sparse read_file output cannot claim more lines than the default range can return"
+    );
+
+    let read_files_schema = crate::tool_runtime::registry::output_schema_for_tool("read_files");
+    let sparse_batch_over_default_limit = json!({
+        "success": true,
+        "output": {
+            "items": [{
+                "index": 0,
+                "path": "src/lib.rs",
+                "success": true,
+                "output": {
+                    "text": "hello",
+                    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "total_lines": default_limit + 1
+                },
+                "error": null
+            }]
+        },
+        "error": null
+    });
+    assert!(
+        crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+            &sparse_batch_over_default_limit,
+            &read_files_schema,
+        )
+        .is_err(),
+        "complete sparse read_files item cannot claim more lines than the default range can return"
+    );
+    let mut sparse_missing_sha = sparse.clone();
+    sparse_missing_sha["output"]
+        .as_object_mut()
+        .unwrap()
+        .remove("sha256");
+    assert!(validate(&sparse_missing_sha).is_err());
+    let mut sparse_fake_continuation = sparse.clone();
+    sparse_fake_continuation["output"]["has_more"] = json!(true);
+    assert!(
+        validate(&sparse_fake_continuation).is_err(),
+        "sparse complete form must not admit partial-read continuation fields"
+    );
+
     let failure = serde_json::to_value(
         crate::tool_runtime::tool_result::ToolResult::err_with_output(
             "read_file failed: not_found",

--- a/src/tool_runtime/tests/script.rs
+++ b/src/tool_runtime/tests/script.rs
@@ -244,16 +244,15 @@ async fn run_script_wire_is_typed_body_free_command_and_supports_more_than_32_ki
     .await;
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["execution_source"], "run_script");
+    assert!(result.output.get("execution_source").is_none());
+    assert!(result.output.get("script_summary").is_none());
     assert_eq!(result.output["execution_state"], "completed");
     assert_eq!(result.output["command_started"], true);
     assert_eq!(result.output["command_completed"], true);
     assert_eq!(result.output["language"], "bash");
     assert_eq!(result.output["purpose"], "operation");
-    assert_eq!(
-        result.output["script_summary"],
-        format!("bash script ({} bytes, 4 args)", large_script.len())
-    );
+    assert!(result.output["cwd"].as_str().is_some());
+    assert!(result.output["executor"].as_str().is_some());
 }
 
 #[tokio::test]
@@ -332,6 +331,8 @@ async fn run_script_fast_success_projects_back_and_removes_the_hidden_job() {
         "stderr_lines",
         "stdout_truncated",
         "stderr_truncated",
+        "script_summary",
+        "execution_source",
     ] {
         assert!(
             result.output.get(omitted).is_none(),
@@ -339,6 +340,14 @@ async fn run_script_fast_success_projects_back_and_removes_the_hidden_job() {
             result.output
         );
     }
+    assert!(result.output["cwd"].as_str().is_some());
+    assert!(result.output["executor"].as_str().is_some());
+    let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
+    assert!(
+        sparse_bytes <= 620,
+        "boring run_script success regressed above the model-facing context budget: {sparse_bytes} bytes"
+    );
+    eprintln!("run_script_sparse_terminal_success_bytes={sparse_bytes}");
     let schema = crate::tool_runtime::registry::output_schema_for_tool("run_script");
     let instance = json!({
         "success": true,

--- a/src/tool_runtime/tests/script.rs
+++ b/src/tool_runtime/tests/script.rs
@@ -316,9 +316,40 @@ async fn run_script_fast_success_projects_back_and_removes_the_hidden_job() {
     assert_eq!(result.output["execution_state"], "completed");
     assert_eq!(result.output["command_started"], true);
     assert_eq!(result.output["command_completed"], true);
-    assert_eq!(result.output["promoted_to_job"], false);
-    assert_eq!(result.output["terminal"], true);
-    assert!(result.output["job_id"].is_null());
+    assert_eq!(result.output["command_ok"], true);
+    for omitted in [
+        "promoted_to_job",
+        "terminal",
+        "job_id",
+        "job_status",
+        "observation_token",
+        "effective_timeout_secs",
+        "sync_wait_secs",
+        "async_handoff_available",
+        "failure_kind",
+        "tool_failure",
+        "stderr_tail",
+        "stderr_lines",
+        "stdout_truncated",
+        "stderr_truncated",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "boring terminal success field {omitted} should be omitted: {}",
+            result.output
+        );
+    }
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("run_script");
+    let instance = json!({
+        "success": true,
+        "output": result.output.clone(),
+        "error": null,
+    });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| {
+            panic!("sparse terminal success must match run_script schema: {error}")
+        });
+
     assert!(runtime
         .shell_clients
         .hidden_job_ids_for_test()
@@ -637,8 +668,18 @@ async fn b2_script_runner_uses_direct_sync_and_rejects_durable_only_timeout() {
     )
     .await;
     let direct = direct.await.unwrap();
-    assert_eq!(direct.output["promoted_to_job"], false);
+    assert!(direct.output.get("promoted_to_job").is_none());
     assert_eq!(direct.output["async_handoff_available"], false);
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("run_script");
+    let instance = json!({
+        "success": true,
+        "output": direct.output.clone(),
+        "error": null,
+    });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| {
+            panic!("B2 sparse terminal success must match run_script schema: {error}")
+        });
 
     let rejected = runtime
         .dispatch_with_auth(

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -230,6 +230,297 @@ fn search_project_texts_schema_and_parser_enforce_strict_batch_contract() {
 }
 
 #[tokio::test]
+async fn search_project_text_default_success_is_sparse_after_session_recording() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-sparse-single";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(Some(project.clone()), None);
+    let session_id = session.session_id.clone();
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let session_id = session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::SearchProjectText {
+                        project,
+                        pattern: "needle".to_string(),
+                        session_id: Some(session_id),
+                        path: None,
+                        limit: Some(20),
+                        context_before: None,
+                        context_after: None,
+                        include_globs: None,
+                        exclude_globs: None,
+                        result_mode: None,
+                        timeout_secs: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("single sparse search request");
+    complete_search_success(&runtime, client_id, &request, "src/a.rs").await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["matches"][0]["path"], "src/a.rs");
+    assert!(result.output["session_event_id"].as_str().is_some());
+    for omitted in [
+        "project",
+        "pattern",
+        "path",
+        "backend",
+        "result_mode",
+        "effective_timeout_secs",
+        "exit_code",
+        "context_before",
+        "context_after",
+        "count",
+        "truncated",
+        "truncation_reason",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "boring search field {omitted} should be omitted: {}",
+            result.output
+        );
+    }
+
+    let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
+    assert!(
+        sparse_bytes <= 512,
+        "default sparse single search regressed above the model-facing context budget: {sparse_bytes} bytes"
+    );
+    eprintln!("search_project_text_sparse_default_bytes={sparse_bytes}");
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("search_project_text");
+    let instance = json!({
+        "success": true,
+        "output": result.output.clone(),
+        "error": null,
+    });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| panic!("sparse search success must match schema: {error}"));
+
+    let summary = runtime.sessions.summary(&session_id, Some(20)).unwrap();
+    let finished = summary
+        .events
+        .iter()
+        .rev()
+        .find(|event| {
+            event.kind == "tool_call_finished" && event.tool_name == "search_project_text"
+        })
+        .expect("recorded search completion");
+    assert!(
+        finished
+            .observed_paths
+            .iter()
+            .any(|path| path == "src/a.rs"),
+        "Session observation extraction must run before model sparsification"
+    );
+}
+
+#[tokio::test]
+async fn search_project_text_nondefault_success_keeps_effective_metadata() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-noteworthy-single";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::SearchProjectText {
+                        project,
+                        pattern: "needle".to_string(),
+                        session_id: None,
+                        path: Some("src".to_string()),
+                        limit: Some(20),
+                        context_before: Some(1),
+                        context_after: None,
+                        include_globs: None,
+                        exclude_globs: None,
+                        result_mode: None,
+                        timeout_secs: Some(5),
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("nondefault search request");
+    complete_search_success(&runtime, client_id, &request, "src/a.rs").await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["path"], "src");
+    assert_eq!(result.output["backend"], "rg");
+    assert_eq!(result.output["result_mode"], "matches");
+    assert_eq!(result.output["effective_timeout_secs"], 5);
+    assert_eq!(result.output["context_before"], 1);
+    assert_eq!(result.output["context_after"], 0);
+    assert_eq!(result.output["count"], 1);
+    assert_eq!(result.output["truncated"], false);
+    assert!(result.output["truncation_reason"].is_null());
+}
+
+#[tokio::test]
+async fn search_project_text_grep_fallback_keeps_backend_metadata() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-grep-visible";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::SearchProjectText {
+                        project,
+                        pattern: "needle".to_string(),
+                        session_id: None,
+                        path: None,
+                        limit: Some(20),
+                        context_before: None,
+                        context_after: None,
+                        include_globs: None,
+                        exclude_globs: None,
+                        result_mode: None,
+                        timeout_secs: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("grep fallback search request");
+    let stdout = concat!(
+        "{\"webcodex_search\":{\"backend\":\"grep\",\"feature_unavailable\":false}}\n",
+        "src/a.rs:1:needle\n"
+    );
+    complete_patch_agent_request(&runtime, client_id, &request.request_id, 0, stdout, "").await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["backend"], "grep");
+    assert_eq!(result.output["result_mode"], "matches");
+    assert_eq!(result.output["effective_timeout_secs"], 30);
+    assert_eq!(result.output["count"], 1);
+    assert_eq!(result.output["truncated"], false);
+    assert!(result.output["truncation_reason"].is_null());
+}
+
+#[tokio::test]
+async fn search_project_texts_default_matches_items_are_sparse_and_schema_valid() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-sparse-batch";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::SearchProjectTexts {
+                        project,
+                        queries: vec![query("first", None), query("second", None)],
+                        session_id: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let requests = [
+        next_patch_agent_request(&runtime, client_id).await.unwrap(),
+        next_patch_agent_request(&runtime, client_id).await.unwrap(),
+    ];
+    for request in &requests {
+        let pattern = request_pattern(request);
+        let path = format!("src/{pattern}.rs");
+        complete_search_success(&runtime, client_id, request, &path).await;
+    }
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    for omitted in [
+        "project",
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "complete all-success batch field {omitted} should be omitted: {}",
+            result.output
+        );
+    }
+    let items = result.output["items"].as_array().unwrap();
+    for item in items {
+        assert_eq!(item["success"], true);
+        assert!(item["error"].is_null());
+        assert!(item["output"]["matches"].as_array().is_some());
+        for omitted in [
+            "path",
+            "backend",
+            "result_mode",
+            "effective_timeout_secs",
+            "exit_code",
+            "context_before",
+            "context_after",
+            "count",
+            "truncated",
+            "truncation_reason",
+        ] {
+            assert!(
+                item["output"].get(omitted).is_none(),
+                "boring batch search field {omitted} should be omitted: {item}"
+            );
+        }
+    }
+
+    let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
+    assert!(
+        sparse_bytes <= 800,
+        "default two-query sparse batch regressed above the model-facing context budget: {sparse_bytes} bytes"
+    );
+    eprintln!("search_project_texts_sparse_default_bytes={sparse_bytes}");
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("search_project_texts");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| panic!("sparse batch search success must match schema: {error}"));
+}
+
+#[tokio::test]
 async fn search_project_texts_retries_one_dropped_agent_request_and_restores_order() {
     let root = tempfile::tempdir().unwrap();
     let runtime = ToolRuntime::new_for_tests();

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -521,6 +521,92 @@ async fn search_project_texts_default_matches_items_are_sparse_and_schema_valid(
 }
 
 #[tokio::test]
+async fn search_project_texts_dispatch_mixed_batch_only_sparsifies_success_item() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-sparse-mixed-batch";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let expected_project = project.clone();
+    let auth = auth_context(None, true);
+    let mut invalid = query("invalid", None);
+    invalid.path = Some("../outside".to_string());
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::SearchProjectTexts {
+                        project,
+                        queries: vec![query("steady", None), invalid],
+                        session_id: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("mixed batch successful query request");
+    assert_eq!(request_pattern(&request), "steady");
+    complete_search_success(&runtime, client_id, &request, "src/steady.rs").await;
+    assert_no_agent_request(&runtime, client_id).await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["project"], expected_project);
+    assert_eq!(result.output["requested_count"], 2);
+    assert_eq!(result.output["returned_count"], 2);
+    assert_eq!(result.output["succeeded_count"], 1);
+    assert_eq!(result.output["failed_count"], 1);
+    assert_eq!(result.output["output_truncated"], false);
+    assert!(result.output["next_index"].is_null());
+
+    let items = result.output["items"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0]["index"], 0);
+    assert_eq!(items[0]["success"], true);
+    assert!(items[0]["error"].is_null());
+    assert_eq!(items[0]["output"]["matches"][0]["path"], "src/steady.rs");
+    for omitted in [
+        "path",
+        "backend",
+        "result_mode",
+        "effective_timeout_secs",
+        "exit_code",
+        "context_before",
+        "context_after",
+        "count",
+        "truncated",
+        "truncation_reason",
+    ] {
+        assert!(
+            items[0]["output"].get(omitted).is_none(),
+            "successful default item field {omitted} should be sparse in a mixed batch: {}",
+            items[0]
+        );
+    }
+
+    assert_eq!(items[1]["index"], 1);
+    assert_eq!(items[1]["success"], false);
+    assert_eq!(
+        items[1]["output"]["error_kind"],
+        "search_project_text_failed"
+    );
+    assert_eq!(items[1]["output"]["reason_code"], "invalid_path");
+    assert_eq!(items[1]["output"]["state_changed"], false);
+    assert!(items[1]["error"].as_str().is_some());
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("search_project_texts");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| panic!("mixed sparse/full batch must match schema: {error}"));
+}
+
+#[tokio::test]
 async fn search_project_texts_retries_one_dropped_agent_request_and_restores_order() {
     let root = tempfile::tempdir().unwrap();
     let runtime = ToolRuntime::new_for_tests();

--- a/src/tool_runtime/tests/sessions.rs
+++ b/src/tool_runtime/tests/sessions.rs
@@ -193,7 +193,7 @@ async fn read_file_without_session_id_omits_session_telemetry() {
 
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["text"], "hello");
-    assert_eq!(result.output["format"], "plain");
+    assert!(result.output.get("format").is_none());
     assert!(result.output.get("session_recorded").is_none());
     assert!(result.output.get("session_hint").is_none());
 }

--- a/src/tool_runtime/tests/support/runtime.rs
+++ b/src/tool_runtime/tests/support/runtime.rs
@@ -86,7 +86,7 @@ pub(in crate::tool_runtime::tests) fn sample_field_value(field: &str) -> Value {
         "text" => json!("// hi\n"),
         "content" => json!("fn main() {}\n"),
         "instruction" => json!("implement the requested change"),
-        "include_project_instructions" => json!(false),
+        "include_project_instructions" | "include_workflow_guidance" => json!(false),
         "content_base64" => json!("AA=="),
         "openaiFileIdRefs" => json!([{
             "download_url": "https://files.oaiusercontent.com/test",

--- a/src/tool_runtime/tests/support/runtime.rs
+++ b/src/tool_runtime/tests/support/runtime.rs
@@ -86,6 +86,7 @@ pub(in crate::tool_runtime::tests) fn sample_field_value(field: &str) -> Value {
         "text" => json!("// hi\n"),
         "content" => json!("fn main() {}\n"),
         "instruction" => json!("implement the requested change"),
+        "include_project_instructions" => json!(false),
         "content_base64" => json!("AA=="),
         "openaiFileIdRefs" => json!([{
             "download_url": "https://files.oaiusercontent.com/test",

--- a/src/tool_runtime/tests/work_on_project.rs
+++ b/src/tool_runtime/tests/work_on_project.rs
@@ -20,11 +20,21 @@ use crate::tool_runtime::{
 use serde_json::{json, Value};
 
 fn work_on_project_call(project: &str, instruction: &str, session_id: Option<&str>) -> ToolCall {
+    work_on_project_call_with_instruction_projection(project, instruction, session_id, true)
+}
+
+fn work_on_project_call_with_instruction_projection(
+    project: &str,
+    instruction: &str,
+    session_id: Option<&str>,
+    include_project_instructions: bool,
+) -> ToolCall {
     ToolCall::WorkOnProject {
         project: project.to_string(),
         client_id: None,
         path: None,
         instruction: instruction.to_string(),
+        include_project_instructions,
         session_id: session_id.map(str::to_string),
     }
 }
@@ -40,6 +50,7 @@ fn path_work_on_project_call(
         client_id: Some(client_id.to_string()),
         path: Some(path.to_string()),
         instruction: instruction.to_string(),
+        include_project_instructions: true,
         session_id: session_id.map(str::to_string),
     }
 }
@@ -338,7 +349,14 @@ fn work_on_project_schema_and_registration() {
     assert_eq!(required_fields(spec), vec!["instruction"]);
     assert_eq!(spec.input_schema["additionalProperties"], false);
     let props = spec.input_schema["properties"].as_object().unwrap();
-    for field in ["project", "client_id", "path", "instruction", "session_id"] {
+    for field in [
+        "project",
+        "client_id",
+        "path",
+        "instruction",
+        "include_project_instructions",
+        "session_id",
+    ] {
         assert!(
             props.contains_key(field),
             "missing explicit {field} property"
@@ -356,6 +374,8 @@ fn work_on_project_schema_and_registration() {
     );
     assert_eq!(props["session_id"]["type"], "string");
     assert_eq!(props["session_id"]["pattern"], "^wc_sess_[A-Za-z0-9_]+$");
+    assert_eq!(props["include_project_instructions"]["type"], "boolean");
+    assert_eq!(props["include_project_instructions"]["default"], true);
     for keyword in [
         "oneOf",
         "anyOf",
@@ -382,6 +402,11 @@ fn work_on_project_schema_and_registration() {
         json!({"project": SAMPLE_PROJECT, "instruction": "do it"})
     ));
     assert!(schema_accepts(json!({
+        "project": SAMPLE_PROJECT,
+        "instruction": "do it",
+        "include_project_instructions": false
+    })));
+    assert!(schema_accepts(json!({
         "client_id": "special",
         "path": "/root/git/example",
         "instruction": "do it"
@@ -397,7 +422,14 @@ fn work_on_project_schema_and_registration() {
         "instruction": "runtime must reject ambiguity"
     })));
     let accepted = crate::tool_runtime::registry::accepted_flattened_args_for_spec(spec);
-    for field in ["project", "client_id", "path", "instruction", "session_id"] {
+    for field in [
+        "project",
+        "client_id",
+        "path",
+        "instruction",
+        "include_project_instructions",
+        "session_id",
+    ] {
         assert!(
             accepted.contains(&field.to_string()),
             "flattened Action projection missing {field}"
@@ -480,13 +512,48 @@ fn work_on_project_schema_and_registration() {
     )
     .unwrap();
     match &call {
-        ToolCall::WorkOnProject { session_id, .. } => {
-            assert_eq!(session_id.as_deref(), Some("wc_sess_target"))
+        ToolCall::WorkOnProject {
+            include_project_instructions,
+            session_id,
+            ..
+        } => {
+            assert!(*include_project_instructions);
+            assert_eq!(session_id.as_deref(), Some("wc_sess_target"));
         }
         _ => panic!("expected WorkOnProject"),
     }
     assert_eq!(call.project(), Some(SAMPLE_PROJECT));
     assert_eq!(call.session_id(), Some("wc_sess_target"));
+
+    let suppressed = ToolCall::from_tool_name(
+        "work_on_project",
+        json!({
+            "project": SAMPLE_PROJECT,
+            "instruction": "do the thing without repeating rules",
+            "include_project_instructions": false
+        }),
+    )
+    .unwrap();
+    match suppressed {
+        ToolCall::WorkOnProject {
+            include_project_instructions,
+            ..
+        } => assert!(!include_project_instructions),
+        _ => panic!("expected WorkOnProject"),
+    }
+
+    let audit = super::super::tool_audit::session_log_arguments_for_tool_request(
+        "work_on_project",
+        &json!({
+            "project": SAMPLE_PROJECT,
+            "instruction": "do not persist this full instruction body",
+            "include_project_instructions": false
+        }),
+    );
+    assert_eq!(audit["include_project_instructions"], false);
+    assert_eq!(audit["instruction_present"], true);
+    assert!(audit["instruction_summary"].is_string());
+    assert!(audit.get("instruction").is_none());
 }
 
 #[test]
@@ -1676,6 +1743,86 @@ async fn work_on_project_new_task_is_lightweight_and_preserves_startup_context()
             .to_string()
             .contains(&root.path().to_string_lossy().to_string()),
         "compact output leaked the absolute repository path"
+    );
+}
+
+#[tokio::test]
+async fn work_on_project_can_omit_instruction_bodies_for_a_fresh_session() {
+    let root = tempfile::tempdir().unwrap();
+    seed_coding_repository(root.path(), "caller already knows this rule");
+    let runtime = ToolRuntime::new_for_tests();
+    let project =
+        register_agent_project_at_path(&runtime, "wop-instruction-projection", "demo", root.path())
+            .await;
+    let auth = auth_context(None, true);
+
+    let first = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-instruction-projection",
+        work_on_project_call(&project, "first task", None),
+        Some(&auth),
+        "wop-instruction-projection-window",
+    )
+    .await;
+    assert!(first.success, "{:?}", first.error);
+    assert_eq!(first.output["instructions"]["content_included"], true);
+    let first_session_id = first.output["session_id"].as_str().unwrap().to_string();
+
+    let (second, request_kinds) = dispatch_recording_startup_requests(
+        &runtime,
+        "wop-instruction-projection",
+        work_on_project_call_with_instruction_projection(
+            &project,
+            "second independent task",
+            None,
+            false,
+        ),
+        Some(&auth),
+        "wop-instruction-projection-window",
+    )
+    .await;
+    assert!(second.success, "{:?}", second.error);
+    let second_session_id = second.output["session_id"].as_str().unwrap().to_string();
+    assert_ne!(second_session_id, first_session_id);
+    assert_eq!(second.output["continuation"], "created");
+
+    let instructions = &second.output["instructions"];
+    assert_eq!(instructions["status"], "loaded");
+    assert_eq!(instructions["content_included"], false);
+    let agents_source = instructions["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["path"] == "AGENTS.md")
+        .expect("AGENTS.md metadata");
+    assert_eq!(agents_source["content"], Value::Null);
+    assert!(agents_source["fingerprint"]
+        .as_str()
+        .is_some_and(|value| value.len() == 64));
+    assert!(agents_source["headings"]
+        .as_array()
+        .is_some_and(|headings| !headings.is_empty()));
+    assert!(
+        request_kinds.iter().any(|kind| kind == "file_read"),
+        "instruction files must still be observed when their bodies are omitted: {request_kinds:?}"
+    );
+
+    let summary = runtime
+        .sessions
+        .summary(&second_session_id, Some(20))
+        .unwrap();
+    let snapshot = summary
+        .project_instructions
+        .expect("fresh Workflow Session instruction summary");
+    assert!(snapshot.loaded);
+    let stored_agents = snapshot
+        .files
+        .iter()
+        .find(|file| file.path == "AGENTS.md")
+        .expect("stored AGENTS.md summary");
+    assert_eq!(
+        Some(stored_agents.fingerprint.as_str()),
+        agents_source["fingerprint"].as_str()
     );
 }
 

--- a/src/tool_runtime/tests/work_on_project.rs
+++ b/src/tool_runtime/tests/work_on_project.rs
@@ -476,8 +476,6 @@ fn work_on_project_schema_and_registration() {
         "blockers",
         "warnings",
         "suggested_next_actions",
-        "deterministic",
-        "llm_summary",
     ] {
         assert!(
             output_props.contains_key(field),
@@ -494,6 +492,8 @@ fn work_on_project_schema_and_registration() {
         "git",
         "continuation_feedback",
         "current_binding",
+        "deterministic",
+        "llm_summary",
     ] {
         assert!(
             !output_props.contains_key(hidden),
@@ -702,6 +702,107 @@ fn work_on_project_projection_does_not_default_missing_instruction_sources() {
         .is_some_and(|detail| detail.contains("sources")));
 }
 
+#[test]
+fn work_on_project_projection_is_sparse_for_defaults_and_keeps_noteworthy_state() {
+    let default_result = crate::tool_runtime::coding_task::project_work_on_project_output(
+        SAMPLE_PROJECT.to_string(),
+        valid_work_on_project_projection_input(),
+    );
+    assert!(default_result.success, "{:?}", default_result.error);
+    for omitted in [
+        "project_resolution",
+        "execution_context",
+        "readiness",
+        "repository",
+        "jobs",
+        "blockers",
+        "warnings",
+        "suggested_next_actions",
+        "deterministic",
+        "llm_summary",
+    ] {
+        assert!(
+            default_result.output.get(omitted).is_none(),
+            "boring default field {omitted} should be omitted: {}",
+            default_result.output
+        );
+    }
+    assert_eq!(default_result.output["workspace"]["status"], "clean");
+    assert!(default_result.output["workspace"]["branch"].is_string());
+    assert!(default_result.output["workspace"]["head"].is_string());
+    for omitted in ["git_available", "clean", "conflicts"] {
+        assert!(default_result.output["workspace"].get(omitted).is_none());
+    }
+    assert_eq!(
+        default_result.output["instructions"]["content_included"],
+        true
+    );
+    for omitted in ["changed_sources", "truncated", "total_chars"] {
+        assert!(default_result.output["instructions"].get(omitted).is_none());
+    }
+
+    let mut noteworthy = valid_work_on_project_projection_input();
+    noteworthy["session"]["execution_context"] = json!({"default_cwd": "src"});
+    noteworthy["project_resolution"] = json!({
+        "source": "path",
+        "outcome": "auto_registered",
+        "resolved_project": "agent:wop:demo",
+        "registered": true,
+    });
+    noteworthy["workspace"]["status"] = json!("blocked");
+    noteworthy["workspace"]["conflicts"] = json!(2);
+    noteworthy["repository"] = json!({
+        "status": "unavailable",
+        "reason_code": "probe_failed",
+    });
+    noteworthy["continuation"]["jobs"]["active_count"] = json!(1);
+    noteworthy["continuation"]["jobs"]["latest_status"] = json!("running");
+    noteworthy["blockers"] = json!(["workspace_conflicts"]);
+    noteworthy["warnings"] = json!(["active_jobs_present"]);
+    noteworthy["startup_verdict"] = json!({
+        "status": "fail",
+        "blocking": true,
+        "suggested_next_actions": ["inspect or await blocking active jobs"],
+    });
+    let noteworthy_result = crate::tool_runtime::coding_task::project_work_on_project_output(
+        SAMPLE_PROJECT.to_string(),
+        noteworthy,
+    );
+    assert!(noteworthy_result.success, "{:?}", noteworthy_result.error);
+    assert_eq!(
+        noteworthy_result.output["project_resolution"]["outcome"],
+        "auto_registered"
+    );
+    assert_eq!(
+        noteworthy_result.output["execution_context"]["default_cwd"],
+        "src"
+    );
+    assert_eq!(noteworthy_result.output["readiness"]["status"], "fail");
+    assert_eq!(
+        noteworthy_result.output["repository"]["reason_code"],
+        "probe_failed"
+    );
+    assert_eq!(noteworthy_result.output["workspace"]["conflicts"], 2);
+    assert_eq!(noteworthy_result.output["jobs"]["active_count"], 1);
+    assert_eq!(noteworthy_result.output["jobs"]["latest_status"], "running");
+    assert_eq!(
+        noteworthy_result.output["blockers"],
+        json!(["workspace_conflicts"])
+    );
+    assert_eq!(
+        noteworthy_result.output["warnings"],
+        json!(["active_jobs_present"])
+    );
+    assert_eq!(
+        noteworthy_result.output["suggested_next_actions"],
+        json!(["inspect or await blocking active jobs"])
+    );
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("work_on_project");
+    let instance = json!({ "success": true, "output": noteworthy_result.output });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| panic!("noteworthy sparse output must match schema: {error}"));
+}
+
 #[tokio::test]
 async fn work_on_project_creates_a_new_normal_session_without_binding() {
     let root = tempfile::tempdir().unwrap();
@@ -720,18 +821,39 @@ async fn work_on_project_creates_a_new_normal_session_without_binding() {
     .await;
     assert!(result.success, "{:?}", result.error);
 
-    // Compact projection fields are present and no full diagnostics leak.
-    assert_eq!(result.output["deterministic"], true);
-    assert_eq!(result.output["llm_summary"], false);
+    // Compact projection keeps identity and omits boring default metadata.
     let session_id = result.output["session_id"].as_str().unwrap().to_string();
     assert!(session_id.starts_with("wc_sess_"));
     assert_eq!(result.output["project"], "demo");
     assert_eq!(result.output["resolved_project"], project);
-    assert_eq!(
-        result.output["project_resolution"]["resolved_project"],
-        project
-    );
     assert_eq!(result.output["continuation"], "created");
+    for omitted in [
+        "project_resolution",
+        "execution_context",
+        "repository",
+        "jobs",
+        "blockers",
+        "suggested_next_actions",
+        "deterministic",
+        "llm_summary",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "boring default field {omitted} should be omitted: {}",
+            result.output
+        );
+    }
+    assert_eq!(result.output["readiness"]["status"], "warn");
+    assert!(result.output["warnings"]
+        .as_array()
+        .is_some_and(|warnings| warnings
+            .iter()
+            .any(|warning| warning == "semantic_navigation_unavailable")));
+    assert!(!result.output["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| warning == "current_binding_unavailable"));
     assert_eq!(
         result.output["workflow"],
         crate::tool_runtime::startup_brief::builtin_coding_workflow_projection()
@@ -1633,25 +1755,19 @@ async fn work_on_project_new_task_is_lightweight_and_preserves_startup_context()
 
     // resolved_project is the full runtime project id.
     assert_eq!(result.output["resolved_project"], project);
-    // readiness mirrors the shared startup verdict.
-    assert_eq!(result.output["readiness"]["status"].as_str(), Some("warn"));
-    assert_eq!(result.output["readiness"]["blocking"], false);
-
-    // work_on_project deliberately omits the optional repository overview. The
-    // compact compatibility field reports intentional omission without any
-    // overview lists or a failure warning.
-    let repository = &result.output["repository"];
-    assert_eq!(repository["status"], "unavailable");
-    assert_eq!(
-        repository["reason_code"],
-        "not_requested_by_work_on_project"
-    );
-    assert_eq!(repository.as_object().unwrap().len(), 2);
-    assert!(!result.output["warnings"]
-        .as_array()
-        .unwrap()
+    // Deliberately disabled window binding is normal for work_on_project. This
+    // fixture still has a real semantic-navigation warning, so readiness/warnings
+    // remain while the binding warning and intentionally skipped repository
+    // overview are omitted.
+    assert!(result.output.get("repository").is_none());
+    assert_eq!(result.output["readiness"]["status"], "warn");
+    let warnings = result.output["warnings"].as_array().unwrap();
+    assert!(warnings
         .iter()
-        .any(|warning| warning == "repository_overview_unavailable"));
+        .any(|warning| warning == "semantic_navigation_unavailable"));
+    assert!(!warnings
+        .iter()
+        .any(|warning| warning == "current_binding_unavailable"));
 
     // Runner request evidence: rules, Git, and LSP probes remain; repository
     // overview is not merely hidden from JSON, it is never enqueued.
@@ -1698,11 +1814,8 @@ async fn work_on_project_new_task_is_lightweight_and_preserves_startup_context()
     assert!(result.output["semantic_navigation"].is_object());
     assert!(result.output["semantic_navigation"]["status"].is_string());
 
-    // jobs block initial counts.
-    let jobs = &result.output["jobs"];
-    assert_eq!(jobs["active_count"], 0);
-    assert_eq!(jobs["blocking_active_count"], 0);
-    assert!(jobs["latest_status"].is_string());
+    // No noteworthy Job state means no jobs block at all.
+    assert!(result.output.get("jobs").is_none());
 
     // No full diagnostics leak.
     for hidden in [
@@ -1788,24 +1901,29 @@ async fn work_on_project_can_omit_instruction_bodies_for_a_fresh_session() {
 
     let instructions = &second.output["instructions"];
     assert_eq!(instructions["status"], "loaded");
-    assert_eq!(instructions["content_included"], false);
+    assert!(instructions.get("content_included").is_none());
     let agents_source = instructions["sources"]
         .as_array()
         .unwrap()
         .iter()
         .find(|source| source["path"] == "AGENTS.md")
         .expect("AGENTS.md metadata");
-    assert_eq!(agents_source["content"], Value::Null);
+    assert!(agents_source.get("content").is_none());
+    assert!(agents_source.get("headings").is_none());
+    assert!(agents_source.get("truncated").is_none());
     assert!(agents_source["fingerprint"]
         .as_str()
         .is_some_and(|value| value.len() == 64));
-    assert!(agents_source["headings"]
-        .as_array()
-        .is_some_and(|headings| !headings.is_empty()));
     assert!(
         request_kinds.iter().any(|kind| kind == "file_read"),
         "instruction files must still be observed when their bodies are omitted: {request_kinds:?}"
     );
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("work_on_project");
+    let instance = json!({ "success": true, "output": second.output.clone() });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| {
+            panic!("sparse instruction metadata must match output schema: {error}")
+        });
 
     let summary = runtime
         .sessions
@@ -1859,14 +1977,12 @@ async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
     assert_eq!(reused.output["continuation"], "resumed_explicitly");
     let reused_instructions = &reused.output["instructions"];
     assert_eq!(reused_instructions["status"], "reused");
-    assert_eq!(reused_instructions["content_included"], false);
-    assert!(reused_instructions["changed_sources"]
-        .as_array()
-        .map(|sources| sources.is_empty())
-        .unwrap_or(false));
+    assert!(reused_instructions.get("content_included").is_none());
+    assert!(reused_instructions.get("changed_sources").is_none());
     for source in reused_instructions["sources"].as_array().unwrap() {
         if source["path"] == "AGENTS.md" {
-            assert_eq!(source["content"], serde_json::Value::Null);
+            assert!(source.get("content").is_none());
+            assert!(source.get("headings").is_none());
             assert!(source["fingerprint"].is_string());
         }
     }
@@ -1946,7 +2062,9 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
     .await;
     assert!(reused.success, "{:?}", reused.error);
     assert_eq!(reused.output["instructions"]["status"], "reused");
-    assert_eq!(reused.output["instructions"]["content_included"], false);
+    assert!(reused.output["instructions"]
+        .get("content_included")
+        .is_none());
 
     let (standard, standard_requests) = dispatch_recording_startup_requests(
         &runtime,
@@ -1964,25 +2082,24 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
     assert_eq!(standard.output["repository"]["status"], "available");
 
     for output in [&fresh.output, &reused.output] {
-        assert_eq!(
-            output["repository"]["reason_code"],
-            "not_requested_by_work_on_project"
-        );
         for omitted in [
-            "project_types",
-            "manifests",
-            "key_files",
-            "roots",
-            "top_level",
-            "suggested_next_reads",
-            "scan",
-            "warnings",
+            "repository",
+            "execution_context",
+            "jobs",
+            "blockers",
+            "deterministic",
+            "llm_summary",
         ] {
             assert!(
-                output["repository"].get(omitted).is_none(),
-                "work_on_project repository unexpectedly contains {omitted}"
+                output.get(omitted).is_none(),
+                "work_on_project boring default field {omitted} should be omitted: {output}"
             );
         }
+        assert!(!output["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|warning| warning == "current_binding_unavailable"));
     }
 
     let fresh_overviews = fresh_requests
@@ -2020,6 +2137,17 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
     assert!(standard_bytes <= hard_max);
     assert!(fresh_bytes < standard_bytes);
     assert!(reused_bytes < standard_bytes);
+    // Before sparse-by-default projection this fixture was 3154 bytes fresh
+    // and 3259 bytes on unchanged continuation. Leave modest headroom while
+    // locking in a material reduction in model-facing context.
+    assert!(
+        fresh_bytes <= 2600,
+        "fresh work_on_project projection regressed above the sparse context budget: {fresh_bytes} bytes"
+    );
+    assert!(
+        reused_bytes <= 2600,
+        "unchanged work_on_project projection regressed above the sparse context budget: {reused_bytes} bytes"
+    );
     eprintln!(
         "work_on_project_fixture_bytes fresh={fresh_bytes} unchanged_continuation={reused_bytes} standard={standard_bytes}; runner_requests fresh={} unchanged_continuation={} standard={}",
         fresh_requests.len(),

--- a/src/tool_runtime/tests/work_on_project.rs
+++ b/src/tool_runtime/tests/work_on_project.rs
@@ -20,7 +20,7 @@ use crate::tool_runtime::{
 use serde_json::{json, Value};
 
 fn work_on_project_call(project: &str, instruction: &str, session_id: Option<&str>) -> ToolCall {
-    work_on_project_call_with_instruction_projection(project, instruction, session_id, true)
+    work_on_project_call_with_projections(project, instruction, session_id, true, true)
 }
 
 fn work_on_project_call_with_instruction_projection(
@@ -29,12 +29,29 @@ fn work_on_project_call_with_instruction_projection(
     session_id: Option<&str>,
     include_project_instructions: bool,
 ) -> ToolCall {
+    work_on_project_call_with_projections(
+        project,
+        instruction,
+        session_id,
+        include_project_instructions,
+        true,
+    )
+}
+
+fn work_on_project_call_with_projections(
+    project: &str,
+    instruction: &str,
+    session_id: Option<&str>,
+    include_project_instructions: bool,
+    include_workflow_guidance: bool,
+) -> ToolCall {
     ToolCall::WorkOnProject {
         project: project.to_string(),
         client_id: None,
         path: None,
         instruction: instruction.to_string(),
         include_project_instructions,
+        include_workflow_guidance,
         session_id: session_id.map(str::to_string),
     }
 }
@@ -51,6 +68,7 @@ fn path_work_on_project_call(
         path: Some(path.to_string()),
         instruction: instruction.to_string(),
         include_project_instructions: true,
+        include_workflow_guidance: true,
         session_id: session_id.map(str::to_string),
     }
 }
@@ -355,6 +373,7 @@ fn work_on_project_schema_and_registration() {
         "path",
         "instruction",
         "include_project_instructions",
+        "include_workflow_guidance",
         "session_id",
     ] {
         assert!(
@@ -376,6 +395,8 @@ fn work_on_project_schema_and_registration() {
     assert_eq!(props["session_id"]["pattern"], "^wc_sess_[A-Za-z0-9_]+$");
     assert_eq!(props["include_project_instructions"]["type"], "boolean");
     assert_eq!(props["include_project_instructions"]["default"], true);
+    assert_eq!(props["include_workflow_guidance"]["type"], "boolean");
+    assert_eq!(props["include_workflow_guidance"]["default"], true);
     for keyword in [
         "oneOf",
         "anyOf",
@@ -404,7 +425,8 @@ fn work_on_project_schema_and_registration() {
     assert!(schema_accepts(json!({
         "project": SAMPLE_PROJECT,
         "instruction": "do it",
-        "include_project_instructions": false
+        "include_project_instructions": false,
+        "include_workflow_guidance": false
     })));
     assert!(schema_accepts(json!({
         "client_id": "special",
@@ -428,6 +450,7 @@ fn work_on_project_schema_and_registration() {
         "path",
         "instruction",
         "include_project_instructions",
+        "include_workflow_guidance",
         "session_id",
     ] {
         assert!(
@@ -514,10 +537,12 @@ fn work_on_project_schema_and_registration() {
     match &call {
         ToolCall::WorkOnProject {
             include_project_instructions,
+            include_workflow_guidance,
             session_id,
             ..
         } => {
             assert!(*include_project_instructions);
+            assert!(*include_workflow_guidance);
             assert_eq!(session_id.as_deref(), Some("wc_sess_target"));
         }
         _ => panic!("expected WorkOnProject"),
@@ -529,16 +554,21 @@ fn work_on_project_schema_and_registration() {
         "work_on_project",
         json!({
             "project": SAMPLE_PROJECT,
-            "instruction": "do the thing without repeating rules",
-            "include_project_instructions": false
+            "instruction": "do the thing without repeating static context",
+            "include_project_instructions": false,
+            "include_workflow_guidance": false
         }),
     )
     .unwrap();
     match suppressed {
         ToolCall::WorkOnProject {
             include_project_instructions,
+            include_workflow_guidance,
             ..
-        } => assert!(!include_project_instructions),
+        } => {
+            assert!(!include_project_instructions);
+            assert!(!include_workflow_guidance);
+        }
         _ => panic!("expected WorkOnProject"),
     }
 
@@ -547,10 +577,12 @@ fn work_on_project_schema_and_registration() {
         &json!({
             "project": SAMPLE_PROJECT,
             "instruction": "do not persist this full instruction body",
-            "include_project_instructions": false
+            "include_project_instructions": false,
+            "include_workflow_guidance": false
         }),
     );
     assert_eq!(audit["include_project_instructions"], false);
+    assert_eq!(audit["include_workflow_guidance"], false);
     assert_eq!(audit["instruction_present"], true);
     assert!(audit["instruction_summary"].is_string());
     assert!(audit.get("instruction").is_none());
@@ -663,20 +695,23 @@ fn work_on_project_projection_fails_closed_for_wrong_field_type() {
 
 #[test]
 fn work_on_project_projection_fails_closed_for_noncanonical_workflow() {
-    let mut output = valid_work_on_project_projection_input();
-    output["workflow"]["version"] = json!(2);
+    for include_workflow_guidance in [true, false] {
+        let mut output = valid_work_on_project_projection_input();
+        output["workflow"]["version"] = json!(2);
 
-    let result = crate::tool_runtime::coding_task::project_work_on_project_output(
-        SAMPLE_PROJECT.to_string(),
-        output,
-    );
-    assert!(!result.success);
-    assert_eq!(
-        result.output["error_kind"],
-        "work_on_project_projection_failed"
-    );
-    assert_eq!(result.output["field"], "workflow");
-    assert_eq!(result.output["state_changed"], true);
+        let result = crate::tool_runtime::coding_task::project_work_on_project_output_with_workflow(
+            SAMPLE_PROJECT.to_string(),
+            output,
+            include_workflow_guidance,
+        );
+        assert!(!result.success);
+        assert_eq!(
+            result.output["error_kind"],
+            "work_on_project_projection_failed"
+        );
+        assert_eq!(result.output["field"], "workflow");
+        assert_eq!(result.output["state_changed"], true);
+    }
 }
 
 #[test]
@@ -1945,6 +1980,51 @@ async fn work_on_project_can_omit_instruction_bodies_for_a_fresh_session() {
 }
 
 #[tokio::test]
+async fn work_on_project_can_omit_static_workflow_guidance() {
+    let root = tempfile::tempdir().unwrap();
+    seed_coding_repository(root.path(), "keep repository guidance visible");
+    let runtime = ToolRuntime::new_for_tests();
+    let project =
+        register_agent_project_at_path(&runtime, "wop-workflow-projection", "demo", root.path())
+            .await;
+    let auth = auth_context(None, true);
+
+    let result = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-workflow-projection",
+        work_on_project_call_with_projections(
+            &project,
+            "caller already knows the static workflow",
+            None,
+            true,
+            false,
+        ),
+        Some(&auth),
+        "wop-workflow-projection-window",
+    )
+    .await;
+    assert!(result.success, "{:?}", result.error);
+    assert!(result.output.get("workflow").is_none());
+    assert_eq!(result.output["instructions"]["content_included"], true);
+    assert!(result.output["instructions"]["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|source| source["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("keep repository guidance visible"))));
+
+    let session_id = result.output["session_id"].as_str().unwrap();
+    let summary = runtime.sessions.summary(session_id, Some(20)).unwrap();
+    assert_eq!(summary.project.as_deref(), Some(project.as_str()));
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("work_on_project");
+    let instance = json!({ "success": true, "output": result.output });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| panic!("workflow-omitted output must match schema: {error}"));
+}
+
+#[tokio::test]
 async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
     let root = tempfile::tempdir().unwrap();
     seed_coding_repository(root.path(), "first rule body");
@@ -2066,6 +2146,23 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
         .get("content_included")
         .is_none());
 
+    let (workflow_omitted, workflow_omitted_requests) = dispatch_recording_startup_requests(
+        &runtime,
+        "wop-size",
+        work_on_project_call_with_projections(
+            &project,
+            "fresh startup without repeated workflow",
+            None,
+            true,
+            false,
+        ),
+        Some(&auth),
+        "wop-size-workflow-omitted",
+    )
+    .await;
+    assert!(workflow_omitted.success, "{:?}", workflow_omitted.error);
+    assert!(workflow_omitted.output.get("workflow").is_none());
+
     let (standard, standard_requests) = dispatch_recording_startup_requests(
         &runtime,
         "wop-size",
@@ -2081,7 +2178,7 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
     assert!(standard.success, "{:?}", standard.error);
     assert_eq!(standard.output["repository"]["status"], "available");
 
-    for output in [&fresh.output, &reused.output] {
+    for output in [&fresh.output, &reused.output, &workflow_omitted.output] {
         for omitted in [
             "repository",
             "execution_context",
@@ -2110,12 +2207,17 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
         .iter()
         .filter(|kind| kind.as_str() == "file_project_overview")
         .count();
+    let workflow_omitted_overviews = workflow_omitted_requests
+        .iter()
+        .filter(|kind| kind.as_str() == "file_project_overview")
+        .count();
     let standard_overviews = standard_requests
         .iter()
         .filter(|kind| kind.as_str() == "file_project_overview")
         .count();
     assert_eq!(fresh_overviews, 0);
     assert_eq!(reused_overviews, 0);
+    assert_eq!(workflow_omitted_overviews, 0);
     assert_eq!(standard_overviews, 1);
     assert_eq!(
         standard_requests.len(),
@@ -2127,9 +2229,15 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
         fresh_requests.len(),
         "unchanged continuation should retain the same lightweight probes"
     );
+    assert_eq!(
+        workflow_omitted_requests.len(),
+        fresh_requests.len(),
+        "omitting static workflow guidance must not reduce repository/runtime probes"
+    );
 
     let fresh_bytes = serde_json::to_vec(&fresh.output).unwrap().len();
     let reused_bytes = serde_json::to_vec(&reused.output).unwrap().len();
+    let workflow_omitted_bytes = serde_json::to_vec(&workflow_omitted.output).unwrap().len();
     let standard_bytes = serde_json::to_vec(&standard.output).unwrap().len();
     let hard_max = crate::tool_runtime::startup_brief::STANDARD_STARTUP_HARD_MAX_BYTES;
     assert!(fresh_bytes < hard_max);
@@ -2137,6 +2245,14 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
     assert!(standard_bytes <= hard_max);
     assert!(fresh_bytes < standard_bytes);
     assert!(reused_bytes < standard_bytes);
+    assert!(workflow_omitted_bytes < fresh_bytes);
+    // With the same repository observations and instruction body retained, the
+    // static workflow-only omission is 757 bytes in this fixture. Keep enough
+    // headroom for small projection growth while preserving the context win.
+    assert!(
+        workflow_omitted_bytes <= 1000,
+        "workflow-omitted projection regressed above the context budget: {workflow_omitted_bytes} bytes"
+    );
     // Before sparse-by-default projection this fixture was 3154 bytes fresh
     // and 3259 bytes on unchanged continuation. Leave modest headroom while
     // locking in a material reduction in model-facing context.
@@ -2149,9 +2265,10 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
         "unchanged work_on_project projection regressed above the sparse context budget: {reused_bytes} bytes"
     );
     eprintln!(
-        "work_on_project_fixture_bytes fresh={fresh_bytes} unchanged_continuation={reused_bytes} standard={standard_bytes}; runner_requests fresh={} unchanged_continuation={} standard={}",
+        "work_on_project_fixture_bytes fresh={fresh_bytes} unchanged_continuation={reused_bytes} workflow_omitted={workflow_omitted_bytes} standard={standard_bytes}; runner_requests fresh={} unchanged_continuation={} workflow_omitted={} standard={}",
         fresh_requests.len(),
         reused_requests.len(),
+        workflow_omitted_requests.len(),
         standard_requests.len()
     );
 }

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -302,7 +302,16 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
             out.insert("execution_context".to_string(), context);
         }
         "work_on_project" => {
-            copy_keys(obj, &mut out, &["project", "client_id", "session_id"]);
+            copy_keys(
+                obj,
+                &mut out,
+                &[
+                    "project",
+                    "client_id",
+                    "session_id",
+                    "include_project_instructions",
+                ],
+            );
             out.insert(
                 "path_source_requested".to_string(),
                 Value::Bool(obj.contains_key("path")),
@@ -2316,6 +2325,7 @@ impl ToolCall {
                 client_id,
                 path,
                 instruction,
+                include_project_instructions,
                 session_id,
             } => serde_json::json!({
                 "project": project,
@@ -2323,6 +2333,7 @@ impl ToolCall {
                 "path_source_requested": path.is_some(),
                 "instruction_present": true,
                 "instruction_summary": crate::shell_client::command_preview(instruction),
+                "include_project_instructions": include_project_instructions,
                 "session_id": session_id,
             }),
             Self::UpdateSessionContext {

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -310,6 +310,7 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
                     "client_id",
                     "session_id",
                     "include_project_instructions",
+                    "include_workflow_guidance",
                 ],
             );
             out.insert(
@@ -2326,6 +2327,7 @@ impl ToolCall {
                 path,
                 instruction,
                 include_project_instructions,
+                include_workflow_guidance,
                 session_id,
             } => serde_json::json!({
                 "project": project,
@@ -2334,6 +2336,7 @@ impl ToolCall {
                 "instruction_present": true,
                 "instruction_summary": crate::shell_client::command_preview(instruction),
                 "include_project_instructions": include_project_instructions,
+                "include_workflow_guidance": include_workflow_guidance,
                 "session_id": session_id,
             }),
             Self::UpdateSessionContext {

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -348,6 +348,8 @@ pub enum ToolCall {
         instruction: String,
         #[serde(default = "default_true")]
         include_project_instructions: bool,
+        #[serde(default = "default_true")]
+        include_workflow_guidance: bool,
         #[serde(default)]
         session_id: Option<String>,
     },

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -346,6 +346,8 @@ pub enum ToolCall {
         #[serde(default)]
         path: Option<String>,
         instruction: String,
+        #[serde(default = "default_true")]
+        include_project_instructions: bool,
         #[serde(default)]
         session_id: Option<String>,
     },


### PR DESCRIPTION
## Summary

- make `work_on_project` sparse by default for boring startup state and stop repeating unchanged project-instruction bodies on exact continuation
- add explicit projection controls for callers that already retain project instructions or the built-in coding workflow guidance
- sparsify complete default `read_file` / `read_files` results while preserving `sha256` and `total_lines`; partial or explicit ranges retain the full continuation tuple
- sparsify ordinary complete default text-search success while preserving non-default modes, context requests, timeouts, fallbacks, partial results, and failures
- sparsify successful synchronous terminal `run_process` / `run_script` results by removing only facts implied by the completed-success state

## Semantic contract

These changes are model-facing projection only. Session/effect recording sees the complete result before sparsification. Failure, timeout, `outcome_unknown`, durable Job handoff, partial read/search, truncation, and non-default execution/search semantics remain explicit.

`work_on_project(include_project_instructions=false)` still observes instruction files and records current path/fingerprint metadata; it only omits bodies from the returned bootstrap projection. `include_workflow_guidance=false` only omits static built-in workflow guidance and does not change Session state, authority, role selection, or execution semantics.

## Validation

Focused review validation on exact HEAD `83c26fa8941b25d8b8da464e04a8d9d54e965bca`:

- `work_on_project`: 30 passed
- `search_project_texts`: 19 passed
- `read_files`: 14 passed
- sparse terminal `run_process` / retained-output regressions: passed
- sparse terminal `run_script` regression: passed
- output-schema suite: 11 passed
- ToolSpec/schema suite: 18 passed
- MCP local-coding and coding-task schema surface checks: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check main...HEAD`: passed

## Live dogfood

Server and `special` Runner were deployed from exact clean commit `83c26fa8941b` and runtime source alignment reported `aligned`.

Through the deployed product surface:

- exact `work_on_project` continuation reused `AGENTS.md` as path + fingerprint without repeating its body
- complete default `read_file` returned only content identity/shape metadata plus text; an explicit partial range restored start/end/limit/continuation fields
- complete default single and batch text search returned sparse match records; a context request restored backend/count/timeout/truncation metadata
- successful `run_process` and `run_script` omitted Job/null/default/failure metadata while preserving actual stdout and core terminal state
- a non-zero `run_process` retained the full failure, timeout-budget, continuation, truncation, and retry-safety metadata

No source or deployment mutation was performed by the live smoke beyond the already-authorized deployed build.