### PR TITLE
Fix current main validation CI regressions

### DIFF
--- a/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
@@ -2960,6 +2960,33 @@ for line in sys.stdin:
     }
 
     #[cfg(unix)]
+    fn wait_for_terminal_observation(
+        manager: &CodingAgentManager,
+        run: &str,
+    ) -> CodingAgentObserveResult {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let entry = manager.runs.lock().unwrap().get(run).cloned().unwrap();
+            let observation = entry
+                .observe(None, 64, 0)
+                .expect("retained fake Run cursor must be valid");
+            if observation.run.state.terminal()
+                && observation
+                    .events
+                    .iter()
+                    .any(|event| event.kind == CodingAgentEventKind::Terminal)
+            {
+                return observation;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for terminal ACP observation: {observation:?}"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    #[cfg(unix)]
     fn run_scenario(
         scenario: &str,
         config: BTreeMap<String, CodingAgentConfigValue>,
@@ -2974,31 +3001,7 @@ for line in sys.stdin:
         let run = "wc_agent_run_0123456789abcdef".to_string();
         let response = manager.handle(start_request(&manager, &root, &run, config), &projects);
         assert!(response.error.is_none(), "{:?}", response.error);
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            if manager
-                .runs
-                .lock()
-                .unwrap()
-                .get(&run)
-                .unwrap()
-                .snapshot()
-                .state
-                .terminal()
-            {
-                break;
-            }
-            assert!(Instant::now() < deadline);
-            thread::sleep(Duration::from_millis(20));
-        }
-        let observation = manager
-            .runs
-            .lock()
-            .unwrap()
-            .get(&run)
-            .unwrap()
-            .observe(None, 64, 0)
-            .expect("retained fake Run cursor must be valid");
+        let observation = wait_for_terminal_observation(&manager, &run);
         std::mem::forget(temp);
         (manager, run, observation)
     }
@@ -3228,8 +3231,8 @@ for line in sys.stdin:
             &projects,
         );
         assert!(response.error.is_none(), "{:?}", response.error);
-        let terminal = wait_for_snapshot(&manager, run, |snapshot| snapshot.state.terminal());
-        assert_eq!(terminal.state, CodingAgentRunState::Completed);
+        let observation = wait_for_terminal_observation(&manager, run);
+        assert_eq!(observation.run.state, CodingAgentRunState::Completed);
 
         let log = wire_log(&temp);
         assert_eq!(
@@ -3260,14 +3263,6 @@ for line in sys.stdin:
         );
         assert_eq!(session_new.pointer("/params/mcpServers"), Some(&json!([])));
 
-        let observation = manager
-            .runs
-            .lock()
-            .unwrap()
-            .get(run)
-            .unwrap()
-            .observe(None, 64, 0)
-            .expect("retained fake Run cursor must be valid");
         for kind in [
             CodingAgentEventKind::AgentMessage,
             CodingAgentEventKind::Reasoning,

--- a/src/mcp_tests/file_import.rs
+++ b/src/mcp_tests/file_import.rs
@@ -88,6 +88,31 @@ async fn lock_mcp_import_test() -> tokio::sync::MutexGuard<'static, ()> {
     crate::tool_runtime::conversation_import::lock_import_test_network().await
 }
 
