### PR TITLE
Enforce final Session response hard cap

### DIFF
--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -142,14 +142,14 @@ fn sparsify_terminal_structured_execution_success(tool_name: &str, result: &mut 
     }
 }
 
-enum SearchModelProjection {
+pub(super) enum SearchModelProjection {
     None,
     SingleDefault,
     Batch { default_queries: Vec<bool> },
 }
 
 impl SearchModelProjection {
-    fn capture(call: &ToolCall) -> Self {
+    pub(super) fn capture(call: &ToolCall) -> Self {
         match call {
             ToolCall::SearchProjectText {
                 result_mode,
@@ -290,7 +290,7 @@ pub(crate) fn sparsify_complete_default_search_output(
     true
 }
 
-fn sparsify_complete_default_search_success(
+pub(super) fn sparsify_complete_default_search_success(
     projection: &SearchModelProjection,
     result: &mut ToolResult,
 ) {
@@ -1196,10 +1196,21 @@ impl ToolRuntime {
                 );
             }
         }
+        let defer_batch_sparsification = !inner_model_facing_recording
+            && !matches!(
+                &batch_budget_projection,
+                BatchResponseBudgetProjection::None
+            );
         match &batch_budget_projection {
             BatchResponseBudgetProjection::None => {}
             BatchResponseBudgetProjection::ReadFiles { max_result_bytes } => {
                 super::read_files::apply_model_facing_output_budget(&mut result, *max_result_bytes);
+                // Direct/business-Session dispatch has already added every
+                // model-facing Session overlay. Enforce the true final ceiling
+                // against that decorated result before sparse projection. Outer
+                // kernel recording defers sparsification and repeats this exact
+                // hard-cap pass after its own overlays are attached.
+                super::read_files::enforce_final_model_facing_hard_cap(&mut result);
             }
             BatchResponseBudgetProjection::SearchProjectTexts { max_result_bytes } => {
                 let default_queries = match &search_projection {
@@ -1211,11 +1222,17 @@ impl ToolRuntime {
                     default_queries,
                     *max_result_bytes,
                 );
+                super::search_project_texts::enforce_final_model_facing_hard_cap(
+                    &mut result,
+                    default_queries,
+                );
             }
         }
         sparsify_terminal_structured_execution_success(tool_name, &mut result);
-        sparsify_complete_default_search_success(&search_projection, &mut result);
-        sparsify_complete_read_success(tool_name, &mut result);
+        if !defer_batch_sparsification {
+            sparsify_complete_default_search_success(&search_projection, &mut result);
+            sparsify_complete_read_success(tool_name, &mut result);
+        }
         result
     }
 

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -600,6 +600,12 @@ impl ToolRuntime {
         }
 
         let project = tool_project(&call);
+        let deferred_search_projection = super::dispatch::SearchModelProjection::capture(&call);
+        let defer_batch_model_projection = context.session_id.is_some()
+            && matches!(
+                &call,
+                ToolCall::ReadFiles { .. } | ToolCall::SearchProjectTexts { .. }
+            );
         // Permission is evaluated once inside dispatch (pre-exec gate). Kernel
         // only reuses the attached decision for the outer recording session —
         // never re-evaluate (no second request id / inconsistent outcome).
@@ -701,6 +707,35 @@ impl ToolRuntime {
                 session_id,
                 &recorder_metadata.ack_session_message_ids,
             );
+        }
+        if defer_batch_model_projection {
+            match request.tool_name.as_str() {
+                "read_files" => {
+                    super::read_files::enforce_final_model_facing_hard_cap(&mut result);
+                }
+                "search_project_texts" => {
+                    let default_queries = match &deferred_search_projection {
+                        super::dispatch::SearchModelProjection::Batch { default_queries } => {
+                            default_queries.as_slice()
+                        }
+                        _ => &[],
+                    };
+                    super::search_project_texts::enforce_final_model_facing_hard_cap(
+                        &mut result,
+                        default_queries,
+                    );
+                }
+                _ => {}
+            }
+            // Dispatch deliberately kept the canonical batch envelope while an
+            // outer recording Session was pending. Only now, after final hard-cap
+            // enforcement has accounted for continuity/recovery/handoff/attention,
+            // project the response to the established sparse model-facing shape.
+            super::dispatch::sparsify_complete_default_search_success(
+                &deferred_search_projection,
+                &mut result,
+            );
+            super::dispatch::sparsify_complete_read_success(&request.tool_name, &mut result);
         }
         ToolCallOutcome {
             success: result.success,

--- a/src/tool_runtime/read_files.rs
+++ b/src/tool_runtime/read_files.rs
@@ -124,9 +124,15 @@ fn truncate_read_item(item: &Value, keep_lines: usize) -> Option<Value> {
         json!(start_line.saturating_add(keep_lines)),
     );
     projected_output.insert("budget_truncated".to_string(), json!(true));
+    let existing_budget_next_limit = output
+        .get("budget_next_limit")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
     projected_output.insert(
         "budget_next_limit".to_string(),
-        json!(returned_lines.saturating_sub(keep_lines)),
+        json!(returned_lines
+            .saturating_sub(keep_lines)
+            .saturating_add(existing_budget_next_limit)),
     );
     Some(projected)
 }
@@ -307,6 +313,134 @@ pub(crate) fn apply_model_facing_output_budget(
     if let Some(budgeted) = budgeted.as_object() {
         for (key, value) in budgeted {
             root.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn final_model_result_len(output: &Value) -> usize {
+    let mut projected = ToolResult::ok(output.clone());
+    super::dispatch::sparsify_complete_read_success("read_files", &mut projected);
+    serde_json::to_vec(&projected)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn mark_final_hard_cap_truncation(output: &mut Value, next_index: usize) {
+    let Some(root) = output.as_object_mut() else {
+        return;
+    };
+    let (returned_count, succeeded_count) = root
+        .get("items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            (
+                items.len(),
+                items
+                    .iter()
+                    .filter(|item| item["success"].as_bool() == Some(true))
+                    .count(),
+            )
+        })
+        .unwrap_or_default();
+    root.insert("returned_count".to_string(), json!(returned_count));
+    root.insert("succeeded_count".to_string(), json!(succeeded_count));
+    root.insert(
+        "failed_count".to_string(),
+        json!(returned_count.saturating_sub(succeeded_count)),
+    );
+    root.insert("output_truncated".to_string(), json!(true));
+    root.insert("next_index".to_string(), json!(next_index));
+    root.insert("truncation_reason".to_string(), json!("hard_result_cap"));
+}
+
+/// Enforce the repository-wide 256 KiB ceiling against the actual final
+/// serialized ToolResult, including Session/continuity overlays. The primary
+/// batch budget remains independent; this pass only removes/shortens read body
+/// content when the fully decorated response would otherwise violate the hard
+/// cap.
+///
+/// This expects the canonical batch envelope (before complete-success sparse
+/// projection), so project/count/continuation metadata can remain truthful when
+/// final hard-cap pressure turns a previously complete response into a partial
+/// one.
+pub(crate) fn enforce_final_model_facing_hard_cap(result: &mut ToolResult) {
+    if !result.success || final_model_result_len(&result.output) <= MAX_SERIALIZED_OUTPUT_BYTES {
+        return;
+    }
+    let Some(root) = result.output.as_object() else {
+        return;
+    };
+    if root.get("project").and_then(Value::as_str).is_none()
+        || root
+            .get("requested_count")
+            .and_then(Value::as_u64)
+            .is_none()
+        || root.get("items").and_then(Value::as_array).is_none()
+    {
+        return;
+    }
+
+    loop {
+        let Some(items) = result.output.get("items").and_then(Value::as_array) else {
+            return;
+        };
+        let Some(last) = items.last() else {
+            return;
+        };
+        let index = last["index"].as_u64().unwrap_or(0) as usize;
+
+        // Preserve as many whole source lines as possible from the last success
+        // item. Measuring the complete decorated ToolResult makes this exact and
+        // naturally accounts for recovery/handoff/attention bytes.
+        if last["success"].as_bool() == Some(true) {
+            let returned_lines = last
+                .get("output")
+                .and_then(|output| output.get("returned_lines"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as usize;
+            if returned_lines > 1 {
+                let mut low = 1usize;
+                let mut high = returned_lines - 1;
+                let mut best = None;
+                while low <= high {
+                    let keep = low + (high - low) / 2;
+                    let Some(partial) = truncate_read_item(last, keep) else {
+                        break;
+                    };
+                    let mut candidate = result.output.clone();
+                    if let Some(candidate_items) =
+                        candidate.get_mut("items").and_then(Value::as_array_mut)
+                    {
+                        let last_index = candidate_items.len() - 1;
+                        candidate_items[last_index] = partial;
+                    }
+                    mark_final_hard_cap_truncation(&mut candidate, index);
+                    if final_model_result_len(&candidate) <= MAX_SERIALIZED_OUTPUT_BYTES {
+                        best = Some(candidate);
+                        low = keep.saturating_add(1);
+                    } else {
+                        high = keep.saturating_sub(1);
+                    }
+                }
+                if let Some(best) = best {
+                    result.output = best;
+                    return;
+                }
+            }
+        }
+
+        let removed_index = {
+            let Some(items) = result.output.get_mut("items").and_then(Value::as_array_mut) else {
+                return;
+            };
+            items
+                .pop()
+                .and_then(|removed| removed["index"].as_u64())
+                .unwrap_or(index as u64) as usize
+        };
+        mark_final_hard_cap_truncation(&mut result.output, removed_index);
+        if final_model_result_len(&result.output) <= MAX_SERIALIZED_OUTPUT_BYTES {
+            return;
         }
     }
 }
@@ -637,6 +771,28 @@ mod tests {
             continuation["items"][0]["output"]["text"].as_str().unwrap()
         );
         assert_eq!(joined, lines.join("\n"));
+    }
+
+    #[test]
+    fn final_read_trim_preserves_existing_budget_tail_without_gaps() {
+        let first_chunk = (0..60)
+            .map(|index| format!("line-{index:03}"))
+            .collect::<Vec<_>>();
+        let mut item = ranged_item(0, 11, &first_chunk);
+        item["output"]["limit"] = json!(100);
+        item["output"]["total_lines"] = json!(110);
+        item["output"]["has_more"] = json!(true);
+        item["output"]["next_start_line"] = json!(71);
+        item["output"]["budget_truncated"] = json!(true);
+        item["output"]["budget_next_limit"] = json!(40);
+
+        let partial = truncate_read_item(&item, 25).expect("second-stage partial read");
+        let output = &partial["output"];
+        assert_eq!(output["returned_lines"], 25);
+        assert_eq!(output["end_line"], 35);
+        assert_eq!(output["next_start_line"], 36);
+        assert_eq!(output["budget_next_limit"], 75);
+        assert_eq!(output["budget_truncated"], true);
     }
 
     #[test]

--- a/src/tool_runtime/search_project_texts.rs
+++ b/src/tool_runtime/search_project_texts.rs
@@ -424,6 +424,89 @@ pub(crate) fn apply_model_facing_output_budget(
     }
 }
 
+fn final_model_result_len(output: &Value, default_queries: &[bool]) -> usize {
+    let mut projected = ToolResult::ok(output.clone());
+    super::dispatch::sparsify_complete_default_search_batch_success(
+        default_queries,
+        &mut projected,
+    );
+    serde_json::to_vec(&projected)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn mark_final_hard_cap_truncation(output: &mut Value, next_index: usize) {
+    let Some(root) = output.as_object_mut() else {
+        return;
+    };
+    let (returned_count, succeeded_count) = root
+        .get("items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            (
+                items.len(),
+                items
+                    .iter()
+                    .filter(|item| item["success"].as_bool() == Some(true))
+                    .count(),
+            )
+        })
+        .unwrap_or_default();
+    root.insert("returned_count".to_string(), json!(returned_count));
+    root.insert("succeeded_count".to_string(), json!(succeeded_count));
+    root.insert(
+        "failed_count".to_string(),
+        json!(returned_count.saturating_sub(succeeded_count)),
+    );
+    root.insert("output_truncated".to_string(), json!(true));
+    root.insert("next_index".to_string(), json!(next_index));
+    root.insert("truncation_reason".to_string(), json!("hard_result_cap"));
+}
+
+/// Enforce the repository-wide 256 KiB ceiling against the actual final
+/// serialized ToolResult, including Session/continuity overlays. Search
+/// continuation remains query-granular: whole query items are removed from the
+/// end until the fully decorated result fits, and next_index points at the first
+/// omitted query.
+pub(crate) fn enforce_final_model_facing_hard_cap(
+    result: &mut ToolResult,
+    default_queries: &[bool],
+) {
+    if !result.success
+        || final_model_result_len(&result.output, default_queries) <= MAX_SERIALIZED_OUTPUT_BYTES
+    {
+        return;
+    }
+    let Some(root) = result.output.as_object() else {
+        return;
+    };
+    if root.get("project").and_then(Value::as_str).is_none()
+        || root
+            .get("requested_count")
+            .and_then(Value::as_u64)
+            .is_none()
+        || root.get("items").and_then(Value::as_array).is_none()
+    {
+        return;
+    }
+
+    loop {
+        let removed_index = {
+            let Some(items) = result.output.get_mut("items").and_then(Value::as_array_mut) else {
+                return;
+            };
+            let Some(removed) = items.pop() else {
+                return;
+            };
+            removed["index"].as_u64().unwrap_or(0) as usize
+        };
+        mark_final_hard_cap_truncation(&mut result.output, removed_index);
+        if final_model_result_len(&result.output, default_queries) <= MAX_SERIALIZED_OUTPUT_BYTES {
+            return;
+        }
+    }
+}
+
 impl ToolRuntime {
     pub(crate) async fn search_project_texts(
         &self,

--- a/src/tool_runtime/session_context.rs
+++ b/src/tool_runtime/session_context.rs
@@ -13,6 +13,9 @@ pub(crate) const ALLOW_CROSS_PROJECT_SESSION_FIELD: &str = "allow_cross_project_
 const SESSION_ATTENTION_MAX_MESSAGES: usize = 3;
 const SESSION_ATTENTION_MAX_BODY_BYTES: usize = 3072;
 const SESSION_CONTINUITY_RECOVERY_EVENT_LIMIT: usize = 20;
+pub(crate) const SESSION_CONTINUITY_RECOVERY_EVENT_BYTES: usize = 48 * 1024;
+const SESSION_RECOVERY_HANDOFF_CHANGED_PATH_LIMIT: usize = 40;
+const SESSION_RECOVERY_HANDOFF_CHANGED_PATH_BYTES: usize = 512;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SessionProjectMismatch {
@@ -391,6 +394,42 @@ pub(crate) fn add_session_telemetry_hint(
     result.output = Value::Object(output);
 }
 
+fn model_facing_recovery_event(event: &sessions::SessionEvent) -> Value {
+    json!({
+        "context_revision": event.context_revision,
+        "tool_name": event.tool_name,
+        "status": event.status,
+        "changed_paths": event.changed_paths,
+        "job_id": event.job_id,
+        "error_kind": event.error_kind,
+        "effect_evidence": event.effect_evidence,
+        "context_result": event.context_result_summary,
+        "execution_summary": event.validation_output_summary,
+    })
+}
+
+fn bounded_model_facing_recovery_events(
+    recorded: &sessions::RecordedModelFacingToolCall,
+) -> Vec<Value> {
+    let mut events = Vec::new();
+    for event in recorded
+        .recovery_events
+        .iter()
+        .rev()
+        .take(SESSION_CONTINUITY_RECOVERY_EVENT_LIMIT)
+    {
+        events.insert(0, model_facing_recovery_event(event));
+        let fits = serde_json::to_vec(&events)
+            .map(|bytes| bytes.len() <= SESSION_CONTINUITY_RECOVERY_EVENT_BYTES)
+            .unwrap_or(false);
+        if !fits {
+            events.remove(0);
+            break;
+        }
+    }
+    events
+}
+
 pub(crate) fn add_session_context_continuity(
     result: &mut ToolResult,
     recorded: &sessions::RecordedModelFacingToolCall,
@@ -458,28 +497,7 @@ pub(crate) fn add_session_context_continuity(
         && !recorded.history_lost;
     if needs_recovery && !suppress_fresh_empty_recovery {
         let total_retained = recorded.recovery_events.len();
-        let events = recorded
-            .recovery_events
-            .iter()
-            .rev()
-            .take(SESSION_CONTINUITY_RECOVERY_EVENT_LIMIT)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .map(|event| {
-                json!({
-                    "context_revision": event.context_revision,
-                    "tool_name": event.tool_name,
-                    "status": event.status,
-                    "changed_paths": event.changed_paths,
-                    "job_id": event.job_id,
-                    "error_kind": event.error_kind,
-                    "effect_evidence": event.effect_evidence,
-                    "context_result": event.context_result_summary,
-                    "execution_summary": event.validation_output_summary,
-                })
-            })
-            .collect::<Vec<_>>();
+        let events = bounded_model_facing_recovery_events(recorded);
         let omitted_count = total_retained.saturating_sub(events.len());
         output.insert(
             "session_continuity".to_string(),
@@ -503,6 +521,21 @@ pub(crate) fn add_session_context_continuity(
     }
     result.output = Value::Object(output);
     true
+}
+
+fn bounded_recovery_handoff_changed_paths(value: Option<&Value>) -> Value {
+    let Some(paths) = value.and_then(Value::as_array) else {
+        return value.cloned().unwrap_or(Value::Null);
+    };
+    Value::Array(
+        paths
+            .iter()
+            .filter_map(Value::as_str)
+            .filter(|path| path.len() <= SESSION_RECOVERY_HANDOFF_CHANGED_PATH_BYTES)
+            .take(SESSION_RECOVERY_HANDOFF_CHANGED_PATH_LIMIT)
+            .map(|path| Value::String(path.to_string()))
+            .collect(),
+    )
 }
 
 impl ToolRuntime {
@@ -554,7 +587,9 @@ impl ToolRuntime {
             "open_guidance": handoff.output.get("open_guidance"),
             "recent_decisions": handoff.output.get("recent_decisions"),
             "work_performed": handoff.output.get("work_performed"),
-            "changed_paths": handoff.output.get("changed_paths"),
+            "changed_paths": bounded_recovery_handoff_changed_paths(
+                handoff.output.get("changed_paths")
+            ),
             "suggested_next_actions": handoff.output.get("suggested_next_actions"),
         });
         if let Some(recovery) = result

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -870,3 +870,354 @@ async fn read_files_records_one_outer_session_event_and_keeps_metadata_outer_onl
     let ledger = serde_json::to_string(&summary.events).unwrap();
     assert!(!ledger.contains("session-private-text"));
 }
+
+#[tokio::test]
+async fn read_files_direct_session_overlay_pressure_keeps_final_response_under_hard_cap() {
+    use crate::tool_runtime::sessions::{
+        SessionContextRevisionAck, SessionTransport, ToolCallRecorderMetadata,
+    };
+    use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "batch-direct-final-cap";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime
+        .sessions
+        .start_session(Some(project.clone()), Some("direct final cap".to_string()));
+    assert_eq!(
+        seed_model_facing_recovery_events(&runtime, &session.session_id, &project, 20),
+        20
+    );
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth_transport_options_and_metadata(
+                    ToolCall::ReadFiles {
+                        project,
+                        items: vec![item("a.rs", None, None), item("b.rs", None, None)],
+                        session_id: Some(session_id),
+                        with_line_numbers: None,
+                        max_result_bytes: Some(MAX_SERIALIZED_OUTPUT_BYTES),
+                    },
+                    Some(&auth),
+                    SessionTransport::Mcp,
+                    true,
+                    false,
+                    ToolCallRecorderMetadata {
+                        ack_session_context_revision: SessionContextRevisionAck::Revision(0),
+                        ..Default::default()
+                    },
+                )
+                .await
+        }
+    });
+    let content = "x".repeat(122 * 1024);
+    for _ in 0..2 {
+        let request = next_read_request(&runtime, client_id).await;
+        complete_read(&runtime, client_id, &request, &content).await;
+    }
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["session_continuity"]["status"], "behind");
+    assert_eq!(
+        result.output["session_recovery"]["model_facing_events"]
+            .as_array()
+            .unwrap()
+            .len(),
+        20
+    );
+    assert_eq!(result.output["output_truncated"], true);
+    assert_eq!(result.output["truncation_reason"], "hard_result_cap");
+    let serialized_len = serde_json::to_vec(&result).unwrap().len();
+    assert!(
+        serialized_len <= MAX_SERIALIZED_OUTPUT_BYTES,
+        "direct Session overlays pushed read_files final response above the 256 KiB hard cap: {serialized_len} bytes"
+    );
+}
+
+#[tokio::test]
+async fn read_files_outer_recording_session_preserves_complete_sparse_shape() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolTransport,
+    };
+    use crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD;
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "batch-outer-sparse";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime
+        .sessions
+        .start_session(Some(project.clone()), Some("outer sparse read".to_string()));
+    let auth = auth_context(None, true);
+    let mut arguments = json!({
+        "project": project,
+        "items": [{"path": "a.rs"}]
+    });
+    arguments[TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD] = json!(0);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .call_tool_with_context_protocol_capability(
+                    ToolCallRequest {
+                        tool_name: "read_files".to_string(),
+                        arguments,
+                    },
+                    ToolCallContext {
+                        transport: ToolTransport::Mcp,
+                        session_id: Some(&session_id),
+                        auth: Some(&auth),
+                        window: None,
+                        record_oauth_scope_denials: false,
+                        host_file_import_trust: HostFileImportTrust::Untrusted,
+                    },
+                    true,
+                )
+                .await
+        }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    complete_read(&runtime, client_id, &request, "small\n").await;
+
+    let result = task.await.unwrap().result.expect("model-facing result");
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["session_recorded"], true);
+    assert_eq!(result.output["session_context_revision"], 1);
+    assert!(result.output.get("session_continuity").is_none());
+    assert!(result.output.get("session_recovery").is_none());
+    for omitted in [
+        "project",
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "outer recording changed complete sparse field {omitted}: {}",
+            result.output
+        );
+    }
+    assert_eq!(result.output["items"].as_array().unwrap().len(), 1);
+    assert_eq!(result.output["items"][0]["output"]["text"], "small");
+    assert!(result.output["items"][0]["output"].get("path").is_none());
+}
+
+#[tokio::test]
+async fn read_files_recovery_handoff_and_attention_overlays_stay_bounded() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolTransport,
+    };
+    use crate::tool_runtime::sessions::{
+        PostSessionMessageInput, SessionMessageKind, SessionMessagePriority,
+        TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
+    };
+    use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "batch-overlay-bound";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("bounded recovery overlays".to_string()),
+    );
+    assert_eq!(
+        seed_model_facing_recovery_events(&runtime, &session.session_id, &project, 50),
+        50
+    );
+    assert_eq!(
+        seed_large_changed_path_recovery_events(&runtime, &session.session_id, &project, 50,),
+        100
+    );
+    for kind in [
+        SessionMessageKind::Guidance,
+        SessionMessageKind::Question,
+        SessionMessageKind::Risk,
+        SessionMessageKind::Todo,
+    ] {
+        for index in 0..5 {
+            runtime
+                .sessions
+                .post_message_with_ack(
+                    PostSessionMessageInput {
+                        session_id: session.session_id.clone(),
+                        kind,
+                        message: format!("overlay-{kind:?}-{index}-{}", "m".repeat(7_900)),
+                        tags: vec!["bounded-overlay".to_string()],
+                        reply_to: None,
+                        priority: SessionMessagePriority::High,
+                    },
+                    kind == SessionMessageKind::Guidance,
+                )
+                .unwrap();
+        }
+    }
+    let auth = auth_context(None, true);
+    let mut arguments = json!({
+        "project": project,
+        "items": [{"path": "a.rs"}]
+    });
+    arguments[TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD] = json!(0);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .call_tool_with_context_protocol_capability(
+                    ToolCallRequest {
+                        tool_name: "read_files".to_string(),
+                        arguments,
+                    },
+                    ToolCallContext {
+                        transport: ToolTransport::Mcp,
+                        session_id: Some(&session_id),
+                        auth: Some(&auth),
+                        window: None,
+                        record_oauth_scope_denials: false,
+                        host_file_import_trust: HostFileImportTrust::Untrusted,
+                    },
+                    true,
+                )
+                .await
+        }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    complete_read(&runtime, client_id, &request, "small\n").await;
+
+    let result = task.await.unwrap().result.expect("model-facing result");
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["session_continuity"]["status"], "behind");
+    assert_eq!(result.output["session_recovery"]["truncated"], true);
+    assert!(result.output["session_recovery"]["current_handoff"].is_object());
+    let recovery_events = result.output["session_recovery"]["model_facing_events"]
+        .as_array()
+        .unwrap();
+    assert!(recovery_events.len() < 20);
+    assert!(
+        serde_json::to_vec(recovery_events).unwrap().len()
+            <= crate::tool_runtime::session_context::SESSION_CONTINUITY_RECOVERY_EVENT_BYTES
+    );
+    let recovery_changed_paths = result.output["session_recovery"]["current_handoff"]
+        ["changed_paths"]
+        .as_array()
+        .unwrap();
+    assert_eq!(recovery_changed_paths.len(), 40);
+    assert!(recovery_changed_paths
+        .iter()
+        .filter_map(Value::as_str)
+        .all(|path| path.len() <= 512));
+    assert_eq!(result.output["session_attention"]["requires_ack"], true);
+    let attention_messages = result.output["session_attention"]["messages"]
+        .as_array()
+        .unwrap();
+    assert_eq!(attention_messages.len(), 1);
+    assert_eq!(attention_messages[0]["message_truncated"], true);
+    assert_eq!(result.output["session_attention"]["truncated"], true);
+    assert_eq!(result.output["session_attention"]["omitted_count"], 4);
+    assert!(result.output.get("output_truncated").is_none());
+    assert_eq!(result.output["items"].as_array().unwrap().len(), 1);
+    let serialized_len = serde_json::to_vec(&result).unwrap().len();
+    eprintln!("maximal_bounded_session_overlay_result_bytes={serialized_len}");
+    assert!(
+        serialized_len <= MAX_SERIALIZED_OUTPUT_BYTES,
+        "bounded Session recovery/handoff/attention overlays alone exceeded the 256 KiB hard cap: {serialized_len} bytes"
+    );
+}
+
+#[tokio::test]
+async fn read_files_outer_recording_session_keeps_final_response_under_hard_cap() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolTransport,
+    };
+    use crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD;
+    use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "batch-final-cap";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("final response cap".to_string()),
+    );
+    assert_eq!(
+        seed_model_facing_recovery_events(&runtime, &session.session_id, &project, 20),
+        20
+    );
+    let auth = auth_context(None, true);
+    let mut arguments = json!({
+        "project": project,
+        "items": [{"path": "a.rs"}, {"path": "b.rs"}],
+        "max_result_bytes": MAX_SERIALIZED_OUTPUT_BYTES
+    });
+    arguments[TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD] = json!(0);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .call_tool_with_context_protocol_capability(
+                    ToolCallRequest {
+                        tool_name: "read_files".to_string(),
+                        arguments,
+                    },
+                    ToolCallContext {
+                        transport: ToolTransport::Mcp,
+                        session_id: Some(&session_id),
+                        auth: Some(&auth),
+                        window: None,
+                        record_oauth_scope_denials: false,
+                        host_file_import_trust: HostFileImportTrust::Untrusted,
+                    },
+                    true,
+                )
+                .await
+        }
+    });
+    let content = "x".repeat(122 * 1024);
+    for _ in 0..2 {
+        let request = next_read_request(&runtime, client_id).await;
+        complete_read(&runtime, client_id, &request, &content).await;
+    }
+
+    let outcome = task.await.unwrap();
+    assert!(outcome.success);
+    let result = outcome.result.expect("model-facing result");
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["session_continuity"]["status"], "behind");
+    assert_eq!(
+        result.output["session_recovery"]["model_facing_events"]
+            .as_array()
+            .unwrap()
+            .len(),
+        20
+    );
+    assert_eq!(result.output["output_truncated"], true);
+    assert_eq!(result.output["truncation_reason"], "hard_result_cap");
+    assert_eq!(result.output["returned_count"], 1);
+    assert_eq!(result.output["next_index"], 1);
+    let serialized_len = serde_json::to_vec(&result).unwrap().len();
+    assert!(
+        serialized_len <= MAX_SERIALIZED_OUTPUT_BYTES,
+        "outer Session overlays pushed read_files final response above the 256 KiB hard cap: {serialized_len} bytes"
+    );
+}

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -1650,3 +1650,174 @@ async fn search_project_texts_records_one_event_without_patterns_and_aggregates_
     assert!(persisted.contains("src/shared.rs"));
     assert!(persisted.contains("src/b.rs"));
 }
