### PR TITLE
Fix macOS release readiness shutdown timing

### DIFF
--- a/crates/webcodex-process/src/unix.rs
+++ b/crates/webcodex-process/src/unix.rs
@@ -187,6 +187,14 @@ impl Drop for ManagedChild {
         {
             self.tree_exited.store(true, Ordering::Release);
         }
+        #[cfg(target_os = "macos")]
+        if self.tree_exited.load(Ordering::Acquire) {
+            match self.child.try_wait() {
+                Ok(Some(_)) | Err(_) => return,
+                Ok(None) if defer_darwin_direct_child_reap(self.child.id()) => return,
+                Ok(None) => {}
+            }
+        }
         let Some(deadline) = Instant::now().checked_add(DROP_REAP_TIMEOUT) else {
             return;
         };
@@ -198,6 +206,43 @@ impl Drop for ManagedChild {
             }
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+fn defer_darwin_direct_child_reap(pid: u32) -> bool {
+    let Ok(pid) = libc::pid_t::try_from(pid) else {
+        return false;
+    };
+    std::thread::Builder::new()
+        .name("webcodex-child-reaper".to_string())
+        .spawn(move || {
+            // Once the exact process-group probe has proven the tree has no
+            // executable member, only direct-child zombie hygiene remains.
+            // Darwin may still report that child as temporarily unreapable, so
+            // finish the bounded reap off the caller's already-consumed
+            // shutdown deadline instead of re-arming Drop for another 200ms.
+            let Some(deadline) = Instant::now().checked_add(DROP_REAP_TIMEOUT) else {
+                return;
+            };
+            loop {
+                let mut status = 0;
+                let waited = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+                if waited == pid {
+                    return;
+                }
+                if waited < 0 {
+                    if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return;
+                }
+                if Instant::now() >= deadline {
+                    return;
+                }
+                std::thread::sleep(TREE_POLL);
+            }
+        })
+        .is_ok()
 }
 
 /// Signal a whole process group, reporting whether it still existed.

--- a/crates/webcodex-runner/src/webcodex_runner/external_tools_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/external_tools_tests.rs
@@ -752,6 +752,11 @@ fn provider_request_timeout_racing_shutdown_is_idempotent() {
     let connection = Arc::clone(&client.connection);
     let pid = connection.child.lock().unwrap().id();
     let request_connection = Arc::clone(&connection);
+    // Hold stdin until the request has registered its pending sender. The
+    // request timeout starts only after the write completes, so this gives the
+    // test a deterministic pre-timeout synchronization point without changing
+    // the timeout-vs-shutdown race under test.
+    let stdin_guard = lock_unpoison(&connection.stdin);
     let request = std::thread::spawn(move || {
         request_connection.request(
             "tools/call",
@@ -763,6 +768,7 @@ fn provider_request_timeout_racing_shutdown_is_idempotent() {
     assert!(wait_until(Duration::from_secs(1), || {
         lock_unpoison(&connection.pending).len() == 1
     }));
+    drop(stdin_guard);
     std::thread::sleep(Duration::from_millis(80));
 
     let outcome = fixture


### PR DESCRIPTION
## Summary

- avoid re-arming a second synchronous macOS direct-child reap wait after the process tree is already confirmed non-live
- keep live-tree SIGKILL and bounded reap behavior unchanged
- stabilize the provider timeout-vs-shutdown race test with a deterministic pre-timeout stdin/pending synchronization point, without extending its timeout

## Validation

- Linux: `webcodex-process` 15 passed / 1 ignored
- Linux: LSP-focused Runner tests 56/56 passed
- macOS exact-source: original LSP blocker 3/3 passed
- macOS exact-source: provider race 5/5 passed after hardening; before hardening it reproduced standalone on attempt 4
- macOS exact-source: `webcodex-process` 15 passed / 1 ignored
- macOS exact-source: full `webcodex-runner` 711 passed / 0 failed / 8 ignored
- `cargo fmt -- --check` passed

This is the focused follow-up for the v0.3.8 pre-tag release-readiness failure. No release tag or publication operation is included in this PR.