### PR TITLE
Prevent macOS Server worker stack overflow

### DIFF
--- a/src/bin/webcodex-server.rs
+++ b/src/bin/webcodex-server.rs
@@ -1,9 +1,22 @@
 use webcodex::{server_binary_action, ServerBinaryAction};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+// The default macOS Tokio worker stack is too small for the deepest MCP request
+// path exercised by the local Server. Keep this explicit instead of requiring
+// callers to set RUST_MIN_STACK for `webcodex share`.
+#[cfg(target_os = "macos")]
+const MACOS_SERVER_RUNTIME_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+fn build_server_runtime() -> std::io::Result<tokio::runtime::Runtime> {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+    #[cfg(target_os = "macos")]
+    builder.thread_stack_size(MACOS_SERVER_RUNTIME_STACK_SIZE);
+    builder.build()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server_binary_action(std::env::args().skip(1)) {
-        ServerBinaryAction::Run => webcodex::run_server().await,
+        ServerBinaryAction::Run => build_server_runtime()?.block_on(webcodex::run_server()),
         ServerBinaryAction::Exit {
             code,
             stdout,
@@ -17,5 +30,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             std::process::exit(code);
         }
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_runtime_uses_large_worker_stack() {
+        let runtime = build_server_runtime().expect("build WebCodex Server runtime");
+        let stack_size = runtime.block_on(async {
+            tokio::spawn(async {
+                // SAFETY: pthread_self returns the current worker thread and
+                // pthread_get_stacksize_np only queries that thread's stack metadata.
+                unsafe { libc::pthread_get_stacksize_np(libc::pthread_self()) }
+            })
+            .await
+            .expect("observe WebCodex Server worker")
+        });
+        assert!(
+            stack_size >= MACOS_SERVER_RUNTIME_STACK_SIZE,
+            "WebCodex Server worker stack was {stack_size} bytes; expected at least {MACOS_SERVER_RUNTIME_STACK_SIZE}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fix a macOS-only WebCodex Server crash observed during real OpenAI Secure MCP Tunnel dogfood.

A normal MCP request could reach the local Server and abort a Tokio worker with `stack overflow`. The same request succeeded when `RUST_MIN_STACK=8388608` was supplied diagnostically.

This change makes the `webcodex-server` binary build its Tokio multi-thread runtime explicitly and uses an 8 MiB worker stack on macOS only. Linux and Windows retain Tokio's default worker stack behavior.

## Evidence

- reproduced the crash twice on mini/macOS during real `webcodex share --tunnel openai` calls
- diagnostic `RUST_MIN_STACK=8388608` removed the crash
- macOS runtime regression verifies the configured worker stack is at least 8 MiB
- `cargo fmt -- --check` passed
- focused Server compilation passed
- macOS arm64 build of WebCodex/Runner/CLI passed
- with `RUST_MIN_STACK` explicitly unset, live `share --tunnel openai` reached `/healthz=200` and `/readyz=200`
- direct MCP `initialize` and `tools/list` both returned HTTP 200 and the Server remained alive
- real ChatGPT Secure Tunnel tool invocation passed after the stack adjustment

The branch was rebased cleanly onto current `main`; the intervening #162 change is Windows Runner-only and does not overlap this fix.