+
+#[tokio::test]
+async fn search_project_texts_outer_recording_session_preserves_complete_sparse_shape() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolTransport,
+    };
+    use crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD;
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-outer-sparse";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("outer sparse search".to_string()),
+    );
+    let auth = auth_context(None, true);
+    let mut arguments = json!({
+        "project": project,
+        "queries": [{"pattern": "needle"}]
+    });
+    arguments[TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD] = json!(0);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .call_tool_with_context_protocol_capability(
+                    ToolCallRequest {
+                        tool_name: "search_project_texts".to_string(),
+                        arguments,
+                    },
+                    ToolCallContext {
+                        transport: ToolTransport::Mcp,
+                        session_id: Some(&session_id),
+                        auth: Some(&auth),
+                        window: None,
+                        record_oauth_scope_denials: false,
+                        host_file_import_trust: HostFileImportTrust::Untrusted,
+                    },
+                    true,
+                )
+                .await
+        }
+    });
+    let request = wait_for_patch_agent_request(&runtime, client_id).await;
+    complete_search_success(&runtime, client_id, &request, "src/a.rs").await;
+
+    let result = task.await.unwrap().result.expect("model-facing result");
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["session_recorded"], true);
+    assert_eq!(result.output["session_context_revision"], 1);
+    assert!(result.output.get("session_continuity").is_none());
+    assert!(result.output.get("session_recovery").is_none());
+    for omitted in [
+        "project",
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "outer recording changed complete sparse field {omitted}: {}",
+            result.output
+        );
+    }
+    assert_eq!(result.output["items"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        result.output["items"][0]["output"]["matches"][0]["path"],
+        "src/a.rs"
+    );
+    assert!(result.output["items"][0]["output"].get("backend").is_none());
+}
+
+#[tokio::test]
+async fn search_project_texts_outer_recording_session_keeps_final_response_under_hard_cap() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolTransport,
+    };
+    use crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD;
+    use webcodex_workspace::file_read_range::MAX_SERIALIZED_OUTPUT_BYTES;
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-final-cap";
+    let project = register_agent_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("search final response cap".to_string()),
+    );
+    assert_eq!(
+        seed_model_facing_recovery_events(&runtime, &session.session_id, &project, 20),
+        20
+    );
+    let auth = auth_context(None, true);
+    let mut arguments = json!({
+        "project": project,
+        "queries": (0..8)
+            .map(|index| json!({"pattern": format!("needle-{index}")}))
+            .collect::<Vec<_>>(),
+        "max_result_bytes": MAX_SERIALIZED_OUTPUT_BYTES
+    });
+    arguments[TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD] = json!(0);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .call_tool_with_context_protocol_capability(
+                    ToolCallRequest {
+                        tool_name: "search_project_texts".to_string(),
+                        arguments,
+                    },
+                    ToolCallContext {
+                        transport: ToolTransport::Mcp,
+                        session_id: Some(&session_id),
+                        auth: Some(&auth),
+                        window: None,
+                        record_oauth_scope_denials: false,
+                        host_file_import_trust: HostFileImportTrust::Untrusted,
+                    },
+                    true,
+                )
+                .await
+        }
+    });
+    let preview = "z".repeat(30 * 1024);
+    for _ in 0..8 {
+        let request = wait_for_patch_agent_request(&runtime, client_id).await;
+        let pattern = request_pattern(&request);
+        let index = pattern
+            .strip_prefix("needle-")
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
+        let stdout = search_stdout("matches", &format!("src/{index}.rs"), &preview);
+        complete_patch_agent_request(&runtime, client_id, &request.request_id, 0, &stdout, "")
+            .await;
+    }
+
+    let outcome = task.await.unwrap();
+    assert!(outcome.success);
+    let result = outcome.result.expect("model-facing result");
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["session_continuity"]["status"], "behind");
+    assert_eq!(
+        result.output["session_recovery"]["model_facing_events"]
+            .as_array()
+            .unwrap()
+            .len(),
+        20
+    );
+    assert_eq!(result.output["output_truncated"], true);
+    assert_eq!(result.output["truncation_reason"], "hard_result_cap");
+    let returned_count = result.output["returned_count"].as_u64().unwrap();
+    let next_index = result.output["next_index"].as_u64().unwrap();
+    assert!(returned_count < 8);
+    assert_eq!(next_index, returned_count);
+    let serialized_len = serde_json::to_vec(&result).unwrap().len();
+    assert!(
+        serialized_len <= MAX_SERIALIZED_OUTPUT_BYTES,
+        "outer Session overlays pushed search_project_texts final response above the 256 KiB hard cap: {serialized_len} bytes"
+    );
+}

