### PR TITLE
Add targeted runtime inventory queries

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -263,8 +263,8 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation(
                     "listProjects",
                     "List agent-registered projects",
-                    "Read-only. Returns projects registered by connected agents with runtime id (`agent:<client_id>:<project_id>`), path, executor, client_id, patch flag, and smoke-selection capabilities such as git_available and recommended_for_smoke. Call this first to learn the project ids required by other actions.",
-                    "EmptyRequest",
+                    "Read-only. When a Runner or Project is already known, pass exact client_id/project instead of reading the full registry; query is bounded text filtering over already-visible metadata and summary_only returns a compact workspace-selection projection.",
+                    "ListProjectsRequest",
                     "ToolResult"
                 )
             },
@@ -330,8 +330,8 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation(
                     "getRuntimeStatus",
                     "Get runtime status",
-                    "Read-only runtime health/observability summary with service metadata, registered agent count/online_count/stale_count, project counts, and job counts. Never exposes tokens, secrets, full env, or stdout/stderr. Call first when troubleshooting.",
-                    "EmptyRequest",
+                    "Read-only runtime health/observability with agent count/online_count/stale_count plus project and Job counts. Pass exact client_id when validating one Runner deployment/source alignment so unrelated fleet mismatches remain secondary; omit it for fleet-wide investigation.",
+                    "RuntimeStatusRequest",
                     "ToolResult"
                 )
             },
