### PR TITLE
Preserve Workflow Session provenance over stateless MCP

### DIFF
--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -86,10 +86,14 @@ For a bounded independent subtask, keep coordinator `C` and worker `W` in
 **separate** Workflow Sessions. The coordinator posts a `todo` to `C`; `W` reads
 `session_handoff_summary(C)` plus that exact `message_id`, performs all tools and
 validation under `W`, then uses `complete_session_message` to atomically create one
-bounded answer and resolve the exact todo. The answer carries trusted
-`author_session_id` provenance from the recording worker Session first, falling
-back to the current worker Session binding only when no recording Session exists;
-the caller cannot forge that field.
+bounded answer and resolve the exact todo. On stateless MCP 2026, send
+`recording_session_id=W` as wrapper metadata while the concrete
+`complete_session_message.session_id=C` remains the coordinator/business target;
+WebCodex strips the recorder metadata before concrete parsing. The answer carries
+trusted `author_session_id` provenance from the recording worker Session first,
+falling back to the current worker Session binding only when no recording Session
+exists; the caller cannot forge that field, and legacy `mcp-session-id` is not used
+as Workflow Session provenance.
 
 The coordinator can retrieve the exact todo or its replies with
 `list_session_messages(message_id=...)` / `list_session_messages(reply_to=...)`,

--- a/docs/agent/manual-window-collaboration.md
+++ b/docs/agent/manual-window-collaboration.md
@@ -16,7 +16,7 @@ Knowing a `session_id`, `message_id`, worker Session id, Job id, checkpoint id, 
 2. **Worker starts its own Session `W`.** Do not resume `C` just to accept the assignment.
 3. **Worker reads bounded coordinator state.** Use `session_handoff_summary(session_id=C)` and then `list_session_messages(session_id=C, message_id=<todo_id>)`. Exact lookup does not depend on the todo being in a recent-message window.
 4. **Worker performs the task under `W`.** Reads, edits, shell/process calls, validation, review evidence, Jobs, checkpoints, and other authoritative activity stay attached to `W`.
-5. **Worker completes the exact todo atomically.** Use `complete_session_message(session_id=C, message_id=<todo_id>, answer=<bounded answer>, completion_key=<caller key>)`. One Session-store mutation creates exactly one `kind=answer` reply, resolves the todo, and records the todo -> answer correlation.
+5. **Worker completes the exact todo atomically.** Use `complete_session_message(session_id=C, message_id=<todo_id>, answer=<bounded answer>, completion_key=<caller key>)`. On stateless MCP 2026, the `tools/call` arguments additionally carry wrapper metadata `recording_session_id=W`; this is distinct from the concrete business `session_id=C` and is stripped before concrete tool parsing. One Session-store mutation creates exactly one `kind=answer` reply, resolves the todo, and records the todo -> answer correlation.
 6. **Coordinator reads the result from `C`.** Use exact todo lookup, `list_session_messages(reply_to=<todo_id>)`, `session_discussion_summary`, or `session_handoff_summary`.
 7. **Coordinator re-observes authoritative state.** A message may reference `W`, a Job, checkpoint, artifact, commit, or PR, but the coordinator explicitly reads/revalidates that source before consequential follow-up.
 
@@ -48,7 +48,7 @@ A successful completion records:
 - a bounded completion identity derived from `completion_key`;
 - `author_session_id` from the trusted recording Session when the tool call is explicitly recorded under one; otherwise from the existing trusted current-window Session binding when available.
 
-The recording Session wins when it differs from the current-window binding, so provenance follows the Session that actually records the completion evidence. If neither trusted source exists, `author_session_id` is `null`; callers cannot supply a trusted author identity themselves.
+The recording Session wins when it differs from the current-window binding, so provenance follows the Session that actually records the completion evidence. If neither trusted source exists, `author_session_id` is `null`; callers cannot supply a trusted author identity themselves. Stateless MCP 2026 has no reliable transport/window Session identity, so callers that want worker provenance must pass the explicit `recording_session_id` wrapper metadata returned by WebCodex's 2026 `tools/list` schema. WebCodex does not infer it from `mcp-session-id`, HTTP connection state, credentials, project identity, or a recent Workflow Session.
 
 When a collaboration call has both a recording Session and a target Session, WebCodex authorizes both independently and then requires their stored project scopes to match exactly. `project/project` is allowed only for the same project, `project/project` with different projects is denied, both `project/project-less` directions are denied, and `project-less/project-less` is allowed only after both owner authorities have independently matched. The generic cross-project escape flag never widens this collaboration relationship.
 
