### PR TITLE
Fix full-display snapshot response bound

### DIFF
--- a/src/shell_client/mod_tests/computer_observe.rs
+++ b/src/shell_client/mod_tests/computer_observe.rs
@@ -192,3 +192,74 @@ async fn computer_snapshot_region_requires_additive_capability() {
     assert_eq!(request.stdin.as_deref(), Some(payload));
     assert!(request.command.is_empty());
 }
+
+#[tokio::test]
+async fn computer_snapshot_display_preserves_large_native_image_response_stdout() {
+    let registry = ShellClientRegistry::default();
+    let alice = auth_context(Some("alice"), false);
+    registry
+        .register(ShellClientRegisterRequest {
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: None,
+            job_inventory: None,
+            client_id: "computer-display-large".to_string(),
+            agent_instance_id: "display-large-inst".to_string(),
+            display_name: None,
+            owner: Some("alice".to_string()),
+            hostname: None,
+            host_context: None,
+            capabilities: Some(ShellClientCapabilities {
+                computer_display_observe: true,
+                ..Default::default()
+            }),
+            projects: None,
+            agent_protocol_version: None,
+            policy: None,
+        })
+        .await
+        .unwrap();
+
+    let payload = r#"{"display_id":"display_0123456789abcdef0123456789abcdef","max_width":null,"max_height":null}"#;
+    let (request_id, response_rx) = registry
+        .enqueue_computer(
+            "computer-display-large".to_string(),
+            "computer_snapshot_display",
+            payload.to_string(),
+            "alice".to_string(),
+            Some(&alice),
+            5,
+        )
+        .await
+        .unwrap();
+    let request = registry
+        .poll(ShellAgentPollRequest {
+            client_id: "computer-display-large".to_string(),
+            agent_instance_id: "display-large-inst".to_string(),
+            projects: None,
+        })
+        .await
+        .unwrap()
+        .expect("queued display snapshot request");
+    assert_eq!(request.kind, "computer_snapshot_display");
+
+    let stdout = "x".repeat(super::super::MAX_OUTPUT_BYTES + 1024);
+    assert!(stdout.len() < crate::artifact_policy::MAX_MCP_IMAGE_RESPONSE_BYTES);
+    registry
+        .complete(ShellAgentResultRequest {
+            client_id: "computer-display-large".to_string(),
+            agent_instance_id: "display-large-inst".to_string(),
+            request_id,
+            exit_code: Some(0),
+            stdout: Some(stdout.clone()),
+            stderr: None,
+            duration_ms: Some(1),
+            error: None,
+        })
+        .await
+        .unwrap();
+
+    let response = response_rx.await.unwrap();
+    assert!(response.success);
+    assert_eq!(response.stdout.as_deref(), Some(stdout.as_str()));
+}

--- a/src/shell_client/polling.rs
+++ b/src/shell_client/polling.rs
@@ -420,7 +420,10 @@ fn truncate_persistent_shell_stream(value: &mut String) -> bool {
 }
 
 fn is_large_native_image_request(request: &ShellAgentShellRequest) -> bool {
-    if request.kind == "computer_snapshot" {
+    if matches!(
+        request.kind.as_str(),
+        "computer_snapshot" | "computer_snapshot_display"
+    ) {
         return true;
     }
     request.kind == "file_read_project_artifact"


### PR DESCRIPTION
## Summary

- Treat `computer_snapshot_display` responses as native image responses when applying the Runner response retention bound.
- Preserve the existing 1 MiB decoded MCP image limit while avoiding the ordinary 256 KiB stdout truncation for full-display snapshots.
- Add a regression test proving a display snapshot response larger than the ordinary stdout cap is retained intact.

## Validation

- `cargo test -p webcodex computer_snapshot_display_preserves_large_native_image_response_stdout` — 1 passed.
- Reviewed the dispatch and MCP framing path: the larger response cap remains gated to the server-generated display snapshot request kind; ordinary Runner stdout remains unchanged.

## Dogfood note

The matching `9d10b313` Windows Runner binary was deployed on MSI and reconnects normally. A live full-display snapshot still fails against the currently deployed Control/Server build because this fix is in `src/shell_client/polling.rs` (server-side), so the Control/Server must include this commit before the live regression is closed.