### PR TITLE
Continuously drain structured execution output

### DIFF
--- a/crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs
@@ -260,12 +260,21 @@ fn accepted_active_record_is_never_reclaimed() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
-    let request = make_payload_request("count_once", Vec::new());
+    let request = make_payload_request("linger", Vec::new());
     let outcome = handoff_detached_job(&store, request.clone()).unwrap();
     assert!(matches!(outcome, DetachedHandoffOutcome::Accepted { .. }));
+    assert!(
+        wait_until(Duration::from_secs(5), || store
+            .read(&request.job_id)
+            .is_ok_and(|record| {
+                record.phase == DetachedJobPhase::Running
+                    && record.ownership_accepted_at_unix_ms.is_some()
+            })),
+        "accepted detached execution never reached a live Running state"
+    );
     let running = store.read(&request.job_id).unwrap();
     assert!(running.ownership_accepted_at_unix_ms.is_some());
-    assert_ne!(running.phase, DetachedJobPhase::Terminal);
+    assert_eq!(running.phase, DetachedJobPhase::Running);
 
     assert_eq!(
         store
@@ -273,14 +282,15 @@ fn accepted_active_record_is_never_reclaimed() {
             .unwrap(),
         1
     );
-    assert_eq!(
-        store.read(&request.job_id).unwrap().execution_id,
-        running.execution_id
-    );
-    store
+    let retained = store.read(&request.job_id).unwrap();
+    assert_eq!(retained.execution_id, running.execution_id);
+    assert_eq!(retained.phase, DetachedJobPhase::Running);
+    let stopped = store
         .request_stop(&request.job_id, &running.execution_id)
         .unwrap();
-    let _ = wait_for_terminal(&store, &request.job_id);
+    assert!(stopped.stop_requested);
+    let terminal = wait_for_terminal(&store, &request.job_id);
+    assert_eq!(terminal.terminal.as_ref().unwrap().status, "stopped");
 }
 
 #[cfg(unix)]

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -1071,15 +1071,42 @@ fn enqueue_structured_process_job(
     timeout_secs: u64,
     sandbox: Option<&str>,
 ) {
+    enqueue_structured_process_job_with_policy(
+        manager,
+        sink,
+        cwd,
+        job_id,
+        executable,
+        args,
+        stdin,
+        timeout_secs,
+        sandbox,
+        AgentPolicy {
+            allow_cwd_anywhere: true,
+            ..AgentPolicy::default()
+        },
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enqueue_structured_process_job_with_policy(
+    manager: &JobManager,
+    sink: AgentSink,
+    cwd: &Path,
+    job_id: &str,
+    executable: &Path,
+    args: Vec<String>,
+    stdin: Option<String>,
+    timeout_secs: u64,
+    sandbox: Option<&str>,
+    policy: AgentPolicy,
+) {
     let context = structured_process_context(cwd, args.len(), stdin.is_some());
     manager.enqueue(
         sink,
         PendingJobStart {
             generation: 1,
-            policy: AgentPolicy {
-                allow_cwd_anywhere: true,
-                ..AgentPolicy::default()
-            },
+            policy,
             shell: ShellConfig::default(),
             ssh: SshConfig::default(),
             projects_dir: cwd.join("projects.d"),
@@ -2261,6 +2288,260 @@ fn structured_process_job_terminal_lifecycle_distinguishes_prestart_nonzero_and_
 }
 
 #[test]
+fn structured_process_job_drains_large_output_without_log_observation_and_runs_once() {
+    let temp = tempfile::tempdir().unwrap();
+    let helper = structured_process_helper();
+    let marker = temp.path().join("chatty-starts.log");
+    let nonce = format!("chatty-{}", uuid::Uuid::new_v4());
+    // Deliberately retain the sink receiver without consuming it. Durable Job
+    // execution must not depend on Server/model log observation to drain the
+    // child OS pipes.
+    let (sink, _unread_rx) = structured_test_sink("structured-agent", "structured-instance");
+    let manager = JobManager::new(1);
+    let output_limit = 16 * 1024;
+    enqueue_structured_process_job_with_policy(
+        &manager,
+        sink,
+        temp.path(),
+        "structured-chatty",
+        &helper.path,
+        vec![
+            "mark-chatty".to_string(),
+            marker.to_string_lossy().into_owned(),
+            nonce.clone(),
+            "512".to_string(),
+        ],
+        None,
+        10,
+        None,
+        AgentPolicy {
+            allow_cwd_anywhere: true,
+            max_output_bytes: output_limit,
+            ..AgentPolicy::default()
+        },
+    );
+
+    wait_for_job_workers(&manager);
+    let snapshot = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "structured-chatty")
+        .expect("same durable Job remains observable at terminal");
+    assert_eq!(snapshot.status, "completed", "{snapshot:?}");
+    assert_eq!(snapshot.request_id, "request-structured-chatty");
+    assert_eq!(
+        snapshot.command_execution_state,
+        Some(ShellCommandExecutionState::Completed)
+    );
+    assert_eq!(snapshot.exit_code, Some(0));
+    for (name, stream, tail_byte) in [
+        ("stdout", &snapshot.stdout, b'x'),
+        ("stderr", &snapshot.stderr, b'y'),
+    ] {
+        assert!(
+            stream.tail.len() <= output_limit,
+            "{name} exceeded policy bound"
+        );
+        assert!(
+            stream.tail.starts_with("[output truncated]\n"),
+            "{name}: {:?}",
+            stream.tail
+        );
+        assert!(stream.tail.as_bytes().iter().any(|byte| *byte == tail_byte));
+        assert!(std::str::from_utf8(stream.tail.as_bytes()).is_ok());
+    }
+    let starts = std::fs::read_to_string(marker).unwrap();
+    assert_eq!(starts.lines().count(), 1, "structured Job was redispatched");
+    assert!(starts.contains(&nonce));
+}
+
+#[test]
+fn structured_process_job_stop_after_large_output_is_bounded_and_exact_once() {
+    let temp = tempfile::tempdir().unwrap();
+    let helper = structured_process_helper();
+    let marker = temp.path().join("chatty-stop-starts.log");
+    let ready = temp.path().join("chatty-stop-ready");
+    let nonce = format!("chatty-stop-{}", uuid::Uuid::new_v4());
+    let (sink, _unread_rx) = structured_test_sink("structured-agent", "structured-instance");
+    let manager = JobManager::new(1);
+    let output_limit = 16 * 1024;
+    enqueue_structured_process_job_with_policy(
+        &manager,
+        sink,
+        temp.path(),
+        "structured-chatty-stop",
+        &helper.path,
+        vec![
+            "mark-chatty-sleep".to_string(),
+            marker.to_string_lossy().into_owned(),
+            ready.to_string_lossy().into_owned(),
+            nonce.clone(),
+            "512".to_string(),
+            "60000".to_string(),
+        ],
+        None,
+        30,
+        None,
+        AgentPolicy {
+            allow_cwd_anywhere: true,
+            max_output_bytes: output_limit,
+            ..AgentPolicy::default()
+        },
+    );
+    assert!(
+        wait_until(Duration::from_secs(10), || ready.exists()),
+        "child never finished writing output far beyond pipe capacity"
+    );
+
+    manager.stop("structured-chatty-stop").unwrap();
+    wait_for_job_workers(&manager);
+    let snapshot = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "structured-chatty-stop")
+        .unwrap();
+    assert_eq!(snapshot.status, "stopped", "{snapshot:?}");
+    assert_eq!(snapshot.request_id, "request-structured-chatty-stop");
+    assert_eq!(
+        snapshot.command_execution_state,
+        Some(ShellCommandExecutionState::Completed)
+    );
+    for stream in [&snapshot.stdout, &snapshot.stderr] {
+        assert!(stream.tail.len() <= output_limit);
+        assert!(stream.tail.starts_with("[output truncated]\n"));
+        assert!(std::str::from_utf8(stream.tail.as_bytes()).is_ok());
+    }
+    let starts = std::fs::read_to_string(marker).unwrap();
+    assert_eq!(starts.lines().count(), 1, "stop redispatched the Job");
+    assert!(starts.contains(&nonce));
+}
+
+#[test]
+fn structured_process_job_timeout_after_large_output_is_bounded_and_exact_once() {
+    let temp = tempfile::tempdir().unwrap();
+    let helper = structured_process_helper();
+    let marker = temp.path().join("chatty-timeout-starts.log");
+    let ready = temp.path().join("chatty-timeout-ready");
+    let nonce = format!("chatty-timeout-{}", uuid::Uuid::new_v4());
+    let (sink, _unread_rx) = structured_test_sink("structured-agent", "structured-instance");
+    let manager = JobManager::new(1);
+    let output_limit = 16 * 1024;
+    enqueue_structured_process_job_with_policy(
+        &manager,
+        sink,
+        temp.path(),
+        "structured-chatty-timeout",
+        &helper.path,
+        vec![
+            "mark-chatty-sleep".to_string(),
+            marker.to_string_lossy().into_owned(),
+            ready.to_string_lossy().into_owned(),
+            nonce.clone(),
+            "512".to_string(),
+            "60000".to_string(),
+        ],
+        None,
+        5,
+        None,
+        AgentPolicy {
+            allow_cwd_anywhere: true,
+            max_output_bytes: output_limit,
+            ..AgentPolicy::default()
+        },
+    );
+    assert!(
+        wait_until(Duration::from_secs(10), || ready.exists()),
+        "child never finished writing output far beyond pipe capacity"
+    );
+
+    wait_for_job_workers(&manager);
+    let snapshot = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "structured-chatty-timeout")
+        .unwrap();
+    assert_eq!(snapshot.status, "timeout", "{snapshot:?}");
+    assert_eq!(snapshot.request_id, "request-structured-chatty-timeout");
+    assert_eq!(
+        snapshot.command_execution_state,
+        Some(ShellCommandExecutionState::TimedOut)
+    );
+    assert!(snapshot.stdout.tail.len() <= output_limit);
+    assert!(snapshot.stderr.tail.len() <= output_limit);
+    assert!(snapshot.stdout.tail.starts_with("[output truncated]\n"));
+    assert!(snapshot
+        .stderr
+        .tail
+        .contains("command timed out after 5 seconds"));
+    assert!(std::str::from_utf8(snapshot.stdout.tail.as_bytes()).is_ok());
+    assert!(std::str::from_utf8(snapshot.stderr.tail.as_bytes()).is_ok());
+    let starts = std::fs::read_to_string(marker).unwrap();
+    assert_eq!(starts.lines().count(), 1, "timeout redispatched the Job");
+    assert!(starts.contains(&nonce));
+}
+
+#[test]
+fn structured_process_job_shutdown_after_large_output_reaps_the_same_execution() {
+    let temp = tempfile::tempdir().unwrap();
+    let helper = structured_process_helper();
+    let marker = temp.path().join("chatty-shutdown-starts.log");
+    let ready = temp.path().join("chatty-shutdown-ready");
+    let nonce = format!("chatty-shutdown-{}", uuid::Uuid::new_v4());
+    let (sink, _unread_rx) = structured_test_sink("structured-agent", "structured-instance");
+    let manager = JobManager::new(1);
+    enqueue_structured_process_job_with_policy(
+        &manager,
+        sink,
+        temp.path(),
+        "structured-chatty-shutdown",
+        &helper.path,
+        vec![
+            "mark-chatty-sleep".to_string(),
+            marker.to_string_lossy().into_owned(),
+            ready.to_string_lossy().into_owned(),
+            nonce.clone(),
+            "512".to_string(),
+            "60000".to_string(),
+        ],
+        None,
+        30,
+        None,
+        AgentPolicy {
+            allow_cwd_anywhere: true,
+            max_output_bytes: 16 * 1024,
+            ..AgentPolicy::default()
+        },
+    );
+    assert!(wait_until(Duration::from_secs(10), || ready.exists()));
+
+    manager.stop_all();
+    wait_for_job_workers(&manager);
+    let snapshot = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "structured-chatty-shutdown")
+        .unwrap();
+    assert_eq!(snapshot.status, "stopped", "{snapshot:?}");
+    assert_eq!(snapshot.request_id, "request-structured-chatty-shutdown");
+    assert_eq!(
+        snapshot.command_execution_state,
+        Some(ShellCommandExecutionState::Completed)
+    );
+    assert!(snapshot.stdout.tail.len() <= 16 * 1024);
+    assert!(snapshot.stderr.tail.len() <= 16 * 1024);
+    assert_eq!(
+        std::fs::read_to_string(&marker).unwrap().lines().count(),
+        1,
+        "shutdown redispatched the structured Job"
+    );
+    assert!(std::fs::read_to_string(&marker).unwrap().contains(&nonce));
+}
+
+#[test]
 fn structured_process_job_handoff_observation_does_not_reset_the_original_total_timeout() {
     let temp = tempfile::tempdir().unwrap();
     let helper = structured_process_helper();
@@ -2639,6 +2920,99 @@ fn structured_script_job_keeps_its_temporary_file_until_terminal_then_removes_it
         "the Runner-owned script file was not removed after terminal completion"
     );
     assert_eq!(std::fs::read_to_string(marker).unwrap().lines().count(), 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn structured_script_job_drains_large_output_without_log_observation_and_runs_once() {
+    let temp = tempfile::tempdir().unwrap();
+    let marker = temp.path().join("script-chatty-starts.log");
+    let stdout_payload = "x".repeat(4096);
+    let stderr_payload = "y".repeat(4096);
+    let script = format!(
+        "printf '%s\\n' \"$$\" >> \"$1\"\nout='{stdout_payload}'\nerr='{stderr_payload}'\ni=0\nwhile [ \"$i\" -lt 512 ]; do\n  printf '%s' \"$out\"\n  printf '%s' \"$err\" >&2\n  i=$((i + 1))\ndone\n"
+    );
+    let args = vec![marker.to_string_lossy().into_owned()];
+    let context = structured_script_context(
+        temp.path(),
+        shell_protocol::ShellScriptLanguage::Sh,
+        script.len(),
+        args.len(),
+        false,
+    );
+    // Keep the transport receiver alive but unread. No model-side log read or
+    // per-chunk consumer is allowed to be necessary for child progress.
+    let (sink, _unread_rx) = structured_test_sink("structured-agent", "structured-instance");
+    let manager = JobManager::new(1);
+    manager.enqueue(
+        sink,
+        PendingJobStart {
+            generation: 1,
+            policy: AgentPolicy {
+                allow_cwd_anywhere: true,
+                max_output_bytes: 16 * 1024,
+                ..AgentPolicy::default()
+            },
+            shell: ShellConfig::default(),
+            ssh: SshConfig::default(),
+            projects_dir: temp.path().join("projects.d"),
+            request: serde_json::from_value(json!({
+                "request_id": "request-structured-script-chatty",
+                "client_id": "structured-agent",
+                "kind": "start_script_job",
+                "job_id": "structured-script-chatty",
+                "cwd": temp.path(),
+                "command": "",
+                "script": {
+                    "language": "sh",
+                    "script": script,
+                    "args": args,
+                },
+                "timeout_secs": 10,
+                "requested_by": "test",
+                "created_at": chrono::Utc::now().timestamp(),
+                "job_context": context,
+            }))
+            .unwrap(),
+        },
+    );
+
+    wait_for_job_workers(&manager);
+    let snapshot = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "structured-script-chatty")
+        .expect("same durable script Job remains observable at terminal");
+    assert_eq!(snapshot.status, "completed", "{snapshot:?}");
+    assert_eq!(snapshot.request_id, "request-structured-script-chatty");
+    assert_eq!(
+        snapshot.command_execution_state,
+        Some(ShellCommandExecutionState::Completed)
+    );
+    assert_eq!(snapshot.exit_code, Some(0));
+    let output_limit = 16 * 1024;
+    for (name, stream, tail_byte) in [
+        ("stdout", &snapshot.stdout, b'x'),
+        ("stderr", &snapshot.stderr, b'y'),
+    ] {
+        assert!(
+            stream.tail.len() <= output_limit,
+            "{name} exceeded policy bound"
+        );
+        assert!(
+            stream.tail.starts_with("[output truncated]\n"),
+            "{name}: {:?}",
+            stream.tail
+        );
+        assert!(stream.tail.as_bytes().iter().any(|byte| *byte == tail_byte));
+        assert!(std::str::from_utf8(stream.tail.as_bytes()).is_ok());
+    }
+    assert_eq!(
+        std::fs::read_to_string(marker).unwrap().lines().count(),
+        1,
+        "structured script Job was redispatched"
+    );
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -1472,6 +1472,16 @@ fn phase_e2_default_four_gates_fifth_and_promotes_same_job_once() {
         4,
         "simultaneously started children exceeded or failed to reach the default"
     );
+    assert!(
+        wait_until(Duration::from_secs(10), || manager
+            .inventory()
+            .jobs
+            .iter()
+            .any(
+                |snapshot| snapshot.job_id == jobs[4].job_id && snapshot.status == "running"
+            )),
+        "promoted fifth child became active before its Runner running state was published"
+    );
     let promoted = manager
         .inventory()
         .jobs
@@ -1529,6 +1539,16 @@ fn runner_job_slots_are_shared_across_runtime_projects() {
         "project A Job never became active"
     );
     assert!(!project_b.started.exists());
+    assert!(
+        wait_until(Duration::from_secs(10), || manager
+            .inventory()
+            .jobs
+            .iter()
+            .any(
+                |snapshot| snapshot.job_id == project_a.job_id && snapshot.status == "running"
+            )),
+        "project A child became active before its Runner running state was published"
+    );
 
     let inventory = manager.inventory();
     assert!(inventory.active_complete);
@@ -1558,6 +1578,16 @@ fn runner_job_slots_are_shared_across_runtime_projects() {
     assert!(
         wait_until(Duration::from_secs(10), || project_b.active.exists()),
         "project B queued Job did not claim the shared Runner slot"
+    );
+    assert!(
+        wait_until(Duration::from_secs(10), || manager
+            .inventory()
+            .jobs
+            .iter()
+            .any(
+                |snapshot| snapshot.job_id == project_b.job_id && snapshot.status == "running"
+            )),
+        "project B child became active before its Runner running state was published"
     );
     let promoted = manager
         .inventory()

--- a/crates/webcodex-runner/src/webcodex_runner/shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell.rs
@@ -1449,51 +1449,91 @@ fn terminate_child_without_output(mut child: ManagedChild) -> Result<(), String>
     result
 }
 
-fn terminate_and_read_pipes(
-    mut child: ManagedChild,
-    max_output_bytes: usize,
-) -> Result<(std::process::ExitStatus, BoundedPipeTail, BoundedPipeTail), String> {
-    let deadline = Instant::now() + Duration::from_secs(1);
-    let cleanup = terminate_child_process_tree_until(&mut child, deadline).err();
-    let output = read_pipes_until(child, max_output_bytes, deadline);
-    match (cleanup, output) {
-        (None, Ok(output)) => Ok(output),
-        (Some(cleanup), Ok(_)) => Err(format!(
-            "failed to terminate command process tree: {cleanup}"
-        )),
-        (None, Err(error)) => Err(error),
-        (Some(cleanup), Err(error)) => Err(format!(
-            "failed to terminate command process tree: {cleanup}; failed to collect output: {error}"
-        )),
+struct ContinuousPipeDrain {
+    stdout_rx: mpsc::Receiver<Result<BoundedPipeTail, String>>,
+    stderr_rx: mpsc::Receiver<Result<BoundedPipeTail, String>>,
+    stdout_handle: std::thread::JoinHandle<()>,
+    stderr_handle: std::thread::JoinHandle<()>,
+}
+
+impl ContinuousPipeDrain {
+    /// Take both child pipes and start independent bounded readers immediately.
+    ///
+    /// The readers own the OS pipe handles for the full child lifetime. They do
+    /// not forward per-chunk data through another bounded queue, so Server/model
+    /// observation cannot backpressure either stream. Each reader retains only
+    /// the existing bounded tail plus UTF-8/BOM validation state.
+    fn start(child: &mut ManagedChild, max_output_bytes: usize) -> Result<Self, String> {
+        let stdout = child
+            .child_mut()
+            .stdout
+            .take()
+            .ok_or_else(|| "stdout pipe missing".to_string())?;
+        let stderr = match child.child_mut().stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                drop(stdout);
+                return Err("stderr pipe missing".to_string());
+            }
+        };
+        let (stdout_tx, stdout_rx) = mpsc::sync_channel(1);
+        let stdout_handle = std::thread::spawn(move || {
+            let _ = stdout_tx.send(read_bounded_pipe_tail(stdout, max_output_bytes, "stdout"));
+        });
+        let (stderr_tx, stderr_rx) = mpsc::sync_channel(1);
+        let stderr_handle = std::thread::spawn(move || {
+            let _ = stderr_tx.send(read_bounded_pipe_tail(stderr, max_output_bytes, "stderr"));
+        });
+        Ok(Self {
+            stdout_rx,
+            stderr_rx,
+            stdout_handle,
+            stderr_handle,
+        })
+    }
+
+    fn finish_until(self, deadline: Instant) -> Result<(BoundedPipeTail, BoundedPipeTail), String> {
+        let Self {
+            stdout_rx,
+            stderr_rx,
+            stdout_handle,
+            stderr_handle,
+        } = self;
+        let receive = |rx: mpsc::Receiver<Result<BoundedPipeTail, String>>,
+                       stream_name: &'static str|
+         -> Result<BoundedPipeTail, String> {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            rx.recv_timeout(remaining).map_err(|_| {
+                format!("{stream_name} reader did not finish before cleanup deadline")
+            })?
+        };
+        // Always give both already-running readers the shared cleanup deadline.
+        // A read error on one stream must not short-circuit collection of the
+        // other stream and turn an otherwise bounded reader into a detached one.
+        let stdout = receive(stdout_rx, "stdout");
+        let stderr = receive(stderr_rx, "stderr");
+        if stdout_handle.is_finished() {
+            let _ = stdout_handle.join();
+        }
+        if stderr_handle.is_finished() {
+            let _ = stderr_handle.join();
+        }
+        match (stdout, stderr) {
+            (Ok(stdout), Ok(stderr)) => Ok((stdout, stderr)),
+            (Err(stdout), Ok(_)) => Err(stdout),
+            (Ok(_), Err(stderr)) => Err(stderr),
+            (Err(stdout), Err(stderr)) => Err(format!("{stdout}; {stderr}")),
+        }
     }
 }
 
-fn read_pipes_until(
-    mut child: ManagedChild,
-    max_output_bytes: usize,
+fn wait_child_until(
+    child: &mut ManagedChild,
     deadline: Instant,
-) -> Result<(std::process::ExitStatus, BoundedPipeTail, BoundedPipeTail), String> {
-    let stdout = child
-        .child_mut()
-        .stdout
-        .take()
-        .ok_or_else(|| "stdout pipe missing".to_string())?;
-    let stderr = child
-        .child_mut()
-        .stderr
-        .take()
-        .ok_or_else(|| "stderr pipe missing".to_string())?;
-    let (stdout_tx, stdout_rx) = mpsc::sync_channel(1);
-    let stdout_handle = std::thread::spawn(move || {
-        let _ = stdout_tx.send(read_bounded_pipe_tail(stdout, max_output_bytes, "stdout"));
-    });
-    let (stderr_tx, stderr_rx) = mpsc::sync_channel(1);
-    let stderr_handle = std::thread::spawn(move || {
-        let _ = stderr_tx.send(read_bounded_pipe_tail(stderr, max_output_bytes, "stderr"));
-    });
-    let status = loop {
+) -> Result<std::process::ExitStatus, String> {
+    loop {
         match child.try_wait() {
-            Ok(Some(status)) => break status,
+            Ok(Some(status)) => return Ok(status),
             Ok(None) => {
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
@@ -1503,22 +1543,67 @@ fn read_pipes_until(
             }
             Err(error) => return Err(format!("failed to wait command: {error}")),
         }
+    }
+}
+
+/// Finish one command whose stdout/stderr readers have already been draining
+/// continuously since immediately after spawn. Tree termination still happens
+/// before waiting for reader EOF so a descendant that inherited a pipe cannot
+/// keep the readers alive after direct-child exit, stop, or timeout.
+fn terminate_and_collect_pipes(
+    mut child: ManagedChild,
+    drains: ContinuousPipeDrain,
+) -> Result<(std::process::ExitStatus, BoundedPipeTail, BoundedPipeTail), String> {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let cleanup = terminate_child_process_tree_until(&mut child, deadline).err();
+    let status = wait_child_until(&mut child, deadline);
+    let output = drains.finish_until(deadline);
+    let mut errors = Vec::new();
+    if let Some(cleanup) = cleanup {
+        errors.push(format!(
+            "failed to terminate command process tree: {cleanup}"
+        ));
+    }
+    let status = match status {
+        Ok(status) => Some(status),
+        Err(error) => {
+            errors.push(error);
+            None
+        }
     };
-    let remaining = deadline.saturating_duration_since(Instant::now());
-    let stdout = stdout_rx
-        .recv_timeout(remaining)
-        .map_err(|_| "stdout reader did not finish before cleanup deadline".to_string())??;
-    let remaining = deadline.saturating_duration_since(Instant::now());
-    let stderr = stderr_rx
-        .recv_timeout(remaining)
-        .map_err(|_| "stderr reader did not finish before cleanup deadline".to_string())??;
-    if stdout_handle.is_finished() {
-        let _ = stdout_handle.join();
+    let output = match output {
+        Ok(output) => Some(output),
+        Err(error) => {
+            errors.push(format!("failed to collect output: {error}"));
+            None
+        }
+    };
+    if !errors.is_empty() {
+        return Err(errors.join("; "));
     }
-    if stderr_handle.is_finished() {
-        let _ = stderr_handle.join();
-    }
-    Ok((status, stdout, stderr))
+    let (stdout, stderr) = output.expect("output exists when no collection error was recorded");
+    Ok((
+        status.expect("status exists when no wait error was recorded"),
+        stdout,
+        stderr,
+    ))
+}
+
+/// Test/error-path convenience wrapper. Production structured execution starts
+/// the drain immediately after spawn rather than waiting until termination.
+#[cfg(test)]
+fn terminate_and_read_pipes(
+    mut child: ManagedChild,
+    max_output_bytes: usize,
+) -> Result<(std::process::ExitStatus, BoundedPipeTail, BoundedPipeTail), String> {
+    let drains = match ContinuousPipeDrain::start(&mut child, max_output_bytes) {
+        Ok(drains) => drains,
+        Err(error) => {
+            let cleanup = terminate_child_process_tree(&mut child).err();
+            return Err(with_cleanup_error(error, cleanup));
+        }
+    };
+    terminate_and_collect_pipes(child, drains)
 }
 
 fn read_bounded_pipe_tail(
@@ -2624,6 +2709,23 @@ fn execute_configured_command(
             });
         }
     };
+    // Structured execution must drain both OS pipes for the entire child
+    // lifetime. Starting independent bounded readers before any lifecycle wait
+    // prevents either stdout or stderr pipe capacity from throttling the child,
+    // even when no caller observes Job logs until terminal completion.
+    let drains = match ContinuousPipeDrain::start(&mut child, policy.max_output_bytes) {
+        Ok(drains) => drains,
+        Err(error) => {
+            let cleanup = terminate_child_process_tree(&mut child).err();
+            return ShellCommandResult::outcome_unknown(CommandResult {
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: Some(start.elapsed().as_millis() as u64),
+                error: Some(with_cleanup_error(error, cleanup)),
+            });
+        }
+    };
     if let Some(on_started) = on_started {
         on_started();
     }
@@ -2638,7 +2740,7 @@ fn execute_configured_command(
                 Some(rx)
             }
             None => {
-                let cleanup = terminate_child_without_output(child).err();
+                let cleanup = terminate_and_collect_pipes(child, drains).err();
                 return ShellCommandResult::outcome_unknown(CommandResult {
                     exit_code: None,
                     stdout: None,
@@ -2652,7 +2754,7 @@ fn execute_configured_command(
     };
     loop {
         if let Err(error) = poll_stdin_writer(&mut stdin_writer) {
-            let cleanup = terminate_child_without_output(child).err();
+            let cleanup = terminate_and_collect_pipes(child, drains).err();
             return ShellCommandResult::outcome_unknown(CommandResult {
                 exit_code: None,
                 stdout: None,
@@ -2669,7 +2771,7 @@ fn execute_configured_command(
             .unwrap_or(false)
         {
             let duration_ms = start.elapsed().as_millis() as u64;
-            return match terminate_and_read_pipes(child, policy.max_output_bytes) {
+            return match terminate_and_collect_pipes(child, drains) {
                 Ok((_status, stdout, stderr)) => {
                     let mut stderr = stderr.normalize(policy.max_output_bytes);
                     append_bounded_text(
@@ -2699,7 +2801,7 @@ fn execute_configured_command(
             Ok(None) => {
                 if start.elapsed() >= Duration::from_secs(timeout_secs) {
                     let duration_ms = start.elapsed().as_millis() as u64;
-                    return match terminate_and_read_pipes(child, policy.max_output_bytes) {
+                    return match terminate_and_collect_pipes(child, drains) {
                         Ok((_status, stdout, stderr)) => {
                             let mut stderr = stderr.normalize(policy.max_output_bytes);
                             append_bounded_text(
@@ -2730,7 +2832,7 @@ fn execute_configured_command(
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
-                let cleanup = terminate_child_without_output(child).err();
+                let cleanup = terminate_and_collect_pipes(child, drains).err();
                 return ShellCommandResult::outcome_unknown(CommandResult {
                     exit_code: None,
                     stdout: None,
@@ -2745,7 +2847,7 @@ fn execute_configured_command(
         }
     }
     if let Err(error) = finish_stdin_writer(stdin_writer) {
-        let cleanup = terminate_child_without_output(child).err();
+        let cleanup = terminate_and_collect_pipes(child, drains).err();
         return ShellCommandResult::outcome_unknown(CommandResult {
             exit_code: None,
             stdout: None,
@@ -2757,7 +2859,7 @@ fn execute_configured_command(
             )),
         });
     }
-    match terminate_and_read_pipes(child, policy.max_output_bytes) {
+    match terminate_and_collect_pipes(child, drains) {
         Ok((status, stdout, stderr)) => ShellCommandResult::completed(CommandResult {
             exit_code: Some(status.code().unwrap_or(-1)),
             stdout: Some(stdout.normalize(policy.max_output_bytes)),

--- a/crates/webcodex-runner/src/webcodex_runner/shell_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell_tests.rs
@@ -659,6 +659,160 @@ fn structured_process_preserves_large_literal_argv_without_shell_parsing() {
 }
 
 #[test]
+fn structured_process_continuously_drains_large_stdout_and_stderr() {
+    let cwd = tempfile::tempdir().unwrap();
+    let projects_dir = tempfile::tempdir().unwrap();
+    let mut policy = unrestricted_policy();
+    policy.max_output_bytes = 16 * 1024;
+    let result = run_process_with_profiles_in_sandbox_and_execution_state(
+        1,
+        &policy,
+        &ShellConfig::default(),
+        projects_dir.path(),
+        &PreparedShellProfileCache::default(),
+        Some(cwd.path().to_string_lossy().as_ref()),
+        &process_argv_helper().to_string_lossy(),
+        &["chatty".to_string(), "512".to_string()],
+        None,
+        10,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        result.execution_state,
+        ShellCommandExecutionState::Completed,
+        "{:?}",
+        result.result
+    );
+    assert_eq!(result.result.exit_code, Some(0));
+    for (name, output, tail_byte) in [
+        ("stdout", result.result.stdout.as_deref().unwrap(), b'x'),
+        ("stderr", result.result.stderr.as_deref().unwrap(), b'y'),
+    ] {
+        assert!(
+            output.len() <= policy.max_output_bytes,
+            "{name} was unbounded"
+        );
+        assert!(
+            output.starts_with("[output truncated]\n"),
+            "{name}: {output:?}"
+        );
+        assert_eq!(output.as_bytes().last().copied(), Some(b'\n'));
+        assert!(
+            output.as_bytes().iter().any(|byte| *byte == tail_byte),
+            "{name} lost its retained tail"
+        );
+        assert!(std::str::from_utf8(output.as_bytes()).is_ok());
+    }
+}
+
+#[test]
+fn structured_script_continuously_drains_large_stdout_and_stderr() {
+    let cwd = tempfile::tempdir().unwrap();
+    let projects_dir = tempfile::tempdir().unwrap();
+    let mut policy = unrestricted_policy();
+    policy.max_output_bytes = 16 * 1024;
+    let stdout_payload = "x".repeat(4096);
+    let stderr_payload = "y".repeat(4096);
+    #[cfg(windows)]
+    let (language, script) = (
+        ShellScriptLanguage::Powershell,
+        format!(
+            "$out = '{stdout_payload}'\n$err = '{stderr_payload}'\nfor ($i = 0; $i -lt 512; $i++) {{ [Console]::Out.Write($out); [Console]::Error.Write($err) }}\n"
+        ),
+    );
+    #[cfg(not(windows))]
+    let (language, script) = (
+        ShellScriptLanguage::Sh,
+        format!(
+            "out='{stdout_payload}'\nerr='{stderr_payload}'\ni=0\nwhile [ \"$i\" -lt 512 ]; do\n  printf '%s' \"$out\"\n  printf '%s' \"$err\" >&2\n  i=$((i + 1))\ndone\n"
+        ),
+    );
+    let result = run_script_with_profiles_in_sandbox_and_execution_state(
+        1,
+        &policy,
+        &ShellConfig::default(),
+        projects_dir.path(),
+        &PreparedShellProfileCache::default(),
+        Some(cwd.path().to_string_lossy().as_ref()),
+        &ShellScriptPayload {
+            language,
+            script,
+            args: Vec::new(),
+        },
+        None,
+        30,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        result.execution_state,
+        ShellCommandExecutionState::Completed,
+        "{:?}",
+        result.result
+    );
+    assert_eq!(result.result.exit_code, Some(0));
+    for (name, output, tail_byte) in [
+        ("stdout", result.result.stdout.as_deref().unwrap(), b'x'),
+        ("stderr", result.result.stderr.as_deref().unwrap(), b'y'),
+    ] {
+        assert!(
+            output.len() <= policy.max_output_bytes,
+            "{name} was unbounded"
+        );
+        assert!(
+            output.starts_with("[output truncated]\n"),
+            "{name}: {output:?}"
+        );
+        assert!(
+            output.as_bytes().iter().any(|byte| *byte == tail_byte),
+            "{name} lost its retained tail"
+        );
+        assert!(std::str::from_utf8(output.as_bytes()).is_ok());
+    }
+}
+
+#[test]
+fn structured_process_parent_exit_closes_descendant_held_pipes_via_tree_cleanup() {
+    let cwd = tempfile::tempdir().unwrap();
+    let marker = cwd.path().join("pipe-descendant-started");
+    let result = run_direct_process(
+        cwd.path(),
+        &process_argv_helper(),
+        &[
+            "spawn-pipe-descendant".to_string(),
+            marker.to_string_lossy().into_owned(),
+            "60000".to_string(),
+        ],
+        None,
+        10,
+    );
+
+    assert_eq!(
+        result.execution_state,
+        ShellCommandExecutionState::Completed,
+        "{:?}",
+        result.result
+    );
+    assert_eq!(result.result.exit_code, Some(0));
+    assert!(
+        result
+            .result
+            .stdout
+            .as_deref()
+            .unwrap_or_default()
+            .contains("DESCENDANT_PID="),
+        "the parent did not prove that a pipe-inheriting descendant was spawned"
+    );
+    // The descendant inherits the parent's stdout/stderr handles and sleeps for
+    // 60 seconds. Returning terminal here proves direct-child exit still drives
+    // whole-tree cleanup before the continuously draining readers wait for EOF.
+    assert!(result.result.duration_ms.unwrap_or_default() < 10_000);
+}
+
+#[test]
 fn structured_process_reports_prestart_completion_and_nonzero_truthfully() {
     let cwd = tempfile::tempdir().unwrap();
     let missing = cwd.path().join("definitely-missing-process");

--- a/tests/fixtures/process_argv_helper.rs
+++ b/tests/fixtures/process_argv_helper.rs
@@ -121,6 +121,36 @@ fn active_oem_sample() -> (String, Vec<u8>) {
     panic!("active OEM code page has no representable non-ASCII test sample");
 }
 
+fn write_chatty(chunks: usize) {
+    use std::io::Write;
+
+    let stdout_payload = vec![b'x'; 8 * 1024];
+    let stderr_payload = vec![b'y'; 8 * 1024];
+    let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr.lock();
+    for _ in 0..chunks {
+        stdout.write_all(&stdout_payload).unwrap();
+        stdout.write_all(b"\n").unwrap();
+        stderr.write_all(&stderr_payload).unwrap();
+        stderr.write_all(b"\n").unwrap();
+    }
+    stdout.flush().unwrap();
+    stderr.flush().unwrap();
+}
+
+fn append_start_marker(marker: &str, nonce: &str) {
+    use std::io::Write;
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(marker)
+        .unwrap();
+    writeln!(file, "{}:{nonce}", std::process::id()).unwrap();
+}
+
 fn main() {
     let mut args = std::env::args().skip(1);
     match args.next().as_deref() {
@@ -143,22 +173,43 @@ fn main() {
             std::thread::sleep(Duration::from_millis(millis));
         }
         Some("chatty") => {
-            use std::io::Write;
-
             let chunks = args.next().unwrap().parse::<usize>().unwrap();
-            let payload = vec![b'x'; 8 * 1024];
-            let stdout = std::io::stdout();
-            let stderr = std::io::stderr();
-            let mut stdout = stdout.lock();
-            let mut stderr = stderr.lock();
-            for _ in 0..chunks {
-                stdout.write_all(&payload).unwrap();
-                stdout.write_all(b"\n").unwrap();
-                stderr.write_all(&payload).unwrap();
-                stderr.write_all(b"\n").unwrap();
-            }
-            stdout.flush().unwrap();
-            stderr.flush().unwrap();
+            write_chatty(chunks);
+        }
+        Some("mark-chatty") => {
+            let marker = args.next().unwrap();
+            let nonce = args.next().unwrap();
+            let chunks = args.next().unwrap().parse::<usize>().unwrap();
+            append_start_marker(&marker, &nonce);
+            write_chatty(chunks);
+        }
+        Some("mark-chatty-sleep") => {
+            let marker = args.next().unwrap();
+            let ready = args.next().unwrap();
+            let nonce = args.next().unwrap();
+            let chunks = args.next().unwrap().parse::<usize>().unwrap();
+            let millis = args.next().unwrap().parse::<u64>().unwrap();
+            append_start_marker(&marker, &nonce);
+            write_chatty(chunks);
+            std::fs::write(ready, "drained\n").unwrap();
+            std::thread::sleep(Duration::from_millis(millis));
+        }
+        Some("spawn-pipe-descendant") => {
+            let marker = args.next().unwrap();
+            let millis = args.next().unwrap().parse::<u64>().unwrap();
+            let child = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("pipe-descendant")
+                .arg(marker)
+                .arg(millis.to_string())
+                .spawn()
+                .unwrap();
+            println!("DESCENDANT_PID={}", child.id());
+        }
+        Some("pipe-descendant") => {
+            let marker = args.next().unwrap();
+            let millis = args.next().unwrap().parse::<u64>().unwrap();
+            std::fs::write(marker, std::process::id().to_string()).unwrap();
+            std::thread::sleep(Duration::from_millis(millis));
         }
         Some("mark") => {
             let marker = args.next().unwrap();


### PR DESCRIPTION
## Summary

Fix durable structured `run_process` / `run_script` backpressure by continuously draining stdout and stderr for the entire child lifetime in the shared Runner execution primitive.

The previous lifecycle waited for child terminal state before reading piped stdout/stderr. High-output commands could therefore fill the OS pipe buffer, block in `pipe_write`, and never reach terminal state even though the durable Job identity itself remained healthy.

## Implementation

- keep `ManagedChild::spawn` exact-once execution and existing process-tree authority
- immediately take stdout/stderr after spawn
- run independent bounded stdout/stderr readers for the full child lifetime
- retain only the existing bounded tail plus UTF-8/BOM validation state
- preserve existing stop / timeout / shutdown / descendant cleanup lifecycle
- terminate/reap the full process tree before waiting for reader EOF, so descendants inheriting pipe handles cannot hold cleanup open
- no retry, redispatch, new Job type, streaming protocol, or unbounded output queue

`run_process` and `run_script` share the same corrected Runner primitive.

## Regression coverage

Added deterministic coverage for:

- multi-MiB stdout and stderr on direct structured process/script execution
- durable Jobs completing without any model/server log consumption
- bounded retained output and truncation markers
- exact-once execution markers
- stop, timeout, and shutdown after output far beyond pipe capacity
- direct-parent exit with a descendant retaining stdout/stderr handles
- existing timeout/handoff/process-tree contracts

A follow-up test-only commit also closes pre-existing lifecycle observation races exposed during review:

- waits for Runner `running` publication instead of treating a child-side `active` marker as the publication barrier
- uses a deterministic long-lived detached payload when proving active records are never reclaimed
- keeps shared Runner slot, same Job identity, exact-once, and detached retention contracts unchanged

## Validation

Focused review reruns on the final head:

- `runner_job_slots_are_shared_across_runtime_projects` — pass
- `accepted_active_record_is_never_reclaimed` — pass
- `phase_e2_default_four_gates_fifth_and_promotes_same_job_once` — pass
- `continuously_drains_large_stdout_and_stderr` — 2 passed
- `after_large_output` — 3 passed
- `cargo check --all-targets -p webcodex-runner` — pass; only the existing 7 Computer dead-code warnings
- `cargo fmt -- --check` — pass
- `git diff --check` — pass

Development validation also completed five consecutive concurrent full Runner suites at `709 passed / 0 failed / 3 ignored`, plus one serial full suite at `709 passed / 0 failed / 3 ignored`.

## Scope

No Server schema, Job protocol, MCP bridge, task messaging, semantic diff, or validation-plan changes. No deploy/restart/release is part of this PR.