### PR TITLE
Preserve Linux Server listener continuity across restarts

### DIFF
--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -49,12 +49,12 @@ use webcodex_cli::{
     run_login, run_logout, run_ops_command, run_pairing_create, run_server_init,
     run_server_install_service, run_server_service, run_server_status, run_setup_single_user,
     run_status, run_token_create_local, server_init_usage, server_install_service_usage,
-    server_status_usage, server_usage, status_usage, system_user_home, system_user_is_root, usage,
-    validate_client_profile, validate_service_file_scope, write_connect_result, write_secret_file,
-    write_text_file, ConnectAuth, ConnectOptions, DisconnectOptions, LoginOptions, LogoutOptions,
-    OpsCommand, OpsCommonOptions, OpsRunnerOptions, OpsSmokePreflightOptions, ServerStatusOptions,
-    ServiceControl, StatusOptions, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE,
-    SERVER_SERVICE_UNIT,
+    server_status_usage, server_usage, service_unit_name, status_usage, system_user_home,
+    system_user_is_root, usage, validate_client_profile, validate_service_file_scope,
+    write_connect_result, write_secret_file, write_text_file, ConnectAuth, ConnectOptions,
+    DisconnectOptions, LoginOptions, LogoutOptions, OpsCommand, OpsCommonOptions, OpsRunnerOptions,
+    OpsSmokePreflightOptions, ServerStatusOptions, ServiceControl, StatusOptions,
+    AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT,
 };
 const SETUP_GPT_SCOPES: &[&str] = &["runtime:read", "project:read", "project:write", "job:run"];
 const SETUP_AGENT_SCOPES: &[&str] = &[
@@ -1604,11 +1604,24 @@ fn parse_server_service_action(
     command: &str,
     args: &[String],
 ) -> Result<ServiceActionOptions, String> {
+    let mut service_file = PathBuf::from(SERVER_SERVICE_FILE);
+    let mut remaining = Vec::new();
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--service-file" => service_file = PathBuf::from(next_value(&mut iter, arg)?),
+            _ => remaining.push(arg.clone()),
+        }
+    }
+    if service_file.as_os_str().is_empty() {
+        return Err("--service-file cannot be empty".to_string());
+    }
+    let unit = service_unit_name(&service_file, SERVER_SERVICE_UNIT);
     Ok(ServiceActionOptions {
         scope: ServiceScope::System,
-        service_file: PathBuf::from(SERVER_SERVICE_FILE),
-        unit: SERVER_SERVICE_UNIT.to_string(),
-        kind: parse_service_kind(command, args)?,
+        service_file,
+        unit,
+        kind: parse_service_kind(command, &remaining)?,
         local_profile: None,
     })
 }
@@ -2058,6 +2071,7 @@ fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
         env_file: Some(default_server_paths()?.env_file),
         env_file_explicit: false,
         token_file: None,
+        service_file: PathBuf::from(SERVER_SERVICE_FILE),
         json: false,
     };
     let mut iter = args.iter();
@@ -2071,6 +2085,7 @@ fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
                 opts.env_file_explicit = true;
             }
             "--token-file" => opts.token_file = Some(PathBuf::from(next_value(&mut iter, arg)?)),
+            "--service-file" => opts.service_file = PathBuf::from(next_value(&mut iter, arg)?),
             "--json" => opts.json = true,
             _ => return Err(format!("unknown server status flag: {}", arg)),
         }
