### PR TITLE
Gracefully drain Linux Server requests on restart

### DIFF
--- a/crates/webcodex-cli/src/webcodex_cli/server.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/server.rs
@@ -1,6 +1,7 @@
 use serde_json::{json, Value};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use webcodex::SERVER_SYSTEMD_TIMEOUT_STOP_SECS;
 use webcodex_admin::ServerHttpOptions;
 
 use crate::{
@@ -213,6 +214,9 @@ fn render_systemd_unit(
     unit.push_str(&format!("ExecStart={exec_start}\n"));
     unit.push_str("Restart=on-failure\n");
     unit.push_str("RestartSec=3\n");
+    unit.push_str(&format!(
+        "TimeoutStopSec={SERVER_SYSTEMD_TIMEOUT_STOP_SECS}s\n"
+    ));
     unit.push_str(&format!("WorkingDirectory={working_directory}\n"));
     if let Some(user) = &opts.user {
         unit.push_str(&format!("User={user}\n"));

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -42,6 +42,11 @@ fn install_service_generates_expected_unit_without_tokens() {
     assert!(unit.contains("Service=webcodex.service\n"));
     assert!(unit.contains("# /etc/systemd/system/webcodex.socket\n"));
     assert!(unit.contains("ExecStart=\"/usr/local/bin/webcodex-server\"\n"));
+    assert!(unit.contains("TimeoutStopSec=330s\n"));
+    assert!(
+        webcodex::SERVER_SYSTEMD_TIMEOUT_STOP_SECS
+            > webcodex::SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS
+    );
     assert!(unit.contains("WorkingDirectory=/var/lib/webcodex\n"));
     assert!(unit.contains("User=webcodex\n"));
     assert!(unit.contains("Group=webcodex\n"));
@@ -210,6 +215,10 @@ fn server_socket_rendering_uses_env_address_custom_sibling_and_no_start_projecti
         .as_str()
         .unwrap()
         .contains("Requires=custom-webcodex.socket\n"));
+    assert!(json["units"]["service"]
+        .as_str()
+        .unwrap()
+        .contains("TimeoutStopSec=330s\n"));
     assert!(json["units"]["socket"]
         .as_str()
         .unwrap()

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -115,12 +115,15 @@ Do **not** restart `webcodex.socket` during the normal Server replacement path.
 The socket remains bound while the old Server drains and the new process later
 inherits the same listener, eliminating the listener/`ECONNREFUSED` ownership
 gap under normal bounded-backlog conditions. On SIGTERM (managed restart/stop)
-or Ctrl-C/SIGINT (foreground), WebCodex asks Salvo to stop accepting/admitting
-new HTTP work and gives already-dispatched finite requests up to 315 seconds to
-complete and flush their response. This is derived from the 300-second ordinary
-HTTP hard timeout plus a 15-second response/teardown margin. The generated
-systemd service uses `TimeoutStopSec=330s`, leaving another 15-second margin so
-systemd does not SIGKILL the process before the application-owned bound.
+or Ctrl-C/SIGINT (foreground), WebCodex first makes a process-local drain fence
+authoritative, then asks Salvo to stop accepting connections and gracefully close
+existing HTTP connections. A request admitted before that fence may run for up to
+315 seconds and flush its response; a request that still reaches the old process
+after the fence receives a retriable HTTP 503 without entering its handler. The
+315-second bound is derived from the 300-second ordinary HTTP hard timeout plus a
+15-second response/teardown margin. The generated systemd service uses
+`TimeoutStopSec=330s`, leaving another 15-second margin so systemd does not
+SIGKILL the process before the application-owned bound.
 
 This is an availability-preserving graceful restart, not overlapping generations.
 During a long drain, new TCP connections can remain queued in the systemd socket

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -112,11 +112,22 @@ sudo systemctl restart webcodex.service
 ```
 
 Do **not** restart `webcodex.socket` during the normal Server replacement path.
-The socket remains bound while the old Server exits and the new process inherits
-the same listener, eliminating the listener/`ECONNREFUSED` gap under normal
-bounded-backlog conditions. Existing HTTP keep-alive, WebSocket, and streaming
-connections may still disconnect and reconnect; graceful in-flight drain is a
-separate L2 capability and is not claimed here.
+The socket remains bound while the old Server drains and the new process later
+inherits the same listener, eliminating the listener/`ECONNREFUSED` ownership
+gap under normal bounded-backlog conditions. On SIGTERM (managed restart/stop)
+or Ctrl-C/SIGINT (foreground), WebCodex asks Salvo to stop accepting/admitting
+new HTTP work and gives already-dispatched finite requests up to 315 seconds to
+complete and flush their response. This is derived from the 300-second ordinary
+HTTP hard timeout plus a 15-second response/teardown margin. The generated
+systemd service uses `TimeoutStopSec=330s`, leaving another 15-second margin so
+systemd does not SIGKILL the process before the application-owned bound.
+
+This is an availability-preserving graceful restart, not overlapping generations.
+During a long drain, new TCP connections can remain queued in the systemd socket
+backlog until the old process exits and the new Server inherits the listener, so
+restart latency may approach the finite-request bound. Existing WebSocket,
+HTTP keep-alive, and streaming connections may still disconnect/reconnect; there
+is no WebSocket continuity or literal zero-interruption guarantee.
 
 Use `--overwrite` on `server install` only when replacing an existing managed
 pair. Migrating an already-active legacy direct-bind `webcodex.service` is a

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -102,10 +102,12 @@ sudo systemctl restart webcodex.service
 正常替换路径不要 restart `webcodex.socket`。旧 Server drain 到新 Server 继承 listener
 期间，socket 仍持续绑定，因此在正常有界 backlog 条件下消除 listener ownership gap /
 `ECONNREFUSED` 窗口。收到 SIGTERM（受管 restart/stop）或 Ctrl-C/SIGINT（前台运行）后，
-WebCodex 会要求 Salvo 停止 accept/admit 新 HTTP work，并给已经 dispatch 的有限生命周期
-request 最多 315 秒完成和写回 response。该值由普通 HTTP hard timeout 300 秒加 15 秒
-response/teardown margin 派生。生成的 systemd service 使用 `TimeoutStopSec=330s`，再留
-15 秒余量，避免 systemd 在应用自己的 bounded shutdown 之前先发 SIGKILL。
+WebCodex 会先让 process-local drain fence 生效，再要求 Salvo 停止 accept 新 connection
+并 graceful close 已有 HTTP connection。fence 生效前已经 admit 的有限生命周期 request
+最多可继续 315 秒完成并写回 response；fence 生效后若 request 仍到达旧进程，则会得到
+可重试的 HTTP 503，且不会进入业务 handler。315 秒由普通 HTTP hard timeout 300 秒加
+15 秒 response/teardown margin 派生。生成的 systemd service 使用 `TimeoutStopSec=330s`，
+再留 15 秒余量，避免 systemd 在应用自己的 bounded shutdown 之前先发 SIGKILL。
 
 这是 availability-preserving graceful restart，不是 overlapping generations。若已有合法
 request 接近最大 deadline，新 TCP connection 可能在 systemd socket backlog 中等待，直到

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -99,10 +99,19 @@ webcodex server status --env-file /etc/webcodex/webcodex.env
 sudo systemctl restart webcodex.service
 ```
 
-正常替换路径不要 restart `webcodex.socket`。旧 Server 退出到新 Server 继承 listener
-期间，socket 仍持续绑定，因此在正常有界 backlog 条件下消除 listener gap / `ECONNREFUSED`
-窗口。已有 HTTP keep-alive、WebSocket 与 streaming connection 仍可能断开后重连；本轮
-不宣称 graceful in-flight drain，这属于后续独立 L2 capability。
+正常替换路径不要 restart `webcodex.socket`。旧 Server drain 到新 Server 继承 listener
+期间，socket 仍持续绑定，因此在正常有界 backlog 条件下消除 listener ownership gap /
+`ECONNREFUSED` 窗口。收到 SIGTERM（受管 restart/stop）或 Ctrl-C/SIGINT（前台运行）后，
+WebCodex 会要求 Salvo 停止 accept/admit 新 HTTP work，并给已经 dispatch 的有限生命周期
+request 最多 315 秒完成和写回 response。该值由普通 HTTP hard timeout 300 秒加 15 秒
+response/teardown margin 派生。生成的 systemd service 使用 `TimeoutStopSec=330s`，再留
+15 秒余量，避免 systemd 在应用自己的 bounded shutdown 之前先发 SIGKILL。
+
+这是 availability-preserving graceful restart，不是 overlapping generations。若已有合法
+request 接近最大 deadline，新 TCP connection 可能在 systemd socket backlog 中等待，直到
+旧进程退出并由新 Server 继承 listener，因此 restart latency 也可能接近该有限 request
+上限。已有 WebSocket、HTTP keep-alive 与 streaming connection 仍可能断开并重连；不保证
+WebSocket continuity，也不宣称 literal zero interruption。
 
 只有替换已有受管 pair 时才在 `server install` 上使用 `--overwrite`。如果当前仍是
 正在运行的 legacy direct-bind `webcodex.service`，第一次迁移属于单独的一次 migration

--- a/scripts/e2e_linux_socket_activation.py
+++ b/scripts/e2e_linux_socket_activation.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
-"""Focused Linux L1 socket-activation and listener-continuity proof.
+"""Focused Linux socket-activation, listener-continuity, and graceful-drain proof.
 
-This deliberately does not require PID 1 systemd. It has two focused scenarios:
+This deliberately does not require PID 1 systemd. It has three focused scenarios:
 1. systemd-socket-activate -> inherited fd 3 -> real webcodex-server -> HTTP.
 2. A parent-owned TCP listener survives Server A termination and is inherited by
    Server B while bounded client probes classify success/reset/timeout/refused.
+3. A real WebCodex run_process request is already executing on a real WebSocket
+   Runner when Server A receives SIGTERM; the response completes before A exits,
+   then Server B inherits the same listener and the Runner reconnects.
 
-L1's authoritative continuity assertion is refused == 0. Resets and timeouts are
-reported separately because graceful in-flight drain belongs to L2.
+Listener continuity requires refused == 0 under the bounded probe/backlog load.
+Resets and timeouts are always reported separately; L2 does not claim they are zero.
 """
 
 from __future__ import annotations
@@ -32,6 +35,10 @@ HTTP_FD_NAME = "webcodex-http"
 LISTEN_FD = 3
 HOST = "127.0.0.1"
 PROBE_PATH = "/openapi.json"
+TOKEN = "linux-socket-activation-e2e-token"
+RUNNER_CLIENT_ID = "linux-graceful-drain-e2e"
+RUNNER_PROJECT_ID = "graceful-drain"
+RUNTIME_PROJECT_ID = f"agent:{RUNNER_CLIENT_ID}:{RUNNER_PROJECT_ID}"
 
 
 def reserve_port() -> int:
@@ -49,7 +56,7 @@ def server_env(port: int, data_dir: Path) -> Dict[str, str]:
         {
             "WEBCODEX_ADDR": f"{HOST}:{port}",
             "WEBCODEX_DATA": str(data_dir),
-            "WEBCODEX_TOKEN": "linux-socket-activation-e2e-token",
+            "WEBCODEX_TOKEN": TOKEN,
             "RUST_LOG": env.get("RUST_LOG", "warn"),
         }
     )
@@ -92,6 +99,49 @@ def http_probe(port: int, timeout: float) -> str:
         raise
     finally:
         conn.close()
+
+
+def api_post_json(port: int, path: str, payload: Dict[str, object], timeout: float) -> tuple[int, Dict[str, object]]:
+    body = json.dumps(payload).encode()
+    conn = http.client.HTTPConnection(HOST, port, timeout=timeout)
+    try:
+        conn.request(
+            "POST",
+            path,
+            body=body,
+            headers={
+                "Authorization": f"Bearer {TOKEN}",
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body)),
+                "Connection": "close",
+            },
+        )
+        response = conn.getresponse()
+        raw = response.read()
+        parsed = json.loads(raw.decode()) if raw else {}
+        if not isinstance(parsed, dict):
+            raise RuntimeError(f"expected JSON object from {path}, got {type(parsed).__name__}")
+        return response.status, parsed
+    finally:
+        conn.close()
+
+
+def wait_agent_online(port: int, proc: subprocess.Popen[bytes], timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    last = "not-started"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"runner exited before online with code {proc.returncode}")
+        try:
+            status, body = api_post_json(port, "/api/runtime/status", {}, 1.0)
+            online = body.get("output", {}).get("agents", {}).get("online_count") if status == 200 else None
+            last = f"status={status} online={online!r}"
+            if online == 1:
+                return
+        except (OSError, ValueError, RuntimeError) as error:
+            last = repr(error)
+        time.sleep(0.05)
+    raise RuntimeError(f"runner did not become online; last={last}")
 
 
 def wait_ready(port: int, proc: subprocess.Popen[bytes], timeout: float = 20.0) -> None:
@@ -180,6 +230,14 @@ def spawn_inherited_server(binary: Path, listener: socket.socket, env: Dict[str,
     )
 
 
+def spawn_runner(binary: Path, config: Path, log) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [str(binary), "--config", str(config)],
+        stdout=log,
+        stderr=subprocess.STDOUT,
+    )
+
+
 def run_continuity(binary: Path) -> Dict[str, object]:
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -258,11 +316,196 @@ def run_continuity(binary: Path) -> Dict[str, object]:
     return result
 
 
+def run_graceful_inflight(binary: Path, runner_binary: Path) -> Dict[str, object]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind((HOST, 0))
+    listener.listen(128)
+    port = int(listener.getsockname()[1])
+    listener.set_inheritable(True)
+
+    counts = {"success": 0, "reset": 0, "timeout": 0, "refused": 0}
+    unexpected = []
+    stop = threading.Event()
+    lock = threading.Lock()
+
+    def probe_loop() -> None:
+        while not stop.is_set():
+            try:
+                outcome = http_probe(port, 0.08)
+                with lock:
+                    counts[outcome] += 1
+            except Exception as error:
+                with lock:
+                    unexpected.append(repr(error))
+            stop.wait(0.01)
+
+    with tempfile.TemporaryDirectory(prefix="webcodex-graceful-inflight-") as root:
+        root_path = Path(root)
+        data = root_path / "data"
+        projects = root_path / "projects.d"
+        project = root_path / "project"
+        data.mkdir()
+        projects.mkdir()
+        project.mkdir()
+        started_marker = project / "inflight-started.txt"
+        finished_marker = project / "inflight-finished.txt"
+        task_script = project / "drain_task.py"
+        task_script.write_text(
+            "from pathlib import Path\n"
+            "import time\n"
+            "Path('inflight-started.txt').write_text('started\\n')\n"
+            "time.sleep(1.0)\n"
+            "Path('inflight-finished.txt').write_text('finished\\n')\n"
+            "print('graceful-inflight-complete')\n"
+        )
+        (project / "README.md").write_text("# graceful drain e2e fixture\n")
+        project_toml = projects / f"{RUNNER_PROJECT_ID}.toml"
+        project_toml.write_text(
+            f"id = {json.dumps(RUNNER_PROJECT_ID)}\n"
+            f"path = {json.dumps(str(project))}\n"
+            'name = "Graceful Drain E2E"\n'
+            "allow_patch = true\n"
+        )
+        runner_config = root_path / "agent.toml"
+        runner_config.write_text(
+            f"server_url = {json.dumps(f'http://{HOST}:{port}')}\n"
+            f"token = {json.dumps(TOKEN)}\n"
+            f"client_id = {json.dumps(RUNNER_CLIENT_ID)}\n"
+            'display_name = "Graceful Drain E2E Runner"\n'
+            'owner = "e2e"\n'
+            f"projects_dir = {json.dumps(str(projects))}\n"
+            "poll_interval_ms = 200\n"
+            'transport = "websocket"\n\n'
+            "[policy]\n"
+            f"allowed_roots = [{json.dumps(str(project))}]\n"
+            "max_timeout_secs = 30\n"
+            "max_output_bytes = 262144\n"
+        )
+        server_log_path = root_path / "server.log"
+        runner_log_path = root_path / "runner.log"
+        env = server_env(port, data)
+        server_a: Optional[subprocess.Popen[bytes]] = None
+        server_b: Optional[subprocess.Popen[bytes]] = None
+        runner: Optional[subprocess.Popen[bytes]] = None
+        probes: Optional[threading.Thread] = None
+        request_thread: Optional[threading.Thread] = None
+        request_result: Dict[str, object] = {}
+
+        def run_inflight_request() -> None:
+            try:
+                status, body = api_post_json(
+                    port,
+                    "/api/tools/call",
+                    {
+                        "tool": "run_process",
+                        "params": {
+                            "project": RUNTIME_PROJECT_ID,
+                            "executable": "python3",
+                            "args": ["drain_task.py"],
+                            "timeout_secs": 10,
+                        },
+                    },
+                    8.0,
+                )
+                request_result.update({"http_status": status, "body": body})
+            except Exception as error:
+                request_result["error"] = repr(error)
+
+        try:
+            with server_log_path.open("ab", buffering=0) as server_log, runner_log_path.open(
+                "ab", buffering=0
+            ) as runner_log:
+                server_a = spawn_inherited_server(binary, listener, env, server_log)
+                wait_ready(port, server_a)
+                runner = spawn_runner(runner_binary, runner_config, runner_log)
+                wait_agent_online(port, runner)
+
+                probes = threading.Thread(target=probe_loop, name="graceful-drain-probe", daemon=True)
+                probes.start()
+                request_thread = threading.Thread(
+                    target=run_inflight_request, name="graceful-inflight-request", daemon=True
+                )
+                request_thread.start()
+
+                marker_deadline = time.monotonic() + 5.0
+                while time.monotonic() < marker_deadline and not started_marker.exists():
+                    if request_result:
+                        break
+                    time.sleep(0.01)
+                if not started_marker.exists():
+                    raise RuntimeError(f"real run_process never started: {request_result!r}")
+
+                signal_started = time.monotonic()
+                server_a.send_signal(signal.SIGTERM)
+                request_thread.join(timeout=5.0)
+                if request_thread.is_alive():
+                    raise RuntimeError("in-flight HTTP request did not complete during graceful drain")
+                if "error" in request_result:
+                    raise RuntimeError(f"in-flight HTTP request failed: {request_result['error']}")
+                if request_result.get("http_status") != 200:
+                    raise RuntimeError(f"in-flight HTTP status was {request_result.get('http_status')}: {request_result!r}")
+                body = request_result.get("body")
+                if not isinstance(body, dict) or body.get("success") is not True:
+                    raise RuntimeError(f"in-flight tool response was not successful: {request_result!r}")
+                if not finished_marker.exists():
+                    raise RuntimeError("in-flight command response returned before command completion marker")
+
+                server_a.wait(timeout=5.0)
+                server_a_exit = server_a.returncode
+                shutdown_elapsed_ms = int((time.monotonic() - signal_started) * 1000)
+                if server_a_exit != 0:
+                    raise RuntimeError(f"Server A did not exit normally after SIGTERM: {server_a_exit}")
+                server_a = None
+                server_b = spawn_inherited_server(binary, listener, env, server_log)
+                wait_ready(port, server_b)
+                wait_agent_online(port, runner)
+                time.sleep(0.25)
+                runner_reconnected = True
+        except Exception as error:
+            server_tail = server_log_path.read_text(errors="replace")[-6000:] if server_log_path.exists() else ""
+            runner_tail = runner_log_path.read_text(errors="replace")[-4000:] if runner_log_path.exists() else ""
+            raise RuntimeError(
+                f"graceful in-flight harness failed: {error}\n--- server ---\n{server_tail}\n--- runner ---\n{runner_tail}"
+            ) from error
+        finally:
+            stop.set()
+            if probes is not None:
+                probes.join(timeout=2)
+            terminate(server_a)
+            terminate(server_b)
+            terminate(runner)
+            listener.close()
+
+    result: Dict[str, object] = {
+        "scenario": "graceful_inflight_restart",
+        **counts,
+        "unexpected_errors": unexpected,
+        "backlog": 128,
+        "inflight_request_http_status": request_result.get("http_status"),
+        "inflight_request_success": isinstance(request_result.get("body"), dict)
+        and request_result["body"].get("success") is True,
+        "server_a_exit_code": server_a_exit,
+        "server_a_shutdown_elapsed_ms": shutdown_elapsed_ms,
+        "runner_reconnected": runner_reconnected,
+        "port": port,
+    }
+    if counts["refused"] != 0:
+        raise RuntimeError(f"L2 listener continuity failed: ECONNREFUSED count={counts['refused']}; result={json.dumps(result)}")
+    if unexpected:
+        raise RuntimeError(f"unexpected probe errors: {json.dumps(result)}")
+    if counts["success"] == 0:
+        raise RuntimeError(f"no successful probes recorded: {json.dumps(result)}")
+    return result
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--server-bin", default="target/dogfood/webcodex-server")
+    parser.add_argument("--runner-bin", default="target/dogfood/webcodex-runner")
     parser.add_argument("--skip-systemd-smoke", action="store_true")
     parser.add_argument("--skip-continuity", action="store_true")
+    parser.add_argument("--skip-graceful-inflight", action="store_true")
     parser.add_argument("--child-exec", nargs=2, metavar=("BINARY", "FD"), help=argparse.SUPPRESS)
     args = parser.parse_args()
 
@@ -273,6 +516,9 @@ def main() -> int:
     binary = Path(args.server_bin).resolve()
     if not binary.is_file():
         parser.error(f"server binary does not exist: {binary}")
+    runner_binary = Path(args.runner_bin).resolve()
+    if not args.skip_graceful_inflight and not runner_binary.is_file():
+        parser.error(f"runner binary does not exist: {runner_binary}")
 
     results = []
     if not args.skip_systemd_smoke:
@@ -282,6 +528,8 @@ def main() -> int:
         results.append(run_systemd_smoke(binary, Path(tool)))
     if not args.skip_continuity:
         results.append(run_continuity(binary))
+    if not args.skip_graceful_inflight:
+        results.append(run_graceful_inflight(binary, runner_binary))
 
     print(json.dumps({"ok": True, "results": results}, sort_keys=True))
     return 0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod projects;
 mod runtime_console_http;
 mod runtime_http;
 mod server_listener;
+mod server_shutdown;
 mod shell_client;
 mod startup;
 mod task_cli;
@@ -124,6 +125,23 @@ where
 /// MCP dispatch hard bound (150s) plus response-write margin so the inner,
 /// better-reported timeouts always fire first.
 const REQUEST_HARD_TIMEOUT_SECS: u64 = 300;
+
+/// A finite request may legitimately consume the full HTTP hard timeout. Give
+/// its response and connection teardown an additional bounded window before
+/// Salvo escalates graceful shutdown to a forcible connection stop.
+const SERVER_GRACEFUL_RESPONSE_MARGIN_SECS: u64 = 15;
+
+/// Application-owned graceful Server drain deadline. This is deliberately
+/// derived from the maximum finite HTTP request lifetime instead of being an
+/// independent operational magic number.
+pub const SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS: u64 =
+    REQUEST_HARD_TIMEOUT_SECS + SERVER_GRACEFUL_RESPONSE_MARGIN_SECS;
+
+/// systemd must outlive the application's own graceful/forced stop lifecycle
+/// so PID 1 does not SIGKILL the Server before WebCodex's bounded deadline.
+const SERVER_SYSTEMD_STOP_MARGIN_SECS: u64 = 15;
+pub const SERVER_SYSTEMD_TIMEOUT_STOP_SECS: u64 =
+    SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS + SERVER_SYSTEMD_STOP_MARGIN_SECS;
 
 pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     let env_loads = load_startup_env_files().map_err(std::io::Error::other)?;
@@ -536,7 +554,12 @@ only for local/trusted-network demos."
             shell_client::recovery_timeout_sweep(&sweep_registry).await;
         }
     });
-    Server::new(acceptor).serve(router).await;
+    server_shutdown::serve_until_termination(
+        Server::new(acceptor),
+        router,
+        std::time::Duration::from_secs(SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS),
+    )
+    .await?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,10 @@ only for local/trusted-network demos."
     // stored here — only the resolved user identity.
     let authorize_session_store = Arc::new(oauth_http::AuthorizeSessionStore::new());
     let shell_registry = Arc::new(ShellClientRegistry::default());
+    // Root HTTP admission consults this process-local state before any
+    // side-effecting handler can run. It closes the small race between the
+    // authoritative drain transition and Salvo consuming its stop command.
+    let shutdown_coordinator = Arc::new(server_shutdown::ShutdownCoordinator::default());
     let quic_cfg = config::QuicServerConfig::from_env();
     let connector_context =
         connector_runtime::ConnectorContext::from_env().map_err(std::io::Error::other)?;
@@ -443,6 +447,9 @@ only for local/trusted-network demos."
         .push(Router::with_path("styles.css").get(console_web::admin_styles_css));
 
     let mut router = Router::new()
+        .hoop(server_shutdown::DrainAdmission::new(
+            shutdown_coordinator.clone(),
+        ))
         // Whole-service backstop: no handler may hold an HTTP request open
         // forever. Sized well above every legitimate request — sync agent
         // waits are <= ~122s and MCP dispatch is hard-bounded at 150s — so it
@@ -557,6 +564,7 @@ only for local/trusted-network demos."
     server_shutdown::serve_until_termination(
         Server::new(acceptor),
         router,
+        shutdown_coordinator,
         std::time::Duration::from_secs(SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS),
     )
     .await?;

--- a/src/server_shutdown.rs
+++ b/src/server_shutdown.rs
@@ -1,0 +1,217 @@
+use salvo::conn::Acceptor;
+use salvo::{Server, Service};
+use std::future::Future;
+use std::io;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShutdownReason {
+    Sigint,
+    Sigterm,
+}
+
+impl ShutdownReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sigint => "SIGINT",
+            Self::Sigterm => "SIGTERM",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShutdownState {
+    Running = 0,
+    Draining = 1,
+    Stopped = 2,
+}
+
+#[derive(Debug)]
+struct ShutdownCoordinator {
+    state: AtomicU8,
+}
+
+impl Default for ShutdownCoordinator {
+    fn default() -> Self {
+        Self {
+            state: AtomicU8::new(ShutdownState::Running as u8),
+        }
+    }
+}
+
+impl ShutdownCoordinator {
+    #[cfg(test)]
+    fn state(&self) -> ShutdownState {
+        match self.state.load(Ordering::Acquire) {
+            0 => ShutdownState::Running,
+            1 => ShutdownState::Draining,
+            2 => ShutdownState::Stopped,
+            value => panic!("invalid Server shutdown state {value}"),
+        }
+    }
+
+    fn begin_draining(&self) -> bool {
+        self.state
+            .compare_exchange(
+                ShutdownState::Running as u8,
+                ShutdownState::Draining as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn mark_stopped(&self) {
+        self.state
+            .store(ShutdownState::Stopped as u8, Ordering::Release);
+    }
+}
+
+#[cfg(unix)]
+struct TerminationSignals {
+    interrupt: tokio::signal::unix::Signal,
+    terminate: tokio::signal::unix::Signal,
+}
+
+#[cfg(unix)]
+impl TerminationSignals {
+    fn new() -> io::Result<Self> {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        Ok(Self {
+            interrupt: signal(SignalKind::interrupt())?,
+            terminate: signal(SignalKind::terminate())?,
+        })
+    }
+
+    async fn recv(&mut self) -> ShutdownReason {
+        tokio::select! {
+            _ = self.interrupt.recv() => ShutdownReason::Sigint,
+            _ = self.terminate.recv() => ShutdownReason::Sigterm,
+        }
+    }
+}
+
+#[cfg(not(unix))]
+struct TerminationSignals;
+
+#[cfg(not(unix))]
+impl TerminationSignals {
+    fn new() -> io::Result<Self> {
+        Ok(Self)
+    }
+
+    async fn recv(&mut self) -> ShutdownReason {
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => ShutdownReason::Sigint,
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "failed to listen for Server Ctrl-C; forcing shutdown"
+                );
+                ShutdownReason::Sigint
+            }
+        }
+    }
+}
+
+pub(crate) async fn serve_until_termination<A, S>(
+    server: Server<A>,
+    service: S,
+    graceful_timeout: Duration,
+) -> io::Result<()>
+where
+    A: Acceptor + Send,
+    S: Into<Service> + Send,
+{
+    let mut signals = TerminationSignals::new()?;
+    let coordinator = Arc::new(ShutdownCoordinator::default());
+    serve_with_signal(
+        server,
+        service,
+        coordinator,
+        signals.recv(),
+        graceful_timeout,
+    )
+    .await
+}
+
+async fn serve_with_signal<A, S, F>(
+    server: Server<A>,
+    service: S,
+    coordinator: Arc<ShutdownCoordinator>,
+    signal: F,
+    graceful_timeout: Duration,
+) -> io::Result<()>
+where
+    A: Acceptor + Send,
+    S: Into<Service> + Send,
+    F: Future<Output = ShutdownReason> + Send,
+{
+    let handle = server.handle();
+    let serve = server.try_serve(service);
+    tokio::pin!(serve);
+    tokio::pin!(signal);
+
+    let reason = tokio::select! {
+        result = &mut serve => {
+            coordinator.mark_stopped();
+            return result;
+        }
+        reason = &mut signal => reason,
+    };
+
+    if coordinator.begin_draining() {
+        tracing::info!(
+            shutdown_signal = reason.as_str(),
+            graceful_deadline_seconds = graceful_timeout.as_secs(),
+            shutdown_state = "draining",
+            "Server graceful shutdown requested"
+        );
+        handle.stop_graceful(Some(graceful_timeout));
+    }
+
+    let started = Instant::now();
+    let deadline = tokio::time::sleep(graceful_timeout);
+    tokio::pin!(deadline);
+    let (result, deadline_elapsed) = tokio::select! {
+        result = &mut serve => (result, false),
+        _ = &mut deadline => {
+            tracing::warn!(
+                shutdown_signal = reason.as_str(),
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                graceful_deadline_seconds = graceful_timeout.as_secs(),
+                "Server graceful shutdown deadline reached; Salvo force-stop escalation is active"
+            );
+            // `stop_graceful(Some(timeout))` owns the force-stop timer. Keep
+            // awaiting the same serve future instead of dropping/cancelling it
+            // or duplicating Salvo's escalation lifecycle.
+            (serve.await, true)
+        }
+    };
+    coordinator.mark_stopped();
+    let elapsed = started.elapsed();
+    if deadline_elapsed {
+        tracing::warn!(
+            shutdown_signal = reason.as_str(),
+            elapsed_ms = elapsed.as_millis() as u64,
+            graceful_deadline_seconds = graceful_timeout.as_secs(),
+            shutdown_state = "stopped",
+            "Server shutdown completed after graceful deadline escalation"
+        );
+    } else {
+        tracing::info!(
+            shutdown_signal = reason.as_str(),
+            elapsed_ms = elapsed.as_millis() as u64,
+            graceful_deadline_seconds = graceful_timeout.as_secs(),
+            shutdown_state = "stopped",
+            "Server graceful shutdown completed"
+        );
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/server_shutdown.rs
+++ b/src/server_shutdown.rs
@@ -1,4 +1,5 @@
 use salvo::conn::Acceptor;
+use salvo::prelude::*;
 use salvo::{Server, Service};
 use std::future::Future;
 use std::io;
@@ -29,7 +30,7 @@ enum ShutdownState {
 }
 
 #[derive(Debug)]
-struct ShutdownCoordinator {
+pub(crate) struct ShutdownCoordinator {
     state: AtomicU8,
 }
 
@@ -63,9 +64,50 @@ impl ShutdownCoordinator {
             .is_ok()
     }
 
+    fn is_running(&self) -> bool {
+        self.state.load(Ordering::Acquire) == ShutdownState::Running as u8
+    }
+
     fn mark_stopped(&self) {
         self.state
             .store(ShutdownState::Stopped as u8, Ordering::Release);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DrainAdmission {
+    coordinator: Arc<ShutdownCoordinator>,
+}
+
+impl DrainAdmission {
+    pub(crate) fn new(coordinator: Arc<ShutdownCoordinator>) -> Self {
+        Self { coordinator }
+    }
+}
+
+#[async_trait]
+impl Handler for DrainAdmission {
+    async fn handle(
+        &self,
+        req: &mut Request,
+        depot: &mut Depot,
+        res: &mut Response,
+        ctrl: &mut FlowCtrl,
+    ) {
+        if !self.coordinator.is_running() {
+            res.status_code(StatusCode::SERVICE_UNAVAILABLE);
+            res.headers_mut().insert(
+                salvo::http::header::RETRY_AFTER,
+                salvo::http::HeaderValue::from_static("1"),
+            );
+            res.render(Json(serde_json::json!({
+                "error": "server_draining",
+                "message": "Server is draining; retry the request against the replacement Server"
+            })));
+            ctrl.skip_rest();
+            return;
+        }
+        ctrl.call_next(req, depot, res).await;
     }
 }
 
@@ -120,6 +162,7 @@ impl TerminationSignals {
 pub(crate) async fn serve_until_termination<A, S>(
     server: Server<A>,
     service: S,
+    coordinator: Arc<ShutdownCoordinator>,
     graceful_timeout: Duration,
 ) -> io::Result<()>
 where
@@ -127,7 +170,6 @@ where
     S: Into<Service> + Send,
 {
     let mut signals = TerminationSignals::new()?;
-    let coordinator = Arc::new(ShutdownCoordinator::default());
     serve_with_signal(
         server,
         service,

--- a/src/server_shutdown/tests.rs
+++ b/src/server_shutdown/tests.rs
@@ -27,6 +27,7 @@ async fn start_test_server(
     let server = Server::new(acceptor);
     let (signal_tx, signal_rx) = oneshot::channel();
     let coordinator = Arc::new(ShutdownCoordinator::default());
+    let router = router.hoop(DrainAdmission::new(coordinator.clone()));
     let task_coordinator = coordinator.clone();
     let task = tokio::spawn(async move {
         serve_with_signal(
@@ -202,6 +203,63 @@ async fn counted_handler(depot: &mut Depot) -> &'static str {
         .0
         .fetch_add(1, Ordering::SeqCst);
     "ok"
+}
+
+#[tokio::test]
+async fn drain_admission_fence_closes_salvo_command_channel_accept_race() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let coordinator = Arc::new(ShutdownCoordinator::default());
+    let router = Router::new()
+        .hoop(DrainAdmission::new(coordinator.clone()))
+        .hoop(affix_state::inject(CountGate(counter.clone())))
+        .get(counted_handler);
+    let acceptor = TcpListener::new("127.0.0.1:0").bind().await;
+    let addr = acceptor.holdings()[0]
+        .local_addr
+        .clone()
+        .into_std()
+        .unwrap();
+    let server = Server::new(acceptor);
+    let force_handle = server.handle();
+    let task_coordinator = coordinator.clone();
+    let server_task = tokio::spawn(async move {
+        serve_with_signal(
+            server,
+            router,
+            task_coordinator,
+            pending::<ShutdownReason>(),
+            Duration::from_secs(1),
+        )
+        .await
+    });
+
+    let first = reqwest::get(format!("http://{addr}/")).await.unwrap();
+    assert_eq!(first.status().as_u16(), 200);
+    assert_eq!(first.text().await.unwrap(), "ok");
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    // Model the exact production race: the WebCodex drain transition is
+    // authoritative, but Salvo has not consumed a stop command yet. Without
+    // the root admission fence another accepted request could still dispatch.
+    assert!(coordinator.begin_draining());
+    let second = reqwest::get(format!("http://{addr}/")).await.unwrap();
+    assert_eq!(second.status().as_u16(), 503);
+    assert_eq!(second.headers().get("retry-after").unwrap(), "1");
+    let body: serde_json::Value = second.json().await.unwrap();
+    assert_eq!(body["error"], "server_draining");
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "post-drain request reached side-effect handler before Salvo stop command"
+    );
+
+    force_handle.stop_forcible();
+    tokio::time::timeout(Duration::from_secs(1), server_task)
+        .await
+        .expect("forced test cleanup timed out")
+        .unwrap()
+        .unwrap();
+    assert_eq!(coordinator.state(), ShutdownState::Stopped);
 }
 
 async fn read_http_response(stream: &mut tokio::net::TcpStream) -> io::Result<Vec<u8>> {

--- a/src/server_shutdown/tests.rs
+++ b/src/server_shutdown/tests.rs
@@ -1,0 +1,364 @@
+use super::*;
+use salvo::conn::{Listener, TcpListener};
+use salvo::prelude::{affix_state, handler, Depot, Request, Response, Router};
+use salvo::websocket::WebSocketUpgrade;
+use std::convert::Infallible;
+use std::future::pending;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::{oneshot, Notify};
+
+async fn start_test_server(
+    router: Router,
+    graceful_timeout: Duration,
+) -> (
+    SocketAddr,
+    oneshot::Sender<ShutdownReason>,
+    Arc<ShutdownCoordinator>,
+    tokio::task::JoinHandle<io::Result<()>>,
+) {
+    let acceptor = TcpListener::new("127.0.0.1:0").bind().await;
+    let addr = acceptor.holdings()[0]
+        .local_addr
+        .clone()
+        .into_std()
+        .expect("test listener should be a TCP socket");
+    let server = Server::new(acceptor);
+    let (signal_tx, signal_rx) = oneshot::channel();
+    let coordinator = Arc::new(ShutdownCoordinator::default());
+    let task_coordinator = coordinator.clone();
+    let task = tokio::spawn(async move {
+        serve_with_signal(
+            server,
+            router,
+            task_coordinator,
+            async move { signal_rx.await.expect("test shutdown sender dropped") },
+            graceful_timeout,
+        )
+        .await
+    });
+    (addr, signal_tx, coordinator, task)
+}
+
+async fn wait_for_state(coordinator: &ShutdownCoordinator, expected: ShutdownState) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if coordinator.state() == expected {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("shutdown state transition timed out");
+}
+
+async fn wait_until_not_running(coordinator: &ShutdownCoordinator) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while coordinator.state() == ShutdownState::Running {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("shutdown did not leave running state");
+}
+
+#[handler]
+async fn hello() -> &'static str {
+    "hello"
+}
+
+#[tokio::test]
+async fn no_signal_keeps_server_running() {
+    let acceptor = TcpListener::new("127.0.0.1:0").bind().await;
+    let addr = acceptor.holdings()[0]
+        .local_addr
+        .clone()
+        .into_std()
+        .unwrap();
+    let server = Server::new(acceptor);
+    let force_handle = server.handle();
+    let coordinator = Arc::new(ShutdownCoordinator::default());
+    let task_coordinator = coordinator.clone();
+    let task = tokio::spawn(async move {
+        serve_with_signal(
+            server,
+            Router::new().get(hello),
+            task_coordinator,
+            pending::<ShutdownReason>(),
+            Duration::from_millis(200),
+        )
+        .await
+    });
+
+    let body = reqwest::get(format!("http://{addr}/"))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(body, "hello");
+    assert_eq!(coordinator.state(), ShutdownState::Running);
+    assert!(!task.is_finished());
+
+    force_handle.stop_forcible();
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("forced test cleanup timed out")
+        .unwrap()
+        .unwrap();
+    assert_eq!(coordinator.state(), ShutdownState::Stopped);
+}
+
+#[test]
+fn shutdown_state_transition_is_authoritative_once() {
+    let coordinator = ShutdownCoordinator::default();
+    assert_eq!(coordinator.state(), ShutdownState::Running);
+    assert!(coordinator.begin_draining());
+    assert_eq!(coordinator.state(), ShutdownState::Draining);
+    assert!(!coordinator.begin_draining());
+    assert_eq!(coordinator.state(), ShutdownState::Draining);
+    coordinator.mark_stopped();
+    assert_eq!(coordinator.state(), ShutdownState::Stopped);
+    assert!(!coordinator.begin_draining());
+}
+
+#[test]
+fn production_grace_exceeds_request_hard_timeout_with_systemd_margin() {
+    assert_eq!(crate::REQUEST_HARD_TIMEOUT_SECS, 300);
+    assert_eq!(crate::SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, 315);
+    assert!(crate::SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS > crate::REQUEST_HARD_TIMEOUT_SECS);
+    assert_eq!(crate::SERVER_SYSTEMD_TIMEOUT_STOP_SECS, 330);
+    assert!(crate::SERVER_SYSTEMD_TIMEOUT_STOP_SECS > crate::SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS);
+}
+
+#[derive(Clone)]
+struct SlowGate {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+#[handler]
+async fn slow_handler(depot: &mut Depot) -> &'static str {
+    let gate = depot.obtain::<SlowGate>().unwrap().clone();
+    gate.started.notify_one();
+    gate.release.notified().await;
+    "slow-complete"
+}
+
+#[tokio::test]
+async fn finite_request_started_before_drain_reaches_client_before_server_exit() {
+    let gate = SlowGate {
+        started: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let router = Router::new()
+        .hoop(affix_state::inject(gate.clone()))
+        .get(slow_handler);
+    let (addr, shutdown, coordinator, server_task) =
+        start_test_server(router, Duration::from_secs(2)).await;
+    let request = tokio::spawn(async move {
+        reqwest::get(format!("http://{addr}/"))
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    });
+    tokio::time::timeout(Duration::from_secs(1), gate.started.notified())
+        .await
+        .expect("slow handler never started");
+
+    shutdown.send(ShutdownReason::Sigterm).unwrap();
+    wait_for_state(&coordinator, ShutdownState::Draining).await;
+    assert!(
+        !request.is_finished(),
+        "in-flight request was cancelled at drain start"
+    );
+    gate.release.notify_waiters();
+
+    let body = tokio::time::timeout(Duration::from_secs(1), request)
+        .await
+        .expect("client did not receive drained response")
+        .unwrap();
+    assert_eq!(body, "slow-complete");
+    tokio::time::timeout(Duration::from_secs(1), server_task)
+        .await
+        .expect("server did not exit after finite request completed")
+        .unwrap()
+        .unwrap();
+    assert_eq!(coordinator.state(), ShutdownState::Stopped);
+}
+
+#[derive(Clone)]
+struct CountGate(Arc<AtomicUsize>);
+
+#[handler]
+async fn counted_handler(depot: &mut Depot) -> &'static str {
+    depot
+        .obtain::<CountGate>()
+        .unwrap()
+        .0
+        .fetch_add(1, Ordering::SeqCst);
+    "ok"
+}
+
+async fn read_http_response(stream: &mut tokio::net::TcpStream) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let mut buf = [0u8; 1024];
+    let header_end = loop {
+        let n = stream.read(&mut buf).await?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "response headers truncated",
+            ));
+        }
+        bytes.extend_from_slice(&buf[..n]);
+        if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break index + 4;
+        }
+    };
+    let headers = std::str::from_utf8(&bytes[..header_end])
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing content-length"))?;
+    while bytes.len() - header_end < content_length {
+        let n = stream.read(&mut buf).await?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "response body truncated",
+            ));
+        }
+        bytes.extend_from_slice(&buf[..n]);
+    }
+    Ok(bytes)
+}
+
+#[tokio::test]
+async fn drain_disables_existing_http1_keepalive_before_new_handler_dispatch() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let router = Router::new()
+        .hoop(affix_state::inject(CountGate(counter.clone())))
+        .get(counted_handler);
+    let (addr, shutdown, coordinator, server_task) =
+        start_test_server(router, Duration::from_secs(1)).await;
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    stream
+        .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        .await
+        .unwrap();
+    let first = read_http_response(&mut stream).await.unwrap();
+    assert!(first.ends_with(b"ok"));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    shutdown.send(ShutdownReason::Sigterm).unwrap();
+    // An idle keepalive may close so quickly that Draining is only transient;
+    // either Draining or Stopped proves the shutdown command became authoritative
+    // before the second request is attempted.
+    wait_until_not_running(&coordinator).await;
+    let _ = stream
+        .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await;
+    let mut byte = [0u8; 1];
+    let _ = tokio::time::timeout(Duration::from_millis(200), stream.read(&mut byte)).await;
+
+    tokio::time::timeout(Duration::from_secs(1), server_task)
+        .await
+        .expect("idle keepalive blocked graceful shutdown")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "post-drain request reached handler"
+    );
+}
+
+#[derive(Clone)]
+struct WsGate {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+#[handler]
+async fn ws_handler(req: &mut Request, depot: &mut Depot, res: &mut Response) {
+    let gate = depot.obtain::<WsGate>().unwrap().clone();
+    WebSocketUpgrade::new()
+        .upgrade(req, res, move |_socket| async move {
+            gate.started.notify_one();
+            gate.release.notified().await;
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn upgraded_websocket_does_not_hold_http_server_graceful_completion() {
+    let gate = WsGate {
+        started: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let router = Router::with_path("ws")
+        .hoop(affix_state::inject(gate.clone()))
+        .get(ws_handler);
+    let (addr, shutdown, _coordinator, server_task) =
+        start_test_server(router, Duration::from_secs(1)).await;
+    let (websocket, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/ws"))
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), gate.started.notified())
+        .await
+        .expect("websocket callback did not start");
+
+    shutdown.send(ShutdownReason::Sigterm).unwrap();
+    tokio::time::timeout(Duration::from_millis(500), server_task)
+        .await
+        .expect("upgraded websocket held HTTP graceful shutdown")
+        .unwrap()
+        .unwrap();
+
+    drop(websocket);
+    gate.release.notify_waiters();
+}
+
+#[tokio::test]
+async fn graceful_deadline_forces_hung_finite_request_boundedly() {
+    let gate = SlowGate {
+        started: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let router = Router::new()
+        .hoop(affix_state::inject(gate.clone()))
+        .get(slow_handler);
+    let (addr, shutdown, _coordinator, server_task) =
+        start_test_server(router, Duration::from_millis(80)).await;
+    let request = tokio::spawn(async move { reqwest::get(format!("http://{addr}/")).await });
+    tokio::time::timeout(Duration::from_secs(1), gate.started.notified())
+        .await
+        .expect("hung test handler did not start");
+
+    let started = Instant::now();
+    shutdown.send(ShutdownReason::Sigterm).unwrap();
+    tokio::time::timeout(Duration::from_secs(1), server_task)
+        .await
+        .expect("grace timeout failed to bound Server exit")
+        .unwrap()
+        .unwrap();
+    assert!(started.elapsed() >= Duration::from_millis(60));
+    assert!(started.elapsed() < Duration::from_secs(1));
+    request.abort();
+    gate.release.notify_waiters();
+}
+
+#[allow(dead_code)]
+fn _assert_infallible(_: Infallible) {}


### PR DESCRIPTION
## Summary

Add L2 graceful in-flight drain on top of the Linux systemd socket-activation listener continuity merged in #149.

- handle SIGTERM/SIGINT through one bounded Server shutdown coordinator
- preserve already-dispatched finite HTTP requests during drain
- fence post-drain HTTP admission before business handlers, including the Salvo 0.93 command-channel/accept-loop race found during independent review
- use Salvo 0.93 `ServerHandle::stop_graceful` without replacing the HTTP shutdown framework
- keep the timeout invariant `300s request < 315s application grace < 330s systemd TimeoutStopSec`
- extend the socket-activation harness with a real Runner-backed in-flight `run_process` restart scenario

## Availability contract

On `systemctl restart webcodex.service`, the systemd-owned socket remains active while the old Server drains finite in-flight work. New work is no longer admitted by the old Server after the process-local draining boundary becomes authoritative. The replacement Server then inherits the same listener.

This improves in-flight request integrity and keeps termination bounded. It does **not** claim overlapping Server generations, zero-latency restart, WebSocket continuity, or literal zero interruption. L3 overlapping generations remains out of scope.

## Validation

Implementation/review evidence on Special:

- `cargo fmt -- --check` — pass
- `cargo check --all-targets -p webcodex` — pass, 0 warnings/errors
- `cargo check --all-targets -p webcodex-cli` — pass, 0 warnings/errors
- `cargo test server_shutdown -p webcodex` — 8 passed / 0 failed
- `cargo test tests::server::service -p webcodex-cli` — 21 passed / 0 failed
- dogfood `webcodex-server` build — pass
- socket activation / listener continuity / graceful in-flight harness — pass
- real Runner-backed in-flight request completed with HTTP 200 across SIGTERM; Runner reconnected
- `scripts/e2e_job_reconciliation_ws.sh` — 80 pass / 0 fail

Independent reviewer also rebuilt the exact reviewer Git tree natively on arm64 under a real PID1 systemd host and exercised isolated temporary `.socket`/`.service` units:

- effective `TimeoutStopUSec=5min 30s`
- socket `InvocationID` and active-enter timestamp unchanged across service restart
- service PID changed
- continuous probes: 96 success / 0 refused / 0 reset / 0 timeout / 0 unexpected
- journal confirmed SIGTERM entered and completed the graceful shutdown path
- all temporary units/worktree/artifacts were removed afterward

The branch was first rebased onto #150 and then, after main advanced again during PR creation, onto `7c515e6e252d8e941d5b271dd798d2d5ba4c7457` (`Publish multi-arch Server images (#151)`). Both rebases completed without conflicts and `git range-diff` reported all four L2 commits as `=`. The first post-rebase shutdown/CLI/package validations were green; #151 intersects L2 only in deployment documentation, and the second rebase preserved the complete four-commit patch identically.