### PR TITLE
Preserve published Server image release records

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -333,8 +333,8 @@ jobs:
           metadata_name=webcodex-server-image.json
           metadata="$RUNNER_TEMP/$metadata_name"
           manifest_json="$RUNNER_TEMP/manifest.json"
-          existing_metadata="$RUNNER_TEMP/existing-metadata"
-          mkdir -p "$existing_metadata"
+          release_record_dir="$RUNNER_TEMP/existing-release-record"
+          mkdir -p "$release_record_dir"
 
           refs=()
           shopt -s nullglob
@@ -445,15 +445,64 @@ jobs:
           PY
           )
 
-          deployment_dir="$RUNNER_TEMP/server-deployment-assets"
-          deployment_summary="$RUNNER_TEMP/server-deployment-assets.json"
-          python3 scripts/prepare_server_deployment_assets.py \
-            --compose compose.yaml \
-            --bootstrap deploy/docker/bootstrap.sh \
-            --output-dir "$deployment_dir" \
-            --digest "$digest" \
-            --summary "$deployment_summary" >/dev/null
-          python3 - "$metadata" "$deployment_summary" "$WORKFLOW_SHA" <<'PY'
+          release_json="$RUNNER_TEMP/release-assets.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" > "$release_json"
+          metadata_asset_id="$(python3 - "$release_json" "$metadata_name" <<'PY'
+          import json
+          import sys
+          release = json.load(open(sys.argv[1], encoding="utf-8"))
+          name = sys.argv[2]
+          print(next((str(asset["id"]) for asset in release.get("assets", []) if asset.get("name") == name), ""))
+          PY
+          )"
+          bootstrap_name=webcodex-server-bootstrap.sh
+          bootstrap_asset_id="$(python3 - "$release_json" "$bootstrap_name" <<'PY'
+          import json
+          import sys
+          release = json.load(open(sys.argv[1], encoding="utf-8"))
+          name = sys.argv[2]
+          print(next((str(asset["id"]) for asset in release.get("assets", []) if asset.get("name") == name), ""))
+          PY
+          )"
+
+          durable_record_exists=false
+          if [ -n "$metadata_asset_id" ]; then
+            if [ -z "$bootstrap_asset_id" ]; then
+              echo "$metadata_name exists without $bootstrap_name; refusing partial durable record reconciliation." >&2
+              exit 1
+            fi
+            for name in "$metadata_name" "$bootstrap_name"; do
+              gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "$name" --dir "$release_record_dir"
+            done
+            python3 - "$metadata" "$release_record_dir/$metadata_name" "$release_record_dir/$bootstrap_name" <<'PY'
+          import json
+          import sys
+
+          from scripts.verify_public_release import validate_server_image_release_record
+
+          expected_path, existing_path, bootstrap_path = sys.argv[1:]
+          expected = json.load(open(expected_path, encoding="utf-8"))
+          existing = json.load(open(existing_path, encoding="utf-8"))
+          validate_server_image_release_record(
+              existing,
+              expected["version"],
+              open(bootstrap_path, "rb").read(),
+              expected_base=expected,
+          )
+          PY
+            cp "$release_record_dir/$metadata_name" "$metadata"
+            durable_record_exists=true
+            echo "Existing immutable GitHub Release deployment record reconciled without regeneration."
+          else
+            deployment_dir="$RUNNER_TEMP/server-deployment-assets"
+            deployment_summary="$RUNNER_TEMP/server-deployment-assets.json"
+            python3 scripts/prepare_server_deployment_assets.py \
+              --compose compose.yaml \
+              --bootstrap deploy/docker/bootstrap.sh \
+              --output-dir "$deployment_dir" \
+              --digest "$digest" \
+              --summary "$deployment_summary" >/dev/null
+            python3 - "$metadata" "$deployment_summary" "$WORKFLOW_SHA" <<'PY'
           import json
           import os
           import re
@@ -475,6 +524,7 @@ jobs:
               handle.write("\n")
           os.replace(tmp, metadata_path)
           PY
+          fi
 
           # The numeric version is an immutable alias of vVERSION. Repair a
           # missing alias, but never retarget one that already points elsewhere.
@@ -495,30 +545,38 @@ jobs:
             docker buildx imagetools create -t "$IMAGE:latest" "$version_ref"
           fi
 