@@ -2078,6 +2093,9 @@ fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
     opts.server_http.validate()?;
     if opts.url.trim().is_empty() {
         return Err("--url cannot be empty".to_string());
+    }
+    if opts.service_file.as_os_str().is_empty() {
+        return Err("--service-file cannot be empty".to_string());
     }
     Ok(opts)
 }

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -95,12 +95,14 @@ pub(crate) use server::{
     ServerStatusOptions,
 };
 pub(crate) use service::{
-    control_service, control_service_for_scope, encode_exec_argument, encode_exec_path_argument,
-    encode_exec_program, encode_unit_path_value, ensure_service_file_parent, install_unit,
-    install_unit_for_scope, query_systemd_service_status_for_scope, query_systemd_status,
-    run_internal_binary, run_logs, run_logs_for_scope, service_unit_name, uninstall_unit,
-    uninstall_unit_for_scope, validate_systemd_identity, ServiceControl, AGENT_SERVICE_UNIT,
-    DEFAULT_LOG_LINES, SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT,
+    control_server_unit_pair, control_service_for_scope, encode_exec_argument,
+    encode_exec_path_argument, encode_exec_program, encode_unit_path_value,
+    ensure_service_file_parent, install_server_unit_pair, install_unit_for_scope,
+    query_systemd_service_status_for_scope, query_systemd_socket_status, query_systemd_status,
+    run_internal_binary, run_logs, run_logs_for_scope, service_unit_name,
+    uninstall_server_unit_pair, uninstall_unit_for_scope, validate_systemd_identity,
+    ServiceControl, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE,
+    SERVER_SERVICE_UNIT, SERVER_SOCKET_UNIT,
 };
 pub(crate) use setup::run_setup_single_user;
 pub(crate) use system::{

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -98,11 +98,11 @@ pub(crate) use service::{
     control_server_unit_pair, control_service_for_scope, encode_exec_argument,
     encode_exec_path_argument, encode_exec_program, encode_unit_path_value,
     ensure_service_file_parent, install_server_unit_pair, install_unit_for_scope,
-    query_systemd_service_status_for_scope, query_systemd_socket_status, query_systemd_status,
-    run_internal_binary, run_logs, run_logs_for_scope, service_unit_name,
-    uninstall_server_unit_pair, uninstall_unit_for_scope, validate_systemd_identity,
-    ServiceControl, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES, SERVER_SERVICE_FILE,
-    SERVER_SERVICE_UNIT, SERVER_SOCKET_UNIT,
+    query_systemd_service_status, query_systemd_service_status_for_scope,
+    query_systemd_socket_status, run_internal_binary, run_logs, run_logs_for_scope,
+    service_unit_name, uninstall_server_unit_pair, uninstall_unit_for_scope,
+    validate_systemd_identity, ServiceControl, AGENT_SERVICE_UNIT, DEFAULT_LOG_LINES,
+    SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT, SERVER_SOCKET_UNIT,
 };
 pub(crate) use setup::run_setup_single_user;
 pub(crate) use system::{

--- a/crates/webcodex-cli/src/webcodex_cli/server.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/server.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 use webcodex_admin::ServerHttpOptions;
 
 use crate::{
@@ -7,11 +8,12 @@ use crate::{
 };
 
 use super::{
-    compare_build_commits, control_service, encode_exec_program, encode_unit_path_value,
-    fetch_runtime_status, generate_bootstrap_token, install_unit, local_cli_build_metadata,
-    query_systemd_status, read_env_file_value, render_build_metadata_block, render_server_env,
-    run_logs, runtime_build_metadata, server_status_revision_check, service_unit_name,
-    token_prefix, uninstall_unit, validate_systemd_identity, SERVER_SERVICE_UNIT,
+    compare_build_commits, control_server_unit_pair, encode_exec_program, encode_unit_path_value,
+    fetch_runtime_status, generate_bootstrap_token, install_server_unit_pair,
+    local_cli_build_metadata, query_systemd_socket_status, query_systemd_status,
+    read_env_file_value, render_build_metadata_block, render_server_env, run_logs,
+    runtime_build_metadata, server_status_revision_check, service_unit_name, token_prefix,
+    uninstall_server_unit_pair, validate_systemd_identity, SERVER_SERVICE_UNIT, SERVER_SOCKET_UNIT,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,54 +81,115 @@ pub(crate) fn run_server_init(opts: ServerInitOptions) -> Result<String, String>
     Ok(out)
 }
 
+fn server_socket_file(service_file: &Path) -> Result<PathBuf, String> {
+    if service_file.file_name().is_none() {
+        return Err(format!(
+            "invalid service unit path: {}",
+            service_file.display()
+        ));
+    }
+    Ok(service_file.with_extension("socket"))
+}
+
+fn configured_socket_addr(env_file: &Path) -> Result<String, String> {
+    if !env_file.exists() {
+        return Err(format!("env file {} does not exist", env_file.display()));
+    }
+    let value = read_env_file_value(env_file, "WEBCODEX_ADDR")?
+        .ok_or_else(|| format!("{} does not define WEBCODEX_ADDR", env_file.display()))?;
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(format!(
+            "{} defines an empty WEBCODEX_ADDR",
+            env_file.display()
+        ));
+    }
+    let addr = value.parse::<SocketAddr>().map_err(|error| {
+        format!(
+            "WEBCODEX_ADDR {value:?} from {} is not a fixed IP socket address valid for systemd ListenStream: {error}",
+            env_file.display()
+        )
+    })?;
+    Ok(addr.to_string())
+}
+
 pub(crate) fn run_server_install_service(
     opts: ServerInstallServiceOptions,
 ) -> Result<String, String> {
-    let rendered = render_systemd_unit(&opts)?;
-    let unit = service_unit_name(&opts.service_file, SERVER_SERVICE_UNIT);
+    let service_unit = service_unit_name(&opts.service_file, SERVER_SERVICE_UNIT);
+    let socket_file = server_socket_file(&opts.service_file)?;
+    let socket_unit = service_unit_name(&socket_file, SERVER_SOCKET_UNIT);
+    let rendered_service = render_systemd_unit(&opts, &socket_unit)?;
+    let listen = configured_socket_addr(&opts.env_file)?;
+    let rendered_socket = render_systemd_socket_unit(&listen, &service_unit)?;
     if opts.output_stdout || opts.dry_run {
         if opts.json {
             return serde_json::to_string_pretty(&json!({
                 "service_file": opts.service_file.to_string_lossy(),
+                "socket_file": socket_file.to_string_lossy(),
                 "env_file": opts.env_file.to_string_lossy(),
                 "bin": opts.bin.to_string_lossy(),
-                "unit_name": unit,
+                "service_unit": service_unit,
+                "socket_unit": socket_unit,
+                "listen": listen,
                 "dry_run": true,
+                "no_start": opts.no_start,
                 "systemd_called": false,
-                "unit": rendered,
+                "units": {
+                    "service": rendered_service,
+                    "socket": rendered_socket,
+                },
             }))
             .map_err(|e| e.to_string());
         }
-        return Ok(rendered);
+        return Ok(format!(
+            "# {}\n{}\n# {}\n{}",
+            opts.service_file.display(),
+            rendered_service,
+            socket_file.display(),
+            rendered_socket
+        ));
     }
-    let result = install_unit(
+    let result = install_server_unit_pair(
         &opts.service_file,
-        &unit,
-        &rendered,
+        &service_unit,
+        &rendered_service,
+        &socket_file,
+        &socket_unit,
+        &rendered_socket,
         opts.overwrite,
         opts.no_start,
     )?;
     if opts.json {
         return serde_json::to_string_pretty(&json!({
             "service_file": opts.service_file.to_string_lossy(),
+            "socket_file": socket_file.to_string_lossy(),
             "env_file": opts.env_file.to_string_lossy(),
             "bin": opts.bin.to_string_lossy(),
-            "unit": result.unit,
+            "service_unit": service_unit,
+            "socket_unit": socket_unit,
+            "listen": listen,
             "enabled": true,
             "started": result.started,
         }))
         .map_err(|e| e.to_string());
     }
     Ok(format!(
-        "Server service installed.\n\n  service file: {}\n  unit:         {}\n  binary:       {}\n  enabled:      yes\n  started:      {}\n",
+        "Server socket/service pair installed.\n\n  service file: {}\n  socket file:  {}\n  service unit: {}\n  socket unit:  {}\n  listen:       {}\n  binary:       {}\n  enabled:      yes\n  started:      {}\n",
         opts.service_file.display(),
-        result.unit,
+        socket_file.display(),
+        service_unit,
+        socket_unit,
+        listen,
         opts.bin.display(),
         if result.started { "yes" } else { "no (--no-start)" }
     ))
 }
 
-fn render_systemd_unit(opts: &ServerInstallServiceOptions) -> Result<String, String> {
+fn render_systemd_unit(
+    opts: &ServerInstallServiceOptions,
+    socket_unit: &str,
+) -> Result<String, String> {
     let environment_file = encode_unit_path_value("EnvironmentFile", &opts.env_file)?;
     let exec_start = encode_exec_program("ExecStart", &opts.bin)?;
     let working_directory = encode_unit_path_value("WorkingDirectory", &opts.working_directory)?;
@@ -140,7 +203,8 @@ fn render_systemd_unit(opts: &ServerInstallServiceOptions) -> Result<String, Str
     let mut unit = String::new();
     unit.push_str("[Unit]\n");
     unit.push_str("Description=WebCodex Runtime\n");
-    unit.push_str("After=network-online.target\n");
+    unit.push_str(&format!("Requires={socket_unit}\n"));
+    unit.push_str(&format!("After=network-online.target {socket_unit}\n"));
     unit.push_str("Wants=network-online.target\n\n");
     unit.push_str("[Service]\n");
     unit.push_str("Type=simple\n");
@@ -160,14 +224,33 @@ fn render_systemd_unit(opts: &ServerInstallServiceOptions) -> Result<String, Str
     Ok(unit)
 }
 
+fn render_systemd_socket_unit(listen: &str, service_unit: &str) -> Result<String, String> {
+    listen
+        .parse::<SocketAddr>()
+        .map_err(|error| format!("invalid systemd ListenStream address {listen:?}: {error}"))?;
+    let mut unit = String::new();
+    unit.push_str("[Unit]\n");
+    unit.push_str("Description=WebCodex HTTP Socket\n\n");
+    unit.push_str("[Socket]\n");
+    unit.push_str(&format!("ListenStream={listen}\n"));
+    unit.push_str(&format!("Service={service_unit}\n"));
+    unit.push_str("FileDescriptorName=webcodex-http\n\n");
+    unit.push_str("[Install]\n");
+    unit.push_str("WantedBy=sockets.target\n");
+    Ok(unit)
+}
+
 pub(crate) fn run_server_service(opts: ServiceActionOptions) -> Result<String, String> {
     match opts.kind {
         ServiceActionKind::Control(control) => {
-            control_service(&opts.unit, control)?;
+            let socket_file = server_socket_file(&opts.service_file)?;
+            let socket_unit = service_unit_name(&socket_file, SERVER_SOCKET_UNIT);
+            control_server_unit_pair(&opts.unit, &socket_unit, control)?;
             Ok(format!(
-                "Server service {} completed for {}.\n",
+                "Server {} completed for service {} and socket {}.\n",
                 control.as_str(),
-                opts.unit
+                opts.unit,
+                socket_unit
             ))
         }
         ServiceActionKind::Logs {
@@ -179,7 +262,14 @@ pub(crate) fn run_server_service(opts: ServiceActionOptions) -> Result<String, S
             if !confirm {
                 return Err("server uninstall requires --confirm; no changes were made".to_string());
             }
-            let result = uninstall_unit(&opts.service_file, &opts.unit)?;
+            let socket_file = server_socket_file(&opts.service_file)?;
+            let socket_unit = service_unit_name(&socket_file, SERVER_SOCKET_UNIT);
+            let result = uninstall_server_unit_pair(
+                &opts.service_file,
+                &opts.unit,
+                &socket_file,
+                &socket_unit,
+            )?;
             Ok(format!(
                 "Server service {}. Configuration and data were not deleted.\n",
                 if result.removed {
@@ -226,6 +316,7 @@ fn resolve_status_token(opts: &ServerStatusOptions) -> Result<Option<String>, St
 
 pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<String, String> {
     let systemd = query_systemd_status();
+    let socket = query_systemd_socket_status(SERVER_SOCKET_UNIT);
     let token = resolve_status_token(&opts)?;
     let http = fetch_runtime_status(&opts.url, &opts.server_http, token.as_deref()).await?;
     let output = http.output.as_ref();
@@ -253,8 +344,14 @@ pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<Strin
             "http_content_type": http.content_type,
             "http_error": http.error,
             "service": {
+                "loaded": systemd.loaded,
                 "active": systemd.active,
                 "enabled": systemd.enabled,
+            },
+            "socket": {
+                "loaded": socket.loaded,
+                "active": socket.active,
+                "enabled": socket.enabled,
             },
             "auth_enabled": auth_enabled.unwrap_or(Value::Null),
             "configured_public_url": configured_public_url,
@@ -297,8 +394,12 @@ pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<Strin
             out.push_str(&format!("  HTTP error:            {}\n", error));
         }
     }
+    out.push_str(&format!("  service loaded:        {}\n", systemd.loaded));
     out.push_str(&format!("  service active:        {}\n", systemd.active));
     out.push_str(&format!("  service enabled:       {}\n", systemd.enabled));
+    out.push_str(&format!("  socket loaded:         {}\n", socket.loaded));
+    out.push_str(&format!("  socket active:         {}\n", socket.active));
+    out.push_str(&format!("  socket enabled:        {}\n", socket.enabled));
     out.push_str(&format!(
         "  auth_enabled:          {}\n",
         auth_enabled

--- a/crates/webcodex-cli/src/webcodex_cli/server.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/server.rs
@@ -10,7 +10,7 @@ use crate::{
 use super::{
     compare_build_commits, control_server_unit_pair, encode_exec_program, encode_unit_path_value,
     fetch_runtime_status, generate_bootstrap_token, install_server_unit_pair,
-    local_cli_build_metadata, query_systemd_socket_status, query_systemd_status,
+    local_cli_build_metadata, query_systemd_service_status, query_systemd_socket_status,
     read_env_file_value, render_build_metadata_block, render_server_env, run_logs,
     runtime_build_metadata, server_status_revision_check, service_unit_name, token_prefix,
     uninstall_server_unit_pair, validate_systemd_identity, SERVER_SERVICE_UNIT, SERVER_SOCKET_UNIT,
@@ -23,6 +23,7 @@ pub(crate) struct ServerStatusOptions {
     pub(crate) env_file: Option<PathBuf>,
     pub(crate) env_file_explicit: bool,
     pub(crate) token_file: Option<PathBuf>,
+    pub(crate) service_file: PathBuf,
     pub(crate) json: bool,
 }
 
@@ -315,8 +316,11 @@ fn resolve_status_token(opts: &ServerStatusOptions) -> Result<Option<String>, St
 }
 
 pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<String, String> {
-    let systemd = query_systemd_status();
-    let socket = query_systemd_socket_status(SERVER_SOCKET_UNIT);
+    let service_unit = service_unit_name(&opts.service_file, SERVER_SERVICE_UNIT);
+    let socket_file = server_socket_file(&opts.service_file)?;
+    let socket_unit = service_unit_name(&socket_file, SERVER_SOCKET_UNIT);
+    let systemd = query_systemd_service_status(&service_unit);
+    let socket = query_systemd_socket_status(&socket_unit);
     let token = resolve_status_token(&opts)?;
     let http = fetch_runtime_status(&opts.url, &opts.server_http, token.as_deref()).await?;
     let output = http.output.as_ref();
@@ -344,11 +348,13 @@ pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<Strin
             "http_content_type": http.content_type,
             "http_error": http.error,
             "service": {
+                "unit": service_unit,
                 "loaded": systemd.loaded,
                 "active": systemd.active,
                 "enabled": systemd.enabled,
             },
             "socket": {
+                "unit": socket_unit,
                 "loaded": socket.loaded,
                 "active": socket.active,
                 "enabled": socket.enabled,
@@ -394,9 +400,11 @@ pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<Strin
             out.push_str(&format!("  HTTP error:            {}\n", error));
         }
     }
+    out.push_str(&format!("  service unit:          {}\n", service_unit));
     out.push_str(&format!("  service loaded:        {}\n", systemd.loaded));
     out.push_str(&format!("  service active:        {}\n", systemd.active));
     out.push_str(&format!("  service enabled:       {}\n", systemd.enabled));
+    out.push_str(&format!("  socket unit:           {}\n", socket_unit));
     out.push_str(&format!("  socket loaded:         {}\n", socket.loaded));
     out.push_str(&format!("  socket active:         {}\n", socket.active));
     out.push_str(&format!("  socket enabled:        {}\n", socket.enabled));

--- a/crates/webcodex-cli/src/webcodex_cli/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/service.rs
@@ -7,6 +7,7 @@ use crate::ServiceScope;
 
 pub(crate) const SERVER_SERVICE_FILE: &str = "/etc/systemd/system/webcodex.service";
 pub(crate) const SERVER_SERVICE_UNIT: &str = "webcodex.service";
+pub(crate) const SERVER_SOCKET_UNIT: &str = "webcodex.socket";
 pub(crate) const AGENT_SERVICE_UNIT: &str = "webcodex-runner.service";
 pub(crate) const DEFAULT_LOG_LINES: u32 = 200;
 
@@ -65,6 +66,7 @@ impl ProcessExecutor for RealProcessExecutor {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SystemdStatus {
+    pub(crate) loaded: String,
     pub(crate) active: String,
     pub(crate) enabled: String,
 }
@@ -995,6 +997,396 @@ pub(crate) fn install_unit_with_executor_for_scope<E: ProcessExecutor>(
     )
 }
 
+fn pair_rollback<E: ProcessExecutor>(
+    executor: &mut E,
+    systemctl: &Path,
+    service_file: &Path,
+    service_unit: &str,
+    service_snapshot: &InstallSnapshot,
+    socket_file: &Path,
+    socket_unit: &str,
+    socket_snapshot: &InstallSnapshot,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    for (unit, label) in [
+        (socket_unit, "socket stop failed"),
+        (service_unit, "service stop failed"),
+    ] {
+        best_effort_execute(
+            executor,
+            &rollback_invocation(systemctl, "stop", unit),
+            label,
+            &mut errors,
+        );
+    }
+    for (unit, snapshot, label) in [
+        (socket_unit, socket_snapshot, "socket disable failed"),
+        (service_unit, service_snapshot, "service disable failed"),
+    ] {
+        if matches!(snapshot.existing_kind, ExistingUnitKind::Absent) {
+            best_effort_execute(
+                executor,
+                &rollback_invocation(systemctl, "disable", unit),
+                label,
+                &mut errors,
+            );
+        }
+    }
+    for (path, snapshot, label) in [
+        (
+            service_file,
+            service_snapshot,
+            "service unit restore failed",
+        ),
+        (socket_file, socket_snapshot, "socket unit restore failed"),
+    ] {
+        if let Err(error) = restore_unit_file(path, snapshot.previous_content.as_deref()) {
+            push_rollback_error(&mut errors, label, error);
+        }
+    }
+    best_effort_execute(
+        executor,
+        &systemctl_invocation(
+            systemctl,
+            "systemctl daemon-reload",
+            vec!["daemon-reload".to_string()],
+            Some(service_unit),
+        ),
+        "daemon-reload failed",
+        &mut errors,
+    );
+    for (unit, snapshot, prefix) in [
+        (socket_unit, socket_snapshot, "socket"),
+        (service_unit, service_snapshot, "service"),
+    ] {
+        if matches!(snapshot.existing_kind, ExistingUnitKind::ManagedRegularFile) {
+            let (operation, label) = match snapshot.enabled.as_str() {
+                "enabled" => (
+                    Some("enable"),
+                    format!("{prefix} enabled state restore failed"),
+                ),
+                "disabled" => (
+                    Some("disable"),
+                    format!("{prefix} disabled state restore failed"),
+                ),
+                _ => (None, String::new()),
+            };
+            if let Some(operation) = operation {
+                best_effort_execute(
+                    executor,
+                    &rollback_invocation(systemctl, operation, unit),
+                    &label,
+                    &mut errors,
+                );
+            }
+        }
+    }
+    if socket_snapshot.active == "active" {
+        best_effort_execute(
+            executor,
+            &rollback_invocation(systemctl, "start", socket_unit),
+            "socket active state restore failed",
+            &mut errors,
+        );
+    }
+    if service_snapshot.active == "active" {
+        best_effort_execute(
+            executor,
+            &rollback_invocation(systemctl, "start", service_unit),
+            "service active state restore failed",
+            &mut errors,
+        );
+    }
+    errors
+}
+
+pub(crate) fn install_server_unit_pair_with_executor<E: ProcessExecutor>(
+    executor: &mut E,
+    systemctl: &Path,
+    service_file: &Path,
+    service_unit: &str,
+    service_content: &str,
+    socket_file: &Path,
+    socket_unit: &str,
+    socket_content: &str,
+    overwrite: bool,
+    no_start: bool,
+) -> Result<InstallUnitResult, String> {
+    let service_target = preflight_unit_path(service_file, overwrite)?;
+    let socket_target = preflight_unit_path(socket_file, overwrite)?;
+    let service_discovery = discover_existing_unit(executor, systemctl, service_unit)?;
+    let socket_discovery = discover_existing_unit(executor, systemctl, socket_unit)?;
+    let service_kind = classify_existing_unit(
+        service_unit,
+        service_file,
+        service_target,
+        &service_discovery,
+    )?;
+    let socket_kind =
+        classify_existing_unit(socket_unit, socket_file, socket_target, &socket_discovery)?;
+    let service_snapshot = capture_install_snapshot(
+        executor,
+        systemctl,
+        service_file,
+        service_unit,
+        service_kind,
+    )?;
+    let socket_snapshot =
+        capture_install_snapshot(executor, systemctl, socket_file, socket_unit, socket_kind)?;
+
+    if service_snapshot.active == "active"
+        && matches!(socket_snapshot.existing_kind, ExistingUnitKind::Absent)
+    {
+        return Err(format!(
+            "cannot migrate an active legacy {service_unit} directly to socket activation: stop the legacy Server first, then rerun `webcodex server install --overwrite`; this one-time migration boundary is intentionally fail-closed"
+        ));
+    }
+
+    write_text_file_atomic(service_file, service_content, overwrite)?;
+    if let Err(error) = write_text_file_atomic(socket_file, socket_content, overwrite) {
+        let _ = restore_unit_file(service_file, service_snapshot.previous_content.as_deref());
+        return Err(format!("installation failed for Server unit pair: {error}"));
+    }
+
+    let mut plan = vec![systemctl_invocation(
+        systemctl,
+        "systemctl daemon-reload",
+        vec!["daemon-reload".to_string()],
+        Some(service_unit),
+    )];
+    for unit in [socket_unit, service_unit] {
+        plan.push(rollback_invocation(systemctl, "enable", unit));
+    }
+    if no_start {
+        for unit in [socket_unit, service_unit] {
+            plan.push(systemctl_invocation(
+                systemctl,
+                "systemctl is-enabled",
+                vec![
+                    "is-enabled".to_string(),
+                    "--quiet".to_string(),
+                    unit.to_string(),
+                ],
+                Some(unit),
+            ));
+        }
+    } else {
+        for unit in [socket_unit, service_unit] {
+            plan.push(rollback_invocation(systemctl, "start", unit));
+            plan.push(systemctl_invocation(
+                systemctl,
+                "systemctl is-active",
+                vec![
+                    "is-active".to_string(),
+                    "--quiet".to_string(),
+                    unit.to_string(),
+                ],
+                Some(unit),
+            ));
+        }
+    }
+    if let Err(error) = execute_plan(executor, &plan) {
+        let rollback_errors = pair_rollback(
+            executor,
+            systemctl,
+            service_file,
+            service_unit,
+            &service_snapshot,
+            socket_file,
+            socket_unit,
+            &socket_snapshot,
+        );
+        return Err(install_error_with_rollback(
+            "webcodex Server unit pair",
+            error,
+            rollback_errors,
+        ));
+    }
+    Ok(InstallUnitResult {
+        unit: service_unit.to_string(),
+        started: !no_start,
+    })
+}
+
+pub(crate) fn install_server_unit_pair(
+    service_file: &Path,
+    service_unit: &str,
+    service_content: &str,
+    socket_file: &Path,
+    socket_unit: &str,
+    socket_content: &str,
+    overwrite: bool,
+    no_start: bool,
+) -> Result<InstallUnitResult, String> {
+    preflight_unit_path(service_file, overwrite)?;
+    preflight_unit_path(socket_file, overwrite)?;
+    let systemctl = systemctl_path()?;
+    let mut executor = RealProcessExecutor;
+    install_server_unit_pair_with_executor(
+        &mut executor,
+        &systemctl,
+        service_file,
+        service_unit,
+        service_content,
+        socket_file,
+        socket_unit,
+        socket_content,
+        overwrite,
+        no_start,
+    )
+}
+
+pub(crate) fn control_server_unit_pair_with_executor<E: ProcessExecutor>(
+    executor: &mut E,
+    systemctl: &Path,
+    service_unit: &str,
+    socket_unit: &str,
+    control: ServiceControl,
+) -> Result<(), String> {
+    let plan = match control {
+        ServiceControl::Start => vec![
+            rollback_invocation(systemctl, "start", socket_unit),
+            systemctl_invocation(
+                systemctl,
+                "systemctl is-active",
+                vec![
+                    "is-active".to_string(),
+                    "--quiet".to_string(),
+                    socket_unit.to_string(),
+                ],
+                Some(socket_unit),
+            ),
+            rollback_invocation(systemctl, "start", service_unit),
+            systemctl_invocation(
+                systemctl,
+                "systemctl is-active",
+                vec![
+                    "is-active".to_string(),
+                    "--quiet".to_string(),
+                    service_unit.to_string(),
+                ],
+                Some(service_unit),
+            ),
+        ],
+        ServiceControl::Stop => vec![
+            rollback_invocation(systemctl, "stop", socket_unit),
+            rollback_invocation(systemctl, "stop", service_unit),
+        ],
+        ServiceControl::Restart => plan_control(systemctl, service_unit, ServiceControl::Restart),
+    };
+    execute_plan(executor, &plan)
+}
+
+pub(crate) fn control_server_unit_pair(
+    service_unit: &str,
+    socket_unit: &str,
+    control: ServiceControl,
+) -> Result<(), String> {
+    let systemctl = systemctl_path()?;
+    let mut executor = RealProcessExecutor;
+    control_server_unit_pair_with_executor(
+        &mut executor,
+        &systemctl,
+        service_unit,
+        socket_unit,
+        control,
+    )
+}
+
+fn read_managed_unit_for_uninstall(path: &Path) -> Result<Option<String>, String> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!("failed to inspect {}: {error}", path.display()));
+        }
+    };
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+        return Err(format!(
+            "refusing to uninstall non-regular or symlinked systemd unit: {}",
+            path.display()
+        ));
+    }
+    std::fs::read_to_string(path)
+        .map(Some)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))
+}
+
+pub(crate) fn uninstall_server_unit_pair_with_executor<E: ProcessExecutor>(
+    executor: &mut E,
+    systemctl: &Path,
+    service_file: &Path,
+    service_unit: &str,
+    socket_file: &Path,
+    socket_unit: &str,
+) -> Result<UninstallUnitResult, String> {
+    let service_previous = read_managed_unit_for_uninstall(service_file)?;
+    let socket_previous = read_managed_unit_for_uninstall(socket_file)?;
+    if service_previous.is_none() && socket_previous.is_none() {
+        return Ok(UninstallUnitResult {
+            unit: service_unit.to_string(),
+            removed: false,
+        });
+    }
+    for unit in [socket_unit, service_unit] {
+        execute_allow_missing(executor, &rollback_invocation(systemctl, "stop", unit))?;
+        execute_allow_missing(executor, &rollback_invocation(systemctl, "disable", unit))?;
+    }
+    if service_previous.is_some() {
+        std::fs::remove_file(service_file)
+            .map_err(|error| format!("failed to remove {}: {error}", service_file.display()))?;
+    }
+    if socket_previous.is_some() {
+        if let Err(error) = std::fs::remove_file(socket_file) {
+            let _ = restore_unit_file(service_file, service_previous.as_deref());
+            return Err(format!(
+                "failed to remove {}: {error}",
+                socket_file.display()
+            ));
+        }
+    }
+    let reload = systemctl_invocation(
+        systemctl,
+        "systemctl daemon-reload",
+        vec!["daemon-reload".to_string()],
+        Some(service_unit),
+    );
+    if let Err(error) = execute_required(executor, &reload) {
+        let _ = restore_unit_file(service_file, service_previous.as_deref());
+        let _ = restore_unit_file(socket_file, socket_previous.as_deref());
+        let _ = execute_allow_missing(executor, &reload);
+        return Err(error);
+    }
+    for unit in [socket_unit, service_unit] {
+        let _ = execute_allow_missing(
+            executor,
+            &rollback_invocation(systemctl, "reset-failed", unit),
+        );
+    }
+    Ok(UninstallUnitResult {
+        unit: service_unit.to_string(),
+        removed: true,
+    })
+}
+
+pub(crate) fn uninstall_server_unit_pair(
+    service_file: &Path,
+    service_unit: &str,
+    socket_file: &Path,
+    socket_unit: &str,
+) -> Result<UninstallUnitResult, String> {
+    let systemctl = systemctl_path()?;
+    let mut executor = RealProcessExecutor;
+    uninstall_server_unit_pair_with_executor(
+        &mut executor,
+        &systemctl,
+        service_file,
+        service_unit,
+        socket_file,
+        socket_unit,
+    )
+}
+
 pub(crate) fn control_service_with_executor<E: ProcessExecutor>(
     executor: &mut E,
     systemctl: &Path,
@@ -1121,27 +1513,6 @@ pub(crate) fn run_logs_with_executor_for_scope<E: ProcessExecutor>(
     run_logs_with_executor(&mut executor, journalctl, unit, lines, since, follow)
 }
 
-pub(crate) fn install_unit(
-    service_file: &Path,
-    unit: &str,
-    content: &str,
-    overwrite: bool,
-    no_start: bool,
-) -> Result<InstallUnitResult, String> {
-    preflight_unit_path(service_file, overwrite)?;
-    let systemctl = systemctl_path()?;
-    let mut executor = RealProcessExecutor;
-    install_unit_with_executor(
-        &mut executor,
-        &systemctl,
-        service_file,
-        unit,
-        content,
-        overwrite,
-        no_start,
-    )
-}
-
 pub(crate) fn install_unit_for_scope(
     scope: ServiceScope,
     service_file: &Path,
@@ -1165,12 +1536,6 @@ pub(crate) fn install_unit_for_scope(
     )
 }
 
-pub(crate) fn control_service(unit: &str, control: ServiceControl) -> Result<(), String> {
-    let systemctl = systemctl_path()?;
-    let mut executor = RealProcessExecutor;
-    control_service_with_executor(&mut executor, &systemctl, unit, control)
-}
-
 pub(crate) fn control_service_for_scope(
     scope: ServiceScope,
     unit: &str,
@@ -1179,15 +1544,6 @@ pub(crate) fn control_service_for_scope(
     let systemctl = systemctl_path()?;
     let mut executor = RealProcessExecutor;
     control_service_with_executor_for_scope(scope, &mut executor, &systemctl, unit, control)
-}
-
-pub(crate) fn uninstall_unit(
-    service_file: &Path,
-    unit: &str,
-) -> Result<UninstallUnitResult, String> {
-    let systemctl = systemctl_path()?;
-    let mut executor = RealProcessExecutor;
-    uninstall_unit_with_executor(&mut executor, &systemctl, service_file, unit)
 }
 
 pub(crate) fn uninstall_unit_for_scope(
@@ -1252,15 +1608,47 @@ pub(crate) fn run_internal_binary(path: &Path, args: &[String]) -> Result<i32, S
     }
 }
 
+fn query_load_state_output<E: ProcessExecutor>(
+    executor: &mut E,
+    systemctl: &Path,
+    unit: &str,
+) -> String {
+    let invocation = systemctl_invocation(
+        systemctl,
+        "systemctl show LoadState",
+        vec![
+            "show".to_string(),
+            unit.to_string(),
+            "--property=LoadState".to_string(),
+            "--value".to_string(),
+            "--no-pager".to_string(),
+        ],
+        Some(unit),
+    );
+    match executor.execute(&invocation) {
+        Ok(output) if output.success => {
+            let value = output.stdout.trim();
+            if value.is_empty() {
+                "unknown".to_string()
+            } else {
+                value.to_string()
+            }
+        }
+        _ => "unknown".to_string(),
+    }
+}
+
 pub(crate) fn query_systemd_service_status(service_name: &str) -> SystemdStatus {
     let Ok(systemctl) = systemctl_path() else {
         return SystemdStatus {
+            loaded: "unknown".to_string(),
             active: "unknown".to_string(),
             enabled: "unknown".to_string(),
         };
     };
     let mut executor = RealProcessExecutor;
     SystemdStatus {
+        loaded: query_load_state_output(&mut executor, &systemctl, service_name),
         active: query_status_output(&mut executor, &systemctl, service_name, "is-active"),
         enabled: query_status_output(&mut executor, &systemctl, service_name, "is-enabled"),
     }
@@ -1272,6 +1660,7 @@ pub(crate) fn query_systemd_service_status_for_scope(
 ) -> SystemdStatus {
     let Ok(systemctl) = systemctl_path() else {
         return SystemdStatus {
+            loaded: "unknown".to_string(),
             active: "unknown".to_string(),
             enabled: "unknown".to_string(),
         };
@@ -1282,6 +1671,7 @@ pub(crate) fn query_systemd_service_status_for_scope(
         scope,
     };
     SystemdStatus {
+        loaded: query_load_state_output(&mut executor, &systemctl, service_name),
         active: query_status_output(&mut executor, &systemctl, service_name, "is-active"),
         enabled: query_status_output(&mut executor, &systemctl, service_name, "is-enabled"),
     }
@@ -1289,6 +1679,10 @@ pub(crate) fn query_systemd_service_status_for_scope(
 
 pub(crate) fn query_systemd_status() -> SystemdStatus {
     query_systemd_service_status(SERVER_SERVICE_UNIT)
+}
+
+pub(crate) fn query_systemd_socket_status(socket_unit: &str) -> SystemdStatus {
+    query_systemd_service_status(socket_unit)
 }
 
 #[cfg(test)]
@@ -1310,6 +1704,249 @@ mod tests {
             no_start[2].args,
             ["is-enabled", "--quiet", AGENT_SERVICE_UNIT]
         );
+    }
+
+    #[test]
+    fn server_pair_control_keeps_restart_socket_out_of_target_and_stop_prevents_activation() {
+        let systemctl = Path::new("/usr/bin/systemctl");
+
+        let mut restart = FakeExecutor::with_outputs(vec![ok(), ok()]);
+        control_server_unit_pair_with_executor(
+            &mut restart,
+            systemctl,
+            SERVER_SERVICE_UNIT,
+            SERVER_SOCKET_UNIT,
+            ServiceControl::Restart,
+        )
+        .unwrap();
+        assert_eq!(restart.calls[0], ["restart", SERVER_SERVICE_UNIT]);
+        assert_eq!(
+            restart.calls[1],
+            ["is-active", "--quiet", SERVER_SERVICE_UNIT]
+        );
+        assert!(restart
+            .calls
+            .iter()
+            .all(|args| !args.contains(&SERVER_SOCKET_UNIT.to_string())));
+
+        let mut stop = FakeExecutor::with_outputs(vec![ok(), ok()]);
+        control_server_unit_pair_with_executor(
+            &mut stop,
+            systemctl,
+            SERVER_SERVICE_UNIT,
+            SERVER_SOCKET_UNIT,
+            ServiceControl::Stop,
+        )
+        .unwrap();
+        assert_eq!(
+            stop.calls,
+            [["stop", SERVER_SOCKET_UNIT], ["stop", SERVER_SERVICE_UNIT]]
+        );
+
+        let mut start = FakeExecutor::with_outputs(vec![ok(), ok(), ok(), ok()]);
+        control_server_unit_pair_with_executor(
+            &mut start,
+            systemctl,
+            SERVER_SERVICE_UNIT,
+            SERVER_SOCKET_UNIT,
+            ServiceControl::Start,
+        )
+        .unwrap();
+        assert_eq!(start.calls[0], ["start", SERVER_SOCKET_UNIT]);
+        assert_eq!(start.calls[1], ["is-active", "--quiet", SERVER_SOCKET_UNIT]);
+        assert_eq!(start.calls[2], ["start", SERVER_SERVICE_UNIT]);
+        assert_eq!(
+            start.calls[3],
+            ["is-active", "--quiet", SERVER_SERVICE_UNIT]
+        );
+    }
+
+    #[test]
+    fn server_pair_no_start_enables_both_without_starting() {
+        let tmp = tempfile::tempdir().unwrap();
+        let service_file = tmp.path().join("webcodex.service");
+        let socket_file = tmp.path().join("webcodex.socket");
+        let mut executor = FakeExecutor::with_outputs(vec![
+            absent_discovery(),
+            absent_discovery(),
+            status("inactive"),
+            status("disabled"),
+            status("inactive"),
+            status("disabled"),
+            ok(),
+            ok(),
+            ok(),
+            status("enabled"),
+            status("enabled"),
+        ]);
+        let result = install_server_unit_pair_with_executor(
+            &mut executor,
+            Path::new("/usr/bin/systemctl"),
+            &service_file,
+            SERVER_SERVICE_UNIT,
+            "service unit",
+            &socket_file,
+            SERVER_SOCKET_UNIT,
+            "socket unit",
+            false,
+            true,
+        )
+        .unwrap();
+        assert!(!result.started);
+        assert_eq!(
+            std::fs::read_to_string(&service_file).unwrap(),
+            "service unit"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&socket_file).unwrap(),
+            "socket unit"
+        );
+        assert!(executor
+            .calls
+            .iter()
+            .any(|args| args == &["enable", SERVER_SOCKET_UNIT]));
+        assert!(executor
+            .calls
+            .iter()
+            .any(|args| args == &["enable", SERVER_SERVICE_UNIT]));
+        assert!(!executor
+            .calls
+            .iter()
+            .any(|args| args.first().map(String::as_str) == Some("start")));
+    }
+
+    #[test]
+    fn server_pair_install_failure_rolls_back_both_unit_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let service_file = tmp.path().join("webcodex.service");
+        let socket_file = tmp.path().join("webcodex.socket");
+        let mut executor = FakeExecutor::with_outputs(vec![
+            absent_discovery(),
+            absent_discovery(),
+            status("inactive"),
+            status("disabled"),
+            status("inactive"),
+            status("disabled"),
+            ok(),
+            ok(),
+            failed("service enable rejected"),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+        ]);
+        let error = install_server_unit_pair_with_executor(
+            &mut executor,
+            Path::new("/usr/bin/systemctl"),
+            &service_file,
+            SERVER_SERVICE_UNIT,
+            "service unit",
+            &socket_file,
+            SERVER_SOCKET_UNIT,
+            "socket unit",
+            false,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.contains("service enable rejected"), "{error}");
+        assert!(!service_file.exists());
+        assert!(!socket_file.exists());
+        assert_eq!(executor.calls[9], ["stop", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[10], ["stop", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[11], ["disable", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[12], ["disable", SERVER_SERVICE_UNIT]);
+    }
+
+    #[test]
+    fn active_legacy_server_migration_fails_before_pair_mutation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let service_file = tmp.path().join("webcodex.service");
+        let socket_file = tmp.path().join("webcodex.socket");
+        std::fs::write(&service_file, "legacy unit").unwrap();
+        let mut executor = FakeExecutor::with_outputs(vec![
+            discovery("loaded", service_file.to_str().unwrap()),
+            absent_discovery(),
+            status("active"),
+            status("enabled"),
+            status("inactive"),
+            status("disabled"),
+        ]);
+        let error = install_server_unit_pair_with_executor(
+            &mut executor,
+            Path::new("/usr/bin/systemctl"),
+            &service_file,
+            SERVER_SERVICE_UNIT,
+            "new service",
+            &socket_file,
+            SERVER_SOCKET_UNIT,
+            "new socket",
+            true,
+            false,
+        )
+        .unwrap_err();
+        assert!(error.contains("active legacy"), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(&service_file).unwrap(),
+            "legacy unit"
+        );
+        assert!(!socket_file.exists());
+        assert_eq!(executor.calls.len(), 6);
+    }
+
+    #[test]
+    fn server_pair_uninstall_stops_socket_before_service_and_removes_both() {
+        let tmp = tempfile::tempdir().unwrap();
+        let service_file = tmp.path().join("webcodex.service");
+        let socket_file = tmp.path().join("webcodex.socket");
+        std::fs::write(&service_file, "service").unwrap();
+        std::fs::write(&socket_file, "socket").unwrap();
+        let mut executor =
+            FakeExecutor::with_outputs(vec![ok(), ok(), ok(), ok(), ok(), ok(), ok()]);
+        let result = uninstall_server_unit_pair_with_executor(
+            &mut executor,
+            Path::new("/usr/bin/systemctl"),
+            &service_file,
+            SERVER_SERVICE_UNIT,
+            &socket_file,
+            SERVER_SOCKET_UNIT,
+        )
+        .unwrap();
+        assert!(result.removed);
+        assert_eq!(executor.calls[0], ["stop", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[1], ["disable", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[2], ["stop", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[3], ["disable", SERVER_SERVICE_UNIT]);
+        assert!(!service_file.exists());
+        assert!(!socket_file.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn server_pair_uninstall_rejects_symlink_before_systemctl() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("real.service");
+        let service_file = tmp.path().join("webcodex.service");
+        let socket_file = tmp.path().join("webcodex.socket");
+        std::fs::write(&target, "service").unwrap();
+        symlink(&target, &service_file).unwrap();
+        std::fs::write(&socket_file, "socket").unwrap();
+        let mut executor = FakeExecutor::default();
+        let error = uninstall_server_unit_pair_with_executor(
+            &mut executor,
+            Path::new("/usr/bin/systemctl"),
+            &service_file,
+            SERVER_SERVICE_UNIT,
+            &socket_file,
+            SERVER_SOCKET_UNIT,
+        )
+        .unwrap_err();
+        assert!(error.contains("symlinked systemd unit"), "{error}");
+        assert!(executor.calls.is_empty());
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "service");
+        assert!(socket_file.exists());
     }
 
     #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/service.rs
@@ -1243,6 +1243,17 @@ pub(crate) fn control_server_unit_pair_with_executor<E: ProcessExecutor>(
     socket_unit: &str,
     control: ServiceControl,
 ) -> Result<(), String> {
+    if control == ServiceControl::Stop {
+        execute_allow_missing(
+            executor,
+            &rollback_invocation(systemctl, "stop", socket_unit),
+        )?;
+        execute_required(
+            executor,
+            &rollback_invocation(systemctl, "stop", service_unit),
+        )?;
+        return Ok(());
+    }
     let plan = match control {
         ServiceControl::Start => vec![
             rollback_invocation(systemctl, "start", socket_unit),
@@ -1268,11 +1279,8 @@ pub(crate) fn control_server_unit_pair_with_executor<E: ProcessExecutor>(
                 Some(service_unit),
             ),
         ],
-        ServiceControl::Stop => vec![
-            rollback_invocation(systemctl, "stop", socket_unit),
-            rollback_invocation(systemctl, "stop", service_unit),
-        ],
         ServiceControl::Restart => plan_control(systemctl, service_unit, ServiceControl::Restart),
+        ServiceControl::Stop => unreachable!("stop is handled above"),
     };
     execute_plan(executor, &plan)
 }
@@ -1677,10 +1685,6 @@ pub(crate) fn query_systemd_service_status_for_scope(
     }
 }
 
-pub(crate) fn query_systemd_status() -> SystemdStatus {
-    query_systemd_service_status(SERVER_SERVICE_UNIT)
-}
-
 pub(crate) fn query_systemd_socket_status(socket_unit: &str) -> SystemdStatus {
     query_systemd_service_status(socket_unit)
 }
@@ -1740,6 +1744,21 @@ mod tests {
         .unwrap();
         assert_eq!(
             stop.calls,
+            [["stop", SERVER_SOCKET_UNIT], ["stop", SERVER_SERVICE_UNIT]]
+        );
+
+        let mut legacy_stop =
+            FakeExecutor::with_outputs(vec![failed("Unit webcodex.socket not found."), ok()]);
+        control_server_unit_pair_with_executor(
+            &mut legacy_stop,
+            systemctl,
+            SERVER_SERVICE_UNIT,
+            SERVER_SOCKET_UNIT,
+            ServiceControl::Stop,
+        )
+        .unwrap();
+        assert_eq!(
+            legacy_stop.calls,
             [["stop", SERVER_SOCKET_UNIT], ["stop", SERVER_SERVICE_UNIT]]
         );
 

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -219,6 +219,23 @@ fn server_socket_rendering_uses_env_address_custom_sibling_and_no_start_projecti
 
 #[cfg(unix)]
 #[test]
+fn server_service_actions_target_custom_service_and_sibling_socket() {
+    let custom = "/etc/systemd/system/webcodex-canary.service";
+    for command in ["start", "stop", "restart", "logs"] {
+        let opts =
+            parse_server_service_action(command, &args(&["--service-file", custom])).unwrap();
+        assert_eq!(opts.service_file, std::path::PathBuf::from(custom));
+        assert_eq!(opts.unit, "webcodex-canary.service");
+    }
+    let uninstall =
+        parse_server_service_action("uninstall", &args(&["--service-file", custom, "--confirm"]))
+            .unwrap();
+    assert_eq!(uninstall.service_file, std::path::PathBuf::from(custom));
+    assert_eq!(uninstall.unit, "webcodex-canary.service");
+}
+
+#[cfg(unix)]
+#[test]
 fn server_socket_rendering_fails_closed_on_missing_or_malformed_address() {
     let tmp = tempfile::tempdir().unwrap();
     let missing = tmp.path().join("missing.env");
@@ -549,15 +566,21 @@ fn special_supported_paths_pass_systemd_analyze_verify() {
         env_file.to_str().unwrap(),
         "--working-directory",
         working.to_str().unwrap(),
-        "--dry-run",
+        "--output",
+        "-",
+        "--json",
     ]))
     .unwrap();
-    let server_unit = run_server_install_service(server).unwrap();
+    let server_json: Value =
+        serde_json::from_str(&run_server_install_service(server).unwrap()).unwrap();
+    let server_unit = server_json["units"]["service"].as_str().unwrap();
+    let socket_unit = server_json["units"]["socket"].as_str().unwrap();
     assert!(server_unit.contains("\\x20"));
     assert!(server_unit.contains("\\x22"));
     assert!(server_unit.contains("\\x5c"));
     assert!(server_unit.contains("%%p"));
-    verify_systemd_unit(&server_unit, "webcodex-special.service");
+    verify_systemd_unit(server_unit, "webcodex-special.service");
+    verify_systemd_unit(socket_unit, "webcodex-special.socket");
 
     let agent = parse_agent_install_service(&args(&[
         "--scope",

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -2,14 +2,27 @@
 #[cfg(unix)]
 use super::super::support::*;
 
+#[cfg(unix)]
+fn server_env(tmp: &tempfile::TempDir) -> std::path::PathBuf {
+    let path = tmp.path().join("webcodex.env");
+    std::fs::write(
+        &path,
+        "WEBCODEX_ADDR=127.0.0.1:8080\nWEBCODEX_TOKEN=secret-never-inline\n",
+    )
+    .unwrap();
+    path
+}
+
 /// Unix-only: systemd service unit semantics with Unix absolute-path
 /// rules. On Windows the systemd service feature fails closed.
 #[cfg(unix)]
 #[test]
 fn install_service_generates_expected_unit_without_tokens() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = server_env(&tmp);
     let opts = parse_server_install_service(&args(&[
         "--env-file",
-        "/etc/webcodex/webcodex.env",
+        env_file.to_str().unwrap(),
         "--bin",
         "/usr/local/bin/webcodex-server",
         "--working-directory",
@@ -23,13 +36,18 @@ fn install_service_generates_expected_unit_without_tokens() {
     .unwrap();
     let unit = run_server_install_service(opts).unwrap();
     assert!(unit.contains("[Unit]\nDescription=WebCodex Runtime\n"));
-    assert!(unit.contains("EnvironmentFile=/etc/webcodex/webcodex.env\n"));
+    assert!(unit.contains(&format!("EnvironmentFile={}\n", env_file.display())));
+    assert!(unit.contains("ListenStream=127.0.0.1:8080\n"));
+    assert!(unit.contains("FileDescriptorName=webcodex-http\n"));
+    assert!(unit.contains("Service=webcodex.service\n"));
+    assert!(unit.contains("# /etc/systemd/system/webcodex.socket\n"));
     assert!(unit.contains("ExecStart=\"/usr/local/bin/webcodex-server\"\n"));
     assert!(unit.contains("WorkingDirectory=/var/lib/webcodex\n"));
     assert!(unit.contains("User=webcodex\n"));
     assert!(unit.contains("Group=webcodex\n"));
     assert!(unit.contains("WantedBy=multi-user.target\n"));
     assert!(!unit.contains("WEBCODEX_TOKEN"));
+    assert!(!unit.contains("secret-never-inline"));
     assert!(!unit.contains("wc_boot_"));
 }
 
@@ -95,10 +113,13 @@ fn explicitly_allowed_root_runner_is_visibly_marked() {
 fn install_service_refuses_overwrite_unless_requested() {
     let tmp = tempfile::tempdir().unwrap();
     let service_file = tmp.path().join("webcodex.service");
+    let env_file = server_env(&tmp);
     std::fs::write(&service_file, "old").unwrap();
     let opts = parse_server_install_service(&args(&[
         "--bin",
         "/usr/local/bin/webcodex-server",
+        "--env-file",
+        env_file.to_str().unwrap(),
         "--service-file",
         service_file.to_str().unwrap(),
     ]))
@@ -112,9 +133,13 @@ fn install_service_refuses_overwrite_unless_requested() {
 #[cfg(unix)]
 #[test]
 fn install_service_dry_run_and_output_work_without_systemd() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = server_env(&tmp);
     let dry = parse_server_install_service(&args(&[
         "--bin",
         "/usr/local/bin/webcodex-server",
+        "--env-file",
+        env_file.to_str().unwrap(),
         "--dry-run",
     ]))
     .unwrap();
@@ -125,6 +150,8 @@ fn install_service_dry_run_and_output_work_without_systemd() {
     let out = parse_server_install_service(&args(&[
         "--bin",
         "/usr/local/bin/webcodex-server",
+        "--env-file",
+        env_file.to_str().unwrap(),
         "--output",
         "-",
         "--json",
@@ -132,7 +159,105 @@ fn install_service_dry_run_and_output_work_without_systemd() {
     .unwrap();
     let json: Value = serde_json::from_str(&run_server_install_service(out).unwrap()).unwrap();
     assert_eq!(json["dry_run"], true);
-    assert!(json["unit"].as_str().unwrap().contains("[Service]"));
+    assert!(json["units"]["service"]
+        .as_str()
+        .unwrap()
+        .contains("[Service]"));
+    assert!(json["units"]["socket"]
+        .as_str()
+        .unwrap()
+        .contains("[Socket]"));
+    assert_eq!(json["listen"], "127.0.0.1:8080");
+}
+
+#[cfg(unix)]
+#[test]
+fn server_socket_rendering_uses_env_address_custom_sibling_and_no_start_projection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("server.env");
+    std::fs::write(
+        &env_file,
+        "WEBCODEX_ADDR=127.0.0.1:9090\nWEBCODEX_TOKEN=hidden\n",
+    )
+    .unwrap();
+    let service_file = tmp.path().join("custom-webcodex.service");
+    let opts = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--service-file",
+        service_file.to_str().unwrap(),
+        "--bin",
+        "/usr/local/bin/webcodex-server",
+        "--no-start",
+        "--output",
+        "-",
+        "--json",
+    ]))
+    .unwrap();
+    let json: Value = serde_json::from_str(&run_server_install_service(opts).unwrap()).unwrap();
+    assert_eq!(json["no_start"], true);
+    assert_eq!(json["listen"], "127.0.0.1:9090");
+    assert_eq!(
+        json["socket_file"],
+        service_file
+            .with_extension("socket")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert_eq!(json["service_unit"], "custom-webcodex.service");
+    assert_eq!(json["socket_unit"], "custom-webcodex.socket");
+    assert!(json["units"]["service"]
+        .as_str()
+        .unwrap()
+        .contains("Requires=custom-webcodex.socket\n"));
+    assert!(json["units"]["socket"]
+        .as_str()
+        .unwrap()
+        .contains("Service=custom-webcodex.service\n"));
+    assert!(!json.to_string().contains("hidden"));
+}
+
+#[cfg(unix)]
+#[test]
+fn server_socket_rendering_fails_closed_on_missing_or_malformed_address() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("missing.env");
+    let opts = parse_server_install_service(&args(&[
+        "--env-file",
+        missing.to_str().unwrap(),
+        "--bin",
+        "/usr/local/bin/webcodex-server",
+        "--dry-run",
+    ]))
+    .unwrap();
+    let error = run_server_install_service(opts).unwrap_err();
+    assert!(error.contains("does not exist"), "{error}");
+
+    let malformed = tmp.path().join("malformed.env");
+    std::fs::write(&malformed, "WEBCODEX_ADDR=localhost:not-a-port\n").unwrap();
+    let opts = parse_server_install_service(&args(&[
+        "--env-file",
+        malformed.to_str().unwrap(),
+        "--bin",
+        "/usr/local/bin/webcodex-server",
+        "--dry-run",
+    ]))
+    .unwrap();
+    let error = run_server_install_service(opts).unwrap_err();
+    assert!(error.contains("systemd ListenStream"), "{error}");
+
+    let absent_key = tmp.path().join("no-address.env");
+    std::fs::write(&absent_key, "WEBCODEX_TOKEN=hidden\n").unwrap();
+    let opts = parse_server_install_service(&args(&[
+        "--env-file",
+        absent_key.to_str().unwrap(),
+        "--bin",
+        "/usr/local/bin/webcodex-server",
+        "--dry-run",
+    ]))
+    .unwrap();
+    let error = run_server_install_service(opts).unwrap_err();
+    assert!(error.contains("does not define WEBCODEX_ADDR"), "{error}");
 }
 
 /// Unix-only: systemd service unit semantics with Unix absolute-path
@@ -259,9 +384,13 @@ fn agent_install_service_dry_run_and_output_work_without_systemd() {
 #[cfg(unix)]
 #[test]
 fn systemd_unit_rendering_quotes_paths_and_rejects_invalid_fields_in_dry_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("env files").join("web\"codex\\main.env");
+    std::fs::create_dir_all(env_file.parent().unwrap()).unwrap();
+    std::fs::write(&env_file, "WEBCODEX_ADDR=127.0.0.1:8080\n").unwrap();
     let server = parse_server_install_service(&args(&[
         "--env-file",
-        "/etc/webcodex/env files/web\"codex\\main.env",
+        env_file.to_str().unwrap(),
         "--bin",
         "/opt/web codex/bin/webcodex-server%p",
         "--working-directory",
@@ -274,7 +403,7 @@ fn systemd_unit_rendering_quotes_paths_and_rejects_invalid_fields_in_dry_run() {
     ]))
     .unwrap();
     let unit = run_server_install_service(server).unwrap();
-    assert!(unit.contains("EnvironmentFile=/etc/webcodex/env\\x20files/web\\x22codex\\x5cmain.env"));
+    assert!(unit.contains("env\\x20files/web\\x22codex\\x5cmain.env"));
     assert!(unit.contains("ExecStart=\"/opt/web codex/bin/webcodex-server%%p\""));
     assert!(unit.contains("WorkingDirectory=/var/lib/web\\x20codex\\x5cwork"));
     assert!(unit.contains("User=web_codex-1.service"));
@@ -350,22 +479,30 @@ fn generated_server_and_agent_units_pass_systemd_analyze_verify() {
     let runner_bin = tmp.path().join("webcodex-runner");
     make_executable(&server_bin);
     make_executable(&runner_bin);
+    let env_file = server_env(&tmp);
 
     let server = parse_server_install_service(&args(&[
         "--bin",
         server_bin.to_str().unwrap(),
         "--env-file",
-        "/etc/webcodex/webcodex.env",
+        env_file.to_str().unwrap(),
         "--working-directory",
         "/var/lib/webcodex",
-        "--dry-run",
+        "--output",
+        "-",
+        "--json",
     ]))
     .unwrap();
-    let server_unit = run_server_install_service(server).unwrap();
-    assert!(server_unit.contains("EnvironmentFile=/etc/webcodex/webcodex.env\n"));
-    assert!(server_unit.contains("WorkingDirectory=/var/lib/webcodex\n"));
-    assert!(server_unit.contains("webcodex-server"));
-    verify_systemd_unit(&server_unit, "webcodex-default.service");
+    let server_json: Value =
+        serde_json::from_str(&run_server_install_service(server).unwrap()).unwrap();
+    let service_unit = server_json["units"]["service"].as_str().unwrap();
+    let socket_unit = server_json["units"]["socket"].as_str().unwrap();
+    assert!(service_unit.contains(&format!("EnvironmentFile={}\n", env_file.display())));
+    assert!(service_unit.contains("WorkingDirectory=/var/lib/webcodex\n"));
+    assert!(service_unit.contains("webcodex-server"));
+    assert!(socket_unit.contains("ListenStream=127.0.0.1:8080\n"));
+    verify_systemd_unit(service_unit, "webcodex-default.service");
+    verify_systemd_unit(socket_unit, "webcodex-default.socket");
 
     let config = tmp.path().join("agent.toml");
     std::fs::write(&config, "server_url = \"http://127.0.0.1\"\n").unwrap();
@@ -401,7 +538,7 @@ fn special_supported_paths_pass_systemd_analyze_verify() {
     let working = tmp.path().join("work space\"slash\\percent%p");
     std::fs::create_dir(&working).unwrap();
     let env_file = tmp.path().join("env space\"slash\\percent%p.env");
-    std::fs::write(&env_file, "WEBCODEX_LISTEN=127.0.0.1:0\n").unwrap();
+    std::fs::write(&env_file, "WEBCODEX_ADDR=127.0.0.1:8080\n").unwrap();
     let config = tmp.path().join("config space\"slash\\percent%p.toml");
     std::fs::write(&config, "server_url = \"http://127.0.0.1\"\n").unwrap();
 

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
@@ -93,6 +93,19 @@ fn server_status_handles_missing_remote_build_metadata() {
     assert!(detail.contains("server may be older than build metadata support"));
 }
 
+#[test]
+fn server_status_accepts_custom_service_file() {
+    let opts = parse_server_status(&args(&[
+        "--service-file",
+        "/etc/systemd/system/webcodex-canary.service",
+    ]))
+    .unwrap();
+    assert_eq!(
+        opts.service_file,
+        std::path::PathBuf::from("/etc/systemd/system/webcodex-canary.service")
+    );
+}
+
 #[tokio::test]
 async fn server_status_parses_env_token_posts_and_does_not_print_token() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -275,7 +275,8 @@ Commands:\n\
   restart     Restart only the Server service while the socket stays active\n\
   status      Check socket/service state, HTTP reachability, and build revisions\n\
   logs        Read bounded Server service journal logs or explicitly follow them\n\
-  uninstall   Remove only the systemd socket/service pair; requires --confirm\n"
+  uninstall   Remove only the systemd socket/service pair; requires --confirm\n\n\
+For start/stop/restart/logs/uninstall, --service-file PATH targets a custom managed service unit and derives its sibling .socket.\n"
 }
 
 pub(crate) fn server_init_usage() -> &'static str {
@@ -318,6 +319,7 @@ pub(crate) fn server_status_usage() -> &'static str {
        --no-system-proxy      Ignore proxy environment and connect directly\n\
        --env-file PATH        Read WEBCODEX_TOKEN from env file [default: root /etc/webcodex/webcodex.env; user ~/.config/webcodex/webcodex.env]\n\
        --token-file PATH      Read bearer token from file\n\
+       --service-file PATH    Managed service unit path; sibling .socket is derived [default: /etc/systemd/system/webcodex.service]\n\
        --json                 Print a machine-readable summary\n\
        -h, --help             Print help and exit\n\n\
      Token priority: --token-file, WEBCODEX_TOKEN from --env-file, process\n\

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -268,14 +268,14 @@ pub(crate) fn server_usage() -> &'static str {
     "Usage: webcodex server <COMMAND>\n\n\
 Commands:\n\
   init        Initialize or update Server configuration\n\
-  install     Install, enable, and start the systemd service\n\
+  install     Install, enable, and start the systemd socket/service pair\n\
   run         Run webcodex-server directly in the foreground\n\
-  start       Start the installed service\n\
-  stop        Stop the installed service\n\
-  restart     Restart and verify the installed service\n\
-  status      Check systemd, HTTP reachability, and build revisions\n\
-  logs        Read bounded journal logs or explicitly follow them\n\
-  uninstall   Remove only the systemd unit; requires --confirm\n"
+  start       Start the listener socket, then the Server service\n\
+  stop        Stop socket activation and the Server service\n\
+  restart     Restart only the Server service while the socket stays active\n\
+  status      Check socket/service state, HTTP reachability, and build revisions\n\
+  logs        Read bounded Server service journal logs or explicitly follow them\n\
+  uninstall   Remove only the systemd socket/service pair; requires --confirm\n"
 }
 
 pub(crate) fn server_init_usage() -> &'static str {
@@ -297,17 +297,17 @@ pub(crate) fn server_install_service_usage() -> &'static str {
 Options:\n\
   --env-file PATH             EnvironmentFile= path\n\
   --bin PATH                  webcodex-server path; sibling then absolute PATH by default\n\
-  --service-file PATH         Unit path [default: /etc/systemd/system/webcodex.service]\n\
+  --service-file PATH         Service unit path; sibling .socket is derived [default: /etc/systemd/system/webcodex.service]\n\
   --user USER                 Optional systemd User=\n\
   --group GROUP               Optional systemd Group=\n\
   --working-directory PATH    WorkingDirectory=\n\
-  --overwrite                 Replace an existing unit\n\
-  --no-start                  Enable without starting immediately\n\
+  --overwrite                 Replace an existing managed socket/service pair\n\
+  --no-start                  Enable both units without starting immediately\n\
   --dry-run                   Render only; never call systemctl\n\
   --output -                  Render only; never call systemctl\n\
   --json                      Print machine-readable output\n\
   -h, --help                  Print help and exit\n\n\
-Normal execution runs daemon-reload, enable --now (or enable with --no-start), and verifies state. Tokens are never inlined.\n"
+Normal execution installs both units coherently, runs daemon-reload, enables both, then starts the socket before the service unless --no-start is used. Tokens are never inlined.\n"
 }
 
 pub(crate) fn server_status_usage() -> &'static str {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -107,12 +107,13 @@ keep their detached-process behavior when `--scope` is omitted.
 | Command | Purpose |
 | --- | --- |
 | `webcodex server init` | Initialize or update the Server env file (creates the bootstrap token) |
-| `webcodex server install` | Install the `webcodex-server` systemd service |
-| `webcodex server run` | Run `webcodex-server` in the foreground |
-| `webcodex server start` / `stop` / `restart` | Control the installed service |
-| `webcodex server status` | Check systemd, HTTP reachability, and build revisions |
-| `webcodex server logs` | Read the service journal |
-| `webcodex server uninstall` | Remove the service unit |
+| `webcodex server install` | Install the Linux systemd `webcodex.socket` + `webcodex.service` pair |
+| `webcodex server run` | Run `webcodex-server` in the foreground (direct bind) |
+| `webcodex server start` / `stop` | Start or stop socket activation and the Server process coherently |
+| `webcodex server restart` | Restart only the Server process; keep the managed listener socket active |
+| `webcodex server status` | Check authoritative socket/service state, HTTP reachability, and build revisions |
+| `webcodex server logs` | Read the Server service journal |
+| `webcodex server uninstall` | Stop, disable, and remove the managed socket/service pair |
 
 ### Operations (read-only operator checks)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -115,6 +115,11 @@ keep their detached-process behavior when `--scope` is omitted.
 | `webcodex server logs` | Read the Server service journal |
 | `webcodex server uninstall` | Stop, disable, and remove the managed socket/service pair |
 
+`webcodex server install --service-file /path/name.service` derives the sibling
+`/path/name.socket`. Use the same `--service-file` on `start`, `stop`, `restart`,
+`status`, `logs`, and `uninstall` to manage or inspect that custom pair; omitting
+it targets the default `webcodex.service` / `webcodex.socket` pair.
+
 ### Operations (read-only operator checks)
 
 | Command | Purpose |

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -98,12 +98,13 @@ detached-process 行为。
 | 命令 | 用途 |
 | --- | --- |
 | `webcodex server init` | 初始化或更新 Server env 文件（创建 bootstrap token） |
-| `webcodex server install` | 安装 `webcodex-server` 的 systemd 服务 |
-| `webcodex server run` | 前台运行 `webcodex-server` |
-| `webcodex server start` / `stop` / `restart` | 控制已安装的服务 |
-| `webcodex server status` | 检查 systemd、HTTP 可达性与构建版本 |
-| `webcodex server logs` | 读取服务日志 |
-| `webcodex server uninstall` | 移除服务单元 |
+| `webcodex server install` | 安装 Linux systemd `webcodex.socket` + `webcodex.service` pair |
+| `webcodex server run` | 前台运行 `webcodex-server`（direct bind） |
+| `webcodex server start` / `stop` | 一致地启动或停止 socket activation 与 Server process |
+| `webcodex server restart` | 只 restart Server process，保持受管 listener socket active |
+| `webcodex server status` | 检查 authoritative socket/service 状态、HTTP 可达性与构建版本 |
+| `webcodex server logs` | 读取 Server service journal |
+| `webcodex server uninstall` | stop/disable/remove 受管 socket/service pair |
 
 ### 运维（只读操作检查）
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -106,6 +106,11 @@ detached-process 行为。
 | `webcodex server logs` | 读取 Server service journal |
 | `webcodex server uninstall` | stop/disable/remove 受管 socket/service pair |
 
+使用 `webcodex server install --service-file /path/name.service` 时，会派生同目录的
+`/path/name.socket`。后续 `start`、`stop`、`restart`、`status`、`logs` 和 `uninstall`
+应传入相同的 `--service-file` 来管理或检查该自定义 pair；省略时仍操作默认的
+`webcodex.service` / `webcodex.socket` pair。
+
 ### 运维（只读操作检查）
 
 | 命令 | 用途 |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -93,18 +93,36 @@ sudo webcodex server init \
 `server init` creates only the server-side bootstrap/admin token. It does not
 create user API tokens or agent tokens.
 
-Install and start the systemd service:
+Install and start the managed systemd socket/service pair:
 
 ```bash
 sudo webcodex server install \
   --env-file /etc/webcodex/webcodex.env \
   --bin /usr/local/bin/webcodex-server
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex
 webcodex server status --env-file /etc/webcodex/webcodex.env
 ```
 
-Use `--overwrite` on `server install` only when replacing an existing unit.
+The managed Linux layout is intentionally split: `webcodex.socket` owns the
+fixed `WEBCODEX_ADDR` listener, while `webcodex.service` owns only the Server
+process. For ordinary binary replacement after this socket-activated layout is
+established, stage the replacement and run:
+
+```bash
+sudo systemctl restart webcodex.service
+```
+
+Do **not** restart `webcodex.socket` during the normal Server replacement path.
+The socket remains bound while the old Server exits and the new process inherits
+the same listener, eliminating the listener/`ECONNREFUSED` gap under normal
+bounded-backlog conditions. Existing HTTP keep-alive, WebSocket, and streaming
+connections may still disconnect and reconnect; graceful in-flight drain is a
+separate L2 capability and is not claimed here.
+
+Use `--overwrite` on `server install` only when replacing an existing managed
+pair. Migrating an already-active legacy direct-bind `webcodex.service` is a
+one-time migration boundary: the installer fails closed rather than competing
+for the live address. Stop the legacy Server first, then rerun the install with
+`--overwrite`. This boundary does not provide a gap-free first migration.
 
 ### Tool invocation tracing
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -82,18 +82,32 @@ sudo webcodex server init \
 `server init` 只创建 server 侧 bootstrap/admin token。它不创建 user API token
 或 agent token。
 
-安装并启动 systemd 服务：
+安装并启动受管 systemd socket/service pair：
 
 ```bash
 sudo webcodex server install \
   --env-file /etc/webcodex/webcodex.env \
   --bin /usr/local/bin/webcodex-server
-sudo systemctl daemon-reload
-sudo systemctl enable --now webcodex
 webcodex server status --env-file /etc/webcodex/webcodex.env
 ```
 
-只有替换已有 unit 时才在 `server install` 上使用 `--overwrite`。
+受管 Linux 部署会明确拆分职责：`webcodex.socket` 持有固定的
+`WEBCODEX_ADDR` listener，`webcodex.service` 只持有 Server process。该结构建立后，
+普通二进制替换应先放置新 binary，然后执行：
+
+```bash
+sudo systemctl restart webcodex.service
+```
+
+正常替换路径不要 restart `webcodex.socket`。旧 Server 退出到新 Server 继承 listener
+期间，socket 仍持续绑定，因此在正常有界 backlog 条件下消除 listener gap / `ECONNREFUSED`
+窗口。已有 HTTP keep-alive、WebSocket 与 streaming connection 仍可能断开后重连；本轮
+不宣称 graceful in-flight drain，这属于后续独立 L2 capability。
+
+只有替换已有受管 pair 时才在 `server install` 上使用 `--overwrite`。如果当前仍是
+正在运行的 legacy direct-bind `webcodex.service`，第一次迁移属于单独的一次 migration
+boundary：installer 会 fail closed，避免与旧进程争抢地址。先停止 legacy Server，再用
+`--overwrite` 重新安装；这次首次迁移本身不保证无 gap。
 
 ### Tool invocation trace
 

--- a/scripts/e2e_linux_socket_activation.py
+++ b/scripts/e2e_linux_socket_activation.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Focused Linux L1 socket-activation and listener-continuity proof.
+
+This deliberately does not require PID 1 systemd. It has two focused scenarios:
+1. systemd-socket-activate -> inherited fd 3 -> real webcodex-server -> HTTP.
+2. A parent-owned TCP listener survives Server A termination and is inherited by
+   Server B while bounded client probes classify success/reset/timeout/refused.
+
+L1's authoritative continuity assertion is refused == 0. Resets and timeouts are
+reported separately because graceful in-flight drain belongs to L2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import http.client
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+HTTP_FD_NAME = "webcodex-http"
+LISTEN_FD = 3
+HOST = "127.0.0.1"
+PROBE_PATH = "/openapi.json"
+
+
+def reserve_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind((HOST, 0))
+        return int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+def server_env(port: int, data_dir: Path) -> Dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "WEBCODEX_ADDR": f"{HOST}:{port}",
+            "WEBCODEX_DATA": str(data_dir),
+            "WEBCODEX_TOKEN": "linux-socket-activation-e2e-token",
+            "RUST_LOG": env.get("RUST_LOG", "warn"),
+        }
+    )
+    for key in ("LISTEN_PID", "LISTEN_FDS", "LISTEN_FDNAMES"):
+        env.pop(key, None)
+    return env
+
+
+def terminate(proc: Optional[subprocess.Popen[bytes]]) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def http_probe(port: int, timeout: float) -> str:
+    conn = http.client.HTTPConnection(HOST, port, timeout=timeout)
+    try:
+        conn.request("GET", PROBE_PATH, headers={"Connection": "close"})
+        response = conn.getresponse()
+        response.read(1024)
+        return "success" if 200 <= response.status < 500 else "reset"
+    except ConnectionRefusedError:
+        return "refused"
+    except (ConnectionResetError, BrokenPipeError):
+        return "reset"
+    except socket.timeout:
+        return "timeout"
+    except OSError as error:
+        if error.errno == errno.ECONNREFUSED:
+            return "refused"
+        if error.errno in (errno.ECONNRESET, errno.EPIPE):
+            return "reset"
+        if error.errno in (errno.ETIMEDOUT, errno.EAGAIN):
+            return "timeout"
+        raise
+    finally:
+        conn.close()
+
+
+def wait_ready(port: int, proc: subprocess.Popen[bytes], timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    last = "not-started"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"server exited before readiness with code {proc.returncode}")
+        try:
+            last = http_probe(port, 0.5)
+            if last == "success":
+                return
+        except OSError as error:
+            last = repr(error)
+        time.sleep(0.05)
+    raise RuntimeError(f"server did not become HTTP-ready; last probe={last}")
+
+
+def run_systemd_smoke(binary: Path, systemd_socket_activate: Path) -> Dict[str, object]:
+    port = reserve_port()
+    with tempfile.TemporaryDirectory(prefix="webcodex-systemd-socket-smoke-") as root:
+        root_path = Path(root)
+        log_path = root_path / "server.log"
+        env = server_env(port, root_path / "data")
+        (root_path / "data").mkdir()
+        with log_path.open("wb") as log:
+            proc = subprocess.Popen(
+                [
+                    str(systemd_socket_activate),
+                    "--listen",
+                    f"{HOST}:{port}",
+                    "--setenv",
+                    f"WEBCODEX_ADDR={env['WEBCODEX_ADDR']}",
+                    "--setenv",
+                    f"WEBCODEX_DATA={env['WEBCODEX_DATA']}",
+                    "--setenv",
+                    f"WEBCODEX_TOKEN={env['WEBCODEX_TOKEN']}",
+                    "--setenv",
+                    f"RUST_LOG={env['RUST_LOG']}",
+                    "--fdname",
+                    HTTP_FD_NAME,
+                    str(binary),
+                ],
+                env=env,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+            )
+            try:
+                wait_ready(port, proc)
+                result = http_probe(port, 1.0)
+                if result != "success":
+                    raise RuntimeError(f"post-readiness smoke probe was {result}")
+                return {
+                    "scenario": "systemd_socket_activate",
+                    "http": result,
+                    "port": port,
+                }
+            except Exception as error:
+                log.flush()
+                tail = log_path.read_text(errors="replace")[-4000:]
+                raise RuntimeError(f"systemd socket activation smoke failed: {error}\n{tail}") from error
+            finally:
+                terminate(proc)
+
+
+def child_exec(binary: Path, inherited_fd: int) -> None:
+    if inherited_fd != LISTEN_FD:
+        os.dup2(inherited_fd, LISTEN_FD, inheritable=True)
+        os.close(inherited_fd)
+    else:
+        os.set_inheritable(LISTEN_FD, True)
+    env = os.environ.copy()
+    env["LISTEN_PID"] = str(os.getpid())
+    env["LISTEN_FDS"] = "1"
+    env["LISTEN_FDNAMES"] = HTTP_FD_NAME
+    os.execve(str(binary), [str(binary)], env)
+
+
+def spawn_inherited_server(binary: Path, listener: socket.socket, env: Dict[str, str], log) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), "--child-exec", str(binary), str(listener.fileno())],
+        env=env,
+        pass_fds=(listener.fileno(),),
+        stdout=log,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def run_continuity(binary: Path) -> Dict[str, object]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind((HOST, 0))
+    listener.listen(128)
+    port = int(listener.getsockname()[1])
+    listener.set_inheritable(True)
+
+    counts = {"success": 0, "reset": 0, "timeout": 0, "refused": 0}
+    unexpected = []
+    stop = threading.Event()
+    lock = threading.Lock()
+
+    def probe_loop() -> None:
+        while not stop.is_set():
+            try:
+                outcome = http_probe(port, 0.08)
+                with lock:
+                    counts[outcome] += 1
+            except Exception as error:  # surfaced separately, never folded into refusal
+                with lock:
+                    unexpected.append(repr(error))
+            stop.wait(0.01)
+
+    with tempfile.TemporaryDirectory(prefix="webcodex-listener-continuity-") as root:
+        root_path = Path(root)
+        data = root_path / "data"
+        data.mkdir()
+        log_path = root_path / "server.log"
+        env = server_env(port, data)
+        server_a: Optional[subprocess.Popen[bytes]] = None
+        server_b: Optional[subprocess.Popen[bytes]] = None
+        thread: Optional[threading.Thread] = None
+        try:
+            with log_path.open("ab", buffering=0) as log:
+                server_a = spawn_inherited_server(binary, listener, env, log)
+                wait_ready(port, server_a)
+                thread = threading.Thread(target=probe_loop, name="listener-continuity-probe", daemon=True)
+                thread.start()
+                time.sleep(0.25)
+
+                terminate(server_a)
+                server_a = None
+                # Deliberate process gap: the parent alone retains the listener.
+                # Probe rate/backlog are bounded so queued connections fit easily.
+                time.sleep(0.20)
+
+                server_b = spawn_inherited_server(binary, listener, env, log)
+                wait_ready(port, server_b)
+                time.sleep(0.35)
+        except Exception as error:
+            tail = log_path.read_text(errors="replace")[-5000:] if log_path.exists() else ""
+            raise RuntimeError(f"listener continuity harness failed: {error}\n{tail}") from error
+        finally:
+            stop.set()
+            if thread is not None:
+                thread.join(timeout=2)
+            terminate(server_a)
+            terminate(server_b)
+            listener.close()
+
+    result: Dict[str, object] = {
+        "scenario": "parent_owned_listener_restart",
+        **counts,
+        "unexpected_errors": unexpected,
+        "backlog": 128,
+        "deliberate_server_gap_ms": 200,
+        "port": port,
+    }
+    if counts["refused"] != 0:
+        raise RuntimeError(f"L1 acceptance failed: ECONNREFUSED count={counts['refused']}; result={json.dumps(result)}")
+    if unexpected:
+        raise RuntimeError(f"unexpected probe errors: {json.dumps(result)}")
+    if counts["success"] == 0:
+        raise RuntimeError(f"no successful probes recorded: {json.dumps(result)}")
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server-bin", default="target/dogfood/webcodex-server")
+    parser.add_argument("--skip-systemd-smoke", action="store_true")
+    parser.add_argument("--skip-continuity", action="store_true")
+    parser.add_argument("--child-exec", nargs=2, metavar=("BINARY", "FD"), help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.child_exec:
+        child_exec(Path(args.child_exec[0]).resolve(), int(args.child_exec[1]))
+        return 127
+
+    binary = Path(args.server_bin).resolve()
+    if not binary.is_file():
+        parser.error(f"server binary does not exist: {binary}")
+
+    results = []
+    if not args.skip_systemd_smoke:
+        tool = shutil.which("systemd-socket-activate")
+        if not tool:
+            parser.error("systemd-socket-activate is required for the activation smoke")
+        results.append(run_systemd_smoke(binary, Path(tool)))
+    if not args.skip_continuity:
+        results.append(run_continuity(binary))
+
+    print(json.dumps({"ok": True, "results": results}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod project_entry;
 mod projects;
 mod runtime_console_http;
 mod runtime_http;
+mod server_listener;
 mod shell_client;
 mod startup;
 mod task_cli;
@@ -144,6 +145,9 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     let config = Config::from_env();
+    let (acceptor, listener_mode, listener_addr) = server_listener::server_acceptor(&config.addr)
+        .await
+        .map_err(std::io::Error::other)?;
     let console_asset_source = Arc::new(
         console_web::ConsoleAssetSource::from_env(&config.addr).map_err(std::io::Error::other)?,
     );
@@ -163,7 +167,12 @@ only for local/trusted-network demos."
     );
     tracing::info!("Data directory: {:?}", config.data_dir);
     let addr = config.addr.clone();
-    tracing::info!("Listening on: {}", addr);
+    tracing::info!(
+        "Listening on: {} (actual {}, mode {:?})",
+        addr,
+        listener_addr,
+        listener_mode
+    );
     tracing::info!("Console assets: {}", console_asset_source.mode_label());
     if let Some(directory) = console_asset_source.directory() {
         tracing::info!("Console assets directory: {}", directory.display());
@@ -481,7 +490,6 @@ only for local/trusted-network demos."
             .push(Router::with_path("session").post(audit_http::audit_session))
             .push(Router::with_path("stats").post(audit_http::audit_stats)),
     );
-    let acceptor = TcpListener::new(addr.clone()).bind().await;
     tracing::info!("Server started successfully!");
     let port = addr.split(':').next_back().unwrap_or("8080");
     let base = format!("http://localhost:{}", port);

--- a/src/server_listener.rs
+++ b/src/server_listener.rs
@@ -113,6 +113,30 @@ fn validate_listening_tcp_fd(fd: i32) -> Result<(), String> {
         ));
     }
 
+    let mut socket_addr: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let mut socket_addr_len = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+    let addr_result = unsafe {
+        libc::getsockname(
+            fd,
+            (&mut socket_addr as *mut libc::sockaddr_storage).cast(),
+            &mut socket_addr_len,
+        )
+    };
+    if addr_result != 0 {
+        return Err(format!(
+            "invalid systemd socket activation: failed to inspect inherited fd {fd} address family: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if !matches!(
+        socket_addr.ss_family as libc::c_int,
+        libc::AF_INET | libc::AF_INET6
+    ) {
+        return Err(format!(
+            "invalid systemd socket activation: inherited fd {fd} is not an IPv4/IPv6 TCP listening socket"
+        ));
+    }
+
     let mut accepting: libc::c_int = 0;
     let mut accepting_len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
     let accept_result = unsafe {
@@ -296,6 +320,24 @@ mod tests {
         let raw_fd = stream.into_raw_fd();
         let error = take_inherited_listener(raw_fd, "127.0.0.1:1").unwrap_err();
         assert!(error.contains("not in listening state"), "{error}");
+        assert_ne!(unsafe { libc::fcntl(raw_fd, libc::F_GETFD) }, -1);
+        unsafe { libc::close(raw_fd) };
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn inherited_fd_rejects_non_tcp_listening_stream_without_taking_ownership() {
+        use std::os::fd::IntoRawFd;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let listener =
+            std::os::unix::net::UnixListener::bind(tmp.path().join("listener.sock")).unwrap();
+        let raw_fd = listener.into_raw_fd();
+        let error = take_inherited_listener(raw_fd, "127.0.0.1:1").unwrap_err();
+        assert!(
+            error.contains("not an IPv4/IPv6 TCP listening socket"),
+            "{error}"
+        );
         assert_ne!(unsafe { libc::fcntl(raw_fd, libc::F_GETFD) }, -1);
         unsafe { libc::close(raw_fd) };
     }

--- a/src/server_listener.rs
+++ b/src/server_listener.rs
@@ -1,0 +1,330 @@
+use salvo::conn::tcp::TcpAcceptor;
+use salvo::conn::{Listener, TcpListener};
+use std::net::{SocketAddr, ToSocketAddrs};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ListenerMode {
+    Direct,
+    SystemdActivated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ActivationMetadata {
+    fd_name: Option<String>,
+}
+
+const SYSTEMD_LISTEN_FD_START: i32 = 3;
+const HTTP_FD_NAME: &str = "webcodex-http";
+
+fn activation_metadata_from_values(
+    listen_pid: Option<&str>,
+    listen_fds: Option<&str>,
+    listen_fdnames: Option<&str>,
+    current_pid: u32,
+) -> Result<Option<ActivationMetadata>, String> {
+    let any_present = listen_pid.is_some() || listen_fds.is_some() || listen_fdnames.is_some();
+    if !any_present {
+        return Ok(None);
+    }
+    let pid = listen_pid.ok_or_else(|| {
+        "invalid systemd socket activation: LISTEN_PID is missing while activation metadata is present"
+            .to_string()
+    })?;
+    let fds = listen_fds.ok_or_else(|| {
+        "invalid systemd socket activation: LISTEN_FDS is missing while activation metadata is present"
+            .to_string()
+    })?;
+    let pid = pid.parse::<u32>().map_err(|_| {
+        format!("invalid systemd socket activation: LISTEN_PID is not a valid process id: {pid:?}")
+    })?;
+    if pid != current_pid {
+        return Err(format!(
+            "invalid systemd socket activation: LISTEN_PID={pid} does not match current process {current_pid}"
+        ));
+    }
+    let fds = fds.parse::<u32>().map_err(|_| {
+        format!("invalid systemd socket activation: LISTEN_FDS is not a valid descriptor count: {fds:?}")
+    })?;
+    if fds != 1 {
+        return Err(format!(
+            "unsupported systemd socket activation: expected exactly one HTTP listening socket, got LISTEN_FDS={fds}"
+        ));
+    }
+    let fd_name = listen_fdnames.map(str::to_string);
+    if let Some(name) = fd_name.as_deref() {
+        if name != HTTP_FD_NAME {
+            return Err(format!(
+                "invalid systemd socket activation: expected LISTEN_FDNAMES={HTTP_FD_NAME:?}, got {name:?}"
+            ));
+        }
+    }
+    Ok(Some(ActivationMetadata { fd_name }))
+}
+
+#[cfg(target_os = "linux")]
+fn activation_metadata_from_env() -> Result<Option<ActivationMetadata>, String> {
+    let listen_pid = std::env::var("LISTEN_PID").ok();
+    let listen_fds = std::env::var("LISTEN_FDS").ok();
+    let listen_fdnames = std::env::var("LISTEN_FDNAMES").ok();
+    activation_metadata_from_values(
+        listen_pid.as_deref(),
+        listen_fds.as_deref(),
+        listen_fdnames.as_deref(),
+        std::process::id(),
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+fn activation_metadata_from_env() -> Result<Option<ActivationMetadata>, String> {
+    Ok(None)
+}
+
+fn configured_addr_matches(configured: &str, actual: SocketAddr) -> Result<bool, String> {
+    let configured_addrs = configured.to_socket_addrs().map_err(|error| {
+        format!("invalid WEBCODEX_ADDR {configured:?}: cannot resolve configured listener address: {error}")
+    })?;
+    Ok(configured_addrs
+        .into_iter()
+        .any(|candidate| candidate == actual))
+}
+
+#[cfg(target_os = "linux")]
+fn validate_listening_tcp_fd(fd: i32) -> Result<(), String> {
+    let mut socket_type: libc::c_int = 0;
+    let mut socket_type_len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let type_result = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_TYPE,
+            (&mut socket_type as *mut libc::c_int).cast(),
+            &mut socket_type_len,
+        )
+    };
+    if type_result != 0 {
+        return Err(format!(
+            "invalid systemd socket activation: inherited fd {fd} is not a valid socket: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if socket_type != libc::SOCK_STREAM {
+        return Err(format!(
+            "invalid systemd socket activation: inherited fd {fd} is not a TCP stream listening socket"
+        ));
+    }
+
+    let mut accepting: libc::c_int = 0;
+    let mut accepting_len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let accept_result = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_ACCEPTCONN,
+            (&mut accepting as *mut libc::c_int).cast(),
+            &mut accepting_len,
+        )
+    };
+    if accept_result != 0 || accepting != 1 {
+        return Err(format!(
+            "invalid systemd socket activation: inherited fd {fd} is not in listening state"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn take_inherited_listener(
+    fd: i32,
+    configured_addr: &str,
+) -> Result<std::net::TcpListener, String> {
+    use std::os::fd::FromRawFd;
+
+    validate_listening_tcp_fd(fd)?;
+    let listener = unsafe { std::net::TcpListener::from_raw_fd(fd) };
+    listener.set_nonblocking(true).map_err(|error| {
+        format!("failed to set inherited systemd HTTP listener nonblocking: {error}")
+    })?;
+    let actual = listener.local_addr().map_err(|error| {
+        format!("failed to inspect inherited systemd HTTP listener address: {error}")
+    })?;
+    if !configured_addr_matches(configured_addr, actual)? {
+        return Err(format!(
+            "inherited systemd HTTP listener address {actual} does not match configured WEBCODEX_ADDR {configured_addr:?}"
+        ));
+    }
+    Ok(listener)
+}
+
+pub(crate) async fn server_acceptor(
+    configured_addr: &str,
+) -> Result<(TcpAcceptor, ListenerMode, SocketAddr), String> {
+    match activation_metadata_from_env()? {
+        None => {
+            let acceptor = TcpListener::new(configured_addr.to_string())
+                .try_bind()
+                .await
+                .map_err(|error| {
+                    format!("failed to bind HTTP listener {configured_addr}: {error}")
+                })?;
+            let actual = acceptor
+                .local_addr()
+                .map_err(|error| format!("failed to inspect bound HTTP listener: {error}"))?;
+            Ok((acceptor, ListenerMode::Direct, actual))
+        }
+        Some(_metadata) => {
+            #[cfg(target_os = "linux")]
+            {
+                let listener = take_inherited_listener(SYSTEMD_LISTEN_FD_START, configured_addr)?;
+                let tokio_listener =
+                    tokio::net::TcpListener::from_std(listener).map_err(|error| {
+                        format!("failed to adopt inherited systemd HTTP listener: {error}")
+                    })?;
+                let acceptor = TcpAcceptor::try_from(tokio_listener).map_err(|error| {
+                    format!("failed to adapt inherited systemd HTTP listener for Salvo: {error}")
+                })?;
+                let actual = acceptor.local_addr().map_err(|error| {
+                    format!("failed to inspect adopted systemd HTTP listener: {error}")
+                })?;
+                Ok((acceptor, ListenerMode::SystemdActivated, actual))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                unreachable!("non-Linux activation metadata is ignored")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activation_metadata_absent_selects_direct_mode() {
+        assert_eq!(
+            activation_metadata_from_values(None, None, None, 42),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn activation_metadata_accepts_exact_current_pid_and_one_fd() {
+        assert_eq!(
+            activation_metadata_from_values(Some("42"), Some("1"), Some(HTTP_FD_NAME), 42),
+            Ok(Some(ActivationMetadata {
+                fd_name: Some(HTTP_FD_NAME.to_string())
+            }))
+        );
+    }
+
+    #[test]
+    fn activation_metadata_rejects_partial_wrong_or_malformed_contracts() {
+        for (pid, fds, names, current, needle) in [
+            (None, Some("1"), None, 42, "LISTEN_PID is missing"),
+            (Some("42"), None, None, 42, "LISTEN_FDS is missing"),
+            (
+                Some("41"),
+                Some("1"),
+                None,
+                42,
+                "does not match current process",
+            ),
+            (
+                Some("wat"),
+                Some("1"),
+                None,
+                42,
+                "LISTEN_PID is not a valid",
+            ),
+            (
+                Some("42"),
+                Some("wat"),
+                None,
+                42,
+                "LISTEN_FDS is not a valid",
+            ),
+            (Some("42"), Some("0"), None, 42, "exactly one"),
+            (Some("42"), Some("2"), None, 42, "exactly one"),
+            (Some("42"), Some("1"), Some("other"), 42, "LISTEN_FDNAMES"),
+        ] {
+            let error = activation_metadata_from_values(pid, fds, names, current).unwrap_err();
+            assert!(
+                error.contains(needle),
+                "{error:?} did not contain {needle:?}"
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn move_to_isolated_test_fd(fd: i32) -> i32 {
+        let isolated = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 1000) };
+        assert!(isolated >= 1000, "failed to duplicate fd for isolated ownership test");
+        unsafe { libc::close(fd) };
+        isolated
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn inherited_fd_rejects_non_socket_without_taking_ownership() {
+        use std::os::fd::RawFd;
+        let mut fds: [RawFd; 2] = [-1, -1];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let error = take_inherited_listener(fds[0], "127.0.0.1:1").unwrap_err();
+        assert!(error.contains("not a valid socket"), "{error}");
+        assert_ne!(unsafe { libc::fcntl(fds[0], libc::F_GETFD) }, -1);
+        unsafe {
+            libc::close(fds[0]);
+            libc::close(fds[1]);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn inherited_fd_rejects_stream_socket_that_is_not_listening() {
+        use std::os::fd::IntoRawFd;
+
+        let stream = std::net::TcpStream::connect({
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            std::thread::spawn(move || listener.accept().unwrap());
+            addr
+        })
+        .unwrap();
+        let raw_fd = stream.into_raw_fd();
+        let error = take_inherited_listener(raw_fd, "127.0.0.1:1").unwrap_err();
+        assert!(error.contains("not in listening state"), "{error}");
+        assert_ne!(unsafe { libc::fcntl(raw_fd, libc::F_GETFD) }, -1);
+        unsafe { libc::close(raw_fd) };
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn inherited_fd_is_owned_once_and_adapts_to_salvo() {
+        use std::os::fd::IntoRawFd;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let actual = listener.local_addr().unwrap();
+        let raw_fd = move_to_isolated_test_fd(listener.into_raw_fd());
+        let listener = take_inherited_listener(raw_fd, &actual.to_string()).unwrap();
+        let tokio_listener = tokio::net::TcpListener::from_std(listener).unwrap();
+        let acceptor = TcpAcceptor::try_from(tokio_listener).unwrap();
+        assert_eq!(acceptor.local_addr().unwrap(), actual);
+        drop(acceptor);
+        assert_eq!(unsafe { libc::fcntl(raw_fd, libc::F_GETFD) }, -1);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn inherited_fd_rejects_configured_address_mismatch() {
+        use std::os::fd::IntoRawFd;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let raw_fd = move_to_isolated_test_fd(listener.into_raw_fd());
+        let error = take_inherited_listener(raw_fd, "127.0.0.1:1").unwrap_err();
+        assert!(
+            error.contains("does not match configured WEBCODEX_ADDR"),
+            "{error}"
+        );
+        assert_eq!(unsafe { libc::fcntl(raw_fd, libc::F_GETFD) }, -1);
+    }
+}

--- a/src/server_listener.rs
+++ b/src/server_listener.rs
@@ -258,7 +258,10 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn move_to_isolated_test_fd(fd: i32) -> i32 {
         let isolated = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 1000) };
-        assert!(isolated >= 1000, "failed to duplicate fd for isolated ownership test");
+        assert!(
+            isolated >= 1000,
+            "failed to duplicate fd for isolated ownership test"
+        );
         unsafe { libc::close(fd) };
         isolated
     }


### PR DESCRIPTION
## Summary

- accept one validated systemd-activated HTTP TCP listener while preserving standalone direct-bind behavior
- install and manage a coherent `webcodex.socket` + `webcodex.service` pair on Linux
- keep the socket active across ordinary Server service restarts so listener ownership does not disappear between generations
- fail closed on malformed activation metadata, non-TCP inherited descriptors, unsafe legacy migration state, and invalid managed unit state
- keep custom `--service-file` lifecycle/status operations paired with the derived sibling `.socket`
- add focused listener/systemd lifecycle coverage, a process-level socket continuity harness, and bilingual deployment/CLI documentation

## Availability contract

Once a deployment has migrated to socket activation, `webcodex server restart` restarts only the Server service while systemd continues owning the listening socket. Under normal bounded-backlog conditions this removes the process-replacement `ECONNREFUSED` listener gap.

This is L1 listener continuity, not graceful in-flight draining. Existing keep-alive, WebSocket, or streaming connections may disconnect and reconnect during a Server process replacement. Graceful in-flight drain remains a separate L2 slice.

## Validation

Post-rebase validation on Special against `main@164ae7038ad345b3d4fa3df949ab1a180d80d0ed`:

- `cargo fmt -- --check` — PASS
- `cargo check --all-targets -p webcodex` — PASS
- `cargo check --all-targets -p webcodex-cli` — PASS
- `cargo test server_listener -p webcodex` — 8/8 PASS
- `cargo test tests::server::service -p webcodex-cli` — 21/21 PASS
- `cargo test tests::server::status -p webcodex-cli` — 15/15 PASS
- `cargo test webcodex_cli::service::tests -p webcodex-cli` — 25/25 PASS
- `cargo build --profile dogfood --bin webcodex-server -p webcodex` — PASS
- `scripts/e2e_linux_socket_activation.py` — PASS
  - deliberate 200 ms Server-process gap
  - success=11
  - ECONNREFUSED=0
  - reset=1
  - timeout=3
  - unexpected=0

Real PID1 systemd acceptance on isolated orb/aarch64 Ubuntu systemd 255 units:

- `systemd-analyze verify` — PASS
- actual activation delivered `LISTEN_FDS=1`, `LISTEN_FDNAMES=webcodex-http`, fd 3 listening
- stopping the temporary service left the temporary socket active
- service replacement changed Server PID while socket `InvocationID` and `ActiveEnterTimestampMonotonic` stayed unchanged
- continuous HTTP probes across real service replacement:
  - success=27
  - ECONNREFUSED=0
  - reset=1
  - timeout=0
  - unexpected=0
- all temporary acceptance units, source/target artifacts, runtime data, and `/run/systemd/system` files were removed afterward

No production `webcodex.service`/`.socket`, Server binary, config, data, or credentials were modified during acceptance.