+fn run_mcp_import_in_large_stack_test_thread<F, Fut>(test: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()>,
+{
+    // These end-to-end import tests retain the OAuth/router/import fixture across
+    // several awaits. Keep their larger stack local to this test group instead
+    // of raising RUST_MIN_STACK for the whole suite.
+    let result = std::thread::Builder::new()
+        .name("mcp-file-import-test".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build isolated file-import test runtime")
+                .block_on(test());
+        })
+        .expect("spawn isolated file-import test thread")
+        .join();
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 struct McpImportNetworkOverride;
 
 impl McpImportNetworkOverride {
@@ -691,8 +716,14 @@ fn mcp_file_import_trust_decision_reports_exact_failure_stage() {
     assert_eq!(trusted.active_client_registration_found, Some(true));
 }
 
-#[tokio::test]
-async fn oauth_mcp_file_import_startup_env_stateless_2026_crosses_provenance_gate() {
+#[test]
+fn oauth_mcp_file_import_startup_env_stateless_2026_crosses_provenance_gate() {
+    run_mcp_import_in_large_stack_test_thread(
+        oauth_mcp_file_import_startup_env_stateless_2026_crosses_provenance_gate_impl,
+    );
+}
+
+async fn oauth_mcp_file_import_startup_env_stateless_2026_crosses_provenance_gate_impl() {
     use crate::auth::{OAuth2Verifier, TokenVerifier};
     use sha2::{Digest, Sha256};
 
@@ -796,8 +827,12 @@ async fn oauth_mcp_file_import_startup_env_stateless_2026_crosses_provenance_gat
     assert!(!serialized.contains("file_stateless_host_rewritten"));
 }
 
-#[tokio::test]
-async fn oauth_mcp_file_import_trusted_client_saves_pptx() {
+#[test]
+fn oauth_mcp_file_import_trusted_client_saves_pptx() {
+    run_mcp_import_in_large_stack_test_thread(oauth_mcp_file_import_trusted_client_saves_pptx_impl);
+}
+
+async fn oauth_mcp_file_import_trusted_client_saves_pptx_impl() {
     use sha2::{Digest, Sha256};
 
     let _lock = lock_mcp_import_test().await;
@@ -880,8 +915,14 @@ async fn oauth_mcp_file_import_trusted_client_saves_pptx() {
     assert!(!error.contains(temporary_url));
 }
 
-#[tokio::test]
-async fn oauth_mcp_file_import_trusted_download_guards_remain_bounded() {
+#[test]
+fn oauth_mcp_file_import_trusted_download_guards_remain_bounded() {
+    run_mcp_import_in_large_stack_test_thread(
+        oauth_mcp_file_import_trusted_download_guards_remain_bounded_impl,
+    );
+}
+
+async fn oauth_mcp_file_import_trusted_download_guards_remain_bounded_impl() {
     let _lock = lock_mcp_import_test().await;
     let (_db_tmp, db) = test_db();
     let user = seed_user(&db, "alice");
@@ -972,8 +1013,14 @@ async fn oauth_mcp_file_import_trusted_download_guards_remain_bounded() {
     }
 }
 
-#[tokio::test]
-async fn mcp_file_import_untrusted_callers_fail_before_dns() {
+#[test]
+fn mcp_file_import_untrusted_callers_fail_before_dns() {
+    run_mcp_import_in_large_stack_test_thread(
+        mcp_file_import_untrusted_callers_fail_before_dns_impl,
+    );
+}
+
+async fn mcp_file_import_untrusted_callers_fail_before_dns_impl() {
     let _lock = lock_mcp_import_test().await;
     let _network = McpImportNetworkOverride::without_download();
     let (_db_tmp, db) = test_db();

--- a/src/tool_runtime/tests/handoff.rs
+++ b/src/tool_runtime/tests/handoff.rs
@@ -2241,7 +2241,16 @@ async fn session_handoff_summary_only_passes_with_resolved_unexpected_cargo_test
         "cargo_test",
         json!({"project": project.clone()}),
         true,
-        json!({"exit_code": 0}),
+        json!({
+            "exit_code": 0,
+            "stdout_tail": "running 1 test\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n",
+            "stderr_tail": "",
+            "stdout_truncated": false,
+            "stderr_truncated": false,
+            "tests_detected": true,
+            "tests_run_count": 1,
+            "zero_tests_run": false
+        }),
     );
 
     let result = dispatch_handoff_summary_only_with_agent(

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -1284,7 +1284,16 @@ fn structured_validation_target_resolves_equivalent_semantic_arguments() {
             "timeout_secs": 120,
         }),
         true,
-        json!({"exit_code": 0}),
+        json!({
+            "exit_code": 0,
+            "stdout_tail": "running 1 test\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n",
+            "stderr_tail": "",
+            "stdout_truncated": false,
+            "stderr_truncated": false,
+            "tests_detected": true,
+            "tests_run_count": 1,
+            "zero_tests_run": false
+        }),
     );
 
     let session = store.summary(&session.session_id, Some(50)).unwrap();


### PR DESCRIPTION
## Summary

Fix current `main` CI regressions exposed after #133 / #134 / #135 without weakening production validation or ACP lifecycle semantics.

The branch is based directly on `main @ 0a0381de` and now contains two focused commits:

- `4a01c6c7` Fix current main validation CI regressions
- `a654f134` Wait for ACP terminal event in runner tests

### #133 validation-evidence regressions

Action #408 exposed two stale test fixtures:

- `structured_validation_target_resolves_equivalent_semantic_arguments`
- `session_handoff_summary_only_passes_with_resolved_unexpected_cargo_test_failure`

#133 intentionally made a successful `cargo_test` unable to resolve a historical failure unless execution-count evidence is structurally proven. The failing fixtures still modeled a successful Cargo test as only `{ "exit_code": 0 }`, so the new fail-closed logic correctly treated that success as unproven.

This PR updates those fixtures to represent a real structured successful Cargo test, including bounded stdout/stderr evidence and explicit `tests_run_count` / `zero_tests_run` metadata. The production reconciliation contract is unchanged. The regression proving that an unproven successful Cargo test remains historically unresolved stays green.

### Action #411 file-import stack overflows

Action #411 aborted the Linux server lane on `oauth_mcp_file_import_startup_env_stateless_2026_crosses_provenance_gate` with a libtest-thread stack overflow / SIGABRT. The failure reproduced locally on exact current main with the default test-thread stack and passed with an 8 MiB stack, confirming finite test-fixture stack pressure rather than recursive production behavior.

After isolating the first test, the full suite exposed another end-to-end file-import test with the same stack pressure. The four OAuth/MCP/router/import end-to-end tests therefore use a shared test-only 8 MiB thread and current-thread Tokio runtime. Tokio scheduling remains equivalent to the default `#[tokio::test]` flavor, test names/assertions are preserved, and `RUST_MIN_STACK` is not raised globally.

### Action #413 ACP Terminal observation race

The next PR run exposed one Linux Runner failure:

`webcodex_runner::coding_agent::tests::acp_v1_sequence_cwd_config_and_normalized_updates_are_exact`

The test observed a terminal Run snapshot and then immediately expected the `Terminal` event. Production terminal completion intentionally updates/persists the terminal snapshot before appending the terminal event, so those two observations are not atomic. CI hit the narrow interval between them.

The follow-up keeps production ordering unchanged and strengthens the test synchronization contract instead: a shared bounded helper waits until both a terminal snapshot and the corresponding `Terminal` event are observable. The same helper replaces the identical snapshot-then-observe pattern in `run_scenario`, closing the related latent flake while retaining the explicit Terminal-event assertions.

No production source path or runtime behavior is changed by these fixes.

## Validation

On current head `a654f134b752f745baddbcff2ebc7f8693366298`:

- #133 focused semantic-resolution and handoff regressions — passed
- unproven Cargo success remains historically unresolved — passed
- all four large file-import E2E tests — passed without `RUST_MIN_STACK` override
- exact Action #411 server command `cargo test --locked -p webcodex` — **2843 passed / 0 failed / 0 ignored**
- failing Action #413 ACP sequence test — passed
- `fake_acp_normalizes_activity_and_terminal_matrix` — passed
- `concurrent_pre_prompt_terminal_transitions_commit_one_terminal_truth` — passed
- pre-fix ACP sequence stress observation — 60 local runs passed (consistent with a narrow scheduler-dependent race; CI provided the actual failure reproduction)
- exact Linux Runner lane command `cargo test --locked -p webcodex-runner` — **776 passed / 0 failed / 4 ignored**
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `bash scripts/test_inventory.sh --self-test` — 2 passed
- `bash scripts/test_inventory.sh` — passed

The worktree is clean and the branch remains a fast-forward descendant of `main @ 0a0381de`.