-          # The GitHub Release is the durable digest/deployment record. Missing
-          # post-publication assets can be repaired only after the canonical image
-          # is reconciled; an existing asset must match byte-for-byte. Determine
-          # existence through release metadata so a transient download failure is
-          # never mistaken for permission to upload a duplicate.
-          # Upload the deployment bytes first and the metadata that commits to
-          # their digests last. A failure before metadata publication therefore
-          # never exposes a durable record claiming missing deployment bytes.
-          for asset in \
-            "$deployment_dir/webcodex-server-bootstrap.sh" \
-            "$metadata"; do
-            asset_name="$(basename "$asset")"
-            asset_id="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" \
-              --jq ".assets[] | select(.name == \"$asset_name\") | .id" | head -n 1)"
-            if [ -n "$asset_id" ]; then
-              gh release download "$TAG" --pattern "$asset_name" --dir "$existing_metadata"
-              if ! cmp -s "$asset" "$existing_metadata/$asset_name"; then
-                echo "$asset_name differs from the immutable GitHub Release record." >&2
-                exit 1
+          # Once metadata exists, it is the immutable durable deployment record.
+          # A rerun from a newer reviewed workflow validates and preserves those
+          # exact bytes rather than trying to rewrite deployment_source_sha.
+          if [ "$durable_record_exists" = false ]; then
+            # Without metadata, a previous bootstrap upload is only a partial
+            # publication. It must still match the current reviewed bytes before
+            # metadata can commit to it.
+            for asset in \
+              "$deployment_dir/$bootstrap_name" \
+              "$metadata"; do
+              asset_name="$(basename "$asset")"
+              asset_id="$(python3 - "$release_json" "$asset_name" <<'PY'
+          import json
+          import sys
+          release = json.load(open(sys.argv[1], encoding="utf-8"))
+          name = sys.argv[2]
+          print(next((str(item["id"]) for item in release.get("assets", []) if item.get("name") == name), ""))
+          PY
+              )"
+              if [ -n "$asset_id" ]; then
+                compare_dir="$RUNNER_TEMP/compare-$asset_name"
+                mkdir -p "$compare_dir"
+                gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "$asset_name" --dir "$compare_dir"
+                if ! cmp -s "$asset" "$compare_dir/$asset_name"; then
+                  echo "$asset_name differs from the immutable GitHub Release record." >&2
+                  exit 1
+                fi
+              else
+                gh release upload "$TAG" "$asset"
               fi
