### PR TITLE
Add Windows persistent shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5191,9 +5191,12 @@ dependencies = [
 name = "webcodex-persistent-shell"
 version = "0.3.8"
 dependencies = [
+ "base64",
  "libc",
  "tempfile",
  "uuid",
+ "webcodex-process",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -276,15 +276,14 @@ async fn ops_http_403_reports_forbidden() {
 
 #[tokio::test]
 async fn ops_connection_failure_reports_runtime_unreachable() {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
+    let (addr, handle) = spawn_connection_drop_server();
     let output = run_ops_command(OpsCommand::Status(ops_common_opts(format!(
         "http://{addr}"
     ))))
     .await
     .unwrap()
     .stdout;
+    handle.join().unwrap();
     assert!(output.contains("Overall: FAIL"), "{output}");
     assert!(output.contains("runtime_unreachable"), "{output}");
 }

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
@@ -191,9 +191,7 @@ async fn server_status_token_file_takes_priority_over_env_file() {
 
 #[tokio::test]
 async fn server_status_connection_failure_reports_unreachable_without_token() {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
+    let (addr, handle) = spawn_connection_drop_server();
 
     let tmp = tempfile::tempdir().unwrap();
     let env_file = tmp.path().join("webcodex.env");
@@ -208,6 +206,7 @@ async fn server_status_connection_failure_reports_unreachable_without_token() {
     ]))
     .unwrap();
     let output = run_server_status(opts).await.unwrap();
+    handle.join().unwrap();
     assert!(output.contains("HTTP reachable:        no"));
     assert!(output.contains("HTTP error:"));
     assert!(!output.contains(token));

--- a/crates/webcodex-cli/src/webcodex_cli/tests/support.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/support.rs
@@ -26,3 +26,32 @@ pub(super) fn direct_server_http() -> ServerHttpOptions {
         no_system_proxy: true,
     }
 }
+
+/// Keep the ephemeral port owned until the client actually connects, then close
+/// the accepted socket without an HTTP response. Dropping a probe listener
+/// before the request lets another concurrent test reuse the port on Windows.
+pub(super) fn spawn_connection_drop_server() -> (std::net::SocketAddr, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = thread::spawn(move || {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    drop(stream);
+                    return;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "connection-failure fixture was never contacted"
+                    );
+                    thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Err(error) => panic!("connection-failure fixture accept failed: {error}"),
+            }
+        }
+    });
+    (addr, handle)
+}

--- a/crates/webcodex-core/src/shell_protocol.rs
+++ b/crates/webcodex-core/src/shell_protocol.rs
@@ -229,18 +229,18 @@ pub const SHELL_CLIENT_CAPABILITY_GIT: &str = "git";
 pub const SHELL_CLIENT_CAPABILITY_JOBS: &str = "jobs";
 pub const SHELL_CLIENT_CAPABILITY_ASYNC_JOBS: &str = "async_jobs";
 pub const SHELL_CLIENT_CAPABILITY_ASYNC_SHELL_JOBS: &str = "async_shell_jobs";
-/// Runner-side SSH shell execution for Workflow Session resources. This is
-/// deliberately separate from ordinary local shell support: older runners
-/// must reject a Session-bound SSH request rather than silently running it on
-/// their local project checkout.
+/// Runner-side one-shot/background SSH shell execution for Workflow Session
+/// resources. This is deliberately separate from persistent SSH support: older
+/// runners must reject such a Session-bound SSH request rather than silently
+/// running it on their local project checkout.
 pub const SHELL_CLIENT_CAPABILITY_SSH_SHELL: &str = "ssh_shell";
-/// Command-oriented, long-lived local shell processes owned by one Workflow
-/// Session. Missing on older runners and therefore fails closed.
+/// Command-oriented, long-lived shell processes owned by one Workflow Session.
+/// Missing on older runners and therefore fails closed.
 pub const SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL: &str = "persistent_shell";
 /// Long-lived persistent shells opened on a Workflow Session's SSH resource.
-/// This is deliberately separate from `ssh_shell` and `persistent_shell`: an
-/// SSH persistent shell requires all three, and older runners that predate it
-/// must reject the request rather than silently opening a local shell.
+/// This is additive to `persistent_shell` and independent of the one-shot
+/// `ssh_shell` capability; older runners that predate it must reject the request
+/// rather than silently opening a local shell.
 pub const SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL: &str = "ssh_persistent_shell";
 pub const SHELL_CLIENT_CAPABILITY_STRUCTURED_VALIDATION_ARGV: &str = "structured_validation_argv";
 /// The Runner preserves the optional Cargo test-count postcondition in durable
