### PR TITLE
Harden systemd Server service lifecycle

### DIFF
--- a/crates/webcodex-cli/src/webcodex_cli/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/service.rs
@@ -812,6 +812,13 @@ fn capture_install_snapshot<E: ProcessExecutor>(
         ExistingUnitKind::Absent => None,
     };
     let active = query_status_output(executor, systemctl, unit, "is-active");
+    if matches!(existing_kind, ExistingUnitKind::ManagedRegularFile)
+        && !matches!(active.as_str(), "active" | "inactive" | "failed")
+    {
+        return Err(format!(
+            "cannot safely overwrite {unit} while systemctl is-active reports '{active}'; wait for the unit to leave its transitional or unknown state before retrying"
+        ));
+    }
     let enabled = query_status_output(executor, systemctl, unit, "is-enabled");
     if matches!(existing_kind, ExistingUnitKind::ManagedRegularFile)
         && !matches!(enabled.as_str(), "enabled" | "disabled")
@@ -934,6 +941,20 @@ fn rollback_failed_install<E: ProcessExecutor>(
 
 fn install_error_with_rollback(unit: &str, error: String, rollback_errors: Vec<String>) -> String {
     let mut message = format!("installation failed for {unit}: {error}");
+    if !rollback_errors.is_empty() {
+        let mut summary = rollback_errors.join("; ");
+        if summary.len() > 600 {
+            summary.truncate(600);
+            summary.push_str("...");
+        }
+        message.push_str("; rollback also encountered: ");
+        message.push_str(&summary);
+    }
+    message
+}
+
+fn uninstall_error_with_rollback(error: String, rollback_errors: Vec<String>) -> String {
+    let mut message = format!("uninstallation failed for webcodex Server unit pair: {error}");
     if !rollback_errors.is_empty() {
         let mut summary = rollback_errors.join("; ");
         if summary.len() > 600 {
@@ -1320,6 +1341,39 @@ fn read_managed_unit_for_uninstall(path: &Path) -> Result<Option<String>, String
         .map_err(|error| format!("failed to read {}: {error}", path.display()))
 }
 
+fn capture_uninstall_snapshot<E: ProcessExecutor>(
+    executor: &mut E,
+    systemctl: &Path,
+    unit: &str,
+    previous_content: Option<String>,
+) -> Result<InstallSnapshot, String> {
+    let existing_kind = if previous_content.is_some() {
+        ExistingUnitKind::ManagedRegularFile
+    } else {
+        ExistingUnitKind::Absent
+    };
+    let active = query_status_output(executor, systemctl, unit, "is-active");
+    let enabled = query_status_output(executor, systemctl, unit, "is-enabled");
+    if matches!(existing_kind, ExistingUnitKind::ManagedRegularFile) {
+        if !matches!(active.as_str(), "active" | "inactive" | "failed") {
+            return Err(format!(
+                "cannot safely uninstall {unit} while systemctl is-active reports '{active}'; wait for the unit to leave its transitional or unknown state before retrying"
+            ));
+        }
+        if !matches!(enabled.as_str(), "enabled" | "disabled") {
+            return Err(format!(
+                "cannot safely uninstall {unit} while systemctl is-enabled reports '{enabled}'; normalize the unit to enabled or disabled before retrying"
+            ));
+        }
+    }
+    Ok(InstallSnapshot {
+        existing_kind,
+        previous_content,
+        active,
+        enabled,
+    })
+}
+
 pub(crate) fn uninstall_server_unit_pair_with_executor<E: ProcessExecutor>(
     executor: &mut E,
     systemctl: &Path,
@@ -1336,34 +1390,45 @@ pub(crate) fn uninstall_server_unit_pair_with_executor<E: ProcessExecutor>(
             removed: false,
         });
     }
-    for unit in [socket_unit, service_unit] {
-        execute_allow_missing(executor, &rollback_invocation(systemctl, "stop", unit))?;
-        execute_allow_missing(executor, &rollback_invocation(systemctl, "disable", unit))?;
-    }
-    if service_previous.is_some() {
-        std::fs::remove_file(service_file)
-            .map_err(|error| format!("failed to remove {}: {error}", service_file.display()))?;
-    }
-    if socket_previous.is_some() {
-        if let Err(error) = std::fs::remove_file(socket_file) {
-            let _ = restore_unit_file(service_file, service_previous.as_deref());
-            return Err(format!(
-                "failed to remove {}: {error}",
-                socket_file.display()
-            ));
-        }
-    }
+    let service_snapshot =
+        capture_uninstall_snapshot(executor, systemctl, service_unit, service_previous)?;
+    let socket_snapshot =
+        capture_uninstall_snapshot(executor, systemctl, socket_unit, socket_previous)?;
+
     let reload = systemctl_invocation(
         systemctl,
         "systemctl daemon-reload",
         vec!["daemon-reload".to_string()],
         Some(service_unit),
     );
-    if let Err(error) = execute_required(executor, &reload) {
-        let _ = restore_unit_file(service_file, service_previous.as_deref());
-        let _ = restore_unit_file(socket_file, socket_previous.as_deref());
-        let _ = execute_allow_missing(executor, &reload);
-        return Err(error);
+    let uninstall = (|| -> Result<(), String> {
+        for unit in [socket_unit, service_unit] {
+            execute_allow_missing(executor, &rollback_invocation(systemctl, "stop", unit))?;
+            execute_allow_missing(executor, &rollback_invocation(systemctl, "disable", unit))?;
+        }
+        if service_snapshot.previous_content.is_some() {
+            std::fs::remove_file(service_file)
+                .map_err(|error| format!("failed to remove {}: {error}", service_file.display()))?;
+        }
+        if socket_snapshot.previous_content.is_some() {
+            std::fs::remove_file(socket_file)
+                .map_err(|error| format!("failed to remove {}: {error}", socket_file.display()))?;
+        }
+        execute_required(executor, &reload)?;
+        Ok(())
+    })();
+    if let Err(error) = uninstall {
+        let rollback_errors = pair_rollback(
+            executor,
+            systemctl,
+            service_file,
+            service_unit,
+            &service_snapshot,
+            socket_file,
+            socket_unit,
+            &socket_snapshot,
+        );
+        return Err(uninstall_error_with_rollback(error, rollback_errors));
     }
     for unit in [socket_unit, service_unit] {
         let _ = execute_allow_missing(
@@ -1920,8 +1985,19 @@ mod tests {
         let socket_file = tmp.path().join("webcodex.socket");
         std::fs::write(&service_file, "service").unwrap();
         std::fs::write(&socket_file, "socket").unwrap();
-        let mut executor =
-            FakeExecutor::with_outputs(vec![ok(), ok(), ok(), ok(), ok(), ok(), ok()]);
+        let mut executor = FakeExecutor::with_outputs(vec![
+            status("active"),
+            status("enabled"),
+            status("active"),
+            status("enabled"),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+        ]);
         let result = uninstall_server_unit_pair_with_executor(
             &mut executor,
             Path::new("/usr/bin/systemctl"),
@@ -1932,12 +2008,107 @@ mod tests {
         )
         .unwrap();
         assert!(result.removed);
-        assert_eq!(executor.calls[0], ["stop", SERVER_SOCKET_UNIT]);
-        assert_eq!(executor.calls[1], ["disable", SERVER_SOCKET_UNIT]);
-        assert_eq!(executor.calls[2], ["stop", SERVER_SERVICE_UNIT]);
-        assert_eq!(executor.calls[3], ["disable", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[4], ["stop", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[5], ["disable", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[6], ["stop", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[7], ["disable", SERVER_SERVICE_UNIT]);
         assert!(!service_file.exists());
         assert!(!socket_file.exists());
+    }
+
+    #[test]
+    fn server_pair_uninstall_control_failure_restores_prior_pair_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let service_file = tmp.path().join("webcodex.service");
+        let socket_file = tmp.path().join("webcodex.socket");
+        std::fs::write(&service_file, "service").unwrap();
+        std::fs::write(&socket_file, "socket").unwrap();
+        let mut executor = FakeExecutor::with_outputs(vec![
+            status("active"),
+            status("enabled"),
+            status("active"),
+            status("enabled"),
+            ok(),
+            ok(),
+            ok(),
+            failed("service disable rejected"),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+        ]);
+
+        let error = uninstall_server_unit_pair_with_executor(
+            &mut executor,
+            Path::new("/usr/bin/systemctl"),
+            &service_file,
+            SERVER_SERVICE_UNIT,
+            &socket_file,
+            SERVER_SOCKET_UNIT,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("service disable rejected"), "{error}");
+        assert_eq!(std::fs::read_to_string(&service_file).unwrap(), "service");
+        assert_eq!(std::fs::read_to_string(&socket_file).unwrap(), "socket");
+        assert_eq!(executor.calls[8], ["stop", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[9], ["stop", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[10], ["daemon-reload"]);
+        assert_eq!(executor.calls[11], ["enable", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[12], ["enable", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[13], ["start", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[14], ["start", SERVER_SERVICE_UNIT]);
+    }
+
+    #[test]
+    fn server_pair_uninstall_reload_failure_restores_files_and_prior_pair_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let service_file = tmp.path().join("webcodex.service");
+        let socket_file = tmp.path().join("webcodex.socket");
+        std::fs::write(&service_file, "service").unwrap();
+        std::fs::write(&socket_file, "socket").unwrap();
+        let mut executor = FakeExecutor::with_outputs(vec![
+            status("active"),
+            status("enabled"),
+            status("active"),
+            status("enabled"),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            failed("daemon reload rejected"),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+            ok(),
+        ]);
+
+        let error = uninstall_server_unit_pair_with_executor(
+            &mut executor,
+            Path::new("/usr/bin/systemctl"),
+            &service_file,
+            SERVER_SERVICE_UNIT,
+            &socket_file,
+            SERVER_SOCKET_UNIT,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("daemon reload rejected"), "{error}");
+        assert_eq!(std::fs::read_to_string(&service_file).unwrap(), "service");
+        assert_eq!(std::fs::read_to_string(&socket_file).unwrap(), "socket");
+        assert_eq!(executor.calls[9], ["stop", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[10], ["stop", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[11], ["daemon-reload"]);
+        assert_eq!(executor.calls[12], ["enable", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[13], ["enable", SERVER_SERVICE_UNIT]);
+        assert_eq!(executor.calls[14], ["start", SERVER_SOCKET_UNIT]);
+        assert_eq!(executor.calls[15], ["start", SERVER_SERVICE_UNIT]);
     }
 
     #[cfg(unix)]
@@ -2435,6 +2606,36 @@ mod tests {
         .unwrap_err();
         assert!(error.contains("non-regular systemd unit"));
         assert!(executor.calls.is_empty());
+    }
+
+    #[test]
+    fn overwrite_rejects_transitional_or_unknown_active_states_before_writing() {
+        for state in ["activating", "deactivating", "reloading", "unknown"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let service_file = tmp.path().join("webcodex.service");
+            std::fs::write(&service_file, "old unit").unwrap();
+            let mut executor = FakeExecutor::with_outputs(vec![
+                discovery("loaded", service_file.to_str().unwrap()),
+                status(state),
+            ]);
+            let error = install_unit_with_executor(
+                &mut executor,
+                Path::new("/usr/bin/systemctl"),
+                &service_file,
+                SERVER_SERVICE_UNIT,
+                "new unit",
+                true,
+                false,
+            )
+            .unwrap_err();
+            assert!(
+                error.contains("cannot safely overwrite"),
+                "{state}: {error}"
+            );
+            assert!(error.contains("systemctl is-active"), "{state}: {error}");
+            assert_eq!(std::fs::read_to_string(&service_file).unwrap(), "old unit");
+            assert_eq!(executor.calls.len(), 2);
+        }
     }
 
     #[test]

--- a/src/bin/webcodex-server.rs
+++ b/src/bin/webcodex-server.rs
@@ -16,7 +16,10 @@ fn build_server_runtime() -> std::io::Result<tokio::runtime::Runtime> {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server_binary_action(std::env::args().skip(1)) {
-        ServerBinaryAction::Run => build_server_runtime()?.block_on(webcodex::run_server()),
+        ServerBinaryAction::Run => {
+            webcodex::prepare_server_process_environment().map_err(std::io::Error::other)?;
+            build_server_runtime()?.block_on(webcodex::run_server())
+        }
         ServerBinaryAction::Exit {
             code,
             stdout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,8 +143,30 @@ const SERVER_SYSTEMD_STOP_MARGIN_SECS: u64 = 15;
 pub const SERVER_SYSTEMD_TIMEOUT_STOP_SECS: u64 =
     SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_SECS + SERVER_SYSTEMD_STOP_MARGIN_SECS;
 
+static PREPARED_SERVER_ENV_LOADS: std::sync::OnceLock<Vec<config::EnvFileLoad>> =
+    std::sync::OnceLock::new();
+
+/// Prepare process-global Server startup state while the binary is still
+/// single-threaded. In particular this consumes systemd `LISTEN_*` metadata
+/// before the Tokio runtime exists, so neither the metadata nor the activation
+/// listener can leak into later child processes.
+#[doc(hidden)]
+pub fn prepare_server_process_environment() -> Result<(), String> {
+    if PREPARED_SERVER_ENV_LOADS.get().is_some() {
+        return Ok(());
+    }
+    let env_loads = load_startup_env_files()?;
+    server_listener::prepare_activation_from_env()?;
+    PREPARED_SERVER_ENV_LOADS
+        .set(env_loads)
+        .map_err(|_| "Server process environment was prepared concurrently".to_string())
+}
+
 pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
-    let env_loads = load_startup_env_files().map_err(std::io::Error::other)?;
+    let env_loads = match PREPARED_SERVER_ENV_LOADS.get() {
+        Some(prepared) => prepared.clone(),
+        None => load_startup_env_files().map_err(std::io::Error::other)?,
+    };
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),

--- a/src/server_listener.rs
+++ b/src/server_listener.rs
@@ -16,6 +16,13 @@ struct ActivationMetadata {
 const SYSTEMD_LISTEN_FD_START: i32 = 3;
 const HTTP_FD_NAME: &str = "webcodex-http";
 
+#[cfg(target_os = "linux")]
+static PREPARED_ACTIVATION_METADATA: std::sync::OnceLock<Option<ActivationMetadata>> =
+    std::sync::OnceLock::new();
+
+#[cfg(target_os = "linux")]
+const SYSTEMD_ACTIVATION_ENV_KEYS: [&str; 3] = ["LISTEN_PID", "LISTEN_FDS", "LISTEN_FDNAMES"];
+
 fn activation_metadata_from_values(
     listen_pid: Option<&str>,
     listen_fds: Option<&str>,
@@ -62,7 +69,7 @@ fn activation_metadata_from_values(
 }
 
 #[cfg(target_os = "linux")]
-fn activation_metadata_from_env() -> Result<Option<ActivationMetadata>, String> {
+fn read_activation_metadata_from_env() -> Result<Option<ActivationMetadata>, String> {
     let listen_pid = std::env::var("LISTEN_PID").ok();
     let listen_fds = std::env::var("LISTEN_FDS").ok();
     let listen_fdnames = std::env::var("LISTEN_FDNAMES").ok();
@@ -72,6 +79,47 @@ fn activation_metadata_from_env() -> Result<Option<ActivationMetadata>, String> 
         listen_fdnames.as_deref(),
         std::process::id(),
     )
+}
+
+#[cfg(target_os = "linux")]
+fn clear_activation_environment() {
+    for key in SYSTEMD_ACTIVATION_ENV_KEYS {
+        std::env::remove_var(key);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn activation_metadata_from_env() -> Result<Option<ActivationMetadata>, String> {
+    if let Some(metadata) = PREPARED_ACTIVATION_METADATA.get() {
+        return Ok(metadata.clone());
+    }
+    read_activation_metadata_from_env()
+}
+
+/// Consume systemd's process-local socket-activation contract before the
+/// Server creates its Tokio worker threads. `LISTEN_*` is one-shot metadata:
+/// descendants must not mistake it for their own activation contract, and the
+/// inherited listener must not leak through later `exec` calls.
+#[cfg(target_os = "linux")]
+pub(crate) fn prepare_activation_from_env() -> Result<(), String> {
+    if PREPARED_ACTIVATION_METADATA.get().is_some() {
+        return Ok(());
+    }
+    let metadata = read_activation_metadata_from_env()?;
+    if metadata.is_some() {
+        validate_listening_tcp_fd(SYSTEMD_LISTEN_FD_START)?;
+        set_close_on_exec(SYSTEMD_LISTEN_FD_START)?;
+    }
+    PREPARED_ACTIVATION_METADATA
+        .set(metadata)
+        .map_err(|_| "systemd socket activation was prepared concurrently".to_string())?;
+    clear_activation_environment();
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn prepare_activation_from_env() -> Result<(), String> {
+    Ok(())
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -86,6 +134,26 @@ fn configured_addr_matches(configured: &str, actual: SocketAddr) -> Result<bool,
     Ok(configured_addrs
         .into_iter()
         .any(|candidate| candidate == actual))
+}
+
+#[cfg(target_os = "linux")]
+fn set_close_on_exec(fd: i32) -> Result<(), String> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(format!(
+            "invalid systemd socket activation: failed to inspect inherited fd {fd} flags: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if flags & libc::FD_CLOEXEC == 0
+        && unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } == -1
+    {
+        return Err(format!(
+            "invalid systemd socket activation: failed to mark inherited fd {fd} close-on-exec: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -164,6 +232,10 @@ fn take_inherited_listener(
     use std::os::fd::FromRawFd;
 
     validate_listening_tcp_fd(fd)?;
+    // systemd deliberately passes activation descriptors without FD_CLOEXEC so
+    // this process can receive them across exec. Once adopted, restore the
+    // normal close-on-exec boundary before any Server child can be spawned.
+    set_close_on_exec(fd)?;
     let listener = unsafe { std::net::TcpListener::from_raw_fd(fd) };
     listener.set_nonblocking(true).map_err(|error| {
         format!("failed to set inherited systemd HTTP listener nonblocking: {error}")
@@ -280,6 +352,36 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    #[test]
+    fn activation_environment_cleanup_removes_one_shot_systemd_metadata() {
+        let mut env = crate::test_support::TestEnvGuard::new();
+        for (key, value) in [
+            ("LISTEN_PID", "123"),
+            ("LISTEN_FDS", "1"),
+            ("LISTEN_FDNAMES", HTTP_FD_NAME),
+        ] {
+            env.set(key, value);
+        }
+        clear_activation_environment();
+        for key in SYSTEMD_ACTIVATION_ENV_KEYS {
+            assert!(std::env::var_os(key).is_none(), "{key} was not cleared");
+        }
+        let inherited = std::process::Command::new("env")
+            .output()
+            .expect("spawn child environment probe");
+        assert!(inherited.status.success());
+        let inherited = String::from_utf8(inherited.stdout).expect("child environment is UTF-8");
+        for key in SYSTEMD_ACTIVATION_ENV_KEYS {
+            assert!(
+                !inherited
+                    .lines()
+                    .any(|line| line.starts_with(&format!("{key}="))),
+                "{key} leaked into a spawned child"
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
     fn move_to_isolated_test_fd(fd: i32) -> i32 {
         let isolated = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 1000) };
         assert!(
@@ -287,6 +389,20 @@ mod tests {
             "failed to duplicate fd for isolated ownership test"
         );
         unsafe { libc::close(fd) };
+        isolated
+    }
+
+    #[cfg(target_os = "linux")]
+    fn move_to_isolated_inheritable_test_fd(fd: i32) -> i32 {
+        let isolated = unsafe { libc::fcntl(fd, libc::F_DUPFD, 1000) };
+        assert!(
+            isolated >= 1000,
+            "failed to duplicate fd for inheritable descriptor test"
+        );
+        unsafe { libc::close(fd) };
+        let flags = unsafe { libc::fcntl(isolated, libc::F_GETFD) };
+        assert_ne!(flags, -1);
+        assert_eq!(flags & libc::FD_CLOEXEC, 0, "test fd was not inheritable");
         isolated
     }
 
@@ -340,6 +456,24 @@ mod tests {
         );
         assert_ne!(unsafe { libc::fcntl(raw_fd, libc::F_GETFD) }, -1);
         unsafe { libc::close(raw_fd) };
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn inherited_listener_is_marked_close_on_exec_when_adopted() {
+        use std::os::fd::{AsRawFd, IntoRawFd};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let actual = listener.local_addr().unwrap();
+        let raw_fd = move_to_isolated_inheritable_test_fd(listener.into_raw_fd());
+        let listener = take_inherited_listener(raw_fd, &actual.to_string()).unwrap();
+        let flags = unsafe { libc::fcntl(listener.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(flags, -1);
+        assert_ne!(
+            flags & libc::FD_CLOEXEC,
+            0,
+            "adopted systemd listener remained inheritable"
+        );
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

- make `webcodex.service` + `webcodex.socket` uninstall/update behavior recoverable as one pair instead of leaving partial stopped/disabled state after failures
- fail closed before overwrite/uninstall when systemd reports transitional or unknown active/enabled state that cannot be restored safely
- consume systemd socket-activation metadata before Tokio workers start, clear `LISTEN_PID` / `LISTEN_FDS` / `LISTEN_FDNAMES`, and mark the inherited listener `FD_CLOEXEC` before Server child processes can inherit it
- add focused rollback, activation-environment, and descriptor-inheritance regressions

## Validation

- `cargo test -p webcodex-cli` — 307 passed
- `cargo test -p webcodex server_listener -- --nocapture` — 10 passed
- `cargo test -p webcodex --lib` — 3022 passed
- `cargo check --all-targets -p webcodex` — passed
- `cargo fmt -- --check` — passed
- `git diff --check` — passed
- real `systemd-socket-activate -> webcodex-server -> HTTP` smoke — passed
- dogfood parent-owned listener continuity — 0 refused / 0 reset, successful probes observed
