### PR TITLE
Update eval for sparse search output

### DIFF
--- a/scripts/eval_coding_loop.sh
+++ b/scripts/eval_coding_loop.sh
@@ -1171,20 +1171,26 @@ import sys
 
 data = json.loads(sys.argv[1])
 out = data.get("output") or {}
+matches = out.get("matches")
 ok = (
     data.get("success") is True
-    and isinstance(out.get("backend"), str)
-    and out.get("backend")
-    and isinstance(out.get("matches"), list)
-    and isinstance(out.get("truncated"), bool)
-    and out.get("count", 0) >= 1
+    and isinstance(matches, list)
+    and any(
+        isinstance(match, dict)
+        and isinstance(match.get("path"), str)
+        and bool(match.get("path"))
+        and isinstance(match.get("line"), int)
+        and match.get("line") >= 1
+        and isinstance(match.get("preview"), str)
+        for match in matches
+    )
 )
 sys.exit(0 if ok else 1)
 PY
     then
-        case_ok "search_project_text returns backend/matches/truncated"
+        case_ok "search_project_text returns structured match records"
     else
-        case_fail "search_project_text structured fields missing"
+        case_fail "search_project_text structured match records missing"
     fi
 
     params="$(python3 - "$RUNTIME_PROJECT_ID" "$session_id" <<'PY'


### PR DESCRIPTION
Fix the release-readiness coding-loop eval after sparse search projection changes.

- validate concrete search match records instead of redundant default metadata
- keep runtime search semantics unchanged
- focused compare eval: 6/6 cases pass
- bash syntax and git diff checks pass