-            else
-              gh release upload "$TAG" "$asset"
-            fi
-          done
+            done
+          fi
 
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           {

--- a/scripts/tests/test_release_publication.py
+++ b/scripts/tests/test_release_publication.py
@@ -549,10 +549,13 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("push-by-digest=true", image)
         self.assertIn("webcodex-server-image.json", image)
         self.assertIn("scripts/prepare_server_deployment_assets.py", image)
+        self.assertIn("validate_server_image_release_record", image)
         self.assertIn("ref: ${{ github.workflow_sha }}", image)
         self.assertIn("deployment_source_sha", image)
         self.assertIn("webcodex-server-bootstrap.sh", image)
         self.assertIn("webcodex-server-compose.yaml", image)
+        self.assertIn("durable_record_exists=false", image)
+        self.assertIn("Existing immutable GitHub Release deployment record reconciled without regeneration.", image)
         self.assertIn("Require anonymous GHCR availability", image)
         self.assertIn('gh release download "$TAG" --repo "$GITHUB_REPOSITORY"', image)
 

--- a/scripts/tests/test_verify_public_release.py
+++ b/scripts/tests/test_verify_public_release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import hashlib
 import json
 import struct
 import tarfile
@@ -88,6 +89,53 @@ class ManifestTests(unittest.TestCase):
         del manifest["artifacts"]["win32-arm64"]
         with self.assertRaises(verifier.VerificationError):
             verifier.validate_public_manifest(manifest, version)
+
+    def test_existing_server_image_release_record_preserves_immutable_deployment_source(self) -> None:
+        version = "0.3.8"
+        digest = "sha256:" + "c" * 64
+        bootstrap = (
+            "#!/bin/sh\n"
+            f"image: ${{WEBCODEX_SERVER_IMAGE:-{verifier.SERVER_IMAGE}@{digest}}}\n"
+            f"compose_target={verifier.SERVER_MATERIALIZED_COMPOSE}\n"
+        ).encode()
+        metadata = {
+            "schema_version": 1,
+            "image": verifier.SERVER_IMAGE,
+            "tag": f"v{version}",
+            "version": version,
+            "image_tag": f"v{version}",
+            "deployment_assets": {
+                verifier.SERVER_BOOTSTRAP_ASSET: hashlib.sha256(bootstrap).hexdigest(),
+            },
+            "deployment_source_sha": "2" * 40,
+            "source_sha": "b" * 40,
+            "created_at": "2026-08-20T15:13:57+08:00",
+            "digest": digest,
+            "platforms": {
+                "linux/amd64": "sha256:" + "d" * 64,
+                "linux/arm64": "sha256:" + "e" * 64,
+            },
+        }
+        expected_base = {key: metadata[key] for key in verifier.SERVER_IMAGE_BASE_METADATA_KEYS}
+        validated = verifier.validate_server_image_release_record(
+            metadata,
+            version,
+            bootstrap,
+            expected_base=expected_base,
+        )
+        self.assertEqual(validated["deployment_source_sha"], "2" * 40)
+
+        drifted = dict(expected_base)
+        drifted["digest"] = "sha256:" + "f" * 64
+        with self.assertRaises(verifier.VerificationError):
+            verifier.validate_server_image_release_record(metadata, version, bootstrap, expected_base=drifted)
+        with self.assertRaises(verifier.VerificationError):
+            verifier.validate_server_image_release_record(
+                metadata,
+                version,
+                bootstrap + b"# drift\n",
+                expected_base=expected_base,
+            )
 
     def test_server_image_metadata_requires_release_identity_and_two_platforms(self) -> None:
         version = "0.3.8"

--- a/scripts/verify_public_release.py
+++ b/scripts/verify_public_release.py
@@ -28,6 +28,19 @@ SERVER_BOOTSTRAP_ASSET = "webcodex-server-bootstrap.sh"
 SERVER_MATERIALIZED_COMPOSE = "webcodex-server-compose.yaml"
 SERVER_DEPLOYMENT_ASSETS = (SERVER_BOOTSTRAP_ASSET,)
 SERVER_IMAGE_PLATFORMS = ("linux/amd64", "linux/arm64")
+SERVER_IMAGE_BASE_METADATA_KEYS = frozenset(
+    {
+        "schema_version",
+        "image",
+        "tag",
+        "version",
+        "image_tag",
+        "source_sha",
+        "created_at",
+        "digest",
+        "platforms",
+    }
+)
 MAX_JSON_BYTES = 2 * 1024 * 1024
 MAX_NPM_TARBALL_BYTES = 16 * 1024 * 1024
 MAX_ARTIFACT_BYTES = 128 * 1024 * 1024
@@ -314,6 +327,39 @@ def validate_server_image_metadata(value: dict, version: str) -> dict[str, str]:
         "deployment_assets": deployment_assets,
         "deployment_source_sha": deployment_source_sha,
     }
+
+
+def validate_server_image_release_record(
+    value: dict,
+    version: str,
+    bootstrap_bytes: bytes,
+    *,
+    expected_base: dict | None = None,
+) -> dict[str, str]:
+    identity = validate_server_image_metadata(value, version)
+    if expected_base is not None:
+        if set(expected_base) != SERVER_IMAGE_BASE_METADATA_KEYS:
+            raise VerificationError("expected server image base metadata has an unexpected schema")
+        for key in SERVER_IMAGE_BASE_METADATA_KEYS:
+            if value.get(key) != expected_base.get(key):
+                raise VerificationError(f"existing server image release record differs from canonical {key}")
+
+    deployment_assets = identity["deployment_assets"]
+    if not isinstance(deployment_assets, dict):
+        raise VerificationError("server deployment asset metadata is invalid")
+    actual_digest = hashlib.sha256(bootstrap_bytes).hexdigest()
+    if actual_digest != deployment_assets[SERVER_BOOTSTRAP_ASSET]:
+        raise VerificationError("server deployment metadata digest mismatch")
+    try:
+        bootstrap_text = bootstrap_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise VerificationError("server deployment bootstrap is not UTF-8") from exc
+    pinned_image = f"{SERVER_IMAGE}@{identity['digest']}"
+    if bootstrap_text.count(pinned_image) != 1 or f"{SERVER_IMAGE}:latest" in bootstrap_text:
+        raise VerificationError("server deployment bootstrap is not pinned to the recorded image digest")
+    if f"compose_target={SERVER_MATERIALIZED_COMPOSE}" not in bootstrap_text:
+        raise VerificationError("server deployment bootstrap does not materialize the canonical compose file")
+    return identity
 
 
 def validate_github_assets(release: dict, version: str) -> dict[str, dict]:
