### PR TITLE
Run Python tooling tests from one entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,7 @@ jobs:
           node-version: 22
       - name: Test release verification tooling
         run: |
-          python3 -m unittest scripts.tests.test_verify_public_release scripts.tests.test_collect_release_bundle scripts.tests.test_release_readiness scripts.tests.test_release_publication scripts.tests.test_check_markdown_links
-          python3 -m py_compile scripts/verify_public_release.py scripts/collect_release_bundle.py scripts/release_readiness.py scripts/release_publication.py scripts/release_operator.py scripts/check_markdown_links.py
+          bash scripts/test_python_tooling.sh
           python3 scripts/release_operator.py --help >/dev/null
           python3 scripts/release_operator.py preflight --help >/dev/null
           python3 scripts/release_operator.py readiness-start --help >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - name: Ensure Python tooling test dependencies
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y ripgrep
+          fi
       - name: Test release verification tooling
         run: |
           bash scripts/test_python_tooling.sh

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -160,8 +160,7 @@ done
 # Stage 9: release verification tooling self-tests
 # ----------------------------------------------------------------------------
 stage_start "release verification tooling self-tests"
-if python3 -m unittest scripts.tests.test_verify_public_release scripts.tests.test_collect_release_bundle scripts.tests.test_release_readiness scripts.tests.test_release_publication scripts.tests.test_check_markdown_links \
-    && python3 -m py_compile scripts/verify_public_release.py scripts/collect_release_bundle.py scripts/release_readiness.py scripts/release_publication.py scripts/release_operator.py scripts/check_markdown_links.py \
+if bash scripts/test_python_tooling.sh \
     && python3 scripts/release_operator.py --help >/dev/null \
     && python3 scripts/release_operator.py preflight --help >/dev/null \
     && python3 scripts/release_operator.py reclaim-tag --help >/dev/null \

--- a/scripts/test_python_tooling.sh
+++ b/scripts/test_python_tooling.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+
+paths = sorted(Path("scripts").rglob("*.py"))
+for path in paths:
+    source = path.read_bytes()
+    compile(source, str(path), "exec")
+print(f"syntax-checked {len(paths)} Python files under scripts/")
+PY
+
+python3 -m unittest discover \
+    --start-directory scripts/tests \
+    --pattern 'test_*.py'


### PR DESCRIPTION
## Summary
- add `scripts/test_python_tooling.sh` as the single Python syntax + unittest discovery entrypoint
- make Linux tooling CI call that entrypoint instead of maintaining a hand-written unittest/py_compile list
- make `release_check.sh` reuse the same entrypoint

This closes the bootstrap-test coverage gap: `scripts/tests/test_server_docker_bootstrap.py` and future `test_*.py` files under `scripts/tests` are discovered automatically, while all Python files under `scripts/` receive a syntax compile check.

## Validation
- `bash scripts/test_python_tooling.sh` — 64 tests passed; 19 Python files syntax-checked
- `bash -n scripts/test_python_tooling.sh scripts/release_check.sh`
- `git diff --check`

Full CI is requested because this PR changes CI orchestration itself.