### PR TITLE
Add adaptive batch response economy

### DIFF
--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -184,6 +184,45 @@ impl SearchModelProjection {
     }
 }
 
+/// Batch response-budget inputs captured before the ToolCall is moved into
+/// canonical execution. Budgeting is intentionally deferred until after
+/// Session recording/decorations so the recorder keeps seeing the canonical
+/// result while the model-facing projection can account for sparse semantics.
+enum BatchResponseBudgetProjection {
+    None,
+    ReadFiles {
+        max_result_bytes: Option<usize>,
+    },
+    SearchProjectTexts {
+        max_result_bytes: Option<usize>,
+        match_offsets: Vec<usize>,
+    },
+}
+
+impl BatchResponseBudgetProjection {
+    fn capture(call: &ToolCall) -> Self {
+        match call {
+            ToolCall::ReadFiles {
+                max_result_bytes, ..
+            } => Self::ReadFiles {
+                max_result_bytes: *max_result_bytes,
+            },
+            ToolCall::SearchProjectTexts {
+                queries,
+                max_result_bytes,
+                ..
+            } => Self::SearchProjectTexts {
+                max_result_bytes: *max_result_bytes,
+                match_offsets: queries
+                    .iter()
+                    .map(|query| query.match_offset.unwrap_or(0))
+                    .collect(),
+            },
+            _ => Self::None,
+        }
+    }
+}
+
 fn caller_uses_default_search_controls(
     result_mode: &Option<super::SearchResultMode>,
     timeout_secs: &Option<i64>,
@@ -208,7 +247,7 @@ fn caller_uses_default_search_controls(
 /// requests stay explicit. Batch defaults may inherit a smaller remaining
 /// timeout from the shared outer deadline without making that derived value
 /// model-relevant.
-fn sparsify_complete_default_search_output(
+pub(crate) fn sparsify_complete_default_search_output(
     output: &mut serde_json::Map<String, Value>,
     allow_batch_deadline_reduction: bool,
 ) -> bool {
@@ -341,12 +380,24 @@ fn sparsify_complete_default_search_success(
     }
 }
 
+pub(crate) fn sparsify_complete_default_search_batch_success(
+    default_queries: &[bool],
+    result: &mut ToolResult,
+) {
+    sparsify_complete_default_search_success(
+        &SearchModelProjection::Batch {
+            default_queries: default_queries.to_vec(),
+        },
+        result,
+    );
+}
+
 /// Remove range bookkeeping only when the returned text is provably the complete
 /// file. `sha256` and `total_lines` remain explicit freshness/content-shape
 /// evidence. Partial reads and every real continuation keep the canonical full
 /// range tuple. In a batch, the outer item path remains the navigation identity,
 /// so an identical inner path is redundant.
-fn sparsify_complete_file_read_output(
+pub(crate) fn sparsify_complete_file_read_output(
     output: &mut serde_json::Map<String, Value>,
     duplicate_outer_path: Option<&str>,
 ) -> bool {
@@ -413,7 +464,7 @@ fn sparsify_complete_file_read_output(
     true
 }
 
-fn sparsify_complete_read_success(tool_name: &str, result: &mut ToolResult) {
+pub(crate) fn sparsify_complete_read_success(tool_name: &str, result: &mut ToolResult) {
     if !result.success || !matches!(tool_name, "read_file" | "read_files") {
         return;
     }
@@ -1081,6 +1132,7 @@ impl ToolRuntime {
         let activity_context =
             Self::capture_workspace_activity_context(&call, activity_project.as_deref());
         let search_projection = SearchModelProjection::capture(&call);
+        let batch_budget_projection = BatchResponseBudgetProjection::capture(&call);
         let tool_name = call.tool_name();
         let mut result = self
             .dispatch_authorized_inner(
@@ -1152,6 +1204,27 @@ impl ToolRuntime {
                         tool: tool_name.to_string(),
                         observed_at: chrono::Utc::now().timestamp(),
                     },
+                );
+            }
+        }
+        match &batch_budget_projection {
+            BatchResponseBudgetProjection::None => {}
+            BatchResponseBudgetProjection::ReadFiles { max_result_bytes } => {
+                super::read_files::apply_model_facing_output_budget(&mut result, *max_result_bytes);
+            }
+            BatchResponseBudgetProjection::SearchProjectTexts {
+                max_result_bytes,
+                match_offsets,
+            } => {
+                let default_queries = match &search_projection {
+                    SearchModelProjection::Batch { default_queries } => default_queries.as_slice(),
+                    _ => &[],
+                };
+                super::search_project_texts::apply_model_facing_output_budget(
+                    &mut result,
+                    default_queries,
+                    match_offsets,
+                    *max_result_bytes,
                 );
             }
         }

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -190,13 +190,8 @@ impl SearchModelProjection {
 /// result while the model-facing projection can account for sparse semantics.
 enum BatchResponseBudgetProjection {
     None,
-    ReadFiles {
-        max_result_bytes: Option<usize>,
-    },
-    SearchProjectTexts {
-        max_result_bytes: Option<usize>,
-        match_offsets: Vec<usize>,
-    },
+    ReadFiles { max_result_bytes: Option<usize> },
+    SearchProjectTexts { max_result_bytes: Option<usize> },
 }
 
 impl BatchResponseBudgetProjection {
@@ -208,15 +203,9 @@ impl BatchResponseBudgetProjection {
                 max_result_bytes: *max_result_bytes,
             },
             ToolCall::SearchProjectTexts {
-                queries,
-                max_result_bytes,
-                ..
+                max_result_bytes, ..
             } => Self::SearchProjectTexts {
                 max_result_bytes: *max_result_bytes,
-                match_offsets: queries
-                    .iter()
-                    .map(|query| query.match_offset.unwrap_or(0))
-                    .collect(),
             },
             _ => Self::None,
         }
@@ -1212,10 +1201,7 @@ impl ToolRuntime {
             BatchResponseBudgetProjection::ReadFiles { max_result_bytes } => {
                 super::read_files::apply_model_facing_output_budget(&mut result, *max_result_bytes);
             }
-            BatchResponseBudgetProjection::SearchProjectTexts {
-                max_result_bytes,
-                match_offsets,
-            } => {
+            BatchResponseBudgetProjection::SearchProjectTexts { max_result_bytes } => {
                 let default_queries = match &search_projection {
                     SearchModelProjection::Batch { default_queries } => default_queries.as_slice(),
                     _ => &[],
@@ -1223,7 +1209,6 @@ impl ToolRuntime {
                 super::search_project_texts::apply_model_facing_output_budget(
                     &mut result,
                     default_queries,
-                    match_offsets,
                     *max_result_bytes,
                 );
             }

--- a/src/tool_runtime/file_tools.rs
+++ b/src/tool_runtime/file_tools.rs
@@ -35,22 +35,14 @@ impl ToolRuntime {
                 items,
                 session_id: _,
                 with_line_numbers,
-                max_result_bytes,
+                max_result_bytes: _,
             } => match project_resolution {
                 Some(Ok(resolved)) => {
-                    self.read_files_resolved_with_budget(
-                        &resolved,
-                        items,
-                        with_line_numbers,
-                        max_result_bytes,
-                    )
-                    .await
-                }
-                Some(Err(error)) => error.into_tool_result(),
-                None => {
-                    self.read_files_with_budget(project, items, with_line_numbers, max_result_bytes)
+                    self.read_files_resolved(&resolved, items, with_line_numbers)
                         .await
                 }
+                Some(Err(error)) => error.into_tool_result(),
+                None => self.read_files(project, items, with_line_numbers).await,
             },
             ToolCall::ListProjectFiles {
                 project,
@@ -129,21 +121,11 @@ impl ToolRuntime {
                 project,
                 queries,
                 session_id: _,
-                max_result_bytes,
+                max_result_bytes: _,
             } => match project_resolution {
-                Some(Ok(resolved)) => {
-                    self.search_project_texts_resolved_with_budget(
-                        &resolved,
-                        queries,
-                        max_result_bytes,
-                    )
-                    .await
-                }
+                Some(Ok(resolved)) => self.search_project_texts_resolved(&resolved, queries).await,
                 Some(Err(error)) => error.into_tool_result(),
-                None => {
-                    self.search_project_texts_with_budget(project, queries, max_result_bytes)
-                        .await
-                }
+                None => self.search_project_texts(project, queries).await,
             },
             ToolCall::WriteProjectFile {
                 project,

--- a/src/tool_runtime/file_tools.rs
+++ b/src/tool_runtime/file_tools.rs
@@ -35,13 +35,22 @@ impl ToolRuntime {
                 items,
                 session_id: _,
                 with_line_numbers,
+                max_result_bytes,
             } => match project_resolution {
                 Some(Ok(resolved)) => {
-                    self.read_files_resolved(&resolved, items, with_line_numbers)
-                        .await
+                    self.read_files_resolved_with_budget(
+                        &resolved,
+                        items,
+                        with_line_numbers,
+                        max_result_bytes,
+                    )
+                    .await
                 }
                 Some(Err(error)) => error.into_tool_result(),
-                None => self.read_files(project, items, with_line_numbers).await,
+                None => {
+                    self.read_files_with_budget(project, items, with_line_numbers, max_result_bytes)
+                        .await
+                }
             },
             ToolCall::ListProjectFiles {
                 project,
@@ -120,10 +129,21 @@ impl ToolRuntime {
                 project,
                 queries,
                 session_id: _,
+                max_result_bytes,
             } => match project_resolution {
-                Some(Ok(resolved)) => self.search_project_texts_resolved(&resolved, queries).await,
+                Some(Ok(resolved)) => {
+                    self.search_project_texts_resolved_with_budget(
+                        &resolved,
+                        queries,
+                        max_result_bytes,
+                    )
+                    .await
+                }
                 Some(Err(error)) => error.into_tool_result(),
-                None => self.search_project_texts(project, queries).await,
+                None => {
+                    self.search_project_texts_with_budget(project, queries, max_result_bytes)
+                        .await
+                }
             },
             ToolCall::WriteProjectFile {
                 project,

--- a/src/tool_runtime/read_files.rs
+++ b/src/tool_runtime/read_files.rs
@@ -50,6 +50,7 @@ fn batch_output(
     output
 }
 
+#[cfg(test)]
 fn serialized_batch_len(output: &Value) -> usize {
     serde_json::to_vec(&ToolResult::ok(output.clone()))
         .map(|bytes| bytes.len())
@@ -60,6 +61,31 @@ fn serialized_value_len(value: &Value) -> usize {
     serde_json::to_vec(value)
         .map(|bytes| bytes.len())
         .unwrap_or(usize::MAX)
+}
+
+fn projected_batch_serialized_len(output: &Value) -> usize {
+    let mut projected = ToolResult::ok(output.clone());
+    super::dispatch::sparsify_complete_read_success("read_files", &mut projected);
+    serde_json::to_vec(&projected)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn projected_read_item_len(item: &Value) -> usize {
+    let mut projected = item.clone();
+    if projected["success"].as_bool() == Some(true) {
+        let outer_path = projected
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if let (Some(outer_path), Some(output)) = (
+            outer_path,
+            projected.get_mut("output").and_then(Value::as_object_mut),
+        ) {
+            super::dispatch::sparsify_complete_file_read_output(output, Some(&outer_path));
+        }
+    }
+    serialized_value_len(&projected)
 }
 
 fn projected_batch_len(base_len: usize, item_bytes: usize, item_count: usize) -> usize {
@@ -145,7 +171,10 @@ fn apply_output_budget(
         None,
         None,
     );
-    if serialized_batch_len(&complete) <= payload_budget {
+    // Budget the shape the model would actually receive after the existing
+    // sparse projection. The canonical representation remains available for
+    // Session recording and for any partial-item cursor construction below.
+    if projected_batch_serialized_len(&complete) <= payload_budget {
         return complete;
     }
 
@@ -157,7 +186,7 @@ fn apply_output_budget(
     // The truncated empty shape fixes all outer-field byte costs up front.
     // Counts and indices are single digits for this 1..=8 batch, so each item
     // can then be accounted exactly by its own serialized size plus one comma.
-    let base_len = serialized_batch_len(&batch_output(
+    let base_len = projected_batch_serialized_len(&batch_output(
         project,
         requested_count,
         Vec::new(),
@@ -171,7 +200,7 @@ fn apply_output_budget(
 
     for item in completed {
         let index = item["index"].as_u64().unwrap_or(returned.len() as u64) as usize;
-        let item_len = serialized_value_len(&item);
+        let item_len = projected_read_item_len(&item);
         let candidate_item_count = returned.len() + 1;
         if projected_batch_len(
             base_len,
@@ -210,7 +239,7 @@ fn apply_output_budget(
     // Defensive exact serialization fallback. Normal accounting above is O(n)
     // plus an O(log lines) partial-item search; this loop should never execute
     // unless a future outer-field change invalidates the fixed-size arithmetic.
-    while serialized_batch_len(&output) > payload_budget {
+    while projected_batch_serialized_len(&output) > payload_budget {
         let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
             break;
         };
@@ -230,39 +259,78 @@ fn apply_output_budget(
     output
 }
 
+pub(crate) fn apply_model_facing_output_budget(
+    result: &mut ToolResult,
+    max_result_bytes: Option<usize>,
+) {
+    if !result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object() else {
+        return;
+    };
+    let Some(project) = output
+        .get("project")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return;
+    };
+    let Some(requested_count) = output
+        .get("requested_count")
+        .and_then(Value::as_u64)
+        .map(|count| count as usize)
+    else {
+        return;
+    };
+    let Some(completed) = output.get("items").and_then(Value::as_array).cloned() else {
+        return;
+    };
+
+    let budgeted = apply_output_budget(&project, requested_count, completed, max_result_bytes);
+    let Some(root) = result.output.as_object_mut() else {
+        return;
+    };
+    for key in [
+        "project",
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "items",
+        "output_truncated",
+        "next_index",
+        "truncation_reason",
+    ] {
+        root.remove(key);
+    }
+    if let Some(budgeted) = budgeted.as_object() {
+        for (key, value) in budgeted {
+            root.insert(key.clone(), value.clone());
+        }
+    }
+}
+
 impl ToolRuntime {
-    #[cfg(test)]
     pub(crate) async fn read_files(
         &self,
         project: String,
         items: Vec<ReadFilesItem>,
         with_line_numbers: Option<bool>,
     ) -> ToolResult {
-        self.read_files_with_budget(project, items, with_line_numbers, None)
-            .await
-    }
-
-    pub(crate) async fn read_files_with_budget(
-        &self,
-        project: String,
-        items: Vec<ReadFilesItem>,
-        with_line_numbers: Option<bool>,
-        max_result_bytes: Option<usize>,
-    ) -> ToolResult {
         let resolved = match self.resolve_project_input(&project).await {
             Ok(project) => project,
             Err(error) => return ToolResult::err(error),
         };
-        self.read_files_resolved_with_budget(&resolved, items, with_line_numbers, max_result_bytes)
+        self.read_files_resolved(&resolved, items, with_line_numbers)
             .await
     }
 
-    pub(crate) async fn read_files_resolved_with_budget(
+    pub(crate) async fn read_files_resolved(
         &self,
         resolved: &ResolvedProject,
         items: Vec<ReadFilesItem>,
         with_line_numbers: Option<bool>,
-        max_result_bytes: Option<usize>,
     ) -> ToolResult {
         if !(1..=MAX_READ_FILES_ITEMS).contains(&items.len())
             || items.iter().any(|item| item.path.trim().is_empty())
@@ -307,11 +375,13 @@ impl ToolRuntime {
             .await;
         completed.sort_by_key(|item| item["index"].as_u64().unwrap_or(u64::MAX));
 
-        ToolResult::ok(apply_output_budget(
+        ToolResult::ok(batch_output(
             &runtime_project_id,
             requested_count,
             completed,
-            max_result_bytes,
+            false,
+            None,
+            None,
         ))
     }
 }
@@ -341,6 +411,79 @@ mod tests {
             },
             "error": null
         })
+    }
+
+    fn default_complete_item(index: usize, lines: &[String]) -> Value {
+        let returned_lines = lines.len();
+        let default_limit =
+            webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
+        json!({
+            "index": index,
+            "path": format!("src/{index}.rs"),
+            "success": true,
+            "output": {
+                "text": lines.join("\n"),
+                "format": "plain",
+                "path": format!("src/{index}.rs"),
+                "sha256": "d".repeat(64),
+                "start_line": 1,
+                "limit": default_limit,
+                "total_lines": returned_lines,
+                "returned_lines": returned_lines,
+                "end_line": if returned_lines == 0 { Value::Null } else { json!(returned_lines) },
+                "has_more": false,
+                "next_start_line": null
+            },
+            "error": null
+        })
+    }
+
+    #[test]
+    fn complete_default_sparse_fit_is_not_preemptively_budget_truncated() {
+        let payload_budget = DEFAULT_READ_FILES_RESULT_BYTES - MODEL_RESULT_ENVELOPE_RESERVE_BYTES;
+        let mut selected = None;
+        for text_bytes in 6_000..=9_000 {
+            let completed = (0..8)
+                .map(|index| default_complete_item(index, &["x".repeat(text_bytes)]))
+                .collect::<Vec<_>>();
+            let canonical = batch_output("agent:oe:demo", 8, completed.clone(), false, None, None);
+            let canonical_bytes = serialized_batch_len(&canonical);
+            let sparse_bytes = projected_batch_serialized_len(&canonical);
+            if canonical_bytes > payload_budget && sparse_bytes <= payload_budget {
+                selected = Some((completed, canonical_bytes, sparse_bytes));
+                break;
+            }
+        }
+        let (completed, canonical_bytes, sparse_bytes) =
+            selected.expect("test fixture must straddle canonical/sparse budget boundary");
+        assert!(canonical_bytes > payload_budget);
+        assert!(sparse_bytes <= payload_budget);
+
+        let mut result = ToolResult::ok(batch_output(
+            "agent:oe:demo",
+            8,
+            completed.clone(),
+            false,
+            None,
+            None,
+        ));
+        apply_model_facing_output_budget(&mut result, None);
+        assert_eq!(result.output["output_truncated"], false);
+        assert!(result.output["next_index"].is_null());
+        assert_eq!(result.output["items"].as_array().unwrap().len(), 8);
+        for (actual, expected) in result.output["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .zip(completed.iter())
+        {
+            assert_eq!(actual["output"]["text"], expected["output"]["text"]);
+        }
+
+        super::super::dispatch::sparsify_complete_read_success("read_files", &mut result);
+        assert!(result.output.get("output_truncated").is_none());
+        assert!(result.output.get("next_index").is_none());
+        assert_eq!(result.output["items"].as_array().unwrap().len(), 8);
     }
 
     #[test]
@@ -442,7 +585,7 @@ mod tests {
         let lines = (0..900)
             .map(|index| format!("第{index:04}行-{}", "界".repeat(40)))
             .collect::<Vec<_>>();
-        let completed = vec![ranged_item(0, 1, &lines)];
+        let completed = vec![default_complete_item(0, &lines)];
 
         let default = apply_output_budget("agent:oe:demo", 1, completed.clone(), None);
         let large = apply_output_budget(

--- a/src/tool_runtime/read_files.rs
+++ b/src/tool_runtime/read_files.rs
@@ -12,6 +12,14 @@ use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
 pub(crate) const MAX_READ_FILES_ITEMS: usize = 8;
 pub(crate) const MAX_READ_FILES_CONCURRENCY: usize = 4;
 pub(crate) const DEFAULT_READ_FILES_DEADLINE: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_READ_FILES_RESULT_BYTES: usize = 64 * 1024;
+pub(crate) const MIN_READ_FILES_RESULT_BYTES: usize = 8 * 1024;
+
+fn normalized_result_budget(max_result_bytes: Option<usize>) -> usize {
+    max_result_bytes
+        .unwrap_or(DEFAULT_READ_FILES_RESULT_BYTES)
+        .clamp(MIN_READ_FILES_RESULT_BYTES, MAX_SERIALIZED_OUTPUT_BYTES)
+}
 
 fn batch_output(
     project: &str,
@@ -19,13 +27,14 @@ fn batch_output(
     items: Vec<Value>,
     output_truncated: bool,
     next_index: Option<usize>,
+    truncation_reason: Option<&str>,
 ) -> Value {
     let succeeded_count = items
         .iter()
         .filter(|item| item["success"].as_bool() == Some(true))
         .count();
     let returned_count = items.len();
-    json!({
+    let mut output = json!({
         "project": project,
         "requested_count": requested_count,
         "returned_count": returned_count,
@@ -34,66 +43,226 @@ fn batch_output(
         "items": items,
         "output_truncated": output_truncated,
         "next_index": next_index,
-    })
+    });
+    if let Some(reason) = truncation_reason {
+        output["truncation_reason"] = json!(reason);
+    }
+    output
 }
 
-fn serialized_batch_fits(output: &Value) -> bool {
+fn serialized_batch_len(output: &Value) -> usize {
     serde_json::to_vec(&ToolResult::ok(output.clone()))
-        .map(|bytes| {
-            bytes.len()
-                <= MAX_SERIALIZED_OUTPUT_BYTES.saturating_sub(MODEL_RESULT_ENVELOPE_RESERVE_BYTES)
-        })
-        .unwrap_or(false)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
 }
 
-fn apply_output_budget(project: &str, requested_count: usize, completed: Vec<Value>) -> Value {
+fn serialized_value_len(value: &Value) -> usize {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn projected_batch_len(base_len: usize, item_bytes: usize, item_count: usize) -> usize {
+    base_len
+        .saturating_add(item_bytes)
+        .saturating_add(item_count.saturating_sub(1))
+}
+
+fn truncate_read_item(item: &Value, keep_lines: usize) -> Option<Value> {
+    if item["success"].as_bool() != Some(true) || keep_lines == 0 {
+        return None;
+    }
+    let output = item.get("output")?.as_object()?;
+    let returned_lines = output.get("returned_lines")?.as_u64()? as usize;
+    if keep_lines >= returned_lines || returned_lines <= 1 {
+        return None;
+    }
+    let start_line = output.get("start_line")?.as_u64()? as usize;
+    let text = output.get("text")?.as_str()?;
+    let lines = text.split('\n').collect::<Vec<_>>();
+    if lines.len() != returned_lines {
+        return None;
+    }
+
+    let mut projected = item.clone();
+    let projected_output = projected.get_mut("output")?.as_object_mut()?;
+    projected_output.insert("text".to_string(), json!(lines[..keep_lines].join("\n")));
+    projected_output.insert("returned_lines".to_string(), json!(keep_lines));
+    projected_output.insert(
+        "end_line".to_string(),
+        json!(start_line.saturating_add(keep_lines).saturating_sub(1)),
+    );
+    projected_output.insert("has_more".to_string(), json!(true));
+    projected_output.insert(
+        "next_start_line".to_string(),
+        json!(start_line.saturating_add(keep_lines)),
+    );
+    projected_output.insert("budget_truncated".to_string(), json!(true));
+    projected_output.insert(
+        "budget_next_limit".to_string(),
+        json!(returned_lines.saturating_sub(keep_lines)),
+    );
+    Some(projected)
+}
+
+fn truncate_read_item_to_fit(item: &Value, max_item_bytes: usize) -> Option<Value> {
+    let returned_lines = item.get("output")?.get("returned_lines")?.as_u64()? as usize;
+    if returned_lines <= 1 {
+        return None;
+    }
+
+    let mut low = 1usize;
+    let mut high = returned_lines - 1;
+    let mut best = None;
+    while low <= high {
+        let keep = low + (high - low) / 2;
+        let Some(candidate) = truncate_read_item(item, keep) else {
+            break;
+        };
+        if serialized_value_len(&candidate) <= max_item_bytes {
+            best = Some(candidate);
+            low = keep.saturating_add(1);
+        } else {
+            high = keep.saturating_sub(1);
+        }
+    }
+    best
+}
+
+fn apply_output_budget(
+    project: &str,
+    requested_count: usize,
+    completed: Vec<Value>,
+    max_result_bytes: Option<usize>,
+) -> Value {
+    let result_budget = normalized_result_budget(max_result_bytes);
+    let payload_budget = result_budget.saturating_sub(MODEL_RESULT_ENVELOPE_RESERVE_BYTES);
+    let complete = batch_output(
+        project,
+        requested_count,
+        completed.clone(),
+        false,
+        None,
+        None,
+    );
+    if serialized_batch_len(&complete) <= payload_budget {
+        return complete;
+    }
+
+    let truncation_reason = if result_budget == MAX_SERIALIZED_OUTPUT_BYTES {
+        "hard_result_cap"
+    } else {
+        "batch_response_budget"
+    };
+    // The truncated empty shape fixes all outer-field byte costs up front.
+    // Counts and indices are single digits for this 1..=8 batch, so each item
+    // can then be accounted exactly by its own serialized size plus one comma.
+    let base_len = serialized_batch_len(&batch_output(
+        project,
+        requested_count,
+        Vec::new(),
+        true,
+        Some(0),
+        Some(truncation_reason),
+    ));
     let mut returned = Vec::with_capacity(completed.len());
+    let mut returned_item_bytes = 0usize;
     let mut next_index = None;
 
     for item in completed {
         let index = item["index"].as_u64().unwrap_or(returned.len() as u64) as usize;
-        let mut candidate_items = returned.clone();
-        candidate_items.push(item.clone());
-        // `false` plus `null` is the largest final flag representation, so a
-        // candidate that fits this shape also fits a truncated final shape.
-        let candidate = batch_output(project, requested_count, candidate_items, false, None);
-        if !serialized_batch_fits(&candidate) {
-            next_index = Some(index);
-            break;
+        let item_len = serialized_value_len(&item);
+        let candidate_item_count = returned.len() + 1;
+        if projected_batch_len(
+            base_len,
+            returned_item_bytes.saturating_add(item_len),
+            candidate_item_count,
+        ) <= payload_budget
+        {
+            returned_item_bytes = returned_item_bytes.saturating_add(item_len);
+            returned.push(item);
+            continue;
         }
-        returned.push(item);
+
+        let separator_bytes = usize::from(!returned.is_empty());
+        let max_item_bytes = payload_budget
+            .saturating_sub(base_len)
+            .saturating_sub(returned_item_bytes)
+            .saturating_sub(separator_bytes);
+        if let Some(partial) = truncate_read_item_to_fit(&item, max_item_bytes) {
+            returned.push(partial);
+        }
+        // A partial current item resumes from its next_start_line, while an
+        // omitted item resumes from its original range. In both cases the
+        // existing next_index can deterministically point at this same item.
+        next_index = Some(index);
+        break;
     }
 
-    let output_truncated = next_index.is_some();
-    batch_output(
+    let mut output = batch_output(
         project,
         requested_count,
         returned,
-        output_truncated,
+        true,
         next_index,
-    )
+        Some(truncation_reason),
+    );
+    // Defensive exact serialization fallback. Normal accounting above is O(n)
+    // plus an O(log lines) partial-item search; this loop should never execute
+    // unless a future outer-field change invalidates the fixed-size arithmetic.
+    while serialized_batch_len(&output) > payload_budget {
+        let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
+            break;
+        };
+        let Some(removed) = items.pop() else {
+            break;
+        };
+        next_index = removed["index"].as_u64().map(|index| index as usize);
+        output = batch_output(
+            project,
+            requested_count,
+            items.clone(),
+            true,
+            next_index,
+            Some(truncation_reason),
+        );
+    }
+    output
 }
 
 impl ToolRuntime {
+    #[cfg(test)]
     pub(crate) async fn read_files(
         &self,
         project: String,
         items: Vec<ReadFilesItem>,
         with_line_numbers: Option<bool>,
     ) -> ToolResult {
+        self.read_files_with_budget(project, items, with_line_numbers, None)
+            .await
+    }
+
+    pub(crate) async fn read_files_with_budget(
+        &self,
+        project: String,
+        items: Vec<ReadFilesItem>,
+        with_line_numbers: Option<bool>,
+        max_result_bytes: Option<usize>,
+    ) -> ToolResult {
         let resolved = match self.resolve_project_input(&project).await {
             Ok(project) => project,
             Err(error) => return ToolResult::err(error),
         };
-        self.read_files_resolved(&resolved, items, with_line_numbers)
+        self.read_files_resolved_with_budget(&resolved, items, with_line_numbers, max_result_bytes)
             .await
     }
 
-    pub(crate) async fn read_files_resolved(
+    pub(crate) async fn read_files_resolved_with_budget(
         &self,
         resolved: &ResolvedProject,
         items: Vec<ReadFilesItem>,
         with_line_numbers: Option<bool>,
+        max_result_bytes: Option<usize>,
     ) -> ToolResult {
         if !(1..=MAX_READ_FILES_ITEMS).contains(&items.len())
             || items.iter().any(|item| item.path.trim().is_empty())
@@ -142,6 +311,7 @@ impl ToolRuntime {
             &runtime_project_id,
             requested_count,
             completed,
+            max_result_bytes,
         ))
     }
 }
@@ -149,6 +319,29 @@ impl ToolRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ranged_item(index: usize, start_line: usize, lines: &[String]) -> Value {
+        let returned_lines = lines.len();
+        json!({
+            "index": index,
+            "path": format!("src/{index}.rs"),
+            "success": true,
+            "output": {
+                "text": lines.join("\n"),
+                "format": "plain",
+                "path": format!("src/{index}.rs"),
+                "sha256": "c".repeat(64),
+                "start_line": start_line,
+                "limit": returned_lines,
+                "total_lines": start_line + returned_lines - 1,
+                "returned_lines": returned_lines,
+                "end_line": start_line + returned_lines - 1,
+                "has_more": false,
+                "next_start_line": null
+            },
+            "error": null
+        })
+    }
 
     #[test]
     fn output_budget_keeps_whole_items_and_points_at_first_omitted_index() {
@@ -180,6 +373,7 @@ mod tests {
                 item(0, "x".repeat(140 * 1024)),
                 item(1, "y".repeat(140 * 1024)),
             ],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
         assert_eq!(output["returned_count"], 1);
         assert_eq!(output["output_truncated"], true);
@@ -220,6 +414,7 @@ mod tests {
                 item(1, "y".repeat(120 * 1024)),
                 item(2, "z".repeat(120 * 1024)),
             ],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
         assert_eq!(output["returned_count"], 2);
         assert_eq!(output["next_index"], 2);
@@ -240,5 +435,72 @@ mod tests {
             "suggested_next_tool": "session_discussion_summary"
         });
         assert!(serde_json::to_vec(&result).unwrap().len() <= MAX_SERIALIZED_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn default_budget_partials_on_line_boundaries_and_explicit_large_returns_more() {
+        let lines = (0..900)
+            .map(|index| format!("第{index:04}行-{}", "界".repeat(40)))
+            .collect::<Vec<_>>();
+        let completed = vec![ranged_item(0, 1, &lines)];
+
+        let default = apply_output_budget("agent:oe:demo", 1, completed.clone(), None);
+        let large = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            completed,
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+        );
+        let partial = &default["items"][0]["output"];
+        let kept = partial["returned_lines"].as_u64().unwrap() as usize;
+        assert!(kept > 0 && kept < lines.len());
+        assert_eq!(default["next_index"], 0);
+        assert_eq!(default["truncation_reason"], "batch_response_budget");
+        assert_eq!(partial["budget_truncated"], true);
+        assert_eq!(partial["next_start_line"], kept + 1);
+        assert_eq!(partial["budget_next_limit"], lines.len() - kept);
+        assert_eq!(partial["text"], lines[..kept].join("\n"));
+        assert!(std::str::from_utf8(partial["text"].as_str().unwrap().as_bytes()).is_ok());
+        assert!(
+            serde_json::to_vec(&ToolResult::ok(default)).unwrap().len()
+                <= DEFAULT_READ_FILES_RESULT_BYTES
+        );
+        assert_eq!(large["output_truncated"], false);
+        assert_eq!(large["items"][0]["output"]["returned_lines"], lines.len());
+    }
+
+    #[test]
+    fn read_budget_cursor_reconstructs_original_range_without_gaps() {
+        let lines = (0..700)
+            .map(|index| format!("line-{index:04}-{}", "x".repeat(90)))
+            .collect::<Vec<_>>();
+        let first = apply_output_budget("agent:oe:demo", 1, vec![ranged_item(0, 11, &lines)], None);
+        let first_output = &first["items"][0]["output"];
+        let kept = first_output["returned_lines"].as_u64().unwrap() as usize;
+        let next_start = first_output["next_start_line"].as_u64().unwrap() as usize;
+        let next_limit = first_output["budget_next_limit"].as_u64().unwrap() as usize;
+        assert_eq!(next_start, 11 + kept);
+        assert_eq!(next_limit, lines.len() - kept);
+
+        let continuation = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            vec![ranged_item(0, next_start, &lines[kept..])],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+        );
+        let joined = format!(
+            "{}\n{}",
+            first_output["text"].as_str().unwrap(),
+            continuation["items"][0]["output"]["text"].as_str().unwrap()
+        );
+        assert_eq!(joined, lines.join("\n"));
+    }
+
+    #[test]
+    fn result_budget_clamps_to_existing_hard_cap() {
+        assert_eq!(
+            normalized_result_budget(Some(MAX_SERIALIZED_OUTPUT_BYTES * 2)),
+            MAX_SERIALIZED_OUTPUT_BYTES
+        );
     }
 }

--- a/src/tool_runtime/registry/input_schemas/files.rs
+++ b/src/tool_runtime/registry/input_schemas/files.rs
@@ -198,7 +198,7 @@ pub(crate) fn search_project_texts_input_schema() -> Value {
         (
             "max_result_bytes",
             "integer",
-            "Optional final model-facing batch budget in bytes. Defaults to 64 KiB for ordinary exploration; increase only for explicit broad/deep search, up to the existing 256 KiB hard safety ceiling.",
+            "Optional primary model-facing batch projection budget in bytes. Defaults to 64 KiB; raise only for explicit broad/deep search, up to 256 KiB. Independently bounded Session/continuity protocol overlays are preserved outside this budget.",
             false,
         ),
     ]));
@@ -256,7 +256,7 @@ pub(crate) fn read_files_input_schema() -> Value {
         (
             "max_result_bytes",
             "integer",
-            "Optional final model-facing batch budget in bytes. Defaults to 64 KiB for ordinary exploration; increase only for explicit broad/deep reads, up to the existing 256 KiB hard safety ceiling.",
+            "Optional primary model-facing batch projection budget in bytes. Defaults to 64 KiB; raise only for explicit broad/deep reads, up to 256 KiB. Independently bounded Session/continuity protocol overlays are preserved outside this budget.",
             false,
         ),
     ]));

--- a/src/tool_runtime/registry/input_schemas/files.rs
+++ b/src/tool_runtime/registry/input_schemas/files.rs
@@ -177,6 +177,15 @@ pub(crate) fn search_project_texts_input_schema() -> Value {
     query_properties
         .get_mut("pattern")
         .expect("search pattern schema")["minLength"] = json!(1);
+    query_properties.insert(
+        "match_offset".to_string(),
+        json!({
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 199,
+            "description": "Optional zero-based matches-mode continuation offset. Use only with the next_match_offset returned for a budget-truncated query; it projects the same canonical ordered backend result and does not change search execution."
+        }),
+    );
 
     let mut schema = object_schema(with_optional_session_id(vec![
         ("project", "string", "Agent-registered project id.", true),
@@ -185,6 +194,12 @@ pub(crate) fn search_project_texts_input_schema() -> Value {
             "array",
             "One to eight independent bounded text-search queries, returned in request order.",
             true,
+        ),
+        (
+            "max_result_bytes",
+            "integer",
+            "Optional final model-facing batch budget in bytes. Defaults to 64 KiB for ordinary exploration; increase only for explicit broad/deep search, up to the existing 256 KiB hard safety ceiling.",
+            false,
         ),
     ]));
     schema["properties"]["queries"] = json!({
@@ -199,6 +214,12 @@ pub(crate) fn search_project_texts_input_schema() -> Value {
             "properties": query_properties,
         }
     });
+    schema["properties"]["max_result_bytes"]["minimum"] =
+        json!(crate::tool_runtime::search_project_texts::MIN_SEARCH_PROJECT_TEXTS_RESULT_BYTES);
+    schema["properties"]["max_result_bytes"]["maximum"] =
+        json!(webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES);
+    schema["properties"]["max_result_bytes"]["default"] =
+        json!(crate::tool_runtime::search_project_texts::DEFAULT_SEARCH_PROJECT_TEXTS_RESULT_BYTES);
     schema
 }
 
@@ -232,6 +253,12 @@ pub(crate) fn read_files_input_schema() -> Value {
             "When true, every successful item returns numbered text instead of plain text.",
             false,
         ),
+        (
+            "max_result_bytes",
+            "integer",
+            "Optional final model-facing batch budget in bytes. Defaults to 64 KiB for ordinary exploration; increase only for explicit broad/deep reads, up to the existing 256 KiB hard safety ceiling.",
+            false,
+        ),
     ]));
     schema["properties"]["items"] = json!({
         "type": "array",
@@ -259,5 +286,11 @@ pub(crate) fn read_files_input_schema() -> Value {
             }
         }
     });
+    schema["properties"]["max_result_bytes"]["minimum"] =
+        json!(crate::tool_runtime::read_files::MIN_READ_FILES_RESULT_BYTES);
+    schema["properties"]["max_result_bytes"]["maximum"] =
+        json!(webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES);
+    schema["properties"]["max_result_bytes"]["default"] =
+        json!(crate::tool_runtime::read_files::DEFAULT_READ_FILES_RESULT_BYTES);
     schema
 }

--- a/src/tool_runtime/registry/input_schemas/files.rs
+++ b/src/tool_runtime/registry/input_schemas/files.rs
@@ -177,16 +177,6 @@ pub(crate) fn search_project_texts_input_schema() -> Value {
     query_properties
         .get_mut("pattern")
         .expect("search pattern schema")["minLength"] = json!(1);
-    query_properties.insert(
-        "match_offset".to_string(),
-        json!({
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 199,
-            "description": "Optional zero-based matches-mode continuation offset. Use only with the next_match_offset returned for a budget-truncated query; it projects the same canonical ordered backend result and does not change search execution."
-        }),
-    );
-
     let mut schema = object_schema(with_optional_session_id(vec![
         ("project", "string", "Agent-registered project id.", true),
         (
@@ -198,7 +188,7 @@ pub(crate) fn search_project_texts_input_schema() -> Value {
         (
             "max_result_bytes",
             "integer",
-            "Optional primary model-facing batch projection budget in bytes. Defaults to 64 KiB; raise only for explicit broad/deep search, up to 256 KiB. Independently bounded Session/continuity protocol overlays are preserved outside this budget.",
+            "Optional primary model-facing batch projection budget in bytes. Defaults to 64 KiB and caps at 256 KiB. Continuation is whole-query via next_index; if the first remaining query cannot fit, raise this budget or narrow that query's limit/context/path. Independently bounded Session/continuity overlays remain outside this budget.",
             false,
         ),
     ]));

--- a/src/tool_runtime/registry/output_schemas/files.rs
+++ b/src/tool_runtime/registry/output_schemas/files.rs
@@ -323,11 +323,9 @@ fn search_project_texts_output_schema() -> Value {
         "count_complete": {"type": "boolean"},
         "total_matches": nullable_schema("integer", "Complete total in count mode; null when incomplete."),
         "truncated": {"type": "boolean"},
-        "budget_truncated": {"type": "boolean", "const": true},
-        "next_match_offset": {"type": "integer", "minimum": 1, "maximum": 199},
         "truncation_reason": {
             "anyOf": [
-                {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport", "batch_response_budget", "hard_result_cap"]},
+                {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport"]},
                 {"type": "null"}
             ]
         }

--- a/src/tool_runtime/registry/output_schemas/files.rs
+++ b/src/tool_runtime/registry/output_schemas/files.rs
@@ -327,7 +327,7 @@ fn search_project_texts_output_schema() -> Value {
         "next_match_offset": {"type": "integer", "minimum": 1, "maximum": 199},
         "truncation_reason": {
             "anyOf": [
-                {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport", "batch_response_budget"]},
+                {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport", "batch_response_budget", "hard_result_cap"]},
                 {"type": "null"}
             ]
         }

--- a/src/tool_runtime/registry/output_schemas/files.rs
+++ b/src/tool_runtime/registry/output_schemas/files.rs
@@ -323,9 +323,11 @@ fn search_project_texts_output_schema() -> Value {
         "count_complete": {"type": "boolean"},
         "total_matches": nullable_schema("integer", "Complete total in count mode; null when incomplete."),
         "truncated": {"type": "boolean"},
+        "budget_truncated": {"type": "boolean", "const": true},
+        "next_match_offset": {"type": "integer", "minimum": 1, "maximum": 199},
         "truncation_reason": {
             "anyOf": [
-                {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport"]},
+                {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport", "batch_response_budget"]},
                 {"type": "null"}
             ]
         }
@@ -431,6 +433,7 @@ fn search_project_texts_output_schema() -> Value {
             "items": {"type": "array", "maxItems": 8, "items": item_schema.clone()},
             "output_truncated": {"type": "boolean"},
             "next_index": {"anyOf": [{"type": "integer", "minimum": 0, "maximum": 7}, {"type": "null"}]},
+            "truncation_reason": {"type": "string", "enum": ["batch_response_budget", "hard_result_cap"]},
             "session_recorded": schema_type("boolean", "True when this batch call was recorded."),
             "session_id": schema_type("string", "Session id used for outer batch telemetry."),
             "session_event_id": schema_type("string", "Outer batch Session event id."),
@@ -690,7 +693,9 @@ fn read_files_output_schema() -> Value {
         "returned_lines": {"type": "integer", "minimum": 0, "maximum": 2000},
         "end_line": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]},
         "has_more": {"type": "boolean"},
-        "next_start_line": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]}
+        "next_start_line": {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]},
+        "budget_truncated": {"type": "boolean", "const": true},
+        "budget_next_limit": {"type": "integer", "minimum": 1, "maximum": 1999}
     });
     let read_success_full = json!({
         "type": "object",
@@ -713,6 +718,8 @@ fn read_files_output_schema() -> Value {
         "end_line",
         "has_more",
         "next_start_line",
+        "budget_truncated",
+        "budget_next_limit",
     ] {
         read_success_sparse_properties.remove(key);
     }
@@ -790,6 +797,7 @@ fn read_files_output_schema() -> Value {
             "items": {"type": "array", "maxItems": 8, "items": item_schema},
             "output_truncated": {"type": "boolean"},
             "next_index": {"anyOf": [{"type": "integer", "minimum": 0, "maximum": 7}, {"type": "null"}]},
+            "truncation_reason": {"type": "string", "enum": ["batch_response_budget", "hard_result_cap"]},
             "session_recorded": schema_type("boolean", "True when this batch call was recorded."),
             "session_id": schema_type("string", "Session id used for outer batch telemetry."),
             "session_event_id": schema_type("string", "Session event id for the outer batch call."),

--- a/src/tool_runtime/registry/tool_specs/files.rs
+++ b/src/tool_runtime/registry/tool_specs/files.rs
@@ -34,7 +34,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "search_project_texts",
-            "Run 1 to 8 searches in request order with isolated failures and two Runner requests in flight. The primary batch projection defaults to ~64 KiB; max_result_bytes raises it to the hard cap. Session/continuity overlays stay separately bounded. Truncated matches return next_index/next_match_offset.",
+            "Run 1 to 8 searches in request order with isolated failures and two Runner requests in flight. Primary batch budget is ~64 KiB, up to 256 KiB. Budget continuation returns whole queries via next_index; if the first remaining query cannot fit, raise max_result_bytes or narrow it.",
             search_project_texts_input_schema(),
         ),
         tool_spec(

--- a/src/tool_runtime/registry/tool_specs/files.rs
+++ b/src/tool_runtime/registry/tool_specs/files.rs
@@ -34,7 +34,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "search_project_texts",
-            "Run 1 to 8 bounded searches in request order. Item failures stay isolated with failure_stage/detail_code, distinct from successful empty results. Uses two Runner requests concurrently, one 30-second batch deadline, and bounded output with next_index; never reads files automatically.",
+            "Run 1 to 8 searches in request order with isolated failures and two Runner requests in flight. Default model-facing output uses a ~64 KiB shared budget; max_result_bytes raises it for explicit deep search up to the hard cap. Budget-truncated matches return next_index/next_match_offset.",
             search_project_texts_input_schema(),
         ),
         tool_spec(
@@ -44,7 +44,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "read_files",
-            "Read 1 to 8 targeted UTF-8 project files or ranges in request order. Item failures are isolated. Runner reads have true four-request concurrency, one 30-second batch deadline, and a 256 KiB serialized-result cap with next_index continuation.",
+            "Read 1 to 8 UTF-8 file ranges in request order with isolated failures and four Runner reads in flight. Default model-facing output uses a ~64 KiB shared budget; max_result_bytes raises it up to 256 KiB. Partial reads return next_index, next_start_line, and budget_next_limit.",
             read_files_input_schema(),
         ),
     ]

--- a/src/tool_runtime/registry/tool_specs/files.rs
+++ b/src/tool_runtime/registry/tool_specs/files.rs
@@ -34,7 +34,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "search_project_texts",
-            "Run 1 to 8 searches in request order with isolated failures and two Runner requests in flight. Default model-facing output uses a ~64 KiB shared budget; max_result_bytes raises it for explicit deep search up to the hard cap. Budget-truncated matches return next_index/next_match_offset.",
+            "Run 1 to 8 searches in request order with isolated failures and two Runner requests in flight. The primary batch projection defaults to ~64 KiB; max_result_bytes raises it to the hard cap. Session/continuity overlays stay separately bounded. Truncated matches return next_index/next_match_offset.",
             search_project_texts_input_schema(),
         ),
         tool_spec(
@@ -44,7 +44,7 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
         ),
         tool_spec(
             "read_files",
-            "Read 1 to 8 UTF-8 file ranges in request order with isolated failures and four Runner reads in flight. Default model-facing output uses a ~64 KiB shared budget; max_result_bytes raises it up to 256 KiB. Partial reads return next_index, next_start_line, and budget_next_limit.",
+            "Read 1 to 8 UTF-8 file ranges in request order with isolated failures and four Runner reads in flight. The primary batch projection defaults to ~64 KiB; max_result_bytes raises it to 256 KiB. Session/continuity overlays stay separately bounded. Partial reads return deterministic cursors.",
             read_files_input_schema(),
         ),
     ]

--- a/src/tool_runtime/search_project_texts.rs
+++ b/src/tool_runtime/search_project_texts.rs
@@ -70,6 +70,7 @@ fn batch_output(
     output
 }
 
+#[cfg(test)]
 fn serialized_batch_len(output: &Value) -> usize {
     serde_json::to_vec(&ToolResult::ok(output.clone()))
         .map(|bytes| bytes.len())
@@ -80,6 +81,27 @@ fn serialized_value_len(value: &Value) -> usize {
     serde_json::to_vec(value)
         .map(|bytes| bytes.len())
         .unwrap_or(usize::MAX)
+}
+
+fn projected_batch_serialized_len(output: &Value, default_queries: &[bool]) -> usize {
+    let mut projected = ToolResult::ok(output.clone());
+    super::dispatch::sparsify_complete_default_search_batch_success(
+        default_queries,
+        &mut projected,
+    );
+    serde_json::to_vec(&projected)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn projected_search_item_len(item: &Value, default_query: bool) -> usize {
+    let mut projected = item.clone();
+    if default_query && projected["success"].as_bool() == Some(true) {
+        if let Some(output) = projected.get_mut("output").and_then(Value::as_object_mut) {
+            super::dispatch::sparsify_complete_default_search_output(output, true);
+        }
+    }
+    serialized_value_len(&projected)
 }
 
 fn projected_batch_len(base_len: usize, item_bytes: usize, item_count: usize) -> usize {
@@ -108,7 +130,11 @@ fn apply_match_offset(mut item: Value, match_offset: usize) -> Value {
     item
 }
 
-fn truncate_matches_item(item: &Value, keep_matches: usize) -> Option<Value> {
+fn truncate_matches_item(
+    item: &Value,
+    keep_matches: usize,
+    budget_truncation_reason: &str,
+) -> Option<Value> {
     if item["success"].as_bool() != Some(true) || keep_matches == 0 {
         return None;
     }
@@ -133,7 +159,7 @@ fn truncate_matches_item(item: &Value, keep_matches: usize) -> Option<Value> {
     {
         projected_output.insert(
             "truncation_reason".to_string(),
-            json!("batch_response_budget"),
+            json!(budget_truncation_reason),
         );
     }
     Some(projected)
@@ -143,6 +169,7 @@ fn truncate_matches_item_to_fit(
     item: &Value,
     max_item_bytes: usize,
     match_offset: usize,
+    budget_truncation_reason: &str,
 ) -> Option<Value> {
     let match_count = item.get("output")?.get("matches")?.as_array()?.len();
     if match_count <= 1 {
@@ -154,7 +181,8 @@ fn truncate_matches_item_to_fit(
     let mut best = None;
     while low <= high {
         let keep = low + (high - low) / 2;
-        let Some(mut candidate) = truncate_matches_item(item, keep) else {
+        let Some(mut candidate) = truncate_matches_item(item, keep, budget_truncation_reason)
+        else {
             break;
         };
         candidate["output"]["next_match_offset"] = json!(match_offset.saturating_add(keep));
@@ -177,6 +205,7 @@ fn apply_output_budget(
     project: &str,
     requested_count: usize,
     completed: Vec<Value>,
+    default_queries: &[bool],
     match_offsets: &[usize],
     max_result_bytes: Option<usize>,
 ) -> Value {
@@ -190,7 +219,10 @@ fn apply_output_budget(
         None,
         None,
     );
-    if serialized_batch_len(&complete) <= payload_budget {
+    // First evaluate the exact sparse model projection. Canonical search
+    // metadata stays intact unless that final applicable projection itself
+    // exceeds the response budget.
+    if projected_batch_serialized_len(&complete, default_queries) <= payload_budget {
         return complete;
     }
 
@@ -199,21 +231,25 @@ fn apply_output_budget(
     } else {
         "batch_response_budget"
     };
-    let base_len = serialized_batch_len(&batch_output(
-        project,
-        requested_count,
-        Vec::new(),
-        true,
-        Some(0),
-        Some(truncation_reason),
-    ));
+    let base_len = projected_batch_serialized_len(
+        &batch_output(
+            project,
+            requested_count,
+            Vec::new(),
+            true,
+            Some(0),
+            Some(truncation_reason),
+        ),
+        default_queries,
+    );
     let mut returned = Vec::with_capacity(completed.len());
     let mut returned_item_bytes = 0usize;
     let mut next_index = None;
 
     for item in completed {
         let index = item["index"].as_u64().unwrap_or(returned.len() as u64) as usize;
-        let item_len = serialized_value_len(&item);
+        let item_len =
+            projected_search_item_len(&item, default_queries.get(index).copied().unwrap_or(false));
         let candidate_item_count = returned.len() + 1;
         if projected_batch_len(
             base_len,
@@ -235,6 +271,7 @@ fn apply_output_budget(
             &item,
             max_item_bytes,
             match_offsets.get(index).copied().unwrap_or(0),
+            truncation_reason,
         ) {
             returned.push(partial);
             // Continue this same query with its item-local next_match_offset.
@@ -253,7 +290,7 @@ fn apply_output_budget(
         next_index,
         Some(truncation_reason),
     );
-    while serialized_batch_len(&output) > payload_budget {
+    while projected_batch_serialized_len(&output, default_queries) > payload_budget {
         let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
             break;
         };
@@ -428,36 +465,84 @@ fn batch_item(index: usize, mut result: ToolResult) -> Value {
     })
 }
 
+pub(crate) fn apply_model_facing_output_budget(
+    result: &mut ToolResult,
+    default_queries: &[bool],
+    match_offsets: &[usize],
+    max_result_bytes: Option<usize>,
+) {
+    if !result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object() else {
+        return;
+    };
+    let Some(project) = output
+        .get("project")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return;
+    };
+    let Some(requested_count) = output
+        .get("requested_count")
+        .and_then(Value::as_u64)
+        .map(|count| count as usize)
+    else {
+        return;
+    };
+    let Some(completed) = output.get("items").and_then(Value::as_array).cloned() else {
+        return;
+    };
+
+    let budgeted = apply_output_budget(
+        &project,
+        requested_count,
+        completed,
+        default_queries,
+        match_offsets,
+        max_result_bytes,
+    );
+    let Some(root) = result.output.as_object_mut() else {
+        return;
+    };
+    for key in [
+        "project",
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "items",
+        "output_truncated",
+        "next_index",
+        "truncation_reason",
+    ] {
+        root.remove(key);
+    }
+    if let Some(budgeted) = budgeted.as_object() {
+        for (key, value) in budgeted {
+            root.insert(key.clone(), value.clone());
+        }
+    }
+}
+
 impl ToolRuntime {
-    #[cfg(test)]
     pub(crate) async fn search_project_texts(
         &self,
         project: String,
         queries: Vec<SearchProjectTextsQuery>,
     ) -> ToolResult {
-        self.search_project_texts_with_budget(project, queries, None)
-            .await
-    }
-
-    pub(crate) async fn search_project_texts_with_budget(
-        &self,
-        project: String,
-        queries: Vec<SearchProjectTextsQuery>,
-        max_result_bytes: Option<usize>,
-    ) -> ToolResult {
         let resolved = match self.resolve_project_input(&project).await {
             Ok(project) => project,
             Err(error) => return error.into_tool_result(),
         };
-        self.search_project_texts_resolved_with_budget(&resolved, queries, max_result_bytes)
-            .await
+        self.search_project_texts_resolved(&resolved, queries).await
     }
 
-    pub(crate) async fn search_project_texts_resolved_with_budget(
+    pub(crate) async fn search_project_texts_resolved(
         &self,
         resolved: &ResolvedProject,
         queries: Vec<SearchProjectTextsQuery>,
-        max_result_bytes: Option<usize>,
     ) -> ToolResult {
         if !(1..=MAX_SEARCH_PROJECT_TEXTS_QUERIES).contains(&queries.len()) {
             return ToolResult::err("search_project_texts requires 1 to 8 queries");
@@ -466,11 +551,6 @@ impl ToolRuntime {
         let runtime_project_id = resolved.resolved_id.clone();
         let requested_count = queries.len();
         let deadline = Instant::now() + self.search_project_texts_deadline;
-        let match_offsets = queries
-            .iter()
-            .map(|query| query.match_offset.unwrap_or(0))
-            .collect::<Vec<_>>();
-
         // Validation, Runner enqueue, and response waiting all happen inside
         // the concurrency slot. A third query cannot enter the Runner queue
         // while two earlier queries still hold their slots.
@@ -547,12 +627,13 @@ impl ToolRuntime {
             .await;
         completed.sort_by_key(|item| item["index"].as_u64().unwrap_or(u64::MAX));
 
-        ToolResult::ok(apply_output_budget(
+        ToolResult::ok(batch_output(
             &runtime_project_id,
             requested_count,
             completed,
-            &match_offsets,
-            max_result_bytes,
+            false,
+            None,
+            None,
         ))
     }
 }
@@ -588,6 +669,69 @@ mod tests {
         })
     }
 
+    fn default_matches_item(index: usize, count: usize, preview_bytes: usize) -> Value {
+        let mut item = matches_item(index, count, preview_bytes);
+        let output = item["output"].as_object_mut().unwrap();
+        output.insert("path".to_string(), json!("."));
+        output.insert("effective_timeout_secs".to_string(), json!(30));
+        output.insert("exit_code".to_string(), json!(0));
+        output.insert("context_before".to_string(), json!(0));
+        output.insert("context_after".to_string(), json!(0));
+        item
+    }
+
+    #[test]
+    fn complete_default_sparse_fit_is_not_preemptively_budget_truncated() {
+        let payload_budget =
+            DEFAULT_SEARCH_PROJECT_TEXTS_RESULT_BYTES - MODEL_RESULT_ENVELOPE_RESERVE_BYTES;
+        let mut selected = None;
+        for preview_bytes in 6_000..=9_000 {
+            let completed = (0..8)
+                .map(|index| default_matches_item(index, 1, preview_bytes))
+                .collect::<Vec<_>>();
+            let canonical = batch_output("agent:oe:demo", 8, completed.clone(), false, None, None);
+            let canonical_bytes = serialized_batch_len(&canonical);
+            let sparse_bytes = projected_batch_serialized_len(&canonical, &[true; 8]);
+            if canonical_bytes > payload_budget && sparse_bytes <= payload_budget {
+                selected = Some((completed, canonical_bytes, sparse_bytes));
+                break;
+            }
+        }
+        let (completed, canonical_bytes, sparse_bytes) =
+            selected.expect("test fixture must straddle canonical/sparse budget boundary");
+        assert!(canonical_bytes > payload_budget);
+        assert!(sparse_bytes <= payload_budget);
+
+        let mut result = ToolResult::ok(batch_output(
+            "agent:oe:demo",
+            8,
+            completed.clone(),
+            false,
+            None,
+            None,
+        ));
+        apply_model_facing_output_budget(&mut result, &[true; 8], &[0; 8], None);
+        assert_eq!(result.output["output_truncated"], false);
+        assert!(result.output["next_index"].is_null());
+        assert_eq!(result.output["items"].as_array().unwrap().len(), 8);
+        for (actual, expected) in result.output["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .zip(completed.iter())
+        {
+            assert_eq!(actual["output"]["matches"], expected["output"]["matches"]);
+        }
+
+        super::super::dispatch::sparsify_complete_default_search_batch_success(
+            &[true; 8],
+            &mut result,
+        );
+        assert!(result.output.get("output_truncated").is_none());
+        assert!(result.output.get("next_index").is_none());
+        assert_eq!(result.output["items"].as_array().unwrap().len(), 8);
+    }
+
     #[test]
     fn output_budget_keeps_whole_items_and_reserves_outer_metadata_space() {
         let item = |index, text: String| {
@@ -619,6 +763,7 @@ mod tests {
                 item(1, "y".repeat(120 * 1024)),
                 item(2, "z".repeat(120 * 1024)),
             ],
+            &[false, false, false],
             &[0, 0, 0],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
@@ -646,12 +791,14 @@ mod tests {
 
     #[test]
     fn default_search_budget_partials_matches_and_explicit_large_returns_more() {
-        let completed = vec![matches_item(0, 120, 900)];
-        let default = apply_output_budget("agent:oe:demo", 1, completed.clone(), &[0], None);
+        let completed = vec![default_matches_item(0, 120, 900)];
+        let default =
+            apply_output_budget("agent:oe:demo", 1, completed.clone(), &[true], &[0], None);
         let large = apply_output_budget(
             "agent:oe:demo",
             1,
             completed,
+            &[true],
             &[0],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
@@ -681,7 +828,14 @@ mod tests {
     #[test]
     fn search_match_offset_continuation_has_no_duplicates_or_gaps() {
         let original = matches_item(0, 100, 1000);
-        let first = apply_output_budget("agent:oe:demo", 1, vec![original.clone()], &[0], None);
+        let first = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            vec![original.clone()],
+            &[false],
+            &[0],
+            None,
+        );
         let first_matches = first["items"][0]["output"]["matches"]
             .as_array()
             .unwrap()
@@ -694,6 +848,7 @@ mod tests {
             "agent:oe:demo",
             1,
             vec![remaining],
+            &[false],
             &[offset],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
@@ -716,9 +871,28 @@ mod tests {
         let mut original = matches_item(0, 100, 1000);
         original["output"]["truncated"] = json!(true);
         original["output"]["truncation_reason"] = json!("limit");
-        let output = apply_output_budget("agent:oe:demo", 1, vec![original], &[0], None);
+        let output = apply_output_budget("agent:oe:demo", 1, vec![original], &[false], &[0], None);
         assert_eq!(output["items"][0]["output"]["budget_truncated"], true);
         assert_eq!(output["items"][0]["output"]["truncation_reason"], "limit");
+    }
+
+    #[test]
+    fn hard_cap_partial_uses_consistent_outer_and_inner_reason() {
+        let output = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            vec![matches_item(0, 199, 2_000)],
+            &[false],
+            &[0],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+        );
+        assert_eq!(output["output_truncated"], true);
+        assert_eq!(output["truncation_reason"], "hard_result_cap");
+        assert_eq!(
+            output["items"][0]["output"]["truncation_reason"],
+            "hard_result_cap"
+        );
+        assert_eq!(output["items"][0]["output"]["budget_truncated"], true);
     }
 
     #[test]

--- a/src/tool_runtime/search_project_texts.rs
+++ b/src/tool_runtime/search_project_texts.rs
@@ -13,6 +13,8 @@ use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
 pub(crate) const MAX_SEARCH_PROJECT_TEXTS_QUERIES: usize = 8;
 pub(crate) const MAX_SEARCH_PROJECT_TEXTS_CONCURRENCY: usize = 2;
 pub(crate) const DEFAULT_SEARCH_PROJECT_TEXTS_DEADLINE: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_SEARCH_PROJECT_TEXTS_RESULT_BYTES: usize = 64 * 1024;
+pub(crate) const MIN_SEARCH_PROJECT_TEXTS_RESULT_BYTES: usize = 8 * 1024;
 
 impl From<SearchProjectTextsQuery> for SearchRequest {
     fn from(query: SearchProjectTextsQuery) -> Self {
@@ -30,19 +32,29 @@ impl From<SearchProjectTextsQuery> for SearchRequest {
     }
 }
 
+fn normalized_result_budget(max_result_bytes: Option<usize>) -> usize {
+    max_result_bytes
+        .unwrap_or(DEFAULT_SEARCH_PROJECT_TEXTS_RESULT_BYTES)
+        .clamp(
+            MIN_SEARCH_PROJECT_TEXTS_RESULT_BYTES,
+            MAX_SERIALIZED_OUTPUT_BYTES,
+        )
+}
+
 fn batch_output(
     project: &str,
     requested_count: usize,
     items: Vec<Value>,
     output_truncated: bool,
     next_index: Option<usize>,
+    truncation_reason: Option<&str>,
 ) -> Value {
     let succeeded_count = items
         .iter()
         .filter(|item| item["success"].as_bool() == Some(true))
         .count();
     let returned_count = items.len();
-    json!({
+    let mut output = json!({
         "project": project,
         "requested_count": requested_count,
         "returned_count": returned_count,
@@ -51,16 +63,109 @@ fn batch_output(
         "items": items,
         "output_truncated": output_truncated,
         "next_index": next_index,
-    })
+    });
+    if let Some(reason) = truncation_reason {
+        output["truncation_reason"] = json!(reason);
+    }
+    output
 }
 
-fn serialized_batch_fits(output: &Value) -> bool {
+fn serialized_batch_len(output: &Value) -> usize {
     serde_json::to_vec(&ToolResult::ok(output.clone()))
-        .map(|bytes| {
-            bytes.len()
-                <= MAX_SERIALIZED_OUTPUT_BYTES.saturating_sub(MODEL_RESULT_ENVELOPE_RESERVE_BYTES)
-        })
-        .unwrap_or(false)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn serialized_value_len(value: &Value) -> usize {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn projected_batch_len(base_len: usize, item_bytes: usize, item_count: usize) -> usize {
+    base_len
+        .saturating_add(item_bytes)
+        .saturating_add(item_count.saturating_sub(1))
+}
+
+fn apply_match_offset(mut item: Value, match_offset: usize) -> Value {
+    if match_offset == 0 || item["success"].as_bool() != Some(true) {
+        return item;
+    }
+    let Some(output) = item.get_mut("output").and_then(Value::as_object_mut) else {
+        return item;
+    };
+    if output.get("result_mode").and_then(Value::as_str) != Some("matches") {
+        return item;
+    }
+    let Some(matches) = output.get_mut("matches").and_then(Value::as_array_mut) else {
+        return item;
+    };
+    let drain = match_offset.min(matches.len());
+    matches.drain(..drain);
+    let remaining = matches.len();
+    output.insert("count".to_string(), json!(remaining));
+    item
+}
+
+fn truncate_matches_item(item: &Value, keep_matches: usize) -> Option<Value> {
+    if item["success"].as_bool() != Some(true) || keep_matches == 0 {
+        return None;
+    }
+    let output = item.get("output")?.as_object()?;
+    if output.get("result_mode")?.as_str()? != "matches" {
+        return None;
+    }
+    let matches = output.get("matches")?.as_array()?;
+    if keep_matches >= matches.len() || matches.len() <= 1 {
+        return None;
+    }
+
+    let mut projected = item.clone();
+    let projected_output = projected.get_mut("output")?.as_object_mut()?;
+    projected_output.insert("matches".to_string(), json!(matches[..keep_matches]));
+    projected_output.insert("count".to_string(), json!(keep_matches));
+    projected_output.insert("budget_truncated".to_string(), json!(true));
+    projected_output.insert("truncated".to_string(), json!(true));
+    if projected_output
+        .get("truncation_reason")
+        .is_some_and(Value::is_null)
+    {
+        projected_output.insert(
+            "truncation_reason".to_string(),
+            json!("batch_response_budget"),
+        );
+    }
+    Some(projected)
+}
+
+fn truncate_matches_item_to_fit(
+    item: &Value,
+    max_item_bytes: usize,
+    match_offset: usize,
+) -> Option<Value> {
+    let match_count = item.get("output")?.get("matches")?.as_array()?.len();
+    if match_count <= 1 {
+        return None;
+    }
+
+    let mut low = 1usize;
+    let mut high = match_count - 1;
+    let mut best = None;
+    while low <= high {
+        let keep = low + (high - low) / 2;
+        let Some(mut candidate) = truncate_matches_item(item, keep) else {
+            break;
+        };
+        candidate["output"]["next_match_offset"] = json!(match_offset.saturating_add(keep));
+        if serialized_value_len(&candidate) <= max_item_bytes {
+            best = Some(candidate);
+            low = keep.saturating_add(1);
+        } else {
+            high = keep.saturating_sub(1);
+        }
+    }
+    best
 }
 
 fn retryable_agent_request_failure(result: &ToolResult) -> bool {
@@ -68,29 +173,104 @@ fn retryable_agent_request_failure(result: &ToolResult) -> bool {
         && result.output.get("code").and_then(Value::as_str) == Some("search_request_dropped")
 }
 
-fn apply_output_budget(project: &str, requested_count: usize, completed: Vec<Value>) -> Value {
+fn apply_output_budget(
+    project: &str,
+    requested_count: usize,
+    completed: Vec<Value>,
+    match_offsets: &[usize],
+    max_result_bytes: Option<usize>,
+) -> Value {
+    let result_budget = normalized_result_budget(max_result_bytes);
+    let payload_budget = result_budget.saturating_sub(MODEL_RESULT_ENVELOPE_RESERVE_BYTES);
+    let complete = batch_output(
+        project,
+        requested_count,
+        completed.clone(),
+        false,
+        None,
+        None,
+    );
+    if serialized_batch_len(&complete) <= payload_budget {
+        return complete;
+    }
+
+    let truncation_reason = if result_budget == MAX_SERIALIZED_OUTPUT_BYTES {
+        "hard_result_cap"
+    } else {
+        "batch_response_budget"
+    };
+    let base_len = serialized_batch_len(&batch_output(
+        project,
+        requested_count,
+        Vec::new(),
+        true,
+        Some(0),
+        Some(truncation_reason),
+    ));
     let mut returned = Vec::with_capacity(completed.len());
+    let mut returned_item_bytes = 0usize;
     let mut next_index = None;
 
     for item in completed {
         let index = item["index"].as_u64().unwrap_or(returned.len() as u64) as usize;
-        let mut candidate_items = returned.clone();
-        candidate_items.push(item.clone());
-        let candidate = batch_output(project, requested_count, candidate_items, false, None);
-        if !serialized_batch_fits(&candidate) {
-            next_index = Some(index);
-            break;
+        let item_len = serialized_value_len(&item);
+        let candidate_item_count = returned.len() + 1;
+        if projected_batch_len(
+            base_len,
+            returned_item_bytes.saturating_add(item_len),
+            candidate_item_count,
+        ) <= payload_budget
+        {
+            returned_item_bytes = returned_item_bytes.saturating_add(item_len);
+            returned.push(item);
+            continue;
         }
-        returned.push(item);
+
+        let separator_bytes = usize::from(!returned.is_empty());
+        let max_item_bytes = payload_budget
+            .saturating_sub(base_len)
+            .saturating_sub(returned_item_bytes)
+            .saturating_sub(separator_bytes);
+        if let Some(partial) = truncate_matches_item_to_fit(
+            &item,
+            max_item_bytes,
+            match_offsets.get(index).copied().unwrap_or(0),
+        ) {
+            returned.push(partial);
+            // Continue this same query with its item-local next_match_offset.
+            next_index = Some(index);
+        } else {
+            next_index = Some(index);
+        }
+        break;
     }
 
-    batch_output(
+    let mut output = batch_output(
         project,
         requested_count,
         returned,
-        next_index.is_some(),
+        true,
         next_index,
-    )
+        Some(truncation_reason),
+    );
+    while serialized_batch_len(&output) > payload_budget {
+        let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
+            break;
+        };
+        let Some(removed) = items.pop() else {
+            break;
+        };
+        next_index = removed["index"].as_u64().map(|index| index as usize);
+        output = batch_output(
+            project,
+            requested_count,
+            items.clone(),
+            true,
+            next_index,
+            Some(truncation_reason),
+        );
+    }
+    output
 }
 
 fn failure_reason_code(result: &ToolResult) -> &'static str {
@@ -249,22 +429,35 @@ fn batch_item(index: usize, mut result: ToolResult) -> Value {
 }
 
 impl ToolRuntime {
+    #[cfg(test)]
     pub(crate) async fn search_project_texts(
         &self,
         project: String,
         queries: Vec<SearchProjectTextsQuery>,
     ) -> ToolResult {
+        self.search_project_texts_with_budget(project, queries, None)
+            .await
+    }
+
+    pub(crate) async fn search_project_texts_with_budget(
+        &self,
+        project: String,
+        queries: Vec<SearchProjectTextsQuery>,
+        max_result_bytes: Option<usize>,
+    ) -> ToolResult {
         let resolved = match self.resolve_project_input(&project).await {
             Ok(project) => project,
             Err(error) => return error.into_tool_result(),
         };
-        self.search_project_texts_resolved(&resolved, queries).await
+        self.search_project_texts_resolved_with_budget(&resolved, queries, max_result_bytes)
+            .await
     }
 
-    pub(crate) async fn search_project_texts_resolved(
+    pub(crate) async fn search_project_texts_resolved_with_budget(
         &self,
         resolved: &ResolvedProject,
         queries: Vec<SearchProjectTextsQuery>,
+        max_result_bytes: Option<usize>,
     ) -> ToolResult {
         if !(1..=MAX_SEARCH_PROJECT_TEXTS_QUERIES).contains(&queries.len()) {
             return ToolResult::err("search_project_texts requires 1 to 8 queries");
@@ -273,6 +466,10 @@ impl ToolRuntime {
         let runtime_project_id = resolved.resolved_id.clone();
         let requested_count = queries.len();
         let deadline = Instant::now() + self.search_project_texts_deadline;
+        let match_offsets = queries
+            .iter()
+            .map(|query| query.match_offset.unwrap_or(0))
+            .collect::<Vec<_>>();
 
         // Validation, Runner enqueue, and response waiting all happen inside
         // the concurrency slot. A third query cannot enter the Runner queue
@@ -281,19 +478,56 @@ impl ToolRuntime {
             stream::iter(queries.into_iter().enumerate().map(|(index, query)| {
                 let project = &resolved.config;
                 let output_project = runtime_project_id.as_str();
+                let match_offset = query.match_offset.unwrap_or(0);
                 async move {
-                    let result = match SearchOptions::normalize(query.into()) {
-                        Ok(options) if project.is_agent() => {
-                            let first = self
-                                .search_one_resolved_project_text(
-                                    project,
-                                    output_project,
-                                    options.clone(),
-                                    Some(deadline),
-                                )
-                                .await;
-                            if retryable_agent_request_failure(&first) && Instant::now() < deadline
-                            {
+                    let offset_out_of_range = match_offset >= 200;
+                    let offset_wrong_mode = match_offset > 0
+                        && !matches!(
+                            query.result_mode,
+                            None | Some(super::SearchResultMode::Matches)
+                        );
+                    let result = if offset_out_of_range || offset_wrong_mode {
+                        let reason = if offset_out_of_range {
+                            "out_of_range"
+                        } else {
+                            "matches_mode_only"
+                        };
+                        ToolResult::err_with_output(
+                            "invalid match_offset for search_project_texts",
+                            json!({
+                                "code": "invalid_search_request",
+                                "failure_stage": "request_validation",
+                                "reason_code": "invalid_search_request",
+                                "field": "match_offset",
+                                "reason": reason,
+                            }),
+                        )
+                    } else {
+                        match SearchOptions::normalize(query.into()) {
+                            Ok(options) if project.is_agent() => {
+                                let first = self
+                                    .search_one_resolved_project_text(
+                                        project,
+                                        output_project,
+                                        options.clone(),
+                                        Some(deadline),
+                                    )
+                                    .await;
+                                if retryable_agent_request_failure(&first)
+                                    && Instant::now() < deadline
+                                {
+                                    self.search_one_resolved_project_text(
+                                        project,
+                                        output_project,
+                                        options,
+                                        Some(deadline),
+                                    )
+                                    .await
+                                } else {
+                                    first
+                                }
+                            }
+                            Ok(options) => {
                                 self.search_one_resolved_project_text(
                                     project,
                                     output_project,
@@ -301,22 +535,11 @@ impl ToolRuntime {
                                     Some(deadline),
                                 )
                                 .await
-                            } else {
-                                first
                             }
+                            Err(error) => error.into_tool_result(),
                         }
-                        Ok(options) => {
-                            self.search_one_resolved_project_text(
-                                project,
-                                output_project,
-                                options,
-                                Some(deadline),
-                            )
-                            .await
-                        }
-                        Err(error) => error.into_tool_result(),
                     };
-                    batch_item(index, result)
+                    apply_match_offset(batch_item(index, result), match_offset)
                 }
             }))
             .buffer_unordered(MAX_SEARCH_PROJECT_TEXTS_CONCURRENCY)
@@ -328,6 +551,8 @@ impl ToolRuntime {
             &runtime_project_id,
             requested_count,
             completed,
+            &match_offsets,
+            max_result_bytes,
         ))
     }
 }
@@ -335,6 +560,33 @@ impl ToolRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn matches_item(index: usize, count: usize, preview_bytes: usize) -> Value {
+        let matches = (0..count)
+            .map(|match_index| {
+                json!({
+                    "path": format!("src/{index}-{match_index:03}.rs"),
+                    "line": match_index + 1,
+                    "preview": format!("m{match_index:03}-{}", "界".repeat(preview_bytes / 3)),
+                    "context_before": [],
+                    "context_after": []
+                })
+            })
+            .collect::<Vec<_>>();
+        json!({
+            "index": index,
+            "success": true,
+            "output": {
+                "backend": "rg",
+                "result_mode": "matches",
+                "count": count,
+                "matches": matches,
+                "truncated": false,
+                "truncation_reason": null
+            },
+            "error": null
+        })
+    }
 
     #[test]
     fn output_budget_keeps_whole_items_and_reserves_outer_metadata_space() {
@@ -367,6 +619,8 @@ mod tests {
                 item(1, "y".repeat(120 * 1024)),
                 item(2, "z".repeat(120 * 1024)),
             ],
+            &[0, 0, 0],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
         assert_eq!(output["returned_count"], 2);
         assert_eq!(output["next_index"], 2);
@@ -388,5 +642,90 @@ mod tests {
             "suggested_next_tool": "session_discussion_summary"
         });
         assert!(serde_json::to_vec(&result).unwrap().len() <= MAX_SERIALIZED_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn default_search_budget_partials_matches_and_explicit_large_returns_more() {
+        let completed = vec![matches_item(0, 120, 900)];
+        let default = apply_output_budget("agent:oe:demo", 1, completed.clone(), &[0], None);
+        let large = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            completed,
+            &[0],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+        );
+        let partial = &default["items"][0]["output"];
+        let kept = partial["matches"].as_array().unwrap().len();
+        assert!(kept > 0 && kept < 120);
+        assert_eq!(default["next_index"], 0);
+        assert_eq!(default["truncation_reason"], "batch_response_budget");
+        assert_eq!(partial["budget_truncated"], true);
+        assert_eq!(partial["next_match_offset"], kept);
+        assert_eq!(partial["truncated"], true);
+        assert_eq!(partial["truncation_reason"], "batch_response_budget");
+        assert!(
+            serde_json::to_vec(&ToolResult::ok(default)).unwrap().len()
+                <= DEFAULT_SEARCH_PROJECT_TEXTS_RESULT_BYTES
+        );
+        assert_eq!(large["output_truncated"], false);
+        assert_eq!(
+            large["items"][0]["output"]["matches"]
+                .as_array()
+                .unwrap()
+                .len(),
+            120
+        );
+    }
+
+    #[test]
+    fn search_match_offset_continuation_has_no_duplicates_or_gaps() {
+        let original = matches_item(0, 100, 1000);
+        let first = apply_output_budget("agent:oe:demo", 1, vec![original.clone()], &[0], None);
+        let first_matches = first["items"][0]["output"]["matches"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let offset = first["items"][0]["output"]["next_match_offset"]
+            .as_u64()
+            .unwrap() as usize;
+        let remaining = apply_match_offset(original.clone(), offset);
+        let second = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            vec![remaining],
+            &[offset],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+        );
+        let mut joined = first_matches;
+        joined.extend(
+            second["items"][0]["output"]["matches"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .cloned(),
+        );
+        assert_eq!(
+            joined,
+            original["output"]["matches"].as_array().unwrap().clone()
+        );
+    }
+
+    #[test]
+    fn budget_truncation_preserves_existing_producer_reason() {
+        let mut original = matches_item(0, 100, 1000);
+        original["output"]["truncated"] = json!(true);
+        original["output"]["truncation_reason"] = json!("limit");
+        let output = apply_output_budget("agent:oe:demo", 1, vec![original], &[0], None);
+        assert_eq!(output["items"][0]["output"]["budget_truncated"], true);
+        assert_eq!(output["items"][0]["output"]["truncation_reason"], "limit");
+    }
+
+    #[test]
+    fn search_result_budget_clamps_to_existing_hard_cap() {
+        assert_eq!(
+            normalized_result_budget(Some(MAX_SERIALIZED_OUTPUT_BYTES * 2)),
+            MAX_SERIALIZED_OUTPUT_BYTES
+        );
     }
 }

--- a/src/tool_runtime/search_project_texts.rs
+++ b/src/tool_runtime/search_project_texts.rs
@@ -110,92 +110,6 @@ fn projected_batch_len(base_len: usize, item_bytes: usize, item_count: usize) ->
         .saturating_add(item_count.saturating_sub(1))
 }
 
-fn apply_match_offset(mut item: Value, match_offset: usize) -> Value {
-    if match_offset == 0 || item["success"].as_bool() != Some(true) {
-        return item;
-    }
-    let Some(output) = item.get_mut("output").and_then(Value::as_object_mut) else {
-        return item;
-    };
-    if output.get("result_mode").and_then(Value::as_str) != Some("matches") {
-        return item;
-    }
-    let Some(matches) = output.get_mut("matches").and_then(Value::as_array_mut) else {
-        return item;
-    };
-    let drain = match_offset.min(matches.len());
-    matches.drain(..drain);
-    let remaining = matches.len();
-    output.insert("count".to_string(), json!(remaining));
-    item
-}
-
-fn truncate_matches_item(
-    item: &Value,
-    keep_matches: usize,
-    budget_truncation_reason: &str,
-) -> Option<Value> {
-    if item["success"].as_bool() != Some(true) || keep_matches == 0 {
-        return None;
-    }
-    let output = item.get("output")?.as_object()?;
-    if output.get("result_mode")?.as_str()? != "matches" {
-        return None;
-    }
-    let matches = output.get("matches")?.as_array()?;
-    if keep_matches >= matches.len() || matches.len() <= 1 {
-        return None;
-    }
-
-    let mut projected = item.clone();
-    let projected_output = projected.get_mut("output")?.as_object_mut()?;
-    projected_output.insert("matches".to_string(), json!(matches[..keep_matches]));
-    projected_output.insert("count".to_string(), json!(keep_matches));
-    projected_output.insert("budget_truncated".to_string(), json!(true));
-    projected_output.insert("truncated".to_string(), json!(true));
-    if projected_output
-        .get("truncation_reason")
-        .is_some_and(Value::is_null)
-    {
-        projected_output.insert(
-            "truncation_reason".to_string(),
-            json!(budget_truncation_reason),
-        );
-    }
-    Some(projected)
-}
-
-fn truncate_matches_item_to_fit(
-    item: &Value,
-    max_item_bytes: usize,
-    match_offset: usize,
-    budget_truncation_reason: &str,
-) -> Option<Value> {
-    let match_count = item.get("output")?.get("matches")?.as_array()?.len();
-    if match_count <= 1 {
-        return None;
-    }
-
-    let mut low = 1usize;
-    let mut high = match_count - 1;
-    let mut best = None;
-    while low <= high {
-        let keep = low + (high - low) / 2;
-        let Some(mut candidate) = truncate_matches_item(item, keep, budget_truncation_reason)
-        else {
-            break;
-        };
-        candidate["output"]["next_match_offset"] = json!(match_offset.saturating_add(keep));
-        if serialized_value_len(&candidate) <= max_item_bytes {
-            best = Some(candidate);
-            low = keep.saturating_add(1);
-        } else {
-            high = keep.saturating_sub(1);
-        }
-    }
-    best
-}
-
 fn retryable_agent_request_failure(result: &ToolResult) -> bool {
     !result.success
         && result.output.get("code").and_then(Value::as_str) == Some("search_request_dropped")
@@ -206,7 +120,6 @@ fn apply_output_budget(
     requested_count: usize,
     completed: Vec<Value>,
     default_queries: &[bool],
-    match_offsets: &[usize],
     max_result_bytes: Option<usize>,
 ) -> Value {
     let result_budget = normalized_result_budget(max_result_bytes);
@@ -262,23 +175,10 @@ fn apply_output_budget(
             continue;
         }
 
-        let separator_bytes = usize::from(!returned.is_empty());
-        let max_item_bytes = payload_budget
-            .saturating_sub(base_len)
-            .saturating_sub(returned_item_bytes)
-            .saturating_sub(separator_bytes);
-        if let Some(partial) = truncate_matches_item_to_fit(
-            &item,
-            max_item_bytes,
-            match_offsets.get(index).copied().unwrap_or(0),
-            truncation_reason,
-        ) {
-            returned.push(partial);
-            // Continue this same query with its item-local next_match_offset.
-            next_index = Some(index);
-        } else {
-            next_index = Some(index);
-        }
+        // Search batch continuation is query-granular. Backend match order is
+        // intentionally unstable, so exposing a partial query and resuming by
+        // match position would permit duplicates and gaps across reruns.
+        next_index = Some(index);
         break;
     }
 
@@ -468,7 +368,6 @@ fn batch_item(index: usize, mut result: ToolResult) -> Value {
 pub(crate) fn apply_model_facing_output_budget(
     result: &mut ToolResult,
     default_queries: &[bool],
-    match_offsets: &[usize],
     max_result_bytes: Option<usize>,
 ) {
     if !result.success {
@@ -500,7 +399,6 @@ pub(crate) fn apply_model_facing_output_budget(
         requested_count,
         completed,
         default_queries,
-        match_offsets,
         max_result_bytes,
     );
     let Some(root) = result.output.as_object_mut() else {
@@ -558,56 +456,19 @@ impl ToolRuntime {
             stream::iter(queries.into_iter().enumerate().map(|(index, query)| {
                 let project = &resolved.config;
                 let output_project = runtime_project_id.as_str();
-                let match_offset = query.match_offset.unwrap_or(0);
                 async move {
-                    let offset_out_of_range = match_offset >= 200;
-                    let offset_wrong_mode = match_offset > 0
-                        && !matches!(
-                            query.result_mode,
-                            None | Some(super::SearchResultMode::Matches)
-                        );
-                    let result = if offset_out_of_range || offset_wrong_mode {
-                        let reason = if offset_out_of_range {
-                            "out_of_range"
-                        } else {
-                            "matches_mode_only"
-                        };
-                        ToolResult::err_with_output(
-                            "invalid match_offset for search_project_texts",
-                            json!({
-                                "code": "invalid_search_request",
-                                "failure_stage": "request_validation",
-                                "reason_code": "invalid_search_request",
-                                "field": "match_offset",
-                                "reason": reason,
-                            }),
-                        )
-                    } else {
-                        match SearchOptions::normalize(query.into()) {
-                            Ok(options) if project.is_agent() => {
-                                let first = self
-                                    .search_one_resolved_project_text(
-                                        project,
-                                        output_project,
-                                        options.clone(),
-                                        Some(deadline),
-                                    )
-                                    .await;
-                                if retryable_agent_request_failure(&first)
-                                    && Instant::now() < deadline
-                                {
-                                    self.search_one_resolved_project_text(
-                                        project,
-                                        output_project,
-                                        options,
-                                        Some(deadline),
-                                    )
-                                    .await
-                                } else {
-                                    first
-                                }
-                            }
-                            Ok(options) => {
+                    let result = match SearchOptions::normalize(query.into()) {
+                        Ok(options) if project.is_agent() => {
+                            let first = self
+                                .search_one_resolved_project_text(
+                                    project,
+                                    output_project,
+                                    options.clone(),
+                                    Some(deadline),
+                                )
+                                .await;
+                            if retryable_agent_request_failure(&first) && Instant::now() < deadline
+                            {
                                 self.search_one_resolved_project_text(
                                     project,
                                     output_project,
@@ -615,11 +476,22 @@ impl ToolRuntime {
                                     Some(deadline),
                                 )
                                 .await
+                            } else {
+                                first
                             }
-                            Err(error) => error.into_tool_result(),
                         }
+                        Ok(options) => {
+                            self.search_one_resolved_project_text(
+                                project,
+                                output_project,
+                                options,
+                                Some(deadline),
+                            )
+                            .await
+                        }
+                        Err(error) => error.into_tool_result(),
                     };
-                    apply_match_offset(batch_item(index, result), match_offset)
+                    batch_item(index, result)
                 }
             }))
             .buffer_unordered(MAX_SEARCH_PROJECT_TEXTS_CONCURRENCY)
@@ -710,7 +582,7 @@ mod tests {
             None,
             None,
         ));
-        apply_model_facing_output_budget(&mut result, &[true; 8], &[0; 8], None);
+        apply_model_facing_output_budget(&mut result, &[true; 8], None);
         assert_eq!(result.output["output_truncated"], false);
         assert!(result.output["next_index"].is_null());
         assert_eq!(result.output["items"].as_array().unwrap().len(), 8);
@@ -764,7 +636,6 @@ mod tests {
                 item(2, "z".repeat(120 * 1024)),
             ],
             &[false, false, false],
-            &[0, 0, 0],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
         assert_eq!(output["returned_count"], 2);
@@ -790,32 +661,25 @@ mod tests {
     }
 
     #[test]
-    fn default_search_budget_partials_matches_and_explicit_large_returns_more() {
+    fn single_query_soft_budget_omits_whole_item_then_larger_budget_returns_it() {
         let completed = vec![default_matches_item(0, 120, 900)];
-        let default =
-            apply_output_budget("agent:oe:demo", 1, completed.clone(), &[true], &[0], None);
+        let default = apply_output_budget("agent:oe:demo", 1, completed.clone(), &[true], None);
+        assert_eq!(default["returned_count"], 0);
+        assert!(default["items"].as_array().unwrap().is_empty());
+        assert_eq!(default["next_index"], 0);
+        assert_eq!(default["output_truncated"], true);
+        assert_eq!(default["truncation_reason"], "batch_response_budget");
+
         let large = apply_output_budget(
             "agent:oe:demo",
             1,
             completed,
             &[true],
-            &[0],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
-        let partial = &default["items"][0]["output"];
-        let kept = partial["matches"].as_array().unwrap().len();
-        assert!(kept > 0 && kept < 120);
-        assert_eq!(default["next_index"], 0);
-        assert_eq!(default["truncation_reason"], "batch_response_budget");
-        assert_eq!(partial["budget_truncated"], true);
-        assert_eq!(partial["next_match_offset"], kept);
-        assert_eq!(partial["truncated"], true);
-        assert_eq!(partial["truncation_reason"], "batch_response_budget");
-        assert!(
-            serde_json::to_vec(&ToolResult::ok(default)).unwrap().len()
-                <= DEFAULT_SEARCH_PROJECT_TEXTS_RESULT_BYTES
-        );
         assert_eq!(large["output_truncated"], false);
+        assert!(large["next_index"].is_null());
+        assert_eq!(large["returned_count"], 1);
         assert_eq!(
             large["items"][0]["output"]["matches"]
                 .as_array()
@@ -826,73 +690,66 @@ mod tests {
     }
 
     #[test]
-    fn search_match_offset_continuation_has_no_duplicates_or_gaps() {
-        let original = matches_item(0, 100, 1000);
+    fn whole_query_continuation_is_independent_of_backend_match_order() {
+        let first_query = default_matches_item(0, 1, 100);
+        let omitted_query = default_matches_item(1, 90, 900);
         let first = apply_output_budget(
             "agent:oe:demo",
-            1,
-            vec![original.clone()],
-            &[false],
-            &[0],
+            2,
+            vec![first_query.clone(), omitted_query],
+            &[true, true],
             None,
         );
-        let first_matches = first["items"][0]["output"]["matches"]
-            .as_array()
-            .unwrap()
-            .clone();
-        let offset = first["items"][0]["output"]["next_match_offset"]
-            .as_u64()
-            .unwrap() as usize;
-        let remaining = apply_match_offset(original.clone(), offset);
-        let second = apply_output_budget(
+        assert_eq!(first["returned_count"], 1);
+        assert_eq!(first["items"][0], first_query);
+        assert_eq!(first["next_index"], 1);
+        assert_eq!(first["output_truncated"], true);
+
+        // A suffix rerun is a fresh query execution. Deliberately reverse its
+        // match order to prove continuation does not stitch by match position.
+        let mut rerun = default_matches_item(0, 90, 900);
+        rerun["output"]["matches"].as_array_mut().unwrap().reverse();
+        let rerun_matches = rerun["output"]["matches"].clone();
+        let continuation = apply_output_budget(
             "agent:oe:demo",
             1,
-            vec![remaining],
-            &[false],
-            &[offset],
+            vec![rerun],
+            &[true],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
-        let mut joined = first_matches;
-        joined.extend(
-            second["items"][0]["output"]["matches"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .cloned(),
-        );
-        assert_eq!(
-            joined,
-            original["output"]["matches"].as_array().unwrap().clone()
-        );
+        assert_eq!(continuation["output_truncated"], false);
+        assert_eq!(continuation["returned_count"], 1);
+        assert_eq!(continuation["items"][0]["output"]["matches"], rerun_matches);
     }
 
     #[test]
-    fn budget_truncation_preserves_existing_producer_reason() {
-        let mut original = matches_item(0, 100, 1000);
-        original["output"]["truncated"] = json!(true);
-        original["output"]["truncation_reason"] = json!("limit");
-        let output = apply_output_budget("agent:oe:demo", 1, vec![original], &[false], &[0], None);
-        assert_eq!(output["items"][0]["output"]["budget_truncated"], true);
-        assert_eq!(output["items"][0]["output"]["truncation_reason"], "limit");
+    fn fitting_producer_truncation_remains_independent_of_batch_budget() {
+        for reason in ["limit", "output_bytes"] {
+            let mut original = matches_item(0, 2, 100);
+            original["output"]["truncated"] = json!(true);
+            original["output"]["truncation_reason"] = json!(reason);
+            let expected = original.clone();
+            let output = apply_output_budget("agent:oe:demo", 1, vec![original], &[false], None);
+            assert_eq!(output["output_truncated"], false);
+            assert!(output["next_index"].is_null());
+            assert_eq!(output["items"][0], expected);
+        }
     }
 
     #[test]
-    fn hard_cap_partial_uses_consistent_outer_and_inner_reason() {
+    fn hard_cap_pressure_omits_oversized_query_without_partial_matches() {
         let output = apply_output_budget(
             "agent:oe:demo",
             1,
             vec![matches_item(0, 199, 2_000)],
             &[false],
-            &[0],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
         );
+        assert_eq!(output["returned_count"], 0);
+        assert!(output["items"].as_array().unwrap().is_empty());
+        assert_eq!(output["next_index"], 0);
         assert_eq!(output["output_truncated"], true);
         assert_eq!(output["truncation_reason"], "hard_result_cap");
-        assert_eq!(
-            output["items"][0]["output"]["truncation_reason"],
-            "hard_result_cap"
-        );
-        assert_eq!(output["items"][0]["output"]["budget_truncated"], true);
     }
 
     #[test]

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -4677,6 +4677,130 @@ fn simultaneous_model_facing_results_allocate_unique_ordered_revisions() {
     assert!(next.recovery_events.is_empty());
 }
 
+#[test]
+fn batch_budget_preserves_compact_and_recovery_session_protocol_overlays() {
+    fn canonical_read_batch(text: String) -> Value {
+        let default_limit =
+            webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
+        json!({
+            "project": "proj",
+            "requested_count": 1,
+            "returned_count": 1,
+            "succeeded_count": 1,
+            "failed_count": 0,
+            "items": [{
+                "index": 0,
+                "path": "src/lib.rs",
+                "success": true,
+                "output": {
+                    "text": text,
+                    "format": "plain",
+                    "path": "src/lib.rs",
+                    "sha256": "a".repeat(64),
+                    "start_line": 1,
+                    "limit": default_limit,
+                    "total_lines": 1,
+                    "returned_lines": 1,
+                    "end_line": 1,
+                    "has_more": false,
+                    "next_start_line": null
+                },
+                "error": null
+            }],
+            "output_truncated": false,
+            "next_index": null
+        })
+    }
+
+    let store = SessionStore::new(10, 100);
+    let session = store.start_session(
+        Some("proj".to_string()),
+        Some("batch budget overlays".to_string()),
+    );
+    let first = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "read_file",
+        SessionContextRevisionAck::Unacknowledged,
+        true,
+        json!({"content": "seed"}),
+    );
+    assert_eq!(first.context_revision, 1);
+
+    let compact_batch = canonical_read_batch("x".repeat(56 * 1024));
+    let exact = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "read_files",
+        SessionContextRevisionAck::Revision(1),
+        true,
+        compact_batch.clone(),
+    );
+    assert_eq!(exact.context_revision, 2);
+    let mut exact_response = super::super::ToolResult::ok(compact_batch);
+    super::super::session_context::add_session_telemetry_hint(
+        &mut exact_response,
+        &store,
+        &session.session_id,
+        Some(exact.event_id.clone()),
+    );
+    assert!(
+        super::super::session_context::add_session_context_continuity(&mut exact_response, &exact,)
+    );
+    assert_eq!(exact_response.output["session_context_revision"], 2);
+    assert!(exact_response.output.get("session_continuity").is_none());
+    assert!(exact_response.output.get("session_recovery").is_none());
+
+    super::super::read_files::apply_model_facing_output_budget(&mut exact_response, None);
+    super::super::dispatch::sparsify_complete_read_success("read_files", &mut exact_response);
+    assert_eq!(exact_response.output["session_recorded"], true);
+    assert_eq!(exact_response.output["session_id"], session.session_id);
+    assert_eq!(exact_response.output["session_context_revision"], 2);
+    assert!(exact_response.output.get("session_continuity").is_none());
+    assert!(exact_response.output.get("session_recovery").is_none());
+    assert!(
+        serde_json::to_vec(&exact_response).unwrap().len()
+            <= super::super::read_files::DEFAULT_READ_FILES_RESULT_BYTES,
+        "compact exact Session overlays must fit inside the reserved default result budget"
+    );
+    assert_eq!(store.context_revision(&session.session_id), Some(2));
+
+    let stale_batch = canonical_read_batch("y".repeat(8 * 1024));
+    let stale = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "read_files",
+        SessionContextRevisionAck::Revision(1),
+        true,
+        stale_batch.clone(),
+    );
+    assert_eq!(stale.context_revision, 3);
+    assert_eq!(stale.recovery_events.len(), 1);
+    let mut stale_response = super::super::ToolResult::ok(stale_batch);
+    super::super::session_context::add_session_telemetry_hint(
+        &mut stale_response,
+        &store,
+        &session.session_id,
+        Some(stale.event_id.clone()),
+    );
+    assert!(
+        super::super::session_context::add_session_context_continuity(&mut stale_response, &stale,)
+    );
+    assert_eq!(
+        stale_response.output["session_continuity"]["status"],
+        "behind"
+    );
+    let continuity = stale_response.output["session_continuity"].clone();
+    let recovery = stale_response.output["session_recovery"].clone();
+
+    super::super::read_files::apply_model_facing_output_budget(&mut stale_response, None);
+    super::super::dispatch::sparsify_complete_read_success("read_files", &mut stale_response);
+    assert_eq!(stale_response.output["session_context_revision"], 3);
+    assert_eq!(stale_response.output["session_continuity"], continuity);
+    assert_eq!(stale_response.output["session_recovery"], recovery);
+    assert_eq!(store.context_revision(&session.session_id), Some(3));
+}
+
 #[tokio::test]
 async fn bounded_session_context_recovery_adds_current_handoff_before_latest_ack() {
     let runtime = super::super::ToolRuntime::new_for_tests();

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -57,6 +57,24 @@ fn read_files_input_schema_enforces_batch_and_item_bounds() {
         schema["properties"]["items"]["items"]["properties"]["path"]["minLength"],
         1
     );
+    assert_eq!(
+        schema["properties"]["max_result_bytes"]["default"],
+        64 * 1024
+    );
+    assert_eq!(
+        schema["properties"]["max_result_bytes"]["maximum"],
+        256 * 1024
+    );
+    assert!(validates(&json!({
+        "project": "demo",
+        "items": [{"path": "a.rs"}],
+        "max_result_bytes": 128 * 1024
+    })));
+    assert!(!validates(&json!({
+        "project": "demo",
+        "items": [{"path": "a.rs"}],
+        "max_result_bytes": 256 * 1024 + 1
+    })));
     assert!(!validates(&json!({
         "project": "demo",
         "items": [{"path": "a.rs", "unexpected": true}]
@@ -400,6 +418,7 @@ async fn read_files_dispatch_complete_batch_is_sparse_and_schema_valid() {
                         ],
                         session_id: None,
                         with_line_numbers: Some(true),
+                        max_result_bytes: None,
                     },
                     Some(&auth),
                 )
@@ -493,6 +512,7 @@ async fn read_files_dispatch_mixed_batch_keeps_outer_and_failure_semantics() {
                         items: vec![item("good.txt", None, None), item(".env", None, None)],
                         session_id: None,
                         with_line_numbers: None,
+                        max_result_bytes: None,
                     },
                     Some(&auth),
                 )
@@ -750,6 +770,7 @@ async fn read_files_records_one_outer_session_event_and_keeps_metadata_outer_onl
                         items: vec![item("a.rs", None, None), item("b.rs", None, None)],
                         session_id: Some(session_id),
                         with_line_numbers: None,
+                        max_result_bytes: None,
                     },
                     Some(&auth),
                 )

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -65,6 +65,10 @@ fn read_files_input_schema_enforces_batch_and_item_bounds() {
         schema["properties"]["max_result_bytes"]["maximum"],
         256 * 1024
     );
+    assert!(schema["properties"]["max_result_bytes"]["description"]
+        .as_str()
+        .unwrap()
+        .contains("protocol overlays"));
     assert!(validates(&json!({
         "project": "demo",
         "items": [{"path": "a.rs"}],
@@ -489,6 +493,64 @@ async fn read_files_dispatch_complete_batch_is_sparse_and_schema_valid() {
     let serialized = serde_json::to_value(&result).unwrap();
     crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
         .unwrap_or_else(|error| panic!("sparse read_files batch must match schema: {error}"));
+}
+
+#[tokio::test]
+async fn read_files_dispatch_large_default_batch_uses_sparse_fit_before_budget() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-sparse-budget-order";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+    let paths = (0..8)
+        .map(|index| format!("src/{index}.rs"))
+        .collect::<Vec<_>>();
+    let expected_text = "x".repeat(7_400);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        let paths = paths.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFiles {
+                        project,
+                        items: paths.iter().map(|path| item(path, None, None)).collect(),
+                        session_id: None,
+                        with_line_numbers: None,
+                        max_result_bytes: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    for _ in 0..8 {
+        let request = next_read_request(&runtime, client_id).await;
+        complete_read(&runtime, client_id, &request, &expected_text).await;
+    }
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert!(
+        result.output.get("output_truncated").is_none(),
+        "{}",
+        result.output
+    );
+    assert!(
+        result.output.get("next_index").is_none(),
+        "{}",
+        result.output
+    );
+    let items = result.output["items"].as_array().unwrap();
+    assert_eq!(items.len(), 8);
+    for item in items {
+        assert_eq!(item["output"]["text"], expected_text);
+        assert!(item["output"].get("start_line").is_none());
+        assert!(item["output"].get("next_start_line").is_none());
+    }
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -19,6 +19,7 @@ fn query(pattern: &str, mode: Option<SearchResultMode>) -> SearchProjectTextsQue
         exclude_globs: None,
         result_mode: mode,
         timeout_secs: None,
+        match_offset: None,
     }
 }
 
@@ -174,6 +175,32 @@ fn search_project_texts_schema_and_parser_enforce_strict_batch_contract() {
         schema["properties"]["queries"]["items"]["additionalProperties"],
         false
     );
+    assert_eq!(
+        schema["properties"]["max_result_bytes"]["default"],
+        64 * 1024
+    );
+    assert_eq!(
+        schema["properties"]["max_result_bytes"]["maximum"],
+        256 * 1024
+    );
+    assert_eq!(
+        schema["properties"]["queries"]["items"]["properties"]["match_offset"]["maximum"],
+        199
+    );
+    assert!(validates(&json!({
+        "project": "demo",
+        "queries": [{"pattern": "needle", "match_offset": 199}],
+        "max_result_bytes": 128 * 1024
+    })));
+    assert!(!validates(&json!({
+        "project": "demo",
+        "queries": [{"pattern": "needle", "match_offset": 200}]
+    })));
+    assert!(!validates(&json!({
+        "project": "demo",
+        "queries": [{"pattern": "needle"}],
+        "max_result_bytes": 256 * 1024 + 1
+    })));
     assert!(
         schema["properties"].get("session_id").is_some(),
         "missing outer business session_id field"
@@ -468,6 +495,7 @@ async fn search_project_texts_default_matches_items_are_sparse_and_schema_valid(
                         project,
                         queries: vec![query("first", None), query("second", None)],
                         session_id: None,
+                        max_result_bytes: None,
                     },
                     Some(&auth),
                 )
@@ -559,6 +587,7 @@ async fn search_project_texts_dispatch_mixed_batch_only_sparsifies_success_item(
                         project,
                         queries: vec![query("steady", None), invalid],
                         session_id: None,
+                        max_result_bytes: None,
                     },
                     Some(&auth),
                 )
@@ -1474,6 +1503,7 @@ async fn search_project_texts_records_one_event_without_patterns_and_aggregates_
                             ),
                         ],
                         session_id: Some(session_id),
+                        max_result_bytes: None,
                     },
                     Some(&auth),
                 )

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -183,6 +183,10 @@ fn search_project_texts_schema_and_parser_enforce_strict_batch_contract() {
         schema["properties"]["max_result_bytes"]["maximum"],
         256 * 1024
     );
+    assert!(schema["properties"]["max_result_bytes"]["description"]
+        .as_str()
+        .unwrap()
+        .contains("protocol overlays"));
     assert_eq!(
         schema["properties"]["queries"]["items"]["properties"]["match_offset"]["maximum"],
         199
@@ -251,6 +255,14 @@ fn search_project_texts_schema_and_parser_enforce_strict_batch_contract() {
         single.input_schema["required"],
         json!(["project", "pattern"]),
         "single-query schema remains unchanged"
+    );
+    let success_full = &batch.output_schema["properties"]["output"]["anyOf"][0]["anyOf"][0]
+        ["properties"]["items"]["items"]["properties"]["output"]["anyOf"][0]["anyOf"][0];
+    assert!(
+        success_full["properties"]["truncation_reason"]["anyOf"][0]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("hard_result_cap"))
     );
     let failure = &batch.output_schema["properties"]["output"]["anyOf"][0]["anyOf"][0]
         ["properties"]["items"]["items"]["properties"]["output"]["anyOf"][1];
@@ -563,6 +575,70 @@ async fn search_project_texts_default_matches_items_are_sparse_and_schema_valid(
     let serialized = serde_json::to_value(&result).unwrap();
     crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
         .unwrap_or_else(|error| panic!("sparse batch search success must match schema: {error}"));
+}
+
+#[tokio::test]
+async fn search_project_texts_dispatch_large_default_batch_uses_sparse_fit_before_budget() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-sparse-budget-order";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+    let patterns = (0..8)
+        .map(|index| format!("needle-{index}"))
+        .collect::<Vec<_>>();
+    let expected_preview = "x".repeat(7_400);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        let patterns = patterns.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::SearchProjectTexts {
+                        project,
+                        queries: patterns
+                            .iter()
+                            .map(|pattern| query(pattern, None))
+                            .collect(),
+                        session_id: None,
+                        max_result_bytes: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    for _ in 0..8 {
+        let request = wait_for_patch_agent_request(&runtime, client_id).await;
+        let pattern = request_pattern(&request);
+        let path = format!("src/{pattern}.rs");
+        let stdout = search_stdout("matches", &path, &expected_preview);
+        complete_patch_agent_request(&runtime, client_id, &request.request_id, 0, &stdout, "")
+            .await;
+    }
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert!(
+        result.output.get("output_truncated").is_none(),
+        "{}",
+        result.output
+    );
+    assert!(
+        result.output.get("next_index").is_none(),
+        "{}",
+        result.output
+    );
+    let items = result.output["items"].as_array().unwrap();
+    assert_eq!(items.len(), 8);
+    for item in items {
+        assert_eq!(item["output"]["matches"][0]["preview"], expected_preview);
+        assert!(item["output"].get("backend").is_none());
+        assert!(item["output"].get("truncation_reason").is_none());
+    }
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -19,7 +19,6 @@ fn query(pattern: &str, mode: Option<SearchResultMode>) -> SearchProjectTextsQue
         exclude_globs: None,
         result_mode: mode,
         timeout_secs: None,
-        match_offset: None,
     }
 }
 
@@ -183,23 +182,24 @@ fn search_project_texts_schema_and_parser_enforce_strict_batch_contract() {
         schema["properties"]["max_result_bytes"]["maximum"],
         256 * 1024
     );
-    assert!(schema["properties"]["max_result_bytes"]["description"]
+    let budget_description = schema["properties"]["max_result_bytes"]["description"]
         .as_str()
+        .unwrap();
+    assert!(budget_description.contains("whole-query"));
+    assert!(budget_description.contains("narrow"));
+    let removed_input_cursor = ["match", "offset"].join("_");
+    assert!(schema["properties"]["queries"]["items"]["properties"]
+        .get(&removed_input_cursor)
+        .is_none());
+    let mut removed_cursor_input = json!({
+        "project": "demo",
+        "queries": [{"pattern": "needle"}]
+    });
+    removed_cursor_input["queries"][0]
+        .as_object_mut()
         .unwrap()
-        .contains("protocol overlays"));
-    assert_eq!(
-        schema["properties"]["queries"]["items"]["properties"]["match_offset"]["maximum"],
-        199
-    );
-    assert!(validates(&json!({
-        "project": "demo",
-        "queries": [{"pattern": "needle", "match_offset": 199}],
-        "max_result_bytes": 128 * 1024
-    })));
-    assert!(!validates(&json!({
-        "project": "demo",
-        "queries": [{"pattern": "needle", "match_offset": 200}]
-    })));
+        .insert(removed_input_cursor, json!(1));
+    assert!(!validates(&removed_cursor_input));
     assert!(!validates(&json!({
         "project": "demo",
         "queries": [{"pattern": "needle"}],
@@ -258,12 +258,16 @@ fn search_project_texts_schema_and_parser_enforce_strict_batch_contract() {
     );
     let success_full = &batch.output_schema["properties"]["output"]["anyOf"][0]["anyOf"][0]
         ["properties"]["items"]["items"]["properties"]["output"]["anyOf"][0]["anyOf"][0];
-    assert!(
-        success_full["properties"]["truncation_reason"]["anyOf"][0]["enum"]
-            .as_array()
-            .unwrap()
-            .contains(&json!("hard_result_cap"))
-    );
+    let removed_output_cursor = ["next", "match", "offset"].join("_");
+    assert!(success_full["properties"]
+        .get(&removed_output_cursor)
+        .is_none());
+    assert!(success_full["properties"].get("budget_truncated").is_none());
+    let producer_reasons = success_full["properties"]["truncation_reason"]["anyOf"][0]["enum"]
+        .as_array()
+        .unwrap();
+    assert!(!producer_reasons.contains(&json!("batch_response_budget")));
+    assert!(!producer_reasons.contains(&json!("hard_result_cap")));
     let failure = &batch.output_schema["properties"]["output"]["anyOf"][0]["anyOf"][0]
         ["properties"]["items"]["items"]["properties"]["output"]["anyOf"][1];
     assert_eq!(

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -69,6 +69,10 @@ pub struct SearchProjectTextsQuery {
     pub result_mode: Option<SearchResultMode>,
     #[serde(default)]
     pub timeout_secs: Option<i64>,
+    /// Zero-based matches-mode projection offset used only to continue a
+    /// budget-truncated batch query. It never changes backend search order.
+    #[serde(default)]
+    pub match_offset: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -940,6 +944,8 @@ pub enum ToolCall {
         session_id: Option<String>,
         #[serde(default)]
         with_line_numbers: Option<bool>,
+        #[serde(default)]
+        max_result_bytes: Option<usize>,
     },
 
     /// Start an async background job (long-running commands, codex CLI, etc.).
@@ -1092,6 +1098,8 @@ pub enum ToolCall {
         queries: Vec<SearchProjectTextsQuery>,
         #[serde(default)]
         session_id: Option<String>,
+        #[serde(default)]
+        max_result_bytes: Option<usize>,
     },
 
     /// Read-only git diff summary for a project: `git status --porcelain`,
@@ -1845,6 +1853,7 @@ fn reject_unknown_read_files_fields(arguments: &Value) -> Result<(), String> {
         "items",
         "session_id",
         "with_line_numbers",
+        "max_result_bytes",
         // Wrapper/session metadata that transports may leave in params.
         "allow_cross_project_session",
         "recording_session_id",
@@ -1899,6 +1908,7 @@ fn reject_unknown_search_project_texts_fields(arguments: &Value) -> Result<(), S
         "project",
         "queries",
         "session_id",
+        "max_result_bytes",
         // Wrapper/session metadata that transports may leave in params.
         "allow_cross_project_session",
         "recording_session_id",

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -69,10 +69,6 @@ pub struct SearchProjectTextsQuery {
     pub result_mode: Option<SearchResultMode>,
     #[serde(default)]
     pub timeout_secs: Option<i64>,
-    /// Zero-based matches-mode projection offset used only to continue a
-    /// budget-truncated batch query. It never changes backend search order.
-    #[serde(default)]
-    pub match_offset: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

Reduce model-facing context cost for successful batch read/search calls without reducing batch capability or Runner concurrency.

- add a 64 KiB default primary model-facing batch projection budget to `read_files` and `search_project_texts`
- retain the existing 256 KiB hard serialized-result ceiling
- add `max_result_bytes` as an explicit broad/deep read/search escape hatch
- keep `read_files` deterministic line-boundary continuation
- use whole-query `next_index` continuation for `search_project_texts`; no match-position cursor is exposed because the search backend intentionally does not guarantee stable match order across reruns
- evaluate the existing final sparse projection before deciding that a complete batch needs truncation
- preserve Session recording/continuity/recovery overlays outside the primary batch budget

## Motivation

Recent dogfood telemetry showed `read_files` and `search_project_texts` dominating model-facing result bytes after batch adoption. The goal is to keep the batch/concurrency win while avoiding routine oversized exploratory responses.

## Continuation semantics

`read_files` may truncate a range on a complete UTF-8 line boundary and returns its existing line-based continuation metadata.

`search_project_texts` treats one complete query result as the minimum batch-economy unit. If the next query cannot fit the remaining primary batch budget, that query is omitted completely and `next_index` points to the first omitted query. The caller resubmits the query suffix. If the first remaining query itself cannot fit the default budget, the caller can raise `max_result_bytes` (up to 256 KiB) or narrow its limit/context/path. No partial match sequence is stitched across backend reruns.

Producer-owned search truncation such as `limit` or `output_bytes` remains independent of batch-budget truncation.

## Design

The canonical batch result remains available for Session recording and continuation construction. After Session recording/decorations, the budget projector evaluates a clone through the existing sparse projection helpers. If that final applicable sparse shape fits the budget, the complete batch is returned without unnecessary continuation. Otherwise only whole search query items are admitted under the shared budget.

No Runner protocol changes, search ordering changes, or additional Runner requests are introduced.

## Validation

Final independent review on `9d8e978d` after rebasing onto `c7ead510` (`Add Windows Runner replacement readiness (#140)`):

- `cargo test -p webcodex search_project_texts` — 29 passed, 0 failed
- `cargo test -p webcodex --lib` — 2909 passed, 0 failed
- `cargo check --all-targets -p webcodex` — passed, 0 warnings/errors
- `cargo fmt -- --check` — passed
- `git diff --check origin/main..HEAD` — passed
- public/runtime `match_offset` / `next_match_offset` references removed from `src`

Independent review completed with no blocking findings.