### PR TITLE
Improve onboarding and first-run UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ capabilities to the chat client without requiring the repository itself to move.
 
 ## Try it with one repository
 
+Platform note: `webcodex share` starts a local WebCodex Server and is supported on
+Linux and macOS. Windows builds support the CLI + Runner against a remote Linux
+Server; on Windows use `webcodex connect <server-url>`. If you do not already
+have a Server, deploy one on Linux first.
+
 For the default temporary public share, install
 [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) and make
 sure it is on `PATH`. Then:

--- a/README.md
+++ b/README.md
@@ -2,149 +2,136 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-WebCodex connects online AI clients such as ChatGPT or Claude to repositories
-and development tools running on your own machines. Through a WebCodex Server
-and a Runner on the machine that owns the code, an AI assistant can inspect and
-edit files, run commands and tests, work with Git, and use the local toolchain —
-from the chat window you already use.
+WebCodex lets ChatGPT, Claude, and other MCP clients work with repositories and
+development tools on your own machines. The Runner executes file, Git, command,
+and test operations where the repository lives; WebCodex exposes those
+capabilities to the chat client without requiring the repository itself to move.
 
-See the [latest release](https://github.com/yyjeqhc/webcodex/releases/latest)
-and the [documentation index](docs/INDEX.md).
+## Try it with one repository
 
-## What it does
-
-- **Files and source inspection** — read, search, and list files inside
-  registered projects.
-- **Guarded edits** — structured file edits and checked patches, applied within
-  project boundaries.
-- **Git** — status, diffs, and focused commit preparation.
-- **Commands and tests** — bounded shell commands and structured validation
-  (Rust, Node, Python, Go).
-- **Long-running Jobs** — work that outlives a single chat turn continues as an
-  observable, queryable Job.
-- **Multiple Runner machines and projects** — one Server can route work to many
-  machines that own repositories.
-- **MCP** — connect from ChatGPT, Claude, or any MCP client.
-- **Optional GPT Actions** — an OpenAPI-based integration for Custom GPTs.
-
-The exact tools available depend on the Server surface, the Runner
-capabilities, and the permissions you configure.
-
-## How it works
-
-```text
-AI client
-   |
-   | MCP / HTTPS (or GPT Actions)
-   v
-WebCodex Server
-   |
-   | authenticated Runner connection
-   v
-webcodex-runner
-   |
-   repository / Git / toolchains
-```
-
-The Server authenticates callers and routes tool requests. The Runner does the
-actual work on the machine that owns the repository. Repositories and local
-toolchains stay on the Runner host; only the requested tool inputs and results
-travel across the connection.
-
-## Quick start
-
-Three common paths:
-
-**1. Connect a repository to an existing Server**
+For the default temporary public share, install
+[`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) and make
+sure it is on `PATH`. Then:
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 cd /path/to/your/repository
-webcodex connect https://your-server.example
-```
-
-`connect` uses the current directory as the project, creates a local profile,
-starts a detached Runner, and prints the MCP URL and a generated key. Paste the
-URL and key into your MCP client, then ask for a real task.
-
-**2. Temporarily share one local project**
-
-```bash
 webcodex share
 ```
 
-`share` starts a local Server + Runner and a Cloudflare Quick Tunnel, then
-prints a temporary HTTPS `/mcp` URL and Bearer credential for that session. It
-is for development and testing, not production.
+`share` is self-contained: it configures the current Git project, starts a local
+WebCodex Server + Runner, creates a temporary Connector credential, and opens a
+Cloudflare Quick Tunnel. You do **not** need to run `setup`, `doctor`, or `run`
+first.
 
-**3. Self-host a Server**
+When the command reports **WebCodex ready**, keep that terminal open and use the
+values it prints:
 
-Deploy the server-only Docker/Compose stack on an always-on host, put a stable
-HTTPS domain in front of it, then enroll each repository machine as a Runner
-with `webcodex login`.
+1. In ChatGPT, enable **Developer Mode** and create a **custom app** using MCP.
+2. Paste the printed **MCP URL**.
+3. Choose **Access token / API key** or the equivalent Bearer-token option.
+4. Paste the printed temporary **Credential**.
+5. Run **Scan Tools**.
+6. Start with a read-only prompt such as:
 
-The detailed steps for each path are in
-[Quick Start](docs/QUICK_START.md), and full production setup is in
-[Deployment](docs/DEPLOYMENT.md).
+```text
+Inspect this repository and summarize its structure. Do not make changes.
+```
+
+ChatGPT UI labels can vary by workspace and rollout. The CLI output is the source
+of truth for the URL, authentication type, and credential for that run.
+
+A default `share` URL and credential are temporary and stop working when the
+command exits. `webcodex share --tunnel none` is available for local-only MCP
+debugging and does not require `cloudflared`.
+
+## What happens after the first connection
+
+WebCodex can read/search files, prepare guarded edits, run commands and focused
+validation, inspect Git, and keep long-running Jobs observable. Coding results
+remain subject to the product's existing authority boundaries. Open `/console`
+to inspect project readiness and the work queue; the Console can guide, cancel,
+Accept, or Reject work where those actions are available. It deliberately does
+not reveal credentials.
+
+## Existing Server and long-lived deployments
+
+If you **already have** a WebCodex Server URL, connect the current repository to
+it instead:
+
+```bash
+cd /path/to/your/repository
+webcodex connect https://webcodex.example
+```
+
+`connect` creates a reusable local profile, starts the Runner, waits for the
+project to become visible through that Server, and prints the MCP setup values.
+This is the long-lived hosted path; it is not the prerequisite for trying
+WebCodex locally.
+
+`webcodex login` and managed OAuth are advanced identity paths for deployments
+that need separate users, revocation, audit, or organization-level controls.
+Self-hosting is an operator workflow; see [Deployment](docs/DEPLOYMENT.md).
+
+## How it works
+
+```text
+ChatGPT / Claude / MCP client
+            |
+            | MCP / HTTPS
+            v
+      WebCodex Server
+            |
+            | authenticated Runner connection
+            v
+     webcodex-runner
+            |
+      repository / Git / toolchains
+```
+
+The Server authenticates callers and routes requests. The Runner performs the
+actual work on the machine that owns the repository. Only requested tool inputs
+and results cross the connection.
 
 ## CLI
 
-The `webcodex` CLI covers project setup, Server and Runner lifecycle, device
-enrollment, and operator checks. Representative commands:
+The common commands are intentionally small:
 
 ```bash
-webcodex connect https://your-server.example   # connect a repo to a hosted Server
-webcodex share                                 # temporarily share the local project
-webcodex login https://your-server.example --code <wc_pair_...>
-webcodex setup                                 # project-first local setup
-webcodex doctor                                # read-only readiness checks
-webcodex run                                   # start the project-bound runtime
-webcodex agent status --profile <profile>      # inspect the Runner
-webcodex ops status                            # operator read-only checks
-webcodex task list                             # review tasks and decide locally
+webcodex share                     # fastest temporary ChatGPT/MCP connection
+webcodex connect <server-url>      # connect to an existing Server
+webcodex status                    # concise project readiness
+webcodex doctor                    # deeper local diagnostics
+webcodex setup                     # manual/local project setup
+webcodex run                       # manual local Server + Runner runtime
+webcodex task list                 # review local tasks
 ```
 
-See the [CLI reference](docs/CLI.md) for the full command map, terminology, and
-credentials.
-
-## Let an AI agent set it up
-
-Prefer having a coding agent configure WebCodex for you? Give the agent this
-repository and ask it to read `docs/AI_ONBOARDING.md` first. A copyable prompt:
-
-```text
-Read docs/AI_ONBOARDING.md and help me connect or deploy WebCodex.
-Verify the current machine and existing configuration first.
-Do not print or copy secrets; tell me when I need to enter a credential.
-```
-
-Two different guides serve two different purposes:
-
-- `docs/AI_ONBOARDING.md` is for an AI agent helping a **user** install,
-  connect, or deploy WebCodex.
-- `AGENTS.md` is for an AI coding agent **developing WebCodex itself**.
+The Runner is the execution component. For compatibility, Runner service
+management still uses the historical `webcodex agent ...` CLI namespace. See
+[CLI](docs/CLI.md) for operator commands and credential reference.
 
 ## Documentation
 
-- [Quick Start](docs/QUICK_START.md) — shortest working setup
-- [AI-assisted setup](docs/AI_ONBOARDING.md) — for an AI agent helping you
-- [CLI](docs/CLI.md) — command map, terminology, credentials
+- [Quick Start](docs/QUICK_START.md) — first ChatGPT/MCP connection
+- [MCP](docs/MCP.md) — ChatGPT, Claude, authentication, then protocol reference
+- [AI-assisted setup](docs/AI_ONBOARDING.md) — instructions for an AI helping a user configure WebCodex
+- [CLI](docs/CLI.md) — commands, compatibility notes, and credentials
 - [Deployment](docs/DEPLOYMENT.md) — self-hosting and production operations
-- [Authentication](docs/AUTH_MODEL.md) — credentials and tokens
-- [Runner](docs/RUNNER.md) — what the Runner/agent is and how to operate it
-- [MCP](docs/MCP.md) — connecting MCP clients, including Grok Custom Connector OAuth
-- [Coding Workflow](docs/CODING_WORKFLOW.md) — bootstrap, behavioral guidance, validation, and closeout
+- [Authentication](docs/AUTH_MODEL.md) — credential and authority model
+- [Runner](docs/RUNNER.md) — Runner operation
+- [Coding Workflow](docs/CODING_WORKFLOW.md) — task workflow, validation, and closeout
 - [Troubleshooting](docs/TROUBLESHOOTING.md)
-- [Architecture](docs/ARCHITECTURE.md)
+- [Documentation index](docs/INDEX.md)
 - [Security](SECURITY.md)
 
 ## Security
 
-WebCodex can modify files and execute commands, so treat a connected client as
-a development assistant with real access to the configured machines. Register
-only the project roots the assistant should use, keep tokens out of prompts,
-logs, and Git, and prefer an ordinary OS user for the Runner. Read
-[SECURITY.md](SECURITY.md) for the complete model.
+WebCodex can modify files and execute commands. Register only project roots the
+assistant should access, keep credentials out of prompts/logs/Git, and prefer an
+ordinary OS user for the Runner. The simplified onboarding does not collapse
+the underlying credential or authority boundaries. Read [SECURITY.md](SECURITY.md)
+for the complete model.
 
 ## Build from source
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ values it prints:
 Inspect this repository and summarize its structure. Do not make changes.
 ```
 
-ChatGPT UI labels can vary by workspace and rollout. The CLI output is the source
-of truth for the URL, authentication type, and credential for that run.
+ChatGPT UI labels can vary by workspace and rollout. Developer Mode, custom MCP
+apps, and write/modify actions are controlled by the ChatGPT plan, workspace, and
+admin settings; WebCodex cannot widen client-side app permissions. The CLI output
+is the source of truth for the WebCodex URL, authentication type, and credential
+for that run.
 
 A default `share` URL and credential are temporary and stop working when the
 command exits. `webcodex share --tunnel none` is available for local-only MCP

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,10 @@ Runner 在仓库所在机器上执行文件、Git、命令与测试操作；仓�
 
 ## 用一个仓库快速试起来
 
+平台说明：`webcodex share` 会启动本地 WebCodex Server，目前只支持 Linux 和 macOS。
+Windows 版本支持 CLI + Runner 连接远程 Linux Server；Windows 上请使用
+`webcodex connect <server-url>`。如果还没有 Server，需要先在 Linux 上部署一个。
+
 默认的临时公网分享依赖
 [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/)。先安装它并确保在
 `PATH` 中，然后执行：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,8 +38,10 @@ webcodex share
 检查这个仓库并总结它的结构。先不要做任何修改。
 ```
 
-ChatGPT 的 UI 文案可能随 workspace 与 rollout 改变；当前这次运行到底该填哪个 URL、
-认证类型和 credential，以 CLI 成功输出为准。
+ChatGPT 的 UI 文案可能随 workspace 与 rollout 改变。Developer Mode、custom MCP app 以及
+write/modify action 是否可用，由 ChatGPT 套餐、workspace 与管理员设置控制；WebCodex
+不能扩大客户端侧 app 权限。当前这次运行到底该填哪个 WebCodex URL、认证类型和
+credential，以 CLI 成功输出为准。
 
 默认 `share` 的 URL 与 credential 都是临时的，命令退出后失效。仅做本地 MCP 调试时可用
 `webcodex share --tunnel none`，此模式不需要 `cloudflared`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,134 +2,121 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-WebCodex 把 ChatGPT、Claude 等在线 AI 客户端，连接到运行在你自己的机器上的仓库
-与开发工具。通过 WebCodex Server 和持有代码的机器上的 Runner，AI 助手可以直接在
-你熟悉的聊天窗口里查看和修改文件、运行命令与测试、操作 Git，并使用项目所在机器上
-已经安装的工具链。
+WebCodex 让 ChatGPT、Claude 和其他 MCP 客户端直接使用你自己机器上的仓库与开发工具。
+Runner 在仓库所在机器上执行文件、Git、命令与测试操作；仓库本身不需要搬到聊天服务端。
 
-参见[最新版本](https://github.com/yyjeqhc/webcodex/releases/latest)和
-[文档索引](docs/INDEX.zh-CN.md)。
+## 用一个仓库快速试起来
 
-## 能做什么
-
-- **文件与源码查看** —— 在已注册项目中读取、搜索、列出文件。
-- **受保护的编辑** —— 在项目边界内执行结构化文件编辑和受校验的补丁。
-- **Git** —— 状态、diff 与聚焦提交的准备。
-- **命令与测试** —— 有界的 shell 命令与结构化校验（Rust、Node、Python、Go）。
-- **长任务 Job** —— 超出单轮聊天的任务会以可观察、可查询的 Job 继续运行。
-- **多台 Runner 机器与多项目** —— 一个 Server 可以把工作路由到多台持有仓库的机器。
-- **MCP** —— 从 ChatGPT、Claude 或任意 MCP 客户端接入。
-- **可选的 GPT Actions** —— 面向 Custom GPT 的 OpenAPI 集成。
-
-实际可用能力取决于 Server surface、Runner 能力和你配置的权限。
-
-## 工作方式
-
-```text
-AI 客户端
-   |
-   | MCP / HTTPS（或 GPT Actions）
-   v
-WebCodex Server
-   |
-   | 已认证的 Runner 连接
-   v
-webcodex-runner
-   |
-   仓库 / Git / 工具链
-```
-
-Server 负责认证调用方并路由工具请求；真正的文件、Git 和命令操作由持有仓库的
-Runner 机器完成。仓库与本地工具链留在 Runner 主机上，连接中只传输当前工具调用
-所需的输入与结果。
-
-## 快速开始
-
-三种常见路径：
-
-**1. 把仓库接入已有的 Server**
+默认的临时公网分享依赖
+[`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/)。先安装它并确保在
+`PATH` 中，然后执行：
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 cd /path/to/your/repository
-webcodex connect https://your-server.example
-```
-
-`connect` 把当前目录作为项目，创建本地 profile，启动 detached Runner，并输出
-MCP URL 与生成的 key。把 URL 和 key 填入 MCP client 后即可提出真实任务。
-
-**2. 临时分享一个本地项目**
-
-```bash
 webcodex share
 ```
 
-`share` 启动本地 Server + Runner 和 Cloudflare Quick Tunnel，并输出本次会话的
-临时 HTTPS `/mcp` URL 与 Bearer credential。它面向开发与测试，不适合生产。
+`share` 是完整入口：它会配置当前 Git 项目、启动本地 WebCodex Server + Runner、创建
+临时 Connector credential，并打开 Cloudflare Quick Tunnel。第一次使用**不需要**先运行
+`setup`、`doctor` 或 `run`。
 
-**3. 自托管一个 Server**
+命令显示 **WebCodex ready** 后保持终端运行，并按它输出的值配置 ChatGPT：
 
-在常在线主机上部署 server-only Docker/Compose，在前面配置稳定的 HTTPS 域名，
-然后在每台持有仓库的机器上用 `webcodex login` 接入为 Runner。
+1. 在 ChatGPT 中启用 **Developer Mode**，创建基于 MCP 的 **custom app**。
+2. 填入输出的 **MCP URL**。
+3. 认证选择 **Access token / API key** 或等价的 Bearer token 选项。
+4. 填入输出的临时 **Credential**。
+5. 点击 **Scan Tools**。
+6. 第一条消息先用只读、安全的请求，例如：
 
-每条路径的详细步骤见[快速开始](docs/QUICK_START.zh-CN.md)，完整生产部署见
-[部署指南](docs/DEPLOYMENT.zh-CN.md)。
+```text
+检查这个仓库并总结它的结构。先不要做任何修改。
+```
+
+ChatGPT 的 UI 文案可能随 workspace 与 rollout 改变；当前这次运行到底该填哪个 URL、
+认证类型和 credential，以 CLI 成功输出为准。
+
+默认 `share` 的 URL 与 credential 都是临时的，命令退出后失效。仅做本地 MCP 调试时可用
+`webcodex share --tunnel none`，此模式不需要 `cloudflared`。
+
+## 第一次连接以后
+
+WebCodex 可以读取/搜索文件、准备受保护的修改、运行命令与聚焦校验、查看 Git，并让长时间
+Job 保持可观察。底层权限边界不会因为 onboarding 简化而改变。打开 `/console` 可以查看
+项目就绪状态与工作队列；Console 在相应状态下可以 Guide、Cancel、Accept 或 Reject，
+但不会显示 credential。
+
+## 已有 Server 与长期部署
+
+只有在你**已经拥有** WebCodex Server URL 时，才使用长期 `connect` 路径：
+
+```bash
+cd /path/to/your/repository
+webcodex connect https://webcodex.example
+```
+
+`connect` 会创建可复用的本地 profile、启动 Runner、等待项目在该 Server 上可见，并输出
+MCP 配置值。它是已有 Server 的长期路径，不是本地试用 WebCodex 的前置条件。
+
+`webcodex login` 与 managed OAuth 是需要独立用户身份、撤销、审计或组织级控制时的高级
+身份路径。自托管属于 operator 工作流，见[部署指南](docs/DEPLOYMENT.zh-CN.md)。
+
+## 工作方式
+
+```text
+ChatGPT / Claude / MCP client
+            |
+            | MCP / HTTPS
+            v
+      WebCodex Server
+            |
+            | 已认证 Runner 连接
+            v
+     webcodex-runner
+            |
+      仓库 / Git / 工具链
+```
+
+Server 负责认证与路由；真正的工作由仓库所在机器上的 Runner 执行。连接中只传输当前工具
+调用需要的输入与结果。
 
 ## CLI
 
-`webcodex` CLI 覆盖项目设置、Server 与 Runner 生命周期、设备接入和运维检查。
-常用命令示例：
+普通用户优先需要这些命令：
 
 ```bash
-webcodex connect https://your-server.example   # 把仓库接入 hosted Server
-webcodex share                                 # 临时分享本地项目
-webcodex login https://your-server.example --code <wc_pair_...>
-webcodex setup                                 # project-first 本地设置
-webcodex doctor                                # 只读就绪检查
-webcodex run                                   # 启动 project-bound runtime
-webcodex agent status --profile <profile>      # 查看 Runner
-webcodex ops status                            # 只读运维检查
-webcodex task list                             # 查看任务并在本地决策
+webcodex share                     # 最快的临时 ChatGPT/MCP 接入
+webcodex connect <server-url>      # 接入已有 Server
+webcodex status                    # 简洁项目就绪状态
+webcodex doctor                    # 更完整的本地诊断
+webcodex setup                     # 手动/本地项目设置
+webcodex run                       # 手动启动本地 Server + Runner
+webcodex task list                 # 审查本地任务
 ```
 
-完整命令、术语与凭据见 [CLI 参考](docs/CLI.zh-CN.md)。
-
-## 让 AI agent 帮你搭建
-
-更愿意让 coding agent 来配置 WebCodex？把本仓库交给它，并请它先阅读
-`docs/AI_ONBOARDING.zh-CN.md`。可以直接复制的提示：
-
-```text
-阅读 docs/AI_ONBOARDING.zh-CN.md，帮我接入或部署 WebCodex。
-先核实当前机器与已有配置。
-不要打印或复制任何密钥；需要我输入凭据时告诉我。
-```
-
-两份指南用途不同：
-
-- `docs/AI_ONBOARDING.md`（及中文版）面向帮助**用户**安装、接入或部署 WebCodex
-  的 AI agent。
-- `AGENTS.md` 面向**开发 WebCodex 本身**的 AI coding agent。
+Runner 是执行组件。为了兼容现有 CLI，Runner 服务管理仍使用历史命名空间
+`webcodex agent ...`。operator 命令与 credential reference 见 [CLI](docs/CLI.zh-CN.md)。
 
 ## 文档
 
-- [快速开始](docs/QUICK_START.zh-CN.md) —— 最短可用的接入路径
-- [AI 接入指南](docs/AI_ONBOARDING.zh-CN.md) —— 供 AI agent 帮你搭建
-- [CLI](docs/CLI.zh-CN.md) —— 命令、术语、凭据
+- [快速开始](docs/QUICK_START.zh-CN.md) —— 第一次 ChatGPT/MCP 接入
+- [MCP](docs/MCP.zh-CN.md) —— 先讲 ChatGPT/Claude 与认证，再进入协议参考
+- [AI 接入指南](docs/AI_ONBOARDING.zh-CN.md) —— 供 AI 帮用户配置 WebCodex
+- [CLI](docs/CLI.zh-CN.md) —— 命令、兼容说明与凭据
 - [部署指南](docs/DEPLOYMENT.zh-CN.md) —— 自托管与生产运维
-- [认证模型](docs/AUTH_MODEL.zh-CN.md) —— 凭据与令牌
-- [Runner](docs/RUNNER.zh-CN.md) —— Runner/agent 是什么，以及如何运维
-- [MCP](docs/MCP.zh-CN.md) —— 接入 MCP 客户端，包括 Grok Custom Connector OAuth
-- [Coding 工作流](docs/CODING_WORKFLOW.zh-CN.md) —— bootstrap、behavioral guidance、validation 与 closeout
+- [认证模型](docs/AUTH_MODEL.zh-CN.md) —— credential 与 authority 模型
+- [Runner](docs/RUNNER.zh-CN.md) —— Runner 运维
+- [Coding 工作流](docs/CODING_WORKFLOW.zh-CN.md)
 - [故障排查](docs/TROUBLESHOOTING.zh-CN.md)
-- [架构](docs/ARCHITECTURE.md)
+- [文档索引](docs/INDEX.zh-CN.md)
 - [安全](SECURITY.md)
 
 ## 安全
 
-WebCodex 可以修改文件并执行命令，因此应把已连接的客户端视为对已配置机器拥有
-真实开发权限的助手。只注册允许助手访问的项目根目录，不要把令牌写进 prompt、
-日志或 Git，Runner 优先使用普通 OS 用户。完整说明见 [SECURITY.md](SECURITY.md)。
+WebCodex 可以修改文件并执行命令。只注册允许助手访问的项目根目录，不要把 credential 写进
+prompt、日志或 Git，并优先让 Runner 使用普通 OS 用户。onboarding 的简化不会合并底层真实
+不同的 credential/authority。完整模型见 [SECURITY.md](SECURITY.md)。
 
 ## 从源码构建
 

--- a/crates/webcodex-cli/src/webcodex_cli/connect/oauth.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/oauth.rs
@@ -451,6 +451,7 @@ fn render_oauth_output(
     runtime_project_id: &str,
     config_path: &Path,
     log_path: &Path,
+    oauth_profile_path: &Path,
     oauth: &OAuthConnectProfile,
     metadata: &OAuthServerMetadata,
     disclose_client_secret: bool,
@@ -458,17 +459,20 @@ fn render_oauth_output(
     let secret_line = if disclose_client_secret {
         format!("Client secret: {}\n", oauth.oauth_client_secret)
     } else {
-        String::new()
+        format!(
+            "Credential source: protected OAuth client profile at {} (client secret not reprinted).\n",
+            oauth_profile_path.display()
+        )
     };
     format!(
-        "Connected to WebCodex\n\nServer:       {server_url}\nMCP URL:      {server_url}/mcp\nProfile:      {profile}\nClient:       {client_id}\nProject:      {runtime_project_id}\nRunner:       running\nConfig:       {}\nLogs:         {}\n\nAuthentication: OAuth 2.0 Authorization Code + PKCE S256\nIssuer:        {}\nAuthorization: {}\nToken endpoint: {}\nClient ID:     {}\n{secret_line}Redirect URI:  {}\nScopes:        {} offline_access\n\nThe OAuth client is managed-user-owned on the remote Server. The Runner uses a separate Agent token and OAuth credentials are never sent to Agent transport.\n",
+        "WebCodex connected\n\nWhat to do next\n1. In ChatGPT Developer Mode, create a custom MCP app.\n2. MCP URL: {server_url}/mcp\n3. Authentication: OAuth 2.0 Authorization Code + PKCE S256\n4. Client ID: {}\n5. {secret_line}6. Redirect URI: {}\n7. Scan Tools and complete browser authorization.\n8. First prompt: \"Inspect this repository and summarize its structure. Do not make changes.\"\n\nDetails\nServer:          {server_url}\nRunner:          running\nProfile:         {profile}\nClient:          {client_id}\nRuntime project: {runtime_project_id}\nConfig:          {}\nLogs:            {}\nIssuer:          {}\nAuthorization:   {}\nToken endpoint:  {}\nScopes:          {} offline_access\n\nThe OAuth client is managed-user-owned on the remote Server. The Runner uses a separate Runner token and OAuth credentials are never sent to Runner transport.\n",
+        oauth.oauth_client_id,
+        oauth.oauth_redirect_uri,
         config_path.display(),
         log_path.display(),
         metadata.issuer,
         metadata.authorization_endpoint,
         metadata.token_endpoint,
-        oauth.oauth_client_id,
-        oauth.oauth_redirect_uri,
         oauth.allowed_scopes.join(" "),
     )
 }
@@ -499,6 +503,7 @@ fn build_oauth_connect_result(
             runtime_project_id,
             config_path,
             log_path,
+            &profile_dir.join(OAUTH_PROFILE_FILE),
             oauth,
             metadata,
             disclose_client_secret,
@@ -1402,12 +1407,18 @@ mod tests {
             "agent:runner:project",
             Path::new("agent.toml"),
             Path::new("runner.log"),
+            Path::new("/protected/profile/oauth-client.toml"),
             &oauth,
             &metadata,
             false,
         );
         assert!(!reused.contains("wc_csec_existing"));
         assert!(!reused.contains("Client secret:"));
+        assert!(reused.starts_with("WebCodex connected\n\nWhat to do next"));
+        assert!(reused.find("MCP URL:").unwrap() < reused.find("Details").unwrap());
+        assert!(reused.contains("Credential source:"));
+        assert!(reused.contains("/protected/profile/oauth-client.toml"));
+        assert!(reused.contains("not reprinted"));
 
         let created = render_oauth_output(
             "https://example.test",
@@ -1416,10 +1427,13 @@ mod tests {
             "agent:runner:project",
             Path::new("agent.toml"),
             Path::new("runner.log"),
+            Path::new("/protected/profile/oauth-client.toml"),
             &oauth,
             &metadata,
             true,
         );
         assert!(created.contains("Client secret: wc_csec_existing"));
+        assert_eq!(created.matches("wc_csec_existing").count(), 1);
+        assert!(created.find("Client secret:").unwrap() < created.find("Details").unwrap());
     }
 }

--- a/crates/webcodex-cli/src/webcodex_cli/connect/output.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/output.rs
@@ -11,31 +11,112 @@ pub(super) fn render_connect_output(
     log_path: &Path,
     resolved_key: &ResolvedKey,
 ) -> String {
+    let credential = if resolved_key.generated {
+        format!("{} (shown once)", resolved_key.value)
+    } else if resolved_key.recovered_profile.is_some() {
+        format!(
+            "saved shared key in {} (top-level token; not reprinted)",
+            config_path.display()
+        )
+    } else {
+        "the shared key supplied to this command (not reprinted)".to_string()
+    };
     let mut output = String::new();
-    output.push_str("Connected to WebCodex\n\n");
-    output.push_str(&format!("Server:       {}\n", server_url));
-    output.push_str(&format!("MCP URL:      {}/mcp\n", server_url));
-    output.push_str(&format!("Profile:      {profile}\n"));
-    output.push_str(&format!("Client:       {client_id}\n"));
-    output.push_str(&format!("Project:      {runtime_project_id}\n"));
-    output.push_str("Runner:       running\n");
-    output.push_str(&format!("Config:       {}\n", config_path.display()));
-    output.push_str(&format!("Logs:         {}\n", log_path.display()));
+    output.push_str("WebCodex connected\n\nWhat to do next\n");
+    output.push_str("1. In ChatGPT Developer Mode, create a custom MCP app.\n");
+    output.push_str(&format!("2. MCP URL: {}/mcp\n", server_url));
+    output.push_str("3. Authentication: Bearer token\n");
+    output.push_str(&format!("4. Credential: {credential}\n"));
+    output.push_str("5. Scan Tools.\n");
+    output.push_str(
+        "6. First prompt: \"Inspect this repository and summarize its structure. Do not make changes.\"\n",
+    );
     if resolved_key.warn_short {
         output.push_str(
             "\nWarning: the supplied shared key is short; use a long random value when possible.\n",
         );
     }
     if resolved_key.generated {
-        output.push_str(&format!("\nMCP key: {}\n", resolved_key.value));
         output.push_str(
-            "Copy this key now. It will not be printed in full by status commands.\n\
-Use the same key in your MCP client.\n",
+            "\nCopy this credential now. It will not be printed in full by status commands.\n",
         );
     }
-    output.push_str(&format!(
-        "\nMCP URL: {}/mcp\nAuthentication: Bearer token\nToken: the same key used by this command\n",
-        server_url
-    ));
+    output.push_str("\nDetails\n");
+    output.push_str(&format!("Server:          {server_url}\n"));
+    output.push_str("Runner:          running\n");
+    output.push_str(&format!("Profile:         {profile}\n"));
+    output.push_str(&format!("Client:          {client_id}\n"));
+    output.push_str(&format!("Runtime project: {runtime_project_id}\n"));
+    output.push_str(&format!("Config:          {}\n", config_path.display()));
+    output.push_str(&format!("Logs:            {}\n", log_path.display()));
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(value: &str, generated: bool, recovered_profile: Option<&str>) -> ResolvedKey {
+        ResolvedKey {
+            value: value.to_string(),
+            generated,
+            recovered_profile: recovered_profile.map(str::to_string),
+            warn_short: false,
+        }
+    }
+
+    #[test]
+    fn generated_key_output_prioritizes_chatgpt_setup_and_discloses_once() {
+        let secret = "wck_generated_once_for_test";
+        let output = render_connect_output(
+            "https://webcodex.example",
+            "profile",
+            "runner",
+            "agent:runner:project",
+            Path::new("agent.toml"),
+            Path::new("runner.log"),
+            &key(secret, true, None),
+        );
+        assert!(output.starts_with("WebCodex connected\n\nWhat to do next"));
+        assert_eq!(output.matches("https://webcodex.example/mcp").count(), 1);
+        assert_eq!(output.matches(secret).count(), 1);
+        assert!(output.contains("Authentication: Bearer token"));
+        assert!(output.contains("Scan Tools"));
+        assert!(output.contains("First prompt:"));
+        assert!(output.find("What to do next").unwrap() < output.find("Details").unwrap());
+    }
+
+    #[test]
+    fn existing_key_output_never_reprints_secret() {
+        let secret = "wck_existing_never_print";
+        let output = render_connect_output(
+            "https://webcodex.example",
+            "profile",
+            "runner",
+            "agent:runner:project",
+            Path::new("agent.toml"),
+            Path::new("runner.log"),
+            &key(secret, false, None),
+        );
+        assert!(!output.contains(secret));
+        assert!(output.contains("shared key supplied to this command"));
+        assert!(!output.contains("Copy this credential now"));
+    }
+
+    #[test]
+    fn recovered_profile_output_points_to_credential_source_without_reprinting_it() {
+        let secret = "wck_recovered_never_print";
+        let output = render_connect_output(
+            "https://webcodex.example",
+            "profile",
+            "runner",
+            "agent:runner:project",
+            Path::new("/protected/profile/agent.toml"),
+            Path::new("runner.log"),
+            &key(secret, false, Some("profile")),
+        );
+        assert!(!output.contains(secret));
+        assert!(output.contains("saved shared key in /protected/profile/agent.toml"));
+        assert!(output.contains("top-level token; not reprinted"));
+    }
 }

--- a/crates/webcodex-cli/src/webcodex_cli/connect/shared_key_oauth.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/shared_key_oauth.rs
@@ -420,6 +420,37 @@ fn bridge_scope_output(profile: &SharedKeyOAuthProfile) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
+fn bridge_browser_authorization_key_line(resolved_key: &ResolvedKey, config_path: &Path) -> String {
+    if resolved_key.generated {
+        format!(
+            "Browser authorization key: {}\nEnter this key only on the WebCodex authorize page; do not put it in ChatGPT.\n",
+            resolved_key.value
+        )
+    } else if resolved_key.recovered_profile.is_some() {
+        format!(
+            "Browser authorization key source: {} (top-level token; not reprinted).\nEnter that key only on the WebCodex authorize page; do not put it in ChatGPT.\n",
+            config_path.display()
+        )
+    } else {
+        "Browser authorization key: use the shared key supplied to this command on the WebCodex authorize page; do not put it in ChatGPT.\n".to_string()
+    }
+}
+
+fn bridge_client_secret_line(
+    oauth: &SharedKeyOAuthProfile,
+    disclose_client_secret: bool,
+    state_path: &Path,
+) -> String {
+    if disclose_client_secret {
+        format!("Client secret: {}\n", oauth.client_secret)
+    } else {
+        format!(
+            "Credential source: protected OAuth client profile at {} (client secret not reprinted).\n",
+            state_path.display()
+        )
+    }
+}
+
 pub(super) async fn finish_shared_key_oauth_connect(
     opts: &ConnectOptions,
     server_url: &str,
@@ -482,30 +513,19 @@ pub(super) async fn finish_shared_key_oauth_connect(
     if disclose_client_secret {
         disclosure_markers.push(secret_marker);
     }
-    let key_line = if resolved_key.generated {
-        format!(
-            "Browser authorization key: {}\nEnter this key only on the WebCodex authorize page; do not put it in ChatGPT.\n",
-            resolved_key.value
-        )
-    } else {
-        "Browser authorization key: use the existing shared key for this hosted profile on the WebCodex authorize page.\n".to_string()
-    };
-    let secret_line = if disclose_client_secret {
-        format!("Client secret: {}\n", oauth.client_secret)
-    } else {
-        String::new()
-    };
+    let key_line = bridge_browser_authorization_key_line(resolved_key, config_path);
+    let secret_line = bridge_client_secret_line(&oauth, disclose_client_secret, &state_path);
     let authorization_endpoint = bridge_authorization_endpoint(&metadata)?;
     let scope_lines = bridge_scope_output(&oauth);
     let output = format!(
-        "Connected to WebCodex\n\nServer:       {server_url}\nMCP URL:      {server_url}/mcp\nProfile:      {profile}\nClient:       {runner_client_id}\nProject:      {runtime_project_id}\nRunner:       running\nConfig:       {}\nLogs:         {}\n\nChatGPT OAuth: Authorization Code + PKCE S256\nIssuer:        {}\nAuthorization: {}\nToken endpoint: {}\nOAuth client ID: {}\n{secret_line}Redirect URI:  {}\n{scope_lines}\n{key_line}The Runner continues to use the direct shared key. ChatGPT receives only OAuth credentials/tokens; OAuth access tokens remain invalid on Agent transport.\n",
+        "WebCodex connected\n\nWhat to do next\n1. In ChatGPT Developer Mode, create a custom MCP app.\n2. MCP URL: {server_url}/mcp\n3. Authentication: OAuth 2.0 Authorization Code + PKCE S256\n4. OAuth client ID: {}\n5. {secret_line}6. Redirect URI: {}\n7. Scan Tools and complete the WebCodex browser authorization flow.\n{key_line}8. First prompt: \"Inspect this repository and summarize its structure. Do not make changes.\"\n\nDetails\nServer:          {server_url}\nRunner:          running\nProfile:         {profile}\nClient:          {runner_client_id}\nRuntime project: {runtime_project_id}\nConfig:          {}\nLogs:            {}\nIssuer:          {}\nAuthorization:   {}\nToken endpoint:  {}\n{scope_lines}\nThe Runner continues to use the direct shared key. ChatGPT receives only OAuth credentials/tokens; OAuth access tokens remain invalid on Runner transport.\n",
+        oauth.client_id,
+        oauth.redirect_uri,
         config_path.display(),
         log_path.display(),
         metadata.issuer,
         authorization_endpoint,
         metadata.token_endpoint,
-        oauth.client_id,
-        oauth.redirect_uri,
     );
     Ok(ConnectResult {
         output,
@@ -872,6 +892,50 @@ mod tests {
             ..enabled
         };
         assert!(profile_scope_ceiling_is_valid(&full_enabled));
+    }
+
+    #[test]
+    fn shared_key_oauth_credential_lines_preserve_first_disclosure_and_recovery_sources() {
+        let oauth = SharedKeyOAuthProfile {
+            version: BRIDGE_PROFILE_VERSION,
+            server_url: "https://server.example".to_string(),
+            client_id: "wc_client_test".to_string(),
+            client_secret: "wc_csec_test_once".to_string(),
+            redirect_uri: "https://chatgpt.example/callback".to_string(),
+            allowed_scopes: vec!["runtime:read".to_string()],
+            computer_permissions_enabled: false,
+            local_mcp_enabled: false,
+        };
+        let state_path = Path::new("/protected/profile/shared-key-oauth.toml");
+        let first = bridge_client_secret_line(&oauth, true, state_path);
+        assert_eq!(first.matches("wc_csec_test_once").count(), 1);
+        let reused = bridge_client_secret_line(&oauth, false, state_path);
+        assert!(!reused.contains("wc_csec_test_once"));
+        assert!(reused.contains("/protected/profile/shared-key-oauth.toml"));
+        assert!(reused.contains("not reprinted"));
+
+        let generated = ResolvedKey {
+            value: "wck_browser_once".to_string(),
+            generated: true,
+            recovered_profile: None,
+            warn_short: false,
+        };
+        let generated_line =
+            bridge_browser_authorization_key_line(&generated, Path::new("agent.toml"));
+        assert_eq!(generated_line.matches("wck_browser_once").count(), 1);
+
+        let recovered = ResolvedKey {
+            value: "wck_browser_hidden".to_string(),
+            generated: false,
+            recovered_profile: Some("profile".to_string()),
+            warn_short: false,
+        };
+        let recovered_line = bridge_browser_authorization_key_line(
+            &recovered,
+            Path::new("/protected/profile/agent.toml"),
+        );
+        assert!(!recovered_line.contains("wck_browser_hidden"));
+        assert!(recovered_line.contains("/protected/profile/agent.toml"));
     }
 
     #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
@@ -91,7 +91,9 @@ fn common_help_entrypoints_smoke() {
             &["--help"],
             &[
                 "Usage: webcodex <COMMAND>",
-                "Project:",
+                "Start here:",
+                "share",
+                "connect",
                 "server init|install|run|start|stop|restart|status|logs|uninstall",
                 "setup single-user",
             ],
@@ -119,6 +121,19 @@ fn common_help_entrypoints_smoke() {
             );
         }
     }
+}
+
+#[test]
+fn top_level_help_prioritizes_first_run_without_hiding_advanced_commands() {
+    let out = cli_exit(["--help"]).unwrap();
+    let start_here = out.find("Start here:").unwrap();
+    let share = out.find("\nshare").unwrap();
+    let connect = out.find("\nconnect").unwrap();
+    let operator = out.find("Operator / service management:").unwrap();
+    assert!(start_here < share && share < connect && connect < operator);
+    assert!(out.contains("cloudflared"));
+    assert!(out.contains("historical `agent` namespace"));
+    assert!(out.contains("agent-tokens create|"));
 }
 
 #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
@@ -304,11 +304,11 @@ fn help_moves_client_enroll_to_advanced_and_keeps_login_as_the_primary_entry() {
                 "help missing client enroll: {stdout}"
             );
             assert!(
-                stdout.contains("Advanced / Compatibility"),
+                stdout.contains("Advanced / compatibility"),
                 "help missing Advanced section: {stdout}"
             );
             // client enroll must sit under the advanced section, after it.
-            let advanced = stdout.find("Advanced / Compatibility").unwrap();
+            let advanced = stdout.find("Advanced / compatibility").unwrap();
             let enroll = stdout.find("client enroll").unwrap();
             assert!(
                 enroll > advanced,

--- a/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
@@ -132,6 +132,7 @@ fn top_level_help_prioritizes_first_run_without_hiding_advanced_commands() {
     let operator = out.find("Operator / service management:").unwrap();
     assert!(start_here < share && share < connect && connect < operator);
     assert!(out.contains("cloudflared"));
+    assert!(out.contains("Windows -> use `webcodex connect <server-url>`"));
     assert!(out.contains("historical `agent` namespace"));
     assert!(out.contains("agent-tokens create|"));
 }

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -1,40 +1,40 @@
 pub(crate) fn usage() -> &'static str {
     "Usage: webcodex <COMMAND>\n\n\
 Unified command-line interface for WebCodex.\n\n\
-Project:\n\
-  setup                         Configure the current Git project\n\
-  doctor                        Diagnose project readiness\n\
+Start here:\n\
+  share                         Share the current project for ChatGPT/MCP over HTTPS\n\
+  connect                       Connect the current project to an existing Server\n\
   status                        Show concise project coding readiness\n\
-  run                           Run the current project runtime and local Agent\n\
-  share                         Temporarily share the local project over HTTPS\n\n\
-Account (quick start):\n\
-  connect                       Connect a local project to a hosted Server\n\
+  doctor                        Diagnose project readiness\n\n\
+Project (local/manual):\n\
+  setup                         Configure the current Git project without starting it\n\
+  run                           Run the project-bound Server and Runner locally\n\
   disconnect                    Disconnect a local project from its hosted Server\n\
+  task                          Review tasks and make host-local decisions\n\n\
+Account / identity (advanced):\n\
   login                         Log this device into a server (one-time pairing code)\n\
   logout                        Remove this device's credentials\n\
   auth status                   Show login status\n\n\
-Server:\n\
+Operator / service management:\n\
   server init|install|run|start|stop|restart|status|logs|uninstall\n\
-                                Configure and manage the Server service\n\n\
-Agent:\n\
+                                Configure and manage the Server service\n\
   agent init|install|run|start|stop|restart|status|logs|uninstall\n\
-                                Configure and manage the standalone Agent service\n\n\
-Operations:\n\
-  task                          Review tasks and make host-local decisions\n\
+                                Manage the Runner service (historical `agent` namespace)\n\
   ops status|agents|projects|smoke-preflight\n\
                                 Read-only operator workflow checks\n\n\
-Advanced / Compatibility:\n\
+Advanced / compatibility:\n\
   pairing create                Create a client enrollment code\n\
   client enroll                 Enroll this machine (advanced; prefer `webcodex login`)\n\
   users create|list             Manage users\n\
   tokens create|create-local|generate|register-hash|list|revoke\n\
                                 Manage personal API tokens\n\
   agent-tokens create|create-local|register-hash|list|revoke\n\
-                                Manage Agent tokens\n\
+                                Manage Runner tokens\n\
   setup single-user             Run the existing single-user bootstrap flow\n\n\
 Options:\n\
   -h, --help                    Print help and exit\n\
-  -V, --version                 Print version and exit\n"
+  -V, --version                 Print version and exit\n\n\
+For a first ChatGPT connection, install `cloudflared`, `cd` into a repository, and run `webcodex share`.\n"
 }
 
 pub(crate) fn connect_usage() -> &'static str {

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -2,7 +2,7 @@ pub(crate) fn usage() -> &'static str {
     "Usage: webcodex <COMMAND>\n\n\
 Unified command-line interface for WebCodex.\n\n\
 Start here:\n\
-  share                         Share the current project for ChatGPT/MCP over HTTPS\n\
+  share                         Share the current project for ChatGPT/MCP over HTTPS (Linux/macOS)\n\
   connect                       Connect the current project to an existing Server\n\
   status                        Show concise project coding readiness\n\
   doctor                        Diagnose project readiness\n\n\
@@ -34,7 +34,7 @@ Advanced / compatibility:\n\
 Options:\n\
   -h, --help                    Print help and exit\n\
   -V, --version                 Print version and exit\n\n\
-For a first ChatGPT connection, install `cloudflared`, `cd` into a repository, and run `webcodex share`.\n"
+First ChatGPT connection: Linux/macOS -> install `cloudflared` and run `webcodex share`; Windows -> use `webcodex connect <server-url>` with a remote Linux Server.\n"
 }
 
 pub(crate) fn connect_usage() -> &'static str {

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -2,170 +2,143 @@
 
 [English](AI_ONBOARDING.md) | [简体中文](AI_ONBOARDING.zh-CN.md)
 
-This guide is for an AI coding agent helping a **user** connect a local
-repository to WebCodex or deploy a WebCodex Server. It is not the same as
-[`AGENTS.md`](../AGENTS.md), which is for an AI coding agent **developing
-WebCodex itself**.
+This guide is for an AI coding agent helping a **user** connect a repository to
+WebCodex or operate an existing deployment. It is not [`AGENTS.md`](../AGENTS.md),
+which governs development of WebCodex itself.
 
-Choose one path before running commands, and verify the current machine and
-existing configuration before changing anything.
+The default user goal is: **"let ChatGPT work with this repository."** Do not
+introduce Server deployment, client ids, runtime project ids, PATs, Runner tokens,
+or OAuth scope ceilings unless the user's chosen path actually requires them.
 
-## Decision tree
+## Choose the smallest path
 
-1. Does the user want the fastest connection to one or more repositories,
-   without operating a Server?
-   - Yes: use **Hosted shared key** and `webcodex connect`.
-2. Does the user need an individual account, device-level authorization,
-   independent token revocation, identity audit, or organization management?
-   - Yes: use the **Managed flow** and `webcodex login`.
-3. Does the user need full infrastructure control, an internal network, their
-   own HTTPS or identity system, or no dependency on the official Server?
-   - Yes: use **Full self-hosting** and read
-     [Deployment](DEPLOYMENT.md).
+1. The user has one local repository and wants to try ChatGPT/MCP now, with no
+   existing WebCodex Server URL: use **`webcodex share`**.
+2. The user already has a WebCodex Server URL and wants a persistent repository
+   connection: use **`webcodex connect <server>`**.
+3. The user needs separate identity, independent revocation, audit, or managed
+   users: use the managed identity path (`webcodex login` / managed OAuth).
+4. The user needs infrastructure control, private networking, stable HTTPS, or
+   their own identity system: use [Deployment](DEPLOYMENT.md).
 
-Do not deploy a WebCodex Server for the hosted path.
+Do not invent `https://your-server.example` as a prerequisite for a new user.
 
-## Fastest connection: hosted shared key
+## First-time ChatGPT path: `share`
 
-Run on the machine that owns the repository:
+Verify Git and the target repository, then verify that `cloudflared` is installed
+for the default public share. If it is absent, point the user to Cloudflare's
+official downloads rather than installing third-party executables silently.
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 cd /path/to/your/repository
-webcodex connect https://your-server.example
+webcodex share
 ```
 
-The current directory is the default project. The command generates the shared
-key unless the user explicitly supplies `--key-file` or `--key`. Configure the
-MCP client from the values printed after the connection check succeeds:
+`share` performs project setup itself. Do not teach `setup → doctor → run → stop
+run → share` as the onboarding sequence.
 
-```text
-MCP URL: https://your-server.example/mcp
-Authentication: Bearer token
-Bearer token: the generated key
-```
+When the CLI reports **WebCodex ready**, tell the human to keep that terminal open
+and follow the printed **What to do next** section:
 
-`connect` performs the complete local setup: it creates or reuses a profile
-scoped to that origin and key, generates a unique client ID, registers the
-local project, writes a `0600` Runner config, starts one detached Runner, and
-waits until the same key can see the Runner and target project. Running the
-same command again reuses the profile and live Runner.
+- ChatGPT Developer Mode → create an MCP custom app.
+- paste the printed MCP URL.
+- select the authentication type printed by the CLI.
+- the **human** pastes the printed credential into ChatGPT.
+- Scan Tools.
+- first prompt: `Inspect this repository and summarize its structure. Do not make changes.`
 
-For automation, prefer `--key-file <path>` over passing a key in shell
-history. Do not pass `--key` and `--key-file` together.
+For local-only debugging, `webcodex share --tunnel none` avoids the Cloudflare
+Quick Tunnel and does not require `cloudflared`.
 
-## Automatic key
+## Existing Server path: `connect`
 
-When `--key`/`--key-file` is omitted, `connect` generates a `wck_...` key with
-more than 256 bits of randomness, stores it in the protected profile, and
-prints the complete value only when first created. Tell the user to copy it
-immediately into the MCP client. A repeat connection recovers the local
-profile and does not print the key again.
-
-The key is stored as the top-level `token` field in
-`~/.config/webcodex/clients/<profile>/agent.toml` (or
-`$XDG_CONFIG_HOME/webcodex/clients/<profile>/agent.toml`). If the user lost
-the printed value, have the human copy it from that field; as an AI agent,
-locate the file and point the user at it — do not echo the value into chat.
-
-The detached Runner survives terminal closure but not a machine reboot. After
-reboot, rerun the same `connect` or use `webcodex agent start --profile
-<profile>`.
-
-The inverse operation is `webcodex disconnect [--project PATH] [--profile NAME]`.
-Use it when the user wants to unregister one hosted repository without deleting or modifying the
-repository, `.git`, the profile credential, `agent.toml`, or sibling projects. It resolves the
-canonical repository path exactly; if several hosted profiles match, let the command fail closed
-and ask the user to choose one with `--profile` rather than guessing. A live Runner is unregistered
-through the structured Server/Runner lifecycle before the local registration is removed.
-
-## Managed flow
-
-Use the managed flow when the user needs a separate user identity, token
-revocation, device-level authorization, identity audit, or organization
-administration:
+Only use this path when a real Server URL is already available:
 
 ```bash
-webcodex login https://your-server.example --code <wc_pair_...> \
+cd /path/to/your/repository
+webcodex connect https://webcodex.example
+```
+
+`connect` creates/reuses a profile, starts a detached Runner, waits for the same
+identity to see the Runner and project, then prints the MCP setup values before
+diagnostic details. If the command generates a shared key, it is printed in full
+only on its permitted first disclosure. A repeat connection reuses the protected
+profile without redisclosing the key.
+
+The inverse operation is:
+
+```bash
+webcodex disconnect
+```
+
+It unregisters only the exact canonical repository; do not delete the checkout,
+`.git`, profile credential, or sibling project registrations.
+
+## OAuth and managed identity are opt-in complexity
+
+Use `share --auth oauth` or `connect --auth oauth` only when the client requires
+OAuth and the exact callback URL is known. Do not collapse OAuth client secrets,
+shared keys, Project Credentials, PATs, or Runner tokens into one concept.
+
+Use the managed flow when the user explicitly needs user identity, revocation,
+device authorization, audit, or organization administration:
+
+```bash
+webcodex login https://webcodex.example --code <wc_pair_...> \
   --allowed-root "$HOME/git"
 ```
 
-The managed flow uses a pairing/account credential, a PAT for MCP/API, and a
-separately bound Runner token. Do not replace that split with a shared key.
+The managed path intentionally keeps user/API authority separate from Runner
+transport authority. See [Authentication](AUTH_MODEL.md) and [MCP](MCP.md) for
+the reference model.
 
-## Full self-hosting
+## What the AI may inspect
 
-Use [Deployment](DEPLOYMENT.md) when the user needs complete Server and data
-control, an internal-network deployment, their own HTTPS endpoint, their own
-identity system, or no dependency on the official Server. That path includes
-Server, database/state, reverse proxy, TLS, service, and credential operations;
-none of those are prerequisites for hosted `webcodex connect`.
+Safe non-secret observations include:
 
-## What the AI agent may inspect
+- repository path and Git status;
+- Server URL;
+- profile/state/log **paths**;
+- service status via `webcodex agent status` / `webcodex server status`;
+- `webcodex status` and `webcodex doctor` output;
+- the location of a token file, but not its contents.
 
-You may safely locate and read **non-secret** configuration:
+`doctor` is a local/manual runtime diagnostic. If it recommends `webcodex run`,
+do not reinterpret that as a prerequisite for hosted ChatGPT; use `share` for the
+first hosted-chat path.
 
-- profile path: `~/.config/webcodex/clients/<profile>/` (or
-  `$XDG_CONFIG_HOME/webcodex/clients/<profile>/`)
-- Runner state and log path:
-  `~/.local/state/webcodex/clients/<profile>/` (or
-  `$XDG_STATE_HOME/webcodex/clients/<profile>/`)
-- token **file** path (not its contents): e.g. `webcodex-user-token`
-- env file **path** and variable **name** (e.g. `WEBCODEX_TOKEN` in the server
-  env file) — not the value
-- server URL
-- service status via `webcodex agent status` / `webcodex server status`
-- `webcodex doctor` output
-
-Useful non-secret commands:
-
-```bash
-webcodex agent status --profile <profile>
-webcodex agent logs --profile <profile> --lines 100
-webcodex status
-webcodex doctor
-webcodex ops status --server-url <url> --token-file <path> --strict
-```
-
-## What the human must copy or paste
+## Secrets remain human-controlled
 
 Do **not** read back, print, log, commit, or echo into chat:
 
-- full token values (shared key, PAT, Runner token, account credential,
-  bootstrap token, OAuth secrets)
-- full `agent.toml` contents
-- server env files
-- `Authorization` headers
-- OAuth client secrets
+- shared keys, PATs, Runner tokens, account credentials, bootstrap tokens;
+- Project Credentials;
+- OAuth client secrets;
+- full `agent.toml` contents or Server env files;
+- `Authorization` headers.
 
-When a secret must be entered into ChatGPT/Claude or another client, tell the
-**human** exactly which local file/value to copy. For example: "Copy the value
-from `~/.config/webcodex/<server>/<user>/webcodex-user-token` into the Bearer
-field." Do not read the file yourself and paste its contents into the chat.
+When a credential must be entered into ChatGPT/Claude, identify the source
+precisely and ask the **human** to copy it. The successful `share`/`connect` output
+is the preferred first-disclosure source. If a stored value must be recovered,
+point the user to the exact protected file/field without echoing it yourself.
+Status/log commands intentionally do not reveal secrets.
 
-### Credential rules for AI agents
+Never substitute a `wc_agent_*` Runner token for an MCP token, never use a
+bootstrap `WEBCODEX_TOKEN` as an MCP credential, and never assume offline
+`webcodex token generate` material is registered on a remote Server.
 
-- Never run `webcodex token generate` and assume a remote Server will accept
-  its output. It creates offline material only; it does not register it.
-- Never use a `wc_*` value as a hosted shared key. Unknown or revoked managed
-  credentials do not fall back to shared-key auth.
-- Never substitute a `wc_agent_*` for an MCP token.
-- Never paste a bootstrap `WEBCODEX_TOKEN` into MCP or a local hosted profile.
-- Never print, log, commit, or copy a full `agent.toml`.
-- Run `connect` before configuring MCP, so the full Runner/project path is
-  verified first.
+## Troubleshooting
 
-## Local state and troubleshooting
+Use the CLI's actionable error first. For established state, inspect only the
+minimum non-secret diagnostics needed:
 
-For a normal non-root user, profile configuration defaults below
-`~/.config/webcodex/clients/<profile>/`; Runner state and logs below
-`~/.local/state/webcodex/clients/<profile>/`. The hosted Runner writes
-`runner.log` in that profile state directory and rotates it while running at
-approximately 10 MiB, keeping `runner.log`, `runner.log.1`, and
-`runner.log.2` (all `0600` on Unix). `agent logs --lines` reads bounded tails;
-`--follow` reopens `runner.log` after rotation.
+```bash
+webcodex status
+webcodex doctor
+webcodex agent status --profile <profile>
+webcodex agent logs --profile <profile> --lines 100
+```
 
-On connection failure, use the profile and log path printed by `connect`.
-Check Server reachability, shared-key enablement, exact key equality, client ID
-collision, and project-path validity. Status and logs do not print the key. See
-[Troubleshooting](TROUBLESHOOTING.md) for stable failure guidance.
+See [Troubleshooting](TROUBLESHOOTING.md) for stable failure codes and operator
+checks.

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -12,8 +12,13 @@ or OAuth scope ceilings unless the user's chosen path actually requires them.
 
 ## Choose the smallest path
 
-1. The user has one local repository and wants to try ChatGPT/MCP now, with no
-   existing WebCodex Server URL: use **`webcodex share`**.
+Check the platform before choosing the path. Windows does not support the local
+Server runtime used by `webcodex share`; on Windows, use `connect` when a remote
+Linux Server already exists, or guide the user through Linux Server deployment
+first. Do not recommend `share` on Windows.
+
+1. On Linux/macOS, the user has one local repository and wants to try ChatGPT/MCP
+   now, with no existing WebCodex Server URL: use **`webcodex share`**.
 2. The user already has a WebCodex Server URL and wants a persistent repository
    connection: use **`webcodex connect <server>`**.
 3. The user needs separate identity, independent revocation, audit, or managed

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -44,7 +44,10 @@ webcodex share
 run → share` as the onboarding sequence.
 
 When the CLI reports **WebCodex ready**, tell the human to keep that terminal open
-and follow the printed **What to do next** section:
+and follow the printed **What to do next** section. Before promising write access,
+remember that ChatGPT Developer Mode, custom MCP apps, and write/modify actions
+are controlled by the user's ChatGPT plan, workspace, and admin settings; these
+client-side permissions are separate from WebCodex authorization:
 
 - ChatGPT Developer Mode → create an MCP custom app.
 - paste the printed MCP URL.

--- a/docs/AI_ONBOARDING.zh-CN.md
+++ b/docs/AI_ONBOARDING.zh-CN.md
@@ -11,8 +11,12 @@ ceiling。
 
 ## 选择最小路径
 
-1. 用户只有一个本地仓库、想马上试 ChatGPT/MCP，并且没有现成 WebCodex Server URL：
-   使用 **`webcodex share`**。
+先检查平台再选路径。Windows 不支持 `webcodex share` 所需的本地 Server runtime；
+Windows 已有远程 Linux Server 时使用 `connect`，没有 Server 时先引导用户部署 Linux
+Server。不要在 Windows 上推荐 `share`。
+
+1. 在 Linux/macOS 上，用户只有一个本地仓库、想马上试 ChatGPT/MCP，并且没有现成
+   WebCodex Server URL：使用 **`webcodex share`**。
 2. 用户已经有 WebCodex Server URL，需要长期连接：使用
    **`webcodex connect <server>`**。
 3. 用户明确需要独立身份、独立撤销、审计或 managed user：使用 managed identity

--- a/docs/AI_ONBOARDING.zh-CN.md
+++ b/docs/AI_ONBOARDING.zh-CN.md
@@ -2,149 +2,131 @@
 
 [English](AI_ONBOARDING.md) | [简体中文](AI_ONBOARDING.zh-CN.md)
 
-本文面向帮助**用户**把本地仓库接入 WebCodex 或部署 WebCodex Server 的 AI coding
-agent。它与 [`AGENTS.md`](../AGENTS.md) 不同——后者面向**开发 WebCodex 本身**的
-AI coding agent。
+本文面向帮助**用户**把仓库接入 WebCodex 或操作已有部署的 AI coding agent。它不是
+[`AGENTS.md`](../AGENTS.md)；后者约束的是 WebCodex 自身开发。
 
-执行命令前先选择一条路径，并在改动任何配置前核实当前机器与已有配置。
+默认用户目标应理解为：**“让 ChatGPT 操作这个仓库。”** 除非用户选择的路径确实需要，
+不要提前引入 Server 部署、client id、runtime project id、PAT、Runner token 或 OAuth scope
+ceiling。
 
-## 决策树
+## 选择最小路径
 
-1. 用户只想最快地把一个或多个仓库接入，且不需要自己运维 Server？
-   - 是：使用 **Hosted shared key** 与 `webcodex connect`。
-2. 用户需要独立账号、设备级授权、独立令牌撤销、身份审计或组织管理？
-   - 是：使用 **Managed flow** 与 `webcodex login`。
-3. 用户需要完整基础设施控制、内网、自有 HTTPS 或身份系统，或不依赖官方
-   Server？
-   - 是：使用 **Full self-hosting**，阅读[部署指南](DEPLOYMENT.zh-CN.md)。
+1. 用户只有一个本地仓库、想马上试 ChatGPT/MCP，并且没有现成 WebCodex Server URL：
+   使用 **`webcodex share`**。
+2. 用户已经有 WebCodex Server URL，需要长期连接：使用
+   **`webcodex connect <server>`**。
+3. 用户明确需要独立身份、独立撤销、审计或 managed user：使用 managed identity
+   （`webcodex login` / managed OAuth）。
+4. 用户需要基础设施控制、内网、稳定 HTTPS 或自有身份系统：使用
+   [部署指南](DEPLOYMENT.zh-CN.md)。
 
-hosted 路径不需要部署 WebCodex Server。
+不要把虚构的 `https://your-server.example` 当作全新用户的前置条件。
 
-## 最快接入：hosted shared key
+## 第一次 ChatGPT 接入：`share`
 
-在持有仓库的机器上执行：
+先确认 Git 和目标仓库；默认公网 share 还要确认 `cloudflared` 已安装。如果缺少它，告诉用户
+使用 Cloudflare 官方下载，不要静默增加“自动下载第三方 executable”的行为。
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 cd /path/to/your/repository
-webcodex connect https://your-server.example
+webcodex share
 ```
 
-当前目录是默认项目。除非用户显式提供 `--key-file` 或 `--key`，命令会生成共享
-key。连接检查通过后，用输出的值配置 MCP client：
+`share` 自己会完成项目 setup。不要把
+`setup → doctor → run → 停掉 run → share` 教成 onboarding 主流程。
 
-```text
-MCP URL: https://your-server.example/mcp
-Authentication: Bearer token
-Bearer token: 生成的 key
-```
+CLI 显示 **WebCodex ready** 后，让人类保持终端运行，并按 **What to do next**：
 
-`connect` 完成完整本地设置：创建或复用 profile、生成唯一 client ID、注册本地
-项目、写入 `0600` Runner 配置、启动一个 detached Runner，并等待同一 key 能看到
-Runner 与目标项目。再次运行同一命令会复用 profile 与存活 Runner。
+- ChatGPT Developer Mode → 创建 MCP custom app；
+- 粘贴输出的 MCP URL；
+- 选择 CLI 输出的认证类型；
+- 由**人类**把输出的 credential 粘贴到 ChatGPT；
+- Scan Tools；
+- 第一条：`检查这个仓库并总结它的结构。先不要做任何修改。`
 
-自动化场景优先用 `--key-file <path>`，避免 key 进入 shell 历史。不要同时传
-`--key` 与 `--key-file`。
+仅做本地调试时可用 `webcodex share --tunnel none`，不启动 Cloudflare Quick Tunnel，也不
+需要 `cloudflared`。
 
-## 自动 key
+## 已有 Server：`connect`
 
-省略 `--key`/`--key-file` 时，`connect` 会生成超过 256 位随机性的 `wck_...`
-key，保存在受保护 profile 中，只在首次创建时完整打印。请让用户立刻把它复制到
-MCP client。重复连接会恢复本地 profile 且不再打印 key。
-
-key 存放在 `~/.config/webcodex/clients/<profile>/agent.toml`（或
-`$XDG_CONFIG_HOME/webcodex/clients/<profile>/agent.toml`）的顶层 `token`
-字段中。如果用户丢失了打印出来的值，请让人类从该字段复制；作为 AI agent，
-请定位文件并把位置告诉用户——不要把值回显到聊天里。
-
-detached Runner 能存活到终端关闭，但不能跨越机器重启。重启后，重新运行同一条
-`connect` 或使用 `webcodex agent start --profile <profile>`。
-
-逆操作是 `webcodex disconnect [--project PATH] [--profile NAME]`。当用户只想注销一个
-hosted 仓库时使用它；它不会删除或修改仓库、`.git`、profile credential、`agent.toml`
-或同 profile 下的其他项目。它严格按 canonical 仓库路径匹配；若多个 hosted profile
-都匹配，应让命令 fail closed 并请用户用 `--profile` 选择，而不是猜测。Runner 在线时，
-必须先通过 structured Server/Runner lifecycle 完成注销，再删除本地 registration。
-
-## Managed flow
-
-用户需要独立身份、令牌撤销、设备级授权、身份审计或组织管理时使用：
+只有真实 Server URL 已存在时才走这条路径：
 
 ```bash
-webcodex login https://your-server.example --code <wc_pair_...> \
+cd /path/to/your/repository
+webcodex connect https://webcodex.example
+```
+
+`connect` 创建/复用 profile、启动 detached Runner、等待同一身份能看到 Runner 与项目，
+然后先输出 MCP 配置，再输出诊断 Details。若自动生成 shared key，完整值只在允许的首次
+disclosure 中显示；重复连接复用受保护 profile，不再次泄露 key。
+
+逆操作：
+
+```bash
+webcodex disconnect
+```
+
+它只注销 canonical 路径精确匹配的仓库；不要删除 checkout、`.git`、profile credential 或
+同 profile 的其他项目注册。
+
+## OAuth 与 managed identity 是按需复杂度
+
+只有 MCP client 要求 OAuth 且精确 callback URL 已知时，才使用 `share --auth oauth` 或
+`connect --auth oauth`。不要把 OAuth client secret、shared key、Project Credential、PAT
+或 Runner token 合并成一个概念。
+
+用户明确需要 user identity、revocation、device authorization、audit 或组织管理时才走：
+
+```bash
+webcodex login https://webcodex.example --code <wc_pair_...> \
   --allowed-root "$HOME/git"
 ```
 
-managed flow 使用 pairing/account 凭据、用于 MCP/API 的 PAT，以及独立绑定的
-Runner 令牌。不要用共享 key 替代这套拆分。
+managed 路径故意把 user/API authority 与 Runner transport authority 分开。reference 见
+[认证模型](AUTH_MODEL.zh-CN.md)和 [MCP](MCP.zh-CN.md)。
 
-## 完全自托管
+## AI 可以检查什么
 
-当用户需要完整的 Server 与数据控制、内网部署、自有 HTTPS endpoint、自有身份
-系统或不依赖官方 Server 时，使用[部署指南](DEPLOYMENT.zh-CN.md)。该路径包含
-Server、数据库/状态、反向代理、TLS、服务与凭据操作；这些都不是 hosted
-`webcodex connect` 的前提。
+可以安全观察的非 secret 信息包括：
 
-## AI agent 可以检查什么
+- 仓库路径和 Git 状态；
+- Server URL；
+- profile/state/log **路径**；
+- `webcodex agent status` / `webcodex server status`；
+- `webcodex status` 与 `webcodex doctor` 输出；
+- token 文件的位置，但不是其内容。
 
-你可以安全地定位并读取**非敏感**配置：
+`doctor` 是本地/手动 runtime 诊断。即使它推荐 `webcodex run`，也不要把这解释成 hosted
+ChatGPT 的前置条件；第一次 hosted-chat 路径用 `share`。
 
-- profile 路径：`~/.config/webcodex/clients/<profile>/`（或
-  `$XDG_CONFIG_HOME/webcodex/clients/<profile>/`）
-- Runner 状态与日志路径：
-  `~/.local/state/webcodex/clients/<profile>/`（或
-  `$XDG_STATE_HOME/webcodex/clients/<profile>/`）
-- 令牌**文件路径**（不是内容）：如 `webcodex-user-token`
-- env 文件**路径**与变量**名**（例如 server env 文件里的 `WEBCODEX_TOKEN`）——
-  不是值
-- server URL
-- 服务状态：`webcodex agent status` / `webcodex server status`
-- `webcodex doctor` 输出
+## Secret 仍由人类控制
 
-有用的非敏感命令：
+**不要**回读、打印、记录、提交或在聊天中回显：
+
+- shared key、PAT、Runner token、account credential、bootstrap token；
+- Project Credential；
+- OAuth client secret；
+- 完整 `agent.toml` 或 Server env 文件；
+- `Authorization` header。
+
+需要把 credential 填进 ChatGPT/Claude 时，要准确说明来源并让**人类**复制。首次优先使用
+成功的 `share`/`connect` disclosure；若必须恢复已保存的值，只指出精确受保护文件/字段，
+不要由 AI 自己回显。status/log 命令故意不显示 secret。
+
+永远不要用 `wc_agent_*` Runner token 替代 MCP token，不要把 bootstrap
+`WEBCODEX_TOKEN` 当作 MCP credential，也不要假设 `webcodex token generate` 的离线素材
+已经在远程 Server 注册。
+
+## 故障排查
+
+优先使用 CLI 的 actionable error。已有状态时只读取最小必要的非 secret 诊断：
 
 ```bash
-webcodex agent status --profile <profile>
-webcodex agent logs --profile <profile> --lines 100
 webcodex status
 webcodex doctor
-webcodex ops status --server-url <url> --token-file <path> --strict
+webcodex agent status --profile <profile>
+webcodex agent logs --profile <profile> --lines 100
 ```
 
-## 必须由人类复制或粘贴的内容
-
-**不要**回读、打印、记录、提交或在聊天里回显：
-
-- 完整令牌值（共享 key、PAT、Runner token、account credential、bootstrap
-  token、OAuth secret）
-- 完整 `agent.toml` 内容
-- server env 文件
-- `Authorization` 头
-- OAuth client secret
-
-当某个 secret 必须填入 ChatGPT/Claude 或其他客户端时，请告诉**人类**具体该复制
-哪个本地文件/值。例如："请把 `~/.config/webcodex/<server>/<user>/webcodex-user-token`
-里的值复制到 Bearer 字段。" 不要自己读取文件并把内容粘贴进聊天。
-
-### 面向 AI agent 的凭据规则
-
-- 永远不要运行 `webcodex token generate` 并假设远程 Server 会接受其输出。它只
-  生成离线素材，不会注册。
-- 永远不要用 `wc_*` 值作为 hosted 共享 key。未知或已撤销的 managed 凭据不会
-  回退到 shared-key 认证。
-- 永远不要用 `wc_agent_*` 替代 MCP 令牌。
-- 永远不要把 bootstrap `WEBCODEX_TOKEN` 粘贴进 MCP 或本地 hosted profile。
-- 永远不要打印、记录、提交或复制完整 `agent.toml`。
-- 配置 MCP 前先运行 `connect`，确保完整 Runner/project 路径先被验证。
-
-## 本地状态与故障排查
-
-普通非 root 用户：profile 配置默认在 `~/.config/webcodex/clients/<profile>/`；
-Runner 状态与日志在 `~/.local/state/webcodex/clients/<profile>/`。hosted Runner
-会写 `runner.log`，运行期间约 10 MiB 轮转，只保留 `runner.log`、
-`runner.log.1`、`runner.log.2`（Unix 上均为 `0600`）。`agent logs --lines` 读取
-有界尾部；`--follow` 会在轮转后重新打开 `runner.log`。
-
-连接失败时，使用 `connect` 打印的 profile 与日志路径。检查 Server 可达性、
-shared-key 是否启用、key 是否完全一致、client ID 冲突与项目路径有效性。status
-与 logs 不会打印 key。稳定的失败指引见[故障排查](TROUBLESHOOTING.zh-CN.md)。
+稳定错误码与 operator 检查见[故障排查](TROUBLESHOOTING.zh-CN.md)。

--- a/docs/AI_ONBOARDING.zh-CN.md
+++ b/docs/AI_ONBOARDING.zh-CN.md
@@ -40,7 +40,10 @@ webcodex share
 `share` 自己会完成项目 setup。不要把
 `setup → doctor → run → 停掉 run → share` 教成 onboarding 主流程。
 
-CLI 显示 **WebCodex ready** 后，让人类保持终端运行，并按 **What to do next**：
+CLI 显示 **WebCodex ready** 后，让人类保持终端运行，并按 **What to do next**。不要在未确认
+前承诺 write 能力：ChatGPT Developer Mode、custom MCP app 与 write/modify action 受用户的
+ChatGPT 套餐、workspace 和管理员设置控制，这些客户端侧权限与 WebCodex authorization 是
+两层独立边界：
 
 - ChatGPT Developer Mode → 创建 MCP custom app；
 - 粘贴输出的 MCP URL；

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,6 +20,12 @@ The CLI produces three binaries when built from source:
 `webcodex --help` lists the top-level namespaces. The sections below explain
 what each namespace is for.
 
+For a first ChatGPT connection, the normal entry is simply `webcodex share` in
+the repository. It performs project setup, starts the local Server and Runner,
+and exposes a temporary HTTPS MCP endpoint. The default Quick Tunnel requires
+`cloudflared` on `PATH`; the command checks that prerequisite before creating
+project/share state and reports an installation link if it is missing.
+
 ## Command map
 
 ### Project / local workflow
@@ -28,15 +34,15 @@ These commands work on the current Git project.
 
 | Command | Purpose | Notes |
 | --- | --- | --- |
-| `webcodex setup` | Configure the current Git project for project-first use | Creates private state and a Project Credential; does not start services. |
-| `webcodex doctor` | Read-only readiness checks for the current project | Reports a stable `next action`; use `--json` for the structured projection. |
-| `webcodex run` | Start the project-bound loopback Server and local Runner | Foreground; Ctrl-C stops both. |
-| `webcodex status` | Concise project coding readiness | Short summary; `doctor` is the full check. |
-| `webcodex share` | Share the local project over HTTPS | Defaults to a temporary Bearer credential; `--auth oauth --oauth-redirect-uri <URL>` enables project-bound OAuth. |
-| `webcodex connect <server>` | Connect the current project to an existing Server | Defaults to hosted shared-key; `--auth oauth --oauth-redirect-uri <URL>` bridges that same shared-key identity into ChatGPT OAuth without a managed login. |
+| `webcodex share` | Share the current project for ChatGPT/MCP over HTTPS | First-run path; includes setup and starts the local Server + Runner. Default Quick Tunnel requires `cloudflared`. |
+| `webcodex connect <server>` | Connect the current project to an existing Server | Long-lived path when you already have a Server URL; defaults to hosted shared-key. |
+| `webcodex status` | Concise project coding readiness | Short summary; `doctor` is the full diagnostic check. |
+| `webcodex doctor` | Read-only readiness checks for the current project | Diagnostics/manual workflow; reports a stable `next action`. |
+| `webcodex setup` | Configure the current Git project without starting it | Local-only/manual workflow; creates private state and a Project Credential. |
+| `webcodex run` | Start the project-bound loopback Server and local Runner | Local-only/manual workflow; foreground, Ctrl-C stops both. |
 | `webcodex disconnect [--project PATH] [--profile NAME]` | Remove one hosted project registration | Exact inverse of `connect` for that repository; never removes the repository or `.git`. |
 
-`webcodex share --auth oauth --oauth-redirect-uri <exact-callback>` uses OAuth 2.0 Authorization Code with PKCE S256. The OAuth client ID/secret are persisted in protected project state for that project + callback, while authorization codes, access tokens, refresh tokens, and the temporary Project Credential are fenced to the current `share` process. Restarting `share` therefore invalidates old OAuth grants without changing the Connector's stable project identity. OAuth access tokens are never accepted on Runner/Agent transport.
+`webcodex share --auth oauth --oauth-redirect-uri <exact-callback>` uses OAuth 2.0 Authorization Code with PKCE S256. The OAuth client ID/secret are persisted in protected project state for that project + callback, while authorization codes, access tokens, refresh tokens, and the temporary Project Credential are fenced to the current `share` process. Restarting `share` therefore invalidates old OAuth grants without changing the Connector's stable project identity. OAuth access tokens are never accepted on Runner transport.
 
 Quick Tunnel origins remain temporary. For an operator-managed stable HTTPS origin, use `--tunnel none --public-url https://share.example` and route that origin to the loopback WebCodex Server yourself; `--public-url` advertises the external origin/issuer and does not create a proxy or tunnel.
 
@@ -179,11 +185,6 @@ normal entry points.
 - **CLI** — the `webcodex` command described here.
 - **Runner** — the `webcodex-runner` process on the machine that owns the
   repositories. It executes the actual work.
-- **Agent / agent CLI namespace** — the CLI namespace `webcodex agent ...`
-  manages the Runner. "Agent" and "Runner" refer to the same execution
-  component, not the same program: `webcodex` and `webcodex-runner` are
-  separate executables. The term "agent" survives from the older
-  `webcodex-agent` name.
 - **profile** — a named local client configuration (paths, `agent.toml`,
   tokens) under the user's WebCodex config directory. `webcodex connect`
   creates one; `webcodex agent ... --profile <name>` targets it.
@@ -230,8 +231,8 @@ quick answer.
 | --- | --- | --- | --- | --- |
 | Server bootstrap token | (env `WEBCODEX_TOKEN`) | `webcodex server init` | server/admin setup, user creation, pairing | GPT Actions, MCP, Runner, daily use |
 | Shared key | `wck_...` | `webcodex connect` (generated once) | hosted shared-key MCP + Runner | production IAM |
-| Project Credential | (private file) | `webcodex setup` | the one project's Connector + Agent | other projects, admin |
-| Account credential | `wc_acct_...` | `webcodex users create --issue-credential` | local token creation | GPT Actions, MCP, agent |
+| Project Credential | (private file) | `webcodex setup` | the one project's Connector + Runner | other projects, admin |
+| Account credential | `wc_acct_...` | `webcodex users create --issue-credential` | local token creation | GPT Actions, MCP, Runner |
 | Personal API token (PAT) | `wc_pat_...` | `webcodex token create-local` | GPT Actions, MCP, REST API | Runner connectivity |
 | Runner token | `wc_agent_...` | `webcodex agent-token create-local` | `webcodex-runner` transport only | MCP, REST, GPT Actions |
 | OAuth access token | `wc_oat_...` | OAuth2 authorization flow | GPT Actions / MCP when OAuth is enabled | — |
@@ -315,7 +316,14 @@ and `wc_oat_*` access tokens are delegated credentials; see
 
 ## Common examples
 
-Project-first workflow:
+First ChatGPT/MCP connection:
+
+```bash
+cd /path/to/your/repository
+webcodex share
+```
+
+Local/manual workflow:
 
 ```bash
 webcodex setup
@@ -327,7 +335,7 @@ webcodex task show <task-id>
 webcodex task accept <task-id>
 ```
 
-Hosted connection:
+Existing hosted Server:
 
 ```bash
 webcodex connect https://your-server.example

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,11 +20,13 @@ The CLI produces three binaries when built from source:
 `webcodex --help` lists the top-level namespaces. The sections below explain
 what each namespace is for.
 
-For a first ChatGPT connection, the normal entry is simply `webcodex share` in
-the repository. It performs project setup, starts the local Server and Runner,
-and exposes a temporary HTTPS MCP endpoint. The default Quick Tunnel requires
-`cloudflared` on `PATH`; the command checks that prerequisite before creating
-project/share state and reports an installation link if it is missing.
+For a first ChatGPT connection on Linux/macOS, the normal entry is simply
+`webcodex share` in the repository. It performs project setup, starts the local
+Server and Runner, and exposes a temporary HTTPS MCP endpoint. The default Quick
+Tunnel requires `cloudflared` on `PATH`; the command checks that prerequisite
+before creating project/share state and reports an installation link if it is
+missing. Windows does not support this local Server/share path; use
+`webcodex connect <server-url>` against a remote Linux Server there.
 
 ## Command map
 
@@ -34,7 +36,7 @@ These commands work on the current Git project.
 
 | Command | Purpose | Notes |
 | --- | --- | --- |
-| `webcodex share` | Share the current project for ChatGPT/MCP over HTTPS | First-run path; includes setup and starts the local Server + Runner. Default Quick Tunnel requires `cloudflared`. |
+| `webcodex share` | Share the current project for ChatGPT/MCP over HTTPS | Linux/macOS first-run path; includes setup and starts the local Server + Runner. Unavailable on Windows. Default Quick Tunnel requires `cloudflared`. |
 | `webcodex connect <server>` | Connect the current project to an existing Server | Long-lived path when you already have a Server URL; defaults to hosted shared-key. |
 | `webcodex status` | Concise project coding readiness | Short summary; `doctor` is the full diagnostic check. |
 | `webcodex doctor` | Read-only readiness checks for the current project | Diagnostics/manual workflow; reports a stable `next action`. |

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -16,10 +16,12 @@ Server API 完成。
 
 `webcodex --help` 会列出顶层命名空间。下面按命名空间说明各自的用途。
 
-第一次连接 ChatGPT 时，普通用户通常只需要在仓库中运行 `webcodex share`。它会完成
-项目设置、启动本地 Server 与 Runner，并暴露临时 HTTPS MCP endpoint。默认 Quick
-Tunnel 要求 `cloudflared` 位于 `PATH`；命令会在创建项目/share 状态之前检查这个
-前置条件，缺失时直接给出安装链接与下一步。
+在 Linux/macOS 上第一次连接 ChatGPT 时，普通用户通常只需要在仓库中运行
+`webcodex share`。它会完成项目设置、启动本地 Server 与 Runner，并暴露临时 HTTPS
+MCP endpoint。默认 Quick Tunnel 要求 `cloudflared` 位于 `PATH`；命令会在创建
+项目/share 状态之前检查这个前置条件，缺失时直接给出安装链接与下一步。Windows
+不支持这条本地 Server/share 路径，请改用 `webcodex connect <server-url>` 连接远程
+Linux Server。
 
 ## 命令总览
 
@@ -29,7 +31,7 @@ Tunnel 要求 `cloudflared` 位于 `PATH`；命令会在创建项目/share 状�
 
 | 命令 | 用途 | 说明 |
 | --- | --- | --- |
-| `webcodex share` | 通过 HTTPS 把当前项目接入 ChatGPT/MCP | 首次使用主路径；包含 setup，并启动本地 Server + Runner。默认 Quick Tunnel 需要 `cloudflared`。 |
+| `webcodex share` | 通过 HTTPS 把当前项目接入 ChatGPT/MCP | Linux/macOS 首次使用主路径；包含 setup，并启动本地 Server + Runner。Windows 不可用。默认 Quick Tunnel 需要 `cloudflared`。 |
 | `webcodex connect <server>` | 把当前项目接入已有的 Server | 已经拥有 Server URL 时的长期路径；默认使用 hosted shared-key。 |
 | `webcodex status` | 简洁的项目 coding 就绪状态 | 简短状态；`doctor` 提供完整诊断。 |
 | `webcodex doctor` | 当前项目的只读就绪检查 | 诊断/手动工作流；输出稳定的 `next action`。 |

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -16,6 +16,11 @@ Server API 完成。
 
 `webcodex --help` 会列出顶层命名空间。下面按命名空间说明各自的用途。
 
+第一次连接 ChatGPT 时，普通用户通常只需要在仓库中运行 `webcodex share`。它会完成
+项目设置、启动本地 Server 与 Runner，并暴露临时 HTTPS MCP endpoint。默认 Quick
+Tunnel 要求 `cloudflared` 位于 `PATH`；命令会在创建项目/share 状态之前检查这个
+前置条件，缺失时直接给出安装链接与下一步。
+
 ## 命令总览
 
 ### 项目 / 本地工作流
@@ -24,15 +29,15 @@ Server API 完成。
 
 | 命令 | 用途 | 说明 |
 | --- | --- | --- |
-| `webcodex setup` | 为当前 Git 项目配置 project-first 使用方式 | 创建私有状态与 Project Credential；不启动服务。 |
-| `webcodex doctor` | 当前项目的只读就绪检查 | 输出稳定的 `next action`；用 `--json` 获取结构化结果。 |
-| `webcodex run` | 启动 project-bound loopback Server 与本地 Runner | 前台运行；Ctrl-C 同时停止两者。 |
-| `webcodex status` | 简洁的项目 coding 就绪状态 | `doctor` 提供完整检查。 |
-| `webcodex share` | 通过 HTTPS 分享本地项目 | 默认使用临时 Bearer credential；`--auth oauth --oauth-redirect-uri <URL>` 可启用 project-bound OAuth。 |
-| `webcodex connect <server>` | 把当前项目接入已有的 Server | 默认使用 hosted shared-key；`--auth oauth --oauth-redirect-uri <URL>` 可把同一个 shared-key 身份桥接成 ChatGPT OAuth，不需要 managed login。 |
+| `webcodex share` | 通过 HTTPS 把当前项目接入 ChatGPT/MCP | 首次使用主路径；包含 setup，并启动本地 Server + Runner。默认 Quick Tunnel 需要 `cloudflared`。 |
+| `webcodex connect <server>` | 把当前项目接入已有的 Server | 已经拥有 Server URL 时的长期路径；默认使用 hosted shared-key。 |
+| `webcodex status` | 简洁的项目 coding 就绪状态 | 简短状态；`doctor` 提供完整诊断。 |
+| `webcodex doctor` | 当前项目的只读就绪检查 | 诊断/手动工作流；输出稳定的 `next action`。 |
+| `webcodex setup` | 只配置当前 Git 项目，不启动 runtime | local-only/手动工作流；创建私有状态与 Project Credential。 |
+| `webcodex run` | 启动 project-bound loopback Server 与本地 Runner | local-only/手动工作流；前台运行，Ctrl-C 同时停止两者。 |
 | `webcodex disconnect [--project PATH] [--profile NAME]` | 移除一个 hosted 项目注册 | 是该仓库 `connect` 的精确逆操作；绝不删除仓库或 `.git`。 |
 
-`webcodex share --auth oauth --oauth-redirect-uri <精确回调地址>` 使用 OAuth 2.0 Authorization Code + PKCE S256。OAuth client ID/secret 会按“项目 + 回调地址”保存在受保护的 project state 中；authorization code、access token、refresh token 与临时 Project Credential 则都被 fenced 到当前 `share` 进程。重启 `share` 会让旧 OAuth grant 失效，但不会改变 Connector 的稳定 project identity。OAuth access token 永远不能用于 Runner/Agent transport。
+`webcodex share --auth oauth --oauth-redirect-uri <精确回调地址>` 使用 OAuth 2.0 Authorization Code + PKCE S256。OAuth client ID/secret 会按“项目 + 回调地址”保存在受保护的 project state 中；authorization code、access token、refresh token 与临时 Project Credential 则都被 fenced 到当前 `share` 进程。重启 `share` 会让旧 OAuth grant 失效，但不会改变 Connector 的稳定 project identity。OAuth access token 永远不能用于 Runner transport。
 
 Cloudflare Quick Tunnel 的公网 origin 仍然是临时的。如需稳定 HTTPS origin，可使用 `--tunnel none --public-url https://share.example`，并由 operator 自己把该 origin 反向代理/隧道到 loopback WebCodex Server；`--public-url` 只声明外部 origin/issuer，不会创建代理或 tunnel。
 
@@ -166,10 +171,6 @@ Admin 用户/令牌操作由 Server API 支撑；`auth status` 读取本机连�
 - **Server** —— 负责认证调用方并路由工具请求的 `webcodex-server` 进程。
 - **CLI** —— 本文档介绍的 `webcodex` 命令。
 - **Runner** —— 运行在持有仓库机器上的 `webcodex-runner` 进程，执行实际工作。
-- **Agent / agent CLI 命名空间** —— `webcodex agent ...` 管理的就是 Runner。
-  "Agent" 与 "Runner" 指同一个执行组件，而不是同一个程序：`webcodex` 与
-  `webcodex-runner` 是两个独立可执行文件。"agent" 一词来自旧的 `webcodex-agent`
-  名称。
 - **profile** —— 用户 WebCodex 配置目录下的一个命名客户端配置（路径、
   `agent.toml`、令牌）。`webcodex connect` 会创建一个；
   `webcodex agent ... --profile <name>` 指向它。
@@ -207,8 +208,8 @@ WebCodex 把 bootstrap 管理、账号接入、runtime API 访问与 Runner 连�
 | --- | --- | --- | --- | --- |
 | Server bootstrap token | （env `WEBCODEX_TOKEN`） | `webcodex server init` | server/admin 设置、建用户、pairing | GPT Actions、MCP、Runner、日常使用 |
 | 共享 key | `wck_...` | `webcodex connect`（一次性生成） | hosted shared-key 的 MCP + Runner | 生产 IAM |
-| Project Credential | （私有文件） | `webcodex setup` | 单个项目的 Connector + Agent | 其他项目、admin |
-| Account credential | `wc_acct_...` | `webcodex users create --issue-credential` | 本地创建令牌 | GPT Actions、MCP、agent |
+| Project Credential | （私有文件） | `webcodex setup` | 单个项目的 Connector + Runner | 其他项目、admin |
+| Account credential | `wc_acct_...` | `webcodex users create --issue-credential` | 本地创建令牌 | GPT Actions、MCP、Runner |
 | 个人 API 令牌（PAT） | `wc_pat_...` | `webcodex token create-local` | GPT Actions、MCP、REST API | Runner 连接 |
 | Runner 令牌 | `wc_agent_...` | `webcodex agent-token create-local` | 仅 `webcodex-runner` 传输 | MCP、REST、GPT Actions |
 | OAuth 访问令牌 | `wc_oat_...` | OAuth2 授权流程 | 启用 OAuth 时的 GPT Actions / MCP | — |
@@ -281,7 +282,14 @@ WebCodex 把 bootstrap 管理、账号接入、runtime API 访问与 Runner 连�
 
 ## 常用示例
 
-Project-first 工作流：
+第一次连接 ChatGPT/MCP：
+
+```bash
+cd /path/to/your/repository
+webcodex share
+```
+
+Local/manual 工作流：
 
 ```bash
 webcodex setup
@@ -293,7 +301,7 @@ webcodex task show <task-id>
 webcodex task accept <task-id>
 ```
 
-Hosted 接入：
+已有 hosted Server：
 
 ```bash
 webcodex connect https://your-server.example

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,8 +4,8 @@
 
 This guide covers self-hosting WebCodex in production: building and installing
 the binaries, bootstrapping the Server, enrolling Runner machines, connecting
-MCP/GPT clients, and running smoke checks. For the shortest local-only setup,
-see [Quick Start](QUICK_START.md).
+MCP/GPT clients, and running smoke checks. For the shortest first ChatGPT/MCP
+connection, see [Quick Start](QUICK_START.md).
 
 ## Components
 
@@ -389,10 +389,14 @@ Recommended production smoke sequence:
 
 ### Runtime console
 
-The Server serves a read-only browser console at `/console` showing the shared
-project-readiness projection (Project, Connection, Agent/coding readiness,
-findings, next action). It does not expose the Agent registry or transport
-details and is not a full admin UI.
+The Server serves a host-local browser console at `/console`. It shows project
+readiness, the work queue, Workflow Session activity, visible Runners, and recent
+mutating activity. For Connector tasks, the same host-local human can send task
+guidance, decide pending approvals, cancel work, and Accept or Reject a stable
+result. These actions use the same authority boundaries as the CLI; the online
+model still cannot accept its own work. The console also shows non-secret client
+connection targets, with ChatGPT Developer Mode MCP custom apps as the primary
+ChatGPT path. Credentials are deliberately never returned by the console API.
 
 ### Runtime job API trust model
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,9 +24,10 @@ The documented distribution path is the npm thin installer/wrapper:
 npm install -g @yyjeqhc/webcodex
 ```
 
-Supported package platforms are Linux x64, Linux arm64, macOS arm64, and
-Windows x64. Windows x64 supports the CLI + Runner workflow against a remote
-Linux Server; a long-running Windows Server is not supported. The npm wrapper
+Supported package platforms are Linux x64, Linux arm64, macOS arm64, Windows
+x64, and Windows arm64. Windows x64/arm64 support the CLI + Runner workflow
+against a remote Linux Server; a long-running Windows Server is not supported.
+The npm wrapper
 requires Node.js 18 or newer. Starting with v0.3.5, the native Linux x64
 artifact targets glibc 2.17 or newer.
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -21,9 +21,10 @@ Runner 机器、连接 MCP/GPT 客户端以及 smoke 检查。第一次连接 Ch
 npm install -g @yyjeqhc/webcodex
 ```
 
-支持 Linux x64、Linux arm64、macOS arm64 与 Windows x64。Windows x64 支持针对
-远程 Linux Server 的 CLI + Runner 工作流；不支持长期运行的 Windows Server。
-npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64 native artifact 以
+支持 Linux x64、Linux arm64、macOS arm64、Windows x64 与 Windows arm64。
+Windows x64/arm64 支持针对远程 Linux Server 的 CLI + Runner 工作流；不支持长期
+运行的 Windows Server。npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64
+native artifact 以
 glibc 2.17 或更新为兼容基线。
 
 从源码构建：

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -3,7 +3,7 @@
 [English](DEPLOYMENT.md) | [简体中文](DEPLOYMENT.zh-CN.md)
 
 本文档覆盖 WebCodex 的生产自托管：构建与安装二进制、bootstrap Server、接入
-Runner 机器、连接 MCP/GPT 客户端以及 smoke 检查。最短的纯本地设置见
+Runner 机器、连接 MCP/GPT 客户端以及 smoke 检查。第一次连接 ChatGPT/MCP 的最短路径见
 [快速开始](QUICK_START.zh-CN.md)。
 
 ## 组件
@@ -355,9 +355,12 @@ webcodex ops smoke-preflight --server-url "$SERVER_URL" \
 
 ### Runtime console
 
-Server 在 `/console` 提供只读浏览器 console，展示共享 project-readiness 投影
-（Project、Connection、Agent/coding 就绪、findings、next action）。它不暴露
-Agent registry 或传输细节，也不是完整 admin UI。
+Server 在 `/console` 提供 host-local 浏览器 console。它展示项目就绪状态、工作队列、
+Workflow Session 活动、当前可见 Runner 与近期变更性活动。对于 Connector task，同机
+人类可以发送 task guidance、处理待审批操作、取消工作，并对稳定结果执行 Accept 或
+Reject；这些动作与 CLI 使用相同的权限边界，在线模型仍然不能接受自己的工作。Console
+还会展示不含 secret 的客户端连接目标，并把 ChatGPT Developer Mode MCP custom app
+作为 ChatGPT 主路径。Credential 不会由 console API 返回。
 
 ### Runtime job API 信任模型
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,22 +4,22 @@
 
 ## Getting started
 
-- [README](../README.md) — what WebCodex is and how to get going
+- [README](../README.md) — what WebCodex is and the `webcodex share` first-run path
+- [Quick Start](QUICK_START.md) — shortest path from a local repository to ChatGPT MCP
+- [MCP](MCP.md) — ChatGPT Developer Mode and other MCP client setup
 - [AI-assisted setup](AI_ONBOARDING.md) — have an AI agent configure WebCodex for you
-- [Quick Start](QUICK_START.md) — shortest local setup
-- [CLI](CLI.md) — command map, terminology, and credentials
+
+## Common operation
+
+- [CLI](CLI.md) — command map, compatibility terminology, and credentials
 - [Coding Workflow](CODING_WORKFLOW.md) — canonical task bootstrap, behavioral guidance, validation, and closeout
+- [Runner](RUNNER.md) — operating the Runner on repository machines
 
-## Self-hosting
+## Advanced deployment and integration
 
-- [Deployment](DEPLOYMENT.md) — build, bootstrap the Server, enroll Runners
-- [Authentication](AUTH_MODEL.md) — credentials and tokens
-- [Runner](RUNNER.md) — what the Runner/agent is and how to operate it
-
-## Client integration
-
-- [MCP](MCP.md) — connect MCP clients (ChatGPT, Claude, and others)
-- [GPT Actions](GPT_ACTIONS.md) — OpenAPI-based Custom GPT integration
+- [Deployment](DEPLOYMENT.md) — self-hosting, Server bootstrap, and long-lived Runner enrollment
+- [Authentication](AUTH_MODEL.md) — detailed credential and token boundaries
+- [GPT Actions](GPT_ACTIONS.md) — optional OpenAPI-based Custom GPT integration
 
 ## Understanding WebCodex
 

--- a/docs/INDEX.zh-CN.md
+++ b/docs/INDEX.zh-CN.md
@@ -4,22 +4,22 @@
 
 ## 入门
 
-- [README](../README.zh-CN.md) —— WebCodex 是什么，以及如何开始
+- [README](../README.zh-CN.md) —— WebCodex 是什么，以及 `webcodex share` 首次体验
+- [快速开始](QUICK_START.zh-CN.md) —— 从本地仓库接入 ChatGPT MCP 的最短路径
+- [MCP](MCP.zh-CN.md) —— ChatGPT Developer Mode 与其他 MCP 客户端配置
 - [AI 接入指南](AI_ONBOARDING.zh-CN.md) —— 让 AI agent 帮你配置 WebCodex
-- [快速开始](QUICK_START.zh-CN.md) —— 最短的本地设置
-- [CLI](CLI.zh-CN.md) —— 命令、术语与凭据
+
+## 日常使用
+
+- [CLI](CLI.zh-CN.md) —— 命令、兼容性术语与凭据
 - [Coding 工作流](CODING_WORKFLOW.zh-CN.md) —— canonical task bootstrap、behavioral guidance、validation 与 closeout
+- [Runner](RUNNER.zh-CN.md) —— 在持有仓库的机器上运维 Runner
 
-## 自托管
+## 高级部署与集成
 
-- [部署指南](DEPLOYMENT.zh-CN.md) —— 构建、bootstrap Server、接入 Runner
-- [认证模型](AUTH_MODEL.zh-CN.md) —— 凭据与令牌
-- [Runner](RUNNER.zh-CN.md) —— Runner/agent 是什么，以及如何运维
-
-## 客户端接入
-
-- [MCP](MCP.zh-CN.md) —— 接入 MCP 客户端（ChatGPT、Claude 等）
-- [GPT Actions](GPT_ACTIONS.zh-CN.md) —— 基于 OpenAPI 的 Custom GPT 集成
+- [部署指南](DEPLOYMENT.zh-CN.md) —— 自托管、Server bootstrap 与长期 Runner 接入
+- [认证模型](AUTH_MODEL.zh-CN.md) —— 详细凭据与令牌边界
+- [GPT Actions](GPT_ACTIONS.zh-CN.md) —— 可选的 OpenAPI Custom GPT 集成
 
 ## 理解 WebCodex
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -2,42 +2,78 @@
 
 [English](MCP.md) | [简体中文](MCP.zh-CN.md)
 
-WebCodex can expose more than one MCP model surface. The project-first
-`webcodex run` / `webcodex share` path starts a Server with the project-bound
-`canonical_connector` surface. `webcodex connect <server>` connects to an
-existing hosted Server and uses the MCP surface selected by that Server;
-without Connector configuration, the default is the broader `local_coding`
-surface. Complete [Quick Start](QUICK_START.md) for the project-first flow.
+WebCodex exposes an MCP endpoint so ChatGPT, Claude, and other MCP clients can
+work with a repository through the Runner that owns it. For a first connection,
+start with the client setup below; protocol surfaces and scope ceilings are
+reference material, not onboarding prerequisites.
 
-## Endpoint and authentication
+## ChatGPT Developer Mode: first connection
 
-Local clients can use:
+For the default temporary public path, install
+[`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) and run:
 
-```text
-http://127.0.0.1:<configured-port>/mcp
+```bash
+npm install -g @yyjeqhc/webcodex
+cd /path/to/your/repository
+webcodex share
 ```
 
-Hosted clients need HTTPS. There are three paths:
+When the CLI says **WebCodex ready**:
 
-- **Hosted:** `webcodex connect <server>` uses an existing hosted Server; only
-  the Runner runs locally. Shared-key authentication remains the default.
-  `webcodex connect <server> --auth oauth --oauth-redirect-uri <URL>` bridges
-  that same shared-key group into OAuth for ChatGPT without login, pairing, PAT,
-  or account identity. The Runner keeps using the direct shared key; ChatGPT
-  receives only OAuth client credentials/tokens. The exposed tool set starts
-  from that Server's configured MCP model surface; for OAuth callers, `tools/list`
-  is additionally projected by the access token's actual scopes.
-- **Local Share:** `webcodex share` starts the local Server + Agent and, by
-  default, a Cloudflare Quick Tunnel with a separate temporary Bearer
-  credential. `webcodex share --auth oauth --oauth-redirect-uri <URL>` instead
-  exposes project-bound OAuth 2.0 Authorization Code + PKCE. The OAuth client
-  remains bound to the same project grant, while every code/access/refresh
-  grant is fenced to the current share process. Use `--tunnel none` for local
-  testing or with an operator-managed `--public-url`.
-- **Self-hosted:** use a stable HTTPS domain/tunnel, durable service
-  management, and OAuth or scoped credentials for long-lived operation.
+1. In ChatGPT Developer Mode, create a custom app using MCP.
+2. Paste the printed **MCP URL**.
+3. Choose **Access token / API key** (Bearer token) for the default share.
+4. Paste the printed temporary **Credential**.
+5. Run **Scan Tools**.
+6. Try: `Inspect this repository and summarize its structure. Do not make changes.`
 
-For ordinary hosted `connect`, use its generated/provided shared key directly or bridge that same identity through OAuth. Managed-user deployments may instead use a scoped user API token (`wc_pat_*`) or the explicit `--auth managed-oauth` flow. Do not use the bootstrap/admin token, account credentials, Runner tokens, or the persistent project-first Connector credential as a public sharing secret. `share` creates and prints its own temporary credential for that session.
+The command performs project setup itself. Hosted ChatGPT cannot reach a
+loopback-only `webcodex run`, so `setup`, `doctor`, and `run` are not required
+steps before `share`. ChatGPT UI labels can vary by rollout; use the CLI output
+as the source of truth for URL and authentication.
+
+## Claude and other MCP clients
+
+Use the same printed `/mcp` URL and authentication values. In Claude, add a
+custom connector and paste the MCP URL. Other MCP clients should be configured
+with the same endpoint and the authentication mechanism reported by the CLI.
+For local-only clients, `webcodex share --tunnel none` exposes the loopback MCP
+endpoint without `cloudflared`.
+
+## Existing Server
+
+If you already have a stable WebCodex Server URL, use the long-lived path:
+
+```bash
+webcodex connect https://webcodex.example
+```
+
+`connect` starts/reuses the local Runner and prints the MCP URL and credential
+source after the connection is verified. A generated shared key is fully
+disclosed only on its allowed first output. `status` and log commands do not
+reveal it. Self-hosting is documented in [Deployment](DEPLOYMENT.md).
+
+Bearer/shared-key authentication is the simplest path. When a client requires
+OAuth, use `share --auth oauth` or `connect --auth oauth` with that client's exact
+callback URL and follow the CLI output. Managed-user OAuth remains a separate
+advanced identity flow.
+
+## Advanced / reference
+
+### MCP model surfaces
+
+The project-first `webcodex run` / `webcodex share` path starts a Server with the
+project-bound `canonical_connector` surface. `webcodex connect <server>` uses
+the MCP surface selected by that existing Server; without Connector
+configuration, the default is the broader `local_coding` surface. Operators may
+explicitly select `full_operator_runtime`. These names describe protocol/tool
+contracts; a first-time user does not need to choose among them.
+
+Hosted clients need public HTTPS. `share` supplies a temporary Cloudflare Quick
+Tunnel by default; `connect` uses an existing hosted Server; self-hosted
+deployments provide their own stable HTTPS origin. Do not use bootstrap/admin
+tokens, Runner tokens, or the persistent project-first Connector credential as
+a public sharing secret.
 
 ### Built-in local MCP gateway
 
@@ -46,11 +82,6 @@ A hosted WebCodex Server can also expose Runner-owned local stdio MCP providers 
 No-argument `mcp_tool(action=list)` reports whether a registered logical provider id is uniquely routable (`resolvable` versus `ambiguous`); it is not a provider health check. `list(server=...)` and `describe` perform provider interaction. The outer `/mcp` endpoint's 2025/2026 support is separate from the Runner-to-provider gateway V1 compatibility contract: configured local providers currently use the bounded 2025-06-18 stdio tool subset documented in [Runner](RUNNER.md#provider-side-gateway-v1-compatibility), not an arbitrary/latest transparent MCP bridge. Outer caller request `_meta` is intentionally not forwarded to local providers.
 
 Configure providers on the Runner in `[mcp]`; no additional daemon, sidecar, public resource URL, or per-provider ChatGPT App is required. Local MCP access is guarded by the explicit `mcp:local` scope. Direct shared-key, project, open-anonymous, and legacy OAuth defaults do not acquire that scope. For ordinary hosted shared-key OAuth, `webcodex connect ... --auth oauth --oauth-local-mcp` explicitly adds the class-level authority for current and future local MCP providers in that same shared-key Runner group. A real ceiling change revokes existing grants and requires browser authorization again. Adding or replacing a provider later therefore does not require a new OAuth client/App, but only credentials that previously opted into `mcp:local` may use it.
-
-In ChatGPT Developer Mode, create a custom app with the printed `/mcp` URL.
-If the authentication menu offers **Access token/API key**, choose it, paste
-the bearer credential, and run **Scan Tools**. ChatGPT UI labels and
-availability can vary by workspace and rollout.
 
 ### OAuth2
 
@@ -61,7 +92,7 @@ enabled when offered (it is a protocol-level refresh-token scope and grants no
 extra permission). Server-side OAuth setup is in
 [Deployment](DEPLOYMENT.md#oauth2).
 
-For project-first sharing, the authorization page asks for the temporary Project share credential and issues an `oauth2_project` identity carrying only `runtime:read`, `project:read`, `project:write`, and `job:run`. It does not create a managed user and OAuth tokens cannot be used on Agent transport. Quick Tunnel issuer URLs change between runs; use `--tunnel none --public-url https://...` behind your own stable HTTPS proxy/tunnel when the OAuth issuer must remain stable.
+For project-first sharing, the authorization page asks for the temporary Project share credential and issues an `oauth2_project` identity carrying only `runtime:read`, `project:read`, `project:write`, and `job:run`. It does not create a managed user and OAuth tokens cannot be used on Runner transport. Quick Tunnel issuer URLs change between runs; use `--tunnel none --public-url https://...` behind your own stable HTTPS proxy/tunnel when the OAuth issuer must remain stable.
 
 For an existing hosted Server, ordinary `connect --auth oauth` uses the shared-key OAuth bridge. The OAuth client and every code/access/refresh grant remain bound to the same `shared_key_hash` that groups the direct shared-key Runner/projects/jobs. Direct shared-key bearer authority stays fixed at `runtime:read`, `project:read`, `project:write`, `job:run`, `computer:read`, and `computer:control`. A fresh OAuth client starts with that full baseline, but a protected existing client may retain a narrower valid baseline subset. `--oauth-computer-permissions` appends only `computer:launch`, `computer:display_read`, `computer:pointer_control`, `computer:clipboard_read`, and `computer:clipboard_write` to that existing baseline subset; it never restores an absent baseline scope. The browser consent page leaves every optional permission unchecked and grants only selected permissions that the OAuth request actually requested. Launch consent requires both `computer:read` and `computer:launch`; display requires `computer:read` plus `computer:display_read`; pointer requires `computer:read`, `computer:control`, `computer:display_read`, and `computer:pointer_control`; clipboard read/write likewise require their baseline read/control prerequisite plus the matching optional scope. Missing request prerequisites are unavailable rather than auto-added, so consent, token projection, and runtime scope gates remain statically aligned. A real ceiling change revokes prior grants. `account:manage`, `admin`, `job:detach`, every `agent:*` transport scope, and future scopes remain outside this bridge. `offline_access` is protocol-only. Consent-page Runner capability is evaluated per same connected Runner and is rechecked on POST; it is backend availability, not a promise of OS/native permission or call success. At runtime, OAuth `tools/list` hides tools whose required scopes are absent, while direct `tools/call` authorization and live Runner/native checks remain authoritative. The managed-user flow remains separate as `connect --auth managed-oauth`.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -9,6 +9,10 @@ reference material, not onboarding prerequisites.
 
 ## ChatGPT Developer Mode: first connection
 
+The self-contained `share` path below requires a local WebCodex Server and is
+supported on Linux/macOS. Windows users should connect the Runner to an existing
+remote Linux Server with `webcodex connect <server-url>` instead.
+
 For the default temporary public path, install
 [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) and run:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -34,7 +34,10 @@ When the CLI says **WebCodex ready**:
 The command performs project setup itself. Hosted ChatGPT cannot reach a
 loopback-only `webcodex run`, so `setup`, `doctor`, and `run` are not required
 steps before `share`. ChatGPT UI labels can vary by rollout; use the CLI output
-as the source of truth for URL and authentication.
+as the source of truth for URL and authentication. Developer Mode, custom MCP
+apps, and write/modify actions are controlled independently by the ChatGPT plan,
+workspace, and admin settings; those client-side permissions are not widened by
+WebCodex scopes.
 
 ## Claude and other MCP clients
 

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -2,40 +2,68 @@
 
 [English](MCP.md) | [简体中文](MCP.zh-CN.md)
 
-WebCodex 可以暴露不止一种 MCP model surface。project-first 的
-`webcodex run` / `webcodex share` 会启动带 project-bound
-`canonical_connector` surface 的 Server。`webcodex connect <server>` 则连接
-已有 hosted Server，并使用该 Server 选择的 MCP surface；没有 Connector 配置时，
-默认是更宽的 `local_coding` surface。project-first 流程先看
-[快速开始](QUICK_START.zh-CN.md)。
+WebCodex 通过 MCP endpoint，让 ChatGPT、Claude 与其他 MCP client 使用持有仓库机器上的
+Runner。第一次接入先完成下面的客户端配置；protocol surface 与 scope ceiling 属于
+reference，不是 onboarding 前置知识。
 
-## Endpoint 与认证
+## ChatGPT Developer Mode：第一次接入
 
-本地客户端可用：
+默认临时公网路径先安装
+[`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/)，然后执行：
 
-```text
-http://127.0.0.1:<configured-port>/mcp
+```bash
+npm install -g @yyjeqhc/webcodex
+cd /path/to/your/repository
+webcodex share
 ```
 
-Hosted 客户端需要 HTTPS。有三种路径：
+CLI 显示 **WebCodex ready** 后：
 
-- **Hosted：** `webcodex connect <server>` 使用已有 hosted Server；本地只运行
-  Runner。默认仍使用 shared-key。`webcodex connect <server> --auth oauth
-  --oauth-redirect-uri <URL>` 会把同一个 shared-key group 桥接成 ChatGPT OAuth，
-  不需要 login、pairing、PAT 或 account identity。Runner 继续使用 direct shared key，
-  ChatGPT 只获得 OAuth client credential/token；工具集合先由远端 Server 的 MCP
-  model surface 决定，OAuth caller 的 `tools/list` 还会按 access token 的实际 scopes
-  进一步投影。
-- **本地分享：** `webcodex share` 启动本地 Server + Agent；默认启动 Cloudflare
-  Quick Tunnel 并使用独立的临时 Bearer credential。`webcodex share --auth oauth
-  --oauth-redirect-uri <URL>` 则暴露 project-bound OAuth 2.0 Authorization Code +
-  PKCE。OAuth client 仍绑定同一个 project grant，而 code/access/refresh grant
-  都 fenced 到当前 share 进程。`--tunnel none` 可用于本地测试，或配合 operator
-  管理的 `--public-url` 使用。
-- **自托管：** 使用稳定 HTTPS 域名/tunnel、持久服务管理与 OAuth 或受限凭据进行
-  长期运行。
+1. 在 ChatGPT Developer Mode 创建基于 MCP 的 custom app。
+2. 填入输出的 **MCP URL**。
+3. 默认 share 选择 **Access token / API key**（Bearer token）。
+4. 填入输出的临时 **Credential**。
+5. 点击 **Scan Tools**。
+6. 第一条可先说：`检查这个仓库并总结它的结构。先不要做任何修改。`
 
-普通 hosted `connect` 直接使用其生成/提供的 shared key，或把同一个身份桥接成 OAuth。managed-user 部署也可使用受限 user API token（`wc_pat_*`）或显式 `--auth managed-oauth` 流程。不要把 bootstrap/admin token、account credential、Runner token 或持久 project-first Connector credential 当作公开分享 secret。`share` 会为该会话创建并打印自己的临时 credential。
+`share` 自己会完成 project setup。Hosted ChatGPT 无法访问 loopback-only 的
+`webcodex run`，因此 `setup`、`doctor`、`run` 都不是 `share` 之前的必经步骤。ChatGPT
+UI 文案可能随 rollout 变化；URL 与认证以 CLI 输出为准。
+
+## Claude 与其他 MCP client
+
+使用同一份输出的 `/mcp` URL 与认证值。Claude 中添加 custom connector 并粘贴 MCP URL；
+其他 MCP client 同样使用 CLI 报告的 endpoint 与认证方式。仅本地 client 可用
+`webcodex share --tunnel none`，不需要 `cloudflared`。
+
+## 已有 Server
+
+如果已经拥有稳定的 WebCodex Server URL，使用长期路径：
+
+```bash
+webcodex connect https://webcodex.example
+```
+
+`connect` 会启动/复用本地 Runner，并在连接验证完成后输出 MCP URL 与 credential source。
+自动生成的 shared key 只会在允许的首次输出中完整显示；status/log 不会泄露它。自托管见
+[部署指南](DEPLOYMENT.zh-CN.md)。
+
+Bearer/shared-key 是最简单的路径。客户端要求 OAuth 时，使用 `share --auth oauth` 或
+`connect --auth oauth` 并传入该客户端的精确 callback URL，然后按 CLI 输出配置。managed-user
+OAuth 仍是独立的高级身份路径。
+
+## Advanced / reference
+
+### MCP model surface
+
+project-first 的 `webcodex run` / `webcodex share` 使用 project-bound
+`canonical_connector` surface。`webcodex connect <server>` 使用已有 Server 选择的 MCP
+surface；没有 Connector 配置时默认是更宽的 `local_coding`，operator 还可显式选择
+`full_operator_runtime`。这些名称描述 protocol/tool contract；第一次用户不需要先做选择。
+
+Hosted client 需要公网 HTTPS：`share` 默认提供临时 Cloudflare Quick Tunnel，`connect` 使用
+已有 hosted Server，自托管部署则提供自己的稳定 HTTPS origin。不要把 bootstrap/admin token、
+Runner token 或持久 project-first Connector credential 当作公网 share secret。
 
 ### 内建 local MCP gateway
 
@@ -45,11 +73,6 @@ hosted WebCodex Server 可以继续通过同一个稳定 `/mcp` 暴露 Runner-ow
 
 Runner 在 `[mcp]` 中配置 provider；不需要额外 daemon/sidecar、第二个公网 resource URL 或 per-provider ChatGPT App。local MCP 使用显式 `mcp:local` scope；direct shared-key、project、open-anonymous 与 legacy OAuth 默认权限都不会自动获得它。普通 hosted shared-key OAuth 必须使用 `webcodex connect ... --auth oauth --oauth-local-mcp` 显式加入“同一 shared-key Runner group 内当前及未来本地 MCP provider”的 class-level authority。ceiling 真正变化会撤销旧 grant 并要求重新走浏览器授权。因此以后新增/替换 provider 不需要新建 OAuth client/App，但只有此前明确 opt in `mcp:local` 的 credential 才能访问。
 
-在 ChatGPT Developer Mode 中，用输出的 `/mcp` URL 创建自定义 app。如果认证菜单
-提供 **访问令牌/API 密钥**，选择它并粘贴 bearer credential，然后执行 **Scan
-Tools / 扫描工具**。ChatGPT 的 UI 文案与可用范围可能随 workspace 与 rollout
-变化。
-
 ### OAuth2
 
 当 managed/自托管 Server 启用 OAuth，或使用 `webcodex share --auth oauth` 时，MCP 客户端可以使用 authorization-code
@@ -57,7 +80,7 @@ Tools / 扫描工具**。ChatGPT 的 UI 文案与可用范围可能随 workspace
 URI；宿主提供 `offline_access` 时保持勾选（它是协议级 refresh-token scope，不授予
 额外权限）。服务端 OAuth 设置见[部署指南](DEPLOYMENT.zh-CN.md#oauth2)。
 
-对于 project-first share，授权页要求输入本次临时 Project share credential，并签发只带 `runtime:read`、`project:read`、`project:write`、`job:run` 的 `oauth2_project` 身份；它不会创建 managed user，OAuth token 也不能用于 Agent transport。Quick Tunnel 的 issuer URL 每次运行都会变化；如果 OAuth issuer 必须稳定，请使用 `--tunnel none --public-url https://...` 并在外部配置稳定 HTTPS proxy/tunnel。
+对于 project-first share，授权页要求输入本次临时 Project share credential，并签发只带 `runtime:read`、`project:read`、`project:write`、`job:run` 的 `oauth2_project` 身份；它不会创建 managed user，OAuth token 也不能用于 Runner transport。Quick Tunnel 的 issuer URL 每次运行都会变化；如果 OAuth issuer 必须稳定，请使用 `--tunnel none --public-url https://...` 并在外部配置稳定 HTTPS proxy/tunnel。
 
 对于已有 hosted Server，普通 `connect --auth oauth` 使用 shared-key OAuth bridge。OAuth client 以及 code/access/refresh grant 都绑定到 direct shared-key Runner/projects/jobs 所使用的同一个 `shared_key_hash`。direct shared-key bearer authority 始终固定为 `runtime:read`、`project:read`、`project:write`、`job:run`、`computer:read`、`computer:control`。fresh OAuth client 从完整 baseline 开始，但已有受保护 client 可以保留合法的窄 baseline subset。`--oauth-computer-permissions` 只在该现有 baseline subset 上追加 `computer:launch`、`computer:display_read`、`computer:pointer_control`、`computer:clipboard_read`、`computer:clipboard_write`，不会恢复缺失的 baseline scope。浏览器授权页仍默认全部未勾选，并且只能 grant 本次 OAuth request 实际请求且用户选择的 permission。Launch consent 要求 `computer:read` + `computer:launch`；display 要求 `computer:read` + `computer:display_read`；pointer 要求 `computer:read`、`computer:control`、`computer:display_read`、`computer:pointer_control`；clipboard read/write 也分别要求 baseline read/control prerequisite 与对应 optional scope。缺失的 request prerequisite 会 unavailable，而不是自动补齐，因此 consent、token projection 与 runtime scope gate 静态一致。ceiling 真正变化会撤销旧 grant。`account:manage`、`admin`、`job:detach`、任何 `agent:*` 与未来 scope 始终在 bridge 之外；`offline_access` 仍只是协议 scope。授权页按同一个在线 Runner 判断 capability，并在 POST 重新计算；这只代表 backend 当前可用，不保证 OS/native permission 或调用一定成功。runtime 中 OAuth `tools/list` 会隐藏 token scope 不足的工具，直接 `tools/call` scope gate 与 Runner/native 实时检查仍是最终 authority。managed-user identity 仍单独使用 `connect --auth managed-oauth`。
 

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -32,7 +32,9 @@ CLI 显示 **WebCodex ready** 后：
 
 `share` 自己会完成 project setup。Hosted ChatGPT 无法访问 loopback-only 的
 `webcodex run`，因此 `setup`、`doctor`、`run` 都不是 `share` 之前的必经步骤。ChatGPT
-UI 文案可能随 rollout 变化；URL 与认证以 CLI 输出为准。
+UI 文案可能随 rollout 变化；URL 与认证以 CLI 输出为准。Developer Mode、custom MCP app
+和 write/modify action 是否可用，还分别受 ChatGPT 套餐、workspace 与管理员设置控制；
+WebCodex scope 不会扩大这些客户端侧权限。
 
 ## Claude 与其他 MCP client
 

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -8,6 +8,10 @@ reference，不是 onboarding 前置知识。
 
 ## ChatGPT Developer Mode：第一次接入
 
+下面的 self-contained `share` 路径需要本地 WebCodex Server，只支持 Linux/macOS。
+Windows 用户应改用 `webcodex connect <server-url>`，把 Runner 连接到已有的远程
+Linux Server。
+
 默认临时公网路径先安装
 [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/)，然后执行：
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3,14 +3,17 @@
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
 This guide gets one local Git repository into ChatGPT through MCP with the fewest
-concepts possible. The normal first-run command is `webcodex share`.
+concepts possible. On Linux/macOS the normal first-run command is `webcodex share`.
+Windows does not support the local Server runtime used by `share`; Windows users
+need an existing remote Linux Server and should use `webcodex connect <server-url>`
+instead. If no Server exists yet, see [Deployment](DEPLOYMENT.md).
 
 ## Prerequisites
 
 - Node.js 18+ for the npm installer.
 - Git on `PATH` and a Git repository you can safely inspect/edit.
-- [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) on `PATH`
-  for the default temporary public HTTPS share.
+- On Linux/macOS, [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/)
+  on `PATH` for the default temporary public HTTPS share.
 
 Install WebCodex:
 
@@ -18,7 +21,7 @@ Install WebCodex:
 npm install -g @yyjeqhc/webcodex
 ```
 
-If you only need local MCP debugging, `webcodex share --tunnel none` does not
+On Linux/macOS, local MCP debugging with `webcodex share --tunnel none` does not
 need `cloudflared`.
 
 ## 1. Share the repository

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2,198 +2,173 @@
 
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
-This is the shortest path to a working WebCodex setup on one local Git project.
-It uses the project-first flow: `webcodex setup` configures the current
-directory without asking for client IDs, runtime project ids, transports, or
-internal config paths.
-
-For connecting to an existing hosted Server, see
-[Deployment](DEPLOYMENT.md#connect-a-repository-to-an-existing-server). For
-letting an AI agent do the setup, see [AI Onboarding](AI_ONBOARDING.md).
+This guide gets one local Git repository into ChatGPT through MCP with the fewest
+concepts possible. The normal first-run command is `webcodex share`.
 
 ## Prerequisites
 
-- All three binaries installed: `webcodex`, `webcodex-server`,
-  `webcodex-runner`.
-- Git available on `PATH`.
-- A Git project you can safely inspect and edit.
+- Node.js 18+ for the npm installer.
+- Git on `PATH` and a Git repository you can safely inspect/edit.
+- [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) on `PATH`
+  for the default temporary public HTTPS share.
 
-Install the packaged build:
+Install WebCodex:
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 ```
 
-Or build from this checkout:
+If you only need local MCP debugging, `webcodex share --tunnel none` does not
+need `cloudflared`.
 
-```bash
-cargo build --release --workspace --bins
-export PATH="$PWD/target/release:$PATH"
-```
-
-## 1. Set up the project
+## 1. Share the repository
 
 ```bash
 cd /path/to/your/repository
-webcodex setup
-```
-
-On first run, `setup` resolves the Git top-level, creates private state outside
-the checkout, creates the minimum project registration and Agent
-configuration, and creates one Project Credential for this project's Connector
-and Agent — without printing it. It leaves the Server and Agent stopped.
-
-Run it again to verify idempotency; the second result is `already configured`.
-If one generated component is missing, `setup` repairs only that component.
-
-## 2. Check readiness
-
-```bash
-webcodex doctor
-```
-
-`doctor` is read-only. Before the Agent starts, its expected verdict is
-`Needs action` with `Next: webcodex run`. Use `--json` for the structured
-projection.
-
-## 3. Start the local runtime
-
-```bash
-webcodex run
-```
-
-This starts the project-bound loopback Server and local Agent in the
-foreground. Leave the terminal open; Ctrl-C stops both. In another terminal,
-from the same project:
-
-```bash
-webcodex status
-```
-
-A ready project reports its Project, Connection, Agent, coding readiness, and
-no next action.
-
-## 4. Connect a client
-
-### Temporarily share over HTTPS
-
-Hosted clients cannot reach a loopback address. For temporary development or
-testing access from a hosted MCP client, stop `webcodex run` and run:
-
-```bash
 webcodex share
 ```
 
-`share` reuses the project setup and local runtime but starts a Cloudflare
-Quick Tunnel and a separate temporary Connector credential. It prints a
-temporary `https://*.trycloudflare.com/mcp` URL and Bearer token; both stop
-being usable when the command exits.
+That single command performs the project setup, starts the local Server + Runner,
+creates a temporary Connector credential, opens a Cloudflare Quick Tunnel, and
+waits for the MCP endpoint to become usable. Do not run `setup`, `doctor`, or
+`run` first unless you specifically want the manual/local workflow described
+later.
 
-For an MCP client that requires OAuth, register its exact callback and run:
+The default share is temporary. Keep the terminal open; Ctrl-C stops the local
+runtime, tunnel, URL, and temporary credential.
 
-```bash
-webcodex share --auth oauth --oauth-redirect-uri https://client.example/callback
-```
+If `cloudflared` is missing, WebCodex fails before project setup/state creation
+and tells you where to install it. Install it and retry, or use `--tunnel none`
+for local-only debugging.
 
-The command prints the temporary Project share credential plus a project-bound OAuth client ID/secret. Enter the Project share credential only on the WebCodex authorization page. OAuth grants are fenced to that `share` process, so a restart invalidates old access and refresh tokens. The client ID/secret remain in protected project state for reuse with the same callback.
+## 2. Add WebCodex to ChatGPT
 
-`webcodex share --tunnel none` starts the same runtime without a public tunnel for local debugging. For a stable operator-managed OAuth origin, combine it with `--public-url https://share.example` and route that HTTPS origin to the local WebCodex port yourself. Quick Tunnels are not a stable-origin or production deployment mechanism.
+When the terminal reports **WebCodex ready**, use the values printed under
+**What to do next**:
 
-### Connect to an existing Server
+1. In ChatGPT, enable **Developer Mode** and create a **custom app** using MCP.
+2. Set **MCP URL** to the printed `https://.../mcp` value.
+3. For the default share, choose **Access token / API key** (Bearer token).
+4. Paste the printed **Credential (this share only)**.
+5. Run **Scan Tools**.
 
-For a stable, long-lived setup against an existing Server, shared-key connect remains available:
+The Console intentionally does not display that credential. If you later open
+`/console`, get connection credentials from the successful CLI output, not from
+the browser page.
 
-```bash
-webcodex connect https://webcodex.example --project .
-```
+## 3. Send a safe first prompt
 
-For ChatGPT OAuth, use the same hosted shared-key identity; no login, pairing, PAT, or account identity is required:
-
-```bash
-webcodex connect https://webcodex.example --auth oauth \
-  --oauth-redirect-uri https://client.example/callback --project .
-```
-
-To opt the OAuth client into the optional Computer consent ceiling, use:
-
-```bash
-webcodex connect https://webcodex.example --auth oauth \
-  --oauth-redirect-uri https://client.example/callback \
-  --oauth-computer-permissions --project .
-```
-
-The Runner keeps the direct shared key and its fixed baseline authority while ChatGPT receives only OAuth credentials/tokens. A fresh ordinary shared-key OAuth client starts with the full baseline (`runtime/project/job`, `computer:read`, `computer:control`), but an existing protected client may retain a narrower valid baseline subset. To let the browser offer the fixed optional launch/full-display/pointer/clipboard permissions, reconnect explicitly with `--oauth-computer-permissions`; the flag appends only those optional scopes to the existing baseline subset and never restores missing baseline authority. All optional permissions remain unchecked until selected on WebCodex's authorize page. Launch can be selected only when the OAuth request already contains both `computer:read` and `computer:launch`; WebCodex never fills a missing request scope. `account:manage`, `admin`, `job:detach`, Agent scopes, and future scopes are never offered. Existing baseline clients are not widened by normal reconnect. Runner capability and OS/native permission are rechecked at runtime, so consent-page availability is not a success guarantee. Advanced managed-user OAuth remains separate as `--auth managed-oauth` after `webcodex login`. See [Deployment](DEPLOYMENT.md).
-
-To remove only this repository from a hosted `connect` profile later, run from the repository:
-
-```bash
-webcodex disconnect
-```
-
-This unregisters the exact canonical repository and leaves the source tree, `.git`, profile
-credential, and any other registered projects intact. If more than one hosted profile registers
-the same repository, rerun with `--profile NAME`.
-
-## 5. Run a coding task
-
-Ask the client for a small, reversible change. The canonical calls are:
+Start by confirming that the client can see the intended repository without
+making changes:
 
 ```text
-task_start
-→ files_list
-→ files_read or files_search
-→ edits_apply
-→ checks_run
-→ task_finish
-→ task_review
+Inspect this repository and summarize its structure. Do not make changes.
 ```
 
-Use a stable `operation_id` for edits, commands, and checks: retrying the same
-payload reuses the operation; a different payload under the same ID fails
-closed.
+After that succeeds, ask for a small, reversible change. WebCodex's project-bound
+coding surface handles project identity internally; ordinary users do not need
+to provide runtime project ids or operation ids in prompts.
 
-`checks_run` accepts `format`, `check`, and `test` plus an optional `recipe`
-(`rust`, `node`, `python`, `go`). Omit the recipe for automatic resolution
-from the nearest manifest directory.
+## 4. Review work
 
-## 6. Review and accept locally
-
-The coding result stays isolated from the target checkout until a human
-decision:
+The browser `/console` shows readiness, work queue, task guidance, approvals, and
+review actions. Where a stable result is ready, a human can Accept or Reject it
+from the Console or CLI:
 
 ```bash
 webcodex task list
 webcodex task show <task-id>
 webcodex task accept <task-id>
+# or: webcodex task reject <task-id>
 ```
 
-Use `webcodex task reject <task-id>` to discard it. Acceptance verifies that
-the target Git state still matches the task baseline before applying the
-result. The online model can propose work but can never accept it.
+The online model cannot accept its own result.
 
-You can also review in the browser: open `/console` and use the work queue.
-Accept and Reject in the browser call the same authority the CLI uses.
+## Existing Server: long-lived connection
+
+If you already have a WebCodex Server URL, use `connect` instead of temporary
+`share`:
+
+```bash
+cd /path/to/your/repository
+webcodex connect https://webcodex.example
+```
+
+`connect` creates/reuses a local profile, starts a detached Runner, waits until
+the Server can see the Runner and project, then prints the MCP URL,
+authentication type, credential source, ChatGPT hint, and diagnostic details.
+When it generates a shared key, the full value is shown only on the permitted
+first disclosure; status/log commands do not reveal it.
+
+To remove only this repository from a hosted profile later:
+
+```bash
+webcodex disconnect
+```
+
+Self-hosting and managed identity are separate operator/advanced workflows; see
+[Deployment](DEPLOYMENT.md).
+
+## Optional OAuth
+
+Bearer authentication is the simplest trial path. If the MCP client requires
+OAuth, provide its exact callback URL.
+
+Temporary project-bound share:
+
+```bash
+webcodex share --auth oauth \
+  --oauth-redirect-uri https://client.example/callback
+```
+
+Existing hosted Server:
+
+```bash
+webcodex connect https://webcodex.example --auth oauth \
+  --oauth-redirect-uri https://client.example/callback
+```
+
+The CLI prints which values belong in the MCP client and which temporary project
+credential belongs only on the WebCodex authorization page. Advanced OAuth
+scope ceilings, optional Computer permissions, managed-user OAuth, and protocol
+contracts are documented in [MCP](MCP.md) and [Authentication](AUTH_MODEL.md).
+
+## Local-only / manual workflow
+
+These commands remain useful for development and diagnostics, but they are not
+prerequisites for a hosted ChatGPT connection:
+
+```bash
+cd /path/to/your/repository
+webcodex setup     # configure private project state only
+webcodex doctor    # read-only local readiness diagnostics
+webcodex run       # foreground loopback Server + Runner
+# in another terminal:
+webcodex status
+```
+
+`doctor` describes the local/manual runtime and may recommend `webcodex run` when
+that loopback runtime is stopped. Hosted clients cannot reach a loopback-only
+runtime, which is why the normal ChatGPT onboarding starts with `share` instead.
 
 ## Troubleshooting
 
-Start with:
+Start with the exact error from `share` or `connect`. For established local
+state, these remain useful:
 
 ```bash
 webcodex status
 webcodex doctor
 ```
 
-Common stable codes and next actions:
+Common examples:
 
-| Code | Meaning | Next action |
-| --- | --- | --- |
-| `project_not_configured` | No setup for this project/profile | `webcodex setup` |
-| `project_credential_invalid` | Private credential state is missing or mismatched | Restore both matching private files or recreate the profile |
-| `server_unreachable` | Loopback runtime cannot be reached | `webcodex run` |
-| `agent_offline` | Server reachable but the local Agent is unavailable | `webcodex run` |
-| `required_capability_unavailable` | Installed Agent too old | Upgrade all binaries |
-| `workspace_unavailable` | Git or project path unavailable | Restore the path/Git workspace |
-| `checks_required` | Normal result has not run checks | Run `checks_run`, then finish |
-| `checks_stale` | Workspace changed after the last check | Run a new check |
+| Symptom | Next action |
+| --- | --- |
+| `cloudflared` missing | Install it from the official Cloudflare downloads and retry, or use `share --tunnel none` locally |
+| loopback port already in use | Stop the conflicting process and retry |
+| local/manual runtime stopped | `webcodex run` |
+| Runner unavailable on an existing hosted profile | rerun `connect` or inspect `webcodex agent status --profile <profile>` |
+| workspace unavailable | restore the Git project/path |
 
 See [Troubleshooting](TROUBLESHOOTING.md) for the full operational checklist.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -57,7 +57,10 @@ When the terminal reports **WebCodex ready**, use the values printed under
 
 The Console intentionally does not display that credential. If you later open
 `/console`, get connection credentials from the successful CLI output, not from
-the browser page.
+the browser page. ChatGPT Developer Mode, custom MCP apps, and write/modify
+actions are separately controlled by the ChatGPT plan, workspace, and admin
+settings; WebCodex cannot enable an action that the client workspace does not
+permit.
 
 ## 3. Send a safe first prompt
 

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -2,14 +2,16 @@
 
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
-本指南用尽可能少的概念，把一个本地 Git 仓库通过 MCP 接入 ChatGPT。普通第一次使用的
-主命令是 `webcodex share`。
+本指南用尽可能少的概念，把一个本地 Git 仓库通过 MCP 接入 ChatGPT。在 Linux/macOS
+上，普通第一次使用的主命令是 `webcodex share`。Windows 不支持 `share` 所需的本地
+Server runtime；Windows 用户需要已有的远程 Linux Server，并改用
+`webcodex connect <server-url>`。如果还没有 Server，请先看[部署指南](DEPLOYMENT.zh-CN.md)。
 
 ## 前置条件
 
 - npm installer 需要 Node.js 18+。
 - `PATH` 中有 Git，并准备一个可以安全查看/编辑的 Git 仓库。
-- 默认临时公网 HTTPS 分享需要把
+- Linux/macOS 的默认临时公网 HTTPS 分享需要把
   [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) 安装到 `PATH`。
 
 安装 WebCodex：
@@ -18,7 +20,8 @@
 npm install -g @yyjeqhc/webcodex
 ```
 
-如果只做本地 MCP 调试，`webcodex share --tunnel none` 不需要 `cloudflared`。
+在 Linux/macOS 上只做本地 MCP 调试时，`webcodex share --tunnel none` 不需要
+`cloudflared`。
 
 ## 1. 分享当前仓库
 

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -2,186 +2,154 @@
 
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
-这是在单个本地 Git 项目上跑通 WebCodex 的最短路径。它使用 project-first 流程：
-`webcodex setup` 配置当前目录，不需要你提供 client id、runtime project id、
-transport 或内部配置路径。
-
-接入已有 hosted Server 见[部署指南](DEPLOYMENT.zh-CN.md#把仓库接入已有的-server)；
-让 AI agent 帮你搭建见 [AI 接入指南](AI_ONBOARDING.zh-CN.md)。
+本指南用尽可能少的概念，把一个本地 Git 仓库通过 MCP 接入 ChatGPT。普通第一次使用的
+主命令是 `webcodex share`。
 
 ## 前置条件
 
-- 三个二进制都已安装：`webcodex`、`webcodex-server`、`webcodex-runner`。
-- Git 在 `PATH` 上。
-- 一个可以安全查看和编辑的 Git 项目。
+- npm installer 需要 Node.js 18+。
+- `PATH` 中有 Git，并准备一个可以安全查看/编辑的 Git 仓库。
+- 默认临时公网 HTTPS 分享需要把
+  [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) 安装到 `PATH`。
 
-安装打包版本：
+安装 WebCodex：
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 ```
 
-或从本 checkout 构建：
+如果只做本地 MCP 调试，`webcodex share --tunnel none` 不需要 `cloudflared`。
 
-```bash
-cargo build --release --workspace --bins
-export PATH="$PWD/target/release:$PATH"
-```
-
-## 1. 设置项目
+## 1. 分享当前仓库
 
 ```bash
 cd /path/to/your/repository
-webcodex setup
-```
-
-首次运行 `setup` 会：解析 Git 顶层目录；在 checkout 之外创建私有状态；创建最小
-的项目注册与 Agent 配置；为当前项目的 Connector 与 Agent 创建一把 Project
-Credential——不会打印它。它会让 Server 与 Agent 保持停止。
-
-再次运行可验证幂等性；第二次结果应为 `already configured`。如果某个生成的组件
-缺失，`setup` 只修复该组件。
-
-## 2. 检查就绪
-
-```bash
-webcodex doctor
-```
-
-`doctor` 只读。在 Agent 启动前，预期结果是 `Needs action`，并给出
-`Next: webcodex run`。用 `--json` 获取结构化结果。
-
-## 3. 启动本地 runtime
-
-```bash
-webcodex run
-```
-
-这会在前台启动 project-bound loopback Server 与本地 Agent。保持该终端打开；
-Ctrl-C 会同时停止两者。在另一个终端、同一个项目下执行：
-
-```bash
-webcodex status
-```
-
-就绪项目会报告 Project、Connection、Agent、coding 就绪状态与 next action。
-
-## 4. 接入客户端
-
-### 临时通过 HTTPS 分享
-
-Hosted 客户端无法访问 loopback 地址。若需要从 hosted MCP 客户端临时访问，
-先停止 `webcodex run`，再执行：
-
-```bash
 webcodex share
 ```
 
-`share` 复用项目设置与本地 runtime，但会额外启动 Cloudflare Quick Tunnel 与
-一把独立的临时 Connector credential。它输出临时 `https://*.trycloudflare.com/mcp`
-URL 与 Bearer token；命令退出后两者都失效。
+这一条命令会完成项目设置、启动本地 Server + Runner、创建临时 Connector credential、
+打开 Cloudflare Quick Tunnel，并等待 MCP endpoint 可用。除非你明确需要后文的手动/本地
+工作流，否则不要先跑 `setup`、`doctor` 或 `run`。
 
-如果 MCP 客户端要求 OAuth，先确定它的精确 callback，然后运行：
+默认 share 是临时的。保持终端运行；Ctrl-C 会停止本地 runtime 与 tunnel，同时使 URL 和
+临时 credential 失效。
 
-```bash
-webcodex share --auth oauth --oauth-redirect-uri https://client.example/callback
-```
+如果缺少 `cloudflared`，WebCodex 会在创建项目 setup/state 之前失败，并给出官方安装地址。
+安装后重试；或者仅本地调试时使用 `--tunnel none`。
 
-命令会输出临时 Project share credential，以及 project-bound OAuth client ID/secret。Project share credential 只应输入 WebCodex 自己的授权页。OAuth grant 被 fenced 到本次 `share` 进程，因此重启后旧 access/refresh token 失效；同一项目与 callback 的 client ID/secret 会保存在受保护的 project state 中以便复用。
+## 2. 在 ChatGPT 中添加 WebCodex
 
-`webcodex share --tunnel none` 在不开放公网 tunnel 的情况下启动同一 runtime，用于本地调试。如需稳定、由 operator 管理的 OAuth origin，可再加 `--public-url https://share.example`，并自行把该 HTTPS origin 反向代理/隧道到本地 WebCodex 端口。Quick Tunnel 不提供稳定 origin，也不适合作为生产部署。
+终端出现 **WebCodex ready** 后，直接按 **What to do next** 中的值填写：
 
-### 接入已有 Server
+1. 在 ChatGPT 开启 **Developer Mode**，创建基于 MCP 的 **custom app**。
+2. **MCP URL** 填输出的 `https://.../mcp`。
+3. 默认 share 的认证选择 **Access token / API key**（Bearer token）。
+4. 粘贴输出的 **Credential (this share only)**。
+5. 点击 **Scan Tools**。
 
-如需接入已有 Server 的稳定长期环境，仍可使用 shared-key：
+Console 故意不显示 credential。以后即使打开 `/console`，认证值也应来自成功的 CLI 首次
+输出，而不是浏览器页面。
 
-```bash
-webcodex connect https://webcodex.example --project .
-```
+## 3. 发送第一条安全请求
 
-ChatGPT OAuth 直接复用同一个 hosted shared-key identity，不需要 login、pairing、PAT 或 account identity：
-
-```bash
-webcodex connect https://webcodex.example --auth oauth \
-  --oauth-redirect-uri https://client.example/callback --project .
-```
-
-如需显式把 OAuth client 升级到可提供 optional Computer consent 的 ceiling：
-
-```bash
-webcodex connect https://webcodex.example --auth oauth \
-  --oauth-redirect-uri https://client.example/callback \
-  --oauth-computer-permissions --project .
-```
-
-Runner 继续使用 direct shared key 及其固定 baseline authority，ChatGPT 只获得 OAuth credential/token。fresh ordinary shared-key OAuth client 从完整 baseline（runtime/project/job、`computer:read`、`computer:control`）开始，但已有受保护 client 可以继续保留合法的窄 baseline subset。只有显式使用 `--oauth-computer-permissions`，浏览器才会提供固定的 launch/full-display/pointer/clipboard optional consent；该 flag 只在现有 baseline subset 上追加这些 optional scopes，不会恢复此前缺失的 baseline authority。所有 optional permission 在 WebCodex authorize 页面仍默认未勾选；Launch 只有在本次 OAuth request 已同时包含 `computer:read` 与 `computer:launch` 时才可选择，Server 不会补缺失 scope。`account:manage`、`admin`、`job:detach`、Agent scope 与未来 scope 永远不会出现。普通 reconnect 不会静默扩大已有 baseline client。Runner capability 与 OS/native permission 会在 runtime 调用时重新检查，因此授权页的 available 不代表操作保证成功。高级 managed-user OAuth 仍与此分离，在 `webcodex login` 后使用 `--auth managed-oauth`。见[部署指南](DEPLOYMENT.zh-CN.md)。
-
-以后如果只想从 hosted `connect` profile 中注销当前仓库，可在仓库中运行：
-
-```bash
-webcodex disconnect
-```
-
-它只注销 canonical 路径精确匹配的仓库，保留 source tree、`.git`、profile credential
-以及其他已注册项目。如果同一仓库存在于多个 hosted profile 中，请显式传
-`--profile NAME`。
-
-## 5. 运行 coding 任务
-
-让客户端做一个小的、可回退的改动。典型调用序列：
+先确认客户端连接的是正确仓库，并且不产生修改：
 
 ```text
-task_start
-→ files_list
-→ files_read 或 files_search
-→ edits_apply
-→ checks_run
-→ task_finish
-→ task_review
+检查这个仓库并总结它的结构。先不要做任何修改。
 ```
 
-编辑、命令与校验使用稳定的 `operation_id`：重试相同 payload 会复用同一操作；
-同一 ID 下不同 payload 会 fail closed。
+确认成功后，再让它完成一个小且可回退的改动。project-bound coding surface 会在内部处理
+项目身份；普通用户不需要在 prompt 中提供 runtime project id 或 operation id。
 
-`checks_run` 支持 `format`、`check`、`test` 与可选 `recipe`（`rust`、`node`、
-`python`、`go`）。省略 recipe 时自动从最近的 manifest 目录解析。
+## 4. 审查结果
 
-## 6. 本地审查与接受
-
-coding 结果在人工决策前与目标 checkout 隔离：
+浏览器 `/console` 可以查看 readiness、工作队列、task guidance、审批与 review action。
+稳定结果准备好后，人类可以在 Console 或 CLI 中 Accept/Reject：
 
 ```bash
 webcodex task list
 webcodex task show <task-id>
 webcodex task accept <task-id>
+# 或：webcodex task reject <task-id>
 ```
 
-用 `webcodex task reject <task-id>` 丢弃它。Accept 会先验证目标 Git 状态仍与
-task 基线一致再应用结果。在线模型可以提出工作，但永远不能接受它。
+在线模型不能接受自己的结果。
 
-也可以在浏览器中审查：打开 `/console` 使用工作队列。浏览器里的 Accept/Reject
-与 CLI 使用同一套决策权威。
+## 已有 Server：长期连接
+
+只有已经拥有 WebCodex Server URL 时，才用 `connect` 替代临时 `share`：
+
+```bash
+cd /path/to/your/repository
+webcodex connect https://webcodex.example
+```
+
+`connect` 创建/复用本地 profile、启动 detached Runner、等待 Server 看见 Runner 与项目，
+然后输出 MCP URL、认证类型、credential 来源、ChatGPT 提示和诊断 Details。若它自动生成
+shared key，完整值只会在允许的首次 disclosure 中出现；status/log 不会泄露它。
+
+以后只注销当前仓库：
+
+```bash
+webcodex disconnect
+```
+
+自托管和 managed identity 属于独立 operator/高级工作流，见[部署指南](DEPLOYMENT.zh-CN.md)。
+
+## 可选 OAuth
+
+Bearer 是最简单的试用路径。如果 MCP client 要求 OAuth，请提供它的精确 callback URL。
+
+临时 project-bound share：
+
+```bash
+webcodex share --auth oauth \
+  --oauth-redirect-uri https://client.example/callback
+```
+
+已有 hosted Server：
+
+```bash
+webcodex connect https://webcodex.example --auth oauth \
+  --oauth-redirect-uri https://client.example/callback
+```
+
+CLI 会明确哪些值填进 MCP client，哪个临时 project credential 只能填在 WebCodex 授权页。
+高级 OAuth scope ceiling、optional Computer permission、managed-user OAuth 与协议 contract
+见 [MCP](MCP.zh-CN.md) 和[认证模型](AUTH_MODEL.zh-CN.md)。
+
+## 仅本地 / 手动工作流
+
+这些命令仍适合开发与诊断，但不是 hosted ChatGPT 接入的前置条件：
+
+```bash
+cd /path/to/your/repository
+webcodex setup     # 只配置私有项目状态
+webcodex doctor    # 只读本地 readiness 诊断
+webcodex run       # 前台 loopback Server + Runner
+# 另一个终端：
+webcodex status
+```
+
+`doctor` 描述的是本地/手动 runtime；loopback runtime 停止时，它仍可能推荐
+`webcodex run`。Hosted client 无法访问 loopback，因此普通 ChatGPT onboarding 从
+`share` 开始，而不是从 `doctor` 开始。
 
 ## 故障排查
 
-先执行：
+优先看 `share` 或 `connect` 返回的精确错误。已有本地状态时也可运行：
 
 ```bash
 webcodex status
 webcodex doctor
 ```
 
-常见稳定错误码与下一步：
+| 现象 | 下一步 |
+| --- | --- |
+| 缺少 `cloudflared` | 从 Cloudflare 官方下载并安装后重试；仅本地调试可用 `share --tunnel none` |
+| loopback 端口已被占用 | 停掉冲突进程后重试 |
+| 本地/手动 runtime 未运行 | `webcodex run` |
+| 已有 hosted profile 的 Runner 不可用 | 重跑 `connect` 或检查 `webcodex agent status --profile <profile>` |
+| workspace 不可用 | 恢复 Git 仓库/路径 |
 
-| 错误码 | 含义 | 下一步 |
-| --- | --- | --- |
-| `project_not_configured` | 该项目/profile 没有 setup | `webcodex setup` |
-| `project_credential_invalid` | 私有凭据状态缺失或不匹配 | 恢复两个匹配的私有文件或重建 profile |
-| `server_unreachable` | 无法访问 loopback runtime | `webcodex run` |
-| `agent_offline` | Server 可达但本地 Agent 不可用 | `webcodex run` |
-| `required_capability_unavailable` | 已安装 Agent 过旧 | 升级所有二进制 |
-| `workspace_unavailable` | Git 或项目路径不可用 | 恢复路径/Git 工作区 |
-| `checks_required` | 普通结果尚未运行检查 | 先 `checks_run` 再 finish |
-| `checks_stale` | 上次检查后工作区已变化 | 运行一次新检查 |
-
-完整运维检查清单见[故障排查](TROUBLESHOOTING.zh-CN.md)。
+完整检查清单见[故障排查](TROUBLESHOOTING.zh-CN.md)。

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -51,7 +51,9 @@ webcodex share
 5. 点击 **Scan Tools**。
 
 Console 故意不显示 credential。以后即使打开 `/console`，认证值也应来自成功的 CLI 首次
-输出，而不是浏览器页面。
+输出，而不是浏览器页面。ChatGPT Developer Mode、custom MCP app 与 write/modify action
+还分别受 ChatGPT 套餐、workspace 和管理员设置控制；客户端 workspace 没有允许的 action，
+WebCodex 不能自行把它开启。
 
 ## 3. 发送第一条安全请求
 

--- a/frontend/dist/console.html
+++ b/frontend/dist/console.html
@@ -181,22 +181,26 @@
         <div class="panel-head">
           <h2>Connect a chat client</h2>
         </div>
-        <p class="muted small">Copy-paste targets for this instance. The Project Credential from <code>webcodex setup</code> stays out of this page by design.</p>
+        <p class="muted small">Connection targets for this instance. Credentials stay out of this page by design; use the credential or OAuth values shown by the successful <code>webcodex share</code> or <code>webcodex connect</code> command.</p>
         <div class="connect-block">
-          <h3>Claude — custom connector (MCP)</h3>
+          <h3>ChatGPT — Developer Mode custom app (MCP)</h3>
           <div class="field-row connect-row">
             <code id="connect-mcp-url" class="connect-url">—</code>
             <button class="btn" type="button" data-copy="connect-mcp-url">Copy</button>
           </div>
-          <p class="muted small">Claude → Settings → Connectors → Add custom connector → paste this URL. OAuth metadata is discovered from <code id="connect-oauth">—</code>.</p>
+          <p class="muted small">In ChatGPT Developer Mode, create a custom app, paste this MCP URL, choose the authentication type printed by the CLI, enter the credential from that first successful CLI output, then Scan Tools. This console never exposes the credential.</p>
         </div>
         <div class="connect-block">
-          <h3>ChatGPT — GPT Action (OpenAPI)</h3>
+          <h3>Claude — custom connector (MCP)</h3>
+          <p class="muted small">Claude → Settings → Connectors → Add custom connector → use the MCP URL above. OAuth metadata is discovered from <code id="connect-oauth">—</code>.</p>
+        </div>
+        <div class="connect-block">
+          <h3>ChatGPT — GPT Action (OpenAPI, optional)</h3>
           <div class="field-row connect-row">
             <code id="connect-schema-url" class="connect-url">—</code>
             <button class="btn" type="button" data-copy="connect-schema-url">Copy</button>
           </div>
-          <p class="muted small">Create a GPT → Actions → Import from URL → Authentication: API key (Bearer) with the Project Credential.</p>
+          <p class="muted small">Optional compatibility path for Custom GPT Actions. Import this schema URL and configure its authentication separately; MCP custom apps are the primary ChatGPT path.</p>
         </div>
         <p class="muted small" id="connect-public-warning" hidden>
           This address is local. Hosted ChatGPT/Claude need a public HTTPS URL — start a tunnel and open the console through it, or set <code>WEBCODEX_PUBLIC_URL</code>.

--- a/frontend/dist/console.html
+++ b/frontend/dist/console.html
@@ -188,7 +188,7 @@
             <code id="connect-mcp-url" class="connect-url">—</code>
             <button class="btn" type="button" data-copy="connect-mcp-url">Copy</button>
           </div>
-          <p class="muted small">In ChatGPT Developer Mode, create a custom app, paste this MCP URL, choose the authentication type printed by the CLI, enter the credential from that first successful CLI output, then Scan Tools. This console never exposes the credential.</p>
+          <p class="muted small">If Developer Mode is enabled for your ChatGPT workspace, create a custom app, paste this MCP URL, choose the authentication type printed by the CLI, enter the credential from that first successful CLI output, then Scan Tools. This console never exposes the credential or changes ChatGPT-side app permissions.</p>
         </div>
         <div class="connect-block">
           <h3>Claude — custom connector (MCP)</h3>

--- a/frontend/src/console.html
+++ b/frontend/src/console.html
@@ -181,22 +181,26 @@
         <div class="panel-head">
           <h2>Connect a chat client</h2>
         </div>
-        <p class="muted small">Copy-paste targets for this instance. The Project Credential from <code>webcodex setup</code> stays out of this page by design.</p>
+        <p class="muted small">Connection targets for this instance. Credentials stay out of this page by design; use the credential or OAuth values shown by the successful <code>webcodex share</code> or <code>webcodex connect</code> command.</p>
         <div class="connect-block">
-          <h3>Claude — custom connector (MCP)</h3>
+          <h3>ChatGPT — Developer Mode custom app (MCP)</h3>
           <div class="field-row connect-row">
             <code id="connect-mcp-url" class="connect-url">—</code>
             <button class="btn" type="button" data-copy="connect-mcp-url">Copy</button>
           </div>
-          <p class="muted small">Claude → Settings → Connectors → Add custom connector → paste this URL. OAuth metadata is discovered from <code id="connect-oauth">—</code>.</p>
+          <p class="muted small">In ChatGPT Developer Mode, create a custom app, paste this MCP URL, choose the authentication type printed by the CLI, enter the credential from that first successful CLI output, then Scan Tools. This console never exposes the credential.</p>
         </div>
         <div class="connect-block">
-          <h3>ChatGPT — GPT Action (OpenAPI)</h3>
+          <h3>Claude — custom connector (MCP)</h3>
+          <p class="muted small">Claude → Settings → Connectors → Add custom connector → use the MCP URL above. OAuth metadata is discovered from <code id="connect-oauth">—</code>.</p>
+        </div>
+        <div class="connect-block">
+          <h3>ChatGPT — GPT Action (OpenAPI, optional)</h3>
           <div class="field-row connect-row">
             <code id="connect-schema-url" class="connect-url">—</code>
             <button class="btn" type="button" data-copy="connect-schema-url">Copy</button>
           </div>
-          <p class="muted small">Create a GPT → Actions → Import from URL → Authentication: API key (Bearer) with the Project Credential.</p>
+          <p class="muted small">Optional compatibility path for Custom GPT Actions. Import this schema URL and configure its authentication separately; MCP custom apps are the primary ChatGPT path.</p>
         </div>
         <p class="muted small" id="connect-public-warning" hidden>
           This address is local. Hosted ChatGPT/Claude need a public HTTPS URL — start a tunnel and open the console through it, or set <code>WEBCODEX_PUBLIC_URL</code>.

--- a/frontend/src/console.html
+++ b/frontend/src/console.html
@@ -188,7 +188,7 @@
             <code id="connect-mcp-url" class="connect-url">—</code>
             <button class="btn" type="button" data-copy="connect-mcp-url">Copy</button>
           </div>
-          <p class="muted small">In ChatGPT Developer Mode, create a custom app, paste this MCP URL, choose the authentication type printed by the CLI, enter the credential from that first successful CLI output, then Scan Tools. This console never exposes the credential.</p>
+          <p class="muted small">If Developer Mode is enabled for your ChatGPT workspace, create a custom app, paste this MCP URL, choose the authentication type printed by the CLI, enter the credential from that first successful CLI output, then Scan Tools. This console never exposes the credential or changes ChatGPT-side app permissions.</p>
         </div>
         <div class="connect-block">
           <h3>Claude — custom connector (MCP)</h3>

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -40,6 +40,9 @@ When it says **WebCodex ready**:
 
 The default share is temporary and ends when the command exits. For local-only
 MCP debugging, `webcodex share --tunnel none` does not require `cloudflared`.
+ChatGPT Developer Mode, custom MCP apps, and write/modify actions are controlled
+by the ChatGPT plan, workspace, and admin settings; WebCodex cannot widen those
+client-side permissions.
 
 If you already operate a WebCodex Server, use the long-lived path instead:
 
@@ -102,7 +105,9 @@ Runner、打开临时 Cloudflare Quick Tunnel，并输出 MCP URL 与临时 cred
 6. 第一条可先说：`检查这个仓库并总结它的结构。先不要做任何修改。`
 
 默认 share 会在命令退出时结束。仅做本地 MCP 调试可用
-`webcodex share --tunnel none`，此时不需要 `cloudflared`。
+`webcodex share --tunnel none`，此时不需要 `cloudflared`。ChatGPT Developer Mode、custom
+MCP app 与 write/modify action 受 ChatGPT 套餐、workspace 和管理员设置控制；WebCodex
+不能扩大这些客户端侧权限。
 
 如果你已经运营一个 WebCodex Server，再使用长期路径：
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -12,8 +12,11 @@ platforms.
 ### Fastest first connection
 
 Supported platforms are Linux x64/arm64, macOS arm64, Windows x64, and native
-Windows arm64. The installer wrapper requires Node.js 18 or newer. The default
-public `share` flow also requires
+Windows arm64. The installer wrapper requires Node.js 18 or newer. Windows is a
+CLI + Runner client platform in this release: local Server runtime and
+`webcodex share` are unsupported there, so use `webcodex connect <server-url>`
+against a remote Linux Server. The `share` steps below apply to Linux/macOS and
+the default public flow also requires
 [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) on `PATH`.
 
 ```bash
@@ -74,7 +77,10 @@ npm package 会为支持的平台安装原生 `webcodex`、`webcodex-server`、
 ### 最快的第一次接入
 
 支持 Linux x64/arm64、macOS arm64、Windows x64 与原生 Windows arm64；installer
-wrapper 需要 Node.js 18 或更新版本。默认公网 `share` 还需要把
+wrapper 需要 Node.js 18 或更新版本。本版本的 Windows 是 CLI + Runner 客户端平台，
+不支持本地 Server runtime 或 `webcodex share`；Windows 请使用
+`webcodex connect <server-url>` 连接远程 Linux Server。下面的 `share` 步骤适用于
+Linux/macOS，默认公网流程还需要把
 [`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) 安装到 `PATH`。
 
 ```bash

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -4,47 +4,61 @@
 
 ## English
 
-WebCodex turns ChatGPT, Claude, and other MCP clients into assistants connected
-to your own repositories and machines. The npm package installs the native
+WebCodex connects ChatGPT, Claude, and other MCP clients to repositories and
+development tools on your own machines. This npm package installs the native
 `webcodex`, `webcodex-server`, and `webcodex-runner` binaries for supported
 platforms.
 
-### Install and connect
+### Fastest first connection
 
-Supported platforms are Linux x64, Linux arm64, macOS arm64, Windows x64, and native Windows
-arm64. Node.js 18 or newer is required by the installer wrapper.
+Supported platforms are Linux x64/arm64, macOS arm64, Windows x64, and native
+Windows arm64. The installer wrapper requires Node.js 18 or newer. The default
+public `share` flow also requires
+[`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) on `PATH`.
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 cd /path/to/your/repository
-webcodex connect https://your-server.example
+webcodex share
 ```
 
-`connect` uses the current directory, creates a local profile, starts a detached
-Runner, and prints the MCP URL and generated key. Add those values to ChatGPT or
-Claude, then ask it to inspect code, edit files, run tests, or work with Git.
+You do not need to run `setup`, `doctor`, or `run` first. `share` configures the
+project, starts a local Server + Runner, opens a temporary Cloudflare Quick
+Tunnel, and prints the MCP URL and temporary credential.
 
-The generated key is printed in full only when first created. Keep it and the
-generated `agent.toml` out of Git. After a machine reboot, rerun `connect` or
-start the profile reported by the first run:
+When it says **WebCodex ready**:
+
+1. In ChatGPT Developer Mode, create a custom MCP app.
+2. Paste the printed MCP URL.
+3. Choose Access token / API key (Bearer token).
+4. Paste the printed Credential.
+5. Scan Tools.
+6. Try: `Inspect this repository and summarize its structure. Do not make changes.`
+
+The default share is temporary and ends when the command exits. For local-only
+MCP debugging, `webcodex share --tunnel none` does not require `cloudflared`.
+
+If you already operate a WebCodex Server, use the long-lived path instead:
 
 ```bash
-webcodex agent start --profile <profile>
+webcodex connect https://webcodex.example
 ```
 
-Advanced users can provide `--key-file`, `--key`, or `--project`.
+`connect` creates a reusable profile and prints the corresponding MCP setup
+values. A generated hosted shared key is disclosed in full only on its permitted
+first output; status/log commands do not reveal it.
 
 ### Package integrity
 
-The npm package exposes one public command: `webcodex`. During installation it
+The package exposes one public command, `webcodex`. During installation it
 downloads the matching release artifact, verifies its SHA-256 checksum, checks
-that all three binaries share one version and build identity, and atomically
+that all three binaries share one version/build identity, and atomically
 replaces the previous complete binary set. A failed download, extraction,
 checksum, or identity check leaves the previous installation intact.
 
 `webcodex-server` and `webcodex-runner` are package-local binaries rather than
 separate npm `bin` entries. The public CLI discovers them for `webcodex server`
-and `webcodex agent` commands.
+and the compatibility `webcodex agent` Runner-management namespace.
 
 ### Disclaimer
 
@@ -53,65 +67,68 @@ project boundaries. Use version control and recoverable backups.
 
 ## 简体中文
 
-WebCodex 让 ChatGPT、Claude 和其他 MCP client 成为连接到你自己仓库和机器的
-专属助手。npm package 会为支持的平台安装原生 `webcodex`、
-`webcodex-server` 和 `webcodex-runner` binaries。
+WebCodex 把 ChatGPT、Claude 和其他 MCP client 连接到你自己机器上的仓库与开发工具。
+npm package 会为支持的平台安装原生 `webcodex`、`webcodex-server`、
+`webcodex-runner` binaries。
 
-### 安装与接入
+### 最快的第一次接入
 
-支持 Linux x64、Linux arm64、macOS arm64、Windows x64 和原生 Windows arm64；installer
-wrapper 需要 Node.js 18 或更新版本。
+支持 Linux x64/arm64、macOS arm64、Windows x64 与原生 Windows arm64；installer
+wrapper 需要 Node.js 18 或更新版本。默认公网 `share` 还需要把
+[`cloudflared`](https://developers.cloudflare.com/tunnel/downloads/) 安装到 `PATH`。
 
 ```bash
 npm install -g @yyjeqhc/webcodex
 cd /path/to/your/repository
-webcodex connect https://your-server.example
+webcodex share
 ```
 
-`connect` 默认使用当前目录，创建本地 profile，启动 detached Runner，并输出 MCP
-URL 与生成的 key。把这些信息添加到 ChatGPT 或 Claude 后，就可以让它查看和修改
-代码、运行测试、执行命令或操作 Git。
+第一次不需要先执行 `setup`、`doctor` 或 `run`。`share` 会配置项目、启动本地 Server +
+Runner、打开临时 Cloudflare Quick Tunnel，并输出 MCP URL 与临时 credential。
 
-生成的 key 只在首次创建时完整显示。不要把它或生成的 `agent.toml` 提交进 Git。
-机器重启后重新执行 `connect`，或者启动首次输出的 profile：
+出现 **WebCodex ready** 后：
+
+1. 在 ChatGPT Developer Mode 创建 MCP custom app。
+2. 填入输出的 MCP URL。
+3. 认证选择 Access token / API key（Bearer token）。
+4. 填入输出的 Credential。
+5. Scan Tools。
+6. 第一条可先说：`检查这个仓库并总结它的结构。先不要做任何修改。`
+
+默认 share 会在命令退出时结束。仅做本地 MCP 调试可用
+`webcodex share --tunnel none`，此时不需要 `cloudflared`。
+
+如果你已经运营一个 WebCodex Server，再使用长期路径：
 
 ```bash
-webcodex agent start --profile <profile>
+webcodex connect https://webcodex.example
 ```
 
-高级用户可以使用 `--key-file`、`--key` 或 `--project`。
+`connect` 会创建可复用 profile 并输出对应 MCP 配置。自动生成的 hosted shared key 只会在
+允许的首次输出中完整显示；status/log 不会泄露它。
 
 ### Package 完整性
 
-npm package 只暴露一个公共命令：`webcodex`。安装时会下载匹配的 release
-artifact，校验 SHA-256，确认三个 binary 的版本和 build identity 一致，再原子替换
-旧的完整 binary set。下载、解压、checksum 或 identity 校验失败时，旧安装保持不变。
+package 只暴露一个公共命令 `webcodex`。安装时会下载匹配的 release artifact、校验
+SHA-256、确认三个 binary 版本/build identity 一致，再原子替换旧 binary set。下载、
+解压、checksum 或 identity 校验失败时，旧安装保持不变。
 
-`webcodex-server` 和 `webcodex-runner` 是 package-local binaries，不单独作为 npm
-`bin` 暴露；公共 CLI 会在 `webcodex server` 和 `webcodex agent` 命令中发现它们。
+`webcodex-server` 与 `webcodex-runner` 是 package-local binaries，不单独作为 npm `bin`
+暴露。公共 CLI 会通过 `webcodex server` 和兼容保留的 `webcodex agent` Runner 管理
+命名空间发现它们。
 
 ### 免责声明
 
-WebCodex 能够在配置的项目边界内读取、修改文件并执行命令，请使用版本控制和可恢复
-备份。
+WebCodex 能够在配置的项目边界内读取、修改文件并执行命令，请使用版本控制和可恢复备份。
 
 ## Development verification / 开发验证
-
-Source-level npm tests do not require publish checksums:
 
 ```bash
 npm --prefix npm/webcodex test
 ```
 
-Release smoke runs against the release-control-host-staged package that contains the generated publish-ready manifest. Reuse the exact extracted `linux-x64` CI candidate so the smoke does not rebuild release bytes:
-
-```bash
-bash scripts/npm_package_smoke.sh \
-  --package-dir <STAGE_DIR>/npm-package \
-  --binary-dir <EXTRACTED_LINUX_X64_DIR>
-```
-
-Omitting `--binary-dir` keeps the development behavior and builds the selected release/debug profile locally.
+Release smoke uses the release-control-host-staged package and exact extracted
+binary candidate; see the repository release documentation for the full command.
 
 ## License
 

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -202,19 +202,20 @@ pub(crate) fn parse_options(
 }
 
 pub(crate) fn usage() -> &'static str {
-    "Usage: webcodex setup [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
-       webcodex doctor [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
-       webcodex status [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
-       webcodex run [--root PATH] [--profile NAME] [--state-dir PATH]\n\
-                              [--console-assets-dir ABSOLUTE_PATH]\n\
-       webcodex share [--root PATH] [--profile NAME] [--state-dir PATH]\n\
+    "Usage: webcodex share [--root PATH] [--profile NAME] [--state-dir PATH]\n\
                      [--tunnel cloudflare|none] [--auth bearer|oauth]\n\
-                     [--oauth-redirect-uri URL] [--public-url URL]\n\n\
-Run setup in a local Git project. It writes private WebCodex state outside the\n\
-checkout and never starts services, modifies Git content, or opens a network\n\
-port. `run` is the explicit foreground runtime step. Its optional\n\
+                     [--oauth-redirect-uri URL] [--public-url URL]\n\
+       webcodex status [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
+       webcodex doctor [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
+       webcodex setup [--root PATH] [--profile NAME] [--state-dir PATH] [--json]\n\
+       webcodex run [--root PATH] [--profile NAME] [--state-dir PATH]\n\
+                              [--console-assets-dir ABSOLUTE_PATH]\n\n\
+`share` is the first-run path for ChatGPT/remote MCP: it performs project setup,\n\
+starts the local Server + Runner, and exposes a temporary credential. The default\n\
+Cloudflare Quick Tunnel requires `cloudflared` on PATH. `setup`, `doctor`, and\n\
+`run` remain the local/manual workflow; setup writes private state without\n\
+starting services. `run` is the explicit foreground local runtime step. Its optional\n\
 `--console-assets-dir` enables loopback-only development assets for that run.\n\
-`share` starts the same local runtime with a temporary Connector credential;\n\
 `--auth oauth` adds project-bound OAuth while preserving that project grant.\n"
 }
 

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -216,7 +216,8 @@ Cloudflare Quick Tunnel requires `cloudflared` on PATH. `setup`, `doctor`, and\n
 `run` remain the local/manual workflow; setup writes private state without\n\
 starting services. `run` is the explicit foreground local runtime step. Its optional\n\
 `--console-assets-dir` enables loopback-only development assets for that run.\n\
-`--auth oauth` adds project-bound OAuth while preserving that project grant.\n"
+`--auth oauth` adds project-bound OAuth while preserving that project grant.\n\
+On Windows, local Server/share runtime is unsupported; use `webcodex connect <server-url>` with a remote Linux Server.\n"
 }
 
 pub(crate) fn readiness_with_probe(

--- a/src/project_entry_share.rs
+++ b/src/project_entry_share.rs
@@ -408,6 +408,11 @@ fn tunnel_runtime_error() -> ProductError {
 }
 
 pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductError> {
+    // Fail before setup/state creation when the default public-share dependency is absent.
+    let cloudflared_binary = match options.tunnel {
+        TunnelProvider::CloudflareQuick => Some(locate_cloudflared()?),
+        TunnelProvider::None => None,
+    };
     setup(&options.project)?;
     let (config, paths) = configured_project(&options.project)?;
     ensure_local_runtime_port_available(
@@ -445,9 +450,11 @@ pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductEr
     let local_url = config.server_url();
     let (public_url, mut tunnel) = match options.tunnel {
         TunnelProvider::CloudflareQuick => {
-            let binary = locate_cloudflared()?;
+            let binary = cloudflared_binary
+                .as_deref()
+                .ok_or_else(tunnel_runtime_error)?;
             let (url, tunnel) =
-                start_cloudflare_quick_with_binary(&binary, &local_url, TUNNEL_START_TIMEOUT)
+                start_cloudflare_quick_with_binary(binary, &local_url, TUNNEL_START_TIMEOUT)
                     .await?;
             (url, Some(tunnel))
         }
@@ -543,14 +550,23 @@ fn render_share_ready(
 ) -> String {
     let (tunnel_name, public_access, ready_message) =
         share_access_labels(tunnel, externally_managed);
+    let base = public_url.trim_end_matches('/');
+    let next_steps = if tunnel == TunnelProvider::CloudflareQuick || externally_managed {
+        format!(
+            "What to do next\n1. In ChatGPT Developer Mode, create a custom MCP app.\n2. MCP URL: {base}/mcp\n3. Authentication: Bearer token\n4. Credential (this share only): {credential}\n5. Scan Tools.\n6. First prompt: \"Inspect this repository and summarize its structure. Do not make changes.\""
+        )
+    } else {
+        format!(
+            "What to do next\n1. Add this MCP endpoint to a local MCP client: {base}/mcp\n2. Authentication: Bearer token\n3. Credential (this share only): {credential}\n4. First prompt: \"Inspect this repository and summarize its structure. Do not make changes.\""
+        )
+    };
     let lifetime_message = if tunnel == TunnelProvider::CloudflareQuick {
         "This credential and tunneled URL are temporary."
     } else {
         "This credential is temporary."
     };
     format!(
-        "Project: {project_name}\nRuntime: local\nTunnel: {tunnel_name}\nPublic access: {public_access}\n\nMCP URL:\n  {}/mcp\n\nAuthentication:\n  Bearer token\n\nToken:\n  {credential}\n\n{ready_message}\n\n{lifetime_message}\nPress Ctrl-C to stop sharing.",
-        public_url.trim_end_matches('/')
+        "WebCodex ready\n\n{next_steps}\n\n{ready_message}\n\nDetails\nProject: {project_name}\nRuntime: local\nTunnel: {tunnel_name}\nPublic access: {public_access}\nCredential lifetime: {lifetime_message}\nPress Ctrl-C to stop sharing."
     )
 }
 
@@ -570,8 +586,13 @@ fn render_share_oauth_ready(
         "The project share credential and OAuth grants are temporary. The client ID/secret are persisted for this project and redirect URI."
     };
     let base = public_url.trim_end_matches('/');
+    let client_step = if tunnel == TunnelProvider::CloudflareQuick || externally_managed {
+        "1. In ChatGPT Developer Mode, create a custom MCP app."
+    } else {
+        "1. In a local MCP client, create an MCP connection."
+    };
     format!(
-        "Project: {project_name}\nRuntime: local\nTunnel: {tunnel_name}\nPublic access: {public_access}\n\nMCP URL:\n  {base}/mcp\n\nAuthentication:\n  OAuth 2.0 Authorization Code + PKCE S256\n\nAuthorization server:\n  {base}\n\nClient ID:\n  {}\n\nClient secret:\n  {}\n\nRedirect URI:\n  {}\n\nProject share credential:\n  {credential}\n\nUse the project share credential only on the WebCodex authorization page. OAuth access/refresh grants are fenced to this share process and cannot survive a restart.\n\n{ready_message}\n\n{lifetime_message}\nPress Ctrl-C to stop sharing.",
+        "WebCodex ready\n\nWhat to do next\n{client_step}\n2. MCP URL: {base}/mcp\n3. Authentication: OAuth 2.0 Authorization Code + PKCE S256\n4. Client ID: {}\n5. Client secret: {}\n6. Redirect URI: {}\n7. Scan Tools and complete the WebCodex authorization flow.\n   Project share credential (this share only): {credential}\n   Enter it only on the WebCodex authorization page; do not put it in ChatGPT.\n8. First prompt: \"Inspect this repository and summarize its structure. Do not make changes.\"\n\n{ready_message}\n\nDetails\nProject: {project_name}\nRuntime: local\nTunnel: {tunnel_name}\nPublic access: {public_access}\nAuthorization server: {base}\nOAuth grant lifetime: fenced to this share process; access/refresh grants cannot survive a restart.\nCredential lifetime: {lifetime_message}\nPress Ctrl-C to stop sharing.",
         oauth.client_id, oauth.client_secret, oauth.redirect_uri
     )
 }
@@ -588,7 +609,7 @@ fn require_cloudflared_from(
     locate_cloudflared_from(override_bin, path).ok_or_else(|| {
         ProductError::new(
             "tunnel_unavailable",
-            "cloudflared was not found",
+            "cloudflared is required for the default public HTTPS share and was not found",
             Some(
                 "Install cloudflared from Cloudflare's official downloads (https://developers.cloudflare.com/tunnel/downloads/), ensure it is on PATH, then retry; or use webcodex share --tunnel none for local-only debugging.",
             ),
@@ -783,7 +804,10 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let error = require_cloudflared_from(Some(&temp.path().join("missing")), None).unwrap_err();
         assert_eq!(error.code, "tunnel_unavailable");
-        assert!(error.message.contains("cloudflared was not found"));
+        assert!(error
+            .message
+            .contains("required for the default public HTTPS share"));
+        assert!(error.message.contains("was not found"));
         let next_action = error.next_action.unwrap();
         assert!(next_action.contains("https://developers.cloudflare.com/tunnel/downloads/"));
         assert!(next_action.contains("--tunnel none"));
@@ -848,7 +872,12 @@ mod tests {
         );
         assert!(output.contains(temporary));
         assert!(!output.contains(persistent));
+        assert!(output.starts_with("WebCodex ready\n\nWhat to do next"));
         assert!(output.contains("https://demo.trycloudflare.com/mcp"));
+        assert!(output.contains("Authentication: Bearer token"));
+        assert!(output.contains("Scan Tools"));
+        assert!(output.contains("First prompt:"));
+        assert!(output.find("What to do next").unwrap() < output.find("Details").unwrap());
     }
 
     #[test]
@@ -862,7 +891,9 @@ mod tests {
         );
         assert!(output.contains("Ready for a local MCP client"));
         assert!(output.contains("No public tunnel is running"));
+        assert!(output.contains("Add this MCP endpoint to a local MCP client"));
         assert!(!output.contains("Ready for ChatGPT"));
+        assert!(!output.contains("In ChatGPT Developer Mode"));
         assert!(!output.contains("tunneled URL"));
     }
 
@@ -886,6 +917,9 @@ mod tests {
         assert!(output.contains("wc_client_test"));
         assert!(output.contains("wc_csec_test"));
         assert!(output.contains("webcodex_temporary-print-once"));
+        assert!(output.starts_with("WebCodex ready\n\nWhat to do next"));
+        assert!(output.contains("Project share credential (this share only)"));
+        assert!(output.find("MCP URL:").unwrap() < output.find("Details").unwrap());
         assert!(output.contains("fenced to this share process"));
         assert!(output.contains("externally managed"));
     }


### PR DESCRIPTION
## Summary

- make `webcodex share` the primary Linux/macOS first-run path and clarify the Windows remote-Server path
- reorganize CLI/connect/share output around actionable ChatGPT Developer Mode MCP setup while preserving one-time credential disclosure
- align README, Quick Start, MCP, deployment, npm, and Console guidance with the current onboarding flow
- fail early when the default public share is missing `cloudflared`
- clarify that ChatGPT Developer Mode/custom MCP/write availability remains controlled by the ChatGPT plan/workspace/admin boundary

## Review fixes

Independent review caught and fixed one stale top-level-help regression (`Advanced / compatibility`) and added the client-side ChatGPT permission boundary to user-facing onboarding docs/Console copy.

## Validation

- `cargo test -p webcodex-cli` — 289 passed
- `cargo test -p webcodex project_entry` — 45 passed
- `cargo check --all-targets -p webcodex -p webcodex-cli` — PASS
- `cargo fmt -- --check` — PASS
- `git diff --check` — PASS
- `frontend/src/console.html` and `frontend/dist/console.html` — identical
