### PR TITLE
Make bootstrap context projection caller-explicit

### DIFF
--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -16,15 +16,20 @@ role selector.
 
 - Use `work_on_project` for the normal coding bootstrap. Its task `instruction`
   is the natural place to state what the agent should do.
-- When the caller's current model context already retains the applicable repository
-  instructions, `work_on_project(include_project_instructions=false)` omits their
-  bodies from that bootstrap response. WebCodex still observes the instruction
-  files and records current instruction metadata for the resulting Workflow Session.
-- When the caller's current model context already retains the built-in WebCodex
-  coding-workflow guidance, `work_on_project(include_workflow_guidance=false)`
-  omits that static `workflow` section from the response. This is projection-only:
-  it does not change Workflow Session state, authority, role selection, or execution
-  semantics.
+- `include_project_instructions=true` (the default) always projects the current
+  bounded repository-instruction bodies, including on an exact Workflow Session
+  continuation whose repository delta status is `reused`. Set it false only when
+  the caller's current model context already retains those instructions. WebCodex
+  still re-observes the files and updates Workflow Session instruction metadata.
+- `include_workflow_guidance=true` (the default) always projects the canonical
+  built-in coding workflow. Set it false only when the caller's current model
+  context already retains that guidance. This is projection-only: it does not
+  change Workflow Session state, authority, role selection, or execution semantics.
+- WebCodex does not infer model-context retention from a `wc_sess_*` Workflow
+  Session, MCP/HTTP transport identity, client window, credential, project, or
+  server lifetime. A Workflow Session is business continuity and may be resumed
+  by multiple independent model contexts. The caller-explicit include flags are
+  the only inputs that suppress these static model-facing bodies.
 - `work_on_project` success output is sparse by default. Omitted default sections
   mean no Session execution defaults, ordinary existing-project resolution, the
   intentionally skipped repository overview, pass/non-blocking readiness, no

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -14,14 +14,18 @@ instructions；它不是 role selector。
 
 - 普通 coding bootstrap 优先用 `work_on_project`；它的 task `instruction` 正是描述模型
   应该做什么的自然位置。
-- 如果 caller 当前的模型上下文已经保留适用的 repository instructions，可使用
-  `work_on_project(include_project_instructions=false)` 省略本轮 bootstrap response 中的
-  instruction 正文。WebCodex 仍会观察这些文件，并为本次 bootstrap 对应的 Workflow
-  Session 记录当前的 instruction metadata。
-- 如果 caller 当前模型上下文已经保留 WebCodex 内置 coding-workflow guidance，可使用
-  `work_on_project(include_workflow_guidance=false)` 省略 response 中静态的 `workflow`
-  section。这只控制 model-facing projection，不改变 Workflow Session state、authority、
-  role selection 或 execution semantics。
+- `include_project_instructions=true`（默认）始终投影当前适用的有界 repository
+  instruction 正文；即使精确续用同一个 Workflow Session 且 repository delta status 为
+  `reused`，正文仍会返回。只有 caller 当前模型上下文已保留这些 instructions 时才应传
+  false；WebCodex 仍会重新观察文件并更新 Workflow Session instruction metadata。
+- `include_workflow_guidance=true`（默认）始终投影 canonical 内置 coding workflow。
+  只有 caller 当前模型上下文已保留该 guidance 时才应传 false。该 flag 只控制
+  model-facing projection，不改变 Workflow Session state、authority、role selection 或
+  execution semantics。
+- WebCodex 不会从 `wc_sess_*` Workflow Session、MCP/HTTP transport identity、client
+  window、credential、project 或 Server process lifetime 推断当前模型上下文是否仍保留
+  静态内容。Workflow Session 只表示业务 continuity，同一个 Session 可以被多个独立模型
+  上下文 resume；只有 caller-explicit 的 include flags 才能省略静态 model-facing 内容。
 - `work_on_project` 的成功输出默认采用 sparse projection。省略的默认 section 表示：没有
   Session execution defaults、普通已有 project 的解析没有特殊事件、repository overview
   按设计未请求、readiness 为 pass/non-blocking、没有值得报告的 Job，或 blockers/warnings

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -278,6 +278,17 @@ use `work_on_project` as the canonical coding entry. The advanced schema remains
 available only to explicit direct/API compatibility callers. With a stable
 transport window, `start_coding_task`'s default behavior is:
 