@@ -71,7 +71,7 @@ All supplied filters use deterministic AND semantics. `message_id` therefore giv
 
 ## Provenance is metadata, not authority
 
-A completed answer can identify the independent worker with `author_session_id`. That value is derived first from the trusted recording Session that owns the completion tool evidence, then from the trusted current-Session binding only when no recording Session exists. It is not a caller-authored claim.
+A completed answer can identify the independent worker with `author_session_id`. That value is derived first from the trusted recording Session that owns the completion tool evidence, then from the trusted current-Session binding only when no recording Session exists. It is not a caller-authored claim. In stateless MCP 2026, `recording_session_id` is explicit wrapper provenance metadata, not a transport Session and not an authority grant; the legacy `mcp-session-id` header remains irrelevant.
 
 The coordinator may then explicitly inspect `session_handoff_summary(worker_session_id)` if it has authority to that Session. WebCodex does not copy the worker's transcript, validation, diff review, Job logs, or workspace evidence into the coordinator Session merely because the answer references `W`.
 

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -86,7 +86,7 @@ handoff, and finish can reason about the same unit of work.
 | ID form | `wc_sess_*` (`SESSION_ID_PREFIX`) |
 | Business field | `session_id` on tools that take a workflow session as input |
 | Coding resume field | `resume_session_id` on `start_coding_task`; distinct from ordinary project-tool `session_id` |
-| Recorder field | `recording_session_id` on generic wrappers (metadata only; stripped before concrete tool dispatch) |
+| Recorder field | `recording_session_id` on generic wrappers, including the stateless MCP 2026 tool-argument projection (metadata only; stripped before concrete tool dispatch) |
 
 ### Storage and ownership
 
@@ -96,6 +96,8 @@ handoff, and finish can reason about the same unit of work.
 | Primary store | In-memory session store |
 | Durability | JSON-oriented session ledger (bounded events/messages per session) |
 | Current-session binding | In-memory exact-key cache plus a bounded durable projection in the same JSON ledger; isolated by client window, principal, transport, resolved project, and canonical repository-root hash |
+
+Stateless MCP 2026 does not have a reliable Workflow Session or ChatGPT-window transport identity. Its `tools/list` schema therefore projects `recording_session_id` as explicit wrapper metadata for runtime tools. A call may carry `recording_session_id=W` while the concrete tool body carries business `session_id=C`; the MCP adapter removes the recorder field before concrete parsing and the kernel independently authorizes `W` before it can record evidence or supply trusted collaboration provenance. This does not revive legacy `mcp-session-id`, grant target authority, or infer a recorder from credentials, project identity, or connection state.
 
 Authenticated project-scoped Workflow Sessions created by current code also persist an internal canonical authority-group fingerprint. A legacy project-scoped record from before that fence may legitimately have no fingerprint; current project authorization or knowledge of its `session_id` is not enough to claim it. The only automatic compatibility upgrade is a coding continuation/resume whose current caller can reconstruct an exact historical `CurrentSessionKey` and whose pre-existing **durable** binding already points to that exact active Session for the same resolved project. The proof ignores the process-local cache. After all continuation validation succeeds, the canonical fingerprint is written atomically with the instruction/capability/context/binding mutation and enters the same persistence generation. Without that durable proof the legacy Session remains fail-closed.
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -494,6 +494,31 @@ fn adapt_computer_snapshot_output_schema_for_mcp(spec: &mut ToolSpec) {
     );
 }
 
