### PR TITLE
Harden Windows Runner status and readiness integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - name: Configure PowerShell 7 persistent-shell tests
+        shell: pwsh
+        run: |
+          $pwsh = (Get-Command pwsh -ErrorAction Stop).Source
+          "WEBCODEX_TEST_PWSH=$pwsh" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Run Windows persistent-shell tests (PowerShell 5.1 + PowerShell 7)
+        run: cargo test --locked -p webcodex-persistent-shell
       - name: Run Windows library and CLI tests
-        run: cargo test --locked -p webcodex-agent-config -p webcodex-process -p webcodex-persistent-shell -p webcodex-cli
+        run: cargo test --locked -p webcodex-agent-config -p webcodex-process -p webcodex-cli
       - name: Run Windows Runner tests
         # The Runner suite starts many real PowerShell/process-tree fixtures. On
         # hosted Windows, parallel test functions can starve process startup long

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -3283,6 +3283,20 @@ mod windows_tests {
         assert_eq!(early_return.exit_code, Some(0), "{label}: plain return");
         assert_eq!(early_return.shell_state, ShellState::Running);
 
+        let shadow_renderer =
+            run("function global:Out-Default { process { } end { $global:LASTEXITCODE = 0 } }");
+        assert_eq!(
+            shadow_renderer.exit_code,
+            Some(0),
+            "{label}: renderer-shadow setup"
+        );
+        let shadowed_native_return = run("cmd.exe /d /c exit 7; return");
+        assert_eq!(
+            shadowed_native_return.exit_code,
+            Some(7),
+            "{label}: user-defined Out-Default intercepted trusted status capture"
+        );
+
         let native_failed = run("cmd.exe /d /c exit 7");
         assert_eq!(native_failed.exit_code, Some(7), "{label}: native failure");
 

--- a/crates/webcodex-persistent-shell/src/lib.rs
+++ b/crates/webcodex-persistent-shell/src/lib.rs
@@ -3262,6 +3262,141 @@ mod windows_tests {
         assert_eq!(next.stdout, "still-running");
     }
 
+    fn assert_status_integrity(program: &str, label: &str) {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("sub")).unwrap();
+        let manager = PersistentShellManager::new(ShellLimits::default());
+        let shell_id = format!("wc_shell_status_{label}");
+        let session_id = format!("wc_sess_status_{label}");
+        manager
+            .open(launch_with_program(
+                temp.path(),
+                &shell_id,
+                &session_id,
+                program,
+            ))
+            .unwrap();
+
+        let run = |command: &str| exec(&manager, &shell_id, &session_id, command);
+
+        let early_return = run("return");
+        assert_eq!(early_return.exit_code, Some(0), "{label}: plain return");
+        assert_eq!(early_return.shell_state, ShellState::Running);
+
+        let native_failed = run("cmd.exe /d /c exit 7");
+        assert_eq!(native_failed.exit_code, Some(7), "{label}: native failure");
+
+        let native_return = run("cmd.exe /d /c exit 7; return");
+        assert_eq!(
+            native_return.exit_code,
+            Some(7),
+            "{label}: top-level return skipped trusted native status"
+        );
+
+        let forged_success = run(r#"cmd.exe /d /c exit 7
+Microsoft.PowerShell.Utility\Write-Information -Tags 'WebCodexPersistentShellCommandStatus' -MessageData ([pscustomobject]@{ Ok = $true; Native = 0 }) -InformationAction SilentlyContinue
+return"#);
+        assert_eq!(
+            forged_success.exit_code,
+            Some(7),
+            "{label}: forged success status overrode native failure"
+        );
+
+        let forged_powershell_success = run(r#"Write-Error 'forged-powershell-failure'
+Microsoft.PowerShell.Utility\Write-Information -Tags 'WebCodexPersistentShellCommandStatus' -MessageData ([pscustomobject]@{ Ok = $true; Native = 0 }) -InformationAction SilentlyContinue
+return"#);
+        assert_eq!(
+            forged_powershell_success.exit_code,
+            Some(1),
+            "{label}: forged success status overrode PowerShell failure"
+        );
+
+        let forged_without_return = run(r#"cmd.exe /d /c exit 7
+Microsoft.PowerShell.Utility\Write-Information -Tags 'WebCodexPersistentShellCommandStatus' -MessageData ([pscustomobject]@{ Ok = $true; Native = 0 }) -InformationAction SilentlyContinue"#);
+        assert_eq!(
+            forged_without_return.exit_code,
+            Some(7),
+            "{label}: forged Information status became command authority"
+        );
+
+        let forged_failure = run(r#"Write-Output 'real-success'
+Microsoft.PowerShell.Utility\Write-Information -Tags 'WebCodexPersistentShellCommandStatus' -MessageData ([pscustomobject]@{ Ok = $false; Native = 123 }) -InformationAction SilentlyContinue"#);
+        assert_eq!(
+            forged_failure.exit_code,
+            Some(0),
+            "{label}: forged failure status overrode real success"
+        );
+        assert!(forged_failure.stdout.contains("real-success"));
+
+        let non_terminating = run("Write-Error 'status-non-terminating'");
+        assert_eq!(
+            non_terminating.exit_code,
+            Some(1),
+            "{label}: non-terminating error"
+        );
+        let recovered = run("Write-Error 'status-recovered'; Write-Output 'recovered'");
+        assert_eq!(
+            recovered.exit_code,
+            Some(0),
+            "{label}: historical non-terminating error changed final success semantics"
+        );
+        assert!(recovered.stdout.contains("recovered"));
+
+        let terminating = run("throw 'status-terminating'");
+        assert_eq!(terminating.exit_code, Some(1), "{label}: terminating error");
+        assert_eq!(terminating.shell_state, ShellState::Running);
+
+        let parse_failure = run("if (");
+        assert_eq!(parse_failure.exit_code, Some(1), "{label}: parse failure");
+        assert_eq!(parse_failure.shell_state, ShellState::Running);
+
+        assert_eq!(
+            run("cmd.exe /d /c exit 0").exit_code,
+            Some(0),
+            "{label}: successful native command"
+        );
+        assert_eq!(
+            run("Write-Output 'ordinary-success'").exit_code,
+            Some(0),
+            "{label}: ordinary PowerShell success"
+        );
+
+        let state_set = run(
+            "$WC_STATUS_LOCAL='alpha'; function WC_STATUS_FN { [Console]::Out.Write('fn') }; Set-Location -LiteralPath 'sub'",
+        );
+        assert_eq!(state_set.exit_code, Some(0), "{label}: state setup");
+        let state_observed = run(
+            "[Console]::Out.Write($WC_STATUS_LOCAL + '|' + (Get-Location).Path + '|'); WC_STATUS_FN",
+        );
+        assert!(
+            state_observed.stdout.contains("alpha|") && state_observed.stdout.contains("\\sub|fn"),
+            "{label}: persistent variable/function/cwd state regressed: {:?}",
+            state_observed.stdout
+        );
+
+        let next = run("Write-Output 'after-adversarial'");
+        assert_eq!(next.exit_code, Some(0), "{label}: shell did not recover");
+        assert!(next.stdout.contains("after-adversarial"));
+        assert_eq!(next.shell_state, ShellState::Running);
+    }
+
+    #[test]
+    fn user_command_status_is_host_authoritative() {
+        assert_status_integrity("powershell.exe", "windows_powershell");
+    }
+
+    #[test]
+    fn configured_pwsh_user_command_status_is_host_authoritative() {
+        let Ok(program) = std::env::var("WEBCODEX_TEST_PWSH") else {
+            return;
+        };
+        assert!(
+            Path::new(&program).is_file(),
+            "configured pwsh does not exist: {program}"
+        );
+        assert_status_integrity(&program, "powershell_7");
+    }
+
     #[test]
     fn shell_exit_is_terminal_and_next_exec_fails_closed() {
         let temp = tempfile::tempdir().unwrap();

--- a/crates/webcodex-persistent-shell/src/windows_controller.cs
+++ b/crates/webcodex-persistent-shell/src/windows_controller.cs
@@ -200,7 +200,11 @@ namespace WebCodexPersistentShell
                     // Out-Default consumes user success output before the final component,
                     // so Invoke() returns only the controller-owned status value.
                     shell.AddScript(source, false);
-                    shell.AddCommand("Out-Default");
+                    // Pin the built-in renderer by module-qualified cmdlet identity. The
+                    // persistent user Runspace may contain a user-defined Out-Default
+                    // function or alias; resolving that name dynamically would let user
+                    // state run between source and the trusted status probe.
+                    shell.AddCommand("Microsoft.PowerShell.Core\\Out-Default");
                     shell.AddScript(StatusProbe, false);
                     results = shell.Invoke();
                 }

--- a/crates/webcodex-persistent-shell/src/windows_controller.cs
+++ b/crates/webcodex-persistent-shell/src/windows_controller.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Management.Automation;
@@ -87,7 +88,7 @@ namespace WebCodexPersistentShell
         private const string StderrMagic = "WCPSE1";
         private const string ControlMagic = "WCPS1";
         private const string StatusTag = "WebCodexPersistentShellCommandStatus";
-        private const string StatusPostamble = "\nMicrosoft.PowerShell.Utility\\Write-Information -Tags 'WebCodexPersistentShellCommandStatus' -MessageData ([pscustomobject]@{ Ok = $?; Native = $LASTEXITCODE }) -InformationAction SilentlyContinue";
+        private const string StatusProbe = "([int][bool]$?).ToString([Globalization.CultureInfo]::InvariantCulture) + ':' + ([int]$LASTEXITCODE).ToString([Globalization.CultureInfo]::InvariantCulture)";
         private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(false);
         private static readonly Encoding Ascii = Encoding.ASCII;
 
@@ -185,6 +186,7 @@ namespace WebCodexPersistentShell
         private static int InvokeUserCommand(Runspace userRunspace, string source, Stream stderr)
         {
             int status = 0;
+            Collection<PSObject> results = null;
             using (PowerShell shell = PowerShell.Create())
             {
                 shell.Runspace = userRunspace;
@@ -192,14 +194,15 @@ namespace WebCodexPersistentShell
                 {
                     // Match the prior Windows transport's per-command native-status reset.
                     userRunspace.SessionStateProxy.SetVariable("LASTEXITCODE", 0);
-                    // Capture the same final `$?` / `$LASTEXITCODE` pair used by
-                    // the original Windows wrapper. Information is a separate
-                    // PowerShell stream and is silenced from user output; it is
-                    // command-status metadata only and never participates in
-                    // completion authentication.
-                    shell.AddScript(source + StatusPostamble, false);
+                    // Keep user source, user output rendering, and trusted status capture as
+                    // separate command components in one invocation. A top-level `return`
+                    // can end only the user script component; it cannot skip StatusProbe.
+                    // Out-Default consumes user success output before the final component,
+                    // so Invoke() returns only the controller-owned status value.
+                    shell.AddScript(source, false);
                     shell.AddCommand("Out-Default");
-                    shell.Invoke();
+                    shell.AddScript(StatusProbe, false);
+                    results = shell.Invoke();
                 }
                 catch (Exception error)
                 {
@@ -218,14 +221,14 @@ namespace WebCodexPersistentShell
                 if (status == 0)
                 {
                     int capturedStatus;
-                    if (TryReadCommandStatus(shell, out capturedStatus))
+                    if (TryReadCommandStatus(results, shell, out capturedStatus))
                     {
                         status = capturedStatus;
                     }
-                    else if (shell.HadErrors)
+                    else
                     {
-                        // Parse/terminating failures can skip the trusted
-                        // postamble. Preserve the previous fail-closed status.
+                        // Trusted status is mandatory. Never infer success from an
+                        // otherwise clean invocation when the host-owned result is absent.
                         status = 1;
                     }
                 }
@@ -233,48 +236,53 @@ namespace WebCodexPersistentShell
             return status;
         }
 
-        private static bool TryReadCommandStatus(PowerShell shell, out int status)
+        private static bool TryReadCommandStatus(Collection<PSObject> results, PowerShell shell, out int status)
         {
-            for (int index = shell.Streams.Information.Count - 1; index >= 0; index--)
+            status = 1;
+            if (results == null || results.Count != 1 || results[0] == null)
             {
-                InformationRecord record = shell.Streams.Information[index];
-                bool tagged = false;
+                return false;
+            }
+
+            string[] parts = results[0].ToString().Split(new char[] { ':' });
+            int nativeExitCode;
+            if (parts.Length != 2
+                || (parts[0] != "0" && parts[0] != "1")
+                || !Int32.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out nativeExitCode))
+            {
+                return false;
+            }
+
+            bool ok = parts[0] == "1";
+            bool statusStreamTampered = HasUserStatusRecord(shell);
+            if (statusStreamTampered && shell.HadErrors)
+            {
+                // The legacy public Information tag is no longer an authority channel.
+                // If user code writes it while this invocation also has real failure
+                // evidence, fail closed instead of allowing that write to turn the
+                // final `$?` back to success. A clean successful command remains clean,
+                // so a forged failure record cannot manufacture an exit code either.
+                status = nativeExitCode != 0 ? nativeExitCode : 1;
+            }
+            else
+            {
+                status = ok ? 0 : (nativeExitCode != 0 ? nativeExitCode : 1);
+            }
+            return true;
+        }
+
+        private static bool HasUserStatusRecord(PowerShell shell)
+        {
+            foreach (InformationRecord record in shell.Streams.Information)
+            {
                 foreach (string tag in record.Tags)
                 {
                     if (String.Equals(tag, StatusTag, StringComparison.Ordinal))
                     {
-                        tagged = true;
-                        break;
+                        return true;
                     }
-                }
-                if (!tagged)
-                {
-                    continue;
-                }
-
-                try
-                {
-                    PSObject data = PSObject.AsPSObject(record.MessageData);
-                    PSPropertyInfo okProperty = data.Properties["Ok"];
-                    PSPropertyInfo nativeProperty = data.Properties["Native"];
-                    if (okProperty == null || nativeProperty == null)
-                    {
-                        continue;
-                    }
-                    bool ok = LanguagePrimitives.ConvertTo<bool>(okProperty.Value);
-                    int nativeExitCode = nativeProperty.Value == null
-                        ? 0
-                        : LanguagePrimitives.ConvertTo<int>(nativeProperty.Value);
-                    status = ok ? 0 : (nativeExitCode != 0 ? nativeExitCode : 1);
-                    return true;
-                }
-                catch (Exception)
-                {
-                    continue;
                 }
             }
-
-            status = 0;
             return false;
         }
 

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -426,6 +426,14 @@ resolution is explicit `-CandidatePath` (legacy `-Candidate` remains an alias),
 then `target\\dogfood\\webcodex-runner.exe`; the helper never runs Cargo itself.
 Replacement success and rollback still use the existing exact process identity and
 bounded fresh control-plane readiness proofs.
+Readiness is package/protocol strict by default: `compatible` is accepted,
+`version_mismatch` is rejected as `runner_version_mismatch`, and missing/unknown
+compatibility facts fail closed. Intentional rolling upgrades must opt in with
+`-AllowVersionMismatch`; that switch can accept only `version_mismatch` and reports
+`version_mismatch_allowed_for_rolling_upgrade` rather than normal
+`exact_fresh_build_ready`. It never overrides capability mismatch, exact candidate
+or rollback commit/dirty identity, fresh `agent_instance_id`, or connected-state
+requirements. `source_alignment.status=different` remains diagnostic-only.
 
 ## macOS local dogfood signing
 

--- a/scripts/deploy_windows_runner_dogfood.ps1
+++ b/scripts/deploy_windows_runner_dogfood.ps1
@@ -28,7 +28,9 @@ param(
     [int]$StartTimeoutSecs = 20,
 
     [ValidateRange(1, 300)]
-    [int]$ReadinessTimeoutSecs = 30
+    [int]$ReadinessTimeoutSecs = 30,
+
+    [switch]$AllowVersionMismatch
 )
 
 $ErrorActionPreference = "Stop"
@@ -106,7 +108,8 @@ $preObservation = Get-RunnerControlPlaneObservation `
 $null = Assert-PreReplacementRunnerObservation `
     -Observation $preObservation `
     -ExpectedClientId $operatorProfile.ClientId `
-    -ExpectedBuild $previousBuild
+    -ExpectedBuild $previousBuild `
+    -AllowVersionMismatch:$AllowVersionMismatch
 $oldAgentInstanceId = [string]$preObservation.agent_instance_id
 
 # Copy first so the source may be a build directory, network path, or even the
@@ -199,7 +202,8 @@ try {
         -ExpectedBuild $candidateBuild `
         -DeadlineUtc ([DateTime]::UtcNow.AddSeconds($ReadinessTimeoutSecs)) `
         -DisallowedAgentInstanceIds @($oldAgentInstanceId) `
-        -FailOnBuildMismatch
+        -FailOnBuildMismatch `
+        -AllowVersionMismatch:$AllowVersionMismatch
     $candidateReadyObservation = $candidateReady.Observation
     $null = Assert-CapturedPrimaryRunnerIdentity -Identity $newPrimary
     if ((Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -ne 1) {
@@ -215,6 +219,7 @@ try {
     Write-Output "  client_id:             $($operatorProfile.ClientId)"
     Write-Output "  old_agent_instance_id: $oldAgentInstanceId"
     Write-Output "  new_agent_instance_id: $($candidateReadyObservation.agent_instance_id)"
+    Write-Output "  readiness_reason:      $($candidateReady.Decision.Reason)"
     Write-Output "  expected_build:        commit=$($candidateBuild.GitCommit) dirty=$($candidateBuild.GitDirty)"
     Write-Output "  observed_build:        commit=$($candidateReadyObservation.build.git_commit) dirty=$($candidateReadyObservation.build.git_dirty)"
     Write-Output "  candidate:             $candidateIdentity"
@@ -319,7 +324,8 @@ try {
             -ExpectedClientId $operatorProfile.ClientId `
             -ExpectedBuild $previousBuild `
             -DeadlineUtc ([DateTime]::UtcNow.AddSeconds($ReadinessTimeoutSecs)) `
-            -DisallowedAgentInstanceIds $rollbackDisallowedIds
+            -DisallowedAgentInstanceIds $rollbackDisallowedIds `
+            -AllowVersionMismatch:$AllowVersionMismatch
         $rollbackReadyObservation = $rollbackReady.Observation
         $null = Assert-CapturedPrimaryRunnerIdentity -Identity $rollbackPrimary
     } catch {
@@ -330,7 +336,7 @@ try {
     if ($rollbackFailure) {
         throw "Deployment failed: $($deploymentError.Exception.Message). Rollback outcome uncertain / rollback readiness failed: $rollbackFailure"
     }
-    Write-Warning "Deployment failed, but rollback readiness was proven for agent_instance_id=$($rollbackReadyObservation.agent_instance_id) commit=$($rollbackReadyObservation.build.git_commit) dirty=$($rollbackReadyObservation.build.git_dirty)"
+    Write-Warning "Deployment failed, but rollback readiness was proven for agent_instance_id=$($rollbackReadyObservation.agent_instance_id) commit=$($rollbackReadyObservation.build.git_commit) dirty=$($rollbackReadyObservation.build.git_dirty) reason=$($rollbackReady.Decision.Reason)"
     throw $deploymentError
 } finally {
     if (Test-Path -LiteralPath $stagedPath) {

--- a/scripts/test_windows_runner_readiness.ps1
+++ b/scripts/test_windows_runner_readiness.ps1
@@ -22,9 +22,10 @@ function New-RunnerObservation {
         [string]$Commit,
         [bool]$Dirty = $false,
         [bool]$Connected = $true,
-        [string]$Compatibility = "compatible"
+        [string]$Compatibility = "compatible",
+        [switch]$OmitCompatibility
     )
-    [pscustomobject]@{
+    $observation = [pscustomobject]@{
         client_id = "msi"
         connected = $Connected
         status = if ($Connected) { "online" } else { "stale" }
@@ -38,6 +39,10 @@ function New-RunnerObservation {
         compatibility_status = $Compatibility
         source_alignment = [pscustomobject]@{ status = "different" }
     }
+    if ($OmitCompatibility) {
+        $observation.PSObject.Properties.Remove('compatibility_status')
+    }
+    return $observation
 }
 
 $candidateBuild = [pscustomobject]@{ GitCommit = "candidate1234"; GitDirty = $false }
@@ -52,11 +57,40 @@ $decision = Get-RunnerReadinessDecision `
     -DisallowedAgentInstanceIds @($oldInstanceId)
 Assert-Equal "not_ready" $decision.State "old agent_instance_id was accepted"
 Assert-Equal "stale_agent_instance_id" $decision.Reason "old instance diagnostic changed"
+$decision = Get-RunnerReadinessDecision `
+    -Observation (New-RunnerObservation -InstanceId $oldInstanceId -Commit $candidateBuild.GitCommit -Compatibility "version_mismatch") `
+    -ExpectedClientId "msi" `
+    -ExpectedBuild $candidateBuild `
+    -DisallowedAgentInstanceIds @($oldInstanceId) `
+    -AllowVersionMismatch
+Assert-Equal "not_ready" $decision.State "version override weakened stale instance fencing"
+Assert-Equal "stale_agent_instance_id" $decision.Reason "stale instance override diagnostic changed"
 
 # Fresh exact candidate is Ready even when source differs from Server.
 $freshCandidate = New-RunnerObservation -InstanceId "instance-new" -Commit $candidateBuild.GitCommit
 $decision = Get-RunnerReadinessDecision -Observation $freshCandidate -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId)
 Assert-Equal "ready" $decision.State "fresh exact candidate was not Ready"
+Assert-Equal "exact_fresh_build_ready" $decision.Reason "compatible readiness reason changed"
+
+# Package version mismatch is strict by default and only the explicit rolling-upgrade
+# override may accept it. Source alignment remains diagnostic-only.
+$versionMismatch = New-RunnerObservation -InstanceId "instance-version-mismatch" -Commit $candidateBuild.GitCommit -Compatibility "version_mismatch"
+$decision = Get-RunnerReadinessDecision -Observation $versionMismatch -ExpectedClientId "msi" -ExpectedBuild $candidateBuild
+Assert-Equal "mismatch" $decision.State "version mismatch was accepted without opt-in"
+Assert-Equal "runner_version_mismatch" $decision.Reason "version mismatch diagnostic changed"
+$decision = Get-RunnerReadinessDecision -Observation $versionMismatch -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
+Assert-Equal "ready" $decision.State "explicit rolling-upgrade version mismatch was rejected"
+Assert-Equal "version_mismatch_allowed_for_rolling_upgrade" $decision.Reason "rolling-upgrade override was not explicit in evidence"
+
+$missingCompatibility = New-RunnerObservation -InstanceId "instance-missing-compatibility" -Commit $candidateBuild.GitCommit -OmitCompatibility
+$decision = Get-RunnerReadinessDecision -Observation $missingCompatibility -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
+Assert-Equal "mismatch" $decision.State "missing compatibility facts were accepted"
+Assert-Equal "runner_compatibility_status_unavailable" $decision.Reason "missing compatibility diagnostic changed"
+
+$unknownCompatibility = New-RunnerObservation -InstanceId "instance-unknown-compatibility" -Commit $candidateBuild.GitCommit -Compatibility "future_unknown"
+$decision = Get-RunnerReadinessDecision -Observation $unknownCompatibility -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
+Assert-Equal "mismatch" $decision.State "unknown compatibility status was accepted"
+Assert-Equal "runner_compatibility_status_unknown" $decision.Reason "unknown compatibility diagnostic changed"
 
 # Fresh wrong source identities must never become Ready.
 $decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-wrong-commit" -Commit "wrong1234567") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId)
@@ -65,15 +99,42 @@ Assert-Equal "unexpected_build_commit" $decision.Reason "wrong commit diagnostic
 $decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-wrong-dirty" -Commit $candidateBuild.GitCommit -Dirty $true) -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -DisallowedAgentInstanceIds @($oldInstanceId)
 Assert-Equal "mismatch" $decision.State "wrong dirty state was accepted"
 Assert-Equal "unexpected_build_dirty_state" $decision.Reason "wrong dirty diagnostic changed"
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-wrong-commit-override" -Commit "wrong1234567" -Compatibility "version_mismatch") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
+Assert-Equal "mismatch" $decision.State "version override weakened exact commit identity"
+Assert-Equal "unexpected_build_commit" $decision.Reason "wrong commit override diagnostic changed"
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-wrong-dirty-override" -Commit $candidateBuild.GitCommit -Dirty $true -Compatibility "version_mismatch") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
+Assert-Equal "mismatch" $decision.State "version override weakened dirty identity"
+Assert-Equal "unexpected_build_dirty_state" $decision.Reason "wrong dirty override diagnostic changed"
 
 # Disconnected state remains transitional/not Ready.
 $decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-disconnected" -Commit $candidateBuild.GitCommit -Connected $false) -ExpectedClientId "msi" -ExpectedBuild $candidateBuild
 Assert-Equal "not_ready" $decision.State "disconnected Runner was accepted"
 Assert-Equal "control_plane_runner_not_connected" $decision.Reason "disconnected diagnostic changed"
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-disconnected-override" -Commit $candidateBuild.GitCommit -Connected $false -Compatibility "version_mismatch") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
+Assert-Equal "not_ready" $decision.State "version override weakened connected-state readiness"
+Assert-Equal "control_plane_runner_not_connected" $decision.Reason "disconnected override diagnostic changed"
 
-# Explicit protocol incompatibility is fatal mismatch; source alignment alone is not.
-$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-incompatible" -Commit $candidateBuild.GitCommit -Compatibility "capability_mismatch") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild
+# Explicit protocol incompatibility is fatal mismatch even with the version-only override.
+$decision = Get-RunnerReadinessDecision -Observation (New-RunnerObservation -InstanceId "instance-incompatible" -Commit $candidateBuild.GitCommit -Compatibility "capability_mismatch") -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
 Assert-Equal "mismatch" $decision.State "unsupported protocol was accepted"
+Assert-Equal "runner_protocol_incompatible" $decision.Reason "protocol mismatch diagnostic changed"
+
+$null = Assert-Throws {
+    Assert-PreReplacementRunnerObservation -Observation $versionMismatch -ExpectedClientId "msi" -ExpectedBuild $candidateBuild
+} "Pre-replacement Runner build identity does not match"
+$acceptedPreReplacement = Assert-PreReplacementRunnerObservation -Observation $versionMismatch -ExpectedClientId "msi" -ExpectedBuild $candidateBuild -AllowVersionMismatch
+Assert-Equal "instance-version-mismatch" $acceptedPreReplacement.agent_instance_id "pre-replacement override did not reach readiness policy"
+
+$waitStart = [DateTime]::Parse("2026-08-24T00:00:00Z").ToUniversalTime()
+$allowedWait = Wait-RunnerControlPlaneReadiness `
+    -Observe { param([int]$RequestTimeoutMilliseconds) $versionMismatch } `
+    -ExpectedClientId "msi" `
+    -ExpectedBuild $candidateBuild `
+    -DeadlineUtc $waitStart.AddSeconds(1) `
+    -AllowVersionMismatch `
+    -UtcNow { $waitStart }
+Assert-Equal "ready" $allowedWait.Decision.State "wait helper dropped version mismatch override"
+Assert-Equal "version_mismatch_allowed_for_rolling_upgrade" $allowedWait.Decision.Reason "wait helper lost explicit override evidence"
 
 # Rollback reconciliation uses rollback build, not candidate build, and excludes
 # both the pre-replacement and already-observed candidate instances.
@@ -134,6 +195,27 @@ $null = Assert-Throws {
 Assert-Equal $deadline $script:fakeNow "readiness wait exceeded or reset its absolute deadline"
 Assert-Equal 4 $script:probeCount "absolute deadline produced unexpected probe count"
 Assert-True (($script:requestTimeouts -join ',') -eq '1000,750,500,250') "request timeout did not track remaining absolute deadline"
+
+# The real deployment entrypoint must expose and explicitly thread the opt-in to
+# pre-replacement, candidate, and rollback readiness. Static AST inspection keeps
+# this test side-effect free while proving the option is not dead wiring.
+$deployPath = Join-Path $PSScriptRoot "deploy_windows_runner_dogfood.ps1"
+$deployTokens = $null
+$deployParseErrors = $null
+$deployAst = [System.Management.Automation.Language.Parser]::ParseFile($deployPath, [ref]$deployTokens, [ref]$deployParseErrors)
+Assert-Equal 0 @($deployParseErrors).Count "deployment helper parser errors"
+$allowVersionParameters = @($deployAst.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'AllowVersionMismatch' })
+Assert-Equal 1 $allowVersionParameters.Count "deployment helper does not expose exactly one AllowVersionMismatch opt-in"
+$deployReadinessCalls = @($deployAst.FindAll({
+    param($Node)
+    if ($Node -isnot [System.Management.Automation.Language.CommandAst]) { return $false }
+    $name = $Node.GetCommandName()
+    return $name -eq 'Assert-PreReplacementRunnerObservation' -or $name -eq 'Wait-RunnerControlPlaneReadiness'
+}, $true))
+Assert-Equal 3 $deployReadinessCalls.Count "deployment helper readiness callsite count changed"
+foreach ($call in $deployReadinessCalls) {
+    Assert-True ($call.Extent.Text -match '-AllowVersionMismatch:\$AllowVersionMismatch') "deployment readiness callsite does not explicitly thread AllowVersionMismatch: $($call.GetCommandName())"
+}
 
 # Operator profile lookup carries only the token FILE PATH; token contents never
 # enter the helper projection or command diagnostics.

--- a/scripts/windows_runner_readiness.ps1
+++ b/scripts/windows_runner_readiness.ps1
@@ -104,7 +104,8 @@ function Get-RunnerReadinessDecision {
         [Parameter(Mandatory = $true)]$Observation,
         [Parameter(Mandatory = $true)][string]$ExpectedClientId,
         [Parameter(Mandatory = $true)]$ExpectedBuild,
-        [string[]]$DisallowedAgentInstanceIds = @()
+        [string[]]$DisallowedAgentInstanceIds = @(),
+        [switch]$AllowVersionMismatch
     )
 
     if (-not $Observation -or $Observation.client_id -ne $ExpectedClientId) {
@@ -135,17 +136,35 @@ function Get-RunnerReadinessDecision {
             ExpectedDirty = [bool]$ExpectedBuild.GitDirty; ObservedDirty = [bool]$Observation.build.git_dirty
         }
     }
-    if ([string]$Observation.compatibility_status -eq 'capability_mismatch') {
-        return [pscustomobject]@{ State = 'mismatch'; Reason = 'runner_protocol_incompatible'; AgentInstanceId = $instanceId }
+    $compatibilityStatus = [string]$Observation.compatibility_status
+    if ([string]::IsNullOrWhiteSpace($compatibilityStatus)) {
+        return [pscustomobject]@{ State = 'mismatch'; Reason = 'runner_compatibility_status_unavailable'; AgentInstanceId = $instanceId }
     }
-    return [pscustomobject]@{ State = 'ready'; Reason = 'exact_fresh_build_ready'; AgentInstanceId = $instanceId }
+    switch ($compatibilityStatus) {
+        'compatible' {
+            return [pscustomobject]@{ State = 'ready'; Reason = 'exact_fresh_build_ready'; AgentInstanceId = $instanceId }
+        }
+        'version_mismatch' {
+            if ($AllowVersionMismatch) {
+                return [pscustomobject]@{ State = 'ready'; Reason = 'version_mismatch_allowed_for_rolling_upgrade'; AgentInstanceId = $instanceId }
+            }
+            return [pscustomobject]@{ State = 'mismatch'; Reason = 'runner_version_mismatch'; AgentInstanceId = $instanceId }
+        }
+        'capability_mismatch' {
+            return [pscustomobject]@{ State = 'mismatch'; Reason = 'runner_protocol_incompatible'; AgentInstanceId = $instanceId }
+        }
+        default {
+            return [pscustomobject]@{ State = 'mismatch'; Reason = 'runner_compatibility_status_unknown'; AgentInstanceId = $instanceId }
+        }
+    }
 }
 
 function Assert-PreReplacementRunnerObservation {
     param(
         [Parameter(Mandatory = $true)]$Observation,
         [Parameter(Mandatory = $true)][string]$ExpectedClientId,
-        [Parameter(Mandatory = $true)]$ExpectedBuild
+        [Parameter(Mandatory = $true)]$ExpectedBuild,
+        [switch]$AllowVersionMismatch
     )
 
     if (-not $Observation -or $Observation.client_id -ne $ExpectedClientId) {
@@ -157,7 +176,7 @@ function Assert-PreReplacementRunnerObservation {
     if ([string]::IsNullOrWhiteSpace([string]$Observation.agent_instance_id)) {
         throw "Pre-replacement Runner agent_instance_id is unavailable"
     }
-    $decision = Get-RunnerReadinessDecision -Observation $Observation -ExpectedClientId $ExpectedClientId -ExpectedBuild $ExpectedBuild
+    $decision = Get-RunnerReadinessDecision -Observation $Observation -ExpectedClientId $ExpectedClientId -ExpectedBuild $ExpectedBuild -AllowVersionMismatch:$AllowVersionMismatch
     if ($decision.State -ne 'ready') {
         $details = "reason=$($decision.Reason) expected_commit=$($ExpectedBuild.GitCommit) observed_commit=$($Observation.build.git_commit) expected_dirty=$($ExpectedBuild.GitDirty) observed_dirty=$($Observation.build.git_dirty)"
         throw "Pre-replacement Runner build identity does not match the installed rollback source: $details"
@@ -199,6 +218,7 @@ function Wait-RunnerControlPlaneReadiness {
         [string[]]$DisallowedAgentInstanceIds = @(),
         [ValidateRange(1, 5000)][int]$PollIntervalMilliseconds = 250,
         [switch]$FailOnBuildMismatch,
+        [switch]$AllowVersionMismatch,
         [scriptblock]$UtcNow = { [DateTime]::UtcNow },
         [scriptblock]$Sleep = { param([int]$Milliseconds) Start-Sleep -Milliseconds $Milliseconds }
     )
@@ -212,7 +232,7 @@ function Wait-RunnerControlPlaneReadiness {
         $requestTimeoutMs = [Math]::Min(5000, $remainingMs)
         try {
             $lastObservation = & $Observe $requestTimeoutMs
-            $decision = Get-RunnerReadinessDecision -Observation $lastObservation -ExpectedClientId $ExpectedClientId -ExpectedBuild $ExpectedBuild -DisallowedAgentInstanceIds $DisallowedAgentInstanceIds
+            $decision = Get-RunnerReadinessDecision -Observation $lastObservation -ExpectedClientId $ExpectedClientId -ExpectedBuild $ExpectedBuild -DisallowedAgentInstanceIds $DisallowedAgentInstanceIds -AllowVersionMismatch:$AllowVersionMismatch
             $lastReason = [string]$decision.Reason
             if ($decision.State -eq 'ready') {
                 return [pscustomobject]@{ Observation = $lastObservation; Decision = $decision }


### PR DESCRIPTION
## Summary

This PR closes two focused Windows correctness gaps discovered during native MSI review/dogfood.

### P1 — Host-authoritative Windows persistent-shell exit status

Windows persistent PowerShell previously concatenated user source and a trusted-looking status postamble into one script body, then recovered status from a public `Information` tag. A user command could combine a forged `WebCodexPersistentShellCommandStatus` record with top-level `return` and turn a real native failure into reported success.

The Windows controller now:

- executes user source and the trusted status probe as separate PowerShell SDK command components;
- no longer treats the public Information stream/tag as status authority;
- fails closed when the trusted probe is missing or malformed;
- pins the intermediate renderer to `Microsoft.PowerShell.Core\\Out-Default`, so persistent user state cannot shadow `Out-Default` and mutate `$LASTEXITCODE` before the trusted probe;
- preserves persistent variables, functions, cwd, stdout/stderr, Unicode, timeout poisoning, and existing completion framing semantics.

Native MSI reproduction before the fix:

```text
native exit 7
+ forged status { Ok = true; Native = 0 }
+ return
=> WebCodex exit_code = 0
```

After the fix the same adversarial command reports exit code `7`.

### P2 — Explicit Windows Runner version-mismatch readiness policy

Replacement readiness previously treated `compatibility_status=version_mismatch` as ordinary `exact_fresh_build_ready` and only rejected `capability_mismatch`.

Readiness is now closed-set and strict by default:

```text
compatible
  -> ready / exact_fresh_build_ready

version_mismatch
  -> mismatch / runner_version_mismatch

version_mismatch + -AllowVersionMismatch
  -> ready / version_mismatch_allowed_for_rolling_upgrade

capability_mismatch
  -> mismatch / runner_protocol_incompatible

missing/unknown compatibility_status
  -> fail closed
```

`-AllowVersionMismatch` is an explicit operator-only rolling-upgrade opt-in and is threaded through pre-replacement, candidate, and rollback readiness. It cannot override exact client identity, connectivity, fresh `agent_instance_id`, exact commit/dirty identity, or capability mismatch. `source_alignment.status=different` remains diagnostic-only.

## Commits

- `5f66537e` Harden Windows persistent shell exit status
- `4ba75341` Pin Windows persistent shell status renderer
- `90514356` Make Windows Runner version readiness explicit

## Validation

Windows persistent-shell coverage on MSI:

- Windows PowerShell 5.1: host-authoritative status adversarial coverage passed
- PowerShell 7.6.5 via `WEBCODEX_TEST_PWSH`: same adversarial coverage passed
- complete Windows persistent-shell suite: 11 passed / 0 failed
- Runner persistent-shell integration: passed

Readiness/operator coverage:

- `scripts/test_windows_runner_readiness.ps1`: PASS
- `scripts/test_windows_runner_process_identity.ps1`: PASS
- compatibility matrix covers default/override version mismatch, capability mismatch, missing/unknown compatibility, wrong commit/dirty state, stale instance, disconnected Runner, and pre/candidate/rollback propagation

Repository checks:

- `cargo fmt --all -- --check`: PASS
- `cargo check --all-targets -p webcodex-persistent-shell`: PASS
- `cargo check --all-targets -p webcodex-runner`: PASS (existing warnings only)
- `git diff --check`: PASS

No production Runner deployment/replacement, rollback, restart, Scheduled Task mutation, or release was performed as part of this work.