### PR TITLE
Improve harness evidence and durable long execution handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 These are the always-on rules for ordinary repository work. Read only the linked sections needed for the current task. A deeper `AGENTS.md` governs its directory.
 
-## V1 maintenance mode
+## V1 active development
 
-The V1 formal product surface is feature-frozen by default: ordinary V1 work should prefer correctness, CI reliability, warning/Clippy hygiene, and test quality over new features. Explicitly experimental surfaces may continue only when the task asks for them. Do not weaken safety, credential, process-tree, transport, durability, or boundedness contracts while cleaning up.
+V2 development is paused; V1 is the active product line and is not feature-frozen. Ordinary V1 work may add explicitly requested capabilities as well as correctness, reliability, and test improvements. Keep changes focused and do not weaken safety, credential, process-tree, transport, durability, or boundedness contracts.
 
 ## 1. Verify and preserve
 
@@ -21,6 +21,7 @@ The V1 formal product surface is feature-frozen by default: ordinary V1 work sho
 - Do not build a general framework for one use case. Wait for a second concrete use case before extracting shared machinery.
 - Do not design for hypothetical consumers, tenants, deployment scales, or trust boundaries that the product does not have.
 - Protect real boundaries—credentials, public entry points, destructive actions, wrong-target execution, repository history, and published artifacts—without adding policy machinery for imaginary ones.
+- A feature that introduces a new externally reachable authority, credential audience, or replaceable runtime target creates a concrete present boundary. Model it explicitly when reusing an existing scope, identity, or lease would broaden existing credentials or allow stale requests to retarget; fewer concepts is not a reason to collapse distinct authority.
 - When two designs satisfy the current need, choose the one with fewer concepts, states, configuration paths, and maintenance costs.
 - For model-facing execution, prefer structured process/argv and durable Job/observation primitives over shell-text orchestration. Keep shell as an escape hatch; structured lifecycle state is the source of truth for retry safety.
 - Treat demonstrated host features such as MCP App orchestration as optional adapters. Core execution and Job semantics must remain protocol-, UI-, transport-, and OS-neutral.
@@ -37,7 +38,7 @@ Product direction: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 - Minimize new concepts rather than the number of touched files. A coherent vertical slice may update several existing layers when each is part of the same current capability.
 - Use compiler, type, schema, and exhaustiveness failures to find missing enum, registry, adapter, and projection closure before broadening validation.
 - After focused tests pass, perform a separate completeness audit and then a trust/bounds/privacy/replay audit before considering the implementation finished.
-- Implementation ownership and independent adversarial review are separate passes. In an implementation-owner pass, prioritize a complete authoritative vertical slice and strong first delivery within the current contract; resolve known correctness issues, but do not fragment the implementation around speculative reviewer concerns. A later review pass independently challenges the resulting design and implementation.
+- Implementation ownership and independent adversarial review are separate passes. In an implementation-owner pass, prioritize a complete authoritative vertical slice and strong first delivery within the current contract; resolve known correctness issues, including concrete authority/identity boundaries created by the feature, but do not fragment the implementation around speculative reviewer concerns. A later review pass independently challenges the resulting design and implementation.
 - Keep only the interfaces actually affected by the change consistent. Do not touch or revalidate unrelated projections merely because they exist.
 - Add focused tests for changed behavior when practical. Update documentation when public behavior or operations change.
 - Ask only when required information cannot be discovered, instructions materially conflict, or proceeding could destroy work. Otherwise continue and report any material deviation.

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2655,6 +2655,10 @@ fn structured_prestart_lifecycle(
     job_prestart_lifecycle_for_kind(request.kind.as_str())
 }
 
