### PR TITLE
Add Windows Runner replacement readiness

### DIFF
--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -42,18 +42,19 @@ use webcodex_cli::{
     client_profile_user_token_file_for_scope, client_usage, connect_usage, current_user_home,
     default_client_output_dir_for_profile, default_device_name, default_server_paths,
     disconnect_usage, discover_internal_binary, is_effective_root, login_usage, logout_usage,
-    ops_agents_usage, ops_projects_usage, ops_smoke_preflight_usage, ops_status_usage, ops_usage,
-    pairing_create_usage, pairing_usage, render_token_generate, run_agent_install_service,
-    run_agent_service, run_agent_status, run_agent_token_create_local, run_client_enroll,
-    run_connect, run_disconnect, run_hosted_log_writer, run_internal_binary, run_login, run_logout,
-    run_ops_command, run_pairing_create, run_server_init, run_server_install_service,
-    run_server_service, run_server_status, run_setup_single_user, run_status,
-    run_token_create_local, server_init_usage, server_install_service_usage, server_status_usage,
-    server_usage, status_usage, system_user_home, system_user_is_root, usage,
+    ops_agents_usage, ops_projects_usage, ops_runner_usage, ops_smoke_preflight_usage,
+    ops_status_usage, ops_usage, pairing_create_usage, pairing_usage, render_token_generate,
+    run_agent_install_service, run_agent_service, run_agent_status, run_agent_token_create_local,
+    run_client_enroll, run_connect, run_disconnect, run_hosted_log_writer, run_internal_binary,
+    run_login, run_logout, run_ops_command, run_pairing_create, run_server_init,
+    run_server_install_service, run_server_service, run_server_status, run_setup_single_user,
+    run_status, run_token_create_local, server_init_usage, server_install_service_usage,
+    server_status_usage, server_usage, status_usage, system_user_home, system_user_is_root, usage,
     validate_client_profile, validate_service_file_scope, write_connect_result, write_secret_file,
     write_text_file, ConnectAuth, ConnectOptions, DisconnectOptions, LoginOptions, LogoutOptions,
-    OpsCommand, OpsCommonOptions, OpsSmokePreflightOptions, ServerStatusOptions, ServiceControl,
-    StatusOptions, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT,
+    OpsCommand, OpsCommonOptions, OpsRunnerOptions, OpsSmokePreflightOptions, ServerStatusOptions,
+    ServiceControl, StatusOptions, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE,
+    SERVER_SERVICE_UNIT,
 };
 const SETUP_GPT_SCOPES: &[&str] = &["runtime:read", "project:read", "project:write", "job:run"];
 const SETUP_AGENT_SCOPES: &[&str] = &[
@@ -1243,6 +1244,23 @@ fn parse_ops_subcommand(args: &[String]) -> CliAction {
                 },
             }
         }
+        "runner" => {
+            if args.get(1).is_some_and(|a| a == "--help" || a == "-h") {
+                return CliAction::Exit {
+                    code: 0,
+                    stdout: ops_runner_usage().to_string(),
+                    stderr: String::new(),
+                };
+            }
+            match parse_ops_runner(&args[1..]) {
+                Ok(opts) => CliAction::Ops(OpsCommand::Runner(opts)),
+                Err(e) => CliAction::Exit {
+                    code: 2,
+                    stdout: String::new(),
+                    stderr: format!("{}\n", e),
+                },
+            }
+        }
         "projects" => {
             if args.get(1).is_some_and(|a| a == "--help" || a == "-h") {
                 return CliAction::Exit {
@@ -1329,6 +1347,48 @@ fn validate_ops_common(opts: &OpsCommonOptions) -> Result<OpsCommonOptions, Stri
         return Err("--token cannot be empty".to_string());
     }
     Ok(opts.clone())
+}
+
+fn parse_ops_runner(args: &[String]) -> Result<OpsRunnerOptions, String> {
+    let mut common = default_ops_common_options();
+    let mut client_id = String::new();
+    let mut request_timeout_ms = webcodex_cli::ops::DEFAULT_RUNNER_REQUEST_TIMEOUT_MS;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--client-id" => client_id = next_value(&mut iter, arg)?,
+            "--request-timeout-ms" => {
+                request_timeout_ms = next_value(&mut iter, arg)?
+                    .parse::<u64>()
+                    .map_err(|_| "--request-timeout-ms must be an integer".to_string())?;
+            }
+            "--server-url" | "--url" => common.server_url = next_value(&mut iter, arg)?,
+            "--proxy" => common.server_http.proxy = Some(next_value(&mut iter, arg)?),
+            "--no-system-proxy" => common.server_http.no_system_proxy = true,
+            "--env-file" => common.env_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
+            "--token-file" => common.token_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
+            "--token" => common.token = Some(next_value(&mut iter, arg)?),
+            "--json" => common.json = true,
+            "--strict" => common.strict = true,
+            other => return Err(format!("unknown ops runner flag: {}", other)),
+        }
+    }
+    common = validate_ops_common(&common)?;
+    let client_id = client_id.trim().to_string();
+    if client_id.is_empty() {
+        return Err("--client-id is required".to_string());
+    }
+    if client_id.chars().count() > 128 {
+        return Err("--client-id must contain 1..=128 characters".to_string());
+    }
+    if !(1..=30_000).contains(&request_timeout_ms) {
+        return Err("--request-timeout-ms must be within 1..=30000".to_string());
+    }
+    Ok(OpsRunnerOptions {
+        common,
+        client_id,
+        request_timeout_ms,
+    })
 }
 
 fn parse_ops_smoke_preflight(args: &[String]) -> Result<OpsSmokePreflightOptions, String> {

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -71,7 +71,9 @@ pub(crate) use login::{
     base_dir_or_default, default_device_name, run_login, run_logout, run_status, LoginOptions,
     LogoutOptions, StatusOptions,
 };
-pub(crate) use ops::{run_ops_command, OpsCommand, OpsCommonOptions, OpsSmokePreflightOptions};
+pub(crate) use ops::{
+    run_ops_command, OpsCommand, OpsCommonOptions, OpsRunnerOptions, OpsSmokePreflightOptions,
+};
 #[cfg(test)]
 pub(crate) use output::RevisionComparison;
 pub(crate) use output::{
@@ -115,9 +117,9 @@ pub(crate) use tokens::{
 pub(crate) use usage::{
     agent_init_usage, agent_install_service_usage, agent_status_usage, agent_usage,
     client_enroll_usage, client_usage, connect_usage, disconnect_usage, login_usage, logout_usage,
-    ops_agents_usage, ops_projects_usage, ops_smoke_preflight_usage, ops_status_usage, ops_usage,
-    pairing_create_usage, pairing_usage, server_init_usage, server_install_service_usage,
-    server_status_usage, server_usage, status_usage, usage,
+    ops_agents_usage, ops_projects_usage, ops_runner_usage, ops_smoke_preflight_usage,
+    ops_status_usage, ops_usage, pairing_create_usage, pairing_usage, server_init_usage,
+    server_install_service_usage, server_status_usage, server_usage, status_usage, usage,
 };
 
 #[cfg(test)]

--- a/crates/webcodex-cli/src/webcodex_cli/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/ops.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use std::time::Duration;
 use webcodex_admin::ServerHttpOptions;
 
 use super::{
@@ -7,6 +8,7 @@ use super::{
 };
 
 const DEFAULT_EXPECTED_TOOL_COUNT: u64 = 66;
+pub(crate) const DEFAULT_RUNNER_REQUEST_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OpsCommonOptions {
@@ -26,9 +28,17 @@ pub(crate) struct OpsSmokePreflightOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OpsRunnerOptions {
+    pub(crate) common: OpsCommonOptions,
+    pub(crate) client_id: String,
+    pub(crate) request_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum OpsCommand {
     Status(OpsCommonOptions),
     Agents(OpsCommonOptions),
+    Runner(OpsRunnerOptions),
     Projects(OpsCommonOptions),
     SmokePreflight(OpsSmokePreflightOptions),
 }
@@ -39,6 +49,7 @@ impl OpsCommand {
             OpsCommand::Status(opts) | OpsCommand::Agents(opts) | OpsCommand::Projects(opts) => {
                 opts.strict
             }
+            OpsCommand::Runner(opts) => opts.common.strict,
             OpsCommand::SmokePreflight(opts) => opts.common.strict,
         }
     }
@@ -144,6 +155,30 @@ pub(crate) async fn run_ops_command(command: OpsCommand) -> Result<OpsCommandOut
                 ),
             };
             render_ops_command_output(report, opts.json, render_ops_agents)
+        }
+        OpsCommand::Runner(opts) => {
+            let token = resolve_ops_token(&opts.common)?;
+            let report = match fetch_ops_json_output_bounded(
+                &opts.common.server_url,
+                &opts.common.server_http,
+                "/api/runtime/status",
+                token.as_deref(),
+                json!({"client_id": opts.client_id}),
+                opts.request_timeout_ms,
+            )
+            .await
+            {
+                Ok(runtime) => {
+                    ops_runner_report(&opts.common.server_url, &opts.client_id, &Some(runtime))
+                }
+                Err(failure) => ops_http_failure_report(
+                    &opts.common.server_url,
+                    "runtime_status",
+                    failure,
+                    token.is_some(),
+                ),
+            };
+            render_ops_command_output(report, opts.common.json, render_ops_runner)
         }
         OpsCommand::Projects(opts) => {
             let token = resolve_ops_token(&opts)?;
@@ -330,6 +365,7 @@ enum OpsHttpFailureKind {
     Unauthorized,
     Forbidden,
     Unreachable,
+    RequestTimeout,
     ServerError,
     NonJson,
     Malformed,
@@ -342,6 +378,7 @@ impl OpsHttpFailureKind {
             OpsHttpFailureKind::Unauthorized => "unauthorized",
             OpsHttpFailureKind::Forbidden => "forbidden",
             OpsHttpFailureKind::Unreachable => "runtime_unreachable",
+            OpsHttpFailureKind::RequestTimeout => "request_timeout",
             OpsHttpFailureKind::ServerError => "server_error",
             OpsHttpFailureKind::NonJson => "non_json_response",
             OpsHttpFailureKind::Malformed => "malformed_response",
@@ -393,6 +430,14 @@ impl OpsHttpFailure {
             content_type: None,
         }
     }
+
+    fn request_timeout() -> Self {
+        Self {
+            kind: OpsHttpFailureKind::RequestTimeout,
+            status_code: None,
+            content_type: None,
+        }
+    }
 }
 
 async fn fetch_ops_json_output(
@@ -412,6 +457,25 @@ async fn fetch_ops_json_output(
             value.is_some(),
         )),
         Err(e) => Err(OpsHttpFailure::from_transport_error(e)),
+    }
+}
+
+async fn fetch_ops_json_output_bounded(
+    server_url: &str,
+    server_http: &ServerHttpOptions,
+    path: &str,
+    token: Option<&str>,
+    body: Value,
+    request_timeout_ms: u64,
+) -> Result<Value, OpsHttpFailure> {
+    match tokio::time::timeout(
+        Duration::from_millis(request_timeout_ms),
+        fetch_ops_json_output(server_url, server_http, path, token, body),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(OpsHttpFailure::request_timeout()),
     }
 }
 
@@ -445,7 +509,10 @@ fn ops_http_failure_report(
     OpsReport {
         verdict: verdict.finish(),
         summary: json!({
-            "runtime_reachable": failure.kind != OpsHttpFailureKind::Unreachable,
+            "runtime_reachable": !matches!(
+                failure.kind,
+                OpsHttpFailureKind::Unreachable | OpsHttpFailureKind::RequestTimeout
+            ),
             "http": http.clone(),
         }),
         source: json!({
@@ -485,6 +552,7 @@ fn ops_http_failure_reason(failure: &OpsHttpFailure, token_present: bool) -> &'s
         OpsHttpFailureKind::Unauthorized => "unauthorized",
         OpsHttpFailureKind::Forbidden => "forbidden",
         OpsHttpFailureKind::Unreachable => "runtime_unreachable",
+        OpsHttpFailureKind::RequestTimeout => "request_timeout",
         OpsHttpFailureKind::ServerError => "server_error",
         OpsHttpFailureKind::NonJson => "non_json_response",
         OpsHttpFailureKind::Malformed => "malformed_response",
@@ -501,6 +569,9 @@ fn ops_http_failure_action(kind: OpsHttpFailureKind) -> &'static str {
             "use a bearer token with the required runtime, project, or job scope"
         }
         OpsHttpFailureKind::Unreachable => "check --server-url, DNS, firewall, and server process",
+        OpsHttpFailureKind::RequestTimeout => {
+            "retry the exact Runner observation within its bounded request deadline"
+        }
         OpsHttpFailureKind::ServerError => {
             "inspect WebCodex server logs for the failing ops request"
         }
@@ -685,6 +756,65 @@ pub(crate) fn ops_agents_report(server_url: &str, runtime: &Option<Value>) -> Op
         "stale_count": stale,
         "active_jobs": active_jobs,
         "agents": clients,
+    });
+    OpsReport {
+        verdict: verdict.finish(),
+        summary,
+        source: source_json(server_url, runtime_commit(runtime), "runtime_status"),
+    }
+}
+
+pub(crate) fn ops_runner_report(
+    server_url: &str,
+    expected_client_id: &str,
+    runtime: &Option<Value>,
+) -> OpsReport {
+    let mut verdict = OpsVerdict::pass();
+    let Some(runtime) = runtime.as_ref() else {
+        verdict.fail_reason(
+            "runtime_unreachable",
+            "check --server-url, network reachability, and bearer token",
+        );
+        return OpsReport {
+            verdict: verdict.finish(),
+            summary: json!({
+                "runtime_reachable": false,
+                "client_id": expected_client_id,
+            }),
+            source: source_json(server_url, None, "runtime_status"),
+        };
+    };
+    let focus = runtime.get("focus").filter(|value| value.is_object());
+    let Some(focus) = focus else {
+        verdict.fail_reason(
+            "runner_not_observed",
+            "verify the exact Runner client_id is registered and caller-visible",
+        );
+        return OpsReport {
+            verdict: verdict.finish(),
+            summary: json!({
+                "runtime_reachable": true,
+                "client_id": expected_client_id,
+                "connected": false,
+            }),
+            source: source_json(server_url, runtime_commit(runtime), "runtime_status"),
+        };
+    };
+    if focus.get("client_id").and_then(Value::as_str) != Some(expected_client_id) {
+        verdict.fail_reason(
+            "unexpected_runner_identity",
+            "retry the exact client_id query and inspect Server runtime registration",
+        );
+    }
+    let summary = json!({
+        "runtime_reachable": true,
+        "client_id": focus.get("client_id").cloned().unwrap_or(Value::Null),
+        "connected": focus.get("connected").cloned().unwrap_or(Value::Null),
+        "status": focus.get("status").cloned().unwrap_or(Value::Null),
+        "agent_instance_id": focus.get("agent_instance_id").cloned().unwrap_or(Value::Null),
+        "build": focus.get("build").cloned().unwrap_or(Value::Null),
+        "compatibility_status": focus.get("compatibility_status").cloned().unwrap_or(Value::Null),
+        "source_alignment": focus.get("source_alignment").cloned().unwrap_or(Value::Null),
     });
     OpsReport {
         verdict: verdict.finish(),
@@ -993,6 +1123,36 @@ pub(crate) fn render_ops_agents(report: &OpsReport, json_output: bool) -> Result
             display_value(&client["active_jobs"]),
             display_value(&client["pending_requests"]),
             display_value(&client["last_seen_age_secs"])
+        ));
+    }
+    out.push_str(&render_reasons(report));
+    Ok(out)
+}
+
+pub(crate) fn render_ops_runner(report: &OpsReport, json_output: bool) -> Result<String, String> {
+    if json_output {
+        return render_ops_json(report);
+    }
+    let mut out = render_overall_header(report);
+    out.push_str(&render_http_failure(report));
+    out.push_str("Runner:\n");
+    for field in [
+        "client_id",
+        "connected",
+        "status",
+        "agent_instance_id",
+        "compatibility_status",
+    ] {
+        out.push_str(&format!(
+            "  {field}: {}\n",
+            display_value(&report.summary[field])
+        ));
+    }
+    out.push_str("Build:\n");
+    for field in ["version", "git_commit", "git_dirty", "built_at"] {
+        out.push_str(&format!(
+            "  {field}: {}\n",
+            display_value(&report.summary["build"][field])
         ));
     }
     out.push_str(&render_reasons(report));

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -1,7 +1,7 @@
 use super::support::*;
 use crate::webcodex_cli::ops::{
-    ops_agents_report, ops_exit_code, ops_projects_report, ops_smoke_preflight_report,
-    ops_status_report, render_ops_status,
+    ops_agents_report, ops_exit_code, ops_projects_report, ops_runner_report,
+    ops_smoke_preflight_report, ops_status_report, render_ops_runner, render_ops_status,
 };
 use crate::webcodex_cli::run_ops_command;
 use std::time::Duration;
@@ -43,6 +43,18 @@ fn ops_help_entrypoints_print_usage() {
                 "--env-file PATH",
                 "--token-file PATH",
                 "--token TOKEN",
+                "--json",
+                "--strict",
+            ],
+        ),
+        (
+            &["ops", "runner", "--help"],
+            &[
+                "Usage: webcodex ops runner",
+                "--client-id CLIENT_ID",
+                "--request-timeout-ms MS",
+                "--server-url URL",
+                "--token-file PATH",
                 "--json",
                 "--strict",
             ],
@@ -91,7 +103,7 @@ fn ops_help_entrypoints_print_usage() {
 #[test]
 fn top_level_help_mentions_ops() {
     let out = cli_exit(["--help"]).unwrap();
-    assert!(out.contains("ops status|agents|projects|smoke-preflight"));
+    assert!(out.contains("ops status|agents|runner|projects|smoke-preflight"));
 }
 
 #[test]
@@ -149,6 +161,41 @@ fn ops_smoke_preflight_requires_project() {
             assert!(stderr.contains("--project is required"));
         }
         other => panic!("expected missing project exit, got {other:?}"),
+    }
+}
+
+#[test]
+fn ops_runner_requires_exact_client_id() {
+    match cli_action(["ops", "runner", "--json"]) {
+        CliAction::Exit { code, stderr, .. } => {
+            assert_eq!(code, 2);
+            assert!(stderr.contains("--client-id is required"));
+        }
+        other => panic!("expected missing client-id exit, got {other:?}"),
+    }
+
+    match cli_action([
+        "ops",
+        "runner",
+        "--client-id",
+        "msi",
+        "--server-url",
+        "https://runtime.example",
+        "--token-file",
+        "/tmp/user-token",
+        "--json",
+    ]) {
+        CliAction::Ops(OpsCommand::Runner(opts)) => {
+            assert_eq!(opts.client_id, "msi");
+            assert_eq!(opts.request_timeout_ms, 5_000);
+            assert_eq!(opts.common.server_url, "https://runtime.example");
+            assert_eq!(
+                opts.common.token_file.as_deref(),
+                Some(Path::new("/tmp/user-token"))
+            );
+            assert!(opts.common.json);
+        }
+        other => panic!("expected ops runner action, got {other:?}"),
     }
 }
 