+`work_on_project` deliberately does not use Workflow Session identity, transport
+identity, a client-window key, credentials, project identity, or Server lifetime
+as evidence that the current model still retains static bootstrap content. The
+same `wc_sess_*` may be explicitly resumed by multiple independent ChatGPT
+conversations. Its `include_workflow_guidance` and
+`include_project_instructions` flags are caller-explicit model-facing projection
+preferences only: their defaults are true, and false is appropriate only when
+the caller's current model context already retains the corresponding content.
+Repository instruction files are still re-observed and Session metadata/delta
+status still update when instruction bodies are suppressed.
+
 - no valid binding creates and binds one active Workflow Session;
 - an exact repository binding reuses that Session and appends the accepted
   instruction as a `task_instruction` event;

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -88,6 +88,7 @@ struct CodingStartupOptions {
     detail: StartupDetail,
     include_repository_overview: bool,
     include_project_instructions: bool,
+    include_reused_instruction_content: bool,
 }
 
 impl CodingStartupOptions {
@@ -96,6 +97,7 @@ impl CodingStartupOptions {
             detail,
             include_repository_overview: true,
             include_project_instructions: true,
+            include_reused_instruction_content: false,
         }
     }
 
@@ -104,6 +106,7 @@ impl CodingStartupOptions {
             detail: StartupDetail::Standard,
             include_repository_overview: false,
             include_project_instructions,
+            include_reused_instruction_content: include_project_instructions,
         }
     }
 }