+fn add_stateless_workflow_recorder_metadata(payload: &mut Value, model_surface: ModelSurface) {
+    if matches!(model_surface, ModelSurface::CanonicalConnector) {
+        return;
+    }
+    let Some(tools) = payload.get_mut("tools").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for tool in tools {
+        let Some(properties) = tool
+            .pointer_mut("/inputSchema/properties")
+            .and_then(Value::as_object_mut)
+        else {
+            continue;
+        };
+        properties.insert(
+            crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD.to_string(),
+            json!({
+                "type": "string",
+                "pattern": "^wc_sess_[A-Za-z0-9_]+$",
+                "description": "MCP wrapper metadata only. Optional explicit existing Workflow Session that records this tools/call and supplies trusted collaboration provenance. It is distinct from any concrete tool business session_id, grants no authority, and is removed before concrete tool parsing."
+            }),
+        );
+    }
+}
+
 fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, _app_enabled: bool) -> Value {
     let tool_name = spec.name.clone();
     if matches!(
@@ -2685,6 +2710,9 @@ async fn handle_mcp_request_with_lifecycle(
             } else {
                 mcp_tools_list_payload(runtime.model_surface())
             };
+            if stateless_2026 {
+                add_stateless_workflow_recorder_metadata(&mut result, runtime.model_surface());
+            }
             if crate::mcp_gateway::authorized(auth) {
                 if let Some(tools) = result.get_mut("tools").and_then(Value::as_array_mut) {
                     tools.push(crate::mcp_gateway::tool_spec());
@@ -2959,7 +2987,16 @@ async fn handle_mcp_request_with_lifecycle(
                     },
                 ));
             }
-            let session_id = strip_reserved_session_id(&mut params.arguments);
+            let session_id = match strip_reserved_session_id(&mut params.arguments) {
+                Ok(session_id) => session_id,
+                Err(message) => {
+                    if let Some(lc) = lifecycle.as_deref() {
+                        lc.dispatch_failed("invalid_arguments");
+                        lc.dispatch_finished(false, Some(false), "invalid_arguments");
+                    }
+                    return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+                }
+            };
             let as_image_requested = params.name == "read_project_artifact"
                 && params.arguments.get("as_image").and_then(Value::as_bool) == Some(true);
             let outcome = runtime
@@ -3305,13 +3342,48 @@ fn require_mcp_scope(auth: Option<&AuthContext>, scope: &'static str) -> Option<
     ))
 }
 