@@ -370,6 +417,33 @@ fn runtime_status_fixture() -> Value {
     })
 }
 
+fn runner_runtime_status_fixture() -> Value {
+    json!({
+        "service": "webcodex",
+        "build": {
+            "git_commit": "server123456",
+            "git_dirty": false
+        },
+        "focus": {
+            "client_id": "msi",
+            "connected": true,
+            "status": "online",
+            "agent_instance_id": "instance-new",
+            "build": {
+                "version": "0.3.8",
+                "git_commit": "candidate1234",
+                "git_dirty": false,
+                "built_at": "1787554000"
+            },
+            "compatibility_status": "compatible",
+            "source_alignment": {
+                "status": "different",
+                "git_commit_matches_server": false
+            }
+        }
+    })
+}
+
 fn projects_fixture(recommended: bool) -> Value {
     json!({
         "count": 1,
@@ -521,6 +595,10 @@ async fn run_ops_with_routes(
         OpsCommand::Agents(mut opts) => {
             opts.server_url = server_url;
             OpsCommand::Agents(opts)
+        }
+        OpsCommand::Runner(mut opts) => {
+            opts.common.server_url = server_url;
+            OpsCommand::Runner(opts)
         }
         OpsCommand::Projects(mut opts) => {
             opts.server_url = server_url;
@@ -725,6 +803,55 @@ fn ops_agents_maps_online_stale_and_jobs() {
     assert_eq!(report.summary["stale_count"], 1);
     assert!(report.summary.get("offline_count").is_none());
     assert_eq!(report.summary["active_jobs"], 1);
+}
+
+#[test]
+fn ops_runner_projects_only_exact_safe_runtime_identity() {
+    let secret = "wc_pat_projection_must_not_leak_0123456789";
+    let mut runtime = runner_runtime_status_fixture();
+    runtime["credential_material"] = json!(secret);
+    runtime["focus"]["credential_material"] = json!(secret);
+    let report = ops_runner_report("https://ops.example.test", "msi", &Some(runtime));
+    assert_eq!(report.verdict.status, "pass");
+    assert_eq!(report.summary["client_id"], "msi");
+    assert_eq!(report.summary["connected"], true);
+    assert_eq!(report.summary["agent_instance_id"], "instance-new");
+    assert_eq!(report.summary["build"]["git_commit"], "candidate1234");
+    assert_eq!(report.summary["build"]["git_dirty"], false);
+    assert_eq!(report.summary["source_alignment"]["status"], "different");
+    let rendered = render_ops_runner(&report, true).unwrap();
+    assert!(!rendered.contains(secret));
+    assert!(!rendered.contains("credential_material"));
+}
+
+#[tokio::test]
+async fn ops_runner_queries_exact_client_id_without_echoing_token() {
+    let secret = "wc_pat_runner_query_secret_0123456789";
+    let (server_url, stop_tx, handle) = spawn_ops_route_server(vec![(
+        "/api/runtime/status",
+        json_http_response(
+            200,
+            json!({"success": true, "output": runner_runtime_status_fixture()}),
+        ),
+    )]);
+    let mut common = ops_common_opts(server_url);
+    common.token = Some(secret.to_string());
+    common.json = true;
+    let output = run_ops_command(OpsCommand::Runner(OpsRunnerOptions {
+        common,
+        client_id: "msi".to_string(),
+        request_timeout_ms: 5_000,
+    }))
+    .await
+    .unwrap()
+    .stdout;
+    stop_tx.send(()).unwrap();
+    let requests = handle.join().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].contains(r#""client_id":"msi""#));
+    assert!(!output.contains(secret));
+    assert!(output.contains("instance-new"));
+    assert!(output.contains("candidate1234"));
 }
 
 #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -20,7 +20,7 @@ Operator / service management:\n\
                                 Configure and manage the Server service\n\
   agent init|install|run|start|stop|restart|status|logs|uninstall\n\
                                 Manage the Runner service (historical `agent` namespace)\n\
-  ops status|agents|projects|smoke-preflight\n\
+  ops status|agents|runner|projects|smoke-preflight\n\
                                 Read-only operator workflow checks\n\n\
 Advanced / compatibility:\n\
   pairing create                Create a client enrollment code\n\
@@ -161,6 +161,7 @@ pub(crate) fn ops_usage() -> &'static str {
      Commands:\n\
        status                  Summarize runtime, tools, jobs, agents, and projects\n\
        agents                  Show compact agent fleet status\n\
+       runner                  Show one exact Runner registration/build identity\n\
        projects                Show compact project inventory and smoke suitability\n\
        smoke-preflight         Check a project before deploy smoke validation\n\n\
      Common flags:\n\
@@ -207,6 +208,25 @@ pub(crate) fn ops_agents_usage() -> &'static str {
        --json                  Print machine-readable output\n\
        --strict                Exit 2 when the ops report status is FAIL\n\
        -h, --help              Print help and exit\n"
+}
+
+pub(crate) fn ops_runner_usage() -> &'static str {
+    "Usage: webcodex ops runner --client-id CLIENT_ID [OPTIONS]\n\n\
+     Show one exact caller-visible Runner registration and build identity.\n\n\
+     Options:\n\
+       --client-id CLIENT_ID   Exact Runner client_id (required)\n\
+       --request-timeout-ms MS Bound one Server observation [default: 5000; max: 30000]\n\
+       --server-url URL        WebCodex server URL [default: http://127.0.0.1:8080]\n\
+       --url URL               Alias for --server-url\n\
+       --proxy http://HOST:PORT Explicit proxy override for Server requests\n\
+       --no-system-proxy       Ignore proxy environment and connect directly\n\
+       --env-file PATH         Read WEBCODEX_TOKEN from env file\n\
+       --token-file PATH       Read bearer token from file\n\
+       --token TOKEN           Bearer token input; never printed\n\
+       --json                  Print machine-readable output\n\
+       --strict                Exit 2 when the ops report status is FAIL\n\
+       -h, --help              Print help and exit\n\n\
+     This command is read-only and projects only bounded runtime identity fields.\n"
 }
 
 pub(crate) fn ops_projects_usage() -> &'static str {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -116,6 +116,7 @@ keep their detached-process behavior when `--scope` is omitted.
 | --- | --- |
 | `webcodex ops status` | Summarize runtime, tools, jobs, agents, and projects |
 | `webcodex ops agents` | Compact agent fleet status |
+| `webcodex ops runner --client-id <id>` | Exact read-only Runner registration/build status |
 | `webcodex ops projects` | Project inventory and smoke suitability |
 | `webcodex ops smoke-preflight --project <id>` | Preflight one project for a deploy smoke |
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -107,6 +107,7 @@ detached-process 行为。
 | --- | --- |
 | `webcodex ops status` | 汇总 runtime、工具、任务、agent 与项目 |
 | `webcodex ops agents` | 简洁的 agent 队列状态 |
+| `webcodex ops runner --client-id <id>` | 精确读取单个 Runner 的注册与构建状态 |
 | `webcodex ops projects` | 项目清单与 smoke 适用性 |
 | `webcodex ops smoke-preflight --project <id>` | 为某项目做 deploy smoke 预检 |
 

--- a/scripts/deploy_windows_runner_dogfood.ps1
+++ b/scripts/deploy_windows_runner_dogfood.ps1
@@ -27,6 +27,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "windows_runner_process_identity.ps1")
 
 function Get-RunnerIdentity {
     param([Parameter(Mandatory = $true)][string]$Path)
@@ -43,19 +44,6 @@ function Get-RunnerIdentity {
         throw "Runner version probe returned an unexpected identity for $Path"
     }
     return $identity
-}
-
-function Get-ExactRunnerProcesses {
-    param([Parameter(Mandatory = $true)][string]$ExactPath)
-
-    $normalized = [System.IO.Path]::GetFullPath($ExactPath)
-    return @(Get-Process -Name "webcodex-runner" -ErrorAction SilentlyContinue | Where-Object {
-        try {
-            $_.Path -and ([System.IO.Path]::GetFullPath($_.Path) -ieq $normalized)
-        } catch {
-            $false
-        }
-    })
 }
 
 function Wait-Until {
@@ -94,6 +82,7 @@ if (-not (Test-Path -LiteralPath $RunnerPath -PathType Leaf)) {
     throw "Existing Runner is required so deployment has a concrete rollback binary: $RunnerPath"
 }
 $previousIdentity = Get-RunnerIdentity -Path $RunnerPath
+$oldPrimary = Get-ExactlyOnePrimaryRunner -ExactPath $RunnerPath
 
 # Copy first so the source may be a build directory, network path, or even the
 # current RunnerPath. The staged image is fully verified before the old process
@@ -115,11 +104,9 @@ try {
     # replacement after we intentionally terminate the old Runner.
     Disable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath | Out-Null
 
-    foreach ($process in Get-ExactRunnerProcesses -ExactPath $RunnerPath) {
-        Stop-Process -Id $process.Id -Force -ErrorAction Stop
-    }
-    Wait-Until -TimeoutSecs $StopTimeoutSecs -FailureMessage "Old Runner process did not exit before replacement" -Condition {
-        (Get-ExactRunnerProcesses -ExactPath $RunnerPath).Count -eq 0
+    Stop-CapturedPrimaryRunner -Identity $oldPrimary
+    Wait-Until -TimeoutSecs $StopTimeoutSecs -FailureMessage "Old Runner process identity did not exit before replacement" -Condition {
+        -not (Test-CapturedProcessIdentityLive -Identity $oldPrimary)
     }
     Wait-Until -TimeoutSecs $StopTimeoutSecs -FailureMessage "Scheduled Task wrapper did not stop before replacement" -Condition {
         (Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath).State -ne "Running"
@@ -145,14 +132,21 @@ try {
 
     Enable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath | Out-Null
     Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
-    Wait-Until -TimeoutSecs $StartTimeoutSecs -FailureMessage "New Runner process did not start" -Condition {
-        (Get-ExactRunnerProcesses -ExactPath $RunnerPath).Count -eq 1
+    $newPrimary = $null
+    Wait-Until -TimeoutSecs $StartTimeoutSecs -FailureMessage "New primary Runner process did not start" -Condition {
+        $matches = @(Get-PrimaryRunnerProcesses -ExactPath $RunnerPath)
+        if ($matches.Count -eq 1) {
+            $script:newPrimary = $matches[0]
+            return $true
+        }
+        return $false
     }
 
     # Catch immediate startup failures before declaring the local handoff good.
     Start-Sleep -Seconds 3
-    if ((Get-ExactRunnerProcesses -ExactPath $RunnerPath).Count -ne 1) {
-        throw "New Runner did not remain alive after startup"
+    $null = Assert-CapturedPrimaryRunnerIdentity -Identity $newPrimary
+    if ((Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -ne 1) {
+        throw "New Runner did not remain the exactly-one primary Runner after startup"
     }
 
     # Successful handoff: remove stale per-deployment staging images but retain
@@ -173,11 +167,17 @@ try {
 
     try {
         Disable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue | Out-Null
-        foreach ($process in Get-ExactRunnerProcesses -ExactPath $RunnerPath) {
-            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+        $rollbackStopTarget = $null
+        $rollbackMatches = @(Get-PrimaryRunnerProcesses -ExactPath $RunnerPath)
+        if ($rollbackMatches.Count -gt 1) {
+            throw "Multiple primary Runners found during rollback: $($rollbackMatches.Count)"
         }
-        Wait-Until -TimeoutSecs $StopTimeoutSecs -FailureMessage "Runner did not stop during rollback" -Condition {
-            (Get-ExactRunnerProcesses -ExactPath $RunnerPath).Count -eq 0
+        if ($rollbackMatches.Count -eq 1) {
+            $rollbackStopTarget = $rollbackMatches[0]
+            Stop-CapturedPrimaryRunner -Identity $rollbackStopTarget
+            Wait-Until -TimeoutSecs $StopTimeoutSecs -FailureMessage "Runner identity did not stop during rollback" -Condition {
+                -not (Test-CapturedProcessIdentityLive -Identity $rollbackStopTarget)
+            }
         }
 
         if ($rollbackAvailable -and (Test-Path -LiteralPath $rollbackPath -PathType Leaf)) {
@@ -192,8 +192,8 @@ try {
         Enable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue | Out-Null
         if (Test-Path -LiteralPath $RunnerPath -PathType Leaf) {
             Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
-            Wait-Until -TimeoutSecs $StartTimeoutSecs -FailureMessage "Rollback Runner did not restart" -Condition {
-                (Get-ExactRunnerProcesses -ExactPath $RunnerPath).Count -eq 1
+            Wait-Until -TimeoutSecs $StartTimeoutSecs -FailureMessage "Rollback primary Runner did not restart" -Condition {
+                (Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -eq 1
             }
         }
     } catch {

--- a/scripts/deploy_windows_runner_dogfood.ps1
+++ b/scripts/deploy_windows_runner_dogfood.ps1
@@ -5,17 +5,18 @@
 # modify credentials, agent configuration, or Scheduled Task definitions.
 #
 # The deployment contract is:
-#   verify candidate -> disable task -> stop exact old runner -> replace with
-#   rollback -> re-enable/start task -> verify the exact new image stays alive.
-# Any failure after replacement restores the previous binary and restarts it.
-# The operator must still verify Control-plane re-registration after this local
-# handoff and redeploy the retained rollback binary if that external check fails.
+#   verify candidate build -> prove exact pre-replacement Server identity ->
+#   P1a exact local replacement -> prove a fresh candidate instance/build Ready.
+# Any failure after destructive replacement begins performs bounded rollback and
+# must prove a fresh rollback instance/build Ready before recovery is considered
+# established. The Server binary/service is never modified by this helper.
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
     [string]$Candidate,
 
     [string]$RunnerPath = "$env:USERPROFILE\.local\bin\webcodex-runner.exe",
+    [string]$WebCodexCliPath = "$env:USERPROFILE\.local\bin\webcodex.exe",
     [string]$TaskName = "WebCodex MSI Dogfood Runner",
     [string]$TaskPath = "\",
 
@@ -23,11 +24,15 @@ param(
     [int]$StopTimeoutSecs = 20,
 
     [ValidateRange(1, 120)]
-    [int]$StartTimeoutSecs = 20
+    [int]$StartTimeoutSecs = 20,
+
+    [ValidateRange(1, 300)]
+    [int]$ReadinessTimeoutSecs = 30
 )
 
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "windows_runner_process_identity.ps1")
+. (Join-Path $PSScriptRoot "windows_runner_readiness.ps1")
 
 function Get-RunnerIdentity {
     param([Parameter(Mandatory = $true)][string]$Path)
@@ -77,12 +82,26 @@ if (-not $taskWasEnabled) {
     throw "Scheduled Task is already disabled: $TaskPath$TaskName"
 }
 
+$candidateBuild = Get-RunnerBuildIdentity -Path $Candidate
 $candidateIdentity = Get-RunnerIdentity -Path $Candidate
 if (-not (Test-Path -LiteralPath $RunnerPath -PathType Leaf)) {
     throw "Existing Runner is required so deployment has a concrete rollback binary: $RunnerPath"
 }
+$previousBuild = Get-RunnerBuildIdentity -Path $RunnerPath
 $previousIdentity = Get-RunnerIdentity -Path $RunnerPath
 $oldPrimary = Get-ExactlyOnePrimaryRunner -ExactPath $RunnerPath
+$operatorProfile = Get-RunnerOperatorProfile -PrimaryIdentity $oldPrimary
+$preObservation = Get-RunnerControlPlaneObservation `
+    -WebCodexCliPath $WebCodexCliPath `
+    -ServerUrl $operatorProfile.ServerUrl `
+    -TokenFile $operatorProfile.TokenFile `
+    -ClientId $operatorProfile.ClientId `
+    -RequestTimeoutMilliseconds ([Math]::Min(5000, $ReadinessTimeoutSecs * 1000))
+$null = Assert-PreReplacementRunnerObservation `
+    -Observation $preObservation `
+    -ExpectedClientId $operatorProfile.ClientId `
+    -ExpectedBuild $previousBuild
+$oldAgentInstanceId = [string]$preObservation.agent_instance_id
 
 # Copy first so the source may be a build directory, network path, or even the
 # current RunnerPath. The staged image is fully verified before the old process
@@ -92,12 +111,18 @@ $rollbackPath = "$RunnerPath.rollback"
 $failedPath = "$RunnerPath.failed"
 $replacementInstalled = $false
 $rollbackAvailable = $false
+$candidateObservedInstanceIds = @()
+$candidateReadyObservation = $null
 
 try {
     Copy-Item -LiteralPath $Candidate -Destination $stagedPath -ErrorAction Stop
     $stagedIdentity = Get-RunnerIdentity -Path $stagedPath
     if ($stagedIdentity -ne $candidateIdentity) {
         throw "Staged Runner identity differs from the candidate"
+    }
+    $stagedBuild = Get-RunnerBuildIdentity -Path $stagedPath
+    if ($stagedBuild.GitCommit -ne $candidateBuild.GitCommit -or $stagedBuild.GitDirty -ne $candidateBuild.GitDirty) {
+        throw "Staged Runner build identity differs from the candidate"
     }
 
     # Prevent the Task Scheduler's RestartOnFailure policy from racing the
@@ -149,24 +174,75 @@ try {
         throw "New Runner did not remain the exactly-one primary Runner after startup"
     }
 
+    $candidateObserve = {
+        param([int]$RequestTimeoutMilliseconds)
+        $observation = Get-RunnerControlPlaneObservation `
+            -WebCodexCliPath $WebCodexCliPath `
+            -ServerUrl $operatorProfile.ServerUrl `
+            -TokenFile $operatorProfile.TokenFile `
+            -ClientId $operatorProfile.ClientId `
+            -RequestTimeoutMilliseconds $RequestTimeoutMilliseconds
+        $instanceId = [string]$observation.agent_instance_id
+        if (-not [string]::IsNullOrWhiteSpace($instanceId) -and
+            $instanceId -ne $oldAgentInstanceId -and
+            $script:candidateObservedInstanceIds -notcontains $instanceId) {
+            $script:candidateObservedInstanceIds += $instanceId
+        }
+        return $observation
+    }
+    $candidateReady = Wait-RunnerControlPlaneReadiness `
+        -Observe $candidateObserve `
+        -ExpectedClientId $operatorProfile.ClientId `
+        -ExpectedBuild $candidateBuild `
+        -DeadlineUtc ([DateTime]::UtcNow.AddSeconds($ReadinessTimeoutSecs)) `
+        -DisallowedAgentInstanceIds @($oldAgentInstanceId) `
+        -FailOnBuildMismatch
+    $candidateReadyObservation = $candidateReady.Observation
+    $null = Assert-CapturedPrimaryRunnerIdentity -Identity $newPrimary
+
     # Successful handoff: remove stale per-deployment staging images but retain
     # one concrete rollback binary for the next operator action.
     Get-ChildItem -LiteralPath $RunnerDir -Filter "webcodex-runner.*.new.exe" -File -ErrorAction SilentlyContinue |
         Remove-Item -Force -ErrorAction SilentlyContinue
 
-    Write-Output "Windows Runner dogfood local handoff succeeded."
-    Write-Output "  candidate: $candidateIdentity"
-    if ($previousIdentity) {
-        Write-Output "  previous:  $previousIdentity"
-        Write-Output "  rollback:  $rollbackPath"
-    }
-    Write-Output "  task:      $TaskPath$TaskName"
-    Write-Output "  runner:    $RunnerPath"
+    Write-Output "Windows Runner dogfood replacement readiness succeeded."
+    Write-Output "  client_id:             $($operatorProfile.ClientId)"
+    Write-Output "  old_agent_instance_id: $oldAgentInstanceId"
+    Write-Output "  new_agent_instance_id: $($candidateReadyObservation.agent_instance_id)"
+    Write-Output "  expected_build:        commit=$($candidateBuild.GitCommit) dirty=$($candidateBuild.GitDirty)"
+    Write-Output "  observed_build:        commit=$($candidateReadyObservation.build.git_commit) dirty=$($candidateReadyObservation.build.git_dirty)"
+    Write-Output "  candidate:             $candidateIdentity"
+    Write-Output "  previous:              $previousIdentity"
+    Write-Output "  rollback:              $rollbackPath"
+    Write-Output "  task:                  $TaskPath$TaskName"
+    Write-Output "  runner:                $RunnerPath"
 } catch {
     $deploymentError = $_
+    $rollbackFailure = $null
+    $rollbackReadyObservation = $null
 
     try {
         Disable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue | Out-Null
+
+        # Capture any fresh candidate instance already visible before stopping it,
+        # so that a stale candidate registration cannot satisfy rollback readiness.
+        try {
+            $beforeRollback = Get-RunnerControlPlaneObservation `
+                -WebCodexCliPath $WebCodexCliPath `
+                -ServerUrl $operatorProfile.ServerUrl `
+                -TokenFile $operatorProfile.TokenFile `
+                -ClientId $operatorProfile.ClientId `
+                -RequestTimeoutMilliseconds ([Math]::Min(2000, $ReadinessTimeoutSecs * 1000))
+            $beforeRollbackInstanceId = [string]$beforeRollback.agent_instance_id
+            if (-not [string]::IsNullOrWhiteSpace($beforeRollbackInstanceId) -and
+                $beforeRollbackInstanceId -ne $oldAgentInstanceId -and
+                $script:candidateObservedInstanceIds -notcontains $beforeRollbackInstanceId) {
+                $script:candidateObservedInstanceIds += $beforeRollbackInstanceId
+            }
+        } catch {
+            # Best-effort only: the bounded rollback readiness proof below remains authoritative.
+        }
+
         $rollbackStopTarget = $null
         $rollbackMatches = @(Get-PrimaryRunnerProcesses -ExactPath $RunnerPath)
         if ($rollbackMatches.Count -gt 1) {
@@ -188,18 +264,54 @@ try {
             $replacementInstalled = $false
             $rollbackAvailable = $false
         }
-
-        Enable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue | Out-Null
-        if (Test-Path -LiteralPath $RunnerPath -PathType Leaf) {
-            Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
-            Wait-Until -TimeoutSecs $StartTimeoutSecs -FailureMessage "Rollback primary Runner did not restart" -Condition {
-                (Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -eq 1
-            }
+        if (-not (Test-Path -LiteralPath $RunnerPath -PathType Leaf)) {
+            throw "Rollback binary is unavailable after restore"
         }
+        $restoredBuild = Get-RunnerBuildIdentity -Path $RunnerPath
+        if ($restoredBuild.GitCommit -ne $previousBuild.GitCommit -or $restoredBuild.GitDirty -ne $previousBuild.GitDirty) {
+            throw "Restored rollback binary build identity differs from the pre-replacement Runner"
+        }
+
+        Enable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction Stop | Out-Null
+        Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction Stop
+        $rollbackPrimary = $null
+        Wait-Until -TimeoutSecs $StartTimeoutSecs -FailureMessage "Rollback primary Runner did not restart" -Condition {
+            $matches = @(Get-PrimaryRunnerProcesses -ExactPath $RunnerPath)
+            if ($matches.Count -eq 1) {
+                $script:rollbackPrimary = $matches[0]
+                return $true
+            }
+            return $false
+        }
+        $null = Assert-CapturedPrimaryRunnerIdentity -Identity $rollbackPrimary
+
+        $rollbackObserve = {
+            param([int]$RequestTimeoutMilliseconds)
+            Get-RunnerControlPlaneObservation `
+                -WebCodexCliPath $WebCodexCliPath `
+                -ServerUrl $operatorProfile.ServerUrl `
+                -TokenFile $operatorProfile.TokenFile `
+                -ClientId $operatorProfile.ClientId `
+                -RequestTimeoutMilliseconds $RequestTimeoutMilliseconds
+        }
+        $rollbackDisallowedIds = @($oldAgentInstanceId) + @($candidateObservedInstanceIds)
+        $rollbackReady = Wait-RunnerControlPlaneReadiness `
+            -Observe $rollbackObserve `
+            -ExpectedClientId $operatorProfile.ClientId `
+            -ExpectedBuild $previousBuild `
+            -DeadlineUtc ([DateTime]::UtcNow.AddSeconds($ReadinessTimeoutSecs)) `
+            -DisallowedAgentInstanceIds $rollbackDisallowedIds
+        $rollbackReadyObservation = $rollbackReady.Observation
+        $null = Assert-CapturedPrimaryRunnerIdentity -Identity $rollbackPrimary
     } catch {
-        Write-Warning "Rollback/restart also encountered an error: $($_.Exception.Message)"
+        $rollbackFailure = $_.Exception.Message
+        Write-Warning "Rollback/restart readiness failed: $rollbackFailure"
     }
 
+    if ($rollbackFailure) {
+        throw "Deployment failed: $($deploymentError.Exception.Message). Rollback outcome uncertain / rollback readiness failed: $rollbackFailure"
+    }
+    Write-Warning "Deployment failed, but rollback readiness was proven for agent_instance_id=$($rollbackReadyObservation.agent_instance_id) commit=$($rollbackReadyObservation.build.git_commit) dirty=$($rollbackReadyObservation.build.git_dirty)"
     throw $deploymentError
 } finally {
     if (Test-Path -LiteralPath $stagedPath) {

--- a/scripts/deploy_windows_runner_dogfood.ps1
+++ b/scripts/deploy_windows_runner_dogfood.ps1
@@ -167,12 +167,9 @@ try {
         return $false
     }
 
-    # Catch immediate startup failures before declaring the local handoff good.
-    Start-Sleep -Seconds 3
-    $null = Assert-CapturedPrimaryRunnerIdentity -Identity $newPrimary
-    if ((Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -ne 1) {
-        throw "New Runner did not remain the exactly-one primary Runner after startup"
-    }
+    # P1b replaces the old arbitrary three-second persistence heuristic with the
+    # stronger bounded Server readiness proof below. The local primary was exact
+    # at startup and is revalidated again after Server readiness before success.
 
     $candidateObserve = {
         param([int]$RequestTimeoutMilliseconds)
@@ -199,6 +196,9 @@ try {
         -FailOnBuildMismatch
     $candidateReadyObservation = $candidateReady.Observation
     $null = Assert-CapturedPrimaryRunnerIdentity -Identity $newPrimary
+    if ((Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -ne 1) {
+        throw "New Runner did not remain the exactly-one primary Runner after readiness"
+    }
 
     # Successful handoff: remove stale per-deployment staging images but retain
     # one concrete rollback binary for the next operator action.
@@ -222,7 +222,17 @@ try {
     $rollbackReadyObservation = $null
 
     try {
-        Disable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue | Out-Null
+        # Capture the local candidate before disabling the Task. The existing
+        # supervisor also reacts to Task disable by stopping its Runner, so doing
+        # discovery afterward can race with that intentional concurrent exit.
+        $rollbackStopTarget = $null
+        $rollbackMatches = @(Get-PrimaryRunnerProcesses -ExactPath $RunnerPath)
+        if ($rollbackMatches.Count -gt 1) {
+            throw "Multiple primary Runners found during rollback: $($rollbackMatches.Count)"
+        }
+        if ($rollbackMatches.Count -eq 1) {
+            $rollbackStopTarget = $rollbackMatches[0]
+        }
 
         # Capture any fresh candidate instance already visible before stopping it,
         # so that a stale candidate registration cannot satisfy rollback readiness.
@@ -243,17 +253,18 @@ try {
             # Best-effort only: the bounded rollback readiness proof below remains authoritative.
         }
 
-        $rollbackStopTarget = $null
-        $rollbackMatches = @(Get-PrimaryRunnerProcesses -ExactPath $RunnerPath)
-        if ($rollbackMatches.Count -gt 1) {
-            throw "Multiple primary Runners found during rollback: $($rollbackMatches.Count)"
-        }
-        if ($rollbackMatches.Count -eq 1) {
-            $rollbackStopTarget = $rollbackMatches[0]
-            Stop-CapturedPrimaryRunner -Identity $rollbackStopTarget
+        Disable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue | Out-Null
+        if ($rollbackStopTarget) {
+            $null = Stop-CapturedPrimaryRunnerForRollback -Identity $rollbackStopTarget
             Wait-Until -TimeoutSecs $StopTimeoutSecs -FailureMessage "Runner identity did not stop during rollback" -Condition {
                 -not (Test-CapturedProcessIdentityLive -Identity $rollbackStopTarget)
             }
+        }
+        Wait-Until -TimeoutSecs $StopTimeoutSecs -FailureMessage "Scheduled Task wrapper did not stop during rollback" -Condition {
+            (Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath).State -ne "Running"
+        }
+        if ((Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -ne 0) {
+            throw "Primary Runner remained live after rollback stop"
         }
 
         if ($rollbackAvailable -and (Test-Path -LiteralPath $rollbackPath -PathType Leaf)) {

--- a/scripts/test_windows_runner_process_identity.ps1
+++ b/scripts/test_windows_runner_process_identity.ps1
@@ -1,0 +1,46 @@
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "windows_runner_process_identity.ps1")
+
+function Assert-True($Value, [string]$Message) {
+    if (-not $Value) { throw $Message }
+}
+function Assert-False($Value, [string]$Message) {
+    if ($Value) { throw $Message }
+}
+function Assert-Throws([scriptblock]$Action, [string]$Pattern) {
+    try { & $Action; throw "Expected failure matching '$Pattern'" }
+    catch {
+        if ($_.Exception.Message -notmatch $Pattern) { throw }
+    }
+}
+
+# Primary classification: ordinary argv is accepted.
+Assert-True (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--config", "runner.toml")) "normal Runner argv was not classified primary"
+
+# Internal mode exclusion: both current modes and any future internal prefix fail closed.
+Assert-False (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--webcodex-internal-detached-supervisor", "x")) "detached supervisor was classified primary"
+Assert-False (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--webcodex-internal-detached-watchdog", "x")) "detached watchdog was classified primary"
+Assert-False (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--webcodex-internal-future-mode")) "future internal mode was classified primary"
+
+# Same executable path is intentionally not sufficient: role comes from exact argv.
+$normal = Test-PrimaryRunnerArguments -Arguments @("C:\same\webcodex-runner.exe")
+$internal = Test-PrimaryRunnerArguments -Arguments @("C:\same\webcodex-runner.exe", "--webcodex-internal-detached-watchdog")
+Assert-True ($normal -and -not $internal) "same executable path did not preserve role distinction"
+
+# Windows command-line parsing is exact argv parsing rather than substring matching.
+$parsed = @(ConvertFrom-WindowsCommandLine -CommandLine '"C:\Program Files\webcodex-runner.exe" --config "C:\Runner Config\runner.toml"')
+Assert-True ($parsed.Count -eq 3 -and $parsed[1] -eq "--config" -and $parsed[2] -eq "C:\Runner Config\runner.toml") "Windows argv parsing contract failed"
+
+# Deterministic creation-identity mismatch seam: live check must reject the current
+# PID when the captured creation FILETIME is not the current creation FILETIME.
+$currentPid = [uint32]$PID
+$currentCreation = [WebCodex.WindowsProcessIdentity]::GetCreationTime($currentPid)
+Assert-True ([WebCodex.WindowsProcessIdentity]::IsLive($currentPid, $currentCreation)) "current process exact identity should be live"
+$differentCreation = if ($currentCreation -eq [uint64]::MaxValue) { [uint64]0 } else { $currentCreation + [uint64]1 }
+Assert-False ([WebCodex.WindowsProcessIdentity]::IsLive($currentPid, $differentCreation)) "creation identity mismatch did not fail closed"
+Assert-False ([WebCodex.WindowsProcessIdentity]::CreationIdentityMatches($currentCreation, $differentCreation)) "creation mismatch seam would allow an effect"
+Assert-True ([WebCodex.WindowsProcessIdentity]::CreationIdentityMatches($currentCreation, $currentCreation)) "matching creation identity seam rejected exact identity"
+Assert-Throws { [WebCodex.WindowsProcessIdentity]::TerminateExact($currentPid, $differentCreation) } "creation identity mismatch"
+Assert-True ([WebCodex.WindowsProcessIdentity]::IsLive($currentPid, $currentCreation)) "mismatched termination attempt affected the current process"
+
+Write-Output "Windows Runner process identity focused tests passed."

--- a/scripts/test_windows_runner_process_identity.ps1
+++ b/scripts/test_windows_runner_process_identity.ps1
@@ -21,6 +21,7 @@ Assert-True (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--
 Assert-False (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--webcodex-internal-detached-supervisor", "x")) "detached supervisor was classified primary"
 Assert-False (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--webcodex-internal-detached-watchdog", "x")) "detached watchdog was classified primary"
 Assert-False (Test-PrimaryRunnerArguments -Arguments @("webcodex-runner.exe", "--webcodex-internal-future-mode")) "future internal mode was classified primary"
+Assert-False (Test-PrimaryRunnerArguments -Arguments @("--webcodex-internal-detached-supervisor", "x")) "internal mode in the first parsed argv token was classified primary"
 
 # Same executable path is intentionally not sufficient: role comes from exact argv.
 $normal = Test-PrimaryRunnerArguments -Arguments @("C:\same\webcodex-runner.exe")

--- a/scripts/test_windows_runner_readiness.ps1
+++ b/scripts/test_windows_runner_readiness.ps1
@@ -1,0 +1,138 @@
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "windows_runner_process_identity.ps1")
+. (Join-Path $PSScriptRoot "windows_runner_readiness.ps1")
+
+function Assert-True($Value, [string]$Message) {
+    if (-not $Value) { throw $Message }
+}
+function Assert-Equal($Expected, $Actual, [string]$Message) {
+    if ($Expected -ne $Actual) { throw "$Message (expected=$Expected actual=$Actual)" }
+}
+function Assert-Throws([scriptblock]$Action, [string]$Pattern) {
+    try { & $Action; throw "Expected failure matching '$Pattern'" }
+    catch {
+        if ($_.Exception.Message -notmatch $Pattern) { throw }
+        return $_.Exception.Message
+    }
+}
+
+function New-RunnerObservation {
+    param(
+        [string]$InstanceId,
+        [string]$Commit,
+        [bool]$Dirty = $false,
+        [bool]$Connected = $true,
+        [string]$Compatibility = "compatible"
+    )
+    [pscustomobject]@{
+        client_id = "msi"
+        connected = $Connected
+        status = if ($Connected) { "online" } else { "stale" }
+        agent_instance_id = $InstanceId
+        build = [pscustomobject]@{
+            version = "0.3.8"
+            git_commit = $Commit
+            git_dirty = $Dirty
+            built_at = "1787554000"
+        }
+        compatibility_status = $Compatibility
+        source_alignment = [pscustomobject]@{ status = "different" }
+    }
+}
+
+$candidateBuild = [pscustomobject]@{ GitCommit = "candidate1234"; GitDirty = $false }
+$rollbackBuild = [pscustomobject]@{ GitCommit = "rollback5678"; GitDirty = $false }
+$oldInstanceId = "instance-old"
+
+# Old registration is stale for replacement readiness.
+$decision = Get-RunnerReadinessDecision `
+    -Observation (New-RunnerObservation -InstanceId $oldInstanceId -Commit $candidateBuild.GitCommit) `
+    -ExpectedClientId "msi" `
+    -ExpectedBuild $candidateBuild `
+    -DisallowedAgentInstanceIds @($oldInstanceId)
+Assert-Equal "not_ready" $decision.State "old agent_instance_id was accepted"
+Assert-Equal "stale_agent_instance_id" $decision.Reason "old instance diagnostic changed"
+
+# Fresh exact candidate is Ready even when source differs from Server.
+$freshCandidate = New-RunnerObservation -InstanceId "instance-new" -Commit $candidateBuild.GitCommit
+$decision = Get-RunnerReadinessDecision -Observation $freshCandidate -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId)
+Assert-Equal "ready" $decision.State "fresh exact candidate was not Ready"
+
+# Fresh wrong source identities must never become Ready.
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-wrong-commit" -Commit "wrong1234567") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId)
+Assert-Equal "mismatch" $decision.State "wrong commit was accepted"
+Assert-Equal "unexpected_build_commit" $decision.Reason "wrong commit diagnostic changed"
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-wrong-dirty" -Commit $candidateBuild.GitCommit -Dirty $true) -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId)
+Assert-Equal "mismatch" $decision.State "wrong dirty state was accepted"
+Assert-Equal "unexpected_build_dirty_state" $decision.Reason "wrong dirty diagnostic changed"
+
+# Disconnected state remains transitional/not Ready.
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-disconnected" -Commit $candidateBuild.GitCommit -Connected $false) -ExpectedClientId "msi" -ExpectedBuild $candidateBuild
+Assert-Equal "not_ready" $decision.State "disconnected Runner was accepted"
+Assert-Equal "control_plane_runner_not_connected" $decision.Reason "disconnected diagnostic changed"
+
+# Explicit protocol incompatibility is fatal mismatch; source alignment alone is not.
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-incompatible" -Commit $candidateBuild.GitCommit -Compatibility "capability_mismatch") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild
+Assert-Equal "mismatch" $decision.State "unsupported protocol was accepted"
+
+# Rollback reconciliation uses rollback build, not candidate build, and excludes
+# both the pre-replacement and already-observed candidate instances.
+$rollbackObservation = New-RunnerObservation -InstanceId "instance-rollback" -Commit $rollbackBuild.GitCommit
+$decision = Get-RunnerReadinessDecision -Observation $rollbackObservation -ExpectedClientId "msi" -ExpectedBuild $rollbackBuild -DisallowedAgentInstanceIds @($oldInstanceId, "instance-new")
+Assert-Equal "ready" $decision.State "exact rollback build was not Ready"
+$decision = Get-RunnerReadinessDecision -Observation $rollbackObservation -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId, "instance-new")
+Assert-Equal "mismatch" $decision.State "rollback build incorrectly satisfied candidate expectation"
+
+# Absolute deadline: transient progress never resets the original deadline, and
+# each control-plane request receives at most the remaining deadline budget.
+$script:fakeNow = [DateTime]::Parse("2026-08-24T00:00:00Z").ToUniversalTime()
+$deadline = $script:fakeNow.AddMilliseconds(1000)
+$script:probeCount = 0
+$script:requestTimeouts = @()
+$observe = {
+    param([int]$RequestTimeoutMilliseconds)
+    $script:probeCount++
+    $script:requestTimeouts += $RequestTimeoutMilliseconds
+    New-RunnerObservation -InstanceId $oldInstanceId -Commit $candidateBuild.GitCommit
+}
+$now = { $script:fakeNow }
+$sleep = { param([int]$Milliseconds) $script:fakeNow = $script:fakeNow.AddMilliseconds($Milliseconds) }
+$null = Assert-Throws {
+    Wait-RunnerControlPlaneReadiness `
+        -Observe $observe `
+        -ExpectedClientId "msi" `
+        -ExpectedBuild $candidateBuild `
+        -DeadlineUtc $deadline `
+        -DisallowedAgentInstanceIds @($oldInstanceId) `
+        -PollIntervalMilliseconds 250 `
+        -UtcNow $now `
+        -Sleep $sleep
+} "Runner readiness timeout"
+Assert-Equal $deadline $script:fakeNow "readiness wait exceeded or reset its absolute deadline"
+Assert-Equal 4 $script:probeCount "absolute deadline produced unexpected probe count"
+Assert-True (($script:requestTimeouts -join ',') -eq '1000,750,500,250') "request timeout did not track remaining absolute deadline"
+
+# Operator profile lookup carries only the token FILE PATH; token contents never
+# enter the helper projection or command diagnostics.
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("webcodex-readiness-test-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tempRoot | Out-Null
+try {
+    $configPath = Join-Path $tempRoot "agent.toml"
+    $tokenPath = Join-Path $tempRoot "webcodex-user-token"
+    $secret = "wc_pat_must_not_leak_from_profile_0123456789"
+    Set-Content -LiteralPath $configPath -Encoding UTF8 -Value @('client_id = "msi-test"', 'server_url = "https://runtime.example"')
+    Set-Content -LiteralPath $tokenPath -Encoding ASCII -NoNewline -Value $secret
+    $primary = [pscustomobject]@{
+        CommandLine = '"C:\fake\webcodex-runner.exe" --config "' + $configPath + '"'
+    }
+    $profile = Get-RunnerOperatorProfile -PrimaryIdentity $primary
+    Assert-Equal "msi-test" $profile.ClientId "operator profile client_id mismatch"
+    Assert-Equal "https://runtime.example" $profile.ServerUrl "operator profile Server URL mismatch"
+    Assert-Equal $tokenPath $profile.TokenFile "operator profile token-file path mismatch"
+    $projection = $profile | ConvertTo-Json -Compress
+    Assert-True (-not $projection.Contains($secret)) "operator profile leaked credential contents"
+} finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output "Windows Runner readiness focused tests passed."

--- a/scripts/test_windows_runner_readiness.ps1
+++ b/scripts/test_windows_runner_readiness.ps1
@@ -83,6 +83,29 @@ Assert-Equal "ready" $decision.State "exact rollback build was not Ready"
 $decision = Get-RunnerReadinessDecision -Observation $rollbackObservation -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId, "instance-new")
 Assert-Equal "mismatch" $decision.State "rollback build incorrectly satisfied candidate expectation"
 
+# Rollback stop tolerates only the exact captured identity exiting concurrently
+# after Task disable; a still-live identity preserves P1a fail-closed behavior.
+$identityFixture = [pscustomobject]@{ Id = 123; CreationTime = [uint64]456 }
+$script:liveChecks = @($true, $false)
+$stopOutcome = Stop-CapturedPrimaryRunnerForRollback `
+    -Identity $identityFixture `
+    -IsLive { param($Identity) $next = $script:liveChecks[0]; $script:liveChecks = @($script:liveChecks | Select-Object -Skip 1); return $next } `
+    -StopExact { param($Identity) throw "exact role no longer provable" }
+Assert-Equal "exited_during_stop" $stopOutcome "concurrent supervisor exit aborted rollback"
+
+$stopOutcome = Stop-CapturedPrimaryRunnerForRollback `
+    -Identity $identityFixture `
+    -IsLive { param($Identity) return $false } `
+    -StopExact { param($Identity) throw "stop should not run" }
+Assert-Equal "already_exited" $stopOutcome "already-exited rollback identity was not accepted"
+
+$null = Assert-Throws {
+    Stop-CapturedPrimaryRunnerForRollback `
+        -Identity $identityFixture `
+        -IsLive { param($Identity) return $true } `
+        -StopExact { param($Identity) throw "exact role no longer provable" }
+} "exact role no longer provable"
+
 # Absolute deadline: transient progress never resets the original deadline, and
 # each control-plane request receives at most the remaining deadline budget.
 $script:fakeNow = [DateTime]::Parse("2026-08-24T00:00:00Z").ToUniversalTime()

--- a/scripts/windows_runner_process_identity.ps1
+++ b/scripts/windows_runner_process_identity.ps1
@@ -149,9 +149,10 @@ namespace WebCodex {
 function Test-PrimaryRunnerArguments {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
-    # argv[0] is the executable. Any current/future internal Runner mode is not a
-    # primary Runner, regardless of executable pathname.
-    foreach ($argument in @($Arguments | Select-Object -Skip 1)) {
+    # CommandLine normally includes the executable as argv[0], but do not rely on
+    # that representation: any current/future internal Runner token anywhere in
+    # parsed argv is non-primary.
+    foreach ($argument in @($Arguments)) {
         if ($argument.StartsWith("--webcodex-internal-", [System.StringComparison]::Ordinal)) {
             return $false
         }

--- a/scripts/windows_runner_process_identity.ps1
+++ b/scripts/windows_runner_process_identity.ps1
@@ -1,0 +1,239 @@
+# Focused Windows process identity helpers for Runner deployment/lifecycle scripts.
+# CreationTime is the raw FILETIME returned by GetProcessTimes, matching the
+# authoritative detached Job PID-reuse fencing in webcodex-runner.
+
+if (-not ("WebCodex.WindowsProcessIdentity" -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace WebCodex {
+    public sealed class ProcessIdentityHandle : SafeHandleZeroOrMinusOneIsInvalid {
+        private ProcessIdentityHandle() : base(true) {}
+        protected override bool ReleaseHandle() { return CloseHandle(handle); }
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr handle);
+    }
+
+    public static class WindowsProcessIdentity {
+        private const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+        private const uint SYNCHRONIZE = 0x00100000;
+        private const uint PROCESS_TERMINATE = 0x0001;
+        private const uint WAIT_OBJECT_0 = 0x00000000;
+        private const uint WAIT_TIMEOUT = 0x00000102;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct FILETIME {
+            public uint Low;
+            public uint High;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern ProcessIdentityHandle OpenProcess(uint access, bool inherit, uint pid);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool GetProcessTimes(ProcessIdentityHandle process, out FILETIME creation, out FILETIME exit, out FILETIME kernel, out FILETIME user);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern uint WaitForSingleObject(ProcessIdentityHandle handle, uint milliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool TerminateProcess(ProcessIdentityHandle process, uint exitCode);
+
+        public static ulong GetCreationTime(uint pid) {
+            using (ProcessIdentityHandle handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, false, pid)) {
+                if (handle == null || handle.IsInvalid) throw new Win32Exception(Marshal.GetLastWin32Error());
+                FILETIME creation, exit, kernel, user;
+                if (!GetProcessTimes(handle, out creation, out exit, out kernel, out user)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                return ((ulong)creation.High << 32) | creation.Low;
+            }
+        }
+
+        public static bool TryGetCreationTime(uint pid, out ulong creationTime) {
+            creationTime = 0;
+            using (ProcessIdentityHandle handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, false, pid)) {
+                if (handle == null || handle.IsInvalid) {
+                    int error = Marshal.GetLastWin32Error();
+                    if (error == 87) return false;
+                    throw new Win32Exception(error);
+                }
+                FILETIME creation, exit, kernel, user;
+                if (!GetProcessTimes(handle, out creation, out exit, out kernel, out user)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                creationTime = ((ulong)creation.High << 32) | creation.Low;
+                return true;
+            }
+        }
+
+        public static bool IsLive(uint pid, ulong expectedCreationTime) {
+            using (ProcessIdentityHandle handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, false, pid)) {
+                if (handle == null || handle.IsInvalid) {
+                    int error = Marshal.GetLastWin32Error();
+                    if (error == 87) return false;
+                    throw new Win32Exception(error);
+                }
+                FILETIME creation, exit, kernel, user;
+                if (!GetProcessTimes(handle, out creation, out exit, out kernel, out user)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                ulong current = ((ulong)creation.High << 32) | creation.Low;
+                if (current != expectedCreationTime) return false;
+                uint wait = WaitForSingleObject(handle, 0);
+                if (wait == WAIT_TIMEOUT) return true;
+                if (wait == WAIT_OBJECT_0) return false;
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+
+        public static bool CreationIdentityMatches(ulong captured, ulong current) {
+            return captured == current;
+        }
+
+        public static void TerminateExact(uint pid, ulong expectedCreationTime) {
+            using (ProcessIdentityHandle handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE | PROCESS_TERMINATE, false, pid)) {
+                if (handle == null || handle.IsInvalid) {
+                    int error = Marshal.GetLastWin32Error();
+                    if (error == 87) throw new InvalidOperationException("process exited before effect");
+                    throw new Win32Exception(error);
+                }
+                FILETIME creation, exit, kernel, user;
+                if (!GetProcessTimes(handle, out creation, out exit, out kernel, out user)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                ulong current = ((ulong)creation.High << 32) | creation.Low;
+                if (current != expectedCreationTime) throw new InvalidOperationException("process creation identity mismatch before effect");
+                uint wait = WaitForSingleObject(handle, 0);
+                if (wait == WAIT_OBJECT_0) throw new InvalidOperationException("process exited before effect");
+                if (wait != WAIT_TIMEOUT) throw new Win32Exception(Marshal.GetLastWin32Error());
+                if (!TerminateProcess(handle, 1)) throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+    }
+}
+'@
+}
+
+function ConvertFrom-WindowsCommandLine {
+    param([Parameter(Mandatory = $true)][string]$CommandLine)
+
+    # PowerShell's parser is not Windows argv parsing. Use the framework's exact
+    # CommandLineToArgvW binding through a tiny on-demand type.
+    if (-not ("WebCodex.CommandLine" -as [type])) {
+        Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+namespace WebCodex {
+    public static class CommandLine {
+        [DllImport("shell32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CommandLineToArgvW(string commandLine, out int argc);
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr LocalFree(IntPtr memory);
+        public static string[] Parse(string commandLine) {
+            int argc;
+            IntPtr argv = CommandLineToArgvW(commandLine, out argc);
+            if (argv == IntPtr.Zero) throw new Win32Exception(Marshal.GetLastWin32Error());
+            try {
+                string[] result = new string[argc];
+                for (int i = 0; i < argc; i++) {
+                    IntPtr value = Marshal.ReadIntPtr(argv, i * IntPtr.Size);
+                    result[i] = Marshal.PtrToStringUni(value);
+                }
+                return result;
+            } finally { LocalFree(argv); }
+        }
+    }
+}
+'@
+    }
+    return @([WebCodex.CommandLine]::Parse($CommandLine))
+}
+
+function Test-PrimaryRunnerArguments {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    # argv[0] is the executable. Any current/future internal Runner mode is not a
+    # primary Runner, regardless of executable pathname.
+    foreach ($argument in @($Arguments | Select-Object -Skip 1)) {
+        if ($argument.StartsWith("--webcodex-internal-", [System.StringComparison]::Ordinal)) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Get-PrimaryRunnerProcesses {
+    param([Parameter(Mandatory = $true)][string]$ExactPath)
+
+    $normalized = [System.IO.Path]::GetFullPath($ExactPath)
+    $records = @(Get-CimInstance Win32_Process -Filter "Name = 'webcodex-runner.exe'" -ErrorAction Stop)
+    $matches = @()
+    foreach ($record in $records) {
+        if (-not $record.ExecutablePath) { continue }
+        try {
+            if ([System.IO.Path]::GetFullPath([string]$record.ExecutablePath) -ine $normalized) { continue }
+        } catch {
+            continue
+        }
+        if (-not $record.CommandLine) {
+            throw "Unable to classify same-path Runner PID $($record.ProcessId): command line is unavailable"
+        }
+        $argv = @(ConvertFrom-WindowsCommandLine -CommandLine ([string]$record.CommandLine))
+        if (-not (Test-PrimaryRunnerArguments -Arguments $argv)) { continue }
+        $creation = [uint64]0
+        if (-not [WebCodex.WindowsProcessIdentity]::TryGetCreationTime([uint32]$record.ProcessId, [ref]$creation)) {
+            # A stale CIM row for a process that already exited is not live identity.
+            continue
+        }
+        $matches += [pscustomobject]@{
+            Id = [uint32]$record.ProcessId
+            CreationTime = [uint64]$creation
+            Path = $normalized
+            CommandLine = [string]$record.CommandLine
+        }
+    }
+    return @($matches)
+}
+
+function Get-ExactlyOnePrimaryRunner {
+    param([Parameter(Mandatory = $true)][string]$ExactPath)
+
+    $matches = @(Get-PrimaryRunnerProcesses -ExactPath $ExactPath)
+    if ($matches.Count -eq 0) { throw "No primary Runner found at $ExactPath" }
+    if ($matches.Count -ne 1) { throw "Multiple primary Runners found at ${ExactPath}: $($matches.Count)" }
+    return $matches[0]
+}
+
+function Test-CapturedProcessIdentityLive {
+    param([Parameter(Mandatory = $true)]$Identity)
+    return [WebCodex.WindowsProcessIdentity]::IsLive([uint32]$Identity.Id, [uint64]$Identity.CreationTime)
+}
+
+function Assert-CapturedPrimaryRunnerIdentity {
+    param([Parameter(Mandatory = $true)]$Identity)
+
+    $currentCreation = [uint64]0
+    if (-not [WebCodex.WindowsProcessIdentity]::TryGetCreationTime([uint32]$Identity.Id, [ref]$currentCreation)) {
+        throw "Primary Runner process exited before effect: PID $($Identity.Id)"
+    }
+    if ($currentCreation -ne [uint64]$Identity.CreationTime) {
+        throw "Primary Runner process creation identity mismatch before effect: PID $($Identity.Id)"
+    }
+    if (-not (Test-CapturedProcessIdentityLive -Identity $Identity)) {
+        throw "Primary Runner process exited before effect: PID $($Identity.Id)"
+    }
+    $current = @(Get-PrimaryRunnerProcesses -ExactPath $Identity.Path | Where-Object {
+        $_.Id -eq $Identity.Id -and $_.CreationTime -eq $Identity.CreationTime
+    })
+    if ($current.Count -ne 1) {
+        throw "Primary Runner identity revalidation failed for PID $($Identity.Id): exact primary role is no longer provable"
+    }
+    return $current[0]
+}
+
+function Stop-CapturedPrimaryRunner {
+    param([Parameter(Mandatory = $true)]$Identity)
+
+    # Role is revalidated first; TerminateExact then reopens the exact PID and
+    # checks creation FILETIME on the same handle used for the termination effect.
+    # A process exit/PID reuse in between therefore fails closed before effect.
+    $null = Assert-CapturedPrimaryRunnerIdentity -Identity $Identity
+    [WebCodex.WindowsProcessIdentity]::TerminateExact([uint32]$Identity.Id, [uint64]$Identity.CreationTime)
+}

--- a/scripts/windows_runner_readiness.ps1
+++ b/scripts/windows_runner_readiness.ps1
@@ -1,0 +1,212 @@
+# Focused control-plane readiness helpers for Windows Runner replacement.
+# Authentication remains inside the existing `webcodex ops runner` CLI path;
+# this script only passes an existing user-token file path and consumes safe JSON.
+
+function Get-RunnerBuildIdentity {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Runner binary does not exist: $Path"
+    }
+    $output = @(& $Path --version 2>&1)
+    if ($LASTEXITCODE -ne 0 -or $output.Count -ne 1) {
+        throw "Runner build identity unavailable for $Path"
+    }
+    $text = [string]$output[0]
+    $pattern = '^webcodex-runner\s+(?<version>\S+)\s+\(commit\s+(?<commit>[0-9A-Fa-f]+),\s+dirty=(?<dirty>true|false)(?:,\s+built_at=(?<built_at>[^)]+))?\)$'
+    if ($text -notmatch $pattern) {
+        throw "Runner build identity unavailable for $Path"
+    }
+    return [pscustomobject]@{
+        Version = [string]$matches['version']
+        GitCommit = [string]$matches['commit']
+        GitDirty = [System.Convert]::ToBoolean([string]$matches['dirty'])
+        BuiltAt = if ($matches['built_at']) { [string]$matches['built_at'] } else { $null }
+        Display = $text
+    }
+}
+
+function Get-RunnerOperatorProfile {
+    param([Parameter(Mandatory = $true)]$PrimaryIdentity)
+
+    $argv = @(ConvertFrom-WindowsCommandLine -CommandLine ([string]$PrimaryIdentity.CommandLine))
+    $configPath = $null
+    for ($i = 0; $i -lt $argv.Count; $i++) {
+        if ($argv[$i] -eq '--config' -and $i + 1 -lt $argv.Count) {
+            $configPath = [string]$argv[$i + 1]
+            break
+        }
+        if ($argv[$i].StartsWith('--config=', [System.StringComparison]::Ordinal)) {
+            $configPath = $argv[$i].Substring('--config='.Length)
+            break
+        }
+    }
+    if (-not $configPath -or -not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+        throw "Primary Runner config path is unavailable"
+    }
+
+    $clientId = $null
+    $serverUrl = $null
+    foreach ($line in Get-Content -LiteralPath $configPath) {
+        if (-not $clientId -and $line -match '^\s*client_id\s*=\s*"([^"]+)"\s*$') {
+            $clientId = [string]$matches[1]
+        } elseif (-not $serverUrl -and $line -match '^\s*server_url\s*=\s*"([^"]+)"\s*$') {
+            $serverUrl = [string]$matches[1]
+        }
+    }
+    if (-not $clientId -or -not $serverUrl) {
+        throw "Primary Runner config does not provide exact client_id and server_url"
+    }
+    $tokenFile = Join-Path (Split-Path -Parent $configPath) 'webcodex-user-token'
+    if (-not (Test-Path -LiteralPath $tokenFile -PathType Leaf)) {
+        throw "Operator user-token file is unavailable: $tokenFile"
+    }
+    return [pscustomobject]@{
+        ClientId = $clientId
+        ServerUrl = $serverUrl.TrimEnd('/')
+        TokenFile = $tokenFile
+        ConfigPath = $configPath
+    }
+}
+
+function Get-RunnerControlPlaneObservation {
+    param(
+        [Parameter(Mandatory = $true)][string]$WebCodexCliPath,
+        [Parameter(Mandatory = $true)][string]$ServerUrl,
+        [Parameter(Mandatory = $true)][string]$TokenFile,
+        [Parameter(Mandatory = $true)][string]$ClientId,
+        [ValidateRange(1, 30000)][int]$RequestTimeoutMilliseconds = 5000
+    )
+
+    if (-not (Test-Path -LiteralPath $WebCodexCliPath -PathType Leaf)) {
+        throw "WebCodex operator CLI does not exist: $WebCodexCliPath"
+    }
+    $raw = @(& $WebCodexCliPath ops runner --client-id $ClientId --server-url $ServerUrl --token-file $TokenFile --request-timeout-ms $RequestTimeoutMilliseconds --json --strict 2>&1)
+    $exitCode = $LASTEXITCODE
+    try {
+        $response = ($raw -join "`n") | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw "Control-plane Runner observation returned invalid JSON"
+    }
+    if ($exitCode -ne 0) {
+        $reason = @($response.blocking_reasons | Select-Object -First 1)
+        if ($reason.Count -eq 0) { $reason = @("operator_query_failed") }
+        throw "Control-plane Runner observation failed: $($reason[0])"
+    }
+    if (-not $response.summary -or $response.summary.client_id -ne $ClientId) {
+        throw "Control-plane Runner observation did not return exact client_id $ClientId"
+    }
+    return $response.summary
+}
+
+function Get-RunnerReadinessDecision {
+    param(
+        [Parameter(Mandatory = $true)]$Observation,
+        [Parameter(Mandatory = $true)][string]$ExpectedClientId,
+        [Parameter(Mandatory = $true)]$ExpectedBuild,
+        [string[]]$DisallowedAgentInstanceIds = @()
+    )
+
+    if (-not $Observation -or $Observation.client_id -ne $ExpectedClientId) {
+        return [pscustomobject]@{ State = 'not_ready'; Reason = 'exact_client_not_observed' }
+    }
+    if ($Observation.connected -ne $true) {
+        return [pscustomobject]@{ State = 'not_ready'; Reason = 'control_plane_runner_not_connected' }
+    }
+    $instanceId = [string]$Observation.agent_instance_id
+    if ([string]::IsNullOrWhiteSpace($instanceId)) {
+        return [pscustomobject]@{ State = 'not_ready'; Reason = 'agent_instance_id_unavailable' }
+    }
+    if (@($DisallowedAgentInstanceIds | Where-Object { $_ -eq $instanceId }).Count -gt 0) {
+        return [pscustomobject]@{ State = 'not_ready'; Reason = 'stale_agent_instance_id'; AgentInstanceId = $instanceId }
+    }
+    if (-not $Observation.build -or [string]::IsNullOrWhiteSpace([string]$Observation.build.git_commit) -or $null -eq $Observation.build.git_dirty) {
+        return [pscustomobject]@{ State = 'mismatch'; Reason = 'observed_build_identity_unavailable'; AgentInstanceId = $instanceId }
+    }
+    if ([string]$Observation.build.git_commit -ne [string]$ExpectedBuild.GitCommit) {
+        return [pscustomobject]@{
+            State = 'mismatch'; Reason = 'unexpected_build_commit'; AgentInstanceId = $instanceId
+            ExpectedCommit = [string]$ExpectedBuild.GitCommit; ObservedCommit = [string]$Observation.build.git_commit
+        }
+    }
+    if ([bool]$Observation.build.git_dirty -ne [bool]$ExpectedBuild.GitDirty) {
+        return [pscustomobject]@{
+            State = 'mismatch'; Reason = 'unexpected_build_dirty_state'; AgentInstanceId = $instanceId
+            ExpectedDirty = [bool]$ExpectedBuild.GitDirty; ObservedDirty = [bool]$Observation.build.git_dirty
+        }
+    }
+    if ([string]$Observation.compatibility_status -eq 'capability_mismatch') {
+        return [pscustomobject]@{ State = 'mismatch'; Reason = 'runner_protocol_incompatible'; AgentInstanceId = $instanceId }
+    }
+    return [pscustomobject]@{ State = 'ready'; Reason = 'exact_fresh_build_ready'; AgentInstanceId = $instanceId }
+}
+
+function Assert-PreReplacementRunnerObservation {
+    param(
+        [Parameter(Mandatory = $true)]$Observation,
+        [Parameter(Mandatory = $true)][string]$ExpectedClientId,
+        [Parameter(Mandatory = $true)]$ExpectedBuild
+    )
+
+    if (-not $Observation -or $Observation.client_id -ne $ExpectedClientId) {
+        throw "Pre-replacement Runner not observable for exact client_id $ExpectedClientId"
+    }
+    if ($Observation.connected -ne $true) {
+        throw "Pre-replacement Runner not connected for exact client_id $ExpectedClientId"
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$Observation.agent_instance_id)) {
+        throw "Pre-replacement Runner agent_instance_id is unavailable"
+    }
+    $decision = Get-RunnerReadinessDecision -Observation $Observation -ExpectedClientId $ExpectedClientId -ExpectedBuild $ExpectedBuild
+    if ($decision.State -ne 'ready') {
+        $details = "reason=$($decision.Reason) expected_commit=$($ExpectedBuild.GitCommit) observed_commit=$($Observation.build.git_commit) expected_dirty=$($ExpectedBuild.GitDirty) observed_dirty=$($Observation.build.git_dirty)"
+        throw "Pre-replacement Runner build identity does not match the installed rollback source: $details"
+    }
+    return $Observation
+}
+
+function Wait-RunnerControlPlaneReadiness {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$Observe,
+        [Parameter(Mandatory = $true)][string]$ExpectedClientId,
+        [Parameter(Mandatory = $true)]$ExpectedBuild,
+        [Parameter(Mandatory = $true)][DateTime]$DeadlineUtc,
+        [string[]]$DisallowedAgentInstanceIds = @(),
+        [ValidateRange(1, 5000)][int]$PollIntervalMilliseconds = 250,
+        [switch]$FailOnBuildMismatch,
+        [scriptblock]$UtcNow = { [DateTime]::UtcNow },
+        [scriptblock]$Sleep = { param([int]$Milliseconds) Start-Sleep -Milliseconds $Milliseconds }
+    )
+
+    $lastReason = 'control_plane_runner_not_observed'
+    $lastObservation = $null
+    while ($true) {
+        $now = & $UtcNow
+        if ($now -ge $DeadlineUtc) { break }
+        $remainingMs = [int][Math]::Max(1, [Math]::Floor(($DeadlineUtc - $now).TotalMilliseconds))
+        $requestTimeoutMs = [Math]::Min(5000, $remainingMs)
+        try {
+            $lastObservation = & $Observe $requestTimeoutMs
+            $decision = Get-RunnerReadinessDecision -Observation $lastObservation -ExpectedClientId $ExpectedClientId -ExpectedBuild $ExpectedBuild -DisallowedAgentInstanceIds $DisallowedAgentInstanceIds
+            $lastReason = [string]$decision.Reason
+            if ($decision.State -eq 'ready') {
+                return [pscustomobject]@{ Observation = $lastObservation; Decision = $decision }
+            }
+            if ($decision.State -eq 'mismatch' -and $FailOnBuildMismatch) {
+                $details = "reason=$($decision.Reason) expected_commit=$($ExpectedBuild.GitCommit) observed_commit=$($lastObservation.build.git_commit) expected_dirty=$($ExpectedBuild.GitDirty) observed_dirty=$($lastObservation.build.git_dirty)"
+                throw "Fresh Runner instance has unexpected build: $details"
+            }
+        } catch {
+            if ($_.Exception.Message.StartsWith('Fresh Runner instance has unexpected build:')) { throw }
+            $lastReason = "control_plane_observation_failed: $($_.Exception.Message)"
+        }
+
+        $now = & $UtcNow
+        if ($now -ge $DeadlineUtc) { break }
+        $remainingMs = [int][Math]::Max(0, [Math]::Floor(($DeadlineUtc - $now).TotalMilliseconds))
+        $delayMs = [Math]::Min($PollIntervalMilliseconds, $remainingMs)
+        if ($delayMs -gt 0) { & $Sleep $delayMs }
+    }
+
+    throw "Runner readiness timeout for $ExpectedClientId; last_reason=$lastReason"
+}

--- a/scripts/windows_runner_readiness.ps1
+++ b/scripts/windows_runner_readiness.ps1
@@ -165,6 +165,31 @@ function Assert-PreReplacementRunnerObservation {
     return $Observation
 }
 
+function Stop-CapturedPrimaryRunnerForRollback {
+    param(
+        [Parameter(Mandatory = $true)]$Identity,
+        [scriptblock]$IsLive = { param($Captured) Test-CapturedProcessIdentityLive -Identity $Captured },
+        [scriptblock]$StopExact = { param($Captured) Stop-CapturedPrimaryRunner -Identity $Captured }
+    )
+
+    if (-not (& $IsLive $Identity)) {
+        return 'already_exited'
+    }
+    try {
+        & $StopExact $Identity
+        return 'terminated'
+    } catch {
+        # Disabling the Scheduled Task asks the existing supervisor to stop its
+        # Runner too. If that concurrent stop wins, no termination effect remains
+        # to perform. Only accept that race when the exact captured PID+creation
+        # identity is now dead; a still-live identity keeps the P1a failure closed.
+        if (-not (& $IsLive $Identity)) {
+            return 'exited_during_stop'
+        }
+        throw
+    }
+}
+
 function Wait-RunnerControlPlaneReadiness {
     param(
         [Parameter(Mandatory = $true)][scriptblock]$Observe,

--- a/scripts/windows_runner_readiness.ps1
+++ b/scripts/windows_runner_readiness.ps1
@@ -86,7 +86,7 @@ function Get-RunnerControlPlaneObservation {
     try {
         $response = ($raw -join "`n") | ConvertFrom-Json -ErrorAction Stop
     } catch {
-        throw "Control-plane Runner observation returned invalid JSON"
+        throw "Control-plane Runner observation returned invalid JSON; WebCodexCliPath must point to a CLI that supports 'ops runner'"
     }
     if ($exitCode -ne 0) {
         $reason = @($response.blocking_reasons | Select-Object -First 1)


### PR DESCRIPTION
## Summary

Restore the accepted Windows Runner replacement identity/readiness stack that was developed locally but never opened as a PR.

- fence the exact primary Windows Runner by executable path, primary/internal role, PID, and creation FILETIME
- terminate only through a revalidated native process handle so PID reuse cannot retarget replacement effects
- add `webcodex ops runner` as the bounded exact-client control-plane observation used by the operator workflow
- require pre-replacement exact build/instance proof, fresh post-replacement `agent_instance_id`, expected candidate build identity, and compatibility readiness
- make rollback prove a fresh rollback instance/build before recovery is considered successful
- add focused PowerShell identity/readiness tests and CLI operator coverage

## Mainline recovery audit

This branch is rebased directly onto current `main@b83c2820` (`Add Windows persistent shells (#139)`). The six accepted predecessor commits were replayed without semantic changes: `git range-diff` reports all six as `=`.

I also audited the other local Windows development branches before forming this PR:

- Computer Use predecessor/integration branches are already represented by merged PRs #54, #58, #76, #86 and #106.
- Windows persistent-shell work is already merged as #139.
- P1c Windows Runner exit diagnostics and its later Windows CI/adversarial hardening are already present in the final #139 tree on the relevant diagnostics/transport/persistent-shell/CLI paths, despite their original local commit subjects not appearing on `main`; they are intentionally not duplicated here.

So this PR contains only the actual remaining mainline gap: the six Windows replacement identity/readiness commits.

## Validation

- PowerShell parser: deploy + identity + readiness + focused test scripts — pass
- `scripts/test_windows_runner_process_identity.ps1` — pass
- `scripts/test_windows_runner_readiness.ps1` — pass
- `cargo fmt -- --check` — pass
- `cargo check -p webcodex-cli` — pass (existing unrelated `tool_request_trace.rs` unused-variable warning only)
- `cargo test -p webcodex-cli ops_ -- --nocapture` — 34 passed, 0 failed
- `git diff --check origin/main...HEAD` — pass
- worktree clean

No Runner deployment, restart, rollback, Scheduled Task mutation, or intentional crash was performed while preparing this PR. P1c exit diagnostics remain deployed on MSI for natural-exit observation.
