### PR TITLE
Parallelize Windows CI lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,26 +187,24 @@ jobs:
       - name: Run native macOS Runner tests
         run: cargo test --locked -p webcodex-runner
 
-  test-windows:
+  # Keep Windows process-heavy suites isolated on separate hosted VMs. The
+  # webcodex-runner lane remains test-function-serial because its real
+  # PowerShell/process-tree fixtures can starve each other on hosted Windows.
+  # Core/library and packaging coverage can run independently in parallel.
+  test-windows-core:
     needs: contract
     if: >-
       github.event_name == 'push' ||
       github.event.pull_request.user.login != github.repository_owner ||
       contains(github.event.pull_request.labels.*.name, 'run-ci')
-    # Windows release gate: the crates that must run natively on Windows 11
-    # (CLI, Runner, persistent-shell's fail-closed gate, and the
-    # cross-platform libraries they depend on), the npm distribution checks,
-    # and the full Windows artifact -> npm install smoke. The Server and its
-    # Unix-only runtime stay Linux-only.
     runs-on: windows-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          shared-key: windows-core-ci
       - name: Configure PowerShell 7 persistent-shell tests
         shell: pwsh
         run: |
@@ -216,12 +214,45 @@ jobs:
         run: cargo test --locked -p webcodex-persistent-shell
       - name: Run Windows library and CLI tests
         run: cargo test --locked -p webcodex-agent-config -p webcodex-process -p webcodex-cli
+
+  test-windows-runner:
+    needs: contract
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.user.login != github.repository_owner ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-runner-ci
       - name: Run Windows Runner tests
         # The Runner suite starts many real PowerShell/process-tree fixtures. On
         # hosted Windows, parallel test functions can starve process startup long
         # enough to trip intentionally tight command timeouts. Serialize only
         # the test functions; concurrency exercised inside each test is unchanged.
         run: cargo test --locked -p webcodex-runner -- --test-threads=1
+
+  test-windows-package:
+    needs: contract
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.user.login != github.repository_owner ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-package-ci
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Test npm installer and release manifest natively
         run: npm --prefix npm/webcodex test
       - name: Windows artifact to npm install smoke