@@ -487,8 +487,8 @@ pub struct ShellClientCapabilities {
     pub async_jobs: bool,
     #[serde(default)]
     pub async_shell_jobs: bool,
-    /// The Runner can execute a Workflow Session's configured SSH resource.
-    /// Missing on older runners and therefore fails closed.
+    /// The Runner can execute one-shot/background shell work through a Workflow
+    /// Session's configured SSH resource. Missing on older runners fails closed.
     #[serde(default)]
     pub ssh_shell: bool,
     /// The Runner supports explicit Workflow Session persistent shells on its
@@ -496,8 +496,8 @@ pub struct ShellClientCapabilities {
     #[serde(default)]
     pub persistent_shell: bool,
     /// The Runner can open a long-lived persistent shell on a Workflow Session's
-    /// SSH resource. Missing on older runners and therefore fails closed; it is
-    /// never inferred from `ssh_shell` + `persistent_shell`.
+    /// SSH resource. Missing on older runners fails closed; this is independent
+    /// of `ssh_shell` and is never inferred from another capability combination.
     #[serde(default)]
     pub ssh_persistent_shell: bool,
     /// Validation plans use a fixed executable plus argv, never shell text.

--- a/crates/webcodex-persistent-shell/Cargo.toml
+++ b/crates/webcodex-persistent-shell/Cargo.toml
@@ -7,11 +7,23 @@ edition.workspace = true
 [dependencies]
 uuid = { version = "1", features = ["v4"] }
 
-# Process-group / descriptor primitives used only by the local persistent shell
-# (`setsid`, `dup2`, `fcntl`, `kill`). Windows has no persistent shell yet and
-# the crate fails closed there, so libc is never needed on that target.
+# Process-group / descriptor primitives used only by the Unix local persistent
+# shell (`setsid`, `dup2`, `fcntl`, `kill`).
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# Windows local persistent shells use the existing managed Job Object process
+# tree owner, Base64-safe stdin framing, and a per-shell private control dir.
+[target.'cfg(windows)'.dependencies]
+base64 = "0.22"
+tempfile = "3"
+webcodex-process = { path = "../webcodex-process" }
+
 [dev-dependencies]
 tempfile = "3"
+
+[target.'cfg(windows)'.dev-dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -279,14 +279,20 @@ pub trait ShellTransport: Send + Sync {
         progress: &mut CompletionProgress,
     ) -> WaitOutcome;
     fn try_wait(&self) -> Option<ExitStatus>;
-    /// Signal the shell's process group during timeout recovery. Best-effort:
-    /// the manager decides whether to keep or poison the shell based on whether
-    /// synchronization is recovered afterward.
+    /// Best-effort timeout interruption. The transport chooses the narrowest
+    /// process-lifecycle primitive its host supports; the manager decides whether
+    /// to keep or poison the shell only from subsequent synchronization evidence.
     fn interrupt(&self);
     fn shutdown(&self);
     fn terminate_remaining_group_after_exit(&self);
     fn stdout(&self) -> &Arc<Mutex<BoundedBuffer>>;
     fn stderr(&self) -> &Arc<Mutex<BoundedBuffer>>;
+    /// Validate the shell-reported cwd in the transport's path namespace.
+    /// Local transports use the host platform's path rules. Remote transports
+    /// can override this when their shell path syntax differs from the Runner.
+    fn reported_cwd_is_absolute(&self, cwd: &Path) -> bool {
+        cwd.is_absolute()
+    }
     /// Opaque binding metadata captured at open. The shared manager stores it
     /// on the entry so callers can validate bindings that a transport depends
     /// on (e.g. an SSH resource + config generation). The default is no
@@ -750,7 +756,7 @@ impl PersistentShellManager {
             &mut completion,
         ) {
             WaitOutcome::Frame(frame) if frame.status == 0 => {
-                if !frame.cwd.is_absolute() {
+                if !entry.process.reported_cwd_is_absolute(&frame.cwd) {
                     self.transition_terminal(
                         entry,
                         ShellState::Poisoned,
@@ -977,7 +983,7 @@ impl PersistentShellManager {
 
         match resolved {
             WaitOutcome::Frame(frame) => {
-                if !frame.cwd.is_absolute() {
+                if !entry.process.reported_cwd_is_absolute(&frame.cwd) {
                     self.transition_terminal(
                         &entry,
                         ShellState::Poisoned,

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -1750,7 +1750,24 @@ fn drain_sync_receiver(
     }
 }
 
+#[cfg(test)]
+thread_local! {
+    static TEST_COMMAND_TOKEN: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn set_test_command_token(token: Option<&str>) {
+    TEST_COMMAND_TOKEN.with(|slot| {
+        *slot.borrow_mut() = token.map(str::to_string);
+    });
+}
+
 fn command_token() -> String {
+    #[cfg(test)]
+    if let Some(token) = TEST_COMMAND_TOKEN.with(|slot| slot.borrow().clone()) {
+        return token;
+    }
     Uuid::new_v4().simple().to_string()
 }
 
@@ -3062,6 +3079,15 @@ mod windows_tests {
     const PROJECT: &str = "agent:msi:test";
 
     fn launch(root: &Path, shell_id: &str, session_id: &str) -> ShellLaunch {
+        launch_with_program(root, shell_id, session_id, "powershell.exe")
+    }
+
+    fn launch_with_program(
+        root: &Path,
+        shell_id: &str,
+        session_id: &str,
+        program: &str,
+    ) -> ShellLaunch {
         let env = std::env::vars().collect::<HashMap<_, _>>();
         ShellLaunch {
             identity: ShellIdentity {
@@ -3073,7 +3099,7 @@ mod windows_tests {
             },
             dialect: "powershell".to_string(),
             profile: None,
-            program: "powershell.exe".to_string(),
+            program: program.to_string(),
             args: vec![
                 "-NoProfile".to_string(),
                 "-NonInteractive".to_string(),
@@ -3195,6 +3221,32 @@ mod windows_tests {
             failed.stdout,
             failed.stderr
         );
+        let recovered = exec(
+            &manager,
+            "wc_shell_failure",
+            "wc_sess_failure",
+            "Write-Error 'transient-error'; [Console]::Out.Write('recovered')",
+        );
+        assert_eq!(recovered.exit_code, Some(0));
+        assert_eq!(recovered.stdout, "recovered");
+        assert!(recovered.stderr.contains("transient-error"));
+
+        let native_failed = exec(
+            &manager,
+            "wc_shell_failure",
+            "wc_sess_failure",
+            "cmd.exe /d /c exit 5",
+        );
+        assert_eq!(native_failed.exit_code, Some(5));
+        let native_recovered = exec(
+            &manager,
+            "wc_shell_failure",
+            "wc_sess_failure",
+            "cmd.exe /d /c exit 5; [Console]::Out.Write('after-native')",
+        );
+        assert_eq!(native_recovered.exit_code, Some(0));
+        assert_eq!(native_recovered.stdout, "after-native");
+
         let next = exec(
             &manager,
             "wc_shell_failure",
@@ -3275,6 +3327,207 @@ mod windows_tests {
         assert!(result.command_completed);
         assert!(result.duration_ms >= 100);
         assert_eq!(result.stdout, "WCPS1 fake WCPSO1 fake WCPSE1 fake|done");
+    }
+
+    const FORGE_PRIVATE_COMPLETION_COMMAND: &str = r#"
+$argv = [Environment]::GetCommandLineArgs()
+[Console]::Out.WriteLine('ARGV|' + ($argv -join '|'))
+$variables = @(Get-Variable)
+$tokenCandidates = @()
+$controlPathCandidates = @()
+$visible = @()
+foreach ($variable in $variables) {
+    $value = ''
+    try { $value = [string]$variable.Value } catch { $value = '<unprintable>' }
+    $visible += ('VAR|' + $variable.Name + '|' + $value)
+    if ($value -match '^[0-9a-f]{32}$') { $tokenCandidates += $value }
+    if ($value -match '(?i)\.frame$') { $controlPathCandidates += $value }
+}
+$visible += @(Get-Command -CommandType Function | ForEach-Object { 'FN|' + $_.Name })
+$visible += @([System.Management.Automation.Runspaces.Runspace]::GetRunspaces() | ForEach-Object { 'RUNSPACE|' + $_.InstanceId + '|' + $_.RunspaceAvailability })
+$visible += @([WebCodexPersistentShell.Controller].GetFields([Reflection.BindingFlags]'Public,NonPublic,Static') | ForEach-Object { 'CONTROLLER_FIELD|' + $_.Name + '|' + [string]$_.GetValue($null) })
+$visible += @($Host.GetType().GetFields([Reflection.BindingFlags]'Public,NonPublic,Instance') | ForEach-Object { try { 'HOST_FIELD|' + $_.Name + '|' + [string]$_.GetValue($Host) } catch { 'HOST_FIELD|' + $_.Name + '|<unreadable>' } })
+$bootstrap = @($argv | Where-Object { $_ -match '(?i)bootstrap\.ps1$' } | Select-Object -First 1)
+if ($bootstrap.Count -eq 1 -and (Test-Path -LiteralPath $bootstrap[0])) {
+    $visible += ('BOOTSTRAP_PATH|' + $bootstrap[0])
+    $visible += ('BOOTSTRAP_TEXT|' + (Get-Content -LiteralPath $bootstrap[0] -Raw))
+    $visible += @(Get-ChildItem -LiteralPath (Split-Path -Parent $bootstrap[0]) -Force | ForEach-Object { 'CONTROL_DIR_ENTRY|' + $_.FullName })
+}
+foreach ($candidateToken in @($tokenCandidates | Select-Object -Unique)) {
+    foreach ($candidatePath in @($controlPathCandidates | Select-Object -Unique)) {
+        try {
+            $candidateCwd = (Get-Location).Path
+            $candidateControl = 'WCPS1' + [char]0 + $candidateToken + [char]0 + '0' + [char]0 + $candidateCwd + [char]0
+            [IO.File]::WriteAllBytes($candidatePath + '.tmp', [Text.Encoding]::UTF8.GetBytes($candidateControl))
+            if (Test-Path -LiteralPath $candidatePath) { Remove-Item -LiteralPath $candidatePath -Force }
+            [IO.File]::Move($candidatePath + '.tmp', $candidatePath)
+        } catch { }
+        [Console]::Out.Write('WCPSO1' + [char]0 + $candidateToken + [char]0)
+        [Console]::Error.Write('WCPSE1' + [char]0 + $candidateToken + [char]0)
+    }
+}
+[Console]::Out.WriteLine('VISIBLE_BEGIN')
+[Console]::Out.WriteLine(($visible -join "`n"))
+[Console]::Out.WriteLine('VISIBLE_END')
+[Console]::Out.Write('WCPS1 fake WCPSO1 fake WCPSE1 fake|before-sleep')
+Start-Sleep -Milliseconds 500
+[Console]::Out.Write('|after-sleep')
+"#;
+
+    fn assert_private_completion_isolation(program: &str, label: &str, token: &'static str) {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = PersistentShellManager::new(ShellLimits::default());
+        let shell_id = format!("wc_shell_forge_{label}");
+        let session_id = format!("wc_sess_forge_{label}");
+        manager
+            .open(launch_with_program(
+                temp.path(),
+                &shell_id,
+                &session_id,
+                program,
+            ))
+            .unwrap();
+
+        let worker_manager = manager.clone();
+        let worker_shell_id = shell_id.clone();
+        let worker_session_id = session_id.clone();
+        let worker = thread::spawn(move || {
+            set_test_command_token(Some(token));
+            let result = worker_manager.exec(
+                &worker_shell_id,
+                &worker_session_id,
+                PROJECT,
+                FORGE_PRIVATE_COMPLETION_COMMAND,
+                Duration::from_secs(3),
+            );
+            set_test_command_token(None);
+            result.unwrap()
+        });
+
+        let busy_deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if manager
+                .status(&shell_id, &session_id, PROJECT)
+                .unwrap()
+                .busy
+            {
+                break;
+            }
+            assert!(
+                !worker.is_finished(),
+                "{label}: adversarial command completed before busy state was observable"
+            );
+            assert!(
+                Instant::now() < busy_deadline,
+                "{label}: adversarial command never entered busy state"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        // The reviewed bug released this guard while the user command was still
+        // sleeping after forging the transport's visible token/control frame.
+        thread::sleep(Duration::from_millis(150));
+        let busy = manager
+            .exec(
+                &shell_id,
+                &session_id,
+                PROJECT,
+                "[Console]::Out.Write('must-not-run')",
+                Duration::from_secs(1),
+            )
+            .unwrap_err();
+        assert_eq!(
+            busy.code, "shell_busy",
+            "{label}: busy guard released early"
+        );
+
+        let result = worker.join().unwrap();
+        assert!(
+            result.command_completed,
+            "{label}: command did not complete"
+        );
+        assert_eq!(result.shell_state, ShellState::Running);
+        assert!(
+            result.duration_ms >= 400,
+            "{label}: completion arrived before the 500ms user sleep returned: {}ms",
+            result.duration_ms
+        );
+        assert!(
+            result.stdout.contains("|after-sleep"),
+            "{label}: trailing user output was not attributed to the command: {:?}",
+            result.stdout
+        );
+        assert!(result.stdout.contains("WCPS1 fake WCPSO1 fake WCPSE1 fake"));
+        assert!(
+            !result.stdout.contains(token) && !result.stderr.contains(token),
+            "{label}: active correlation token leaked into user-visible state"
+        );
+
+        let argv_line = result
+            .stdout
+            .lines()
+            .find(|line| line.starts_with("ARGV|"))
+            .unwrap_or_else(|| panic!("{label}: process argv was not observed"));
+        let bootstrap = argv_line
+            .split('|')
+            .skip(1)
+            .find(|value| value.to_ascii_lowercase().ends_with("bootstrap.ps1"))
+            .unwrap_or_else(|| panic!("{label}: bootstrap path was not discoverable from argv"));
+        let expected_control_path = Path::new(bootstrap)
+            .parent()
+            .unwrap()
+            .join(format!("{token}.frame"))
+            .to_string_lossy()
+            .to_string();
+        let visible_output = format!("{}\n{}", result.stdout, result.stderr).to_ascii_lowercase();
+        assert!(
+            !visible_output.contains(&expected_control_path.to_ascii_lowercase()),
+            "{label}: active control publication target leaked into user-visible state"
+        );
+        assert!(
+            result.stdout.contains("BOOTSTRAP_TEXT|"),
+            "{label}: test did not inspect the ordinary bootstrap file"
+        );
+
+        let clean = exec(
+            &manager,
+            &shell_id,
+            &session_id,
+            "[Console]::Out.Write('clean')",
+        );
+        assert_eq!(
+            clean.stdout, "clean",
+            "{label}: prior stdout leaked forward"
+        );
+        assert!(
+            clean.stderr.is_empty(),
+            "{label}: prior stderr leaked forward"
+        );
+    }
+
+    #[test]
+    fn user_command_cannot_forge_private_completion() {
+        assert_private_completion_isolation(
+            "powershell.exe",
+            "windows_powershell",
+            "13579bdf2468ace013579bdf2468ace0",
+        );
+    }
+
+    #[test]
+    fn configured_pwsh_user_command_cannot_forge_private_completion() {
+        let Ok(program) = std::env::var("WEBCODEX_TEST_PWSH") else {
+            return;
+        };
+        assert!(
+            Path::new(&program).is_file(),
+            "configured pwsh does not exist: {program}"
+        );
+        assert_private_completion_isolation(
+            &program,
+            "powershell_7",
+            "02468ace13579bdf02468ace13579bdf",
+        );
     }
 
     #[test]

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -3385,14 +3385,13 @@ Start-Sleep -Milliseconds 500
         let manager = PersistentShellManager::new(ShellLimits::default());
         let shell_id = format!("wc_shell_forge_{label}");
         let session_id = format!("wc_sess_forge_{label}");
-        manager
-            .open(launch_with_program(
-                temp.path(),
-                &shell_id,
-                &session_id,
-                program,
-            ))
-            .unwrap();
+        let mut launch = launch_with_program(temp.path(), &shell_id, &session_id, program);
+        // This adversarial regression intentionally inventories PowerShell-visible
+        // state. GitHub's Windows image can expose substantially more host/module
+        // metadata than a local runner, so retain a larger but still bounded test
+        // transcript rather than silently dropping the earliest evidence.
+        launch.max_output_bytes = 1024 * 1024;
+        manager.open(launch).unwrap();
 
         let worker_manager = manager.clone();
         let worker_shell_id = shell_id.clone();
@@ -3461,6 +3460,10 @@ Start-Sleep -Milliseconds 500
             result.error_code
         );
         assert_eq!(result.shell_state, ShellState::Running);
+        assert!(
+            !result.stdout_truncated && !result.stderr_truncated,
+            "{label}: adversarial visibility evidence was truncated"
+        );
         assert!(
             result.duration_ms >= 400,
             "{label}: completion arrived before the 500ms user sleep returned: {}ms",

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -1,26 +1,26 @@
 //! Bounded, command-oriented persistent shell processes.
 //!
-//! A shell managed here is a real long-lived `sh`/`bash` process. Commands are
-//! serialized, stdout/stderr are retained in bounded ring buffers, and command
-//! completion plus stream-drain boundaries use dedicated inherited descriptors.
-//! This crate deliberately does not provide a PTY, raw input, resize, or
-//! terminal byte-stream API.
+//! A shell managed here is a real long-lived local shell process (`sh`/`bash`
+//! on Unix or configured PowerShell on Windows). Commands are serialized,
+//! stdout/stderr are retained in bounded ring buffers, and command completion
+//! plus stream-drain boundaries use transport-private control framing. This
+//! crate deliberately does not provide a PTY, raw input, resize, or terminal
+//! byte-stream API.
 
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-// `mpsc` is used only by the Unix local-shell readers; Windows has no shell yet.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
-// The local persistent shell spawn/primitives below are Unix-only. Windows has
-// no persistent shell yet; `spawn_shell_process` fails closed there and these
-// imports are compiled out entirely.
+#[cfg(windows)]
+mod windows;
+
 #[cfg(unix)]
 use std::ffi::OsString;
 #[cfg(unix)]
@@ -46,18 +46,15 @@ const CONTROL_FD: i32 = 9;
 pub const CONTROL_MAGIC: &[u8] = b"WCPS1";
 pub const STDOUT_SYNC_MAGIC: &[u8] = b"WCPSO1";
 pub const STDERR_SYNC_MAGIC: &[u8] = b"WCPSE1";
-// Constants used only by the Unix local-shell implementation are declared
-// `cfg(unix)` so they do not warn as dead on Windows, where the local shell is
-// fail-closed.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const CONTROL_FIELD_MAX_BYTES: usize = 8 * 1024;
 #[cfg(unix)]
 const CONTROL_CHANNEL_CAPACITY: usize = 2;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const OUTPUT_SYNC_CHANNEL_CAPACITY: usize = 2;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const OUTPUT_READ_SLEEP: Duration = Duration::from_millis(5);
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const PROCESS_SIGNAL_GRACE: Duration = Duration::from_millis(100);
 const TIMEOUT_RECOVERY_WINDOW: Duration = Duration::from_millis(750);
 const OPEN_INITIALIZATION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -111,8 +108,10 @@ pub struct ShellLaunch {
     pub dialect: String,
     pub profile: Option<String>,
     pub program: String,
-    /// Arguments used to start the long-lived shell. Command-mode flags such
-    /// as `-c` must not be supplied.
+    /// Startup arguments owned by the selected shell/profile before any
+    /// transport-specific payload mode. Unix command-mode `-c` is forbidden;
+    /// Windows receives the configured PowerShell prefix arguments and the
+    /// transport appends its private `-File` bootstrap.
     pub args: Vec<String>,
     pub initial_cwd: PathBuf,
     pub env: HashMap<String, String>,
@@ -594,7 +593,9 @@ impl PersistentShellManager {
 
         #[cfg(unix)]
         let process: Box<dyn ShellTransport> = Box::new(spawn_shell_process(&launch)?);
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        let process: Box<dyn ShellTransport> = windows::spawn_shell_process(&launch)?;
+        #[cfg(not(any(unix, windows)))]
         let process: Box<dyn ShellTransport> = spawn_shell_process(&launch)?;
         let timestamp = now_ts();
 
@@ -1640,21 +1641,25 @@ impl ShellTransport for ShellProcess {
     }
 }
 
-#[cfg(unix)]
+pub const fn local_shell_supported() -> bool {
+    cfg!(any(unix, windows))
+}
+
+#[cfg(any(unix, windows))]
 fn ensure_local_shell_supported() -> Result<(), ShellError> {
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn ensure_local_shell_supported() -> Result<(), ShellError> {
     Err(persistent_shell_unsupported_error())
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn persistent_shell_unsupported_error() -> ShellError {
     ShellError::new(
         "persistent_shell_unsupported",
-        "persistent shell is not supported on Windows yet",
+        "persistent local shell is not supported on this platform",
     )
 }
 
@@ -1680,20 +1685,43 @@ fn validate_launch(launch: &ShellLaunch) -> Result<(), ShellError> {
             ));
         }
     }
+    #[cfg(unix)]
     if !matches!(launch.dialect.as_str(), "sh" | "bash") {
         return Err(ShellError::new(
             "persistent_shell_dialect_unsupported",
-            "persistent shells support only sh or bash",
+            "Unix persistent shells support only sh or bash",
         ));
     }
-    if launch
-        .args
-        .iter()
-        .any(|arg| arg == "-c" || arg.contains('\0'))
-    {
+    #[cfg(windows)]
+    if launch.dialect != "powershell" {
+        return Err(ShellError::new(
+            "persistent_shell_dialect_unsupported",
+            "Windows persistent shells require a configured PowerShell program",
+        ));
+    }
+    if launch.args.iter().any(|arg| arg.contains('\0')) {
         return Err(ShellError::new(
             "persistent_shell_invalid_open",
-            "persistent shell startup args cannot contain -c or NUL",
+            "persistent shell startup args cannot contain NUL",
+        ));
+    }
+    #[cfg(windows)]
+    if launch.args.iter().any(|arg| {
+        matches!(
+            arg.to_ascii_lowercase().as_str(),
+            "-command" | "-encodedcommand" | "-file"
+        )
+    }) {
+        return Err(ShellError::new(
+            "persistent_shell_invalid_open",
+            "Windows persistent shell startup args cannot contain PowerShell command/file payload switches",
+        ));
+    }
+    #[cfg(unix)]
+    if launch.args.iter().any(|arg| arg == "-c") {
+        return Err(ShellError::new(
+            "persistent_shell_invalid_open",
+            "Unix persistent shell startup args cannot contain -c",
         ));
     }
     if !launch.initial_cwd.is_dir() {
@@ -1705,7 +1733,7 @@ fn validate_launch(launch: &ShellLaunch) -> Result<(), ShellError> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn drain_sync_receiver(
     receiver: &Mutex<mpsc::Receiver<String>>,
     token: &str,
@@ -1990,12 +2018,7 @@ fn spawn_shell_process(launch: &ShellLaunch) -> Result<ShellProcess, ShellError>
     })
 }
 
-/// Windows has no persistent shell implementation yet. Fail closed with a
-/// stable, explicit error instead of spawning a degraded child that could not
-/// honor the FD-7/8/9 protocol, silently pretending to succeed, or panicking.
-/// The concrete `ShellProcess` type is Unix-only, so the Windows stub reports
-/// through the boxed trait and `open` never constructs a shell on Windows.
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn spawn_shell_process(_launch: &ShellLaunch) -> Result<Box<dyn ShellTransport>, ShellError> {
     Err(persistent_shell_unsupported_error())
 }
@@ -2078,7 +2101,7 @@ fn spawn_output_reader(
         })
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn process_output_pending(
     pending: &mut Vec<u8>,
     buffer: &Arc<Mutex<BoundedBuffer>>,
@@ -2278,13 +2301,15 @@ fn spawn_idle_sweeper(weak: Weak<ManagerInner>) {
 }
 
 pub fn canonical_dialect(program: &str) -> Option<&'static str> {
-    match Path::new(program)
+    let basename = Path::new(program)
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or(program)
-    {
+        .to_ascii_lowercase();
+    match basename.as_str() {
         "sh" => Some("sh"),
         "bash" => Some("bash"),
+        "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe" => Some("powershell"),
         _ => None,
     }
 }
@@ -3029,75 +3054,316 @@ mod tests {
     }
 }
 
-/// Windows-specific fail-closed tests. Persistent shells are not implemented
-/// on Windows yet; every entry point must return a stable, explicit
-/// `persistent_shell_unsupported` error rather than panic, pretend to succeed,
-/// or silently degrade.
-#[cfg(all(test, not(unix)))]
+#[cfg(all(test, windows))]
 mod windows_tests {
     use super::*;
+    use std::sync::Barrier;
 
-    fn unsupported_launch(root: &Path) -> ShellLaunch {
+    const PROJECT: &str = "agent:msi:test";
+
+    fn launch(root: &Path, shell_id: &str, session_id: &str) -> ShellLaunch {
+        let env = std::env::vars().collect::<HashMap<_, _>>();
         ShellLaunch {
             identity: ShellIdentity {
-                shell_id: "wc_shell_windows".to_string(),
-                workflow_session_id: "wc_sess_windows".to_string(),
-                runtime_project_id: "agent:oe:test".to_string(),
-                executor: "local".to_string(),
-                client_id: None,
+                shell_id: shell_id.to_string(),
+                workflow_session_id: session_id.to_string(),
+                runtime_project_id: PROJECT.to_string(),
+                executor: "agent".to_string(),
+                client_id: Some("msi".to_string()),
             },
-            dialect: "bash".to_string(),
+            dialect: "powershell".to_string(),
             profile: None,
-            program: "bash".to_string(),
-            args: vec!["--noprofile".to_string(), "--norc".to_string()],
+            program: "powershell.exe".to_string(),
+            args: vec![
+                "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
+                "-ExecutionPolicy".to_string(),
+                "Bypass".to_string(),
+            ],
             initial_cwd: root.to_path_buf(),
-            env: HashMap::new(),
+            env,
             initialization: None,
-            max_output_bytes: 4096,
+            max_output_bytes: 64 * 1024,
         }
     }
 
+    fn exec(
+        manager: &PersistentShellManager,
+        shell_id: &str,
+        session_id: &str,
+        command: &str,
+    ) -> ShellExecResult {
+        manager
+            .exec(
+                shell_id,
+                session_id,
+                PROJECT,
+                command,
+                Duration::from_secs(5),
+            )
+            .unwrap()
+    }
+
+    fn process_alive(pid: u32) -> bool {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            return false;
+        }
+        let mut exit_code = 0u32;
+        let ok = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
+        unsafe { CloseHandle(handle) };
+        ok == 1 && exit_code == 259
+    }
+
     #[test]
-    fn open_fails_closed_with_stable_unsupported_error() {
+    fn state_stdout_stderr_and_unicode_persist() {
         let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("sub")).unwrap();
         let manager = PersistentShellManager::new(ShellLimits::default());
-        let error = manager.open(unsupported_launch(temp.path())).unwrap_err();
-        assert_eq!(error.code, "persistent_shell_unsupported");
-        assert_eq!(
-            error.message,
-            "persistent shell is not supported on Windows yet"
+        manager
+            .open(launch(temp.path(), "wc_shell_state", "wc_sess_state"))
+            .unwrap();
+
+        let set = exec(
+            &manager,
+            "wc_shell_state",
+            "wc_sess_state",
+            "$env:WEBCODEX_PERSIST_TEST='alpha'; Set-Location -LiteralPath 'sub'; $WC_LOCAL='beta'; function WC_FN { [Console]::Out.Write('fn') }",
         );
-        // The failed open must not register any shell or start background work.
-        assert_eq!(manager.active_count(), 0);
-        assert!(!manager.inner.sweeper_started.load(Ordering::SeqCst));
+        assert_eq!(set.exit_code, Some(0));
+        let observed = exec(
+            &manager,
+            "wc_shell_state",
+            "wc_sess_state",
+            "[Console]::Out.Write($env:WEBCODEX_PERSIST_TEST + '|' + (Get-Location).Path + '|' + $WC_LOCAL + '|'); WC_FN; [Console]::Error.Write('stderr-only')",
+        );
+        assert!(observed.stdout.starts_with("alpha|"), "{}", observed.stdout);
+        assert!(
+            observed.stdout.contains("\\sub|beta|fn"),
+            "{}",
+            observed.stdout
+        );
+        assert_eq!(observed.stderr, "stderr-only");
+
+        let unicode = exec(
+            &manager,
+            "wc_shell_state",
+            "wc_sess_state",
+            "[Console]::Out.Write(\"hello`r`n中文`r`n🙂`r`nmixed ASCII + Unicode\")",
+        );
+        assert_eq!(
+            unicode.stdout,
+            "hello\r\n中文\r\n🙂\r\nmixed ASCII + Unicode"
+        );
+        assert!(!unicode.stdout.contains("WCPSO1"));
+        assert!(!unicode.stderr.contains("WCPSE1"));
+        let host_unicode = exec(
+            &manager,
+            "wc_shell_state",
+            "wc_sess_state",
+            "Write-Output '中文🙂 host-output'",
+        );
+        assert!(
+            host_unicode.stdout.contains("中文🙂 host-output"),
+            "{:?}",
+            host_unicode.stdout
+        );
     }
 
     #[test]
-    fn unsupported_error_does_not_panic() {
+    fn command_failure_does_not_lose_shell() {
         let temp = tempfile::tempdir().unwrap();
         let manager = PersistentShellManager::new(ShellLimits::default());
-        let result = manager.open(unsupported_launch(temp.path()));
-        // The error is returned, not panicked; the code and message are stable
-        // so callers can match on them.
-        let error = result.unwrap_err();
-        assert_eq!(error.code, "persistent_shell_unsupported");
-        assert!(format!("{error}").contains("not supported on Windows"));
+        manager
+            .open(launch(temp.path(), "wc_shell_failure", "wc_sess_failure"))
+            .unwrap();
+        let failed = exec(
+            &manager,
+            "wc_shell_failure",
+            "wc_sess_failure",
+            "Write-Error 'expected-failure'",
+        );
+        assert_eq!(failed.exit_code, Some(1));
+        assert_eq!(failed.shell_state, ShellState::Running);
+        assert!(
+            failed.stderr.contains("expected-failure"),
+            "stdout={:?} stderr={:?}",
+            failed.stdout,
+            failed.stderr
+        );
+        let next = exec(
+            &manager,
+            "wc_shell_failure",
+            "wc_sess_failure",
+            "[Console]::Out.Write('still-running')",
+        );
+        assert_eq!(next.stdout, "still-running");
     }
 
     #[test]
-    fn spawn_shell_process_reports_unsupported() {
+    fn shell_exit_is_terminal_and_next_exec_fails_closed() {
         let temp = tempfile::tempdir().unwrap();
-        // The concrete `ShellProcess` type is Unix-only, so the Windows stub
-        // returns the boxed trait and reports through `ShellError`.
-        match spawn_shell_process(&unsupported_launch(temp.path())) {
-            Ok(_) => panic!("Windows persistent shell must fail closed, not spawn"),
-            Err(error) => {
-                assert_eq!(error.code, "persistent_shell_unsupported");
-                assert_eq!(
-                    error.message,
-                    "persistent shell is not supported on Windows yet"
-                );
-            }
+        let manager = PersistentShellManager::new(ShellLimits::default());
+        manager
+            .open(launch(temp.path(), "wc_shell_exit", "wc_sess_exit"))
+            .unwrap();
+        let exited = exec(&manager, "wc_shell_exit", "wc_sess_exit", "exit 7");
+        assert_eq!(exited.shell_state, ShellState::Exited);
+        assert_eq!(exited.exit_code, Some(7));
+        let error = manager
+            .exec(
+                "wc_shell_exit",
+                "wc_sess_exit",
+                PROJECT,
+                "[Console]::Out.Write('forbidden')",
+                Duration::from_secs(1),
+            )
+            .unwrap_err();
+        assert_eq!(error.code, "persistent_shell_stale");
+    }
+
+    #[test]
+    fn timeout_poisoning_is_bounded_and_never_reuses_uncertain_stream() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = PersistentShellManager::new(ShellLimits::default());
+        manager
+            .open(launch(temp.path(), "wc_shell_timeout", "wc_sess_timeout"))
+            .unwrap();
+        let started = Instant::now();
+        let timed = manager
+            .exec(
+                "wc_shell_timeout",
+                "wc_sess_timeout",
+                PROJECT,
+                "Start-Sleep -Seconds 5",
+                Duration::from_millis(100),
+            )
+            .unwrap();
+        assert_eq!(timed.execution_state, "timed_out");
+        assert_eq!(timed.shell_state, ShellState::Poisoned);
+        assert_eq!(timed.error_code.as_deref(), Some("shell_reset_required"));
+        assert!(started.elapsed() < Duration::from_secs(3));
+        let error = manager
+            .exec(
+                "wc_shell_timeout",
+                "wc_sess_timeout",
+                PROJECT,
+                "[Console]::Out.Write('forbidden')",
+                Duration::from_secs(1),
+            )
+            .unwrap_err();
+        assert_eq!(error.code, "persistent_shell_stale");
+    }
+
+    #[test]
+    fn marker_like_user_output_cannot_complete_control_framing() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = PersistentShellManager::new(ShellLimits::default());
+        manager
+            .open(launch(temp.path(), "wc_shell_marker", "wc_sess_marker"))
+            .unwrap();
+        let result = exec(
+            &manager,
+            "wc_shell_marker",
+            "wc_sess_marker",
+            "[Console]::Out.Write('WCPS1 fake WCPSO1 fake WCPSE1 fake'); Start-Sleep -Milliseconds 150; [Console]::Out.Write('|done')",
+        );
+        assert!(result.command_completed);
+        assert!(result.duration_ms >= 100);
+        assert_eq!(result.stdout, "WCPS1 fake WCPSO1 fake WCPSE1 fake|done");
+    }
+
+    #[test]
+    fn concurrent_exec_is_serialized_by_busy_guard() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = PersistentShellManager::new(ShellLimits::default());
+        manager
+            .open(launch(temp.path(), "wc_shell_busy_win", "wc_sess_busy_win"))
+            .unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_manager = manager.clone();
+        let worker_barrier = Arc::clone(&barrier);
+        let worker = thread::spawn(move || {
+            worker_barrier.wait();
+            worker_manager
+                .exec(
+                    "wc_shell_busy_win",
+                    "wc_sess_busy_win",
+                    PROJECT,
+                    "Start-Sleep -Milliseconds 300; [Console]::Out.Write('first')",
+                    Duration::from_secs(2),
+                )
+                .unwrap()
+        });
+        barrier.wait();
+        while !manager
+            .status("wc_shell_busy_win", "wc_sess_busy_win", PROJECT)
+            .unwrap()
+            .busy
+        {
+            thread::yield_now();
         }
+        let busy = manager
+            .exec(
+                "wc_shell_busy_win",
+                "wc_sess_busy_win",
+                PROJECT,
+                "[Console]::Out.Write('second')",
+                Duration::from_secs(1),
+            )
+            .unwrap_err();
+        assert_eq!(busy.code, "shell_busy");
+        assert_eq!(worker.join().unwrap().stdout, "first");
+    }
+
+    #[test]
+    fn close_is_idempotent_and_kills_owned_descendants() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = PersistentShellManager::new(ShellLimits::default());
+        manager
+            .open(launch(
+                temp.path(),
+                "wc_shell_close_win",
+                "wc_sess_close_win",
+            ))
+            .unwrap();
+        let child = exec(
+            &manager,
+            "wc_shell_close_win",
+            "wc_sess_close_win",
+            "$p = Start-Process -FilePath 'powershell.exe' -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30' -PassThru; [Console]::Out.Write($p.Id)",
+        );
+        let child_pid: u32 = child.stdout.parse().unwrap();
+        assert!(process_alive(child_pid));
+        let closed = manager
+            .close(
+                "wc_shell_close_win",
+                "wc_sess_close_win",
+                PROJECT,
+                "explicit_close",
+            )
+            .unwrap();
+        assert_eq!(closed.summary.state, ShellState::Closed);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && process_alive(child_pid) {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !process_alive(child_pid),
+            "owned child {child_pid} leaked after close"
+        );
+        let again = manager
+            .close(
+                "wc_shell_close_win",
+                "wc_sess_close_win",
+                PROJECT,
+                "explicit_close",
+            )
+            .unwrap();
+        assert!(again.already_closed);
     }
 }

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -3409,7 +3409,7 @@ Start-Sleep -Milliseconds 500
                 // Keep the security assertions time-relative below, but give
                 // the command enough bounded wall-clock budget to finish on a
                 // cold or contended runner.
-                Duration::from_secs(10),
+                Duration::from_secs(30),
             );
             set_test_command_token(None);
             result.unwrap()
@@ -3455,7 +3455,10 @@ Start-Sleep -Milliseconds 500
         let result = worker.join().unwrap();
         assert!(
             result.command_completed,
-            "{label}: command did not complete"
+            "{label}: command did not complete: execution_state={} shell_state={:?} error_code={:?}",
+            result.execution_state,
+            result.shell_state,
+            result.error_code
         );
         assert_eq!(result.shell_state, ShellState::Running);
         assert!(

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -3404,7 +3404,12 @@ Start-Sleep -Milliseconds 500
                 &worker_session_id,
                 PROJECT,
                 FORGE_PRIVATE_COMPLETION_COMMAND,
-                Duration::from_secs(3),
+                // Windows CI can spend several seconds in PowerShell/.NET
+                // introspection before reaching the deliberate 500ms sleep.
+                // Keep the security assertions time-relative below, but give
+                // the command enough bounded wall-clock budget to finish on a
+                // cold or contended runner.
+                Duration::from_secs(10),
             );
             set_test_command_token(None);
             result.unwrap()

--- a/crates/webcodex-persistent-shell/src/windows.rs
+++ b/crates/webcodex-persistent-shell/src/windows.rs
@@ -1,0 +1,442 @@
+use super::*;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{ChildStdin, Command, Stdio};
+use tempfile::TempDir;
+use webcodex_process::ManagedChild;
+
+const POWERSHELL_UTF8_PREAMBLE: &str = concat!(
+    "try { $OutputEncoding = [Console]::InputEncoding = ",
+    "[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false) } catch { }",
+);
+const READER_JOIN_GRACE: Duration = Duration::from_millis(250);
+
+#[derive(Debug)]
+struct WindowsShellProcess {
+    child: Mutex<ManagedChild>,
+    stdin: Mutex<Option<ChildStdin>>,
+    control_dir: TempDir,
+    expected_token: Arc<Mutex<Option<String>>>,
+    stdout_sync_rx: Mutex<mpsc::Receiver<String>>,
+    stderr_sync_rx: Mutex<mpsc::Receiver<String>>,
+    stdout: Arc<Mutex<BoundedBuffer>>,
+    stderr: Arc<Mutex<BoundedBuffer>>,
+    readers_stop: Arc<AtomicBool>,
+    reader_threads: Mutex<Option<Vec<thread::JoinHandle<()>>>>,
+    shutdown_started: AtomicBool,
+}
+
+impl WindowsShellProcess {
+    fn control_path(&self, token: &str) -> PathBuf {
+        self.control_dir.path().join(format!("{token}.frame"))
+    }
+
+    fn control_temp_path(&self, token: &str) -> PathBuf {
+        self.control_dir.path().join(format!("{token}.frame.tmp"))
+    }
+
+    fn clear_expected_token(&self, token: &str) {
+        let mut expected = lock_unpoison(&self.expected_token);
+        if expected.as_deref() == Some(token) {
+            *expected = None;
+        }
+    }
+
+    fn parse_control_file(&self, token: &str) -> Result<Option<ControlFrame>, ()> {
+        let path = self.control_path(token);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(()),
+        };
+        if bytes.len() > CONTROL_FIELD_MAX_BYTES {
+            let _ = fs::remove_file(path);
+            return Err(());
+        }
+        if bytes.last() != Some(&0) {
+            return Ok(None);
+        }
+        let fields = bytes.split(|byte| *byte == 0).collect::<Vec<_>>();
+        if fields.len() != 5
+            || fields[0] != CONTROL_MAGIC
+            || fields[1] != token.as_bytes()
+            || !fields[4].is_empty()
+        {
+            let _ = fs::remove_file(path);
+            return Err(());
+        }
+        let status = std::str::from_utf8(fields[2])
+            .ok()
+            .and_then(|value| value.parse::<i32>().ok())
+            .ok_or(())?;
+        let cwd = std::str::from_utf8(fields[3]).map_err(|_| ())?;
+        if cwd.is_empty() {
+            let _ = fs::remove_file(path);
+            return Err(());
+        }
+        let _ = fs::remove_file(path);
+        Ok(Some(ControlFrame {
+            token: token.to_string(),
+            status,
+            cwd: PathBuf::from(cwd),
+        }))
+    }
+
+    fn finish_readers(&self) {
+        self.readers_stop.store(true, Ordering::SeqCst);
+        let Some(mut handles) = lock_unpoison(&self.reader_threads).take() else {
+            return;
+        };
+        let deadline = Instant::now() + READER_JOIN_GRACE;
+        while Instant::now() < deadline && handles.iter().any(|handle| !handle.is_finished()) {
+            thread::sleep(Duration::from_millis(5));
+        }
+        for handle in handles.drain(..) {
+            if handle.is_finished() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn terminate_tree(&self) {
+        let mut child = lock_unpoison(&self.child);
+        let _ = child.terminate_tree();
+        let _ = child.wait_tree_exit(PROCESS_SIGNAL_GRACE);
+    }
+
+    fn wait_for_direct_exit(&self, timeout: Duration) -> Option<ExitStatus> {
+        let deadline = Instant::now().checked_add(timeout)?;
+        loop {
+            if let Some(status) = self.try_wait() {
+                return Some(status);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+}
+
+impl ShellTransport for WindowsShellProcess {
+    fn set_expected_token(&self, token: &str) {
+        *lock_unpoison(&self.expected_token) = Some(token.to_string());
+        let _ = fs::remove_file(self.control_path(token));
+        let _ = fs::remove_file(self.control_temp_path(token));
+    }
+
+    fn write_command(&self, command: &str, token: &str) -> Result<(), ShellError> {
+        let frame = powershell_command_frame(command, token, &self.control_path(token));
+        let mut stdin = lock_unpoison(&self.stdin);
+        let Some(stdin) = stdin.as_mut() else {
+            return Err(ShellError::new(
+                "persistent_shell_stale",
+                "persistent shell stdin is closed",
+            ));
+        };
+        stdin.write_all(frame.as_bytes()).map_err(|error| {
+            ShellError::new(
+                "persistent_shell_write_failed",
+                format!("failed to write command to persistent shell: {error}"),
+            )
+        })?;
+        stdin.flush().map_err(|error| {
+            ShellError::new(
+                "persistent_shell_write_failed",
+                format!("failed to flush persistent shell command: {error}"),
+            )
+        })
+    }
+
+    fn wait_for_completion(
+        &self,
+        token: &str,
+        timeout: Duration,
+        progress: &mut CompletionProgress,
+    ) -> WaitOutcome {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let stdout_disconnected =
+                drain_sync_receiver(&self.stdout_sync_rx, token, &mut progress.stdout_synced);
+            let stderr_disconnected =
+                drain_sync_receiver(&self.stderr_sync_rx, token, &mut progress.stderr_synced);
+            if progress.control.is_none() {
+                match self.parse_control_file(token) {
+                    Ok(Some(frame)) => progress.control = Some(frame),
+                    Ok(None) => {}
+                    Err(()) => return WaitOutcome::ControlLost,
+                }
+            }
+            if progress.stdout_synced && progress.stderr_synced {
+                if let Some(frame) = progress.control.take() {
+                    self.clear_expected_token(token);
+                    return WaitOutcome::Frame(frame);
+                }
+            }
+            if let Some(status) = self.try_wait() {
+                return WaitOutcome::Exited(status);
+            }
+            if (stdout_disconnected && !progress.stdout_synced)
+                || (stderr_disconnected && !progress.stderr_synced)
+            {
+                // On Windows the reader can observe pipe EOF a few scheduler
+                // ticks before `Child::try_wait` reports the direct PowerShell
+                // exit. Give only the remaining command budget (capped at the
+                // normal process-signal grace) to distinguish an authoritative
+                // shell exit from a live process whose framing was actually lost.
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                let grace = remaining.min(PROCESS_SIGNAL_GRACE);
+                if let Some(status) = self.wait_for_direct_exit(grace) {
+                    return WaitOutcome::Exited(status);
+                }
+                return WaitOutcome::ControlLost;
+            }
+            if Instant::now() >= deadline {
+                return WaitOutcome::TimedOut;
+            }
+            thread::sleep(OUTPUT_READ_SLEEP);
+        }
+    }
+
+    fn try_wait(&self) -> Option<ExitStatus> {
+        lock_unpoison(&self.child).try_wait().ok().flatten()
+    }
+
+    fn interrupt(&self) {
+        // A redirected, non-ConPTY PowerShell has no safe command-scoped Ctrl-C
+        // primitive. The shared manager waits a bounded recovery window; if the
+        // frame does not arrive, it poisons the shell and `shutdown` kills the
+        // complete Job Object tree instead of reusing an uncertain stream.
+    }
+
+    fn shutdown(&self) {
+        if self.shutdown_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        lock_unpoison(&self.stdin).take();
+        self.terminate_tree();
+        self.finish_readers();
+        if let Some(token) = lock_unpoison(&self.expected_token).take() {
+            let _ = fs::remove_file(self.control_path(&token));
+            let _ = fs::remove_file(self.control_temp_path(&token));
+        }
+    }
+
+    fn terminate_remaining_group_after_exit(&self) {
+        self.terminate_tree();
+        self.finish_readers();
+    }
+
+    fn stdout(&self) -> &Arc<Mutex<BoundedBuffer>> {
+        &self.stdout
+    }
+
+    fn stderr(&self) -> &Arc<Mutex<BoundedBuffer>> {
+        &self.stderr
+    }
+}
+
+impl Drop for WindowsShellProcess {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+pub(super) fn spawn_shell_process(
+    launch: &ShellLaunch,
+) -> Result<Box<dyn ShellTransport>, ShellError> {
+    let control_dir = tempfile::Builder::new()
+        .prefix("webcodex-persistent-shell-")
+        .tempdir()
+        .map_err(|error| {
+            ShellError::new(
+                "persistent_shell_spawn_failed",
+                format!("failed to create persistent shell control directory: {error}"),
+            )
+        })?;
+    let bootstrap_suffix = Uuid::new_v4().simple().to_string();
+    let bootstrap = powershell_bootstrap_script(&bootstrap_suffix);
+    let bootstrap_path = control_dir.path().join("bootstrap.ps1");
+    fs::write(&bootstrap_path, bootstrap.as_bytes()).map_err(|error| {
+        ShellError::new(
+            "persistent_shell_spawn_failed",
+            format!("failed to write persistent shell bootstrap: {error}"),
+        )
+    })?;
+    let mut command = Command::new(&launch.program);
+    command
+        .args(&launch.args)
+        .arg("-File")
+        .arg(&bootstrap_path)
+        .current_dir(&launch.initial_cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env_clear()
+        .envs(&launch.env);
+    let mut child = ManagedChild::spawn(&mut command).map_err(|error| {
+        ShellError::new(
+            "persistent_shell_spawn_failed",
+            format!("failed to spawn managed PowerShell process: {error}"),
+        )
+    })?;
+    let stdin = child.child_mut().stdin.take().ok_or_else(|| {
+        ShellError::new(
+            "persistent_shell_spawn_failed",
+            "persistent shell stdin pipe was not created",
+        )
+    })?;
+    let stdout = child.child_mut().stdout.take().ok_or_else(|| {
+        ShellError::new(
+            "persistent_shell_spawn_failed",
+            "persistent shell stdout pipe was not created",
+        )
+    })?;
+    let stderr = child.child_mut().stderr.take().ok_or_else(|| {
+        ShellError::new(
+            "persistent_shell_spawn_failed",
+            "persistent shell stderr pipe was not created",
+        )
+    })?;
+
+    let readers_stop = Arc::new(AtomicBool::new(false));
+    let stdout_buffer = Arc::new(Mutex::new(BoundedBuffer::new(launch.max_output_bytes)));
+    let stderr_buffer = Arc::new(Mutex::new(BoundedBuffer::new(launch.max_output_bytes)));
+    let expected_token = Arc::new(Mutex::new(None));
+    let (stdout_sync_tx, stdout_sync_rx) = mpsc::sync_channel(OUTPUT_SYNC_CHANNEL_CAPACITY);
+    let (stderr_sync_tx, stderr_sync_rx) = mpsc::sync_channel(OUTPUT_SYNC_CHANNEL_CAPACITY);
+    let handles = vec![
+        spawn_output_reader(
+            "stdout",
+            stdout,
+            Arc::clone(&stdout_buffer),
+            Arc::clone(&expected_token),
+            stdout_sync_tx,
+            STDOUT_SYNC_MAGIC,
+            Arc::clone(&readers_stop),
+        )?,
+        spawn_output_reader(
+            "stderr",
+            stderr,
+            Arc::clone(&stderr_buffer),
+            Arc::clone(&expected_token),
+            stderr_sync_tx,
+            STDERR_SYNC_MAGIC,
+            Arc::clone(&readers_stop),
+        )?,
+    ];
+    Ok(Box::new(WindowsShellProcess {
+        child: Mutex::new(child),
+        stdin: Mutex::new(Some(stdin)),
+        control_dir,
+        expected_token,
+        stdout_sync_rx: Mutex::new(stdout_sync_rx),
+        stderr_sync_rx: Mutex::new(stderr_sync_rx),
+        stdout: stdout_buffer,
+        stderr: stderr_buffer,
+        readers_stop,
+        reader_threads: Mutex::new(Some(handles)),
+        shutdown_started: AtomicBool::new(false),
+    }))
+}
+
+fn spawn_output_reader(
+    name: &'static str,
+    mut pipe: impl Read + Send + 'static,
+    buffer: Arc<Mutex<BoundedBuffer>>,
+    expected_token: Arc<Mutex<Option<String>>>,
+    sync_sender: mpsc::SyncSender<String>,
+    sync_magic: &'static [u8],
+    stop: Arc<AtomicBool>,
+) -> Result<thread::JoinHandle<()>, ShellError> {
+    thread::Builder::new()
+        .name(format!("wc-persistent-shell-win-{name}"))
+        .spawn(move || {
+            let mut chunk = [0_u8; 8192];
+            let mut pending = Vec::new();
+            let mut last_synced_token: Option<String> = None;
+            loop {
+                match pipe.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(read) => {
+                        pending.extend_from_slice(&chunk[..read]);
+                        process_output_pending(
+                            &mut pending,
+                            &buffer,
+                            &expected_token,
+                            &sync_sender,
+                            sync_magic,
+                            &mut last_synced_token,
+                        );
+                        if stop.load(Ordering::SeqCst) {
+                            break;
+                        }
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(_) => break,
+                }
+            }
+            lock_unpoison(&buffer).append(&pending);
+        })
+        .map_err(|error| {
+            ShellError::new(
+                "persistent_shell_reader_failed",
+                format!("failed to start persistent shell {name} reader: {error}"),
+            )
+        })
+}
+
+fn powershell_command_frame(command: &str, token: &str, control_path: &Path) -> String {
+    let command_b64 = BASE64.encode(command.as_bytes());
+    let control_path_b64 = BASE64.encode(control_path.to_string_lossy().as_bytes());
+    format!("{token}\t{command_b64}\t{control_path_b64}\r\n")
+}
+
+fn powershell_bootstrap_script(suffix: &str) -> String {
+    // The bootstrap is trusted transport code evaluated once from a private
+    // temporary `-File`. This avoids Windows PowerShell 5.1's `-EncodedCommand`
+    // CLIXML stderr serialization, whose buffered tail can otherwise overtake
+    // our explicit stderr drain marker. User command text still never enters
+    // the PowerShell parser through stdin: each command arrives as one ASCII
+    // Base64 frame read by an explicit UTF-8 StreamReader and is dot-sourced
+    // only after decoding. The loop itself runs in one script scope, so
+    // cwd/env/variables/functions persist across frames.
+    format!(
+        "{POWERSHELL_UTF8_PREAMBLE}\n\
+         $__wc_input_{suffix} = [IO.StreamReader]::new([Console]::OpenStandardInput(), [Text.UTF8Encoding]::new($false), $false, 4096, $true)\n\
+         while (($__wc_line_{suffix} = $__wc_input_{suffix}.ReadLine()) -ne $null) {{\n\
+         $__wc_parts_{suffix} = $__wc_line_{suffix}.Split([char]9)\n\
+         if ($__wc_parts_{suffix}.Length -ne 3) {{ [Environment]::Exit(125) }}\n\
+         $__wc_token_{suffix} = $__wc_parts_{suffix}[0]\n\
+         if ($__wc_token_{suffix}.Length -ne 32 -or $__wc_token_{suffix} -notmatch '^[0-9a-f]+$') {{ [Environment]::Exit(125) }}\n\
+         $__wc_source_{suffix} = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($__wc_parts_{suffix}[1]))\n\
+         $__wc_script_{suffix} = [ScriptBlock]::Create($__wc_source_{suffix} + [Environment]::NewLine + '$__wc_ok_{suffix} = $?; $__wc_native_{suffix} = $LASTEXITCODE')\n\
+         $__wc_control_path_{suffix} = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($__wc_parts_{suffix}[2]))\n\
+         $__wc_status_{suffix} = 0\n\
+         $__wc_ok_{suffix} = $true\n\
+         $__wc_native_{suffix} = 0\n\
+         $LASTEXITCODE = 0\n\
+         try {{\n\
+         . $__wc_script_{suffix}\n\
+         if (-not $__wc_ok_{suffix}) {{ if ($__wc_native_{suffix}) {{ $__wc_status_{suffix} = [int]$__wc_native_{suffix} }} else {{ $__wc_status_{suffix} = 1 }} }}\n\
+         }} catch {{\n\
+         $__wc_status_{suffix} = 1\n\
+         [Console]::Error.WriteLine($_.ToString())\n\
+         }}\n\
+         $__wc_stdout_{suffix} = [Console]::OpenStandardOutput()\n\
+         $__wc_stdout_bytes_{suffix} = [Text.Encoding]::ASCII.GetBytes('WCPSO1' + [char]0 + $__wc_token_{suffix} + [char]0)\n\
+         $__wc_stdout_{suffix}.Write($__wc_stdout_bytes_{suffix}, 0, $__wc_stdout_bytes_{suffix}.Length); $__wc_stdout_{suffix}.Flush()\n\
+         $__wc_stderr_{suffix} = [Console]::OpenStandardError()\n\
+         $__wc_stderr_bytes_{suffix} = [Text.Encoding]::ASCII.GetBytes('WCPSE1' + [char]0 + $__wc_token_{suffix} + [char]0)\n\
+         $__wc_stderr_{suffix}.Write($__wc_stderr_bytes_{suffix}, 0, $__wc_stderr_bytes_{suffix}.Length); $__wc_stderr_{suffix}.Flush()\n\
+         $__wc_cwd_{suffix} = $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath\n\
+         $__wc_control_text_{suffix} = 'WCPS1' + [char]0 + $__wc_token_{suffix} + [char]0 + [string]$__wc_status_{suffix} + [char]0 + $__wc_cwd_{suffix} + [char]0\n\
+         $__wc_control_tmp_{suffix} = $__wc_control_path_{suffix} + '.tmp'\n\
+         [IO.File]::WriteAllBytes($__wc_control_tmp_{suffix}, [Text.Encoding]::UTF8.GetBytes($__wc_control_text_{suffix}))\n\
+         [IO.File]::Move($__wc_control_tmp_{suffix}, $__wc_control_path_{suffix})\n\
+         }}"
+    )
+}

--- a/crates/webcodex-persistent-shell/src/windows.rs
+++ b/crates/webcodex-persistent-shell/src/windows.rs
@@ -12,6 +12,7 @@ const POWERSHELL_UTF8_PREAMBLE: &str = concat!(
     "try { $OutputEncoding = [Console]::InputEncoding = ",
     "[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false) } catch { }",
 );
+const POWERSHELL_CONTROLLER_SOURCE: &str = include_str!("windows_controller.cs");
 const READER_JOIN_GRACE: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
@@ -257,8 +258,7 @@ pub(super) fn spawn_shell_process(
                 format!("failed to create persistent shell control directory: {error}"),
             )
         })?;
-    let bootstrap_suffix = Uuid::new_v4().simple().to_string();
-    let bootstrap = powershell_bootstrap_script(&bootstrap_suffix);
+    let bootstrap = powershell_bootstrap_script();
     let bootstrap_path = control_dir.path().join("bootstrap.ps1");
     fs::write(&bootstrap_path, bootstrap.as_bytes()).map_err(|error| {
         ShellError::new(
@@ -395,48 +395,20 @@ fn powershell_command_frame(command: &str, token: &str, control_path: &Path) -> 
     format!("{token}\t{command_b64}\t{control_path_b64}\r\n")
 }
 
-fn powershell_bootstrap_script(suffix: &str) -> String {
-    // The bootstrap is trusted transport code evaluated once from a private
-    // temporary `-File`. This avoids Windows PowerShell 5.1's `-EncodedCommand`
-    // CLIXML stderr serialization, whose buffered tail can otherwise overtake
-    // our explicit stderr drain marker. User command text still never enters
-    // the PowerShell parser through stdin: each command arrives as one ASCII
-    // Base64 frame read by an explicit UTF-8 StreamReader and is dot-sourced
-    // only after decoding. The loop itself runs in one script scope, so
-    // cwd/env/variables/functions persist across frames.
+fn powershell_bootstrap_script() -> String {
+    // The bootstrap contains only static controller code. Per-command framing
+    // authority is parsed and retained inside Controller.Run's C# stack locals;
+    // the persistent user Runspace never receives the token or control path.
+    // Keeping the controller outside PowerShell SessionState is important:
+    // PowerShell exposes Runspace::GetRunspaces(), so a second Runspace alone
+    // would not hide variables kept by an outer PowerShell controller.
     format!(
         "{POWERSHELL_UTF8_PREAMBLE}\n\
-         $__wc_input_{suffix} = [IO.StreamReader]::new([Console]::OpenStandardInput(), [Text.UTF8Encoding]::new($false), $false, 4096, $true)\n\
-         while (($__wc_line_{suffix} = $__wc_input_{suffix}.ReadLine()) -ne $null) {{\n\
-         $__wc_parts_{suffix} = $__wc_line_{suffix}.Split([char]9)\n\
-         if ($__wc_parts_{suffix}.Length -ne 3) {{ [Environment]::Exit(125) }}\n\
-         $__wc_token_{suffix} = $__wc_parts_{suffix}[0]\n\
-         if ($__wc_token_{suffix}.Length -ne 32 -or $__wc_token_{suffix} -notmatch '^[0-9a-f]+$') {{ [Environment]::Exit(125) }}\n\
-         $__wc_source_{suffix} = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($__wc_parts_{suffix}[1]))\n\
-         $__wc_script_{suffix} = [ScriptBlock]::Create($__wc_source_{suffix} + [Environment]::NewLine + '$__wc_ok_{suffix} = $?; $__wc_native_{suffix} = $LASTEXITCODE')\n\
-         $__wc_control_path_{suffix} = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($__wc_parts_{suffix}[2]))\n\
-         $__wc_status_{suffix} = 0\n\
-         $__wc_ok_{suffix} = $true\n\
-         $__wc_native_{suffix} = 0\n\
-         $LASTEXITCODE = 0\n\
-         try {{\n\
-         . $__wc_script_{suffix}\n\
-         if (-not $__wc_ok_{suffix}) {{ if ($__wc_native_{suffix}) {{ $__wc_status_{suffix} = [int]$__wc_native_{suffix} }} else {{ $__wc_status_{suffix} = 1 }} }}\n\
-         }} catch {{\n\
-         $__wc_status_{suffix} = 1\n\
-         [Console]::Error.WriteLine($_.ToString())\n\
-         }}\n\
-         $__wc_stdout_{suffix} = [Console]::OpenStandardOutput()\n\
-         $__wc_stdout_bytes_{suffix} = [Text.Encoding]::ASCII.GetBytes('WCPSO1' + [char]0 + $__wc_token_{suffix} + [char]0)\n\
-         $__wc_stdout_{suffix}.Write($__wc_stdout_bytes_{suffix}, 0, $__wc_stdout_bytes_{suffix}.Length); $__wc_stdout_{suffix}.Flush()\n\
-         $__wc_stderr_{suffix} = [Console]::OpenStandardError()\n\
-         $__wc_stderr_bytes_{suffix} = [Text.Encoding]::ASCII.GetBytes('WCPSE1' + [char]0 + $__wc_token_{suffix} + [char]0)\n\
-         $__wc_stderr_{suffix}.Write($__wc_stderr_bytes_{suffix}, 0, $__wc_stderr_bytes_{suffix}.Length); $__wc_stderr_{suffix}.Flush()\n\
-         $__wc_cwd_{suffix} = $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath\n\
-         $__wc_control_text_{suffix} = 'WCPS1' + [char]0 + $__wc_token_{suffix} + [char]0 + [string]$__wc_status_{suffix} + [char]0 + $__wc_cwd_{suffix} + [char]0\n\
-         $__wc_control_tmp_{suffix} = $__wc_control_path_{suffix} + '.tmp'\n\
-         [IO.File]::WriteAllBytes($__wc_control_tmp_{suffix}, [Text.Encoding]::UTF8.GetBytes($__wc_control_text_{suffix}))\n\
-         [IO.File]::Move($__wc_control_tmp_{suffix}, $__wc_control_path_{suffix})\n\
-         }}"
+         $__wc_controller_source = @'\n\
+{POWERSHELL_CONTROLLER_SOURCE}\n\
+'@\n\
+         Add-Type -TypeDefinition $__wc_controller_source -Language CSharp\n\
+         Remove-Variable __wc_controller_source -Force\n\
+         try {{ [WebCodexPersistentShell.Controller]::Run($Host) }} catch {{ [Console]::Error.WriteLine($_.Exception.ToString()); [Environment]::Exit(125) }}\n"
     )
 }

--- a/crates/webcodex-persistent-shell/src/windows_controller.cs
+++ b/crates/webcodex-persistent-shell/src/windows_controller.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
+using System.Text;
+
+namespace WebCodexPersistentShell
+{
+    public sealed class UserHost : PSHost
+    {
+        private readonly PSHost inner;
+        private readonly Guid instanceId = Guid.NewGuid();
+
+        public UserHost(PSHost inner)
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException("inner");
+            }
+            this.inner = inner;
+        }
+
+        public override Guid InstanceId
+        {
+            get { return instanceId; }
+        }
+
+        public override string Name
+        {
+            get { return "WebCodexPersistentShellUserHost"; }
+        }
+
+        public override Version Version
+        {
+            get { return inner.Version; }
+        }
+
+        public override PSHostUserInterface UI
+        {
+            get { return inner.UI; }
+        }
+
+        public override CultureInfo CurrentCulture
+        {
+            get { return inner.CurrentCulture; }
+        }
+
+        public override CultureInfo CurrentUICulture
+        {
+            get { return inner.CurrentUICulture; }
+        }
+
+        public override void SetShouldExit(int requestedExitCode)
+        {
+            // `exit N` is shell termination, not command completion. Terminate
+            // the owned PowerShell process immediately so controller code can
+            // never publish a completion frame for an exited user shell.
+            Environment.Exit(requestedExitCode);
+        }
+
+        public override void EnterNestedPrompt()
+        {
+            inner.EnterNestedPrompt();
+        }
+
+        public override void ExitNestedPrompt()
+        {
+            inner.ExitNestedPrompt();
+        }
+
+        public override void NotifyBeginApplication()
+        {
+            inner.NotifyBeginApplication();
+        }
+
+        public override void NotifyEndApplication()
+        {
+            inner.NotifyEndApplication();
+        }
+    }
+
+    public static class Controller
+    {
+        private const string StdoutMagic = "WCPSO1";
+        private const string StderrMagic = "WCPSE1";
+        private const string ControlMagic = "WCPS1";
+        private const string StatusTag = "WebCodexPersistentShellCommandStatus";
+        private const string StatusPostamble = "\nMicrosoft.PowerShell.Utility\\Write-Information -Tags 'WebCodexPersistentShellCommandStatus' -MessageData ([pscustomobject]@{ Ok = $?; Native = $LASTEXITCODE }) -InformationAction SilentlyContinue";
+        private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(false);
+        private static readonly Encoding Ascii = Encoding.ASCII;
+
+        public static void Run(PSHost outerHost)
+        {
+            Stream stdin = Console.OpenStandardInput();
+            Stream stdout = Console.OpenStandardOutput();
+            Stream stderr = Console.OpenStandardError();
+            StreamReader reader = new StreamReader(stdin, Utf8NoBom, false, 4096, true);
+            UserHost userHost = new UserHost(outerHost);
+            Runspace userRunspace = RunspaceFactory.CreateRunspace(userHost);
+            userRunspace.Open();
+
+            try
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    string[] parts = line.Split(new char[] { '\t' });
+                    if (parts.Length != 3 || !ValidToken(parts[0]))
+                    {
+                        Environment.Exit(125);
+                        return;
+                    }
+
+                    // Framing authority is deliberately confined to these stack locals.
+                    // Neither the token nor the publication target is stored in a
+                    // PowerShell variable, Runspace SessionState, host field, or static field.
+                    string token = parts[0];
+                    string source;
+                    string controlPath;
+                    try
+                    {
+                        source = Utf8NoBom.GetString(Convert.FromBase64String(parts[1]));
+                        controlPath = Utf8NoBom.GetString(Convert.FromBase64String(parts[2]));
+                    }
+                    catch (Exception)
+                    {
+                        Environment.Exit(125);
+                        return;
+                    }
+                    if (String.IsNullOrEmpty(controlPath))
+                    {
+                        Environment.Exit(125);
+                        return;
+                    }
+
+                    int status = InvokeUserCommand(userRunspace, source, stderr);
+
+                    // These writes are reachable only after InvokeUserCommand returned.
+                    // User PowerShell can write marker-like bytes, but it cannot learn
+                    // the active token/control target through shell-language state.
+                    WriteSync(stdout, StdoutMagic, token);
+                    WriteSync(stderr, StderrMagic, token);
+
+                    string cwd;
+                    try
+                    {
+                        cwd = userRunspace.SessionStateProxy.Path.CurrentLocation.ProviderPath;
+                    }
+                    catch (Exception)
+                    {
+                        Environment.Exit(125);
+                        return;
+                    }
+                    if (String.IsNullOrEmpty(cwd))
+                    {
+                        Environment.Exit(125);
+                        return;
+                    }
+
+                    string controlText = ControlMagic + '\0' + token + '\0' + status.ToString(CultureInfo.InvariantCulture) + '\0' + cwd + '\0';
+                    string temporaryControlPath = controlPath + ".tmp";
+                    try
+                    {
+                        File.WriteAllBytes(temporaryControlPath, Utf8NoBom.GetBytes(controlText));
+                        File.Move(temporaryControlPath, controlPath);
+                    }
+                    catch (Exception)
+                    {
+                        try { File.Delete(temporaryControlPath); } catch (Exception) { }
+                        Environment.Exit(125);
+                        return;
+                    }
+                }
+            }
+            finally
+            {
+                try { userRunspace.Close(); } catch (Exception) { }
+                userRunspace.Dispose();
+                reader.Dispose();
+            }
+        }
+
+        private static int InvokeUserCommand(Runspace userRunspace, string source, Stream stderr)
+        {
+            int status = 0;
+            using (PowerShell shell = PowerShell.Create())
+            {
+                shell.Runspace = userRunspace;
+                try
+                {
+                    // Match the prior Windows transport's per-command native-status reset.
+                    userRunspace.SessionStateProxy.SetVariable("LASTEXITCODE", 0);
+                    // Capture the same final `$?` / `$LASTEXITCODE` pair used by
+                    // the original Windows wrapper. Information is a separate
+                    // PowerShell stream and is silenced from user output; it is
+                    // command-status metadata only and never participates in
+                    // completion authentication.
+                    shell.AddScript(source + StatusPostamble, false);
+                    shell.AddCommand("Out-Default");
+                    shell.Invoke();
+                }
+                catch (Exception error)
+                {
+                    status = 1;
+                    if (shell.Streams.Error.Count == 0)
+                    {
+                        WriteErrorLine(stderr, error.ToString());
+                    }
+                }
+
+                foreach (ErrorRecord errorRecord in shell.Streams.Error)
+                {
+                    WriteErrorLine(stderr, errorRecord.ToString());
+                }
+
+                if (status == 0)
+                {
+                    int capturedStatus;
+                    if (TryReadCommandStatus(shell, out capturedStatus))
+                    {
+                        status = capturedStatus;
+                    }
+                    else if (shell.HadErrors)
+                    {
+                        // Parse/terminating failures can skip the trusted
+                        // postamble. Preserve the previous fail-closed status.
+                        status = 1;
+                    }
+                }
+            }
+            return status;
+        }
+
+        private static bool TryReadCommandStatus(PowerShell shell, out int status)
+        {
+            for (int index = shell.Streams.Information.Count - 1; index >= 0; index--)
+            {
+                InformationRecord record = shell.Streams.Information[index];
+                bool tagged = false;
+                foreach (string tag in record.Tags)
+                {
+                    if (String.Equals(tag, StatusTag, StringComparison.Ordinal))
+                    {
+                        tagged = true;
+                        break;
+                    }
+                }
+                if (!tagged)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    PSObject data = PSObject.AsPSObject(record.MessageData);
+                    PSPropertyInfo okProperty = data.Properties["Ok"];
+                    PSPropertyInfo nativeProperty = data.Properties["Native"];
+                    if (okProperty == null || nativeProperty == null)
+                    {
+                        continue;
+                    }
+                    bool ok = LanguagePrimitives.ConvertTo<bool>(okProperty.Value);
+                    int nativeExitCode = nativeProperty.Value == null
+                        ? 0
+                        : LanguagePrimitives.ConvertTo<int>(nativeProperty.Value);
+                    status = ok ? 0 : (nativeExitCode != 0 ? nativeExitCode : 1);
+                    return true;
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+            }
+
+            status = 0;
+            return false;
+        }
+
+        private static void WriteSync(Stream stream, string magic, string token)
+        {
+            byte[] bytes = Ascii.GetBytes(magic + '\0' + token + '\0');
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Flush();
+        }
+
+        private static void WriteErrorLine(Stream stderr, string text)
+        {
+            byte[] bytes = Utf8NoBom.GetBytes((text ?? String.Empty) + Environment.NewLine);
+            stderr.Write(bytes, 0, bytes.Length);
+            stderr.Flush();
+        }
+
+        private static bool ValidToken(string token)
+        {
+            if (token == null || token.Length != 32)
+            {
+                return false;
+            }
+            for (int index = 0; index < token.Length; index++)
+            {
+                char value = token[index];
+                if (!((value >= '0' && value <= '9') || (value >= 'a' && value <= 'f')))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -1878,7 +1878,7 @@ fn agent_register_capabilities(cfg: &AgentConfig) -> ShellClientCapabilities {
     capabilities.ssh_shell = SshConnectionPool::is_available();
     // This binary installs the bounded, process-local persistent-shell
     // manager. Older binaries omit this field and therefore fail closed.
-    capabilities.persistent_shell = cfg!(unix);
+    capabilities.persistent_shell = webcodex_persistent_shell::local_shell_supported();
     // SSH persistent shells reuse the same OpenSSH executable as `ssh_shell`.
     // Older binaries omit this field and therefore fail closed; it is never
     // inferred from `ssh_shell` + `persistent_shell`.

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -1882,7 +1882,7 @@ fn agent_register_capabilities(cfg: &AgentConfig) -> ShellClientCapabilities {
     // SSH persistent shells reuse the same OpenSSH executable as `ssh_shell`.
     // Older binaries omit this field and therefore fail closed; it is never
     // inferred from `ssh_shell` + `persistent_shell`.
-    capabilities.ssh_persistent_shell = SshConnectionPool::is_available() && cfg!(unix);
+    capabilities.ssh_persistent_shell = SshConnectionPool::persistent_shell_available();
     capabilities.structured_validation_argv = true;
     // This binary durably round-trips Cargo test-count assertions with
     // validation Job context and reconciliation snapshots.

--- a/crates/webcodex-runner/src/main_tests/registration.rs
+++ b/crates/webcodex-runner/src/main_tests/registration.rs
@@ -180,6 +180,16 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
     assert!(caps.structured_file_delete);
     assert!(caps.async_jobs);
     assert!(caps.async_shell_jobs);
+    assert_eq!(
+        caps.persistent_shell,
+        webcodex_persistent_shell::local_shell_supported(),
+        "local persistent-shell capability must match the platform transport compiled into this Runner"
+    );
+    assert_eq!(
+        caps.ssh_persistent_shell,
+        SshConnectionPool::is_available() && cfg!(unix),
+        "Windows Stage 1 must not advertise SSH persistent shells"
+    );
     assert!(caps.structured_validation_argv);
     assert!(caps.structured_cargo_test_count_assertion);
     assert!(caps.structured_go_test_json);

--- a/crates/webcodex-runner/src/main_tests/registration.rs
+++ b/crates/webcodex-runner/src/main_tests/registration.rs
@@ -187,8 +187,8 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
     );
     assert_eq!(
         caps.ssh_persistent_shell,
-        SshConnectionPool::is_available() && cfg!(unix),
-        "Windows Stage 1 must not advertise SSH persistent shells"
+        SshConnectionPool::persistent_shell_available(),
+        "SSH persistent-shell capability must match the platform backend and local OpenSSH availability"
     );
     assert!(caps.structured_validation_argv);
     assert!(caps.structured_cargo_test_count_assertion);

--- a/crates/webcodex-runner/src/webcodex_runner/config.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/config.rs
@@ -315,7 +315,7 @@ pub(crate) fn dialect_for_program(program: &str) -> Option<ShellDialect> {
         .unwrap_or(program)
     {
         "sh" | "bash" => Some(ShellDialect::Posix),
-        "powershell" | "powershell.exe" | "pwsh" => Some(ShellDialect::PowerShell),
+        "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe" => Some(ShellDialect::PowerShell),
         _ => None,
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/exit_diagnostics.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/exit_diagnostics.rs
@@ -1,0 +1,567 @@
+use super::shutdown::ShutdownReport;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, TryLockError};
+use std::time::{Duration, Instant};
+use windows_sys::Win32::Storage::FileSystem::{
+    MoveFileExW, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE, MOVEFILE_REPLACE_EXISTING,
+    MOVEFILE_WRITE_THROUGH,
+};
+
+const DIAGNOSTICS_DIR: &str = "runner-exit-diagnostics-v1";
+const STATE_SCHEMA_VERSION: u32 = 1;
+const RECORD_MAX_BYTES: usize = 16 * 1024;
+const MAX_LIFECYCLE_RECORDS: usize = 8;
+const ATOMIC_REPLACE_RETRY: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LifecycleState {
+    Starting,
+    Running,
+    ShutdownRequested,
+    TransportReturned,
+    Exited,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TransportOutcome {
+    Ok,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TerminalOutcome {
+    Clean,
+    Fatal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BuildEvidence {
+    version: Option<String>,
+    git_commit: Option<String>,
+    git_dirty: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TransportReturnEvidence {
+    at_unix_ms: i64,
+    outcome: TransportOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ShutdownEvidence {
+    elapsed_ms: u64,
+    timed_out_phases: Vec<String>,
+    failed_phases: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TerminalEvidence {
+    at_unix_ms: i64,
+    outcome: TerminalOutcome,
+    reason_code: String,
+    shutdown: Option<ShutdownEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LifecycleRecord {
+    schema_version: u32,
+    diagnostic_id: String,
+    client_id: String,
+    process_id: u32,
+    process_started_at_unix_s: i64,
+    record_started_at_unix_ms: i64,
+    updated_at_unix_ms: i64,
+    transport: String,
+    build: BuildEvidence,
+    state: LifecycleState,
+    shutdown_signal_received_at_unix_ms: Option<i64>,
+    transport_return: Option<TransportReturnEvidence>,
+    terminal: Option<TerminalEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PanicEvidence {
+    schema_version: u32,
+    diagnostic_id: String,
+    process_id: u32,
+    at_unix_ms: i64,
+    thread_name: Option<String>,
+    source_file: Option<String>,
+    source_line: Option<u32>,
+    source_column: Option<u32>,
+}
+
+pub(crate) struct RunnerExitDiagnostics {
+    record_path: PathBuf,
+    panic_path: PathBuf,
+    record: Mutex<LifecycleRecord>,
+    panic_write: Mutex<()>,
+}
+
+impl RunnerExitDiagnostics {
+    pub(crate) fn start(
+        client_id: &str,
+        server_url: &str,
+        transport: &str,
+        process_started_at_unix_s: i64,
+        build_version: Option<&str>,
+        build_git_commit: Option<&str>,
+        build_git_dirty: Option<bool>,
+    ) -> Result<Arc<Self>, String> {
+        let root = default_root_for_runner(client_id, server_url)?;
+        Self::start_in_root(
+            root,
+            client_id,
+            transport,
+            process_started_at_unix_s,
+            build_version,
+            build_git_commit,
+            build_git_dirty,
+            chrono::Utc::now().timestamp_millis(),
+            std::process::id(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn start_in_root(
+        root: PathBuf,
+        client_id: &str,
+        transport: &str,
+        process_started_at_unix_s: i64,
+        build_version: Option<&str>,
+        build_git_commit: Option<&str>,
+        build_git_dirty: Option<bool>,
+        now_ms: i64,
+        process_id: u32,
+    ) -> Result<Arc<Self>, String> {
+        fs::create_dir_all(&root).map_err(|error| {
+            format!("failed to create Runner exit diagnostic directory: {error}")
+        })?;
+        ensure_directory_not_symlink(&root)?;
+
+        let diagnostic_id = uuid::Uuid::new_v4().simple().to_string();
+        let prefix = format!("{now_ms:020}-{process_id}-{diagnostic_id}");
+        let record_path = root.join(format!("{prefix}.json"));
+        let panic_path = root.join(format!("{prefix}.panic.json"));
+        let record = LifecycleRecord {
+            schema_version: STATE_SCHEMA_VERSION,
+            diagnostic_id,
+            client_id: bounded_single_line(client_id, 128),
+            process_id,
+            process_started_at_unix_s,
+            record_started_at_unix_ms: now_ms,
+            updated_at_unix_ms: now_ms,
+            transport: bounded_single_line(transport, 32),
+            build: BuildEvidence {
+                version: build_version.map(|value| bounded_single_line(value, 128)),
+                git_commit: build_git_commit.map(|value| bounded_single_line(value, 128)),
+                git_dirty: build_git_dirty,
+            },
+            state: LifecycleState::Starting,
+            shutdown_signal_received_at_unix_ms: None,
+            transport_return: None,
+            terminal: None,
+        };
+        atomic_write_json(&record_path, &record)?;
+        prune_old_records(&root, &record_path);
+        Ok(Arc::new(Self {
+            record_path,
+            panic_path,
+            record: Mutex::new(record),
+            panic_write: Mutex::new(()),
+        }))
+    }
+
+    pub(crate) fn install_panic_hook(self: &Arc<Self>) {
+        let previous = std::panic::take_hook();
+        let weak = Arc::downgrade(self);
+        std::panic::set_hook(Box::new(move |info| {
+            if let Some(diagnostics) = weak.upgrade() {
+                diagnostics.record_panic(info);
+            }
+            previous(info);
+        }));
+    }
+
+    pub(crate) fn mark_running(&self) {
+        self.update(|record, now_ms| {
+            record.state = LifecycleState::Running;
+            record.updated_at_unix_ms = now_ms;
+        });
+    }
+
+    pub(crate) fn mark_shutdown_signal_received(&self) {
+        self.update(|record, now_ms| {
+            record.state = LifecycleState::ShutdownRequested;
+            record
+                .shutdown_signal_received_at_unix_ms
+                .get_or_insert(now_ms);
+            record.updated_at_unix_ms = now_ms;
+        });
+    }
+
+    pub(crate) fn mark_transport_returned(&self, ok: bool) {
+        self.update(|record, now_ms| {
+            record.state = LifecycleState::TransportReturned;
+            record.transport_return = Some(TransportReturnEvidence {
+                at_unix_ms: now_ms,
+                outcome: if ok {
+                    TransportOutcome::Ok
+                } else {
+                    TransportOutcome::Error
+                },
+            });
+            record.updated_at_unix_ms = now_ms;
+        });
+    }
+
+    pub(crate) fn mark_terminal(
+        &self,
+        clean: bool,
+        reason_code: &'static str,
+        shutdown: Option<&ShutdownReport>,
+    ) {
+        self.update(|record, now_ms| {
+            record.state = LifecycleState::Exited;
+            record.terminal = Some(TerminalEvidence {
+                at_unix_ms: now_ms,
+                outcome: if clean {
+                    TerminalOutcome::Clean
+                } else {
+                    TerminalOutcome::Fatal
+                },
+                reason_code: reason_code.to_string(),
+                shutdown: shutdown.map(|report| ShutdownEvidence {
+                    elapsed_ms: report.elapsed_ms,
+                    timed_out_phases: report
+                        .timed_out_phases
+                        .iter()
+                        .map(|phase| (*phase).to_string())
+                        .collect(),
+                    failed_phases: report
+                        .failed_phases
+                        .iter()
+                        .map(|phase| (*phase).to_string())
+                        .collect(),
+                }),
+            });
+            record.updated_at_unix_ms = now_ms;
+        });
+    }
+
+    #[cfg(test)]
+    fn record_path(&self) -> &Path {
+        &self.record_path
+    }
+
+    fn update(&self, update: impl FnOnce(&mut LifecycleRecord, i64)) {
+        let mut record = self
+            .record
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        update(&mut record, chrono::Utc::now().timestamp_millis());
+        if let Err(error) = atomic_write_json(&self.record_path, &*record) {
+            tracing::warn!(error = %error, "Windows Runner exit diagnostic update failed; Runner continues");
+        }
+    }
+
+    fn record_panic(&self, info: &std::panic::PanicHookInfo<'_>) {
+        let _guard = match self.panic_write.try_lock() {
+            Ok(guard) => guard,
+            Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+            Err(TryLockError::WouldBlock) => return,
+        };
+        let location = info.location();
+        let current = std::thread::current();
+        let evidence = PanicEvidence {
+            schema_version: STATE_SCHEMA_VERSION,
+            diagnostic_id: self
+                .record
+                .try_lock()
+                .map(|record| record.diagnostic_id.clone())
+                .unwrap_or_else(|_| "unavailable".to_string()),
+            process_id: std::process::id(),
+            at_unix_ms: chrono::Utc::now().timestamp_millis(),
+            thread_name: current.name().map(|name| bounded_single_line(name, 128)),
+            source_file: location.map(|location| bounded_single_line(location.file(), 512)),
+            source_line: location.map(|location| location.line()),
+            source_column: location.map(|location| location.column()),
+        };
+        let _ = atomic_write_json(&self.panic_path, &evidence);
+    }
+}
+
+fn default_root_for_runner(client_id: &str, server_url: &str) -> Result<PathBuf, String> {
+    let base = webcodex_agent_config::paths::default_client_state_base_dir()?;
+    Ok(default_root_for_runner_with_base(
+        &base, client_id, server_url,
+    ))
+}
+
+fn default_root_for_runner_with_base(base: &Path, client_id: &str, server_url: &str) -> PathBuf {
+    let server_url = server_url.trim().trim_end_matches('/');
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex-runner-exit-diagnostics-v1\0");
+    hasher.update(client_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(server_url.as_bytes());
+    base.join(DIAGNOSTICS_DIR)
+        .join(format!("{:x}", hasher.finalize()))
+}
+
+fn bounded_single_line(value: &str, max_chars: usize) -> String {
+    value
+        .chars()
+        .filter(|ch| *ch != '\r' && *ch != '\n')
+        .take(max_chars)
+        .collect()
+}
+
+fn ensure_directory_not_symlink(path: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("failed to inspect Runner exit diagnostic directory: {error}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err("Runner exit diagnostic path must be a regular directory".to_string());
+    }
+    Ok(())
+}
+
+fn prune_old_records(root: &Path, current: &Path) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    let mut lifecycle = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let file_type = entry.file_type().ok()?;
+            (file_type.is_file() && name.ends_with(".json") && !name.ends_with(".panic.json"))
+                .then_some((name, entry.path()))
+        })
+        .collect::<Vec<_>>();
+    lifecycle.sort_by(|a, b| a.0.cmp(&b.0));
+    let remove_count = lifecycle.len().saturating_sub(MAX_LIFECYCLE_RECORDS);
+    for (_, path) in lifecycle
+        .into_iter()
+        .filter(|(_, path)| path != current)
+        .take(remove_count)
+    {
+        let panic = panic_path_for(&path);
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(panic);
+    }
+}
+
+fn panic_path_for(record_path: &Path) -> PathBuf {
+    let stem = record_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("runner");
+    record_path.with_file_name(format!("{stem}.panic.json"))
+}
+
+fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("failed to encode Runner exit diagnostic: {error}"))?;
+    if bytes.len() > RECORD_MAX_BYTES {
+        return Err(format!(
+            "Runner exit diagnostic exceeds {RECORD_MAX_BYTES} bytes"
+        ));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Runner exit diagnostic path has no parent".to_string())?;
+    ensure_directory_not_symlink(parent)?;
+    reject_symlink_or_non_file(path)?;
+    let temp = path.with_file_name(format!(
+        ".{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("runner-exit-diagnostic")
+    ));
+    match fs::symlink_metadata(&temp) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err("Runner exit diagnostic temp path is not a regular file".to_string());
+            }
+            fs::remove_file(&temp)
+                .map_err(|error| format!("failed to remove stale diagnostic temp file: {error}"))?;
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect Runner exit diagnostic temp file: {error}"
+            ));
+        }
+    }
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .share_mode(FILE_SHARE_DELETE)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(&temp)
+            .map_err(|error| {
+                format!("failed to create Runner exit diagnostic temp file: {error}")
+            })?;
+        file.write_all(&bytes)
+            .map_err(|error| format!("failed to write Runner exit diagnostic: {error}"))?;
+        file.sync_all()
+            .map_err(|error| format!("failed to sync Runner exit diagnostic: {error}"))?;
+        publish_state_file(&temp, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+fn reject_symlink_or_non_file(path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            Err("Runner exit diagnostic destination is not a regular file".to_string())
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "failed to inspect Runner exit diagnostic destination: {error}"
+        )),
+    }
+}
+
+fn publish_state_file(temp: &Path, state_path: &Path) -> Result<(), String> {
+    let from = windows_wide_path(temp);
+    let to = windows_wide_path(state_path);
+    let retry_deadline = Instant::now() + ATOMIC_REPLACE_RETRY;
+    loop {
+        if unsafe {
+            MoveFileExW(
+                from.as_ptr(),
+                to.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        } != 0
+        {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        let retryable = matches!(error.raw_os_error(), Some(5) | Some(32) | Some(33));
+        if !retryable || Instant::now() >= retry_deadline {
+            return Err(format!("failed to publish Runner exit diagnostic: {error}"));
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn windows_wide_path(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_record(path: &Path) -> LifecycleRecord {
+        serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn lifecycle_record_preserves_exit_classification_without_payloads() {
+        let temp = tempfile::tempdir().unwrap();
+        let diagnostics = RunnerExitDiagnostics::start_in_root(
+            temp.path().to_path_buf(),
+            "msi",
+            "websocket",
+            123,
+            Some("0.3.8"),
+            Some("deadbeef"),
+            Some(false),
+            456_000,
+            42,
+        )
+        .unwrap();
+
+        diagnostics.mark_running();
+        diagnostics.mark_shutdown_signal_received();
+        diagnostics.mark_transport_returned(false);
+        diagnostics.mark_terminal(false, "transport_returned_error", None);
+
+        let record = read_record(diagnostics.record_path());
+        assert_eq!(record.client_id, "msi");
+        assert_eq!(record.process_id, 42);
+        assert_eq!(record.state, LifecycleState::Exited);
+        assert!(record.shutdown_signal_received_at_unix_ms.is_some());
+        assert_eq!(
+            record.transport_return.as_ref().map(|item| item.outcome),
+            Some(TransportOutcome::Error)
+        );
+        let terminal = record.terminal.unwrap();
+        assert_eq!(terminal.outcome, TerminalOutcome::Fatal);
+        assert_eq!(terminal.reason_code, "transport_returned_error");
+        let encoded = fs::read_to_string(diagnostics.record_path()).unwrap();
+        for forbidden in ["Authorization", "Bearer ", "token=", "command", "payload"] {
+            assert!(!encoded.contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn profile_namespace_hashes_server_url_and_retention_is_bounded() {
+        let base = tempfile::tempdir().unwrap();
+        let root = default_root_for_runner_with_base(base.path(), "msi", "https://sg4.yyjeqhc.cn/");
+        assert!(!root.to_string_lossy().contains("sg4.yyjeqhc.cn"));
+        fs::create_dir_all(&root).unwrap();
+        for index in 0..(MAX_LIFECYCLE_RECORDS + 3) {
+            let diagnostics = RunnerExitDiagnostics::start_in_root(
+                root.clone(),
+                "msi",
+                "websocket",
+                index as i64,
+                None,
+                None,
+                None,
+                1_000 + index as i64,
+                10 + index as u32,
+            )
+            .unwrap();
+            diagnostics.mark_running();
+        }
+        // Retention must remain bounded even if the wall clock moves backward
+        // and the current process record sorts before older records.
+        let skewed = RunnerExitDiagnostics::start_in_root(
+            root.clone(),
+            "msi",
+            "websocket",
+            99,
+            None,
+            None,
+            None,
+            1,
+            999,
+        )
+        .unwrap();
+        skewed.mark_running();
+        let lifecycle_count = fs::read_dir(&root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                entry.file_type().is_ok_and(|kind| kind.is_file())
+                    && name.ends_with(".json")
+                    && !name.ends_with(".panic.json")
+            })
+            .count();
+        assert_eq!(lifecycle_count, MAX_LIFECYCLE_RECORDS);
+    }
+}

--- a/crates/webcodex-runner/src/webcodex_runner/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/mod.rs
@@ -15,9 +15,9 @@ pub(crate) mod patches;
 pub(crate) mod persistent_shell;
 pub(crate) mod projects;
 // The remote SSH persistent-shell transport is built on Unix process groups and
-// inherited descriptors; Windows has no persistent shell yet (the local shell
-// fails closed there and `ssh_persistent_shell` is advertised false), so the
-// whole module is compiled out on non-Unix targets.
+// inherited descriptors. Windows Stage 1 has a separate local PowerShell
+// transport, while `ssh_persistent_shell` remains false there, so this remote
+// module stays compiled only on Unix.
 #[cfg(unix)]
 pub(crate) mod remote_shell;
 pub(crate) mod shell;

--- a/crates/webcodex-runner/src/webcodex_runner/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/mod.rs
@@ -5,6 +5,8 @@ pub(crate) mod computer;
 pub(crate) mod config;
 pub(crate) mod detached_job;
 pub(crate) mod dispatch;
+#[cfg(windows)]
+pub(crate) mod exit_diagnostics;
 pub(crate) mod external_tools;
 pub(crate) mod files;
 pub(crate) mod lsp;

--- a/crates/webcodex-runner/src/webcodex_runner/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/mod.rs
@@ -14,11 +14,10 @@ pub(crate) mod output_text;
 pub(crate) mod patches;
 pub(crate) mod persistent_shell;
 pub(crate) mod projects;
-// The remote SSH persistent-shell transport is built on Unix process groups and
-// inherited descriptors. Windows Stage 1 has a separate local PowerShell
-// transport, while `ssh_persistent_shell` remains false there, so this remote
-// module stays compiled only on Unix.
-#[cfg(unix)]
+// Remote persistent shells always run POSIX sh/bash on the SSH target. Their
+// local child ownership is platform-specific: Unix uses a private process group,
+// while Windows owns ssh.exe through ManagedChild's Job Object.
+#[cfg(any(unix, windows))]
 pub(crate) mod remote_shell;
 pub(crate) mod shell;
 pub(crate) mod shutdown;

--- a/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
@@ -1,10 +1,16 @@
+#[cfg(windows)]
+use super::config::{dialect_for_program, platform_default_dialect, ShellDialect};
 use super::config::{
     validate_shell_config, AgentPolicy, ShellConfig, ShellProfileConfig, SshConfig,
 };
 use super::projects::{find_project_shell_context_by_id, AgentProjectShellContext};
 #[cfg(unix)]
 use super::remote_shell::{remote_shell_bootstrap, RemoteShellTransport};
-use super::shell::{base_shell_env, cwd_allowed, shell_quote};
+#[cfg(unix)]
+use super::shell::shell_quote;
+#[cfg(windows)]
+use super::shell::shell_quote_powershell;
+use super::shell::{base_shell_env, cwd_allowed};
 #[cfg(unix)]
 use super::ssh::SshConnectionPool;
 use crate::shell_protocol::{
@@ -13,9 +19,11 @@ use crate::shell_protocol::{
 };
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+#[cfg(unix)]
+use webcodex_persistent_shell::canonical_dialect;
 use webcodex_persistent_shell::{
-    canonical_dialect, PersistentShellManager as ProcessManager, ShellError, ShellExecResult,
-    ShellIdentity, ShellLaunch, ShellLimits, ShellState, ShellSummary,
+    PersistentShellManager as ProcessManager, ShellError, ShellExecResult, ShellIdentity,
+    ShellLaunch, ShellLimits, ShellState, ShellSummary,
 };
 
 const EXECUTOR_AGENT: &str = "agent";
@@ -238,9 +246,8 @@ impl PersistentShellManager {
         }
     }
 
-    /// Windows has no SSH persistent shell (and no persistent shell at all
-    /// yet). Fail closed with a stable error; the Runner never advertises
-    /// `ssh_persistent_shell` on Windows.
+    /// Windows Stage 1 supports only the local persistent PowerShell transport.
+    /// Named SSH persistent shells remain unsupported and are not advertised.
     #[cfg(not(unix))]
     fn open_ssh(
         &self,
@@ -257,7 +264,7 @@ impl PersistentShellManager {
             &operation.workflow_session_id,
             &operation.runtime_project_id,
             "persistent_shell_unsupported",
-            "persistent shell is not supported on Windows yet",
+            "named SSH persistent shell is not supported on Windows",
         )
     }
 
@@ -617,7 +624,7 @@ impl PersistentShellManager {
         self.processes.close_all(reason)
     }
 
-    #[cfg(all(test, unix))]
+    #[cfg(test)]
     pub(crate) fn active_count(&self) -> usize {
         self.processes.active_count()
     }
@@ -845,38 +852,89 @@ fn build_launch_at_cwd(
     max_output_bytes: usize,
 ) -> Result<ShellLaunch, (&'static str, String)> {
     let (profile_name, profile) = selected_profile(shell, project)?;
-    let explicit = operation.shell.as_deref();
-    if explicit.is_some_and(|dialect| !matches!(dialect, "sh" | "bash")) {
-        return Err((
-            "persistent_shell_dialect_unsupported",
-            "persistent shell must be 'sh' or 'bash'".to_string(),
-        ));
-    }
-    let program = explicit
-        .map(str::to_string)
-        .or_else(|| profile.and_then(|profile| profile.program.clone()))
-        .unwrap_or_else(|| shell.program.clone());
-    let dialect = canonical_dialect(&program).ok_or_else(|| {
-        (
-            "persistent_shell_dialect_unsupported",
-            "configured persistent shell program must resolve to sh or bash".to_string(),
-        )
-    })?;
     let empty_profile = ShellProfileConfig::default();
     let env = base_shell_env(shell, profile.unwrap_or(&empty_profile))
         .map_err(|message| ("persistent_shell_environment_invalid", message))?;
-    let initialization = match profile {
-        Some(profile) => profile.init_script.clone(),
-        None => shell
-            .init_script
-            .as_ref()
-            .map(|path| format!(". {}", shell_quote(&path.to_string_lossy()))),
+
+    #[cfg(unix)]
+    let (program, dialect, args, initialization) = {
+        let explicit = operation.shell.as_deref();
+        if explicit.is_some_and(|dialect| !matches!(dialect, "sh" | "bash")) {
+            return Err((
+                "persistent_shell_dialect_unsupported",
+                "persistent shell must be 'sh' or 'bash'".to_string(),
+            ));
+        }
+        let program = explicit
+            .map(str::to_string)
+            .or_else(|| profile.and_then(|profile| profile.program.clone()))
+            .unwrap_or_else(|| shell.program.clone());
+        let dialect = canonical_dialect(&program).ok_or_else(|| {
+            (
+                "persistent_shell_dialect_unsupported",
+                "configured persistent shell program must resolve to sh or bash".to_string(),
+            )
+        })?;
+        let initialization = match profile {
+            Some(profile) => profile.init_script.clone(),
+            None => shell
+                .init_script
+                .as_ref()
+                .map(|path| format!(". {}", shell_quote(&path.to_string_lossy()))),
+        };
+        let args = if dialect == "bash" {
+            vec!["--noprofile".to_string(), "--norc".to_string()]
+        } else {
+            Vec::new()
+        };
+        (program, dialect.to_string(), args, initialization)
     };
-    let args = if dialect == "bash" {
-        vec!["--noprofile".to_string(), "--norc".to_string()]
-    } else {
-        Vec::new()
+
+    #[cfg(windows)]
+    let (program, dialect, args, initialization) = {
+        if let Some(explicit) = operation.shell.as_deref() {
+            return Err((
+                "persistent_shell_dialect_unsupported",
+                format!(
+                    "Windows local persistent shell uses the configured PowerShell profile; explicit shell override '{explicit}' is unsupported"
+                ),
+            ));
+        }
+        let program = profile
+            .and_then(|profile| profile.program.clone())
+            .unwrap_or_else(|| shell.program.clone());
+        let resolved_dialect = profile
+            .and_then(|profile| profile.dialect)
+            .or(shell.dialect)
+            .or_else(|| dialect_for_program(&program))
+            .unwrap_or_else(platform_default_dialect);
+        if resolved_dialect != ShellDialect::PowerShell {
+            return Err((
+                "persistent_shell_dialect_unsupported",
+                "Windows local persistent shell requires a configured PowerShell program/profile"
+                    .to_string(),
+            ));
+        }
+        let configured_args = profile
+            .and_then(|profile| profile.args.clone())
+            .unwrap_or_else(|| shell.args.clone());
+        let args = windows_persistent_shell_prefix_args(&configured_args)?;
+        let initialization = match profile {
+            Some(profile) => profile.init_script.clone(),
+            None => shell
+                .init_script
+                .as_ref()
+                .map(|path| format!(". {}", shell_quote_powershell(&path.to_string_lossy()))),
+        };
+        (program, "powershell".to_string(), args, initialization)
     };
+
+    #[cfg(not(any(unix, windows)))]
+    return Err((
+        "persistent_shell_unsupported",
+        "local persistent shell is unsupported on this platform".to_string(),
+    ));
+
     Ok(ShellLaunch {
         identity: ShellIdentity {
             shell_id: operation.shell_id.clone(),
@@ -885,7 +943,7 @@ fn build_launch_at_cwd(
             executor: EXECUTOR_AGENT.to_string(),
             client_id: Some(request.client_id.clone()),
         },
-        dialect: dialect.to_string(),
+        dialect,
         profile: profile_name,
         program,
         args,
@@ -894,6 +952,38 @@ fn build_launch_at_cwd(
         initialization,
         max_output_bytes,
     })
+}
+
+#[cfg(windows)]
+fn windows_persistent_shell_prefix_args(
+    configured_args: &[String],
+) -> Result<Vec<String>, (&'static str, String)> {
+    let Some((command_flag, prefix)) = configured_args.split_last() else {
+        return Err((
+            "persistent_shell_config_invalid",
+            "Windows PowerShell shell args must end with -Command".to_string(),
+        ));
+    };
+    if !command_flag.eq_ignore_ascii_case("-Command") {
+        return Err((
+            "persistent_shell_config_invalid",
+            "Windows PowerShell shell args must end with -Command so persistent-shell transport can replace the one-shot payload mode"
+                .to_string(),
+        ));
+    }
+    if prefix.iter().any(|arg| {
+        matches!(
+            arg.to_ascii_lowercase().as_str(),
+            "-command" | "-encodedcommand" | "-file"
+        )
+    }) {
+        return Err((
+            "persistent_shell_config_invalid",
+            "Windows PowerShell shell args contain a conflicting command/file payload switch"
+                .to_string(),
+        ));
+    }
+    Ok(prefix.to_vec())
 }
 
 fn validate_open_shell_boundary(
@@ -1449,5 +1539,283 @@ mod tests {
             Some("persistent_shell_project_mismatch")
         );
         assert_eq!(manager.active_count(), 0);
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::super::ssh::SshConnectionPool;
+    use super::*;
+    use crate::shell_protocol::ShellAgentShellRequest;
+    use std::collections::BTreeMap;
+
+    fn request(action: &str, shell_id: &str, command: Option<&str>) -> ShellAgentShellRequest {
+        ShellAgentShellRequest {
+            request_id: format!("req-{action}"),
+            client_id: "msi".to_string(),
+            kind: "persistent_shell".to_string(),
+            job_id: None,
+            cwd: None,
+            path: None,
+            content: None,
+            max_bytes: None,
+            expected_sha256: None,
+            expected_prefix: None,
+            start_line: None,
+            end_line: None,
+            create_dirs: false,
+            command: command.unwrap_or_default().to_string(),
+            process: None,
+            script: None,
+            stdin: None,
+            timeout_secs: 5,
+            requested_by: "tester".to_string(),
+            created_at: 0,
+            validation: None,
+            lsp: None,
+            sandbox: None,
+            job_context: None,
+            mcp_gateway: None,
+            coding_agent: None,
+            persistent_shell: Some(PersistentShellRequest {
+                action: action.to_string(),
+                shell_id: shell_id.to_string(),
+                workflow_session_id: "wc_sess_windows".to_string(),
+                runtime_project_id: "agent:msi:demo".to_string(),
+                cwd: None,
+                shell: None,
+                command: command.map(str::to_string),
+                timeout_secs: Some(5),
+                purpose: None,
+            }),
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, PathBuf, PathBuf, AgentPolicy) {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let projects = temp.path().join("projects.d");
+        std::fs::create_dir_all(project.join("sub")).unwrap();
+        std::fs::create_dir_all(&projects).unwrap();
+        let escaped = project.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            projects.join("demo.toml"),
+            format!("id = \"demo\"\npath = \"{escaped}\"\n"),
+        )
+        .unwrap();
+        let policy = AgentPolicy {
+            allow_raw_shell: true,
+            allow_cwd_anywhere: false,
+            allowed_roots: vec![project.clone()],
+            max_timeout_secs: 30,
+            max_output_bytes: 16 * 1024,
+        };
+        (temp, project, projects, policy)
+    }
+
+    #[test]
+    fn runner_windows_local_persistent_shell_preserves_state_and_existing_protocol() {
+        let (_temp, _project, projects, mut policy) = fixture();
+        let shell = ShellConfig::default();
+        let manager = PersistentShellManager::new(&shell, SshConnectionPool::default());
+
+        let opened = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request("open", "wc_shell_windows_runner", None),
+        );
+        assert_eq!(opened.shell_state, "running");
+        assert_eq!(opened.shell.as_deref(), Some("powershell"));
+
+        let set = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request(
+                "exec",
+                "wc_shell_windows_runner",
+                Some("$env:WC_RUNNER_STATE='ready'; Set-Location -LiteralPath 'sub'; $WC_LOCAL='beta'; function WC_FN { [Console]::Out.Write('fn') }"),
+            ),
+        );
+        assert_eq!(set.exit_code, Some(0));
+        let observed = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request(
+                "exec",
+                "wc_shell_windows_runner",
+                Some("[Console]::Out.Write($env:WC_RUNNER_STATE + '|' + (Get-Location).Path + '|' + $WC_LOCAL + '|'); WC_FN"),
+            ),
+        );
+        assert!(observed.stdout.starts_with("ready|"), "{}", observed.stdout);
+        assert!(
+            observed.stdout.contains("\\sub|beta|fn"),
+            "{}",
+            observed.stdout
+        );
+
+        let unicode = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request(
+                "exec",
+                "wc_shell_windows_runner",
+                Some("[Console]::Out.Write(\"hello`r`n中文`r`n🙂\")"),
+            ),
+        );
+        assert_eq!(unicode.stdout, "hello\r\n中文\r\n🙂");
+
+        let failed = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request(
+                "exec",
+                "wc_shell_windows_runner",
+                Some("Write-Error 'expected-runner-failure'"),
+            ),
+        );
+        assert_eq!(failed.exit_code, Some(1));
+        assert_eq!(failed.shell_state, "running");
+        assert!(failed.stderr.contains("expected-runner-failure"));
+
+        let next = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request(
+                "exec",
+                "wc_shell_windows_runner",
+                Some("[Console]::Out.Write('still-running')"),
+            ),
+        );
+        assert_eq!(next.stdout, "still-running");
+        assert!(
+            next.stderr.is_empty(),
+            "previous stderr leaked: {}",
+            next.stderr
+        );
+
+        policy.max_output_bytes = 1024;
+        let bounded = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request(
+                "exec",
+                "wc_shell_windows_runner",
+                Some("[Console]::Out.Write('x' * 5000)"),
+            ),
+        );
+        assert!(bounded.stdout_truncated);
+        assert!(bounded.stdout.len() <= policy.max_output_bytes);
+
+        let closed = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &request("close", "wc_shell_windows_runner", None),
+        );
+        assert_eq!(closed.shell_state, "closed");
+        assert_eq!(manager.active_count(), 0);
+    }
+
+    #[test]
+    fn windows_launch_uses_configured_powershell_profile_and_rejects_payload_modes() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().to_path_buf();
+        let mut profiles = BTreeMap::new();
+        profiles.insert(
+            "modern".to_string(),
+            ShellProfileConfig {
+                program: Some("pwsh.exe".to_string()),
+                args: Some(vec![
+                    "-NoProfile".to_string(),
+                    "-NonInteractive".to_string(),
+                    "-Command".to_string(),
+                ]),
+                init_script: Some("$env:WC_PROFILE='ready'".to_string()),
+                ..ShellProfileConfig::default()
+            },
+        );
+        let shell = ShellConfig {
+            profiles,
+            ..ShellConfig::default()
+        };
+        let project = AgentProjectShellContext {
+            id: "demo".to_string(),
+            path: cwd.to_string_lossy().to_string(),
+            shell_profile: Some("modern".to_string()),
+        };
+        let open = request("open", "wc_shell_profile_mapping", None);
+        let operation = open.persistent_shell.as_ref().unwrap();
+        let launch =
+            build_launch_at_cwd(&shell, &open, operation, &project, cwd.clone(), 4096).unwrap();
+        assert_eq!(launch.program, "pwsh.exe");
+        assert_eq!(launch.dialect, "powershell");
+        assert_eq!(launch.args, vec!["-NoProfile", "-NonInteractive"]);
+        assert_eq!(
+            launch.initialization.as_deref(),
+            Some("$env:WC_PROFILE='ready'")
+        );
+        assert_eq!(
+            dialect_for_program("pwsh.exe"),
+            Some(ShellDialect::PowerShell)
+        );
+
+        let mut explicit = request("open", "wc_shell_explicit_sh", None);
+        explicit.persistent_shell.as_mut().unwrap().shell = Some("bash".to_string());
+        let error = build_launch_at_cwd(
+            &ShellConfig::default(),
+            &explicit,
+            explicit.persistent_shell.as_ref().unwrap(),
+            &AgentProjectShellContext {
+                id: "demo".to_string(),
+                path: cwd.to_string_lossy().to_string(),
+                shell_profile: None,
+            },
+            cwd.clone(),
+            4096,
+        )
+        .unwrap_err();
+        assert_eq!(error.0, "persistent_shell_dialect_unsupported");
+
+        let mut invalid_shell = ShellConfig::default();
+        invalid_shell.args = vec!["-NoProfile".to_string()];
+        let default_project = AgentProjectShellContext {
+            id: "demo".to_string(),
+            path: cwd.to_string_lossy().to_string(),
+            shell_profile: None,
+        };
+        let invalid = request("open", "wc_shell_bad_args", None);
+        let error = build_launch_at_cwd(
+            &invalid_shell,
+            &invalid,
+            invalid.persistent_shell.as_ref().unwrap(),
+            &default_project,
+            cwd,
+            4096,
+        )
+        .unwrap_err();
+        assert_eq!(error.0, "persistent_shell_config_invalid");
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
@@ -4,14 +4,13 @@ use super::config::{
     validate_shell_config, AgentPolicy, ShellConfig, ShellProfileConfig, SshConfig,
 };
 use super::projects::{find_project_shell_context_by_id, AgentProjectShellContext};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use super::remote_shell::{remote_shell_bootstrap, RemoteShellTransport};
 #[cfg(unix)]
 use super::shell::shell_quote;
 #[cfg(windows)]
 use super::shell::shell_quote_powershell;
 use super::shell::{base_shell_env, cwd_allowed};
-#[cfg(unix)]
 use super::ssh::SshConnectionPool;
 use crate::shell_protocol::{
     PersistentShellRequest, PersistentShellResult, ShellAgentShellRequest,
@@ -19,7 +18,7 @@ use crate::shell_protocol::{
 };
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use webcodex_persistent_shell::canonical_dialect;
 use webcodex_persistent_shell::{
     PersistentShellManager as ProcessManager, ShellError, ShellExecResult, ShellIdentity,
@@ -27,32 +26,23 @@ use webcodex_persistent_shell::{
 };
 
 const EXECUTOR_AGENT: &str = "agent";
-/// Only the Unix remote (SSH) transport opens shells under this executor id.
-#[cfg(unix)]
+/// Remote named-SSH persistent shells use this executor on supported hosts.
+#[cfg(any(unix, windows))]
 const EXECUTOR_SSH: &str = "ssh";
 const TERMINAL_RECORDS: usize = 128;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PersistentShellManager {
     processes: ProcessManager,
-    /// Pool reused only by the Unix remote (SSH) persistent shell transport.
-    #[cfg(unix)]
+    /// Runner-local SSH authority/preparation state. Windows persistent SSH uses
+    /// the named-resource resolver without Unix ControlMaster multiplexing.
     ssh_pool: SshConnectionPool,
 }
 
 impl PersistentShellManager {
-    /// `ssh_pool` is consumed only by the Unix remote (SSH) transport. The
-    /// parameter stays on every platform so the constructor signature is
-    /// identical across targets; Windows names it with a leading underscore
-    /// because it is intentionally unused there.
-    pub(crate) fn new(
-        shell: &ShellConfig,
-        #[cfg(unix)] ssh_pool: super::ssh::SshConnectionPool,
-        #[cfg(not(unix))] _ssh_pool: super::ssh::SshConnectionPool,
-    ) -> Self {
+    pub(crate) fn new(shell: &ShellConfig, ssh_pool: super::ssh::SshConnectionPool) -> Self {
         Self {
             processes: ProcessManager::new(limits(shell)),
-            #[cfg(unix)]
             ssh_pool,
         }
     }
@@ -146,7 +136,7 @@ impl PersistentShellManager {
         }
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn open_ssh(
         &self,
         policy: &AgentPolicy,
@@ -246,9 +236,7 @@ impl PersistentShellManager {
         }
     }
 
-    /// Windows Stage 1 supports only the local persistent PowerShell transport.
-    /// Named SSH persistent shells remain unsupported and are not advertised.
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn open_ssh(
         &self,
         _policy: &AgentPolicy,
@@ -264,7 +252,7 @@ impl PersistentShellManager {
             &operation.workflow_session_id,
             &operation.runtime_project_id,
             "persistent_shell_unsupported",
-            "named SSH persistent shell is not supported on Windows",
+            "named SSH persistent shell is not supported on this Runner host",
         )
     }
 
@@ -1544,6 +1532,7 @@ mod tests {
 
 #[cfg(all(test, windows))]
 mod windows_tests {
+    use super::super::config::SshResourceConfig;
     use super::super::ssh::SshConnectionPool;
     use super::*;
     use crate::shell_protocol::ShellAgentShellRequest;
@@ -1589,6 +1578,45 @@ mod windows_tests {
                 purpose: None,
             }),
         }
+    }
+
+    fn ssh_request(
+        action: &str,
+        shell_id: &str,
+        resource: &str,
+        command: Option<&str>,
+    ) -> ShellAgentShellRequest {
+        serde_json::from_value(serde_json::json!({
+            "request_id": format!("req-ssh-{action}-{shell_id}"),
+            "client_id": "msi",
+            "kind": "persistent_shell",
+            "command": command.unwrap_or(""),
+            "timeout_secs": 5,
+            "requested_by": "tester",
+            "created_at": 0,
+            "job_context": {
+                "runtime_project_id": "agent:msi:demo",
+                "workflow_session_id": "wc_sess_windows",
+                "ssh_resource": resource,
+                "project_cwd": ".",
+                "purpose": "other",
+                "shell": "remote",
+                "command_preview": "",
+                "validation_steps": []
+            },
+            "persistent_shell": {
+                "action": action,
+                "shell_id": shell_id,
+                "workflow_session_id": "wc_sess_windows",
+                "runtime_project_id": "agent:msi:demo",
+                "cwd": null,
+                "shell": "bash",
+                "command": command,
+                "timeout_secs": 5,
+                "purpose": null
+            }
+        }))
+        .expect("build Windows named-SSH persistent-shell request")
     }
 
     fn fixture() -> (tempfile::TempDir, PathBuf, PathBuf, AgentPolicy) {
@@ -1817,5 +1845,305 @@ mod windows_tests {
         )
         .unwrap_err();
         assert_eq!(error.0, "persistent_shell_config_invalid");
+    }
+
+    #[test]
+    fn windows_named_ssh_resource_routes_remote_without_changing_local_powershell() {
+        let (_temp, _project, projects, policy) = fixture();
+        let shell = ShellConfig::default();
+        let manager = PersistentShellManager::new(&shell, SshConnectionPool::default());
+
+        let mut local_bash = request("open", "wc_shell_local_bash", None);
+        local_bash.persistent_shell.as_mut().unwrap().shell = Some("bash".to_string());
+        let local = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &local_bash,
+        );
+        assert_eq!(
+            local.error_code.as_deref(),
+            Some("persistent_shell_dialect_unsupported"),
+            "Windows local shell must remain PowerShell: {local:?}"
+        );
+
+        let remote = manager.handle(
+            &policy,
+            &shell,
+            &SshConfig::default(),
+            1,
+            &projects,
+            &ssh_request("open", "wc_shell_remote_missing", "missing", None),
+        );
+        assert_eq!(
+            remote.error_code.as_deref(),
+            Some("ssh_persistent_shell_spawn_failed"),
+            "named resource must route to SSH before local PowerShell validation: {remote:?}"
+        );
+        assert!(
+            remote
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_resource_not_found")),
+            "missing named SSH resource must fail from SSH authority: {remote:?}"
+        );
+        assert_eq!(manager.active_count(), 0);
+    }
+
+    #[test]
+    fn windows_named_ssh_persistent_shell_real_transport_opt_in() {
+        let Ok(host) = std::env::var("WEBCODEX_TEST_WINDOWS_SSH_HOST") else {
+            eprintln!("skipping Windows SSH persistent-shell integration test; WEBCODEX_TEST_WINDOWS_SSH_HOST is unset");
+            return;
+        };
+        let (_temp, _project, projects, mut policy) = fixture();
+        let shell = ShellConfig::default();
+        let mut resources = BTreeMap::new();
+        resources.insert(
+            "dogfood".to_string(),
+            SshResourceConfig {
+                host,
+                default_cwd: Some("/tmp".to_string()),
+            },
+        );
+        let config = SshConfig { resources };
+        let manager = PersistentShellManager::new(&shell, SshConnectionPool::default());
+
+        let opened = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            7,
+            &projects,
+            &ssh_request("open", "wc_shell_win_ssh_state", "dogfood", None),
+        );
+        assert_eq!(opened.shell_state, "running", "{opened:?}");
+        assert_eq!(opened.shell.as_deref(), Some("bash"), "{opened:?}");
+        assert_eq!(opened.cwd.as_deref(), Some("/tmp"), "{opened:?}");
+
+        let setup = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            7,
+            &projects,
+            &ssh_request(
+                "exec",
+                "wc_shell_win_ssh_state",
+                "dogfood",
+                Some("export WC_WIN_SSH=ready; cd /tmp; wc_win_fn() { printf fn; }"),
+            ),
+        );
+        assert_eq!(setup.exit_code, Some(0), "{setup:?}");
+        let observed = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            7,
+            &projects,
+            &ssh_request(
+                "exec",
+                "wc_shell_win_ssh_state",
+                "dogfood",
+                Some("printf '%s|%s|' \"$WC_WIN_SSH\" \"$PWD\"; wc_win_fn; printf '|中文🙂'; printf '错误🙂' >&2"),
+            ),
+        );
+        assert_eq!(observed.exit_code, Some(0), "{observed:?}");
+        assert!(
+            observed.stdout.contains("ready|/tmp|fn|中文🙂"),
+            "{observed:?}"
+        );
+        assert!(observed.stderr.contains("错误🙂"), "{observed:?}");
+        assert!(!observed.stdout.contains("WCPS"), "{observed:?}");
+        assert!(!observed.stderr.contains("WCPS"), "{observed:?}");
+
+        let failed = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            7,
+            &projects,
+            &ssh_request("exec", "wc_shell_win_ssh_state", "dogfood", Some("false")),
+        );
+        assert_eq!(failed.exit_code, Some(1), "{failed:?}");
+        assert_eq!(failed.shell_state, "running", "{failed:?}");
+        let next = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            7,
+            &projects,
+            &ssh_request(
+                "exec",
+                "wc_shell_win_ssh_state",
+                "dogfood",
+                Some("printf clean"),
+            ),
+        );
+        assert_eq!(next.stdout, "clean", "{next:?}");
+        assert!(next.stderr.is_empty(), "previous stderr leaked: {next:?}");
+
+        policy.max_output_bytes = 1024;
+        let bounded = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            7,
+            &projects,
+            &ssh_request(
+                "exec",
+                "wc_shell_win_ssh_state",
+                "dogfood",
+                Some("i=0; while [ \"$i\" -lt 5000 ]; do printf x; i=$((i+1)); done"),
+            ),
+        );
+        assert!(bounded.stdout_truncated, "{bounded:?}");
+        assert!(
+            bounded.stdout.len() <= policy.max_output_bytes,
+            "{bounded:?}"
+        );
+
+        let mut removed = config.clone();
+        removed.resources.remove("dogfood");
+        let removed_status = manager.handle(
+            &policy,
+            &shell,
+            &removed,
+            7,
+            &projects,
+            &ssh_request("status", "wc_shell_win_ssh_state", "dogfood", None),
+        );
+        assert_eq!(
+            removed_status.error_code.as_deref(),
+            Some("shell_reset_required"),
+            "{removed_status:?}"
+        );
+        assert_eq!(manager.active_count(), 0, "{removed_status:?}");
+
+        let generation_open = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            7,
+            &projects,
+            &ssh_request("open", "wc_shell_win_ssh_generation", "dogfood", None),
+        );
+        assert_eq!(
+            generation_open.shell_state, "running",
+            "{generation_open:?}"
+        );
+        let stale = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request("status", "wc_shell_win_ssh_generation", "dogfood", None),
+        );
+        assert_eq!(
+            stale.error_code.as_deref(),
+            Some("shell_reset_required"),
+            "{stale:?}"
+        );
+        assert_eq!(manager.active_count(), 0, "{stale:?}");
+
+        let reopened = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request("open", "wc_shell_win_ssh_timeout", "dogfood", None),
+        );
+        assert_eq!(reopened.shell_state, "running", "{reopened:?}");
+        let mut timeout_request = ssh_request(
+            "exec",
+            "wc_shell_win_ssh_timeout",
+            "dogfood",
+            Some("sleep 3; printf late"),
+        );
+        timeout_request
+            .persistent_shell
+            .as_mut()
+            .unwrap()
+            .timeout_secs = Some(1);
+        let timed_out = manager.handle(&policy, &shell, &config, 8, &projects, &timeout_request);
+        assert_eq!(timed_out.execution_state, "timed_out", "{timed_out:?}");
+        assert_ne!(timed_out.shell_state, "running", "{timed_out:?}");
+        assert_eq!(
+            timed_out.error_code.as_deref(),
+            Some("shell_reset_required"),
+            "{timed_out:?}"
+        );
+        let after_timeout = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request(
+                "exec",
+                "wc_shell_win_ssh_timeout",
+                "dogfood",
+                Some("printf forbidden"),
+            ),
+        );
+        assert!(!after_timeout.command_started, "{after_timeout:?}");
+
+        let reopened = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request("open", "wc_shell_win_ssh_exit", "dogfood", None),
+        );
+        assert_eq!(reopened.shell_state, "running", "{reopened:?}");
+        let exited = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request("exec", "wc_shell_win_ssh_exit", "dogfood", Some("exit 7")),
+        );
+        assert_eq!(exited.shell_state, "exited", "{exited:?}");
+        assert_eq!(exited.exit_code, Some(7), "{exited:?}");
+        let after_exit = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request(
+                "exec",
+                "wc_shell_win_ssh_exit",
+                "dogfood",
+                Some("printf forbidden"),
+            ),
+        );
+        assert!(!after_exit.command_started, "{after_exit:?}");
+
+        let reopened = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request("open", "wc_shell_win_ssh_close", "dogfood", None),
+        );
+        assert_eq!(reopened.shell_state, "running", "{reopened:?}");
+        let closed = manager.handle(
+            &policy,
+            &shell,
+            &config,
+            8,
+            &projects,
+            &ssh_request("close", "wc_shell_win_ssh_close", "dogfood", None),
+        );
+        assert_eq!(closed.shell_state, "closed", "{closed:?}");
+        assert_eq!(manager.active_count(), 0, "{closed:?}");
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/remote_shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/remote_shell.rs
@@ -1,10 +1,13 @@
 //! Remote persistent-shell transport: one long-lived `sh`/`bash` running on a
 //! Workflow Session's SSH resource.
 //!
-//! The transport spawns `ssh -o ControlMaster=no -S <pool path> <host> <shell>`
-//! on the Runner host, reusing the existing [`SshConnectionPool`]'s
-//! authenticated control socket for auth and Host-alias resolution. No second
-//! SSH configuration, authentication, or connection pool is introduced.
+//! On Unix the transport spawns `ssh -o ControlMaster=no -S <pool path> <host>
+//! <shell>` and reuses the existing [`SshConnectionPool`]'s authenticated mux
+//! transport. On Windows it spawns one direct long-lived `ssh.exe <host> <shell>`
+//! because OpenSSH-for-Windows has no usable Unix control socket in this runtime.
+//! Both paths delegate authentication and Host-alias resolution to the Runner's
+//! local OpenSSH configuration; no second credential or model-facing SSH input is
+//! introduced.
 //!
 //! Because an SSH exec channel exposes only stdout and stderr (no extra control
 //! FD), the remote shell reserves FD 7 (a dup of the channel's original stdout)
@@ -20,8 +23,10 @@ use super::config::SshConfig;
 use super::shutdown::lock_unpoison;
 use super::ssh::{PreparedPersistentShellCommand, SshConnectionPool};
 use std::io::{Read, Write};
-use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ExitStatus, Stdio};
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::Child;
+use std::process::{ChildStdin, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -31,10 +36,14 @@ use webcodex_persistent_shell::{
     CompletionProgress, ControlFrame, ShellError, ShellTransport, TransportMetadata, WaitOutcome,
     CONTROL_MAGIC, STDERR_SYNC_MAGIC, STDOUT_SYNC_MAGIC,
 };
+#[cfg(windows)]
+use webcodex_process::ManagedChild;
 
 /// How long to wait for the ssh child to exit after signalling it during
 /// shutdown/interrupt before forcing a kill. Mirrors the local shell's grace.
 const REMOTE_SIGNAL_GRACE: Duration = Duration::from_millis(100);
+#[cfg(windows)]
+const REMOTE_READER_JOIN_GRACE: Duration = Duration::from_millis(250);
 /// Poll interval for non-blocking reads and completion waits.
 const REMOTE_READ_SLEEP: Duration = Duration::from_millis(5);
 /// Bound on a single control-frame field, matching the local control reader.
@@ -44,8 +53,12 @@ const CONTROL_CHANNEL_CAPACITY: usize = 2;
 
 /// A remote persistent shell ready to be driven by the shared manager.
 pub(crate) struct RemoteShellTransport {
+    #[cfg(unix)]
     child: Mutex<Child>,
+    #[cfg(windows)]
+    child: Mutex<ManagedChild>,
     stdin: Mutex<Option<ChildStdin>>,
+    #[cfg(unix)]
     process_group_id: u32,
     /// Named SSH resource this shell is bound to, captured at open so the
     /// shared manager can validate it against the current Runner config.
@@ -92,26 +105,39 @@ impl RemoteShellTransport {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        #[cfg(unix)]
         let mut child = command.spawn().map_err(|error| {
             ShellError::new(
                 "ssh_persistent_shell_spawn_failed",
                 format!("failed to spawn remote persistent shell: {error}"),
             )
         })?;
+        #[cfg(windows)]
+        let mut child = ManagedChild::spawn(&mut command).map_err(|error| {
+            ShellError::new(
+                "ssh_persistent_shell_spawn_failed",
+                format!("failed to spawn managed remote persistent shell: {error}"),
+            )
+        })?;
+        #[cfg(unix)]
         let process_group_id = child.id();
-        let stdin = child.stdin.take().ok_or_else(|| {
+        #[cfg(unix)]
+        let child_stdio = &mut child;
+        #[cfg(windows)]
+        let child_stdio = child.child_mut();
+        let stdin = child_stdio.stdin.take().ok_or_else(|| {
             ShellError::new(
                 "ssh_persistent_shell_spawn_failed",
                 "remote persistent shell stdin pipe was not created",
             )
         })?;
-        let stdout = child.stdout.take().ok_or_else(|| {
+        let stdout = child_stdio.stdout.take().ok_or_else(|| {
             ShellError::new(
                 "ssh_persistent_shell_spawn_failed",
                 "remote persistent shell stdout pipe was not created",
             )
         })?;
-        let stderr = child.stderr.take().ok_or_else(|| {
+        let stderr = child_stdio.stderr.take().ok_or_else(|| {
             ShellError::new(
                 "ssh_persistent_shell_spawn_failed",
                 "remote persistent shell stderr pipe was not created",
@@ -148,6 +174,7 @@ impl RemoteShellTransport {
             Self {
                 child: Mutex::new(child),
                 stdin: Mutex::new(Some(stdin)),
+                #[cfg(unix)]
                 process_group_id,
                 resource_name: resource_name.to_string(),
                 generation,
@@ -232,6 +259,21 @@ impl RemoteShellTransport {
                 || (stdout_disconnected && !progress.stdout_synced)
                 || (stderr_disconnected && !progress.stderr_synced)
             {
+                #[cfg(windows)]
+                {
+                    // Windows pipe EOF can become visible just before the direct
+                    // ssh.exe exit status. Give only the remaining command budget,
+                    // capped by the normal ownership grace, to classify a real
+                    // process exit instead of spuriously reporting framing loss.
+                    let grace = deadline
+                        .saturating_duration_since(Instant::now())
+                        .min(REMOTE_SIGNAL_GRACE);
+                    if !grace.is_zero() {
+                        if let Some(status) = self.wait_for_direct_exit(grace) {
+                            return WaitOutcome::Exited(status);
+                        }
+                    }
+                }
                 // The ssh child died before reaching sync. Report it as a lost
                 // control channel so the manager poisons the shell.
                 return WaitOutcome::ControlLost;
@@ -247,11 +289,42 @@ impl RemoteShellTransport {
         lock_unpoison(&self.child).try_wait().ok().flatten()
     }
 
+    #[cfg(windows)]
+    fn wait_for_direct_exit(&self, timeout: Duration) -> Option<ExitStatus> {
+        let deadline = Instant::now().checked_add(timeout)?;
+        loop {
+            if let Some(status) = self.try_wait() {
+                return Some(status);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[cfg(windows)]
+    fn terminate_managed_tree(&self) {
+        let mut child = lock_unpoison(&self.child);
+        let _ = child.terminate_tree();
+        let _ = child.wait_tree_exit(REMOTE_SIGNAL_GRACE);
+    }
+
     fn interrupt(&self) {
-        // SIGINT the ssh child's private process group so the remote shell and
-        // any foreground command receive the interrupt. The manager decides
-        // whether sync is recovered afterward.
-        let _ = signal_process_group(self.process_group_id, libc::SIGINT);
+        #[cfg(unix)]
+        {
+            // SIGINT the ssh child's private process group so the remote shell and
+            // any foreground command receive the interrupt. The manager decides
+            // whether sync is recovered afterward.
+            let _ = signal_process_group(self.process_group_id, libc::SIGINT);
+        }
+        #[cfg(windows)]
+        {
+            // Redirected Windows OpenSSH has no safe command-scoped Ctrl-C
+            // primitive. Force the owned Job Object tree down; the manager's
+            // recovery wait then observes exit and never reuses an uncertain stream.
+            self.terminate_managed_tree();
+        }
     }
 
     fn shutdown(&self) {
@@ -263,44 +336,52 @@ impl RemoteShellTransport {
             self.finish_readers();
             return;
         }
-        let _ = signal_process_group(self.process_group_id, libc::SIGTERM);
-        let deadline = Instant::now() + REMOTE_SIGNAL_GRACE;
-        while Instant::now() < deadline {
-            if self.try_wait().is_some() {
-                break;
-            }
-            thread::sleep(Duration::from_millis(5));
-        }
-        if self.try_wait().is_none() {
-            let _ = signal_process_group(self.process_group_id, libc::SIGKILL);
-            let kill_deadline = Instant::now() + REMOTE_SIGNAL_GRACE;
-            while Instant::now() < kill_deadline {
+        #[cfg(unix)]
+        {
+            let _ = signal_process_group(self.process_group_id, libc::SIGTERM);
+            let deadline = Instant::now() + REMOTE_SIGNAL_GRACE;
+            while Instant::now() < deadline {
                 if self.try_wait().is_some() {
                     break;
                 }
                 thread::sleep(Duration::from_millis(5));
             }
+            if self.try_wait().is_none() {
+                let _ = signal_process_group(self.process_group_id, libc::SIGKILL);
+                let kill_deadline = Instant::now() + REMOTE_SIGNAL_GRACE;
+                while Instant::now() < kill_deadline {
+                    if self.try_wait().is_some() {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(5));
+                }
+            }
         }
+        #[cfg(windows)]
+        self.terminate_managed_tree();
         self.finish_readers();
     }
 
     fn terminate_remaining_group_after_exit(&self) {
-        // The remote shell runs inside the ssh child's process group; once the
-        // child has exited there is nothing local to reap, but any reader still
-        // blocked means the pipe is held open by a peer. Forcing the readers
-        // stops is the remote analogue of clearing the local group.
+        // Once the direct ssh child exits, any locally owned descendants or pipe
+        // holders must still be reclaimed before this transport is considered done.
         if !self.reader_threads_running() {
             self.finish_readers();
             return;
         }
-        let _ = signal_process_group(self.process_group_id, libc::SIGTERM);
-        let deadline = Instant::now() + REMOTE_SIGNAL_GRACE;
-        while Instant::now() < deadline && self.reader_threads_running() {
-            thread::sleep(Duration::from_millis(5));
+        #[cfg(unix)]
+        {
+            let _ = signal_process_group(self.process_group_id, libc::SIGTERM);
+            let deadline = Instant::now() + REMOTE_SIGNAL_GRACE;
+            while Instant::now() < deadline && self.reader_threads_running() {
+                thread::sleep(Duration::from_millis(5));
+            }
+            if self.reader_threads_running() {
+                let _ = signal_process_group(self.process_group_id, libc::SIGKILL);
+            }
         }
-        if self.reader_threads_running() {
-            let _ = signal_process_group(self.process_group_id, libc::SIGKILL);
-        }
+        #[cfg(windows)]
+        self.terminate_managed_tree();
         self.finish_readers();
     }
 
@@ -312,9 +393,23 @@ impl RemoteShellTransport {
 
     fn finish_readers(&self) {
         self.readers_stop.store(true, Ordering::SeqCst);
-        if let Some(handles) = lock_unpoison(&self.reader_threads).take() {
-            for handle in handles {
-                let _ = handle.join();
+        let Some(mut handles) = lock_unpoison(&self.reader_threads).take() else {
+            return;
+        };
+        #[cfg(unix)]
+        for handle in handles {
+            let _ = handle.join();
+        }
+        #[cfg(windows)]
+        {
+            let deadline = Instant::now() + REMOTE_READER_JOIN_GRACE;
+            while Instant::now() < deadline && handles.iter().any(|handle| !handle.is_finished()) {
+                thread::sleep(Duration::from_millis(5));
+            }
+            for handle in handles.drain(..) {
+                if handle.is_finished() {
+                    let _ = handle.join();
+                }
             }
         }
     }
@@ -366,6 +461,13 @@ impl ShellTransport for RemoteShellTransport {
 
     fn stderr(&self) -> &Arc<Mutex<BoundedBuffer>> {
         &self.stderr
+    }
+
+    fn reported_cwd_is_absolute(&self, cwd: &Path) -> bool {
+        // The remote shell is always POSIX sh/bash, even when its local ssh.exe
+        // transport runs on Windows. Do not apply Windows Path::is_absolute to
+        // the remote namespace (`/tmp` is not absolute under Windows rules).
+        cwd.to_string_lossy().starts_with('/')
     }
 
     fn metadata(&self) -> Option<TransportMetadata> {
@@ -652,6 +754,7 @@ fn process_control_pending(
     }
 }
 
+#[cfg(unix)]
 fn signal_process_group(process_group_id: u32, signal: i32) -> Result<(), ShellError> {
     let process_group_id = i32::try_from(process_group_id).map_err(|_| {
         ShellError::new(

--- a/crates/webcodex-runner/src/webcodex_runner/shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell.rs
@@ -70,7 +70,7 @@ pub(crate) fn shell_quote(value: &str) -> String {
 /// PowerShell's single-quoted strings are literal, so spaces, backslashes,
 /// double quotes, `$`, Unicode, and `C:\...` Windows paths need no further
 /// escaping; only `'` does.
-fn shell_quote_powershell(value: &str) -> String {
+pub(crate) fn shell_quote_powershell(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -11,7 +11,7 @@ use super::shutdown::lock_unpoison;
 use super::AgentPolicy;
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
@@ -50,11 +50,11 @@ struct SshPoolState {
     test_config_path: Option<PathBuf>,
 }
 
-/// Lightweight, process-local OpenSSH multiplex pool.
+/// Runner-local OpenSSH resource preparation state.
 ///
-/// Each `ssh` command still opens an independent remote exec channel. The
-/// control socket only reuses the authenticated transport and is not restored
-/// across a Runner restart.
+/// Unix one-shot and persistent SSH paths reuse a process-local multiplex
+/// transport. Windows persistent SSH resolves the same named resources but owns
+/// one direct long-lived ssh.exe channel instead; no mux state is created there.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SshConnectionPool {
     state: Arc<Mutex<SshPoolState>>,
@@ -67,8 +67,9 @@ pub(crate) struct PreparedSshCommand {
 }
 
 /// A ready-to-spawn long-lived SSH shell command with the resource's default
-/// remote cwd. Used only by the Unix remote persistent-shell transport.
-#[cfg(unix)]
+/// remote cwd. Unix reuses the authenticated mux transport; Windows opens one
+/// direct long-lived ssh.exe channel owned by the persistent-shell transport.
+#[cfg(any(unix, windows))]
 pub(crate) struct PreparedPersistentShellCommand {
     pub(crate) command: Command,
     pub(crate) default_cwd: Option<String>,
@@ -81,12 +82,27 @@ impl SshConnectionPool {
         if !cfg!(unix) {
             return false;
         }
-        Command::new("ssh")
+        Command::new(ssh_executable())
             .arg("-V")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
             .is_ok()
+    }
+
+    /// Whether this host can open a named SSH persistent shell. Unlike the
+    /// existing one-shot SSH path, Windows does not require Unix ControlMaster
+    /// sockets: one long-lived ssh.exe process is itself the persistent channel.
+    pub(crate) fn persistent_shell_available() -> bool {
+        if !cfg!(any(unix, windows)) {
+            return false;
+        }
+        Command::new(ssh_executable())
+            .arg("-V")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
     }
 
     /// Resolve a named resource, establish/reuse its control transport, and
@@ -208,13 +224,16 @@ impl SshConnectionPool {
         }
     }
 
-    /// Resolve a named resource, establish/reuse its control transport, and
-    /// construct a ready-to-spawn `ssh` command that runs one long-lived remote
-    /// shell. Unlike `prepare_command`, the remote command is just the shell
-    /// binary (no `-c` script); the Runner drives it over stdin. The long-lived
-    /// channel reuses the same authenticated control socket (`ControlMaster=no
-    /// -S <path>`) and never creates a second master.
-    #[cfg(unix)]
+    /// Resolve a named resource and construct a ready-to-spawn `ssh` command
+    /// that runs one long-lived remote shell. The remote command is just sh/bash
+    /// (no `-c` script); the Runner drives it over stdin.
+    ///
+    /// Unix preserves the existing authenticated ControlMaster reuse. OpenSSH for
+    /// Windows does not provide a usable Unix-domain mux socket in the supported
+    /// Runner environment, so Windows opens one direct BatchMode ssh.exe channel.
+    /// Authentication, Host aliases, and keys still come only from the Runner's
+    /// local OpenSSH configuration; no credential or executable is caller input.
+    #[cfg(any(unix, windows))]
     pub(crate) fn prepare_persistent_shell_command(
         &self,
         generation: u64,
@@ -223,9 +242,6 @@ impl SshConnectionPool {
         session_id: &str,
         shell_program: &str,
     ) -> Result<PreparedPersistentShellCommand, String> {
-        if !cfg!(unix) {
-            return Err("ssh_shell_unavailable: this Runner host does not support SSH resources; shell was not started".to_string());
-        }
         if !is_safe_resource_name(resource_name) {
             return Err(
                 "ssh_resource_invalid: resource name is invalid; shell was not started".to_string(),
@@ -246,29 +262,49 @@ impl SshConnectionPool {
                 ));
             }
         };
-        let connection = self.connection_for(
-            generation,
-            resource_name,
-            session_id,
-            &resource.host,
-            resource.default_cwd.as_deref(),
-        )?;
-        let mut ssh = ssh_command(&connection);
-        ssh.arg("-o")
-            .arg("BatchMode=yes")
-            .arg("-o")
-            .arg("LogLevel=ERROR")
-            .arg("-o")
-            .arg("ControlMaster=no")
-            .arg("-S")
-            .arg(&connection.control_path)
-            .arg(&connection.host)
-            .arg(shell_program);
-        configure_private_process_group(&mut ssh);
-        Ok(PreparedPersistentShellCommand {
-            command: ssh,
-            default_cwd: connection.default_cwd.clone(),
-        })
+
+        #[cfg(unix)]
+        {
+            let connection = self.connection_for(
+                generation,
+                resource_name,
+                session_id,
+                &resource.host,
+                resource.default_cwd.as_deref(),
+            )?;
+            let mut ssh = ssh_command(&connection);
+            ssh.arg("-o")
+                .arg("BatchMode=yes")
+                .arg("-o")
+                .arg("LogLevel=ERROR")
+                .arg("-o")
+                .arg("ControlMaster=no")
+                .arg("-S")
+                .arg(&connection.control_path)
+                .arg(&connection.host)
+                .arg(shell_program);
+            configure_private_process_group(&mut ssh);
+            return Ok(PreparedPersistentShellCommand {
+                command: ssh,
+                default_cwd: connection.default_cwd.clone(),
+            });
+        }
+
+        #[cfg(windows)]
+        {
+            let _ = generation;
+            let mut ssh = Command::new(ssh_executable());
+            ssh.arg("-o")
+                .arg("BatchMode=yes")
+                .arg("-o")
+                .arg("LogLevel=ERROR")
+                .arg(&resource.host)
+                .arg(shell_program);
+            Ok(PreparedPersistentShellCommand {
+                command: ssh,
+                default_cwd: resource.default_cwd.clone(),
+            })
+        }
     }
 
     /// Release every Session's generation for a resource that is no longer
@@ -696,11 +732,26 @@ fn control_master_pid(connection: &SshConnection) -> Option<i32> {
 }
 
 fn ssh_command(connection: &SshConnection) -> Command {
-    let mut command = Command::new("ssh");
-    if let Some(config_path) = &connection.config_path {
+    ssh_command_with_config(connection.config_path.as_deref())
+}
+
+fn ssh_command_with_config(config_path: Option<&Path>) -> Command {
+    let mut command = Command::new(ssh_executable());
+    if let Some(config_path) = config_path {
         command.arg("-F").arg(config_path);
     }
     command
+}
+
+fn ssh_executable() -> &'static str {
+    #[cfg(windows)]
+    {
+        "ssh.exe"
+    }
+    #[cfg(not(windows))]
+    {
+        "ssh"
+    }
 }
 
 fn normalize_remote_cwd(cwd: Option<&str>) -> Result<Option<String>, String> {
@@ -2349,5 +2400,61 @@ mod tests {
             "failed open must leave no usable shell: {stale:?}"
         );
         assert_eq!(stale.stdout, "", "{stale:?}");
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_persistent_tests {
+    use super::*;
+    use crate::webcodex_runner::config::SshResourceConfig;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn windows_persistent_shell_prepares_direct_literal_ssh_exe_argv() {
+        let mut resources = BTreeMap::new();
+        resources.insert(
+            "spe".to_string(),
+            SshResourceConfig {
+                host: "spe".to_string(),
+                default_cwd: Some("/srv/webcodex".to_string()),
+            },
+        );
+        let config = SshConfig { resources };
+        let pool = SshConnectionPool::default();
+        let prepared = pool
+            .prepare_persistent_shell_command(7, &config, "spe", "wc_sess_windows_ssh", "bash")
+            .expect("prepare Windows persistent SSH command");
+
+        assert_eq!(prepared.command.get_program(), "ssh.exe");
+        let args = prepared
+            .command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec!["-o", "BatchMode=yes", "-o", "LogLevel=ERROR", "spe", "bash"]
+        );
+        assert!(!args.iter().any(|arg| arg.contains("ControlMaster")));
+        assert!(!args.iter().any(|arg| arg == "-S"));
+        assert_eq!(prepared.default_cwd.as_deref(), Some("/srv/webcodex"));
+    }
+
+    #[test]
+    fn windows_persistent_shell_capability_tracks_ssh_exe_discovery() {
+        let executable_available = Command::new("ssh.exe")
+            .arg("-V")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success());
+        assert_eq!(
+            SshConnectionPool::persistent_shell_available(),
+            executable_available
+        );
+        assert!(
+            !SshConnectionPool::is_available(),
+            "one-shot SSH remains Unix-only in this focused slice"
+        );
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -4,6 +4,8 @@ use super::config::{
 };
 #[cfg(any(target_os = "linux", target_os = "macos", windows))]
 use super::detached_job::DetachedJobStore;
+#[cfg(windows)]
+use super::exit_diagnostics::RunnerExitDiagnostics;
 use super::lsp::LspSupervisor;
 use super::projects::AgentProjectCache;
 use super::shutdown::{
@@ -166,6 +168,8 @@ pub(crate) struct AgentRuntimeState {
     reload_threads: Arc<BackgroundThreads>,
     background_threads: Arc<BackgroundThreads>,
     dispatches: ActivityTracker,
+    #[cfg(windows)]
+    exit_diagnostics: Option<Arc<RunnerExitDiagnostics>>,
 }
 
 impl AgentRuntimeState {
@@ -189,6 +193,8 @@ impl AgentRuntimeState {
             reload_threads: Arc::new(BackgroundThreads::default()),
             background_threads: Arc::new(BackgroundThreads::default()),
             dispatches: ActivityTracker::default(),
+            #[cfg(windows)]
+            exit_diagnostics: None,
         }
     }
 
@@ -199,6 +205,10 @@ impl AgentRuntimeState {
         self.jobs.stop_accepting_work();
         self.persistent_shells.close_all("runner_shutdown");
         self.lsp.begin_shutdown_until(deadline);
+        #[cfg(windows)]
+        if let Some(diagnostics) = self.exit_diagnostics.as_ref() {
+            diagnostics.mark_shutdown_signal_received();
+        }
     }
 
     fn shutdown_flag(&self) -> Arc<AtomicBool> {
@@ -1344,7 +1354,8 @@ pub(crate) fn run_agent(cfg: AgentConfig, config_path: PathBuf, once: bool) -> R
     // Generate the per-process agent instance identity once. It is stable for
     // the whole process lifetime, including across WebSocket reconnects, so the
     // server can treat this process as a single active lease for `client_id`.
-    // It is not a secret and is never persisted to disk.
+    // It is not a secret and is never persisted to disk. Windows exit diagnostics
+    // use a separate local diagnostic id and therefore preserve that boundary.
     let agent_instance_id = uuid::Uuid::new_v4().to_string();
     let transport = cfg
         .transport
@@ -1353,9 +1364,37 @@ pub(crate) fn run_agent(cfg: AgentConfig, config_path: PathBuf, once: bool) -> R
         .filter(|s| !s.is_empty())
         .unwrap_or(TRANSPORT_WEBSOCKET)
         .to_string();
+    #[cfg(windows)]
+    let exit_diagnostics = {
+        let build = crate::runner_build_info();
+        match RunnerExitDiagnostics::start(
+            &cfg.client_id,
+            &cfg.server_url,
+            &transport,
+            crate::process_started_at(),
+            build.version.as_deref(),
+            build.git_commit.as_deref(),
+            build.git_dirty,
+        ) {
+            Ok(diagnostics) => {
+                diagnostics.install_panic_hook();
+                Some(diagnostics)
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "Windows Runner exit diagnostics unavailable; Runner continues");
+                None
+            }
+        }
+    };
     // The LSP supervisor belongs to the agent process rather than any server
     // transport session and is shared across reconnects.
     let runtime = AgentRuntimeState::new(&cfg, config_path.clone());
+    #[cfg(windows)]
+    let runtime = {
+        let mut runtime = runtime;
+        runtime.exit_diagnostics = exit_diagnostics.clone();
+        runtime
+    };
     #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     match DetachedJobStore::default_root_for_runner(&cfg.client_id, &cfg.server_url) {
         Ok(root) => match runtime.jobs.recover_detached_jobs(
@@ -1378,8 +1417,21 @@ pub(crate) fn run_agent(cfg: AgentConfig, config_path: PathBuf, once: bool) -> R
             tracing::error!(error = %error, "detached Job state root is unavailable");
         }
     }
-    let shutdown_listener = install_shutdown_listener(runtime.clone())?;
+    let shutdown_listener = match install_shutdown_listener(runtime.clone()) {
+        Ok(listener) => listener,
+        Err(error) => {
+            #[cfg(windows)]
+            if let Some(diagnostics) = exit_diagnostics.as_ref() {
+                diagnostics.mark_terminal(false, "shutdown_listener_install_failed", None);
+            }
+            return Err(error);
+        }
+    };
     runtime.register_background_thread(shutdown_listener);
+    #[cfg(windows)]
+    if let Some(diagnostics) = exit_diagnostics.as_ref() {
+        diagnostics.mark_running();
+    }
     #[cfg(unix)]
     match install_reload_listener(Arc::clone(&runtime.config)) {
         Ok(reload_listener) => runtime.register_reload_thread(reload_listener),
@@ -1394,7 +1446,23 @@ pub(crate) fn run_agent(cfg: AgentConfig, config_path: PathBuf, once: bool) -> R
         TRANSPORT_AUTO => run_auto_agent(cfg, once, &agent_instance_id, &runtime),
         _ => run_polling_agent(cfg, once, &agent_instance_id, &runtime),
     };
-    runtime.shutdown();
+    #[cfg(windows)]
+    if let Some(diagnostics) = exit_diagnostics.as_ref() {
+        diagnostics.mark_transport_returned(result.is_ok());
+    }
+    let _shutdown = runtime.shutdown();
+    #[cfg(windows)]
+    if let Some(diagnostics) = exit_diagnostics.as_ref() {
+        diagnostics.mark_terminal(
+            result.is_ok(),
+            if result.is_ok() {
+                "transport_completed"
+            } else {
+                "transport_returned_error"
+            },
+            Some(&_shutdown),
+        );
+    }
     result
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -200,15 +200,19 @@ impl AgentRuntimeState {
 
     fn request_shutdown_signal(&self) {
         self.coordinator.request_signal();
+        #[cfg(windows)]
+        if let Some(diagnostics) = self.exit_diagnostics.as_ref() {
+            // Persist signal provenance before any cleanup work. If the process
+            // disappears while cleanup is in progress, the lifecycle record must
+            // still distinguish an interrupted graceful shutdown from an exit
+            // that never entered Rust shutdown handling.
+            diagnostics.mark_shutdown_signal_received();
+        }
         let deadline = self.coordinator.deadline().instant();
         self.config.begin_shutdown();
         self.jobs.stop_accepting_work();
         self.persistent_shells.close_all("runner_shutdown");
         self.lsp.begin_shutdown_until(deadline);
-        #[cfg(windows)]
-        if let Some(diagnostics) = self.exit_diagnostics.as_ref() {
-            diagnostics.mark_shutdown_signal_received();
-        }
     }
 
     fn shutdown_flag(&self) -> Arc<AtomicBool> {

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -348,6 +348,26 @@ After a machine reboot, a hosted `connect` profile is restarted by rerunning
 `webcodex connect` or `webcodex agent start --profile <profile>`. Automatic
 startup at logon is not implemented for hosted profiles.
 
+On Windows, each Runner process also writes one small bounded lifecycle record under
+`%LOCALAPPDATA%\webcodex\runner-exit-diagnostics-v1\<runner-hash>\` (falling
+back to `%USERPROFILE%\.local\state\webcodex` and then `%TEMP%\webcodex` through
+the normal Runner state-path rules). Only the newest eight process records are
+retained. A record contains the local PID, process start time, build identity,
+transport, shutdown-signal observation, transport return class, and clean/fatal
+terminal classification. A sibling `*.panic.json` file is written best-effort
+when a Rust panic hook runs and contains only the thread name and source location;
+it never stores the panic payload. These diagnostics never contain credentials,
+commands, Job output, request payloads, or Server response bodies, and a state
+write failure never changes Runner lifecycle behavior.
+
+For an unexpected supervised exit, correlate the supervisor's PID/timestamp with
+the matching lifecycle record. `terminal=null` means the process disappeared
+before Rust recorded a clean/fatal return. A panic sibling narrows that to a Rust
+panic; `shutdown_signal_received_at_unix_ms` without a terminal record points to
+an interrupted graceful-shutdown path. If neither is present, investigate an
+external/native process termination or supervisor action before adding broader
+Runner telemetry.
+
 ## macOS local dogfood signing
 
 macOS privacy grants such as Screen Recording and Accessibility should not be

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -240,12 +240,15 @@ Resolution order: `project.shell_profile`, then `shell.default_profile`, then
 the plain shell config (no snapshot).
 
 `open_session_shell` is the separate long-lived shell path. On Unix it keeps a
-real `sh`/`bash` process; on Windows Stage 1 it keeps the configured
+real `sh`/`bash` process; on Windows the local path keeps the configured
 `powershell.exe`/`pwsh.exe`-compatible process and reuses the same profile/env
 selection. Windows PowerShell shell/profile args must retain their normal final
 `-Command` flag in configuration; the persistent transport replaces that
-one-shot payload mode internally with its private bootstrap. Windows named SSH
-persistent shells and PTY/ConPTY terminal emulation are not part of Stage 1.
+one-shot payload mode internally with its private bootstrap. Windows Stage 2
+also supports a named SSH persistent shell through the installed `ssh.exe`, with
+the remote side remaining `sh`/`bash`. That path requires `persistent_shell` +
+`ssh_persistent_shell`; the separate `ssh_shell` capability remains the
+one-shot/background SSH path. PTY/ConPTY terminal emulation is not included.
 
 Security notes for profiles:
 

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -239,6 +239,14 @@ shell_profile = "conda-ml"
 Resolution order: `project.shell_profile`, then `shell.default_profile`, then
 the plain shell config (no snapshot).
 
+`open_session_shell` is the separate long-lived shell path. On Unix it keeps a
+real `sh`/`bash` process; on Windows Stage 1 it keeps the configured
+`powershell.exe`/`pwsh.exe`-compatible process and reuses the same profile/env
+selection. Windows PowerShell shell/profile args must retain their normal final
+`-Command` flag in configuration; the persistent transport replaces that
+one-shot payload mode internally with its private bootstrap. Windows named SSH
+persistent shells and PTY/ConPTY terminal emulation are not part of Stage 1.
+
 Security notes for profiles:
 
 - Never put tokens in `init_script`, and never `echo` secrets into it — the

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -241,20 +241,25 @@ session_shell_status
 close_session_shell
 ```
 
-Opening creates one real long-lived `sh` or `bash` process, at most one active
-shell per Workflow Session. For an `agent:<client>:<project>` the Runner owns
+Opening creates one real long-lived local shell process, at most one active
+shell per Workflow Session: `sh`/`bash` on Unix, or the configured PowerShell
+program/profile on Windows. For an `agent:<client>:<project>` the Runner owns
 and controls the shell. Without `execution_context.resource`, it runs against
 the registered project host. With a named resource, the Runner opens a remote
 persistent shell through that SSH resource; this requires the Runner's SSH and
-SSH-persistent-shell capabilities and never silently falls back locally. The
+SSH-persistent-shell capabilities and never silently falls back locally. Windows
+Stage 1 does not advertise SSH persistent shells. The
 process manager also has a Server-owned executor branch for a hosting surface
 that supplies a Server-local project, although the current built-in public
 project registry advertises Agent projects only. `inspect` and `read_only`
 Sessions cannot open or execute a persistent shell.
 
 Local open resolution is explicit `cwd`/`shell`, then the exact Session's
-`default_cwd`/`default_shell`, then the project/Runner defaults. For an SSH
-persistent shell, cwd precedence is explicit open `cwd`, Session `default_cwd`,
+`default_cwd`/`default_shell`, then the project/Runner defaults. The explicit
+`sh`/`bash` override is Unix-only; Windows callers omit it and the Runner uses
+the configured PowerShell program/profile, failing closed for incompatible
+configuration. For an SSH persistent shell, cwd precedence is explicit open
+`cwd`, Session `default_cwd`,
 the named resource's default cwd, then the remote login default; the selected
 Session `default_shell` is also inherited when `shell` is omitted. Profile
 environment and initialization run once at open. Later commands retain the
@@ -276,12 +281,14 @@ disconnect/shutdown, and detected process/control-channel damage release the
 process group and its pipes.
 
 Commands are serialized; a concurrent command receives `shell_busy`. Output is
-bounded independently for stdout and stderr. Completion uses a dedicated
-control file descriptor with a high-entropy per-command token, not a marker in
-ordinary output. On timeout, the owner interrupts the shell process group and
-waits for a bounded synchronization frame. If synchronization cannot be
-proved, it kills the group, marks the shell poisoned/lost, returns
-`shell_reset_required`, and never writes another command to that process.
+bounded independently for stdout and stderr. Completion uses transport-private
+control framing with a high-entropy per-command token, never an ordinary output
+marker: Unix uses inherited control descriptors; Windows uses a private control
+file plus exact stdout/stderr drain boundaries. On timeout the owner performs
+only the platform's safe bounded recovery attempt. If framing synchronization
+cannot be proved, it terminates the owned process tree, marks the shell
+poisoned/lost, returns `shell_reset_required`, and never writes another command
+to that process.
 
 Persistent shells are process-local and are not durable Job records. Neither a
 Server nor Runner restart claims to recover or reattach one from ledger data.

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -203,9 +203,11 @@ per-call cwd
 ```
 
 Each SSH `run_shell` / `run_job` command gets an independent remote exec
-channel. The Runner may reuse the authenticated transport for the same
-Session/resource pair, but it does not preserve `cd`, exports, aliases,
-functions, umask, or shell-process state between commands.
+channel and requires the Runner's `ssh_shell` capability. The Runner may reuse
+the authenticated transport for the same Session/resource pair, but it does not
+preserve `cd`, exports, aliases, functions, umask, or shell-process state between
+commands. This one-shot/background capability is independent of named SSH
+persistent-shell support.
 
 Raw shell text has one shared model-authored ceiling of 16,000 UTF-8 bytes for
 `run_shell`, raw `run_job`, and `session_shell_exec`. Larger shell program text
@@ -246,10 +248,11 @@ shell per Workflow Session: `sh`/`bash` on Unix, or the configured PowerShell
 program/profile on Windows. For an `agent:<client>:<project>` the Runner owns
 and controls the shell. Without `execution_context.resource`, it runs against
 the registered project host. With a named resource, the Runner opens a remote
-persistent shell through that SSH resource; this requires the Runner's SSH and
-SSH-persistent-shell capabilities and never silently falls back locally. Windows
-Stage 1 does not advertise SSH persistent shells. The
-process manager also has a Server-owned executor branch for a hosting surface
+persistent shell through that SSH resource; this requires `persistent_shell` +
+`ssh_persistent_shell`, not the separate one-shot/background `ssh_shell`
+capability, and never silently falls back locally. Windows Stage 2 supports this
+same named SSH persistent-shell model through its OpenSSH client while the remote
+shell remains `sh`/`bash`. The process manager also has a Server-owned executor branch for a hosting surface
 that supplies a Server-local project, although the current built-in public
 project registry advertises Agent projects only. `inspect` and `read_only`
 Sessions cannot open or execute a persistent shell.

--- a/src/shell_client/requests.rs
+++ b/src/shell_client/requests.rs
@@ -1335,9 +1335,9 @@ impl ShellClientRegistry {
     ///
     /// `job_context` carries safe Session/resource metadata so the Runner can
     /// route an SSH persistent shell to its bound resource; it is `None` for
-    /// local persistent shells. SSH persistent shells additionally require the
-    /// `ssh_persistent_shell` capability (plus `ssh_shell` and
-    /// `persistent_shell`); absence fails closed before enqueue.
+    /// local persistent shells. SSH persistent shells require
+    /// `persistent_shell` plus the additive `ssh_persistent_shell` capability;
+    /// `ssh_shell` remains the separate one-shot/background SSH capability.
     pub(crate) async fn enqueue_persistent_shell(
         &self,
         client_id: String,
@@ -1416,13 +1416,13 @@ impl ShellClientRegistry {
                 "agent_capability_unavailable: agent client {client_id} does not support {SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL}"
             ));
         }
-        // An SSH persistent shell requires all three capabilities; a legacy
-        // runner that predates ssh_persistent_shell must fail closed here rather
-        // than silently opening a local shell on the Runner host.
+        // `persistent_shell` is checked above. A named SSH persistent shell
+        // additionally requires only `ssh_persistent_shell`; it intentionally
+        // does not depend on the one-shot/background `ssh_shell` capability.
         if job_context
             .as_ref()
             .is_some_and(|ctx| ctx.ssh_resource.is_some())
-            && (!client.capabilities.ssh_shell || !client.capabilities.ssh_persistent_shell)
+            && !client.capabilities.ssh_persistent_shell
         {
             return Err(format!(
                 "agent_capability_unavailable: agent client {client_id} does not support {SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL}"

--- a/src/tool_runtime/agent_authorization.rs
+++ b/src/tool_runtime/agent_authorization.rs
@@ -188,31 +188,14 @@ impl ToolRuntime {
             }
         }
         if ssh_resource.is_some() {
-            // Every SSH-resource request routes to a Runner-local SSH
-            // connection pool (`run_ssh_shell` / `start_ssh_shell_job`).
-            // `ssh_shell` was introduced together with SSH resource routing in
-            // the same change, so it is both necessary and sufficient to
-            // guarantee a legacy Runner understands SSH resources instead of
-            // silently executing the command on the Runner host.
-            if !self
-                .shell_clients
-                .client_supports_for_auth(&client_id, SHELL_CLIENT_CAPABILITY_SSH_SHELL, auth)
-                .await
-                .map_err(ToolResult::err)?
-            {
-                return Err(agent_capability_unavailable_result(format!(
-                    "agent_capability_unavailable: agent client {} does not support {}",
-                    client_id, SHELL_CLIENT_CAPABILITY_SSH_SHELL
-                )));
-            }
-            // Only `OpenSessionShell` inherits the Session SSH resource at this
-            // pre-dispatch authorization point. Its ordinary `persistent_shell`
-            // capability is already enforced through the tool definition; the
-            // SSH-specific capability is the additional fail-closed gate for a
-            // Runner predating SSH persistent shells. Later exec/status/close
-            // operations route by the shell record created during open.
-            if matches!(call, ToolCall::OpenSessionShell { .. })
-                && !self
+            if matches!(call, ToolCall::OpenSessionShell { .. }) {
+                // `OpenSessionShell` already requires `persistent_shell` through
+                // the tool definition. A named persistent SSH shell has its own
+                // additive capability and deliberately does not require the
+                // one-shot/background `ssh_shell` capability. Later
+                // exec/status/close route by the resource saved in the shell
+                // record rather than inheriting Session context here.
+                if !self
                     .shell_clients
                     .client_supports_for_auth(
                         &client_id,
@@ -221,11 +204,27 @@ impl ToolRuntime {
                     )
                     .await
                     .map_err(ToolResult::err)?
-            {
-                return Err(agent_capability_unavailable_result(format!(
-                    "agent_capability_unavailable: agent client {} does not support {}",
-                    client_id, SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL
-                )));
+                {
+                    return Err(agent_capability_unavailable_result(format!(
+                        "agent_capability_unavailable: agent client {} does not support {}",
+                        client_id, SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL
+                    )));
+                }
+            } else {
+                // Accepted one-shot/background SSH-resource execution still
+                // requires the historical `ssh_shell` capability. Structured
+                // process/script resource calls have already failed closed above.
+                if !self
+                    .shell_clients
+                    .client_supports_for_auth(&client_id, SHELL_CLIENT_CAPABILITY_SSH_SHELL, auth)
+                    .await
+                    .map_err(ToolResult::err)?
+                {
+                    return Err(agent_capability_unavailable_result(format!(
+                        "agent_capability_unavailable: agent client {} does not support {}",
+                        client_id, SHELL_CLIENT_CAPABILITY_SSH_SHELL
+                    )));
+                }
             }
         }
         Ok(())

--- a/src/tool_runtime/registry/input_schemas/jobs.rs
+++ b/src/tool_runtime/registry/input_schemas/jobs.rs
@@ -298,7 +298,7 @@ pub(crate) fn open_session_shell_input_schema() -> Value {
         (
             "shell",
             "string",
-            "Optional long-lived shell dialect: sh or bash.",
+            "Optional Unix local-shell override: sh or bash. Omit on Windows so the Runner uses its configured PowerShell program/profile.",
             false,
         ),
     ]);
@@ -325,7 +325,7 @@ pub(crate) fn session_shell_exec_input_schema() -> Value {
         (
             "timeout_secs",
             "integer",
-            "Command timeout in seconds (1..=3600, default 60). A timeout interrupts the process group and requires verified resynchronization.",
+            "Command timeout in seconds (1..=3600, default 60). Timeout recovery requires verified framing resynchronization; otherwise the shell is poisoned and terminated before reuse.",
             false,
         ),
         (

--- a/src/tool_runtime/registry/tool_specs/jobs.rs
+++ b/src/tool_runtime/registry/tool_specs/jobs.rs
@@ -32,7 +32,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "open_session_shell",
-            "Open one bounded, long-lived configured local shell for an active Workflow Session (sh/bash on Unix, PowerShell on Windows). Its cwd, variables, functions, and process-local state are isolated from one-shot commands and every other Session.",
+            "Open one bounded long-lived shell for a Workflow Session: local sh/bash, Windows PowerShell, or sh/bash on a named SSH resource. Keeps cwd, variables, and functions isolated from one-shot commands and other Sessions.",
             open_session_shell_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/registry/tool_specs/jobs.rs
+++ b/src/tool_runtime/registry/tool_specs/jobs.rs
@@ -32,7 +32,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "open_session_shell",
-            "Open one bounded, long-lived sh/bash process for an active Workflow Session. Its cwd, variables, functions, and umask are isolated from one-shot commands and every other Session.",
+            "Open one bounded, long-lived configured local shell for an active Workflow Session (sh/bash on Unix, PowerShell on Windows). Its cwd, variables, functions, and process-local state are isolated from one-shot commands and every other Session.",
             open_session_shell_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/tests/session_shells.rs
+++ b/src/tool_runtime/tests/session_shells.rs
@@ -702,13 +702,8 @@ async fn capability_modes_and_ssh_resource_fail_closed_without_enqueue() {
         .unwrap()
         .contains("agent_capability_unavailable"));
 
-    let ssh_context = sessions::SessionExecutionContext {
-        default_cwd: None,
-        default_shell: None,
-        resource: Some("prod".to_string()),
-    };
     let (ssh_runtime, ssh_project, ssh_session) =
-        setup(temp.path(), true, SessionMode::Normal, Some(ssh_context)).await;
+        setup_ssh_with_capabilities(temp.path(), "prod", true, false).await;
     let ssh = {
         let auth = auth_context(None, true);
         ssh_runtime
@@ -727,16 +722,17 @@ async fn capability_modes_and_ssh_resource_fail_closed_without_enqueue() {
     assert_eq!(ssh.output["error_kind"], "agent_capability_unavailable");
     assert_eq!(ssh.output["recovery_kind"], "none");
     assert!(ssh.output.get("recovery_tool").is_none());
-    // An SSH persistent shell routes through the SSH connection pool and the
-    // persistent-shell manager, so it requires ssh_shell + ssh_persistent_shell
-    // (persistent_shell is enforced through the PersistentShell tool
-    // capability). The default test agent advertises only persistent_shell, so
-    // the request fails closed without enqueuing.
+    // A legacy Runner may support one-shot SSH plus persistent shells while
+    // predating the additive SSH-persistent capability. It still fails closed
+    // before enqueue rather than falling back to a local persistent shell.
     assert!(ssh
         .error
         .as_deref()
         .unwrap()
-        .contains("agent_capability_unavailable"));
+        .contains("ssh_persistent_shell"));
+    assert!(probe_patch_agent_request(&ssh_runtime, CLIENT)
+        .await
+        .is_none());
 
     for mode in [SessionMode::Inspect, SessionMode::ReadOnly] {
         let (runtime, project, session) = setup(temp.path(), true, mode, None).await;
@@ -764,9 +760,11 @@ async fn capability_modes_and_ssh_resource_fail_closed_without_enqueue() {
 /// the bound resource, and later exec/status/close route by the saved record
 /// (not the current Session context). A context change after open must not
 /// redirect an already-open shell.
-async fn setup_ssh(
+async fn setup_ssh_with_capabilities(
     root: &std::path::Path,
     resource: &str,
+    ssh_shell: bool,
+    ssh_persistent_shell: bool,
 ) -> (ToolRuntime, String, sessions::SessionSummary) {
     let runtime = test_runtime();
     register_agent_with_projects(
@@ -775,9 +773,10 @@ async fn setup_ssh(
         None,
         ShellClientCapabilities {
             shell: true,
+            async_jobs: true,
             persistent_shell: true,
-            ssh_shell: true,
-            ssh_persistent_shell: true,
+            ssh_shell,
+            ssh_persistent_shell,
             ..Default::default()
         },
         vec![ShellAgentProjectSummary {
@@ -818,12 +817,69 @@ async fn setup_ssh(
     (runtime, project, session)
 }
 
+async fn setup_ssh(
+    root: &std::path::Path,
+    resource: &str,
+) -> (ToolRuntime, String, sessions::SessionSummary) {
+    // Exact Windows Stage 2 capability shape: persistent SSH is available even
+    // though the existing one-shot/background SSH capability remains absent.
+    setup_ssh_with_capabilities(root, resource, false, true).await
+}
+
 #[tokio::test]
 async fn ssh_persistent_shell_enqueues_with_bound_resource_and_routes_by_record() {
     let temp = tempfile::tempdir().unwrap();
     let (runtime, project, session) = setup_ssh(temp.path(), "prod").await;
+    let auth = auth_context(None, true);
 
-    // Open carries the bound SSH resource on job_context.
+    let one_shot = runtime
+        .dispatch_with_auth(
+            ToolCall::RunShell {
+                project: project.clone(),
+                command: "printf one-shot".to_string(),
+                session_id: Some(session.session_id.clone()),
+                timeout_secs: Some(30),
+                cwd: None,
+                purpose: None,
+                shell: None,
+            },
+            Some(&auth),
+        )
+        .await;
+    assert!(!one_shot.success, "{one_shot:?}");
+    assert_eq!(
+        one_shot.output["error_kind"],
+        "agent_capability_unavailable"
+    );
+    assert!(one_shot.error.as_deref().unwrap().contains("ssh_shell"));
+
+    let background = runtime
+        .dispatch_with_auth(
+            ToolCall::RunJob {
+                project: project.clone(),
+                command: "printf background".to_string(),
+                session_id: Some(session.session_id.clone()),
+                timeout_secs: Some(30),
+                cwd: None,
+                purpose: None,
+                shell: None,
+            },
+            Some(&auth),
+        )
+        .await;
+    assert!(!background.success, "{background:?}");
+    assert_eq!(
+        background.output["error_kind"],
+        "agent_capability_unavailable"
+    );
+    assert!(background.error.as_deref().unwrap().contains("ssh_shell"));
+    assert!(
+        probe_patch_agent_request(&runtime, CLIENT).await.is_none(),
+        "one-shot/background SSH work must not enqueue without ssh_shell"
+    );
+
+    // Open carries the bound SSH resource on job_context and must still enqueue
+    // with persistent_shell=true + ssh_persistent_shell=true + ssh_shell=false.
     let open_task = dispatch(
         runtime.clone(),
         ToolCall::OpenSessionShell {
@@ -885,6 +941,30 @@ async fn ssh_persistent_shell_enqueues_with_bound_resource_and_routes_by_record(
     let exec = exec_task.await.unwrap();
     assert!(exec.success, "{exec:?}");
     assert_eq!(exec.output["stdout"], "remote");
+
+    let status_task = dispatch(
+        runtime.clone(),
+        ToolCall::SessionShellStatus {
+            project: project.clone(),
+            session_id: session.session_id.clone(),
+            shell_id: shell_id.clone(),
+        },
+    );
+    let status_request = next_persistent_request(&runtime).await;
+    assert_eq!(
+        status_request.persistent_shell.as_ref().unwrap().action,
+        "status"
+    );
+    assert_eq!(
+        status_request
+            .job_context
+            .as_ref()
+            .and_then(|ctx| ctx.ssh_resource.as_deref()),
+        Some("prod"),
+        "status must route by the saved SSH resource binding"
+    );
+    complete(&runtime, &status_request, "running", "idle", "", None, None).await;
+    assert!(status_task.await.unwrap().success);
 
     // Close also routes by the saved record.
     let close_task = dispatch(


### PR DESCRIPTION
## Summary

- add Windows local persistent PowerShell support while preserving command-scoped framing, timeout poisoning, and Runner-owned process cleanup
- add Windows named SSH persistent shells by reusing the existing Session/PersistentShell model and remote `sh`/`bash` transport semantics
- keep Windows one-shot/background SSH intentionally disabled (`ssh_shell=false`) while advertising `persistent_shell=true` and `ssh_persistent_shell=true`
- fix Server/control-plane capability gates so named SSH persistent shells require `persistent_shell + ssh_persistent_shell`, independent of the one-shot `ssh_shell` capability

## Windows SSH architecture

- local persistent shell: configured PowerShell (`powershell.exe` / `pwsh.exe`)
- named SSH persistent shell: Runner-owned long-lived `ssh.exe` -> remote `sh`/`bash`
- named SSH routing remains controlled by `execution_context.resource` and Runner-local `[ssh.resources.<name>]` configuration
- Windows OpenSSH credentials/config remain local to the Runner; no credential material is added to protocol/tool input
- local `ssh.exe` remains owned through the existing `ManagedChild` / Job Object lifecycle
- resource/config generation fencing continues to fail closed rather than retarget an existing shell

## Validation

Focused implementation/review validation included:

- Windows local persistent-shell regressions: 9/9 PASS
- Windows Runner persistent-shell regressions: PASS
- Windows SSH capability / literal argv regressions: PASS
- Server exact capability regression for `persistent_shell=true / ssh_persistent_shell=true / ssh_shell=false`: PASS
- legacy `ssh_persistent_shell=false` fail-closed regression: PASS
- `cargo fmt --check`: PASS
- affected Cargo checks: PASS
- Linux/Unix `cargo check -p webcodex-runner` in WSL: PASS
- `git diff --check`: PASS

## Live dogfood

Dogfooded the deployed Server + MSI Runner against a real named SSH resource `mini`:

- `open_session_shell` succeeded with `executor=ssh`, `resource=mini`, remote `bash`
- remote host: `mini.tailf5bfb6.ts.net`, user `yyjeqhc`
- cwd persisted across calls (`/Users/yyjeqhc` -> `/tmp`)
- exported environment and shell function persisted across subsequent `session_shell_exec`
- Unicode stdout, stderr, and normal nonzero command handling behaved correctly
- `session_shell_status` reported the shell running/idle
- ordinary `run_shell` and `run_job` with the same SSH-bound Session remained rejected because `ssh_shell=false`
- explicit close succeeded and left zero matching persistent `ssh.exe` processes on MSI

No PTY/ConPTY/terminal-streaming capability is included in this PR.