### PR TITLE
Fix Windows Runner exactly-one primary recheck

### DIFF
--- a/scripts/deploy_windows_runner_dogfood.ps1
+++ b/scripts/deploy_windows_runner_dogfood.ps1
@@ -206,7 +206,10 @@ try {
         -AllowVersionMismatch:$AllowVersionMismatch
     $candidateReadyObservation = $candidateReady.Observation
     $null = Assert-CapturedPrimaryRunnerIdentity -Identity $newPrimary
-    if ((Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -ne 1) {
+    # Windows PowerShell 5.1 unwraps a single pipeline object, so a bare
+    # `(Get-PrimaryRunnerProcesses ...).Count` is `$null` for the healthy
+    # exactly-one case. Force array semantics before checking cardinality.
+    if (@(Get-PrimaryRunnerProcesses -ExactPath $RunnerPath).Count -ne 1) {
         throw "New Runner did not remain the exactly-one primary Runner after readiness"
     }
 

--- a/scripts/test_windows_runner_readiness.ps1
+++ b/scripts/test_windows_runner_readiness.ps1
@@ -204,6 +204,10 @@ $deployTokens = $null
 $deployParseErrors = $null
 $deployAst = [System.Management.Automation.Language.Parser]::ParseFile($deployPath, [ref]$deployTokens, [ref]$deployParseErrors)
 Assert-Equal 0 @($deployParseErrors).Count "deployment helper parser errors"
+# Windows PowerShell 5.1 unwraps a one-item pipeline result to a scalar.
+# The final local exactly-one-primary proof must therefore force array semantics;
+# otherwise the healthy one-primary case observes `$null` for `.Count` and rolls back.
+Assert-True ($deployAst.Extent.Text -match 'if\s*\(\s*@\(Get-PrimaryRunnerProcesses\s+-ExactPath\s+\$RunnerPath\)\.Count\s+-ne\s+1\s*\)') "deployment helper exactly-one primary recheck is not array-wrapped"
 $allowVersionParameters = @($deployAst.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'AllowVersionMismatch' })
 Assert-Equal 1 $allowVersionParameters.Count "deployment helper does not expose exactly one AllowVersionMismatch opt-in"
 $deployReadinessCalls = @($deployAst.FindAll({


### PR DESCRIPTION
## Summary

- force array semantics for the final Windows Runner primary-count recheck so Windows PowerShell 5.1 does not scalar-unroll the healthy exactly-one result
- add focused regression coverage in the existing Windows Runner readiness test

## Validation

- `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts\test_windows_runner_readiness.ps1`
- `git diff --check`
- `cargo build --profile dogfood --bin webcodex-runner -p webcodex-runner`
- candidate identity: `c40aa52734f2 / dirty=false`

## MSI dogfood

Real replacement completed successfully through the existing deployment helper:

- old instance: `538bd437-ba03-4512-bf17-d8db14d33e62`, build `b46ece5ef747 / dirty=false`
- new instance: `7cdec7c3-687d-4826-9c70-abb291c6608c`, build `c40aa52734f2 / dirty=false`
- readiness: `exact_fresh_build_ready`
- expected and observed build identities matched exactly
- post-deployment lifecycle: Scheduled Task `Running`, `RunLevel=Limited`, exactly one primary Runner, zero unexpected primaries
- temporary dogfood controller/task files were removed; the standard rollback binary was retained by the successful deployment helper

The bounded failure/rollback path was also exercised during the preceding #97 dogfood and proved a fresh rollback Runner before this fix was developed.

`origin/main` advanced during dogfood only by #161, whose changed files do not overlap these Windows scripts. This branch intentionally preserves the exact dogfooded commit rather than rewriting its history after validation.

Fixes #97