@@ -1130,9 +1133,10 @@ impl ToolRuntime {
         // Reload rule bodies only when there is no prior snapshot to compare
         // against (fresh session, or a session whose rules were never
         // persisted, e.g. restored after a restart). Otherwise the shared
-        // brief compares fingerprints and reports reused/changed: an exact
-        // resume with unchanged rules returns `reused` without repeating the
-        // body, and changed rules return `changed` with the new bounded body.
+        // brief compares fingerprints and reports reused/changed. Whether a
+        // reused body is projected is intentionally separate: advanced
+        // start_coding_task stays incremental, while work_on_project follows
+        // its caller-explicit include_project_instructions preference.
         let force_instruction_load = previous_instructions.is_none();
         let binding_reason_code = if binding_available {
             None
@@ -1170,6 +1174,7 @@ impl ToolRuntime {
             previous_instructions,
             force_instruction_load,
             include_project_instructions: startup.include_project_instructions,
+            include_reused_instruction_content: startup.include_reused_instruction_content,
             git: &git,
             semantic_navigation: &semantic_navigation,
             repository: &repository_overview,

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -2073,9 +2073,9 @@ fn sparse_work_on_project_instruction_source(
             projected["headings"] = json!(headings);
         }
         projected["content"] = json!(content);
-    }
-    if let Some(read_more) = read_more.0 {
-        projected["read_more"] = json!(read_more);
+        if let Some(read_more) = read_more.0 {
+            projected["read_more"] = json!(read_more);
+        }
     }
     projected
 }

--- a/src/tool_runtime/registry/input_schemas/coding.rs
+++ b/src/tool_runtime/registry/input_schemas/coding.rs
@@ -135,12 +135,12 @@ pub(crate) fn work_on_project_input_schema() -> Value {
             "include_project_instructions": {
                 "type": "boolean",
                 "default": true,
-                "description": "Whether this bootstrap response should include bounded project-instruction bodies such as AGENTS.md. Defaults to true. Set false when the caller's current model context already retains the applicable repository instructions. Instruction files are still observed for Workflow Session state and metadata; this flag controls only model-facing instruction-content projection."
+                "description": "Whether this bootstrap response should include bounded project-instruction bodies such as AGENTS.md. Defaults to true. Set false only when the caller's current model context already retains the applicable repository instructions. WebCodex does not infer that from session_id or transport identity. Instruction files are still re-observed and Workflow Session metadata is updated; this flag controls only model-facing instruction-content projection."
             },
             "include_workflow_guidance": {
                 "type": "boolean",
                 "default": true,
-                "description": "Whether this bootstrap response should include the static built-in WebCodex coding-workflow guidance. Defaults to true. Set false when the caller's current model context already retains that workflow guidance. This flag controls only model-facing workflow projection; it does not change Workflow Session state, authority, role selection, or execution semantics."
+                "description": "Whether this bootstrap response should include the static built-in WebCodex coding-workflow guidance. Defaults to true. Set false only when the caller's current model context already retains that workflow guidance. WebCodex does not infer that from session_id or transport identity. This flag controls only model-facing workflow projection; it does not change Workflow Session state, authority, role selection, or execution semantics."
             },
             "session_id": {
                 "type": "string",

--- a/src/tool_runtime/registry/output_schemas/coding_tasks.rs
+++ b/src/tool_runtime/registry/output_schemas/coding_tasks.rs
@@ -1038,7 +1038,7 @@ fn work_on_project_output_schema() -> Value {
     });
     let compact_instructions = json!({
         "type": "object",
-        "description": "Compact project-local repository instruction projection, separate from the WebCodex built-in workflow. False/null/empty body-projection defaults are omitted.",
+        "description": "Compact project-local repository instruction projection, separate from the WebCodex built-in workflow. status reports repository/Workflow Session delta; content_included reports this call's caller-explicit model-facing body projection. False/null/empty body-projection defaults are omitted.",
         "properties": {
             "status": {
                 "type": "string",
@@ -1065,7 +1065,7 @@ fn work_on_project_output_schema() -> Value {
                     ]
                 }
             },
-            "content_included": {"type": "boolean", "description": "Emitted only when bounded instruction bodies are included; omission means false."},
+            "content_included": {"type": "boolean", "description": "Emitted only when bounded instruction bodies are included for this call; omission means false. This is independent of status=reused."},
             "truncated": {"type": "boolean", "description": "Emitted only when true."},
             "total_chars": {"type": "integer", "minimum": 1, "maximum": 32768, "description": "Emitted only with truncated=true to quantify the observed instruction extent."}
         },
@@ -1170,7 +1170,7 @@ fn work_on_project_output_schema() -> Value {
             "workflow",
             {
                 let mut schema = startup_workflow_schema();
-                schema["description"] = json!("Static built-in WebCodex coding-workflow guidance. Omitted when work_on_project is called with include_workflow_guidance=false.");
+                schema["description"] = json!("Canonical static built-in WebCodex coding-workflow guidance. Included on every work_on_project call with include_workflow_guidance=true and omitted only when the caller explicitly passes false; Workflow Session or transport identity never suppresses it automatically.");
                 schema
             },
         ),

--- a/src/tool_runtime/startup_brief.rs
+++ b/src/tool_runtime/startup_brief.rs
@@ -108,6 +108,7 @@ pub(crate) struct StartupBriefInput<'a> {
     pub(crate) previous_instructions: Option<&'a ProjectInstructionsSummarySnapshot>,
     pub(crate) force_instruction_load: bool,
     pub(crate) include_project_instructions: bool,
+    pub(crate) include_reused_instruction_content: bool,
     pub(crate) git: &'a Value,
     pub(crate) semantic_navigation: &'a Value,
     pub(crate) repository: &'a Value,
@@ -126,6 +127,7 @@ pub(crate) fn build_startup_brief(input: StartupBriefInput<'_>) -> Value {
         input.previous_instructions,
         input.force_instruction_load,
         !minimal && input.include_project_instructions,
+        input.include_reused_instruction_content,
         minimal,
     );
     let continuation = continuation_projection(
@@ -528,11 +530,13 @@ fn instructions_projection(
     previous: Option<&ProjectInstructionsSummarySnapshot>,
     force_load: bool,
     allow_content: bool,
+    include_reused_content: bool,
     minimal: bool,
 ) -> Value {
     let status = instruction_status(current, previous, force_load);
     let include_content = allow_content
         && (matches!(status, "loaded" | "changed")
+            || (status == "reused" && include_reused_content)
             || (status == "unavailable" && !current.files.is_empty()));
     let changed_sources = if status == "changed" {
         changed_instruction_sources(current, previous)
@@ -1825,6 +1829,32 @@ mod tests {
         )
     }
 
+    #[test]
+    fn reused_instruction_status_and_body_projection_are_independent() {
+        let current = instruction_snapshot();
+        let previous = current.to_summary();
+
+        let advanced =
+            instructions_projection(&current, Some(&previous), false, true, false, false);
+        assert_eq!(advanced["status"], "reused");
+        assert_eq!(advanced["content_included"], false);
+        assert!(advanced["sources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|source| source["content"].is_null()));
+
+        let canonical =
+            instructions_projection(&current, Some(&previous), false, true, true, false);
+        assert_eq!(canonical["status"], "reused");
+        assert_eq!(canonical["content_included"], true);
+        assert!(canonical["sources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|source| source["content"].is_string()));
+    }
+
     fn delta_feedback(new_total: usize, resolved_total: usize, still_total: usize) -> Value {
         let failures = |total: usize, offset: usize| {
             (0..total.min(20))
@@ -2090,6 +2120,7 @@ mod tests {
                 previous_instructions: None,
                 force_instruction_load: true,
                 include_project_instructions: true,
+                include_reused_instruction_content: false,
                 git: &git,
                 semantic_navigation: &semantic_navigation,
                 repository: &large_repository(),

--- a/src/tool_runtime/tests/work_on_project.rs
+++ b/src/tool_runtime/tests/work_on_project.rs
@@ -192,6 +192,40 @@ async fn dispatch_recording_startup_requests(
     (task.await.unwrap(), request_kinds)
 }
 
+async fn dispatch_startup_without_window(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    call: ToolCall,
+    auth: Option<&crate::auth::AuthContext>,
+) -> ToolResult {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let auth = auth.cloned();
+        async move {
+            runtime
+                .dispatch_with_auth_transport_options_and_metadata_with_sandbox(
+                    call,
+                    auth.as_ref(),
+                    crate::tool_runtime::sessions::SessionTransport::Mcp,
+                    true,
+                    false,
+                    Default::default(),
+                    None,
+                    None,
+                )
+                .await
+        }
+    });
+    while !task.is_finished() {
+        if let Some(request) = next_patch_agent_request(runtime, client_id).await {
+            complete_agent_request_by_running_locally(runtime, client_id, request).await;
+        } else {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    }
+    task.await.unwrap()
+}
+
 async fn dispatch_with_path_runner(
     runtime: &ToolRuntime,
     client_id: &str,
@@ -2178,6 +2212,184 @@ async fn work_on_project_can_omit_static_workflow_guidance() {
 }
 
 #[tokio::test]
+async fn work_on_project_static_projection_is_caller_explicit_not_window_state() {
+    let root = tempfile::tempdir().unwrap();
+    seed_coding_repository(root.path(), "static caller-explicit rule");
+    let runtime = ToolRuntime::new_for_tests();
+    let project =
+        register_agent_project_at_path(&runtime, "wop-explicit", "demo", root.path()).await;
+    let auth = auth_context(None, true);
+
+    let first = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-explicit",
+        work_on_project_call(&project, "first", None),
+        Some(&auth),
+        "same-window",
+    )
+    .await;
+    assert!(first.success, "{:?}", first.error);
+    let session_id = first.output["session_id"].as_str().unwrap().to_string();
+    assert!(first.output["workflow"].is_object());
+
+    let repeated = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-explicit",
+        work_on_project_call(&project, "repeat true", Some(&session_id)),
+        Some(&auth),
+        "same-window",
+    )
+    .await;
+    assert!(repeated.success, "{:?}", repeated.error);
+    assert!(repeated.output["workflow"].is_object());
+    assert_eq!(repeated.output["instructions"]["status"], "reused");
+    assert_eq!(repeated.output["instructions"]["content_included"], true);
+
+    let suppressed = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-explicit",
+        work_on_project_call_with_projections(
+            &project,
+            "caller suppresses static content",
+            Some(&session_id),
+            false,
+            false,
+        ),
+        Some(&auth),
+        "same-window",
+    )
+    .await;
+    assert!(suppressed.success, "{:?}", suppressed.error);
+    assert!(suppressed.output.get("workflow").is_none());
+    assert_eq!(suppressed.output["instructions"]["status"], "reused");
+    assert!(suppressed.output["instructions"]
+        .get("content_included")
+        .is_none());
+    let suppressed_agents = suppressed.output["instructions"]["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["path"] == "AGENTS.md")
+        .unwrap();
+    assert!(suppressed_agents["fingerprint"].is_string());
+    assert!(suppressed_agents.get("content").is_none());
+    assert!(suppressed_agents.get("headings").is_none());
+    assert!(suppressed_agents.get("read_more").is_none());
+
+    let restored_other_window = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-explicit",
+        work_on_project_call(&project, "true in another window", Some(&session_id)),
+        Some(&auth),
+        "different-window",
+    )
+    .await;
+    assert!(
+        restored_other_window.success,
+        "{:?}",
+        restored_other_window.error
+    );
+    assert!(restored_other_window.output["workflow"].is_object());
+    assert_eq!(
+        restored_other_window.output["instructions"]["content_included"],
+        true
+    );
+
+    let no_window = dispatch_startup_without_window(
+        &runtime,
+        "wop-explicit",
+        work_on_project_call(&project, "true without window", Some(&session_id)),
+        Some(&auth),
+    )
+    .await;
+    assert!(no_window.success, "{:?}", no_window.error);
+    assert!(no_window.output["workflow"].is_object());
+    assert_eq!(no_window.output["instructions"]["content_included"], true);
+}
+
+#[tokio::test]
+async fn work_on_project_suppressed_instruction_bodies_still_track_changed_rules() {
+    let root = tempfile::tempdir().unwrap();
+    seed_coding_repository(root.path(), "old body");
+    let runtime = ToolRuntime::new_for_tests();
+    let project =
+        register_agent_project_at_path(&runtime, "wop-suppressed-change", "demo", root.path())
+            .await;
+    let auth = auth_context(None, true);
+
+    let first = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-suppressed-change",
+        work_on_project_call(&project, "first", None),
+        Some(&auth),
+        "window-a",
+    )
+    .await;
+    assert!(first.success, "{:?}", first.error);
+    let session_id = first.output["session_id"].as_str().unwrap().to_string();
+    let old_fingerprint = first.output["instructions"]["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["path"] == "AGENTS.md")
+        .unwrap()["fingerprint"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    overwrite_agents_rule(root.path(), "new body while projection is suppressed");
+    let changed = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-suppressed-change",
+        work_on_project_call_with_instruction_projection(
+            &project,
+            "observe change without body",
+            Some(&session_id),
+            false,
+        ),
+        Some(&auth),
+        "window-a",
+    )
+    .await;
+    assert!(changed.success, "{:?}", changed.error);
+    assert_eq!(changed.output["instructions"]["status"], "changed");
+    assert!(changed.output["instructions"]["changed_sources"]
+        .as_array()
+        .unwrap()
+        .contains(&json!("AGENTS.md")));
+    let changed_agents = changed.output["instructions"]["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["path"] == "AGENTS.md")
+        .unwrap();
+    assert_ne!(changed_agents["fingerprint"], old_fingerprint);
+    assert!(changed_agents.get("content").is_none());
+    assert!(changed_agents.get("headings").is_none());
+    assert!(changed_agents.get("read_more").is_none());
+
+    let projected = dispatch_start_coding_task_in_window(
+        &runtime,
+        "wop-suppressed-change",
+        work_on_project_call(&project, "project current body", Some(&session_id)),
+        Some(&auth),
+        "window-b",
+    )
+    .await;
+    assert!(projected.success, "{:?}", projected.error);
+    assert_eq!(projected.output["instructions"]["status"], "reused");
+    assert_eq!(projected.output["instructions"]["content_included"], true);
+    assert!(projected.output["instructions"]["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|source| source["path"] == "AGENTS.md"
+            && source["content"].as_str().is_some_and(
+                |content| content.contains("new body while projection is suppressed")
+            )));
+}
+
+#[tokio::test]
 async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
     let root = tempfile::tempdir().unwrap();
     seed_coding_repository(root.path(), "first rule body");
@@ -2196,7 +2408,8 @@ async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
     assert!(first.success, "{:?}", first.error);
     let session_id = first.output["session_id"].as_str().unwrap().to_string();
 
-    // Exact resume with unchanged rules: status=reused, no repeated content.
+    // Exact resume with unchanged rules: repository delta status remains reused,
+    // while the caller-explicit default still projects the current bounded body.
     let reused = dispatch_start_coding_task_in_window(
         &runtime,
         "wop-reuse",
@@ -2210,15 +2423,19 @@ async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
     assert_eq!(reused.output["continuation"], "resumed_explicitly");
     let reused_instructions = &reused.output["instructions"];
     assert_eq!(reused_instructions["status"], "reused");
-    assert!(reused_instructions.get("content_included").is_none());
+    assert_eq!(reused_instructions["content_included"], true);
     assert!(reused_instructions.get("changed_sources").is_none());
-    for source in reused_instructions["sources"].as_array().unwrap() {
-        if source["path"] == "AGENTS.md" {
-            assert!(source.get("content").is_none());
-            assert!(source.get("headings").is_none());
-            assert!(source["fingerprint"].is_string());
-        }
-    }
+    let reused_agents = reused_instructions["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["path"] == "AGENTS.md")
+        .expect("reused AGENTS.md source");
+    assert!(reused_agents["content"]
+        .as_str()
+        .is_some_and(|content| content.contains("first rule body")));
+    assert!(reused_agents["headings"].is_array());
+    assert!(reused_agents["fingerprint"].is_string());
 
     // Change the rule then resume: status=changed, changed_sources includes it.
     overwrite_agents_rule(root.path(), "changed rule body");
@@ -2295,9 +2512,7 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
     .await;
     assert!(reused.success, "{:?}", reused.error);
     assert_eq!(reused.output["instructions"]["status"], "reused");
-    assert!(reused.output["instructions"]
-        .get("content_included")
-        .is_none());
+    assert_eq!(reused.output["instructions"]["content_included"], true);
 
     let (workflow_omitted, workflow_omitted_requests) = dispatch_recording_startup_requests(
         &runtime,

--- a/src/tool_runtime/tests/work_on_project.rs
+++ b/src/tool_runtime/tests/work_on_project.rs
@@ -2337,7 +2337,11 @@ async fn work_on_project_suppressed_instruction_bodies_still_track_changed_rules
         .unwrap()
         .to_string();
 
-    overwrite_agents_rule(root.path(), "new body while projection is suppressed");
+    let long_changed_body = std::iter::once("new body while projection is suppressed".to_string())
+        .chain((0..500).map(|index| format!("suppressed-line-{index}")))
+        .collect::<Vec<_>>()
+        .join("\n");
+    overwrite_agents_rule(root.path(), &long_changed_body);
     let changed = dispatch_start_coding_task_in_window(
         &runtime,
         "wop-suppressed-change",


### PR DESCRIPTION
## Summary

- replace the earlier window-receipt implementation with caller-explicit bootstrap projection controls
- keep `work_on_project` fully window-agnostic: Workflow Session continuity uses only the explicit `session_id`, never HTTP/MCP/window identity or credential-wide fallback
- keep `include_project_instructions=true` and `include_workflow_guidance=true` as safe defaults; callers may set either false only when their current model context already retains that static content
- continue re-observing repository instruction files and updating Workflow Session metadata even when instruction bodies are omitted from the model-facing response
- preserve sparse/default bootstrap output while keeping changed rules, warnings, blockers, noteworthy Job state, and other non-default state explicit
- suppress instruction continuation/read hints when the corresponding instruction content itself is intentionally omitted

## Why this was reworked

The previous E3b implementation used a process-local `(Workflow Session, stable window, workflow fingerprint)` receipt to infer that a model window had already received static workflow context. That assumption was rejected: transport/window identity is not reliable evidence that the current model context still retains a body of instructions.

The replacement deliberately separates the concepts:

- Workflow Session = durable business/task continuity
- transport/window identity = not a source of model-context truth
- caller-explicit include flags = the only authority for suppressing static model-facing bootstrap bodies

This remains correct when the same Workflow Session is continued from another window or when no stable window identity exists at all.

## Scope

Focused E3b only. This PR does not change Session collaboration, collaboration provenance, stateless MCP recorder metadata, Runtime Console messaging, Job observation delta behavior, execution authority, retry/idempotency, or stop semantics.

## Validation

- `cargo test work_on_project -p webcodex`: 34 passed, 0 failed
- `cargo fmt -- --check`: passed
- `git diff --check origin/main...HEAD`: passed
- exact base / merge-base: `7383010cf74045a3d74db2ffaae34fbecce74f52`
- reviewed head: `0244050305bd5bcdea599918f970633082f75644`

## Review state

The caller-explicit replacement has been independently reviewed. The previous window-receipt/store machinery was removed rather than retained as compatibility state.