-fn strip_reserved_session_id(arguments: &mut Value) -> Option<String> {
-    arguments
-        .as_object_mut()
-        .and_then(|obj| obj.remove(MCP_RESERVED_SESSION_ID_FIELD))
+fn strip_reserved_session_id(arguments: &mut Value) -> Result<Option<String>, String> {
+    let Some(object) = arguments.as_object_mut() else {
+        return Ok(None);
+    };
+    let canonical =
+        object.remove(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD);
+    let legacy = object.remove(MCP_RESERVED_SESSION_ID_FIELD);
+
+    let canonical = match canonical {
+        None => None,
+        Some(Value::String(value)) => {
+            let value = value.trim();
+            if value.is_empty() {
+                return Err(format!(
+                    "field '{}' must be a non-empty string",
+                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
+                ));
+            }
+            Some(value.to_string())
+        }
+        Some(_) => {
+            return Err(format!(
+                "field '{}' must be a non-empty string",
+                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
+            ));
+        }
+    };
+    let legacy = legacy
         .and_then(|value| value.as_str().map(str::to_string))
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if let (Some(canonical), Some(legacy)) = (&canonical, &legacy) {
+        if canonical != legacy {
+            return Err(format!(
+                "fields '{}' and '{}' must identify the same Workflow Session when both are provided",
+                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,
+                MCP_RESERVED_SESSION_ID_FIELD
+            ));
+        }
+    }
+    Ok(canonical.or(legacy))
 }
 
 fn scope_forbidden(

--- a/src/mcp_tests/http_transport.rs
+++ b/src/mcp_tests/http_transport.rs
@@ -1,5 +1,65 @@
 use super::*;
 
+fn with_mcp_recording_session(mut arguments: Value, session_id: &str) -> Value {
+    arguments
+        .as_object_mut()
+        .expect("tool arguments must be an object")
+        .insert(
+            crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD.to_string(),
+            Value::from(session_id),
+        );
+    arguments
+}
+
+async fn stateless_2026_tool_call(
+    service: &Service,
+    token: &str,
+    id: i64,
+    name: &str,
+    arguments: Value,
+    legacy_session_id: Option<&str>,
+) -> (StatusCode, Value) {
+    let params = mcp_2026_params(json!({
+        "name": name,
+        "arguments": arguments,
+    }));
+    let mut request = TestClient::post("http://localhost/mcp")
+        .bearer_auth(token)
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .add_header(MCP_NAME_HEADER, name, true);
+    if let Some(legacy_session_id) = legacy_session_id {
+        request = request.add_header(
+            crate::client_window::MCP_SESSION_HEADER,
+            legacy_session_id,
+            true,
+        );
+    }
+    let mut response = request
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": params,
+        }))
+        .send(service)
+        .await;
+    assert!(
+        response
+            .headers()
+            .get(crate::client_window::MCP_SESSION_HEADER)
+            .is_none(),
+        "stateless-2026 must never issue a legacy MCP session id"
+    );
+    let status = effective_status(&response);
+    let body = response.take_json::<Value>().await.unwrap();
+    (status, body)
+}
+
 #[tokio::test]
 async fn mcp_tools_call_writes_a_summary_action_audit_row() {
     // list_tools is a full-operator-only tool; select that surface so the
@@ -282,6 +342,249 @@ async fn http_mcp_accepts_chatgpt_2025_11_25_protocol_header() {
     let body: Value = response.take_json().await.unwrap();
     assert!(body["result"]["tools"].is_array());
     assert!(body["result"].get("resultType").is_none());
+}
+
+#[tokio::test]
+async fn http_mcp_2026_collaboration_completion_preserves_explicit_recorder_provenance() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));
+    let service = Service::new(build_test_router(config, db, runtime.clone()));
+
+    let (status, coordinator_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        230,
+        "start_session",
+        json!({"title": "Coordinator C"}),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{coordinator_body}");
+    let coordinator_id = coordinator_body["result"]["structuredContent"]["output"]["session_id"]
+        .as_str()
+        .expect("coordinator Workflow Session")
+        .to_string();
+
+    let (status, worker_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        231,
+        "start_session",
+        json!({"title": "Worker W"}),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{worker_body}");
+    let worker_id = worker_body["result"]["structuredContent"]["output"]["session_id"]
+        .as_str()
+        .expect("worker Workflow Session")
+        .to_string();
+
+    let (status, replay_worker_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        232,
+        "start_session",
+        json!({"title": "Replay worker X"}),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{replay_worker_body}");
+    let replay_worker_id = replay_worker_body["result"]["structuredContent"]["output"]
+        ["session_id"]
+        .as_str()
+        .expect("replay worker Workflow Session")
+        .to_string();
+
+    let (status, posted_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        233,
+        "post_session_message",
+        json!({
+            "session_id": coordinator_id,
+            "kind": "todo",
+            "message": "Review the stateless collaboration provenance path.",
+            "priority": "high"
+        }),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{posted_body}");
+    let todo_id = posted_body["result"]["structuredContent"]["output"]["message_id"]
+        .as_str()
+        .expect("todo message id")
+        .to_string();
+
+    let completion_arguments = with_mcp_recording_session(
+        json!({
+            "session_id": coordinator_id,
+            "message_id": todo_id,
+            "answer": "Reviewed and completed under the explicit worker recorder.",
+            "completion_key": "stateless-recorder-v1",
+            "author_session_id": "wc_sess_forged_should_not_win"
+        }),
+        &worker_id,
+    );
+    let (status, completed_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        234,
+        "complete_session_message",
+        completion_arguments,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{completed_body}");
+    assert_eq!(completed_body["result"]["isError"], false);
+    let completed = &completed_body["result"]["structuredContent"]["output"];
+    assert_eq!(completed["answer"]["author_session_id"], worker_id);
+    assert_eq!(completed["answer"]["reply_to"], todo_id);
+    assert_eq!(completed["todo"]["status"], "resolved");
+    let answer_message_id = completed["answer_message_id"].clone();
+
+    let worker_summary = runtime.sessions.summary(&worker_id, Some(100)).unwrap();
+    assert!(worker_summary.events.iter().any(|event| {
+        event.kind == "tool_call_finished" && event.tool_name == "complete_session_message"
+    }));
+    let worker_audit = serde_json::to_string(&worker_summary.events).unwrap();
+    for private in [
+        "recording_session_id",
+        "Reviewed and completed under the explicit worker recorder.",
+        "stateless-recorder-v1",
+        "wc_sess_forged_should_not_win",
+    ] {
+        assert!(
+            !worker_audit.contains(private),
+            "MCP wrapper/private completion data leaked into Session audit: {private}"
+        );
+    }
+    let coordinator_summary = runtime
+        .sessions
+        .summary(&coordinator_id, Some(100))
+        .unwrap();
+    assert!(!coordinator_summary.events.iter().any(|event| {
+        event.kind == "tool_call_finished" && event.tool_name == "complete_session_message"
+    }));
+
+    let replay_arguments = with_mcp_recording_session(
+        json!({
+            "session_id": coordinator_id,
+            "message_id": todo_id,
+            "answer": "Reviewed and completed under the explicit worker recorder.",
+            "completion_key": "stateless-recorder-v1"
+        }),
+        &replay_worker_id,
+    );
+    let (status, replay_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        235,
+        "complete_session_message",
+        replay_arguments,
+        Some("legacy-session-must-not-affect-2026"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{replay_body}");
+    let replayed = &replay_body["result"]["structuredContent"]["output"];
+    assert_eq!(replayed["replayed"], true);
+    assert_eq!(replayed["answer_message_id"], answer_message_id);
+    assert_eq!(replayed["answer"]["author_session_id"], worker_id);
+
+    let (status, missing_todo_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        236,
+        "post_session_message",
+        json!({
+            "session_id": coordinator_id,
+            "kind": "todo",
+            "message": "Exercise missing recorder compatibility."
+        }),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{missing_todo_body}");
+    let missing_todo_id = missing_todo_body["result"]["structuredContent"]["output"]["message_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (status, missing_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        237,
+        "complete_session_message",
+        json!({
+            "session_id": coordinator_id,
+            "message_id": missing_todo_id,
+            "answer": "Compatibility completion without recorder.",
+            "completion_key": "stateless-no-recorder-v1"
+        }),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{missing_body}");
+    assert_eq!(
+        missing_body["result"]["structuredContent"]["output"]["answer"]["author_session_id"],
+        Value::Null
+    );
+
+    let (status, unknown_todo_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        238,
+        "post_session_message",
+        json!({
+            "session_id": coordinator_id,
+            "kind": "todo",
+            "message": "An unknown recorder must fail before completion mutation."
+        }),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{unknown_todo_body}");
+    let unknown_todo_id = unknown_todo_body["result"]["structuredContent"]["output"]["message_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let before_unknown = runtime
+        .sessions
+        .summary(&coordinator_id, Some(100))
+        .unwrap();
+    let unknown_arguments = with_mcp_recording_session(
+        json!({
+            "session_id": coordinator_id,
+            "message_id": unknown_todo_id,
+            "answer": "must not be written",
+            "completion_key": "unknown-recorder-must-fail"
+        }),
+        "wc_sess_missing_recorder",
+    );
+    let (status, unknown_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        239,
+        "complete_session_message",
+        unknown_arguments,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{unknown_body}");
+    assert_eq!(unknown_body["result"]["isError"], true);
+    assert_eq!(
+        unknown_body["result"]["structuredContent"]["output"]["error_kind"],
+        "unknown_session_id"
+    );
+    let after_unknown = runtime
+        .sessions
+        .summary(&coordinator_id, Some(100))
+        .unwrap();
+    assert_eq!(after_unknown.messages.total, before_unknown.messages.total);
+    assert!(runtime
+        .sessions
+        .summary("wc_sess_missing_recorder", None)
+        .is_none());
 }
 
 #[tokio::test]

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -74,12 +74,32 @@ async fn mcp_tools_list_returns_same_names_as_runtime() {
             stateless_names, runtime_names,
             "stateless-2026 tools/list must match the full runtime registry (compact={compact})"
         );
+        for tool in stateless_value["result"]["tools"].as_array().unwrap() {
+            let properties = tool["inputSchema"]["properties"].as_object().unwrap();
+            let recorder = properties
+                .get(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD)
+                .unwrap_or_else(|| {
+                    panic!("stateless recorder metadata missing for {}", tool["name"])
+                });
+            assert_eq!(recorder["type"], "string");
+            assert_eq!(recorder["pattern"], "^wc_sess_[A-Za-z0-9_]+$");
+            let description = recorder["description"].as_str().unwrap();
+            assert!(description.contains("wrapper metadata"));
+            assert!(description.contains("distinct from any concrete tool business session_id"));
+            assert!(!properties.contains_key(MCP_RESERVED_SESSION_ID_FIELD));
+        }
         // Exercise the real env adapter, not just the pure renderer: compact
         // must change outputSchema shape while preserving the common fields.
+        // Legacy MCP keeps its historical public schema; recorder metadata is
+        // a stateless-2026 transport projection only.
         for tool in tools {
             assert!(tool["name"].is_string());
             assert!(tool["description"].is_string());
             assert!(tool["inputSchema"].is_object());
+            let properties = tool["inputSchema"]["properties"].as_object().unwrap();
+            assert!(!properties
+                .contains_key(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD));
+            assert!(!properties.contains_key(MCP_RESERVED_SESSION_ID_FIELD));
             if compact {
                 assert!(
                     tool.get("outputSchema").is_none(),
@@ -96,6 +116,28 @@ async fn mcp_tools_list_returns_same_names_as_runtime() {
         }
     }
     std::env::remove_var("WEBCODEX_MCP_COMPACT_SCHEMAS");
+}
+
+#[test]
+fn stateless_workflow_recorder_metadata_does_not_expand_connector_or_generic_tool_schema() {
+    let mut connector =
+        mcp_tools_list_payload_with_compact(ModelSurface::CanonicalConnector, false);
+    add_stateless_workflow_recorder_metadata(&mut connector, ModelSurface::CanonicalConnector);
+    for tool in connector["tools"].as_array().unwrap() {
+        assert!(!tool["inputSchema"]["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD));
+    }
+
+    let generic = registered_tool_specs()
+        .into_iter()
+        .find(|tool| tool.name == "complete_session_message")
+        .expect("generic complete_session_message spec");
+    assert!(!generic.input_schema["properties"]
+        .as_object()
+        .unwrap()
+        .contains_key(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD));
 }
 
 #[test]
@@ -896,6 +938,46 @@ async fn mcp_tools_call_strips_reserved_session_id_before_dispatch() {
             .contains(MCP_RESERVED_SESSION_ID_FIELD),
         "_session_id must be stripped before recording/dispatch"
     );
+}
+
+#[tokio::test]
+async fn mcp_tools_call_rejects_conflicting_recorder_metadata_before_dispatch() {
+    let runtime = test_runtime();
+    let canonical = runtime
+        .sessions
+        .start_session(None, Some("canonical recorder".to_string()));
+    let legacy = runtime
+        .sessions
+        .start_session(None, Some("legacy recorder".to_string()));
+
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(Value::from(320)),
+            mcp_2026_params(json!({
+                "name": "list_projects",
+                "arguments": {
+                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD: &canonical.session_id,
+                    MCP_RESERVED_SESSION_ID_FIELD: &legacy.session_id
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    let value = match outcome {
+        McpOutcome::BadRequest(value) => value,
+        other => panic!("expected invalid-params BadRequest, got {other:?}"),
+    };
+    assert_eq!(value["error"]["code"], -32602);
+    assert!(value["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("must identify the same Workflow Session")));
+    for session_id in [&canonical.session_id, &legacy.session_id] {
+        let summary = runtime.sessions.summary(session_id, Some(10)).unwrap();
+        assert_eq!(summary.counts.tool_calls, 0);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fix Workflow Session recorder provenance for direct Stateless MCP 2026 tool calls.

A collaboration worker can now explicitly provide `recording_session_id=W` as MCP wrapper metadata while `complete_session_message.session_id=C` remains the coordinator/business target. This closes the real cross-window handoff gap where successful completions were stored with `author_session_id=null` despite being performed under an independent worker Workflow Session.

## Root cause

The existing kernel/session path already supported trusted recorder provenance once `ToolCallContext.session_id` was populated. Direct MCP 2026 `tools/list`, however, never declared recorder metadata, so a ChatGPT MCP host had no schema reason to send it. The hidden `_session_id` field was only adapter compatibility machinery and could not serve as a model-visible contract.

## Changes

- Project optional `recording_session_id` into Stateless MCP 2026 runtime tool schemas only.
- Strip recorder metadata before concrete tool parsing and pass it through the existing `ToolCallContext.session_id` path.
- Reject conflicting canonical `recording_session_id` and hidden `_session_id` values before dispatch.
- Preserve legacy MCP public schemas, Canonical Connector schemas, generic ToolSpecs, REST/OpenAPI behavior, and the private `trusted_recording_session_id` derivation.
- Document the explicit `W` recorder / `C` business-target distinction.
- Add a real `/mcp` Stateless2026 HTTP integration regression for collaboration completion provenance.

## Authority and compatibility

- Stateless MCP 2026 remains stateless; legacy `mcp-session-id` is still ignored.
- Recorder `W` is authorized independently before any ledger/provenance use.
- Collaboration target `C` is authorized independently.
- Existing exact project-scope and scoped/unscoped fences remain fail closed.
- `author_session_id` remains server-derived and cannot be supplied as trusted caller input.
- Missing recorder retains existing compatibility behavior (`author_session_id=null` when no trusted current binding exists).
- Idempotent replay preserves the original trusted author.

## Validation

Implementation-owner validation passed, including `cargo check --all-targets -p webcodex`, focused MCP/collaboration suites, formatting, and diff checks.

Independent review also re-ran the key regressions successfully:

- Stateless2026 collaboration provenance HTTP integration
- conflicting recorder metadata rejection before dispatch
- stateless schema isolation from Connector/generic ToolSpec surfaces
- `mcp-session-id` ignored under Stateless2026
- foreign recorder authority denial
- cross-project recorder denial
- scoped/unscoped collaboration denial in both directions
- `cargo fmt -- --check`

No merge or deployment is included in this PR.