### PR TITLE
Add first-class Windows Runner lifecycle bootstrap

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -379,6 +379,14 @@ supervisor remains an explicit host-specific input: the lifecycle helpers inspec
 and register the task around that script but never rewrite its proxy, routing, or
 other machine policy.
 
+The first-class lifecycle is intentionally least-privileged: it registers the
+interactive current-user principal with Scheduled Task `RunLevel=Limited` (LUA),
+not `Highest`. The Runner binary, supervisor script, and config may live in the
+user's writable profile/repository tree, so an elevated task must not consume
+those inputs as an implicit UAC boundary. If a future host needs privileged OS
+operations, model that as a separate explicit privileged helper/boundary rather
+than elevating the model-facing Runner lifecycle.
+
 Use the read-only status surface to inspect the task plus exact primary process
 identity (PID + creation FILETIME). Same-path `--webcodex-internal-*` roles are
 excluded by the shared Windows Runner identity helper:
@@ -403,6 +411,12 @@ powershell -NoProfile -File scripts/install_windows_runner_lifecycle.ps1 `
   -Json
 # Review the plan, then repeat with -Apply when an operator change is intended.
 ```
+
+An existing owned lifecycle registered with `RunLevel=Highest` is reported as
+`task_principal_run_level` drift and plans an `update` to `Limited`. Applying that
+definition changes future task launches only: an already-running Runner keeps its
+existing Windows token until an operator-controlled stop/restart. This installer
+never performs that restart itself.
 
 The dogfood deployment helper keeps build and deploy separate. Its operator CLI
 resolution order is explicit `-WebCodexCliPath`, then the current repo's

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -368,6 +368,51 @@ an interrupted graceful-shutdown path. If neither is present, investigate an
 external/native process termination or supervisor action before adding broader
 Runner telemetry.
 
+### Windows dogfood Runner lifecycle
+
+For Windows dogfood hosts that need an interactive desktop session, the supported
+host-specific topology is a Scheduled Task that runs a PowerShell supervisor; the
+supervisor launches the exact primary `webcodex-runner.exe` through WMI
+`Win32_Process.Create`. This preserves the Runner's own ManagedChild/Job Object
+semantics instead of making Task Scheduler the direct Runner process owner. The
+supervisor remains an explicit host-specific input: the lifecycle helpers inspect
+and register the task around that script but never rewrite its proxy, routing, or
+other machine policy.
+
+Use the read-only status surface to inspect the task plus exact primary process
+identity (PID + creation FILETIME). Same-path `--webcodex-internal-*` roles are
+excluded by the shared Windows Runner identity helper:
+
+```powershell
+powershell -NoProfile -File scripts/status_windows_runner_lifecycle.ps1 -Json
+```
+
+`install_windows_runner_lifecycle.ps1` is plan-only unless `-Apply` is supplied.
+It canonicalizes and validates the Runner, config, supervisor, and working-directory
+paths; reports task/runtime mismatches; and refuses to update an existing task that
+does not look like a WebCodex PowerShell-supervisor lifecycle. Applying the plan
+creates, updates, or enables only that Scheduled Task definition. It does not
+replace the Runner binary, read token contents, start/restart the Runner, or change
+the supervisor script:
+
+```powershell
+powershell -NoProfile -File scripts/install_windows_runner_lifecycle.ps1 `
+  -RunnerConfigPath <agent.toml> `
+  -SupervisorPath <supervisor.ps1> `
+  -WorkingDirectory <repo-root> `
+  -Json
+# Review the plan, then repeat with -Apply when an operator change is intended.
+```
+
+The dogfood deployment helper keeps build and deploy separate. Its operator CLI
+resolution order is explicit `-WebCodexCliPath`, then the current repo's
+`target\\dogfood\\webcodex.exe`, then the installed CLI. The installed fallback
+must support `webcodex ops runner` or deployment fails closed. Runner candidate
+resolution is explicit `-CandidatePath` (legacy `-Candidate` remains an alias),
+then `target\\dogfood\\webcodex-runner.exe`; the helper never runs Cargo itself.
+Replacement success and rollback still use the existing exact process identity and
+bounded fresh control-plane readiness proofs.
+
 ## macOS local dogfood signing
 
 macOS privacy grants such as Screen Recording and Accessibility should not be

--- a/scripts/deploy_windows_runner_dogfood.ps1
+++ b/scripts/deploy_windows_runner_dogfood.ps1
@@ -10,13 +10,14 @@
 # Any failure after destructive replacement begins performs bounded rollback and
 # must prove a fresh rollback instance/build Ready before recovery is considered
 # established. The Server binary/service is never modified by this helper.
+# Candidate/CLI defaults are dogfood-first; this helper never runs Cargo itself.
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
-    [string]$Candidate,
+    [Alias('Candidate')]
+    [string]$CandidatePath,
 
     [string]$RunnerPath = "$env:USERPROFILE\.local\bin\webcodex-runner.exe",
-    [string]$WebCodexCliPath = "$env:USERPROFILE\.local\bin\webcodex.exe",
+    [string]$WebCodexCliPath,
     [string]$TaskName = "WebCodex MSI Dogfood Runner",
     [string]$TaskPath = "\",
 
@@ -33,6 +34,7 @@ param(
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "windows_runner_process_identity.ps1")
 . (Join-Path $PSScriptRoot "windows_runner_readiness.ps1")