--- a/src/tool_runtime/tests/support/runtime.rs
+++ b/src/tool_runtime/tests/support/runtime.rs
@@ -170,6 +170,104 @@ pub(in crate::tool_runtime::tests) fn required_fields(spec: &ToolSpec) -> Vec<St
         .unwrap_or_default()
 }
 
+pub(in crate::tool_runtime::tests) fn seed_model_facing_recovery_events(
+    runtime: &ToolRuntime,
+    session_id: &str,
+    project: &str,
+    count: usize,
+) -> u64 {
+    use crate::tool_runtime::sessions::{
+        SessionContextRevisionAck, SessionTransport, ToolCallRecorderMetadata,
+    };
+
+    let mut revision = 0u64;
+    for index in 0..count {
+        let start = runtime.sessions.record_tool_call_started_with_metadata(
+            Some(session_id),
+            SessionTransport::Mcp,
+            "run_process",
+            &json!({"project": project, "executable": "true"}),
+            Some(project.to_string()),
+            ToolCallRecorderMetadata {
+                ack_session_context_revision: SessionContextRevisionAck::Revision(revision),
+                ..Default::default()
+            },
+        );
+        let evidence = format!("event-{index:02}-{}", "x".repeat(760));
+        let recorded = runtime
+            .sessions
+            .record_model_facing_tool_call_finished(
+                start,
+                true,
+                &json!({
+                    "exit_code": 0,
+                    "stdout_tail": evidence,
+                    "stderr_tail": "y".repeat(760),
+                    "stdout_truncated": false,
+                    "stderr_truncated": false,
+                    "stdout_lines": 1,
+                    "stderr_lines": 1,
+                    "purpose": "test",
+                    "command_summary": "true",
+                    "cwd": ".",
+                    "executor": "agent",
+                    "execution_state": "completed"
+                }),
+                None,
+                None,
+            )
+            .expect("seeded model-facing recovery event");
+        revision = recorded.context_revision;
+    }
+    revision
+}
+
+pub(in crate::tool_runtime::tests) fn seed_large_changed_path_recovery_events(
+    runtime: &ToolRuntime,
+    session_id: &str,
+    project: &str,
+    count: usize,
+) -> u64 {
+    use crate::tool_runtime::sessions::{
+        SessionContextRevisionAck, SessionTransport, ToolCallRecorderMetadata,
+    };
+
+    let mut revision = runtime.sessions.context_revision(session_id).unwrap_or(0);
+    for index in 0..count {
+        let paths = (0..8)
+            .map(|path_index| {
+                format!(
+                    "src/recovery-{index:02}-{path_index:02}-{}",
+                    "p".repeat(450)
+                )
+            })
+            .collect::<Vec<_>>();
+        let start = runtime.sessions.record_tool_call_started_with_metadata(
+            Some(session_id),
+            SessionTransport::Mcp,
+            "delete_project_files",
+            &json!({"project": project, "paths": paths}),
+            Some(project.to_string()),
+            ToolCallRecorderMetadata {
+                ack_session_context_revision: SessionContextRevisionAck::Revision(revision),
+                ..Default::default()
+            },
+        );
+        let recorded = runtime
+            .sessions
+            .record_model_facing_tool_call_finished(
+                start,
+                true,
+                &json!({"deleted_count": 8}),
+                None,
+                None,
+            )
+            .expect("seeded large changed-path recovery event");
+        revision = recorded.context_revision;
+    }
+    revision
+}
+
 pub(in crate::tool_runtime::tests) fn local_project_config(path: &str) -> ProjectConfig {
     ProjectConfig {
         path: path.to_string(),


### PR DESCRIPTION
## Summary

- enforce the 256 KiB hard ceiling against the final model-facing `read_files` / `search_project_texts` response after Session telemetry, continuity, recovery, handoff, and attention overlays are attached
- preserve the existing ~64 KiB / explicit `max_result_bytes` primary batch budget and established sparse projections
- keep `read_files` continuation line-safe across a second final-cap trim and keep `search_project_texts` continuation whole-query via `next_index`
- bound Session recovery event serialization and compact handoff `changed_paths` so overlays themselves have a provable bounded footprint

## Reproduction

Before the fix, the real outer recording path through `ToolKernel` reproduced a final serialized `ToolResult` of **292,112 bytes** with a 262,144-byte hard cap.

The regression exercises `call_tool_with_context` with an outer recording Session, unacknowledged recovery, and a 256 KiB batch request. Direct MCP-capable dispatch pressure is covered separately as well.

## Semantics

- primary batch economy remains unchanged: default ~64 KiB, explicit `max_result_bytes` up to 256 KiB
- final 256 KiB ceiling is measured after all model-facing Session decoration using the actual sparse response shape
- `read_files` only trims at whole source-line boundaries and preserves accumulated `budget_next_limit`
- `search_project_texts` only removes whole query results and returns the first omitted `next_index`
- Session recovery retains the newest continuous suffix, now additionally bounded to 48 KiB serialized event metadata; existing `truncated`, `omitted_count`, and `current_handoff` recovery semantics remain intact
- compact recovery handoff keeps at most 40 complete `changed_paths`, each at most 512 bytes

## Validation

- `cargo test -p webcodex read_files` — 24 passed
- `cargo test -p webcodex search_project_texts` — 31 passed
- bounded Session recovery compatibility regression — passed
- maximum recovery/handoff/attention pressure regression — 131,301-byte final response, below 256 KiB
- `cargo test -p webcodex --lib` — 2947 passed / 0 failed
- `cargo check --all-targets -p webcodex` — passed, 0 warnings
- `cargo fmt -- --check` — passed
- `git diff --check` — passed

Base: `b99b5b49e109260042dc9103b70ac636e2706f54`
Head: `f8b6aca236a2f4c9c6006f701787c13ccdd2f650`