@@ -380,7 +380,7 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation_with_examples(
                     "listRuntimeJobs",
                     "List runtime jobs",
-                    "Read-only bounded runtime job summaries across agent and local executors. Never returns stdout/stderr bodies — only metadata (job_id, kind, status, project, timestamps, exit_code). Optional `status` filter and `limit`.",
+                    "Read-only bounded runtime job summaries. Inside a coding Session, prefer exact project/session_id filters; status combines with them using AND semantics. Filters only reduce caller-visible Jobs and are applied before limit. Never returns stdout/stderr bodies.",
                     "ListJobsRequest",
                     "ToolResult",
                     json!({
@@ -393,6 +393,13 @@ pub(crate) fn build_openapi_spec() -> Value {
                             "value": {
                                 "status": "running",
                                 "limit": 20
+                            }
+                        },
+                        "session": {
+                            "summary": "List Jobs for one coding Session",
+                            "value": {
+                                "project": "agent:special:webcodex",
+                                "session_id": "wc_sess_example"
                             }
                         }
                     })
@@ -1031,6 +1038,28 @@ fn schemas() -> Value {
             "additionalProperties": false,
             "properties": {},
             "description": "Empty request body. Send {} for actions that take no arguments."
+        },
+        "ListProjectsRequest": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Optional targeted Project inventory filters. Omit all fields for legacy full-registry behavior.",
+            "properties": {
+                "client_id": {"type": "string", "maxLength": 128, "description": "Exact caller-visible Runner client_id."},
+                "project": {"type": "string", "maxLength": 512, "description": "Exact full runtime Project id."},
+                "query": {"type": "string", "maxLength": 200, "description": "Bounded deterministic text filter over already-visible Project metadata; blank queries are rejected."},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "description": "Maximum Projects after filtering; targeted calls default to 100."},
+                "summary_only": {"type": "boolean", "description": "Return compact workspace-selection metadata instead of full Project detail."}
+            }
+        },
+        "RuntimeStatusRequest": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Optional focused runtime observation. Omit client_id for legacy fleet-wide semantics.",
+            "properties": {
+                "client_id": {"type": "string", "maxLength": 128, "description": "Exact caller-visible Runner client_id to evaluate independently of unrelated fleet mismatches."},
+                "compact": {"type": "boolean", "description": "Return compact runtime observability."},
+                "summary_only": {"type": "boolean", "description": "Alias for compact=true."}
+            }
         },
         "ToolsListRequest": {
             "type": "object",
@@ -1738,15 +1767,27 @@ fn schemas() -> Value {
         "ListJobsRequest": {
             "type": "object",
             "additionalProperties": false,
-            "description": "List bounded runtime job summaries. Read-only; never returns stdout/stderr bodies.",
+            "description": "List bounded caller-visible runtime Job summaries. Exact project/session_id/status filters use AND semantics before limit; never returns stdout/stderr bodies.",
             "properties": {
                 "limit": {
                     "type": "integer",
-                    "description": "Optional maximum number of job summaries to return."
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Optional maximum number of matching Job summaries to return."
                 },
                 "status": {
                     "type": "string",
-                    "description": "Optional status filter (e.g. running, completed, failed)."
+                    "description": "Optional exact status filter (e.g. running, completed, failed)."
+                },
+                "project": {
+                    "type": "string",
+                    "maxLength": 512,
+                    "description": "Optional exact full runtime Project id."
+                },
+                "session_id": {
+                    "type": "string",
+                    "maxLength": 128,
+                    "description": "Optional exact workflow Session id."
                 }
             }
         },

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -1594,6 +1594,34 @@ fn openapi_call_runtime_tool_examples_cover_alias_and_no_params() {
 }
 
 #[test]
+fn openapi_targeted_inventory_request_schemas_are_bounded() {
+    let spec = build_openapi_spec();
+    let schemas = &spec["components"]["schemas"];
+
+    let projects = &schemas["ListProjectsRequest"]["properties"];
+    assert_eq!(projects["client_id"]["maxLength"], 128);
+    assert_eq!(projects["project"]["maxLength"], 512);
+    assert_eq!(projects["query"]["maxLength"], 200);
+    assert_eq!(projects["limit"]["maximum"], 100);
+    assert!(projects.get("summary_only").is_some());
+    assert_eq!(
+        spec["paths"]["/api/projects/list"]["post"]["requestBody"]["content"]["application/json"]
+            ["schema"]["$ref"],
+        "#/components/schemas/ListProjectsRequest"
+    );
+
+    let runtime = &schemas["RuntimeStatusRequest"]["properties"];
+    assert_eq!(runtime["client_id"]["maxLength"], 128);
+    assert!(runtime.get("compact").is_some());
+    assert!(runtime.get("summary_only").is_some());
+
+    let jobs = &schemas["ListJobsRequest"]["properties"];
+    assert_eq!(jobs["limit"]["maximum"], 100);
+    assert_eq!(jobs["project"]["maxLength"], 512);
+    assert_eq!(jobs["session_id"]["maxLength"], 128);
+}
+
+#[test]
 fn openapi_spec_serializes_as_valid_json() {
     // Building the spec must not panic and must produce a JSON object with
     // the top-level OpenAPI 3.1 keys ChatGPT expects.

--- a/src/runtime_console_http.rs
+++ b/src/runtime_console_http.rs
@@ -150,7 +150,16 @@ async fn visible_project_values(
     auth: &AuthContext,
 ) -> Result<Vec<Value>, RuntimeConsoleError> {
     let result = runtime
-        .dispatch_with_auth(ToolCall::ListProjects, Some(auth))
+        .dispatch_with_auth(
+            ToolCall::ListProjects {
+                client_id: None,
+                project: None,
+                query: None,
+                limit: None,
+                summary_only: false,
+            },
+            Some(auth),
+        )
         .await;
     if !result.success {
         return Err(RuntimeConsoleError::Internal);
@@ -496,7 +505,16 @@ mod tests {
         register_project(&runtime, "client-b", "proj-b", "/private/b", Some(&auth_b)).await;
 
         let direct = runtime
-            .dispatch_with_auth(ToolCall::ListProjects, Some(&auth_a))
+            .dispatch_with_auth(
+                ToolCall::ListProjects {
+                    client_id: None,
+                    project: None,
+                    query: None,
+                    limit: None,
+                    summary_only: false,
+                },
+                Some(&auth_a),
+            )
             .await;
         let projected = projects_for_auth(&runtime, &auth_a, Some(100))
             .await

--- a/src/runtime_http.rs
+++ b/src/runtime_http.rs
@@ -78,6 +78,42 @@ where
     }
 }
 
+/// Parse an optional JSON request body while distinguishing a truly absent body
+/// from malformed non-empty JSON. Empty/whitespace bodies and explicit `null`
+/// preserve legacy no-argument behavior; malformed bodies fail closed with 400
+/// instead of silently widening a targeted inventory request.
+pub(crate) async fn parse_optional_json_body(
+    req: &mut Request,
+    res: &mut Response,
+) -> Option<Value> {
+    let payload = match req.payload().await {
+        Ok(payload) => payload,
+        Err(e) => {
+            res.status_code(StatusCode::BAD_REQUEST);
+            res.render(json_error(
+                StatusCode::BAD_REQUEST,
+                format!("Failed to read request body: {}", e),
+            ));
+            return None;
+        }
+    };
+    if payload.is_empty() || payload.iter().all(|byte| byte.is_ascii_whitespace()) {
+        return Some(Value::Object(Default::default()));
+    }
+    match serde_json::from_slice::<Value>(payload) {
+        Ok(Value::Null) => Some(Value::Object(Default::default())),
+        Ok(body) => Some(body),
+        Err(e) => {
+            res.status_code(StatusCode::BAD_REQUEST);
+            res.render(json_error(
+                StatusCode::BAD_REQUEST,
+                format!("Invalid JSON: {}", e),
+            ));
+            None
+        }
+    }
+}
+
 fn render_result(
     res: &mut Response,
     audit: &ActionAudit,
@@ -401,17 +437,10 @@ pub async fn runtime_status(req: &mut Request, depot: &mut Depot, res: &mut Resp
     let Some(runtime) = require_runtime(depot, res) else {
         return;
     };
-    // Body remains optional for compatibility. When present, parse it through
-    // the canonical tool-call contract so the focused client_id path is shared
-    // with MCP/generic runtime calls.
-    let body: Value = match req.parse_json().await {
-        Ok(body) => body,
-        Err(_) => Value::Null,
-    };
-    let arguments = if body.is_null() {
-        Value::Object(Default::default())
-    } else {
-        body
+    // Body remains optional for compatibility. Non-empty malformed JSON must
+    // fail closed instead of silently widening a focused request to fleet-wide.
+    let Some(arguments) = parse_optional_json_body(req, res).await else {
+        return;
     };
     let call = match ToolCall::from_tool_name("runtime_status", arguments) {
         Ok(call) => call,

--- a/src/runtime_http.rs
+++ b/src/runtime_http.rs
@@ -401,23 +401,33 @@ pub async fn runtime_status(req: &mut Request, depot: &mut Depot, res: &mut Resp
     let Some(runtime) = require_runtime(depot, res) else {
         return;
     };
-    // Body is optional; tolerate an empty/missing body since this call takes
-    // no arguments.
+    // Body remains optional for compatibility. When present, parse it through
+    // the canonical tool-call contract so the focused client_id path is shared
+    // with MCP/generic runtime calls.
     let body: Value = match req.parse_json().await {
         Ok(body) => body,
         Err(_) => Value::Null,
     };
-    let _ = body;
+    let arguments = if body.is_null() {
+        Value::Object(Default::default())
+    } else {
+        body
+    };
+    let call = match ToolCall::from_tool_name("runtime_status", arguments) {
+        Ok(call) => call,
+        Err(error) => {
+            render_result(
+                res,
+                &audit,
+                "runtime_status",
+                None,
+                crate::tool_runtime::ToolResult::err(error),
+            );
+            return;
+        }
+    };
     let auth = depot.obtain::<crate::auth::AuthContext>().ok().cloned();
-    let result = runtime
-        .dispatch_with_auth(
-            ToolCall::RuntimeStatus {
-                compact: false,
-                summary_only: false,
-            },
-            auth.as_ref(),
-        )
-        .await;
+    let result = runtime.dispatch_with_auth(call, auth.as_ref()).await;
     render_result(res, &audit, "runtime_status", None, result);
 }
 

--- a/src/runtime_http/jobs.rs
+++ b/src/runtime_http/jobs.rs
@@ -64,6 +64,10 @@ struct ListJobsRequest {
     pub limit: Option<usize>,
     #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -226,6 +230,8 @@ pub async fn jobs_list(req: &mut Request, depot: &mut Depot, res: &mut Response)
             ToolCall::ListJobs {
                 limit: body.limit,
                 status: body.status,
+                project: body.project,
+                session_id: body.session_id,
             },
             auth.as_ref(),
         )

--- a/src/runtime_http/projects.rs
+++ b/src/runtime_http/projects.rs
@@ -62,17 +62,33 @@ pub async fn projects_list(req: &mut Request, depot: &mut Depot, res: &mut Respo
     let Some(runtime) = require_runtime(depot, res) else {
         return;
     };
-    // Body is optional; reject non-empty invalid JSON for consistency but
-    // tolerate an empty/missing body since this call takes no arguments.
+    // Body remains optional for compatibility. When present, parse it through
+    // the canonical tool-call contract so dedicated REST and MCP/generic calls
+    // share the same bounded targeted-inventory validation.
     let body: Value = match req.parse_json().await {
         Ok(body) => body,
         Err(_) => Value::Null,
     };
-    let _ = body;
+    let arguments = if body.is_null() {
+        Value::Object(Default::default())
+    } else {
+        body
+    };
+    let call = match ToolCall::from_tool_name("list_projects", arguments) {
+        Ok(call) => call,
+        Err(error) => {
+            render_result(
+                res,
+                &audit,
+                "list_projects",
+                None,
+                crate::tool_runtime::ToolResult::err(error),
+            );
+            return;
+        }
+    };
     let auth = depot.obtain::<crate::auth::AuthContext>().ok().cloned();
-    let result = runtime
-        .dispatch_with_auth(ToolCall::ListProjects, auth.as_ref())
-        .await;
+    let result = runtime.dispatch_with_auth(call, auth.as_ref()).await;
     render_result(res, &audit, "list_projects", None, result);
 }
 

--- a/src/runtime_http/projects.rs
+++ b/src/runtime_http/projects.rs
@@ -1,4 +1,4 @@
-use super::{parse_json_body, render_result, require_runtime};
+use super::{parse_json_body, parse_optional_json_body, render_result, require_runtime};
 use crate::action_audit::ActionAudit;
 use crate::tool_runtime::ToolCall;
 use salvo::prelude::*;
@@ -62,17 +62,11 @@ pub async fn projects_list(req: &mut Request, depot: &mut Depot, res: &mut Respo
     let Some(runtime) = require_runtime(depot, res) else {
         return;
     };
-    // Body remains optional for compatibility. When present, parse it through
-    // the canonical tool-call contract so dedicated REST and MCP/generic calls
-    // share the same bounded targeted-inventory validation.
-    let body: Value = match req.parse_json().await {
-        Ok(body) => body,
-        Err(_) => Value::Null,
-    };
-    let arguments = if body.is_null() {
-        Value::Object(Default::default())
-    } else {
-        body
+    // Body remains optional for compatibility. Non-empty malformed JSON must
+    // fail closed instead of silently widening a targeted request to the full
+    // caller-visible registry.
+    let Some(arguments) = parse_optional_json_body(req, res).await else {
+        return;
     };
     let call = match ToolCall::from_tool_name("list_projects", arguments) {
         Ok(call) => call,

--- a/src/runtime_http/tests/projects_tests.rs
+++ b/src/runtime_http/tests/projects_tests.rs
@@ -51,6 +51,34 @@ async fn http_projects_list_ignores_server_configured_projects() {
     );
 }
 
+#[tokio::test]
+async fn http_projects_list_optional_body_accepts_empty_and_rejects_malformed_json() {
+    let config = super::test_config(Some("secret"));
+    let (_tmp, db) = super::test_db();
+    let tmp_proj = tempfile::tempdir().unwrap();
+    let runtime = Arc::new(super::runtime_with_local_project(tmp_proj.path(), "demo"));
+    let service = Service::new(super::build_projects_router(config, db, runtime));
+
+    let resp = TestClient::post("http://localhost/api/projects/list")
+        .bearer_auth("secret")
+        .send(&service)
+        .await;
+    assert_eq!(super::effective_status(&resp), StatusCode::OK);
+
+    let mut resp = TestClient::post("http://localhost/api/projects/list")
+        .bearer_auth("secret")
+        .add_header("content-type", "application/json", true)
+        .body("{\"client_id\":")
+        .send(&service)
+        .await;
+    assert_eq!(super::effective_status(&resp), StatusCode::BAD_REQUEST);
+    let body: Value = resp.take_json().await.unwrap();
+    assert_eq!(body["status"], 400);
+    assert!(body["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("Invalid JSON")));
+}
+
 // =========================================================================
 // register_project / create_project REST endpoints
 // =========================================================================

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -527,6 +527,34 @@ async fn http_runtime_status_correct_bearer_returns_summary() {
     }
 }
 
+#[tokio::test]
+async fn http_runtime_status_optional_body_accepts_empty_and_rejects_malformed_json() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let tmp_proj = tempfile::tempdir().unwrap();
+    let (runtime, _registry) = register_import_agent(tmp_proj.path()).await;
+    let service = Service::new(build_projects_router(config, db, runtime));
+
+    let resp = TestClient::post("http://localhost/api/runtime/status")
+        .bearer_auth("secret")
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::OK);
+
+    let mut resp = TestClient::post("http://localhost/api/runtime/status")
+        .bearer_auth("secret")
+        .add_header("content-type", "application/json", true)
+        .body("{\"client_id\":")
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::BAD_REQUEST);
+    let body: Value = resp.take_json().await.unwrap();
+    assert_eq!(body["status"], 400);
+    assert!(body["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("Invalid JSON")));
+}
+
 // =========================================================================
 // Phase 2: callRuntimeTool / /api/tools/call generic entry point
 // =========================================================================

--- a/src/tool_runtime/discovery_tools.rs
+++ b/src/tool_runtime/discovery_tools.rs
@@ -1,5 +1,6 @@
 //! Runtime dispatch adapters for discovery and observability tool calls.
 
+use super::runtime_info::ListAgentsOptions;
 use super::tool_inputs::ListToolsOptions;
 use super::{ToolCall, ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
@@ -22,12 +23,29 @@ impl ToolRuntime {
                 summary_only,
                 limit,
             })),
-            ToolCall::ListAgents => self.list_agents(auth).await,
+            ToolCall::ListAgents {
+                client_id,
+                client_ids,
+                include_projects,
+                summary_only,
+            } => {
+                self.list_agents_with_options(
+                    auth,
+                    ListAgentsOptions {
+                        client_id,
+                        client_ids,
+                        include_projects,
+                        summary_only,
+                    },
+                )
+                .await
+            }
             ToolCall::RuntimeStatus {
                 compact,
                 summary_only,
+                client_id,
             } => {
-                self.runtime_status_with_options(auth, compact, summary_only)
+                self.runtime_status_with_options(auth, compact, summary_only, client_id)
                     .await
             }
             ToolCall::ToolManifest {

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -1076,7 +1076,7 @@ impl ToolRuntime {
     ) -> ToolResult {
         match call {
             call @ (ToolCall::ListTools { .. }
-            | ToolCall::ListAgents
+            | ToolCall::ListAgents { .. }
             | ToolCall::RuntimeStatus { .. }
             | ToolCall::ToolManifest { .. }) => self.dispatch_discovery_tool(call, auth).await,
 
@@ -1139,7 +1139,7 @@ impl ToolRuntime {
                 self.dispatch_computer_tool(call, auth).await
             }
 
-            call @ (ToolCall::ListProjects
+            call @ (ToolCall::ListProjects { .. }
             | ToolCall::RegisterProject { .. }
             | ToolCall::UnregisterProject { .. }
             | ToolCall::CreateProject { .. }) => self.dispatch_project_tool(call, auth).await,

--- a/src/tool_runtime/job_tools.rs
+++ b/src/tool_runtime/job_tools.rs
@@ -77,8 +77,14 @@ impl ToolRuntime {
                 self.observe_jobs_for_auth(items, tail_lines, wait_secs, auth)
                     .await
             }
-            ToolCall::ListJobs { limit, status } => {
-                self.list_jobs_for_auth(limit, status, auth).await
+            ToolCall::ListJobs {
+                limit,
+                status,
+                project,
+                session_id,
+            } => {
+                self.list_jobs_for_auth_with_filters(limit, status, project, session_id, auth)
+                    .await
             }
             ToolCall::JobTail {
                 job_id,

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -1824,41 +1824,104 @@ impl ToolRuntime {
         }
     }
 
+    #[cfg(test)]
     pub(crate) async fn list_jobs_for_auth(
         &self,
         limit: Option<usize>,
         status: Option<String>,
         auth: Option<&AuthContext>,
     ) -> ToolResult {
+        self.list_jobs_for_auth_with_filters(limit, status, None, None, auth)
+            .await
+    }
+
+    pub(crate) async fn list_jobs_for_auth_with_filters(
+        &self,
+        limit: Option<usize>,
+        status: Option<String>,
+        project: Option<String>,
+        session_id: Option<String>,
+        auth: Option<&AuthContext>,
+    ) -> ToolResult {
         let max = limit.unwrap_or(20).clamp(1, 100);
         let status_filter = status
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
-        // Agent jobs come pre-bounded to `max` by the registry. Local jobs are
-        // collected fully (the in-memory map is small) so truncation can be
-        // detected accurately for the common local-only case.
-        let agent_jobs = self.shell_clients.list_jobs_for_auth(auth, Some(max)).await;
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let project_filter = match project {
+            Some(value) => {
+                let value = value.trim();
+                if value.is_empty() || value.chars().count() > 512 {
+                    return ToolResult::err_with_output(
+                        "invalid_project_filter: project must contain 1..=512 characters"
+                            .to_string(),
+                        json!({"error_kind": "invalid_project_filter"}),
+                    );
+                }
+                Some(value.to_string())
+            }
+            None => None,
+        };
+        let session_filter = match session_id {
+            Some(value) => {
+                let value = value.trim();
+                if value.is_empty() || value.chars().count() > 128 {
+                    return ToolResult::err_with_output(
+                        "invalid_session_filter: session_id must contain 1..=128 characters"
+                            .to_string(),
+                        json!({"error_kind": "invalid_session_filter"}),
+                    );
+                }
+                Some(value.to_string())
+            }
+            None => None,
+        };
+
+        // Authorization/visibility is applied by the registry first. Focused
+        // filters only reduce that already-visible set, and limit is applied
+        // after every filter so exact project/session targets cannot be hidden
+        // behind unrelated recent Jobs.
+        let agent_jobs = self.shell_clients.list_all_jobs_for_auth(auth).await;
         let mut summaries: Vec<Value> = agent_jobs
             .iter()
-            .filter(|j| {
+            .filter(|job| {
                 status_filter
                     .as_ref()
-                    .map(|s| s == &j.status)
+                    .map(|status| status == &job.status)
                     .unwrap_or(true)
+                    && project_filter
+                        .as_deref()
+                        .map(|project| job.project_id.as_deref() == Some(project))
+                        .unwrap_or(true)
+                    && session_filter
+                        .as_deref()
+                        .map(|session_id| job.session_id.as_deref() == Some(session_id))
+                        .unwrap_or(true)
             })
             .map(agent_job_summary_value)
             .collect();
+
         let local_records: Vec<(String, LocalJobRecord)> = if local_jobs_visible_to_auth(auth) {
             let local_jobs_map = self.local_jobs.lock().await;
             local_jobs_map
                 .iter()
                 .filter(|(_, record)| record.is_public())
+                .filter(|(_, record)| {
+                    project_filter
+                        .as_deref()
+                        .map(|project| record.project == project)
+                        .unwrap_or(true)
+                })
                 .map(|(job_id, record)| (job_id.clone(), record.clone()))
                 .collect()
         } else {
             Vec::new()
         };
         for (job_id, record) in &local_records {
+            if session_filter.as_deref().is_some_and(|session_id| {
+                local_job_session_id(record).as_deref() != Some(session_id)
+            }) {
+                continue;
+            }
             if let Some(summary) = local_job_summary_value(job_id, record, &status_filter) {
                 summaries.push(summary);
             }
@@ -1868,12 +1931,20 @@ impl ToolRuntime {
                 .as_i64()
                 .unwrap_or(0)
                 .cmp(&a["created_at"].as_i64().unwrap_or(0))
+                .then_with(|| {
+                    a["job_id"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .cmp(b["job_id"].as_str().unwrap_or_default())
+                })
         });
-        let truncated = summaries.len() > max;
+        let matched_count = summaries.len();
+        let truncated = matched_count > max;
         summaries.truncate(max);
         ToolResult::ok(json!({
             "jobs": summaries,
             "count": summaries.len(),
+            "matched_count": matched_count,
             "truncated": truncated,
         }))
     }

--- a/src/tool_runtime/project_tools.rs
+++ b/src/tool_runtime/project_tools.rs
@@ -1,5 +1,6 @@
 //! Runtime dispatch adapters for project management tool calls.
 
+use super::projects::ListProjectsOptions;
 use super::{ToolCall, ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
 
@@ -10,7 +11,25 @@ impl ToolRuntime {
         auth: Option<&AuthContext>,
     ) -> ToolResult {
         match call {
-            ToolCall::ListProjects => self.list_projects(auth).await,
+            ToolCall::ListProjects {
+                client_id,
+                project,
+                query,
+                limit,
+                summary_only,
+            } => {
+                self.list_projects_with_options(
+                    auth,
+                    ListProjectsOptions {
+                        client_id,
+                        project,
+                        query,
+                        limit,
+                        summary_only,
+                    },
+                )
+                .await
+            }
             ToolCall::RegisterProject {
                 client_id,
                 id,

--- a/src/tool_runtime/projects.rs
+++ b/src/tool_runtime/projects.rs
@@ -31,28 +31,147 @@ const PROJECT_OP_WAIT_SECS: u64 = 32;
 const MANAGED_TEMPORARY_PROJECT_SOURCE: &str = "managed_temporary";
 const AUTO_REGISTERED_PROJECT_SOURCE: &str = "auto_registered";
 
+const LIST_PROJECTS_MAX_QUERY_CHARS: usize = 200;
+const LIST_PROJECTS_MAX_RESULTS: usize = 100;
+
+#[derive(Debug, Default)]
+pub(crate) struct ListProjectsOptions {
+    pub(crate) client_id: Option<String>,
+    pub(crate) project: Option<String>,
+    pub(crate) query: Option<String>,
+    pub(crate) limit: Option<usize>,
+    pub(crate) summary_only: bool,
+}
+
 impl ToolRuntime {
     pub(crate) async fn list_projects(&self, auth: Option<&AuthContext>) -> ToolResult {
-        let mut list: Vec<Value> = Vec::new();
-        for client in self.shell_clients.list_clients_for_auth(auth).await {
-            // Sanitized shell-profiles summary for this agent (carried inside
-            // the registration policy). Used to resolve which profile a project
-            // actually uses and whether that profile is configured. `None` for
-            // older agents that did not report one.
+        self.list_projects_with_options(auth, ListProjectsOptions::default())
+            .await
+    }
+
+    pub(crate) async fn list_projects_with_options(
+        &self,
+        auth: Option<&AuthContext>,
+        options: ListProjectsOptions,
+    ) -> ToolResult {
+        if options
+            .client_id
+            .as_deref()
+            .is_some_and(|value| value.is_empty() || value.chars().count() > 128)
+        {
+            return ToolResult::err_with_output(
+                "invalid_client_id: client_id must contain 1..=128 characters".to_string(),
+                json!({"error_kind": "invalid_client_id"}),
+            );
+        }
+        if options
+            .project
+            .as_deref()
+            .is_some_and(|value| value.is_empty() || value.chars().count() > 512)
+        {
+            return ToolResult::err_with_output(
+                "invalid_project: project must contain 1..=512 characters".to_string(),
+                json!({"error_kind": "invalid_project"}),
+            );
+        }
+        let query = match options.query.as_deref() {
+            Some(raw) => {
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    return ToolResult::err_with_output(
+                        "invalid_query: query must not be empty after trimming".to_string(),
+                        json!({"error_kind": "invalid_query"}),
+                    );
+                }
+                if trimmed.chars().count() > LIST_PROJECTS_MAX_QUERY_CHARS {
+                    return ToolResult::err_with_output(
+                        format!(
+                            "invalid_query: query exceeds {LIST_PROJECTS_MAX_QUERY_CHARS} characters"
+                        ),
+                        json!({"error_kind": "invalid_query"}),
+                    );
+                }
+                Some(trimmed.to_lowercase())
+            }
+            None => None,
+        };
+        let filtered =
+            options.client_id.is_some() || options.project.is_some() || options.query.is_some();
+        let limit = options
+            .limit
+            .map(|limit| limit.clamp(1, LIST_PROJECTS_MAX_RESULTS))
+            .or_else(|| filtered.then_some(LIST_PROJECTS_MAX_RESULTS));
+
+        let clients = self.shell_clients.list_clients_for_auth(auth).await;
+        let mut candidates = Vec::new();
+        for client in clients {
+            if options
+                .client_id
+                .as_deref()
+                .is_some_and(|expected| client.client_id != expected)
+            {
+                continue;
+            }
+            for project in &client.projects {
+                let runtime_id = agent_project_runtime_id(&client.client_id, &project.id);
+                if options
+                    .project
+                    .as_deref()
+                    .is_some_and(|expected| runtime_id != expected)
+                {
+                    continue;
+                }
+                if query
+                    .as_deref()
+                    .is_some_and(|needle| !project_query_matches(needle, &runtime_id, project))
+                {
+                    continue;
+                }
+                candidates.push((runtime_id, client.clone(), project.clone()));
+            }
+        }
+        candidates.sort_by(|a, b| a.0.cmp(&b.0));
+        let matched_count = candidates.len();
+        if let Some(limit) = limit {
+            candidates.truncate(limit);
+        }
+        let truncated = candidates.len() < matched_count;
+
+        let mut list = Vec::with_capacity(candidates.len());
+        for (runtime_id, client, project) in candidates {
             let shell_profiles = client
                 .policy
                 .as_ref()
-                .and_then(|p| p.shell_profiles.as_ref());
-            for project in &client.projects {
-                let (resolved_shell_profile, shell_profile_status) =
-                    resolve_project_shell_profile(project.shell_profile.as_deref(), shell_profiles);
-                let capabilities = smoke_project_capabilities(&client, project);
-                let runtime_id = agent_project_runtime_id(&client.client_id, &project.id);
-                let active_jobs = self
-                    .shell_clients
-                    .count_active_jobs_for_project(auth, &runtime_id)
-                    .await;
-                list.push(json!({
+                .and_then(|policy| policy.shell_profiles.as_ref());
+            let (resolved_shell_profile, shell_profile_status) =
+                resolve_project_shell_profile(project.shell_profile.as_deref(), shell_profiles);
+            let capabilities = smoke_project_capabilities(&client, &project);
+            let active_jobs = self
+                .shell_clients
+                .count_active_jobs_for_project(auth, &runtime_id)
+                .await;
+            let value = if options.summary_only {
+                json!({
+                    "id": runtime_id,
+                    "agent_project_id": project.id,
+                    "name": project.name,
+                    "description": project.description,
+                    "executor": "agent",
+                    "client_id": client.client_id,
+                    "enabled": !project.disabled,
+                    "active_jobs": active_jobs,
+                    "source": project_source(&project),
+                    "agent_status": client.status,
+                    "connected": client.connected,
+                    "resolved_shell_profile": resolved_shell_profile,
+                    "shell_profile_status": shell_profile_status,
+                    "capabilities": {
+                        "git_available": capabilities["git_available"],
+                        "recommended_for_smoke": capabilities["recommended_for_smoke"],
+                    },
+                })
+            } else {
+                json!({
                     "id": runtime_id,
                     "agent_project_id": project.id,
                     "name": project.name,
@@ -65,7 +184,7 @@ impl ToolRuntime {
                     "disabled": project.disabled,
                     "revision": project.revision,
                     "active_jobs": active_jobs,
-                    "source": project_source(project),
+                    "source": project_source(&project),
                     "agent_status": client.status,
                     "connected": client.connected,
                     "last_seen": client.last_seen,
@@ -73,15 +192,10 @@ impl ToolRuntime {
                     "resolved_shell_profile": resolved_shell_profile,
                     "shell_profile_status": shell_profile_status,
                     "capabilities": capabilities,
-                }));
-            }
+                })
+            };
+            list.push(value);
         }
-        list.sort_by(|a, b| {
-            a["id"]
-                .as_str()
-                .unwrap_or_default()
-                .cmp(b["id"].as_str().unwrap_or_default())
-        });
         let recommended_for_smoke: Vec<Value> = list
             .iter()
             .filter(|project| {
@@ -93,6 +207,8 @@ impl ToolRuntime {
             .collect();
         ToolResult::ok(json!({
             "count": list.len(),
+            "matched_count": matched_count,
+            "truncated": truncated,
             "projects": list,
             "recommended_for_smoke": recommended_for_smoke,
         }))
@@ -458,6 +574,23 @@ fn agent_protocol_reports_project_git(protocol: &str) -> bool {
             | crate::shell_protocol::AGENT_PROTOCOL_VERSION_WEBSOCKET_V1
             | crate::shell_protocol::AGENT_PROTOCOL_VERSION_QUIC_V1
     )
+}
+
+fn project_query_matches(
+    needle: &str,
+    runtime_id: &str,
+    project: &ShellAgentProjectSummary,
+) -> bool {
+    [
+        Some(runtime_id),
+        Some(project.id.as_str()),
+        project.name.as_deref(),
+        project.description.as_deref(),
+        Some(project.path.as_str()),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|value| value.to_lowercase().contains(needle))
 }
 
 fn project_source(project: &ShellAgentProjectSummary) -> &'static str {

--- a/src/tool_runtime/projects.rs
+++ b/src/tool_runtime/projects.rs
@@ -21,7 +21,7 @@ use super::tool_result::ToolResult;
 use super::{agent_project_runtime_id, ToolRuntime};
 use crate::auth::AuthContext;
 use crate::shell_protocol::{
-    ShellAgentProjectSummary, SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION,
+    ShellAgentProjectSummary, ShellClientView, SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION,
 };
 
 /// Maximum time the runtime waits for an agent project-op response. Project
@@ -43,6 +43,103 @@ pub(crate) struct ListProjectsOptions {
     pub(crate) summary_only: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ProjectCandidate {
+    pub(super) runtime_id: String,
+    pub(super) client_index: usize,
+    pub(super) project_index: usize,
+}
+
+fn validate_list_projects_options(
+    options: &ListProjectsOptions,
+) -> Result<(Option<String>, Option<usize>), ToolResult> {
+    if options
+        .client_id
+        .as_deref()
+        .is_some_and(|value| value.is_empty() || value.chars().count() > 128)
+    {
+        return Err(ToolResult::err_with_output(
+            "invalid_client_id: client_id must contain 1..=128 characters".to_string(),
+            json!({"error_kind": "invalid_client_id"}),
+        ));
+    }
+    if options
+        .project
+        .as_deref()
+        .is_some_and(|value| value.is_empty() || value.chars().count() > 512)
+    {
+        return Err(ToolResult::err_with_output(
+            "invalid_project: project must contain 1..=512 characters".to_string(),
+            json!({"error_kind": "invalid_project"}),
+        ));
+    }
+    let query = match options.query.as_deref() {
+        Some(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Err(ToolResult::err_with_output(
+                    "invalid_query: query must not be empty after trimming".to_string(),
+                    json!({"error_kind": "invalid_query"}),
+                ));
+            }
+            if trimmed.chars().count() > LIST_PROJECTS_MAX_QUERY_CHARS {
+                return Err(ToolResult::err_with_output(
+                    format!(
+                        "invalid_query: query exceeds {LIST_PROJECTS_MAX_QUERY_CHARS} characters"
+                    ),
+                    json!({"error_kind": "invalid_query"}),
+                ));
+            }
+            Some(trimmed.to_lowercase())
+        }
+        None => None,
+    };
+    let filtered =
+        options.client_id.is_some() || options.project.is_some() || options.query.is_some();
+    let limit = options
+        .limit
+        .map(|limit| limit.clamp(1, LIST_PROJECTS_MAX_RESULTS))
+        .or_else(|| filtered.then_some(LIST_PROJECTS_MAX_RESULTS));
+    Ok((query, limit))
+}
+
+fn project_candidates(
+    clients: &[ShellClientView],
+    options: &ListProjectsOptions,
+    query: Option<&str>,
+) -> Vec<ProjectCandidate> {
+    let mut candidates = Vec::new();
+    for (client_index, client) in clients.iter().enumerate() {
+        if options
+            .client_id
+            .as_deref()
+            .is_some_and(|expected| client.client_id != expected)
+        {
+            continue;
+        }
+        for (project_index, project) in client.projects.iter().enumerate() {
+            let runtime_id = agent_project_runtime_id(&client.client_id, &project.id);
+            if options
+                .project
+                .as_deref()
+                .is_some_and(|expected| runtime_id != expected)
+            {
+                continue;
+            }
+            if query.is_some_and(|needle| !project_query_matches(needle, &runtime_id, project)) {
+                continue;
+            }
+            candidates.push(ProjectCandidate {
+                runtime_id,
+                client_index,
+                project_index,
+            });
+        }
+    }
+    candidates.sort_by(|a, b| a.runtime_id.cmp(&b.runtime_id));
+    candidates
+}
+
 impl ToolRuntime {
     pub(crate) async fn list_projects(&self, auth: Option<&AuthContext>) -> ToolResult {
         self.list_projects_with_options(auth, ListProjectsOptions::default())
@@ -54,83 +151,39 @@ impl ToolRuntime {
         auth: Option<&AuthContext>,
         options: ListProjectsOptions,
     ) -> ToolResult {
-        if options
-            .client_id
-            .as_deref()
-            .is_some_and(|value| value.is_empty() || value.chars().count() > 128)
-        {
-            return ToolResult::err_with_output(
-                "invalid_client_id: client_id must contain 1..=128 characters".to_string(),
-                json!({"error_kind": "invalid_client_id"}),
-            );
-        }
-        if options
-            .project
-            .as_deref()
-            .is_some_and(|value| value.is_empty() || value.chars().count() > 512)
-        {
-            return ToolResult::err_with_output(
-                "invalid_project: project must contain 1..=512 characters".to_string(),
-                json!({"error_kind": "invalid_project"}),
-            );
-        }
-        let query = match options.query.as_deref() {
-            Some(raw) => {
-                let trimmed = raw.trim();
-                if trimmed.is_empty() {
-                    return ToolResult::err_with_output(
-                        "invalid_query: query must not be empty after trimming".to_string(),
-                        json!({"error_kind": "invalid_query"}),
-                    );
-                }
-                if trimmed.chars().count() > LIST_PROJECTS_MAX_QUERY_CHARS {
-                    return ToolResult::err_with_output(
-                        format!(
-                            "invalid_query: query exceeds {LIST_PROJECTS_MAX_QUERY_CHARS} characters"
-                        ),
-                        json!({"error_kind": "invalid_query"}),
-                    );
-                }
-                Some(trimmed.to_lowercase())
-            }
-            None => None,
+        let (query, limit) = match validate_list_projects_options(&options) {
+            Ok(validated) => validated,
+            Err(result) => return result,
         };
-        let filtered =
-            options.client_id.is_some() || options.project.is_some() || options.query.is_some();
-        let limit = options
-            .limit
-            .map(|limit| limit.clamp(1, LIST_PROJECTS_MAX_RESULTS))
-            .or_else(|| filtered.then_some(LIST_PROJECTS_MAX_RESULTS));
-
         let clients = self.shell_clients.list_clients_for_auth(auth).await;
-        let mut candidates = Vec::new();
-        for client in clients {
-            if options
-                .client_id
-                .as_deref()
-                .is_some_and(|expected| client.client_id != expected)
-            {
-                continue;
-            }
-            for project in &client.projects {
-                let runtime_id = agent_project_runtime_id(&client.client_id, &project.id);
-                if options
-                    .project
-                    .as_deref()
-                    .is_some_and(|expected| runtime_id != expected)
-                {
-                    continue;
-                }
-                if query
-                    .as_deref()
-                    .is_some_and(|needle| !project_query_matches(needle, &runtime_id, project))
-                {
-                    continue;
-                }
-                candidates.push((runtime_id, client.clone(), project.clone()));
-            }
-        }
-        candidates.sort_by(|a, b| a.0.cmp(&b.0));
+        self.list_projects_from_visible_clients(auth, &options, query.as_deref(), limit, &clients)
+            .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn list_projects_with_visible_clients_for_test(
+        &self,
+        auth: Option<&AuthContext>,
+        options: ListProjectsOptions,
+        clients: &[ShellClientView],
+    ) -> ToolResult {
+        let (query, limit) = match validate_list_projects_options(&options) {
+            Ok(validated) => validated,
+            Err(result) => return result,
+        };
+        self.list_projects_from_visible_clients(auth, &options, query.as_deref(), limit, clients)
+            .await
+    }
+
+    async fn list_projects_from_visible_clients(
+        &self,
+        auth: Option<&AuthContext>,
+        options: &ListProjectsOptions,
+        query: Option<&str>,
+        limit: Option<usize>,
+        clients: &[ShellClientView],
+    ) -> ToolResult {
+        let mut candidates = project_candidates(clients, options, query);
         let matched_count = candidates.len();
         if let Some(limit) = limit {
             candidates.truncate(limit);
@@ -138,14 +191,45 @@ impl ToolRuntime {
         let truncated = candidates.len() < matched_count;
 
         let mut list = Vec::with_capacity(candidates.len());
-        for (runtime_id, client, project) in candidates {
-            let shell_profiles = client
-                .policy
-                .as_ref()
-                .and_then(|policy| policy.shell_profiles.as_ref());
-            let (resolved_shell_profile, shell_profile_status) =
-                resolve_project_shell_profile(project.shell_profile.as_deref(), shell_profiles);
-            let capabilities = smoke_project_capabilities(&client, &project);
+        for ProjectCandidate {
+            runtime_id,
+            client_index,
+            project_index,
+        } in candidates
+        {
+            // Extract only one selected Project and the small Runner fields used by
+            // its projection before awaiting Job state. Candidate staging above
+            // never owns or clones a ShellClientView (and therefore never clones
+            // the Runner's complete projects Vec per match).
+            let (
+                client_id,
+                agent_status,
+                connected,
+                last_seen,
+                project,
+                resolved_shell_profile,
+                shell_profile_status,
+                capabilities,
+            ) = {
+                let client = &clients[client_index];
+                let project = &client.projects[project_index];
+                let shell_profiles = client
+                    .policy
+                    .as_ref()
+                    .and_then(|policy| policy.shell_profiles.as_ref());
+                let (resolved_shell_profile, shell_profile_status) =
+                    resolve_project_shell_profile(project.shell_profile.as_deref(), shell_profiles);
+                (
+                    client.client_id.clone(),
+                    client.status.clone(),
+                    client.connected,
+                    client.last_seen,
+                    project.clone(),
+                    resolved_shell_profile,
+                    shell_profile_status,
+                    smoke_project_capabilities(client, project),
+                )
+            };
             let active_jobs = self
                 .shell_clients
                 .count_active_jobs_for_project(auth, &runtime_id)
@@ -157,12 +241,12 @@ impl ToolRuntime {
                     "name": project.name,
                     "description": project.description,
                     "executor": "agent",
-                    "client_id": client.client_id,
+                    "client_id": client_id,
                     "enabled": !project.disabled,
                     "active_jobs": active_jobs,
                     "source": project_source(&project),
-                    "agent_status": client.status,
-                    "connected": client.connected,
+                    "agent_status": agent_status,
+                    "connected": connected,
                     "resolved_shell_profile": resolved_shell_profile,
                     "shell_profile_status": shell_profile_status,
                     "capabilities": {
@@ -177,7 +261,7 @@ impl ToolRuntime {
                     "name": project.name,
                     "path": project.path,
                     "executor": "agent",
-                    "client_id": client.client_id,
+                    "client_id": client_id,
                     "allow_patch": project.allow_patch,
                     "description": project.description,
                     "enabled": !project.disabled,
@@ -185,9 +269,9 @@ impl ToolRuntime {
                     "revision": project.revision,
                     "active_jobs": active_jobs,
                     "source": project_source(&project),
-                    "agent_status": client.status,
-                    "connected": client.connected,
-                    "last_seen": client.last_seen,
+                    "agent_status": agent_status,
+                    "connected": connected,
+                    "last_seen": last_seen,
                     "shell_profile": project.shell_profile,
                     "resolved_shell_profile": resolved_shell_profile,
                     "shell_profile_status": shell_profile_status,

--- a/src/tool_runtime/registry/input_schemas.rs
+++ b/src/tool_runtime/registry/input_schemas.rs
@@ -52,8 +52,8 @@ pub(crate) use discovery::accepted_flattened_args_for_spec;
 #[cfg(test)]
 pub(crate) use discovery::ACCEPTED_FLATTENED_ARG_PREFERRED_ORDER;
 pub(crate) use discovery::{
-    empty_input_schema, list_tools_input_schema, runtime_status_input_schema,
-    tool_manifest_input_schema,
+    empty_input_schema, list_agents_input_schema, list_projects_input_schema,
+    list_tools_input_schema, runtime_status_input_schema, tool_manifest_input_schema,
 };
 pub(super) use files::{
     list_project_files_input_schema, list_project_tracked_files_input_schema,

--- a/src/tool_runtime/registry/input_schemas/discovery.rs
+++ b/src/tool_runtime/registry/input_schemas/discovery.rs
@@ -57,10 +57,86 @@ pub(crate) fn tool_manifest_input_schema() -> Value {
     })
 }
 
+pub(crate) fn list_projects_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "client_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "description": "Exact Runner client_id. Filters only caller-visible Projects on that Runner."
+            },
+            "project": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "description": "Exact full runtime Project id (agent:<client_id>:<project_id>)."
+            },
+            "query": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Bounded deterministic case-insensitive text filter over already-visible Project metadata."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "description": "Maximum Projects returned after all filters. Omit to preserve the legacy full visible registry result."
+            },
+            "summary_only": {
+                "type": "boolean",
+                "description": "Return a compact workspace-selection projection without paths, revisions, or broad smoke metadata."
+            }
+        },
+        "required": [],
+        "additionalProperties": false,
+    })
+}
+
+pub(crate) fn list_agents_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "client_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "description": "Exact single Runner client_id. Mutually exclusive with client_ids."
+            },
+            "client_ids": {
+                "type": "array",
+                "maxItems": 8,
+                "minItems": 1,
+                "uniqueItems": true,
+                "description": "Bounded exact Runner client_ids. Mutually exclusive with client_id; duplicates are rejected.",
+                "items": {"type": "string", "minLength": 1, "maxLength": 128}
+            },
+            "include_projects": {
+                "type": "boolean",
+                "description": "When false, omit Project bodies while retaining each Runner project count. Defaults to true for compatibility."
+            },
+            "summary_only": {
+                "type": "boolean",
+                "description": "Return compact Runner identity, health, build, project-count, and shared Job-concurrency facts."
+            }
+        },
+        "required": [],
+        "additionalProperties": false,
+    })
+}
+
 pub(crate) fn runtime_status_input_schema() -> Value {
     json!({
         "type": "object",
         "properties": {
+            "client_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "description": "Exact caller-visible Runner client_id. Focused source alignment evaluates only this Runner; omit for fleet-wide status."
+            },
             "compact": {
                 "type": "boolean",
                 "description": "When true, return compact runtime observability with service/version, build revision, tool/job counts, agent health summary, and project effective/server status. Defaults to false."
@@ -81,6 +157,9 @@ pub(crate) fn empty_input_schema() -> Value {
 
 pub(crate) const ACCEPTED_FLATTENED_ARG_PREFERRED_ORDER: &[&str] = &[
     "project",
+    "client_id",
+    "client_ids",
+    "query",
     "path",
     "title",
     "instruction",
@@ -107,6 +186,7 @@ pub(crate) const ACCEPTED_FLATTENED_ARG_PREFERRED_ORDER: &[&str] = &[
     "intent",
     "features",
     "summary_only",
+    "include_projects",
     "limit",
     "allow_missing",
     "upload_id",

--- a/src/tool_runtime/registry/input_schemas/jobs.rs
+++ b/src/tool_runtime/registry/input_schemas/jobs.rs
@@ -489,18 +489,37 @@ pub(crate) fn observe_jobs_input_schema() -> Value {
 }
 
 pub(crate) fn list_jobs_input_schema() -> Value {
-    object_schema(vec![
+    let mut schema = object_schema(vec![
         (
             "limit",
             "integer",
-            "Maximum number of job summaries to return.",
+            "Maximum number of job summaries to return after all filters.",
             false,
         ),
         (
             "status",
             "string",
-            "Optional status filter (e.g. running, completed, failed).",
+            "Optional exact status filter (e.g. running, completed, failed).",
             false,
         ),
-    ])
+        (
+            "project",
+            "string",
+            "Optional exact full runtime Project id; filters only already caller-visible Jobs.",
+            false,
+        ),
+        (
+            "session_id",
+            "string",
+            "Optional exact Workflow Session id; filters only already caller-visible Jobs.",
+            false,
+        ),
+    ]);
+    schema["properties"]["limit"]["minimum"] = json!(1);
+    schema["properties"]["limit"]["maximum"] = json!(100);
+    schema["properties"]["project"]["minLength"] = json!(1);
+    schema["properties"]["project"]["maxLength"] = json!(512);
+    schema["properties"]["session_id"]["minLength"] = json!(1);
+    schema["properties"]["session_id"]["maxLength"] = json!(128);
+    schema
 }

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -18,6 +18,18 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             ("version", schema_type("string", "Runtime version.")),
             (
+                "focus",
+                open_object_schema("Exact focused Runner status when client_id is supplied."),
+            ),
+            (
+                "server",
+                open_object_schema("Server build/version identity in focused mode."),
+            ),
+            (
+                "fleet_summary",
+                open_object_schema("Secondary aggregate fleet mismatch counts in focused mode; never overrides focus truth."),
+            ),
+            (
                 "build",
                 open_object_schema("Build revision metadata for the running binary."),
             ),
@@ -59,6 +71,14 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 array_schema(open_object_schema("Project summary including capabilities.git_available, supports_cleanup_verification, and recommended_for_smoke."), "Runtime projects."),
             ),
             ("count", schema_type("integer", "Project count.")),
+            (
+                "matched_count",
+                schema_type("integer", "Caller-visible Project count matching filters before limit."),
+            ),
+            (
+                "truncated",
+                schema_type("boolean", "Whether limit truncated matching Projects."),
+            ),
             (
                 "recommended_for_smoke",
                 array_schema(

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -895,6 +895,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             ("count", schema_type("integer", "Returned job summary count.")),
             (
+                "matched_count",
+                schema_type("integer", "Caller-visible Job count matching all filters before limit."),
+            ),
+            (
                 "truncated",
                 schema_type(
                     "boolean",

--- a/src/tool_runtime/registry/tool_specs/jobs.rs
+++ b/src/tool_runtime/registry/tool_specs/jobs.rs
@@ -77,7 +77,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "list_jobs",
-            "List bounded lifecycle metadata for existing Jobs across Runner and local executors; stdout/stderr bodies are never included.".to_string(),
+            "List bounded lifecycle metadata for caller-visible Jobs. Inside a coding Session, prefer exact project/session_id filters; status combines with them using AND semantics. stdout/stderr bodies are never included.".to_string(),
             list_jobs_input_schema(),
         ),
     ]

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -13,6 +13,16 @@ use std::path::PathBuf;
 const RUNNING_JOB_STATUSES: &[&str] = &["running", "started"];
 const AGENT_QUEUED_JOB_STATUSES: &[&str] = &["queued", "agent_queued"];
 const LOCAL_QUEUED_JOB_STATUSES: &[&str] = &["queued"];
+const LIST_AGENTS_MAX_CLIENT_IDS: usize = 8;
+const TARGET_CLIENT_ID_MAX_CHARS: usize = 128;
+
+#[derive(Debug, Default)]
+pub(crate) struct ListAgentsOptions {
+    pub(crate) client_id: Option<String>,
+    pub(crate) client_ids: Option<Vec<String>>,
+    pub(crate) include_projects: Option<bool>,
+    pub(crate) summary_only: bool,
+}
 
 /// Lightweight runtime metadata injected into `ToolRuntime` so observability
 /// tools (e.g. `runtime_status`) can report auth/public-url state without the
@@ -57,39 +67,161 @@ impl RuntimeInfo {
 
 impl ToolRuntime {
     pub(crate) async fn list_agents(&self, auth: Option<&AuthContext>) -> ToolResult {
-        let clients = self.shell_clients.list_clients_for_auth(auth).await;
-        let agent_jobs = self.shell_clients.list_all_jobs_for_auth(auth).await;
-        let now = chrono::Utc::now().timestamp();
-        let agents: Vec<Value> = clients
-            .iter()
-            .map(|c| {
-                json!({
-                    "client_id": c.client_id,
-                    "agent_instance_id": c.agent_instance_id,
-                    "display_name": c.display_name,
-                    "owner": c.owner,
-                    "hostname": c.hostname,
-                    "host_context": host_context_projection(c.host_context.as_ref()),
-                    "status": c.status,
-                    "connected": c.connected,
-                    "agent_protocol_version": c.agent_protocol_version,
-                    "transport": c.transport,
-                    "last_seen": c.last_seen,
-                    "last_seen_age_secs": last_seen_age_secs(c, now),
-                    "pending_requests": c.pending_requests,
-                    "projects_count": enabled_projects_count(c),
-                    "active_jobs": active_jobs_for_client(&agent_jobs, &c.client_id),
-                    "job_concurrency": job_concurrency_for_client(c, &agent_jobs),
-                    "capabilities": c.capabilities,
-                    "projects": c.projects,
-                    "policy": sanitized_policy_summary(c.policy.as_ref()),
-                    "shell_profiles": sanitized_shell_profiles_summary(
-                        c.policy.as_ref().and_then(|p| p.shell_profiles.as_ref())
+        self.list_agents_with_options(auth, ListAgentsOptions::default())
+            .await
+    }
+
+    pub(crate) async fn list_agents_with_options(
+        &self,
+        auth: Option<&AuthContext>,
+        options: ListAgentsOptions,
+    ) -> ToolResult {
+        if options.client_id.is_some() && options.client_ids.is_some() {
+            return ToolResult::err_with_output(
+                "invalid_client_filter: client_id and client_ids are mutually exclusive"
+                    .to_string(),
+                json!({"error_kind": "invalid_client_filter"}),
+            );
+        }
+        if options
+            .client_id
+            .as_deref()
+            .is_some_and(|value| !valid_target_client_id(value))
+        {
+            return ToolResult::err_with_output(
+                "invalid_client_id: client_id must contain 1..=128 characters".to_string(),
+                json!({"error_kind": "invalid_client_id"}),
+            );
+        }
+        if let Some(client_ids) = options.client_ids.as_ref() {
+            if client_ids.is_empty() {
+                return ToolResult::err_with_output(
+                    "invalid_client_ids: at least one client id is required".to_string(),
+                    json!({"error_kind": "invalid_client_ids"}),
+                );
+            }
+            if client_ids.len() > LIST_AGENTS_MAX_CLIENT_IDS {
+                return ToolResult::err_with_output(
+                    format!(
+                        "invalid_client_ids: at most {LIST_AGENTS_MAX_CLIENT_IDS} client ids are allowed"
                     ),
-                    "tool_providers": c.policy.as_ref().and_then(|p| p.tool_providers.as_ref()),
+                    json!({"error_kind": "invalid_client_ids"}),
+                );
+            }
+            let mut seen = std::collections::HashSet::new();
+            for client_id in client_ids {
+                if !valid_target_client_id(client_id) {
+                    return ToolResult::err_with_output(
+                        "invalid_client_ids: every client id must contain 1..=128 characters"
+                            .to_string(),
+                        json!({"error_kind": "invalid_client_ids"}),
+                    );
+                }
+                if !seen.insert(client_id.as_str()) {
+                    return ToolResult::err_with_output(
+                        "invalid_client_ids: duplicate client ids are not allowed".to_string(),
+                        json!({"error_kind": "invalid_client_ids"}),
+                    );
+                }
+            }
+        }
+
+        let mut clients = self.shell_clients.list_clients_for_auth(auth).await;
+        clients.sort_by(|a, b| a.client_id.cmp(&b.client_id));
+        clients.retain(|client| {
+            if let Some(expected) = options.client_id.as_deref() {
+                return client.client_id == expected;
+            }
+            if let Some(expected) = options.client_ids.as_ref() {
+                return expected
+                    .iter()
+                    .any(|client_id| client_id == &client.client_id);
+            }
+            true
+        });
+        let mut agent_jobs = self.shell_clients.list_all_jobs_for_auth(auth).await;
+        if options.client_id.is_some() || options.client_ids.is_some() {
+            agent_jobs.retain(|job| {
+                clients
+                    .iter()
+                    .any(|client| client.client_id == job.client_id)
+            });
+        }
+        let now = chrono::Utc::now().timestamp();
+        let include_projects = options.include_projects.unwrap_or(true);
+        let agents: Vec<Value> = if options.summary_only {
+            clients
+                .iter()
+                .map(|client| {
+                    json!({
+                        "client_id": client.client_id,
+                        "agent_instance_id": client.agent_instance_id,
+                        "display_name": client.display_name,
+                        "status": client.status,
+                        "connected": client.connected,
+                        "agent_protocol_version": client.agent_protocol_version,
+                        "transport": client.transport,
+                        "last_seen_age_secs": last_seen_age_secs(client, now),
+                        "pending_requests": client.pending_requests,
+                        "projects_count": enabled_projects_count(client),
+                        "active_jobs": active_jobs_for_client(&agent_jobs, &client.client_id),
+                        "job_concurrency": job_concurrency_for_client(client, &agent_jobs),
+                        "build": client.build,
+                    })
                 })
-            })
-            .collect();
+                .collect()
+        } else {
+            clients
+                .iter()
+                .map(|client| {
+                    let mut value = json!({
+                        "client_id": client.client_id,
+                        "agent_instance_id": client.agent_instance_id,
+                        "display_name": client.display_name,
+                        "owner": client.owner,
+                        "hostname": client.hostname,
+                        "host_context": host_context_projection(client.host_context.as_ref()),
+                        "status": client.status,
+                        "connected": client.connected,
+                        "agent_protocol_version": client.agent_protocol_version,
+                        "transport": client.transport,
+                        "last_seen": client.last_seen,
+                        "last_seen_age_secs": last_seen_age_secs(client, now),
+                        "pending_requests": client.pending_requests,
+                        "projects_count": enabled_projects_count(client),
+                        "active_jobs": active_jobs_for_client(&agent_jobs, &client.client_id),
+                        "job_concurrency": job_concurrency_for_client(client, &agent_jobs),
+                        "capabilities": client.capabilities,
+                        "policy": sanitized_policy_summary(client.policy.as_ref()),
+                        "shell_profiles": sanitized_shell_profiles_summary(
+                            client.policy.as_ref().and_then(|policy| policy.shell_profiles.as_ref())
+                        ),
+                        "tool_providers": client.policy.as_ref().and_then(|policy| policy.tool_providers.as_ref()),
+                    });
+                    if include_projects {
+                        value["projects"] = json!(client.projects);
+                    }
+                    value
+                })
+                .collect()
+        };
+        if options.summary_only {
+            let online = clients.iter().filter(|client| client.connected).count();
+            let stale = clients
+                .iter()
+                .filter(|client| client.status == "stale")
+                .count();
+            return ToolResult::ok(json!({
+                "agents": agents,
+                "summary": {
+                    "count": clients.len(),
+                    "online": online,
+                    "offline": clients.len().saturating_sub(online),
+                    "stale": stale,
+                },
+                "count": clients.len(),
+            }));
+        }
         ToolResult::ok(json!({
             "agents": agents,
             "clients": agent_health_clients(&clients, &agent_jobs, now),
@@ -336,9 +468,13 @@ impl ToolRuntime {
         auth: Option<&AuthContext>,
         compact: bool,
         summary_only: bool,
+        client_id: Option<String>,
     ) -> ToolResult {
-        let result = self.runtime_status(auth).await;
-        if compact || summary_only {
+        let result = match client_id {
+            Some(client_id) => self.runtime_status_for_client(auth, client_id).await,
+            None => self.runtime_status(auth).await,
+        };
+        if result.success && (compact || summary_only) {
             ToolResult {
                 output: compact_runtime_status(&result.output),
                 ..result
@@ -347,10 +483,221 @@ impl ToolRuntime {
             result
         }
     }
+
+    async fn runtime_status_for_client(
+        &self,
+        auth: Option<&AuthContext>,
+        client_id: String,
+    ) -> ToolResult {
+        if !valid_target_client_id(&client_id) {
+            return ToolResult::err_with_output(
+                "invalid_client_id: client_id must contain 1..=128 characters".to_string(),
+                json!({"error_kind": "invalid_client_id"}),
+            );
+        }
+        let visible_clients = self.shell_clients.list_clients_for_auth(auth).await;
+        let Some(client) = visible_clients
+            .iter()
+            .find(|client| client.client_id == client_id)
+            .cloned()
+        else {
+            return ToolResult::err_with_output(
+                "unknown_client_id: no caller-visible Runner matches the exact client_id"
+                    .to_string(),
+                json!({"error_kind": "unknown_client_id", "client_id": client_id}),
+            );
+        };
+        let visible_jobs = self.shell_clients.list_all_jobs_for_auth(auth).await;
+        let selected_jobs: Vec<ShellJobInfo> = visible_jobs
+            .iter()
+            .filter(|job| job.client_id == client.client_id)
+            .cloned()
+            .collect();
+        let clients = vec![client.clone()];
+        let now = chrono::Utc::now().timestamp();
+        let project_count = enabled_projects_count(&client);
+        let online_project_count = if client.connected { project_count } else { 0 };
+        let target_compatibility = version_compatibility(&clients);
+        let target_runner = target_compatibility
+            .pointer("/runners/0")
+            .cloned()
+            .unwrap_or(Value::Null);
+        let source_alignment = target_runner
+            .get("source_alignment")
+            .cloned()
+            .unwrap_or_else(|| json!({"status": "unknown"}));
+        let fleet_compatibility = version_compatibility(&visible_clients);
+        let fleet_runners = fleet_compatibility
+            .get("runners")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let mismatched_agents_count = fleet_runners
+            .iter()
+            .filter(|runner| runner.get("status").and_then(Value::as_str) != Some("compatible"))
+            .count();
+        let source_mismatched_agents_count = fleet_runners
+            .iter()
+            .filter(|runner| {
+                runner
+                    .pointer("/source_alignment/status")
+                    .and_then(Value::as_str)
+                    == Some("different")
+            })
+            .count();
+        let agent_active = selected_jobs
+            .iter()
+            .filter(|job| ACTIVE_JOB_STATUSES.contains(&job.status.as_str()))
+            .count();
+        let running_count = selected_jobs
+            .iter()
+            .filter(|job| job_status_is_running(&job.status))
+            .count();
+        let queued_count = selected_jobs
+            .iter()
+            .filter(|job| job_status_is_agent_queued(&job.status))
+            .count();
+        let recovering_count = selected_jobs
+            .iter()
+            .filter(|job| job.status == "recovering")
+            .count();
+        let reconciled_count = selected_jobs
+            .iter()
+            .filter(|job| job.recovery_state.as_deref() == Some("reconciled"))
+            .count();
+        let lost_after_reconcile_count = selected_jobs
+            .iter()
+            .filter(|job| {
+                job.status == "lost"
+                    && matches!(
+                        job.recovery_reason_code.as_deref(),
+                        Some(
+                            "runner_inventory_missing"
+                                | "runner_instance_replaced"
+                                | "runner_recovery_deadline_exceeded"
+                        )
+                    )
+            })
+            .count();
+        let projects = json!({
+            "mode": "agent_registered",
+            "agent_registered": {
+                "count": project_count,
+                "online_count": online_project_count,
+            },
+            "effective": {
+                "count": project_count,
+                "status": if project_count > 0 { "ok" } else { "no_projects" },
+            },
+            "count": project_count,
+        });
+        let agents = json!({
+            "count": 1,
+            "online_count": usize::from(client.connected),
+            "stale_count": usize::from(!client.connected),
+            "clients": [{
+                "client_id": client.client_id,
+                "agent_instance_id": client.agent_instance_id,
+                "display_name": client.display_name,
+                "status": client.status,
+                "connected": client.connected,
+                "agent_protocol_version": client.agent_protocol_version,
+                "transport": client.transport,
+                "last_seen": client.last_seen,
+                "last_seen_age_secs": last_seen_age_secs(&client, now),
+                "pending_requests": client.pending_requests,
+                "active_jobs": active_jobs_for_client(&selected_jobs, &client.client_id),
+                "job_concurrency": job_concurrency_for_client(&client, &selected_jobs),
+                "projects_count": project_count,
+            }],
+            "summary": agent_health_summary(&clients, &selected_jobs, now),
+        });
+        let jobs = json!({
+            "agent_known_count": selected_jobs.len(),
+            "local_known_count": 0,
+            "active_count": agent_active,
+            "running_count": running_count,
+            "queued_count": queued_count,
+            "recovering_count": recovering_count,
+            "reconciled_count": reconciled_count,
+            "lost_after_reconcile_count": lost_after_reconcile_count,
+        });
+        let specs = registered_tool_specs();
+        let tools = json!({
+            "count": specs.len(),
+            "names": specs.iter().map(|spec| spec.name.clone()).collect::<Vec<_>>(),
+        });
+        let server_build = crate::build_info::runtime_build_info();
+        ToolResult::ok(json!({
+            "service": "webcodex",
+            "model_surface": self.model_surface().name(),
+            "version": env!("CARGO_PKG_VERSION"),
+            "build": server_build,
+            "server_time": now,
+            "pid": std::process::id(),
+            "auth_enabled": self.runtime_info.auth_enabled,
+            "configured_public_url": self.runtime_info.configured_public_url,
+            "focus": {
+                "client_id": client.client_id,
+                "connected": client.connected,
+                "status": client.status,
+                "agent_instance_id": client.agent_instance_id,
+                "build": client.build,
+                "project_count": project_count,
+                "active_jobs": agent_active,
+                "job_concurrency": job_concurrency_for_client(&client, &selected_jobs),
+                "compatibility_status": target_runner.get("status").cloned().unwrap_or(Value::Null),
+                "source_alignment": source_alignment,
+            },
+            "server": {
+                "version": env!("CARGO_PKG_VERSION"),
+                "build": server_build,
+            },
+            "fleet_summary": {
+                "visible_runner_count": visible_clients.len(),
+                "mismatched_agents_count": mismatched_agents_count,
+                "source_mismatched_agents_count": source_mismatched_agents_count,
+                "mixed_builds_present": mismatched_agents_count > 0 || source_mismatched_agents_count > 0,
+            },
+            "projects": projects,
+            "agents": agents,
+            "version_compatibility": target_compatibility,
+            "jobs": jobs,
+            "tools": tools,
+            "authority": permissions::authority_profile_payload(),
+        }))
+    }
 }
 
 pub(crate) fn compact_runtime_status(status: &Value) -> Value {
-    json!({
+    if status.get("focus").is_some() {
+        return json!({
+            "compact": true,
+            "service": status.get("service").cloned().unwrap_or_else(|| json!("webcodex")),
+            "model_surface": status
+                .get("model_surface")
+                .cloned()
+                .unwrap_or_else(|| json!(crate::model_surface::MODEL_SURFACE_LOCAL_CODING)),
+            "version": status.get("version").cloned().unwrap_or(Value::Null),
+            "focus": status.get("focus").cloned().unwrap_or(Value::Null),
+            "server": status.get("server").cloned().unwrap_or(Value::Null),
+            "fleet_summary": status.get("fleet_summary").cloned().unwrap_or(Value::Null),
+            "projects": {
+                "effective": status.pointer("/projects/effective").cloned().unwrap_or(Value::Null),
+                "agent_registered": status.pointer("/projects/agent_registered").cloned().unwrap_or(Value::Null),
+            },
+            "jobs": {
+                "active_count": status.pointer("/jobs/active_count").cloned().unwrap_or(Value::Null),
+                "running_count": status.pointer("/jobs/running_count").cloned().unwrap_or(Value::Null),
+                "queued_count": status.pointer("/jobs/queued_count").cloned().unwrap_or(Value::Null),
+            },
+            "version_compatibility": {
+                "status": status.pointer("/version_compatibility/status").cloned().unwrap_or_else(|| json!("unknown")),
+                "source_alignment": status.pointer("/version_compatibility/source_alignment").cloned().unwrap_or_else(|| json!({"status": "unknown"})),
+            },
+        });
+    }
+    let mut compact = json!({
         "compact": true,
         "service": status.get("service").cloned().unwrap_or_else(|| json!("webcodex")),
         "model_surface": status
@@ -409,7 +756,15 @@ pub(crate) fn compact_runtime_status(status: &Value) -> Value {
             "source_alignment": status.pointer("/version_compatibility/source_alignment").cloned().unwrap_or_else(|| json!({"status": "unknown"})),
         },
         "authority": status.get("authority").cloned().unwrap_or(Value::Null),
-    })
+    });
+    if let Some(object) = compact.as_object_mut() {
+        for field in ["focus", "server", "fleet_summary"] {
+            if let Some(value) = status.get(field) {
+                object.insert(field.to_string(), value.clone());
+            }
+        }
+    }
+    compact
 }
 
 fn compact_runner_clients(status: &Value) -> Vec<Value> {
@@ -431,17 +786,20 @@ fn compact_runner_clients(status: &Value) -> Vec<Value> {
             let compat = compatibility
                 .iter()
                 .find(|candidate| candidate.get("client_id").and_then(Value::as_str) == Some(client_id));
-            Some(json!({
+            let mut compact = json!({
                 "client_id": client_id,
                 "agent_instance_id": agent.get("agent_instance_id").cloned().unwrap_or(Value::Null),
                 "status": agent.get("status").cloned().unwrap_or(Value::Null),
                 "transport": agent.get("transport").cloned().unwrap_or(Value::Null),
-                "host_context": agent.get("host_context").cloned().unwrap_or(Value::Null),
                 "build_git_commit": compat.and_then(|value| value.get("build_git_commit")).cloned().unwrap_or(Value::Null),
                 "build_git_dirty": compat.and_then(|value| value.get("build_git_dirty")).cloned().unwrap_or(Value::Null),
                 "version_matches_server": compat.and_then(|value| value.get("version_matches_server")).cloned().unwrap_or(Value::Null),
                 "source_alignment": compat.and_then(|value| value.get("source_alignment")).cloned().unwrap_or_else(|| json!({"status": "unknown"})),
-            }))
+            });
+            if status.get("focus").is_none() {
+                compact["host_context"] = agent.get("host_context").cloned().unwrap_or(Value::Null);
+            }
+            Some(compact)
         })
         .collect()
 }
@@ -795,8 +1153,23 @@ fn connection_layers(
 /// capability-compatible. Reports facts about which side to upgrade without
 /// exposing paths or environment.
 fn version_compatibility(clients: &[ShellClientView]) -> Value {
-    let server_version = env!("CARGO_PKG_VERSION");
     let build = crate::build_info::runtime_build_info();
+    version_compatibility_against(
+        clients,
+        env!("CARGO_PKG_VERSION"),
+        build.git_commit,
+        build.git_dirty,
+        json!(build),
+    )
+}
+
+fn version_compatibility_against(
+    clients: &[ShellClientView],
+    server_version: &str,
+    server_git_commit: Option<&str>,
+    server_git_dirty: Option<bool>,
+    server_build: Value,
+) -> Value {
     let mut overall = if clients.is_empty() {
         "no_runners"
     } else {
@@ -818,14 +1191,14 @@ fn version_compatibility(clients: &[ShellClientView]) -> Value {
             let version_matches_server = build_version
                 .as_deref()
                 .map(|version| version == server_version);
-            let git_commit_matches_server = match (build_git_commit.as_deref(), build.git_commit) {
+            let git_commit_matches_server = match (build_git_commit.as_deref(), server_git_commit) {
                 (Some(runner), Some(server)) => Some(runner == server),
                 _ => None,
             };
             let source_matches_server = match (
                 git_commit_matches_server,
                 build_git_dirty,
-                build.git_dirty,
+                server_git_dirty,
             ) {
                 (Some(false), _, _) => Some(false),
                 (Some(true), Some(false), Some(false)) => Some(true),
@@ -906,10 +1279,34 @@ fn version_compatibility(clients: &[ShellClientView]) -> Value {
         },
         "server": {
             "version": server_version,
-            "build": build,
+            "build": server_build,
         },
         "runners": runners,
     })
+}
+
+fn valid_target_client_id(client_id: &str) -> bool {
+    !client_id.is_empty() && client_id.chars().count() <= TARGET_CLIENT_ID_MAX_CHARS
+}
+
+#[cfg(test)]
+pub(crate) fn version_compatibility_for_test(
+    clients: &[ShellClientView],
+    server_version: &str,
+    server_git_commit: Option<&str>,
+    server_git_dirty: Option<bool>,
+) -> Value {
+    version_compatibility_against(
+        clients,
+        server_version,
+        server_git_commit,
+        server_git_dirty,
+        json!({
+            "git_commit": server_git_commit,
+            "git_dirty": server_git_dirty,
+            "built_at": null,
+        }),
+    )
 }
 
 fn enabled_projects_count(client: &ShellClientView) -> usize {

--- a/src/tool_runtime/sessions/events.rs
+++ b/src/tool_runtime/sessions/events.rs
@@ -407,6 +407,22 @@ pub(crate) fn session_input_summary_for_tool(tool_name: &str, arguments: &Value)
         return summary;
     };
     match tool_name {
+        "list_projects" => {
+            object.remove("client_id");
+            object.remove("project");
+            object.remove("query");
+        }
+        "list_agents" => {
+            object.remove("client_id");
+            object.remove("client_ids");
+        }
+        "runtime_status" => {
+            object.remove("client_id");
+        }
+        "list_jobs" => {
+            object.remove("project");
+            object.remove("session_id");
+        }
         "search_project_text" => {
             object.remove("pattern");
         }

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -2503,12 +2503,22 @@ async fn start_agent_runtime_job(
     project_id: &str,
     auth: &crate::auth::AuthContext,
 ) -> String {
+    start_agent_runtime_job_in_session(runtime, client_id, project_id, None, auth).await
+}
+
+async fn start_agent_runtime_job_in_session(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project_id: &str,
+    session_id: Option<&str>,
+    auth: &crate::auth::AuthContext,
+) -> String {
     let result = runtime
         .dispatch_with_auth(
             ToolCall::RunJob {
                 project: format!("agent:{client_id}:{project_id}"),
                 command: format!("echo {client_id}"),
-                session_id: None,
+                session_id: session_id.map(str::to_string),
                 timeout_secs: None,
                 cwd: None,
                 purpose: None,
@@ -2598,6 +2608,8 @@ async fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group() {
             ToolCall::ListJobs {
                 limit: None,
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&shared_a),
         )
@@ -2609,6 +2621,8 @@ async fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group() {
             ToolCall::ListJobs {
                 limit: None,
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&bridge_a),
         )
@@ -2620,6 +2634,8 @@ async fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group() {
             ToolCall::ListJobs {
                 limit: None,
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&bridge_b),
         )
@@ -2631,6 +2647,8 @@ async fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group() {
             ToolCall::ListJobs {
                 limit: None,
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&open),
         )
@@ -2642,6 +2660,8 @@ async fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group() {
             ToolCall::ListJobs {
                 limit: None,
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&bootstrap),
         )
@@ -2806,6 +2826,8 @@ async fn lightweight_auth_cannot_enumerate_unrelated_local_jobs() {
                 ToolCall::ListJobs {
                     limit: None,
                     status: None,
+                    project: None,
+                    session_id: None,
                 },
                 Some(auth),
             )
@@ -2829,6 +2851,8 @@ async fn lightweight_auth_cannot_enumerate_unrelated_local_jobs() {
             ToolCall::ListJobs {
                 limit: None,
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&managed_oauth),
         )
@@ -2851,11 +2875,221 @@ async fn lightweight_auth_cannot_enumerate_unrelated_local_jobs() {
             ToolCall::ListJobs {
                 limit: None,
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&bootstrap),
         )
         .await;
     assert_eq!(listed_job_ids(&result), vec!["job-local".to_string()]);
+}
+
+#[tokio::test]
+async fn list_jobs_filters_visible_jobs_by_project_session_and_status_before_limit() {
+    let runtime = test_runtime();
+    let auth_a = shared_key_auth_context("targeted-jobs-a");
+    let auth_b = shared_key_auth_context("targeted-jobs-b");
+    register_job_agent_for_auth(&runtime, "target-a", "proj-a", &auth_a).await;
+    register_job_agent_for_auth(&runtime, "target-b", "proj-b", &auth_b).await;
+    let project_a = "agent:target-a:proj-a".to_string();
+    let project_b = "agent:target-b:proj-b".to_string();
+    let session_a1 = runtime
+        .sessions
+        .start_session(Some(project_a.clone()), Some("A1".to_string()));
+    let session_a2 = runtime
+        .sessions
+        .start_session(Some(project_a.clone()), Some("A2".to_string()));
+    let session_b1 = runtime
+        .sessions
+        .start_session(Some(project_b.clone()), Some("B1".to_string()));
+
+    let job_a1_running = start_agent_runtime_job_in_session(
+        &runtime,
+        "target-a",
+        "proj-a",
+        Some(&session_a1.session_id),
+        &auth_a,
+    )
+    .await;
+    let job_a1_completed = start_agent_runtime_job_in_session(
+        &runtime,
+        "target-a",
+        "proj-a",
+        Some(&session_a1.session_id),
+        &auth_a,
+    )
+    .await;
+    let job_a2 = start_agent_runtime_job_in_session(
+        &runtime,
+        "target-a",
+        "proj-a",
+        Some(&session_a2.session_id),
+        &auth_a,
+    )
+    .await;
+    let _job_b1 = start_agent_runtime_job_in_session(
+        &runtime,
+        "target-b",
+        "proj-b",
+        Some(&session_b1.session_id),
+        &auth_b,
+    )
+    .await;
+
+    assert_eq!(
+        mark_next_agent_job_running(&runtime, "target-a").await,
+        job_a1_running
+    );
+    let completed_request = next_agent_request_for_instance(&runtime, "target-a", "inst")
+        .await
+        .expect("second A1 Job request");
+    assert_eq!(
+        completed_request.job_id.as_deref(),
+        Some(job_a1_completed.as_str())
+    );
+    complete_patch_agent_request(
+        &runtime,
+        "target-a",
+        &completed_request.request_id,
+        0,
+        "done",
+        "",
+    )
+    .await;
+
+    let by_project = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: None,
+                project: Some(project_a.clone()),
+                session_id: None,
+            },
+            Some(&auth_a),
+        )
+        .await;
+    assert!(by_project.success, "{:?}", by_project.error);
+    assert_eq!(by_project.output["matched_count"], 3);
+    assert_eq!(by_project.output["count"], 3);
+
+    let running = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: Some("running".to_string()),
+                project: Some(project_a.clone()),
+                session_id: None,
+            },
+            Some(&auth_a),
+        )
+        .await;
+    assert_eq!(listed_job_ids(&running), vec![job_a1_running.clone()]);
+
+    let a1 = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: None,
+                project: Some(project_a.clone()),
+                session_id: Some(session_a1.session_id.clone()),
+            },
+            Some(&auth_a),
+        )
+        .await;
+    let mut a1_ids = listed_job_ids(&a1);
+    a1_ids.sort();
+    let mut expected_a1 = vec![job_a1_running.clone(), job_a1_completed.clone()];
+    expected_a1.sort();
+    assert_eq!(a1_ids, expected_a1);
+
+    let a2 = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: None,
+                project: None,
+                session_id: Some(session_a2.session_id.clone()),
+            },
+            Some(&auth_a),
+        )
+        .await;
+    assert_eq!(listed_job_ids(&a2), vec![job_a2.clone()]);
+
+    let completed = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: Some("completed".to_string()),
+                project: Some(project_a.clone()),
+                session_id: Some(session_a1.session_id.clone()),
+            },
+            Some(&auth_a),
+        )
+        .await;
+    assert_eq!(listed_job_ids(&completed), vec![job_a1_completed.clone()]);
+
+    let limited = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: Some(1),
+                status: None,
+                project: Some(project_a.clone()),
+                session_id: Some(session_a1.session_id.clone()),
+            },
+            Some(&auth_a),
+        )
+        .await;
+    assert!(limited.success);
+    assert_eq!(limited.output["matched_count"], 2);
+    assert_eq!(limited.output["count"], 1);
+    assert_eq!(limited.output["truncated"], true);
+
+    let mismatched = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: None,
+                project: Some(project_a),
+                session_id: Some(session_b1.session_id.clone()),
+            },
+            Some(&auth_a),
+        )
+        .await;
+    assert!(mismatched.success);
+    assert_eq!(mismatched.output["count"], 0);
+
+    for foreign_filter in [
+        ToolCall::ListJobs {
+            limit: None,
+            status: None,
+            project: Some(project_b),
+            session_id: None,
+        },
+        ToolCall::ListJobs {
+            limit: None,
+            status: None,
+            project: None,
+            session_id: Some(session_b1.session_id),
+        },
+    ] {
+        let hidden = runtime
+            .dispatch_with_auth(foreign_filter, Some(&auth_a))
+            .await;
+        assert!(hidden.success, "{:?}", hidden.error);
+        assert_eq!(hidden.output["count"], 0);
+        assert_eq!(hidden.output["matched_count"], 0);
+    }
+
+    let status = runtime
+        .dispatch_with_auth(
+            ToolCall::JobStatus {
+                job_id: job_a1_running,
+                include_command_preview: false,
+            },
+            Some(&auth_a),
+        )
+        .await;
+    assert_eq!(status.output["status"], "running");
 }
 
 #[tokio::test]
@@ -2889,6 +3123,7 @@ async fn runtime_status_and_list_agents_filter_concurrency_counts_by_auth_group(
             ToolCall::RuntimeStatus {
                 compact: false,
                 summary_only: false,
+                client_id: None,
             },
             Some(&shared_a),
         )
@@ -2910,7 +3145,15 @@ async fn runtime_status_and_list_agents_filter_concurrency_counts_by_auth_group(
         .is_none());
 
     let agents_a = runtime
-        .dispatch_with_auth(ToolCall::ListAgents, Some(&shared_a))
+        .dispatch_with_auth(
+            ToolCall::ListAgents {
+                client_id: None,
+                client_ids: None,
+                include_projects: None,
+                summary_only: false,
+            },
+            Some(&shared_a),
+        )
         .await;
     assert!(agents_a.success, "{:?}", agents_a.error);
     assert_eq!(agents_a.output["count"], 1);
@@ -2945,6 +3188,7 @@ async fn runtime_status_and_list_agents_filter_concurrency_counts_by_auth_group(
             ToolCall::RuntimeStatus {
                 compact: false,
                 summary_only: false,
+                client_id: None,
             },
             Some(&open),
         )
@@ -2960,6 +3204,7 @@ async fn runtime_status_and_list_agents_filter_concurrency_counts_by_auth_group(
             ToolCall::RuntimeStatus {
                 compact: false,
                 summary_only: false,
+                client_id: None,
             },
             Some(&bootstrap),
         )
@@ -2976,6 +3221,7 @@ async fn runtime_status_and_list_agents_filter_concurrency_counts_by_auth_group(
             ToolCall::RuntimeStatus {
                 compact: true,
                 summary_only: false,
+                client_id: None,
             },
             Some(&shared_a),
         )
@@ -3000,6 +3246,7 @@ async fn runtime_concurrency_counts_cover_all_visible_jobs_beyond_list_paginatio
             ToolCall::RuntimeStatus {
                 compact: false,
                 summary_only: false,
+                client_id: None,
             },
             Some(&auth),
         )
@@ -3038,6 +3285,8 @@ async fn list_jobs_returns_bounded_summaries_without_stdout_stderr() {
         .dispatch(ToolCall::ListJobs {
             limit: None,
             status: None,
+            project: None,
+            session_id: None,
         })
         .await;
     assert!(result.success, "{:?}", result.error);
@@ -3095,6 +3344,8 @@ async fn list_jobs_respects_limit_bound() {
         .dispatch(ToolCall::ListJobs {
             limit: Some(2),
             status: None,
+            project: None,
+            session_id: None,
         })
         .await;
     assert!(result.success);
@@ -3112,6 +3363,8 @@ async fn list_jobs_requires_no_agent_capability() {
         .dispatch(ToolCall::ListJobs {
             limit: None,
             status: None,
+            project: None,
+            session_id: None,
         })
         .await;
     assert!(result.success);

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -80,6 +80,26 @@ fn runtime_status_call() -> ToolCall {
     ToolCall::RuntimeStatus {
         compact: false,
         summary_only: false,
+        client_id: None,
+    }
+}
+
+fn list_projects_call() -> ToolCall {
+    ToolCall::ListProjects {
+        client_id: None,
+        project: None,
+        query: None,
+        limit: None,
+        summary_only: false,
+    }
+}
+
+fn list_agents_call() -> ToolCall {
+    ToolCall::ListAgents {
+        client_id: None,
+        client_ids: None,
+        include_projects: None,
+        summary_only: false,
     }
 }
 
@@ -368,7 +388,7 @@ async fn list_projects_returns_agent_registered_projects_without_server_config()
     )
     .await;
 
-    let result = runtime.dispatch(ToolCall::ListProjects).await;
+    let result = runtime.dispatch(list_projects_call()).await;
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["count"], 1);
     let projects = result.output["projects"].as_array().unwrap();
@@ -406,7 +426,7 @@ async fn list_projects_reports_smoke_selection_capabilities() {
     )
     .await;
 
-    let result = runtime.dispatch(ToolCall::ListProjects).await;
+    let result = runtime.dispatch(list_projects_call()).await;
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["count"], 2);
     let projects = result.output["projects"].as_array().unwrap();
@@ -451,7 +471,7 @@ async fn shared_key_list_projects_and_dispatch_are_filtered_by_auth_group() {
     register_agent_projects_for_auth(&runtime, "client-open", &open, "proj-open").await;
 
     let result = runtime
-        .dispatch_with_auth(ToolCall::ListProjects, Some(&shared_a))
+        .dispatch_with_auth(list_projects_call(), Some(&shared_a))
         .await;
     assert!(result.success, "{:?}", result.error);
     let ids: Vec<&str> = result
@@ -465,7 +485,7 @@ async fn shared_key_list_projects_and_dispatch_are_filtered_by_auth_group() {
     assert_eq!(ids, vec!["agent:client-a:proj-a"]);
 
     let result = runtime
-        .dispatch_with_auth(ToolCall::ListProjects, Some(&bridge_a))
+        .dispatch_with_auth(list_projects_call(), Some(&bridge_a))
         .await;
     assert!(result.success, "{:?}", result.error);
     let ids: Vec<&str> = result
@@ -530,7 +550,7 @@ async fn shared_key_list_projects_and_dispatch_are_filtered_by_auth_group() {
     assert_eq!(result.output["error_kind"], "unknown_project");
 
     let result = runtime
-        .dispatch_with_auth(ToolCall::ListProjects, Some(&bridge_b))
+        .dispatch_with_auth(list_projects_call(), Some(&bridge_b))
         .await;
     assert!(result.success, "{:?}", result.error);
     let ids: Vec<&str> = result
@@ -560,7 +580,7 @@ async fn shared_key_list_projects_and_dispatch_are_filtered_by_auth_group() {
     assert_eq!(result.output["error_kind"], "unknown_project");
 
     let result = runtime
-        .dispatch_with_auth(ToolCall::ListProjects, Some(&open))
+        .dispatch_with_auth(list_projects_call(), Some(&open))
         .await;
     let ids: Vec<&str> = result
         .output
@@ -657,7 +677,7 @@ async fn shared_key_list_projects_and_dispatch_are_filtered_by_auth_group() {
     assert_eq!(result.output["error_kind"], "unknown_project");
 
     let result = runtime
-        .dispatch_with_auth(ToolCall::ListProjects, Some(&bootstrap))
+        .dispatch_with_auth(list_projects_call(), Some(&bootstrap))
         .await;
     let ids: Vec<&str> = result
         .output
@@ -746,7 +766,7 @@ async fn list_projects_shows_shell_profile_resolution() {
     )
     .await;
 
-    let result = runtime.dispatch(ToolCall::ListProjects).await;
+    let result = runtime.dispatch(list_projects_call()).await;
     assert!(result.success, "{:?}", result.error);
     let projects = result.output["projects"].as_array().unwrap();
     let by_id: std::collections::HashMap<&str, &Value> = projects
@@ -783,7 +803,7 @@ async fn list_projects_shell_profile_status_unknown_without_summary() {
     project.shell_profile = Some("rust".to_string());
     register_agent_with_shell_profiles(&runtime, "legacy", None, vec![project]).await;
 
-    let result = runtime.dispatch(ToolCall::ListProjects).await;
+    let result = runtime.dispatch(list_projects_call()).await;
     assert!(result.success);
     let projects = result.output["projects"].as_array().unwrap();
     assert_eq!(projects[0]["resolved_shell_profile"], "rust");
@@ -806,7 +826,7 @@ async fn project_path_registration_capability_is_projected_safely() {
     )
     .await;
 
-    let listed = runtime.dispatch(ToolCall::ListAgents).await;
+    let listed = runtime.dispatch(list_agents_call()).await;
     assert!(listed.success, "{:?}", listed.error);
     assert_eq!(
         listed.output["agents"][0]["capabilities"]["project_path_registration"],
@@ -1213,6 +1233,8 @@ fn runtime_status_input_schema_exposes_compact_flags() {
     let properties = spec.input_schema["properties"]
         .as_object()
         .expect("runtime_status input properties");
+    assert_eq!(properties["client_id"]["type"], "string");
+    assert_eq!(properties["client_id"]["maxLength"], 128);
     for field in ["compact", "summary_only"] {
         assert!(
             properties.contains_key(field),
@@ -2241,7 +2263,7 @@ async fn runtime_status_includes_sanitized_policy_summary() {
     assert!(policy.get("env").is_none());
     assert!(policy.get("init_script").is_none());
 
-    let listed = runtime.dispatch(ToolCall::ListAgents).await;
+    let listed = runtime.dispatch(list_agents_call()).await;
     assert_eq!(
         listed.output["agents"][0]["tool_providers"]["claude_code"]["last_call"]["fallback_used"],
         false
@@ -2653,7 +2675,7 @@ async fn list_agents_includes_sanitized_policy_summary() {
         .await
         .unwrap();
     let runtime = ToolRuntime::new(registry, Arc::new(RuntimeInfo::default()));
-    let result = runtime.dispatch(ToolCall::ListAgents).await;
+    let result = runtime.dispatch(list_agents_call()).await;
     assert!(result.success);
     assert_eq!(result.output["count"], 1);
     assert_eq!(result.output["summary"]["online"], 1);

--- a/src/tool_runtime/tests/mod.rs
+++ b/src/tool_runtime/tests/mod.rs
@@ -37,6 +37,7 @@ mod sessions_instructions;
 mod sessions_resolver;
 mod startup_brief;
 mod sync_timeout;
+mod targeted_inventory;
 mod tool_call;
 mod trusted_smoke;
 mod validation_events;

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -1232,6 +1232,8 @@ async fn run_process_slow_handoff_is_queryable_once_and_keeps_the_original_budge
             ToolCall::ListJobs {
                 limit: Some(10),
                 status: None,
+                project: None,
+                session_id: None,
             },
             Some(&auth),
         )

--- a/src/tool_runtime/tests/reconnect.rs
+++ b/src/tool_runtime/tests/reconnect.rs
@@ -276,6 +276,7 @@ async fn meaningful_activity_is_scoped_and_not_refreshed_by_status_calls() {
                 ToolCall::RuntimeStatus {
                     compact: false,
                     summary_only: false,
+                    client_id: None,
                 },
                 None,
             )
@@ -320,6 +321,7 @@ async fn meaningful_activity_is_scoped_and_not_refreshed_by_status_calls() {
                 ToolCall::RuntimeStatus {
                     compact: false,
                     summary_only: false,
+                    client_id: None,
                 },
                 None,
             )

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -284,10 +284,7 @@ fn tool_definitions_drive_session_and_permission_policy() {
         .filter(|definition| definition.uses_unit_arguments())
         .map(|definition| definition.name)
         .collect::<Vec<_>>();
-    assert_eq!(
-        unit_argument_tools,
-        vec!["computer_list_targets", "list_projects", "list_agents"]
-    );
+    assert_eq!(unit_argument_tools, vec!["computer_list_targets"]);
 
     let artifact_upload_path_binding_tools = tool_definitions()
         .filter(|definition| definition.requires_artifact_upload_path_binding())

--- a/src/tool_runtime/tests/targeted_inventory.rs
+++ b/src/tool_runtime/tests/targeted_inventory.rs
@@ -737,6 +737,37 @@ fn targeted_inventory_schemas_and_tool_parsing_are_bounded() {
 }
 
 #[test]
+fn targeted_inventory_tool_calls_reject_unknown_filter_fields() {
+    for (tool, arguments, typo) in [
+        (
+            "list_projects",
+            serde_json::json!({"clinet_id": "special"}),
+            "clinet_id",
+        ),
+        (
+            "list_agents",
+            serde_json::json!({"clinet_id": "special"}),
+            "clinet_id",
+        ),
+        (
+            "runtime_status",
+            serde_json::json!({"clinet_id": "special"}),
+            "clinet_id",
+        ),
+        (
+            "list_jobs",
+            serde_json::json!({"sesion_id": "wc_sess_example"}),
+            "sesion_id",
+        ),
+    ] {
+        let error = ToolCall::from_tool_name(tool, arguments)
+            .expect_err("unknown targeted-inventory fields must not widen the query");
+        assert!(error.contains("unknown field"), "{tool}: {error}");
+        assert!(error.contains(typo), "{tool}: {error}");
+    }
+}
+
+#[test]
 fn targeted_inventory_audit_summaries_do_not_persist_raw_query_or_id_filters() {
     let query = "/private/worktree/needle";
     let raw = serde_json::json!({

--- a/src/tool_runtime/tests/targeted_inventory.rs
+++ b/src/tool_runtime/tests/targeted_inventory.rs
@@ -1,3 +1,4 @@
+use super::super::projects::{ListProjectsOptions, ProjectCandidate};
 use super::super::*;
 use super::support::*;
 use crate::shell_protocol::{AgentBuildInfo, ShellClientCapabilities, ShellClientRegisterRequest};
@@ -104,6 +105,129 @@ async fn register_target_agent_for_auth(
         )
         .await
         .unwrap();
+}
+
+fn large_fixture_projects(count: usize) -> Vec<crate::shell_protocol::ShellAgentProjectSummary> {
+    (0..count)
+        .map(|index| {
+            let mut project = registered_project(
+                &format!("project-{index:04}"),
+                &format!("/tmp/large-fixture/project-{index:04}"),
+            );
+            project.name = Some(format!("Large Fixture Project {index:04}"));
+            project.description = Some("large-fixture".to_string());
+            project
+        })
+        .collect()
+}
+
+#[test]
+fn project_candidate_staging_is_index_only() {
+    let candidate = ProjectCandidate {
+        runtime_id: "agent:special:project-0007".to_string(),
+        client_index: 3,
+        project_index: 7,
+    };
+    let ProjectCandidate {
+        runtime_id,
+        client_index,
+        project_index,
+    } = candidate;
+    assert_eq!(runtime_id, "agent:special:project-0007");
+    assert_eq!(client_index, 3);
+    assert_eq!(project_index, 7);
+}
+
+#[tokio::test]
+async fn list_projects_large_single_runner_inventory_preserves_linear_staging_contract() {
+    for project_count in [256usize, 1024] {
+        let runtime = test_runtime();
+        register_target_agent(&runtime, "special", Vec::new(), None).await;
+        let mut clients = runtime.shell_clients.list_clients_for_auth(None).await;
+        assert_eq!(clients.len(), 1);
+        clients[0].projects = large_fixture_projects(project_count);
+
+        let exact_index = if project_count == 1024 { 999 } else { 255 };
+        let exact_id = format!("agent:special:project-{exact_index:04}");
+        let exact = runtime
+            .list_projects_with_visible_clients_for_test(
+                None,
+                ListProjectsOptions {
+                    project: Some(exact_id.clone()),
+                    limit: Some(1),
+                    summary_only: true,
+                    ..Default::default()
+                },
+                &clients,
+            )
+            .await;
+        assert!(exact.success, "{:?}", exact.error);
+        assert_eq!(exact.output["count"], 1);
+        assert_eq!(exact.output["matched_count"], 1);
+        assert_eq!(exact.output["truncated"], false);
+        assert_eq!(exact.output["projects"][0]["id"], exact_id);
+
+        let broad = runtime
+            .list_projects_with_visible_clients_for_test(
+                None,
+                ListProjectsOptions {
+                    client_id: Some("special".to_string()),
+                    query: Some("large-fixture".to_string()),
+                    limit: Some(10),
+                    summary_only: true,
+                    ..Default::default()
+                },
+                &clients,
+            )
+            .await;
+        assert!(broad.success, "{:?}", broad.error);
+        assert_eq!(broad.output["matched_count"], project_count);
+        assert_eq!(broad.output["count"], 10);
+        assert_eq!(broad.output["truncated"], true);
+        let broad_ids = broad.output["projects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|project| project["id"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        let expected_ids = (0..10)
+            .map(|index| format!("agent:special:project-{index:04}"))
+            .collect::<Vec<_>>();
+        assert_eq!(broad_ids, expected_ids);
+
+        let full = runtime
+            .list_projects_with_visible_clients_for_test(
+                None,
+                ListProjectsOptions::default(),
+                &clients,
+            )
+            .await;
+        assert!(full.success, "{:?}", full.error);
+        assert_eq!(full.output["matched_count"], project_count);
+        assert_eq!(full.output["count"], project_count);
+        assert_eq!(full.output["truncated"], false);
+        assert_eq!(
+            full.output["projects"][0]["id"],
+            "agent:special:project-0000"
+        );
+        assert_eq!(
+            full.output["projects"][project_count - 1]["id"],
+            format!("agent:special:project-{:04}", project_count - 1)
+        );
+        let first = &full.output["projects"][0];
+        assert!(
+            first.get("path").is_some(),
+            "legacy full projection lost path: {first}"
+        );
+        assert!(
+            first.get("allow_patch").is_some(),
+            "legacy full projection lost allow_patch: {first}"
+        );
+        assert!(
+            first.get("revision").is_some(),
+            "legacy full projection lost revision: {first}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/targeted_inventory.rs
+++ b/src/tool_runtime/tests/targeted_inventory.rs
@@ -1,0 +1,640 @@
+use super::super::*;
+use super::support::*;
+use crate::shell_protocol::{AgentBuildInfo, ShellClientCapabilities, ShellClientRegisterRequest};
+
+fn list_projects_call(
+    client_id: Option<&str>,
+    project: Option<&str>,
+    query: Option<&str>,
+    limit: Option<usize>,
+    summary_only: bool,
+) -> ToolCall {
+    ToolCall::ListProjects {
+        client_id: client_id.map(str::to_string),
+        project: project.map(str::to_string),
+        query: query.map(str::to_string),
+        limit,
+        summary_only,
+    }
+}
+
+fn list_agents_call(
+    client_id: Option<&str>,
+    client_ids: Option<&[&str]>,
+    include_projects: Option<bool>,
+    summary_only: bool,
+) -> ToolCall {
+    ToolCall::ListAgents {
+        client_id: client_id.map(str::to_string),
+        client_ids: client_ids.map(|ids| ids.iter().map(|id| (*id).to_string()).collect()),
+        include_projects,
+        summary_only,
+    }
+}
+
+fn runtime_status_call(client_id: Option<&str>, compact: bool) -> ToolCall {
+    ToolCall::RuntimeStatus {
+        compact,
+        summary_only: false,
+        client_id: client_id.map(str::to_string),
+    }
+}
+
+async fn register_target_agent(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    projects: Vec<crate::shell_protocol::ShellAgentProjectSummary>,
+    build: Option<AgentBuildInfo>,
+) {
+    runtime
+        .shell_clients
+        .register(ShellClientRegisterRequest {
+            process_started_at: None,
+            build,
+            job_concurrency_limit: Some(4),
+            job_inventory: None,
+            client_id: client_id.to_string(),
+            agent_instance_id: format!("inst-{client_id}"),
+            display_name: Some(format!("Runner {client_id}")),
+            owner: None,
+            hostname: Some(format!("host-{client_id}")),
+            host_context: None,
+            capabilities: Some(ShellClientCapabilities {
+                git: true,
+                async_shell_jobs: true,
+                ..Default::default()
+            }),
+            projects: Some(projects),
+            agent_protocol_version: Some("polling-v1".to_string()),
+            policy: None,
+        })
+        .await
+        .unwrap();
+}
+
+async fn register_target_agent_for_auth(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project_id: &str,
+    auth: &crate::auth::AuthContext,
+) {
+    runtime
+        .shell_clients
+        .register_with_auth(
+            ShellClientRegisterRequest {
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: Some(4),
+                job_inventory: None,
+                client_id: client_id.to_string(),
+                agent_instance_id: format!("inst-{client_id}"),
+                display_name: None,
+                owner: None,
+                hostname: None,
+                host_context: None,
+                capabilities: Some(ShellClientCapabilities::default()),
+                projects: Some(vec![registered_project(
+                    project_id,
+                    &format!("/tmp/{client_id}/{project_id}"),
+                )]),
+                agent_protocol_version: Some("polling-v1".to_string()),
+                policy: None,
+            },
+            Some(auth),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn list_projects_targets_visible_inventory_before_limit_and_compacts() {
+    let runtime = test_runtime();
+    let mut projects = (0..63)
+        .map(|index| {
+            registered_project(
+                &format!("ordinary-{index:03}"),
+                &format!("/tmp/ordinary-{index:03}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut target = registered_project("webcodex-target", "/root/git/webcodex-target");
+    target.name = Some("WebCodex Target".to_string());
+    target.description = Some("Focused Runtime Inventory".to_string());
+    target.git_branch = Some("feat/targeted-inventory".to_string());
+    target.git_head = Some("abc123".to_string());
+    target.git_dirty = Some(false);
+    projects.push(target);
+    register_target_agent(&runtime, "special", projects, None).await;
+    let mini_projects = (0..60)
+        .map(|index| {
+            registered_project(
+                &format!("mini-ordinary-{index:03}"),
+                &format!("/tmp/mini-ordinary-{index:03}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    register_target_agent(&runtime, "mini", mini_projects, None).await;
+
+    let full = runtime
+        .dispatch(list_projects_call(None, None, None, None, false))
+        .await;
+    assert!(full.success, "{:?}", full.error);
+    assert_eq!(full.output["count"], 124);
+
+    let focused = runtime
+        .dispatch(list_projects_call(
+            Some("special"),
+            None,
+            Some("WEBCODEX"),
+            Some(1),
+            true,
+        ))
+        .await;
+    assert!(focused.success, "{:?}", focused.error);
+    assert_eq!(focused.output["matched_count"], 1);
+    assert_eq!(focused.output["count"], 1);
+    assert_eq!(focused.output["truncated"], false);
+    let project = &focused.output["projects"][0];
+    assert_eq!(project["id"], "agent:special:webcodex-target");
+    for omitted in [
+        "path",
+        "revision",
+        "last_seen",
+        "allow_patch",
+        "shell_profile",
+    ] {
+        assert!(
+            project.get(omitted).is_none(),
+            "summary_only leaked {omitted}: {project}"
+        );
+    }
+    let capabilities = project["capabilities"].as_object().unwrap();
+    assert_eq!(capabilities.len(), 2);
+    assert!(capabilities.contains_key("git_available"));
+    assert!(capabilities.contains_key("recommended_for_smoke"));
+
+    let exact = runtime
+        .dispatch(list_projects_call(
+            None,
+            Some("agent:special:webcodex-target"),
+            None,
+            Some(1),
+            false,
+        ))
+        .await;
+    assert!(exact.success, "{:?}", exact.error);
+    assert_eq!(exact.output["count"], 1);
+    assert_eq!(
+        exact.output["projects"][0]["id"],
+        "agent:special:webcodex-target"
+    );
+
+    let wrong_runner = runtime
+        .dispatch(list_projects_call(
+            Some("mini"),
+            Some("agent:special:webcodex-target"),
+            None,
+            Some(1),
+            false,
+        ))
+        .await;
+    assert!(wrong_runner.success);
+    assert_eq!(wrong_runner.output["count"], 0);
+
+    let again = runtime
+        .dispatch(list_projects_call(
+            Some("special"),
+            None,
+            Some("webcodex"),
+            Some(1),
+            true,
+        ))
+        .await;
+    assert_eq!(focused.output, again.output);
+
+    let bounded_query = runtime
+        .dispatch(list_projects_call(None, None, Some("ordinary"), None, true))
+        .await;
+    assert!(bounded_query.success);
+    assert_eq!(bounded_query.output["matched_count"], 123);
+    assert_eq!(bounded_query.output["count"], 100);
+    assert_eq!(bounded_query.output["truncated"], true);
+
+    for query in ["   ".to_string(), "x".repeat(201)] {
+        let invalid = runtime
+            .dispatch(list_projects_call(None, None, Some(&query), None, false))
+            .await;
+        assert!(!invalid.success);
+        assert_eq!(invalid.output["error_kind"], "invalid_query");
+    }
+}
+
+#[tokio::test]
+async fn list_projects_filters_only_after_authorization_visibility() {
+    let runtime = test_runtime();
+    let auth_a = shared_key_auth_context("targeted-a");
+    let auth_b = shared_key_auth_context("targeted-b");
+    register_target_agent_for_auth(&runtime, "client-a", "visible-a", &auth_a).await;
+    register_target_agent_for_auth(&runtime, "client-b", "private-b", &auth_b).await;
+
+    for call in [
+        list_projects_call(None, Some("agent:client-b:private-b"), None, None, false),
+        list_projects_call(None, None, Some("private-b"), None, false),
+        list_projects_call(Some("client-b"), None, None, None, false),
+    ] {
+        let result = runtime.dispatch_with_auth(call, Some(&auth_a)).await;
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(result.output["count"], 0);
+        assert_eq!(result.output["matched_count"], 0);
+    }
+
+    let hidden_agent = runtime
+        .dispatch_with_auth(
+            list_agents_call(Some("client-b"), None, Some(false), true),
+            Some(&auth_a),
+        )
+        .await;
+    assert!(hidden_agent.success);
+    assert_eq!(hidden_agent.output["count"], 0);
+
+    let hidden_status = runtime
+        .dispatch_with_auth(runtime_status_call(Some("client-b"), true), Some(&auth_a))
+        .await;
+    assert!(!hidden_status.success);
+    assert_eq!(hidden_status.output["error_kind"], "unknown_client_id");
+}
+
+#[tokio::test]
+async fn list_agents_supports_exact_batch_and_compact_projection() {
+    let runtime = test_runtime();
+    register_target_agent(
+        &runtime,
+        "sf",
+        vec![registered_project("server", "/tmp/server")],
+        None,
+    )
+    .await;
+    register_target_agent(
+        &runtime,
+        "special",
+        vec![
+            registered_project("webcodex", "/root/git/webcodex"),
+            registered_project("other", "/tmp/other"),
+        ],
+        None,
+    )
+    .await;
+    register_target_agent(
+        &runtime,
+        "mini",
+        vec![registered_project("mini-proj", "/tmp/mini")],
+        None,
+    )
+    .await;
+
+    let legacy = runtime
+        .dispatch(list_agents_call(None, None, None, false))
+        .await;
+    assert!(legacy.success);
+    assert_eq!(legacy.output["count"], 3);
+    assert!(legacy.output["agents"][0].get("projects").is_some());
+
+    let focused = runtime
+        .dispatch(list_agents_call(Some("special"), None, Some(false), true))
+        .await;
+    assert!(focused.success, "{:?}", focused.error);
+    assert_eq!(focused.output["count"], 1);
+    assert!(focused.output.get("clients").is_none());
+    let agent = &focused.output["agents"][0];
+    assert_eq!(agent["client_id"], "special");
+    assert_eq!(agent["projects_count"], 2);
+    for omitted in [
+        "projects",
+        "capabilities",
+        "host_context",
+        "policy",
+        "shell_profiles",
+    ] {
+        assert!(
+            agent.get(omitted).is_none(),
+            "summary_only leaked {omitted}: {agent}"
+        );
+    }
+
+    let batch = runtime
+        .dispatch(list_agents_call(
+            None,
+            Some(&["special", "mini"]),
+            Some(false),
+            false,
+        ))
+        .await;
+    assert!(batch.success);
+    let ids = batch.output["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|agent| agent["client_id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["mini", "special"]);
+    assert!(batch.output["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|agent| agent.get("projects").is_none()));
+
+    let duplicate = runtime
+        .dispatch(list_agents_call(
+            None,
+            Some(&["special", "special"]),
+            None,
+            false,
+        ))
+        .await;
+    assert!(!duplicate.success);
+    assert_eq!(duplicate.output["error_kind"], "invalid_client_ids");
+
+    let too_many_ids = (0..9)
+        .map(|index| format!("client-{index}"))
+        .collect::<Vec<_>>();
+    let too_many = runtime
+        .dispatch(ToolCall::ListAgents {
+            client_id: None,
+            client_ids: Some(too_many_ids),
+            include_projects: None,
+            summary_only: false,
+        })
+        .await;
+    assert!(!too_many.success);
+    assert_eq!(too_many.output["error_kind"], "invalid_client_ids");
+
+    let unknown = runtime
+        .dispatch(list_agents_call(Some("not-registered"), None, None, false))
+        .await;
+    assert!(unknown.success);
+    assert_eq!(unknown.output["count"], 0);
+}
+
+#[tokio::test]
+async fn runtime_status_focus_is_not_polluted_by_unrelated_runner_mismatch() {
+    let runtime = test_runtime();
+    let special_build = AgentBuildInfo {
+        version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_commit: Some("A".to_string()),
+        git_dirty: Some(false),
+    };
+    let mini_build = AgentBuildInfo {
+        version: Some("0.0.1".to_string()),
+        git_commit: Some("B".to_string()),
+        git_dirty: Some(false),
+    };
+    register_target_agent(
+        &runtime,
+        "special",
+        vec![registered_project("webcodex", "/tmp/webcodex")],
+        Some(special_build),
+    )
+    .await;
+    register_target_agent(
+        &runtime,
+        "mini",
+        vec![registered_project("mini", "/tmp/mini")],
+        Some(mini_build),
+    )
+    .await;
+
+    let visible_clients = runtime.shell_clients.list_clients_for_auth(None).await;
+    let synthetic = super::super::runtime_info::version_compatibility_for_test(
+        &visible_clients,
+        env!("CARGO_PKG_VERSION"),
+        Some("A"),
+        Some(false),
+    );
+    assert_eq!(synthetic["source_alignment"]["status"], "different");
+    let synthetic_runners = synthetic["runners"].as_array().unwrap();
+    let synthetic_special = synthetic_runners
+        .iter()
+        .find(|runner| runner["client_id"] == "special")
+        .unwrap();
+    let synthetic_mini = synthetic_runners
+        .iter()
+        .find(|runner| runner["client_id"] == "mini")
+        .unwrap();
+    assert_eq!(synthetic_special["source_alignment"]["status"], "aligned");
+    assert_eq!(synthetic_mini["source_alignment"]["status"], "different");
+
+    let global = runtime.dispatch(runtime_status_call(None, false)).await;
+    assert!(global.success);
+    assert_eq!(
+        global.output["version_compatibility"]["status"],
+        "version_mismatch"
+    );
+    let global_special = global.output["version_compatibility"]["runners"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|runner| runner["client_id"] == "special")
+        .unwrap();
+
+    let special = runtime
+        .dispatch(runtime_status_call(Some("special"), true))
+        .await;
+    assert!(special.success, "{:?}", special.error);
+    assert_eq!(special.output["focus"]["client_id"], "special");
+    assert_eq!(
+        special.output["version_compatibility"]["status"],
+        "compatible"
+    );
+    assert_eq!(
+        special.output["focus"]["source_alignment"],
+        global_special["source_alignment"]
+    );
+    assert_eq!(
+        special.output["fleet_summary"]["mismatched_agents_count"],
+        1
+    );
+    let serialized = special.output.to_string();
+    assert!(!serialized.contains("inst-mini"));
+    assert!(!serialized.contains("/tmp/mini"));
+
+    let mini = runtime
+        .dispatch(runtime_status_call(Some("mini"), true))
+        .await;
+    assert!(mini.success);
+    assert_eq!(mini.output["focus"]["client_id"], "mini");
+    assert_eq!(
+        mini.output["version_compatibility"]["status"],
+        "version_mismatch"
+    );
+
+    let unknown = runtime
+        .dispatch(runtime_status_call(Some("missing"), true))
+        .await;
+    assert!(!unknown.success);
+    assert_eq!(unknown.output["error_kind"], "unknown_client_id");
+}
+
+#[tokio::test]
+async fn runtime_status_focus_preserves_selected_stale_runner_truth() {
+    let runtime = test_runtime();
+    register_target_agent(
+        &runtime,
+        "special",
+        vec![registered_project("webcodex", "/tmp/webcodex")],
+        None,
+    )
+    .await;
+    runtime
+        .shell_clients
+        .set_last_seen_for_test("special", chrono::Utc::now().timestamp() - 120)
+        .await;
+
+    let focused = runtime
+        .dispatch(runtime_status_call(Some("special"), false))
+        .await;
+    assert!(focused.success, "{:?}", focused.error);
+    assert_eq!(focused.output["focus"]["connected"], false);
+    assert_eq!(focused.output["focus"]["status"], "stale");
+    assert_eq!(focused.output["agents"]["count"], 1);
+}
+
+#[test]
+fn targeted_inventory_schemas_and_tool_parsing_are_bounded() {
+    let specs = registered_tool_specs();
+    let project_spec = specs
+        .iter()
+        .find(|spec| spec.name == "list_projects")
+        .unwrap();
+    let project_props = project_spec.input_schema["properties"].as_object().unwrap();
+    assert_eq!(project_props["query"]["maxLength"], 200);
+    assert_eq!(project_props["limit"]["maximum"], 100);
+    assert!(project_spec.description.contains("exact client_id/project"));
+
+    let agent_spec = specs
+        .iter()
+        .find(|spec| spec.name == "list_agents")
+        .unwrap();
+    let agent_props = agent_spec.input_schema["properties"].as_object().unwrap();
+    assert_eq!(agent_props["client_ids"]["minItems"], 1);
+    assert_eq!(agent_props["client_ids"]["maxItems"], 8);
+    assert_eq!(agent_props["client_ids"]["uniqueItems"], true);
+
+    let status_spec = specs
+        .iter()
+        .find(|spec| spec.name == "runtime_status")
+        .unwrap();
+    assert_eq!(
+        status_spec.input_schema["properties"]["client_id"]["maxLength"],
+        128
+    );
+    assert!(status_spec.description.contains("exact client_id"));
+
+    let jobs_spec = specs.iter().find(|spec| spec.name == "list_jobs").unwrap();
+    let job_props = jobs_spec.input_schema["properties"].as_object().unwrap();
+    assert!(job_props.contains_key("project"));
+    assert!(job_props.contains_key("session_id"));
+    assert_eq!(job_props["limit"]["maximum"], 100);
+    assert!(jobs_spec.description.contains("project/session_id"));
+
+    let projects = ToolCall::from_tool_name(
+        "list_projects",
+        serde_json::json!({
+            "client_id": "special",
+            "project": "agent:special:webcodex",
+            "query": "webcodex",
+            "limit": 3,
+            "summary_only": true,
+        }),
+    )
+    .unwrap();
+    assert!(matches!(
+        projects,
+        ToolCall::ListProjects {
+            client_id: Some(_),
+            project: Some(_),
+            query: Some(_),
+            limit: Some(3),
+            summary_only: true,
+        }
+    ));
+
+    let agents = ToolCall::from_tool_name(
+        "list_agents",
+        serde_json::json!({
+            "client_ids": ["special", "mini"],
+            "include_projects": false,
+            "summary_only": true,
+        }),
+    )
+    .unwrap();
+    assert!(matches!(
+        agents,
+        ToolCall::ListAgents {
+            client_id: None,
+            client_ids: Some(_),
+            include_projects: Some(false),
+            summary_only: true,
+        }
+    ));
+
+    let status = ToolCall::from_tool_name(
+        "runtime_status",
+        serde_json::json!({"client_id": "special", "compact": true}),
+    )
+    .unwrap();
+    assert!(matches!(
+        status,
+        ToolCall::RuntimeStatus {
+            client_id: Some(_),
+            compact: true,
+            summary_only: false,
+        }
+    ));
+
+    let jobs = ToolCall::from_tool_name(
+        "list_jobs",
+        serde_json::json!({
+            "project": "agent:special:webcodex",
+            "session_id": "wc_sess_example",
+            "status": "running",
+            "limit": 2,
+        }),
+    )
+    .unwrap();
+    assert!(matches!(
+        jobs,
+        ToolCall::ListJobs {
+            limit: Some(2),
+            status: Some(_),
+            project: Some(_),
+            session_id: Some(_),
+        }
+    ));
+}
+
+#[test]
+fn targeted_inventory_audit_summaries_do_not_persist_raw_query_or_id_filters() {
+    let query = "/private/worktree/needle";
+    let raw = serde_json::json!({
+        "client_id": "special",
+        "project": "agent:special:secret-project",
+        "query": query,
+        "limit": 4,
+        "summary_only": true,
+    });
+    let summary =
+        super::super::tool_audit::session_log_arguments_for_tool_request("list_projects", &raw);
+    assert_eq!(summary["client_id_present"], true);
+    assert_eq!(summary["project_present"], true);
+    assert_eq!(summary["query_present"], true);
+    assert_eq!(summary["query_length"], query.chars().count());
+    let serialized = summary.to_string();
+    assert!(!serialized.contains(query));
+    assert!(!serialized.contains("secret-project"));
+    assert!(!serialized.contains("special"));
+
+    let defensive = super::super::sessions::session_input_summary_for_tool("list_projects", &raw);
+    let defensive_text = defensive.to_string();
+    assert!(!defensive_text.contains(query));
+    assert!(!defensive_text.contains("secret-project"));
+}

--- a/src/tool_runtime/tests/tool_call.rs
+++ b/src/tool_runtime/tests/tool_call.rs
@@ -19,8 +19,8 @@ fn from_tool_name_parses_unit_tools_without_arguments() {
                 call,
                 ToolCall::ListTools { .. }
                     | ToolCall::ComputerListTargets
-                    | ToolCall::ListProjects
-                    | ToolCall::ListAgents
+                    | ToolCall::ListProjects { .. }
+                    | ToolCall::ListAgents { .. }
                     | ToolCall::RuntimeStatus { .. }
             ),
             "unit tool {} should parse",
@@ -494,9 +494,18 @@ fn tool_call_session_id_accessor_covers_session_tool_specs() {
         }
         let call = ToolCall::from_tool_name(&spec.name, sample_tool_args_with_session(&spec.name))
             .unwrap_or_else(|e| panic!("{} should deserialize: {}", spec.name, e));
+        let expected = if spec.name == "list_jobs" {
+            // list_jobs.session_id is an exact metadata filter over the
+            // already-authorized Job set. It deliberately does not opt into
+            // generic Workflow Session lookup/recording, which would turn a
+            // foreign or missing filter value into an existence oracle.
+            None
+        } else {
+            Some("wc_sess_accessor")
+        };
         assert_eq!(
             call.session_id(),
-            Some("wc_sess_accessor"),
+            expected,
             "{} ToolCall::session_id() mismatch",
             spec.name
         );
@@ -594,7 +603,8 @@ fn from_tool_name_parses_runtime_status() {
         call,
         ToolCall::RuntimeStatus {
             compact: false,
-            summary_only: false
+            summary_only: false,
+            client_id: None,
         }
     ));
     // Also accepts an empty object.
@@ -603,7 +613,8 @@ fn from_tool_name_parses_runtime_status() {
         call,
         ToolCall::RuntimeStatus {
             compact: false,
-            summary_only: false
+            summary_only: false,
+            client_id: None,
         }
     ));
     let call = ToolCall::from_tool_name(
@@ -615,7 +626,8 @@ fn from_tool_name_parses_runtime_status() {
         call,
         ToolCall::RuntimeStatus {
             compact: true,
-            summary_only: true
+            summary_only: true,
+            client_id: None,
         }
     ));
 }
@@ -1061,13 +1073,15 @@ fn from_tool_name_parses_phase_a_tools() {
         call,
         ToolCall::ListJobs {
             limit: None,
-            status: None
+            status: None,
+            project: None,
+            session_id: None,
         }
     ));
     let call =
         ToolCall::from_tool_name("list_jobs", json!({"limit": 3, "status": "running"})).unwrap();
     match call {
-        ToolCall::ListJobs { limit, status } => {
+        ToolCall::ListJobs { limit, status, .. } => {
             assert_eq!(limit, Some(3));
             assert_eq!(status.as_deref(), Some("running"));
         }

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -268,6 +268,59 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
             );
             copy_keys(obj, &mut out, &["tail_lines", "wait_secs"]);
         }
+        "list_projects" => {
+            out.remove("project");
+            out.insert(
+                "client_id_present".to_string(),
+                Value::Bool(obj.get("client_id").is_some_and(|value| !value.is_null())),
+            );
+            out.insert(
+                "project_present".to_string(),
+                Value::Bool(obj.get("project").is_some_and(|value| !value.is_null())),
+            );
+            let query = obj.get("query").and_then(Value::as_str);
+            out.insert("query_present".to_string(), Value::Bool(query.is_some()));
+            out.insert(
+                "query_length".to_string(),
+                Value::from(query.map(|value| value.chars().count()).unwrap_or_default()),
+            );
+            copy_keys(obj, &mut out, &["limit", "summary_only"]);
+        }
+        "list_agents" => {
+            out.insert(
+                "client_id_present".to_string(),
+                Value::Bool(obj.get("client_id").is_some_and(|value| !value.is_null())),
+            );
+            out.insert(
+                "client_ids_count".to_string(),
+                Value::from(
+                    obj.get("client_ids")
+                        .and_then(Value::as_array)
+                        .map(Vec::len)
+                        .unwrap_or_default(),
+                ),
+            );
+            copy_keys(obj, &mut out, &["include_projects", "summary_only"]);
+        }
+        "runtime_status" => {
+            out.insert(
+                "client_id_present".to_string(),
+                Value::Bool(obj.get("client_id").is_some_and(|value| !value.is_null())),
+            );
+            copy_keys(obj, &mut out, &["compact", "summary_only"]);
+        }
+        "list_jobs" => {
+            out.remove("project");
+            out.insert(
+                "project_present".to_string(),
+                Value::Bool(obj.get("project").is_some_and(|value| !value.is_null())),
+            );
+            out.insert(
+                "session_id_present".to_string(),
+                Value::Bool(obj.get("session_id").is_some_and(|value| !value.is_null())),
+            );
+            copy_keys(obj, &mut out, &["limit", "status"]);
+        }
         "start_session" | "start_coding_task" | "update_session_context" => {
             copy_keys(
                 obj,
@@ -2666,6 +2719,42 @@ impl ToolCall {
                 "include_handoff": include_handoff,
                 "include_validation_summary": include_validation_summary,
             }),
+            Self::ListProjects {
+                client_id,
+                project,
+                query,
+                limit,
+                summary_only,
+            } => serde_json::json!({
+                "client_id_present": client_id.is_some(),
+                "project_present": project.is_some(),
+                "query_present": query.is_some(),
+                "query_length": query.as_deref().map(|value| value.chars().count()).unwrap_or_default(),
+                "limit": limit,
+                "summary_only": summary_only,
+            }),
+            Self::ListAgents {
+                client_id,
+                client_ids,
+                include_projects,
+                summary_only,
+            } => serde_json::json!({
+                "client_id_present": client_id.is_some(),
+                "client_ids_count": client_ids.as_ref().map(Vec::len).unwrap_or_default(),
+                "include_projects": include_projects,
+                "summary_only": summary_only,
+            }),
+            Self::ListJobs {
+                limit,
+                status,
+                project,
+                session_id,
+            } => serde_json::json!({
+                "limit": limit,
+                "status": status,
+                "project_present": project.is_some(),
+                "session_id_present": session_id.is_some(),
+            }),
             Self::ToolManifest {
                 category,
                 intent,
@@ -2691,9 +2780,11 @@ impl ToolCall {
             Self::RuntimeStatus {
                 compact,
                 summary_only,
+                client_id,
             } => serde_json::json!({
                 "compact": compact,
                 "summary_only": summary_only,
+                "client_id_present": client_id.is_some(),
             }),
             Self::WorkspaceHygieneCheck {
                 project,

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -395,9 +395,7 @@ pub enum ToolCall {
     /// explicit `session_id` (never current-session fallback). Idempotent when
     /// already closed. Does not archive or evict; clears bindings to the closed
     /// Session.
-    CloseSession {
-        session_id: String,
-    },
+    CloseSession { session_id: String },
 
     /// Read bounded structured validation evidence already present in an
     /// explicit project-scoped session ledger. Never executes validation,
@@ -475,22 +473,15 @@ pub enum ToolCall {
 
     /// Explicitly bind an existing project-scoped session as current for the
     /// client window, caller, transport, and project.
-    BindCurrentSession {
-        project: String,
-        session_id: String,
-    },
+    BindCurrentSession { project: String, session_id: String },
 
     /// Return this window/caller/transport's exact current session binding for
     /// a project, restoring its process-local cache from the ledger if needed.
-    CurrentSession {
-        project: String,
-    },
+    CurrentSession { project: String },
 
     /// Remove this window/caller/transport's exact current session binding from
     /// both the process-local cache and durable ledger projection. Idempotent.
-    UnbindCurrentSession {
-        project: String,
-    },
+    UnbindCurrentSession { project: String },
 
     /// Create a bounded last-known-good workspace checkpoint outside the
     /// project worktree.
@@ -1068,6 +1059,10 @@ pub enum ToolCall {
         limit: Option<usize>,
         #[serde(default)]
         status: Option<String>,
+        #[serde(default)]
+        project: Option<String>,
+        #[serde(default)]
+        session_id: Option<String>,
     },
 
     /// Return bounded stdout/stderr tails for a job. Defaults to a bounded tail
@@ -1384,9 +1379,7 @@ pub enum ToolCall {
     },
 
     /// Read the exact Runner's macOS Accessibility trust status without prompting.
-    ComputerAccessibilityStatus {
-        client_id: String,
-    },
+    ComputerAccessibilityStatus { client_id: String },
 
     /// Inspect one exact previously listed macOS surface as a bounded AX tree.
     ComputerAccessibilityTree {
@@ -1454,15 +1447,10 @@ pub enum ToolCall {
     },
 
     /// Read bounded native plain Unicode text from the global clipboard.
-    ComputerReadClipboard {
-        client_id: String,
-    },
+    ComputerReadClipboard { client_id: String },
 
     /// Replace the global clipboard with bounded native plain Unicode text.
-    ComputerWriteClipboard {
-        client_id: String,
-        text: String,
-    },
+    ComputerWriteClipboard { client_id: String, text: String },
 
     /// Move the native macOS or Windows pointer using one latest unspent full-display snapshot generation.
     ComputerPointerMove {
@@ -1528,7 +1516,18 @@ pub enum ToolCall {
         session_id: Option<String>,
     },
 
-    ListProjects,
+    ListProjects {
+        #[serde(default)]
+        client_id: Option<String>,
+        #[serde(default)]
+        project: Option<String>,
+        #[serde(default)]
+        query: Option<String>,
+        #[serde(default)]
+        limit: Option<usize>,
+        #[serde(default)]
+        summary_only: bool,
+    },
 
     /// Register an existing directory as a WebCodex project on a selected
     /// agent. The agent validates the path against its own policy, writes a
@@ -1589,7 +1588,16 @@ pub enum ToolCall {
     },
 
     /// List connected shell/agent clients.
-    ListAgents,
+    ListAgents {
+        #[serde(default)]
+        client_id: Option<String>,
+        #[serde(default)]
+        client_ids: Option<Vec<String>>,
+        #[serde(default)]
+        include_projects: Option<bool>,
+        #[serde(default)]
+        summary_only: bool,
+    },
 
     /// Return a structured runtime health/observability summary.
     ///
@@ -1601,6 +1609,8 @@ pub enum ToolCall {
         compact: bool,
         #[serde(default)]
         summary_only: bool,
+        #[serde(default)]
+        client_id: Option<String>,
     },
 
     /// Return a compact, bounded tool manifest with categories, risk summary,
@@ -2074,11 +2084,11 @@ impl ToolCall {
             Self::ComputerSnapshot { .. } => "computer_snapshot",
             Self::ComputerSnapshotDisplay { .. } => "computer_snapshot_display",
             Self::ComputerSaveSnapshot { .. } => "computer_save_snapshot",
-            Self::ListProjects => "list_projects",
+            Self::ListProjects { .. } => "list_projects",
             Self::RegisterProject { .. } => "register_project",
             Self::UnregisterProject { .. } => "unregister_project",
             Self::CreateProject { .. } => "create_project",
-            Self::ListAgents => "list_agents",
+            Self::ListAgents { .. } => "list_agents",
             Self::RuntimeStatus { .. } => "runtime_status",
             Self::ToolManifest { .. } => "tool_manifest",
         }

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -1844,6 +1844,40 @@ fn reject_unknown_search_project_texts_fields(arguments: &Value) -> Result<(), S
     ))
 }
 
+fn reject_unknown_targeted_inventory_fields(
+    tool_name: &str,
+    arguments: &Value,
+) -> Result<(), String> {
+    let allowed: &[&str] = match tool_name {
+        "list_projects" => &["client_id", "project", "query", "limit", "summary_only"],
+        "list_agents" => &[
+            "client_id",
+            "client_ids",
+            "include_projects",
+            "summary_only",
+        ],
+        "runtime_status" => &["client_id", "compact", "summary_only"],
+        "list_jobs" => &["limit", "status", "project", "session_id"],
+        _ => return Ok(()),
+    };
+    let Some(object) = arguments.as_object() else {
+        return Ok(());
+    };
+    let unknown: Vec<&str> = object
+        .keys()
+        .map(String::as_str)
+        .filter(|key| !allowed.contains(key))
+        .collect();
+    if unknown.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid arguments for tool '{tool_name}': unknown field(s) {}",
+            unknown.join(", ")
+        ))
+    }
+}
+
 fn reject_unknown_bounded_computer_fields(
     tool_name: &str,
     arguments: &Value,
@@ -1916,6 +1950,12 @@ impl ToolCall {
         }
         if name == "search_project_texts" {
             reject_unknown_search_project_texts_fields(&arguments)?;
+        }
+        if matches!(
+            name,
+            "list_projects" | "list_agents" | "runtime_status" | "list_jobs"
+        ) {
+            reject_unknown_targeted_inventory_fields(name, &arguments)?;
         }
         if matches!(
             name,

--- a/src/tool_runtime/tool_definition/discovery.rs
+++ b/src/tool_runtime/tool_definition/discovery.rs
@@ -1,20 +1,19 @@
 use super::ToolVisibility::ModelVisible;
-use super::{
-    def, model_spec, unit_arguments, ToolDefinition, TOOL_CATEGORY_PROJECT, TOOL_CATEGORY_RUNTIME,
-};
+use super::{def, model_spec, ToolDefinition, TOOL_CATEGORY_PROJECT, TOOL_CATEGORY_RUNTIME};
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath,
     ToolRisk::{ProjectWrite, ReadOnly},
     PROJECT_READ, PROJECT_WRITE, RUNTIME_READ, TOOL_PROVIDER_CONTROL,
 };
 use crate::tool_runtime::registry::input_schemas::{
-    create_project_input_schema, empty_input_schema, register_project_input_schema,
-    runtime_status_input_schema, tool_manifest_input_schema, unregister_project_input_schema,
+    create_project_input_schema, list_agents_input_schema, list_projects_input_schema,
+    register_project_input_schema, runtime_status_input_schema, tool_manifest_input_schema,
+    unregister_project_input_schema,
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
     model_spec(
-        unit_arguments(def(
+        def(
             "list_projects",
             ModelVisible,
             TOOL_CATEGORY_PROJECT,
@@ -26,9 +25,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             NoPath,
             false,
             false,
-        )),
-        "List agent-registered runtime projects, execution mode, and smoke-selection capabilities such as git_available and recommended_for_smoke.",
-        empty_input_schema,
+        ),
+        "List caller-visible Projects. When Runner/Project identity is known, pass exact client_id/project; use bounded query and summary_only instead of reading the full registry.",
+        list_projects_input_schema,
     ),
     model_spec(
         def(
@@ -82,7 +81,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         create_project_input_schema,
     ),
     model_spec(
-        unit_arguments(def(
+        def(
             "list_agents",
             ModelVisible,
             TOOL_CATEGORY_RUNTIME,
@@ -94,9 +93,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             NoPath,
             false,
             false,
-        )),
-        "List authorized Runners with identity, connectivity, capabilities, Projects, and shared Job concurrency. host_context is bounded Runner-configured advisory data, never authority or proof of current state.",
-        empty_input_schema,
+        ),
+        "List caller-visible Runners; use exact client_id/client_ids if known, summary_only + include_projects=false for health. Full mode includes shared Job concurrency and host_context advisory metadata; never authority.",
+        list_agents_input_schema,
     ),
     model_spec(
         def(
@@ -112,7 +111,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             false,
             false,
         ),
-        "Read Server/Project/Runner observations, build/source diagnostics, and shared Job concurrency. host_context is bounded configured advisory data, not observed truth or authority. compact=true returns a small snapshot.",
+        "Read runtime status; pass exact client_id for one Runner deployment/source alignment, omit for fleet-wide. Reports shared Job concurrency; global mode includes bounded host_context advisory metadata, never authority.",
         runtime_status_input_schema,
     ),
     model_spec(


### PR DESCRIPTION
## Summary

Reduce model-visible runtime inventory cost when the caller already knows the target Runner, Project, or Session.

- add exact/bounded filters to `list_projects`, `list_agents`, `runtime_status`, and `list_jobs`
- keep legacy unfiltered behavior compatible
- make focused `runtime_status(client_id=...)` evaluate the selected Runner independently of unrelated fleet mismatches
- keep filtering strictly inside the caller-visible inventory and preserve existing authorization boundaries
- add compact projections and audit sanitization for targeted queries
- avoid quadratic `list_projects` candidate cloning for large single-Runner inventories

## Validation

- `cargo test targeted_inventory -p webcodex` — 10 passed
- focused Job filtering regression — passed
- `cargo test tool_runtime::tests::schema -p webcodex` — 104 passed
- `cargo test -p webcodex` — 2699 passed
- `cargo check --all-targets -p webcodex` — passed
- `cargo fmt -- --check` — passed
- `git diff --check` — passed

## Dogfood / model-visible size

Using the same real runtime inventory snapshot from development, targeted projections reduced serialized result size substantially, including ~99% reductions for exact Project and Runner lookups and ~88% for focused runtime status.

No deployment, restart, release, or authority expansion is part of this PR.