### PR TITLE
Return only new Job observation output

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -271,6 +271,11 @@ poll it.
 The broader `local_coding` and `full_operator_runtime` MCP surfaces expose raw
 Job tools such as `job_status`, `job_log`, `validation_summary`, and
 `stop_job`; those tools are not part of the fourteen Connector capabilities.
+Return `job_log` / `observe_jobs` observation tokens unchanged: the first call
+returns a bounded baseline, later cursor-aware calls return only new log output,
+and `reset` returns a bounded recovery tail when continuity (including across a
+Server restart) cannot be proved. The token is observation state, never Job
+identity, retry authority, or execution identity.
 
 ## First safe prompt
 

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -244,6 +244,10 @@ validator 返回非零是断言失败。
 更宽的 `local_coding` 与 `full_operator_runtime` MCP surface 才暴露
 `job_status`、`job_log`、`validation_summary`、`stop_job` 等原始 Job 工具；这些
 工具不属于十四个 Connector capability。
+`job_log` / `observe_jobs` 返回的 observation token 必须原样回传：首次调用返回
+有界 baseline；后续 cursor-aware 调用只返回新增日志；如果无法证明连续性（包括
+Server 重启），`reset` 会返回有界 recovery tail。该 token 只是 observation
+state，绝不是 Job identity、retry authority 或 execution identity。
 
 ## 第一个安全 prompt
 

--- a/docs/agent/job-reliability-and-concurrency.md
+++ b/docs/agent/job-reliability-and-concurrency.md
@@ -213,6 +213,8 @@ description plus observation-field schemas should make clear that:
 - `after_observation_token` is an opaque observation cursor, not Job identity;
 - first log observation is a bounded baseline and cursor-aware follow-ups are
   delta-only when continuity is provable;
+- an unterminated final line is not conclusively consumed; a follow-up may
+  conservatively repeat that bounded partial line until a line boundary is observed;
 - `reset` is a bounded recovery refresh, not proof that no intervening output
   existed;
 - Control Server restart may invalidate the token while leaving `job_id` valid;

--- a/docs/agent/job-reliability-and-concurrency.md
+++ b/docs/agent/job-reliability-and-concurrency.md
@@ -17,7 +17,7 @@ Three identities have different lifetimes:
 |---|---|---|
 | MCP / HTTP request | One transport request or bounded wait | No. The connection/request may fail immediately. |
 | `job_id` | Identity of one already-dispatched execution | Yes, when the same reconciliation-capable Runner process survives and reports the Job in inventory. |
-| `after_observation_token` | Opaque cursor for one observed Job snapshot | No. Its Server epoch is process-local; a surviving Job should return a fresh token immediately after restart. |
+| `after_observation_token` | Opaque lifecycle and bounded log-delta state for one observed Job snapshot | No. Its Server epoch is process-local; a surviving Job should return a reset baseline and fresh token immediately after restart. |
 
 A dropped `observe_jobs`, `job_log`, or other MCP request therefore does **not**
 mean that the underlying Job was lost. The caller should keep the original
@@ -26,6 +26,14 @@ mean that the underlying Job was lost. The caller should keep the original
 Observation tokens are opaque. They must be returned unchanged by clients and
 must never become business identity, retry identity, authorization, or evidence
 that an execution no longer exists.
+
+The first log observation returns a bounded current baseline. A later
+cursor-aware token returns only newly observed stdout/stderr when continuity is
+provable, or empty tails when only lifecycle metadata changed. `reset` means
+continuity could not be proved (for example, retained logs advanced past the
+token or the Server epoch changed), so the response contains a bounded recovery
+tail and a new current token. One conservative repeat after a reset is expected;
+silently assuming missing output is not.
 
 ## 2. Control Server restart recovery contract
 
@@ -203,6 +211,10 @@ description plus observation-field schemas should make clear that:
 - observation never launches or retries the Job;
 - `wait_secs` is one bounded wait, not a subscription;
 - `after_observation_token` is an opaque observation cursor, not Job identity;
+- first log observation is a bounded baseline and cursor-aware follow-ups are
+  delta-only when continuity is provable;
+- `reset` is a bounded recovery refresh, not proof that no intervening output
+  existed;
 - Control Server restart may invalidate the token while leaving `job_id` valid;
 - a stale Server epoch should refresh immediately when the same Job has been
   reconciled;

--- a/src/job_observation.rs
+++ b/src/job_observation.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
-const TOKEN_PREFIX: &str = "wjob1";
+const LEGACY_TOKEN_PREFIX: &str = "wjob1";
+const TOKEN_V2_AGENT_PREFIX: &str = "wj2a";
+const TOKEN_V2_LOCAL_PREFIX: &str = "wj2l";
 pub(crate) const MAX_JOB_OBSERVATION_TOKEN_LEN: usize = 192;
 const MAX_JOB_ID_LEN: usize = 80;
 const MAX_EPOCH_LEN: usize = 64;
@@ -12,28 +14,51 @@ pub(crate) enum JobObservationExecutor {
 }
 
 impl JobObservationExecutor {
-    fn code(self) -> &'static str {
+    fn legacy_code(self) -> &'static str {
         match self {
             Self::Agent => "a",
             Self::Local => "l",
         }
     }
 
-    fn parse(value: &str) -> Result<Self, JobObservationTokenError> {
+    fn v2_prefix(self) -> &'static str {
+        match self {
+            Self::Agent => TOKEN_V2_AGENT_PREFIX,
+            Self::Local => TOKEN_V2_LOCAL_PREFIX,
+        }
+    }
+
+    fn parse_legacy(value: &str) -> Result<Self, JobObservationTokenError> {
         match value {
             "a" => Ok(Self::Agent),
             "l" => Ok(Self::Local),
             _ => Err(JobObservationTokenError::Malformed),
         }
     }
+
+    fn parse_v2_prefix(value: &str) -> Result<Self, JobObservationTokenError> {
+        match value {
+            TOKEN_V2_AGENT_PREFIX => Ok(Self::Agent),
+            TOKEN_V2_LOCAL_PREFIX => Ok(Self::Local),
+            _ => Err(JobObservationTokenError::Malformed),
+        }
+    }
 }
 
+/// Opaque, Job-bound model observation state.
+///
+/// Legacy `wjob1` tokens have no log cursor proof. Current `wj2*` tokens carry
+/// the next absolute stdout/stderr line that an automatic delta observation
+/// should inspect. These cursors are observation state only: they are not
+/// execution identity, authority, idempotency, or Runner protocol sequence.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct JobObservationToken {
     pub(crate) executor: JobObservationExecutor,
     pub(crate) job_id: String,
     pub(crate) epoch: String,
     pub(crate) revision: u64,