+fn post_spawn_interruption_lifecycle_for_kind(kind: &str) -> Option<ShellCommandExecutionState> {
+    (kind == "start_job").then_some(ShellCommandExecutionState::OutcomeUnknown)
+}
+
 fn raw_shell_job_terminal_lifecycle(
     status: &str,
     exit_code: Option<i32>,
@@ -4532,6 +4536,18 @@ impl JobManager {
             self.shutdown_rejection(&request);
             return;
         };
+        // Preserve the pre-start proof boundary explicitly. A stop/shutdown
+        // observed here is still known to precede ManagedChild::spawn; the
+        // fence below is intentionally repeated after spawn because that later
+        // race can no longer claim NotStarted.
+        if stop_requested.load(Ordering::SeqCst) {
+            self.fail_job(&request, "job stopped before start".to_string(), None);
+            return;
+        }
+        if self.shutting_down.load(Ordering::SeqCst) {
+            self.shutdown_rejection(&request);
+            return;
+        }
         let start = Instant::now();
         let mut command = commands.pop_front().expect("validated non-empty plan");
         let spawn = ManagedChild::spawn(&mut command);
@@ -4566,20 +4582,42 @@ impl JobManager {
         let mut stdout = child.child_mut().stdout.take();
         let mut stderr = child.child_mut().stderr.take();
         let mut child = Arc::new(Mutex::new(child));
-        let reject_for_shutdown = {
+        let post_spawn_rejection = {
             let _lifecycle = lock_unpoison(&self.lifecycle);
-            if self.shutting_down.load(Ordering::SeqCst) || stop_requested.load(Ordering::SeqCst) {
-                true
+            if self.shutting_down.load(Ordering::SeqCst) {
+                Some("runner began shutdown after command start")
+            } else if stop_requested.load(Ordering::SeqCst) {
+                Some("job stop requested after command start")
             } else if let Some(job) = lock_unpoison(&self.jobs).get_mut(&job_id) {
                 job.child = Some(child.clone());
-                false
+                None
             } else {
-                true
+                Some("runner lost the Job record after command start")
             }
         };
-        if reject_for_shutdown {
+        if let Some(error) = post_spawn_rejection {
             let _ = terminate_managed_tree(&child);
-            self.shutdown_rejection(&request);
+            // ManagedChild::spawn succeeded before this fence. Even if the
+            // termination request succeeds, the user command may already have
+            // executed and we do not wait here for a trustworthy exit status.
+            // Raw shell must therefore remain conservatively started/unknown;
+            // never recycle the pre-start NotStarted evidence across this
+            // spawn boundary.
+            self.update_and_send(
+                &job_id,
+                RunnerJobDelta {
+                    status: "failed".to_string(),
+                    exit_code: None,
+                    duration_ms: Some(start.elapsed().as_millis() as u64),
+                    error: Some(error.to_string()),
+                    command_execution_state: post_spawn_interruption_lifecycle_for_kind(
+                        request.kind.as_str(),
+                    ),
+                    finished: true,
+                    ..Default::default()
+                },
+            );
+            self.start_available_queued();
             return;
         }
         self.update_and_send(

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2641,14 +2641,30 @@ fn runner_job_is_active(status: &str) -> bool {
     matches!(status, "agent_queued" | "running" | "stop_requested")
 }
 
+fn job_prestart_lifecycle_for_kind(kind: &str) -> Option<ShellCommandExecutionState> {
+    matches!(
+        kind,
+        "start_job" | "start_process_job" | "start_detached_process_job" | "start_script_job"
+    )
+    .then_some(ShellCommandExecutionState::NotStarted)
+}
+
 fn structured_prestart_lifecycle(
     request: &ShellAgentShellRequest,
 ) -> Option<ShellCommandExecutionState> {
-    matches!(
-        request.kind.as_str(),
-        "start_process_job" | "start_detached_process_job" | "start_script_job"
-    )
-    .then_some(ShellCommandExecutionState::NotStarted)
+    job_prestart_lifecycle_for_kind(request.kind.as_str())
+}
+
+fn raw_shell_job_terminal_lifecycle(
+    status: &str,
+    exit_code: Option<i32>,
+) -> ShellCommandExecutionState {
+    match status {
+        "timeout" | "timed_out" => ShellCommandExecutionState::TimedOut,
+        "completed" | "stopped" | "cancelled" => ShellCommandExecutionState::Completed,
+        "failed" if exit_code.is_some() => ShellCommandExecutionState::Completed,
+        _ => ShellCommandExecutionState::OutcomeUnknown,
+    }
 }
 
 fn job_update_from_snapshot(
@@ -4845,6 +4861,8 @@ impl JobManager {
                 });
                 break (step_status, out, err, progress);
             };
+            let command_execution_state = (!validation)
+                .then(|| raw_shell_job_terminal_lifecycle(&final_status.0, final_status.1));
             manager.update_and_send(
                 &job_id,
                 RunnerJobDelta {
@@ -4854,9 +4872,9 @@ impl JobManager {
                     exit_code: final_status.1,
                     duration_ms: Some(start.elapsed().as_millis() as u64),
                     error: final_status.2,
+                    command_execution_state,
                     validation_progress: final_progress,
                     finished: true,
-                    ..Default::default()
                 },
             );
             manager.start_available_queued();

--- a/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
+++ b/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
@@ -134,6 +134,7 @@ fn file_apply_text_edits_hash_conflict_keeps_every_file_unchanged() {
 
     assert_eq!(out["error_kind"], "sha256_conflict");
     assert_eq!(out["change_index"], 1);
+    assert_eq!(out["state_changed"], false);
     assert_eq!(
         std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
         "alpha\n"

--- a/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
+++ b/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
@@ -56,6 +56,39 @@ fn shell_job_filters_sensitive_env_case_insensitive() {
 }
 
 #[test]
+fn raw_shell_job_lifecycle_distinguishes_terminal_truth_without_error_text_matching() {
+    assert_eq!(
+        raw_shell_job_terminal_lifecycle("completed", Some(0)),
+        ShellCommandExecutionState::Completed
+    );
+    assert_eq!(
+        raw_shell_job_terminal_lifecycle("failed", Some(7)),
+        ShellCommandExecutionState::Completed
+    );
+    assert_eq!(
+        raw_shell_job_terminal_lifecycle("stopped", Some(-1)),
+        ShellCommandExecutionState::Completed
+    );
+    assert_eq!(
+        raw_shell_job_terminal_lifecycle("timeout", Some(-1)),
+        ShellCommandExecutionState::TimedOut
+    );
+    assert_eq!(
+        raw_shell_job_terminal_lifecycle("failed", None),
+        ShellCommandExecutionState::OutcomeUnknown
+    );
+}
+
+#[test]
+fn raw_shell_job_prestart_rejection_is_explicitly_not_started() {
+    assert_eq!(
+        job_prestart_lifecycle_for_kind("start_job"),
+        Some(ShellCommandExecutionState::NotStarted)
+    );
+    assert_eq!(job_prestart_lifecycle_for_kind("run_shell"), None);
+}
+
+#[test]
 fn shell_job_success_and_failure_results_are_structured() {
     let tmp = tempfile::tempdir().unwrap();
     let cfg = test_config(tmp.path().join("config/projects.d"));

--- a/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
+++ b/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
@@ -89,6 +89,18 @@ fn raw_shell_job_prestart_rejection_is_explicitly_not_started() {
 }
 
 #[test]
+fn raw_shell_job_post_spawn_interruption_never_reuses_not_started_proof() {
+    assert_eq!(
+        post_spawn_interruption_lifecycle_for_kind("start_job"),
+        Some(ShellCommandExecutionState::OutcomeUnknown)
+    );
+    assert_eq!(
+        post_spawn_interruption_lifecycle_for_kind("start_validation_job"),
+        None
+    );
+}
+
+#[test]
 fn shell_job_success_and_failure_results_are_structured() {
     let tmp = tempfile::tempdir().unwrap();
     let cfg = test_config(tmp.path().join("config/projects.d"));

--- a/crates/webcodex-runner/src/main_tests/shell_profiles.rs
+++ b/crates/webcodex-runner/src/main_tests/shell_profiles.rs
@@ -166,19 +166,22 @@ fn project_shell_profile_overrides_default_profile() {
     assert_eq!(result.stdout.as_deref(), Some("project"));
 }
 
-fn wait_for_job_stdout(rx: &mut tokio::sync::mpsc::Receiver<AgentEnvelope>) -> String {
+fn wait_for_job_stdout(
+    rx: &mut tokio::sync::mpsc::Receiver<AgentEnvelope>,
+) -> (String, Option<ShellCommandExecutionState>) {
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut stdout = String::new();
     while Instant::now() < deadline {
         match rx.try_recv() {
             Ok(AgentEnvelope::JobUpdate { payload }) => {
+                let command_execution_state = payload.command_execution_state;
                 if let Some(snapshot) = payload.log_snapshot {
                     stdout = snapshot.stdout.tail;
                 } else if let Some(chunk) = payload.stdout_chunk {
                     stdout.push_str(&chunk);
                 }
                 if payload.finished {
-                    return stdout;
+                    return (stdout, command_execution_state);
                 }
             }
             Ok(_) => {}
@@ -239,7 +242,13 @@ fn prepared_profile_run_shell_and_run_job_see_same_env() {
         shell_job_request(&project_dir, &shell_env_var("WEBCODEX_TEST_PROFILE")),
     )
     .unwrap();
-    assert_eq!(wait_for_job_stdout(&mut rx), "same");
+    let (job_stdout, execution_state) = wait_for_job_stdout(&mut rx);
+    assert_eq!(job_stdout, "same");
+    assert_eq!(
+        execution_state,
+        Some(ShellCommandExecutionState::Completed),
+        "raw shell Job terminal update must carry authoritative lifecycle"
+    );
 }
 
 #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -1195,13 +1195,13 @@ fn detached_process_jobmanager_initiation_handoffs_once_and_stops_via_durable_co
             .execution_source,
         "run_detached_process"
     );
-    assert_eq!(
-        lock_unpoison(&manager.detached_jobs)
-            .get(job_id)
-            .unwrap()
-            .execution_id,
-        running.execution_id
-    );
+    assert!(wait_until(Duration::from_secs(5), || lock_unpoison(
+        &manager.detached_jobs
+    )
+    .get(job_id)
+    .is_some_and(
+        |detached| detached.execution_id == running.execution_id
+    )));
     let starts = std::fs::read_to_string(&marker).unwrap();
     assert_eq!(starts.lines().count(), 1);
     assert!(starts.contains(nonce));

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -483,6 +483,7 @@ fn batch_error(
         serde_json::json!({
             "changed": false,
             "error_kind": code,
+            "state_changed": false,
             "change_index": change_index,
             "kind": kind,
             "path": path,
@@ -1005,6 +1006,7 @@ pub(crate) fn handle_apply_text_edits_file_request(
                                     serde_json::json!({
                                         "changed": false,
                                         "error_kind": "edit_conflict",
+                                        "state_changed": false,
                                         "change_index": index,
                                         "edit_index": edit_index,
                                         "kind": edit_kind,

--- a/crates/webcodex-workspace/src/workspace_checkpoint.rs
+++ b/crates/webcodex-workspace/src/workspace_checkpoint.rs
@@ -58,7 +58,7 @@ fn create_workspace_checkpoint_inner(root: &Path, include_untracked: bool) -> Re
         return Err(fail_extra(
             "sensitive_or_invalid_path",
             "checkpoint tracked diff contains a sensitive path",
-            vec![("path", json!(entry.path))],
+            vec![("path", json!(entry.path)), ("state_changed", json!(false))],
         ));
     }
 
@@ -848,15 +848,9 @@ pub fn sensitive_path(path: &str) -> bool {
         ) {
             return true;
         }
-        if part.starts_with(".env")
+        if part.starts_with(".env.")
             || part.starts_with("agent.toml")
             || part.starts_with("webcodex.env")
-        {
-            return true;
-        }
-        if ["secret", "token", "credential", "password"]
-            .iter()
-            .any(|marker| part.contains(marker))
         {
             return true;
         }

--- a/crates/webcodex-workspace/src/workspace_checkpoint.rs
+++ b/crates/webcodex-workspace/src/workspace_checkpoint.rs
@@ -848,7 +848,7 @@ pub fn sensitive_path(path: &str) -> bool {
         ) {
             return true;
         }
-        if part.starts_with(".env.")
+        if part.starts_with(".env")
             || part.starts_with("agent.toml")
             || part.starts_with("webcodex.env")
         {

--- a/src/shell_client/job_updates.rs
+++ b/src/shell_client/job_updates.rs
@@ -1092,19 +1092,27 @@ impl ShellClientRegistry {
         }
         let client_id = job.client_id.clone();
         let agent_instance_id = job.agent_instance_id.clone();
-        let Some(client) = inner.clients.get_mut(&client_id) else {
-            return false;
-        };
-        if client.agent_instance_id != agent_instance_id {
-            return false;
+        // Preserve same-instance reconnect suppression whenever the exact
+        // Runner lease is still current. If that lease disappeared or was
+        // replaced after the terminal snapshot was already projected, do not
+        // strand the hidden terminal record forever: a replacement instance
+        // cannot consume the retired lease, while a later registration after
+        // the Server forgot the lease is conservatively equivalent to fresh
+        // recovery and may reconstruct retained Runner terminal evidence.
+        if let Some(client) = inner
+            .clients
+            .get_mut(&client_id)
+            .filter(|client| client.agent_instance_id == agent_instance_id)
+        {
+            // The suppression store predates raw-shell/validation hidden
+            // handoff, but its proof is only the exact
+            // client/instance/job/request tuple.
+            client.remember_projected_structured_terminal(
+                job_id.to_string(),
+                request_id.clone(),
+                now_ts(),
+            );
         }
-        // The suppression store predates raw-shell/validation hidden handoff,
-        // but its proof is only the exact client/instance/job/request tuple.
-        client.remember_projected_structured_terminal(
-            job_id.to_string(),
-            request_id.clone(),
-            now_ts(),
-        );
 
         let removed = inner
             .jobs_by_id

--- a/src/shell_client/job_updates.rs
+++ b/src/shell_client/job_updates.rs
@@ -1052,6 +1052,7 @@ impl ShellClientRegistry {
     /// then fail harmlessly as "unknown shell job"). Also drops any still
     /// pending start request so a queued-but-never-run job leaves no request
     /// behind.
+    #[cfg(test)]
     pub(crate) async fn remove_job_record(&self, job_id: &str) -> bool {
         let mut inner = self.inner.lock().await;
         let Some(job) = inner.jobs_by_id.remove(job_id) else {
@@ -1067,14 +1068,16 @@ impl ShellClientRegistry {
         true
     }
 
-    /// Discard a terminal hidden structured Job after its result has been
-    /// projected into the initiating `run_process` or `run_script` response.
+    /// Discard a terminal hidden Job after its result has already been projected
+    /// into the initiating tool response.
     ///
     /// The exact discarded handle is retained only in the current Server
     /// process, bounded by the Runner terminal-inventory limits. A same-runner
     /// registration replay can then suppress that already-projected terminal
-    /// evidence without changing fresh-Server conservative recovery.
-    pub(crate) async fn remove_projected_hidden_structured_job_record(&self, job_id: &str) -> bool {
+    /// evidence without changing fresh-Server conservative recovery. This is
+    /// shared by typed process/script execution, structured validation, and
+    /// long `run_shell`; all of them use `HiddenUntilHandoff` before projection.
+    pub(crate) async fn remove_projected_hidden_terminal_job_record(&self, job_id: &str) -> bool {
         let mut inner = self.inner.lock().await;
         let Some(job) = inner.jobs_by_id.get(job_id) else {
             return false;
@@ -1084,7 +1087,6 @@ impl ShellClientRegistry {
         };
         if job.visibility != ShellJobVisibility::HiddenUntilHandoff
             || !is_final_job_status(&job.status)
-            || job.structured_execution.is_none()
         {
             return false;
         }
@@ -1096,6 +1098,8 @@ impl ShellClientRegistry {
         if client.agent_instance_id != agent_instance_id {
             return false;
         }
+        // The suppression store predates raw-shell/validation hidden handoff,
+        // but its proof is only the exact client/instance/job/request tuple.
         client.remember_projected_structured_terminal(
             job_id.to_string(),
             request_id.clone(),
@@ -1105,13 +1109,18 @@ impl ShellClientRegistry {
         let removed = inner
             .jobs_by_id
             .remove(job_id)
-            .expect("projected structured Job was checked under the registry lock");
+            .expect("projected hidden Job was checked under the registry lock");
         inner.request_to_job.remove(&request_id);
         inner.pending_by_id.remove(&request_id);
         if let Some(queue) = inner.queues_by_client.get_mut(&removed.client_id) {
             queue.retain(|id| id != &request_id);
         }
         true
+    }
+
+    pub(crate) async fn remove_projected_hidden_structured_job_record(&self, job_id: &str) -> bool {
+        self.remove_projected_hidden_terminal_job_record(job_id)
+            .await
     }
 
     pub async fn get_job(&self, job_id: &str) -> Result<ShellJobInfo, String> {

--- a/src/shell_client/reconciliation.rs
+++ b/src/shell_client/reconciliation.rs
@@ -906,7 +906,6 @@ pub(super) fn reconcile_inventory_locked(
 
     for snapshot in &inventory.jobs {
         let suppress_unknown_terminal = is_final_job_status(&snapshot.status)
-            && snapshot.context.structured_execution.is_some()
             && inner.clients.get(client_id).is_some_and(|client| {
                 client.suppresses_projected_structured_terminal(
                     client_id,

--- a/src/shell_client/reconciliation_tests.rs
+++ b/src/shell_client/reconciliation_tests.rs
@@ -919,6 +919,106 @@ async fn projected_hidden_structured_terminal_is_suppressed_only_by_same_server_
 }
 
 #[tokio::test]
+async fn projected_hidden_raw_shell_terminal_does_not_resurrect_on_same_instance_reconnect() {
+    let registry = ShellClientRegistry::default();
+    register(&registry, INSTANCE_A, empty_inventory()).await;
+    let job = registry
+        .start_job_with_metadata(
+            start_request("printf raw-shell"),
+            "tester".to_string(),
+            ShellJobStartMetadata {
+                project_id: Some(RUNTIME_PROJECT_ID.to_string()),
+                session_id: Some(SESSION_ID.to_string()),
+                project_cwd: Some("/srv/demo".to_string()),
+                purpose: Some("test".to_string()),
+                shell: Some("bash".to_string()),
+                visibility: ShellJobVisibility::HiddenUntilHandoff,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let request = registry
+        .poll(ShellAgentPollRequest {
+            client_id: CLIENT_ID.to_string(),
+            agent_instance_id: INSTANCE_A.to_string(),
+            projects: None,
+        })
+        .await
+        .unwrap()
+        .expect("raw shell Job request");
+    assert_eq!(request.kind, "start_job");
+
+    registry
+        .update_job(update(
+            INSTANCE_A,
+            &job.job_id,
+            1,
+            "running",
+            Some("raw started\n"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let mut terminal_update = update(
+        INSTANCE_A,
+        &job.job_id,
+        2,
+        "completed",
+        Some("raw done\n"),
+        true,
+    );
+    terminal_update.command_execution_state = Some(ShellCommandExecutionState::Completed);
+    registry.update_job(terminal_update).await.unwrap();
+
+    let mut retained_snapshot = snapshot_from_request(
+        &job,
+        &request,
+        "completed",
+        2,
+        stream("raw started\nraw done\n", 1, false),
+    );
+    retained_snapshot.command_execution_state = Some(ShellCommandExecutionState::Completed);
+
+    assert!(
+        registry
+            .remove_projected_hidden_terminal_job_record(&job.job_id)
+            .await
+    );
+    assert!(registry.list_jobs(Some(10)).await.is_empty());
+
+    register(
+        &registry,
+        INSTANCE_A,
+        ShellJobInventory {
+            active_complete: true,
+            jobs: vec![retained_snapshot.clone()],
+        },
+    )
+    .await;
+
+    assert!(
+        registry.get_job(&job.job_id).await.is_err(),
+        "same-Server inventory replay must not resurrect a terminal hidden raw shell Job"
+    );
+    assert!(registry.list_jobs(Some(10)).await.is_empty());
+
+    let fresh_registry = ShellClientRegistry::default();
+    register(
+        &fresh_registry,
+        INSTANCE_A,
+        ShellJobInventory {
+            active_complete: true,
+            jobs: vec![retained_snapshot],
+        },
+    )
+    .await;
+    let recovered = fresh_registry.get_job(&job.job_id).await.unwrap();
+    assert_eq!(recovered.status, "completed");
+    assert!(recovered.recovered_after_server_restart);
+}
+
+#[tokio::test]
 async fn projected_structured_terminal_suppressions_are_bounded_and_expire() {
     let registry = ShellClientRegistry::default();
     register(&registry, INSTANCE_A, empty_inventory()).await;

--- a/src/shell_client/reconciliation_tests.rs
+++ b/src/shell_client/reconciliation_tests.rs
@@ -5,8 +5,8 @@ use super::reconciliation::{
 };
 use super::state::{PendingShellRequest, ShellJobVisibility};
 use super::{
-    clamp_grace, job_recovery_grace_secs, now_ts, ShellClientRegistry, JOB_RECOVERY_GRACE_SECS,
-    MAX_OUTPUT_BYTES,
+    clamp_grace, job_recovery_grace_secs, now_ts, ShellClientRegistry, CLIENT_ONLINE_WINDOW_SECS,
+    JOB_RECOVERY_GRACE_SECS, MAX_OUTPUT_BYTES,
 };
 use crate::shell_protocol::{
     PersistentShellResult, ShellAgentJobUpdateRequest, ShellAgentPollRequest,
@@ -1016,6 +1016,72 @@ async fn projected_hidden_raw_shell_terminal_does_not_resurrect_on_same_instance
     let recovered = fresh_registry.get_job(&job.job_id).await.unwrap();
     assert_eq!(recovered.status, "completed");
     assert!(recovered.recovered_after_server_restart);
+}
+
+#[tokio::test]
+async fn projected_hidden_terminal_removes_after_runner_instance_replacement() {
+    let registry = ShellClientRegistry::default();
+    register(&registry, INSTANCE_A, empty_inventory()).await;
+    let job = registry
+        .start_job_with_metadata(
+            start_request("printf projected-before-replacement"),
+            "tester".to_string(),
+            ShellJobStartMetadata {
+                project_id: Some(RUNTIME_PROJECT_ID.to_string()),
+                session_id: Some(SESSION_ID.to_string()),
+                project_cwd: Some("/srv/demo".to_string()),
+                purpose: Some("test".to_string()),
+                shell: Some("bash".to_string()),
+                visibility: ShellJobVisibility::HiddenUntilHandoff,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let request = registry
+        .poll(ShellAgentPollRequest {
+            client_id: CLIENT_ID.to_string(),
+            agent_instance_id: INSTANCE_A.to_string(),
+            projects: None,
+        })
+        .await
+        .unwrap()
+        .expect("hidden Job request");
+    registry
+        .update_job(update(
+            INSTANCE_A,
+            &job.job_id,
+            1,
+            "completed",
+            Some("projected result\n"),
+            true,
+        ))
+        .await
+        .unwrap();
+
+    registry
+        .set_last_seen_for_test(
+            CLIENT_ID,
+            now_ts().saturating_sub(CLIENT_ONLINE_WINDOW_SECS + 1),
+        )
+        .await;
+    register(&registry, INSTANCE_B, empty_inventory()).await;
+
+    assert!(
+        registry
+            .remove_projected_hidden_terminal_job_record(&job.job_id)
+            .await,
+        "a terminal result already projected to the caller must not remain hidden forever when the Runner lease changes"
+    );
+    let inner = registry.inner.lock().await;
+    assert!(!inner.jobs_by_id.contains_key(&job.job_id));
+    assert!(!inner.request_to_job.contains_key(&request.request_id));
+    assert!(inner
+        .clients
+        .get(CLIENT_ID)
+        .unwrap()
+        .projected_structured_terminal_suppressions
+        .is_empty());
 }
 
 #[tokio::test]

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -1732,7 +1732,9 @@ impl ToolRuntime {
         if passed {
             // Discard the hidden Job record so a fast validation never leaves a
             // redundant visible job in list_jobs.
-            self.shell_clients.remove_job_record(&job_id).await;
+            self.shell_clients
+                .remove_projected_hidden_terminal_job_record(&job_id)
+                .await;
             ToolResult::ok(payload)
         } else {
             let failure_kind = if timed_out {
@@ -1754,7 +1756,9 @@ impl ToolRuntime {
                     format!("structured validation command failed; {VALIDATION_FAILURE_GUIDANCE}")
                 }),
             };
-            self.shell_clients.remove_job_record(&job_id).await;
+            self.shell_clients
+                .remove_projected_hidden_terminal_job_record(&job_id)
+                .await;
             result
         }
     }

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -244,6 +244,10 @@ fn apply_text_edits_agent_stdout_result(stdout: &str) -> ToolResult {
     ToolResult::ok(obj)
 }
 
+fn apply_text_edits_preflight_rejection(message: impl Into<String>) -> ToolResult {
+    ToolResult::err_with_output(message, json!({"state_changed": false}))
+}
+
 /// Pure, allocation-only computation of an `apply_text_edits` plan against
 /// `original` UTF-8 content. Performs every semantic validation (unique
 /// match, no overlap, whole-file sha guard) and returns the new content plus
@@ -891,10 +895,12 @@ impl ToolRuntime {
         dry_run: Option<bool>,
     ) -> ToolResult {
         if changes.is_empty() {
-            return ToolResult::err("changes must contain at least one file change");
+            return apply_text_edits_preflight_rejection(
+                "changes must contain at least one file change",
+            );
         }
         if changes.len() > MAX_APPLY_FILE_CHANGES {
-            return ToolResult::err(format!(
+            return apply_text_edits_preflight_rejection(format!(
                 "too many file changes; maximum is {}",
                 MAX_APPLY_FILE_CHANGES
             ));
@@ -905,7 +911,7 @@ impl ToolRuntime {
                 return super::permissions::edit_path_policy_rejected_result(&change.path, error);
             }
             if !touched_paths.insert(change.path.as_str()) {
-                return ToolResult::err(format!(
+                return apply_text_edits_preflight_rejection(format!(
                     "change {change_index} reuses path '{}'; each source/destination path may appear only once",
                     change.path
                 ));
@@ -915,13 +921,13 @@ impl ToolRuntime {
                     return super::permissions::edit_path_policy_rejected_result(to_path, error);
                 }
                 if !touched_paths.insert(to_path) {
-                    return ToolResult::err(format!(
+                    return apply_text_edits_preflight_rejection(format!(
                         "change {change_index} reuses destination path '{to_path}'; each source/destination path may appear only once"
                     ));
                 }
             }
             if let Err(message) = validate_apply_file_change(change_index, change) {
-                return ToolResult::err(message);
+                return apply_text_edits_preflight_rejection(message);
             }
         }
 
@@ -932,13 +938,13 @@ impl ToolRuntime {
         let serialized = match serde_json::to_string(&payload) {
             Ok(serialized) if serialized.len() <= MAX_APPLY_FILE_CHANGES_BYTES => serialized,
             Ok(_) => {
-                return ToolResult::err(format!(
+                return apply_text_edits_preflight_rejection(format!(
                     "serialized file changes exceed {} bytes",
                     MAX_APPLY_FILE_CHANGES_BYTES
                 ))
             }
             Err(error) => {
-                return ToolResult::err(format!(
+                return apply_text_edits_preflight_rejection(format!(
                     "failed to serialize file changes payload: {error}"
                 ))
             }

--- a/src/tool_runtime/handoff.rs
+++ b/src/tool_runtime/handoff.rs
@@ -1168,8 +1168,8 @@ fn unexpected_failure_is_proven_non_actionable(event: &SessionEvent) -> bool {
         return true;
     }
     if effect.and_then(|effect| effect.state_changed) == Some(false)
-        && !event.shell_like
-        && !event.git_like
+        && ((!event.shell_like && !event.git_like)
+            || event.tool_name == "workspace_checkpoint_create")
     {
         return true;
     }

--- a/src/tool_runtime/helpers.rs
+++ b/src/tool_runtime/helpers.rs
@@ -1024,9 +1024,9 @@ pub(crate) const DEFAULT_CARGO_FMT_TIMEOUT_SECS: u64 = 120;
 
 /// Internal synchronous wait window for a structured validation. The tool call
 /// blocks up to this long for the command to finish in-process; after that the
-/// same execution is promoted to a queryable Job. Kept below the 120s MCP
-/// hard ceiling so transport/result serialization keeps ~30s of headroom.
-pub(crate) const SYNC_VALIDATION_WAIT_SECS: u64 = 90;
+/// same execution is promoted to a queryable Job. Kept well below the 120s MCP
+/// hard ceiling so transport/result serialization retains substantial headroom.
+pub(crate) const SYNC_VALIDATION_WAIT_SECS: u64 = 60;
 
 /// Resolve a synchronous command timeout. Out-of-range values are rejected
 /// (not clamped) so callers cannot request longer waits than the sync path

--- a/src/tool_runtime/patch.rs
+++ b/src/tool_runtime/patch.rs
@@ -50,6 +50,18 @@ pub(crate) fn reject_unsupported_patch_wrapper(patch: &str) -> Option<String> {
     }
 }
 
+fn patch_preflight_rejection(message: impl Into<String>) -> ToolResult {
+    ToolResult::err_with_output(
+        message,
+        json!({
+            "state_changed": false,
+            "command_started": false,
+            "command_completed": false,
+            "execution_state": "not_started",
+        }),
+    )
+}
+
 pub(crate) fn validate_patch_file_path(path: &str) -> Result<(), String> {
     if path.is_empty() {
         return Err("patch path cannot be empty".to_string());
@@ -300,34 +312,34 @@ impl ToolRuntime {
     ) -> ToolResult {
         // ---- Input validation (before any project resolution) ----
         if patch.is_empty() {
-            return ToolResult::err("Patch cannot be empty");
+            return patch_preflight_rejection("Patch cannot be empty");
         }
         if patch.contains('\0') {
-            return ToolResult::err("Patch contains NUL byte");
+            return patch_preflight_rejection("Patch contains NUL byte");
         }
         if patch.len() > MAX_VALIDATE_PATCH_BYTES {
-            return ToolResult::err(format!(
+            return patch_preflight_rejection(format!(
                 "Patch too large ({} bytes); maximum is {} bytes",
                 patch.len(),
                 MAX_VALIDATE_PATCH_BYTES
             ));
         }
         if let Some(err) = reject_unsupported_patch_wrapper(&patch) {
-            return ToolResult::err(err);
+            return patch_preflight_rejection(err);
         }
 
         // ---- Project resolution (agent-registered only) ----
         let proj = match self.resolve_project(&project).await {
             Ok(p) => p,
-            Err(e) => return ToolResult::err(e),
+            Err(e) => return patch_preflight_rejection(e),
         };
         if !proj.allow_patch() {
-            return ToolResult::err("Patch is not allowed for this project");
+            return patch_preflight_rejection("Patch is not allowed for this project");
         }
         // ---- Patch path analysis ----
         let affected = parse_changed_files_from_patch(&patch);
         if affected.is_empty() {
-            return ToolResult::err("Patch does not declare any changed files");
+            return patch_preflight_rejection("Patch does not declare any changed files");
         }
         // Hard-reject paths that escape the project boundary. Collect warnings
         // for sensitive filenames. Callers can request a hard policy block so
@@ -335,7 +347,7 @@ impl ToolRuntime {
         let mut warnings: Vec<String> = Vec::new();
         for file in &affected {
             if let Err(e) = validate_preflight_path(file) {
-                return ToolResult::err(e);
+                return patch_preflight_rejection(e);
             }
             warnings.extend(sensitive_path_warnings(file));
         }
@@ -359,14 +371,14 @@ impl ToolRuntime {
         // reads the agent project filesystem directly, and server-configured
         // legacy projects are not a supported runtime surface for this tool.
         if !proj.is_agent() {
-            return ToolResult::err(
+            return patch_preflight_rejection(
                 "validate_patch requires an agent-registered project; \
                  server-configured projects are not supported",
             );
         }
         let client_id = match proj.agent_client_id() {
             Ok(id) => id.to_string(),
-            Err(e) => return ToolResult::err(e),
+            Err(e) => return patch_preflight_rejection(e),
         };
 
         // ---- 1) git apply --check (read-only applicability test) ----

--- a/src/tool_runtime/permissions/mod.rs
+++ b/src/tool_runtime/permissions/mod.rs
@@ -203,6 +203,7 @@ pub(crate) fn edit_path_policy_rejected_result(path: &str, message: String) -> T
             "error": message,
             "failure_kind": "policy_rejected",
             "error_kind": "policy_rejected",
+            "state_changed": false,
         }),
     )
 }

--- a/src/tool_runtime/permissions/tests.rs
+++ b/src/tool_runtime/permissions/tests.rs
@@ -165,6 +165,7 @@ fn hard_security_rules_are_not_bypassed_by_authority_mode() {
         &rejected.output,
         rejected.error.as_deref()
     ));
+    assert_eq!(rejected.output["state_changed"], false);
 }
 
 #[test]

--- a/src/tool_runtime/registry/input_schemas/jobs.rs
+++ b/src/tool_runtime/registry/input_schemas/jobs.rs
@@ -185,7 +185,7 @@ pub(crate) fn run_shell_input_schema() -> Value {
         (
             "timeout_secs",
             "integer",
-            "Synchronous command timeout in seconds (1..=120, default 60). Out-of-range values are rejected before start; choose asynchronous execution for longer work.",
+            "Total command timeout in seconds (1..=120, default 60). Explicit values above 60 may hand off the same original execution as a durable Job when the Runner supports async shell Jobs; default 60-second calls remain synchronous.",
             false,
         ),
         (

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -257,7 +257,7 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
             "promoted_to_job",
             schema_type(
                 "boolean",
-                "True only when the same original execution continues as a durable Job. Omitted from run_process/run_script model-facing output after ordinary synchronous terminal success.",
+                "True only when the same original execution continues as a durable Job. Omitted from run_process/run_script model-facing output after ordinary synchronous terminal success; run_shell may expose it only for explicit long-call handoff.",
             ),
         ),
         (
@@ -271,14 +271,14 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
             "job_id",
             nullable_schema(
                 "string",
-                "Durable continuation Job id. Non-promoted terminal run_process/run_script success omits this field rather than returning null.",
+                "Durable continuation Job id. Non-promoted terminal execution may return null or omit this field according to the initiating tool's sparse contract.",
             ),
         ),
         (
             "job_status",
             nullable_schema(
                 "string",
-                "Authoritative durable Job status. Non-promoted terminal run_process/run_script success omits this field rather than returning null.",
+                "Authoritative durable Job status. Non-promoted terminal execution may return null or omit this field according to the initiating tool's sparse contract.",
             ),
         ),
         (
@@ -306,7 +306,7 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
             "async_handoff_available",
             schema_type(
                 "boolean",
-                "Whether this Runner can continue typed structured execution as the same durable Job. True is omitted after ordinary synchronous terminal run_process/run_script success; false remains explicit as a noteworthy capability limitation.",
+                "Whether this Runner can continue the same original execution as a durable Job. True is omitted after ordinary synchronous terminal run_process/run_script success; run_shell exposes it only on its explicit long-call durable path.",
             ),
         ),
     ]
@@ -731,106 +731,107 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 structured_execution_lifecycle_constraints("run_script");
             Some(schema)
         }
-        "run_shell" => Some(wrapped_output_schema(vec![
-            (
-                "duration_ms",
-                schema_type("integer", "Command duration in milliseconds."),
-            ),
-            (
-                "exit_code",
-                nullable_schema("integer", "Process exit code, when available."),
-            ),
-            (
-                "stdout_tail",
-                schema_type("string", "Bounded stdout tail."),
-            ),
-            (
-                "stderr_tail",
-                schema_type("string", "Bounded stderr tail."),
-            ),
-            (
-                "stdout_lines",
-                schema_type("integer", "Total captured stdout line count."),
-            ),
-            (
-                "stderr_lines",
-                schema_type("integer", "Total captured stderr line count."),
-            ),
-            (
-                "stdout_truncated",
-                schema_type("boolean", "Whether stdout_tail was truncated."),
-            ),
-            (
-                "stderr_truncated",
-                schema_type("boolean", "Whether stderr_tail was truncated."),
-            ),
-            (
-                "command_started",
-                schema_type(
-                    "boolean",
-                    "Whether callers must conservatively treat the command as started; true includes outcome_unknown because side effects may have occurred.",
+        "run_shell" => {
+            let mut properties = vec![
+                (
+                    "duration_ms",
+                    schema_type("integer", "Command duration in milliseconds."),
                 ),
-            ),
-            (
-                "command_completed",
-                schema_type(
-                    "boolean",
-                    "Whether the command reached a terminal result before tool timeout.",
+                (
+                    "exit_code",
+                    nullable_schema("integer", "Process exit code, when available."),
                 ),
-            ),
-            (
-                "command_ok",
-                schema_type("boolean", "Whether the command completed with exit code 0."),
-            ),
-            (
-                "failure_kind",
-                nullable_schema(
-                    "string",
-                    "Structured failure kind such as command_exit_nonzero, timeout, outcome_unknown, agent_offline, spawn_failed, permission_denied, tool_schema_error, or runtime_error.",
+                (
+                    "stdout_tail",
+                    schema_type("string", "Bounded stdout tail."),
                 ),
-            ),
-            (
-                "tool_failure",
-                schema_type(
-                    "boolean",
-                    "True for WebCodex tool/runtime failures; false for command exit status failures.",
+                (
+                    "stderr_tail",
+                    schema_type("string", "Bounded stderr tail."),
                 ),
-            ),
-            ("purpose", schema_type("string", "Declared execution purpose.")),
-            (
-                "command_summary",
-                schema_type("string", "Bounded first-line command summary."),
-            ),
-            (
-                "cwd",
-                schema_type(
-                    "string",
-                    "Resolved project-relative cwd, or the selected SSH resource's remote cwd.",
+                (
+                    "stdout_lines",
+                    schema_type("integer", "Total captured stdout line count."),
                 ),
-            ),
-            (
-                "shell",
-                schema_type(
-                    "string",
-                    "Actual selected shell, configured executor shell, or remote SSH executor.",
+                (
+                    "stderr_lines",
+                    schema_type("integer", "Total captured stderr line count."),
                 ),
-            ),
-            ("executor", schema_type("string", "Executor type: local or agent.")),
-            (
-                "ssh_resource",
-                nullable_schema(
-                    "string",
-                    "Named Runner-local SSH resource used for this command, when any.",
+                (
+                    "stdout_truncated",
+                    schema_type("boolean", "Whether stdout_tail was truncated."),
                 ),
-            ),
-            (
-                "execution_state",
-                schema_type(
-                    "string",
-                    "Canonical lifecycle state: not_started, outcome_unknown, completed, or timed_out. Only not_started is structurally safe to retry without first inspecting target state.",
+                (
+                    "stderr_truncated",
+                    schema_type("boolean", "Whether stderr_tail was truncated."),
                 ),
-            ),
-        ])),
+                (
+                    "command_started",
+                    schema_type(
+                        "boolean",
+                        "Whether callers must conservatively treat the command as started; true includes outcome_unknown because side effects may have occurred.",
+                    ),
+                ),
+                (
+                    "command_completed",
+                    schema_type(
+                        "boolean",
+                        "Whether the command reached a known terminal result. A durable Job handoff reports false while the same original execution continues.",
+                    ),
+                ),
+                (
+                    "command_ok",
+                    schema_type("boolean", "Whether the command completed with exit code 0."),
+                ),
+                (
+                    "failure_kind",
+                    nullable_schema(
+                        "string",
+                        "Structured failure kind such as command_exit_nonzero, timeout, outcome_unknown, agent_offline, spawn_failed, permission_denied, tool_schema_error, or runtime_error.",
+                    ),
+                ),
+                (
+                    "tool_failure",
+                    schema_type(
+                        "boolean",
+                        "True for WebCodex tool/runtime failures; false for command exit status failures or a healthy durable handoff.",
+                    ),
+                ),
+                ("purpose", schema_type("string", "Declared execution purpose.")),
+                (
+                    "command_summary",
+                    schema_type("string", "Bounded first-line command summary."),
+                ),
+                (
+                    "cwd",
+                    schema_type(
+                        "string",
+                        "Resolved project-relative cwd, or the selected SSH resource's remote cwd.",
+                    ),
+                ),
+                (
+                    "shell",
+                    schema_type(
+                        "string",
+                        "Actual selected shell, configured executor shell, or remote SSH executor.",
+                    ),
+                ),
+                ("executor", schema_type("string", "Executor type: local or agent.")),
+                (
+                    "ssh_resource",
+                    nullable_schema(
+                        "string",
+                        "Named Runner-local SSH resource used for this command, when any.",
+                    ),
+                ),
+                ("execution_state", process_execution_state_schema()),
+            ];
+            properties.extend(structured_continuation_properties());
+            let mut schema = wrapped_output_schema(properties);
+            schema["properties"]["output"]["allOf"] =
+                structured_execution_lifecycle_constraints("run_shell");
+            Some(schema)
+        }
         "open_session_shell"
         | "session_shell_exec"
         | "session_shell_status"

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -9,7 +9,7 @@ fn process_execution_state_schema() -> Value {
     json!({
         "type": "string",
         "enum": ["not_started", "outcome_unknown", "completed", "timed_out", "queued", "running"],
-        "description": "Canonical result lifecycle, plus queued/running only when the same execution has been exposed as a durable Job. Only not_started is structurally safe to retry without first inspecting target state."
+        "description": "Canonical lifecycle: not_started means no command dispatch; outcome_unknown means effects may have occurred and must be reconciled before retry; completed and timed_out are terminal. queued/running appear only when the same execution has been exposed as a durable Job. Only not_started is structurally safe to retry without first inspecting target state."
     })
 }
 
@@ -257,7 +257,7 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
             "promoted_to_job",
             schema_type(
                 "boolean",
-                "True only when the same original execution continues as a durable Job. Omitted from run_process/run_script model-facing output after ordinary synchronous terminal success; run_shell may expose it only for explicit long-call handoff.",
+                "True only when the same original execution continues as a durable Job. Omitted after ordinary synchronous terminal success; exposed only when the initiating tool selects explicit durable handoff.",
             ),
         ),
         (
@@ -306,7 +306,7 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
             "async_handoff_available",
             schema_type(
                 "boolean",
-                "Whether this Runner can continue the same original execution as a durable Job. True is omitted after ordinary synchronous terminal run_process/run_script success; run_shell exposes it only on its explicit long-call durable path.",
+                "Whether this Runner can continue the same original execution as a durable Job. Omitted after ordinary synchronous terminal success; exposed only when this tool's durable handoff path is relevant.",
             ),
         ),
     ]

--- a/src/tool_runtime/shell.rs
+++ b/src/tool_runtime/shell.rs
@@ -10,10 +10,17 @@ use super::helpers::{
     validate_raw_shell_command_length, LocalRunFailure, COMMAND_STDIO_TAIL_CHARS,
     DEFAULT_RUN_SHELL_TIMEOUT_SECS, MAX_SYNC_TIMEOUT_SECS, MIN_SYNC_TIMEOUT_SECS,
 };
+use super::process::add_structured_continuation_facts;
+use super::structured_execution::{
+    await_hidden_structured_job, HiddenStructuredJobWait, STRUCTURED_EXECUTION_SYNC_WAIT_SECS,
+};
 use super::tool_result::ToolResult;
 use super::{ExecutionPurpose, ExecutionShell, ToolRuntime};
-use crate::shell_client::command_preview;
-use crate::shell_protocol::{ShellCommandExecutionState, ShellRunRequest, ShellRunResponse};
+use crate::auth::AuthContext;
+use crate::shell_client::{command_preview, ShellJobStartMetadata, ShellJobVisibility};
+use crate::shell_protocol::{
+    ShellCommandExecutionState, ShellJobInfo, ShellJobOpRequest, ShellRunRequest, ShellRunResponse,
+};
 
 pub(crate) struct ProjectCommandOutput {
     pub(crate) exit_code: Option<i32>,
@@ -410,6 +417,71 @@ impl ToolRuntime {
         }
     }
 
+    fn run_shell_terminal_job_result(
+        job: &ShellJobInfo,
+        stdout: String,
+        stderr: String,
+        timeout_secs: u64,
+    ) -> ToolResult {
+        let state = job
+            .command_execution_state
+            .unwrap_or(ShellCommandExecutionState::OutcomeUnknown);
+        let mut result = match state {
+            ShellCommandExecutionState::NotStarted => {
+                let reason = job
+                    .error
+                    .as_deref()
+                    .unwrap_or("Runner rejected the shell Job before command start");
+                Self::run_shell_tool_failure_result(
+                    command_rejected_message(
+                        reason,
+                        "inspect the rejection reason and retry only after confirming no command started.",
+                    ),
+                    Self::classify_run_shell_enqueue_failure(reason),
+                    state,
+                )
+            }
+            ShellCommandExecutionState::OutcomeUnknown => Self::run_shell_outcome_unknown_result(
+                job.error
+                    .as_deref()
+                    .unwrap_or("the Runner lost a trustworthy terminal shell Job result"),
+            ),
+            ShellCommandExecutionState::TimedOut => Self::run_shell_command_failure_result(
+                job.exit_code,
+                stdout,
+                stderr,
+                job.duration_ms,
+                timeout_secs,
+                state,
+            ),
+            ShellCommandExecutionState::Completed
+                if job.status == "completed" && job.exit_code == Some(0) && job.error.is_none() =>
+            {
+                ToolResult::ok(Self::run_shell_success_output(
+                    0,
+                    stdout,
+                    stderr,
+                    job.duration_ms,
+                ))
+            }
+            ShellCommandExecutionState::Completed => Self::run_shell_command_failure_result(
+                job.exit_code,
+                stdout,
+                stderr,
+                job.duration_ms,
+                timeout_secs,
+                state,
+            ),
+        };
+        if job.stdout_log_truncated {
+            result.output["stdout_truncated"] = json!(true);
+        }
+        if job.stderr_log_truncated {
+            result.output["stderr_truncated"] = json!(true);
+        }
+        result
+    }
+
     pub(crate) async fn run_shell(
         &self,
         project: String,
@@ -440,6 +512,7 @@ impl ToolRuntime {
             None,
             None,
             None,
+            None,
         )
         .await
     }
@@ -455,7 +528,8 @@ impl ToolRuntime {
         shell: Option<ExecutionShell>,
         sandbox: Option<&str>,
         ssh_resource: Option<&str>,
-        ssh_session_id: Option<&str>,
+        session_id: Option<&str>,
+        auth: Option<&AuthContext>,
     ) -> ToolResult {
         if let Err(error) = validate_raw_shell_command_length(&command) {
             return Self::run_shell_tool_failure_result(
@@ -551,7 +625,7 @@ impl ToolRuntime {
                     .unwrap_or_else(|_| ".".to_string());
                 (Some(effective_cwd), resolved_cwd)
             };
-            if ssh_resource.is_some() && ssh_session_id.is_none() {
+            if ssh_resource.is_some() && session_id.is_none() {
                 return Self::run_shell_tool_failure_result(
                     command_rejected_message(
                         "ssh_session_required: an SSH resource requires a Workflow Session id",
@@ -583,6 +657,153 @@ impl ToolRuntime {
                 },
                 None => command.clone(),
             };
+            let async_handoff_available =
+                if timeout > DEFAULT_RUN_SHELL_TIMEOUT_SECS && ssh_resource.is_none() {
+                    self.shell_clients
+                        .get_client_capabilities(&client_id)
+                        .await
+                        .is_ok_and(|capabilities| {
+                            capabilities.shell
+                                && (capabilities.async_jobs || capabilities.async_shell_jobs)
+                        })
+                } else {
+                    false
+                };
+            if async_handoff_available {
+                let job = self
+                    .shell_clients
+                    .start_job_with_metadata_for_auth(
+                        ShellJobOpRequest {
+                            op: "start".to_string(),
+                            client_id: Some(client_id.clone()),
+                            cwd: effective_cwd.clone(),
+                            command: Some(dispatched_command.clone()),
+                            timeout_secs: Some(timeout),
+                            job_id: None,
+                            since_stdout_line: None,
+                            since_stderr_line: None,
+                            tail_lines: None,
+                            limit: None,
+                            codex: None,
+                        },
+                        "tool_runtime".to_string(),
+                        ShellJobStartMetadata {
+                            project_id: Some(project.clone()),
+                            session_id: session_id.map(str::to_string),
+                            project_cwd: Some(resolved_cwd.clone()),
+                            purpose: Some(declared_purpose.as_str().to_string()),
+                            shell: Some(actual_shell.to_string()),
+                            visibility: ShellJobVisibility::HiddenUntilHandoff,
+                            sandbox: sandbox.map(str::to_string),
+                            ..Default::default()
+                        },
+                        auth,
+                    )
+                    .await;
+                let job = match job {
+                    Ok(job) => job,
+                    Err(error) => {
+                        let mut result = Self::run_shell_tool_failure_result(
+                            command_rejected_message(
+                                &error,
+                                "confirm the Runner is connected and retry only after confirming no shell Job started.",
+                            ),
+                            Self::classify_run_shell_enqueue_failure(&error),
+                            ShellCommandExecutionState::NotStarted,
+                        );
+                        add_structured_continuation_facts(
+                            &mut result,
+                            timeout,
+                            STRUCTURED_EXECUTION_SYNC_WAIT_SECS,
+                            true,
+                        );
+                        decorate_execution_output(
+                            &mut result.output,
+                            declared_purpose,
+                            &command_summary,
+                            &resolved_cwd,
+                            actual_shell,
+                            "agent",
+                        );
+                        return result;
+                    }
+                };
+                let wait = self
+                    .structured_execution_sync_wait
+                    .min(Duration::from_secs(STRUCTURED_EXECUTION_SYNC_WAIT_SECS));
+                let handoff = await_hidden_structured_job(
+                    self.shell_clients.clone(),
+                    job.job_id.clone(),
+                    wait,
+                    auth.cloned(),
+                )
+                .await;
+                let mut result = match handoff {
+                    Ok(HiddenStructuredJobWait::Terminal {
+                        job,
+                        stdout,
+                        stderr,
+                    }) => {
+                        let result = Self::run_shell_terminal_job_result(
+                            &job,
+                            stdout,
+                            stderr,
+                            timeout,
+                        );
+                        self.shell_clients.remove_job_record(&job.job_id).await;
+                        result
+                    }
+                    Ok(HiddenStructuredJobWait::Continued {
+                        job,
+                        execution_state,
+                        command_started,
+                    }) => ToolResult::ok(json!({
+                        "execution_state": execution_state,
+                        "command_started": command_started,
+                        "command_completed": false,
+                        "command_ok": false,
+                        "exit_code": null,
+                        "failure_kind": null,
+                        "tool_failure": false,
+                        "promoted_to_job": true,
+                        "terminal": false,
+                        "job_id": job.job_id,
+                        "job_status": job.status,
+                        "observation_token": job.observation_token,
+                        "effective_timeout_secs": timeout,
+                        "sync_wait_secs": STRUCTURED_EXECUTION_SYNC_WAIT_SECS,
+                        "async_handoff_available": true,
+                        "stdout_tail": "",
+                        "stderr_tail": "",
+                        "stdout_lines": 0,
+                        "stderr_lines": 0,
+                        "stdout_truncated": false,
+                        "stderr_truncated": false,
+                    })),
+                    Err(error) => Self::run_shell_outcome_unknown_result(format!(
+                        "the hidden durable shell Job {} could not be safely promoted or observed during handoff: {error}. Do not redispatch this command; inspect Job inventory and target state before deciding whether any retry is safe.",
+                        job.job_id
+                    )),
+                };
+                if result.output["promoted_to_job"] != json!(true) {
+                    add_structured_continuation_facts(
+                        &mut result,
+                        timeout,
+                        STRUCTURED_EXECUTION_SYNC_WAIT_SECS,
+                        true,
+                    );
+                }
+                decorate_execution_output(
+                    &mut result.output,
+                    declared_purpose,
+                    &command_summary,
+                    &resolved_cwd,
+                    actual_shell,
+                    "agent",
+                );
+                return result;
+            }
+
             let wait_timeout = timeout;
             let (request_id, rx) = match self
                 .shell_clients
@@ -599,7 +820,7 @@ impl ToolRuntime {
                     sandbox.map(str::to_string),
                     ssh_resource.map(str::to_string),
                     ssh_resource
-                        .zip(ssh_session_id)
+                        .zip(session_id)
                         .map(|(_, session_id)| session_id.to_string()),
                 )
                 .await

--- a/src/tool_runtime/shell.rs
+++ b/src/tool_runtime/shell.rs
@@ -750,7 +750,9 @@ impl ToolRuntime {
                             stderr,
                             timeout,
                         );
-                        self.shell_clients.remove_job_record(&job.job_id).await;
+                        self.shell_clients
+                            .remove_projected_hidden_terminal_job_record(&job.job_id)
+                            .await;
                         result
                     }
                     Ok(HiddenStructuredJobWait::Continued {

--- a/src/tool_runtime/shell_tools.rs
+++ b/src/tool_runtime/shell_tools.rs
@@ -110,6 +110,7 @@ impl ToolRuntime {
                     sandbox,
                     ssh_resource,
                     session_id.as_deref(),
+                    auth,
                 )
                 .await
             }

--- a/src/tool_runtime/tests/apply_text_edits.rs
+++ b/src/tool_runtime/tests/apply_text_edits.rs
@@ -298,6 +298,16 @@ fn apply_text_edits_rejects_bare_cr_edit_text_without_file_line_endings() {
 }
 
 #[tokio::test]
+async fn apply_text_edits_empty_batch_proves_preflight_no_effect() {
+    let runtime = test_runtime();
+    let result = runtime
+        .apply_text_edits("agent:unused:unused".to_string(), Vec::new(), None)
+        .await;
+    assert!(!result.success);
+    assert_eq!(result.output["state_changed"], false);
+}
+
+#[tokio::test]
 async fn apply_text_edits_dry_run_does_not_write() {
     let runtime = runtime_with_agent_project("ate-dry");
     register_agent(

--- a/src/tool_runtime/tests/checkpoint.rs
+++ b/src/tool_runtime/tests/checkpoint.rs
@@ -884,6 +884,50 @@ async fn checkpoint_skips_large_or_binary_untracked() {
 }
 
 #[tokio::test]
+async fn checkpoint_allows_security_domain_source_names_but_keeps_envrc_protected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    init_git_repo(root);
+    fs::create_dir_all(root.join("src/oauth_http/tests")).unwrap();
+    commit_file(
+        root,
+        "src/oauth_http/tests/token.rs",
+        "fn token_test() {}\n",
+        "add token test source",
+    );
+    fs::write(
+        root.join("src/oauth_http/tests/token.rs"),
+        "fn token_test() { assert!(true); }\n",
+    )
+    .unwrap();
+    let runtime = test_runtime().with_checkpoint_state_dir(state.path());
+    let project =
+        register_agent_project_at_path(&runtime, "ckpt-security-source-name", "agent-proj", root)
+            .await;
+
+    let allowed = dispatch_checkpoint_with_local_agent(
+        &runtime,
+        "ckpt-security-source-name",
+        checkpoint_create_call(project.clone(), None, None, Some(false)),
+    )
+    .await;
+    assert!(allowed.success, "{:?}", allowed.error);
+
+    commit_file(root, ".envrc", "export API_TOKEN=base\n", "add envrc");
+    fs::write(root.join(".envrc"), "export API_TOKEN=changed\n").unwrap();
+    let blocked = dispatch_checkpoint_with_local_agent(
+        &runtime,
+        "ckpt-security-source-name",
+        checkpoint_create_call(project, None, None, Some(false)),
+    )
+    .await;
+    assert!(!blocked.success);
+    assert_eq!(blocked.output["path"], ".envrc");
+    assert_eq!(blocked.output["state_changed"], false);
+}
+
+#[tokio::test]
 async fn checkpoint_restore_rejects_malicious_untracked_paths() {
     let tmp = tempfile::tempdir().unwrap();
     let state = tempfile::tempdir().unwrap();

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -1296,6 +1296,26 @@ async fn validate_patch_rejects_invalid_inputs() {
             case.expected_error_any,
             err
         );
+        assert_eq!(
+            result.output["state_changed"], false,
+            "case `{}`",
+            case.label
+        );
+        assert_eq!(
+            result.output["command_started"], false,
+            "case `{}`",
+            case.label
+        );
+        assert_eq!(
+            result.output["command_completed"], false,
+            "case `{}`",
+            case.label
+        );
+        assert_eq!(
+            result.output["execution_state"], "not_started",
+            "case `{}`",
+            case.label
+        );
     }
 }
 

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -548,6 +548,530 @@ async fn run_shell_via_agent_lifecycle_error(
     task.await.unwrap()
 }
 
+async fn update_agent_shell_job(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    request_id: &str,
+    job_id: &str,
+    status: &str,
+    command_execution_state: Option<ShellCommandExecutionState>,
+    exit_code: Option<i32>,
+    stdout_chunk: Option<&str>,
+    stderr_chunk: Option<&str>,
+    error: Option<&str>,
+    finished: bool,
+) {
+    runtime
+        .shell_clients
+        .update_job(ShellAgentJobUpdateRequest {
+            client_id: client_id.to_string(),
+            agent_instance_id: "inst".to_string(),
+            job_id: job_id.to_string(),
+            request_id: Some(request_id.to_string()),
+            update_seq: None,
+            status: status.to_string(),
+            stdout_chunk: stdout_chunk.map(str::to_string),
+            stderr_chunk: stderr_chunk.map(str::to_string),
+            stdout_tail: None,
+            stderr_tail: None,
+            log_snapshot: None,
+            exit_code,
+            duration_ms: finished.then_some(25),
+            error: error.map(str::to_string),
+            command_execution_state,
+            validation_progress: None,
+            finished,
+        })
+        .await
+        .unwrap();
+}
+
+fn assert_run_shell_result_matches_schema(result: &ToolResult) {
+    let schema = super::super::registry::output_schema_for_tool("run_shell");
+    let instance = serde_json::to_value(result).unwrap();
+    super::super::startup_brief::validate_schema_instance_for_test(&instance, &schema)
+        .unwrap_or_else(|error| {
+            panic!("run_shell result did not match output schema: {error}; {instance}")
+        });
+}
+
+#[tokio::test]
+async fn long_run_shell_hands_off_same_job_once_and_status_log_stop_observe_it() {
+    let client_id = "shell-long-handoff";
+    let project_id = "proj-long-handoff";
+    let runtime =
+        test_runtime().with_structured_execution_sync_wait(std::time::Duration::from_millis(20));
+    let auth = open_auth_context();
+    register_job_agent_for_auth(&runtime, client_id, project_id, &auth).await;
+    let project = format!("agent:{client_id}:{project_id}");
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("long run_shell durable handoff".to_string()),
+    );
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::RunShell {
+                        project,
+                        command: "printf durable-shell; sleep 30".to_string(),
+                        session_id: Some(session_id),
+                        timeout_secs: Some(120),
+                        cwd: Some(".".to_string()),
+                        purpose: Some(ExecutionPurpose::Diagnostic),
+                        shell: Some(ExecutionShell::Bash),
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+
+    let start = match next_patch_agent_request(&runtime, client_id).await {
+        Some(start) => start,
+        None => {
+            let early = task.await.unwrap();
+            panic!(
+                "long run_shell ended before durable Job start: success={} error={:?} output={}",
+                early.success, early.error, early.output
+            );
+        }
+    };
+    assert_eq!(start.kind, "start_job");
+    assert_eq!(start.timeout_secs, 120);
+    assert!(start.command.starts_with("exec bash -c "));
+    let job_id = start.job_id.clone().expect("durable Job id");
+    update_agent_shell_job(
+        &runtime,
+        client_id,
+        &start.request_id,
+        &job_id,
+        "running",
+        None,
+        None,
+        Some("durable-shell\n"),
+        None,
+        None,
+        false,
+    )
+    .await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["promoted_to_job"], true);
+    assert_eq!(result.output["terminal"], false);
+    assert_eq!(result.output["execution_state"], "running");
+    assert_eq!(result.output["command_started"], true);
+    assert_eq!(result.output["command_completed"], false);
+    assert_eq!(result.output["effective_timeout_secs"], 120);
+    assert_eq!(result.output["sync_wait_secs"], 10);
+    assert_eq!(result.output["job_id"], job_id);
+    assert_eq!(result.output["purpose"], "diagnostic");
+    assert_eq!(result.output["shell"], "bash");
+    assert_eq!(result.output["cwd"], ".");
+    assert!(result.output["observation_token"].is_string());
+    assert_run_shell_result_matches_schema(&result);
+    assert!(
+        next_patch_agent_request(&runtime, client_id)
+            .await
+            .is_none(),
+        "handoff must not redispatch the shell command"
+    );
+
+    let summary = runtime
+        .sessions
+        .summary(&session.session_id, Some(20))
+        .expect("session summary");
+    let finished = summary
+        .events
+        .iter()
+        .find(|event| event.kind == "tool_call_finished" && event.tool_name == "run_shell")
+        .expect("run_shell finish event");
+    assert_eq!(finished.status.as_deref(), Some("succeeded"));
+    assert!(finished.failure_kind.is_none());
+
+    let status = runtime
+        .dispatch_with_auth(
+            ToolCall::JobStatus {
+                job_id: job_id.clone(),
+                include_command_preview: false,
+            },
+            Some(&auth),
+        )
+        .await;
+    assert!(status.success, "{:?}", status.error);
+    assert_eq!(status.output["job_id"], job_id);
+    assert_eq!(status.output["status"], "running");
+
+    let log = runtime
+        .job_log_for_auth(job_id.clone(), None, Some(40), Some(&auth), None, None)
+        .await;
+    assert!(log.success, "{:?}", log.error);
+    assert_eq!(log.output["job_id"], job_id);
+    assert!(log.output["stdout_tail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("durable-shell"));
+
+    let stopped = runtime
+        .dispatch_with_auth(
+            ToolCall::StopJob {
+                project: project.clone(),
+                job_id: job_id.clone(),
+                session_id: Some(session.session_id.clone()),
+                confirm: true,
+            },
+            Some(&auth),
+        )
+        .await;
+    assert!(stopped.success, "{:?}", stopped.error);
+    let stop_request = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("stop_job request");
+    assert_eq!(stop_request.kind, "stop_job");
+    assert_eq!(stop_request.job_id.as_deref(), Some(job_id.as_str()));
+    update_agent_shell_job(
+        &runtime,
+        client_id,
+        &start.request_id,
+        &job_id,
+        "stopped",
+        Some(ShellCommandExecutionState::Completed),
+        None,
+        None,
+        None,
+        None,
+        true,
+    )
+    .await;
+    let terminal = runtime
+        .job_status_for_auth(job_id.clone(), false, Some(&auth))
+        .await;
+    assert!(terminal.success, "{:?}", terminal.error);
+    assert_eq!(terminal.output["status"], "stopped");
+    assert!(runtime.shell_clients.remove_job_record(&job_id).await);
+}
+
+#[tokio::test]
+async fn long_run_shell_fast_terminal_returns_ordinary_result_without_visible_job() {
+    let client_id = "shell-long-fast";
+    let runtime = runtime_with_agent_project(client_id)
+        .with_structured_execution_sync_wait(std::time::Duration::from_millis(200));
+    register_agent(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            async_shell_jobs: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id(client_id);
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .run_shell(project, "printf fast".to_string(), Some(120), None)
+                .await
+        }
+    });
+    let start = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("durable start request");
+    assert_eq!(start.kind, "start_job");
+    let job_id = start.job_id.clone().unwrap();
+    update_agent_shell_job(
+        &runtime,
+        client_id,
+        &start.request_id,
+        &job_id,
+        "completed",
+        Some(ShellCommandExecutionState::Completed),
+        Some(0),
+        Some("fast\n"),
+        None,
+        None,
+        true,
+    )
+    .await;
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["execution_state"], "completed");
+    assert_eq!(result.output["promoted_to_job"], false);
+    assert_eq!(result.output["terminal"], true);
+    assert_eq!(result.output["job_id"], serde_json::Value::Null);
+    assert_eq!(result.output["effective_timeout_secs"], 120);
+    assert_eq!(result.output["sync_wait_secs"], 10);
+    assert_run_shell_result_matches_schema(&result);
+    assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
+}
+
+#[tokio::test]
+async fn run_shell_default_sixty_stays_synchronous_even_with_async_job_capability() {
+    let client_id = "shell-default-sync";
+    let runtime = runtime_with_agent_project(client_id);
+    register_agent(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            async_shell_jobs: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id(client_id);
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .run_shell(project, "printf default".to_string(), None, None)
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("ordinary synchronous run_shell request");
+    assert_eq!(request.kind, "run_shell");
+    assert_eq!(request.timeout_secs, 60);
+    complete_patch_agent_request(&runtime, client_id, &request.request_id, 0, "default", "").await;
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert!(result.output.get("promoted_to_job").is_none());
+    assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
+}
+
+#[tokio::test]
+async fn long_run_shell_without_async_job_capability_keeps_legacy_sync_dispatch() {
+    let client_id = "shell-long-legacy";
+    let runtime = runtime_with_agent_project(client_id);
+    register_agent(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id(client_id);
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .run_shell(project, "printf legacy".to_string(), Some(120), None)
+                .await
+        }
+    });
+    let request = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("legacy synchronous request");
+    assert_eq!(request.kind, "run_shell");
+    assert_eq!(request.timeout_secs, 120);
+    complete_patch_agent_request(&runtime, client_id, &request.request_id, 0, "legacy", "").await;
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert!(result.output.get("promoted_to_job").is_none());
+    assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
+}
+
+#[tokio::test]
+async fn long_run_shell_async_job_capability_does_not_bypass_shell_authority() {
+    let client_id = "shell-long-no-shell";
+    let project_id = "proj-long-no-shell";
+    let runtime = test_runtime();
+    let auth = open_auth_context();
+    runtime
+        .shell_clients
+        .register_with_auth(
+            ShellClientRegisterRequest {
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: Some(4),
+                job_inventory: None,
+                client_id: client_id.to_string(),
+                agent_instance_id: "inst".to_string(),
+                display_name: None,
+                owner: None,
+                hostname: None,
+                host_context: None,
+                capabilities: Some(ShellClientCapabilities {
+                    shell: false,
+                    async_shell_jobs: true,
+                    ..Default::default()
+                }),
+                projects: Some(vec![registered_project(
+                    project_id,
+                    &format!("/tmp/{project_id}"),
+                )]),
+                agent_protocol_version: Some("polling-v1".to_string()),
+                policy: None,
+            },
+            Some(&auth),
+        )
+        .await
+        .unwrap();
+    let project = format!("agent:{client_id}:{project_id}");
+    let result = runtime
+        .dispatch_with_auth(
+            ToolCall::RunShell {
+                project,
+                command: "printf denied".to_string(),
+                session_id: None,
+                timeout_secs: Some(120),
+                cwd: None,
+                purpose: None,
+                shell: None,
+            },
+            Some(&auth),
+        )
+        .await;
+    assert!(!result.success);
+    let error = result.error.as_deref().unwrap_or_default();
+    assert!(error.contains("does not support shell"), "{error}");
+    assert!(error.contains(client_id), "{error}");
+    assert!(next_patch_agent_request(&runtime, client_id)
+        .await
+        .is_none());
+    assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
+}
+
+#[tokio::test]
+async fn long_run_shell_job_start_rejection_is_not_started_and_enqueues_nothing() {
+    let client_id = "shell-long-start-reject";
+    let runtime = runtime_with_agent_project(client_id);
+    register_agent(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            async_shell_jobs: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id(client_id);
+    let result = runtime
+        .run_shell_with_contract_in_sandbox(
+            project,
+            "printf never".to_string(),
+            Some(120),
+            None,
+            None,
+            None,
+            Some("invalid-sandbox-mode"),
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(!result.success);
+    assert_eq!(result.output["execution_state"], "not_started");
+    assert_eq!(result.output["command_started"], false);
+    assert_eq!(result.output["command_completed"], false);
+    assert_eq!(result.output["promoted_to_job"], false);
+    assert_eq!(result.output["async_handoff_available"], true);
+    assert_run_shell_result_matches_schema(&result);
+    assert!(next_patch_agent_request(&runtime, client_id)
+        .await
+        .is_none());
+    assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
+}
+
+#[tokio::test]
+async fn long_run_shell_job_timeout_is_terminal_and_never_becomes_fake_outcome_unknown() {
+    let client_id = "shell-long-timeout";
+    let runtime = runtime_with_agent_project(client_id)
+        .with_structured_execution_sync_wait(std::time::Duration::from_millis(20));
+    register_agent(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            shell: true,
+            async_shell_jobs: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    let project = agent_test_project_id(client_id);
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .run_shell(
+                    project,
+                    "printf partial; sleep 30".to_string(),
+                    Some(120),
+                    None,
+                )
+                .await
+        }
+    });
+    let start = next_patch_agent_request(&runtime, client_id)
+        .await
+        .expect("durable Job start");
+    let job_id = start.job_id.clone().unwrap();
+    update_agent_shell_job(
+        &runtime,
+        client_id,
+        &start.request_id,
+        &job_id,
+        "running",
+        None,
+        None,
+        Some("partial\n"),
+        None,
+        None,
+        false,
+    )
+    .await;
+    let handoff = task.await.unwrap();
+    assert!(handoff.success, "{:?}", handoff.error);
+    assert_eq!(handoff.output["job_id"], job_id);
+    assert_eq!(handoff.output["promoted_to_job"], true);
+
+    update_agent_shell_job(
+        &runtime,
+        client_id,
+        &start.request_id,
+        &job_id,
+        "timeout",
+        Some(ShellCommandExecutionState::TimedOut),
+        Some(-1),
+        None,
+        Some("runner deadline reached\n"),
+        Some("command timed out"),
+        true,
+    )
+    .await;
+    let status = runtime.job_status(job_id.clone()).await;
+    assert!(status.success, "{:?}", status.error);
+    assert_eq!(status.output["status"], "timeout");
+    assert_eq!(status.output["command_execution_state"], "timed_out");
+    assert_ne!(status.output["command_execution_state"], "outcome_unknown");
+    let log = runtime.job_log(job_id.clone(), None, Some(40)).await;
+    assert!(log.success, "{:?}", log.error);
+    assert_eq!(log.output["command_execution_state"], "timed_out");
+    assert!(log.output["stderr_tail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("runner deadline reached"));
+    assert!(next_patch_agent_request(&runtime, client_id)
+        .await
+        .is_none());
+    assert!(runtime.shell_clients.remove_job_record(&job_id).await);
+}
+
 #[tokio::test]
 async fn run_shell_failure_reports_command_started_and_output_tail() {
     let result = run_shell_via_agent(

--- a/src/tool_runtime/tests/sync_timeout.rs
+++ b/src/tool_runtime/tests/sync_timeout.rs
@@ -3,8 +3,9 @@
 //! Read-only structured validation tools (`cargo_check`, `cargo_test`,
 //! `cargo_fmt(check=true)`) now define `timeout_secs` as the total runtime
 //! budget of the command (1..=3600). Short validations return immediately; a
-//! long validation continues as a Job and returns `job_id`. `run_shell`
-//! keeps the synchronous 1..=120 contract.
+//! long validation continues as a Job and returns `job_id`. `run_shell` keeps
+//! the public 1..=120 total-timeout contract; explicit values above 60 may use
+//! the same durable Job execution while the default 60-second call stays sync.
 
 use super::support::*;
 use crate::shell_protocol::{
@@ -13,6 +14,7 @@ use crate::shell_protocol::{
 };
 use crate::tool_runtime::helpers::{
     resolve_sync_timeout_secs, DEFAULT_RUN_SHELL_TIMEOUT_SECS, MIN_SYNC_TIMEOUT_SECS,
+    SYNC_VALIDATION_WAIT_SECS,
 };
 use crate::tool_runtime::validation_events::validation_summary_for_session;
 use crate::tool_runtime::{SessionMode, ToolCall, ToolResult};
@@ -79,6 +81,11 @@ fn resolve_sync_timeout_secs_rejects_out_of_range() {
     assert!(resolve_sync_timeout_secs(Some(121), 120).is_err());
     assert!(resolve_sync_timeout_secs(Some(300), 120).is_err());
     assert!(resolve_sync_timeout_secs(Some(600), 60).is_err());
+}
+
+#[test]
+fn structured_validation_sync_grace_is_sixty_seconds() {
+    assert_eq!(SYNC_VALIDATION_WAIT_SECS, 60);
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -115,7 +115,7 @@ fn cargo_check_success_produces_validation_event() {
     assert!(event.get("input_summary").is_none());
     assert!(event["identity"]
         .as_str()
-        .is_some_and(|identity| identity.starts_with("command:")));
+        .is_some_and(|identity| identity.starts_with("target:")));
     assert_eq!(event["execution_source"], "cargo_check");
     assert_eq!(event["purpose"], "validation");
     assert_eq!(validation["parser"]["available"], false);
@@ -880,6 +880,53 @@ fn structured_validation_target_resolves_equivalent_semantic_arguments() {
         .as_str()
         .unwrap();
     assert!(identity.starts_with("target:"), "{identity}");
+}
+
+#[test]
+fn same_validation_identity_success_in_another_project_does_not_resolve_failure() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:alpha".to_string()), None);
+    let shared_target = json!({
+        "cwd": "crate",
+        "package": "pkg",
+        "filter": "focus",
+        "features": "feat"
+    });
+
+    let mut failed = shared_target.clone();
+    failed["project"] = json!("agent:eval:alpha");
+    record_finished_tool(
+        &store,
+        &session.session_id,
+        "cargo_test",
+        failed,
+        false,
+        json!({"exit_code": 101}),
+    );
+
+    let mut succeeded_elsewhere = shared_target;
+    succeeded_elsewhere["project"] = json!("agent:eval:bravo");
+    record_finished_tool(
+        &store,
+        &session.session_id,
+        "cargo_test",
+        succeeded_elsewhere,
+        true,
+        json!({
+            "exit_code": 0,
+            "stdout_tail": "running 1 test\n\ntest result: ok. 1 passed; 0 failed; 0 ignored\n",
+            "stderr_tail": "",
+        }),
+    );
+
+    let session = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&session);
+    assert_eq!(validation["resolved_failures"]["count"], 0);
+    assert_eq!(validation["unresolved_failures"]["count"], 1);
+    assert_eq!(
+        validation["unresolved_failures"]["events"][0]["project"],
+        "agent:eval:alpha"
+    );
 }
 
 #[test]

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -830,6 +830,117 @@ fn same_validation_identity_success_resolves_failure_without_deleting_history() 
 }
 
 #[test]
+fn structured_validation_target_resolves_equivalent_semantic_arguments() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_finished_tool(
+        &store,
+        &session.session_id,
+        "cargo_test",
+        json!({
+            "project": "agent:eval:demo",
+            "cwd": "./crate/",
+            "filter": "  oversized_result  ",
+            "all_targets": true,
+            "all_features": false,
+            "no_default_features": false,
+            "features": "  serde  ",
+            "package": "  webcodex  ",
+            "no_run": false,
+            "timeout_secs": 30,
+        }),
+        false,
+        json!({"exit_code": 101}),
+    );
+    record_finished_tool(
+        &store,
+        &session.session_id,
+        "cargo_test",
+        json!({
+            "project": "agent:eval:demo",
+            "cwd": "crate",
+            "filter": "oversized_result",
+            "all_targets": true,
+            "all_features": false,
+            "no_default_features": false,
+            "features": "serde",
+            "package": "webcodex",
+            "no_run": false,
+            "timeout_secs": 120,
+        }),
+        true,
+        json!({"exit_code": 0}),
+    );
+
+    let session = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&session);
+    assert_eq!(validation["resolved_failures"]["count"], 1);
+    assert_eq!(validation["unresolved_failures"]["count"], 0);
+    let identity = validation["resolved_failures"]["events"][0]["identity"]
+        .as_str()
+        .unwrap();
+    assert!(identity.starts_with("target:"), "{identity}");
+}
+
+#[test]
+fn structured_validation_target_does_not_cross_semantic_scope() {
+    let cases = [
+        (
+            "cwd",
+            json!({"project":"agent:eval:demo","cwd":"crate_a","package":"pkg","filter":"focus","features":"feat"}),
+            json!({"project":"agent:eval:demo","cwd":"crate_b","package":"pkg","filter":"focus","features":"feat"}),
+        ),
+        (
+            "package",
+            json!({"project":"agent:eval:demo","cwd":"crate","package":"pkg_a","filter":"focus","features":"feat"}),
+            json!({"project":"agent:eval:demo","cwd":"crate","package":"pkg_b","filter":"focus","features":"feat"}),
+        ),
+        (
+            "filter",
+            json!({"project":"agent:eval:demo","cwd":"crate","package":"pkg","filter":"focus_a","features":"feat"}),
+            json!({"project":"agent:eval:demo","cwd":"crate","package":"pkg","filter":"focus_b","features":"feat"}),
+        ),
+        (
+            "features",
+            json!({"project":"agent:eval:demo","cwd":"crate","package":"pkg","filter":"focus","features":"feat_a"}),
+            json!({"project":"agent:eval:demo","cwd":"crate","package":"pkg","filter":"focus","features":"feat_b"}),
+        ),
+    ];
+
+    for (label, failed_args, successful_args) in cases {
+        let store = SessionStore::default();
+        let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+        record_finished_tool(
+            &store,
+            &session.session_id,
+            "cargo_test",
+            failed_args,
+            false,
+            json!({"exit_code": 101}),
+        );
+        record_finished_tool(
+            &store,
+            &session.session_id,
+            "cargo_test",
+            successful_args,
+            true,
+            json!({"exit_code": 0}),
+        );
+
+        let session = store.summary(&session.session_id, Some(50)).unwrap();
+        let validation = validation_summary_for_session(&session);
+        assert_eq!(
+            validation["resolved_failures"]["count"], 0,
+            "{label}: {validation}"
+        );
+        assert_eq!(
+            validation["unresolved_failures"]["count"], 1,
+            "{label}: {validation}"
+        );
+    }
+}
+
+#[test]
 fn same_assertion_identity_resolves_only_its_own_failure() {
     let store = SessionStore::default();
     let session = store.start_session(Some("agent:eval:demo".to_string()), None);

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -543,7 +543,7 @@ async fn fast_go_test_uses_exact_structured_argv_cwd_and_records_session_evidenc
     assert!(validation["latest"]["identity"]
         .as_str()
         .unwrap_or_default()
-        .starts_with("command:"));
+        .starts_with("target:"));
     assert_eq!(validation["latest"]["tests_run_count"], 2);
     assert_eq!(
         validation["latest"]["diagnostics"]["test_summary"]["ignored"],

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -828,7 +828,7 @@ async fn fast_cargo_check_completes_in_windows_and_leaves_no_visible_job() {
     assert_eq!(result.output["promoted_to_job"], false);
     assert_eq!(result.output["effective_timeout_secs"], 600);
     assert!(result.output.get("observation_token").is_none());
-    assert_eq!(result.output["sync_wait_secs"], 90);
+    assert_eq!(result.output["sync_wait_secs"], 60);
     assert_cargo_result_matches_schema("cargo_check", &result);
     // No redundant visible job.
     let list = runtime.list_jobs_for_auth(None, None, None).await;
@@ -990,7 +990,7 @@ async fn long_cargo_test_hands_off_to_queryable_job() {
     assert_eq!(result.output["command_started"], true);
     assert_eq!(result.output["command_completed"], false);
     assert_eq!(result.output["effective_timeout_secs"], 1800);
-    assert_eq!(result.output["sync_wait_secs"], 90);
+    assert_eq!(result.output["sync_wait_secs"], 60);
     assert!(result.output.get("passed").is_none());
     assert!(result.output.get("failure_kind").is_none());
     assert_eq!(result.output["job_id"].as_str().unwrap(), job_id.as_str());
@@ -2082,7 +2082,7 @@ async fn terminal_validation_result_fields_are_consistent_between_executors() {
                 .await
         }
     });
-    // Short path (120 <= 90? No: 120 > 90, so it uses the agent Job path).
+    // 120 exceeds the 60-second sync grace, so it uses the same agent Job path.
     // This exercises the agent terminal result path and returns a full
     // terminal projection in-window.
     let (request, job_id) = poll_start_validation_job(&runtime, client_id).await;
@@ -2932,7 +2932,7 @@ fn cargo_output_schema_enforces_handoff_terminal_and_rejection_branches() {
             "command_started": true,
             "command_completed": false,
             "effective_timeout_secs": 1800,
-            "sync_wait_secs": 90,
+            "sync_wait_secs": 60,
             "terminal": false,
             "stdout_tail": "",
             "stderr_tail": "",
@@ -3006,7 +3006,7 @@ fn cargo_output_schema_enforces_handoff_terminal_and_rejection_branches() {
             "command_completed": true,
             "promoted_to_job": false,
             "effective_timeout_secs": 1800,
-            "sync_wait_secs": 90,
+            "sync_wait_secs": 60,
             "terminal": true,
             "tests_detected": true,
             "tests_run_count": 1,

--- a/src/tool_runtime/tests/validation_profile.rs
+++ b/src/tool_runtime/tests/validation_profile.rs
@@ -1,3 +1,4 @@
+use super::super::tool_audit::is_structured_validation_target_identity;
 use super::super::validation_parser::{
     parse_cargo_check_diagnostics, parse_cargo_test_diagnostics, parse_go_test_diagnostics,
     PARSER_KIND, PARSER_VERSION,
@@ -148,8 +149,20 @@ fn go_test_schema_and_audit_projection_are_bounded_and_explicit() {
     });
     let raw_audit =
         super::super::tool_audit::session_log_arguments_for_tool_request("go_test", &raw);
+    let target_id = raw_audit["validation_target_id"]
+        .as_str()
+        .expect("go_test audit projection should include validation_target_id");
+    assert!(
+        is_structured_validation_target_identity(target_id),
+        "unexpected go_test validation target identity: {target_id}"
+    );
+    let mut audit_without_target = raw_audit.clone();
+    audit_without_target
+        .as_object_mut()
+        .unwrap()
+        .remove("validation_target_id");
     assert_eq!(
-        raw_audit,
+        audit_without_target,
         serde_json::json!({
             "project": "agent:test:demo",
             "cwd": "internal/control",

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -3,6 +3,7 @@
 use super::tool_call::ToolCall;
 use super::tool_inputs::{is_checkpoint_kind, is_checkpoint_validation_status};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments: &Value) -> Value {
     let Some(obj) = arguments.as_object() else {
@@ -463,6 +464,65 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
                 ),
             );
         }
+        "cargo_fmt" => {
+            copy_keys(obj, &mut out, &["cwd", "check", "timeout_secs"]);
+            insert_structured_validation_target(tool_name, obj, &mut out);
+        }
+        "cargo_check" => {
+            copy_keys(
+                obj,
+                &mut out,
+                &[
+                    "cwd",
+                    "all_targets",
+                    "all_features",
+                    "no_default_features",
+                    "package",
+                    "timeout_secs",
+                ],
+            );
+            out.insert(
+                "features_present".to_string(),
+                Value::Bool(
+                    obj.get("features")
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| !value.is_empty()),
+                ),
+            );
+            insert_structured_validation_target(tool_name, obj, &mut out);
+        }
+        "cargo_test" => {
+            copy_keys(
+                obj,
+                &mut out,
+                &[
+                    "cwd",
+                    "all_targets",
+                    "all_features",
+                    "no_default_features",
+                    "package",
+                    "no_run",
+                    "timeout_secs",
+                ],
+            );
+            out.insert(
+                "filter_present".to_string(),
+                Value::Bool(
+                    obj.get("filter")
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| !value.is_empty()),
+                ),
+            );
+            out.insert(
+                "features_present".to_string(),
+                Value::Bool(
+                    obj.get("features")
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| !value.is_empty()),
+                ),
+            );
+            insert_structured_validation_target(tool_name, obj, &mut out);
+        }
         "go_test" => {
             copy_keys(obj, &mut out, &["cwd", "timeout_secs"]);
             let packages = obj.get("packages").and_then(Value::as_array);
@@ -474,6 +534,7 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
                 "package_count".to_string(),
                 Value::from(packages.map(Vec::len).unwrap_or_default()),
             );
+            insert_structured_validation_target(tool_name, obj, &mut out);
         }
         "workspace_checkpoint_create" => {
             copy_keys(obj, &mut out, &["title", "include_untracked"]);
@@ -686,6 +747,165 @@ fn copy_keys(
             out.insert((*key).to_string(), value);
         }
     }
+}
+
+const STRUCTURED_VALIDATION_TARGET_PREFIX: &str = "target:";
+const STRUCTURED_VALIDATION_TARGET_HEX_LEN: usize = 24;
+
+fn insert_structured_validation_target(
+    tool_name: &str,
+    arguments: &serde_json::Map<String, Value>,
+    out: &mut serde_json::Map<String, Value>,
+) {
+    if let Some(identity) =
+        structured_validation_target_identity(tool_name, &Value::Object(arguments.clone()))
+    {
+        out.insert("validation_target_id".to_string(), Value::String(identity));
+    }
+}
+
+pub(crate) fn structured_validation_target_identity(
+    tool_name: &str,
+    arguments: &Value,
+) -> Option<String> {
+    let obj = arguments.as_object()?;
+    let cwd = normalized_validation_target_cwd(obj.get("cwd"))?;
+    let semantic = match tool_name {
+        "cargo_fmt" => serde_json::json!({
+            "tool": tool_name,
+            "kind": "format",
+            "cwd": cwd,
+            "check": obj.get("check").and_then(Value::as_bool).unwrap_or(false),
+        }),
+        "cargo_check" => {
+            if obj.get("features_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("features").is_none()
+            {
+                return None;
+            }
+            let features = normalized_cargo_target_value(obj.get("features"))?;
+            let package = normalized_cargo_target_value(obj.get("package"))?;
+            serde_json::json!({
+                "tool": tool_name,
+                "kind": "check",
+                "cwd": cwd,
+                "package": package,
+                "features": features,
+                "all_targets": obj.get("all_targets").and_then(Value::as_bool).unwrap_or(true),
+                "all_features": obj.get("all_features").and_then(Value::as_bool).unwrap_or(false),
+                "no_default_features": obj.get("no_default_features").and_then(Value::as_bool).unwrap_or(false),
+            })
+        }
+        "cargo_test" => {
+            if obj.get("filter_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("filter").is_none()
+            {
+                return None;
+            }
+            if obj.get("features_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("features").is_none()
+            {
+                return None;
+            }
+            let filter = normalized_rust_test_target_filter(obj.get("filter"))?;
+            let features = normalized_cargo_target_value(obj.get("features"))?;
+            let package = normalized_cargo_target_value(obj.get("package"))?;
+            serde_json::json!({
+                "tool": tool_name,
+                "kind": "test",
+                "cwd": cwd,
+                "package": package,
+                "filter": filter,
+                "features": features,
+                "all_targets": obj.get("all_targets").and_then(Value::as_bool).unwrap_or(false),
+                "all_features": obj.get("all_features").and_then(Value::as_bool).unwrap_or(false),
+                "no_default_features": obj.get("no_default_features").and_then(Value::as_bool).unwrap_or(false),
+                "no_run": obj.get("no_run").and_then(Value::as_bool).unwrap_or(false),
+            })
+        }
+        "go_test" => {
+            if obj.get("packages_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("packages").is_none()
+            {
+                return None;
+            }
+            let packages = normalized_go_test_target_packages(obj.get("packages"))?;
+            serde_json::json!({
+                "tool": tool_name,
+                "kind": "test",
+                "cwd": cwd,
+                "packages": packages,
+            })
+        }
+        _ => return None,
+    };
+    let encoded = serde_json::to_vec(&semantic).ok()?;
+    let digest = format!("{:x}", Sha256::digest(encoded));
+    Some(format!(
+        "{STRUCTURED_VALIDATION_TARGET_PREFIX}{}",
+        &digest[..STRUCTURED_VALIDATION_TARGET_HEX_LEN]
+    ))
+}
+
+pub(crate) fn is_structured_validation_target_identity(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix(STRUCTURED_VALIDATION_TARGET_PREFIX) else {
+        return false;
+    };
+    hex.len() == STRUCTURED_VALIDATION_TARGET_HEX_LEN
+        && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn normalized_validation_target_cwd(value: Option<&Value>) -> Option<String> {
+    let Some(value) = value else {
+        return Some(".".to_string());
+    };
+    if value.is_null() {
+        return Some(".".to_string());
+    }
+    let raw = value.as_str()?;
+    let trimmed = raw.trim().trim_start_matches("./").trim_end_matches('/');
+    Some(if trimmed.is_empty() || trimmed == "." {
+        ".".to_string()
+    } else {
+        trimmed.to_string()
+    })
+}
+
+fn normalized_cargo_target_value(value: Option<&Value>) -> Option<Option<String>> {
+    let Some(value) = value else {
+        return Some(None);
+    };
+    if value.is_null() {
+        return Some(None);
+    }
+    crate::shell_protocol::normalize_cargo_value(value.as_str()?).ok()
+}
+
+fn normalized_rust_test_target_filter(value: Option<&Value>) -> Option<Option<String>> {
+    let Some(value) = value else {
+        return Some(None);
+    };
+    if value.is_null() {
+        return Some(None);
+    }
+    crate::shell_protocol::normalize_rust_test_filter(value.as_str()?).ok()
+}
+
+fn normalized_go_test_target_packages(value: Option<&Value>) -> Option<Vec<String>> {
+    let packages = match value {
+        None | Some(Value::Null) => None,
+        Some(Value::Array(values)) => Some(
+            values
+                .iter()
+                .map(Value::as_str)
+                .collect::<Option<Vec<_>>>()?
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>(),
+        ),
+        Some(_) => return None,
+    };
+    crate::shell_protocol::normalize_go_test_packages(packages.as_deref()).ok()
 }
 
 #[cfg(test)]
@@ -1768,12 +1988,15 @@ impl ToolCall {
                 check,
                 timeout_secs,
                 ..
-            } => serde_json::json!({
-                "project": project,
-                "cwd": cwd,
-                "check": check,
-                "timeout_secs": timeout_secs,
-            }),
+            } => session_log_arguments_for_tool_request(
+                "cargo_fmt",
+                &serde_json::json!({
+                    "project": project,
+                    "cwd": cwd,
+                    "check": check,
+                    "timeout_secs": timeout_secs,
+                }),
+            ),
             Self::CargoCheck {
                 project,
                 cwd,
@@ -1784,16 +2007,19 @@ impl ToolCall {
                 package,
                 timeout_secs,
                 ..
-            } => serde_json::json!({
-                "project": project,
-                "cwd": cwd,
-                "all_targets": all_targets,
-                "all_features": all_features,
-                "no_default_features": no_default_features,
-                "features_present": features.as_ref().is_some_and(|v| !v.is_empty()),
-                "package": package,
-                "timeout_secs": timeout_secs,
-            }),
+            } => session_log_arguments_for_tool_request(
+                "cargo_check",
+                &serde_json::json!({
+                    "project": project,
+                    "cwd": cwd,
+                    "all_targets": all_targets,
+                    "all_features": all_features,
+                    "no_default_features": no_default_features,
+                    "features": features,
+                    "package": package,
+                    "timeout_secs": timeout_secs,
+                }),
+            ),
             Self::CargoTest {
                 project,
                 cwd,
@@ -1806,31 +2032,36 @@ impl ToolCall {
                 no_run,
                 timeout_secs,
                 ..
-            } => serde_json::json!({
-                "project": project,
-                "cwd": cwd,
-                "filter_present": filter.as_ref().is_some_and(|v| !v.is_empty()),
-                "all_targets": all_targets,
-                "all_features": all_features,
-                "no_default_features": no_default_features,
-                "features_present": features.as_ref().is_some_and(|v| !v.is_empty()),
-                "package": package,
-                "no_run": no_run,
-                "timeout_secs": timeout_secs,
-            }),
+            } => session_log_arguments_for_tool_request(
+                "cargo_test",
+                &serde_json::json!({
+                    "project": project,
+                    "cwd": cwd,
+                    "filter": filter,
+                    "all_targets": all_targets,
+                    "all_features": all_features,
+                    "no_default_features": no_default_features,
+                    "features": features,
+                    "package": package,
+                    "no_run": no_run,
+                    "timeout_secs": timeout_secs,
+                }),
+            ),
             Self::GoTest {
                 project,
                 cwd,
                 packages,
                 timeout_secs,
                 ..
-            } => serde_json::json!({
-                "project": project,
-                "cwd": cwd,
-                "packages_present": packages.is_some(),
-                "package_count": packages.as_ref().map(Vec::len).unwrap_or_default(),
-                "timeout_secs": timeout_secs,
-            }),
+            } => session_log_arguments_for_tool_request(
+                "go_test",
+                &serde_json::json!({
+                    "project": project,
+                    "cwd": cwd,
+                    "packages": packages,
+                    "timeout_secs": timeout_secs,
+                }),
+            ),
             Self::ReadFile {
                 project,
                 path,

--- a/src/tool_runtime/validation_events.rs
+++ b/src/tool_runtime/validation_events.rs
@@ -14,6 +14,9 @@ use super::session_context::{
     session_project_mismatch_result, unknown_session_result, SessionProjectMismatch,
 };
 use super::sessions::{SessionEvent, SessionSummary};
+use super::tool_audit::{
+    is_structured_validation_target_identity, structured_validation_target_identity,
+};
 use super::validation_parser::{
     ValidationDiagnostics, PARSER_KIND, PARSER_LIMITATIONS, PARSER_VERSION,
     VALIDATION_OUTPUT_METADATA_ABSENT_REASON,
@@ -798,6 +801,20 @@ fn execution_identity(
         .filter(|value| !value.is_empty())
     {
         return format!("assertion:{assertion}");
+    }
+    if validation_adapter_for_tool(tool_name).is_some() {
+        if let Some(input) = started.and_then(|event| event.input_summary.as_ref()) {
+            if let Some(identity) = input
+                .get("validation_target_id")
+                .and_then(Value::as_str)
+                .filter(|value| is_structured_validation_target_identity(value))
+            {
+                return identity.to_string();
+            }
+            if let Some(identity) = structured_validation_target_identity(tool_name, input) {
+                return identity;
+            }
+        }
     }
     let command = started
         .and_then(|event| event.input_summary.as_ref())

--- a/src/tool_runtime/validation_events.rs
+++ b/src/tool_runtime/validation_events.rs
@@ -455,10 +455,15 @@ fn classify_validation_failures(
     ValidationFailureSet,
     ValidationFailureSet,
 ) {
-    let mut latest_success_by_identity = HashMap::<String, usize>::new();
+    // Identity is meaningful only inside the exact resolved project. Workflow
+    // Sessions can explicitly record cross-project tool calls, so a successful
+    // validation in project B must never resolve a same-shaped failure from
+    // project A merely because cwd/package/filter/features match.
+    let mut latest_success_by_identity = HashMap::<(Option<String>, String), usize>::new();
     for (index, event) in events.iter().enumerate() {
         if event.success && validation_event_decides_historical_failure_status(event) {
-            latest_success_by_identity.insert(event.identity.clone(), index);
+            latest_success_by_identity
+                .insert((event.project.clone(), event.identity.clone()), index);
         }
     }
     let mut resolved = Vec::new();
@@ -468,7 +473,7 @@ fn classify_validation_failures(
             continue;
         }
         let is_resolved = latest_success_by_identity
-            .get(&event.identity)
+            .get(&(event.project.clone(), event.identity.clone()))
             .is_some_and(|success_index| *success_index > index);
         event.unresolved_failure = !is_resolved;
         if is_resolved {


### PR DESCRIPTION
## Summary

This PR completes the current Harness Ergonomics work across evidence reporting and long execution handoff.

### Evidence ergonomics
- tighten mutation/effect evidence and no-effect reporting
- improve validation/session closeout regressions and evidence integrity
- preserve deterministic, bounded harness-facing output

### Long execution / timeout handoff
- reduce structured validation synchronous grace to 60s for cargo_check, cargo_test, cargo_fmt(check=true), and go_test
- keep one execution and promote the same hidden Job when validation is still running
- give explicit long agent-backed run_shell (`timeout_secs > 60`) a durable Job identity from initial dispatch, with the existing 10s structured-execution grace
- preserve the public run_shell timeout contract (`1..=120`, default 60) and legacy/SSH synchronous paths
- add Runner-authoritative `command_execution_state` for raw shell Job terminal lifecycle
- report actual Runner timeout as `timed_out` rather than manufacturing `outcome_unknown` from a waiter ceiling

### Review hardening
- prevent fast-terminal hidden Jobs from resurfacing as public Jobs during same-instance terminal inventory replay, while preserving fresh-Server conservative recovery
- keep `NotStarted` proof strictly before `ManagedChild::spawn`; post-spawn interruption is conservatively `OutcomeUnknown`

## Safety properties

- no retry or redispatch for handoff
- no second validation/run_shell command
- same `job_id` is used for continuation, logs, status, and stop
- no expansion of run_shell timeout bounds
- no new streaming/subscription framework
- no named-SSH migration in this PR

## Validation

- `cargo test run_shell_ -p webcodex` — 31 passed
- `cargo test long_run_shell_ -p webcodex` — 6 passed
- `cargo test projected_hidden_ -p webcodex` — 2 passed
- `cargo test long_cargo_ -p webcodex` — 2 passed
- `cargo test long_go_test_hands_off_same_job_and_terminal_evidence_is_queryable -p webcodex` — 1 passed
- `cargo test raw_shell_job_ -p webcodex-runner` — 3 passed
- `cargo test prepared_profile_run_shell_and_run_job_see_same_env -p webcodex-runner` — 1 passed
- `cargo check --all-targets -p webcodex` — pass, 0 warnings
- `cargo check --all-targets -p webcodex-runner` — pass; only pre-existing Computer dead-code warnings
- `cargo fmt -- --check` — pass
- `git diff --check` — pass

## Deployment note

Full Phase 2 behavior requires both Server and Runner updates. Server contains the 60s validation grace, hidden Job promotion/cleanup, long run_shell durable initiation, and replay suppression; Runner supplies authoritative terminal lifecycle evidence. A conservative rollout order is Server first, then Runner.