@@ -638,27 +684,13 @@ def verify_public_release(version: str, timeout: float) -> None:
                 raise VerificationError("server image metadata asset is not valid JSON") from exc
             if not isinstance(image_metadata, dict):
                 raise VerificationError("server image metadata asset must be a JSON object")
-            image_identity = validate_server_image_metadata(image_metadata, version)
-            deployment_assets = image_identity["deployment_assets"]
-            if not isinstance(deployment_assets, dict):
-                raise VerificationError("server deployment asset metadata is invalid")
             asset = assets[SERVER_BOOTSTRAP_ASSET]
             bootstrap_bytes = fetch_bytes(asset["browser_download_url"], MAX_JSON_BYTES, timeout)
             github_digest = _asset_digest(asset)
             actual_digest = hashlib.sha256(bootstrap_bytes).hexdigest()
             if github_digest is not None and actual_digest != github_digest:
                 raise VerificationError("GitHub deployment bootstrap digest mismatch")
-            if actual_digest != deployment_assets[SERVER_BOOTSTRAP_ASSET]:
-                raise VerificationError("server deployment metadata digest mismatch")
-            try:
-                bootstrap_text = bootstrap_bytes.decode("utf-8")
-            except UnicodeDecodeError as exc:
-                raise VerificationError("server deployment bootstrap is not UTF-8") from exc
-            pinned_image = f"{SERVER_IMAGE}@{image_identity['digest']}"
-            if bootstrap_text.count(pinned_image) != 1 or f"{SERVER_IMAGE}:latest" in bootstrap_text:
-                raise VerificationError("server deployment bootstrap is not pinned to the recorded image digest")
-            if f"compose_target={SERVER_MATERIALIZED_COMPOSE}" not in bootstrap_text:
-                raise VerificationError("server deployment bootstrap does not materialize the canonical compose file")
+            image_identity = validate_server_image_release_record(image_metadata, version, bootstrap_bytes)
 
         print(f"npm={PACKAGE}@{version} manifest=ok")
         print(f"github_release=v{version} assets={len(assets)}")


### PR DESCRIPTION
## Summary

Close the real rerun-idempotency gap exposed by the partially successful v0.3.8 Server image backfill.

- treat an existing `webcodex-server-image.json` plus bootstrap as the immutable durable deployment record for that Release
- validate the existing record against the canonical image/tag/source/digest/platform identity and its recorded bootstrap SHA/pinned image before reuse
- preserve the original `deployment_source_sha` and asset bytes when a newer reviewed `release-image.yml` reruns the same immutable Release
- keep the existing conservative partial-publication behavior when metadata is still absent: an already-uploaded bootstrap must byte-match the current reviewed bytes before metadata can commit to it
- keep anonymous GHCR/public verification unchanged

This does not redesign the image workflow or rewrite existing v0.3.8 Release assets. It only makes a safe rerun from newer workflow source reconcile an already-published durable record instead of failing because regenerated metadata would contain a newer `deployment_source_sha`.

## Validation

- `python3 -m unittest scripts.tests.test_verify_public_release scripts.tests.test_release_publication` — 29 passed
- Python compile checks for changed release scripts/tests — pass
- all five Bash `run: |` blocks in `release-image.yml` extracted and `bash -n` validated
- `git diff --check` — pass
- actual public v0.3.8 `webcodex-server-image.json` + bootstrap accepted by the new reconciliation helper while preserving `deployment_source_sha=d22c7614...`

## Public-only deployment evidence

In parallel, the already-published v0.3.8 assets were exercised on a clean Azure Ubuntu x86_64 host using an empty Docker config (anonymous registry access only):

`GitHub Release latest bootstrap -> anonymous GHCR pull -> docker compose up -> healthy -> /openapi.json -> docker compose restart -> healthy -> /openapi.json`

Result: PASS. The deployed image was the public immutable digest `sha256:6aa8a130...` and Server/CLI both reported v0.3.8 source `477c1f754e8b`, dirty=false. The disposable stack and volume were removed afterward.

After this PR merges, the intended next action is to re-dispatch `release-image.yml(tag=v0.3.8)` from latest `main` and require the whole workflow, including `verify-public`, to finish successfully.