+    pub(crate) stdout_cursor: Option<u64>,
+    pub(crate) stderr_cursor: Option<u64>,
 }
 
 impl JobObservationToken {
@@ -42,12 +67,51 @@ impl JobObservationToken {
         job_id: impl Into<String>,
         epoch: impl Into<String>,
         revision: u64,
+        stdout_cursor: u64,
+        stderr_cursor: u64,
     ) -> Result<Self, JobObservationTokenError> {
+        Self::build(
+            executor,
+            job_id.into(),
+            epoch.into(),
+            revision,
+            Some(stdout_cursor),
+            Some(stderr_cursor),
+        )
+    }
+
+    pub(crate) fn new_legacy(
+        executor: JobObservationExecutor,
+        job_id: impl Into<String>,
+        epoch: impl Into<String>,
+        revision: u64,
+    ) -> Result<Self, JobObservationTokenError> {
+        Self::build(executor, job_id.into(), epoch.into(), revision, None, None)
+    }
+
+    fn build(
+        executor: JobObservationExecutor,
+        job_id: String,
+        epoch: String,
+        revision: u64,
+        stdout_cursor: Option<u64>,
+        stderr_cursor: Option<u64>,
+    ) -> Result<Self, JobObservationTokenError> {
+        if stdout_cursor.is_some() != stderr_cursor.is_some() {
+            return Err(JobObservationTokenError::Malformed);
+        }
+        if stdout_cursor.is_some_and(|cursor| cursor == 0)
+            || stderr_cursor.is_some_and(|cursor| cursor == 0)
+        {
+            return Err(JobObservationTokenError::Malformed);
+        }
         let token = Self {
             executor,
-            job_id: job_id.into(),
-            epoch: epoch.into(),
+            job_id,
+            epoch,
             revision,
+            stdout_cursor,
+            stderr_cursor,
         };
         validate_component(&token.job_id, MAX_JOB_ID_LEN)?;
         validate_component(&token.epoch, MAX_EPOCH_LEN)?;
@@ -64,11 +128,19 @@ impl JobObservationToken {
         if value.len() > MAX_JOB_OBSERVATION_TOKEN_LEN {
             return Err(JobObservationTokenError::Oversized);
         }
+        if value.starts_with("wjob1:") {
+            Self::parse_legacy(value)
+        } else {
+            Self::parse_v2(value)
+        }
+    }
+
+    fn parse_legacy(value: &str) -> Result<Self, JobObservationTokenError> {
         let mut parts = value.split(':');
-        if parts.next() != Some(TOKEN_PREFIX) {
+        if parts.next() != Some(LEGACY_TOKEN_PREFIX) {
             return Err(JobObservationTokenError::Malformed);
         }
-        let executor = JobObservationExecutor::parse(
+        let executor = JobObservationExecutor::parse_legacy(
             parts.next().ok_or(JobObservationTokenError::Malformed)?,
         )?;
         let job_id = parts
@@ -79,25 +151,44 @@ impl JobObservationToken {
             .next()
             .ok_or(JobObservationTokenError::Malformed)?
             .to_string();
-        let revision_text = parts.next().ok_or(JobObservationTokenError::Malformed)?;
-        if parts.next().is_some()
-            || revision_text.is_empty()
-            || (revision_text.len() > 1 && revision_text.starts_with('0'))
-            || !revision_text.bytes().all(|byte| byte.is_ascii_digit())
-        {
+        let revision = parse_decimal(parts.next().ok_or(JobObservationTokenError::Malformed)?)?;
+        if parts.next().is_some() {
             return Err(JobObservationTokenError::Malformed);
         }
-        validate_component(&job_id, MAX_JOB_ID_LEN)?;
-        validate_component(&epoch, MAX_EPOCH_LEN)?;
-        let revision = revision_text
-            .parse::<u64>()
-            .map_err(|_| JobObservationTokenError::Malformed)?;
-        let token = Self {
+        let token = Self::build(executor, job_id, epoch, revision, None, None)?;
+        if token.encode() != value {
+            return Err(JobObservationTokenError::Malformed);
+        }
+        Ok(token)
+    }
+
+    fn parse_v2(value: &str) -> Result<Self, JobObservationTokenError> {
+        let mut parts = value.split(':');
+        let executor = JobObservationExecutor::parse_v2_prefix(
+            parts.next().ok_or(JobObservationTokenError::Malformed)?,
+        )?;
+        let job_id = parts
+            .next()
+            .ok_or(JobObservationTokenError::Malformed)?
+            .to_string();
+        let epoch = parts
+            .next()
+            .ok_or(JobObservationTokenError::Malformed)?
+            .to_string();
+        let revision = parse_base36(parts.next().ok_or(JobObservationTokenError::Malformed)?)?;
+        let stdout_cursor = parse_base36(parts.next().ok_or(JobObservationTokenError::Malformed)?)?;
+        let stderr_cursor = parse_base36(parts.next().ok_or(JobObservationTokenError::Malformed)?)?;
+        if parts.next().is_some() {
+            return Err(JobObservationTokenError::Malformed);
+        }
+        let token = Self::build(
             executor,
             job_id,
             epoch,
             revision,
-        };
+            Some(stdout_cursor),
+            Some(stderr_cursor),
+        )?;
         if token.encode() != value {
             return Err(JobObservationTokenError::Malformed);
         }
@@ -119,15 +210,77 @@ impl JobObservationToken {
         Ok(token)
     }
 
-    pub(crate) fn encode(&self) -> String {
-        format!(
-            "{TOKEN_PREFIX}:{}:{}:{}:{}",
-            self.executor.code(),
-            self.job_id,
-            self.epoch,
-            self.revision
-        )
+    pub(crate) fn is_legacy(&self) -> bool {
+        self.stdout_cursor.is_none()
     }
+
+    pub(crate) fn encode(&self) -> String {
+        match (self.stdout_cursor, self.stderr_cursor) {
+            (Some(stdout_cursor), Some(stderr_cursor)) => format!(
+                "{}:{}:{}:{}:{}:{}",
+                self.executor.v2_prefix(),
+                self.job_id,
+                self.epoch,
+                encode_base36(self.revision),
+                encode_base36(stdout_cursor),
+                encode_base36(stderr_cursor),
+            ),
+            (None, None) => format!(
+                "{LEGACY_TOKEN_PREFIX}:{}:{}:{}:{}",
+                self.executor.legacy_code(),
+                self.job_id,
+                self.epoch,
+                self.revision
+            ),
+            _ => unreachable!("Job observation cursors are both present or both absent"),
+        }
+    }
+}
+
+fn parse_decimal(value: &str) -> Result<u64, JobObservationTokenError> {
+    if value.is_empty()
+        || (value.len() > 1 && value.starts_with('0'))
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(JobObservationTokenError::Malformed);
+    }
+    value
+        .parse::<u64>()
+        .map_err(|_| JobObservationTokenError::Malformed)
+}
+
+fn encode_base36(mut value: u64) -> String {
+    if value == 0 {
+        return "0".to_string();
+    }
+    let mut encoded = [0_u8; 13];
+    let mut index = encoded.len();
+    while value > 0 {
+        index -= 1;
+        let digit = (value % 36) as u8;
+        encoded[index] = if digit < 10 {
+            b'0' + digit
+        } else {
+            b'a' + digit - 10
+        };
+        value /= 36;
+    }
+    String::from_utf8(encoded[index..].to_vec()).expect("base36 is ASCII")
+}
+
+fn parse_base36(value: &str) -> Result<u64, JobObservationTokenError> {
+    if value.is_empty() || (value.len() > 1 && value.starts_with('0')) {
+        return Err(JobObservationTokenError::Malformed);
+    }
+    let parsed = value.bytes().try_fold(0_u64, |parsed, byte| {
+        let digit = match byte {
+            b'0'..=b'9' => u64::from(byte - b'0'),
+            b'a'..=b'z' => u64::from(byte - b'a' + 10),
+            _ => return None,
+        };
+        parsed.checked_mul(36)?.checked_add(digit)
+    });
+    parsed.ok_or(JobObservationTokenError::Malformed)
 }
 
 fn validate_component(value: &str, max_len: usize) -> Result<(), JobObservationTokenError> {
@@ -141,6 +294,132 @@ fn validate_component(value: &str, max_len: usize) -> Result<(), JobObservationT
         return Err(JobObservationTokenError::Malformed);
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JobLogDeltaStatus {
+    Baseline,
+    Delta,
+    Unchanged,
+    Reset,
+}
+
+impl JobLogDeltaStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+            Self::Delta => "delta",
+            Self::Unchanged => "unchanged",
+            Self::Reset => "reset",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JobLogSelectionMode {
+    Baseline,
+    Delta { cursor: u64 },
+    Reset,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JobLogStreamProjection {
+    pub(crate) text: String,
+    pub(crate) next_line: usize,
+    pub(crate) total_lines: usize,
+    pub(crate) returned_lines: usize,
+    pub(crate) first_retained_line: usize,
+    pub(crate) truncated: bool,
+    pub(crate) delta_reset: bool,
+}
+
+/// Select one bounded model-facing stream from an already frozen retained
+/// snapshot. Storage remains executor-specific; only baseline/delta/reset
+/// range semantics are shared.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn project_log_stream(
+    retained_text: &str,
+    first_retained_line: usize,
+    next_line: usize,
+    storage_truncated: bool,
+    tail_lines: Option<usize>,
+    mode: JobLogSelectionMode,
+    preserve_trailing_newline: bool,
+) -> JobLogStreamProjection {
+    let lines = retained_text.lines().collect::<Vec<_>>();
+    let first_retained_line = first_retained_line.max(1);
+    let expected_next = first_retained_line.saturating_add(lines.len());
+    let next_line = next_line.max(1);
+    let snapshot_consistent = next_line == expected_next;
+    let tail_bound = tail_lines.filter(|lines| *lines > 0);
+
+    let baseline_start = || {
+        tail_bound
+            .map(|tail| lines.len().saturating_sub(tail))
+            .unwrap_or(0)
+    };
+    let (start, delta_reset) = match mode {
+        JobLogSelectionMode::Baseline => (baseline_start(), false),
+        JobLogSelectionMode::Reset => (baseline_start(), true),
+        JobLogSelectionMode::Delta { cursor } => {
+            let cursor = usize::try_from(cursor).ok();
+            let continuous = snapshot_consistent
+                && cursor
+                    .is_some_and(|cursor| cursor >= first_retained_line && cursor <= next_line);
+            if !continuous {
+                (baseline_start(), true)
+            } else {
+                let delta_start = cursor
+                    .expect("continuous cursor is present")
+                    .saturating_sub(first_retained_line)
+                    .min(lines.len());
+                let bounded_start = tail_bound
+                    .map(|tail| lines.len().saturating_sub(tail).max(delta_start))
+                    .unwrap_or(delta_start);
+                (bounded_start, bounded_start > delta_start)
+            }
+        }
+    };
+    let selected = lines[start..].join("\n");
+    let text = if preserve_trailing_newline && !selected.is_empty() {
+        format!("{selected}\n")
+    } else {
+        selected
+    };
+    let baseline_or_reset = matches!(
+        mode,
+        JobLogSelectionMode::Baseline | JobLogSelectionMode::Reset
+    );
+    let truncated = baseline_or_reset
+        && (storage_truncated || first_retained_line > 1 || start > 0)
+        || delta_reset && matches!(mode, JobLogSelectionMode::Delta { .. }) && start > 0;
+    JobLogStreamProjection {
+        text,
+        next_line,
+        total_lines: next_line.saturating_sub(1),
+        returned_lines: lines.len().saturating_sub(start),
+        first_retained_line,
+        truncated,
+        delta_reset,
+    }
+}
+
+pub(crate) fn combined_delta_status(
+    mode: JobLogSelectionMode,
+    stdout: &JobLogStreamProjection,
+    stderr: &JobLogStreamProjection,
+) -> JobLogDeltaStatus {
+    match mode {
+        JobLogSelectionMode::Baseline => JobLogDeltaStatus::Baseline,
+        JobLogSelectionMode::Reset => JobLogDeltaStatus::Reset,
+        JobLogSelectionMode::Delta { .. } if stdout.delta_reset || stderr.delta_reset => {
+            JobLogDeltaStatus::Reset
+        }
+        JobLogSelectionMode::Delta { .. } if stdout.text.is_empty() && stderr.text.is_empty() => {
+            JobLogDeltaStatus::Unchanged
+        }
+        JobLogSelectionMode::Delta { .. } => JobLogDeltaStatus::Delta,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -173,40 +452,159 @@ mod tests {
     use super::*;
 
     #[test]
-    fn observation_token_round_trips_canonically() {
+    fn observation_token_v2_round_trips_canonically_with_independent_cursors() {
         let token = JobObservationToken::new(
             JobObservationExecutor::Agent,
             "11111111-2222-3333-4444-555555555555",
             "0123456789abcdef0123456789abcdef",
             42,
+            101,
+            21,
         )
         .unwrap();
         let encoded = token.encode();
+        assert!(encoded.starts_with("wj2a:"));
         assert!(encoded.len() <= MAX_JOB_OBSERVATION_TOKEN_LEN);
         assert_eq!(JobObservationToken::parse(&encoded).unwrap(), token);
+        assert_eq!(
+            JobObservationToken::parse(&encoded).unwrap().encode(),
+            encoded
+        );
+        assert_eq!(token.stdout_cursor, Some(101));
+        assert_eq!(token.stderr_cursor, Some(21));
     }
 
     #[test]
-    fn observation_token_rejects_wrong_job_and_malformed_values() {
+    fn observation_token_v2_maximum_components_fit_exact_existing_bound() {
+        let token = JobObservationToken::new(
+            JobObservationExecutor::Local,
+            "j".repeat(MAX_JOB_ID_LEN),
+            "e".repeat(MAX_EPOCH_LEN),
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+        )
+        .unwrap();
+        assert_eq!(token.encode().len(), MAX_JOB_OBSERVATION_TOKEN_LEN);
+        assert_eq!(JobObservationToken::parse(&token.encode()).unwrap(), token);
+    }
+
+    #[test]
+    fn observation_token_v2_rejects_wrong_binding_and_noncanonical_integers() {
         let encoded = JobObservationToken::new(
+            JobObservationExecutor::Local,
+            "job-one",
+            "0123456789abcdef",
+            36,
+            101,
+            21,
+        )
+        .unwrap()
+        .encode();
+        assert_eq!(
+            JobObservationToken::parse_bound(&encoded, JobObservationExecutor::Agent, "job-one"),
+            Err(JobObservationTokenError::WrongExecutor)
+        );
+        assert_eq!(
+            JobObservationToken::parse_bound(&encoded, JobObservationExecutor::Local, "job-two"),
+            Err(JobObservationTokenError::WrongJob)
+        );
+        for malformed in [
+            "wj2l:job:epoch:01:1:1",
+            "wj2l:job:epoch:1:01:1",
+            "wj2l:job:epoch:1:1:01",
+            "wj2l:job:epoch:A:1:1",
+            "wj2l:job:epoch:1:1",
+            "wj2l:job:epoch:1:1:1:extra",
+            "wj2x:job:epoch:1:1:1",
+            "wj2l:job:epoch:1:0:1",
+            "wj2l:job:epoch:1:1:0",
+        ] {
+            assert_eq!(
+                JobObservationToken::parse(malformed),
+                Err(JobObservationTokenError::Malformed),
+                "{malformed}"
+            );
+        }
+        assert_eq!(
+            JobObservationToken::parse(&"x".repeat(MAX_JOB_OBSERVATION_TOKEN_LEN + 1)),
+            Err(JobObservationTokenError::Oversized)
+        );
+    }
+
+    #[test]
+    fn legacy_observation_token_remains_canonical_and_has_no_cursor_proof() {
+        let legacy = JobObservationToken::new_legacy(
             JobObservationExecutor::Local,
             "job-one",
             "0123456789abcdef",
             1,
         )
-        .unwrap()
-        .encode();
-        assert_eq!(
-            JobObservationToken::parse_bound(&encoded, JobObservationExecutor::Local, "job-two"),
-            Err(JobObservationTokenError::WrongJob)
-        );
+        .unwrap();
+        let encoded = legacy.encode();
+        assert_eq!(encoded, "wjob1:l:job-one:0123456789abcdef:1");
+        let parsed = JobObservationToken::parse(&encoded).unwrap();
+        assert!(parsed.is_legacy());
+        assert_eq!(parsed.stdout_cursor, None);
+        assert_eq!(parsed.stderr_cursor, None);
+        assert_eq!(parsed.encode(), encoded);
         assert_eq!(
             JobObservationToken::parse("wjob1:l:job:epoch:01"),
             Err(JobObservationTokenError::Malformed)
         );
-        assert_eq!(
-            JobObservationToken::parse(&"x".repeat(MAX_JOB_OBSERVATION_TOKEN_LEN + 1)),
-            Err(JobObservationTokenError::Oversized)
+    }
+
+    #[test]
+    fn delta_projection_distinguishes_unchanged_delta_and_reset() {
+        let unchanged = project_log_stream(
+            "l8\nl9\nl10\n",
+            8,
+            11,
+            true,
+            Some(3),
+            JobLogSelectionMode::Delta { cursor: 11 },
+            true,
         );
+        assert_eq!(unchanged.text, "");
+        assert!(!unchanged.delta_reset);
+        assert!(!unchanged.truncated);
+
+        let delta = project_log_stream(
+            "l8\nl9\nl10\nl11\nl12\n",
+            8,
+            13,
+            true,
+            Some(3),
+            JobLogSelectionMode::Delta { cursor: 11 },
+            true,
+        );
+        assert_eq!(delta.text, "l11\nl12\n");
+        assert!(!delta.delta_reset);
+
+        let reset = project_log_stream(
+            "l8\nl9\nl10\n",
+            8,
+            11,
+            true,
+            Some(2),
+            JobLogSelectionMode::Delta { cursor: 3 },
+            false,
+        );
+        assert_eq!(reset.text, "l9\nl10");
+        assert!(reset.delta_reset);
+        assert!(reset.truncated);
+
+        let inconsistent_snapshot = project_log_stream(
+            "l8\nl9\nl10\n",
+            8,
+            99,
+            false,
+            Some(2),
+            JobLogSelectionMode::Delta { cursor: 11 },
+            false,
+        );
+        assert_eq!(inconsistent_snapshot.text, "l9\nl10");
+        assert_eq!(inconsistent_snapshot.next_line, 99);
+        assert!(inconsistent_snapshot.delta_reset);
     }
 }

--- a/src/job_observation.rs
+++ b/src/job_observation.rs
@@ -349,8 +349,18 @@ pub(crate) fn project_log_stream(
     let lines = retained_text.lines().collect::<Vec<_>>();
     let first_retained_line = first_retained_line.max(1);
     let expected_next = first_retained_line.saturating_add(lines.len());
-    let next_line = next_line.max(1);
-    let snapshot_consistent = next_line == expected_next;
+    let observed_next_line = next_line.max(1);
+    let snapshot_consistent = observed_next_line == expected_next;
+    // A visible final partial line is not conclusively consumed: later bytes
+    // may extend the same logical line without changing its absolute line count.
+    let next_line =
+        if snapshot_consistent && !retained_text.is_empty() && !retained_text.ends_with('\n') {
+            observed_next_line
+                .saturating_sub(1)
+                .max(first_retained_line)
+        } else {
+            observed_next_line
+        };
     let tail_bound = tail_lines.filter(|lines| *lines > 0);
 
     let baseline_start = || {
@@ -364,8 +374,9 @@ pub(crate) fn project_log_stream(
         JobLogSelectionMode::Delta { cursor } => {
             let cursor = usize::try_from(cursor).ok();
             let continuous = snapshot_consistent
-                && cursor
-                    .is_some_and(|cursor| cursor >= first_retained_line && cursor <= next_line);
+                && cursor.is_some_and(|cursor| {
+                    cursor >= first_retained_line && cursor <= observed_next_line
+                });
             if !continuous {
                 (baseline_start(), true)
             } else {
@@ -390,13 +401,12 @@ pub(crate) fn project_log_stream(
         mode,
         JobLogSelectionMode::Baseline | JobLogSelectionMode::Reset
     );
-    let truncated = baseline_or_reset
-        && (storage_truncated || first_retained_line > 1 || start > 0)
-        || delta_reset && matches!(mode, JobLogSelectionMode::Delta { .. }) && start > 0;
+    let truncated = (baseline_or_reset || delta_reset)
+        && (storage_truncated || first_retained_line > 1 || start > 0);
     JobLogStreamProjection {
         text,
         next_line,
-        total_lines: next_line.saturating_sub(1),
+        total_lines: observed_next_line.saturating_sub(1),
         returned_lines: lines.len().saturating_sub(start),
         first_retained_line,
         truncated,
@@ -606,5 +616,127 @@ mod tests {
         assert_eq!(inconsistent_snapshot.text, "l9\nl10");
         assert_eq!(inconsistent_snapshot.next_line, 99);
         assert!(inconsistent_snapshot.delta_reset);
+    }
+
+    #[test]
+    fn partial_final_line_remains_the_next_delta_cursor_until_completed() {
+        let baseline = project_log_stream(
+            "abc",
+            1,
+            2,
+            false,
+            Some(10),
+            JobLogSelectionMode::Baseline,
+            false,
+        );
+        assert_eq!(baseline.text, "abc");
+        assert_eq!(baseline.next_line, 1);
+        assert_eq!(baseline.total_lines, 1);
+
+        let first_growth = project_log_stream(
+            "abcdef",
+            1,
+            2,
+            false,
+            Some(10),
+            JobLogSelectionMode::Delta {
+                cursor: baseline.next_line as u64,
+            },
+            false,
+        );
+        assert_eq!(first_growth.text, "abcdef");
+        assert_eq!(first_growth.next_line, 1);
+        assert!(!first_growth.delta_reset);
+
+        let second_growth = project_log_stream(
+            "abcdefgh",
+            1,
+            2,
+            false,
+            Some(10),
+            JobLogSelectionMode::Delta {
+                cursor: first_growth.next_line as u64,
+            },
+            false,
+        );
+        assert_eq!(second_growth.text, "abcdefgh");
+        assert_eq!(second_growth.next_line, 1);
+
+        let completed = project_log_stream(
+            "abcdefgh\n",
+            1,
+            2,
+            false,
+            Some(10),
+            JobLogSelectionMode::Delta {
+                cursor: second_growth.next_line as u64,
+            },
+            false,
+        );
+        assert_eq!(completed.text, "abcdefgh");
+        assert_eq!(completed.next_line, 2);
+        assert_eq!(completed.total_lines, 1);
+
+        let unchanged = project_log_stream(
+            "abcdefgh\n",
+            1,
+            2,
+            false,
+            Some(10),
+            JobLogSelectionMode::Delta {
+                cursor: completed.next_line as u64,
+            },
+            false,
+        );
+        assert_eq!(unchanged.text, "");
+        assert_eq!(unchanged.next_line, 2);
+    }
+
+    #[test]
+    fn partial_line_cursors_remain_independent_between_streams() {
+        let stdout = project_log_stream(
+            "stdout partial",
+            1,
+            2,
+            false,
+            Some(10),
+            JobLogSelectionMode::Delta { cursor: 1 },
+            false,
+        );
+        let stderr = project_log_stream(
+            "stderr complete\n",
+            1,
+            2,
+            false,
+            Some(10),
+            JobLogSelectionMode::Delta { cursor: 2 },
+            false,
+        );
+        assert_eq!(stdout.text, "stdout partial");
+        assert_eq!(stdout.next_line, 1);
+        assert_eq!(stderr.text, "");
+        assert_eq!(stderr.next_line, 2);
+        assert_eq!(
+            combined_delta_status(JobLogSelectionMode::Delta { cursor: 1 }, &stdout, &stderr),
+            JobLogDeltaStatus::Delta
+        );
+    }
+
+    #[test]
+    fn retention_gap_reset_reports_truncation_even_when_all_retained_lines_fit() {
+        let reset = project_log_stream(
+            "l8\nl9\nl10\n",
+            8,
+            11,
+            true,
+            Some(10),
+            JobLogSelectionMode::Delta { cursor: 3 },
+            false,
+        );
+        assert_eq!(reset.text, "l8\nl9\nl10");
+        assert!(reset.delta_reset);
+        assert!(reset.truncated);
+        assert_eq!(reset.first_retained_line, 8);
+        assert_eq!(reset.returned_lines, 3);
     }
 }

--- a/src/shell_client/job_updates.rs
+++ b/src/shell_client/job_updates.rs
@@ -83,6 +83,195 @@ impl Default for JobLogWait {
     }
 }
 
+/// Frozen Server-side observation details accompanying one public Job log
+/// projection. The analysis context is bounded by the retained Server log and
+/// is consumed only by validation/summary projection; it is never repeated as
+/// model-facing output when the delta is empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShellJobLogObservation {
+    pub(crate) wait: JobLogWait,
+    pub(crate) log_delta_status: crate::job_observation::JobLogDeltaStatus,
+    pub(crate) stdout_delta_reset: bool,
+    pub(crate) stderr_delta_reset: bool,
+    pub(crate) stdout_truncated: bool,
+    pub(crate) stderr_truncated: bool,
+    pub(crate) stdout_returned_lines: usize,
+    pub(crate) stderr_returned_lines: usize,
+    pub(crate) analysis_stdout: String,
+    pub(crate) analysis_stderr: String,
+    pub(crate) analysis_truncated: bool,
+}
+
+impl std::ops::Deref for ShellJobLogObservation {
+    type Target = JobLogWait;
+
+    fn deref(&self) -> &Self::Target {
+        &self.wait
+    }
+}
+
+impl Default for ShellJobLogObservation {
+    fn default() -> Self {
+        Self {
+            wait: JobLogWait::default(),
+            log_delta_status: crate::job_observation::JobLogDeltaStatus::Baseline,
+            stdout_delta_reset: false,
+            stderr_delta_reset: false,
+            stdout_truncated: false,
+            stderr_truncated: false,
+            stdout_returned_lines: 0,
+            stderr_returned_lines: 0,
+            analysis_stdout: String::new(),
+            analysis_stderr: String::new(),
+            analysis_truncated: false,
+        }
+    }
+}
+
+fn frozen_shell_job_log_projection(
+    job: &ShellJobRecord,
+    after: Option<&crate::job_observation::JobObservationToken>,
+    since_stdout_line: Option<usize>,
+    since_stderr_line: Option<usize>,
+    tail_lines: Option<usize>,
+    wait: JobLogWait,
+) -> (
+    ShellJobInfo,
+    Option<String>,
+    Option<String>,
+    usize,
+    usize,
+    ShellJobLogObservation,
+) {
+    let (analysis_stdout, _, _, analysis_stdout_truncated) =
+        select_log_lines(&job.stdout, None, None);
+    let (analysis_stderr, _, _, analysis_stderr_truncated) =
+        select_log_lines(&job.stderr, None, None);
+    let analysis_stdout = analysis_stdout.unwrap_or_default();
+    let analysis_stderr = analysis_stderr.unwrap_or_default();
+    let analysis_truncated = analysis_stdout_truncated
+        || analysis_stderr_truncated
+        || job.stdout.first_retained_line > 1
+        || job.stderr.first_retained_line > 1;
+    let explicit_paging = since_stdout_line.is_some() || since_stderr_line.is_some();
+
+    if explicit_paging {
+        // Preserve the established explicit cursor/tail precedence exactly.
+        // The cursor-less token prevents a later automatic observation from
+        // assuming that this explicit page represented complete log receipt.
+        let (stdout, next_stdout_line, _, stdout_truncated) =
+            select_log_lines(&job.stdout, since_stdout_line, tail_lines);
+        let (stderr, next_stderr_line, _, stderr_truncated) =
+            select_log_lines(&job.stderr, since_stderr_line, tail_lines);
+        let mut view = job_view(job);
+        view.observation_token = crate::job_observation::JobObservationToken::new_legacy(
+            crate::job_observation::JobObservationExecutor::Agent,
+            job.job_id.clone(),
+            job.observation_epoch.to_string(),
+            job.public_revision.load(Ordering::Relaxed),
+        )
+        .ok()
+        .map(|token| token.encode());
+        let observation = ShellJobLogObservation {
+            wait,
+            log_delta_status: crate::job_observation::JobLogDeltaStatus::Baseline,
+            stdout_delta_reset: false,
+            stderr_delta_reset: false,
+            stdout_truncated,
+            stderr_truncated,
+            stdout_returned_lines: stdout.as_deref().unwrap_or_default().lines().count(),
+            stderr_returned_lines: stderr.as_deref().unwrap_or_default().lines().count(),
+            analysis_stdout,
+            analysis_stderr,
+            analysis_truncated,
+        };
+        return (
+            view,
+            stdout,
+            stderr,
+            next_stdout_line,
+            next_stderr_line,
+            observation,
+        );
+    }
+
+    let epoch_matches = after.is_none_or(|token| token.epoch == job.observation_epoch.as_ref());
+    let base_mode = match after {
+        None => crate::job_observation::JobLogSelectionMode::Baseline,
+        Some(token) if token.is_legacy() || !epoch_matches => {
+            crate::job_observation::JobLogSelectionMode::Reset
+        }
+        Some(token) => crate::job_observation::JobLogSelectionMode::Delta {
+            cursor: token
+                .stdout_cursor
+                .expect("cursor-aware token has stdout cursor"),
+        },
+    };
+    let stderr_mode = match after {
+        None => crate::job_observation::JobLogSelectionMode::Baseline,
+        Some(token) if token.is_legacy() || !epoch_matches => {
+            crate::job_observation::JobLogSelectionMode::Reset
+        }
+        Some(token) => crate::job_observation::JobLogSelectionMode::Delta {
+            cursor: token
+                .stderr_cursor
+                .expect("cursor-aware token has stderr cursor"),
+        },
+    };
+    let stdout = crate::job_observation::project_log_stream(
+        &job.stdout.tail,
+        job.stdout.first_retained_line,
+        job.stdout.next_line,
+        job.stdout.truncated,
+        tail_lines,
+        base_mode,
+        true,
+    );
+    let stderr = crate::job_observation::project_log_stream(
+        &job.stderr.tail,
+        job.stderr.first_retained_line,
+        job.stderr.next_line,
+        job.stderr.truncated,
+        tail_lines,
+        stderr_mode,
+        true,
+    );
+    let mut view = job_view(job);
+    view.observation_token = crate::job_observation::JobObservationToken::new(
+        crate::job_observation::JobObservationExecutor::Agent,
+        job.job_id.clone(),
+        job.observation_epoch.to_string(),
+        job.public_revision.load(Ordering::Relaxed),
+        stdout.next_line as u64,
+        stderr.next_line as u64,
+    )
+    .ok()
+    .map(|token| token.encode());
+    let observation = ShellJobLogObservation {
+        wait,
+        log_delta_status: crate::job_observation::combined_delta_status(
+            base_mode, &stdout, &stderr,
+        ),
+        stdout_delta_reset: stdout.delta_reset,
+        stderr_delta_reset: stderr.delta_reset,
+        stdout_truncated: stdout.truncated,
+        stderr_truncated: stderr.truncated,
+        stdout_returned_lines: stdout.returned_lines,
+        stderr_returned_lines: stderr.returned_lines,
+        analysis_stdout,
+        analysis_stderr,
+        analysis_truncated,
+    };
+    (
+        view,
+        Some(stdout.text),
+        Some(stderr.text),
+        stdout.next_line,
+        stderr.next_line,
+        observation,
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct JobPublicMutationSignature {
     status: String,
@@ -1342,7 +1531,7 @@ impl ShellClientRegistry {
             Option<String>,
             usize,
             usize,
-            JobLogWait,
+            ShellJobLogObservation,
         ),
         String,
     > {
@@ -1395,16 +1584,12 @@ impl ShellClientRegistry {
                     changed,
                     terminal,
                 };
-                let (stdout, next_stdout_line, _, _) =
-                    select_log_lines(&job.stdout, since_stdout_line, tail_lines);
-                let (stderr, next_stderr_line, _, _) =
-                    select_log_lines(&job.stderr, since_stderr_line, tail_lines);
-                return Ok((
-                    job_view(job),
-                    stdout,
-                    stderr,
-                    next_stdout_line,
-                    next_stderr_line,
+                return Ok(frozen_shell_job_log_projection(
+                    job,
+                    after.as_ref(),
+                    since_stdout_line,
+                    since_stderr_line,
+                    tail_lines,
                     wait,
                 ));
             }
@@ -1439,16 +1624,12 @@ impl ShellClientRegistry {
                     changed,
                     terminal,
                 };
-                let (stdout, next_stdout_line, _, _) =
-                    select_log_lines(&job.stdout, since_stdout_line, tail_lines);
-                let (stderr, next_stderr_line, _, _) =
-                    select_log_lines(&job.stderr, since_stderr_line, tail_lines);
-                return Ok((
-                    job_view(job),
-                    stdout,
-                    stderr,
-                    next_stdout_line,
-                    next_stderr_line,
+                return Ok(frozen_shell_job_log_projection(
+                    job,
+                    after.as_ref(),
+                    since_stdout_line,
+                    since_stderr_line,
+                    tail_lines,
                     wait,
                 ));
             }
@@ -1490,16 +1671,12 @@ impl ShellClientRegistry {
                     changed,
                     terminal,
                 };
-                let (stdout, next_stdout_line, _, _) =
-                    select_log_lines(&job.stdout, since_stdout_line, tail_lines);
-                let (stderr, next_stderr_line, _, _) =
-                    select_log_lines(&job.stderr, since_stderr_line, tail_lines);
-                return Ok((
-                    job_view(job),
-                    stdout,
-                    stderr,
-                    next_stdout_line,
-                    next_stderr_line,
+                return Ok(frozen_shell_job_log_projection(
+                    job,
+                    after.as_ref(),
+                    since_stdout_line,
+                    since_stderr_line,
+                    tail_lines,
                     wait,
                 ));
             }

--- a/src/shell_client/jobs.rs
+++ b/src/shell_client/jobs.rs
@@ -325,7 +325,10 @@ pub(super) fn job_view(job: &ShellJobRecord) -> ShellJobInfo {
         recovered_after_server_restart: job.recovered_after_server_restart,
         reconciled_at: job.reconciled_at,
         recovery_reason_code: job.recovery_reason_code.clone(),
-        observation_token: crate::job_observation::JobObservationToken::new(
+        // General lifecycle views do not project log bodies, so they retain a
+        // cursor-less legacy token. `job_log_for_auth` replaces this with a
+        // cursor-aware v2 token for its frozen returned log snapshot.
+        observation_token: crate::job_observation::JobObservationToken::new_legacy(
             crate::job_observation::JobObservationExecutor::Agent,
             job.job_id.clone(),
             job.observation_epoch.to_string(),

--- a/src/shell_client/mod_tests/job_log_wait.rs
+++ b/src/shell_client/mod_tests/job_log_wait.rs
@@ -682,6 +682,196 @@ async fn agent_job_log_observation_is_baseline_then_independent_deltas() {
 }
 
 #[tokio::test]
+async fn agent_job_log_replays_partial_lines_until_each_stream_completes() {
+    let registry = ShellClientRegistry::default();
+    let job = start_wait_job(&registry).await;
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            1,
+            "running",
+            Some("abc"),
+            false,
+        ))
+        .await
+        .unwrap();
+
+    let (baseline_job, stdout, stderr, _, _, baseline) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        baseline.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Baseline
+    );
+    assert_eq!(stdout.as_deref(), Some("abc\n"));
+    assert_eq!(stderr.as_deref(), Some(""));
+    let token0 = baseline_job.observation_token.unwrap();
+    let parsed0 = crate::job_observation::JobObservationToken::parse(&token0).unwrap();
+    assert_eq!(parsed0.stdout_cursor, Some(1));
+    assert_eq!(parsed0.stderr_cursor, Some(1));
+
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            2,
+            "running",
+            Some("def"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let (first_job, stdout, _, _, _, first_growth) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), Some(&token0), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        first_growth.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some("abcdef\n"));
+    let token1 = first_job.observation_token.unwrap();
+    assert_eq!(
+        crate::job_observation::JobObservationToken::parse(&token1)
+            .unwrap()
+            .stdout_cursor,
+        Some(1)
+    );
+
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            3,
+            "running",
+            Some("ghi"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let (second_job, stdout, _, _, _, second_growth) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), Some(&token1), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        second_growth.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some("abcdefghi\n"));
+    let token2 = second_job.observation_token.unwrap();
+    assert_eq!(
+        crate::job_observation::JobObservationToken::parse(&token2)
+            .unwrap()
+            .stdout_cursor,
+        Some(1)
+    );
+
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            4,
+            "running",
+            Some("\n"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let (completed_stdout_job, stdout, _, _, _, completed_stdout) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), Some(&token2), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        completed_stdout.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some("abcdefghi\n"));
+    let token3 = completed_stdout_job.observation_token.unwrap();
+    let parsed3 = crate::job_observation::JobObservationToken::parse(&token3).unwrap();
+    assert_eq!(parsed3.stdout_cursor, Some(2));
+    assert_eq!(parsed3.stderr_cursor, Some(1));
+
+    registry
+        .update_job(ShellAgentJobUpdateRequest {
+            client_id: "oe".into(),
+            agent_instance_id: "inst-wait".into(),
+            job_id: job.job_id.clone(),
+            request_id: None,
+            update_seq: Some(5),
+            status: "running".into(),
+            stdout_chunk: None,
+            stderr_chunk: Some("err".into()),
+            stdout_tail: None,
+            stderr_tail: None,
+            log_snapshot: None,
+            exit_code: None,
+            duration_ms: None,
+            error: None,
+            command_execution_state: None,
+            validation_progress: None,
+            finished: false,
+        })
+        .await
+        .unwrap();
+    let (stderr_job, stdout, stderr, _, _, stderr_growth) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), Some(&token3), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        stderr_growth.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some("err\n"));
+    let token4 = stderr_job.observation_token.unwrap();
+    let parsed4 = crate::job_observation::JobObservationToken::parse(&token4).unwrap();
+    assert_eq!(parsed4.stdout_cursor, Some(2));
+    assert_eq!(parsed4.stderr_cursor, Some(1));
+
+    registry
+        .update_job(ShellAgentJobUpdateRequest {
+            client_id: "oe".into(),
+            agent_instance_id: "inst-wait".into(),
+            job_id: job.job_id.clone(),
+            request_id: None,
+            update_seq: Some(6),
+            status: "completed".into(),
+            stdout_chunk: None,
+            stderr_chunk: Some("or\n".into()),
+            stdout_tail: None,
+            stderr_tail: None,
+            log_snapshot: None,
+            exit_code: Some(0),
+            duration_ms: Some(2_000),
+            error: None,
+            command_execution_state: None,
+            validation_progress: None,
+            finished: true,
+        })
+        .await
+        .unwrap();
+    let (terminal_job, stdout, stderr, _, _, terminal) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), Some(&token4), None)
+        .await
+        .unwrap();
+    assert!(terminal.terminal);
+    assert_eq!(terminal_job.status, "completed");
+    assert_eq!(
+        terminal.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some("error\n"));
+    let terminal_token = terminal_job.observation_token.unwrap();
+    let parsed_terminal =
+        crate::job_observation::JobObservationToken::parse(&terminal_token).unwrap();
+    assert_eq!(parsed_terminal.stdout_cursor, Some(2));
+    assert_eq!(parsed_terminal.stderr_cursor, Some(2));
+}
+
+#[tokio::test]
 async fn agent_job_log_resets_when_retention_advances_past_token_cursor() {
     let registry = ShellClientRegistry::default();
     let job = start_wait_job(&registry).await;

--- a/src/shell_client/mod_tests/job_log_wait.rs
+++ b/src/shell_client/mod_tests/job_log_wait.rs
@@ -164,8 +164,12 @@ async fn job_log_wait_server_transition_between_calls_is_immediate() {
 async fn job_log_wait_epoch_mismatch_refreshes_immediately() {
     let registry = ShellClientRegistry::default();
     let job = start_wait_job(&registry).await;
+    let (baseline, _, _, _, _, _) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), None, None)
+        .await
+        .unwrap();
     let parsed = crate::job_observation::JobObservationToken::parse(
-        job.observation_token.as_deref().unwrap(),
+        baseline.observation_token.as_deref().unwrap(),
     )
     .unwrap();
     let stale = crate::job_observation::JobObservationToken::new(
@@ -173,6 +177,8 @@ async fn job_log_wait_epoch_mismatch_refreshes_immediately() {
         job.job_id.clone(),
         "ffffffffffffffffffffffffffffffff",
         parsed.revision,
+        parsed.stdout_cursor.unwrap(),
+        parsed.stderr_cursor.unwrap(),
     )
     .unwrap()
     .encode();
@@ -183,6 +189,10 @@ async fn job_log_wait_epoch_mismatch_refreshes_immediately() {
         .unwrap();
     assert_eq!(wait.wait_outcome, JobLogWaitOutcome::Immediate);
     assert!(wait.changed);
+    assert_eq!(
+        wait.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Reset
+    );
     assert!(started.elapsed() < std::time::Duration::from_secs(1));
 }
 
@@ -503,6 +513,281 @@ async fn job_log_wait_legacy_update_between_calls_and_noop_replacement() {
     let token1 = info.observation_token.unwrap();
     registry.update_job(update()).await.unwrap();
     let current = registry.get_job(&job.job_id).await.unwrap();
-    assert_eq!(current.observation_token.as_deref(), Some(token1.as_str()));
+    let response_token = crate::job_observation::JobObservationToken::parse(&token1).unwrap();
+    let lifecycle_token = crate::job_observation::JobObservationToken::parse(
+        current.observation_token.as_deref().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(response_token.epoch, lifecycle_token.epoch);
+    assert_eq!(response_token.revision, lifecycle_token.revision);
+    assert_eq!(response_token.stdout_cursor, Some(2));
+    assert_eq!(response_token.stderr_cursor, Some(1));
     assert_eq!(current.last_update_seq, Some(0));
+}
+
+#[tokio::test]
+async fn agent_job_log_observation_is_baseline_then_independent_deltas() {
+    let registry = ShellClientRegistry::default();
+    let job = start_wait_job(&registry).await;
+    let stdout = (1..=10)
+        .map(|line| format!("stdout {line}\n"))
+        .collect::<String>();
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            1,
+            "running",
+            Some(&stdout),
+            false,
+        ))
+        .await
+        .unwrap();
+
+    let (baseline_job, stdout, stderr, _, _, baseline) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(20), None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        baseline.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Baseline
+    );
+    assert!(stdout.as_deref().unwrap().starts_with("stdout 1\n"));
+    assert_eq!(stderr.as_deref(), Some(""));
+    let token0 = baseline_job.observation_token.unwrap();
+    let parsed0 = crate::job_observation::JobObservationToken::parse(&token0).unwrap();
+    assert_eq!(parsed0.stdout_cursor, Some(11));
+    assert_eq!(parsed0.stderr_cursor, Some(1));
+
+    let (same_job, stdout, stderr, _, _, unchanged) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(20), Some(&token0), None)
+        .await
+        .unwrap();
+    assert!(!unchanged.changed);
+    assert_eq!(
+        unchanged.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Unchanged
+    );
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some(""));
+    assert_eq!(same_job.observation_token.as_deref(), Some(token0.as_str()));
+
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            2,
+            "running",
+            Some("stdout 11\nstdout 12\nstdout 13\n"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let (stdout_job, stdout, stderr, _, _, stdout_delta) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(20), Some(&token0), None)
+        .await
+        .unwrap();
+    assert!(stdout_delta.changed);
+    assert_eq!(
+        stdout_delta.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some("stdout 11\nstdout 12\nstdout 13\n"));
+    assert_eq!(stderr.as_deref(), Some(""));
+    let token1 = stdout_job.observation_token.unwrap();
+
+    registry
+        .update_job(ShellAgentJobUpdateRequest {
+            client_id: "oe".into(),
+            agent_instance_id: "inst-wait".into(),
+            job_id: job.job_id.clone(),
+            request_id: None,
+            update_seq: Some(3),
+            status: "running".into(),
+            stdout_chunk: None,
+            stderr_chunk: Some("stderr 1\nstderr 2\n".into()),
+            stdout_tail: None,
+            stderr_tail: None,
+            log_snapshot: None,
+            exit_code: None,
+            duration_ms: None,
+            error: None,
+            command_execution_state: None,
+            validation_progress: None,
+            finished: false,
+        })
+        .await
+        .unwrap();
+    let (stderr_job, stdout, stderr, _, _, stderr_delta) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(20), Some(&token1), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        stderr_delta.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some("stderr 1\nstderr 2\n"));
+    let token2 = stderr_job.observation_token.unwrap();
+
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            4,
+            "running",
+            None,
+            false,
+        ))
+        .await
+        .unwrap();
+    let (lifecycle_job, stdout, stderr, _, _, lifecycle) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(20), Some(&token2), None)
+        .await
+        .unwrap();
+    assert!(lifecycle.changed);
+    assert_eq!(
+        lifecycle.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Unchanged
+    );
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some(""));
+    let token3 = lifecycle_job.observation_token.unwrap();
+
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            5,
+            "completed",
+            None,
+            true,
+        ))
+        .await
+        .unwrap();
+    let (terminal_job, stdout, stderr, _, _, terminal) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(20), Some(&token3), None)
+        .await
+        .unwrap();
+    assert!(terminal.changed);
+    assert!(terminal.terminal);
+    assert_eq!(terminal_job.status, "completed");
+    assert_eq!(terminal_job.exit_code, Some(0));
+    assert_eq!(
+        terminal.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Unchanged
+    );
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some(""));
+}
+
+#[tokio::test]
+async fn agent_job_log_resets_when_retention_advances_past_token_cursor() {
+    let registry = ShellClientRegistry::default();
+    let job = start_wait_job(&registry).await;
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            1,
+            "running",
+            Some("first\n"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let (baseline_job, _, _, _, _, _) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), None, None)
+        .await
+        .unwrap();
+    let token = baseline_job.observation_token.unwrap();
+    let large = "discarded line\n".repeat(30_000);
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            2,
+            "running",
+            Some(&large),
+            false,
+        ))
+        .await
+        .unwrap();
+    let (current, stdout, _, _, _, reset) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(3), Some(&token), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        reset.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Reset
+    );
+    assert!(reset.stdout_delta_reset);
+    assert!(reset.stdout_truncated);
+    assert_eq!(stdout.as_deref().unwrap().lines().count(), 3);
+    assert!(current.stdout_retained_from_line.unwrap() > 2);
+    assert!(current.stdout_log_truncated);
+}
+
+#[tokio::test]
+async fn agent_job_log_bounded_wait_uses_v2_delta_and_timeout_is_empty() {
+    let registry = ShellClientRegistry::default();
+    let job = start_wait_job(&registry).await;
+    let (baseline_job, _, _, _, _, _) = registry
+        .job_log_for_auth(None, &job.job_id, None, None, Some(10), None, None)
+        .await
+        .unwrap();
+    let token0 = baseline_job.observation_token.unwrap();
+    let task = tokio::spawn({
+        let registry = registry.clone();
+        let job_id = job.job_id.clone();
+        let token0 = token0.clone();
+        async move {
+            registry
+                .job_log_for_auth(None, &job_id, None, None, Some(10), Some(&token0), Some(5))
+                .await
+                .unwrap()
+        }
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    registry
+        .update_job(wait_job_update(
+            "inst-wait",
+            &job.job_id,
+            1,
+            "running",
+            Some("new\n"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let (updated_job, stdout, stderr, _, _, updated) = task.await.unwrap();
+    assert_eq!(updated.wait_outcome, JobLogWaitOutcome::Updated);
+    assert_eq!(
+        updated.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Delta
+    );
+    assert_eq!(stdout.as_deref(), Some("new\n"));
+    assert_eq!(stderr.as_deref(), Some(""));
+    let token1 = updated_job.observation_token.unwrap();
+
+    let (_, stdout, stderr, _, _, timed_out) = registry
+        .job_log_for_auth(
+            None,
+            &job.job_id,
+            None,
+            None,
+            Some(10),
+            Some(&token1),
+            Some(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(timed_out.wait_outcome, JobLogWaitOutcome::Timeout);
+    assert!(!timed_out.changed);
+    assert_eq!(
+        timed_out.log_delta_status,
+        crate::job_observation::JobLogDeltaStatus::Unchanged
+    );
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some(""));
 }

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -7,8 +7,8 @@ use super::helpers::{
     resolve_local_cwd, shell_escape_simple, validate_raw_shell_command_length, MAX_LOCAL_LOG_LINES,
 };
 use super::local_jobs::{
-    retain_inspect_job_until_terminal, LocalJobKiller, LocalJobRecord, TerminateOutcome,
-    ACTIVE_JOB_STATUSES, ACTIVE_LOCAL_STATUSES,
+    retain_inspect_job_until_terminal, LocalJobKiller, LocalJobLogSnapshot, LocalJobRecord,
+    TerminateOutcome, ACTIVE_JOB_STATUSES, ACTIVE_LOCAL_STATUSES,
 };
 use super::tool_result::ToolResult;
 use super::{ExecutionPurpose, ExecutionShell, ToolRuntime};
@@ -357,18 +357,27 @@ fn local_read_trim(record: &LocalJobRecord, name: &str) -> Option<String> {
 async fn local_read_log_pair(
     record: LocalJobRecord,
     offset: Option<usize>,
-    tail_lines: Option<usize>,
     stdout_len: u64,
     stderr_len: u64,
-) -> ((String, usize, usize, bool), (String, usize, usize, bool)) {
+) -> (LocalJobLogSnapshot, LocalJobLogSnapshot) {
     tokio::task::spawn_blocking(move || {
         (
-            record.read_log_lines_at("stdout.log", offset, tail_lines, stdout_len),
-            record.read_log_lines_at("stderr.log", offset, tail_lines, stderr_len),
+            record.read_log_snapshot_at("stdout.log", offset, stdout_len),
+            record.read_log_snapshot_at("stderr.log", offset, stderr_len),
         )
     })
     .await
-    .unwrap_or_else(|_| ((String::new(), 1, 0, false), (String::new(), 1, 0, false)))
+    .ok()
+    .and_then(|(stdout, stderr)| Some((stdout?, stderr?)))
+    .unwrap_or_else(|| {
+        let empty = || LocalJobLogSnapshot {
+            retained_text: String::new(),
+            total_lines: 0,
+            first_retained_line: 1,
+            truncated: false,
+        };
+        (empty(), empty())
+    })
 }
 
 fn local_runtime_deadline(meta: &Value) -> Option<tokio::time::Instant> {
@@ -637,10 +646,6 @@ pub(crate) async fn local_job_log(
     if wait_outcome == "timeout" {
         changed = false;
     }
-    let observation_token = match observation.token(job_id) {
-        Ok(token) => token,
-        Err(error) => return ToolResult::err(error),
-    };
     let frozen_stdout_len = observation.stdout_len;
     let frozen_stderr_len = observation.stderr_len;
     let final_exit_code = if final_terminal {
@@ -648,14 +653,140 @@ pub(crate) async fn local_job_log(
     } else {
         None
     };
-    let (stdout, stderr) = local_read_log_pair(
+    let explicit_paging = offset.is_some();
+    let (stdout_snapshot, stderr_snapshot) = local_read_log_pair(
         record.clone(),
-        offset,
-        tail_lines,
+        if explicit_paging { offset } else { None },
         frozen_stdout_len,
         frozen_stderr_len,
     )
     .await;
+    let (analysis_stdout_snapshot, analysis_stderr_snapshot) = if explicit_paging {
+        local_read_log_pair(record.clone(), None, frozen_stdout_len, frozen_stderr_len).await
+    } else {
+        (stdout_snapshot.clone(), stderr_snapshot.clone())
+    };
+    let analysis_stdout = crate::job_observation::project_log_stream(
+        &analysis_stdout_snapshot.retained_text,
+        analysis_stdout_snapshot.first_retained_line,
+        analysis_stdout_snapshot.total_lines.saturating_add(1),
+        analysis_stdout_snapshot.truncated,
+        Some(MAX_LOCAL_LOG_LINES),
+        crate::job_observation::JobLogSelectionMode::Baseline,
+        false,
+    );
+    let analysis_stderr = crate::job_observation::project_log_stream(
+        &analysis_stderr_snapshot.retained_text,
+        analysis_stderr_snapshot.first_retained_line,
+        analysis_stderr_snapshot.total_lines.saturating_add(1),
+        analysis_stderr_snapshot.truncated,
+        Some(MAX_LOCAL_LOG_LINES),
+        crate::job_observation::JobLogSelectionMode::Baseline,
+        false,
+    );
+    let (
+        stdout,
+        stderr,
+        log_delta_status,
+        observation_token,
+        stdout_delta_reset,
+        stderr_delta_reset,
+    ) = if explicit_paging {
+        let stdout = stdout_snapshot.read_lines(offset, tail_lines);
+        let stderr = stderr_snapshot.read_lines(offset, tail_lines);
+        let stdout = crate::job_observation::JobLogStreamProjection {
+            returned_lines: stdout.0.lines().count(),
+            text: stdout.0,
+            next_line: stdout.1,
+            total_lines: stdout.2,
+            first_retained_line: stdout_snapshot.first_retained_line,
+            truncated: stdout.3,
+            delta_reset: false,
+        };
+        let stderr = crate::job_observation::JobLogStreamProjection {
+            returned_lines: stderr.0.lines().count(),
+            text: stderr.0,
+            next_line: stderr.1,
+            total_lines: stderr.2,
+            first_retained_line: stderr_snapshot.first_retained_line,
+            truncated: stderr.3,
+            delta_reset: false,
+        };
+        let observation_token = match observation.token(job_id) {
+            Ok(token) => token,
+            Err(error) => return ToolResult::err(error),
+        };
+        (
+            stdout,
+            stderr,
+            crate::job_observation::JobLogDeltaStatus::Baseline,
+            observation_token,
+            false,
+            false,
+        )
+    } else {
+        let automatic_tail_lines = tail_lines.or(Some(super::helpers::DEFAULT_JOB_LOG_TAIL_LINES));
+        let epoch_matches = after
+            .as_ref()
+            .is_none_or(|token| token.epoch == observation.epoch);
+        let stdout_mode = match after.as_ref() {
+            None => crate::job_observation::JobLogSelectionMode::Baseline,
+            Some(token) if token.is_legacy() || !epoch_matches => {
+                crate::job_observation::JobLogSelectionMode::Reset
+            }
+            Some(token) => crate::job_observation::JobLogSelectionMode::Delta {
+                cursor: token
+                    .stdout_cursor
+                    .expect("cursor-aware token has stdout cursor"),
+            },
+        };
+        let stderr_mode = match after.as_ref() {
+            None => crate::job_observation::JobLogSelectionMode::Baseline,
+            Some(token) if token.is_legacy() || !epoch_matches => {
+                crate::job_observation::JobLogSelectionMode::Reset
+            }
+            Some(token) => crate::job_observation::JobLogSelectionMode::Delta {
+                cursor: token
+                    .stderr_cursor
+                    .expect("cursor-aware token has stderr cursor"),
+            },
+        };
+        let stdout = crate::job_observation::project_log_stream(
+            &stdout_snapshot.retained_text,
+            stdout_snapshot.first_retained_line,
+            stdout_snapshot.total_lines.saturating_add(1),
+            stdout_snapshot.truncated,
+            automatic_tail_lines,
+            stdout_mode,
+            false,
+        );
+        let stderr = crate::job_observation::project_log_stream(
+            &stderr_snapshot.retained_text,
+            stderr_snapshot.first_retained_line,
+            stderr_snapshot.total_lines.saturating_add(1),
+            stderr_snapshot.truncated,
+            automatic_tail_lines,
+            stderr_mode,
+            false,
+        );
+        let log_delta_status =
+            crate::job_observation::combined_delta_status(stdout_mode, &stdout, &stderr);
+        let observation_token =
+            match observation.token_with_cursors(job_id, stdout.next_line, stderr.next_line) {
+                Ok(token) => token,
+                Err(error) => return ToolResult::err(error),
+            };
+        let stdout_delta_reset = stdout.delta_reset;
+        let stderr_delta_reset = stderr.delta_reset;
+        (
+            stdout,
+            stderr,
+            log_delta_status,
+            observation_token,
+            stdout_delta_reset,
+            stderr_delta_reset,
+        )
+    };
     let purpose = meta
         .get("purpose")
         .and_then(Value::as_str)
@@ -670,8 +801,8 @@ pub(crate) async fn local_job_log(
         Some(purpose),
         &final_status,
         final_exit_code.map(i64::from),
-        &stdout.0,
-        &stderr.0,
+        &analysis_stdout.text,
+        &analysis_stderr.text,
     );
     let (validation_tool, validation_kind) = local_validation_identity(&meta);
     let validation = validation_job_projection(
@@ -679,17 +810,28 @@ pub(crate) async fn local_job_log(
         validation_kind,
         &final_status,
         final_exit_code.map(i64::from),
-        &stdout.0,
-        &stderr.0,
-        stdout.3 || stderr.3,
+        &analysis_stdout.text,
+        &analysis_stderr.text,
+        analysis_stdout.truncated || analysis_stderr.truncated,
     );
     let mut output = json!({
         "job_id": job_id, "status": final_status, "exit_code": final_exit_code,
-        "stdout_tail": stdout.0, "stderr_tail": stderr.0,
-        "stdout_lines": stdout.2, "stderr_lines": stderr.2,
-        "stdout_truncated": stdout.3, "stderr_truncated": stderr.3,
-        "cursor": { "stdout": stdout.1, "stderr": stderr.1 },
+        "stdout_tail": stdout.text, "stderr_tail": stderr.text,
+        "stdout_lines": stdout.total_lines, "stderr_lines": stderr.total_lines,
+        "stdout_returned_lines": stdout.returned_lines,
+        "stderr_returned_lines": stderr.returned_lines,
+        "stdout_truncated": stdout.truncated, "stderr_truncated": stderr.truncated,
+        "stdout_retained_from_line": stdout.first_retained_line,
+        "stderr_retained_from_line": stderr.first_retained_line,
+        "earlier_stdout_unavailable": stdout_snapshot.first_retained_line > 1
+            || stdout_snapshot.truncated,
+        "earlier_stderr_unavailable": stderr_snapshot.first_retained_line > 1
+            || stderr_snapshot.truncated,
+        "cursor": { "stdout": stdout.next_line, "stderr": stderr.next_line },
         "observation_token": observation_token,
+        "log_delta_status": log_delta_status.as_str(),
+        "stdout_delta_reset": stdout_delta_reset,
+        "stderr_delta_reset": stderr_delta_reset,
         "wait_outcome": wait_outcome, "waited_ms": waited_ms,
         "changed": changed, "terminal": final_terminal, "executor": "local",
         "cwd": meta.get("cwd").cloned().unwrap_or_else(|| json!(".")),
@@ -1728,8 +1870,6 @@ impl ToolRuntime {
             Ok((job, stdout, stderr, next_stdout_line, next_stderr_line, wait)) => {
                 let stdout = stdout.unwrap_or_default();
                 let stderr = stderr.unwrap_or_default();
-                let stdout_lines = stdout.lines().count();
-                let stderr_lines = stderr.lines().count();
                 let command_summary = job.command_preview.clone();
                 let purpose = job.purpose.clone().unwrap_or_else(|| "other".to_string());
                 let detected_summary = detected_job_summary(
@@ -1737,8 +1877,8 @@ impl ToolRuntime {
                     Some(&purpose),
                     &job.status,
                     job.exit_code.map(i64::from),
-                    &stdout,
-                    &stderr,
+                    &wait.analysis_stdout,
+                    &wait.analysis_stderr,
                 );
                 let validation_tool = job
                     .validation
@@ -1748,26 +1888,14 @@ impl ToolRuntime {
                     .validation
                     .as_ref()
                     .map(|metadata| metadata.kind.as_str());
-                let stdout_incomplete = agent_log_stream_incomplete(
-                    job.stdout_log_truncated,
-                    job.stdout_retained_from_line,
-                    stdout_lines,
-                    next_stdout_line,
-                );
-                let stderr_incomplete = agent_log_stream_incomplete(
-                    job.stderr_log_truncated,
-                    job.stderr_retained_from_line,
-                    stderr_lines,
-                    next_stderr_line,
-                );
                 let validation = validation_job_projection(
                     validation_tool,
                     validation_kind,
                     &job.status,
                     job.exit_code.map(i64::from),
-                    &stdout,
-                    &stderr,
-                    stdout_incomplete || stderr_incomplete,
+                    &wait.analysis_stdout,
+                    &wait.analysis_stderr,
+                    wait.analysis_truncated,
                 );
                 ToolResult::ok(json!({
                     "job_id": job.job_id,
@@ -1779,10 +1907,10 @@ impl ToolRuntime {
                     "stderr_tail": stderr,
                     "stdout_lines": next_stdout_line.saturating_sub(1),
                     "stderr_lines": next_stderr_line.saturating_sub(1),
-                    "stdout_returned_lines": stdout_lines,
-                    "stderr_returned_lines": stderr_lines,
-                    "stdout_truncated": stdout_incomplete,
-                    "stderr_truncated": stderr_incomplete,
+                    "stdout_returned_lines": wait.stdout_returned_lines,
+                    "stderr_returned_lines": wait.stderr_returned_lines,
+                    "stdout_truncated": wait.stdout_truncated,
+                    "stderr_truncated": wait.stderr_truncated,
                     "stdout_retained_from_line": job.stdout_retained_from_line,
                     "stderr_retained_from_line": job.stderr_retained_from_line,
                     "earlier_stdout_unavailable": job
@@ -1800,6 +1928,9 @@ impl ToolRuntime {
                         job.recovery_reason_code.as_deref(),
                     ),
                     "observation_token": job.observation_token,
+                    "log_delta_status": wait.log_delta_status.as_str(),
+                    "stdout_delta_reset": wait.stdout_delta_reset,
+                    "stderr_delta_reset": wait.stderr_delta_reset,
                     "last_update_seq": job.last_update_seq,
                     "cursor": {
                         "stdout": next_stdout_line,

--- a/src/tool_runtime/local_jobs.rs
+++ b/src/tool_runtime/local_jobs.rs
@@ -41,11 +41,29 @@ impl LocalJobObservation {
         super::jobs::is_terminal_job_status(&super::helpers::normalize_local_status(&self.status))
     }
     pub(crate) fn token(&self, job_id: &str) -> Result<String, String> {
+        crate::job_observation::JobObservationToken::new_legacy(
+            crate::job_observation::JobObservationExecutor::Local,
+            job_id,
+            self.epoch.clone(),
+            self.revision,
+        )
+        .map(|token| token.encode())
+        .map_err(|error| error.to_string())
+    }
+
+    pub(crate) fn token_with_cursors(
+        &self,
+        job_id: &str,
+        stdout_cursor: usize,
+        stderr_cursor: usize,
+    ) -> Result<String, String> {
         crate::job_observation::JobObservationToken::new(
             crate::job_observation::JobObservationExecutor::Local,
             job_id,
             self.epoch.clone(),
             self.revision,
+            stdout_cursor as u64,
+            stderr_cursor as u64,
         )
         .map(|token| token.encode())
         .map_err(|error| error.to_string())
@@ -67,11 +85,11 @@ pub(crate) struct LocalJobTerminalSnapshot {
     logs: HashMap<String, LocalJobLogSnapshot>,
 }
 #[derive(Debug, Clone)]
-struct LocalJobLogSnapshot {
-    retained_text: String,
-    total_lines: usize,
-    first_retained_line: usize,
-    truncated: bool,
+pub(crate) struct LocalJobLogSnapshot {
+    pub(crate) retained_text: String,
+    pub(crate) total_lines: usize,
+    pub(crate) first_retained_line: usize,
+    pub(crate) truncated: bool,
 }
 impl LocalJobRecord {
     #[cfg(test)]
@@ -194,20 +212,6 @@ impl LocalJobRecord {
             .or_else(|| snapshot.files.get(name).cloned())
     }
 
-    fn terminal_log_lines(
-        &self,
-        name: &str,
-        offset: Option<usize>,
-        tail_lines: Option<usize>,
-    ) -> Option<(String, usize, usize, bool)> {
-        self.terminal_snapshot
-            .lock()
-            .unwrap()
-            .as_ref()
-            .and_then(|snapshot| snapshot.logs.get(name))
-            .map(|log| log.read_lines(offset, tail_lines))
-    }
-
     pub(crate) fn observe(&self) -> Result<LocalJobObservation, String> {
         if let Some(observation) = self.terminal_observation() {
             return Ok(observation);
@@ -317,15 +321,37 @@ impl LocalJobRecord {
         tail_lines: Option<usize>,
         snapshot_len: u64,
     ) -> (String, usize, usize, bool) {
-        if let Some(lines) = self.terminal_log_lines(name, offset, tail_lines) {
-            return lines;
+        self.read_log_snapshot_at(name, offset, snapshot_len)
+            .map(|log| log.read_lines(offset, tail_lines))
+            .unwrap_or_else(|| (String::new(), 1, 0, false))
+    }
+
+    pub(crate) fn read_log_snapshot_at(
+        &self,
+        name: &str,
+        offset: Option<usize>,
+        snapshot_len: u64,
+    ) -> Option<LocalJobLogSnapshot> {
+        if let Some(log) = self
+            .terminal_snapshot
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|snapshot| snapshot.logs.get(name))
+            .cloned()
+        {
+            return Some(log);
         }
-        match read_bounded_log(&self.dir.join(name), offset, Some(snapshot_len)) {
-            Ok(log) => log.read_lines(offset, tail_lines),
-            Err(_) => self
-                .terminal_log_lines(name, offset, tail_lines)
-                .unwrap_or_else(|| (String::new(), 1, 0, false)),
-        }
+        read_bounded_log(&self.dir.join(name), offset, Some(snapshot_len))
+            .ok()
+            .or_else(|| {
+                self.terminal_snapshot
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.logs.get(name))
+                    .cloned()
+            })
     }
     pub(crate) fn read_json(&self, name: &str) -> Value {
         self.read_text(name)
@@ -394,7 +420,7 @@ pub(crate) fn set_bounded_log_read_delay(path: &Path, delay: Option<Duration>) {
 }
 
 impl LocalJobLogSnapshot {
-    fn read_lines(
+    pub(crate) fn read_lines(
         &self,
         offset: Option<usize>,
         tail_lines: Option<usize>,

--- a/src/tool_runtime/registry/input_schemas/jobs.rs
+++ b/src/tool_runtime/registry/input_schemas/jobs.rs
@@ -426,7 +426,7 @@ pub(crate) fn job_log_input_schema() -> Value {
         (
             "after_observation_token",
             "string",
-            "Opaque token from the latest Job snapshot. Return it unchanged. It is bound to one job_id, not execution identity; a Server epoch change causes an immediate refresh when that Job still exists.",
+            "Opaque token from the latest Job observation. Return it unchanged; it carries bounded lifecycle and automatic log-delta state. It is bound to one job_id, not execution identity or retry authority. A Server epoch change causes an immediate conservative log reset when that Job still exists.",
             false,
         ),
         (
@@ -436,7 +436,8 @@ pub(crate) fn job_log_input_schema() -> Value {
             false,
         ),
     ]);
-    schema["properties"]["after_observation_token"]["maxLength"] = json!(192);
+    schema["properties"]["after_observation_token"]["maxLength"] =
+        json!(crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN);
     schema["properties"]["wait_secs"]["minimum"] = json!(1);
     schema["properties"]["wait_secs"]["maximum"] = json!(60);
     schema
@@ -463,8 +464,8 @@ pub(crate) fn observe_jobs_input_schema() -> Value {
                         },
                         "after_observation_token": {
                             "type": "string",
-                            "maxLength": 192,
-                            "description": "Optional opaque Job-bound token from the latest snapshot. Return it unchanged. A stale server epoch is immediately actionable."
+                            "maxLength": crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN,
+                            "description": "Optional opaque Job-bound lifecycle/log-delta token from the latest observation. Return it unchanged without interpreting its cursor state. It is not execution identity or retry authority; a stale Server epoch is immediately actionable and conservatively resets the bounded log projection."
                         }
                     },
                     "required": ["job_id"]
@@ -475,7 +476,7 @@ pub(crate) fn observe_jobs_input_schema() -> Value {
                 "minimum": 1,
                 "maximum": 200,
                 "default": 40,
-                "description": "Global bounded trailing line count per stdout/stderr stream for every returned Job."
+                "description": "Global per-stream bound. First observations return a current tail; cursor-aware follow-ups return at most this many new or reset-recovery lines."
             },
             "wait_secs": {
                 "type": "integer",

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -364,12 +364,19 @@ fn observe_jobs_output_schema() -> Value {
             "exit_code": nullable_schema("integer", "Process exit code, when terminal and available."),
             "command_execution_state": job_command_execution_state_schema(),
             "structured_execution": job_structured_execution_metadata_schema(),
-            "stdout_tail": schema_type("string", "Bounded stdout tail."),
-            "stderr_tail": schema_type("string", "Bounded stderr tail."),
+            "stdout_tail": schema_type("string", "Bounded stdout baseline, delta, or reset-recovery tail. Empty for a continuous observation with no new stdout."),
+            "stderr_tail": schema_type("string", "Bounded stderr baseline, delta, or reset-recovery tail. Empty for a continuous observation with no new stderr."),
             "stdout_lines": schema_type("integer", "Total observed stdout line count."),
             "stderr_lines": schema_type("integer", "Total observed stderr line count."),
-            "stdout_truncated": schema_type("boolean", "Whether stdout_tail omits observed output."),
-            "stderr_truncated": schema_type("boolean", "Whether stderr_tail omits observed output."),
+            "stdout_truncated": schema_type("boolean", "Whether the requested stdout baseline/delta/reset projection was bounded or unavailable."),
+            "stderr_truncated": schema_type("boolean", "Whether the requested stderr baseline/delta/reset projection was bounded or unavailable."),
+            "log_delta_status": {
+                "type": "string",
+                "enum": ["baseline", "delta", "unchanged", "reset"],
+                "description": "baseline is a bounded non-delta selection (first observation or explicit pagination); delta contains only new output; unchanged has no new output; reset is a bounded recovery tail because exact continuity could not be proved."
+            },
+            "stdout_delta_reset": schema_type("boolean", "Whether stdout automatic delta continuity was reset for this observation."),
+            "stderr_delta_reset": schema_type("boolean", "Whether stderr automatic delta continuity was reset for this observation."),
             "stdout_retained_from_line": nullable_schema("integer", "First retained absolute stdout line, when available."),
             "stderr_retained_from_line": nullable_schema("integer", "First retained absolute stderr line, when available."),
             "earlier_stdout_unavailable": schema_type("boolean", "Whether earlier stdout is outside retained bounded logs."),
@@ -377,7 +384,12 @@ fn observe_jobs_output_schema() -> Value {
             "recovery_state": nullable_schema("string", "Canonical bounded recovery state."),
             "recovery_reason_code": nullable_schema("string", "Canonical bounded recovery reason code."),
             "recovery_reason": nullable_schema("string", "Canonical bounded recovery explanation."),
-            "observation_token": schema_type("string", "Opaque Job-bound token for this returned snapshot."),
+            "observation_token": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN,
+                "description": "Opaque Job-bound lifecycle/log-delta token for this frozen returned snapshot. Return it unchanged."
+            },
             "last_update_seq": nullable_schema("integer", "Agent protocol diagnostic sequence, when available."),
             "cursor": {
                 "type": "object",
@@ -390,7 +402,7 @@ fn observe_jobs_output_schema() -> Value {
             },
             "wait_outcome": schema_type("string", "Canonical per-Job internal observation outcome; outer wake_reason is the batch wait fact."),
             "waited_ms": schema_type("integer", "Canonical per-Job internal wait time. Final batch snapshots are non-waiting."),
-            "changed": schema_type("boolean", "Whether this snapshot differs from the item's supplied token."),
+            "changed": schema_type("boolean", "Whether the lifecycle revision or Server epoch differs from the item's supplied token. Token format upgrades alone do not set changed."),
             "terminal": schema_type("boolean", "Canonical terminal classification."),
             "executor": {
                 "type": "string",
@@ -416,6 +428,7 @@ fn observe_jobs_output_schema() -> Value {
         "required": [
             "job_id", "status", "exit_code", "stdout_tail", "stderr_tail",
             "stdout_lines", "stderr_lines", "stdout_truncated", "stderr_truncated",
+            "log_delta_status", "stdout_delta_reset", "stderr_delta_reset",
             "observation_token", "cursor", "wait_outcome", "waited_ms", "changed",
             "terminal", "executor", "cwd", "shell", "purpose", "command_summary",
             "detected_summary", "validation"
@@ -1101,7 +1114,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "changed",
-                schema_type("boolean", "Whether the current observation_token differs from the supplied after_observation_token."),
+                schema_type("boolean", "Whether the lifecycle revision or Server epoch differs from the supplied token. Token format upgrades alone do not set changed."),
             ),
             (
                 "terminal",
@@ -1121,11 +1134,11 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "stdout_tail",
-                schema_type("string", "Bounded stdout tail or cursor segment."),
+                schema_type("string", "Bounded stdout baseline, automatic delta, explicit cursor segment, or reset-recovery tail. Empty when no new stdout is available."),
             ),
             (
                 "stderr_tail",
-                schema_type("string", "Bounded stderr tail or cursor segment."),
+                schema_type("string", "Bounded stderr baseline, automatic delta, explicit cursor segment, or reset-recovery tail. Empty when no new stderr is available."),
             ),
             (
                 "stdout_lines",
@@ -1137,11 +1150,27 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "stdout_truncated",
-                schema_type("boolean", "Whether stdout_tail omits observed lines."),
+                schema_type("boolean", "Whether the requested stdout baseline/delta/reset projection was bounded or unavailable."),
             ),
             (
                 "stderr_truncated",
-                schema_type("boolean", "Whether stderr_tail omits observed lines."),
+                schema_type("boolean", "Whether the requested stderr baseline/delta/reset projection was bounded or unavailable."),
+            ),
+            (
+                "log_delta_status",
+                json!({
+                    "type": "string",
+                    "enum": ["baseline", "delta", "unchanged", "reset"],
+                    "description": "baseline is a bounded non-delta selection (first observation or explicit pagination); delta contains only new output; unchanged has no new output; reset is a bounded recovery tail because exact continuity could not be proved."
+                }),
+            ),
+            (
+                "stdout_delta_reset",
+                schema_type("boolean", "Whether stdout automatic delta continuity was reset for this observation."),
+            ),
+            (
+                "stderr_delta_reset",
+                schema_type("boolean", "Whether stderr automatic delta continuity was reset for this observation."),
             ),
             (
                 "stdout_retained_from_line",
@@ -1169,7 +1198,12 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "observation_token",
-                schema_type("string", "Opaque Job-bound observation token for the returned status and frozen log snapshot."),
+                json!({
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN,
+                    "description": "Opaque Job-bound lifecycle/log-delta token for the returned status and frozen log snapshot. Return it unchanged."
+                }),
             ),
             (
                 "last_update_seq",

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -364,8 +364,8 @@ fn observe_jobs_output_schema() -> Value {
             "exit_code": nullable_schema("integer", "Process exit code, when terminal and available."),
             "command_execution_state": job_command_execution_state_schema(),
             "structured_execution": job_structured_execution_metadata_schema(),
-            "stdout_tail": schema_type("string", "Bounded stdout baseline, delta, or reset-recovery tail. Empty for a continuous observation with no new stdout."),
-            "stderr_tail": schema_type("string", "Bounded stderr baseline, delta, or reset-recovery tail. Empty for a continuous observation with no new stderr."),
+            "stdout_tail": schema_type("string", "Bounded stdout baseline, delta, conservative partial-line replay, or reset-recovery tail. A previously observed unterminated final line may repeat until its line boundary is observed."),
+            "stderr_tail": schema_type("string", "Bounded stderr baseline, delta, conservative partial-line replay, or reset-recovery tail. A previously observed unterminated final line may repeat until its line boundary is observed."),
             "stdout_lines": schema_type("integer", "Total observed stdout line count."),
             "stderr_lines": schema_type("integer", "Total observed stderr line count."),
             "stdout_truncated": schema_type("boolean", "Whether the requested stdout baseline/delta/reset projection was bounded or unavailable."),
@@ -373,7 +373,7 @@ fn observe_jobs_output_schema() -> Value {
             "log_delta_status": {
                 "type": "string",
                 "enum": ["baseline", "delta", "unchanged", "reset"],
-                "description": "baseline is a bounded non-delta selection (first observation or explicit pagination); delta contains only new output; unchanged has no new output; reset is a bounded recovery tail because exact continuity could not be proved."
+                "description": "baseline is a bounded non-delta selection (first observation or explicit pagination); delta contains newly observable output and may conservatively replay an unterminated final line; unchanged has no model-facing output; reset is a bounded recovery tail because exact continuity could not be proved."
             },
             "stdout_delta_reset": schema_type("boolean", "Whether stdout automatic delta continuity was reset for this observation."),
             "stderr_delta_reset": schema_type("boolean", "Whether stderr automatic delta continuity was reset for this observation."),
@@ -395,8 +395,8 @@ fn observe_jobs_output_schema() -> Value {
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "stdout": {"type": "integer", "minimum": 1},
-                    "stderr": {"type": "integer", "minimum": 1}
+                    "stdout": {"type": "integer", "minimum": 1, "description": "Next absolute stdout line requiring automatic inspection; may remain on a returned unterminated final line."},
+                    "stderr": {"type": "integer", "minimum": 1, "description": "Next absolute stderr line requiring automatic inspection; may remain on a returned unterminated final line."}
                 },
                 "required": ["stdout", "stderr"]
             },
@@ -1134,11 +1134,11 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "stdout_tail",
-                schema_type("string", "Bounded stdout baseline, automatic delta, explicit cursor segment, or reset-recovery tail. Empty when no new stdout is available."),
+                schema_type("string", "Bounded stdout baseline, automatic delta, conservative partial-line replay, explicit cursor segment, or reset-recovery tail. An unterminated final line may repeat until its line boundary is observed."),
             ),
             (
                 "stderr_tail",
-                schema_type("string", "Bounded stderr baseline, automatic delta, explicit cursor segment, or reset-recovery tail. Empty when no new stderr is available."),
+                schema_type("string", "Bounded stderr baseline, automatic delta, conservative partial-line replay, explicit cursor segment, or reset-recovery tail. An unterminated final line may repeat until its line boundary is observed."),
             ),
             (
                 "stdout_lines",
@@ -1161,7 +1161,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 json!({
                     "type": "string",
                     "enum": ["baseline", "delta", "unchanged", "reset"],
-                    "description": "baseline is a bounded non-delta selection (first observation or explicit pagination); delta contains only new output; unchanged has no new output; reset is a bounded recovery tail because exact continuity could not be proved."
+                    "description": "baseline is a bounded non-delta selection (first observation or explicit pagination); delta contains newly observable output and may conservatively replay an unterminated final line; unchanged has no model-facing output; reset is a bounded recovery tail because exact continuity could not be proved."
                 }),
             ),
             (
@@ -1212,7 +1212,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             (
                 "cursor",
                 super::common::open_object_schema(
-                    "Next 1-based stdout/stderr cursors for bounded continuation.",
+                    "Next 1-based stdout/stderr cursors for bounded continuation; an unterminated final line remains pending until its boundary is observed.",
                 ),
             ),
             (

--- a/src/tool_runtime/registry/tool_specs.rs
+++ b/src/tool_runtime/registry/tool_specs.rs
@@ -317,6 +317,17 @@ mod tests {
             .expect("job_log observation token description");
         assert!(token.contains("not execution identity"), "{token}");
         assert!(token.contains("Server epoch"), "{token}");
+        assert!(token.contains("log-delta state"), "{token}");
+        assert!(token.contains("Return it unchanged"), "{token}");
+        let batch_token = find("observe_jobs").input_schema["properties"]["items"]["items"]
+            ["properties"]["after_observation_token"]["description"]
+            .as_str()
+            .expect("observe_jobs observation token description");
+        assert!(batch_token.contains("log-delta token"), "{batch_token}");
+        assert!(
+            batch_token.contains("without interpreting"),
+            "{batch_token}"
+        );
         let wait = job_log.input_schema["properties"]["wait_secs"]["description"]
             .as_str()
             .expect("job_log wait description");

--- a/src/tool_runtime/registry/tool_specs/jobs.rs
+++ b/src/tool_runtime/registry/tool_specs/jobs.rs
@@ -67,12 +67,12 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "job_log",
-            "Read bounded stdout/stderr for one existing Job. With an observation token, wait_secs is one bounded wait; never starts or retries work and never subscribes.",
+            "Read bounded stdout/stderr for one Job. Return its opaque token to receive only new output; reset means a bounded recovery tail. wait_secs performs one bounded wait. Never starts or retries execution.",
             job_log_input_schema(),
         ),
         tool_spec(
             "observe_jobs",
-            "Observe 1 to 8 existing Jobs with bounded tails and isolated item errors. Optionally wait once for any change; never launches, retries, stops, or subscribes.",
+            "Observe 1 to 8 Jobs with bounded baseline/delta logs and isolated errors. Return each opaque token unchanged for compact follow-ups. Optionally wait once for any change; never launches, retries, stops, or subscribes.",
             observe_jobs_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -3512,7 +3512,7 @@ fn local_persistence_failure_does_not_publish_new_revision() {
 
 #[test]
 fn job_log_parses_opaque_observation_token_and_rejects_non_string_values() {
-    let token = crate::job_observation::JobObservationToken::new(
+    let token = crate::job_observation::JobObservationToken::new_legacy(
         crate::job_observation::JobObservationExecutor::Local,
         "abc",
         "0123456789abcdef",
@@ -3702,7 +3702,13 @@ async fn local_append_during_read_is_visible_on_next_call_and_excluded_from_wait
     assert_eq!(first_response.output["status"], "running");
     assert!(first_response.output["exit_code"].is_null());
     assert_eq!(first_response.output["stdout_tail"], "one");
-    assert_eq!(first_response.output["observation_token"], token1);
+    assert_eq!(first_response.output["log_delta_status"], "reset");
+    let frozen_token = first_response.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(frozen_token.starts_with("wj2l:"));
+    assert_ne!(frozen_token, token1);
 
     let second_response = super::super::jobs::local_job_log(
         "job-append-during-read",
@@ -3710,7 +3716,7 @@ async fn local_append_during_read_is_visible_on_next_call_and_excluded_from_wait
         &SystemJobKiller,
         None,
         None,
-        Some(token1.clone()),
+        Some(frozen_token),
         Some(5),
     )
     .await;
@@ -3720,7 +3726,8 @@ async fn local_append_during_read_is_visible_on_next_call_and_excluded_from_wait
     assert_eq!(second_response.output["terminal"], true);
     assert_eq!(second_response.output["status"], "completed");
     assert_eq!(second_response.output["exit_code"], 0);
-    assert_eq!(second_response.output["stdout_tail"], "one\ntwo");
+    assert_eq!(second_response.output["log_delta_status"], "delta");
+    assert_eq!(second_response.output["stdout_tail"], "two");
     assert_ne!(second_response.output["observation_token"], token1);
 }
 
@@ -3772,4 +3779,428 @@ async fn local_runtime_deadline_crossing_preempts_longer_update_wait() {
     assert_eq!(response.output["status"], "lost");
     assert_ne!(response.output["observation_token"], token0);
     assert_eq!(killer.calls(), vec![(4242, 4242)]);
+}
+
+#[tokio::test]
+async fn local_job_log_observation_is_baseline_then_independent_deltas() {
+    let (_temp, record, _) = make_local_record("job-delta-local");
+    let stdout_path = record.dir.join("stdout.log");
+    let stderr_path = record.dir.join("stderr.log");
+    let stdout = (1..=10)
+        .map(|line| format!("stdout {line}\n"))
+        .collect::<String>();
+    fs::write(&stdout_path, stdout).unwrap();
+
+    let baseline = super::super::jobs::local_job_log(
+        "job-delta-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(20),
+        None,
+        None,
+    )
+    .await;
+    assert!(baseline.success, "{:?}", baseline.error);
+    assert_eq!(baseline.output["log_delta_status"], "baseline");
+    assert_eq!(baseline.output["stdout_returned_lines"], 10);
+    assert!(baseline.output["stdout_tail"]
+        .as_str()
+        .unwrap()
+        .starts_with("stdout 1\n"));
+    let token0 = baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let parsed0 = crate::job_observation::JobObservationToken::parse(&token0).unwrap();
+    assert_eq!(parsed0.stdout_cursor, Some(11));
+    assert_eq!(parsed0.stderr_cursor, Some(1));
+
+    let unchanged = super::super::jobs::local_job_log(
+        "job-delta-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(20),
+        Some(token0.clone()),
+        None,
+    )
+    .await;
+    assert!(unchanged.success, "{:?}", unchanged.error);
+    assert_eq!(unchanged.output["changed"], false);
+    assert_eq!(unchanged.output["log_delta_status"], "unchanged");
+    assert_eq!(unchanged.output["stdout_tail"], "");
+    assert_eq!(unchanged.output["stderr_tail"], "");
+    assert_eq!(unchanged.output["observation_token"], token0);
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&stdout_path)
+        .unwrap()
+        .write_all(b"stdout 11\nstdout 12\nstdout 13\n")
+        .unwrap();
+    let stdout_delta = super::super::jobs::local_job_log(
+        "job-delta-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(20),
+        Some(token0),
+        None,
+    )
+    .await;
+    assert!(stdout_delta.success, "{:?}", stdout_delta.error);
+    assert_eq!(stdout_delta.output["changed"], true);
+    assert_eq!(stdout_delta.output["log_delta_status"], "delta");
+    assert_eq!(
+        stdout_delta.output["stdout_tail"],
+        "stdout 11\nstdout 12\nstdout 13"
+    );
+    assert_eq!(stdout_delta.output["stderr_tail"], "");
+    assert!(!stdout_delta.output["stdout_tail"]
+        .as_str()
+        .unwrap()
+        .contains("stdout 10"));
+    let token1 = stdout_delta.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    fs::write(&stderr_path, "stderr 1\nstderr 2\n").unwrap();
+    let stderr_delta = super::super::jobs::local_job_log(
+        "job-delta-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(20),
+        Some(token1),
+        None,
+    )
+    .await;
+    assert!(stderr_delta.success, "{:?}", stderr_delta.error);
+    assert_eq!(stderr_delta.output["log_delta_status"], "delta");
+    assert_eq!(stderr_delta.output["stdout_tail"], "");
+    assert_eq!(stderr_delta.output["stderr_tail"], "stderr 1\nstderr 2");
+    let token2 = stderr_delta.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    fs::write(record.dir.join("exit_code"), "0").unwrap();
+    fs::write(record.dir.join("status"), "completed").unwrap();
+    let terminal = super::super::jobs::local_job_log(
+        "job-delta-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(20),
+        Some(token2),
+        None,
+    )
+    .await;
+    assert!(terminal.success, "{:?}", terminal.error);
+    assert_eq!(terminal.output["changed"], true);
+    assert_eq!(terminal.output["terminal"], true);
+    assert_eq!(terminal.output["status"], "completed");
+    assert_eq!(terminal.output["exit_code"], 0);
+    assert_eq!(terminal.output["log_delta_status"], "unchanged");
+    assert_eq!(terminal.output["stdout_tail"], "");
+    assert_eq!(terminal.output["stderr_tail"], "");
+}
+
+#[tokio::test]
+async fn local_job_log_resets_on_retention_epoch_and_legacy_boundaries() {
+    let (_temp, record, initial) = make_local_record("job-reset-local");
+    let stdout_path = record.dir.join("stdout.log");
+    let first = (1..=10)
+        .map(|line| format!("line {line}\n"))
+        .collect::<String>();
+    fs::write(&stdout_path, first).unwrap();
+    let baseline = super::super::jobs::local_job_log(
+        "job-reset-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        None,
+        None,
+    )
+    .await;
+    let old_token = baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let replacement = (1..=600)
+        .map(|line| format!("line {line}\n"))
+        .collect::<String>();
+    fs::write(&stdout_path, replacement).unwrap();
+
+    let retention_reset = super::super::jobs::local_job_log(
+        "job-reset-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(old_token),
+        None,
+    )
+    .await;
+    assert!(retention_reset.success, "{:?}", retention_reset.error);
+    assert_eq!(retention_reset.output["log_delta_status"], "reset");
+    assert_eq!(retention_reset.output["stdout_delta_reset"], true);
+    assert_eq!(retention_reset.output["stdout_truncated"], true);
+    assert_eq!(retention_reset.output["earlier_stdout_unavailable"], true);
+    assert!(
+        retention_reset.output["stdout_retained_from_line"]
+            .as_u64()
+            .unwrap()
+            > 1
+    );
+    assert!(retention_reset.output["stdout_tail"]
+        .as_str()
+        .unwrap()
+        .starts_with("line 591\n"));
+    let current = record.observe().unwrap();
+    let current_cursor = retention_reset.output["cursor"]["stdout"].as_u64().unwrap();
+    let stale_epoch = crate::job_observation::JobObservationToken::new(
+        crate::job_observation::JobObservationExecutor::Local,
+        "job-reset-local",
+        "old-server-epoch",
+        current.revision,
+        current_cursor,
+        1,
+    )
+    .unwrap()
+    .encode();
+    let epoch_reset = super::super::jobs::local_job_log(
+        "job-reset-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(stale_epoch),
+        Some(5),
+    )
+    .await;
+    assert_eq!(epoch_reset.output["wait_outcome"], "immediate");
+    assert_eq!(epoch_reset.output["changed"], true);
+    assert_eq!(epoch_reset.output["log_delta_status"], "reset");
+
+    let legacy = current.token("job-reset-local").unwrap();
+    let legacy_reset = super::super::jobs::local_job_log(
+        "job-reset-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(legacy),
+        None,
+    )
+    .await;
+    assert_eq!(legacy_reset.output["log_delta_status"], "reset");
+    assert!(legacy_reset.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .starts_with("wj2l:"));
+    assert_ne!(initial.epoch, "old-server-epoch");
+}
+
+#[tokio::test]
+async fn local_job_log_explicit_offset_wins_and_followup_resets_safely() {
+    let (_temp, record, _) = make_local_record("job-explicit-local");
+    let stdout = (1..=10)
+        .map(|line| format!("line {line}\n"))
+        .collect::<String>();
+    fs::write(record.dir.join("stdout.log"), stdout).unwrap();
+    let baseline = super::super::jobs::local_job_log(
+        "job-explicit-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        None,
+        None,
+    )
+    .await;
+    let explicit = super::super::jobs::local_job_log(
+        "job-explicit-local",
+        &record,
+        &SystemJobKiller,
+        Some(4),
+        None,
+        Some(
+            baseline.output["observation_token"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+        ),
+        None,
+    )
+    .await;
+    assert!(explicit.success, "{:?}", explicit.error);
+    assert!(explicit.output["stdout_tail"]
+        .as_str()
+        .unwrap()
+        .starts_with("line 4\n"));
+    assert_eq!(explicit.output["cursor"]["stdout"], 11);
+    assert_eq!(explicit.output["log_delta_status"], "baseline");
+    let explicit_token = explicit.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(explicit_token.starts_with("wjob1:"));
+
+    let automatic = super::super::jobs::local_job_log(
+        "job-explicit-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(3),
+        Some(explicit_token),
+        None,
+    )
+    .await;
+    assert_eq!(automatic.output["log_delta_status"], "reset");
+    assert_eq!(automatic.output["stdout_tail"], "line 8\nline 9\nline 10");
+}
+
+#[tokio::test]
+async fn local_job_log_wait_timeout_returns_no_repeated_output() {
+    let (_temp, record, _) = make_local_record("job-timeout-local");
+    fs::write(record.dir.join("stdout.log"), "already seen\n").unwrap();
+    let baseline = super::super::jobs::local_job_log(
+        "job-timeout-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        None,
+        None,
+    )
+    .await;
+    let token = baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let timed_out = super::super::jobs::local_job_log(
+        "job-timeout-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(token),
+        Some(1),
+    )
+    .await;
+    assert!(timed_out.success, "{:?}", timed_out.error);
+    assert_eq!(timed_out.output["wait_outcome"], "timeout");
+    assert_eq!(timed_out.output["changed"], false);
+    assert_eq!(timed_out.output["log_delta_status"], "unchanged");
+    assert_eq!(timed_out.output["stdout_tail"], "");
+    assert_eq!(timed_out.output["stderr_tail"], "");
+}
+
+#[tokio::test]
+async fn job_log_delta_serialized_size_measurement_is_deterministic() {
+    let (_temp, record, _) = make_local_record("job-delta-measure");
+    let initial = (1..=40)
+        .map(|line| format!("stdout {line:02} {}\n", "x".repeat(32)))
+        .collect::<String>();
+    fs::write(record.dir.join("stdout.log"), &initial).unwrap();
+    let baseline = super::super::jobs::local_job_log(
+        "job-delta-measure",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(40),
+        None,
+        None,
+    )
+    .await;
+    let token0 = baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let unchanged = super::super::jobs::local_job_log(
+        "job-delta-measure",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(40),
+        Some(token0.clone()),
+        None,
+    )
+    .await;
+    let mut unchanged_full_tail_equivalent = serde_json::to_value(&unchanged).unwrap();
+    unchanged_full_tail_equivalent["output"]["stdout_tail"] =
+        baseline.output["stdout_tail"].clone();
+    unchanged_full_tail_equivalent["output"]["stdout_returned_lines"] =
+        baseline.output["stdout_returned_lines"].clone();
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(record.dir.join("stdout.log"))
+        .unwrap()
+        .write_all(b"new 41\nnew 42\n")
+        .unwrap();
+    let delta = super::super::jobs::local_job_log(
+        "job-delta-measure",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(40),
+        Some(token0),
+        None,
+    )
+    .await;
+    let current_full = super::super::jobs::local_job_log(
+        "job-delta-measure",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(40),
+        None,
+        None,
+    )
+    .await;
+    let mut delta_full_tail_equivalent = serde_json::to_value(&delta).unwrap();
+    delta_full_tail_equivalent["output"]["stdout_tail"] =
+        current_full.output["stdout_tail"].clone();
+    delta_full_tail_equivalent["output"]["stdout_returned_lines"] =
+        current_full.output["stdout_returned_lines"].clone();
+    let token1 = delta.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    fs::write(record.dir.join("exit_code"), "0").unwrap();
+    fs::write(record.dir.join("status"), "completed").unwrap();
+    let terminal = super::super::jobs::local_job_log(
+        "job-delta-measure",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(40),
+        Some(token1),
+        None,
+    )
+    .await;
+    let baseline_bytes = serde_json::to_vec(&baseline).unwrap().len();
+    let unchanged_full_bytes = serde_json::to_vec(&unchanged_full_tail_equivalent)
+        .unwrap()
+        .len();
+    let unchanged_bytes = serde_json::to_vec(&unchanged).unwrap().len();
+    let delta_full_bytes = serde_json::to_vec(&delta_full_tail_equivalent)
+        .unwrap()
+        .len();
+    let delta_bytes = serde_json::to_vec(&delta).unwrap().len();
+    let terminal_bytes = serde_json::to_vec(&terminal).unwrap().len();
+    eprintln!(
+        "E4_SINGLE_BYTES baseline={baseline_bytes} unchanged_full={unchanged_full_bytes} unchanged_delta={unchanged_bytes} append_full={delta_full_bytes} append_delta={delta_bytes} terminal_no_new={terminal_bytes}"
+    );
+    assert!(unchanged_bytes < unchanged_full_bytes);
+    assert!(delta_bytes < delta_full_bytes);
+    assert_eq!(unchanged.output["stdout_tail"], "");
+    assert_eq!(delta.output["stdout_tail"], "new 41\nnew 42");
+    assert_eq!(terminal.output["stdout_tail"], "");
 }

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -2292,7 +2292,9 @@ async fn job_log_returns_bounded_output_for_in_memory_local_job() {
     assert!(result.output["exit_code"].is_null());
     assert_eq!(result.output["stdout_lines"], 1000);
     assert_eq!(result.output["stdout_truncated"], true);
-    assert_eq!(result.output["cursor"]["stdout"], 1001);
+    // The final line is unterminated, so automatic observation must leave it
+    // as the next line to inspect rather than conclusively consuming it.
+    assert_eq!(result.output["cursor"]["stdout"], 1000);
     assert_eq!(result.output["command_summary"], "echo test");
     assert_eq!(result.output["detected_summary"]["kind"], "operation");
     assert_eq!(result.output["detected_summary"]["outcome"], "failed");
@@ -3909,6 +3911,227 @@ async fn local_job_log_observation_is_baseline_then_independent_deltas() {
 }
 
 #[tokio::test]
+async fn local_job_log_replays_partial_lines_and_keeps_stream_cursors_independent() {
+    let (_temp, record, _) = make_local_record("job-partial-local");
+    let stdout_path = record.dir.join("stdout.log");
+    let stderr_path = record.dir.join("stderr.log");
+    fs::write(&stdout_path, "abc").unwrap();
+
+    let baseline = super::super::jobs::local_job_log(
+        "job-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        None,
+        None,
+    )
+    .await;
+    assert!(baseline.success, "{:?}", baseline.error);
+    assert_eq!(baseline.output["log_delta_status"], "baseline");
+    assert_eq!(baseline.output["stdout_tail"], "abc");
+    let token0 = baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let parsed0 = crate::job_observation::JobObservationToken::parse(&token0).unwrap();
+    assert_eq!(parsed0.stdout_cursor, Some(1));
+    assert_eq!(parsed0.stderr_cursor, Some(1));
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&stdout_path)
+        .unwrap()
+        .write_all(b"def")
+        .unwrap();
+    let first_growth = super::super::jobs::local_job_log(
+        "job-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(token0),
+        None,
+    )
+    .await;
+    assert_eq!(first_growth.output["log_delta_status"], "delta");
+    assert_eq!(first_growth.output["stdout_tail"], "abcdef");
+    let token1 = first_growth.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        crate::job_observation::JobObservationToken::parse(&token1)
+            .unwrap()
+            .stdout_cursor,
+        Some(1)
+    );
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&stdout_path)
+        .unwrap()
+        .write_all(b"ghi")
+        .unwrap();
+    let second_growth = super::super::jobs::local_job_log(
+        "job-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(token1),
+        None,
+    )
+    .await;
+    assert_eq!(second_growth.output["stdout_tail"], "abcdefghi");
+    let token2 = second_growth.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        crate::job_observation::JobObservationToken::parse(&token2)
+            .unwrap()
+            .stdout_cursor,
+        Some(1)
+    );
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&stdout_path)
+        .unwrap()
+        .write_all(b"\n")
+        .unwrap();
+    let completed_stdout = super::super::jobs::local_job_log(
+        "job-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(token2),
+        None,
+    )
+    .await;
+    assert_eq!(completed_stdout.output["stdout_tail"], "abcdefghi");
+    let token3 = completed_stdout.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let parsed3 = crate::job_observation::JobObservationToken::parse(&token3).unwrap();
+    assert_eq!(parsed3.stdout_cursor, Some(2));
+    assert_eq!(parsed3.stderr_cursor, Some(1));
+
+    fs::write(&stderr_path, "err").unwrap();
+    let stderr_partial = super::super::jobs::local_job_log(
+        "job-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(token3),
+        None,
+    )
+    .await;
+    assert_eq!(stderr_partial.output["stdout_tail"], "");
+    assert_eq!(stderr_partial.output["stderr_tail"], "err");
+    let token4 = stderr_partial.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let parsed4 = crate::job_observation::JobObservationToken::parse(&token4).unwrap();
+    assert_eq!(parsed4.stdout_cursor, Some(2));
+    assert_eq!(parsed4.stderr_cursor, Some(1));
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&stderr_path)
+        .unwrap()
+        .write_all(b"or\n")
+        .unwrap();
+    fs::write(record.dir.join("exit_code"), "0").unwrap();
+    fs::write(record.dir.join("status"), "completed").unwrap();
+    let terminal = super::super::jobs::local_job_log(
+        "job-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(token4),
+        None,
+    )
+    .await;
+    assert!(terminal.success, "{:?}", terminal.error);
+    assert_eq!(terminal.output["terminal"], true);
+    assert_eq!(terminal.output["log_delta_status"], "delta");
+    assert_eq!(terminal.output["stdout_tail"], "");
+    assert_eq!(terminal.output["stderr_tail"], "error");
+    let terminal_token = terminal.output["observation_token"].as_str().unwrap();
+    let parsed_terminal =
+        crate::job_observation::JobObservationToken::parse(terminal_token).unwrap();
+    assert_eq!(parsed_terminal.stdout_cursor, Some(2));
+    assert_eq!(parsed_terminal.stderr_cursor, Some(2));
+}
+
+#[tokio::test]
+async fn local_job_log_long_partial_line_stays_bounded_without_silent_omission() {
+    let (_temp, record, _) = make_local_record("job-long-partial-local");
+    let stdout_path = record.dir.join("stdout.log");
+    fs::write(
+        &stdout_path,
+        "x".repeat(super::super::local_jobs::MAX_LOCAL_LOG_BYTES_PER_STREAM + 4096),
+    )
+    .unwrap();
+
+    let baseline = super::super::jobs::local_job_log(
+        "job-long-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        None,
+        None,
+    )
+    .await;
+    assert!(baseline.success, "{:?}", baseline.error);
+    let baseline_tail = baseline.output["stdout_tail"].as_str().unwrap();
+    assert!(baseline_tail.len() <= super::super::local_jobs::MAX_LOCAL_LOG_BYTES_PER_STREAM);
+    assert_eq!(baseline.output["stdout_truncated"], true);
+    assert_eq!(baseline.output["earlier_stdout_unavailable"], true);
+    let token = baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        crate::job_observation::JobObservationToken::parse(&token)
+            .unwrap()
+            .stdout_cursor,
+        Some(1)
+    );
+
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&stdout_path)
+        .unwrap()
+        .write_all(b"tail\n")
+        .unwrap();
+    let follow = super::super::jobs::local_job_log(
+        "job-long-partial-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        Some(token),
+        None,
+    )
+    .await;
+    assert!(follow.success, "{:?}", follow.error);
+    let follow_tail = follow.output["stdout_tail"].as_str().unwrap();
+    assert!(!(follow.output["log_delta_status"] == "unchanged" && follow_tail.is_empty()));
+    assert!(follow_tail.len() <= super::super::local_jobs::MAX_LOCAL_LOG_BYTES_PER_STREAM);
+    assert!(follow_tail.ends_with("tail"));
+    assert_eq!(follow.output["earlier_stdout_unavailable"], true);
+}
+
+#[tokio::test]
 async fn local_job_log_resets_on_retention_epoch_and_legacy_boundaries() {
     let (_temp, record, initial) = make_local_record("job-reset-local");
     let stdout_path = record.dir.join("stdout.log");
@@ -4003,6 +4226,54 @@ async fn local_job_log_resets_on_retention_epoch_and_legacy_boundaries() {
         .unwrap()
         .starts_with("wj2l:"));
     assert_ne!(initial.epoch, "old-server-epoch");
+}
+
+#[tokio::test]
+async fn local_job_log_retention_gap_all_retained_lines_fit_is_still_truncated() {
+    let (_temp, record, _) = make_local_record("job-retention-all-fit-local");
+    let stdout_path = record.dir.join("stdout.log");
+    fs::write(&stdout_path, "first\n").unwrap();
+    let baseline = super::super::jobs::local_job_log(
+        "job-retention-all-fit-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(10),
+        None,
+        None,
+    )
+    .await;
+    let token = baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let replacement = (1..=MAX_LOCAL_LOG_LINES + 100)
+        .map(|line| format!("line {line}\n"))
+        .collect::<String>();
+    fs::write(&stdout_path, replacement).unwrap();
+    let reset = super::super::jobs::local_job_log(
+        "job-retention-all-fit-local",
+        &record,
+        &SystemJobKiller,
+        None,
+        Some(MAX_LOCAL_LOG_LINES),
+        Some(token),
+        None,
+    )
+    .await;
+
+    assert!(reset.success, "{:?}", reset.error);
+    assert_eq!(reset.output["log_delta_status"], "reset");
+    assert_eq!(reset.output["stdout_delta_reset"], true);
+    assert_eq!(reset.output["stdout_truncated"], true);
+    assert_eq!(reset.output["earlier_stdout_unavailable"], true);
+    assert_eq!(reset.output["stdout_returned_lines"], MAX_LOCAL_LOG_LINES);
+    assert_eq!(reset.output["stdout_retained_from_line"], 101);
+    assert!(reset.output["stdout_tail"]
+        .as_str()
+        .unwrap()
+        .starts_with("line 101\n"));
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -7,6 +7,7 @@ use crate::shell_protocol::{
     ShellCommandExecutionState, ShellJobInventory,
 };
 use serde_json::json;
+use std::io::Write;
 use std::time::{Duration, Instant};
 
 fn item(job_id: &str, token: Option<String>) -> ObserveJobsItem {
@@ -60,6 +61,18 @@ async fn seed_local_job(
         .await
         .insert(job_id.to_string(), record.clone());
     (record, token)
+}
+
+async fn local_cursor_token(runtime: &ToolRuntime, job_id: &str, tail_lines: usize) -> String {
+    let baseline = runtime
+        .job_log_for_auth(job_id.to_string(), None, Some(tail_lines), None, None, None)
+        .await;
+    assert!(baseline.success, "{:?}", baseline.error);
+    assert_eq!(baseline.output["log_delta_status"], "baseline");
+    baseline.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string()
 }
 
 async fn register_and_start_agent_job(
@@ -297,6 +310,30 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
         spec.output_schema["properties"]["output"]["anyOf"][0]["properties"]["wake_reason"]["enum"],
         json!(["immediate", "updated", "terminal", "item_error", "timeout"])
     );
+    let observation = &spec.output_schema["properties"]["output"]["anyOf"][0]["properties"]
+        ["items"]["items"]["properties"]["output"]["anyOf"][0];
+    assert_eq!(
+        observation["properties"]["log_delta_status"]["enum"],
+        json!(["baseline", "delta", "unchanged", "reset"])
+    );
+    assert_eq!(
+        observation["properties"]["observation_token"]["maxLength"],
+        crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN
+    );
+    for required in [
+        "log_delta_status",
+        "stdout_delta_reset",
+        "stderr_delta_reset",
+    ] {
+        assert!(
+            observation["required"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|field| field == required),
+            "observe_jobs item output must require {required}"
+        );
+    }
 
     let definition = super::super::tool_definition::lookup_tool_definition("observe_jobs").unwrap();
     assert!(definition.visibility.is_model_visible());
@@ -438,7 +475,7 @@ async fn observe_jobs_isolates_unknown_and_token_binding_failures() {
         seed_local_job(&runtime, temp.path(), "token-three", "running", "", "").await;
     let (_, token_four) =
         seed_local_job(&runtime, temp.path(), "token-four", "running", "", "").await;
-    let wrong_executor = crate::job_observation::JobObservationToken::new(
+    let wrong_executor = crate::job_observation::JobObservationToken::new_legacy(
         crate::job_observation::JobObservationExecutor::Agent,
         "token-three",
         "epoch",
@@ -520,7 +557,7 @@ async fn observe_jobs_old_epoch_token_refreshes_without_waiting() {
     let temp = tempfile::tempdir().unwrap();
     let runtime = test_runtime();
     seed_local_job(&runtime, temp.path(), "epoch-job", "running", "", "").await;
-    let stale = crate::job_observation::JobObservationToken::new(
+    let stale = crate::job_observation::JobObservationToken::new_legacy(
         crate::job_observation::JobObservationExecutor::Local,
         "epoch-job",
         "old-server-epoch",
@@ -1021,4 +1058,268 @@ fn observe_jobs_session_sanitizer_removes_nested_token_bodies() {
     assert!(!serialized.contains(opaque));
     assert_eq!(summary["items"][0]["job_id"], "job");
     assert!(summary["items"][0].get("after_observation_token").is_none());
+}
+
+#[tokio::test]
+async fn observe_jobs_cursor_tokens_make_unchanged_siblings_empty() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let mut items = Vec::new();
+    for index in 0..3 {
+        let job_id = format!("delta-unchanged-{index}");
+        seed_local_job(
+            &runtime,
+            temp.path(),
+            &job_id,
+            "running",
+            &format!("old output {index}\n"),
+            "",
+        )
+        .await;
+        let token = local_cursor_token(&runtime, &job_id, 40).await;
+        items.push(item(&job_id, Some(token)));
+    }
+
+    let result = runtime.observe_jobs_for_auth(items, 40, None, None).await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["changed_count"], 0);
+    assert_eq!(result.output["returned_count"], 3);
+    for observed in result.output["items"].as_array().unwrap() {
+        assert_eq!(observed["output"]["log_delta_status"], "unchanged");
+        assert_eq!(observed["output"]["stdout_tail"], "");
+        assert_eq!(observed["output"]["stderr_tail"], "");
+    }
+}
+
+#[tokio::test]
+async fn observe_jobs_returns_delta_only_for_the_changed_item() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let mut records = Vec::new();
+    let mut items = Vec::new();
+    for index in 0..3 {
+        let job_id = format!("delta-one-{index}");
+        let (record, _) = seed_local_job(
+            &runtime,
+            temp.path(),
+            &job_id,
+            "running",
+            &format!("old output {index}\n"),
+            "",
+        )
+        .await;
+        let token = local_cursor_token(&runtime, &job_id, 40).await;
+        records.push(record);
+        items.push(item(&job_id, Some(token)));
+    }
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(records[1].dir.join("stdout.log"))
+        .unwrap()
+        .write_all(b"only new output\n")
+        .unwrap();
+
+    let result = runtime.observe_jobs_for_auth(items, 40, None, None).await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["changed_count"], 1);
+    assert_eq!(result.output["items"][0]["output"]["stdout_tail"], "");
+    assert_eq!(
+        result.output["items"][1]["output"]["stdout_tail"],
+        "only new output"
+    );
+    assert_eq!(
+        result.output["items"][1]["output"]["log_delta_status"],
+        "delta"
+    );
+    assert_eq!(result.output["items"][2]["output"]["stdout_tail"], "");
+}
+
+#[tokio::test]
+async fn observe_jobs_terminal_without_new_output_wakes_without_repeating_tail() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let (record, _) = seed_local_job(
+        &runtime,
+        temp.path(),
+        "delta-terminal",
+        "running",
+        "already observed\n",
+        "",
+    )
+    .await;
+    let token = local_cursor_token(&runtime, "delta-terminal", 40).await;
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .observe_jobs_for_auth(vec![item("delta-terminal", Some(token))], 40, Some(5), None)
+                .await
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    std::fs::write(record.dir.join("exit_code"), "0").unwrap();
+    std::fs::write(
+        record.dir.join("finished_at"),
+        chrono::Utc::now().timestamp().to_string(),
+    )
+    .unwrap();
+    std::fs::write(record.dir.join("status"), "completed").unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(2), task)
+        .await
+        .expect("terminal observation should wake")
+        .unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["wake_reason"], "terminal");
+    assert_eq!(result.output["changed_count"], 1);
+    assert_eq!(result.output["items"][0]["output"]["terminal"], true);
+    assert_eq!(
+        result.output["items"][0]["output"]["log_delta_status"],
+        "unchanged"
+    );
+    assert_eq!(result.output["items"][0]["output"]["stdout_tail"], "");
+    assert_eq!(result.output["items"][0]["output"]["stderr_tail"], "");
+}
+
+#[tokio::test]
+async fn observe_jobs_shared_timeout_keeps_all_cursor_items_compact() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let mut items = Vec::new();
+    for index in 0..4 {
+        let job_id = format!("delta-timeout-{index}");
+        seed_local_job(
+            &runtime,
+            temp.path(),
+            &job_id,
+            "running",
+            &format!("already observed {index}\n"),
+            "",
+        )
+        .await;
+        let token = local_cursor_token(&runtime, &job_id, 40).await;
+        items.push(item(&job_id, Some(token)));
+    }
+    let started = Instant::now();
+    let result = runtime
+        .observe_jobs_for_auth(items, 40, Some(1), None)
+        .await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["wake_reason"], "timeout");
+    assert_eq!(result.output["changed_count"], 0);
+    assert!(started.elapsed() < Duration::from_secs(3));
+    for observed in result.output["items"].as_array().unwrap() {
+        assert_eq!(observed["output"]["log_delta_status"], "unchanged");
+        assert_eq!(observed["output"]["stdout_tail"], "");
+        assert_eq!(observed["output"]["stderr_tail"], "");
+    }
+}
+
+#[tokio::test]
+async fn observe_jobs_resets_only_legacy_item_and_preserves_other_deltas() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let (_, legacy) = seed_local_job(
+        &runtime,
+        temp.path(),
+        "delta-legacy",
+        "running",
+        "legacy baseline\n",
+        "",
+    )
+    .await;
+    seed_local_job(
+        &runtime,
+        temp.path(),
+        "delta-current",
+        "running",
+        "current baseline\n",
+        "",
+    )
+    .await;
+    let current = local_cursor_token(&runtime, "delta-current", 40).await;
+
+    let result = runtime
+        .observe_jobs_for_auth(
+            vec![
+                item("delta-legacy", Some(legacy)),
+                item("delta-current", Some(current)),
+            ],
+            40,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["wake_reason"], "immediate");
+    assert_eq!(
+        result.output["items"][0]["output"]["log_delta_status"],
+        "reset"
+    );
+    assert_eq!(
+        result.output["items"][0]["output"]["stdout_tail"],
+        "legacy baseline"
+    );
+    assert_eq!(
+        result.output["items"][1]["output"]["log_delta_status"],
+        "unchanged"
+    );
+    assert_eq!(result.output["items"][1]["output"]["stdout_tail"], "");
+}
+
+#[tokio::test]
+async fn observe_jobs_delta_measurement_and_budget_are_deterministic() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let log = (1..=40)
+        .map(|line| format!("line {line:02} {}", "x".repeat(32)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut legacy_items = Vec::new();
+    for index in 0..4 {
+        let job_id = format!("delta-measure-{index}");
+        let (_, legacy) = seed_local_job(&runtime, temp.path(), &job_id, "running", &log, "").await;
+        legacy_items.push(item(&job_id, Some(legacy)));
+    }
+    let legacy_full = runtime
+        .observe_jobs_for_auth(legacy_items, 40, None, None)
+        .await;
+    assert!(legacy_full.success, "{:?}", legacy_full.error);
+    for observed in legacy_full.output["items"].as_array().unwrap() {
+        assert_eq!(observed["output"]["log_delta_status"], "reset");
+        assert_eq!(observed["output"]["stdout_returned_lines"], 40);
+    }
+    let follow_items = legacy_full.output["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|observed| {
+            item(
+                observed["job_id"].as_str().unwrap(),
+                Some(
+                    observed["output"]["observation_token"]
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                ),
+            )
+        })
+        .collect();
+    let unchanged = runtime
+        .observe_jobs_for_auth(follow_items, 40, None, None)
+        .await;
+    assert!(unchanged.success, "{:?}", unchanged.error);
+    assert_eq!(unchanged.output["output_truncated"], false);
+    assert_eq!(unchanged.output["next_index"], serde_json::Value::Null);
+    assert_eq!(unchanged.output["returned_count"], 4);
+
+    let legacy_full_bytes = serde_json::to_vec(&legacy_full).unwrap().len();
+    let unchanged_bytes = serde_json::to_vec(&unchanged).unwrap().len();
+    eprintln!(
+        "E4_BATCH_BYTES legacy_full_tail={legacy_full_bytes} unchanged_delta={unchanged_bytes}"
+    );
+    assert!(
+        unchanged_bytes * 2 < legacy_full_bytes,
+        "delta output should be materially smaller: legacy={legacy_full_bytes}, unchanged={unchanged_bytes}"
+    );
 }

--- a/src/tool_runtime/tests/schema/outputs.rs
+++ b/src/tool_runtime/tests/schema/outputs.rs
@@ -872,6 +872,9 @@ fn key_tool_output_schemas_include_expected_fields() {
         "stderr_lines",
         "stdout_truncated",
         "stderr_truncated",
+        "log_delta_status",
+        "stdout_delta_reset",
+        "stderr_delta_reset",
         "cursor",
         "status",
         "executor",
@@ -947,6 +950,9 @@ fn key_tool_output_schemas_include_expected_fields() {
         "stderr_lines",
         "stdout_truncated",
         "stderr_truncated",
+        "log_delta_status",
+        "stdout_delta_reset",
+        "stderr_delta_reset",
         "cursor",
         "status",
         "executor",
@@ -975,6 +981,14 @@ fn key_tool_output_schemas_include_expected_fields() {
             "job_log {field} description must describe bounded tail text: {description}"
         );
     }
+    assert_eq!(
+        output_schema_property(&specs, "job_log", "log_delta_status")["enum"],
+        serde_json::json!(["baseline", "delta", "unchanged", "reset"])
+    );
+    assert_eq!(
+        output_schema_property(&specs, "job_log", "observation_token")["maxLength"],
+        crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN
+    );
     let cursor_description = output_schema_property(&specs, "job_log", "cursor")["description"]
         .as_str()
         .expect("job_log cursor description")

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -48,6 +48,25 @@ async fn wait_for_agent_request(
     panic!("agent request was not enqueued for {client_id}");
 }
 
+fn assert_agent_observation_upgrades_without_changing_snapshot(
+    job_id: &str,
+    legacy_token: &str,
+    cursor_token: &str,
+) {
+    use crate::job_observation::{JobObservationExecutor, JobObservationToken};
+
+    let legacy =
+        JobObservationToken::parse_bound(legacy_token, JobObservationExecutor::Agent, job_id)
+            .expect("handoff token should bind the agent Job");
+    let cursor =
+        JobObservationToken::parse_bound(cursor_token, JobObservationExecutor::Agent, job_id)
+            .expect("observed token should bind the agent Job");
+    assert!(legacy.is_legacy());
+    assert!(!cursor.is_legacy());
+    assert_eq!(cursor.epoch, legacy.epoch);
+    assert_eq!(cursor.revision, legacy.revision);
+}
+
 async fn complete_sync_shell_lifecycle(
     runtime: &ToolRuntime,
     client_id: &str,
@@ -722,9 +741,12 @@ async fn long_go_test_hands_off_same_job_and_terminal_evidence_is_queryable() {
         .await;
     assert!(observed.success, "{:?}", observed.error);
     assert_eq!(observed.output["items"][0]["success"], true);
-    assert_eq!(
-        observed.output["items"][0]["output"]["observation_token"],
-        observation_token
+    assert_agent_observation_upgrades_without_changing_snapshot(
+        &job_id,
+        &observation_token,
+        observed.output["items"][0]["output"]["observation_token"]
+            .as_str()
+            .expect("observed go_test observation token"),
     );
     assert_cargo_result_matches_schema("go_test", &result);
 
@@ -912,9 +934,12 @@ async fn long_cargo_check_hands_off_with_immediately_observable_token() {
         .await;
     assert!(observed.success, "{:?}", observed.error);
     assert_eq!(observed.output["items"][0]["success"], true);
-    assert_eq!(
-        observed.output["items"][0]["output"]["observation_token"],
-        observation_token
+    assert_agent_observation_upgrades_without_changing_snapshot(
+        &job_id,
+        &observation_token,
+        observed.output["items"][0]["output"]["observation_token"]
+            .as_str()
+            .expect("observed cargo_check observation token"),
     );
     assert_cargo_result_matches_schema("cargo_check", &result);
 }
@@ -1013,9 +1038,12 @@ async fn long_cargo_test_hands_off_to_queryable_job() {
         .await;
     assert!(observed.success, "{:?}", observed.error);
     assert_eq!(observed.output["items"][0]["success"], true);
-    assert_eq!(
-        observed.output["items"][0]["output"]["observation_token"],
-        observation_token
+    assert_agent_observation_upgrades_without_changing_snapshot(
+        &job_id,
+        &observation_token,
+        observed.output["items"][0]["output"]["observation_token"]
+            .as_str()
+            .expect("observed cargo_test observation token"),
     );
 
     // Job is immediately queryable and still active.
@@ -1266,7 +1294,7 @@ async fn handoff_job_terminal_success_produces_passed_validation_summary() {
 }
 
 #[tokio::test]
-async fn partial_agent_job_logs_null_complete_validation_counts_everywhere() {
+async fn partial_agent_status_is_conservative_while_delta_log_uses_frozen_validation_context() {
     let client_id = "vhandoff-partial-counts";
     let runtime = runtime_with_agent_project(client_id)
         .with_validation_sync_wait(std::time::Duration::from_millis(50));
@@ -1326,10 +1354,39 @@ async fn partial_agent_job_logs_null_complete_validation_counts_everywhere() {
     assert!(handoff.success, "{:?}", handoff.error);
     assert_eq!(handoff.output["promoted_to_job"], true);
 
-    let mut stdout = (0..600)
-        .map(|index| format!("progress line {index}\n"))
-        .collect::<String>();
+    let mut stdout = String::from("running 3 tests\n");
+    stdout.push_str(
+        &(0..600)
+            .map(|index| format!("progress line {index}\n"))
+            .collect::<String>(),
+    );
     stdout.push_str("test result: ok. 3 passed; 0 failed; 0 ignored\n");
+    runtime
+        .shell_clients
+        .update_job(cargo_test_update(
+            client_id,
+            &request.request_id,
+            &job_id,
+            "running",
+            &stdout,
+            "",
+            None,
+            running_progress("test"),
+            false,
+        ))
+        .await
+        .unwrap();
+    let running_log = runtime
+        .job_log_for_auth(job_id.clone(), None, Some(200), Some(&auth), None, None)
+        .await;
+    assert!(running_log.success, "{:?}", running_log.error);
+    assert_eq!(running_log.output["status"], "running");
+    assert_eq!(running_log.output["log_delta_status"], "baseline");
+    let running_token = running_log.output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
     runtime
         .shell_clients
         .update_job(cargo_test_update(
@@ -1362,19 +1419,26 @@ async fn partial_agent_job_logs_null_complete_validation_counts_everywhere() {
     }
 
     let log = runtime
-        .job_log_for_auth(job_id.clone(), None, Some(200), Some(&auth), None, None)
+        .job_log_for_auth(
+            job_id.clone(),
+            None,
+            Some(200),
+            Some(&auth),
+            Some(running_token),
+            None,
+        )
         .await;
     assert!(log.success, "{:?}", log.error);
+    assert_eq!(log.output["status"], "completed");
+    assert_eq!(log.output["log_delta_status"], "unchanged");
+    assert_eq!(log.output["stdout_tail"], "");
+    assert_eq!(log.output["stderr_tail"], "");
     assert_eq!(log.output["validation"]["passed"], true);
-    assert_eq!(log.output["validation"]["truncated"], true);
-    for field in [
-        "tests_run_count",
-        "tests_passed",
-        "tests_failed",
-        "zero_tests_run",
-    ] {
-        assert!(log.output["validation"][field].is_null(), "{field}");
-    }
+    assert_eq!(log.output["validation"]["truncated"], false);
+    assert_eq!(log.output["validation"]["tests_run_count"], 3);
+    assert_eq!(log.output["validation"]["tests_passed"], 3);
+    assert_eq!(log.output["validation"]["tests_failed"], 0);
+    assert_eq!(log.output["validation"]["zero_tests_run"], false);
 
     let summary = runtime
         .sessions


### PR DESCRIPTION
## Summary

- add versioned cursor-aware Job observation tokens for local and agent Jobs
- return bounded baseline output on first observation and only newly observable stdout/stderr on follow-up observations
- preserve lifecycle-only legacy tokens and explicit pagination semantics
- conservatively replay an unterminated final line until its boundary is observed so partial chunk growth cannot be silently omitted
- make retention-gap reset/truncation metadata remain truthful when earlier retained history is unavailable
- keep validation/detected summaries based on authoritative retained context rather than sparse model-facing deltas
- preserve existing `observe_jobs` orchestration, Job execution/authorization/ownership, retry/idempotency, and stop semantics

## Validation

- `cargo test job_observation -p webcodex`: 8 passed
- `cargo test job_log -p webcodex`: 37 passed
- `cargo test observe_jobs -p webcodex`: 24 passed
- `cargo test job_log_wait -p webcodex`: 16 passed
- structured validation delta regression: passed
- `cargo test tool_runtime::tests::schema -p webcodex`: 104 passed
- `cargo test openapi -p webcodex`: 56 passed
- `cargo check --all-targets -p webcodex`: passed
- `cargo fmt -- --check`: passed
- `git diff --check`: passed
- final `cargo test -p webcodex`: 2768 passed, 0 failed

## Review history

Independent review found one correctness blocker in the initial commit: line cursors could treat an unterminated final line as fully consumed and silently omit bytes appended to that same logical line. The follow-up commit preserves the line-based token format but leaves the partial line pending for bounded replay until a newline is observed. A nearby retention-gap truncation metadata defect was fixed in the same focused closure.

No Runner protocol, Job execution, authorization, ownership, retry/idempotency, stop, collaboration, or E3b semantics are expanded by this PR.