### PR TITLE
Complete Windows SSH resource parity

### DIFF
--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2824,6 +2824,34 @@ fn post_spawn_interruption_lifecycle_for_kind(kind: &str) -> Option<ShellCommand
     (kind == "start_job").then_some(ShellCommandExecutionState::OutcomeUnknown)
 }
 
+fn post_spawn_interruption_reason(
+    shutting_down: bool,
+    stop_requested: bool,
+    job_record_present: bool,
+) -> Option<&'static str> {
+    if shutting_down {
+        Some("runner began shutdown after command start")
+    } else if stop_requested {
+        Some("job stop requested after command start")
+    } else if !job_record_present {
+        Some("runner lost the Job record after command start")
+    } else {
+        None
+    }
+}
+
+fn post_spawn_interruption_delta(kind: &str, duration_ms: u64, error: &str) -> RunnerJobDelta {
+    RunnerJobDelta {
+        status: "failed".to_string(),
+        exit_code: None,
+        duration_ms: Some(duration_ms),
+        error: Some(error.to_string()),
+        command_execution_state: post_spawn_interruption_lifecycle_for_kind(kind),
+        finished: true,
+        ..Default::default()
+    }
+}
+
 fn raw_shell_job_terminal_lifecycle(
     status: &str,
     exit_code: Option<i32>,
@@ -4781,16 +4809,19 @@ impl JobManager {
         let mut child = Arc::new(Mutex::new(child));
         let post_spawn_rejection = {
             let _lifecycle = lock_unpoison(&self.lifecycle);
-            if self.shutting_down.load(Ordering::SeqCst) {
-                Some("runner began shutdown after command start")
-            } else if stop_requested.load(Ordering::SeqCst) {
-                Some("job stop requested after command start")
-            } else if let Some(job) = lock_unpoison(&self.jobs).get_mut(&job_id) {
-                job.child = Some(child.clone());
-                None
-            } else {
-                Some("runner lost the Job record after command start")
+            let mut jobs = lock_unpoison(&self.jobs);
+            let mut job = jobs.get_mut(&job_id);
+            let rejection = post_spawn_interruption_reason(
+                self.shutting_down.load(Ordering::SeqCst),
+                stop_requested.load(Ordering::SeqCst),
+                job.is_some(),
+            );
+            if rejection.is_none() {
+                if let Some(job) = job.as_mut() {
+                    job.child = Some(child.clone());
+                }
             }
+            rejection
         };
         if let Some(error) = post_spawn_rejection {
             let _ = terminate_managed_tree(&child);
@@ -4802,17 +4833,11 @@ impl JobManager {
             // spawn boundary.
             self.update_and_send(
                 &job_id,
-                RunnerJobDelta {
-                    status: "failed".to_string(),
-                    exit_code: None,
-                    duration_ms: Some(start.elapsed().as_millis() as u64),
-                    error: Some(error.to_string()),
-                    command_execution_state: post_spawn_interruption_lifecycle_for_kind(
-                        request.kind.as_str(),
-                    ),
-                    finished: true,
-                    ..Default::default()
-                },
+                post_spawn_interruption_delta(
+                    request.kind.as_str(),
+                    start.elapsed().as_millis() as u64,
+                    error,
+                ),
             );
             self.start_available_queued();
             return;
@@ -5222,20 +5247,36 @@ impl JobManager {
         let mut stdout = child.child_mut().stdout.take();
         let mut stderr = child.child_mut().stderr.take();
         let child = Arc::new(Mutex::new(child));
-        let reject_for_shutdown = {
+        let post_spawn_rejection = {
             let _lifecycle = lock_unpoison(&self.lifecycle);
-            if self.shutting_down.load(Ordering::SeqCst) || stop_requested.load(Ordering::SeqCst) {
-                true
-            } else if let Some(job) = lock_unpoison(&self.jobs).get_mut(&job_id) {
-                job.child = Some(Arc::clone(&child));
-                false
-            } else {
-                true
+            let mut jobs = lock_unpoison(&self.jobs);
+            let mut job = jobs.get_mut(&job_id);
+            let rejection = post_spawn_interruption_reason(
+                self.shutting_down.load(Ordering::SeqCst),
+                stop_requested.load(Ordering::SeqCst),
+                job.is_some(),
+            );
+            if rejection.is_none() {
+                if let Some(job) = job.as_mut() {
+                    job.child = Some(Arc::clone(&child));
+                }
             }
+            rejection
         };
-        if reject_for_shutdown {
+        if let Some(error) = post_spawn_rejection {
             let _ = terminate_managed_tree(&child);
-            self.shutdown_rejection(&request);
+            // ManagedChild::spawn has already resumed ssh.exe. A successful
+            // local tree termination cannot prove that the remote command was
+            // never dispatched, so do not recycle pre-start NotStarted here.
+            self.update_and_send(
+                &job_id,
+                post_spawn_interruption_delta(
+                    request.kind.as_str(),
+                    start.elapsed().as_millis() as u64,
+                    error,
+                ),
+            );
+            self.start_available_queued();
             return;
         }
         self.update_and_send(

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -5206,11 +5206,14 @@ impl JobManager {
             }
         };
         let transport = prepared.transport.clone();
+        let program_delivery = prepared.program_delivery;
         let mut command = prepared.command;
-        command
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        if program_delivery.requires_stdin() || request.stdin.is_some() {
+            command.stdin(Stdio::piped());
+        } else {
+            command.stdin(Stdio::null());
+        }
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
         let stop_requested = {
             let _lifecycle = lock_unpoison(&self.lifecycle);
@@ -5244,6 +5247,7 @@ impl JobManager {
                 return;
             }
         };
+        let mut child_stdin = child.child_mut().stdin.take();
         let mut stdout = child.child_mut().stdout.take();
         let mut stderr = child.child_mut().stderr.take();
         let child = Arc::new(Mutex::new(child));
@@ -5312,9 +5316,26 @@ impl JobManager {
                 ));
             }
             drop(tx);
+            // Readers must already be draining before program/caller stdin can
+            // block. The writer is tracked and polled by this same Job worker.
+            let mut writer_start_error = None;
+            let mut stdin_writer = match program_delivery.spawn_writer(
+                child_stdin.take(),
+                request
+                    .stdin
+                    .as_deref()
+                    .map(|input| input.as_bytes().to_vec()),
+            ) {
+                Ok(writer) => writer,
+                Err(error) => {
+                    writer_start_error = Some(error);
+                    let _ = terminate_managed_tree(&child);
+                    None
+                }
+            };
             let timeout_secs = request.timeout_secs.min(policy.max_timeout_secs).max(1);
             let mut transport_stderr = String::new();
-            let (mut status, exit_code, mut error, interrupted_after_dispatch) = loop {
+            let (mut status, mut exit_code, mut error, interrupted_after_dispatch) = loop {
                 let mut out = String::new();
                 let mut err = String::new();
                 while let Ok(chunk) = rx.try_recv() {
@@ -5337,6 +5358,14 @@ impl JobManager {
                             ..Default::default()
                         },
                     );
+                }
+                if let Some(writer_error) = writer_start_error.take().or_else(|| {
+                    stdin_writer
+                        .as_mut()
+                        .and_then(|writer| writer.poll_failure())
+                }) {
+                    let _ = terminate_managed_tree(&child);
+                    break ("failed".to_string(), None, Some(writer_error), true);
                 }
                 let wait_result = {
                     let mut child = lock_unpoison(&child);
@@ -5402,6 +5431,16 @@ impl JobManager {
             // update indefinitely.
             cleanup_managed_tree(&child);
             let tree_cleanup_uncertain = managed_tree_running(&child);
+            let writer_finish_error = stdin_writer.as_mut().and_then(|writer| {
+                let interrupted =
+                    interrupted_after_dispatch || status == "timeout" || tree_cleanup_uncertain;
+                let result = if interrupted {
+                    writer.finish_after_tree_cleanup()
+                } else {
+                    writer.finish_bounded()
+                };
+                result.err()
+            });
             join_reader_threads_until(readers, Instant::now() + Duration::from_secs(1));
             let mut final_out = String::new();
             let mut final_err = String::new();
@@ -5419,6 +5458,12 @@ impl JobManager {
             } else {
                 raw_shell_job_terminal_lifecycle(&status, exit_code)
             };
+            if let Some(writer_error) = writer_finish_error {
+                status = "failed".to_string();
+                exit_code = None;
+                error = Some(writer_error);
+                command_execution_state = ShellCommandExecutionState::OutcomeUnknown;
+            }
             if tree_cleanup_uncertain {
                 status = "failed".to_string();
                 error = Some(

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -5314,7 +5314,7 @@ impl JobManager {
             drop(tx);
             let timeout_secs = request.timeout_secs.min(policy.max_timeout_secs).max(1);
             let mut transport_stderr = String::new();
-            let (mut status, exit_code, mut error) = loop {
+            let (mut status, exit_code, mut error, interrupted_after_dispatch) = loop {
                 let mut out = String::new();
                 let mut err = String::new();
                 while let Ok(chunk) = rx.try_recv() {
@@ -5346,23 +5346,31 @@ impl JobManager {
                     Ok(Some(status)) => {
                         if stop_requested.load(Ordering::SeqCst) {
                             break (
-                                "stopped".to_string(),
-                                Some(-1),
-                                Some("job stopped by request".to_string()),
+                                "failed".to_string(),
+                                None,
+                                Some(
+                                    "ssh_command_stopped_after_dispatch: local SSH tree was terminated, remote command outcome is unknown; do not blindly retry"
+                                        .to_string(),
+                                ),
+                                true,
                             );
                         }
                         if status.success() {
-                            break ("completed".to_string(), Some(0), None);
+                            break ("completed".to_string(), Some(0), None, false);
                         }
-                        break ("failed".to_string(), status.code(), None);
+                        break ("failed".to_string(), status.code(), None, false);
                     }
                     Ok(None) => {
                         if stop_requested.load(Ordering::SeqCst) {
                             let _ = terminate_managed_tree(&child);
                             break (
-                                "stopped".to_string(),
-                                Some(-1),
-                                Some("job stopped by request".to_string()),
+                                "failed".to_string(),
+                                None,
+                                Some(
+                                    "ssh_command_stopped_after_dispatch: local SSH tree was terminated, remote command outcome is unknown; do not blindly retry"
+                                        .to_string(),
+                                ),
+                                true,
                             );
                         }
                         if start.elapsed() >= Duration::from_secs(timeout_secs) {
@@ -5372,6 +5380,7 @@ impl JobManager {
                                 "timeout".to_string(),
                                 Some(-1),
                                 Some(format!("job timed out after {timeout_secs} seconds")),
+                                false,
                             );
                         }
                     }
@@ -5382,6 +5391,7 @@ impl JobManager {
                             Some(format!(
                                 "ssh_command_wait_failed: command may have started and was not retried: {wait_error}"
                             )),
+                            false,
                         );
                     }
                 }
@@ -5404,7 +5414,11 @@ impl JobManager {
             if !final_err.is_empty() {
                 append_bounded_tail(&mut transport_stderr, &final_err, 16 * 1024);
             }
-            let mut command_execution_state = raw_shell_job_terminal_lifecycle(&status, exit_code);
+            let mut command_execution_state = if interrupted_after_dispatch {
+                ShellCommandExecutionState::OutcomeUnknown
+            } else {
+                raw_shell_job_terminal_lifecycle(&status, exit_code)
+            };
             if tree_cleanup_uncertain {
                 status = "failed".to_string();
                 error = Some(

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2790,6 +2790,7 @@ struct RunnerJobDelta {
     duration_ms: Option<u64>,
     error: Option<String>,
     command_execution_state: Option<ShellCommandExecutionState>,
+    stream_limit_bytes: Option<usize>,
     validation_progress: Option<ShellJobValidationProgress>,
     finished: bool,
 }
@@ -3379,6 +3380,11 @@ impl JobManager {
             let now = chrono::Utc::now().timestamp();
             append_runner_stream(&mut job.snapshot.stdout, delta.stdout_chunk.as_deref());
             append_runner_stream(&mut job.snapshot.stderr, delta.stderr_chunk.as_deref());
+            if let Some(max_bytes) = delta.stream_limit_bytes {
+                let max_bytes = max_bytes.min(JOB_SNAPSHOT_STREAM_MAX_BYTES);
+                trim_runner_stream_to(&mut job.snapshot.stdout, max_bytes);
+                trim_runner_stream_to(&mut job.snapshot.stderr, max_bytes);
+            }
             job.snapshot.update_seq = job.snapshot.update_seq.saturating_add(1);
             if !delta.status.trim().is_empty() {
                 let incoming_status = delta.status.trim();
@@ -5102,6 +5108,7 @@ impl JobManager {
                     duration_ms: Some(start.elapsed().as_millis() as u64),
                     error: final_status.2,
                     command_execution_state,
+                    stream_limit_bytes: None,
                     validation_progress: final_progress,
                     finished: true,
                 },
@@ -5110,9 +5117,9 @@ impl JobManager {
         });
     }
 
-    /// Start one remote SSH command as a normal runner job. The transport is
-    /// established before this child is spawned, so a preparation failure is
-    /// unambiguously a command-not-started error. Once `ssh` is running, we
+    /// Start one remote SSH command as a normal runner job. Resource/session
+    /// validation and local command preparation happen before spawn, so those
+    /// failures are unambiguously command-not-started. Once `ssh` is running,
     /// never retry because remote delivery may already have happened.
     fn start_ssh_shell_job(
         &self,
@@ -5173,7 +5180,7 @@ impl JobManager {
                 return;
             }
         };
-        let connection_key = prepared.key.clone();
+        let transport = prepared.transport.clone();
         let mut command = prepared.command;
         command
             .stdin(Stdio::null())
@@ -5240,6 +5247,7 @@ impl JobManager {
         );
         let manager = self.clone_for_worker();
         let ssh_pool = self.ssh_pool.clone();
+        let output_limit_bytes = policy.max_output_bytes;
         let worker_guard = self.workers.enter();
         std::thread::spawn(move || {
             let _worker_guard = worker_guard;
@@ -5284,6 +5292,7 @@ impl JobManager {
                             status: "running".to_string(),
                             stdout_chunk: (!out.is_empty()).then_some(out),
                             stderr_chunk: (!err.is_empty()).then_some(err),
+                            stream_limit_bytes: Some(output_limit_bytes),
                             ..Default::default()
                         },
                     );
@@ -5341,6 +5350,7 @@ impl JobManager {
             // background child holding either pipe cannot delay the terminal
             // update indefinitely.
             cleanup_managed_tree(&child);
+            let tree_cleanup_uncertain = managed_tree_running(&child);
             join_reader_threads_until(readers, Instant::now() + Duration::from_secs(1));
             let mut final_out = String::new();
             let mut final_err = String::new();
@@ -5353,13 +5363,29 @@ impl JobManager {
             if !final_err.is_empty() {
                 append_bounded_tail(&mut transport_stderr, &final_err, 16 * 1024);
             }
-            if is_transport_failure(exit_code, Some(&transport_stderr)) {
-                ssh_pool.invalidate_after_transport_failure(&connection_key);
+            let mut command_execution_state = raw_shell_job_terminal_lifecycle(&status, exit_code);
+            if tree_cleanup_uncertain {
+                status = "failed".to_string();
+                error = Some(
+                    "ssh_command_cleanup_failed: local SSH process tree exit could not be proven; command may have started and was not retried"
+                        .to_string(),
+                );
+                command_execution_state = ShellCommandExecutionState::OutcomeUnknown;
+            }
+            if matches!(status.as_str(), "completed" | "failed")
+                && matches!(
+                    command_execution_state,
+                    ShellCommandExecutionState::Completed
+                )
+                && is_transport_failure(&transport, exit_code, Some(&transport_stderr))
+            {
+                ssh_pool.invalidate_after_transport_failure(&transport);
                 status = "failed".to_string();
                 error = Some(
                     "ssh_transport_failed: command may have started and was not retried"
                         .to_string(),
                 );
+                command_execution_state = ShellCommandExecutionState::OutcomeUnknown;
                 if !final_err.is_empty() && !final_err.ends_with('\n') {
                     final_err.push('\n');
                 }
@@ -5376,6 +5402,8 @@ impl JobManager {
                     exit_code,
                     duration_ms: Some(start.elapsed().as_millis() as u64),
                     error,
+                    command_execution_state: Some(command_execution_state),
+                    stream_limit_bytes: Some(output_limit_bytes),
                     finished: true,
                     ..Default::default()
                 },

--- a/crates/webcodex-runner/src/main_tests/registration.rs
+++ b/crates/webcodex-runner/src/main_tests/registration.rs
@@ -183,6 +183,11 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
     assert!(caps.async_jobs);
     assert!(caps.async_shell_jobs);
     assert_eq!(
+        caps.ssh_shell,
+        SshConnectionPool::is_available(),
+        "one-shot/background SSH capability must match the platform backend and local OpenSSH availability"
+    );
+    assert_eq!(
         caps.persistent_shell,
         webcodex_persistent_shell::local_shell_supported(),
         "local persistent-shell capability must match the platform transport compiled into this Runner"

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -1071,19 +1071,20 @@ fn run_piped_ssh_command(
         .unwrap_or_default();
     let mut stderr = String::from_utf8_lossy(&stderr).into_owned();
     if stopped {
-        append_line(&mut stderr, "job stopped by request");
-        let result = CommandResult {
-            exit_code: Some(-1),
+        append_line(
+            &mut stderr,
+            "webcodex: local SSH client was stopped after dispatch; remote command outcome is unknown; do not blindly retry",
+        );
+        return ShellCommandResult::outcome_unknown(CommandResult {
+            exit_code: None,
             stdout: Some(String::from_utf8_lossy(&stdout).into_owned()),
             stderr: Some(stderr),
             duration_ms: Some(start.elapsed().as_millis() as u64),
-            error: Some("job stopped".to_string()),
-        };
-        return if status.is_some() {
-            ShellCommandResult::completed(result)
-        } else {
-            ShellCommandResult::outcome_unknown(result)
-        };
+            error: Some(
+                "ssh_command_stopped_after_dispatch: local SSH tree was terminated, remote command outcome is unknown; do not blindly retry"
+                    .to_string(),
+            ),
+        });
     }
     if timed_out {
         append_line(
@@ -1749,11 +1750,18 @@ mod tests {
         assert!(!running.finished, "{running:?}");
         manager.stop("ssh-job-stop").expect("stop remote job");
         let stopped = wait_for_job_update(&mut rx, "ssh-job-stop", |update| update.finished);
-        assert_eq!(stopped.status, "stopped", "{stopped:?}");
-        assert_eq!(stopped.exit_code, Some(-1), "{stopped:?}");
+        assert_eq!(stopped.status, "failed", "{stopped:?}");
+        assert_eq!(stopped.exit_code, None, "{stopped:?}");
         assert_eq!(
             stopped.command_execution_state,
-            Some(crate::shell_protocol::ShellCommandExecutionState::Completed),
+            Some(crate::shell_protocol::ShellCommandExecutionState::OutcomeUnknown),
+            "{stopped:?}"
+        );
+        assert!(
+            stopped
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_stopped_after_dispatch")),
             "{stopped:?}"
         );
 
@@ -2737,6 +2745,11 @@ fn main() {
         thread::sleep(Duration::from_secs(60));
         return;
     }
+    if let Some(marker) = suffix(script, "WC_FAKE_WAIT_FOR_STOP::") {
+        fs::write(marker, format!("{}", std::process::id())).unwrap();
+        thread::sleep(Duration::from_secs(60));
+        return;
+    }
     if script.contains("WC_FAKE_SLEEP") {
         thread::sleep(Duration::from_secs(60));
         return;
@@ -3121,6 +3134,65 @@ fn main() {
     }
 
     #[test]
+    fn windows_one_shot_post_dispatch_stop_is_outcome_unknown_and_reaps_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let started_marker = temp.path().join("one-shot-stop.started");
+        let stop_requested = Arc::new(AtomicBool::new(false));
+        let stop_signal = Arc::clone(&stop_requested);
+        let marker_for_stop = started_marker.clone();
+        let stopper = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !marker_for_stop.exists() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                marker_for_stop.exists(),
+                "fake SSH never reached dispatch point"
+            );
+            stop_signal.store(true, Ordering::SeqCst);
+        });
+
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config("spe", None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_one_shot_stop",
+            None,
+            &format!("WC_FAKE_WAIT_FOR_STOP::{}", started_marker.display()),
+            None,
+            30,
+            Some(stop_requested.as_ref()),
+            None,
+        );
+        stopper.join().expect("join one-shot SSH stopper");
+        let pid = std::fs::read_to_string(&started_marker)
+            .unwrap()
+            .trim()
+            .parse::<u32>()
+            .unwrap();
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::OutcomeUnknown,
+            "{result:?}"
+        );
+        assert_eq!(result.result.exit_code, None, "{result:?}");
+        assert!(
+            result
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_stopped_after_dispatch")),
+            "{result:?}"
+        );
+        assert!(
+            wait_for_process_exit(pid),
+            "one-shot SSH client survived post-dispatch stop: {pid}"
+        );
+    }
+
+    #[test]
     fn windows_one_shot_spawn_failure_is_not_started() {
         let temp = tempfile::tempdir().unwrap();
         let pool = SshConnectionPool::with_test_executable(temp.path().join("missing-ssh.exe"));
@@ -3456,10 +3528,18 @@ fn main() {
         let stop_pid = grandchild_pid(&observed.log_snapshot.as_ref().unwrap().stdout.tail);
         manager.stop("win-ssh-stop").expect("stop Windows SSH job");
         let stopped = wait_for_job_update(&mut rx, "win-ssh-stop", |update| update.finished);
-        assert_eq!(stopped.status, "stopped", "{stopped:?}");
+        assert_eq!(stopped.status, "failed", "{stopped:?}");
+        assert_eq!(stopped.exit_code, None, "{stopped:?}");
         assert_eq!(
             stopped.command_execution_state,
-            Some(ShellCommandExecutionState::Completed),
+            Some(ShellCommandExecutionState::OutcomeUnknown),
+            "{stopped:?}"
+        );
+        assert!(
+            stopped
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_stopped_after_dispatch")),
             "{stopped:?}"
         );
         assert!(
@@ -3535,6 +3615,21 @@ fn main() {
             "background SSH grandchild survived Runner shutdown: {pid}"
         );
         assert!(!marker.exists());
+        let terminal = wait_for_job_update(&mut rx, "win-ssh-shutdown", |update| update.finished);
+        assert_eq!(terminal.status, "failed", "{terminal:?}");
+        assert_eq!(terminal.exit_code, None, "{terminal:?}");
+        assert_eq!(
+            terminal.command_execution_state,
+            Some(ShellCommandExecutionState::OutcomeUnknown),
+            "{terminal:?}"
+        );
+        assert!(
+            terminal
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_stopped_after_dispatch")),
+            "{terminal:?}"
+        );
     }
 
     #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -16,6 +16,8 @@ use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
+#[cfg(windows)]
+use webcodex_process::ManagedChild;
 
 const SSH_CONNECT_TIMEOUT_SECS: u64 = 10;
 const SSH_CONTROL_PERSIST_SECS: u64 = 300;
@@ -48,22 +50,34 @@ struct SshPoolState {
     entries: HashMap<SshConnectionKey, SshConnection>,
     next_control_id: u64,
     test_config_path: Option<PathBuf>,
+    #[cfg(all(test, windows))]
+    test_executable: Option<PathBuf>,
 }
 
 /// Runner-local OpenSSH resource preparation state.
 ///
-/// Unix one-shot and persistent SSH paths reuse a process-local multiplex
-/// transport. Windows persistent SSH resolves the same named resources but owns
-/// one direct long-lived ssh.exe channel instead; no mux state is created there.
+/// Unix one-shot/background and persistent SSH paths may reuse a process-local
+/// multiplex transport. Windows resolves the same named resources without mux
+/// state: one-shot/background calls own one direct ssh.exe process, while a
+/// persistent shell owns one direct long-lived ssh.exe channel.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SshConnectionPool {
     state: Arc<Mutex<SshPoolState>>,
 }
 
-/// A ready-to-spawn SSH command paired with the pool entry it used.
+/// Local transport used by one prepared SSH command. Unix keeps its existing
+/// Runner-local mux identity; Windows owns one direct ssh.exe process and has no
+/// reusable transport to invalidate.
+#[derive(Debug, Clone)]
+pub(crate) enum PreparedSshTransport {
+    Mux(SshConnectionKey),
+    Direct,
+}
+
+/// A ready-to-spawn SSH command paired with its transport semantics.
 pub(crate) struct PreparedSshCommand {
     pub(crate) command: Command,
-    pub(crate) key: SshConnectionKey,
+    pub(crate) transport: PreparedSshTransport,
 }
 
 /// A ready-to-spawn long-lived SSH shell command with the resource's default
@@ -79,7 +93,7 @@ impl SshConnectionPool {
     /// Whether this Runner can advertise SSH-shell support. A missing OpenSSH
     /// executable is a capability absence, not a later silent local fallback.
     pub(crate) fn is_available() -> bool {
-        if !cfg!(unix) {
+        if !cfg!(any(unix, windows)) {
             return false;
         }
         Command::new(ssh_executable())
@@ -87,12 +101,12 @@ impl SshConnectionPool {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
-            .is_ok()
+            .is_ok_and(|status| status.success())
     }
 
-    /// Whether this host can open a named SSH persistent shell. Unlike the
-    /// existing one-shot SSH path, Windows does not require Unix ControlMaster
-    /// sockets: one long-lived ssh.exe process is itself the persistent channel.
+    /// Whether this host can open a named SSH persistent shell. This is separate
+    /// from one-shot/background `ssh_shell`; Windows uses one direct long-lived
+    /// ssh.exe process rather than a Unix ControlMaster socket.
     pub(crate) fn persistent_shell_available() -> bool {
         if !cfg!(any(unix, windows)) {
             return false;
@@ -105,8 +119,9 @@ impl SshConnectionPool {
             .is_ok_and(|status| status.success())
     }
 
-    /// Resolve a named resource, establish/reuse its control transport, and
-    /// build a direct SSH command that owns its local process group itself.
+    /// Resolve a named resource and prepare the platform transport for one raw
+    /// remote shell command. Unix may reuse its mux; Windows prepares direct
+    /// ssh.exe without creating pool state.
     pub(crate) fn prepare_command(
         &self,
         generation: u64,
@@ -127,8 +142,8 @@ impl SshConnectionPool {
         )
     }
 
-    /// Build an SSH command whose process tree is owned by JobManager's
-    /// ManagedChild rather than the legacy setsid hook.
+    /// Build an SSH command for the existing JobManager ManagedChild lifecycle.
+    /// Unix still uses its mux transport; Windows returns one direct ssh.exe.
     pub(crate) fn prepare_job_command(
         &self,
         generation: u64,
@@ -159,9 +174,6 @@ impl SshConnectionPool {
         command: &str,
         configure_process_group: bool,
     ) -> Result<PreparedSshCommand, String> {
-        if !cfg!(unix) {
-            return Err("ssh_shell_unavailable: this Runner host does not support SSH resources; command was not started".to_string());
-        }
         if !is_safe_resource_name(resource_name) {
             return Err(
                 "ssh_resource_invalid: resource name is invalid; command was not started"
@@ -187,37 +199,71 @@ impl SshConnectionPool {
             }
         };
         let requested_cwd = normalize_remote_cwd(cwd)?;
-        let connection = self.connection_for(
-            generation,
-            resource_name,
-            session_id,
-            &resource.host,
-            resource.default_cwd.as_deref(),
-        )?;
-        let effective_cwd = requested_cwd.or(connection.default_cwd.clone());
-        let remote_script = remote_script(effective_cwd.as_deref(), command);
-        let mut ssh = ssh_command(&connection);
-        ssh.arg("-o")
-            .arg("BatchMode=yes")
-            .arg("-o")
-            .arg("LogLevel=ERROR")
-            .arg("-S")
-            .arg(&connection.control_path)
-            .arg(&connection.host)
-            .arg(remote_script);
-        if configure_process_group {
-            configure_private_process_group(&mut ssh);
+
+        #[cfg(unix)]
+        {
+            let connection = self.connection_for(
+                generation,
+                resource_name,
+                session_id,
+                &resource.host,
+                resource.default_cwd.as_deref(),
+            )?;
+            let effective_cwd = requested_cwd.or(connection.default_cwd.clone());
+            let remote_script = remote_script(effective_cwd.as_deref(), command);
+            let mut ssh = ssh_command(&connection);
+            ssh.arg("-o")
+                .arg("BatchMode=yes")
+                .arg("-o")
+                .arg("LogLevel=ERROR")
+                .arg("-S")
+                .arg(&connection.control_path)
+                .arg(&connection.host)
+                .arg(remote_script);
+            if configure_process_group {
+                configure_private_process_group(&mut ssh);
+            }
+            return Ok(PreparedSshCommand {
+                command: ssh,
+                transport: PreparedSshTransport::Mux(connection.key),
+            });
         }
-        Ok(PreparedSshCommand {
-            command: ssh,
-            key: connection.key,
-        })
+
+        #[cfg(windows)]
+        {
+            let _ = generation;
+            let _ = configure_process_group;
+            let effective_cwd = requested_cwd.or_else(|| resource.default_cwd.clone());
+            let remote_script = remote_script(effective_cwd.as_deref(), command);
+            let mut ssh = self.direct_ssh_command();
+            ssh.arg("-o")
+                .arg("BatchMode=yes")
+                .arg("-o")
+                .arg("LogLevel=ERROR")
+                .arg(&resource.host)
+                .arg(remote_script);
+            return Ok(PreparedSshCommand {
+                command: ssh,
+                transport: PreparedSshTransport::Direct,
+            });
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = generation;
+            let _ = configure_process_group;
+            Err("ssh_shell_unavailable: this Runner host does not support SSH resources; command was not started".to_string())
+        }
     }
 
     /// A transport error after spawning has uncertain remote delivery. Forget
     /// the entry so the *next* command establishes a fresh transport; never
-    /// retry the just-submitted command automatically.
-    pub(crate) fn invalidate_after_transport_failure(&self, key: &SshConnectionKey) {
+    /// retry the just-submitted command automatically. Direct Windows commands
+    /// have no reusable transport state to invalidate.
+    pub(crate) fn invalidate_after_transport_failure(&self, transport: &PreparedSshTransport) {
+        let PreparedSshTransport::Mux(key) = transport else {
+            return;
+        };
         let mut state = lock_unpoison(&self.state);
         if let Some(connection) = state.entries.remove(key) {
             close_control_socket(&connection);
@@ -327,7 +373,7 @@ impl SshConnectionPool {
         }
     }
 
-    #[cfg(all(test, unix))]
+    #[cfg(test)]
     pub(crate) fn connection_count(&self) -> usize {
         lock_unpoison(&self.state).entries.len()
     }
@@ -354,6 +400,25 @@ impl SshConnectionPool {
                 session_id: session_id.to_string(),
             })
             .map(|connection| connection.control_path.clone())
+    }
+
+    #[cfg(all(test, windows))]
+    pub(crate) fn with_test_executable(executable: PathBuf) -> Self {
+        let pool = Self::default();
+        lock_unpoison(&pool.state).test_executable = Some(executable);
+        pool
+    }
+
+    #[cfg(windows)]
+    fn direct_ssh_command(&self) -> Command {
+        #[cfg(test)]
+        {
+            let test_executable = lock_unpoison(&self.state).test_executable.clone();
+            if let Some(executable) = test_executable {
+                return Command::new(executable);
+            }
+        }
+        Command::new(ssh_executable())
     }
 
     fn connection_for(
@@ -442,7 +507,7 @@ impl Drop for SshConnectionPool {
 }
 
 /// Execute a short remote shell command through a Session-bound SSH resource.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 pub(crate) fn run_ssh_shell(
     pool: &SshConnectionPool,
     generation: u64,
@@ -507,7 +572,7 @@ pub(crate) fn run_ssh_shell_with_execution_state(
             Ok(prepared) => prepared,
             Err(error) => return ShellCommandResult::not_started(command_error(start, error)),
         };
-    let key = prepared.key.clone();
+    let transport = prepared.transport.clone();
     let mut result = run_piped_ssh_command(
         prepared.command,
         policy.max_output_bytes,
@@ -516,31 +581,54 @@ pub(crate) fn run_ssh_shell_with_execution_state(
         stop_requested,
         start,
     );
-    if is_transport_failure(result.result.exit_code, result.result.stderr.as_deref()) {
-        pool.invalidate_after_transport_failure(&key);
-        if let Some(stderr) = result.result.stderr.as_mut() {
-            if !stderr.is_empty() && !stderr.ends_with('\n') {
-                stderr.push('\n');
-            }
-            stderr.push_str(
-                "webcodex: SSH transport ended after dispatch; the command may have started and was not retried",
-            );
-        }
-        if result.result.error.is_none() {
-            result.result.error = Some(
-                "ssh_transport_failed: command may have started and was not retried".to_string(),
-            );
-        }
-        result.execution_state = crate::shell_protocol::ShellCommandExecutionState::OutcomeUnknown;
-    }
+    apply_transport_failure_policy(pool, &transport, &mut result);
     result
+}
+
+fn apply_transport_failure_policy(
+    pool: &SshConnectionPool,
+    transport: &PreparedSshTransport,
+    result: &mut ShellCommandResult,
+) {
+    if !matches!(
+        result.execution_state,
+        crate::shell_protocol::ShellCommandExecutionState::Completed
+    ) || !is_transport_failure(
+        transport,
+        result.result.exit_code,
+        result.result.stderr.as_deref(),
+    ) {
+        return;
+    }
+    pool.invalidate_after_transport_failure(transport);
+    if let Some(stderr) = result.result.stderr.as_mut() {
+        append_line(
+            stderr,
+            "webcodex: SSH transport ended after dispatch; the command may have started and was not retried",
+        );
+    }
+    if result.result.error.is_none() {
+        result.result.error =
+            Some("ssh_transport_failed: command may have started and was not retried".to_string());
+    }
+    result.execution_state = crate::shell_protocol::ShellCommandExecutionState::OutcomeUnknown;
 }
 
 /// Used by async job handling to apply the same conservative invalidation
 /// decision after its SSH child exits.
-pub(crate) fn is_transport_failure(exit_code: Option<i32>, stderr: Option<&str>) -> bool {
+pub(crate) fn is_transport_failure(
+    transport: &PreparedSshTransport,
+    exit_code: Option<i32>,
+    stderr: Option<&str>,
+) -> bool {
     if exit_code != Some(255) {
         return false;
+    }
+    if matches!(transport, PreparedSshTransport::Direct) {
+        // Direct OpenSSH cannot distinguish a local transport/auth/connect 255
+        // from a remote command that deliberately exits 255. Once ssh.exe was
+        // spawned, preserve at-most-once semantics and report uncertainty.
+        return true;
     }
     let stderr = stderr.unwrap_or_default().to_ascii_lowercase();
     [
@@ -826,6 +914,44 @@ fn configure_private_process_group(command: &mut Command) {
     }
 }
 
+#[cfg(unix)]
+type PipedSshChild = Child;
+#[cfg(windows)]
+type PipedSshChild = ManagedChild;
+
+fn spawn_piped_ssh_child(command: &mut Command) -> std::io::Result<PipedSshChild> {
+    #[cfg(unix)]
+    {
+        command.spawn()
+    }
+    #[cfg(windows)]
+    {
+        ManagedChild::spawn(command)
+    }
+}
+
+fn piped_ssh_process_mut(child: &mut PipedSshChild) -> &mut Child {
+    #[cfg(unix)]
+    {
+        child
+    }
+    #[cfg(windows)]
+    {
+        child.child_mut()
+    }
+}
+
+fn try_wait_piped_ssh_child(child: &mut PipedSshChild) -> std::io::Result<Option<ExitStatus>> {
+    #[cfg(unix)]
+    {
+        child.try_wait()
+    }
+    #[cfg(windows)]
+    {
+        child.try_wait()
+    }
+}
+
 fn run_piped_ssh_command(
     mut command: Command,
     max_output_bytes: usize,
@@ -838,7 +964,7 @@ fn run_piped_ssh_command(
     if stdin.is_some() {
         command.stdin(Stdio::piped());
     }
-    let mut child = match command.spawn() {
+    let mut child = match spawn_piped_ssh_child(&mut command) {
         Ok(child) => child,
         Err(_) => {
             return ShellCommandResult::not_started(command_error(
@@ -848,16 +974,14 @@ fn run_piped_ssh_command(
         }
     };
     if let Some(input) = stdin {
-        if let Some(mut child_stdin) = child.stdin.take() {
-            if let Err(error) = child_stdin.write_all(input.as_bytes()) {
-                if error.kind() != std::io::ErrorKind::BrokenPipe {
-                    let _ = terminate_ssh_child(&mut child);
-                    return ShellCommandResult::outcome_unknown(command_error(
-                        start,
-                        "ssh_command_stdin_failed: command may have started and was not retried"
-                            .to_string(),
-                    ));
-                }
+        if let Some(mut child_stdin) = piped_ssh_process_mut(&mut child).stdin.take() {
+            if child_stdin.write_all(input.as_bytes()).is_err() {
+                let _ = terminate_ssh_child(&mut child);
+                return ShellCommandResult::outcome_unknown(command_error(
+                    start,
+                    "ssh_command_stdin_failed: command may have started and was not retried"
+                        .to_string(),
+                ));
             }
         } else {
             let _ = terminate_ssh_child(&mut child);
@@ -868,8 +992,10 @@ fn run_piped_ssh_command(
             ));
         }
     }
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
+    let (stdout, stderr) = {
+        let process = piped_ssh_process_mut(&mut child);
+        (process.stdout.take(), process.stderr.take())
+    };
     let (stdout_tx, stdout_rx) = mpsc::sync_channel(1);
     let (stderr_tx, stderr_rx) = mpsc::sync_channel(1);
     if let Some(stdout) = stdout {
@@ -890,7 +1016,7 @@ fn run_piped_ssh_command(
     let mut stopped = false;
     let mut timed_out = false;
     let status = loop {
-        match child.try_wait() {
+        match try_wait_piped_ssh_child(&mut child) {
             Ok(Some(status)) => break Some(status),
             Ok(None) => {
                 if stop_requested.is_some_and(|stop| stop.load(Ordering::SeqCst)) {
@@ -914,6 +1040,8 @@ fn run_piped_ssh_command(
         }
     };
     let deadline = Instant::now() + Duration::from_secs(SSH_PIPE_DRAIN_TIMEOUT_SECS);
+    let tree_cleanup_uncertain =
+        !stopped && !timed_out && ensure_piped_ssh_tree_exit(&mut child).is_err();
     let stdout = stdout_rx
         .recv_timeout(deadline.saturating_duration_since(Instant::now()))
         .ok()
@@ -958,6 +1086,17 @@ fn run_piped_ssh_command(
             ShellCommandResult::outcome_unknown(result)
         };
     }
+    if tree_cleanup_uncertain {
+        return ShellCommandResult::outcome_unknown(CommandResult {
+            exit_code: status.and_then(|status| status.code()).or(Some(-1)),
+            stdout: Some(String::from_utf8_lossy(&stdout).into_owned()),
+            stderr: Some(stderr),
+            duration_ms: Some(start.elapsed().as_millis() as u64),
+            error: Some(
+                "ssh_command_cleanup_failed: local SSH process tree exit could not be proven; command may have started and was not retried".to_string(),
+            ),
+        });
+    }
     ShellCommandResult::completed(CommandResult {
         exit_code: status.and_then(|status| status.code()).or(Some(-1)),
         stdout: Some(String::from_utf8_lossy(&stdout).into_owned()),
@@ -967,7 +1106,7 @@ fn run_piped_ssh_command(
     })
 }
 
-fn terminate_ssh_child(child: &mut Child) -> Result<ExitStatus, String> {
+fn terminate_ssh_child(child: &mut PipedSshChild) -> Result<ExitStatus, String> {
     #[cfg(unix)]
     {
         let pid = child.id();
@@ -979,15 +1118,49 @@ fn terminate_ssh_child(child: &mut Child) -> Result<ExitStatus, String> {
             }
         }
     }
-    #[cfg(not(unix))]
-    let _ = child.kill();
+    #[cfg(windows)]
+    {
+        child.terminate_tree().map_err(|error| error.to_string())?;
+        if !child
+            .wait_tree_exit(Duration::from_secs(1))
+            .map_err(|error| error.to_string())?
+        {
+            return Err("SSH process tree did not exit after termination".to_string());
+        }
+    }
     let deadline = Instant::now() + Duration::from_secs(1);
     loop {
-        match child.try_wait() {
+        match try_wait_piped_ssh_child(child) {
             Ok(Some(status)) => return Ok(status),
             Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(10)),
             Ok(None) => return Err("SSH child did not exit after termination".to_string()),
             Err(error) => return Err(error.to_string()),
+        }
+    }
+}
+
+fn ensure_piped_ssh_tree_exit(child: &mut PipedSshChild) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        let _ = child;
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        if child
+            .wait_tree_exit(Duration::from_millis(100))
+            .map_err(|error| error.to_string())?
+        {
+            return Ok(());
+        }
+        child.terminate_tree().map_err(|error| error.to_string())?;
+        if child
+            .wait_tree_exit(Duration::from_secs(1))
+            .map_err(|error| error.to_string())?
+        {
+            Ok(())
+        } else {
+            Err("SSH process tree remained live after direct child exit".to_string())
         }
     }
 }
@@ -1028,7 +1201,10 @@ fn command_error(start: Instant, error: String) -> CommandResult {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::{remote_script, run_ssh_shell, shell_quote, SshConnectionPool};
+    use super::{
+        is_transport_failure, remote_script, run_ssh_shell, shell_quote, PreparedSshTransport,
+        SshConnectionKey, SshConnectionPool,
+    };
     use crate::webcodex_runner::config::{AgentPolicy, SshConfig, SshResourceConfig};
     use std::collections::BTreeMap;
     #[cfg(target_os = "linux")]
@@ -1516,6 +1692,11 @@ mod tests {
         let completed = wait_for_job_update(&mut rx, "ssh-job-complete", |update| update.finished);
         assert_eq!(completed.status, "completed", "{completed:?}");
         assert_eq!(completed.exit_code, Some(0), "{completed:?}");
+        assert_eq!(
+            completed.command_execution_state,
+            Some(crate::shell_protocol::ShellCommandExecutionState::Completed),
+            "{completed:?}"
+        );
         assert!(
             completed
                 .log_snapshot
@@ -1542,6 +1723,11 @@ mod tests {
         let stopped = wait_for_job_update(&mut rx, "ssh-job-stop", |update| update.finished);
         assert_eq!(stopped.status, "stopped", "{stopped:?}");
         assert_eq!(stopped.exit_code, Some(-1), "{stopped:?}");
+        assert_eq!(
+            stopped.command_execution_state,
+            Some(crate::shell_protocol::ShellCommandExecutionState::Completed),
+            "{stopped:?}"
+        );
 
         manager.enqueue(
             sink,
@@ -1556,6 +1742,11 @@ mod tests {
         );
         let missing = wait_for_job_update(&mut rx, "ssh-job-missing", |update| update.finished);
         assert_eq!(missing.status, "failed", "{missing:?}");
+        assert_eq!(
+            missing.command_execution_state,
+            Some(crate::shell_protocol::ShellCommandExecutionState::NotStarted),
+            "{missing:?}"
+        );
         assert!(
             missing
                 .error
@@ -1570,6 +1761,30 @@ mod tests {
                 .is_some_and(|error| error.contains("command was not started")),
             "{missing:?}"
         );
+    }
+
+    #[test]
+    fn unix_mux_exit_255_classification_remains_transport_evidence_based() {
+        let transport = PreparedSshTransport::Mux(SshConnectionKey {
+            session_id: "wc_sess_mux_classifier".to_string(),
+            resource_name: "tmp".to_string(),
+            generation: 7,
+        });
+        assert!(!is_transport_failure(
+            &transport,
+            Some(7),
+            Some("mux_client")
+        ));
+        assert!(!is_transport_failure(
+            &transport,
+            Some(255),
+            Some("remote command deliberately exited 255")
+        ));
+        assert!(is_transport_failure(
+            &transport,
+            Some(255),
+            Some("mux_client: master is dead")
+        ));
     }
 
     fn ssh_job_request(
@@ -2404,33 +2619,813 @@ mod tests {
 }
 
 #[cfg(all(test, windows))]
-mod windows_persistent_tests {
+mod windows_tests {
     use super::*;
-    use crate::webcodex_runner::config::SshResourceConfig;
+    use crate::shell_protocol::ShellCommandExecutionState;
+    use crate::webcodex_runner::config::{AgentPolicy, SshResourceConfig};
     use std::collections::BTreeMap;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::sync::{Arc, OnceLock};
+    use std::time::{Duration, Instant};
 
-    #[test]
-    fn windows_persistent_shell_prepares_direct_literal_ssh_exe_argv() {
+    struct FakeSsh {
+        _temp: tempfile::TempDir,
+        path: PathBuf,
+    }
+
+    static FAKE_SSH: OnceLock<Arc<FakeSsh>> = OnceLock::new();
+
+    fn fake_ssh() -> Arc<FakeSsh> {
+        FAKE_SSH
+            .get_or_init(|| {
+                let temp = tempfile::tempdir().expect("create fake SSH tempdir");
+                let source = temp.path().join("fake_ssh.rs");
+                let output = temp
+                    .path()
+                    .join(format!("fake-ssh{}", std::env::consts::EXE_SUFFIX));
+                std::fs::write(
+                    &source,
+                    r#"
+use std::env;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+fn suffix<'a>(script: &'a str, marker: &str) -> Option<&'a str> {
+    script.rfind(marker).map(|index| script[index + marker.len()..].trim())
+}
+
+fn append_start(path: &str) {
+    let mut file = OpenOptions::new().create(true).append(true).open(path).unwrap();
+    writeln!(file, "start").unwrap();
+}
+
+fn main() {
+    let args = env::args().collect::<Vec<_>>();
+    if args.get(1).map(String::as_str) == Some("--grandchild") {
+        let marker = args.get(2).expect("grandchild marker");
+        thread::sleep(Duration::from_secs(3));
+        fs::write(marker, format!("{}", std::process::id())).unwrap();
+        thread::sleep(Duration::from_secs(60));
+        return;
+    }
+
+    let script = args.last().map(String::as_str).unwrap_or_default();
+    if let Some(path) = suffix(script, "WC_FAKE_EXIT_255::") {
+        append_start(path);
+        eprintln!("ambiguous direct ssh exit");
+        std::process::exit(255);
+    }
+    if script.contains("WC_FAKE_EXIT_7") {
+        eprintln!("remote-like command failure");
+        std::process::exit(7);
+    }
+    if script.contains("WC_FAKE_STDIN_FAILURE") {
+        thread::sleep(Duration::from_millis(100));
+        return;
+    }
+    if script.contains("WC_FAKE_OUTPUT") {
+        io::stdout().write_all(&vec![b'o'; 32 * 1024]).unwrap();
+        io::stdout().flush().unwrap();
+        io::stderr().write_all(&vec![b'e'; 32 * 1024]).unwrap();
+        io::stderr().flush().unwrap();
+        return;
+    }
+    if let Some(marker) = suffix(script, "WC_FAKE_TREE::") {
+        let child = Command::new(env::current_exe().unwrap())
+            .arg("--grandchild")
+            .arg(marker)
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap();
+        println!("GRANDCHILD_PID={}", child.id());
+        io::stdout().flush().unwrap();
+        thread::sleep(Duration::from_secs(60));
+        return;
+    }
+    if script.contains("WC_FAKE_SLEEP") {
+        thread::sleep(Duration::from_secs(60));
+        return;
+    }
+    print!("fake-ssh-ok");
+    io::stdout().flush().unwrap();
+}
+"#,
+                )
+                .expect("write fake SSH source");
+                let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+                let result = Command::new(rustc)
+                    .arg("--edition=2021")
+                    .arg("--crate-name=webcodex_fake_ssh")
+                    .arg(&source)
+                    .arg("-o")
+                    .arg(&output)
+                    .output()
+                    .expect("run rustc for fake SSH");
+                assert!(
+                    result.status.success(),
+                    "fake SSH compilation failed: {}",
+                    String::from_utf8_lossy(&result.stderr)
+                );
+                Arc::new(FakeSsh {
+                    _temp: temp,
+                    path: output,
+                })
+            })
+            .clone()
+    }
+
+    fn ssh_config(host: &str, default_cwd: Option<&str>) -> SshConfig {
         let mut resources = BTreeMap::new();
         resources.insert(
             "spe".to_string(),
             SshResourceConfig {
-                host: "spe".to_string(),
-                default_cwd: Some("/srv/webcodex".to_string()),
+                host: host.to_string(),
+                default_cwd: default_cwd.map(str::to_string),
             },
         );
-        let config = SshConfig { resources };
+        SshConfig { resources }
+    }
+
+    fn command_args(command: &Command) -> Vec<String> {
+        command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn assert_direct_args(args: &[String], host: &str) {
+        assert_eq!(
+            &args[..5],
+            ["-o", "BatchMode=yes", "-o", "LogLevel=ERROR", host]
+        );
+        assert!(!args.iter().any(|arg| arg == "-S"), "{args:?}");
+        assert!(
+            !args.iter().any(|arg| arg.contains("ControlMaster")),
+            "{args:?}"
+        );
+        assert!(
+            !args.iter().any(|arg| arg.contains("ControlPersist")),
+            "{args:?}"
+        );
+    }
+
+    fn fake_pool() -> SshConnectionPool {
+        SshConnectionPool::with_test_executable(fake_ssh().path.clone())
+    }
+
+    fn grandchild_pid(text: &str) -> u32 {
+        text.lines()
+            .find_map(|line| line.trim().strip_prefix("GRANDCHILD_PID="))
+            .and_then(|value| value.parse::<u32>().ok())
+            .unwrap_or_else(|| panic!("missing GRANDCHILD_PID in {text:?}"))
+    }
+
+    fn wait_for_process_exit(pid: u32) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !crate::job_manager_tests::process_running(pid) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        !crate::job_manager_tests::process_running(pid)
+    }
+
+    fn ssh_job_request(
+        job_id: &str,
+        command: &str,
+        timeout_secs: u64,
+    ) -> crate::shell_protocol::ShellAgentShellRequest {
+        serde_json::from_value(serde_json::json!({
+            "request_id": format!("request-{job_id}"),
+            "client_id": "ssh-agent",
+            "kind": "start_job",
+            "job_id": job_id,
+            "command": command,
+            "timeout_secs": timeout_secs,
+            "requested_by": "test",
+            "created_at": 1,
+            "job_context": {
+                "runtime_project_id": "agent:ssh-agent:remote-project",
+                "workflow_session_id": "wc_sess_windows_ssh_job",
+                "ssh_resource": "spe",
+                "project_cwd": ".",
+                "purpose": "other",
+                "shell": "remote",
+                "command_preview": "remote test command",
+                "validation_steps": []
+            }
+        }))
+        .expect("build Windows SSH job request")
+    }
+
+    fn wait_for_job_update(
+        rx: &mut tokio::sync::mpsc::Receiver<crate::shell_protocol::AgentEnvelope>,
+        job_id: &str,
+        predicate: impl Fn(&crate::shell_protocol::ShellAgentJobUpdateRequest) -> bool,
+    ) -> crate::shell_protocol::ShellAgentJobUpdateRequest {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while Instant::now() < deadline {
+            match rx.try_recv() {
+                Ok(crate::shell_protocol::AgentEnvelope::JobUpdate { payload })
+                    if payload.job_id == job_id && predicate(&payload) =>
+                {
+                    return payload;
+                }
+                Ok(_) | Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    panic!("Windows SSH job update channel closed")
+                }
+            }
+        }
+        panic!("timed out waiting for Windows SSH job {job_id}");
+    }
+
+    fn enqueue_job(
+        manager: &crate::JobManager,
+        sink: crate::webcodex_runner::AgentSink,
+        config: SshConfig,
+        policy: AgentPolicy,
+        job_id: &str,
+        command: &str,
+        timeout_secs: u64,
+    ) {
+        manager.enqueue(
+            sink,
+            crate::PendingJobStart {
+                generation: 11,
+                policy,
+                shell: crate::webcodex_runner::ShellConfig::default(),
+                ssh: config,
+                projects_dir: PathBuf::new(),
+                request: ssh_job_request(job_id, command, timeout_secs),
+            },
+        );
+    }
+
+    #[test]
+    fn windows_ssh_capabilities_track_ssh_exe_discovery() {
+        let executable_available = Command::new("ssh.exe")
+            .arg("-V")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success());
+        assert_eq!(SshConnectionPool::is_available(), executable_available);
+        assert_eq!(
+            SshConnectionPool::persistent_shell_available(),
+            executable_available
+        );
+    }
+
+    #[test]
+    fn windows_one_shot_and_job_prepare_direct_literal_ssh_exe_without_mux_state() {
+        let config = ssh_config("spe", Some("/srv/webcodex"));
+        let pool = SshConnectionPool::default();
+        let prepared = pool
+            .prepare_command(
+                7,
+                &config,
+                "spe",
+                "wc_sess_windows_ssh",
+                Some("/srv/override"),
+                "printf test",
+            )
+            .expect("prepare Windows one-shot SSH command");
+        assert_eq!(prepared.command.get_program(), "ssh.exe");
+        assert!(matches!(prepared.transport, PreparedSshTransport::Direct));
+        let args = command_args(&prepared.command);
+        assert_direct_args(&args, "spe");
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("if ! cd '/srv/override'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf test")
+        );
+        assert_eq!(pool.connection_count(), 0);
+
+        let job = pool
+            .prepare_job_command(7, &config, "spe", "wc_sess_windows_ssh", None, "printf job")
+            .expect("prepare Windows background SSH command");
+        assert_eq!(job.command.get_program(), "ssh.exe");
+        assert!(matches!(job.transport, PreparedSshTransport::Direct));
+        let job_args = command_args(&job.command);
+        assert_direct_args(&job_args, "spe");
+        assert_eq!(
+            job_args.last().map(String::as_str),
+            Some("if ! cd '/srv/webcodex'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf job")
+        );
+        assert_eq!(pool.connection_count(), 0);
+    }
+
+    #[test]
+    fn windows_direct_preparation_uses_current_generation_resource_mapping() {
+        let pool = SshConnectionPool::default();
+        let generation_7 = ssh_config("host-a", None);
+        let old = pool
+            .prepare_command(
+                7,
+                &generation_7,
+                "spe",
+                "wc_sess_windows_generation",
+                None,
+                "printf old",
+            )
+            .unwrap();
+        assert_direct_args(&command_args(&old.command), "host-a");
+
+        let generation_8 = ssh_config("host-b", None);
+        let current = pool
+            .prepare_command(
+                8,
+                &generation_8,
+                "spe",
+                "wc_sess_windows_generation",
+                None,
+                "printf current",
+            )
+            .unwrap();
+        assert_direct_args(&command_args(&current.command), "host-b");
+        assert_eq!(
+            pool.connection_count(),
+            0,
+            "Windows direct SSH must not create mux state"
+        );
+    }
+
+    #[test]
+    fn windows_direct_transport_classifies_only_exit_255_as_unknown() {
+        let transport = PreparedSshTransport::Direct;
+        assert!(!is_transport_failure(&transport, Some(0), None));
+        assert!(!is_transport_failure(&transport, Some(7), Some("anything")));
+        assert!(is_transport_failure(
+            &transport,
+            Some(255),
+            Some("remote command deliberately exited 255")
+        ));
+    }
+
+    #[test]
+    fn windows_one_shot_direct_ssh_preserves_execution_state_and_no_retry() {
+        let config = ssh_config("spe", None);
+        let policy = AgentPolicy::default();
+        let pool = fake_pool();
+
+        let ok = run_ssh_shell_with_execution_state(
+            &pool,
+            7,
+            &config,
+            &policy,
+            "spe",
+            "wc_sess_windows_one_shot",
+            None,
+            "WC_FAKE_EXIT_0",
+            None,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            ok.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{ok:?}"
+        );
+        assert_eq!(ok.result.exit_code, Some(0), "{ok:?}");
+
+        let failed = run_ssh_shell_with_execution_state(
+            &pool,
+            7,
+            &config,
+            &policy,
+            "spe",
+            "wc_sess_windows_one_shot",
+            None,
+            "WC_FAKE_EXIT_7",
+            None,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            failed.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{failed:?}"
+        );
+        assert_eq!(failed.result.exit_code, Some(7), "{failed:?}");
+
+        let large_stdin = "x".repeat(1024 * 1024);
+        let stdin_unknown = run_ssh_shell_with_execution_state(
+            &pool,
+            7,
+            &config,
+            &policy,
+            "spe",
+            "wc_sess_windows_one_shot",
+            None,
+            "WC_FAKE_STDIN_FAILURE",
+            Some(&large_stdin),
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            stdin_unknown.execution_state,
+            ShellCommandExecutionState::OutcomeUnknown,
+            "{stdin_unknown:?}"
+        );
+        assert!(
+            stdin_unknown
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_stdin_failed")),
+            "{stdin_unknown:?}"
+        );
+
+        let temp = tempfile::tempdir().unwrap();
+        let starts = temp.path().join("exit255.starts");
+        let unknown = run_ssh_shell_with_execution_state(
+            &pool,
+            7,
+            &config,
+            &policy,
+            "spe",
+            "wc_sess_windows_one_shot",
+            None,
+            &format!("WC_FAKE_EXIT_255::{}", starts.display()),
+            None,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            unknown.execution_state,
+            ShellCommandExecutionState::OutcomeUnknown,
+            "{unknown:?}"
+        );
+        assert_eq!(unknown.result.exit_code, Some(255), "{unknown:?}");
+        assert!(
+            unknown
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_transport_failed")),
+            "{unknown:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&starts).unwrap().lines().count(),
+            1,
+            "direct exit 255 was retried"
+        );
+    }
+
+    #[test]
+    fn windows_one_shot_spawn_failure_is_not_started() {
+        let temp = tempfile::tempdir().unwrap();
+        let pool = SshConnectionPool::with_test_executable(temp.path().join("missing-ssh.exe"));
+        let result = run_ssh_shell_with_execution_state(
+            &pool,
+            7,
+            &ssh_config("spe", None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_spawn_failure",
+            None,
+            "printf never",
+            None,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::NotStarted,
+            "{result:?}"
+        );
+        assert!(
+            result
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_spawn_failed")),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn windows_background_ssh_spawn_failure_is_not_started() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manager = crate::JobManager::new(1);
+        manager.ssh_pool =
+            SshConnectionPool::with_test_executable(temp.path().join("missing-ssh.exe"));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let sink = crate::webcodex_runner::AgentSink::WebSocket {
+            tx,
+            client_id: "ssh-agent".to_string(),
+            agent_instance_id: "ssh-instance".to_string(),
+        };
+        enqueue_job(
+            &manager,
+            sink,
+            ssh_config("spe", None),
+            AgentPolicy::default(),
+            "win-ssh-spawn-failure",
+            "printf never",
+            5,
+        );
+        let failed =
+            wait_for_job_update(&mut rx, "win-ssh-spawn-failure", |update| update.finished);
+        assert_eq!(failed.status, "failed", "{failed:?}");
+        assert_eq!(
+            failed.command_execution_state,
+            Some(ShellCommandExecutionState::NotStarted),
+            "{failed:?}"
+        );
+        assert!(
+            failed
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_spawn_failed")),
+            "{failed:?}"
+        );
+    }
+
+    #[test]
+    fn windows_one_shot_timeout_reaps_the_managed_ssh_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let delayed_marker = temp.path().join("one-shot-grandchild.marker");
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config("spe", None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_tree",
+            None,
+            &format!("WC_FAKE_TREE::{}", delayed_marker.display()),
+            None,
+            1,
+            None,
+            None,
+        );
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::TimedOut,
+            "{result:?}"
+        );
+        let pid = grandchild_pid(result.result.stdout.as_deref().unwrap_or_default());
+        assert!(
+            wait_for_process_exit(pid),
+            "one-shot SSH grandchild survived timeout cleanup: {pid}"
+        );
+        assert!(
+            !delayed_marker.exists(),
+            "terminated grandchild reached its delayed marker"
+        );
+    }
+
+    #[test]
+    fn windows_background_ssh_reuses_job_manager_lifecycle_and_bounds_output() {
+        let config = ssh_config("spe", None);
+        let mut manager = crate::JobManager::new(1);
+        manager.ssh_pool = fake_pool();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let sink = crate::webcodex_runner::AgentSink::WebSocket {
+            tx,
+            client_id: "ssh-agent".to_string(),
+            agent_instance_id: "ssh-instance".to_string(),
+        };
+
+        enqueue_job(
+            &manager,
+            sink.clone(),
+            config.clone(),
+            AgentPolicy::default(),
+            "win-ssh-0",
+            "WC_FAKE_EXIT_0",
+            5,
+        );
+        let ok = wait_for_job_update(&mut rx, "win-ssh-0", |update| update.finished);
+        assert_eq!(ok.status, "completed", "{ok:?}");
+        assert_eq!(ok.exit_code, Some(0), "{ok:?}");
+        assert_eq!(
+            ok.command_execution_state,
+            Some(ShellCommandExecutionState::Completed),
+            "{ok:?}"
+        );
+
+        enqueue_job(
+            &manager,
+            sink.clone(),
+            config.clone(),
+            AgentPolicy::default(),
+            "win-ssh-7",
+            "WC_FAKE_EXIT_7",
+            5,
+        );
+        let failed = wait_for_job_update(&mut rx, "win-ssh-7", |update| update.finished);
+        assert_eq!(failed.status, "failed", "{failed:?}");
+        assert_eq!(failed.exit_code, Some(7), "{failed:?}");
+        assert_eq!(
+            failed.command_execution_state,
+            Some(ShellCommandExecutionState::Completed),
+            "{failed:?}"
+        );
+
+        let starts_dir = tempfile::tempdir().unwrap();
+        let starts = starts_dir.path().join("job-255.starts");
+        enqueue_job(
+            &manager,
+            sink.clone(),
+            config.clone(),
+            AgentPolicy::default(),
+            "win-ssh-255",
+            &format!("WC_FAKE_EXIT_255::{}", starts.display()),
+            5,
+        );
+        let unknown = wait_for_job_update(&mut rx, "win-ssh-255", |update| update.finished);
+        assert_eq!(unknown.status, "failed", "{unknown:?}");
+        assert_eq!(unknown.exit_code, Some(255), "{unknown:?}");
+        assert_eq!(
+            unknown.command_execution_state,
+            Some(ShellCommandExecutionState::OutcomeUnknown),
+            "{unknown:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&starts).unwrap().lines().count(),
+            1,
+            "background direct exit 255 was retried"
+        );
+
+        let bounded_policy = AgentPolicy {
+            max_output_bytes: 4 * 1024,
+            ..AgentPolicy::default()
+        };
+        enqueue_job(
+            &manager,
+            sink.clone(),
+            config.clone(),
+            bounded_policy,
+            "win-ssh-output",
+            "WC_FAKE_OUTPUT",
+            5,
+        );
+        let output = wait_for_job_update(&mut rx, "win-ssh-output", |update| update.finished);
+        let snapshot = output
+            .log_snapshot
+            .as_ref()
+            .expect("bounded SSH job log snapshot");
+        assert!(snapshot.stdout.tail.len() <= 4 * 1024, "{snapshot:?}");
+        assert!(snapshot.stderr.tail.len() <= 4 * 1024, "{snapshot:?}");
+        assert!(snapshot.stdout.truncated, "{snapshot:?}");
+        assert!(snapshot.stderr.truncated, "{snapshot:?}");
+
+        enqueue_job(
+            &manager,
+            sink,
+            config,
+            AgentPolicy::default(),
+            "win-ssh-slot",
+            "WC_FAKE_EXIT_0",
+            5,
+        );
+        let slot = wait_for_job_update(&mut rx, "win-ssh-slot", |update| update.finished);
+        assert_eq!(
+            slot.status, "completed",
+            "terminal SSH jobs must release the Job slot: {slot:?}"
+        );
+    }
+
+    #[test]
+    fn windows_background_ssh_stop_and_timeout_reap_owned_trees() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = ssh_config("spe", None);
+        let mut manager = crate::JobManager::new(1);
+        manager.ssh_pool = fake_pool();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let sink = crate::webcodex_runner::AgentSink::WebSocket {
+            tx,
+            client_id: "ssh-agent".to_string(),
+            agent_instance_id: "ssh-instance".to_string(),
+        };
+
+        let stop_marker = temp.path().join("stop-grandchild.marker");
+        enqueue_job(
+            &manager,
+            sink.clone(),
+            config.clone(),
+            AgentPolicy::default(),
+            "win-ssh-stop",
+            &format!("WC_FAKE_TREE::{}", stop_marker.display()),
+            30,
+        );
+        let observed = wait_for_job_update(&mut rx, "win-ssh-stop", |update| {
+            update
+                .log_snapshot
+                .as_ref()
+                .is_some_and(|snapshot| snapshot.stdout.tail.contains("GRANDCHILD_PID="))
+        });
+        let stop_pid = grandchild_pid(&observed.log_snapshot.as_ref().unwrap().stdout.tail);
+        manager.stop("win-ssh-stop").expect("stop Windows SSH job");
+        let stopped = wait_for_job_update(&mut rx, "win-ssh-stop", |update| update.finished);
+        assert_eq!(stopped.status, "stopped", "{stopped:?}");
+        assert_eq!(
+            stopped.command_execution_state,
+            Some(ShellCommandExecutionState::Completed),
+            "{stopped:?}"
+        );
+        assert!(
+            wait_for_process_exit(stop_pid),
+            "background SSH grandchild survived stop: {stop_pid}"
+        );
+        assert!(!stop_marker.exists());
+
+        let timeout_marker = temp.path().join("timeout-grandchild.marker");
+        enqueue_job(
+            &manager,
+            sink,
+            config,
+            AgentPolicy::default(),
+            "win-ssh-timeout",
+            &format!("WC_FAKE_TREE::{}", timeout_marker.display()),
+            1,
+        );
+        let timed_out = wait_for_job_update(&mut rx, "win-ssh-timeout", |update| update.finished);
+        assert_eq!(timed_out.status, "timeout", "{timed_out:?}");
+        assert_eq!(
+            timed_out.command_execution_state,
+            Some(ShellCommandExecutionState::TimedOut),
+            "{timed_out:?}"
+        );
+        let timeout_pid = grandchild_pid(&timed_out.log_snapshot.as_ref().unwrap().stdout.tail);
+        assert!(
+            wait_for_process_exit(timeout_pid),
+            "background SSH grandchild survived timeout: {timeout_pid}"
+        );
+        assert!(!timeout_marker.exists());
+    }
+
+    #[test]
+    fn windows_background_ssh_shutdown_drain_is_bounded_and_reaps_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("shutdown-grandchild.marker");
+        let mut manager = crate::JobManager::new(1);
+        manager.ssh_pool = fake_pool();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        let sink = crate::webcodex_runner::AgentSink::WebSocket {
+            tx,
+            client_id: "ssh-agent".to_string(),
+            agent_instance_id: "ssh-instance".to_string(),
+        };
+        enqueue_job(
+            &manager,
+            sink,
+            ssh_config("spe", None),
+            AgentPolicy::default(),
+            "win-ssh-shutdown",
+            &format!("WC_FAKE_TREE::{}", marker.display()),
+            30,
+        );
+        let observed = wait_for_job_update(&mut rx, "win-ssh-shutdown", |update| {
+            update
+                .log_snapshot
+                .as_ref()
+                .is_some_and(|snapshot| snapshot.stdout.tail.contains("GRANDCHILD_PID="))
+        });
+        let pid = grandchild_pid(&observed.log_snapshot.as_ref().unwrap().stdout.tail);
+        let started = Instant::now();
+        manager.stop_accepting_work();
+        let batch = manager.signal_all_for_shutdown();
+        let outcome = manager.drain_shutdown(batch, Instant::now() + Duration::from_secs(2));
+        assert_eq!(outcome.timed_out, 0, "{outcome:?}");
+        assert!(
+            started.elapsed() < Duration::from_millis(2500),
+            "SSH shutdown drain exceeded its bound"
+        );
+        assert!(
+            wait_for_process_exit(pid),
+            "background SSH grandchild survived Runner shutdown: {pid}"
+        );
+        assert!(!marker.exists());
+    }
+
+    #[test]
+    fn windows_persistent_shell_prepares_direct_literal_ssh_exe_argv() {
+        let config = ssh_config("spe", Some("/srv/webcodex"));
         let pool = SshConnectionPool::default();
         let prepared = pool
             .prepare_persistent_shell_command(7, &config, "spe", "wc_sess_windows_ssh", "bash")
             .expect("prepare Windows persistent SSH command");
 
         assert_eq!(prepared.command.get_program(), "ssh.exe");
-        let args = prepared
-            .command
-            .get_args()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
+        let args = command_args(&prepared.command);
         assert_eq!(
             args,
             vec!["-o", "BatchMode=yes", "-o", "LogLevel=ERROR", "spe", "bash"]
@@ -2441,20 +3436,104 @@ mod windows_persistent_tests {
     }
 
     #[test]
-    fn windows_persistent_shell_capability_tracks_ssh_exe_discovery() {
-        let executable_available = Command::new("ssh.exe")
-            .arg("-V")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success());
+    fn windows_real_host_one_shot_and_background_are_opt_in() {
+        let Ok(host) = std::env::var("WEBCODEX_TEST_WINDOWS_SSH_HOST") else {
+            eprintln!("skipping Windows real-host SSH integration: WEBCODEX_TEST_WINDOWS_SSH_HOST is unset");
+            return;
+        };
+        let host = host.trim();
+        if host.is_empty() {
+            eprintln!("skipping Windows real-host SSH integration: WEBCODEX_TEST_WINDOWS_SSH_HOST is empty");
+            return;
+        }
+        let config = ssh_config(host, None);
+        let one_shot = run_ssh_shell_with_execution_state(
+            &SshConnectionPool::default(),
+            7,
+            &config,
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_real_ssh",
+            None,
+            "printf wc-windows-one-shot",
+            None,
+            15,
+            None,
+            None,
+        );
         assert_eq!(
-            SshConnectionPool::persistent_shell_available(),
-            executable_available
+            one_shot.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{one_shot:?}"
+        );
+        assert_eq!(one_shot.result.exit_code, Some(0), "{one_shot:?}");
+        assert_eq!(
+            one_shot.result.stdout.as_deref(),
+            Some("wc-windows-one-shot")
+        );
+
+        let manager = crate::JobManager::new(1);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        let sink = crate::webcodex_runner::AgentSink::WebSocket {
+            tx,
+            client_id: "ssh-agent".to_string(),
+            agent_instance_id: "ssh-instance".to_string(),
+        };
+        enqueue_job(
+            &manager,
+            sink,
+            config,
+            AgentPolicy::default(),
+            "win-ssh-real-background",
+            "printf wc-windows-background",
+            15,
+        );
+        let background =
+            wait_for_job_update(&mut rx, "win-ssh-real-background", |update| update.finished);
+        assert_eq!(background.status, "completed", "{background:?}");
+        assert_eq!(background.exit_code, Some(0), "{background:?}");
+        assert_eq!(
+            background.command_execution_state,
+            Some(ShellCommandExecutionState::Completed),
+            "{background:?}"
         );
         assert!(
-            !SshConnectionPool::is_available(),
-            "one-shot SSH remains Unix-only in this focused slice"
+            background
+                .log_snapshot
+                .as_ref()
+                .is_some_and(|snapshot| snapshot.stdout.tail.contains("wc-windows-background")),
+            "{background:?}"
+        );
+    }
+
+    #[test]
+    fn windows_remote_cwd_validation_stays_prestart() {
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config("spe", None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_invalid_cwd",
+            Some("/tmp\ninvalid"),
+            "printf never",
+            None,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::NotStarted,
+            "{result:?}"
+        );
+        assert!(
+            result
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_remote_cwd_invalid")),
+            "{result:?}"
         );
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -96,12 +96,13 @@ impl SshConnectionPool {
         if !cfg!(any(unix, windows)) {
             return false;
         }
-        Command::new(ssh_executable())
-            .arg("-V")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
+        ssh_shell_probe_available(
+            Command::new(ssh_executable())
+                .arg("-V")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status(),
+        )
     }
 
     /// Whether this host can open a named SSH persistent shell. This is separate
@@ -842,6 +843,22 @@ fn ssh_executable() -> &'static str {
     }
 }
 
+fn ssh_shell_probe_available(status: std::io::Result<ExitStatus>) -> bool {
+    #[cfg(unix)]
+    {
+        status.is_ok()
+    }
+    #[cfg(windows)]
+    {
+        status.is_ok_and(|status| status.success())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = status;
+        false
+    }
+}
+
 fn normalize_remote_cwd(cwd: Option<&str>) -> Result<Option<String>, String> {
     let Some(cwd) = cwd.map(str::trim).filter(|cwd| !cwd.is_empty()) else {
         return Ok(None);
@@ -1202,8 +1219,8 @@ fn command_error(start: Instant, error: String) -> CommandResult {
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        is_transport_failure, remote_script, run_ssh_shell, shell_quote, PreparedSshTransport,
-        SshConnectionKey, SshConnectionPool,
+        is_transport_failure, remote_script, run_ssh_shell, shell_quote, ssh_shell_probe_available,
+        PreparedSshTransport, SshConnectionKey, SshConnectionPool,
     };
     use crate::webcodex_runner::config::{AgentPolicy, SshConfig, SshResourceConfig};
     use std::collections::BTreeMap;
@@ -1409,6 +1426,17 @@ mod tests {
             None,
             None,
         )
+    }
+
+    #[test]
+    fn unix_ssh_shell_capability_preserves_launch_only_probe_semantics() {
+        let nonzero = Command::new("sh")
+            .arg("-c")
+            .arg("exit 7")
+            .status()
+            .expect("start Unix capability probe fixture");
+        assert!(!nonzero.success());
+        assert!(ssh_shell_probe_available(Ok(nonzero)));
     }
 
     #[test]
@@ -2881,6 +2909,12 @@ fn main() {
             .status()
             .is_ok_and(|status| status.success());
         assert_eq!(SshConnectionPool::is_available(), executable_available);
+        let nonzero = Command::new("cmd.exe")
+            .args(["/d", "/c", "exit /b 7"])
+            .status()
+            .expect("start Windows capability probe fixture");
+        assert!(!nonzero.success());
+        assert!(!ssh_shell_probe_available(Ok(nonzero)));
         assert_eq!(
             SshConnectionPool::persistent_shell_available(),
             executable_available
@@ -3155,6 +3189,93 @@ fn main() {
                 .is_some_and(|error| error.contains("ssh_command_spawn_failed")),
             "{failed:?}"
         );
+    }
+
+    #[test]
+    fn windows_background_ssh_post_spawn_rejections_are_outcome_unknown() {
+        for (shutting_down, stop_requested, job_record_present, expected_error) in [
+            (
+                true,
+                false,
+                true,
+                "runner began shutdown after command start",
+            ),
+            (false, true, true, "job stop requested after command start"),
+            (
+                false,
+                false,
+                false,
+                "runner lost the Job record after command start",
+            ),
+        ] {
+            let error = crate::post_spawn_interruption_reason(
+                shutting_down,
+                stop_requested,
+                job_record_present,
+            )
+            .expect("post-spawn interruption is rejected");
+            assert_eq!(error, expected_error);
+            let delta = crate::post_spawn_interruption_delta("start_job", 7, error);
+            assert_eq!(delta.status, "failed");
+            assert_eq!(delta.exit_code, None);
+            assert_eq!(delta.duration_ms, Some(7));
+            assert_eq!(
+                delta.command_execution_state,
+                Some(ShellCommandExecutionState::OutcomeUnknown)
+            );
+            assert!(delta.finished);
+        }
+        assert!(crate::post_spawn_interruption_reason(false, false, true).is_none());
+    }
+
+    #[test]
+    fn windows_background_ssh_post_spawn_rejection_reaps_owned_tree() {
+        use std::io::{BufRead, BufReader};
+
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("post-spawn-grandchild.marker");
+        let fake = fake_ssh();
+        let mut command = Command::new(&fake.path);
+        command
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg("-o")
+            .arg("LogLevel=ERROR")
+            .arg("spe")
+            .arg(format!("WC_FAKE_TREE::{}", marker.display()))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let mut child = ManagedChild::spawn(&mut command).expect("spawn owned fake SSH tree");
+        let stdout = child
+            .child_mut()
+            .stdout
+            .take()
+            .expect("fake SSH stdout pipe");
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .expect("read fake SSH grandchild pid");
+        let pid = grandchild_pid(&line);
+        let child = Arc::new(Mutex::new(child));
+
+        let error = crate::post_spawn_interruption_reason(true, false, true)
+            .expect("shutdown after spawn is rejected");
+        crate::terminate_managed_tree(&child).expect("terminate owned SSH tree");
+        assert!(
+            wait_for_process_exit(pid),
+            "post-spawn SSH grandchild survived owned-tree termination: {pid}"
+        );
+        assert!(!marker.exists(), "terminated grandchild reached marker");
+
+        let delta = crate::post_spawn_interruption_delta("start_job", 0, error);
+        assert_eq!(
+            delta.command_execution_state,
+            Some(ShellCommandExecutionState::OutcomeUnknown)
+        );
+        assert_eq!(delta.status, "failed");
+        assert_eq!(delta.exit_code, None);
     }
 
     #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -28,7 +28,7 @@ const SSH_REMOTE_CWD_MAX_BYTES: usize = 4096;
 /// It is transport headroom, not a smaller Windows product limit.
 const WINDOWS_DIRECT_PROGRAM_MAX_BYTES: usize =
     crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES + SSH_REMOTE_CWD_MAX_BYTES * 5 + 512;
-const WINDOWS_DIRECT_BOOTSTRAP_PREFIX: &str = "WEBCODEX_SSH_PROGRAM_BYTES=";
+const WINDOWS_DIRECT_BOOTSTRAP_PREFIX: &str = ": WEBCODEX_SSH_PROGRAM_BYTES=";
 
 /// In-memory identity for one OpenSSH multiplex transport. The Runner config
 /// generation protects a request after an operator changes a resource host.
@@ -1052,12 +1052,15 @@ fn shell_quote(value: &str) -> String {
 }
 
 /// Small fixed remote loader for Windows Direct SSH. The only dynamic argv
-/// material is a bounded decimal byte count. `dd bs=1 count=N` cannot consume
-/// caller stdin past the program region; the explicit `wc -c` check also makes
-/// short/partial uploads fail before the program is evaluated.
+/// material is a bounded decimal byte count. OpenSSH's one remote shell runs
+/// the final `eval`; all framing state lives only in a command-substitution
+/// subshell. `dd bs=1 count=N` consumes only the program region, an inner
+/// non-newline sentinel preserves program trailing newlines, and the outer
+/// comment sentinel prevents the final command substitution from trimming them.
+/// The complete frame is byte-counted before any program text reaches `eval`.
 fn windows_direct_program_bootstrap(program_len: usize) -> String {
     format!(
-        "{WINDOWS_DIRECT_BOOTSTRAP_PREFIX}{program_len}; n=$WEBCODEX_SSH_PROGRAM_BYTES; unset WEBCODEX_SSH_PROGRAM_BYTES; case \"$n\" in ''|*[!0-9]*) printf >&2 '%s\\n' 'webcodex: invalid SSH program length'; exit 126;; esac; [ \"$n\" -gt 0 ] && [ \"$n\" -le {WINDOWS_DIRECT_PROGRAM_MAX_BYTES} ] || {{ printf >&2 '%s\\n' 'webcodex: SSH program length out of range'; exit 126; }}; umask 077; i=0; while :; do d=/tmp/.webcodex-ssh-$$-$i; if mkdir \"$d\" 2>/dev/null; then break; fi; i=$((i+1)); [ \"$i\" -lt 32 ] || {{ printf >&2 '%s\\n' 'webcodex: SSH program temp allocation failed'; exit 126; }}; done; f=$d/program; cleanup(){{ rm -f \"$f\"; rmdir \"$d\" 2>/dev/null || :; }}; trap 'cleanup' 0; trap 'exit 129' HUP; trap 'exit 130' INT; trap 'exit 143' TERM; if ! dd of=\"$f\" bs=1 count=\"$n\" 2>/dev/null; then printf >&2 '%s\\n' 'webcodex: SSH program upload failed'; exit 126; fi; set -- $(wc -c < \"$f\"); actual=${{1-}}; case \"$actual\" in ''|*[!0-9]*) printf >&2 '%s\\n' 'webcodex: SSH program size check failed'; exit 126;; esac; [ \"$actual\" = \"$n\" ] || {{ printf >&2 '%s\\n' 'webcodex: incomplete SSH program upload'; exit 126; }}; \"$0\" -c 'f=$1; shift; p=$(cat \"$f\"; printf x) || exit 126; p=${{p%x}}; eval \"$p\"' \"$0\" \"$f\"; rc=$?; exit \"$rc\""
+        r#"{WINDOWS_DIRECT_BOOTSTRAP_PREFIX}{program_len}; eval "$(set +e; WEBCODEX_SSH_N={program_len}; case "$WEBCODEX_SSH_N" in ''|*[!0-9]*) printf >&2 '%s\n' 'webcodex: invalid SSH program length'; printf '%s' 'exit 126'; exit 0;; esac; [ "$WEBCODEX_SSH_N" -gt 0 ] && [ "$WEBCODEX_SSH_N" -le {WINDOWS_DIRECT_PROGRAM_MAX_BYTES} ] || {{ printf >&2 '%s\n' 'webcodex: SSH program length out of range'; printf '%s' 'exit 126'; exit 0; }}; WEBCODEX_SSH_FRAMED=$(dd bs=1 count="$WEBCODEX_SSH_N" 2>/dev/null; WEBCODEX_SSH_DD_STATUS=$?; printf x; exit "$WEBCODEX_SSH_DD_STATUS"); WEBCODEX_SSH_DD_STATUS=$?; [ "$WEBCODEX_SSH_DD_STATUS" -eq 0 ] || {{ printf >&2 '%s\n' 'webcodex: SSH program upload failed'; printf '%s' 'exit 126'; exit 0; }}; WEBCODEX_SSH_PROGRAM=${{WEBCODEX_SSH_FRAMED%x}}; WEBCODEX_SSH_ACTUAL=$(printf '%s' "$WEBCODEX_SSH_PROGRAM" | wc -c); [ "$WEBCODEX_SSH_ACTUAL" -eq "$WEBCODEX_SSH_N" ] 2>/dev/null || {{ printf >&2 '%s\n' 'webcodex: incomplete SSH program upload'; printf '%s' 'exit 126'; exit 0; }}; printf '%s\n#webcodex-ssh-frame' "$WEBCODEX_SSH_PROGRAM")""#
     )
 }
 
@@ -1453,9 +1456,7 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::os::unix::fs::{symlink, PermissionsExt};
     use std::path::{Path, PathBuf};
-    #[cfg(target_os = "linux")]
-    use std::process::Stdio;
-    use std::process::{Child, Command};
+    use std::process::{Child, Command, Stdio};
     use std::time::{Duration, Instant};
 
     struct TestSshServer {
@@ -1690,23 +1691,41 @@ mod tests {
         assert_eq!(output.stdout, dense.as_bytes());
     }
 
+    fn bootstrap_output(
+        shell: &str,
+        setup: &str,
+        program: &str,
+        caller_stdin: &[u8],
+        env_paths: &[(&str, &Path)],
+    ) -> std::process::Output {
+        let bootstrap = windows_direct_program_bootstrap(program.len());
+        let command_text = if setup.is_empty() {
+            bootstrap
+        } else {
+            format!("{setup}; {bootstrap}")
+        };
+        let mut command = Command::new(shell);
+        command
+            .arg("-c")
+            .arg(command_text)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for (name, path) in env_paths {
+            command.env(name, path);
+        }
+        let mut child = command.spawn().expect("spawn bootstrap probe");
+        let mut input = child.stdin.take().expect("bootstrap stdin");
+        input.write_all(program.as_bytes()).unwrap();
+        input.write_all(caller_stdin).unwrap();
+        drop(input);
+        child.wait_with_output().unwrap()
+    }
+
     #[test]
     fn windows_direct_bootstrap_preserves_caller_stdin_and_rejects_partial_program() {
         let program = "IFS= read -r line; printf '<%s>' \"$line\"";
-        let bootstrap = windows_direct_program_bootstrap(program.len());
-        let mut child = Command::new("sh")
-            .arg("-c")
-            .arg(&bootstrap)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .expect("spawn bootstrap framing probe");
-        let mut input = child.stdin.take().expect("bootstrap stdin");
-        input.write_all(program.as_bytes()).unwrap();
-        input.write_all(b"caller-data\n").unwrap();
-        drop(input);
-        let output = child.wait_with_output().unwrap();
+        let output = bootstrap_output("sh", "", program, b"caller-data\n", &[]);
         assert!(output.status.success(), "{output:?}");
         assert_eq!(output.stdout, b"<caller-data>");
 
@@ -1719,10 +1738,10 @@ mod tests {
         let bootstrap = windows_direct_program_bootstrap(partial_program.len() + 9);
         let mut child = Command::new("sh")
             .arg("-c")
-            .arg(&bootstrap)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
+            .arg(format!("set -e; {bootstrap}"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .spawn()
             .expect("spawn partial bootstrap probe");
         let mut input = child.stdin.take().expect("partial bootstrap stdin");
@@ -1735,6 +1754,157 @@ mod tests {
             "{output:?}"
         );
         assert!(!marker.exists(), "partial remote program was executed");
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_preserves_umask_and_loader_state() {
+        for (mask, expected_file_mode, expected_dir_mode) in
+            [("022", 0o644, 0o755), ("027", 0o640, 0o750)]
+        {
+            let temp = tempfile::tempdir().unwrap();
+            let file = temp.path().join(format!("umask-{mask}.file"));
+            let dir = temp.path().join(format!("umask-{mask}.dir"));
+            let setup = format!(
+                "umask {mask}; set -- before 'two words'; export WEBCODEX_SSH_PROGRAM_BYTES=original WEBCODEX_SSH_N=OLD_N WEBCODEX_SSH_FRAMED=OLD_FRAME WEBCODEX_SSH_DD_STATUS=OLD_STATUS WEBCODEX_SSH_PROGRAM=OLD_PROGRAM WEBCODEX_SSH_ACTUAL=OLD_ACTUAL n=N i=I d=D f=F actual=A; cleanup() {{ printf cleanup-original; }}"
+            );
+            let program = format!(
+                "printf 'mask=%s|meta=%s|private=%s,%s,%s,%s,%s|generic=%s,%s,%s,%s,%s|args=%s,%s,%s|' \"$(umask)\" \"$WEBCODEX_SSH_PROGRAM_BYTES\" \"$WEBCODEX_SSH_N\" \"$WEBCODEX_SSH_FRAMED\" \"$WEBCODEX_SSH_DD_STATUS\" \"$WEBCODEX_SSH_PROGRAM\" \"$WEBCODEX_SSH_ACTUAL\" \"$n\" \"$i\" \"$d\" \"$f\" \"$actual\" \"$#\" \"$1\" \"$2\"; cleanup; touch {}; mkdir {}",
+                shell_quote(file.to_string_lossy().as_ref()),
+                shell_quote(dir.to_string_lossy().as_ref())
+            );
+            let output = bootstrap_output("sh", &setup, &program, b"", &[]);
+            assert!(output.status.success(), "{mask}: {output:?}");
+            assert_eq!(
+                String::from_utf8(output.stdout).unwrap(),
+                format!("mask=0{mask}|meta=original|private=OLD_N,OLD_FRAME,OLD_STATUS,OLD_PROGRAM,OLD_ACTUAL|generic=N,I,D,F,A|args=2,before,two words|cleanup-original")
+            );
+            assert_eq!(
+                std::fs::metadata(&file).unwrap().permissions().mode() & 0o777,
+                expected_file_mode
+            );
+            assert_eq!(
+                std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777,
+                expected_dir_mode
+            );
+        }
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_preserves_traps_exit_and_exec() {
+        let exited = bootstrap_output("sh", "trap 'printf exit-trap' 0", "exit 7", b"", &[]);
+        assert_eq!(exited.status.code(), Some(7), "{exited:?}");
+        assert_eq!(exited.stdout, b"exit-trap");
+
+        let terminated = bootstrap_output(
+            "sh",
+            "trap 'printf term-trap; exit 42' TERM",
+            "kill -TERM $$; printf never",
+            b"",
+            &[],
+        );
+        assert_eq!(terminated.status.code(), Some(42), "{terminated:?}");
+        assert_eq!(terminated.stdout, b"term-trap");
+
+        let execed = bootstrap_output("sh", "", "exec printf exec-ok", b"", &[]);
+        assert!(execed.status.success(), "{execed:?}");
+        assert_eq!(execed.stdout, b"exec-ok");
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_preserves_trailing_newlines_quotes_and_unicode() {
+        for (program, expected) in [
+            ("printf no-trailing", "no-trailing"),
+            ("printf one\\\n", "one"),
+            ("printf many\\\n\n\n", "many"),
+        ] {
+            let output = bootstrap_output("sh", "", program, b"", &[]);
+            assert!(output.status.success(), "{program:?}: {output:?}");
+            assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+        }
+
+        let text = "中文🙂 'single' \"double\" $ & | ;";
+        let program = format!("printf '%s' {}\n\n", shell_quote(text));
+        let output = bootstrap_output("sh", "", &program, b"", &[]);
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), text);
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_does_not_restart_bash() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("bash-env.marker");
+        let hook = temp.path().join("bash-env.sh");
+        std::fs::write(
+            &hook,
+            format!(
+                "printf '%s\\n' hook >> {}\n",
+                shell_quote(marker.to_string_lossy().as_ref())
+            ),
+        )
+        .unwrap();
+
+        let control = Command::new("bash")
+            .arg("-c")
+            .arg("printf control")
+            .env("BASH_ENV", &hook)
+            .output()
+            .expect("run ordinary single-shell BASH_ENV control");
+        assert!(control.status.success(), "{control:?}");
+        assert_eq!(control.stdout, b"control");
+        assert_eq!(std::fs::read_to_string(&marker).unwrap().lines().count(), 1);
+        std::fs::remove_file(&marker).unwrap();
+
+        let output = bootstrap_output("bash", "", "printf user", b"", &[("BASH_ENV", &hook)]);
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(output.stdout, b"user");
+        assert_eq!(
+            std::fs::read_to_string(&marker).unwrap().lines().count(),
+            1,
+            "BASH_ENV must run only for the one shell OpenSSH would start"
+        );
+        let bootstrap = windows_direct_program_bootstrap(1);
+        for forbidden in ["\"$0\" -c", "sh -c", "bash -c", "zsh -c"] {
+            assert!(!bootstrap.contains(forbidden), "{forbidden}: {bootstrap}");
+        }
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_does_not_restart_zsh_when_available() {
+        if Command::new("zsh").arg("--version").output().is_err() {
+            eprintln!("skipping zsh startup-hook regression because zsh is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("zshenv.marker");
+        let hook = temp.path().join(".zshenv");
+        std::fs::write(
+            &hook,
+            format!(
+                "printf '%s\\n' hook >> {}\n",
+                shell_quote(marker.to_string_lossy().as_ref())
+            ),
+        )
+        .unwrap();
+
+        let control = Command::new("zsh")
+            .arg("-c")
+            .arg("printf control")
+            .env("ZDOTDIR", temp.path())
+            .output()
+            .expect("run ordinary single-shell zshenv control");
+        assert!(control.status.success(), "{control:?}");
+        assert_eq!(control.stdout, b"control");
+        assert_eq!(std::fs::read_to_string(&marker).unwrap().lines().count(), 1);
+        std::fs::remove_file(&marker).unwrap();
+
+        let output = bootstrap_output("zsh", "", "printf user", b"", &[("ZDOTDIR", temp.path())]);
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(output.stdout, b"user");
+        assert_eq!(
+            std::fs::read_to_string(&marker).unwrap().lines().count(),
+            1,
+            ".zshenv must run only for the one shell OpenSSH would start"
+        );
     }
 
     #[test]
@@ -2980,7 +3150,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
-const PROGRAM_PREFIX: &str = "WEBCODEX_SSH_PROGRAM_BYTES=";
+const PROGRAM_PREFIX: &str = ": WEBCODEX_SSH_PROGRAM_BYTES=";
 
 fn suffix<'a>(script: &'a str, marker: &str) -> Option<&'a str> {
     script.rfind(marker).map(|index| script[index + marker.len()..].trim())
@@ -3421,6 +3591,11 @@ fn main() {
         assert!(
             crate::shell_protocol::validate_raw_shell_wire_command(&format!("{max_wire}x"))
                 .is_err()
+        );
+        assert!(
+            crate::shell_protocol::validate_raw_shell_wire_command("printf ok\0printf never")
+                .is_err(),
+            "raw-shell NUL rejection must remain platform-neutral"
         );
         let max_prepared = pool
             .prepare_command(
@@ -4422,6 +4597,29 @@ fn main() {
             Some("wc-explicit-bash")
         );
 
+        let execed = run(None, "exec printf wc-top-level-exec");
+        assert_eq!(
+            execed.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{execed:?}"
+        );
+        assert_eq!(execed.result.exit_code, Some(0), "{execed:?}");
+        assert_eq!(execed.result.stdout.as_deref(), Some("wc-top-level-exec"));
+
+        let umask = run(None, "umask");
+        assert_eq!(
+            umask.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{umask:?}"
+        );
+        assert_eq!(umask.result.exit_code, Some(0), "{umask:?}");
+        let observed_umask = umask.result.stdout.as_deref().unwrap_or_default().trim();
+        assert!(
+            matches!(observed_umask.len(), 3 | 4)
+                && observed_umask.chars().all(|ch| matches!(ch, '0'..='7')),
+            "unexpected remote umask projection: {umask:?}"
+        );
+
         let cwd_ok = run(Some("/tmp"), "pwd");
         assert_eq!(
             cwd_ok.execution_state,
@@ -4508,7 +4706,7 @@ fn main() {
             config.clone(),
             AgentPolicy::default(),
             "win-ssh-real-background",
-            "printf wc-windows-background",
+            "printf 'wc-windows-background|'; umask",
             15,
         );
         let background =
@@ -4520,12 +4718,20 @@ fn main() {
             Some(ShellCommandExecutionState::Completed),
             "{background:?}"
         );
+        let background_snapshot = background
+            .log_snapshot
+            .as_ref()
+            .expect("real Windows SSH background log snapshot");
         assert!(
-            background
-                .log_snapshot
-                .as_ref()
-                .is_some_and(|snapshot| snapshot.stdout.tail.contains("wc-windows-background")),
+            background_snapshot
+                .stdout
+                .tail
+                .contains("wc-windows-background"),
             "{background:?}"
+        );
+        assert!(
+            background_snapshot.stdout.tail.contains(observed_umask),
+            "background loader changed remote umask: one-shot={observed_umask:?}, background={background:?}"
         );
     }
 

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -28,6 +28,11 @@ const SSH_REMOTE_CWD_MAX_BYTES: usize = 4096;
 /// It is transport headroom, not a smaller Windows product limit.
 const WINDOWS_DIRECT_PROGRAM_MAX_BYTES: usize =
     crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES + SSH_REMOTE_CWD_MAX_BYTES * 5 + 512;
+/// Windows Direct transports a shell-quoted `eval <program>` frame over stdin.
+/// POSIX single-quote encoding expands each input byte by at most 5x; the fixed
+/// `eval ` prefix and surrounding quotes add seven bytes. This is internal
+/// transport headroom only and does not lower the public raw-shell ceilings.
+const WINDOWS_DIRECT_FRAME_MAX_BYTES: usize = WINDOWS_DIRECT_PROGRAM_MAX_BYTES * 5 + 7;
 const WINDOWS_DIRECT_BOOTSTRAP_PREFIX: &str = ": WEBCODEX_SSH_PROGRAM_BYTES=";
 
 /// In-memory identity for one OpenSSH multiplex transport. The Runner config
@@ -84,8 +89,9 @@ pub(crate) enum PreparedSshTransport {
 /// How one prepared SSH invocation receives the remote program.
 ///
 /// Unix mux commands keep their historical remote-program argv. Windows Direct
-/// keeps only a fixed bootstrap in CreateProcess argv and sends the exact remote
-/// program over the SSH stdin stream before any caller stdin bytes.
+/// keeps only a fixed bootstrap in CreateProcess argv and sends a bounded,
+/// shell-quoted transport frame over SSH stdin before any caller stdin bytes.
+/// The frame unwraps to the exact remote program in the same remote shell.
 #[derive(Debug, Clone)]
 pub(crate) enum PreparedSshProgramDelivery {
     Argv,
@@ -386,7 +392,9 @@ impl SshConnectionPool {
                     "ssh_program_too_long: prepared remote program exceeds internal Windows transport headroom ({WINDOWS_DIRECT_PROGRAM_MAX_BYTES} bytes); command was not started"
                 ));
             }
-            let bootstrap = windows_direct_program_bootstrap(remote_script.len());
+            let program_frame = windows_direct_program_frame(&remote_script);
+            debug_assert!(program_frame.len() <= WINDOWS_DIRECT_FRAME_MAX_BYTES);
+            let bootstrap = windows_direct_program_bootstrap(program_frame.len());
             let mut ssh = self.direct_ssh_command();
             ssh.arg("-o")
                 .arg("BatchMode=yes")
@@ -398,7 +406,7 @@ impl SshConnectionPool {
                 command: ssh,
                 transport: PreparedSshTransport::Direct,
                 program_delivery: PreparedSshProgramDelivery::StdinFramed {
-                    program: remote_script.into_bytes(),
+                    program: program_frame.into_bytes(),
                 },
             });
         }
@@ -1051,16 +1059,27 @@ fn shell_quote(value: &str) -> String {
     escaped
 }
 
+/// Encode the exact user program as transport data whose own lexical EOF is
+/// independent from the user's EOF. The outer loader evaluates this complete
+/// wrapper; the inner `eval` builtin then receives exactly `program` as one
+/// argument. The frame always ends in a closing single quote, so command
+/// substitution cannot strip user trailing newlines from the represented data.
+fn windows_direct_program_frame(program: &str) -> String {
+    format!("eval {}", shell_quote(program))
+}
+
 /// Small fixed remote loader for Windows Direct SSH. The only dynamic argv
-/// material is a bounded decimal byte count. OpenSSH's one remote shell runs
-/// the final `eval`; all framing state lives only in a command-substitution
-/// subshell. `dd bs=1 count=N` consumes only the program region, an inner
-/// non-newline sentinel preserves program trailing newlines, and the outer
-/// comment sentinel prevents the final command substitution from trimming them.
-/// The complete frame is byte-counted before any program text reaches `eval`.
-fn windows_direct_program_bootstrap(program_len: usize) -> String {
+/// material is a bounded decimal transport-frame byte count. OpenSSH's one
+/// remote shell runs the outer `eval`; all framing state lives only in a
+/// command-substitution subshell. The stdin frame is already a self-contained
+/// `eval <shell-quoted exact program>` wrapper and always ends in a non-newline
+/// quote, so no parser-visible trailing sentinel is needed. `dd bs=1 count=N`
+/// consumes only the frame region, and the complete frame is byte-counted before
+/// any user program can execute. The wrapper's inner builtin `eval` receives the
+/// exact original program text, with its own lexical EOF.
+fn windows_direct_program_bootstrap(frame_len: usize) -> String {
     format!(
-        r#"{WINDOWS_DIRECT_BOOTSTRAP_PREFIX}{program_len}; eval "$(set +e; WEBCODEX_SSH_N={program_len}; case "$WEBCODEX_SSH_N" in ''|*[!0-9]*) printf >&2 '%s\n' 'webcodex: invalid SSH program length'; printf '%s' 'exit 126'; exit 0;; esac; [ "$WEBCODEX_SSH_N" -gt 0 ] && [ "$WEBCODEX_SSH_N" -le {WINDOWS_DIRECT_PROGRAM_MAX_BYTES} ] || {{ printf >&2 '%s\n' 'webcodex: SSH program length out of range'; printf '%s' 'exit 126'; exit 0; }}; WEBCODEX_SSH_FRAMED=$(dd bs=1 count="$WEBCODEX_SSH_N" 2>/dev/null; WEBCODEX_SSH_DD_STATUS=$?; printf x; exit "$WEBCODEX_SSH_DD_STATUS"); WEBCODEX_SSH_DD_STATUS=$?; [ "$WEBCODEX_SSH_DD_STATUS" -eq 0 ] || {{ printf >&2 '%s\n' 'webcodex: SSH program upload failed'; printf '%s' 'exit 126'; exit 0; }}; WEBCODEX_SSH_PROGRAM=${{WEBCODEX_SSH_FRAMED%x}}; WEBCODEX_SSH_ACTUAL=$(printf '%s' "$WEBCODEX_SSH_PROGRAM" | wc -c); [ "$WEBCODEX_SSH_ACTUAL" -eq "$WEBCODEX_SSH_N" ] 2>/dev/null || {{ printf >&2 '%s\n' 'webcodex: incomplete SSH program upload'; printf '%s' 'exit 126'; exit 0; }}; printf '%s\n#webcodex-ssh-frame' "$WEBCODEX_SSH_PROGRAM")""#
+        r#"{WINDOWS_DIRECT_BOOTSTRAP_PREFIX}{frame_len}; eval "$(set +e; WEBCODEX_SSH_N={frame_len}; case "$WEBCODEX_SSH_N" in ''|*[!0-9]*) printf >&2 '%s\n' 'webcodex: invalid SSH program length'; printf '%s' 'exit 126'; exit 0;; esac; [ "$WEBCODEX_SSH_N" -gt 0 ] && [ "$WEBCODEX_SSH_N" -le {WINDOWS_DIRECT_FRAME_MAX_BYTES} ] || {{ printf >&2 '%s\n' 'webcodex: SSH program length out of range'; printf '%s' 'exit 126'; exit 0; }}; WEBCODEX_SSH_FRAME=$(dd bs=1 count="$WEBCODEX_SSH_N" 2>/dev/null); WEBCODEX_SSH_DD_STATUS=$?; [ "$WEBCODEX_SSH_DD_STATUS" -eq 0 ] || {{ printf >&2 '%s\n' 'webcodex: SSH program upload failed'; printf '%s' 'exit 126'; exit 0; }}; WEBCODEX_SSH_ACTUAL=$(printf '%s' "$WEBCODEX_SSH_FRAME" | wc -c); [ "$WEBCODEX_SSH_ACTUAL" -eq "$WEBCODEX_SSH_N" ] 2>/dev/null || {{ printf >&2 '%s\n' 'webcodex: incomplete SSH program upload'; printf '%s' 'exit 126'; exit 0; }}; printf '%s' "$WEBCODEX_SSH_FRAME")""#
     )
 }
 
@@ -1446,8 +1465,8 @@ fn command_error(start: Instant, error: String) -> CommandResult {
 mod tests {
     use super::{
         is_transport_failure, remote_script, run_ssh_shell, shell_quote, ssh_shell_probe_available,
-        windows_direct_program_bootstrap, PreparedSshTransport, SshConnectionKey,
-        SshConnectionPool,
+        windows_direct_program_bootstrap, windows_direct_program_frame, PreparedSshTransport,
+        SshConnectionKey, SshConnectionPool,
     };
     use crate::webcodex_runner::config::{AgentPolicy, SshConfig, SshResourceConfig};
     use std::collections::BTreeMap;
@@ -1691,6 +1710,30 @@ mod tests {
         assert_eq!(output.stdout, dense.as_bytes());
     }
 
+    fn shell_output(
+        shell: &str,
+        setup: &str,
+        program: &str,
+        env_paths: &[(&str, &Path)],
+    ) -> std::process::Output {
+        let command_text = if setup.is_empty() {
+            program.to_string()
+        } else {
+            format!("{setup}; {program}")
+        };
+        let mut command = Command::new(shell);
+        command
+            .arg("-c")
+            .arg(command_text)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for (name, path) in env_paths {
+            command.env(name, path);
+        }
+        command.output().expect("run direct shell control")
+    }
+
     fn bootstrap_output(
         shell: &str,
         setup: &str,
@@ -1698,7 +1741,8 @@ mod tests {
         caller_stdin: &[u8],
         env_paths: &[(&str, &Path)],
     ) -> std::process::Output {
-        let bootstrap = windows_direct_program_bootstrap(program.len());
+        let frame = windows_direct_program_frame(program);
+        let bootstrap = windows_direct_program_bootstrap(frame.len());
         let command_text = if setup.is_empty() {
             bootstrap
         } else {
@@ -1716,10 +1760,145 @@ mod tests {
         }
         let mut child = command.spawn().expect("spawn bootstrap probe");
         let mut input = child.stdin.take().expect("bootstrap stdin");
-        input.write_all(program.as_bytes()).unwrap();
+        input.write_all(frame.as_bytes()).unwrap();
         input.write_all(caller_stdin).unwrap();
         drop(input);
         child.wait_with_output().unwrap()
+    }
+
+    fn assert_bootstrap_matches_direct(shell: &str, program: &str) {
+        let direct = shell_output(shell, "", program, &[]);
+        let candidate = bootstrap_output(shell, "", program, b"", &[]);
+        assert_eq!(
+            candidate.status.code(),
+            direct.status.code(),
+            "{shell} exit mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+        );
+        assert_eq!(
+            candidate.stdout, direct.stdout,
+            "{shell} stdout mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+        );
+        assert_eq!(
+            candidate.stderr, direct.stderr,
+            "{shell} stderr mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+        );
+    }
+
+    fn syntax_error_class(stderr: &[u8]) -> bool {
+        let text = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+        ["syntax", "unexpected", "unterminated", "end of file", "eof"]
+            .iter()
+            .any(|needle| text.contains(needle))
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_matches_direct_shell_at_exact_eof() {
+        let backslash = '\\';
+        let cases = vec![
+            "printf x".to_string(),
+            "printf x\n".to_string(),
+            "printf x\n\n\n".to_string(),
+            "printf x\\\n".to_string(),
+            format!("printf x{backslash}"),
+            format!("printf x{backslash}{backslash}"),
+            format!("printf x{backslash}{backslash}{backslash}"),
+            "printf '%s' 'quoted\\'".to_string(),
+            "printf x # ending comment".to_string(),
+            "printf '%s' '#webcodex-ssh-frame'".to_string(),
+            "printf x;".to_string(),
+            "printf x   \t".to_string(),
+            "printf '%s' '中文🙂'".to_string(),
+        ];
+        for shell in ["sh", "bash"] {
+            for program in &cases {
+                assert_bootstrap_matches_direct(shell, program);
+            }
+        }
+        let frame = windows_direct_program_frame(&format!("printf x{}", '\\'));
+        let bootstrap = windows_direct_program_bootstrap(frame.len());
+        assert!(
+            frame.ends_with('\''),
+            "transport frame must have lexical closure: {frame:?}"
+        );
+        assert!(
+            !bootstrap.contains("#webcodex-ssh-frame"),
+            "transport sentinel must not enter parser input: {bootstrap}"
+        );
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_preserves_lone_trailing_backslash_eof() {
+        let program = format!("printf x{}", '\\');
+        for shell in ["sh", "bash"] {
+            assert_bootstrap_matches_direct(shell, &program);
+        }
+        if Command::new("zsh").arg("--version").output().is_ok() {
+            assert_bootstrap_matches_direct("zsh", &program);
+        }
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_preserves_shell_syntax_error_class() {
+        for shell in ["sh", "bash"] {
+            for program in [
+                "printf \"unterminated",
+                "printf x &&",
+                "if true; then printf x",
+                "(printf x",
+            ] {
+                let direct = shell_output(shell, "", program, &[]);
+                let candidate = bootstrap_output(shell, "", program, b"", &[]);
+                assert_eq!(
+                    candidate.status.code(),
+                    direct.status.code(),
+                    "{shell} syntax exit mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+                );
+                assert_eq!(
+                    candidate.stdout, direct.stdout,
+                    "{shell} syntax stdout mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+                );
+                assert!(
+                    !direct.status.success()
+                        && syntax_error_class(&direct.stderr)
+                        && syntax_error_class(&candidate.stderr),
+                    "{shell} syntax error class drift for {program:?}: direct={direct:?} candidate={candidate:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_preserves_top_level_eval_scope() {
+        for shell in ["sh", "bash"] {
+            for program in [
+                "return",
+                "return 7",
+                "break",
+                "continue",
+                "false; printf '|%s' \"$?\"",
+            ] {
+                assert_bootstrap_matches_direct(shell, program);
+            }
+        }
+        let setup = "set -- before 'two words'";
+        let program = "printf '%s|%s|%s' \"$#\" \"$1\" \"$2\"";
+        for shell in ["sh", "bash"] {
+            let direct = shell_output(shell, setup, program, &[]);
+            let candidate = bootstrap_output(shell, setup, program, b"", &[]);
+            assert_eq!(
+                candidate.status.code(),
+                direct.status.code(),
+                "{shell}: {direct:?} {candidate:?}"
+            );
+            assert_eq!(
+                candidate.stdout, direct.stdout,
+                "{shell}: {direct:?} {candidate:?}"
+            );
+            assert_eq!(
+                candidate.stderr, direct.stderr,
+                "{shell}: {direct:?} {candidate:?}"
+            );
+        }
     }
 
     #[test]
@@ -1735,7 +1914,8 @@ mod tests {
             "printf ran > {}",
             shell_quote(marker.to_string_lossy().as_ref())
         );
-        let bootstrap = windows_direct_program_bootstrap(partial_program.len() + 9);
+        let partial_frame = windows_direct_program_frame(&partial_program);
+        let bootstrap = windows_direct_program_bootstrap(partial_frame.len() + 9);
         let mut child = Command::new("sh")
             .arg("-c")
             .arg(format!("set -e; {bootstrap}"))
@@ -1745,7 +1925,7 @@ mod tests {
             .spawn()
             .expect("spawn partial bootstrap probe");
         let mut input = child.stdin.take().expect("partial bootstrap stdin");
-        input.write_all(partial_program.as_bytes()).unwrap();
+        input.write_all(partial_frame.as_bytes()).unwrap();
         drop(input);
         let output = child.wait_with_output().unwrap();
         assert!(!output.status.success(), "{output:?}");
@@ -1765,10 +1945,10 @@ mod tests {
             let file = temp.path().join(format!("umask-{mask}.file"));
             let dir = temp.path().join(format!("umask-{mask}.dir"));
             let setup = format!(
-                "umask {mask}; set -- before 'two words'; export WEBCODEX_SSH_PROGRAM_BYTES=original WEBCODEX_SSH_N=OLD_N WEBCODEX_SSH_FRAMED=OLD_FRAME WEBCODEX_SSH_DD_STATUS=OLD_STATUS WEBCODEX_SSH_PROGRAM=OLD_PROGRAM WEBCODEX_SSH_ACTUAL=OLD_ACTUAL n=N i=I d=D f=F actual=A; cleanup() {{ printf cleanup-original; }}"
+                "umask {mask}; set -- before 'two words'; export WEBCODEX_SSH_PROGRAM_BYTES=original WEBCODEX_SSH_N=OLD_N WEBCODEX_SSH_FRAME=OLD_TRANSPORT_FRAME WEBCODEX_SSH_FRAMED=OLD_FRAME WEBCODEX_SSH_DD_STATUS=OLD_STATUS WEBCODEX_SSH_PROGRAM=OLD_PROGRAM WEBCODEX_SSH_ACTUAL=OLD_ACTUAL n=N i=I d=D f=F actual=A; cleanup() {{ printf cleanup-original; }}"
             );
             let program = format!(
-                "printf 'mask=%s|meta=%s|private=%s,%s,%s,%s,%s|generic=%s,%s,%s,%s,%s|args=%s,%s,%s|' \"$(umask)\" \"$WEBCODEX_SSH_PROGRAM_BYTES\" \"$WEBCODEX_SSH_N\" \"$WEBCODEX_SSH_FRAMED\" \"$WEBCODEX_SSH_DD_STATUS\" \"$WEBCODEX_SSH_PROGRAM\" \"$WEBCODEX_SSH_ACTUAL\" \"$n\" \"$i\" \"$d\" \"$f\" \"$actual\" \"$#\" \"$1\" \"$2\"; cleanup; touch {}; mkdir {}",
+                "printf 'mask=%s|meta=%s|private=%s,%s,%s,%s,%s,%s|generic=%s,%s,%s,%s,%s|args=%s,%s,%s|' \"$(umask)\" \"$WEBCODEX_SSH_PROGRAM_BYTES\" \"$WEBCODEX_SSH_N\" \"$WEBCODEX_SSH_FRAME\" \"$WEBCODEX_SSH_FRAMED\" \"$WEBCODEX_SSH_DD_STATUS\" \"$WEBCODEX_SSH_PROGRAM\" \"$WEBCODEX_SSH_ACTUAL\" \"$n\" \"$i\" \"$d\" \"$f\" \"$actual\" \"$#\" \"$1\" \"$2\"; cleanup; touch {}; mkdir {}",
                 shell_quote(file.to_string_lossy().as_ref()),
                 shell_quote(dir.to_string_lossy().as_ref())
             );
@@ -1776,7 +1956,7 @@ mod tests {
             assert!(output.status.success(), "{mask}: {output:?}");
             assert_eq!(
                 String::from_utf8(output.stdout).unwrap(),
-                format!("mask=0{mask}|meta=original|private=OLD_N,OLD_FRAME,OLD_STATUS,OLD_PROGRAM,OLD_ACTUAL|generic=N,I,D,F,A|args=2,before,two words|cleanup-original")
+                format!("mask=0{mask}|meta=original|private=OLD_N,OLD_TRANSPORT_FRAME,OLD_FRAME,OLD_STATUS,OLD_PROGRAM,OLD_ACTUAL|generic=N,I,D,F,A|args=2,before,two words|cleanup-original")
             );
             assert_eq!(
                 std::fs::metadata(&file).unwrap().permissions().mode() & 0o777,
@@ -1862,7 +2042,7 @@ mod tests {
             1,
             "BASH_ENV must run only for the one shell OpenSSH would start"
         );
-        let bootstrap = windows_direct_program_bootstrap(1);
+        let bootstrap = windows_direct_program_bootstrap(windows_direct_program_frame("x").len());
         for forbidden in ["\"$0\" -c", "sh -c", "bash -c", "zsh -c"] {
             assert!(!bootstrap.contains(forbidden), "{forbidden}: {bootstrap}");
         }
@@ -3152,6 +3332,14 @@ use std::time::Duration;
 
 const PROGRAM_PREFIX: &str = ": WEBCODEX_SSH_PROGRAM_BYTES=";
 
+fn decode_program_frame(frame: &str) -> Option<String> {
+    let quoted = frame.strip_prefix("eval ")?;
+    if quoted.len() < 2 || !quoted.starts_with('\'') || !quoted.ends_with('\'') {
+        return None;
+    }
+    Some(quoted[1..quoted.len() - 1].replace("'\"'\"'", "'"))
+}
+
 fn suffix<'a>(script: &'a str, marker: &str) -> Option<&'a str> {
     script.rfind(marker).map(|index| script[index + marker.len()..].trim())
 }
@@ -3209,7 +3397,8 @@ fn main() {
             eprintln!("fake ssh: incomplete program frame");
             std::process::exit(126);
         }
-        owned_script = Some(String::from_utf8(program).expect("UTF-8 program frame"));
+        let frame = String::from_utf8(program).expect("UTF-8 program frame");
+        owned_script = Some(decode_program_frame(&frame).expect("valid Windows Direct program frame"));
     }
     let script = owned_script
         .as_deref()
@@ -3314,6 +3503,39 @@ fn main() {
             .collect()
     }
 
+    fn direct_windows_ssh_output(
+        host: &str,
+        program: &str,
+        caller_stdin: Option<&[u8]>,
+    ) -> std::process::Output {
+        let mut command = Command::new("ssh.exe");
+        command
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg("-o")
+            .arg("LogLevel=ERROR")
+            .arg(host)
+            .arg(program)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if caller_stdin.is_some() {
+            command.stdin(Stdio::piped());
+        } else {
+            command.stdin(Stdio::null());
+        }
+        let mut child = command.spawn().expect("spawn direct ssh.exe control");
+        if let Some(caller_stdin) = caller_stdin {
+            let mut stdin = child.stdin.take().expect("direct ssh.exe control stdin");
+            stdin
+                .write_all(caller_stdin)
+                .expect("write direct ssh.exe control stdin");
+            drop(stdin);
+        }
+        child
+            .wait_with_output()
+            .expect("wait direct ssh.exe control")
+    }
+
     fn assert_direct_args(args: &[String], host: &str) {
         assert_eq!(
             &args[..5],
@@ -3330,11 +3552,11 @@ fn main() {
         );
     }
 
-    fn stdin_program(delivery: &PreparedSshProgramDelivery) -> &str {
+    fn stdin_frame(delivery: &PreparedSshProgramDelivery) -> &str {
         let PreparedSshProgramDelivery::StdinFramed { program } = delivery else {
             panic!("Windows Direct SSH must use framed stdin program delivery");
         };
-        std::str::from_utf8(program).expect("prepared remote program is UTF-8")
+        std::str::from_utf8(program).expect("prepared transport frame is UTF-8")
     }
 
     fn conservative_windows_command_line_utf16_bound(command: &Command) -> usize {
@@ -3505,8 +3727,8 @@ fn main() {
             "{args:?}"
         );
         assert_eq!(
-            stdin_program(&prepared.program_delivery),
-            "if ! cd '/srv/override'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf test"
+            stdin_frame(&prepared.program_delivery),
+            windows_direct_program_frame("if ! cd '/srv/override'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf test")
         );
         assert_eq!(pool.connection_count(), 0);
 
@@ -3526,8 +3748,8 @@ fn main() {
             "{job_args:?}"
         );
         assert_eq!(
-            stdin_program(&job.program_delivery),
-            "if ! cd '/srv/webcodex'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf job"
+            stdin_frame(&job.program_delivery),
+            windows_direct_program_frame("if ! cd '/srv/webcodex'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf job")
         );
         assert_eq!(pool.connection_count(), 0);
     }
@@ -3553,7 +3775,11 @@ fn main() {
             .expect("prepare 16K quote-dense explicit bash command");
         let args = command_args(&prepared.command);
         assert_direct_args(&args, &max_host);
-        assert_eq!(stdin_program(&prepared.program_delivery), wrapped);
+        assert_eq!(
+            stdin_frame(&prepared.program_delivery),
+            windows_direct_program_frame(&wrapped)
+        );
+        assert!(stdin_frame(&prepared.program_delivery).len() <= WINDOWS_DIRECT_FRAME_MAX_BYTES);
         assert!(!args.iter().any(|arg| arg.contains(&authored)));
         let argv_bound = conservative_windows_command_line_utf16_bound(&prepared.command);
         assert!(
@@ -3607,7 +3833,10 @@ fn main() {
                 &max_wire,
             )
             .expect("prepare exact max wire command");
-        assert_eq!(stdin_program(&max_prepared.program_delivery), max_wire);
+        assert_eq!(
+            stdin_frame(&max_prepared.program_delivery),
+            windows_direct_program_frame(&max_wire)
+        );
 
         let quote_dense_cwd = "'".repeat(SSH_REMOTE_CWD_MAX_BYTES);
         let cwd_prepared = pool
@@ -3621,8 +3850,8 @@ fn main() {
             )
             .expect("prepare max quote-dense cwd");
         assert_eq!(
-            stdin_program(&cwd_prepared.program_delivery),
-            remote_script(Some(&quote_dense_cwd), "printf cwd")
+            stdin_frame(&cwd_prepared.program_delivery),
+            windows_direct_program_frame(&remote_script(Some(&quote_dense_cwd), "printf cwd"))
         );
         let cwd_args = command_args(&cwd_prepared.command);
         assert!(!cwd_args.iter().any(|arg| arg.contains(&quote_dense_cwd)));
@@ -3638,7 +3867,10 @@ fn main() {
                 &wrapped,
             )
             .expect("prepare long Windows SSH Job payload");
-        assert_eq!(stdin_program(&job.program_delivery), wrapped);
+        assert_eq!(
+            stdin_frame(&job.program_delivery),
+            windows_direct_program_frame(&wrapped)
+        );
         assert!(!command_args(&job.command)
             .iter()
             .any(|arg| arg.contains(&authored)));
@@ -4549,6 +4781,44 @@ fn main() {
                 None,
             )
         };
+        let assert_direct_equivalent = |program: &str| {
+            let direct = direct_windows_ssh_output(host, program, None);
+            let candidate = run(None, program);
+            assert_eq!(
+                candidate.execution_state,
+                ShellCommandExecutionState::Completed,
+                "real-host EOF candidate was not definite for {program:?}: {candidate:?}"
+            );
+            assert_eq!(
+                candidate.result.exit_code,
+                direct.status.code(),
+                "real-host EOF exit mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+            );
+            assert_eq!(
+                candidate.result.stdout.as_deref().unwrap_or_default().as_bytes(),
+                direct.stdout.as_slice(),
+                "real-host EOF stdout mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+            );
+            assert_eq!(
+                candidate.result.stderr.as_deref().unwrap_or_default().as_bytes(),
+                direct.stderr.as_slice(),
+                "real-host EOF stderr mismatch for {program:?}: direct={direct:?} candidate={candidate:?}"
+            );
+        };
+
+        let backslash = '\\';
+        for program in [
+            "printf wc-eof-control".to_string(),
+            "printf wc-one-newline\n".to_string(),
+            "printf wc-many-newlines\n\n\n".to_string(),
+            format!("printf x{backslash}"),
+            format!("printf x{backslash}{backslash}"),
+            format!("printf x{backslash}{backslash}{backslash}"),
+            "exit 7".to_string(),
+            "exec printf wc-real-exec-control".to_string(),
+        ] {
+            assert_direct_equivalent(&program);
+        }
 
         let one_shot = run(None, "printf wc-windows-one-shot");
         assert_eq!(
@@ -4667,6 +4937,26 @@ fn main() {
         );
         assert_eq!(stdin_result.result.exit_code, Some(0), "{stdin_result:?}");
         assert_eq!(stdin_result.result.stdout.as_deref(), Some(caller_stdin));
+        let direct_stdin = direct_windows_ssh_output(host, "cat", Some(caller_stdin.as_bytes()));
+        assert_eq!(stdin_result.result.exit_code, direct_stdin.status.code());
+        assert_eq!(
+            stdin_result
+                .result
+                .stdout
+                .as_deref()
+                .unwrap_or_default()
+                .as_bytes(),
+            direct_stdin.stdout.as_slice()
+        );
+        assert_eq!(
+            stdin_result
+                .result
+                .stderr
+                .as_deref()
+                .unwrap_or_default()
+                .as_bytes(),
+            direct_stdin.stderr.as_slice()
+        );
 
         let prefix = "printf wc-max-wire; #";
         let max_wire = format!(
@@ -4702,7 +4992,7 @@ fn main() {
         };
         enqueue_job(
             &manager,
-            sink,
+            sink.clone(),
             config.clone(),
             AgentPolicy::default(),
             "win-ssh-real-background",
@@ -4732,6 +5022,46 @@ fn main() {
         assert!(
             background_snapshot.stdout.tail.contains(observed_umask),
             "background loader changed remote umask: one-shot={observed_umask:?}, background={background:?}"
+        );
+
+        let background_eof_program = format!("printf x{}", '\\');
+        let background_eof_control = direct_windows_ssh_output(host, &background_eof_program, None);
+        enqueue_job(
+            &manager,
+            sink,
+            config,
+            AgentPolicy::default(),
+            "win-ssh-real-background-eof",
+            &background_eof_program,
+            15,
+        );
+        let background_eof =
+            wait_for_job_update(&mut rx, "win-ssh-real-background-eof", |update| {
+                update.finished
+            });
+        assert_eq!(
+            background_eof.exit_code,
+            background_eof_control.status.code(),
+            "background EOF exit mismatch: control={background_eof_control:?} job={background_eof:?}"
+        );
+        assert_eq!(
+            background_eof.command_execution_state,
+            Some(ShellCommandExecutionState::Completed),
+            "{background_eof:?}"
+        );
+        let background_eof_snapshot = background_eof
+            .log_snapshot
+            .as_ref()
+            .expect("background EOF log snapshot");
+        assert_eq!(
+            background_eof_snapshot.stdout.tail.as_bytes(),
+            background_eof_control.stdout.as_slice(),
+            "background EOF stdout mismatch: control={background_eof_control:?} job={background_eof:?}"
+        );
+        assert_eq!(
+            background_eof_snapshot.stderr.tail.as_bytes(),
+            background_eof_control.stderr.as_slice(),
+            "background EOF stderr mismatch: control={background_eof_control:?} job={background_eof:?}"
         );
     }
 

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -12,7 +12,7 @@ use super::AgentPolicy;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -22,6 +22,13 @@ use webcodex_process::ManagedChild;
 const SSH_CONNECT_TIMEOUT_SECS: u64 = 10;
 const SSH_CONTROL_PERSIST_SECS: u64 = 300;
 const SSH_PIPE_DRAIN_TIMEOUT_SECS: u64 = 2;
+const SSH_REMOTE_CWD_MAX_BYTES: usize = 4096;
+/// The public wire command plus the worst-case POSIX single-quote expansion of
+/// a maximum remote cwd and fixed cwd wrapper fit below this internal ceiling.
+/// It is transport headroom, not a smaller Windows product limit.
+const WINDOWS_DIRECT_PROGRAM_MAX_BYTES: usize =
+    crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES + SSH_REMOTE_CWD_MAX_BYTES * 5 + 512;
+const WINDOWS_DIRECT_BOOTSTRAP_PREFIX: &str = "WEBCODEX_SSH_PROGRAM_BYTES=";
 
 /// In-memory identity for one OpenSSH multiplex transport. The Runner config
 /// generation protects a request after an operator changes a resource host.
@@ -74,10 +81,147 @@ pub(crate) enum PreparedSshTransport {
     Direct,
 }
 
-/// A ready-to-spawn SSH command paired with its transport semantics.
+/// How one prepared SSH invocation receives the remote program.
+///
+/// Unix mux commands keep their historical remote-program argv. Windows Direct
+/// keeps only a fixed bootstrap in CreateProcess argv and sends the exact remote
+/// program over the SSH stdin stream before any caller stdin bytes.
+#[derive(Debug, Clone)]
+pub(crate) enum PreparedSshProgramDelivery {
+    Argv,
+    StdinFramed { program: Vec<u8> },
+}
+
+impl PreparedSshProgramDelivery {
+    pub(crate) fn requires_stdin(&self) -> bool {
+        matches!(self, Self::StdinFramed { .. })
+    }
+
+    pub(crate) fn spawn_writer(
+        self,
+        child_stdin: Option<ChildStdin>,
+        caller_stdin: Option<Vec<u8>>,
+    ) -> Result<Option<SshStdinWriter>, String> {
+        let needs_stdin = self.requires_stdin() || caller_stdin.is_some();
+        if !needs_stdin {
+            return Ok(None);
+        }
+        let mut child_stdin = child_stdin.ok_or_else(|| {
+            "ssh_command_stdin_unavailable: SSH was already started but its stdin pipe is unavailable; remote command outcome is unknown; do not blindly retry".to_string()
+        })?;
+        let (completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let handle = std::thread::spawn(move || {
+            let result = (|| {
+                if let Self::StdinFramed { program } = self {
+                    child_stdin.write_all(&program).map_err(|error| {
+                        format!(
+                            "ssh_program_write_failed: remote program delivery failed after SSH start; remote command outcome is unknown; do not blindly retry: {error}"
+                        )
+                    })?;
+                }
+                if let Some(caller_stdin) = caller_stdin {
+                    child_stdin.write_all(&caller_stdin).map_err(|error| {
+                        format!(
+                            "ssh_command_stdin_failed: caller stdin delivery failed after SSH start; remote command outcome is unknown; do not blindly retry: {error}"
+                        )
+                    })?;
+                }
+                Ok(())
+            })();
+            drop(child_stdin);
+            let _ = completion_tx.send(result);
+        });
+        Ok(Some(SshStdinWriter {
+            completion_rx,
+            handle: Some(handle),
+            result: None,
+        }))
+    }
+}
+
+/// Tracked writer for the single SSH stdin byte stream. It keeps the program
+/// and caller-input regions logically separate while allowing stop/timeout
+/// polling to proceed independently of potentially blocking pipe writes.
+pub(crate) struct SshStdinWriter {
+    completion_rx: mpsc::Receiver<Result<(), String>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+    result: Option<Result<(), String>>,
+}
+
+impl SshStdinWriter {
+    fn observe_result(&mut self) -> Option<Result<(), String>> {
+        if self.result.is_none() {
+            match self.completion_rx.try_recv() {
+                Ok(result) => self.result = Some(result),
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.result = Some(Err(
+                        "ssh_stdin_writer_failed: stdin writer exited without reporting completion; remote command outcome is unknown; do not blindly retry"
+                            .to_string(),
+                    ));
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
+        }
+        self.result.clone()
+    }
+
+    pub(crate) fn poll_failure(&mut self) -> Option<String> {
+        match self.observe_result() {
+            Some(Err(error)) => Some(error),
+            _ => None,
+        }
+    }
+
+    fn wait_completion_until(&mut self, deadline: Instant) -> Result<Result<(), String>, String> {
+        loop {
+            if let Some(result) = self.observe_result() {
+                if self
+                    .handle
+                    .as_ref()
+                    .is_some_and(|handle| handle.is_finished())
+                {
+                    if let Some(handle) = self.handle.take() {
+                        let _ = handle.join();
+                    }
+                    return Ok(result);
+                }
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(
+                    "ssh_stdin_writer_drain_failed: stdin writer did not stop within the bounded drain after SSH tree cleanup; remote command outcome is unknown; do not blindly retry"
+                        .to_string(),
+                );
+            }
+            std::thread::sleep(Duration::from_millis(10).min(remaining));
+        }
+    }
+
+    /// Natural completion must also prove that every program/caller-input byte
+    /// was accepted by the local SSH client.
+    pub(crate) fn finish_bounded(&mut self) -> Result<(), String> {
+        self.wait_completion_until(
+            Instant::now() + Duration::from_secs(SSH_PIPE_DRAIN_TIMEOUT_SECS),
+        )?
+    }
+
+    /// Once stop/timeout/wait failure has already terminated the SSH tree, a
+    /// BrokenPipe-like writer result is expected. Only failure to quiesce the
+    /// writer itself is a new cleanup uncertainty.
+    pub(crate) fn finish_after_tree_cleanup(&mut self) -> Result<(), String> {
+        let _ = self.wait_completion_until(
+            Instant::now() + Duration::from_secs(SSH_PIPE_DRAIN_TIMEOUT_SECS),
+        )?;
+        Ok(())
+    }
+}
+
+/// A ready-to-spawn SSH command paired with its transport semantics and program
+/// delivery contract.
 pub(crate) struct PreparedSshCommand {
     pub(crate) command: Command,
     pub(crate) transport: PreparedSshTransport,
+    pub(crate) program_delivery: PreparedSshProgramDelivery,
 }
 
 /// A ready-to-spawn long-lived SSH shell command with the resource's default
@@ -227,6 +371,7 @@ impl SshConnectionPool {
             return Ok(PreparedSshCommand {
                 command: ssh,
                 transport: PreparedSshTransport::Mux(connection.key),
+                program_delivery: PreparedSshProgramDelivery::Argv,
             });
         }
 
@@ -236,16 +381,25 @@ impl SshConnectionPool {
             let _ = configure_process_group;
             let effective_cwd = requested_cwd.or_else(|| resource.default_cwd.clone());
             let remote_script = remote_script(effective_cwd.as_deref(), command);
+            if remote_script.len() > WINDOWS_DIRECT_PROGRAM_MAX_BYTES {
+                return Err(format!(
+                    "ssh_program_too_long: prepared remote program exceeds internal Windows transport headroom ({WINDOWS_DIRECT_PROGRAM_MAX_BYTES} bytes); command was not started"
+                ));
+            }
+            let bootstrap = windows_direct_program_bootstrap(remote_script.len());
             let mut ssh = self.direct_ssh_command();
             ssh.arg("-o")
                 .arg("BatchMode=yes")
                 .arg("-o")
                 .arg("LogLevel=ERROR")
                 .arg(&resource.host)
-                .arg(remote_script);
+                .arg(bootstrap);
             return Ok(PreparedSshCommand {
                 command: ssh,
                 transport: PreparedSshTransport::Direct,
+                program_delivery: PreparedSshProgramDelivery::StdinFramed {
+                    program: remote_script.into_bytes(),
+                },
             });
         }
 
@@ -576,13 +730,14 @@ pub(crate) fn run_ssh_shell_with_execution_state(
     let transport = prepared.transport.clone();
     let mut result = run_piped_ssh_command(
         prepared.command,
+        prepared.program_delivery,
         policy.max_output_bytes,
         timeout_secs.min(policy.max_timeout_secs).max(1),
         stdin,
         stop_requested,
         start,
     );
-    apply_transport_failure_policy(pool, &transport, &mut result);
+    apply_transport_failure_policy(pool, &transport, &mut result, policy.max_output_bytes);
     result
 }
 
@@ -590,6 +745,7 @@ fn apply_transport_failure_policy(
     pool: &SshConnectionPool,
     transport: &PreparedSshTransport,
     result: &mut ShellCommandResult,
+    max_output_bytes: usize,
 ) {
     if !matches!(
         result.execution_state,
@@ -603,9 +759,10 @@ fn apply_transport_failure_policy(
     }
     pool.invalidate_after_transport_failure(transport);
     if let Some(stderr) = result.result.stderr.as_mut() {
-        append_line(
+        append_bounded_line(
             stderr,
             "webcodex: SSH transport ended after dispatch; the command may have started and was not retried",
+            max_output_bytes,
         );
     }
     if result.result.error.is_none() {
@@ -863,7 +1020,7 @@ fn normalize_remote_cwd(cwd: Option<&str>) -> Result<Option<String>, String> {
     let Some(cwd) = cwd.map(str::trim).filter(|cwd| !cwd.is_empty()) else {
         return Ok(None);
     };
-    if cwd.len() > 4096 || cwd.chars().any(char::is_control) {
+    if cwd.len() > SSH_REMOTE_CWD_MAX_BYTES || cwd.chars().any(char::is_control) {
         return Err(
             "ssh_remote_cwd_invalid: cwd must be a bounded remote path without control characters; command was not started".to_string(),
         );
@@ -884,14 +1041,24 @@ fn remote_script(cwd: Option<&str>, command: &str) -> String {
 
 fn shell_quote(value: &str) -> String {
     let mut escaped = String::from("'");
-    for part in value.split('\'') {
-        if escaped.len() > 1 {
+    for (index, part) in value.split('\'').enumerate() {
+        if index > 0 {
             escaped.push_str("'\"'\"'");
         }
         escaped.push_str(part);
     }
     escaped.push('\'');
     escaped
+}
+
+/// Small fixed remote loader for Windows Direct SSH. The only dynamic argv
+/// material is a bounded decimal byte count. `dd bs=1 count=N` cannot consume
+/// caller stdin past the program region; the explicit `wc -c` check also makes
+/// short/partial uploads fail before the program is evaluated.
+fn windows_direct_program_bootstrap(program_len: usize) -> String {
+    format!(
+        "{WINDOWS_DIRECT_BOOTSTRAP_PREFIX}{program_len}; n=$WEBCODEX_SSH_PROGRAM_BYTES; unset WEBCODEX_SSH_PROGRAM_BYTES; case \"$n\" in ''|*[!0-9]*) printf >&2 '%s\\n' 'webcodex: invalid SSH program length'; exit 126;; esac; [ \"$n\" -gt 0 ] && [ \"$n\" -le {WINDOWS_DIRECT_PROGRAM_MAX_BYTES} ] || {{ printf >&2 '%s\\n' 'webcodex: SSH program length out of range'; exit 126; }}; umask 077; i=0; while :; do d=/tmp/.webcodex-ssh-$$-$i; if mkdir \"$d\" 2>/dev/null; then break; fi; i=$((i+1)); [ \"$i\" -lt 32 ] || {{ printf >&2 '%s\\n' 'webcodex: SSH program temp allocation failed'; exit 126; }}; done; f=$d/program; cleanup(){{ rm -f \"$f\"; rmdir \"$d\" 2>/dev/null || :; }}; trap 'cleanup' 0; trap 'exit 129' HUP; trap 'exit 130' INT; trap 'exit 143' TERM; if ! dd of=\"$f\" bs=1 count=\"$n\" 2>/dev/null; then printf >&2 '%s\\n' 'webcodex: SSH program upload failed'; exit 126; fi; set -- $(wc -c < \"$f\"); actual=${{1-}}; case \"$actual\" in ''|*[!0-9]*) printf >&2 '%s\\n' 'webcodex: SSH program size check failed'; exit 126;; esac; [ \"$actual\" = \"$n\" ] || {{ printf >&2 '%s\\n' 'webcodex: incomplete SSH program upload'; exit 126; }}; \"$0\" -c 'f=$1; shift; p=$(cat \"$f\"; printf x) || exit 126; p=${{p%x}}; eval \"$p\"' \"$0\" \"$f\"; rc=$?; exit \"$rc\""
+    )
 }
 
 fn is_safe_resource_name(value: &str) -> bool {
@@ -971,14 +1138,16 @@ fn try_wait_piped_ssh_child(child: &mut PipedSshChild) -> std::io::Result<Option
 
 fn run_piped_ssh_command(
     mut command: Command,
+    program_delivery: PreparedSshProgramDelivery,
     max_output_bytes: usize,
     timeout_secs: u64,
     stdin: Option<&str>,
     stop_requested: Option<&AtomicBool>,
     start: Instant,
 ) -> ShellCommandResult {
+    let needs_stdin = program_delivery.requires_stdin() || stdin.is_some();
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    if stdin.is_some() {
+    if needs_stdin {
         command.stdin(Stdio::piped());
     }
     let mut child = match spawn_piped_ssh_child(&mut command) {
@@ -990,28 +1159,16 @@ fn run_piped_ssh_command(
             ))
         }
     };
-    if let Some(input) = stdin {
-        if let Some(mut child_stdin) = piped_ssh_process_mut(&mut child).stdin.take() {
-            if child_stdin.write_all(input.as_bytes()).is_err() {
-                let _ = terminate_ssh_child(&mut child);
-                return ShellCommandResult::outcome_unknown(command_error(
-                    start,
-                    "ssh_command_stdin_failed: command may have started and was not retried"
-                        .to_string(),
-                ));
-            }
-        } else {
-            let _ = terminate_ssh_child(&mut child);
-            return ShellCommandResult::outcome_unknown(command_error(
-                start,
-                "ssh_command_stdin_failed: command may have started and was not retried"
-                    .to_string(),
-            ));
-        }
-    }
-    let (stdout, stderr) = {
+
+    // Drain output before starting any potentially blocking stdin write. This
+    // ordering prevents the classic full-stdin/full-output pipe deadlock.
+    let (child_stdin, stdout, stderr) = {
         let process = piped_ssh_process_mut(&mut child);
-        (process.stdout.take(), process.stderr.take())
+        (
+            process.stdin.take(),
+            process.stdout.take(),
+            process.stderr.take(),
+        )
     };
     let (stdout_tx, stdout_rx) = mpsc::sync_channel(1);
     let (stderr_tx, stderr_rx) = mpsc::sync_channel(1);
@@ -1030,9 +1187,29 @@ fn run_piped_ssh_command(
         drop(stderr_tx);
     }
 
+    let mut writer_start_error = None;
+    let mut stdin_writer = match program_delivery
+        .spawn_writer(child_stdin, stdin.map(|input| input.as_bytes().to_vec()))
+    {
+        Ok(writer) => writer,
+        Err(error) => {
+            writer_start_error = Some(error);
+            let _ = terminate_ssh_child(&mut child);
+            None
+        }
+    };
+    let mut writer_error = None;
+    let mut wait_error = None;
     let mut stopped = false;
     let mut timed_out = false;
     let status = loop {
+        if let Some(error) = writer_start_error
+            .take()
+            .or_else(|| stdin_writer.as_mut().and_then(SshStdinWriter::poll_failure))
+        {
+            writer_error = Some(error);
+            break terminate_ssh_child(&mut child).ok();
+        }
         match try_wait_piped_ssh_child(&mut child) {
             Ok(Some(status)) => break Some(status),
             Ok(None) => {
@@ -1046,19 +1223,30 @@ fn run_piped_ssh_command(
                 }
                 std::thread::sleep(Duration::from_millis(25));
             }
-            Err(_) => {
-                let _ = terminate_ssh_child(&mut child);
-                return ShellCommandResult::outcome_unknown(command_error(
-                    start,
-                    "ssh_command_wait_failed: command may have started and was not retried"
-                        .to_string(),
+            Err(error) => {
+                wait_error = Some(format!(
+                    "ssh_command_wait_failed: command may have started and was not retried: {error}"
                 ));
+                break terminate_ssh_child(&mut child).ok();
             }
         }
     };
+
+    // Natural exit and every interruption converge on bounded local cleanup.
+    // Killing the SSH tree closes the pipe read end, which unblocks a writer
+    // stalled in write_all; we observe it rather than joining blindly.
+    let tree_cleanup_uncertain = ensure_piped_ssh_tree_exit(&mut child).is_err();
+    let writer_finish_error = stdin_writer.as_mut().and_then(|writer| {
+        let interrupted = stopped || timed_out || writer_error.is_some() || wait_error.is_some();
+        let result = if interrupted {
+            writer.finish_after_tree_cleanup()
+        } else {
+            writer.finish_bounded()
+        };
+        result.err()
+    });
+
     let deadline = Instant::now() + Duration::from_secs(SSH_PIPE_DRAIN_TIMEOUT_SECS);
-    let tree_cleanup_uncertain =
-        !stopped && !timed_out && ensure_piped_ssh_tree_exit(&mut child).is_err();
     let stdout = stdout_rx
         .recv_timeout(deadline.saturating_duration_since(Instant::now()))
         .ok()
@@ -1069,15 +1257,27 @@ fn run_piped_ssh_command(
         .ok()
         .and_then(Result::ok)
         .unwrap_or_default();
+    let stdout = String::from_utf8_lossy(&stdout).into_owned();
     let mut stderr = String::from_utf8_lossy(&stderr).into_owned();
+
+    if let Some(error) = writer_finish_error {
+        return ShellCommandResult::outcome_unknown(CommandResult {
+            exit_code: None,
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            duration_ms: Some(start.elapsed().as_millis() as u64),
+            error: Some(error),
+        });
+    }
     if stopped {
-        append_line(
+        append_bounded_line(
             &mut stderr,
             "webcodex: local SSH client was stopped after dispatch; remote command outcome is unknown; do not blindly retry",
+            max_output_bytes,
         );
         return ShellCommandResult::outcome_unknown(CommandResult {
             exit_code: None,
-            stdout: Some(String::from_utf8_lossy(&stdout).into_owned()),
+            stdout: Some(stdout),
             stderr: Some(stderr),
             duration_ms: Some(start.elapsed().as_millis() as u64),
             error: Some(
@@ -1087,27 +1287,37 @@ fn run_piped_ssh_command(
         });
     }
     if timed_out {
-        append_line(
+        append_bounded_line(
             &mut stderr,
             &format!("command timed out after {timeout_secs} seconds"),
+            max_output_bytes,
         );
         let result = CommandResult {
             exit_code: Some(-1),
-            stdout: Some(String::from_utf8_lossy(&stdout).into_owned()),
+            stdout: Some(stdout),
             stderr: Some(stderr),
             duration_ms: Some(start.elapsed().as_millis() as u64),
             error: Some("command timed out".to_string()),
         };
-        return if status.is_some() {
+        return if status.is_some() && !tree_cleanup_uncertain {
             ShellCommandResult::timed_out(result)
         } else {
             ShellCommandResult::outcome_unknown(result)
         };
     }
+    if let Some(error) = writer_error.or(wait_error) {
+        return ShellCommandResult::outcome_unknown(CommandResult {
+            exit_code: None,
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            duration_ms: Some(start.elapsed().as_millis() as u64),
+            error: Some(error),
+        });
+    }
     if tree_cleanup_uncertain {
         return ShellCommandResult::outcome_unknown(CommandResult {
             exit_code: status.and_then(|status| status.code()).or(Some(-1)),
-            stdout: Some(String::from_utf8_lossy(&stdout).into_owned()),
+            stdout: Some(stdout),
             stderr: Some(stderr),
             duration_ms: Some(start.elapsed().as_millis() as u64),
             error: Some(
@@ -1117,7 +1327,7 @@ fn run_piped_ssh_command(
     }
     ShellCommandResult::completed(CommandResult {
         exit_code: status.and_then(|status| status.code()).or(Some(-1)),
-        stdout: Some(String::from_utf8_lossy(&stdout).into_owned()),
+        stdout: Some(stdout),
         stderr: Some(stderr),
         duration_ms: Some(start.elapsed().as_millis() as u64),
         error: None,
@@ -1200,11 +1410,23 @@ fn read_bounded_pipe_tail(mut pipe: impl Read, max_bytes: usize) -> Result<Vec<u
     }
 }
 
-fn append_line(value: &mut String, suffix: &str) {
+fn append_bounded_line(value: &mut String, suffix: &str, max_bytes: usize) {
     if !value.is_empty() && !value.ends_with('\n') {
         value.push('\n');
     }
     value.push_str(suffix);
+    if value.len() <= max_bytes {
+        return;
+    }
+    if max_bytes == 0 {
+        value.clear();
+        return;
+    }
+    let mut start = value.len().saturating_sub(max_bytes);
+    while start < value.len() && !value.is_char_boundary(start) {
+        start += 1;
+    }
+    value.drain(..start);
 }
 
 fn command_error(start: Instant, error: String) -> CommandResult {
@@ -1221,10 +1443,12 @@ fn command_error(start: Instant, error: String) -> CommandResult {
 mod tests {
     use super::{
         is_transport_failure, remote_script, run_ssh_shell, shell_quote, ssh_shell_probe_available,
-        PreparedSshTransport, SshConnectionKey, SshConnectionPool,
+        windows_direct_program_bootstrap, PreparedSshTransport, SshConnectionKey,
+        SshConnectionPool,
     };
     use crate::webcodex_runner::config::{AgentPolicy, SshConfig, SshResourceConfig};
     use std::collections::BTreeMap;
+    use std::io::Write;
     #[cfg(target_os = "linux")]
     use std::net::{TcpListener, TcpStream};
     use std::os::unix::fs::{symlink, PermissionsExt};
@@ -1446,6 +1670,71 @@ mod tests {
         assert!(script.contains("cd '/tmp/a'\"'\"' b'"), "{script}");
         assert!(script.ends_with("printf ok"), "{script}");
         assert_eq!(shell_quote("plain"), "'plain'");
+
+        for value in ["abc", "a'b", "'a", "''"] {
+            let output = Command::new("sh")
+                .arg("-c")
+                .arg(format!("printf '%s' {}", shell_quote(value)))
+                .output()
+                .expect("run shell_quote round-trip probe");
+            assert!(output.status.success(), "{value:?}: {output:?}");
+            assert_eq!(output.stdout, value.as_bytes(), "{value:?}");
+        }
+        let dense = "'".repeat(4096);
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg(format!("printf '%s' {}", shell_quote(&dense)))
+            .output()
+            .expect("run dense shell_quote round-trip probe");
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(output.stdout, dense.as_bytes());
+    }
+
+    #[test]
+    fn windows_direct_bootstrap_preserves_caller_stdin_and_rejects_partial_program() {
+        let program = "IFS= read -r line; printf '<%s>' \"$line\"";
+        let bootstrap = windows_direct_program_bootstrap(program.len());
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(&bootstrap)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn bootstrap framing probe");
+        let mut input = child.stdin.take().expect("bootstrap stdin");
+        input.write_all(program.as_bytes()).unwrap();
+        input.write_all(b"caller-data\n").unwrap();
+        drop(input);
+        let output = child.wait_with_output().unwrap();
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(output.stdout, b"<caller-data>");
+
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("partial-program-ran");
+        let partial_program = format!(
+            "printf ran > {}",
+            shell_quote(marker.to_string_lossy().as_ref())
+        );
+        let bootstrap = windows_direct_program_bootstrap(partial_program.len() + 9);
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(&bootstrap)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn partial bootstrap probe");
+        let mut input = child.stdin.take().expect("partial bootstrap stdin");
+        input.write_all(partial_program.as_bytes()).unwrap();
+        drop(input);
+        let output = child.wait_with_output().unwrap();
+        assert!(!output.status.success(), "{output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("incomplete SSH program upload"),
+            "{output:?}"
+        );
+        assert!(!marker.exists(), "partial remote program was executed");
     }
 
     #[test]
@@ -2686,10 +2975,12 @@ mod windows_tests {
                     r#"
 use std::env;
 use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
+
+const PROGRAM_PREFIX: &str = "WEBCODEX_SSH_PROGRAM_BYTES=";
 
 fn suffix<'a>(script: &'a str, marker: &str) -> Option<&'a str> {
     script.rfind(marker).map(|index| script[index + marker.len()..].trim())
@@ -2698,6 +2989,12 @@ fn suffix<'a>(script: &'a str, marker: &str) -> Option<&'a str> {
 fn append_start(path: &str) {
     let mut file = OpenOptions::new().create(true).append(true).open(path).unwrap();
     writeln!(file, "start").unwrap();
+}
+
+fn direct_program_len(args: &[String]) -> Option<usize> {
+    let bootstrap = args.last()?;
+    let rest = bootstrap.strip_prefix(PROGRAM_PREFIX)?;
+    rest.split(';').next()?.parse().ok()
 }
 
 fn main() {
@@ -2710,7 +3007,53 @@ fn main() {
         return;
     }
 
-    let script = args.last().map(String::as_str).unwrap_or_default();
+    let host = args.get(5).map(String::as_str).unwrap_or_default();
+    if host == "fake-exit-before-program" {
+        std::process::exit(0);
+    }
+    if let Some(marker) = host.strip_prefix("fake-never-read-stop=") {
+        fs::write(marker, format!("{}", std::process::id())).unwrap();
+        println!("FAKE_SSH_PID={}", std::process::id());
+        io::stdout().flush().unwrap();
+        thread::sleep(Duration::from_secs(60));
+        return;
+    }
+    if host == "fake-never-read" || host == "fake-never-read-output" {
+        println!("FAKE_SSH_PID={}", std::process::id());
+        io::stdout().flush().unwrap();
+        if host == "fake-never-read-output" {
+            io::stdout().write_all(&vec![b'o'; 2 * 1024 * 1024]).unwrap();
+            io::stdout().flush().unwrap();
+            io::stderr().write_all(&vec![b'e'; 2 * 1024 * 1024]).unwrap();
+            io::stderr().flush().unwrap();
+        }
+        thread::sleep(Duration::from_secs(60));
+        return;
+    }
+
+    let mut stdin = io::stdin().lock();
+    let mut owned_script = None;
+    if let Some(program_len) = direct_program_len(&args) {
+        let mut program = vec![0_u8; program_len];
+        if stdin.read_exact(&mut program).is_err() {
+            eprintln!("fake ssh: incomplete program frame");
+            std::process::exit(126);
+        }
+        owned_script = Some(String::from_utf8(program).expect("UTF-8 program frame"));
+    }
+    let script = owned_script
+        .as_deref()
+        .unwrap_or_else(|| args.last().map(String::as_str).unwrap_or_default());
+
+    if let Some(base) = suffix(script, "WC_FAKE_CAPTURE_FRAME::") {
+        fs::write(format!("{base}.program"), script.as_bytes()).unwrap();
+        let mut caller_stdin = Vec::new();
+        stdin.read_to_end(&mut caller_stdin).unwrap();
+        fs::write(format!("{base}.stdin"), caller_stdin).unwrap();
+        print!("capture-ok");
+        io::stdout().flush().unwrap();
+        return;
+    }
     if let Some(path) = suffix(script, "WC_FAKE_EXIT_255::") {
         append_start(path);
         eprintln!("ambiguous direct ssh exit");
@@ -2815,6 +3158,31 @@ fn main() {
             !args.iter().any(|arg| arg.contains("ControlPersist")),
             "{args:?}"
         );
+    }
+
+    fn stdin_program(delivery: &PreparedSshProgramDelivery) -> &str {
+        let PreparedSshProgramDelivery::StdinFramed { program } = delivery else {
+            panic!("Windows Direct SSH must use framed stdin program delivery");
+        };
+        std::str::from_utf8(program).expect("prepared remote program is UTF-8")
+    }
+
+    fn conservative_windows_command_line_utf16_bound(command: &Command) -> usize {
+        std::iter::once(command.get_program())
+            .chain(command.get_args())
+            .map(|value| {
+                let units = value.to_string_lossy().encode_utf16().count();
+                // Rust/Windows argv quoting cannot more than double every input
+                // code unit plus a pair of surrounding quotes and a separator.
+                units * 2 + 3
+            })
+            .sum::<usize>()
+            + 1
+    }
+
+    fn explicit_bash_wire_command(authored: &str) -> String {
+        let escaped = authored.replace('\'', "'\\''");
+        format!("exec bash -c '{escaped}'")
     }
 
     fn fake_pool() -> SshConnectionPool {
@@ -2935,7 +3303,7 @@ fn main() {
     }
 
     #[test]
-    fn windows_one_shot_and_job_prepare_direct_literal_ssh_exe_without_mux_state() {
+    fn windows_one_shot_and_job_keep_remote_program_out_of_createprocess_argv() {
         let config = ssh_config("spe", Some("/srv/webcodex"));
         let pool = SshConnectionPool::default();
         let prepared = pool
@@ -2952,9 +3320,23 @@ fn main() {
         assert!(matches!(prepared.transport, PreparedSshTransport::Direct));
         let args = command_args(&prepared.command);
         assert_direct_args(&args, "spe");
+        assert_eq!(args.len(), 6, "{args:?}");
+        assert!(
+            args.last()
+                .is_some_and(|arg| arg.starts_with(WINDOWS_DIRECT_BOOTSTRAP_PREFIX)),
+            "{args:?}"
+        );
+        assert!(
+            !args.iter().any(|arg| arg.contains("printf test")),
+            "{args:?}"
+        );
+        assert!(
+            !args.iter().any(|arg| arg.contains("/srv/override")),
+            "{args:?}"
+        );
         assert_eq!(
-            args.last().map(String::as_str),
-            Some("if ! cd '/srv/override'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf test")
+            stdin_program(&prepared.program_delivery),
+            "if ! cd '/srv/override'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf test"
         );
         assert_eq!(pool.connection_count(), 0);
 
@@ -2965,11 +3347,136 @@ fn main() {
         assert!(matches!(job.transport, PreparedSshTransport::Direct));
         let job_args = command_args(&job.command);
         assert_direct_args(&job_args, "spe");
+        assert!(
+            !job_args.iter().any(|arg| arg.contains("printf job")),
+            "{job_args:?}"
+        );
+        assert!(
+            !job_args.iter().any(|arg| arg.contains("/srv/webcodex")),
+            "{job_args:?}"
+        );
         assert_eq!(
-            job_args.last().map(String::as_str),
-            Some("if ! cd '/srv/webcodex'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf job")
+            stdin_program(&job.program_delivery),
+            "if ! cd '/srv/webcodex'; then printf >&2 '%s\\n' 'webcodex: remote cwd is unavailable'; exit 125; fi\nprintf job"
         );
         assert_eq!(pool.connection_count(), 0);
+    }
+
+    #[test]
+    fn windows_direct_large_program_and_cwd_contract_fit_bounded_argv() {
+        let pool = SshConnectionPool::default();
+        let authored = "'".repeat(crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES);
+        let wrapped = explicit_bash_wire_command(&authored);
+        assert_eq!(wrapped.len(), 64_015);
+        assert!(wrapped.len() <= crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES);
+
+        let max_host = "h".repeat(512);
+        let prepared = pool
+            .prepare_command(
+                7,
+                &ssh_config(&max_host, None),
+                "spe",
+                "wc_sess_windows_long_program",
+                None,
+                &wrapped,
+            )
+            .expect("prepare 16K quote-dense explicit bash command");
+        let args = command_args(&prepared.command);
+        assert_direct_args(&args, &max_host);
+        assert_eq!(stdin_program(&prepared.program_delivery), wrapped);
+        assert!(!args.iter().any(|arg| arg.contains(&authored)));
+        let argv_bound = conservative_windows_command_line_utf16_bound(&prepared.command);
+        assert!(
+            argv_bound < 8 * 1024,
+            "conservative UTF-16 argv bound={argv_bound}"
+        );
+        assert!(
+            argv_bound < 32_767,
+            "CreateProcessW argv bound={argv_bound}"
+        );
+
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config("spe", None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_long_program",
+            None,
+            &wrapped,
+            None,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{result:?}"
+        );
+        assert_eq!(result.result.exit_code, Some(0), "{result:?}");
+
+        let max_wire = "x".repeat(crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES);
+        crate::shell_protocol::validate_raw_shell_wire_command(&max_wire).unwrap();
+        assert!(
+            crate::shell_protocol::validate_raw_shell_wire_command(&format!("{max_wire}x"))
+                .is_err()
+        );
+        let max_prepared = pool
+            .prepare_command(
+                7,
+                &ssh_config("spe", None),
+                "spe",
+                "wc_sess_windows_max_wire",
+                None,
+                &max_wire,
+            )
+            .expect("prepare exact max wire command");
+        assert_eq!(stdin_program(&max_prepared.program_delivery), max_wire);
+
+        let quote_dense_cwd = "'".repeat(SSH_REMOTE_CWD_MAX_BYTES);
+        let cwd_prepared = pool
+            .prepare_command(
+                7,
+                &ssh_config("spe", None),
+                "spe",
+                "wc_sess_windows_max_cwd",
+                Some(&quote_dense_cwd),
+                "printf cwd",
+            )
+            .expect("prepare max quote-dense cwd");
+        assert_eq!(
+            stdin_program(&cwd_prepared.program_delivery),
+            remote_script(Some(&quote_dense_cwd), "printf cwd")
+        );
+        let cwd_args = command_args(&cwd_prepared.command);
+        assert!(!cwd_args.iter().any(|arg| arg.contains(&quote_dense_cwd)));
+        assert!(conservative_windows_command_line_utf16_bound(&cwd_prepared.command) < 8 * 1024);
+
+        let job = pool
+            .prepare_job_command(
+                7,
+                &ssh_config("spe", None),
+                "spe",
+                "wc_sess_windows_long_job",
+                None,
+                &wrapped,
+            )
+            .expect("prepare long Windows SSH Job payload");
+        assert_eq!(stdin_program(&job.program_delivery), wrapped);
+        assert!(!command_args(&job.command)
+            .iter()
+            .any(|arg| arg.contains(&authored)));
+    }
+
+    #[test]
+    fn windows_shell_quote_handles_leading_and_dense_single_quotes() {
+        assert_eq!(shell_quote("abc"), "'abc'");
+        assert_eq!(shell_quote("a'b"), "'a'\"'\"'b'");
+        assert_eq!(shell_quote("'a"), "''\"'\"'a'");
+        assert_eq!(shell_quote("''"), "''\"'\"''\"'\"''");
+        let dense = "'".repeat(SSH_REMOTE_CWD_MAX_BYTES);
+        assert_eq!(shell_quote(&dense).len(), 2 + dense.len() * 5);
     }
 
     #[test]
@@ -3017,6 +3524,173 @@ fn main() {
             Some(255),
             Some("remote command deliberately exited 255")
         ));
+    }
+
+    #[test]
+    fn windows_direct_framing_keeps_program_and_caller_stdin_exactly_separate() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("frame-capture");
+        let program = format!("WC_FAKE_CAPTURE_FRAME::{}", base.display());
+        let caller_stdin = "caller stdin\nwith 'quotes' and WC_FAKE markers\n";
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config("spe", None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_frame",
+            None,
+            &program,
+            Some(caller_stdin),
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{result:?}"
+        );
+        assert_eq!(
+            result.result.stdout.as_deref(),
+            Some("capture-ok"),
+            "{result:?}"
+        );
+        assert_eq!(
+            std::fs::read(format!("{}.program", base.display())).unwrap(),
+            program.as_bytes()
+        );
+        assert_eq!(
+            std::fs::read(format!("{}.stdin", base.display())).unwrap(),
+            caller_stdin.as_bytes()
+        );
+    }
+
+    #[test]
+    fn windows_program_writer_failure_after_spawn_is_outcome_unknown() {
+        let command = "x".repeat(crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES);
+        let cwd = "'".repeat(SSH_REMOTE_CWD_MAX_BYTES);
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config("fake-exit-before-program", None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_program_writer_failure",
+            Some(&cwd),
+            &command,
+            None,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::OutcomeUnknown,
+            "{result:?}"
+        );
+        assert_eq!(result.result.exit_code, None, "{result:?}");
+        assert!(
+            result
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_program_write_failed")),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn windows_blocked_program_writer_timeout_drains_output_and_returns_bounded() {
+        let policy = AgentPolicy {
+            max_output_bytes: 4 * 1024,
+            ..AgentPolicy::default()
+        };
+        let program = "x".repeat(crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES);
+        let started = Instant::now();
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config("fake-never-read-output", None),
+            &policy,
+            "spe",
+            "wc_sess_windows_blocked_timeout",
+            None,
+            &program,
+            None,
+            1,
+            None,
+            None,
+        );
+        assert!(started.elapsed() < Duration::from_secs(4), "{result:?}");
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::TimedOut,
+            "{result:?}"
+        );
+        assert!(result.result.stdout.as_deref().unwrap_or_default().len() <= 4 * 1024);
+        assert!(result.result.stderr.as_deref().unwrap_or_default().len() <= 4 * 1024);
+    }
+
+    #[test]
+    fn windows_blocked_program_writer_stop_is_outcome_unknown_and_reaps_client() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("blocked-writer.pid");
+        let host = format!("fake-never-read-stop={}", marker.display());
+        let stop_requested = Arc::new(AtomicBool::new(false));
+        let stop_signal = Arc::clone(&stop_requested);
+        let marker_for_stop = marker.clone();
+        let stopper = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !marker_for_stop.exists() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                marker_for_stop.exists(),
+                "fake SSH never reached blocked-writer state"
+            );
+            stop_signal.store(true, Ordering::SeqCst);
+        });
+        let program = "x".repeat(crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES);
+        let started = Instant::now();
+        let result = run_ssh_shell_with_execution_state(
+            &fake_pool(),
+            7,
+            &ssh_config(&host, None),
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_blocked_stop",
+            None,
+            &program,
+            None,
+            30,
+            Some(stop_requested.as_ref()),
+            None,
+        );
+        stopper.join().unwrap();
+        assert!(started.elapsed() < Duration::from_secs(4), "{result:?}");
+        assert_eq!(
+            result.execution_state,
+            ShellCommandExecutionState::OutcomeUnknown,
+            "{result:?}"
+        );
+        assert!(
+            result
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("ssh_command_stopped_after_dispatch")),
+            "{result:?}"
+        );
+        let pid = std::fs::read_to_string(&marker)
+            .unwrap()
+            .trim()
+            .parse::<u32>()
+            .unwrap();
+        assert!(
+            wait_for_process_exit(pid),
+            "blocked-writer SSH client survived stop: {pid}"
+        );
     }
 
     #[test]
@@ -3364,7 +4038,7 @@ fn main() {
             None,
             &format!("WC_FAKE_TREE::{}", delayed_marker.display()),
             None,
-            1,
+            2,
             None,
             None,
         );
@@ -3455,6 +4129,26 @@ fn main() {
             std::fs::read_to_string(&starts).unwrap().lines().count(),
             1,
             "background direct exit 255 was retried"
+        );
+
+        let long_authored = "'".repeat(crate::shell_protocol::RAW_SHELL_COMMAND_MAX_BYTES);
+        let long_wire = explicit_bash_wire_command(&long_authored);
+        enqueue_job(
+            &manager,
+            sink.clone(),
+            config.clone(),
+            AgentPolicy::default(),
+            "win-ssh-long-program",
+            &long_wire,
+            5,
+        );
+        let long = wait_for_job_update(&mut rx, "win-ssh-long-program", |update| update.finished);
+        assert_eq!(long.status, "completed", "{long:?}");
+        assert_eq!(long.exit_code, Some(0), "{long:?}");
+        assert_eq!(
+            long.command_execution_state,
+            Some(ShellCommandExecutionState::Completed),
+            "{long:?}"
         );
 
         let bounded_policy = AgentPolicy {
@@ -3663,20 +4357,25 @@ fn main() {
             return;
         }
         let config = ssh_config(host, None);
-        let one_shot = run_ssh_shell_with_execution_state(
-            &SshConnectionPool::default(),
-            7,
-            &config,
-            &AgentPolicy::default(),
-            "spe",
-            "wc_sess_windows_real_ssh",
-            None,
-            "printf wc-windows-one-shot",
-            None,
-            15,
-            None,
-            None,
-        );
+        let pool = SshConnectionPool::default();
+        let run = |cwd: Option<&str>, command: &str| {
+            run_ssh_shell_with_execution_state(
+                &pool,
+                7,
+                &config,
+                &AgentPolicy::default(),
+                "spe",
+                "wc_sess_windows_real_ssh",
+                cwd,
+                command,
+                None,
+                15,
+                None,
+                None,
+            )
+        };
+
+        let one_shot = run(None, "printf wc-windows-one-shot");
         assert_eq!(
             one_shot.execution_state,
             ShellCommandExecutionState::Completed,
@@ -3686,6 +4385,114 @@ fn main() {
         assert_eq!(
             one_shot.result.stdout.as_deref(),
             Some("wc-windows-one-shot")
+        );
+
+        let exit_7 = run(None, "exit 7");
+        assert_eq!(
+            exit_7.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{exit_7:?}"
+        );
+        assert_eq!(exit_7.result.exit_code, Some(7), "{exit_7:?}");
+
+        let exit_255 = run(None, "exit 255");
+        assert_eq!(
+            exit_255.execution_state,
+            ShellCommandExecutionState::OutcomeUnknown,
+            "{exit_255:?}"
+        );
+        assert_eq!(exit_255.result.exit_code, Some(255), "{exit_255:?}");
+
+        let explicit_sh = run(None, "exec sh -c 'printf wc-explicit-sh'");
+        assert_eq!(
+            explicit_sh.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{explicit_sh:?}"
+        );
+        assert_eq!(explicit_sh.result.stdout.as_deref(), Some("wc-explicit-sh"));
+
+        let explicit_bash = run(None, "exec bash -c 'printf wc-explicit-bash'");
+        assert_eq!(
+            explicit_bash.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{explicit_bash:?}"
+        );
+        assert_eq!(
+            explicit_bash.result.stdout.as_deref(),
+            Some("wc-explicit-bash")
+        );
+
+        let cwd_ok = run(Some("/tmp"), "pwd");
+        assert_eq!(
+            cwd_ok.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{cwd_ok:?}"
+        );
+        assert_eq!(cwd_ok.result.exit_code, Some(0), "{cwd_ok:?}");
+
+        let missing_cwd = format!("/tmp/webcodex-missing-{}", uuid::Uuid::new_v4().simple());
+        let cwd_missing = run(Some(&missing_cwd), "printf never");
+        assert_eq!(
+            cwd_missing.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{cwd_missing:?}"
+        );
+        assert_eq!(cwd_missing.result.exit_code, Some(125), "{cwd_missing:?}");
+        assert!(
+            cwd_missing
+                .result
+                .stderr
+                .as_deref()
+                .is_some_and(|stderr| stderr.contains("webcodex: remote cwd is unavailable")),
+            "{cwd_missing:?}"
+        );
+
+        let caller_stdin = "wc-real-caller-stdin\n";
+        let stdin_result = run_ssh_shell_with_execution_state(
+            &pool,
+            7,
+            &config,
+            &AgentPolicy::default(),
+            "spe",
+            "wc_sess_windows_real_ssh",
+            None,
+            "cat",
+            Some(caller_stdin),
+            15,
+            None,
+            None,
+        );
+        assert_eq!(
+            stdin_result.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{stdin_result:?}"
+        );
+        assert_eq!(stdin_result.result.exit_code, Some(0), "{stdin_result:?}");
+        assert_eq!(stdin_result.result.stdout.as_deref(), Some(caller_stdin));
+
+        let prefix = "printf wc-max-wire; #";
+        let max_wire = format!(
+            "{prefix}{}",
+            "x".repeat(crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES - prefix.len())
+        );
+        assert_eq!(
+            max_wire.len(),
+            crate::shell_protocol::RAW_SHELL_WIRE_MAX_BYTES
+        );
+        let max_wire_result = run(None, &max_wire);
+        assert_eq!(
+            max_wire_result.execution_state,
+            ShellCommandExecutionState::Completed,
+            "{max_wire_result:?}"
+        );
+        assert_eq!(
+            max_wire_result.result.exit_code,
+            Some(0),
+            "{max_wire_result:?}"
+        );
+        assert_eq!(
+            max_wire_result.result.stdout.as_deref(),
+            Some("wc-max-wire")
         );
 
         let manager = crate::JobManager::new(1);
@@ -3698,7 +4505,7 @@ fn main() {
         enqueue_job(
             &manager,
             sink,
-            config,
+            config.clone(),
             AgentPolicy::default(),
             "win-ssh-real-background",
             "printf wc-windows-background",

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -244,11 +244,11 @@ real `sh`/`bash` process; on Windows the local path keeps the configured
 `powershell.exe`/`pwsh.exe`-compatible process and reuses the same profile/env
 selection. Windows PowerShell shell/profile args must retain their normal final
 `-Command` flag in configuration; the persistent transport replaces that
-one-shot payload mode internally with its private bootstrap. Windows Stage 2
-also supports a named SSH persistent shell through the installed `ssh.exe`, with
-the remote side remaining `sh`/`bash`. That path requires `persistent_shell` +
-`ssh_persistent_shell`; the separate `ssh_shell` capability remains the
-one-shot/background SSH path. PTY/ConPTY terminal emulation is not included.
+one-shot payload mode internally with its private bootstrap. Named SSH resources
+support `run_shell`/`run_job` on Unix and Windows through the separate `ssh_shell`
+capability. Persistent SSH requires `persistent_shell` + `ssh_persistent_shell`:
+Unix may reuse a Runner-local OpenSSH mux, while Windows owns one direct long-lived
+`ssh.exe` channel. PTY/ConPTY terminal emulation is not implied.
 
 Security notes for profiles:
 
@@ -474,11 +474,15 @@ a separate distribution identity without sharing the local development grant.
 
 ## SSH session resources (advanced)
 
-A Runner that can invoke the local OpenSSH client advertises the `ssh_shell`
+A Runner with an available local OpenSSH client advertises the `ssh_shell`
 capability. A Workflow Session may select a named SSH resource so `run_shell`
-and `run_job` execute on a remote host through the Runner's own OpenSSH client.
-On Unix, a Runner that also advertises `ssh_persistent_shell` can use the same
-resource for `open_session_shell`:
+and `run_job` execute on a remote host through the Runner's own OpenSSH client
+on both Unix and Windows. Unix may reuse a Runner-local ControlMaster transport;
+Windows starts one direct `ssh.exe` process per one-shot/background execution and
+does not use `ControlMaster`, `ControlPersist`, or `-S`. The separate
+`ssh_persistent_shell` capability allows the same resource to be used by
+`open_session_shell`: Unix may reuse its mux, while Windows owns one direct
+long-lived `ssh.exe` channel.
 
 ```toml
 [ssh.resources.tmp]
@@ -492,7 +496,9 @@ that machine. Do not put credentials, private keys, or complete SSH
 configuration into session data, Server storage, or tool input. A Session's
 `execution_context.resource` routes `run_shell`, `run_job`, and supported
 `open_session_shell` calls through that resource; file, Git, and LSP tools
-remain local.
+remain local. Configuration reloads bind future commands to the current resource
+generation; already-started SSH commands keep their own bounded lifecycle and
+are never redirected, replayed, or blindly retried.
 
 ## LSP navigation (read-only)
 

--- a/docs/RUNNER.zh-CN.md
+++ b/docs/RUNNER.zh-CN.md
@@ -326,10 +326,13 @@ macOS release 可以使用独立的 distribution identity，不与本地开发�
 
 ## SSH 会话资源（高级）
 
-能够调用本地 OpenSSH 客户端的 Runner 会声明 `ssh_shell` capability。Workflow
-Session 可以选择命名的 SSH 资源，使 `run_shell` 与 `run_job` 通过 Runner 自己的
-OpenSSH 客户端在远程主机上执行。在 Unix 上，如果 Runner 还声明
-`ssh_persistent_shell`，同一资源也可以用于 `open_session_shell`：
+本地 OpenSSH 客户端可用时，Runner 会声明 `ssh_shell` capability。Workflow
+Session 可以选择命名的 SSH 资源，使 `run_shell` 与 `run_job` 在 Unix 和 Windows
+上都通过 Runner 自己的 OpenSSH 客户端在远程主机执行。Unix 可以复用 Runner 本地
+ControlMaster 传输；Windows 的每次 one-shot/background 执行都会启动一个直接的
+`ssh.exe`，不使用 `ControlMaster`、`ControlPersist` 或 `-S`。独立的
+`ssh_persistent_shell` capability 允许同一资源用于 `open_session_shell`：Unix
+可以复用 mux，Windows 则拥有一个直接的长生命周期 `ssh.exe` channel。 这些 SSH resource 语义不意味着 PTY/ConPTY 或额外的终端控制协议。
 
 ```toml
 [ssh.resources.tmp]
@@ -341,7 +344,9 @@ default_cwd = "/opt/webcodex-edge"
 `ssh-agent`、`ProxyJump` 等配置都留在该机器上。不要把凭据、私钥或完整 SSH 配置
 放进 Session 数据、Server 存储或工具输入。Session 的 `execution_context.resource`
 会让 `run_shell`、`run_job` 以及受支持的 `open_session_shell` 调用通过该资源执行；
-文件、Git、LSP 工具仍在本地。
+文件、Git、LSP 工具仍在本地。配置 reload 后，后续命令绑定当前 resource
+generation；已经启动的 SSH 命令继续自己的有界生命周期，不会被重定向、replay
+或盲目重试。
 
 ## LSP 导航（只读）
 

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -203,11 +203,15 @@ per-call cwd
 ```
 
 Each SSH `run_shell` / `run_job` command gets an independent remote exec
-channel and requires the Runner's `ssh_shell` capability. The Runner may reuse
-the authenticated transport for the same Session/resource pair, but it does not
-preserve `cd`, exports, aliases, functions, umask, or shell-process state between
-commands. This one-shot/background capability is independent of named SSH
-persistent-shell support.
+channel and requires the Runner's `ssh_shell` capability. Unix may reuse a
+Runner-local authenticated ControlMaster transport for the same
+Session/resource/generation; Windows starts one direct `ssh.exe` process for
+each one-shot/background execution and creates no mux state. Neither transport
+preserves `cd`, exports, aliases, functions, umask, or shell-process state between
+commands. A generation change affects future preparation only: an already-spawned
+command is never redirected, replayed, or blindly retried. This
+one-shot/background capability is independent of named SSH persistent-shell
+support.
 
 Raw shell text has one shared model-authored ceiling of 16,000 UTF-8 bytes for
 `run_shell`, raw `run_job`, and `session_shell_exec`. Larger shell program text
@@ -250,9 +254,10 @@ and controls the shell. Without `execution_context.resource`, it runs against
 the registered project host. With a named resource, the Runner opens a remote
 persistent shell through that SSH resource; this requires `persistent_shell` +
 `ssh_persistent_shell`, not the separate one-shot/background `ssh_shell`
-capability, and never silently falls back locally. Windows Stage 2 supports this
-same named SSH persistent-shell model through its OpenSSH client while the remote
-shell remains `sh`/`bash`. The process manager also has a Server-owned executor branch for a hosting surface
+capability, and never silently falls back locally. Unix may reuse its OpenSSH mux;
+Windows owns one direct long-lived `ssh.exe` channel while the remote shell remains
+`sh`/`bash`. No PTY/ConPTY or terminal-control protocol is implied. The process
+manager also has a Server-owned executor branch for a hosting surface
 that supplies a Server-local project, although the current built-in public
 project registry advertises Agent projects only. `inspect` and `read_only`
 Sessions cannot open or execute a persistent shell.


### PR DESCRIPTION
## Summary

Completes the remaining Windows named-SSH resource parity for #75.

Windows Runners now support the existing Session SSH resource contract for both:

- `run_shell + resource`
- `run_job + resource`

without changing the model-facing API, Server schema, or Workflow Session contract.

### Windows transport

Windows uses one direct `ssh.exe` process per one-shot/background execution:

```text
Session/resource/cwd validation
→ current Runner SSH resource config
→ ssh.exe -o BatchMode=yes -o LogLevel=ERROR
→ configured host
→ safe remote script
```

No Windows ControlMaster, ControlPersist, Unix control socket, or `-S` path is introduced. Unix keeps the existing mux path.

### Process ownership and lifecycle

Windows one-shot SSH now uses `ManagedChild`, so `ssh.exe` and local descendants are owned by a Windows Job Object. Background SSH continues through the existing JobManager/ManagedChild lifecycle.

Execution-state boundaries remain conservative:

- pre-spawn rejection/spawn failure → `NotStarted`
- ordinary exit `0` → `Completed`
- ordinary exit `7` → `Completed` failure
- Windows direct SSH exit `255` → `OutcomeUnknown`
- post-spawn shutdown/stop/Job-record loss → `OutcomeUnknown`
- no blind retry after possible remote dispatch

The follow-up commit also preserves the existing Unix `ssh_shell` availability semantics while keeping Windows capability advertisement dependent on a successful `ssh.exe -V` probe.

### Capability

On a Windows Runner with working OpenSSH:

```text
persistent_shell     = true
ssh_persistent_shell = true
ssh_shell            = true
```

`ssh_shell` and `ssh_persistent_shell` remain independent capabilities.

## Validation

Focused implementation validation before the final rebase covered:

- Windows SSH tests: 20 passed / 0 failed
- `cargo check --all-targets -p webcodex-runner`: PASS
- Windows process-tree cleanup, stop/timeout/shutdown, output bounds, generation/resource/cwd, spawn failure, and 0/7/255 semantics
- Unix SSH tests in WSL: 15 passed / 0 failed
- existing Unix mux and persistent SSH regressions

### Post-rebase live dogfood

The rebased/deployed MSI Runner is currently:

```text
Runner: de14ab48579a8e9d90a6bb85f95ef4c540b3f918
Base:   a30ba8bdc8b83b206f976d786571b60d4772761f
```

The existing Server is still on `0222e42a5600...`; Runner/Server report `compatibility_status=compatible`, so no Server update was required for this slice.

Using the real configured MSI Session SSH resource `mini` through that existing Server:

```text
run_shell → remote Darwin host → exit 0
run_job   → remote background command → completed / exit 0
run_shell → remote exit 7 → completed / exit 7
run_shell → remote exit 255 → outcome_unknown, no retry
```

This verifies the new Windows Runner capability through the actual product routing path rather than only direct unit fixtures.

Closes #75