### PR TITLE
Add contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ are included.
 ## Before you start
 
 - Check the latest `main` and existing issues before starting substantial work.
+- Small documentation fixes and focused corrections can be submitted directly.
+  For larger features or architectural changes, opening an issue first helps
+  avoid duplicated or misaligned work.
 - For bugs and client interoperability problems, opening an issue first is
   usually the best way to confirm the problem and share reproduction details.
 - For security-sensitive reports, follow [SECURITY.md](SECURITY.md) instead of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to WebCodex
+
+[简体中文](CONTRIBUTING.zh-CN.md)
+
+Contributions are welcome, including bug reports, documentation improvements,
+focused fixes, and new capabilities that fit WebCodex's current product
+direction.
+
+Contributions created with WebCodex itself or with other coding agents are also
+welcome. The contributor remains responsible for reviewing the resulting diff,
+validating the change, and making sure no credentials or machine-private data
+are included.
+
+## Before you start
+
+- Check the latest `main` and existing issues before starting substantial work.
+- For bugs and client interoperability problems, opening an issue first is
+  usually the best way to confirm the problem and share reproduction details.
+- For security-sensitive reports, follow [SECURITY.md](SECURITY.md) instead of
+  opening a public issue.
+- Keep changes focused. Avoid unrelated refactors or generated changes in the
+  same pull request.
+
+A useful bug report should include, when relevant:
+
+- the WebCodex version or commit;
+- Server and Runner operating systems;
+- the client in use, such as ChatGPT, Claude, Gemini, Grok, or another MCP
+  client;
+- the authentication mode, such as Bearer or OAuth;
+- clear reproduction steps and expected versus actual behavior;
+- redacted logs or error messages that help identify the failing stage.
+
+Never include tokens, authorization headers, private keys, cookies, passwords,
+or other secrets.
+
+## Development workflow
+
+1. Start from the current `main` branch and create a focused branch for the
+   change.
+2. Follow the repository guidance in [AGENTS.md](AGENTS.md) and any more
+   specific guidance referenced from it.
+3. Match the existing architecture and naming. Prefer the smallest coherent
+   change that solves the current problem.
+4. Add or update focused tests when behavior changes, and update documentation
+   when public behavior or operations change.
+5. Run the smallest relevant validation for the files you changed.
+   Documentation-only changes do not require a Cargo build.
+6. Review the final diff and worktree state before committing.
+
+For repository testing guidance, see [docs/TESTING.md](docs/TESTING.md). For the
+coding workflow and closeout conventions, see
+[docs/CODING_WORKFLOW.md](docs/CODING_WORKFLOW.md).
+
+## Pull requests
+
+A pull request should explain what changed, why the change is needed, and what
+validation was performed. Link the relevant issue when one exists.
+
+Please keep each pull request reviewable and limited to one coherent purpose. If
+a change affects authentication, authorization, process lifecycle, persistence,
+public protocol behavior, or another trust boundary, include focused regression
+evidence for that boundary.
+
+By contributing, you agree that your contribution is licensed under the
+repository's [Apache License 2.0](LICENSE).

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -9,6 +9,8 @@
 ## 开始之前
 
 - 开始较大改动前，先检查最新 `main` 和已有 issues。
+- 小型文档修正和 focused fix 可以直接提交；较大的功能或架构改动建议先创建 issue，
+  避免重复工作或方向不一致。
 - 对于 bug 和客户端兼容性问题，通常建议先创建 issue，确认问题并共享复现信息。
 - 安全相关问题请按照 [SECURITY.md](SECURITY.md) 处理，不要创建公开 issue。
 - 保持改动 focused，不要在同一个 pull request 中混入无关重构或无关的生成内容。

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,45 @@
+# 参与 WebCodex 开发
+
+[English](CONTRIBUTING.md)
+
+欢迎通过 bug 报告、文档改进、focused fix，以及符合 WebCodex 当前产品方向的新能力参与贡献。
+
+也欢迎直接使用 WebCodex 本身或其他 coding agent 来完成贡献。无论使用什么工具，提交者仍需要负责检查最终 diff、验证改动，并确认其中不包含 credential 或机器私有数据。
+
+## 开始之前
+
+- 开始较大改动前，先检查最新 `main` 和已有 issues。
+- 对于 bug 和客户端兼容性问题，通常建议先创建 issue，确认问题并共享复现信息。
+- 安全相关问题请按照 [SECURITY.md](SECURITY.md) 处理，不要创建公开 issue。
+- 保持改动 focused，不要在同一个 pull request 中混入无关重构或无关的生成内容。
+
+一个有帮助的 bug 报告可以根据实际情况包含：
+
+- WebCodex version 或 commit；
+- Server 和 Runner 的操作系统；
+- 使用的客户端，例如 ChatGPT、Claude、Gemini、Grok 或其他 MCP client；
+- Bearer、OAuth 等认证方式；
+- 清晰的复现步骤，以及预期行为与实际行为；
+- 能帮助定位失败阶段的脱敏日志或错误信息。
+
+不要提交 token、Authorization header、private key、cookie、password 或其他 secret。
+
+## 开发流程
+
+1. 从当前 `main` 创建 focused branch。
+2. 遵循 [AGENTS.md](AGENTS.md) 以及其中链接的相关仓库规则。
+3. 保持现有架构和命名风格，优先选择能够解决当前问题的最小完整改动。
+4. 行为发生变化时补充或更新 focused test；公共行为或运维方式变化时同步更新文档。
+5. 对改动文件执行最小但足够的验证。纯文档改动不需要运行 Cargo build。
+6. 提交前检查最终 diff 和 worktree 状态。
+
+仓库测试说明见 [docs/TESTING.md](docs/TESTING.md)，coding workflow 与 closeout 约定见
+[docs/CODING_WORKFLOW.zh-CN.md](docs/CODING_WORKFLOW.zh-CN.md)。
+
+## Pull requests
+
+Pull request 应说明改了什么、为什么需要这项改动，以及执行了哪些验证。有相关 issue 时请进行关联。
+
+每个 pull request 应保持可评审，并只解决一个完整而集中的目标。如果改动涉及认证、授权、process lifecycle、持久化、公共协议行为或其他 trust boundary，请提供针对该边界的 focused regression evidence。
+
+提交贡献即表示你同意按照仓库的 [Apache License 2.0](LICENSE) 对该贡献进行许可。

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ cargo build --release --workspace --bins
 export PATH="$PWD/target/release:$PATH"
 ```
 
+## Contributing
+
+Contributions are welcome, including contributions created with WebCodex itself
+or other coding agents. For bug reports, development workflow, and pull request
+guidance, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Acknowledgements
 
 Thanks to the [LINUX DO](https://linux.do/) community for its welcoming space

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,6 +166,12 @@ cargo build --release --workspace --bins
 export PATH="$PWD/target/release:$PATH"
 ```
 
+## 参与贡献
+
+欢迎参与 WebCodex 开发，也欢迎直接使用 WebCodex 本身或其他 coding agent 来完成贡献。
+Bug 报告、开发流程和 pull request 说明见
+[CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)。
+
 ## 鸣谢
 
 感谢 [LINUX DO](https://linux.do/) 社区提供的交流氛围与开源推广支持。


### PR DESCRIPTION
## Summary

- add English and Simplified Chinese contribution guides
- document bug-reporting, focused development, validation, security, and pull request expectations
- explicitly welcome contributions created with WebCodex itself or other coding agents
- add concise contribution links to both READMEs

## Validation

- verified all referenced repository documentation paths exist
- `git diff --cached --check`
- documentation-only change; no Cargo build or tests were required