+. (Join-Path $PSScriptRoot "windows_runner_lifecycle.ps1")
 
 function Get-RunnerIdentity {
     param([Parameter(Mandatory = $true)][string]$Path)
@@ -68,7 +70,11 @@ function Wait-Until {
     throw $FailureMessage
 }
 
-$Candidate = [System.IO.Path]::GetFullPath($Candidate)
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$candidateSelection = Resolve-WebCodexRunnerCandidatePath -ExplicitPath $CandidatePath -RepoRoot $repoRoot
+$cliSelection = Resolve-WebCodexOperatorCliPath -ExplicitPath $WebCodexCliPath -RepoRoot $repoRoot
+$Candidate = $candidateSelection.Path
+$WebCodexCliPath = $cliSelection.Path
 $RunnerPath = [System.IO.Path]::GetFullPath($RunnerPath)
 $RunnerDir = Split-Path -Parent $RunnerPath
 if (-not (Test-Path -LiteralPath $RunnerDir -PathType Container)) {
@@ -212,6 +218,8 @@ try {
     Write-Output "  expected_build:        commit=$($candidateBuild.GitCommit) dirty=$($candidateBuild.GitDirty)"
     Write-Output "  observed_build:        commit=$($candidateReadyObservation.build.git_commit) dirty=$($candidateReadyObservation.build.git_dirty)"
     Write-Output "  candidate:             $candidateIdentity"
+    Write-Output "  candidate_source:      $($candidateSelection.Source)"
+    Write-Output "  operator_cli_source:   $($cliSelection.Source)"
     Write-Output "  previous:              $previousIdentity"
     Write-Output "  rollback:              $rollbackPath"
     Write-Output "  task:                  $TaskPath$TaskName"

--- a/scripts/install_windows_runner_lifecycle.ps1
+++ b/scripts/install_windows_runner_lifecycle.ps1
@@ -1,0 +1,89 @@
+# Install or update the supported Windows Runner Scheduled Task lifecycle.
+#
+# This script never replaces the Runner binary and never reads token contents.
+# Without -Apply it is a read-only plan renderer.
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$RunnerPath = "$env:USERPROFILE\.local\bin\webcodex-runner.exe",
+
+    [Parameter(Mandatory = $true)]
+    [string]$RunnerConfigPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SupervisorPath,
+
+    [string]$TaskName = 'WebCodex MSI Dogfood Runner',
+    [string]$TaskPath = '\',
+    [string]$WorkingDirectory = (Split-Path -Parent $PSScriptRoot),
+
+    [switch]$Apply,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'windows_runner_lifecycle.ps1')
+
+$expected = New-WindowsRunnerLifecycleExpectedSpec `
+    -RunnerPath $RunnerPath `
+    -RunnerConfigPath $RunnerConfigPath `
+    -SupervisorPath $SupervisorPath `
+    -TaskName $TaskName `
+    -TaskPath $TaskPath `
+    -WorkingDirectory $WorkingDirectory
+$current = Get-WindowsRunnerLifecycleTaskObservation -TaskName $expected.TaskName -TaskPath $expected.TaskPath
+$inventory = @(Get-WindowsRunnerPrimaryInventory)
+$plan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $current -PrimaryInventory $inventory
+
+if ($Apply) {
+    if (-not $plan.can_apply) {
+        throw "Windows Runner lifecycle plan is not safe to apply; inspect task_mismatches/runtime_mismatches first"
+    }
+
+    $changed = $false
+    switch ($plan.task_operation) {
+        'create' {
+            if ($PSCmdlet.ShouldProcess("$($expected.TaskPath)$($expected.TaskName)", 'Create WebCodex Windows Runner lifecycle Scheduled Task')) {
+                $definition = New-WindowsRunnerScheduledTaskDefinition -ExpectedSpec $expected
+                Register-ScheduledTask -TaskName $expected.TaskName -TaskPath $expected.TaskPath -InputObject $definition -ErrorAction Stop | Out-Null
+                $changed = $true
+            }
+        }
+        'update' {
+            if (-not $current.IsLifecycleLike) {
+                throw "Refusing to update an unrecognized existing Scheduled Task: $($expected.TaskPath)$($expected.TaskName)"
+            }
+            if ($PSCmdlet.ShouldProcess("$($expected.TaskPath)$($expected.TaskName)", 'Update WebCodex Windows Runner lifecycle Scheduled Task definition')) {
+                $definition = New-WindowsRunnerScheduledTaskDefinition -ExpectedSpec $expected
+                Register-ScheduledTask -TaskName $expected.TaskName -TaskPath $expected.TaskPath -InputObject $definition -Force -ErrorAction Stop | Out-Null
+                $changed = $true
+            }
+        }
+        'enable' {
+            if ($PSCmdlet.ShouldProcess("$($expected.TaskPath)$($expected.TaskName)", 'Enable WebCodex Windows Runner lifecycle Scheduled Task')) {
+                Enable-ScheduledTask -TaskName $expected.TaskName -TaskPath $expected.TaskPath -ErrorAction Stop | Out-Null
+                $changed = $true
+            }
+        }
+        'noop' { }
+        default { throw "Unknown lifecycle task operation: $($plan.task_operation)" }
+    }
+
+    if ($changed) {
+        $afterTask = Get-WindowsRunnerLifecycleTaskObservation -TaskName $expected.TaskName -TaskPath $expected.TaskPath
+        $afterInventory = @(Get-WindowsRunnerPrimaryInventory)
+        $plan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $afterTask -PrimaryInventory $afterInventory
+        if ($plan.task_operation -ne 'noop') {
+            throw "Scheduled Task lifecycle apply did not converge to the expected task definition"
+        }
+    }
+
+    $plan | Add-Member -NotePropertyName applied -NotePropertyValue $changed -Force
+} else {
+    $plan | Add-Member -NotePropertyName applied -NotePropertyValue $false -Force
+}
+
+if ($Json) {
+    $plan | ConvertTo-Json -Depth 8
+} else {
+    $plan
+}

--- a/scripts/install_windows_runner_lifecycle.ps1
+++ b/scripts/install_windows_runner_lifecycle.ps1
@@ -47,6 +47,13 @@ if ($Apply) {
         'create' {
             if ($PSCmdlet.ShouldProcess("$($expected.TaskPath)$($expected.TaskName)", 'Create WebCodex Windows Runner lifecycle Scheduled Task')) {
                 $definition = New-WindowsRunnerScheduledTaskDefinition -ExpectedSpec $expected
+                $freshCurrent = Get-WindowsRunnerLifecycleTaskObservation `
+                    -TaskName $expected.TaskName `
+                    -TaskPath $expected.TaskPath `
+                    -ExpectedSupervisorPath $expected.SupervisorPath
+                $freshInventory = @(Get-WindowsRunnerPrimaryInventory)
+                $freshPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $freshCurrent -PrimaryInventory $freshInventory
+                $null = Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $freshPlan -ExpectedOperation 'create'
                 Register-ScheduledTask -TaskName $expected.TaskName -TaskPath $expected.TaskPath -InputObject $definition -ErrorAction Stop | Out-Null
                 $changed = $true
             }

--- a/scripts/install_windows_runner_lifecycle.ps1
+++ b/scripts/install_windows_runner_lifecycle.ps1
@@ -30,7 +30,10 @@ $expected = New-WindowsRunnerLifecycleExpectedSpec `
     -TaskName $TaskName `
     -TaskPath $TaskPath `
     -WorkingDirectory $WorkingDirectory
-$current = Get-WindowsRunnerLifecycleTaskObservation -TaskName $expected.TaskName -TaskPath $expected.TaskPath
+$current = Get-WindowsRunnerLifecycleTaskObservation `
+    -TaskName $expected.TaskName `
+    -TaskPath $expected.TaskPath `
+    -ExpectedSupervisorPath $expected.SupervisorPath
 $inventory = @(Get-WindowsRunnerPrimaryInventory)
 $plan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $current -PrimaryInventory $inventory
 
@@ -69,12 +72,13 @@ if ($Apply) {
     }
 
     if ($changed) {
-        $afterTask = Get-WindowsRunnerLifecycleTaskObservation -TaskName $expected.TaskName -TaskPath $expected.TaskPath
+        $afterTask = Get-WindowsRunnerLifecycleTaskObservation `
+            -TaskName $expected.TaskName `
+            -TaskPath $expected.TaskPath `
+            -ExpectedSupervisorPath $expected.SupervisorPath
         $afterInventory = @(Get-WindowsRunnerPrimaryInventory)
         $plan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $afterTask -PrimaryInventory $afterInventory
-        if ($plan.task_operation -ne 'noop') {
-            throw "Scheduled Task lifecycle apply did not converge to the expected task definition"
-        }
+        $null = Assert-WindowsRunnerLifecycleSafeConvergence -Plan $plan
     }
 
     $plan | Add-Member -NotePropertyName applied -NotePropertyValue $changed -Force

--- a/scripts/install_windows_runner_lifecycle.ps1
+++ b/scripts/install_windows_runner_lifecycle.ps1
@@ -57,12 +57,26 @@ if ($Apply) {
             }
             if ($PSCmdlet.ShouldProcess("$($expected.TaskPath)$($expected.TaskName)", 'Update WebCodex Windows Runner lifecycle Scheduled Task definition')) {
                 $definition = New-WindowsRunnerScheduledTaskDefinition -ExpectedSpec $expected
+                $freshCurrent = Get-WindowsRunnerLifecycleTaskObservation `
+                    -TaskName $expected.TaskName `
+                    -TaskPath $expected.TaskPath `
+                    -ExpectedSupervisorPath $expected.SupervisorPath
+                $freshInventory = @(Get-WindowsRunnerPrimaryInventory)
+                $freshPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $freshCurrent -PrimaryInventory $freshInventory
+                $null = Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $freshPlan -ExpectedOperation 'update'
                 Register-ScheduledTask -TaskName $expected.TaskName -TaskPath $expected.TaskPath -InputObject $definition -Force -ErrorAction Stop | Out-Null
                 $changed = $true
             }
         }
         'enable' {
             if ($PSCmdlet.ShouldProcess("$($expected.TaskPath)$($expected.TaskName)", 'Enable WebCodex Windows Runner lifecycle Scheduled Task')) {
+                $freshCurrent = Get-WindowsRunnerLifecycleTaskObservation `
+                    -TaskName $expected.TaskName `
+                    -TaskPath $expected.TaskPath `
+                    -ExpectedSupervisorPath $expected.SupervisorPath
+                $freshInventory = @(Get-WindowsRunnerPrimaryInventory)
+                $freshPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $freshCurrent -PrimaryInventory $freshInventory
+                $null = Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $freshPlan -ExpectedOperation 'enable'
                 Enable-ScheduledTask -TaskName $expected.TaskName -TaskPath $expected.TaskPath -ErrorAction Stop | Out-Null
                 $changed = $true
             }

--- a/scripts/status_windows_runner_lifecycle.ps1
+++ b/scripts/status_windows_runner_lifecycle.ps1
@@ -1,0 +1,25 @@
+# Read-only status for the supported Windows Runner Scheduled Task lifecycle.
+[CmdletBinding()]
+param(
+    [string]$RunnerPath = "$env:USERPROFILE\.local\bin\webcodex-runner.exe",
+    [string]$TaskName = 'WebCodex MSI Dogfood Runner',
+    [string]$TaskPath = '\',
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'windows_runner_lifecycle.ps1')
+
+$expectedRunnerPath = ConvertTo-WindowsRunnerLifecycleFullPath -Path $RunnerPath
+$task = Get-WindowsRunnerLifecycleTaskObservation -TaskName $TaskName -TaskPath $TaskPath
+$inventory = @(Get-WindowsRunnerPrimaryInventory)
+$status = New-WindowsRunnerLifecycleStatusProjection `
+    -ExpectedRunnerPath $expectedRunnerPath `
+    -TaskObservation $task `
+    -PrimaryInventory $inventory
+
+if ($Json) {
+    $status | ConvertTo-Json -Depth 8
+} else {
+    $status
+}

--- a/scripts/test_windows_runner_lifecycle.ps1
+++ b/scripts/test_windows_runner_lifecycle.ps1
@@ -13,8 +13,10 @@ function Assert-Equal($Expected, $Actual, [string]$Message) {
 function Assert-Throws([scriptblock]$Action, [string]$Pattern) {
     try { & $Action; throw "Expected failure matching '$Pattern'" }
     catch {
-        if ($_.Exception.Message -notmatch $Pattern) { throw }
-        return $_.Exception.Message
+        $message = [string]$_.Exception.Message
+        $errorId = [string]$_.FullyQualifiedErrorId
+        if ($message -notmatch $Pattern -and $errorId -notmatch $Pattern) { throw }
+        return $message
     }
 }
 function Assert-HasMismatch($Items, [string]$Field, [string]$Message) {
@@ -203,10 +205,10 @@ try {
     $planText = $exactPlan | ConvertTo-Json -Depth 8 -Compress
     Assert-False $planText.Contains($secret) 'lifecycle plan leaked config secret contents'
 
-    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath (Join-Path $tempRoot 'missing.exe') -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path'
-    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath (Join-Path $tempRoot 'missing.toml') -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path'
-    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath (Join-Path $tempRoot 'missing.ps1') -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path'
-    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory (Join-Path $tempRoot 'missing-dir') } 'does not exist|Cannot find path'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath (Join-Path $tempRoot 'missing.exe') -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path|PathNotFound'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath (Join-Path $tempRoot 'missing.toml') -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path|PathNotFound'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath (Join-Path $tempRoot 'missing.ps1') -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path|PathNotFound'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory (Join-Path $tempRoot 'missing-dir') } 'does not exist|Cannot find path|PathNotFound'
     $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'Unrelated Task' -WorkingDirectory $workingDirectory } 'TaskName must identify a WebCodex task'
 
     # B. Status projection preserves exact PID+creation identity and handles cardinality/task state.

--- a/scripts/test_windows_runner_lifecycle.ps1
+++ b/scripts/test_windows_runner_lifecycle.ps1
@@ -107,11 +107,13 @@ try {
     $freshPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $missingTask -PrimaryInventory @()
     Assert-Equal 'create' $freshPlan.task_operation 'missing task did not produce create plan'
     Assert-True $freshPlan.can_apply 'fresh create plan was unexpectedly blocked'
+    $null = Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $freshPlan -ExpectedOperation 'create'
 
     $unsupervisedPrimary = [pscustomobject]@{ pid=77; process_creation_filetime=[uint64]88; normalized_executable_path=$expected.RunnerPath; runner_config_path=$expected.RunnerConfigPath; role='primary' }
     $unsafeFreshPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $missingTask -PrimaryInventory @($unsupervisedPrimary)
     Assert-HasMismatch $unsafeFreshPlan.runtime_mismatches 'unsupervised_primary_runner_count' 'fresh task plan ignored an already-running unsupervised primary'
     Assert-False $unsafeFreshPlan.can_apply 'fresh task plan could create beside an unsupervised primary'
+    $null = Assert-Throws { Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $unsafeFreshPlan -ExpectedOperation 'create' } 'changed before create effect'
 
     $exactTask = New-TestTaskObservation -Expected $expected
     $exactPrimary = [pscustomobject]@{ pid=101; process_creation_filetime=[uint64]202; normalized_executable_path=$expected.RunnerPath; runner_config_path=$expected.RunnerConfigPath; role='primary' }

--- a/scripts/test_windows_runner_lifecycle.ps1
+++ b/scripts/test_windows_runner_lifecycle.ps1
@@ -1,0 +1,205 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'windows_runner_lifecycle.ps1')
+
+function Assert-True($Value, [string]$Message) {
+    if (-not $Value) { throw $Message }
+}
+function Assert-False($Value, [string]$Message) {
+    if ($Value) { throw $Message }
+}
+function Assert-Equal($Expected, $Actual, [string]$Message) {
+    if ($Expected -ne $Actual) { throw "$Message (expected=$Expected actual=$Actual)" }
+}
+function Assert-Throws([scriptblock]$Action, [string]$Pattern) {
+    try { & $Action; throw "Expected failure matching '$Pattern'" }
+    catch {
+        if ($_.Exception.Message -notmatch $Pattern) { throw }
+        return $_.Exception.Message
+    }
+}
+function Assert-HasMismatch($Items, [string]$Field, [string]$Message) {
+    if (@($Items | Where-Object { $_.field -eq $Field }).Count -ne 1) { throw $Message }
+}
+function New-TestTaskObservation {
+    param(
+        [Parameter(Mandatory = $true)]$Expected,
+        [bool]$Exists = $true,
+        [bool]$Enabled = $true,
+        [string]$State = 'Running',
+        [int]$ActionCount = 1,
+        [string]$ActionExecutable,
+        [string]$ActionArguments,
+        [string]$WorkingDirectory,
+        [bool]$IsLifecycleLike = $true
+    )
+    if (-not $Exists) {
+        return [pscustomobject]@{
+            Exists=$false; Enabled=$false; State='Missing'; ActionCount=0; ActionExecutable=$null; ActionArguments=$null
+            WorkingDirectory=$null; SupervisorPath=$null; IsLifecycleLike=$false
+            PrincipalSid=$null; PrincipalLogonType=$null; PrincipalRunLevel=$null
+            TriggerCount=0; TriggerType=$null; TriggerSid=$null; TriggerEnabled=$false
+            MultipleInstances=$null; RestartCount=$null; RestartInterval=$null; ExecutionTimeLimit=$null; StartWhenAvailable=$false
+        }
+    }
+    if (-not $PSBoundParameters.ContainsKey('ActionExecutable')) { $ActionExecutable = $Expected.ActionExecutable }
+    if (-not $PSBoundParameters.ContainsKey('ActionArguments')) { $ActionArguments = $Expected.ActionArguments }
+    if (-not $PSBoundParameters.ContainsKey('WorkingDirectory')) { $WorkingDirectory = $Expected.WorkingDirectory }
+    return [pscustomobject]@{
+        Exists=$true; Enabled=$Enabled; State=$State; ActionCount=$ActionCount
+        ActionExecutable=$ActionExecutable; ActionArguments=$ActionArguments
+        WorkingDirectory=$WorkingDirectory; SupervisorPath=$Expected.SupervisorPath
+        IsLifecycleLike=$IsLifecycleLike
+        PrincipalSid=$Expected.PrincipalSid; PrincipalLogonType=$Expected.PrincipalLogonType; PrincipalRunLevel=$Expected.PrincipalRunLevel
+        TriggerCount=$Expected.TriggerCount; TriggerType=$Expected.TriggerType; TriggerSid=$Expected.TriggerSid; TriggerEnabled=$Expected.TriggerEnabled
+        MultipleInstances=$Expected.MultipleInstances; RestartCount=$Expected.RestartCount; RestartInterval=$Expected.RestartInterval
+        ExecutionTimeLimit=$Expected.ExecutionTimeLimit; StartWhenAvailable=$Expected.StartWhenAvailable
+    }
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('webcodex-lifecycle-test-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot | Out-Null
+try {
+    $runnerPath = Join-Path $tempRoot 'webcodex-runner.exe'
+    $configPath = Join-Path $tempRoot 'agent.toml'
+    $supervisorPath = Join-Path $tempRoot 'runner supervisor.ps1'
+    $workingDirectory = Join-Path $tempRoot 'work'
+    $secret = 'wc_pat_lifecycle_must_not_leak_0123456789'
+    New-Item -ItemType File -Path $runnerPath | Out-Null
+    Set-Content -LiteralPath $configPath -Encoding UTF8 -Value @('client_id = "msi-test"', ('token = "{0}"' -f $secret))
+    Set-Content -LiteralPath $supervisorPath -Encoding UTF8 -Value '# fixture supervisor'
+    New-Item -ItemType Directory -Path $workingDirectory | Out-Null
+
+    # A. Deterministic install plan and idempotence.
+    $expected = New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory
+    $expectedAgain = New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory
+    Assert-Equal ($expected | ConvertTo-Json -Compress) ($expectedAgain | ConvertTo-Json -Compress) 'fresh lifecycle spec was not deterministic'
+    Assert-Equal $expected.SupervisorPath (Get-PowerShellFileArgument -Arguments $expected.ActionArguments) 'supported supervisor argv was not recognized'
+    Assert-Equal $null (Get-PowerShellFileArgument -Arguments ($expected.ActionArguments + ' --token ' + $secret)) 'extra potentially-secret supervisor argv was treated as safe'
+
+    $definition = New-WindowsRunnerScheduledTaskDefinition -ExpectedSpec $expected
+    Assert-Equal 1 @($definition.Actions).Count 'task definition action count changed'
+    Assert-Equal $expected.ActionExecutable ([string]$definition.Actions[0].Execute) 'task definition executable changed'
+    Assert-Equal $expected.ActionArguments ([string]$definition.Actions[0].Arguments) 'task definition arguments changed'
+    Assert-Equal $expected.WorkingDirectory ([string]$definition.Actions[0].WorkingDirectory) 'task definition working directory changed'
+    Assert-Equal 1 @($definition.Triggers).Count 'task definition trigger count changed'
+    Assert-Equal 'MSFT_TaskLogonTrigger' ([string]$definition.Triggers[0].CimClass.CimClassName) 'task definition trigger type changed'
+    Assert-Equal 'Interactive' ([string]$definition.Principal.LogonType) 'task definition logon type changed'
+    Assert-Equal 'Highest' ([string]$definition.Principal.RunLevel) 'task definition run level changed'
+    Assert-Equal 20 ([int]$definition.Settings.RestartCount) 'task definition restart count changed'
+    Assert-Equal 'PT1M' ([string]$definition.Settings.RestartInterval) 'task definition restart interval changed'
+    Assert-Equal 'PT0S' ([string]$definition.Settings.ExecutionTimeLimit) 'task definition execution limit changed'
+    Assert-Equal 'IgnoreNew' ([string]$definition.Settings.MultipleInstances) 'task definition multiple-instance policy changed'
+    Assert-True ([bool]$definition.Settings.StartWhenAvailable) 'task definition StartWhenAvailable changed'
+
+    $missingTask = New-TestTaskObservation -Expected $expected -Exists $false
+    $freshPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $missingTask -PrimaryInventory @()
+    Assert-Equal 'create' $freshPlan.task_operation 'missing task did not produce create plan'
+    Assert-True $freshPlan.can_apply 'fresh create plan was unexpectedly blocked'
+
+    $unsupervisedPrimary = [pscustomobject]@{ pid=77; process_creation_filetime=[uint64]88; normalized_executable_path=$expected.RunnerPath; runner_config_path=$expected.RunnerConfigPath; role='primary' }
+    $unsafeFreshPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $missingTask -PrimaryInventory @($unsupervisedPrimary)
+    Assert-HasMismatch $unsafeFreshPlan.runtime_mismatches 'unsupervised_primary_runner_count' 'fresh task plan ignored an already-running unsupervised primary'
+    Assert-False $unsafeFreshPlan.can_apply 'fresh task plan could create beside an unsupervised primary'
+
+    $exactTask = New-TestTaskObservation -Expected $expected
+    $exactPrimary = [pscustomobject]@{ pid=101; process_creation_filetime=[uint64]202; normalized_executable_path=$expected.RunnerPath; runner_config_path=$expected.RunnerConfigPath; role='primary' }
+    $exactPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $exactTask -PrimaryInventory @($exactPrimary)
+    Assert-Equal 'noop' $exactPlan.task_operation 'repeated same lifecycle config was not idempotent'
+    Assert-True $exactPlan.idempotent_noop 'exact lifecycle did not report idempotent noop'
+
+    $actionMismatch = New-TestTaskObservation -Expected $expected -ActionArguments '-NoProfile -File "C:\wrong\supervisor.ps1"'
+    $actionPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $actionMismatch -PrimaryInventory @($exactPrimary)
+    Assert-Equal 'update' $actionPlan.task_operation 'action mismatch did not require update'
+    Assert-HasMismatch $actionPlan.task_mismatches 'task_action_arguments' 'action mismatch was not reported'
+
+    $executableMismatch = New-TestTaskObservation -Expected $expected -ActionExecutable 'C:\\unexpected\\powershell.exe'
+    $executablePlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $executableMismatch -PrimaryInventory @($exactPrimary)
+    Assert-HasMismatch $executablePlan.task_mismatches 'task_action_executable' 'action executable mismatch was not reported'
+
+    $unrelatedTask = New-TestTaskObservation -Expected $expected -IsLifecycleLike $false
+    $unrelatedPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $unrelatedTask -PrimaryInventory @($exactPrimary)
+    Assert-False $unrelatedPlan.can_apply 'unrecognized existing task was allowed to update'
+    Assert-HasMismatch $unrelatedPlan.task_mismatches 'task_identity' 'unrecognized task mismatch was not reported'
+
+    $otherWorking = Join-Path $tempRoot 'other-work'
+    New-Item -ItemType Directory -Path $otherWorking | Out-Null
+    $workingMismatch = New-TestTaskObservation -Expected $expected -WorkingDirectory $otherWorking
+    $workingPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $workingMismatch -PrimaryInventory @($exactPrimary)
+    Assert-HasMismatch $workingPlan.task_mismatches 'task_working_directory' 'working-directory mismatch was not reported'
+
+    $settingsMismatch = New-TestTaskObservation -Expected $expected
+    $settingsMismatch.RestartCount = 1
+    $settingsPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $settingsMismatch -PrimaryInventory @($exactPrimary)
+    Assert-HasMismatch $settingsPlan.task_mismatches 'task_restart_count' 'owned restart setting mismatch was not reported'
+
+    $otherRunner = Join-Path $tempRoot 'other\webcodex-runner.exe'
+    New-Item -ItemType Directory -Path (Split-Path -Parent $otherRunner) | Out-Null
+    New-Item -ItemType File -Path $otherRunner | Out-Null
+    $wrongPrimary = [pscustomobject]@{ pid=303; process_creation_filetime=[uint64]404; normalized_executable_path=[System.IO.Path]::GetFullPath($otherRunner); runner_config_path=$expected.RunnerConfigPath; role='primary' }
+    $runnerPathPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $exactTask -PrimaryInventory @($wrongPrimary)
+    Assert-HasMismatch $runnerPathPlan.runtime_mismatches 'runner_path' 'Runner path mismatch was not reported'
+    Assert-False $runnerPathPlan.can_apply 'running wrong-path lifecycle was allowed to apply silently'
+
+    $planText = $exactPlan | ConvertTo-Json -Depth 8 -Compress
+    Assert-False $planText.Contains($secret) 'lifecycle plan leaked config secret contents'
+
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath (Join-Path $tempRoot 'missing.exe') -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath (Join-Path $tempRoot 'missing.toml') -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath (Join-Path $tempRoot 'missing.ps1') -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory } 'does not exist|Cannot find path'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory (Join-Path $tempRoot 'missing-dir') } 'does not exist|Cannot find path'
+    $null = Assert-Throws { New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'Unrelated Task' -WorkingDirectory $workingDirectory } 'TaskName must identify a WebCodex task'
+
+    # B. Status projection preserves exact PID+creation identity and handles cardinality/task state.
+    $statusOne = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $exactTask -PrimaryInventory @($exactPrimary)
+    Assert-Equal 1 $statusOne.primary_runner_count 'exactly-one primary status count changed'
+    Assert-Equal 101 $statusOne.primary_runners[0].pid 'status lost primary PID'
+    Assert-Equal ([uint64]202) $statusOne.primary_runners[0].process_creation_filetime 'status lost creation FILETIME'
+    Assert-Equal 'primary' $statusOne.primary_runners[0].role 'status role changed'
+
+    $statusZero = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $exactTask -PrimaryInventory @()
+    Assert-Equal 0 $statusZero.primary_runner_count 'zero-primary status changed'
+    $secondPrimary = [pscustomobject]@{ pid=505; process_creation_filetime=[uint64]606; normalized_executable_path=$expected.RunnerPath; runner_config_path=$expected.RunnerConfigPath; role='primary' }
+    $statusMany = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $exactTask -PrimaryInventory @($exactPrimary,$secondPrimary)
+    Assert-Equal 2 $statusMany.primary_runner_count 'multiple-primary status changed'
+
+    Assert-False (Test-PrimaryRunnerArguments -Arguments @('webcodex-runner.exe','--webcodex-internal-detached-supervisor','x')) 'canonical internal role classification regressed'
+    $disabledTask = New-TestTaskObservation -Expected $expected -Enabled $false -State 'Disabled'
+    $statusDisabled = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $disabledTask -PrimaryInventory @()
+    Assert-False $statusDisabled.task_enabled 'disabled task was reported enabled'
+    $statusMissing = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $missingTask -PrimaryInventory @()
+    Assert-False $statusMissing.task_exists 'missing task was reported present'
+    Assert-Equal 'Missing' $statusMissing.task_state 'missing task state changed'
+
+    # C. Dogfood-first path resolution.
+    $repoRoot = Join-Path $tempRoot 'repo'
+    $dogfoodDir = Join-Path $repoRoot 'target\dogfood'
+    New-Item -ItemType Directory -Path $dogfoodDir -Force | Out-Null
+    $dogfoodCli = Join-Path $dogfoodDir 'webcodex.exe'
+    $dogfoodRunner = Join-Path $dogfoodDir 'webcodex-runner.exe'
+    $explicitCli = Join-Path $tempRoot 'explicit-webcodex.exe'
+    $explicitRunner = Join-Path $tempRoot 'explicit-runner.exe'
+    $installedCli = Join-Path $tempRoot 'installed-webcodex.exe'
+    foreach ($path in @($dogfoodCli,$dogfoodRunner,$explicitCli,$explicitRunner,$installedCli)) { New-Item -ItemType File -Path $path | Out-Null }
+    $supportAll = { param($Path) return $true }
+
+    $cliSelection = Resolve-WebCodexOperatorCliPath -ExplicitPath $explicitCli -RepoRoot $repoRoot -InstalledPath $installedCli -SupportsOpsRunner $supportAll
+    Assert-Equal 'explicit' $cliSelection.Source 'explicit CLI path did not win'
+    Assert-Equal ([System.IO.Path]::GetFullPath($explicitCli)) $cliSelection.Path 'explicit CLI path changed'
+
+    $cliSelection = Resolve-WebCodexOperatorCliPath -RepoRoot $repoRoot -InstalledPath $installedCli -SupportsOpsRunner $supportAll
+    Assert-Equal 'repo_dogfood' $cliSelection.Source 'repo dogfood CLI was not preferred'
+    Assert-Equal ([System.IO.Path]::GetFullPath($dogfoodCli)) $cliSelection.Path 'repo dogfood CLI path changed'
+
+    Remove-Item -LiteralPath $dogfoodCli -Force
+    $supportNone = { param($Path) return $false }
+    $null = Assert-Throws { Resolve-WebCodexOperatorCliPath -RepoRoot $repoRoot -InstalledPath $installedCli -SupportsOpsRunner $supportNone } 'stale or unsupported.*ops runner'
+
+    $candidateSelection = Resolve-WebCodexRunnerCandidatePath -ExplicitPath $explicitRunner -RepoRoot $repoRoot
+    Assert-Equal 'explicit' $candidateSelection.Source 'explicit Runner candidate did not win'
+    $candidateSelection = Resolve-WebCodexRunnerCandidatePath -RepoRoot $repoRoot
+    Assert-Equal 'repo_dogfood' $candidateSelection.Source 'repo dogfood Runner candidate was not preferred'
+
+    Write-Output 'Windows Runner lifecycle focused tests passed.'
+} finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/test_windows_runner_lifecycle.ps1
+++ b/scripts/test_windows_runner_lifecycle.ps1
@@ -74,7 +74,9 @@ try {
     $expectedAgain = New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory
     Assert-Equal ($expected | ConvertTo-Json -Compress) ($expectedAgain | ConvertTo-Json -Compress) 'fresh lifecycle spec was not deterministic'
     Assert-Equal $expected.SupervisorPath (Get-PowerShellFileArgument -Arguments $expected.ActionArguments) 'supported supervisor argv was not recognized'
+    Assert-Equal $expected.SupervisorPath (Get-PowerShellLifecycleSupervisorArgument -Arguments $expected.ActionArguments) 'canonical supervisor ownership argv was not recognized'
     Assert-Equal $null (Get-PowerShellFileArgument -Arguments ($expected.ActionArguments + ' --token ' + $secret)) 'extra potentially-secret supervisor argv was treated as safe'
+    Assert-Equal $null (Get-PowerShellLifecycleSupervisorArgument -Arguments ($expected.ActionArguments + ' --token ' + $secret)) 'extra supervisor argv established lifecycle ownership'
     Assert-True (Test-WindowsRunnerLifecycleSupervisorOwnership -ObservedSupervisorPath $expected.SupervisorPath -ExpectedSupervisorPath $expected.SupervisorPath) 'exact expected supervisor path did not establish lifecycle ownership'
 
     $differentSupervisorPath = Join-Path $tempRoot 'different supervisor.ps1'
@@ -132,10 +134,20 @@ try {
     $webCodexBackupPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $webCodexBackupTask -PrimaryInventory @($exactPrimary)
     Assert-False $webCodexBackupPlan.can_apply 'webcodex-named unrelated supervisor path established ownership'
 
-    $actionMismatch = New-TestTaskObservation -Expected $expected -ActionArguments '-NoProfile -File "C:\wrong\supervisor.ps1"'
+    $driftArguments = $expected.ActionArguments.Replace('-WindowStyle Hidden', '-WindowStyle Normal')
+    Assert-Equal $null (Get-PowerShellFileArgument -Arguments $driftArguments) 'noncanonical action drift was treated as safe for raw projection'
+    $driftSupervisor = Get-PowerShellLifecycleSupervisorArgument -Arguments $driftArguments
+    Assert-Equal $expected.SupervisorPath $driftSupervisor 'reconcilable action drift lost exact supervisor ownership'
+    $actionMismatch = New-TestTaskObservation -Expected $expected -ActionArguments '<unrecognized>'
+    $actionMismatch.SupervisorPath = $driftSupervisor
+    $actionMismatch.IsLifecycleLike = Test-WindowsRunnerLifecycleSupervisorOwnership -ObservedSupervisorPath $driftSupervisor -ExpectedSupervisorPath $expected.SupervisorPath
     $actionPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $actionMismatch -PrimaryInventory @($exactPrimary)
     Assert-Equal 'update' $actionPlan.task_operation 'action mismatch did not require update'
+    Assert-True $actionPlan.can_apply 'same-supervisor action drift was not safely reconcilable'
     Assert-HasMismatch $actionPlan.task_mismatches 'task_action_arguments' 'action mismatch was not reported'
+    $null = Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $actionPlan -ExpectedOperation 'update'
+    $null = Assert-Throws { Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $exactPlan -ExpectedOperation 'update' } 'changed before update effect'
+    $null = Assert-Throws { Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $differentSupervisorPlan -ExpectedOperation 'update' } 'changed before update effect'
 
     $executableMismatch = New-TestTaskObservation -Expected $expected -ActionExecutable 'C:\\unexpected\\powershell.exe'
     $executablePlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $executableMismatch -PrimaryInventory @($exactPrimary)
@@ -169,6 +181,8 @@ try {
     $runningDisabledPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $runningDisabledTask -PrimaryInventory @($exactPrimary)
     Assert-False $runningDisabledTask.Enabled 'running disabled fixture lost Settings.Enabled authority'
     Assert-Equal 'enable' $runningDisabledPlan.task_operation 'running task with Settings.Enabled=false did not require enable'
+    $null = Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $runningDisabledPlan -ExpectedOperation 'enable'
+    $null = Assert-Throws { Assert-WindowsRunnerLifecycleEffectStillSafe -FreshPlan $exactPlan -ExpectedOperation 'enable' } 'changed before enable effect'
 
     $readyEnabledTask = New-TestTaskObservation -Expected $expected -Enabled $true -State 'Ready'
     $readyEnabledStatus = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $readyEnabledTask -PrimaryInventory @()

--- a/scripts/test_windows_runner_lifecycle.ps1
+++ b/scripts/test_windows_runner_lifecycle.ps1
@@ -75,6 +75,14 @@ try {
     Assert-Equal ($expected | ConvertTo-Json -Compress) ($expectedAgain | ConvertTo-Json -Compress) 'fresh lifecycle spec was not deterministic'
     Assert-Equal $expected.SupervisorPath (Get-PowerShellFileArgument -Arguments $expected.ActionArguments) 'supported supervisor argv was not recognized'
     Assert-Equal $null (Get-PowerShellFileArgument -Arguments ($expected.ActionArguments + ' --token ' + $secret)) 'extra potentially-secret supervisor argv was treated as safe'
+    Assert-True (Test-WindowsRunnerLifecycleSupervisorOwnership -ObservedSupervisorPath $expected.SupervisorPath -ExpectedSupervisorPath $expected.SupervisorPath) 'exact expected supervisor path did not establish lifecycle ownership'
+
+    $differentSupervisorPath = Join-Path $tempRoot 'different supervisor.ps1'
+    $webCodexBackupSupervisorPath = Join-Path $tempRoot 'webcodex-backup.ps1'
+    Set-Content -LiteralPath $differentSupervisorPath -Encoding UTF8 -Value '# different fixture supervisor'
+    Set-Content -LiteralPath $webCodexBackupSupervisorPath -Encoding UTF8 -Value '# unrelated webcodex-named fixture supervisor'
+    Assert-False (Test-WindowsRunnerLifecycleSupervisorOwnership -ObservedSupervisorPath $differentSupervisorPath -ExpectedSupervisorPath $expected.SupervisorPath) 'different supervisor path established lifecycle ownership'
+    Assert-False (Test-WindowsRunnerLifecycleSupervisorOwnership -ObservedSupervisorPath $webCodexBackupSupervisorPath -ExpectedSupervisorPath $expected.SupervisorPath) 'path merely containing webcodex established lifecycle ownership'
 
     $definition = New-WindowsRunnerScheduledTaskDefinition -ExpectedSpec $expected
     Assert-Equal 1 @($definition.Actions).Count 'task definition action count changed'
@@ -106,6 +114,23 @@ try {
     $exactPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $exactTask -PrimaryInventory @($exactPrimary)
     Assert-Equal 'noop' $exactPlan.task_operation 'repeated same lifecycle config was not idempotent'
     Assert-True $exactPlan.idempotent_noop 'exact lifecycle did not report idempotent noop'
+    Assert-True $exactPlan.can_apply 'exact expected-supervisor lifecycle was not updateable'
+
+    $differentSupervisorTask = New-TestTaskObservation -Expected $expected
+    $differentSupervisorTask.SupervisorPath = [System.IO.Path]::GetFullPath($differentSupervisorPath)
+    $differentSupervisorTask.ActionArguments = Get-WindowsRunnerSupervisorArguments -SupervisorPath $differentSupervisorTask.SupervisorPath
+    $differentSupervisorTask.IsLifecycleLike = $false
+    $differentSupervisorPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $differentSupervisorTask -PrimaryInventory @($exactPrimary)
+    Assert-False $differentSupervisorPlan.can_apply 'different valid supervisor path was allowed to overwrite an existing task'
+    Assert-HasMismatch $differentSupervisorPlan.task_mismatches 'task_identity' 'different supervisor ownership did not report task identity mismatch'
+    Assert-HasMismatch $differentSupervisorPlan.task_mismatches 'task_supervisor_path' 'different supervisor ownership did not report supervisor mismatch'
+
+    $webCodexBackupTask = New-TestTaskObservation -Expected $expected
+    $webCodexBackupTask.SupervisorPath = [System.IO.Path]::GetFullPath($webCodexBackupSupervisorPath)
+    $webCodexBackupTask.ActionArguments = Get-WindowsRunnerSupervisorArguments -SupervisorPath $webCodexBackupTask.SupervisorPath
+    $webCodexBackupTask.IsLifecycleLike = $false
+    $webCodexBackupPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $webCodexBackupTask -PrimaryInventory @($exactPrimary)
+    Assert-False $webCodexBackupPlan.can_apply 'webcodex-named unrelated supervisor path established ownership'
 
     $actionMismatch = New-TestTaskObservation -Expected $expected -ActionArguments '-NoProfile -File "C:\wrong\supervisor.ps1"'
     $actionPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $actionMismatch -PrimaryInventory @($exactPrimary)
@@ -120,6 +145,9 @@ try {
     $unrelatedPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $unrelatedTask -PrimaryInventory @($exactPrimary)
     Assert-False $unrelatedPlan.can_apply 'unrecognized existing task was allowed to update'
     Assert-HasMismatch $unrelatedPlan.task_mismatches 'task_identity' 'unrecognized task mismatch was not reported'
+    Assert-Equal 'noop' $unrelatedPlan.task_operation 'unrecognized exact-definition task unexpectedly changed task operation'
+    Assert-False $unrelatedPlan.idempotent_noop 'task_operation=noop masked failed ownership in idempotent convergence'
+    $null = Assert-Throws { Assert-WindowsRunnerLifecycleSafeConvergence -Plan $unrelatedPlan } 'did not converge to a safe idempotent lifecycle state'
 
     $otherWorking = Join-Path $tempRoot 'other-work'
     New-Item -ItemType Directory -Path $otherWorking | Out-Null
@@ -132,6 +160,20 @@ try {
     $settingsPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $settingsMismatch -PrimaryInventory @($exactPrimary)
     Assert-HasMismatch $settingsPlan.task_mismatches 'task_restart_count' 'owned restart setting mismatch was not reported'
 
+    $runningDisabledRawTask = [pscustomobject]@{ State='Running'; Settings=[pscustomobject]@{ Enabled=$false } }
+    $readyEnabledRawTask = [pscustomobject]@{ State='Ready'; Settings=[pscustomobject]@{ Enabled=$true } }
+    Assert-False (Get-WindowsRunnerLifecycleTaskEnabled -Task $runningDisabledRawTask) 'Settings.Enabled=false was ignored while task state was Running'
+    Assert-True (Get-WindowsRunnerLifecycleTaskEnabled -Task $readyEnabledRawTask) 'Settings.Enabled=true was ignored while task state was Ready'
+
+    $runningDisabledTask = New-TestTaskObservation -Expected $expected -Enabled $false -State 'Running'
+    $runningDisabledPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $runningDisabledTask -PrimaryInventory @($exactPrimary)
+    Assert-False $runningDisabledTask.Enabled 'running disabled fixture lost Settings.Enabled authority'
+    Assert-Equal 'enable' $runningDisabledPlan.task_operation 'running task with Settings.Enabled=false did not require enable'
+
+    $readyEnabledTask = New-TestTaskObservation -Expected $expected -Enabled $true -State 'Ready'
+    $readyEnabledStatus = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $readyEnabledTask -PrimaryInventory @()
+    Assert-True $readyEnabledStatus.task_enabled 'ready task with Settings.Enabled=true was reported disabled'
+
     $otherRunner = Join-Path $tempRoot 'other\webcodex-runner.exe'
     New-Item -ItemType Directory -Path (Split-Path -Parent $otherRunner) | Out-Null
     New-Item -ItemType File -Path $otherRunner | Out-Null
@@ -139,6 +181,10 @@ try {
     $runnerPathPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $exactTask -PrimaryInventory @($wrongPrimary)
     Assert-HasMismatch $runnerPathPlan.runtime_mismatches 'runner_path' 'Runner path mismatch was not reported'
     Assert-False $runnerPathPlan.can_apply 'running wrong-path lifecycle was allowed to apply silently'
+    Assert-Equal 'noop' $runnerPathPlan.task_operation 'runtime mismatch unexpectedly changed task definition operation'
+    Assert-False $runnerPathPlan.idempotent_noop 'task_operation=noop masked runtime mismatch in idempotent convergence'
+    $null = Assert-Throws { Assert-WindowsRunnerLifecycleSafeConvergence -Plan $runnerPathPlan } 'did not converge to a safe idempotent lifecycle state'
+    $null = Assert-WindowsRunnerLifecycleSafeConvergence -Plan $exactPlan
 
     $planText = $exactPlan | ConvertTo-Json -Depth 8 -Compress
     Assert-False $planText.Contains($secret) 'lifecycle plan leaked config secret contents'

--- a/scripts/test_windows_runner_lifecycle.ps1
+++ b/scripts/test_windows_runner_lifecycle.ps1
@@ -75,6 +75,7 @@ try {
     $expected = New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory
     $expectedAgain = New-WindowsRunnerLifecycleExpectedSpec -RunnerPath $runnerPath -RunnerConfigPath $configPath -SupervisorPath $supervisorPath -TaskName 'WebCodex Test Runner' -WorkingDirectory $workingDirectory
     Assert-Equal ($expected | ConvertTo-Json -Compress) ($expectedAgain | ConvertTo-Json -Compress) 'fresh lifecycle spec was not deterministic'
+    Assert-Equal 'Limited' $expected.PrincipalRunLevel 'first-class lifecycle must use the least-privileged Scheduled Task run level'
     Assert-Equal $expected.SupervisorPath (Get-PowerShellFileArgument -Arguments $expected.ActionArguments) 'supported supervisor argv was not recognized'
     Assert-Equal $expected.SupervisorPath (Get-PowerShellLifecycleSupervisorArgument -Arguments $expected.ActionArguments) 'canonical supervisor ownership argv was not recognized'
     Assert-Equal $null (Get-PowerShellFileArgument -Arguments ($expected.ActionArguments + ' --token ' + $secret)) 'extra potentially-secret supervisor argv was treated as safe'
@@ -96,7 +97,7 @@ try {
     Assert-Equal 1 @($definition.Triggers).Count 'task definition trigger count changed'
     Assert-Equal 'MSFT_TaskLogonTrigger' ([string]$definition.Triggers[0].CimClass.CimClassName) 'task definition trigger type changed'
     Assert-Equal 'Interactive' ([string]$definition.Principal.LogonType) 'task definition logon type changed'
-    Assert-Equal 'Highest' ([string]$definition.Principal.RunLevel) 'task definition run level changed'
+    Assert-Equal 'Limited' ([string]$definition.Principal.RunLevel) 'task definition run level changed'
     Assert-Equal 20 ([int]$definition.Settings.RestartCount) 'task definition restart count changed'
     Assert-Equal 'PT1M' ([string]$definition.Settings.RestartInterval) 'task definition restart interval changed'
     Assert-Equal 'PT0S' ([string]$definition.Settings.ExecutionTimeLimit) 'task definition execution limit changed'
@@ -121,6 +122,14 @@ try {
     Assert-Equal 'noop' $exactPlan.task_operation 'repeated same lifecycle config was not idempotent'
     Assert-True $exactPlan.idempotent_noop 'exact lifecycle did not report idempotent noop'
     Assert-True $exactPlan.can_apply 'exact expected-supervisor lifecycle was not updateable'
+
+    $highestTask = New-TestTaskObservation -Expected $expected
+    $highestTask.PrincipalRunLevel = 'Highest'
+    $highestPlan = Get-WindowsRunnerLifecyclePlan -ExpectedSpec $expected -CurrentTask $highestTask -PrimaryInventory @($exactPrimary)
+    Assert-Equal 'update' $highestPlan.task_operation 'legacy Highest lifecycle did not require a least-privilege update'
+    Assert-True $highestPlan.can_apply 'owned legacy Highest lifecycle could not be migrated to Limited'
+    Assert-HasMismatch $highestPlan.task_mismatches 'task_principal_run_level' 'Highest-to-Limited privilege drift was not reported'
+    Assert-Equal 'Limited' $highestPlan.expected_principal_run_level 'plan did not expose the least-privileged expected run level'
 
     $differentSupervisorTask = New-TestTaskObservation -Expected $expected
     $differentSupervisorTask.SupervisorPath = [System.IO.Path]::GetFullPath($differentSupervisorPath)
@@ -219,6 +228,7 @@ try {
     Assert-Equal 101 $statusOne.primary_runners[0].pid 'status lost primary PID'
     Assert-Equal ([uint64]202) $statusOne.primary_runners[0].process_creation_filetime 'status lost creation FILETIME'
     Assert-Equal 'primary' $statusOne.primary_runners[0].role 'status role changed'
+    Assert-Equal 'Limited' $statusOne.task_principal_run_level 'status did not expose the Scheduled Task run level'
 
     $statusZero = New-WindowsRunnerLifecycleStatusProjection -ExpectedRunnerPath $expected.RunnerPath -TaskObservation $exactTask -PrimaryInventory @()
     Assert-Equal 0 $statusZero.primary_runner_count 'zero-primary status changed'

--- a/scripts/windows_runner_lifecycle.ps1
+++ b/scripts/windows_runner_lifecycle.ps1
@@ -1,0 +1,485 @@
+# Focused Windows Runner lifecycle operator helpers.
+#
+# This module intentionally owns only the supported Scheduled Task topology:
+#   Scheduled Task -> PowerShell supervisor -> WMI Win32_Process.Create -> Runner.
+# The host-specific supervisor remains an explicit input and is not rewritten here.
+
+if (-not (Get-Command Get-PrimaryRunnerProcesses -ErrorAction SilentlyContinue)) {
+    . (Join-Path $PSScriptRoot "windows_runner_process_identity.ps1")
+}
+
+function Resolve-WindowsRunnerLifecycleExistingPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][ValidateSet('File','Directory')][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Description,
+        [switch]$RequireExe
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "$Description path is required"
+    }
+    $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if ($Kind -eq 'File' -and $item.PSIsContainer) {
+        throw "$Description must be a regular file: $Path"
+    }
+    if ($Kind -eq 'Directory' -and -not $item.PSIsContainer) {
+        throw "$Description must be a directory: $Path"
+    }
+    if ($RequireExe -and $item.Extension -ine '.exe') {
+        throw "$Description must be an .exe file: $Path"
+    }
+    return [System.IO.Path]::GetFullPath([string]$item.FullName)
+}
+
+function ConvertTo-WindowsRunnerLifecycleFullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Get-WindowsRunnerSupervisorArguments {
+    param([Parameter(Mandatory = $true)][string]$SupervisorPath)
+    if ($SupervisorPath.Contains('"')) {
+        throw "Supervisor path contains an unsupported quote character"
+    }
+    return '-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "{0}"' -f $SupervisorPath
+}
+
+function Get-PowerShellFileArgument {
+    param([Parameter(Mandatory = $true)][string]$Arguments)
+
+    try {
+        $argv = @(ConvertFrom-WindowsCommandLine -CommandLine ('powershell.exe ' + $Arguments))
+    } catch {
+        return $null
+    }
+    if ($argv.Count -ne 9) { return $null }
+    if ($argv[1] -ine '-NoProfile') { return $null }
+    if ($argv[2] -ine '-NonInteractive') { return $null }
+    if ($argv[3] -ine '-WindowStyle' -or $argv[4] -ine 'Hidden') { return $null }
+    if ($argv[5] -ine '-ExecutionPolicy' -or $argv[6] -ine 'Bypass') { return $null }
+    if ($argv[7] -ine '-File' -or [string]::IsNullOrWhiteSpace([string]$argv[8])) { return $null }
+    return [string]$argv[8]
+}
+
+function ConvertTo-WindowsAccountSid {
+    param([Parameter(Mandatory = $true)][string]$UserId)
+    try {
+        $account = New-Object System.Security.Principal.NTAccount($UserId)
+        return $account.Translate([System.Security.Principal.SecurityIdentifier]).Value
+    } catch {
+        return $null
+    }
+}
+
+function New-WindowsRunnerLifecycleExpectedSpec {
+    param(
+        [Parameter(Mandatory = $true)][string]$RunnerPath,
+        [Parameter(Mandatory = $true)][string]$RunnerConfigPath,
+        [Parameter(Mandatory = $true)][string]$SupervisorPath,
+        [Parameter(Mandatory = $true)][string]$TaskName,
+        [string]$TaskPath = '\',
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory
+    )
+
+    $runner = Resolve-WindowsRunnerLifecycleExistingPath -Path $RunnerPath -Kind File -Description 'Runner' -RequireExe
+    $config = Resolve-WindowsRunnerLifecycleExistingPath -Path $RunnerConfigPath -Kind File -Description 'Runner config'
+    $supervisor = Resolve-WindowsRunnerLifecycleExistingPath -Path $SupervisorPath -Kind File -Description 'Supervisor'
+    $working = Resolve-WindowsRunnerLifecycleExistingPath -Path $WorkingDirectory -Kind Directory -Description 'Working directory'
+    if ([string]::IsNullOrWhiteSpace($TaskName)) { throw 'TaskName is required' }
+    if (-not $TaskName.StartsWith('WebCodex ', [System.StringComparison]::OrdinalIgnoreCase)) { throw 'TaskName must identify a WebCodex task (prefix: WebCodex )' }
+    if ($TaskPath -ne '\') { throw 'Only the root Scheduled Task path is supported for the WebCodex Windows Runner lifecycle' }
+
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $userSid = [string]$identity.User.Value
+
+    return [pscustomobject][ordered]@{
+        TaskName = $TaskName
+        TaskPath = '\'
+        RunnerPath = $runner
+        RunnerConfigPath = $config
+        SupervisorPath = $supervisor
+        WorkingDirectory = $working
+        ActionExecutable = 'powershell.exe'
+        ActionArguments = Get-WindowsRunnerSupervisorArguments -SupervisorPath $supervisor
+        PrincipalSid = $userSid
+        PrincipalLogonType = 'Interactive'
+        PrincipalRunLevel = 'Highest'
+        TriggerCount = 1
+        TriggerType = 'MSFT_TaskLogonTrigger'
+        TriggerSid = $userSid
+        TriggerEnabled = $true
+        MultipleInstances = 'IgnoreNew'
+        RestartCount = 20
+        RestartInterval = 'PT1M'
+        ExecutionTimeLimit = 'PT0S'
+        StartWhenAvailable = $true
+    }
+}
+
+function New-WindowsRunnerScheduledTaskDefinition {
+    param([Parameter(Mandatory = $true)]$ExpectedSpec)
+
+    $user = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $action = New-ScheduledTaskAction `
+        -Execute $ExpectedSpec.ActionExecutable `
+        -Argument $ExpectedSpec.ActionArguments `
+        -WorkingDirectory $ExpectedSpec.WorkingDirectory
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
+    $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType $ExpectedSpec.PrincipalLogonType -RunLevel $ExpectedSpec.PrincipalRunLevel
+    $settings = New-ScheduledTaskSettingsSet `
+        -MultipleInstances $ExpectedSpec.MultipleInstances `
+        -RestartCount $ExpectedSpec.RestartCount `
+        -RestartInterval ([System.Xml.XmlConvert]::ToTimeSpan([string]$ExpectedSpec.RestartInterval)) `
+        -ExecutionTimeLimit ([System.Xml.XmlConvert]::ToTimeSpan([string]$ExpectedSpec.ExecutionTimeLimit)) `
+        -StartWhenAvailable:$ExpectedSpec.StartWhenAvailable
+    return New-ScheduledTask `
+        -Action $action `
+        -Trigger $trigger `
+        -Principal $principal `
+        -Settings $settings `
+        -Description 'WebCodex Windows Runner lifecycle: Scheduled Task -> PowerShell supervisor -> WMI Win32_Process.Create -> primary Runner.'
+}
+
+function Get-WindowsRunnerLifecycleTaskObservation {
+    param(
+        [Parameter(Mandatory = $true)][string]$TaskName,
+        [string]$TaskPath = '\'
+    )
+
+    if (-not $TaskName.StartsWith('WebCodex ', [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw 'TaskName must identify a WebCodex task (prefix: WebCodex )'
+    }
+    if ($TaskPath -ne '\') {
+        throw 'Only the root Scheduled Task path is supported for the WebCodex Windows Runner lifecycle'
+    }
+
+    $tasks = @(Get-ScheduledTask -TaskPath $TaskPath -ErrorAction Stop | Where-Object { [string]$_.TaskName -ieq $TaskName })
+    if ($tasks.Count -gt 1) {
+        throw "Multiple Scheduled Tasks matched exact identity: $TaskPath$TaskName"
+    }
+    $task = if ($tasks.Count -eq 1) { $tasks[0] } else { $null }
+    if (-not $task) {
+        return [pscustomobject][ordered]@{
+            Exists = $false
+            Enabled = $false
+            State = 'Missing'
+            ActionCount = 0
+            ActionExecutable = $null
+            ActionArguments = $null
+            WorkingDirectory = $null
+            SupervisorPath = $null
+            IsLifecycleLike = $false
+            PrincipalSid = $null
+            PrincipalLogonType = $null
+            PrincipalRunLevel = $null
+            TriggerCount = 0
+            TriggerType = $null
+            TriggerSid = $null
+            TriggerEnabled = $false
+            MultipleInstances = $null
+            RestartCount = $null
+            RestartInterval = $null
+            ExecutionTimeLimit = $null
+            StartWhenAvailable = $false
+        }
+    }
+
+    $actions = @($task.Actions)
+    $action = if ($actions.Count -eq 1) { $actions[0] } else { $null }
+    $execute = if ($action) { [string]$action.Execute } else { $null }
+    $rawArguments = if ($action) { [string]$action.Arguments } else { $null }
+    $working = if ($action) { [string]$action.WorkingDirectory } else { $null }
+    $supervisor = if ($rawArguments) { Get-PowerShellFileArgument -Arguments $rawArguments } else { $null }
+    $arguments = if ($supervisor) { $rawArguments } elseif ($rawArguments) { '<unrecognized>' } else { $null }
+    $isPowerShell = $false
+    if ($execute) {
+        $isPowerShell = ([System.IO.Path]::GetFileName($execute) -ieq 'powershell.exe')
+    }
+    $looksWebCodex = $false
+    if ($supervisor) {
+        $looksWebCodex = ($supervisor.IndexOf('webcodex', [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+    }
+
+    $principalSid = ConvertTo-WindowsAccountSid -UserId ([string]$task.Principal.UserId)
+    $triggers = @($task.Triggers)
+    $trigger = if ($triggers.Count -eq 1) { $triggers[0] } else { $null }
+    $triggerType = if ($trigger) { [string]$trigger.CimClass.CimClassName } else { $null }
+    $triggerSid = $null
+    $triggerEnabled = $false
+    if ($trigger) {
+        $triggerEnabled = [bool]$trigger.Enabled
+        if ($trigger.UserId) { $triggerSid = ConvertTo-WindowsAccountSid -UserId ([string]$trigger.UserId) }
+    }
+
+    return [pscustomobject][ordered]@{
+        Exists = $true
+        Enabled = ([string]$task.State -ne 'Disabled')
+        State = [string]$task.State
+        ActionCount = $actions.Count
+        ActionExecutable = $execute
+        ActionArguments = $arguments
+        WorkingDirectory = $working
+        SupervisorPath = $supervisor
+        IsLifecycleLike = ($actions.Count -eq 1 -and $isPowerShell -and $supervisor -and $TaskName.StartsWith('WebCodex ', [System.StringComparison]::OrdinalIgnoreCase) -and $looksWebCodex)
+        PrincipalSid = $principalSid
+        PrincipalLogonType = [string]$task.Principal.LogonType
+        PrincipalRunLevel = [string]$task.Principal.RunLevel
+        TriggerCount = $triggers.Count
+        TriggerType = $triggerType
+        TriggerSid = $triggerSid
+        TriggerEnabled = $triggerEnabled
+        MultipleInstances = [string]$task.Settings.MultipleInstances
+        RestartCount = [int]$task.Settings.RestartCount
+        RestartInterval = [string]$task.Settings.RestartInterval
+        ExecutionTimeLimit = [string]$task.Settings.ExecutionTimeLimit
+        StartWhenAvailable = [bool]$task.Settings.StartWhenAvailable
+    }
+}
+
+function Get-RunnerConfigPathFromPrimaryIdentity {
+    param([Parameter(Mandatory = $true)]$Identity)
+
+    $argv = @(ConvertFrom-WindowsCommandLine -CommandLine ([string]$Identity.CommandLine))
+    for ($i = 0; $i -lt $argv.Count; $i++) {
+        if ($argv[$i] -ieq '--config' -and $i + 1 -lt $argv.Count) {
+            $value = [string]$argv[$i + 1]
+            if ([System.IO.Path]::IsPathRooted($value)) { return [System.IO.Path]::GetFullPath($value) }
+            return $value
+        }
+        if ($argv[$i].StartsWith('--config=', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $value = $argv[$i].Substring('--config='.Length)
+            if ([System.IO.Path]::IsPathRooted($value)) { return [System.IO.Path]::GetFullPath($value) }
+            return $value
+        }
+    }
+    return $null
+}
+
+function Get-WindowsRunnerPrimaryInventory {
+    $records = @(Get-CimInstance Win32_Process -Filter "Name = 'webcodex-runner.exe'" -ErrorAction Stop)
+    $paths = @($records | Where-Object { $_.ExecutablePath } | ForEach-Object {
+        try { [System.IO.Path]::GetFullPath([string]$_.ExecutablePath) } catch { $null }
+    } | Where-Object { $_ } | Sort-Object -Unique)
+    if ($paths.Count -gt 32) {
+        throw "Refusing unbounded Windows Runner process inventory: found $($paths.Count) executable paths"
+    }
+
+    $seen = @{}
+    $result = @()
+    foreach ($path in $paths) {
+        foreach ($identity in @(Get-PrimaryRunnerProcesses -ExactPath $path)) {
+            $key = '{0}:{1}' -f $identity.Id,$identity.CreationTime
+            if ($seen.ContainsKey($key)) { continue }
+            $seen[$key] = $true
+            $result += [pscustomobject][ordered]@{
+                pid = [uint32]$identity.Id
+                process_creation_filetime = [uint64]$identity.CreationTime
+                normalized_executable_path = [System.IO.Path]::GetFullPath([string]$identity.Path)
+                runner_config_path = Get-RunnerConfigPathFromPrimaryIdentity -Identity $identity
+                role = 'primary'
+            }
+        }
+    }
+    return @($result | Sort-Object pid)
+}
+
+function New-WindowsRunnerLifecycleStatusProjection {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExpectedRunnerPath,
+        [Parameter(Mandatory = $true)]$TaskObservation,
+        [object[]]$PrimaryInventory = @()
+    )
+
+    $expected = ConvertTo-WindowsRunnerLifecycleFullPath -Path $ExpectedRunnerPath
+    $matching = @($PrimaryInventory | Where-Object { $_.normalized_executable_path -ieq $expected })
+    $unexpected = @($PrimaryInventory | Where-Object { $_.normalized_executable_path -ine $expected })
+
+    return [pscustomobject][ordered]@{
+        task_exists = [bool]$TaskObservation.Exists
+        task_enabled = [bool]$TaskObservation.Enabled
+        task_state = [string]$TaskObservation.State
+        task_action_executable = $TaskObservation.ActionExecutable
+        task_action_arguments = $TaskObservation.ActionArguments
+        task_working_directory = $TaskObservation.WorkingDirectory
+        expected_runner_path = $expected
+        primary_runner_count = $matching.Count
+        primary_runners = @($matching)
+        unexpected_primary_runner_count = $unexpected.Count
+        unexpected_primary_runners = @($unexpected | Select-Object -First 8)
+    }
+}
+
+function Get-WindowsRunnerLifecyclePlan {
+    param(
+        [Parameter(Mandatory = $true)]$ExpectedSpec,
+        [Parameter(Mandatory = $true)]$CurrentTask,
+        [object[]]$PrimaryInventory = @()
+    )
+
+    $taskMismatches = @()
+    $runtimeMismatches = @()
+    $definitionMismatch = $false
+    $blocked = $false
+
+    if (-not $CurrentTask.Exists) {
+        $taskOperation = 'create'
+    } else {
+        if (-not $CurrentTask.IsLifecycleLike) {
+            $blocked = $true
+            $taskMismatches += [pscustomobject]@{ field = 'task_identity'; expected = 'WebCodex PowerShell supervisor task'; observed = 'unrecognized existing task' }
+        }
+        if ($CurrentTask.ActionCount -ne 1) {
+            $definitionMismatch = $true
+            $taskMismatches += [pscustomobject]@{ field = 'task_action_count'; expected = 1; observed = $CurrentTask.ActionCount }
+        }
+        if ([string]$CurrentTask.ActionExecutable -ine [string]$ExpectedSpec.ActionExecutable) {
+            $definitionMismatch = $true
+            $taskMismatches += [pscustomobject]@{ field = 'task_action_executable'; expected = $ExpectedSpec.ActionExecutable; observed = $CurrentTask.ActionExecutable }
+        }
+        if ([string]$CurrentTask.ActionArguments -cne [string]$ExpectedSpec.ActionArguments) {
+            $definitionMismatch = $true
+            $taskMismatches += [pscustomobject]@{ field = 'task_action_arguments'; expected = $ExpectedSpec.ActionArguments; observed = $CurrentTask.ActionArguments }
+        }
+        $observedWorking = $null
+        if (-not [string]::IsNullOrWhiteSpace([string]$CurrentTask.WorkingDirectory)) {
+            try { $observedWorking = [System.IO.Path]::GetFullPath([string]$CurrentTask.WorkingDirectory) } catch { $observedWorking = [string]$CurrentTask.WorkingDirectory }
+        }
+        if ($observedWorking -ine [string]$ExpectedSpec.WorkingDirectory) {
+            $definitionMismatch = $true
+            $taskMismatches += [pscustomobject]@{ field = 'task_working_directory'; expected = $ExpectedSpec.WorkingDirectory; observed = $CurrentTask.WorkingDirectory }
+        }
+        $ownedFields = @(
+            @('task_principal_sid', $ExpectedSpec.PrincipalSid, $CurrentTask.PrincipalSid, $true),
+            @('task_principal_logon_type', $ExpectedSpec.PrincipalLogonType, $CurrentTask.PrincipalLogonType, $false),
+            @('task_principal_run_level', $ExpectedSpec.PrincipalRunLevel, $CurrentTask.PrincipalRunLevel, $false),
+            @('task_trigger_count', $ExpectedSpec.TriggerCount, $CurrentTask.TriggerCount, $false),
+            @('task_trigger_type', $ExpectedSpec.TriggerType, $CurrentTask.TriggerType, $false),
+            @('task_trigger_sid', $ExpectedSpec.TriggerSid, $CurrentTask.TriggerSid, $true),
+            @('task_trigger_enabled', $ExpectedSpec.TriggerEnabled, $CurrentTask.TriggerEnabled, $false),
+            @('task_multiple_instances', $ExpectedSpec.MultipleInstances, $CurrentTask.MultipleInstances, $false),
+            @('task_restart_count', $ExpectedSpec.RestartCount, $CurrentTask.RestartCount, $false),
+            @('task_restart_interval', $ExpectedSpec.RestartInterval, $CurrentTask.RestartInterval, $false),
+            @('task_execution_time_limit', $ExpectedSpec.ExecutionTimeLimit, $CurrentTask.ExecutionTimeLimit, $false),
+            @('task_start_when_available', $ExpectedSpec.StartWhenAvailable, $CurrentTask.StartWhenAvailable, $false)
+        )
+        foreach ($owned in $ownedFields) {
+            $field = [string]$owned[0]
+            $expectedValue = $owned[1]
+            $observedValue = $owned[2]
+            $caseInsensitive = [bool]$owned[3]
+            $equal = if ($caseInsensitive) { [string]$expectedValue -ieq [string]$observedValue } else { $expectedValue -eq $observedValue }
+            if (-not $equal) {
+                $definitionMismatch = $true
+                $taskMismatches += [pscustomobject]@{ field = $field; expected = $expectedValue; observed = $observedValue }
+            }
+        }
+
+        if (-not $CurrentTask.Enabled) {
+            $taskMismatches += [pscustomobject]@{ field = 'task_enabled'; expected = $true; observed = $false }
+        }
+
+        if ($definitionMismatch) { $taskOperation = 'update' }
+        elseif (-not $CurrentTask.Enabled) { $taskOperation = 'enable' }
+        else { $taskOperation = 'noop' }
+    }
+
+    $primaryCount = @($PrimaryInventory).Count
+    $taskRunning = ($CurrentTask.Exists -and [string]$CurrentTask.State -eq 'Running')
+    if ($taskRunning) {
+        if ($primaryCount -ne 1) {
+            $runtimeMismatches += [pscustomobject]@{ field = 'primary_runner_count'; expected = 1; observed = $primaryCount }
+        }
+    } elseif ($primaryCount -ne 0) {
+        $runtimeMismatches += [pscustomobject]@{ field = 'unsupervised_primary_runner_count'; expected = 0; observed = $primaryCount }
+    }
+
+    if ($primaryCount -eq 1) {
+        $primary = @($PrimaryInventory)[0]
+        if ([string]$primary.normalized_executable_path -ine [string]$ExpectedSpec.RunnerPath) {
+            $runtimeMismatches += [pscustomobject]@{ field = 'runner_path'; expected = $ExpectedSpec.RunnerPath; observed = $primary.normalized_executable_path }
+        }
+        if ([string]$primary.runner_config_path -ine [string]$ExpectedSpec.RunnerConfigPath) {
+            $runtimeMismatches += [pscustomobject]@{ field = 'runner_config_path'; expected = $ExpectedSpec.RunnerConfigPath; observed = $primary.runner_config_path }
+        }
+    }
+
+    $canApply = (-not $blocked -and $runtimeMismatches.Count -eq 0)
+    return [pscustomobject][ordered]@{
+        task_name = $ExpectedSpec.TaskName
+        task_path = $ExpectedSpec.TaskPath
+        task_operation = $taskOperation
+        can_apply = $canApply
+        idempotent_noop = ($taskOperation -eq 'noop' -and $runtimeMismatches.Count -eq 0)
+        expected_runner_path = $ExpectedSpec.RunnerPath
+        expected_runner_config_path = $ExpectedSpec.RunnerConfigPath
+        expected_supervisor_path = $ExpectedSpec.SupervisorPath
+        expected_working_directory = $ExpectedSpec.WorkingDirectory
+        task_mismatches = @($taskMismatches)
+        runtime_mismatches = @($runtimeMismatches)
+    }
+}
+
+function Test-WebCodexOpsRunnerSupport {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    try {
+        $output = @(& $Path ops runner --help 2>&1)
+        $code = $LASTEXITCODE
+        if ($code -ne 0) { return $false }
+        return (($output -join "`n").IndexOf('Usage: webcodex ops runner', [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+    } catch {
+        return $false
+    }
+}
+
+function Resolve-WebCodexOperatorCliPath {
+    param(
+        [string]$ExplicitPath,
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [string]$InstalledPath = "$env:USERPROFILE\.local\bin\webcodex.exe",
+        [scriptblock]$SupportsOpsRunner = { param($Path) Test-WebCodexOpsRunnerSupport -Path $Path }
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
+        $path = Resolve-WindowsRunnerLifecycleExistingPath -Path $ExplicitPath -Kind File -Description 'Explicit WebCodex CLI'
+        if (-not (& $SupportsOpsRunner $path)) {
+            throw "Explicit WebCodex CLI does not support 'webcodex ops runner': $path"
+        }
+        return [pscustomobject]@{ Path = $path; Source = 'explicit' }
+    }
+
+    $repo = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot 'target\dogfood\webcodex.exe'))
+    if (Test-Path -LiteralPath $repo -PathType Leaf) {
+        if (-not (& $SupportsOpsRunner $repo)) {
+            throw "Repo dogfood WebCodex CLI exists but does not support 'webcodex ops runner': $repo"
+        }
+        return [pscustomobject]@{ Path = $repo; Source = 'repo_dogfood' }
+    }
+
+    if (-not (Test-Path -LiteralPath $InstalledPath -PathType Leaf)) {
+        throw "No supported WebCodex operator CLI found; build target\dogfood\webcodex.exe or pass -WebCodexCliPath explicitly"
+    }
+    $installed = Resolve-WindowsRunnerLifecycleExistingPath -Path $InstalledPath -Kind File -Description 'Installed WebCodex CLI'
+    if (-not (& $SupportsOpsRunner $installed)) {
+        throw "Installed WebCodex CLI is stale or unsupported and does not support 'webcodex ops runner': $installed"
+    }
+    return [pscustomobject]@{ Path = $installed; Source = 'installed' }
+}
+
+function Resolve-WebCodexRunnerCandidatePath {
+    param(
+        [string]$ExplicitPath,
+        [Parameter(Mandatory = $true)][string]$RepoRoot
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
+        $path = Resolve-WindowsRunnerLifecycleExistingPath -Path $ExplicitPath -Kind File -Description 'Explicit Runner candidate' -RequireExe
+        return [pscustomobject]@{ Path = $path; Source = 'explicit' }
+    }
+    $repo = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot 'target\dogfood\webcodex-runner.exe'))
+    if (-not (Test-Path -LiteralPath $repo -PathType Leaf)) {
+        throw "Runner candidate is unavailable; build target\dogfood\webcodex-runner.exe or pass -CandidatePath explicitly"
+    }
+    return [pscustomobject]@{ Path = $repo; Source = 'repo_dogfood' }
+}

--- a/scripts/windows_runner_lifecycle.ps1
+++ b/scripts/windows_runner_lifecycle.ps1
@@ -170,7 +170,7 @@ function New-WindowsRunnerLifecycleExpectedSpec {
         ActionArguments = Get-WindowsRunnerSupervisorArguments -SupervisorPath $supervisor
         PrincipalSid = $userSid
         PrincipalLogonType = 'Interactive'
-        PrincipalRunLevel = 'Highest'
+        PrincipalRunLevel = 'Limited'
         TriggerCount = 1
         TriggerType = 'MSFT_TaskLogonTrigger'
         TriggerSid = $userSid
@@ -366,6 +366,7 @@ function New-WindowsRunnerLifecycleStatusProjection {
         task_exists = [bool]$TaskObservation.Exists
         task_enabled = [bool]$TaskObservation.Enabled
         task_state = [string]$TaskObservation.State
+        task_principal_run_level = $TaskObservation.PrincipalRunLevel
         task_action_executable = $TaskObservation.ActionExecutable
         task_action_arguments = $TaskObservation.ActionArguments
         task_working_directory = $TaskObservation.WorkingDirectory
@@ -488,6 +489,7 @@ function Get-WindowsRunnerLifecyclePlan {
         expected_runner_config_path = $ExpectedSpec.RunnerConfigPath
         expected_supervisor_path = $ExpectedSpec.SupervisorPath
         expected_working_directory = $ExpectedSpec.WorkingDirectory
+        expected_principal_run_level = $ExpectedSpec.PrincipalRunLevel
         task_mismatches = @($taskMismatches)
         runtime_mismatches = @($runtimeMismatches)
     }

--- a/scripts/windows_runner_lifecycle.ps1
+++ b/scripts/windows_runner_lifecycle.ps1
@@ -503,7 +503,7 @@ function Assert-WindowsRunnerLifecycleSafeConvergence {
 function Assert-WindowsRunnerLifecycleEffectStillSafe {
     param(
         [Parameter(Mandatory = $true)]$FreshPlan,
-        [Parameter(Mandatory = $true)][ValidateSet('update','enable')][string]$ExpectedOperation
+        [Parameter(Mandatory = $true)][ValidateSet('create','update','enable')][string]$ExpectedOperation
     )
     if (-not [bool]$FreshPlan.can_apply -or [string]$FreshPlan.task_operation -ne $ExpectedOperation) {
         throw "Scheduled Task lifecycle changed before $ExpectedOperation effect; refusing stale mutation"

--- a/scripts/windows_runner_lifecycle.ps1
+++ b/scripts/windows_runner_lifecycle.ps1
@@ -63,6 +63,32 @@ function Get-PowerShellFileArgument {
     return [string]$argv[8]
 }
 
+function Test-WindowsRunnerLifecycleSupervisorOwnership {
+    param(
+        [string]$ObservedSupervisorPath,
+        [string]$ExpectedSupervisorPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ObservedSupervisorPath) -or [string]::IsNullOrWhiteSpace($ExpectedSupervisorPath)) {
+        return $false
+    }
+    try {
+        if (-not [System.IO.Path]::IsPathRooted($ObservedSupervisorPath) -or -not [System.IO.Path]::IsPathRooted($ExpectedSupervisorPath)) {
+            return $false
+        }
+        $observed = [System.IO.Path]::GetFullPath($ObservedSupervisorPath)
+        $expected = [System.IO.Path]::GetFullPath($ExpectedSupervisorPath)
+        return $observed -ieq $expected
+    } catch {
+        return $false
+    }
+}
+
+function Get-WindowsRunnerLifecycleTaskEnabled {
+    param([Parameter(Mandatory = $true)]$Task)
+    return [bool]$Task.Settings.Enabled
+}
+
 function ConvertTo-WindowsAccountSid {
     param([Parameter(Mandatory = $true)][string]$UserId)
     try {
@@ -145,7 +171,8 @@ function New-WindowsRunnerScheduledTaskDefinition {
 function Get-WindowsRunnerLifecycleTaskObservation {
     param(
         [Parameter(Mandatory = $true)][string]$TaskName,
-        [string]$TaskPath = '\'
+        [string]$TaskPath = '\',
+        [string]$ExpectedSupervisorPath
     )
 
     if (-not $TaskName.StartsWith('WebCodex ', [System.StringComparison]::OrdinalIgnoreCase)) {
@@ -197,10 +224,9 @@ function Get-WindowsRunnerLifecycleTaskObservation {
     if ($execute) {
         $isPowerShell = ([System.IO.Path]::GetFileName($execute) -ieq 'powershell.exe')
     }
-    $looksWebCodex = $false
-    if ($supervisor) {
-        $looksWebCodex = ($supervisor.IndexOf('webcodex', [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
-    }
+    $ownsExpectedSupervisor = Test-WindowsRunnerLifecycleSupervisorOwnership `
+        -ObservedSupervisorPath $supervisor `
+        -ExpectedSupervisorPath $ExpectedSupervisorPath
 
     $principalSid = ConvertTo-WindowsAccountSid -UserId ([string]$task.Principal.UserId)
     $triggers = @($task.Triggers)
@@ -215,14 +241,14 @@ function Get-WindowsRunnerLifecycleTaskObservation {
 
     return [pscustomobject][ordered]@{
         Exists = $true
-        Enabled = ([string]$task.State -ne 'Disabled')
+        Enabled = Get-WindowsRunnerLifecycleTaskEnabled -Task $task
         State = [string]$task.State
         ActionCount = $actions.Count
         ActionExecutable = $execute
         ActionArguments = $arguments
         WorkingDirectory = $working
         SupervisorPath = $supervisor
-        IsLifecycleLike = ($actions.Count -eq 1 -and $isPowerShell -and $supervisor -and $TaskName.StartsWith('WebCodex ', [System.StringComparison]::OrdinalIgnoreCase) -and $looksWebCodex)
+        IsLifecycleLike = ($actions.Count -eq 1 -and $isPowerShell -and $supervisor -and $TaskName.StartsWith('WebCodex ', [System.StringComparison]::OrdinalIgnoreCase) -and $ownsExpectedSupervisor)
         PrincipalSid = $principalSid
         PrincipalLogonType = [string]$task.Principal.LogonType
         PrincipalRunLevel = [string]$task.Principal.RunLevel
@@ -326,9 +352,15 @@ function Get-WindowsRunnerLifecyclePlan {
     if (-not $CurrentTask.Exists) {
         $taskOperation = 'create'
     } else {
-        if (-not $CurrentTask.IsLifecycleLike) {
+        $ownsExpectedSupervisor = Test-WindowsRunnerLifecycleSupervisorOwnership `
+            -ObservedSupervisorPath ([string]$CurrentTask.SupervisorPath) `
+            -ExpectedSupervisorPath ([string]$ExpectedSpec.SupervisorPath)
+        if (-not $CurrentTask.IsLifecycleLike -or -not $ownsExpectedSupervisor) {
             $blocked = $true
-            $taskMismatches += [pscustomobject]@{ field = 'task_identity'; expected = 'WebCodex PowerShell supervisor task'; observed = 'unrecognized existing task' }
+            $taskMismatches += [pscustomobject]@{ field = 'task_identity'; expected = 'WebCodex lifecycle task owned by the exact expected supervisor path'; observed = 'unrecognized or differently-owned existing task' }
+        }
+        if (-not $ownsExpectedSupervisor) {
+            $taskMismatches += [pscustomobject]@{ field = 'task_supervisor_path'; expected = $ExpectedSpec.SupervisorPath; observed = $CurrentTask.SupervisorPath }
         }
         if ($CurrentTask.ActionCount -ne 1) {
             $definitionMismatch = $true
@@ -411,13 +443,20 @@ function Get-WindowsRunnerLifecyclePlan {
         task_path = $ExpectedSpec.TaskPath
         task_operation = $taskOperation
         can_apply = $canApply
-        idempotent_noop = ($taskOperation -eq 'noop' -and $runtimeMismatches.Count -eq 0)
+        idempotent_noop = ($taskOperation -eq 'noop' -and $canApply -and $runtimeMismatches.Count -eq 0)
         expected_runner_path = $ExpectedSpec.RunnerPath
         expected_runner_config_path = $ExpectedSpec.RunnerConfigPath
         expected_supervisor_path = $ExpectedSpec.SupervisorPath
         expected_working_directory = $ExpectedSpec.WorkingDirectory
         task_mismatches = @($taskMismatches)
         runtime_mismatches = @($runtimeMismatches)
+    }
+}
+
+function Assert-WindowsRunnerLifecycleSafeConvergence {
+    param([Parameter(Mandatory = $true)]$Plan)
+    if (-not [bool]$Plan.idempotent_noop) {
+        throw 'Scheduled Task lifecycle apply did not converge to a safe idempotent lifecycle state'
     }
 }
 

--- a/scripts/windows_runner_lifecycle.ps1
+++ b/scripts/windows_runner_lifecycle.ps1
@@ -63,6 +63,45 @@ function Get-PowerShellFileArgument {
     return [string]$argv[8]
 }
 
+function Get-PowerShellLifecycleSupervisorArgument {
+    param([Parameter(Mandatory = $true)][string]$Arguments)
+
+    try {
+        $argv = @(ConvertFrom-WindowsCommandLine -CommandLine ('powershell.exe ' + $Arguments))
+    } catch {
+        return $null
+    }
+    if ($argv.Count -lt 3) { return $null }
+
+    $seen = @{}
+    for ($i = 1; $i -lt $argv.Count; $i++) {
+        $argument = [string]$argv[$i]
+        if ($argument -ieq '-File') {
+            if ($seen.ContainsKey('File') -or $i + 1 -ne $argv.Count - 1) { return $null }
+            $supervisor = [string]$argv[$i + 1]
+            if ([string]::IsNullOrWhiteSpace($supervisor)) { return $null }
+            return $supervisor
+        }
+        if ($argument -ieq '-NoProfile' -or $argument -ieq '-NonInteractive') {
+            $key = $argument.ToLowerInvariant()
+            if ($seen.ContainsKey($key)) { return $null }
+            $seen[$key] = $true
+            continue
+        }
+        if ($argument -ieq '-WindowStyle' -or $argument -ieq '-ExecutionPolicy') {
+            $key = $argument.ToLowerInvariant()
+            if ($seen.ContainsKey($key) -or $i + 1 -ge $argv.Count) { return $null }
+            $value = [string]$argv[$i + 1]
+            if ([string]::IsNullOrWhiteSpace($value) -or $value.StartsWith('-')) { return $null }
+            $seen[$key] = $true
+            $i++
+            continue
+        }
+        return $null
+    }
+    return $null
+}
+
 function Test-WindowsRunnerLifecycleSupervisorOwnership {
     param(
         [string]$ObservedSupervisorPath,
@@ -218,8 +257,9 @@ function Get-WindowsRunnerLifecycleTaskObservation {
     $execute = if ($action) { [string]$action.Execute } else { $null }
     $rawArguments = if ($action) { [string]$action.Arguments } else { $null }
     $working = if ($action) { [string]$action.WorkingDirectory } else { $null }
-    $supervisor = if ($rawArguments) { Get-PowerShellFileArgument -Arguments $rawArguments } else { $null }
-    $arguments = if ($supervisor) { $rawArguments } elseif ($rawArguments) { '<unrecognized>' } else { $null }
+    $safeSupervisor = if ($rawArguments) { Get-PowerShellFileArgument -Arguments $rawArguments } else { $null }
+    $supervisor = if ($rawArguments) { Get-PowerShellLifecycleSupervisorArgument -Arguments $rawArguments } else { $null }
+    $arguments = if ($safeSupervisor) { $rawArguments } elseif ($rawArguments) { '<unrecognized>' } else { $null }
     $isPowerShell = $false
     if ($execute) {
         $isPowerShell = ([System.IO.Path]::GetFileName($execute) -ieq 'powershell.exe')
@@ -458,6 +498,17 @@ function Assert-WindowsRunnerLifecycleSafeConvergence {
     if (-not [bool]$Plan.idempotent_noop) {
         throw 'Scheduled Task lifecycle apply did not converge to a safe idempotent lifecycle state'
     }
+}
+
+function Assert-WindowsRunnerLifecycleEffectStillSafe {
+    param(
+        [Parameter(Mandatory = $true)]$FreshPlan,
+        [Parameter(Mandatory = $true)][ValidateSet('update','enable')][string]$ExpectedOperation
+    )
+    if (-not [bool]$FreshPlan.can_apply -or [string]$FreshPlan.task_operation -ne $ExpectedOperation) {
+        throw "Scheduled Task lifecycle changed before $ExpectedOperation effect; refusing stale mutation"
+    }
+    return $FreshPlan
 }
 
 function Test-WebCodexOpsRunnerSupport {


### PR DESCRIPTION
## Summary
- add repo-supported Windows Runner Scheduled Task lifecycle install/plan/status surfaces
- reuse exact primary Runner identity and readiness fencing from #140
- make dogfood CLI/Runner resolution explicit and fail closed on stale operator CLI
- harden task ownership, Settings.Enabled authority, pre-effect race revalidation, safe post-apply convergence, privacy projection, and locale-independent Windows tests

## Supported topology
Scheduled Task -> PowerShell supervisor -> WMI Win32_Process.Create -> exact primary webcodex-runner.exe

The host-specific supervisor remains an explicit dependency; this does not generalize MSI proxy/Mihomo policy or change Runner Rust/ManagedChild semantics.

## Validation
- PowerShell parser checks: pass
- scripts/test_windows_runner_lifecycle.ps1: pass
- scripts/test_windows_runner_process_identity.ps1: pass
- scripts/test_windows_runner_readiness.ps1: pass
- cargo fmt --all -- --check: pass
- git diff --check: pass
- production Scheduled Task status observed read-only: Running, Enabled, exactly one primary, no unexpected primary

No deploy/restart/release or production Scheduled Task mutation was performed.