### PR TITLE
Add exact committed-range diff hunks

### DIFF
--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -2635,6 +2635,8 @@ pub(crate) fn git_diff_hunks_command(paths: &[String], cached: bool) -> Result<S
     if cached {
         parts.push("--cached".to_string());
     }
+    parts.push("--no-ext-diff".to_string());
+    parts.push("--no-textconv".to_string());
     parts.push("--unified=80".to_string());
     if !paths.is_empty() {
         parts.push("--".to_string());
@@ -2649,6 +2651,8 @@ fn git_diff_hunks_fingerprint_command(paths: &[String], cached: bool) -> String 
         parts.push("--cached".to_string());
     }
     parts.extend([
+        "--no-ext-diff".to_string(),
+        "--no-textconv".to_string(),
         "--binary".to_string(),
         "--full-index".to_string(),
         "--unified=80".to_string(),
@@ -3020,6 +3024,27 @@ fn strip_diff_prefix(path: &str) -> String {
         .to_string()
 }
 
+fn parse_binary_diff_paths(line: &str) -> Option<(Option<String>, Option<String>)> {
+    let body = line
+        .strip_prefix("Binary files ")?
+        .strip_suffix(" differ")?;
+    for (index, _) in body.match_indices(" and ") {
+        let old_raw = &body[..index];
+        let new_raw = &body[index + " and ".len()..];
+        let old_path = (old_raw != "/dev/null").then(|| strip_diff_prefix(old_raw));
+        let path = (new_raw != "/dev/null").then(|| strip_diff_prefix(new_raw));
+        let plausible = match (&old_path, &path) {
+            (None, Some(_)) | (Some(_), None) => true,
+            (Some(old_path), Some(path)) => old_path == path,
+            (None, None) => false,
+        };
+        if plausible {
+            return Some((old_path, path));
+        }
+    }
+    None
+}
+
 fn parse_hunk_header(header: &str) -> (i64, i64, i64, i64) {
     fn parse_range(raw: &str) -> (i64, i64) {
         let raw = raw.trim_start_matches(['-', '+']);
@@ -3121,6 +3146,17 @@ pub(crate) fn parse_git_diff_hunks(
             file.insert("status".to_string(), json!("renamed"));
         } else if line.starts_with("Binary files ") {
             file.insert("binary".to_string(), json!(true));
+            if file.get("status").and_then(Value::as_str) != Some("renamed") {
+                if let Some((old_path, path)) = parse_binary_diff_paths(line) {
+                    file.insert("old_path".to_string(), json!(old_path));
+                    file.insert("path".to_string(), json!(path));
+                    if file.get("old_path").is_some_and(Value::is_null) {
+                        file.insert("status".to_string(), json!("added"));
+                    } else if file.get("path").is_some_and(Value::is_null) {
+                        file.insert("status".to_string(), json!("deleted"));
+                    }
+                }
+            }
         } else if let Some(path) = line.strip_prefix("--- ") {
             if path == "/dev/null" {
                 file.insert("old_path".to_string(), json!(null));

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -7,6 +7,10 @@ use std::time::Duration;
 use webcodex_workspace::file_read_normalize::MODEL_RESULT_ENVELOPE_RESERVE_BYTES;
 use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
 
+use super::git_committed::{
+    committed_git_discovery_prefix, committed_git_isolated_view_setup, normalize_exact_commit_id,
+    CommittedGitScope,
+};
 use super::helpers::{
     run_command_sync_bounded, shell_escape_simple, validate_limited_cleanup_paths,
     validate_project_relative_path, LocalRunFailure,
@@ -30,6 +34,7 @@ const MAX_MAX_HUNK_LINES: usize = 400;
 pub(crate) const GIT_DIFF_HUNKS_CONTINUATION_MAX_BYTES: usize = 512;
 const GIT_DIFF_HUNKS_CONTINUATION_PREFIX: &str = "wcdh1.";
 const GIT_DIFF_HUNKS_CONTINUATION_VERSION: u8 = 1;
+const GIT_DIFF_HUNKS_COMMITTED_CONTINUATION_VERSION: u8 = 2;
 pub(crate) const GIT_DIFF_HUNKS_PAGE_BYTES: usize = 32 * 1024;
 const GIT_DIFF_HUNKS_STDERR_BYTES: usize = 8 * 1024;
 const GIT_DIFF_HUNKS_BLOCK_TRAILER_BYTES: usize = 30;
@@ -2279,6 +2284,10 @@ struct GitDiffHunksContinuationV1 {
     scope: String,
     fence: String,
     next: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    mac: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2318,6 +2327,77 @@ fn git_diff_hunks_scope_digest(resolved_project: &str, paths: &[String], cached:
     format!("{:x}", hasher.finalize())
 }
 
+fn git_diff_hunks_committed_scope_digest(
+    resolved_project: &str,
+    paths: &[String],
+    scope: &CommittedGitScope,
+    max_hunks: usize,
+    max_hunk_lines: usize,
+) -> String {
+    let mut normalized_paths = paths.to_vec();
+    normalized_paths.sort();
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex.git-diff-hunks.scope.committed.v1\0");
+    for value in [
+        resolved_project,
+        scope.requested_base.as_str(),
+        scope.requested_head.as_str(),
+        scope.merge_base.as_str(),
+    ] {
+        hasher.update((value.len() as u64).to_be_bytes());
+        hasher.update(value.as_bytes());
+        hasher.update([0]);
+    }
+    hasher.update((max_hunks as u64).to_be_bytes());
+    hasher.update((max_hunk_lines as u64).to_be_bytes());
+    hasher.update((GIT_DIFF_HUNKS_PAGE_BYTES as u64).to_be_bytes());
+    for path in normalized_paths {
+        hasher.update((path.len() as u64).to_be_bytes());
+        hasher.update(path.as_bytes());
+        hasher.update([0]);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn git_diff_hunks_committed_token_mac(
+    key: &[u8; 32],
+    scope: &str,
+    fence: &str,
+    next: u64,
+) -> String {
+    const BLOCK_BYTES: usize = 64;
+    let mut ipad = [0x36u8; BLOCK_BYTES];
+    let mut opad = [0x5cu8; BLOCK_BYTES];
+    for (index, byte) in key.iter().enumerate() {
+        ipad[index] ^= byte;
+        opad[index] ^= byte;
+    }
+    let mut inner = Sha256::new();
+    inner.update(ipad);
+    inner.update(b"webcodex.git-diff-hunks.continuation.committed.v2\0");
+    inner.update((scope.len() as u64).to_be_bytes());
+    inner.update(scope.as_bytes());
+    inner.update((fence.len() as u64).to_be_bytes());
+    inner.update(fence.as_bytes());
+    inner.update(next.to_be_bytes());
+    let inner = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(opad);
+    outer.update(inner);
+    format!("{:x}", outer.finalize())
+}
+
+fn fixed_time_ascii_eq(left: &str, right: &str) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .fold(0u8, |diff, (left, right)| diff | (left ^ right))
+        == 0
+}
+
 fn encode_git_diff_hunks_continuation(
     scope: &str,
     fence: &str,
@@ -2328,6 +2408,32 @@ fn encode_git_diff_hunks_continuation(
         scope: scope.to_string(),
         fence: fence.to_string(),
         next: next as u64,
+        mode: None,
+        mac: None,
+    };
+    let encoded = general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&token).map_err(|_| "failed to encode git diff continuation")?);
+    let value = format!("{GIT_DIFF_HUNKS_CONTINUATION_PREFIX}{encoded}");
+    if value.len() > GIT_DIFF_HUNKS_CONTINUATION_MAX_BYTES {
+        return Err("git diff continuation exceeded its size bound".to_string());
+    }
+    Ok(value)
+}
+
+fn encode_git_diff_hunks_committed_continuation(
+    key: &[u8; 32],
+    scope: &str,
+    fence: &str,
+    next: usize,
+) -> Result<String, String> {
+    let next = next as u64;
+    let token = GitDiffHunksContinuationV1 {
+        v: GIT_DIFF_HUNKS_COMMITTED_CONTINUATION_VERSION,
+        scope: scope.to_string(),
+        fence: fence.to_string(),
+        next,
+        mode: Some("committed".to_string()),
+        mac: Some(git_diff_hunks_committed_token_mac(key, scope, fence, next)),
     };
     let encoded = general_purpose::URL_SAFE_NO_PAD
         .encode(serde_json::to_vec(&token).map_err(|_| "failed to encode git diff continuation")?);
@@ -2341,6 +2447,7 @@ fn encode_git_diff_hunks_continuation(
 fn decode_git_diff_hunks_continuation(
     raw: &str,
     expected_scope: &str,
+    committed_mac_key: Option<&[u8; 32]>,
 ) -> Result<GitDiffHunksContinuationV1, GitDiffHunksContinuationError> {
     if raw.is_empty() || raw.len() > GIT_DIFF_HUNKS_CONTINUATION_MAX_BYTES {
         return Err(GitDiffHunksContinuationError::Invalid);
@@ -2356,13 +2463,34 @@ fn decode_git_diff_hunks_continuation(
     }
     let token: GitDiffHunksContinuationV1 =
         serde_json::from_slice(&decoded).map_err(|_| GitDiffHunksContinuationError::Invalid)?;
-    if token.v != GIT_DIFF_HUNKS_CONTINUATION_VERSION
-        || !is_lower_hex(&token.scope, 64)
+    if !is_lower_hex(&token.scope, 64)
         || !is_git_object_hex(&token.fence)
         || token.next == 0
         || usize::try_from(token.next).is_err()
     {
         return Err(GitDiffHunksContinuationError::Invalid);
+    }
+    if let Some(key) = committed_mac_key {
+        if token.v != GIT_DIFF_HUNKS_COMMITTED_CONTINUATION_VERSION
+            || token.mode.as_deref() != Some("committed")
+        {
+            return Err(GitDiffHunksContinuationError::ScopeMismatch);
+        }
+        let mac = token
+            .mac
+            .as_deref()
+            .filter(|value| is_lower_hex(value, 64))
+            .ok_or(GitDiffHunksContinuationError::Invalid)?;
+        let expected_mac =
+            git_diff_hunks_committed_token_mac(key, &token.scope, &token.fence, token.next);
+        if !fixed_time_ascii_eq(mac, &expected_mac) {
+            return Err(GitDiffHunksContinuationError::Invalid);
+        }
+    } else if token.v != GIT_DIFF_HUNKS_CONTINUATION_VERSION
+        || token.mode.is_some()
+        || token.mac.is_some()
+    {
+        return Err(GitDiffHunksContinuationError::ScopeMismatch);
     }
     if token.scope != expected_scope {
         return Err(GitDiffHunksContinuationError::ScopeMismatch);
@@ -2408,6 +2536,65 @@ fn git_diff_hunks_failure(
             "state_changed": false,
         }),
     )
+}
+
+fn committed_git_diff_hunks_scope_value(scope: &CommittedGitScope) -> Value {
+    json!({
+        "mode": "committed",
+        "requested_base": scope.requested_base,
+        "requested_head": scope.requested_head,
+        "merge_base": scope.merge_base,
+        "base_is_ancestor": scope.base_is_ancestor,
+        "diff_range": format!("{}..{}", scope.merge_base, scope.requested_head),
+    })
+}
+
+fn git_diff_hunks_committed_failure(
+    project: &str,
+    paths: &[String],
+    requested_base: Option<&str>,
+    requested_head: Option<&str>,
+    reason_code: &'static str,
+    exit_code: Option<i32>,
+    stderr: &str,
+) -> ToolResult {
+    let mut result = git_diff_hunks_failure(project, paths, false, reason_code, exit_code, stderr);
+    let requested_base = requested_base.and_then(|value| normalize_exact_commit_id(value).ok());
+    let requested_head = requested_head.and_then(|value| normalize_exact_commit_id(value).ok());
+    if let Some(output) = result.output.as_object_mut() {
+        output.insert(
+            "scope".to_string(),
+            json!({
+                "mode": "committed",
+                "requested_base": requested_base,
+                "requested_head": requested_head,
+                "merge_base": null,
+                "base_is_ancestor": null,
+                "diff_range": null,
+            }),
+        );
+    }
+    result
+}
+
+fn normalize_git_diff_hunks_committed_range(
+    base_commit: Option<&str>,
+    head_commit: Option<&str>,
+    cached_present: bool,
+) -> Result<Option<(String, String)>, &'static str> {
+    match (base_commit, head_commit) {
+        (None, None) => Ok(None),
+        (Some(_), None) | (None, Some(_)) => Err("committed_range_requires_base_and_head"),
+        (Some(base), Some(head)) => {
+            if cached_present {
+                return Err("committed_range_conflicts_with_cached");
+            }
+            Ok(Some((
+                normalize_exact_commit_id(&base)?,
+                normalize_exact_commit_id(&head)?,
+            )))
+        }
+    }
 }
 
 fn clean_optional_paths(paths: Option<Vec<String>>) -> Result<Vec<String>, String> {
@@ -2457,6 +2644,38 @@ fn git_diff_hunks_fingerprint_command(paths: &[String], cached: bool) -> String 
     parts.join(" ")
 }
 
+fn git_diff_hunks_committed_command(
+    scope: &CommittedGitScope,
+    paths: &[String],
+    fingerprint: bool,
+) -> String {
+    let head_q = shell_escape_simple(&scope.requested_head);
+    let mut parts = vec![
+        "git".to_string(),
+        "--no-pager".to_string(),
+        "-c".to_string(),
+        "core.quotePath=false".to_string(),
+        "-c".to_string(),
+        format!("attr.tree={head_q}"),
+        "diff".to_string(),
+        "--no-ext-diff".to_string(),
+        "--no-textconv".to_string(),
+        "--find-renames".to_string(),
+    ];
+    if fingerprint {
+        parts.push("--binary".to_string());
+        parts.push("--full-index".to_string());
+    }
+    parts.push("--unified=80".to_string());
+    parts.push(shell_escape_simple(&scope.merge_base));
+    parts.push(head_q);
+    if !paths.is_empty() {
+        parts.push("--".to_string());
+        parts.extend(paths.iter().map(|path| shell_escape_simple(path)));
+    }
+    parts.join(" ")
+}
+
 fn git_diff_hunks_page_command(
     paths: &[String],
     cached: bool,
@@ -2464,11 +2683,27 @@ fn git_diff_hunks_page_command(
     max_hunks: usize,
     max_hunk_lines: usize,
     expected_fence: Option<&str>,
+    committed_scope: Option<&CommittedGitScope>,
 ) -> Result<String, String> {
-    let diff_command = git_diff_hunks_command(paths, cached)?;
-    let fingerprint_command = git_diff_hunks_fingerprint_command(paths, cached);
+    let (diff_command, fingerprint_command, prelude) = match committed_scope {
+        Some(scope) => (
+            git_diff_hunks_committed_command(scope, paths, false),
+            git_diff_hunks_committed_command(scope, paths, true),
+            format!(
+                "{}{}",
+                committed_git_discovery_prefix(),
+                committed_git_isolated_view_setup(&scope.requested_head, "exit 91")
+            ),
+        ),
+        None => (
+            git_diff_hunks_command(paths, cached)?,
+            git_diff_hunks_fingerprint_command(paths, cached),
+            String::new(),
+        ),
+    };
     let expected_fence = shell_escape_simple(expected_fence.unwrap_or(""));
-    let script = r#"LC_ALL=C; export LC_ALL
+    let script = r#"__PRELUDE__
+LC_ALL=C; export LC_ALL
 page_budget=__PAGE_BUDGET__
 max_hunks=__MAX_HUNKS__
 max_hunk_lines=__MAX_HUNK_LINES__
@@ -2608,6 +2843,7 @@ fi
 exit 1
 "#;
     Ok(script
+        .replace("__PRELUDE__", &prelude)
         .replace("__PAGE_BUDGET__", &GIT_DIFF_HUNKS_PAGE_BYTES.to_string())
         .replace("__MAX_HUNKS__", &max_hunks.to_string())
         .replace("__MAX_HUNK_LINES__", &max_hunk_lines.to_string())
@@ -3195,6 +3431,7 @@ impl ToolRuntime {
             .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn git_diff_hunks_continued(
         &self,
         project: String,
@@ -3204,9 +3441,51 @@ impl ToolRuntime {
         cached: Option<bool>,
         continuation: Option<String>,
     ) -> ToolResult {
+        self.git_diff_hunks_continued_with_range(
+            project,
+            paths,
+            max_hunks,
+            max_hunk_lines,
+            cached,
+            None,
+            None,
+            continuation,
+        )
+        .await
+    }
+
+    pub(crate) async fn git_diff_hunks_continued_with_range(
+        &self,
+        project: String,
+        paths: Option<Vec<String>>,
+        max_hunks: Option<usize>,
+        max_hunk_lines: Option<usize>,
+        cached: Option<bool>,
+        base_commit: Option<String>,
+        head_commit: Option<String>,
+        continuation: Option<String>,
+    ) -> ToolResult {
         let paths = match clean_optional_paths(paths) {
             Ok(paths) => paths,
             Err(e) => return ToolResult::err(e),
+        };
+        let committed_range = match normalize_git_diff_hunks_committed_range(
+            base_commit.as_deref(),
+            head_commit.as_deref(),
+            cached.is_some(),
+        ) {
+            Ok(range) => range,
+            Err(reason) => {
+                return git_diff_hunks_committed_failure(
+                    &project,
+                    &paths,
+                    base_commit.as_deref(),
+                    head_commit.as_deref(),
+                    reason,
+                    None,
+                    "",
+                )
+            }
         };
         let max_hunks = max_hunks
             .filter(|n| *n > 0)
@@ -3234,33 +3513,70 @@ impl ToolRuntime {
             Ok(resolved) => resolved,
             Err(error) => return error.into_tool_result(),
         };
-        let scope = git_diff_hunks_scope_digest(&resolved.resolved_id, &paths, cached);
-        let mut command_paths = paths.clone();
-        command_paths.sort();
-        let decoded = match continuation.as_deref() {
-            Some(raw) => match decode_git_diff_hunks_continuation(raw, &scope) {
-                Ok(token) => Some(token),
-                Err(GitDiffHunksContinuationError::Invalid) => {
-                    return git_diff_hunks_failure(
+        let committed_scope = match committed_range.as_ref() {
+            Some((base, head)) => match self
+                .resolve_committed_git_scope(&resolved.resolved_id, base, head)
+                .await
+            {
+                Ok(scope) => Some(scope),
+                Err(reason) => {
+                    return git_diff_hunks_committed_failure(
                         &project,
                         &paths,
-                        cached,
-                        "invalid_continuation",
-                        None,
-                        "",
-                    )
-                }
-                Err(GitDiffHunksContinuationError::ScopeMismatch) => {
-                    return git_diff_hunks_failure(
-                        &project,
-                        &paths,
-                        cached,
-                        "continuation_mismatch",
+                        Some(base),
+                        Some(head),
+                        reason,
                         None,
                         "",
                     )
                 }
             },
+            None => None,
+        };
+        let scope = match committed_scope.as_ref() {
+            Some(committed_scope) => git_diff_hunks_committed_scope_digest(
+                &resolved.resolved_id,
+                &paths,
+                committed_scope,
+                max_hunks,
+                max_hunk_lines,
+            ),
+            None => git_diff_hunks_scope_digest(&resolved.resolved_id, &paths, cached),
+        };
+        let mut command_paths = paths.clone();
+        command_paths.sort();
+        let decoded = match continuation.as_deref() {
+            Some(raw) => {
+                match decode_git_diff_hunks_continuation(
+                    raw,
+                    &scope,
+                    committed_scope
+                        .as_ref()
+                        .map(|_| self.git_diff_hunks_continuation_mac_key.as_ref()),
+                ) {
+                    Ok(token) => Some(token),
+                    Err(GitDiffHunksContinuationError::Invalid) => {
+                        return git_diff_hunks_failure(
+                            &project,
+                            &paths,
+                            cached,
+                            "invalid_continuation",
+                            None,
+                            "",
+                        )
+                    }
+                    Err(GitDiffHunksContinuationError::ScopeMismatch) => {
+                        return git_diff_hunks_failure(
+                            &project,
+                            &paths,
+                            cached,
+                            "continuation_mismatch",
+                            None,
+                            "",
+                        )
+                    }
+                }
+            }
             None => None,
         };
         let start_position = decoded
@@ -3275,6 +3591,7 @@ impl ToolRuntime {
             max_hunks,
             max_hunk_lines,
             expected_fence,
+            committed_scope.as_ref(),
         ) {
             Ok(command) => command,
             Err(_) => {
@@ -3434,7 +3751,17 @@ impl ToolRuntime {
             truncation_reasons.push("page_byte_budget");
         }
         let next_continuation = if wire.has_more {
-            match encode_git_diff_hunks_continuation(&scope, &wire.pre_fence, wire.next_position) {
+            let encoded = if committed_scope.is_some() {
+                encode_git_diff_hunks_committed_continuation(
+                    self.git_diff_hunks_continuation_mac_key.as_ref(),
+                    &scope,
+                    &wire.pre_fence,
+                    wire.next_position,
+                )
+            } else {
+                encode_git_diff_hunks_continuation(&scope, &wire.pre_fence, wire.next_position)
+            };
+            match encoded {
                 Ok(value) => Some(value),
                 Err(_) => {
                     return git_diff_hunks_failure(
@@ -3450,7 +3777,7 @@ impl ToolRuntime {
         } else {
             None
         };
-        let payload = json!({
+        let mut payload = json!({
             "project": project,
             "paths": paths,
             "cached": cached,
@@ -3463,6 +3790,14 @@ impl ToolRuntime {
             "exit_code": wire.diff_exit,
             "stderr": stderr,
         });
+        if let Some(committed_scope) = committed_scope.as_ref() {
+            if let Some(payload) = payload.as_object_mut() {
+                payload.insert(
+                    "scope".to_string(),
+                    committed_git_diff_hunks_scope_value(committed_scope),
+                );
+            }
+        }
         let result = ToolResult::ok(payload);
         if serde_json::to_vec(&result)
             .map(|bytes| {

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -12,8 +12,8 @@ use super::git_committed::{
     CommittedGitScope,
 };
 use super::helpers::{
-    run_command_sync_bounded, shell_escape_simple, validate_limited_cleanup_paths,
-    validate_project_relative_path, LocalRunFailure,
+    decode_git_quoted_path, run_command_sync_bounded, shell_escape_simple,
+    validate_limited_cleanup_paths, validate_project_relative_path, LocalRunFailure,
 };
 use super::tool_result::ToolResult;
 use super::ToolRuntime;
@@ -2614,6 +2614,22 @@ fn clean_optional_paths(paths: Option<Vec<String>>) -> Result<Vec<String>, Strin
     Ok(clean)
 }
 
+fn git_diff_hunks_paths_include_secret(paths: &[String]) -> bool {
+    paths
+        .iter()
+        .any(|path| crate::sensitive_paths::is_secret_path(path))
+}
+
+fn git_diff_hunks_files_include_secret(files: &[Value]) -> bool {
+    files.iter().any(|file| {
+        ["path", "old_path"].into_iter().any(|field| {
+            file.get(field)
+                .and_then(Value::as_str)
+                .is_some_and(crate::sensitive_paths::is_secret_path)
+        })
+    })
+}
+
 pub(crate) fn git_diff_hunks_command(paths: &[String], cached: bool) -> Result<String, String> {
     let mut parts = vec!["git".to_string(), "diff".to_string()];
     if cached {
@@ -2996,9 +3012,11 @@ fn mark_git_diff_hunks_page_metadata(
 }
 
 fn strip_diff_prefix(path: &str) -> String {
-    path.strip_prefix("a/")
-        .or_else(|| path.strip_prefix("b/"))
-        .unwrap_or(path)
+    let decoded = decode_git_quoted_path(path).unwrap_or_else(|| path.to_string());
+    decoded
+        .strip_prefix("a/")
+        .or_else(|| decoded.strip_prefix("b/"))
+        .unwrap_or(&decoded)
         .to_string()
 }
 
@@ -3096,10 +3114,10 @@ pub(crate) fn parse_git_diff_hunks(
         } else if line.starts_with("deleted file mode ") {
             file.insert("status".to_string(), json!("deleted"));
         } else if let Some(path) = line.strip_prefix("rename from ") {
-            file.insert("old_path".to_string(), json!(path));
+            file.insert("old_path".to_string(), json!(strip_diff_prefix(path)));
             file.insert("status".to_string(), json!("renamed"));
         } else if let Some(path) = line.strip_prefix("rename to ") {
-            file.insert("path".to_string(), json!(path));
+            file.insert("path".to_string(), json!(strip_diff_prefix(path)));
             file.insert("status".to_string(), json!("renamed"));
         } else if line.starts_with("Binary files ") {
             file.insert("binary".to_string(), json!(true));
@@ -3469,6 +3487,16 @@ impl ToolRuntime {
             Ok(paths) => paths,
             Err(e) => return ToolResult::err(e),
         };
+        if git_diff_hunks_paths_include_secret(&paths) {
+            return git_diff_hunks_failure(
+                &project,
+                &paths,
+                cached.unwrap_or(false),
+                "sensitive_path",
+                None,
+                "",
+            );
+        }
         let committed_range = match normalize_git_diff_hunks_committed_range(
             base_commit.as_deref(),
             head_commit.as_deref(),
@@ -3719,6 +3747,16 @@ impl ToolRuntime {
         }
         let (mut files, parsed_hunks, parser_truncated) =
             parse_git_diff_hunks(&wire.diff, MAX_MAX_HUNKS, MAX_MAX_HUNK_LINES);
+        if git_diff_hunks_files_include_secret(&files) {
+            return git_diff_hunks_failure(
+                &project,
+                &paths,
+                cached,
+                "sensitive_path",
+                output.exit_code,
+                "",
+            );
+        }
         let marked_hunks = mark_git_diff_hunks_page_metadata(
             &mut files,
             &wire.truncated_hunks,

--- a/src/tool_runtime/git_committed.rs
+++ b/src/tool_runtime/git_committed.rs
@@ -1,0 +1,209 @@
+use super::helpers::shell_escape_simple;
+use super::ToolRuntime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommittedGitScope {
+    pub(crate) requested_base: String,
+    pub(crate) requested_head: String,
+    pub(crate) merge_base: String,
+    pub(crate) base_is_ancestor: bool,
+    pub(crate) commit_count: u64,
+    pub(crate) files_changed: u64,
+    pub(crate) insertions: u64,
+    pub(crate) deletions: u64,
+    pub(crate) binary_files: u64,
+}
+
+pub(crate) fn normalize_exact_commit_id(value: &str) -> Result<String, &'static str> {
+    if value.len() != 40 || !value.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err("invalid_commit_id");
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+pub(crate) fn committed_git_discovery_prefix() -> &'static str {
+    concat!(
+        "export LC_ALL=C GIT_PAGER=cat GIT_NO_REPLACE_OBJECTS=1 GIT_NO_LAZY_FETCH=1 ",
+        "GIT_OPTIONAL_LOCKS=0 GIT_ATTR_NOSYSTEM=1 GIT_CONFIG_COUNT=0; ",
+        "unset GIT_EXTERNAL_DIFF GIT_DIFF_OPTS GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE ",
+        "GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR ",
+        "GIT_CEILING_DIRECTORIES GIT_ATTR_SOURCE GIT_CONFIG GIT_CONFIG_PARAMETERS ",
+        "GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM GIT_SHALLOW_FILE ",
+        "GIT_NAMESPACE; "
+    )
+}
+
+pub(crate) fn committed_git_isolated_view_setup(head: &str, failure: &str) -> String {
+    format!(
+        concat!(
+            "object_dir=$(git rev-parse --path-format=absolute --git-path objects 2>/dev/null) || {{ {failure}; }}; ",
+            "view=$(mktemp -d /tmp/webcodex-git-review.XXXXXX 2>/dev/null) || {{ {failure}; }}; ",
+            "cleanup_git_review_view() {{ rm -rf -- \"$view\"; }}; ",
+            "trap cleanup_git_review_view EXIT; trap 'exit 130' HUP INT TERM; ",
+            "mkdir -p \"$view/refs\" \"$view/objects/info\" || {{ {failure}; }}; ",
+            "printf 'ref: refs/heads/unused\\n' >\"$view/HEAD\" || {{ {failure}; }}; ",
+            "printf '[core]\\n\\trepositoryformatversion = 0\\n\\tbare = true\\n\\tattributesFile = /dev/null\\n' >\"$view/config\" || {{ {failure}; }}; ",
+            "export GIT_DIR=\"$view\" GIT_OBJECT_DIRECTORY=\"$object_dir\" GIT_ATTR_SOURCE={head_q} ",
+            "GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1; "
+        ),
+        failure = failure,
+        head_q = shell_escape_simple(head),
+    )
+}
+
+pub(crate) fn checked_git_pipeline_to_file(
+    producer: &str,
+    consumer: &str,
+    stem: &str,
+    failure: &str,
+) -> String {
+    debug_assert!(stem
+        .as_bytes()
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_'));
+    format!(
+        concat!(
+            "rm -f \"$view/{stem}.status\" \"$view/{stem}.out\"; ",
+            "{{ {producer}; producer_exit=$?; printf '%s\\n' \"$producer_exit\" >\"$view/{stem}.status\"; }} | ",
+            "{consumer} >\"$view/{stem}.out\"; ",
+            "consumer_exit=$?; ",
+            "producer_exit=$(cat \"$view/{stem}.status\" 2>/dev/null || true); ",
+            "if [ \"$consumer_exit\" -ne 0 ] || [ \"$producer_exit\" != 0 ]; then {failure}; fi; "
+        ),
+        producer = producer,
+        consumer = consumer,
+        stem = stem,
+        failure = failure,
+    )
+}
+
+pub(crate) fn committed_git_scope_command(base: &str, head: &str) -> String {
+    let isolated_view =
+        committed_git_isolated_view_setup(head, "printf 'status=git_view_unavailable\\n'; exit 0");
+    let head_q = shell_escape_simple(head);
+    let stats_producer = format!(
+        "git --no-pager -c core.quotePath=false -c attr.tree={head_q} diff --no-ext-diff --no-textconv --find-renames --numstat \"$merge_base\" {head_q}"
+    );
+    let stats_pipeline = checked_git_pipeline_to_file(
+        &stats_producer,
+        "awk 'BEGIN{f=0;a=0;d=0;b=0} {f++; if ($1==\"-\" || $2==\"-\") b++; else {a+=$1; d+=$2}} END{printf \"files_changed=%d\\ninsertions=%d\\ndeletions=%d\\nbinary_files=%d\\n\",f,a,d,b}'",
+        "scope_stats",
+        "printf 'status=diff_failed\\n'; exit 0",
+    );
+    format!(
+        concat!(
+            "{prefix}",
+            "if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then printf 'status=not_git\\n'; exit 0; fi; ",
+            "{isolated_view}",
+            "base_type=$(git cat-file -t {base_q} 2>/dev/null || true); ",
+            "if [ \"$base_type\" != commit ]; then printf 'status=base_not_commit\\n'; exit 0; fi; ",
+            "head_type=$(git cat-file -t {head_q} 2>/dev/null || true); ",
+            "if [ \"$head_type\" != commit ]; then printf 'status=head_not_commit\\n'; exit 0; fi; ",
+            "merge_bases=$(git merge-base --all {base_q} {head_q} 2>/dev/null || true); ",
+            "if [ -z \"$merge_bases\" ]; then printf 'status=no_merge_base\\n'; exit 0; fi; ",
+            "merge_base_count=$(printf '%s\\n' \"$merge_bases\" | awk 'NF{{n++}} END{{print n+0}}'); ",
+            "if [ \"$merge_base_count\" -ne 1 ]; then printf 'status=ambiguous_merge_base\\n'; exit 0; fi; ",
+            "merge_base=$merge_bases; ",
+            "if git merge-base --is-ancestor {base_q} {head_q} >/dev/null 2>&1; then base_is_ancestor=true; ",
+            "else ancestor_exit=$?; if [ \"$ancestor_exit\" -eq 1 ]; then base_is_ancestor=false; else printf 'status=ancestor_failed\\n'; exit 0; fi; fi; ",
+            "commit_count=$(git rev-list --count \"$merge_base..{head}\" 2>/dev/null) || {{ printf 'status=rev_list_failed\\n'; exit 0; }}; ",
+            "{stats_pipeline}",
+            "stats=$(cat \"$view/scope_stats.out\" 2>/dev/null) || {{ printf 'status=stats_failed\\n'; exit 0; }}; ",
+            "printf 'status=ok\\nrequested_base=%s\\nrequested_head=%s\\nmerge_base=%s\\nbase_is_ancestor=%s\\ncommit_count=%s\\n%s' ",
+            "{base_q} {head_q} \"$merge_base\" \"$base_is_ancestor\" \"$commit_count\" \"$stats\""
+        ),
+        prefix = committed_git_discovery_prefix(),
+        isolated_view = isolated_view,
+        stats_pipeline = stats_pipeline,
+        base_q = shell_escape_simple(base),
+        head_q = head_q,
+        head = head,
+    )
+}
+
+fn parse_scope_value<'a>(stdout: &'a str, key: &str) -> Option<&'a str> {
+    stdout.lines().find_map(|line| {
+        let (field, value) = line.split_once('=')?;
+        (field == key).then_some(value)
+    })
+}
+
+fn parse_u64_scope(stdout: &str, key: &str) -> Option<u64> {
+    parse_scope_value(stdout, key)?.parse().ok()
+}
+
+pub(crate) fn parse_committed_git_scope(stdout: &str) -> Result<CommittedGitScope, &'static str> {
+    match parse_scope_value(stdout, "status") {
+        Some("ok") => {}
+        Some("not_git") => return Err("not_a_git_repository"),
+        Some("base_not_commit") => return Err("base_commit_missing_or_not_commit"),
+        Some("head_not_commit") => return Err("head_commit_missing_or_not_commit"),
+        Some("no_merge_base") => return Err("no_merge_base"),
+        Some("ambiguous_merge_base") => return Err("ambiguous_merge_base"),
+        Some("git_view_unavailable") => return Err("git_isolated_view_unavailable"),
+        Some("ancestor_failed") => return Err("merge_base_ancestor_check_failed"),
+        Some("rev_list_failed") => return Err("commit_count_unavailable"),
+        Some("diff_failed") | Some("stats_failed") => return Err("git_diff_failed"),
+        _ => return Err("scope_observation_unavailable"),
+    }
+    let requested_base = normalize_exact_commit_id(
+        parse_scope_value(stdout, "requested_base").ok_or("scope_observation_unavailable")?,
+    )
+    .map_err(|_| "scope_observation_unavailable")?;
+    let requested_head = normalize_exact_commit_id(
+        parse_scope_value(stdout, "requested_head").ok_or("scope_observation_unavailable")?,
+    )
+    .map_err(|_| "scope_observation_unavailable")?;
+    let merge_base = normalize_exact_commit_id(
+        parse_scope_value(stdout, "merge_base").ok_or("scope_observation_unavailable")?,
+    )
+    .map_err(|_| "scope_observation_unavailable")?;
+    let base_is_ancestor = match parse_scope_value(stdout, "base_is_ancestor") {
+        Some("true") => true,
+        Some("false") => false,
+        _ => return Err("scope_observation_unavailable"),
+    };
+    Ok(CommittedGitScope {
+        requested_base,
+        requested_head,
+        merge_base,
+        base_is_ancestor,
+        commit_count: parse_u64_scope(stdout, "commit_count")
+            .ok_or("scope_observation_unavailable")?,
+        files_changed: parse_u64_scope(stdout, "files_changed")
+            .ok_or("scope_observation_unavailable")?,
+        insertions: parse_u64_scope(stdout, "insertions").ok_or("scope_observation_unavailable")?,
+        deletions: parse_u64_scope(stdout, "deletions").ok_or("scope_observation_unavailable")?,
+        binary_files: parse_u64_scope(stdout, "binary_files")
+            .ok_or("scope_observation_unavailable")?,
+    })
+}
+
+impl ToolRuntime {
+    pub(crate) async fn resolve_committed_git_scope(
+        &self,
+        resolved_project: &str,
+        base_commit: &str,
+        head_commit: &str,
+    ) -> Result<CommittedGitScope, &'static str> {
+        let base = normalize_exact_commit_id(base_commit)?;
+        let head = normalize_exact_commit_id(head_commit)?;
+        let output = self
+            .run_project_internal_posix_script_capture(
+                resolved_project,
+                committed_git_scope_command(&base, &head),
+                30,
+                None,
+            )
+            .await
+            .map_err(|_| "scope_observation_unavailable")?;
+        if output.exit_code != Some(0) || output.error.is_some() {
+            return Err("scope_observation_unavailable");
+        }
+        let scope = parse_committed_git_scope(&output.stdout)?;
+        if scope.requested_base != base || scope.requested_head != head {
+            return Err("scope_observation_mismatch");
+        }
+        Ok(scope)
+    }
+}

--- a/src/tool_runtime/git_review.rs
+++ b/src/tool_runtime/git_review.rs
@@ -3,6 +3,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use webcodex_workspace::file_read_normalize::MODEL_RESULT_ENVELOPE_RESERVE_BYTES;
 use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
 
+use super::git_committed::{
+    checked_git_pipeline_to_file, committed_git_discovery_prefix,
+    committed_git_isolated_view_setup, normalize_exact_commit_id,
+};
 use super::helpers::{shell_escape_simple, validate_project_relative_path};
 use super::tool_result::ToolResult;
 use super::ToolRuntime;
@@ -19,19 +23,6 @@ pub(crate) const GIT_REVIEW_MAX_DIFF_BYTES: usize = 64 * 1024;
 const GIT_REVIEW_METADATA_BYTES: usize = 64 * 1024;
 const GIT_REVIEW_MAX_WARNINGS: usize = 16;
 const GIT_REVIEW_ERROR_SENTINEL: &str = "@@WEBCODEX_GIT_REVIEW_COMMAND_FAILED@@";
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ReviewScope {
-    requested_base: String,
-    requested_head: String,
-    merge_base: String,
-    base_is_ancestor: bool,
-    commit_count: u64,
-    files_changed: u64,
-    insertions: u64,
-    deletions: u64,
-    binary_files: u64,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NameStatusRecord {
@@ -77,13 +68,6 @@ struct ReviewSignal {
     paths_truncated: bool,
 }
 
-fn normalize_exact_commit_id(value: &str) -> Result<String, &'static str> {
-    if value.len() != 40 || !value.as_bytes().iter().all(u8::is_ascii_hexdigit) {
-        return Err("invalid_commit_id");
-    }
-    Ok(value.to_ascii_lowercase())
-}
-
 fn git_review_failure(
     project: &str,
     requested_base: &str,
@@ -112,164 +96,6 @@ fn git_review_failure(
     )
 }
 
-fn review_git_discovery_prefix() -> &'static str {
-    concat!(
-        "export LC_ALL=C GIT_PAGER=cat GIT_NO_REPLACE_OBJECTS=1 GIT_NO_LAZY_FETCH=1 ",
-        "GIT_OPTIONAL_LOCKS=0 GIT_ATTR_NOSYSTEM=1 GIT_CONFIG_COUNT=0; ",
-        "unset GIT_EXTERNAL_DIFF GIT_DIFF_OPTS GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE ",
-        "GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR ",
-        "GIT_CEILING_DIRECTORIES GIT_ATTR_SOURCE GIT_CONFIG GIT_CONFIG_PARAMETERS ",
-        "GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM GIT_SHALLOW_FILE ",
-        "GIT_NAMESPACE; "
-    )
-}
-
-fn review_git_isolated_view_setup(head: &str, failure: &str) -> String {
-    format!(
-        concat!(
-            "object_dir=$(git rev-parse --path-format=absolute --git-path objects 2>/dev/null) || {{ {failure}; }}; ",
-            "view=$(mktemp -d /tmp/webcodex-git-review.XXXXXX 2>/dev/null) || {{ {failure}; }}; ",
-            "cleanup_git_review_view() {{ rm -rf -- \"$view\"; }}; ",
-            "trap cleanup_git_review_view EXIT; trap 'exit 130' HUP INT TERM; ",
-            "mkdir -p \"$view/refs\" \"$view/objects/info\" || {{ {failure}; }}; ",
-            "printf 'ref: refs/heads/unused\\n' >\"$view/HEAD\" || {{ {failure}; }}; ",
-            "printf '[core]\\n\\trepositoryformatversion = 0\\n\\tbare = true\\n\\tattributesFile = /dev/null\\n' >\"$view/config\" || {{ {failure}; }}; ",
-            "export GIT_DIR=\"$view\" GIT_OBJECT_DIRECTORY=\"$object_dir\" GIT_ATTR_SOURCE={head_q} ",
-            "GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1; "
-        ),
-        failure = failure,
-        head_q = shell_escape_simple(head),
-    )
-}
-
-fn checked_git_pipeline_to_file(
-    producer: &str,
-    consumer: &str,
-    stem: &str,
-    failure: &str,
-) -> String {
-    debug_assert!(stem
-        .as_bytes()
-        .iter()
-        .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_'));
-    format!(
-        concat!(
-            "rm -f \"$view/{stem}.status\" \"$view/{stem}.out\"; ",
-            "{{ {producer}; producer_exit=$?; printf '%s\\n' \"$producer_exit\" >\"$view/{stem}.status\"; }} | ",
-            "{consumer} >\"$view/{stem}.out\"; ",
-            "consumer_exit=$?; ",
-            "producer_exit=$(cat \"$view/{stem}.status\" 2>/dev/null || true); ",
-            "if [ \"$consumer_exit\" -ne 0 ] || [ \"$producer_exit\" != 0 ]; then {failure}; fi; "
-        ),
-        producer = producer,
-        consumer = consumer,
-        stem = stem,
-        failure = failure,
-    )
-}
-
-fn git_review_scope_command(base: &str, head: &str) -> String {
-    let isolated_view =
-        review_git_isolated_view_setup(head, "printf 'status=git_view_unavailable\\n'; exit 0");
-    let head_q = shell_escape_simple(head);
-    let stats_producer = format!(
-        "git --no-pager -c core.quotePath=false -c attr.tree={head_q} diff --no-ext-diff --no-textconv --find-renames --numstat \"$merge_base\" {head_q}"
-    );
-    let stats_pipeline = checked_git_pipeline_to_file(
-        &stats_producer,
-        "awk 'BEGIN{f=0;a=0;d=0;b=0} {f++; if ($1==\"-\" || $2==\"-\") b++; else {a+=$1; d+=$2}} END{printf \"files_changed=%d\\ninsertions=%d\\ndeletions=%d\\nbinary_files=%d\\n\",f,a,d,b}'",
-        "scope_stats",
-        "printf 'status=diff_failed\\n'; exit 0",
-    );
-    format!(
-        concat!(
-            "{prefix}",
-            "if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then printf 'status=not_git\\n'; exit 0; fi; ",
-            "{isolated_view}",
-            "base_type=$(git cat-file -t {base_q} 2>/dev/null || true); ",
-            "if [ \"$base_type\" != commit ]; then printf 'status=base_not_commit\\n'; exit 0; fi; ",
-            "head_type=$(git cat-file -t {head_q} 2>/dev/null || true); ",
-            "if [ \"$head_type\" != commit ]; then printf 'status=head_not_commit\\n'; exit 0; fi; ",
-            "merge_bases=$(git merge-base --all {base_q} {head_q} 2>/dev/null || true); ",
-            "if [ -z \"$merge_bases\" ]; then printf 'status=no_merge_base\\n'; exit 0; fi; ",
-            "merge_base_count=$(printf '%s\\n' \"$merge_bases\" | awk 'NF{{n++}} END{{print n+0}}'); ",
-            "if [ \"$merge_base_count\" -ne 1 ]; then printf 'status=ambiguous_merge_base\\n'; exit 0; fi; ",
-            "merge_base=$merge_bases; ",
-            "if git merge-base --is-ancestor {base_q} {head_q} >/dev/null 2>&1; then base_is_ancestor=true; ",
-            "else ancestor_exit=$?; if [ \"$ancestor_exit\" -eq 1 ]; then base_is_ancestor=false; else printf 'status=ancestor_failed\\n'; exit 0; fi; fi; ",
-            "commit_count=$(git rev-list --count \"$merge_base..{head}\" 2>/dev/null) || {{ printf 'status=rev_list_failed\\n'; exit 0; }}; ",
-            "{stats_pipeline}",
-            "stats=$(cat \"$view/scope_stats.out\" 2>/dev/null) || {{ printf 'status=stats_failed\\n'; exit 0; }}; ",
-            "printf 'status=ok\\nrequested_base=%s\\nrequested_head=%s\\nmerge_base=%s\\nbase_is_ancestor=%s\\ncommit_count=%s\\n%s' ",
-            "{base_q} {head_q} \"$merge_base\" \"$base_is_ancestor\" \"$commit_count\" \"$stats\""
-        ),
-        prefix = review_git_discovery_prefix(),
-        isolated_view = isolated_view,
-        stats_pipeline = stats_pipeline,
-        base_q = shell_escape_simple(base),
-        head_q = head_q,
-        head = head,
-    )
-}
-
-fn parse_scope_value<'a>(stdout: &'a str, key: &str) -> Option<&'a str> {
-    stdout.lines().find_map(|line| {
-        let (field, value) = line.split_once('=')?;
-        (field == key).then_some(value)
-    })
-}
-
-fn parse_u64_scope(stdout: &str, key: &str) -> Option<u64> {
-    parse_scope_value(stdout, key)?.parse().ok()
-}
-
-fn parse_git_review_scope(stdout: &str) -> Result<ReviewScope, &'static str> {
-    match parse_scope_value(stdout, "status") {
-        Some("ok") => {}
-        Some("not_git") => return Err("not_a_git_repository"),
-        Some("base_not_commit") => return Err("base_commit_missing_or_not_commit"),
-        Some("head_not_commit") => return Err("head_commit_missing_or_not_commit"),
-        Some("no_merge_base") => return Err("no_merge_base"),
-        Some("ambiguous_merge_base") => return Err("ambiguous_merge_base"),
-        Some("git_view_unavailable") => return Err("git_isolated_view_unavailable"),
-        Some("ancestor_failed") => return Err("merge_base_ancestor_check_failed"),
-        Some("rev_list_failed") => return Err("commit_count_unavailable"),
-        Some("diff_failed") | Some("stats_failed") => return Err("git_diff_failed"),
-        _ => return Err("scope_observation_unavailable"),
-    }
-    let requested_base = normalize_exact_commit_id(
-        parse_scope_value(stdout, "requested_base").ok_or("scope_observation_unavailable")?,
-    )
-    .map_err(|_| "scope_observation_unavailable")?;
-    let requested_head = normalize_exact_commit_id(
-        parse_scope_value(stdout, "requested_head").ok_or("scope_observation_unavailable")?,
-    )
-    .map_err(|_| "scope_observation_unavailable")?;
-    let merge_base = normalize_exact_commit_id(
-        parse_scope_value(stdout, "merge_base").ok_or("scope_observation_unavailable")?,
-    )
-    .map_err(|_| "scope_observation_unavailable")?;
-    let base_is_ancestor = match parse_scope_value(stdout, "base_is_ancestor") {
-        Some("true") => true,
-        Some("false") => false,
-        _ => return Err("scope_observation_unavailable"),
-    };
-    Ok(ReviewScope {
-        requested_base,
-        requested_head,
-        merge_base,
-        base_is_ancestor,
-        commit_count: parse_u64_scope(stdout, "commit_count")
-            .ok_or("scope_observation_unavailable")?,
-        files_changed: parse_u64_scope(stdout, "files_changed")
-            .ok_or("scope_observation_unavailable")?,
-        insertions: parse_u64_scope(stdout, "insertions").ok_or("scope_observation_unavailable")?,
-        deletions: parse_u64_scope(stdout, "deletions").ok_or("scope_observation_unavailable")?,
-        binary_files: parse_u64_scope(stdout, "binary_files")
-            .ok_or("scope_observation_unavailable")?,
-    })
-}
-
 fn bounded_review_diff_command(
     merge_base: &str,
     head: &str,
@@ -283,7 +109,7 @@ fn bounded_review_diff_command(
         _ => unreachable!("closed git review diff mode"),
     };
     let failure = format!("printf '{}\\n'; exit 0", GIT_REVIEW_ERROR_SENTINEL);
-    let isolated_view = review_git_isolated_view_setup(head, &failure);
+    let isolated_view = committed_git_isolated_view_setup(head, &failure);
     let producer = format!(
         "git --no-pager -c core.quotePath=false -c attr.tree={head_q} diff --no-ext-diff --no-textconv --find-renames {mode} {base_q} {head_q}",
         head_q = shell_escape_simple(head),
@@ -309,7 +135,7 @@ fn bounded_review_diff_command(
             "{pipeline}",
             "cat \"$view/metadata.out\" 2>/dev/null || {{ {failure}; }}"
         ),
-        prefix = review_git_discovery_prefix(),
+        prefix = committed_git_discovery_prefix(),
         isolated_view = isolated_view,
         pipeline = pipeline,
         error = GIT_REVIEW_ERROR_SENTINEL,
@@ -792,7 +618,7 @@ fn git_review_symbol_command(merge_base: &str, head: &str, paths: &[String]) -> 
         .collect::<Vec<_>>()
         .join(" ");
     let failure = format!("printf '{}\\n'; exit 0", GIT_REVIEW_ERROR_SENTINEL);
-    let isolated_view = review_git_isolated_view_setup(head, &failure);
+    let isolated_view = committed_git_isolated_view_setup(head, &failure);
     let producer = format!(
         "git --no-pager -c core.quotePath=false -c attr.tree={head_q} diff --no-ext-diff --no-textconv --find-renames --unified=0 --src-prefix=a/ --dst-prefix=b/ {base_q} {head_q} -- {paths}",
         base_q = shell_escape_simple(merge_base),
@@ -812,7 +638,7 @@ fn git_review_symbol_command(merge_base: &str, head: &str, paths: &[String]) -> 
             "{pipeline}",
             "cat \"$view/symbols.out\" 2>/dev/null || {{ {failure}; }}"
         ),
-        prefix = review_git_discovery_prefix(),
+        prefix = committed_git_discovery_prefix(),
         isolated_view = isolated_view,
         pipeline = pipeline,
         error = GIT_REVIEW_ERROR_SENTINEL,
@@ -1089,30 +915,13 @@ impl ToolRuntime {
             Ok(resolved) => resolved,
             Err(error) => return error.into_tool_result(),
         };
-        let scope_output = match self
-            .run_project_internal_posix_script_capture(
-                &resolved.resolved_id,
-                git_review_scope_command(&base, &head),
-                30,
-                None,
-            )
+        let scope = match self
+            .resolve_committed_git_scope(&resolved.resolved_id, &base, &head)
             .await
         {
-            Ok(output) => output,
-            Err(_) => {
-                return git_review_failure(&project, &base, &head, "scope_observation_unavailable")
-            }
-        };
-        if scope_output.exit_code != Some(0) || scope_output.error.is_some() {
-            return git_review_failure(&project, &base, &head, "scope_observation_unavailable");
-        }
-        let scope = match parse_git_review_scope(&scope_output.stdout) {
             Ok(scope) => scope,
             Err(reason) => return git_review_failure(&project, &base, &head, reason),
         };
-        if scope.requested_base != base || scope.requested_head != head {
-            return git_review_failure(&project, &base, &head, "scope_observation_mismatch");
-        }
 
         let max_lines = GIT_REVIEW_MAX_FILES;
         let mut observations = Vec::new();
@@ -1418,6 +1227,12 @@ impl ToolRuntime {
         }
     }
 }
+
+#[cfg(test)]
+use super::git_committed::{
+    committed_git_scope_command as git_review_scope_command,
+    parse_committed_git_scope as parse_git_review_scope,
+};
 
 #[cfg(test)]
 mod tests {

--- a/src/tool_runtime/git_review.rs
+++ b/src/tool_runtime/git_review.rs
@@ -7,7 +7,7 @@ use super::git_committed::{
     checked_git_pipeline_to_file, committed_git_discovery_prefix,
     committed_git_isolated_view_setup, normalize_exact_commit_id,
 };
-use super::helpers::{shell_escape_simple, validate_project_relative_path};
+use super::helpers::{decode_git_quoted_path, shell_escape_simple, validate_project_relative_path};
 use super::tool_result::ToolResult;
 use super::ToolRuntime;
 
@@ -141,64 +141,6 @@ fn bounded_review_diff_command(
         error = GIT_REVIEW_ERROR_SENTINEL,
         failure = failure,
     )
-}
-
-fn decode_git_quoted_path(raw: &str) -> Option<String> {
-    let raw = raw.strip_suffix('\r').unwrap_or(raw);
-    if !raw.starts_with('"') {
-        return Some(raw.to_string());
-    }
-    if raw.len() < 2 || !raw.ends_with('"') {
-        return None;
-    }
-    let inner = &raw[1..raw.len() - 1];
-    let bytes = inner.as_bytes();
-    let mut out = Vec::with_capacity(inner.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] != b'\\' {
-            let ch = inner[index..].chars().next()?;
-            let mut buf = [0u8; 4];
-            out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
-            index += ch.len_utf8();
-            continue;
-        }
-        index += 1;
-        let escaped = *bytes.get(index)?;
-        match escaped {
-            b'a' => out.push(0x07),
-            b'b' => out.push(0x08),
-            b't' => out.push(b'\t'),
-            b'n' => out.push(b'\n'),
-            b'v' => out.push(0x0b),
-            b'f' => out.push(0x0c),
-            b'r' => out.push(b'\r'),
-            b'\\' => out.push(b'\\'),
-            b'"' => out.push(b'"'),
-            b'0'..=b'7' => {
-                let mut value = (escaped - b'0') as u16;
-                let mut consumed = 1;
-                while consumed < 3 {
-                    let Some(next) = bytes.get(index + consumed).copied() else {
-                        break;
-                    };
-                    if !(b'0'..=b'7').contains(&next) {
-                        break;
-                    }
-                    value = value * 8 + (next - b'0') as u16;
-                    consumed += 1;
-                }
-                if value > u8::MAX as u16 {
-                    return None;
-                }
-                out.push(value as u8);
-                index += consumed - 1;
-            }
-            _ => return None,
-        }
-        index += 1;
-    }
-    String::from_utf8(out).ok()
 }
 
 fn bounded_output_path(path: String) -> (Option<String>, bool) {
@@ -1320,6 +1262,14 @@ mod tests {
             "space name.rs"
         );
         assert_eq!(decode_git_quoted_path("路径.rs").unwrap(), "路径.rs");
+        assert_eq!(
+            decode_git_quoted_path("secret key.pem\t").unwrap(),
+            "secret key.pem"
+        );
+        assert_eq!(
+            decode_git_quoted_path("\"secret\\tkey.pem\"\t").unwrap(),
+            "secret\tkey.pem"
+        );
         assert_eq!(
             decode_git_quoted_path("\"tab\\tname.rs\"").unwrap(),
             "tab\tname.rs"

--- a/src/tool_runtime/git_tools.rs
+++ b/src/tool_runtime/git_tools.rs
@@ -31,14 +31,18 @@ impl ToolRuntime {
                 max_hunks,
                 max_hunk_lines,
                 cached,
+                base_commit,
+                head_commit,
                 continuation,
             } => {
-                self.git_diff_hunks_continued(
+                self.git_diff_hunks_continued_with_range(
                     project,
                     paths,
                     max_hunks,
                     max_hunk_lines,
                     cached,
+                    base_commit,
+                    head_commit,
                     continuation,
                 )
                 .await

--- a/src/tool_runtime/helpers.rs
+++ b/src/tool_runtime/helpers.rs
@@ -896,6 +896,87 @@ pub(crate) fn validate_project_relative_path(path: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Decode Git's C-style quoted path representation. `core.quotePath=false`
+/// preserves UTF-8 but Git still quotes whitespace/control characters, so
+/// callers must decode before applying path policy or returning path metadata.
+pub(crate) fn decode_git_quoted_path(raw: &str) -> Option<String> {
+    let raw = raw.strip_suffix('\r').unwrap_or(raw);
+    let raw = if raw.starts_with('"') {
+        let bytes = raw.as_bytes();
+        let mut index = 1usize;
+        let mut closing = None;
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' => index = index.saturating_add(2),
+                b'"' => {
+                    closing = Some(index);
+                    break;
+                }
+                _ => index += 1,
+            }
+        }
+        let closing = closing?;
+        let suffix = &raw[closing + 1..];
+        if !suffix.is_empty() && !suffix.starts_with('\t') {
+            return None;
+        }
+        &raw[..=closing]
+    } else {
+        raw.split_once('\t').map(|(path, _)| path).unwrap_or(raw)
+    };
+    if !raw.starts_with('"') {
+        return Some(raw.to_string());
+    }
+    let inner = &raw[1..raw.len() - 1];
+    let bytes = inner.as_bytes();
+    let mut out = Vec::with_capacity(inner.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'\\' {
+            let ch = inner[index..].chars().next()?;
+            let mut buf = [0u8; 4];
+            out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            index += ch.len_utf8();
+            continue;
+        }
+        index += 1;
+        let escaped = *bytes.get(index)?;
+        match escaped {
+            b'a' => out.push(0x07),
+            b'b' => out.push(0x08),
+            b't' => out.push(b'\t'),
+            b'n' => out.push(b'\n'),
+            b'v' => out.push(0x0b),
+            b'f' => out.push(0x0c),
+            b'r' => out.push(b'\r'),
+            b'\\' => out.push(b'\\'),
+            b'"' => out.push(b'"'),
+            b'0'..=b'7' => {
+                let mut value = (escaped - b'0') as u16;
+                let mut consumed = 1;
+                while consumed < 3 {
+                    let Some(next) = bytes.get(index + consumed).copied() else {
+                        break;
+                    };
+                    if !(b'0'..=b'7').contains(&next) {
+                        break;
+                    }
+                    value = value * 8 + (next - b'0') as u16;
+                    consumed += 1;
+                }
+                if value > u8::MAX as u16 {
+                    return None;
+                }
+                out.push(value as u8);
+                index += consumed - 1;
+            }
+            _ => return None,
+        }
+        index += 1;
+    }
+    String::from_utf8(out).ok()
+}
+
 pub(crate) fn validate_raw_shell_command_length(command: &str) -> Result<(), String> {
     if command.len() > RAW_SHELL_COMMAND_MAX_BYTES {
         return Err(format!(

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -20,6 +20,7 @@ mod file_listing;
 mod file_tools;
 pub(crate) mod files;
 mod git;
+mod git_committed;
 mod git_review;
 mod git_tools;
 mod handoff;

--- a/src/tool_runtime/registry/input_schemas/git.rs
+++ b/src/tool_runtime/registry/input_schemas/git.rs
@@ -1,4 +1,4 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::common::{object_schema, with_optional_session_id};
 
@@ -115,14 +115,58 @@ pub(crate) fn git_diff_hunks_input_schema() -> Value {
             false,
         ),
         (
+            "base_commit",
+            "string",
+            "Optional exact 40-hex Git commit object id; requires head_commit and committed-range mode.",
+            false,
+        ),
+        (
+            "head_commit",
+            "string",
+            "Optional exact 40-hex Git commit object id reviewed from the single merge-base; requires base_commit.",
+            false,
+        ),
+        (
             "continuation",
             "string",
             "Optional opaque continuation returned by a previous git_diff_hunks page.",
             false,
         ),
     ]));
+    for field in ["base_commit", "head_commit"] {
+        schema["properties"][field]["minLength"] = Value::from(40);
+        schema["properties"][field]["maxLength"] = Value::from(40);
+        schema["properties"][field]["pattern"] = Value::from("^[0-9A-Fa-f]{40}$");
+    }
     schema["properties"]["continuation"]["maxLength"] =
         Value::from(crate::tool_runtime::git::GIT_DIFF_HUNKS_CONTINUATION_MAX_BYTES);
+    schema["allOf"] = json!([
+        {
+            "if": { "required": ["base_commit"] },
+            "then": {
+                "required": ["head_commit"],
+                "not": { "required": ["cached"] }
+            }
+        },
+        {
+            "if": { "required": ["head_commit"] },
+            "then": {
+                "required": ["base_commit"],
+                "not": { "required": ["cached"] }
+            }
+        },
+        {
+            "if": { "required": ["cached"] },
+            "then": {
+                "not": {
+                    "anyOf": [
+                        { "required": ["base_commit"] },
+                        { "required": ["head_commit"] }
+                    ]
+                }
+            }
+        }
+    ]);
     schema
 }
 

--- a/src/tool_runtime/registry/output_schemas/git.rs
+++ b/src/tool_runtime/registry/output_schemas/git.rs
@@ -86,6 +86,33 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             ("cached", schema_type("boolean", "Whether the staged diff is inspected.")),
             (
+                "scope",
+                json!({
+                    "type": "object",
+                    "description": "Committed-range identity when base_commit/head_commit mode is used; omitted for worktree/cached mode.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "mode": {
+                            "type": "string",
+                            "enum": ["committed"]
+                        },
+                        "requested_base": nullable_schema("string", "Normalized exact requested base commit id, or null when input is invalid."),
+                        "requested_head": nullable_schema("string", "Normalized exact requested head commit id, or null when input is invalid."),
+                        "merge_base": nullable_schema("string", "Single exact best merge-base used for the review diff, or null before range resolution succeeds."),
+                        "base_is_ancestor": nullable_schema("boolean", "Whether requested_base is an ancestor of requested_head, or null before range resolution succeeds."),
+                        "diff_range": nullable_schema("string", "Effective merge_base..requested_head committed diff range, or null before range resolution succeeds.")
+                    },
+                    "required": [
+                        "mode",
+                        "requested_base",
+                        "requested_head",
+                        "merge_base",
+                        "base_is_ancestor",
+                        "diff_range"
+                    ]
+                }),
+            ),
+            (
                 "files",
                 array_schema(open_object_schema("File diff hunks."), "Changed files."),
             ),

--- a/src/tool_runtime/registry/tool_specs/git.rs
+++ b/src/tool_runtime/registry/tool_specs/git.rs
@@ -38,7 +38,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "git_diff_hunks",
-            "Return producer-bounded structured git diff hunks with fenced opaque continuation. Supports optional paths and cached diff; does not modify the worktree.",
+            "Return producer-bounded structured git diff hunks for worktree/cached state or an exact committed base/head range, with fenced opaque continuation. Read-only.",
             git_diff_hunks_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/runtime.rs
+++ b/src/tool_runtime/runtime.rs
@@ -7,11 +7,21 @@ use super::runtime_info::RuntimeInfo;
 use super::sessions;
 use super::SessionShellRegistry;
 use crate::shell_client::ShellClientRegistry;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
+use uuid::Uuid;
+
+fn new_git_diff_hunks_continuation_mac_key() -> Arc<[u8; 32]> {
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex.git-diff-hunks.runtime-mac-key.v1\0");
+    hasher.update(Uuid::new_v4().as_bytes());
+    hasher.update(Uuid::new_v4().as_bytes());
+    Arc::new(hasher.finalize().into())
+}
 
 #[derive(Clone)]
 pub struct ToolRuntime {
@@ -37,6 +47,10 @@ pub struct ToolRuntime {
     /// Internal synchronous grace for typed process/script Jobs. It controls
     /// only when the existing execution is exposed, never its total timeout.
     pub(crate) structured_execution_sync_wait: Duration,
+    /// Per-runtime secret used only to authenticate opaque committed-range
+    /// git_diff_hunks continuation state. Clones share the same key; a runtime
+    /// restart intentionally invalidates old committed continuations fail-closed.
+    pub(crate) git_diff_hunks_continuation_mac_key: Arc<[u8; 32]>,
     /// Authoritative permission evaluator for this runtime instance.
     /// Resolved once at construction (`WEBCODEX_AUTHORITY_MODE`); dispatch
     /// evaluates once per tool request before mutation.
@@ -73,6 +87,7 @@ impl ToolRuntime {
             structured_execution_sync_wait: Duration::from_secs(
                 super::structured_execution::STRUCTURED_EXECUTION_SYNC_WAIT_SECS,
             ),
+            git_diff_hunks_continuation_mac_key: new_git_diff_hunks_continuation_mac_key(),
             permission_evaluator: PermissionEvaluator::from_env(),
             activity: Arc::new(NoopActivityRecorder),
             observations: Arc::new(RuntimeObservations::default()),

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -449,6 +449,8 @@ fn git_diff_hunks_tool_is_known_and_schema_is_bounded() {
         "max_hunks",
         "max_hunk_lines",
         "cached",
+        "base_commit",
+        "head_commit",
         "continuation",
     ] {
         assert!(props.contains_key(field), "missing {}", field);
@@ -457,6 +459,31 @@ fn git_diff_hunks_tool_is_known_and_schema_is_bounded() {
         props["continuation"]["maxLength"],
         GIT_DIFF_HUNKS_CONTINUATION_MAX_BYTES
     );
+    for field in ["base_commit", "head_commit"] {
+        assert_eq!(props[field]["minLength"], 40);
+        assert_eq!(props[field]["maxLength"], 40);
+        assert_eq!(props[field]["pattern"], "^[0-9A-Fa-f]{40}$");
+    }
+    assert!(spec.input_schema["allOf"].is_array());
+    let committed_call = ToolCall::from_tool_name(
+        "git_diff_hunks",
+        json!({
+            "project": "agent:oe:webcodex",
+            "base_commit": "A".repeat(40),
+            "head_commit": "b".repeat(40),
+            "paths": ["src/runtime_http.rs"]
+        }),
+    )
+    .unwrap();
+    assert!(matches!(
+        committed_call,
+        ToolCall::GitDiffHunks {
+            base_commit: Some(base),
+            head_commit: Some(head),
+            cached: None,
+            ..
+        } if base == "A".repeat(40) && head == "b".repeat(40)
+    ));
     assert!(ToolCall::from_tool_name(
         "git_diff_hunks",
         json!({
@@ -564,6 +591,59 @@ fn git_diff_hunks_session_audit_redacts_continuation() {
     assert!(!serde_json::to_string(input_summary)
         .unwrap()
         .contains(continuation));
+
+    let base = "A".repeat(40);
+    let head = "b".repeat(40);
+    let committed_arguments = json!({
+        "project": "agent:oe:webcodex",
+        "paths": ["src/runtime_http.rs"],
+        "base_commit": base,
+        "head_commit": head,
+        "continuation": continuation,
+    });
+    let committed_summary = super::super::tool_audit::session_log_arguments_for_tool_request(
+        "git_diff_hunks",
+        &committed_arguments,
+    );
+    assert_eq!(committed_summary["base_commit"], "a".repeat(40));
+    assert_eq!(committed_summary["head_commit"], "b".repeat(40));
+    assert_eq!(committed_summary["base_commit_valid"], true);
+    assert_eq!(committed_summary["head_commit_valid"], true);
+    assert!(committed_summary.get("continuation").is_none());
+
+    let private_hunk = "PRIVATE_GIT_DIFF_HUNK_BODY_91e2";
+    let result_summary = super::super::tool_audit::session_log_result_for_tool(
+        "git_diff_hunks",
+        &json!({
+            "project": "agent:oe:webcodex",
+            "scope": {
+                "mode": "committed",
+                "requested_base": "a".repeat(40),
+                "requested_head": "b".repeat(40),
+                "merge_base": "a".repeat(40),
+                "base_is_ancestor": true,
+                "diff_range": format!("{}..{}", "a".repeat(40), "b".repeat(40))
+            },
+            "cached": false,
+            "files": [{"path": "src/runtime_http.rs", "hunks": [{"diff": private_hunk}]}],
+            "hunk_count": 1,
+            "truncated": true,
+            "truncation_reasons": ["page_hunk_limit"],
+            "has_more": true,
+            "next_continuation": continuation,
+            "exit_code": 0,
+            "stderr": "PRIVATE_STDERR",
+        }),
+    );
+    let serialized_result = serde_json::to_string(&result_summary).unwrap();
+    assert_eq!(result_summary["hunk_count"], 1);
+    assert_eq!(result_summary["file_count"], 1);
+    assert!(result_summary.get("files").is_none());
+    assert!(result_summary.get("next_continuation").is_none());
+    assert!(result_summary.get("stderr").is_none());
+    assert!(!serialized_result.contains(private_hunk));
+    assert!(!serialized_result.contains(continuation));
+    assert!(!serialized_result.contains("PRIVATE_STDERR"));
 }
 
 #[test]
@@ -662,6 +742,883 @@ async fn run_agent_git_diff_hunks_page(
     )
     .await;
     (task.await.unwrap(), stdout_bytes, script)
+}
+
+async fn run_agent_git_diff_hunks_committed_page(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: &str,
+    repo: &Path,
+    paths: Option<Vec<String>>,
+    max_hunks: usize,
+    max_hunk_lines: usize,
+    base_commit: String,
+    head_commit: String,
+    continuation: Option<String>,
+) -> (ToolResult, usize, Vec<String>) {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.to_string();
+        async move {
+            runtime
+                .git_diff_hunks_continued_with_range(
+                    project,
+                    paths,
+                    Some(max_hunks),
+                    Some(max_hunk_lines),
+                    None,
+                    Some(base_commit),
+                    Some(head_commit),
+                    continuation,
+                )
+                .await
+        }
+    });
+    let mut scripts = Vec::new();
+    let mut page_stdout_bytes = 0usize;
+    for _ in 0..16 {
+        if task.is_finished() {
+            break;
+        }
+        if let Some(request) = next_patch_agent_request(runtime, client_id).await {
+            assert_eq!(request.kind, "run_internal_posix_script");
+            assert_eq!(
+                request.cwd.as_deref(),
+                Some(repo.to_string_lossy().as_ref())
+            );
+            assert!(request.command.is_empty());
+            let payload = request
+                .script
+                .as_ref()
+                .expect("committed git_diff_hunks must use typed internal scripts");
+            let script = payload.script.clone();
+            assert!(script.contains("GIT_NO_REPLACE_OBJECTS=1"));
+            assert!(script.contains("GIT_NO_LAZY_FETCH=1"));
+            assert!(script.contains("GIT_OPTIONAL_LOCKS=0"));
+            assert!(script.contains("GIT_CONFIG_GLOBAL=/dev/null"));
+            assert!(script.contains("attributesFile = /dev/null"));
+            for forbidden in [
+                "git fetch",
+                "git apply",
+                "git commit",
+                "git checkout",
+                "git reset",
+                "git push",
+                "git stash",
+                "git rebase",
+                "git clean",
+                "git add ",
+            ] {
+                assert!(
+                    !script.contains(forbidden),
+                    "committed git_diff_hunks must remain read-only; found {forbidden}: {script}"
+                );
+            }
+            if script.contains(" diff ") {
+                assert!(script.contains("--no-ext-diff"));
+                assert!(script.contains("--no-textconv"));
+            }
+            let (exit_code, stdout, stderr) = run_agent_shell_request_locally(&request);
+            if script.contains("page_budget=") {
+                page_stdout_bytes = stdout.len();
+            }
+            complete_patch_agent_request(
+                runtime,
+                client_id,
+                &request.request_id,
+                exit_code,
+                &stdout,
+                &stderr,
+            )
+            .await;
+            scripts.push(script);
+        } else {
+            tokio::task::yield_now().await;
+        }
+    }
+    assert!(
+        task.is_finished(),
+        "committed git_diff_hunks did not finish after bounded agent requests"
+    );
+    (task.await.unwrap(), page_stdout_bytes, scripts)
+}
+
+#[tokio::test]
+async fn git_diff_hunks_committed_exact_range_isolated_targeted_and_head_attributed() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    write_git_review_fixture_file(tmp.path(), "src/a.rs", "pub fn a() -> u8 { 1 }\n");
+    write_git_review_fixture_file(tmp.path(), "src/b.rs", "pub fn b() -> u8 { 1 }\n");
+    write_git_review_fixture_file(
+        tmp.path(),
+        "src/space file.rs",
+        "pub fn spaced() -> u8 { 1 }\n",
+    );
+    write_git_review_fixture_file(tmp.path(), "src/你好.rs", "pub fn unicode() -> u8 { 1 }\n");
+    write_git_review_fixture_file(tmp.path(), "src/old.rs", "pub fn renamed() -> u8 { 1 }\n");
+    write_git_review_fixture_file(tmp.path(), "src/delete.rs", "pub fn deleted() {}\n");
+    fs::write(tmp.path().join("asset.bin"), [0u8, 1, 2, 3, 0, 4]).unwrap();
+    let base = commit_git_review_fixture(tmp.path(), "base");
+
+    write_git_review_fixture_file(tmp.path(), "src/a.rs", "pub fn a() -> u8 { 2 }\n");
+    write_git_review_fixture_file(tmp.path(), "src/b.rs", "pub fn b() -> u8 { 2 }\n");
+    write_git_review_fixture_file(
+        tmp.path(),
+        "src/space file.rs",
+        "pub fn spaced() -> u8 { 2 }\n",
+    );
+    write_git_review_fixture_file(tmp.path(), "src/你好.rs", "pub fn unicode() -> u8 { 2 }\n");
+    fs::rename(tmp.path().join("src/old.rs"), tmp.path().join("src/new.rs")).unwrap();
+    fs::remove_file(tmp.path().join("src/delete.rs")).unwrap();
+    write_git_review_fixture_file(tmp.path(), "src/add.rs", "pub fn added() {}\n");
+    fs::write(tmp.path().join("asset.bin"), [0u8, 255, 2, 3, 0, 4]).unwrap();
+    write_git_review_fixture_file(tmp.path(), ".gitattributes", "src/b.rs -diff\n");
+    let head = commit_git_review_fixture(tmp.path(), "head");
+
+    write_git_review_fixture_file(tmp.path(), "src/a.rs", "DIRTY_WORKTREE_MUST_NOT_APPEAR\n");
+    write_git_review_fixture_file(
+        tmp.path(),
+        ".gitattributes",
+        "src/a.rs -diff\nsrc/b.rs diff\n",
+    );
+    fs::create_dir_all(tmp.path().join(".git/info")).unwrap();
+    fs::write(
+        tmp.path().join(".git/info/attributes"),
+        "src/a.rs -diff\nsrc/b.rs diff\n",
+    )
+    .unwrap();
+    git_test_command_ok(tmp.path(), "git config diff.external false");
+    git_test_command_ok(tmp.path(), "git config diff.custom.textconv false");
+
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "committed-targeted", "repo", tmp.path())
+            .await;
+    let paths = vec![
+        "src/a.rs".to_string(),
+        "src/b.rs".to_string(),
+        "src/space file.rs".to_string(),
+        "src/你好.rs".to_string(),
+    ];
+    let (result, raw_bytes, scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-targeted",
+        &project,
+        tmp.path(),
+        Some(paths.clone()),
+        20,
+        120,
+        base.clone(),
+        head.clone(),
+        None,
+    )
+    .await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["scope"]["mode"], "committed");
+    assert_eq!(result.output["scope"]["requested_base"], base);
+    assert_eq!(result.output["scope"]["requested_head"], head);
+    assert_eq!(result.output["scope"]["merge_base"], base);
+    assert_eq!(result.output["scope"]["base_is_ancestor"], true);
+    assert_eq!(result.output["paths"], json!(paths));
+    assert!(
+        raw_bytes < 48 * 1024,
+        "page producer output must remain bounded"
+    );
+    assert_eq!(scripts.len(), 2, "scope + page observation expected");
+    let serialized = serde_json::to_string(&result.output).unwrap();
+    assert!(!serialized.contains("DIRTY_WORKTREE_MUST_NOT_APPEAR"));
+    assert!(serialized.contains("space file.rs"));
+    assert!(serialized.contains("你好.rs"));
+    let files = result.output["files"].as_array().unwrap();
+    let a = files
+        .iter()
+        .find(|file| {
+            file["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("a.rs"))
+        })
+        .expect("src/a.rs committed hunk");
+    assert!(!a["hunks"].as_array().unwrap().is_empty());
+    let b = files
+        .iter()
+        .find(|file| {
+            file["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("b.rs"))
+        })
+        .expect("src/b.rs committed file");
+    assert_eq!(
+        b["binary"], true,
+        "reviewed-head attributes must be authoritative"
+    );
+    assert!(b["hunks"].as_array().unwrap().is_empty());
+
+    let (all_result, _, _) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-targeted",
+        &project,
+        tmp.path(),
+        None,
+        40,
+        120,
+        base,
+        head,
+        None,
+    )
+    .await;
+    assert!(all_result.success, "{:?}", all_result.error);
+    let all_files = all_result.output["files"].as_array().unwrap();
+    assert!(all_files.iter().any(|file| file["status"] == "renamed"));
+    assert!(all_files.iter().any(|file| file["status"] == "deleted"));
+    assert!(all_files.iter().any(|file| file["status"] == "added"));
+    assert!(all_files.iter().any(|file| file["binary"] == true));
+}
+
+#[tokio::test]
+async fn git_diff_hunks_committed_range_validation_and_merge_base_fail_closed() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    write_git_review_fixture_file(tmp.path(), "base.txt", "base\n");
+    let base = commit_git_review_fixture(tmp.path(), "base");
+    write_git_review_fixture_file(tmp.path(), "base.txt", "head\n");
+    let head = commit_git_review_fixture(tmp.path(), "head");
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "committed-validation", "repo", tmp.path())
+            .await;
+
+    for (base_arg, head_arg, cached, reason) in [
+        (
+            Some("HEAD".to_string()),
+            Some(head.clone()),
+            None,
+            "invalid_commit_id",
+        ),
+        (
+            Some(base.clone()),
+            None,
+            None,
+            "committed_range_requires_base_and_head",
+        ),
+        (
+            Some(base.clone()),
+            Some(head.clone()),
+            Some(false),
+            "committed_range_conflicts_with_cached",
+        ),
+    ] {
+        let result = runtime
+            .git_diff_hunks_continued_with_range(
+                project.clone(),
+                None,
+                Some(10),
+                Some(80),
+                cached,
+                base_arg,
+                head_arg,
+                None,
+            )
+            .await;
+        assert!(!result.success);
+        assert_eq!(result.output["reason_code"], reason);
+        assert!(
+            next_patch_agent_request(&runtime, "committed-validation")
+                .await
+                .is_none(),
+            "invalid committed input must fail before Runner dispatch"
+        );
+    }
+
+    let (same, _, _) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-validation",
+        &project,
+        tmp.path(),
+        None,
+        10,
+        80,
+        base.clone(),
+        base.clone(),
+        None,
+    )
+    .await;
+    assert!(same.success, "{:?}", same.error);
+    assert_eq!(same.output["hunk_count"], 0);
+    assert_eq!(same.output["files"], json!([]));
+
+    let missing = "f".repeat(40);
+    let (missing_result, _, missing_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-validation",
+        &project,
+        tmp.path(),
+        None,
+        10,
+        80,
+        base.clone(),
+        missing.clone(),
+        None,
+    )
+    .await;
+    assert!(!missing_result.success);
+    assert_eq!(
+        missing_result.output["reason_code"],
+        "head_commit_missing_or_not_commit"
+    );
+    assert_eq!(
+        missing_scripts.len(),
+        1,
+        "missing object must stop before page diff"
+    );
+
+    let (blob_exit, blob_stdout, blob_stderr, _) =
+        run_command_sync("printf blob | git hash-object -w --stdin", tmp.path(), 30);
+    assert_eq!(blob_exit, 0, "{blob_stderr}");
+    let blob = blob_stdout.trim().to_string();
+    let (blob_result, _, blob_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-validation",
+        &project,
+        tmp.path(),
+        None,
+        10,
+        80,
+        base,
+        blob,
+        None,
+    )
+    .await;
+    assert!(!blob_result.success);
+    assert_eq!(
+        blob_result.output["reason_code"],
+        "head_commit_missing_or_not_commit"
+    );
+    assert_eq!(blob_scripts.len(), 1);
+}
+
+#[tokio::test]
+async fn git_diff_hunks_committed_nonancestor_disconnected_and_ambiguous_merge_base() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    write_git_review_fixture_file(tmp.path(), "root.txt", "root\n");
+    let root = commit_git_review_fixture(tmp.path(), "root");
+    let (_, root_branch, _, _) = run_command_sync("git branch --show-current", tmp.path(), 30);
+    let root_branch = root_branch.trim().to_string();
+    git_test_command_ok(tmp.path(), "git checkout -b feature");
+    write_git_review_fixture_file(tmp.path(), "feature.txt", "feature\n");
+    let feature = commit_git_review_fixture(tmp.path(), "feature");
+    git_test_command_ok(
+        tmp.path(),
+        &format!("git checkout {}", shell_escape_simple(&root_branch)),
+    );
+    write_git_review_fixture_file(tmp.path(), "main.txt", "main\n");
+    let requested_base = commit_git_review_fixture(tmp.path(), "main");
+
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "committed-merge-base", "repo", tmp.path())
+            .await;
+    let (nonancestor, _, _) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-merge-base",
+        &project,
+        tmp.path(),
+        None,
+        10,
+        80,
+        requested_base.clone(),
+        feature.clone(),
+        None,
+    )
+    .await;
+    assert!(nonancestor.success, "{:?}", nonancestor.error);
+    assert_eq!(
+        nonancestor.output["scope"]["requested_base"],
+        requested_base
+    );
+    assert_eq!(nonancestor.output["scope"]["requested_head"], feature);
+    assert_eq!(nonancestor.output["scope"]["merge_base"], root);
+    assert_eq!(nonancestor.output["scope"]["base_is_ancestor"], false);
+
+    let disconnected = tempfile::tempdir().unwrap();
+    init_git_repo(disconnected.path());
+    write_git_review_fixture_file(disconnected.path(), "one.txt", "one\n");
+    let first = commit_git_review_fixture(disconnected.path(), "one");
+    git_test_command_ok(disconnected.path(), "git checkout --orphan other");
+    git_test_command_ok(disconnected.path(), "git rm -rf .");
+    write_git_review_fixture_file(disconnected.path(), "two.txt", "two\n");
+    let second = commit_git_review_fixture(disconnected.path(), "two");
+    let runtime2 = test_runtime();
+    let project2 = register_structured_git_agent_at_path(
+        &runtime2,
+        "committed-disconnected",
+        "repo",
+        disconnected.path(),
+    )
+    .await;
+    let (no_base, _, scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime2,
+        "committed-disconnected",
+        &project2,
+        disconnected.path(),
+        None,
+        10,
+        80,
+        first,
+        second,
+        None,
+    )
+    .await;
+    assert!(!no_base.success);
+    assert_eq!(no_base.output["reason_code"], "no_merge_base");
+    assert_eq!(scripts.len(), 1);
+
+    let ambiguous = tempfile::tempdir().unwrap();
+    init_git_repo(ambiguous.path());
+    write_git_review_fixture_file(ambiguous.path(), "root.txt", "root\n");
+    commit_git_review_fixture(ambiguous.path(), "root");
+    git_test_command_ok(ambiguous.path(), "git checkout -b side-a");
+    write_git_review_fixture_file(ambiguous.path(), "a.txt", "a\n");
+    let a1 = commit_git_review_fixture(ambiguous.path(), "a1");
+    git_test_command_ok(ambiguous.path(), "git checkout -b side-b HEAD~1");
+    write_git_review_fixture_file(ambiguous.path(), "b.txt", "b\n");
+    let b1 = commit_git_review_fixture(ambiguous.path(), "b1");
+    git_test_command_ok(ambiguous.path(), "git checkout side-a");
+    git_test_command_ok(
+        ambiguous.path(),
+        &format!("git merge --no-ff -m merge-b {}", shell_escape_simple(&b1)),
+    );
+    let (_, a2, _, _) = run_command_sync("git rev-parse HEAD", ambiguous.path(), 30);
+    let a2 = a2.trim().to_string();
+    git_test_command_ok(ambiguous.path(), "git checkout side-b");
+    git_test_command_ok(
+        ambiguous.path(),
+        &format!("git merge --no-ff -m merge-a {}", shell_escape_simple(&a1)),
+    );
+    let (_, b2, _, _) = run_command_sync("git rev-parse HEAD", ambiguous.path(), 30);
+    let b2 = b2.trim().to_string();
+    let runtime3 = test_runtime();
+    let project3 = register_structured_git_agent_at_path(
+        &runtime3,
+        "committed-ambiguous",
+        "repo",
+        ambiguous.path(),
+    )
+    .await;
+    let (ambiguous_result, _, ambiguous_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime3,
+        "committed-ambiguous",
+        &project3,
+        ambiguous.path(),
+        None,
+        10,
+        80,
+        a2,
+        b2,
+        None,
+    )
+    .await;
+    assert!(!ambiguous_result.success);
+    assert_eq!(
+        ambiguous_result.output["reason_code"],
+        "ambiguous_merge_base"
+    );
+    assert_eq!(ambiguous_scripts.len(), 1);
+}
+
+#[tokio::test]
+async fn git_diff_hunks_committed_continuation_binds_range_paths_mode_and_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    let base_body = (0..1200)
+        .map(|line| format!("line-{line:04}\n"))
+        .collect::<String>();
+    write_git_review_fixture_file(tmp.path(), "large.txt", &base_body);
+    write_git_review_fixture_file(tmp.path(), "other.txt", "same\n");
+    let base = commit_git_review_fixture(tmp.path(), "base");
+    let head_body = (0..1200)
+        .map(|line| {
+            if matches!(line, 10 | 310 | 610 | 910) {
+                format!("changed-{line:04}\n")
+            } else {
+                format!("line-{line:04}\n")
+            }
+        })
+        .collect::<String>();
+    write_git_review_fixture_file(tmp.path(), "large.txt", &head_body);
+    let head = commit_git_review_fixture(tmp.path(), "head");
+
+    let runtime = test_runtime();
+    let project = register_structured_git_agent_at_path(
+        &runtime,
+        "committed-continuation",
+        "repo",
+        tmp.path(),
+    )
+    .await;
+    let paths = Some(vec!["large.txt".to_string()]);
+    let (first, first_bytes, first_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        1,
+        120,
+        base.clone(),
+        head.clone(),
+        None,
+    )
+    .await;
+    assert!(first.success, "{:?}", first.error);
+    assert_eq!(first.output["has_more"], true);
+    assert!(first_bytes < 48 * 1024);
+    assert_eq!(first_scripts.len(), 2);
+    let token = first.output["next_continuation"]
+        .as_str()
+        .expect("first committed page continuation")
+        .to_string();
+    assert!(token.starts_with("wcdh1."));
+    let first_diff = first.output["files"][0]["hunks"][0]["diff"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let (second, _, _) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        1,
+        120,
+        base.clone(),
+        head.clone(),
+        Some(token.clone()),
+    )
+    .await;
+    assert!(second.success, "{:?}", second.error);
+    let second_diff = second.output["files"][0]["hunks"][0]["diff"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_ne!(
+        first_diff, second_diff,
+        "continuation must not replay page one"
+    );
+
+    let (second_again, _, _) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        1,
+        120,
+        base.clone(),
+        head.clone(),
+        Some(token.clone()),
+    )
+    .await;
+    assert!(second_again.success);
+    assert_eq!(second_again.output["files"], second.output["files"]);
+    assert_eq!(
+        second_again.output["next_continuation"],
+        second.output["next_continuation"]
+    );
+
+    let mut seen = vec![first_diff, second_diff];
+    let mut next = second.output["next_continuation"]
+        .as_str()
+        .map(str::to_string);
+    while let Some(current) = next {
+        let (page, _, _) = run_agent_git_diff_hunks_committed_page(
+            &runtime,
+            "committed-continuation",
+            &project,
+            tmp.path(),
+            paths.clone(),
+            1,
+            120,
+            base.clone(),
+            head.clone(),
+            Some(current),
+        )
+        .await;
+        assert!(page.success, "{:?}", page.error);
+        if page.output["hunk_count"].as_u64().unwrap_or(0) > 0 {
+            let diff = page.output["files"][0]["hunks"][0]["diff"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert!(!seen.contains(&diff), "hunk page replayed: {diff}");
+            seen.push(diff);
+        }
+        next = page.output["next_continuation"]
+            .as_str()
+            .map(str::to_string);
+    }
+    assert_eq!(
+        seen.len(),
+        4,
+        "all four committed hunks must be returned once"
+    );
+
+    let (path_mismatch, _, path_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        Some(vec!["other.txt".to_string()]),
+        1,
+        120,
+        base.clone(),
+        head.clone(),
+        Some(token.clone()),
+    )
+    .await;
+    assert!(!path_mismatch.success);
+    assert_eq!(path_mismatch.output["reason_code"], "continuation_mismatch");
+    assert_eq!(
+        path_scripts.len(),
+        1,
+        "mismatch must stop before page producer"
+    );
+
+    let (range_mismatch, _, range_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        1,
+        120,
+        base.clone(),
+        base.clone(),
+        Some(token.clone()),
+    )
+    .await;
+    assert!(!range_mismatch.success);
+    assert_eq!(
+        range_mismatch.output["reason_code"],
+        "continuation_mismatch"
+    );
+    assert_eq!(range_scripts.len(), 1);
+
+    let mut tampered = token.clone().into_bytes();
+    let last = tampered.len() - 1;
+    tampered[last] = if tampered[last] == b'A' { b'B' } else { b'A' };
+    let tampered = String::from_utf8(tampered).unwrap();
+    let (tampered_result, _, tampered_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        1,
+        120,
+        base.clone(),
+        head.clone(),
+        Some(tampered),
+    )
+    .await;
+    assert!(!tampered_result.success);
+    assert_eq!(
+        tampered_result.output["reason_code"],
+        "invalid_continuation"
+    );
+    assert_eq!(tampered_scripts.len(), 1);
+
+    {
+        use base64::{engine::general_purpose, Engine as _};
+        let encoded = token.strip_prefix("wcdh1.").unwrap();
+        let decoded = general_purpose::URL_SAFE_NO_PAD.decode(encoded).unwrap();
+        let mut state: Value = serde_json::from_slice(&decoded).unwrap();
+        state["next"] = json!(999u64);
+        let forged_next = format!(
+            "wcdh1.{}",
+            general_purpose::URL_SAFE_NO_PAD.encode(serde_json::to_vec(&state).unwrap())
+        );
+        let (forged_result, _, forged_scripts) = run_agent_git_diff_hunks_committed_page(
+            &runtime,
+            "committed-continuation",
+            &project,
+            tmp.path(),
+            paths.clone(),
+            1,
+            120,
+            base.clone(),
+            head.clone(),
+            Some(forged_next),
+        )
+        .await;
+        assert!(!forged_result.success);
+        assert_eq!(forged_result.output["reason_code"], "invalid_continuation");
+        assert_eq!(
+            forged_scripts.len(),
+            1,
+            "pagination-state tamper must fail after scope resolution and before page observation"
+        );
+    }
+
+    let dirty_body = (0..1200)
+        .map(|line| {
+            if matches!(line, 20 | 500 | 1000) {
+                format!("dirty-{line:04}\n")
+            } else {
+                if line == 10 || line == 310 || line == 610 || line == 910 {
+                    format!("changed-{line:04}\n")
+                } else {
+                    format!("line-{line:04}\n")
+                }
+            }
+        })
+        .collect::<String>();
+    write_git_review_fixture_file(tmp.path(), "large.txt", &dirty_body);
+    let (worktree_page, _, _) = run_agent_git_diff_hunks_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        1,
+        120,
+        false,
+        None,
+    )
+    .await;
+    assert!(worktree_page.success);
+    let worktree_token = worktree_page.output["next_continuation"]
+        .as_str()
+        .expect("worktree continuation")
+        .to_string();
+    let (wrong_mode, _, wrong_mode_scripts) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "committed-continuation",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        1,
+        120,
+        base.clone(),
+        head.clone(),
+        Some(worktree_token),
+    )
+    .await;
+    assert!(!wrong_mode.success);
+    assert_eq!(wrong_mode.output["reason_code"], "continuation_mismatch");
+    assert_eq!(wrong_mode_scripts.len(), 1);
+
+    let reverse_mode = runtime
+        .git_diff_hunks_continued(project, paths, Some(1), Some(120), Some(false), Some(token))
+        .await;
+    assert!(!reverse_mode.success);
+    assert_eq!(reverse_mode.output["reason_code"], "continuation_mismatch");
+}
+
+#[tokio::test]
+async fn git_diff_hunks_committed_drains_bounded_consumer_and_preserves_producer_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    write_git_review_fixture_file(tmp.path(), "file.txt", "old\n");
+    let base = commit_git_review_fixture(tmp.path(), "base");
+    write_git_review_fixture_file(tmp.path(), "file.txt", "new\n");
+    let head = commit_git_review_fixture(tmp.path(), "head");
+    let runtime = test_runtime();
+    let project = register_structured_git_agent_at_path(
+        &runtime,
+        "committed-producer-failure",
+        "repo",
+        tmp.path(),
+    )
+    .await;
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let base = base.clone();
+        let head = head.clone();
+        async move {
+            runtime
+                .git_diff_hunks_continued_with_range(
+                    project,
+                    Some(vec!["file.txt".to_string()]),
+                    Some(1),
+                    Some(40),
+                    None,
+                    Some(base),
+                    Some(head),
+                    None,
+                )
+                .await
+        }
+    });
+
+    let scope_request = next_patch_agent_request(&runtime, "committed-producer-failure")
+        .await
+        .expect("scope request");
+    complete_agent_request_by_running_locally(
+        &runtime,
+        "committed-producer-failure",
+        scope_request,
+    )
+    .await;
+
+    let mut page_request = next_patch_agent_request(&runtime, "committed-producer-failure")
+        .await
+        .expect("page request");
+    let page_script = page_request
+        .script
+        .as_ref()
+        .expect("typed page script")
+        .script
+        .clone();
+    let head_q = shell_escape_simple(&head);
+    let needle = format!(
+        "git --no-pager -c core.quotePath=false -c attr.tree={head_q} diff --no-ext-diff --no-textconv --find-renames --unified=80 {} {head_q} -- 'file.txt'",
+        shell_escape_simple(&base),
+    );
+    assert_eq!(
+        page_script.matches(&needle).count(),
+        1,
+        "middle diff producer must be uniquely injectable"
+    );
+    let producer_body = concat!(
+        "printf 'diff --git a/file.txt b/file.txt\\n--- a/file.txt\\n+++ b/file.txt\\n@@ -1 +1 @@\\n-old\\n'; ",
+        "i=0; while [ \"$i\" -lt 120000 ]; do printf '+payload-%06d\\n' \"$i\"; i=$((i+1)); done; ",
+        "exit 7"
+    );
+    let injected = format!("sh -c {}", shell_escape_simple(producer_body));
+    page_request
+        .script
+        .as_mut()
+        .expect("typed page script")
+        .script = page_script.replacen(&needle, &injected, 1);
+    let (exit_code, stdout, stderr) = run_agent_shell_request_locally(&page_request);
+    assert_eq!(
+        exit_code, 0,
+        "page envelope should carry producer failure structurally: {stderr}"
+    );
+    assert!(
+        stdout.contains("diff_exit=7\n"),
+        "bounded consumer must drain to the producer's real exit status, not SIGPIPE: {stdout}"
+    );
+    assert!(!stdout.contains("diff_exit=141\n"));
+    assert!(
+        stdout.len() < 48 * 1024,
+        "consumer must retain only a bounded page despite multi-megabyte producer output"
+    );
+    complete_patch_agent_request(
+        &runtime,
+        "committed-producer-failure",
+        &page_request.request_id,
+        exit_code,
+        &stdout,
+        &stderr,
+    )
+    .await;
+    let result = task.await.unwrap();
+    assert!(!result.success);
+    assert_eq!(result.output["reason_code"], "git_diff_failed");
 }
 
 fn git_test_command_ok(repo: &Path, command: &str) {

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -975,6 +975,92 @@ async fn git_diff_hunks_committed_exact_range_isolated_targeted_and_head_attribu
 }
 
 #[tokio::test]
+async fn git_diff_hunks_never_returns_secret_path_content_in_any_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    write_git_review_fixture_file(tmp.path(), ".env", "API_TOKEN=base-secret\n");
+    write_git_review_fixture_file(tmp.path(), "secret key.pem", "API_TOKEN=worktree-base\n");
+    let base = commit_git_review_fixture(tmp.path(), "secret base");
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+    fs::rename(tmp.path().join(".env"), tmp.path().join("src/config.rs")).unwrap();
+    write_git_review_fixture_file(tmp.path(), "src/config.rs", "API_TOKEN=committed-secret\n");
+    let head = commit_git_review_fixture(tmp.path(), "secret head");
+    write_git_review_fixture_file(tmp.path(), "secret key.pem", "API_TOKEN=dirty-secret\n");
+
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "diff-secret-boundary", "repo", tmp.path())
+            .await;
+
+    let (committed, _, _) = run_agent_git_diff_hunks_committed_page(
+        &runtime,
+        "diff-secret-boundary",
+        &project,
+        tmp.path(),
+        None,
+        20,
+        120,
+        base,
+        head,
+        None,
+    )
+    .await;
+    assert!(!committed.success);
+    assert_eq!(committed.output["reason_code"], "sensitive_path");
+    let committed_serialized = serde_json::to_string(&committed).unwrap();
+    for secret in [
+        "base-secret",
+        "committed-secret",
+        "worktree-base",
+        "dirty-secret",
+    ] {
+        assert!(
+            !committed_serialized.contains(secret),
+            "committed diff leaked protected content: {committed_serialized}"
+        );
+    }
+
+    let (worktree, _, _) = run_agent_git_diff_hunks_page(
+        &runtime,
+        "diff-secret-boundary",
+        &project,
+        tmp.path(),
+        None,
+        20,
+        120,
+        false,
+        None,
+    )
+    .await;
+    assert!(
+        !worktree.success,
+        "unexpected protected diff success: {worktree:?}"
+    );
+    assert_eq!(worktree.output["reason_code"], "sensitive_path");
+    let worktree_serialized = serde_json::to_string(&worktree).unwrap();
+    assert!(!worktree_serialized.contains("dirty-secret"));
+
+    let explicit = runtime
+        .git_diff_hunks_continued(
+            project,
+            Some(vec![".env".to_string()]),
+            Some(20),
+            Some(120),
+            Some(false),
+            None,
+        )
+        .await;
+    assert!(!explicit.success);
+    assert_eq!(explicit.output["reason_code"], "sensitive_path");
+    assert!(
+        next_patch_agent_request(&runtime, "diff-secret-boundary")
+            .await
+            .is_none(),
+        "explicit protected path must fail before Runner dispatch"
+    );
+}
+
+#[tokio::test]
 async fn git_diff_hunks_committed_range_validation_and_merge_base_fail_closed() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -974,6 +974,83 @@ async fn git_diff_hunks_committed_exact_range_isolated_targeted_and_head_attribu
     assert!(all_files.iter().any(|file| file["binary"] == true));
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn git_diff_hunks_ignores_external_diff_helpers_in_worktree_and_cached_modes() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    write_git_review_fixture_file(tmp.path(), "safe.txt", "safe-old\n");
+    write_git_review_fixture_file(tmp.path(), ".env", "FAKE_PRIVATE_MARKER_117\n");
+    commit_git_review_fixture(tmp.path(), "base");
+    write_git_review_fixture_file(tmp.path(), "safe.txt", "safe-new\n");
+    let helper = tmp.path().join("extdiff.sh");
+    fs::write(
+        &helper,
+        "#!/bin/sh\nprintf '%s\\n' 'diff --git a/safe.txt b/safe.txt' '--- a/safe.txt' '+++ b/safe.txt' '@@ -1 +1 @@' '-safe-old'\nprintf '+%s\\n' \"$(cat .env)\"\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&helper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&helper, permissions).unwrap();
+    git_test_command_ok(
+        tmp.path(),
+        &format!(
+            "git config diff.external {}",
+            shell_escape_simple(helper.to_string_lossy().as_ref())
+        ),
+    );
+
+    let runtime = test_runtime();
+    let project = register_structured_git_agent_at_path(
+        &runtime,
+        "diff-hunks-no-external",
+        "repo",
+        tmp.path(),
+    )
+    .await;
+    let paths = Some(vec!["safe.txt".to_string()]);
+    let (worktree, _, worktree_script) = run_agent_git_diff_hunks_page(
+        &runtime,
+        "diff-hunks-no-external",
+        &project,
+        tmp.path(),
+        paths.clone(),
+        10,
+        80,
+        false,
+        None,
+    )
+    .await;
+    assert!(worktree.success, "{:?}", worktree.error);
+    assert!(worktree_script.contains("--no-ext-diff"));
+    assert!(worktree_script.contains("--no-textconv"));
+    let worktree_output = serde_json::to_string(&worktree.output).unwrap();
+    assert!(worktree_output.contains("safe-new"));
+    assert!(!worktree_output.contains("FAKE_PRIVATE_MARKER_117"));
+
+    git_test_command_ok(tmp.path(), "git add -- safe.txt");
+    let (cached, _, cached_script) = run_agent_git_diff_hunks_page(
+        &runtime,
+        "diff-hunks-no-external",
+        &project,
+        tmp.path(),
+        paths,
+        10,
+        80,
+        true,
+        None,
+    )
+    .await;
+    assert!(cached.success, "{:?}", cached.error);
+    assert!(cached_script.contains("--no-ext-diff"));
+    assert!(cached_script.contains("--no-textconv"));
+    let cached_output = serde_json::to_string(&cached.output).unwrap();
+    assert!(cached_output.contains("safe-new"));
+    assert!(!cached_output.contains("FAKE_PRIVATE_MARKER_117"));
+}
+
 #[tokio::test]
 async fn git_diff_hunks_never_returns_secret_path_content_in_any_mode() {
     let tmp = tempfile::tempdir().unwrap();
@@ -2218,6 +2295,19 @@ async fn git_diff_hunks_malformed_continuation_fails_before_runner_dispatch() {
 
 #[test]
 fn git_diff_hunks_parser_handles_modified_empty_and_limits() {
+    let binary = "\
+diff --git a/binary file.bin b/binary file.bin
+index 1111111..2222222 100644
+Binary files a/binary file.bin and b/binary file.bin differ
+";
+    let (binary_files, binary_hunks, binary_truncated) = parse_git_diff_hunks(binary, 10, 20);
+    assert!(!binary_truncated);
+    assert_eq!(binary_hunks, 0);
+    assert_eq!(binary_files.len(), 1);
+    assert_eq!(binary_files[0]["path"], "binary file.bin");
+    assert_eq!(binary_files[0]["old_path"], "binary file.bin");
+    assert_eq!(binary_files[0]["binary"], true);
+
     let diff = "\
 diff --git a/src/lib.rs b/src/lib.rs
 index 1111111..2222222 100644
@@ -3469,9 +3559,11 @@ async fn show_changes_untracked_sensitive_path_preview_is_skipped() {
 
 #[test]
 fn git_diff_hunks_command_rejects_unsafe_paths() {
-    assert!(git_diff_hunks_command(&["src/lib.rs".to_string()], false)
-        .unwrap()
-        .contains("git diff --unified=80 -- 'src/lib.rs'"));
+    let command = git_diff_hunks_command(&["src/lib.rs".to_string()], false).unwrap();
+    assert!(command.contains("git diff"));
+    assert!(command.contains("--no-ext-diff"));
+    assert!(command.contains("--no-textconv"));
+    assert!(command.contains("--unified=80 -- 'src/lib.rs'"));
     assert!(validate_project_relative_path("../outside").is_err());
 }
 

--- a/src/tool_runtime/tests/handoff.rs
+++ b/src/tool_runtime/tests/handoff.rs
@@ -3523,7 +3523,7 @@ async fn review_evidence_git_review_summary_counts_as_mapping_not_diff_review() 
 
     let result = runtime
         .dispatch(ToolCall::SessionHandoffSummary {
-            session_id: sid,
+            session_id: sid.clone(),
             project: None,
             include_workspace: None,
             include_checkpoints: None,
@@ -3538,6 +3538,49 @@ async fn review_evidence_git_review_summary_counts_as_mapping_not_diff_review() 
     assert_eq!(review["diff_review_count"], 0);
     assert_eq!(review["total"], 1);
     assert_eq!(review["tools"], json!(["git_review_summary"]));
+    assert_review_evidence_tools_safe(review);
+
+    record_handoff_tool_event(
+        &runtime,
+        &sid,
+        "git_diff_hunks",
+        json!({
+            "project": "agent:eval:demo",
+            "base_commit": "a".repeat(40),
+            "head_commit": "b".repeat(40),
+            "paths": ["src/runtime.rs"]
+        }),
+        true,
+        json!({
+            "scope": {
+                "mode": "committed",
+                "requested_base": "a".repeat(40),
+                "requested_head": "b".repeat(40),
+                "merge_base": "a".repeat(40)
+            },
+            "hunk_count": 1
+        }),
+    );
+    let result = runtime
+        .dispatch(ToolCall::SessionHandoffSummary {
+            session_id: sid,
+            project: None,
+            include_workspace: None,
+            include_checkpoints: None,
+            include_validation: None,
+            summary_only: false,
+            limit: None,
+        })
+        .await;
+    assert!(result.success, "{:?}", result.error);
+    let review = &result.output["review_evidence"];
+    assert_eq!(review["read_only_inspection_count"], 1);
+    assert_eq!(review["diff_review_count"], 1);
+    assert_eq!(review["total"], 2);
+    assert_eq!(
+        review["tools"],
+        json!(["git_review_summary", "git_diff_hunks"])
+    );
     assert_review_evidence_tools_safe(review);
 }
 

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -460,6 +460,8 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
                 &mut out,
                 &["paths", "max_hunks", "max_hunk_lines", "cached"],
             );
+            insert_exact_git_commit_audit(obj, &mut out, "base_commit");
+            insert_exact_git_commit_audit(obj, &mut out, "head_commit");
             out.insert(
                 "continuation_present".to_string(),
                 Value::Bool(
@@ -612,6 +614,19 @@ pub(crate) fn session_log_result_for_tool(tool_name: &str, output: &Value) -> Va
             "truncated": output.get("truncated").cloned().unwrap_or(Value::Null),
             "reason_code": output.get("reason_code").cloned().unwrap_or(Value::Null),
             "signal_count": output.get("signals").and_then(Value::as_array).map(Vec::len),
+            "file_count": output.get("files").and_then(Value::as_array).map(Vec::len),
+        }),
+        "git_diff_hunks" => serde_json::json!({
+            "project": output.get("project").cloned().unwrap_or(Value::Null),
+            "scope": output.get("scope").cloned().unwrap_or(Value::Null),
+            "cached": output.get("cached").cloned().unwrap_or(Value::Null),
+            "hunk_count": output.get("hunk_count").cloned().unwrap_or(Value::Null),
+            "truncated": output.get("truncated").cloned().unwrap_or(Value::Null),
+            "truncation_reasons": output.get("truncation_reasons").cloned().unwrap_or(Value::Null),
+            "has_more": output.get("has_more").cloned().unwrap_or(Value::Null),
+            "exit_code": output.get("exit_code").cloned().unwrap_or(Value::Null),
+            "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
+            "reason_code": output.get("reason_code").cloned().unwrap_or(Value::Null),
             "file_count": output.get("files").and_then(Value::as_array).map(Vec::len),
         }),
         "computer_list_targets" => serde_json::json!({

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -763,6 +763,10 @@ pub enum ToolCall {
         max_hunk_lines: Option<usize>,
         #[serde(default)]
         cached: Option<bool>,
+        #[serde(default)]
+        base_commit: Option<String>,
+        #[serde(default)]
+        head_commit: Option<String>,
         #[serde(
             default,
             deserialize_with = "deserialize_optional_git_diff_hunks_continuation"

--- a/src/tool_runtime/tool_catalog.rs
+++ b/src/tool_runtime/tool_catalog.rs
@@ -325,7 +325,7 @@ pub(crate) const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
     },
     ToolRecommendedFlow {
         name: "review",
-        summary: "Review: use show_changes / git_diff_hunks / workspace_hygiene_check before final response; for committed ranges, call git_review_summary first and then targeted read_file as needed.",
+        summary: "Review: use show_changes / git_diff_hunks / workspace_hygiene_check before final response; for committed ranges, map with git_review_summary, inspect targeted exact-range git_diff_hunks, then read_file as needed.",
         manifest_purpose: "Map committed review ranges, inspect targeted diffs, and check workspace hygiene before the final response.",
         tools: &[
             "git_review_summary",


### PR DESCRIPTION
## Summary

- add exact committed-range mode to `git_diff_hunks` via optional `base_commit` / `head_commit`
- share deterministic committed Git scope/isolation logic with `git_review_summary`
- add HMAC-fenced v2 continuation for committed pages while preserving worktree/cached v1 compatibility
- preserve bounded producer/consumer failure semantics and raw-hunk audit privacy
- enforce the shared secret-path read boundary across committed/worktree/cached diff hunks, including rename old paths and Git-quoted filenames

## Contract

Committed mode accepts only exact local 40-hex SHA-1 commit IDs, resolves exactly one best merge-base, and reviews `merge_base..head`. It does not fetch, checkout, widen OAuth/capability authority, or expose mutable Git config/textconv/external-diff behavior.

Committed continuations bind project identity, requested base/head, resolved merge-base, mode, normalized paths, page limits, fixed byte budget, fence and next position with a per-runtime HMAC key. Tokens fail closed after runtime restart by design.

## Review closure

Independent review found and fixed one privacy blocker: raw diff hunks could expose content from paths covered by the shared `is_secret_path` policy (for example historical `.env` or `*.pem`). The follow-up commit fails closed before model output for protected current/old paths and shares canonical Git path decoding with the review-summary parser.

## Validation

- `cargo test git_diff_hunks -p webcodex` — 19 passed
- `cargo test git_review_summary -p webcodex` — 22 passed
- `cargo test tool_runtime::tests::schema -p webcodex` — 104 passed
- `cargo check --all-targets -p webcodex` — pass, 0 warnings/errors
- `cargo fmt -- --check` — pass
- `git diff --check` — pass
- implementation commit full suite: `cargo test -p webcodex` — 2686 passed / 0 failed

No deploy, restart, or release is part of this PR.