@@ -232,3 +263,34 @@ jobs:
         # touches the npm registry.
         shell: pwsh
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/npm_install_windows_smoke.ps1
+
+  test-windows:
+    needs: [contract, test-windows-core, test-windows-runner, test-windows-package]
+    # Preserve the historical required Windows status while moving the expensive
+    # work into parallel VMs. Eligible heavy runs inspect every lane even after a
+    # failure so branch protection cannot see a false-success aggregate.
+    if: >-
+      always() &&
+      (
+        github.event_name == 'push' ||
+        github.event.pull_request.user.login != github.repository_owner ||
+        contains(github.event.pull_request.labels.*.name, 'run-ci')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require successful Windows lanes
+        env:
+          CONTRACT_RESULT: ${{ needs.contract.result }}
+          CORE_RESULT: ${{ needs.test-windows-core.result }}
+          RUNNER_RESULT: ${{ needs.test-windows-runner.result }}
+          PACKAGE_RESULT: ${{ needs.test-windows-package.result }}
+        run: |
+          echo "contract=$CONTRACT_RESULT core=$CORE_RESULT runner=$RUNNER_RESULT package=$PACKAGE_RESULT"
+          if [ "$CONTRACT_RESULT" != success ] || \
+             [ "$CORE_RESULT" != success ] || \
+             [ "$RUNNER_RESULT" != success ] || \
+             [ "$PACKAGE_RESULT" != success ]; then
+            echo "required Windows CI lane did not succeed" >&2
+            exit 1
+          fi

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -455,7 +455,7 @@ fn systemd_unit_rendering_quotes_paths_and_rejects_invalid_fields_in_dry_run() {
 }
 
 #[cfg(target_os = "linux")]
-fn verify_systemd_unit(unit: &str, name: &str) {
+fn verify_systemd_units(units: &[(&str, &str)]) {
     let available = std::process::Command::new("systemd-analyze")
         .arg("--version")
         .output()
@@ -465,16 +465,24 @@ fn verify_systemd_unit(unit: &str, name: &str) {
         return;
     }
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join(name);
-    std::fs::write(&path, unit).unwrap();
-    let output = std::process::Command::new("systemd-analyze")
-        .arg("verify")
-        .arg(&path)
-        .output()
-        .unwrap();
+    let mut paths = Vec::with_capacity(units.len());
+    for (name, unit) in units {
+        let path = tmp.path().join(name);
+        std::fs::write(&path, unit).unwrap();
+        paths.push(path);
+    }
+    let mut command = std::process::Command::new("systemd-analyze");
+    command.arg("verify");
+    command.args(&paths);
+    let output = command.output().unwrap();
+    let names = units
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>()
+        .join(", ");
     assert!(
         output.status.success(),
-        "systemd-analyze verify failed for {name}: {}",
+        "systemd-analyze verify failed for {names}: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }
@@ -514,12 +522,13 @@ fn generated_server_and_agent_units_pass_systemd_analyze_verify() {
         serde_json::from_str(&run_server_install_service(server).unwrap()).unwrap();
     let service_unit = server_json["units"]["service"].as_str().unwrap();
     let socket_unit = server_json["units"]["socket"].as_str().unwrap();
+    let service_name = server_json["service_unit"].as_str().unwrap();
+    let socket_name = server_json["socket_unit"].as_str().unwrap();
     assert!(service_unit.contains(&format!("EnvironmentFile={}\n", env_file.display())));
     assert!(service_unit.contains("WorkingDirectory=/var/lib/webcodex\n"));
     assert!(service_unit.contains("webcodex-server"));
     assert!(socket_unit.contains("ListenStream=127.0.0.1:8080\n"));
-    verify_systemd_unit(service_unit, "webcodex-default.service");
-    verify_systemd_unit(socket_unit, "webcodex-default.socket");
+    verify_systemd_units(&[(service_name, service_unit), (socket_name, socket_unit)]);
 
     let config = tmp.path().join("agent.toml");
     std::fs::write(&config, "server_url = \"http://127.0.0.1\"\n").unwrap();
@@ -540,7 +549,7 @@ fn generated_server_and_agent_units_pass_systemd_analyze_verify() {
     let agent_unit = run_agent_install_service(agent).unwrap();
     assert!(agent_unit.contains("webcodex-runner\" \"--config\""));
     assert!(agent_unit.contains("WorkingDirectory=/var/lib/webcodex\n"));
-    verify_systemd_unit(&agent_unit, "webcodex-runner-default.service");
+    verify_systemd_units(&[("webcodex-runner-default.service", &agent_unit)]);
 }
 
 #[cfg(target_os = "linux")]
@@ -575,12 +584,13 @@ fn special_supported_paths_pass_systemd_analyze_verify() {
         serde_json::from_str(&run_server_install_service(server).unwrap()).unwrap();
     let server_unit = server_json["units"]["service"].as_str().unwrap();
     let socket_unit = server_json["units"]["socket"].as_str().unwrap();
+    let service_name = server_json["service_unit"].as_str().unwrap();
+    let socket_name = server_json["socket_unit"].as_str().unwrap();
     assert!(server_unit.contains("\\x20"));
     assert!(server_unit.contains("\\x22"));
     assert!(server_unit.contains("\\x5c"));
     assert!(server_unit.contains("%%p"));
-    verify_systemd_unit(server_unit, "webcodex-special.service");
-    verify_systemd_unit(socket_unit, "webcodex-special.socket");
+    verify_systemd_units(&[(service_name, server_unit), (socket_name, socket_unit)]);
 
     let agent = parse_agent_install_service(&args(&[
         "--scope",
@@ -598,7 +608,7 @@ fn special_supported_paths_pass_systemd_analyze_verify() {
     .unwrap();
     let agent_unit = run_agent_install_service(agent).unwrap();
     assert!(agent_unit.contains("\\\"slash\\\\percent%%p.toml"));
-    verify_systemd_unit(&agent_unit, "webcodex-runner-special.service");
+    verify_systemd_units(&[("webcodex-runner-special.service", &agent_unit)]);
 }
 
 /// Unix-only: systemd service unit semantics with Unix absolute-path


### PR DESCRIPTION
## Summary

- split the existing Windows CI gate into three independent hosted-VM lanes for core/CLI, Runner, and packaging coverage
- preserve `cargo test --locked -p webcodex-runner -- --test-threads=1` inside the Runner lane to keep the existing process-startup stability contract
- retain `test-windows` as the aggregate status so existing branch-protection/status consumers keep one stable gate
- fix the existing main CI regression introduced by the new Server socket/service pairing by verifying generated service+socket units together with `systemd-analyze verify`

## Why

The latest main Windows job took roughly 17 minutes because persistent-shell, CLI/library, serialized Runner, and packaging smoke all ran sequentially on one VM. These suites do not need to share a VM, so job-level parallelism can reduce wall-clock time without re-enabling flaky test-function parallelism in the Runner suite.

Main CI run #460 also exposed a separate real failure in the Linux workspace-crates lane: the CLI systemd verification helper wrote and verified the service unit alone after #149 made it require its sibling socket. The updated helper writes the exact generated service/socket names into one temporary unit set and verifies them together.

## Validation

- `cargo test 'systemd_analyze_verify' -p webcodex-cli` — 2 passed, 0 failed
- `cargo test -p webcodex-cli` — 304 passed, 0 failed
- `cargo fmt -- --check`
- `git diff --check`

The Windows behavior itself is intentionally unchanged; the PR relies on GitHub's Windows runners for the native lane validation.