### PR TITLE
Improve first-run onboarding and package discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,192 +2,110 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-WebCodex lets ChatGPT, Claude, and other MCP clients work with repositories and
-development tools on your own machines. The Runner executes file, Git, command,
-and test operations where the repository lives; WebCodex exposes those
-capabilities to the chat client without requiring the repository itself to move.
+**WebCodex lets ChatGPT, Claude, and other AI agents work directly with code and developer tools on your own machines.**
 
-## Try it with one repository
+Ask your assistant to inspect a repository, modify code, run tests, use Git, or investigate a failure. Your repository stays on the machine where it already lives; you do not need to move the project into a hosted workspace just to use an AI coding agent.
 
-Platform note: `webcodex share` starts a local WebCodex Server and is supported on
-Linux and macOS. Windows builds support the CLI + Runner against a remote Linux
-Server; on Windows use `webcodex connect <server-url>`. If you do not already
-have a Server, deploy one on Linux first.
+## Quick start
 
-For the fastest Linux/macOS trial, no global install is required:
+On Linux or macOS, with Node.js 18+ and Git installed:
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-The npm wrapper lazily bootstraps the verified native binary set if lifecycle
-installation did not leave it behind. If you prefer a persistent CLI, install it
-once and then use bare `webcodex` inside a Git repository:
+Keep the terminal open after it reports **WebCodex ready**. Then in ChatGPT:
 
-```bash
-npm install -g @yyjeqhc/webcodex
-cd /path/to/your/repository
-webcodex
-```
+1. Enable **Developer Mode** and open **Settings -> Apps -> Create**.
+2. Paste the **MCP URL** printed by WebCodex.
+3. Choose **Access token / API key** (or the equivalent Bearer-token option) and paste the printed **Credential**.
+4. Run **Scan Tools**.
 
-In an interactive Linux/macOS Git repository, bare `webcodex` is a convenience
-alias for the normal `webcodex share` first-run path. Scripts, non-interactive
-calls, Windows, and directories outside a Git checkout do not auto-start a
-runtime; use explicit `webcodex share` when deterministic dispatch matters.
-
-For the default temporary public share, WebCodex reuses `cloudflared` from
-`WEBCODEX_CLOUDFLARED_BIN` or `PATH` when available. Otherwise it downloads and
-verifies a WebCodex-managed copy automatically. When launched through the npm
-wrapper, that managed download also reuses npm's proxy, `noproxy`, CA, and
-`strict-ssl` settings; otherwise standard proxy/system trust behavior remains
-available. `share` is self-contained: it prepares the tunnel dependency when
-needed, configures the current Git project,
-starts a local WebCodex Server + Runner,
-creates a temporary Connector credential, and opens a Cloudflare Quick Tunnel.
-You do **not** need to run `setup`, `doctor`, or `run` first.
-
-When the command reports **WebCodex ready**, keep that terminal open. For the
-default public share, WebCodex best-effort copies the **MCP URL** to the clipboard;
-the credential is not copied automatically. In an interactive terminal, press
-Enter to open ChatGPT App settings, then:
-
-1. In ChatGPT, enable **Developer Mode** and go to **Settings -> Apps -> Create**.
-2. Paste the copied **MCP URL** (or copy the printed fallback URL).
-3. Choose **Access token / API key** or the equivalent Bearer-token option.
-4. Paste the printed temporary **Credential**.
-5. Run **Scan Tools**.
-6. Start with a read-only prompt such as:
+Try a read-only first request:
 
 ```text
 Inspect this repository and summarize its structure. Do not make changes.
 ```
 
-ChatGPT UI labels can vary by workspace and rollout. Developer Mode, custom MCP
-apps, and write/modify actions are controlled by the ChatGPT plan, workspace, and
-admin settings; WebCodex cannot widen client-side app permissions. The CLI output
-is the source of truth for the WebCodex URL, authentication type, and credential
-for that run.
-Use `webcodex share --no-copy-url` when clipboard access is undesirable.
-
-If a client cannot configure a Bearer header and OAuth setup is undesirable, use
-`webcodex share --auth query-token`. This explicit opt-in prints (and, for a public
-share, copies) one MCP URL whose `?token=` query contains only that run's temporary
-share credential; choose **No authentication** in the MCP client. Treat the entire
-URL as a secret because query strings can appear in client, proxy, clipboard, or
-access logs. The default remains the safer separate Bearer header + credential flow.
-
-A default `share` URL and credential are temporary and stop working when the
-command exits. `webcodex share --tunnel none` is available for local-only MCP
-debugging and does not require `cloudflared`.
-
-### Optional: OpenAI Secure MCP Tunnel
-
-If the repository should be reachable only from a supported OpenAI product, use
-`webcodex share --tunnel openai`. Create/select a Secure MCP Tunnel in the OpenAI
-Platform first, then export `CONTROL_PLANE_TUNNEL_ID` and a Restricted
-`CONTROL_PLANE_API_KEY` with **Tunnels Read + Use**. WebCodex reuses a matching
-`tunnel-client` from `WEBCODEX_TUNNEL_CLIENT_BIN` or `PATH`, or downloads and
-verifies pinned OpenAI `tunnel-client` v0.0.12 for Linux/macOS amd64/arm64.
-
-This provider keeps the temporary WebCodex Bearer credential in private local
-share state and gives `tunnel-client` a file-backed `Authorization` header for
-the loopback MCP hop. In ChatGPT choose **Connection: Tunnel**, select/paste the
-Tunnel ID, and choose **No authentication**; do not paste the local WebCodex
-credential into ChatGPT. `--tunnel openai` currently supports the default
-`--auth bearer` path only. Ctrl-C stops the local runtime and `tunnel-client` and
-removes the temporary WebCodex credential; the Platform Tunnel identity remains
-operator-managed for later reuse.
-
-## What happens after the first connection
-
-WebCodex can read/search files, prepare guarded edits, run commands and focused
-validation, inspect Git, and keep long-running Jobs observable. Coding results
-remain subject to the product's existing authority boundaries. Open `/console`
-to inspect project readiness and the work queue; the Console can guide, cancel,
-Accept, or Reject work where those actions are available. It deliberately does
-not reveal credentials.
-
-## Existing Server and long-lived deployments
-
-For a hosted Server whose operator intentionally gave you a shared key, connect
-the current repository with that shared-key identity:
+If ChatGPT does not show a Bearer/access-token option, or tries OAuth discovery and reports **does not implement OAuth**, use:
 
 ```bash
-cd /path/to/your/repository
-webcodex connect https://webcodex.example --key-file /private/path/shared-key
+npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-`connect` creates a reusable local profile, starts the Runner, waits for the
-project to become visible through that Server, and prints the MCP setup values.
-This is the hosted shared-key path; it is not the enrollment path for a freshly
-self-hosted Docker Server.
+Paste the complete `/mcp?token=...` URL and choose **No authentication**. That URL contains a temporary secret, so do not publish or log it. If WebCodex is installed globally, the equivalent command is `webcodex share --auth query-token`. See the [Quick Start](docs/QUICK_START.md) and [MCP setup guide](docs/MCP.md) for details and other clients.
 
-For a fresh self-hosted Server, keep its bootstrap administrator token on the
-Server. Create a short-lived pairing code there, then use `webcodex login` with
-that `wc_pair_...` code on the repository machine and explicitly install the
-reported Runner config as a user service. Managed OAuth remains an advanced
-identity option. See [Deployment](docs/DEPLOYMENT.md) for the complete flow.
+WebCodex automatically prepares the temporary connection it needs. Advanced networking, OAuth, private tunnels, and self-hosting options are documented separately.
+
+## What can it do?
+
+- **Understand and edit code** — read, search, inspect, and make guarded changes inside configured projects.
+- **Use the real toolchain** — run commands, tests, formatters, compilers, and project-specific tooling on the machine that owns the repository.
+- **Work with Git** — inspect status and diffs while keeping repository operations visible and reviewable.
+- **Handle long-running work** — keep jobs observable instead of requiring one model turn to stay open indefinitely.
+- **Support human review** — use the Runtime Console and task workflow to guide, cancel, accept, or reject work where those actions are available.
+
+## Why WebCodex?
+
+- **Your code stays on your machine.** The repository does not need to be copied into the chat service.
+- **The agent gets a real development environment.** It can use the same files, Git checkout, compilers, tests, and tools you already use.
+- **Work survives beyond a single request.** Long-running execution and evidence remain observable through WebCodex.
+- **Start temporary or run it long-term.** Use one-command sharing for a quick session, or connect machines to a self-hosted Server for a durable setup.
 
 ## How it works
 
 ```text
-ChatGPT / Claude / MCP client
-            |
-            | MCP / HTTPS
-            v
-      WebCodex Server
-            |
-            | authenticated Runner connection
-            v
-     webcodex-runner
-            |
-      repository / Git / toolchains
+AI client
+   |
+   | MCP / HTTPS
+   v
+WebCodex
+   |
+   v
+your machine
+   |
+   +-- repository
+   +-- Git
+   +-- compilers / tests / developer tools
 ```
 
-The Server authenticates callers and routes requests. The Runner performs the
-actual work on the machine that owns the repository. Only requested tool inputs
-and results cross the connection.
+For the internal Server/Runner architecture, protocol surfaces, and authority boundaries, see [Architecture](docs/ARCHITECTURE.md), [MCP](docs/MCP.md), and [Authentication](docs/AUTH_MODEL.md).
 
-## CLI
+## Platforms
 
-The common commands are intentionally small:
+- **Linux x64/arm64** — local `share`, Server, and Runner workflows.
+- **macOS arm64** — local `share` and Runner workflows.
+- **Windows x64/arm64** — CLI + Runner against a remote Linux Server. Local `webcodex share` is not supported on Windows in this release.
+
+Windows and long-lived deployments are covered in [Deployment](docs/DEPLOYMENT.md) and [MCP](docs/MCP.md).
+
+## Long-lived and advanced setup
+
+If you want to keep the CLI installed:
 
 ```bash
-webcodex share                     # fastest temporary ChatGPT/MCP connection
-webcodex connect <server-url>      # connect to an existing Server
-webcodex status                    # concise project readiness
-webcodex doctor                    # deeper local diagnostics
-webcodex setup                     # manual/local project setup
-webcodex run                       # manual local Server + Runner runtime
-webcodex task list                 # review local tasks
+npm install -g @yyjeqhc/webcodex
 ```
 
-The Runner is the execution component. For compatibility, Runner service
-management still uses the historical `webcodex agent ...` CLI namespace. See
-[CLI](docs/CLI.md) for operator commands and credential reference.
+If you already have a hosted WebCodex Server, `webcodex connect <server-url>` connects the current repository using the authentication configured by that Server.
+
+For production/self-hosted deployment, Windows enrollment, OAuth, private tunnels, proxy/CA configuration, and other operator workflows, use the documentation below rather than the first-run path.
 
 ## Documentation
 
-- [Quick Start](docs/QUICK_START.md) — first ChatGPT/MCP connection
-- [MCP](docs/MCP.md) — ChatGPT, Claude, authentication, then protocol reference
-- [AI-assisted setup](docs/AI_ONBOARDING.md) — instructions for an AI helping a user configure WebCodex
-- [CLI](docs/CLI.md) — commands, compatibility notes, and credentials
-- [Deployment](docs/DEPLOYMENT.md) — self-hosting and production operations
-- [Authentication](docs/AUTH_MODEL.md) — credential and authority model
-- [Runner](docs/RUNNER.md) — Runner operation
-- [Coding Workflow](docs/CODING_WORKFLOW.md) — task workflow, validation, and closeout
-- [Troubleshooting](docs/TROUBLESHOOTING.md)
-- [Documentation index](docs/INDEX.md)
-- [Security](SECURITY.md)
+- [Quick Start](docs/QUICK_START.md) — from zero to the first successful AI connection
+- [MCP](docs/MCP.md) — ChatGPT, Claude, authentication choices, and MCP reference
+- [Deployment](docs/DEPLOYMENT.md) — self-hosting, permanent Servers, and machine enrollment
+- [Troubleshooting](docs/TROUBLESHOOTING.md) — connection and runtime problems
+- [CLI](docs/CLI.md) — command and credential reference
+- [AI-assisted setup](docs/AI_ONBOARDING.md) — have an AI agent help configure WebCodex
+- [Security](SECURITY.md) — security model and operational guidance
+- [Documentation index](docs/INDEX.md) — all user and contributor documentation
 
 ## Security
 
-WebCodex can modify files and execute commands. Register only project roots the
-assistant should access, keep credentials out of prompts/logs/Git, and prefer an
-ordinary OS user for the Runner. The simplified onboarding does not collapse
-the underlying credential or authority boundaries. Read [SECURITY.md](SECURITY.md)
-for the complete model.
+WebCodex can read and modify files and execute commands inside configured project boundaries. Use version control, keep credentials out of prompts/logs/Git, and register only project roots the assistant should access. Read [SECURITY.md](SECURITY.md) for the complete model.
 
 ## Build from source
 
@@ -198,14 +116,11 @@ export PATH="$PWD/target/release:$PATH"
 
 ## Contributing
 
-Contributions are welcome, including contributions created with WebCodex itself
-or other coding agents. For bug reports, development workflow, and pull request
-guidance, see [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions are welcome, including contributions created with WebCodex itself or other coding agents. For bug reports, development workflow, and pull request guidance, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Acknowledgements
 
-Thanks to the [LINUX DO](https://linux.do/) community for its welcoming space
-for technical discussion and support for open-source sharing.
+Thanks to the [LINUX DO](https://linux.do/) community for its welcoming space for technical discussion and support for open-source sharing.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-Keep the terminal open after it reports **WebCodex ready**. Then in ChatGPT:
+When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL** is normally copied to your clipboard; press **Enter** in the terminal to open ChatGPT App settings, or open **Settings -> Apps -> Create** manually. Then:
 
-1. Enable **Developer Mode** and open **Settings -> Apps -> Create**.
-2. Paste the **MCP URL** printed by WebCodex.
+1. Enable **Developer Mode** if needed and choose **Create**.
+2. Paste the copied **MCP URL** (or use the URL printed by WebCodex).
 3. Choose **Access token / API key** (or the equivalent Bearer-token option) and paste the printed **Credential**.
 4. Run **Scan Tools**.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,168 +2,110 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-WebCodex 让 ChatGPT、Claude 和其他 MCP 客户端直接使用你自己机器上的仓库与开发工具。
-Runner 在仓库所在机器上执行文件、Git、命令与测试操作；仓库本身不需要搬到聊天服务端。
+**WebCodex 让 ChatGPT、Claude 和其他 AI Agent 直接使用你自己机器上的代码仓库和开发工具。**
 
-## 用一个仓库快速试起来
+你可以直接让 AI 理解项目、修改代码、运行测试、检查 Git 或排查问题。仓库仍然留在原来的机器上，不需要为了使用 WebCodex 把整个项目搬到托管环境里。
 
-平台说明：`webcodex share` 会启动本地 WebCodex Server，目前只支持 Linux 和 macOS。
-Windows 版本支持 CLI + Runner 连接远程 Linux Server；Windows 上请使用
-`webcodex connect <server-url>`。如果还没有 Server，需要先在 Linux 上部署一个。
+## 快速开始
 
-Linux/macOS 最快的试用路径不需要全局安装：
+Linux 或 macOS 上准备好 Node.js 18+ 和 Git，然后进入一个仓库：
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-如果 npm lifecycle 没有留下 native binary，wrapper 会在第一次执行时用同一套校验与原子安装
-逻辑 lazy bootstrap。希望长期保留 CLI 时再全局安装：
+看到 **WebCodex ready** 后保持终端运行。接着在 ChatGPT 中：
 
-```bash
-npm install -g @yyjeqhc/webcodex
-cd /path/to/your/repository
-webcodex
-```
+1. 开启 **Developer Mode**，进入 **Settings -> Apps -> Create**。
+2. 粘贴 WebCodex 输出的 **MCP URL**。
+3. 认证选择 **Access token / API key**（或等价的 Bearer 令牌选项），再填入输出的临时 **Credential**。
+4. 点击 **Scan Tools**。
 
-在 Linux/macOS 的交互式 Git 仓库中，裸 `webcodex` 等价于普通 first-run 的
-`webcodex share`。脚本/非交互调用、Windows、以及 Git checkout 之外不会自动启动 runtime；
-需要确定性分发时继续显式使用 `webcodex share`。
-
-默认临时公网分享会优先复用 `WEBCODEX_CLOUDFLARED_BIN` 或 `PATH` 中已有的
-`cloudflared`；如果没有，WebCodex 会自动下载并校验自己管理的副本。如果通过 npm wrapper
-启动，这次 managed 下载也会复用 npm 的 proxy、`noproxy`、CA 与 `strict-ssl` 配置；否则
-继续保留标准 proxy/系统信任配置路径。`share` 是完整入口：需要时它会先准备 tunnel 依赖，
-然后配置当前 Git 项目、启动本地
-WebCodex Server + Runner、创建临时 Connector credential，并打开 Cloudflare Quick Tunnel。
-第一次使用**不需要**先运行 `setup`、`doctor` 或 `run`。
-
-命令显示 **WebCodex ready** 后保持终端运行。默认公网 share 会 best-effort 把 **MCP URL**
-复制到剪贴板；credential 不会自动复制。交互式终端还可以直接按 Enter 打开 ChatGPT
-App 设置。然后：
-
-1. 在 ChatGPT 启用 **Developer Mode**，进入 **Settings -> Apps -> Create**。
-2. 粘贴已复制的 **MCP URL**；复制失败时使用终端中照常打印的 URL。
-3. 认证选择 **Access token / API key** 或等价的 Bearer token 选项。
-4. 填入输出的临时 **Credential**。
-5. 点击 **Scan Tools**。
-6. 第一条消息先用只读、安全的请求，例如：
+第一条消息可以先只读检查：
 
 ```text
 检查这个仓库并总结它的结构。先不要做任何修改。
 ```
 
-ChatGPT 的 UI 文案可能随 workspace 与 rollout 改变。Developer Mode、custom MCP app 以及
-write/modify action 是否可用，由 ChatGPT 套餐、workspace 与管理员设置控制；WebCodex
-不能扩大客户端侧 app 权限。当前这次运行到底该填哪个 WebCodex URL、认证类型和
-credential，以 CLI 成功输出为准。
-不希望访问剪贴板时可使用 `webcodex share --no-copy-url`。
-
-如果 MCP client 无法配置 Bearer header，又不想搭 OAuth，可显式使用
-`webcodex share --auth query-token`。这个 opt-in 会输出一个 `?token=` 中携带**本次临时
-share credential** 的 MCP URL；公网 share 也会复制这条敏感 URL，此时 client 选择
-**No authentication**。必须把整条 URL 当作 secret，因为 query string 可能进入 client、
-proxy、剪贴板或 access log。默认行为仍保持更安全的“Bearer header + 单独 credential”。
-
-默认 `share` 的 URL 与 credential 都是临时的，命令退出后失效。仅做本地 MCP 调试时可用
-`webcodex share --tunnel none`，此模式不需要 `cloudflared`。
-
-### 可选：OpenAI Secure MCP Tunnel
-
-如果只希望受支持的 OpenAI 产品访问本机仓库，可以使用
-`webcodex share --tunnel openai`。先在 OpenAI Platform 创建/选择 Secure MCP Tunnel，
-然后导出 `CONTROL_PLANE_TUNNEL_ID` 与只授予 **Tunnels Read + Use** 的 Restricted
-`CONTROL_PLANE_API_KEY`。WebCodex 会依次复用 `WEBCODEX_TUNNEL_CLIENT_BIN`、`PATH`
-中匹配的 `tunnel-client`，否则为 Linux/macOS amd64/arm64 下载并校验固定的 OpenAI
-`tunnel-client` v0.0.12。
-
-这条路径把临时 WebCodex Bearer credential 留在私有本地 share state，只通过 file-backed
-`Authorization` header 交给 `tunnel-client` 访问 loopback MCP。在 ChatGPT 里选择
-**Connection: Tunnel**，选择/粘贴 Tunnel ID，并把认证选择为 **No authentication**；不要把
-本地 WebCodex credential 粘贴到 ChatGPT。`--tunnel openai` 当前只支持默认的
-`--auth bearer`。Ctrl-C 会停止本地 runtime 与 `tunnel-client` 并删除临时 WebCodex
-credential；Platform Tunnel identity 仍由 operator 管理，可以以后继续复用。
-
-## 第一次连接以后
-
-WebCodex 可以读取/搜索文件、准备受保护的修改、运行命令与聚焦校验、查看 Git，并让长时间
-Job 保持可观察。底层权限边界不会因为 onboarding 简化而改变。打开 `/console` 可以查看
-项目就绪状态与工作队列；Console 在相应状态下可以 Guide、Cancel、Accept 或 Reject，
-但不会显示 credential。
-
-## 已有 Server 与长期部署
-
-如果 hosted Server 的 operator 明确给了 shared key，用这个 shared-key identity 连接当前仓库：
+如果 ChatGPT 没有显示 Bearer/访问令牌选项，或者自动尝试 OAuth 后出现 **does not implement OAuth**，直接运行：
 
 ```bash
-cd /path/to/your/repository
-webcodex connect https://webcodex.example --key-file /private/path/shared-key
+npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-`connect` 会创建可复用的本地 profile、启动 Runner、等待项目在该 Server 上可见，并输出
-MCP 配置值。它是 hosted shared-key 路径，不是刚完成 Docker bootstrap 的自托管 Server
-的 enrollment 路径。
+把输出的完整 `/mcp?token=...` 地址粘贴到 ChatGPT，并选择 **No authentication**。这条地址包含本次临时密钥，不要公开、转发或记录到日志中。如果已经全局安装 WebCodex，也可以使用等价命令 `webcodex share --auth query-token`。更多客户端配置见[快速开始](docs/QUICK_START.zh-CN.md)和 [MCP 接入指南](docs/MCP.zh-CN.md)。
 
-对于新的自托管 Server，把 bootstrap administrator token 留在 Server。Server 侧创建短期
-pairing code 后，在仓库机器上用 `webcodex login` 兑换，再显式把 CLI 报告的 Runner config
-安装成 user service。managed OAuth 仍是高级 identity 选项。完整流程见[部署指南](docs/DEPLOYMENT.zh-CN.md)。
+WebCodex 会自动准备临时连接所需的组件。代理网络、OAuth、私有隧道、自托管等高级配置都放在单独的文档中，不是第一次使用的前置条件。
+
+## 能做什么？
+
+- **理解和修改代码** —— 读取、搜索、分析项目，并在配置好的项目范围内进行受保护的修改。
+- **使用真实开发环境** —— 在仓库所在机器上运行命令、测试、格式化、编译器和项目自己的工具。
+- **检查 Git** —— 查看状态和差异，让代码变化保持可见、可审查。
+- **处理长时间任务** —— 任务可以持续运行并保持可观察，不需要一次模型回复一直等待到底。
+- **保留人工审查** —— 可以通过运行时控制台和任务流程进行指导、取消、接受或拒绝。
+
+## 为什么用 WebCodex？
+
+- **代码留在自己的机器上。** 不需要把整个仓库上传到聊天服务。
+- **AI 使用的是真实开发环境。** 文件、Git、编译器、测试和已有工具链都可以直接复用。
+- **工作不局限于一次请求。** 长时间执行、测试结果和相关证据可以继续观察。
+- **既能临时使用，也能长期部署。** 可以一条命令快速分享，也可以连接到自托管服务长期使用。
 
 ## 工作方式
 
 ```text
-ChatGPT / Claude / MCP client
-            |
-            | MCP / HTTPS
-            v
-      WebCodex Server
-            |
-            | 已认证 Runner 连接
-            v
-     webcodex-runner
-            |
-      仓库 / Git / 工具链
+AI 客户端
+   |
+   | MCP / HTTPS
+   v
+WebCodex
+   |
+   v
+你的机器
+   |
+   +-- 代码仓库
+   +-- Git
+   +-- 编译器 / 测试 / 开发工具
 ```
 
-Server 负责认证与路由；真正的工作由仓库所在机器上的 Runner 执行。连接中只传输当前工具
-调用需要的输入与结果。
+如果需要了解内部的 Server/Runner 架构、协议接口和权限边界，再阅读[架构说明](docs/ARCHITECTURE.md)、[MCP](docs/MCP.zh-CN.md)和[认证模型](docs/AUTH_MODEL.zh-CN.md)。
 
-## CLI
+## 平台支持
 
-普通用户优先需要这些命令：
+- **Linux x64/arm64** —— 支持本机 `share`、Server 和 Runner 工作流。
+- **macOS arm64** —— 支持本机 `share` 和 Runner 工作流。
+- **Windows x64/arm64** —— 支持 CLI 和 Runner，连接远程 Linux Server；本版本不在 Windows 本机运行 `webcodex share`。
+
+Windows 接入和长期部署见[部署指南](docs/DEPLOYMENT.zh-CN.md)与 [MCP](docs/MCP.zh-CN.md)。
+
+## 长期使用与高级配置
+
+希望长期保留命令行工具时可以全局安装：
 
 ```bash
-webcodex share                     # 最快的临时 ChatGPT/MCP 接入
-webcodex connect <server-url>      # 接入已有 Server
-webcodex status                    # 简洁项目就绪状态
-webcodex doctor                    # 更完整的本地诊断
-webcodex setup                     # 手动/本地项目设置
-webcodex run                       # 手动启动本地 Server + Runner
-webcodex task list                 # 审查本地任务
+npm install -g @yyjeqhc/webcodex
 ```
 
-Runner 是执行组件。为了兼容现有 CLI，Runner 服务管理仍使用历史命名空间
-`webcodex agent ...`。operator 命令与 credential reference 见 [CLI](docs/CLI.zh-CN.md)。
+如果已经有 WebCodex Server，使用 `webcodex connect <server-url>` 把当前仓库接入该服务，并按照服务端配置的认证方式连接。
+
+生产环境、自托管、Windows 接入、OAuth、私有隧道、代理/私有 CA 等运维配置请直接查看下面的专题文档，不需要在第一次体验前理解这些概念。
 
 ## 文档
 
-- [快速开始](docs/QUICK_START.zh-CN.md) —— 第一次 ChatGPT/MCP 接入
-- [MCP](docs/MCP.zh-CN.md) —— 先讲 ChatGPT/Claude 与认证，再进入协议参考
-- [AI 接入指南](docs/AI_ONBOARDING.zh-CN.md) —— 供 AI 帮用户配置 WebCodex
-- [CLI](docs/CLI.zh-CN.md) —— 命令、兼容说明与凭据
-- [部署指南](docs/DEPLOYMENT.zh-CN.md) —— 自托管与生产运维
-- [认证模型](docs/AUTH_MODEL.zh-CN.md) —— credential 与 authority 模型
-- [Runner](docs/RUNNER.zh-CN.md) —— Runner 运维
-- [Coding 工作流](docs/CODING_WORKFLOW.zh-CN.md)
-- [故障排查](docs/TROUBLESHOOTING.zh-CN.md)
-- [文档索引](docs/INDEX.zh-CN.md)
-- [安全](SECURITY.md)
+- [快速开始](docs/QUICK_START.zh-CN.md) —— 从零到第一次成功连接 AI
+- [MCP](docs/MCP.zh-CN.md) —— ChatGPT、Claude、认证方式和 MCP 参考
+- [部署指南](docs/DEPLOYMENT.zh-CN.md) —— 自托管、长期 Server 和机器接入
+- [故障排查](docs/TROUBLESHOOTING.zh-CN.md) —— 连接和运行问题
+- [CLI](docs/CLI.zh-CN.md) —— 命令与凭据参考
+- [AI 辅助接入](docs/AI_ONBOARDING.zh-CN.md) —— 让 AI 帮你配置 WebCodex
+- [安全说明](SECURITY.md) —— 安全模型与使用建议
+- [文档索引](docs/INDEX.zh-CN.md) —— 全部用户和贡献者文档
 
 ## 安全
 
-WebCodex 可以修改文件并执行命令。只注册允许助手访问的项目根目录，不要把 credential 写进
-prompt、日志或 Git，并优先让 Runner 使用普通 OS 用户。onboarding 的简化不会合并底层真实
-不同的 credential/authority。完整模型见 [SECURITY.md](SECURITY.md)。
+WebCodex 能在配置的项目范围内读取和修改文件、执行命令。建议使用版本控制，不要把凭据写进提示词、日志或 Git，只注册确实希望 AI 访问的项目目录。完整安全模型见 [SECURITY.md](SECURITY.md)。
 
 ## 从源码构建
 
@@ -174,14 +116,12 @@ export PATH="$PWD/target/release:$PATH"
 
 ## 参与贡献
 
-欢迎参与 WebCodex 开发，也欢迎直接使用 WebCodex 本身或其他 coding agent 来完成贡献。
-Bug 报告、开发流程和 pull request 说明见
-[CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)。
+欢迎提交贡献，也欢迎使用 WebCodex 或其他 coding agent 辅助开发。Bug 报告、开发流程与 PR 说明见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
-## 鸣谢
+## 致谢
 
-感谢 [LINUX DO](https://linux.do/) 社区提供的交流氛围与开源推广支持。
+感谢 [LINUX DO](https://linux.do/) 社区提供友好的技术交流与开源分享环境。
 
-## License
+## 许可证
 
-Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE).
+使用 Apache License 2.0，见 [LICENSE](LICENSE)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,10 +15,10 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-看到 **WebCodex ready** 后保持终端运行。接着在 ChatGPT 中：
+看到 **WebCodex ready** 后保持终端运行。**MCP URL** 通常已经复制到剪贴板；可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。然后：
 
-1. 开启 **Developer Mode**，进入 **Settings -> Apps -> Create**。
-2. 粘贴 WebCodex 输出的 **MCP URL**。
+1. 如有需要，开启 **Developer Mode** 并选择 **Create**。
+2. 粘贴已经复制的 **MCP URL**；也可以使用 WebCodex 终端中打印的地址。
 3. 认证选择 **Access token / API key**（或等价的 Bearer 令牌选项），再填入输出的临时 **Credential**。
 4. 点击 **Scan Tools**。
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,46 +2,50 @@
 
 [English](INDEX.md) | [简体中文](INDEX.zh-CN.md)
 
-## Getting started
+Start with the goal that matches what you are trying to do.
 
-- [README](../README.md) — what WebCodex is and the `webcodex share` first-run path
-- [Quick Start](QUICK_START.md) — shortest path from a local repository to ChatGPT MCP
-- [MCP](MCP.md) — ChatGPT Developer Mode and other MCP client setup
-- [AI-assisted setup](AI_ONBOARDING.md) — have an AI agent configure WebCodex for you
+## I want to try WebCodex
 
-## Common operation
+- [README](../README.md) — what WebCodex does and the one-command first-run path
+- [Quick Start](QUICK_START.md) — zero to the first successful AI-assisted development request
+- [MCP](MCP.md) — ChatGPT, Claude, authentication choices, and other MCP clients
+- [AI-assisted setup](AI_ONBOARDING.md) — have an AI agent help configure WebCodex
 
-- [CLI](CLI.md) — command map, compatibility terminology, and credentials
-- [Coding Workflow](CODING_WORKFLOW.md) — canonical task bootstrap, behavioral guidance, validation, and closeout
-- [Runner](RUNNER.md) — operating the Runner on repository machines
+## I need Windows or a permanent deployment
 
-## Advanced deployment and integration
+- [Deployment](DEPLOYMENT.md) — self-hosting, Linux Server setup, Windows/Runner enrollment, and long-lived operation
+- [Runner](RUNNER.md) — operate the component that works beside your repositories
+- [CLI](CLI.md) — commands, profiles, credentials, and operator reference
 
-- [Deployment](DEPLOYMENT.md) — self-hosting, Server bootstrap, and long-lived Runner enrollment
-- [Authentication](AUTH_MODEL.md) — detailed credential and token boundaries
+## I need authentication or network options
+
+- [MCP](MCP.md) — Bearer, query-token fallback, OAuth, private tunnel, and MCP protocol reference
+- [Authentication](AUTH_MODEL.md) — detailed credential and authority boundaries
+- [Deployment](DEPLOYMENT.md) — stable HTTPS origins, self-hosting, and production networking
 - [GPT Actions](GPT_ACTIONS.md) — optional OpenAPI-based Custom GPT integration
 
-## Understanding WebCodex
+## I need help
 
-- [Architecture](ARCHITECTURE.md) — how the pieces fit together
+- [Troubleshooting](TROUBLESHOOTING.md) — installation, connection, runtime, and Runner problems
+- [Security](../SECURITY.md) — safe operating guidance and security model
+
+## I want to understand or extend WebCodex
+
+- [Architecture](ARCHITECTURE.md) — how the major components fit together
+- [Coding Workflow](CODING_WORKFLOW.md) — task bootstrap, guidance, validation, and closeout
 - [Computer Use roadmap](COMPUTER_USE.md) — semantic-first desktop automation direction and dogfood priorities
-- [Security](../SECURITY.md) — security model and policy
 
-## Help
-
-- [Troubleshooting](TROUBLESHOOTING.md)
-
-## Contributing
+## I want to contribute or release WebCodex
 
 - [AGENTS.md](../AGENTS.md) — repository instructions for coding/AI agents
-- [Maintenance](MAINTENANCE.md) — canonical maintenance queue, dependency cadence, PR/CI expectations, and bilingual-doc policy
+- [Maintenance](MAINTENANCE.md) — maintenance queue, dependency cadence, PR/CI expectations, and bilingual-doc policy
 - [Testing](TESTING.md) — testing strategy
 - [Release checklist](RELEASE_CHECKLIST.md) — release readiness
 - [Architecture decisions](agent/architecture-decisions.md)
-- [Runtime host context](agent/runtime-host-context.md) — bounded Runner-configured planning context and exact-source runtime diagnostics
-- [Job reliability and Runner concurrency](agent/job-reliability-and-concurrency.md) — Control restart recovery, observation semantics, shared Job capacity, and tool-description requirements
+- [Runtime host context](agent/runtime-host-context.md) — Runner-configured planning context and runtime diagnostics
+- [Job reliability and Runner concurrency](agent/job-reliability-and-concurrency.md) — restart recovery, observation semantics, shared Job capacity, and tool-description requirements
 - [Authority model](agent/permission-model.md)
 - [Session model](agent/session-model.md)
-- [Manual multi-window collaboration](agent/manual-window-collaboration.md) — coordinator/worker handoff through existing Workflow Session message primitives
+- [Manual multi-window collaboration](agent/manual-window-collaboration.md)
 - [OpenAPI guidelines](agent/openapi-guidelines.md)
 - [Release process](agent/release-process.md)

--- a/docs/INDEX.zh-CN.md
+++ b/docs/INDEX.zh-CN.md
@@ -2,44 +2,48 @@
 
 [English](INDEX.md) | [简体中文](INDEX.zh-CN.md)
 
-## 入门
+按你现在想完成的事情选择文档即可。
 
-- [README](../README.zh-CN.md) —— WebCodex 是什么，以及 `webcodex share` 首次体验
-- [快速开始](QUICK_START.zh-CN.md) —— 从本地仓库接入 ChatGPT MCP 的最短路径
-- [MCP](MCP.zh-CN.md) —— ChatGPT Developer Mode 与其他 MCP 客户端配置
-- [AI 接入指南](AI_ONBOARDING.zh-CN.md) —— 让 AI agent 帮你配置 WebCodex
+## 我想先试用 WebCodex
 
-## 日常使用
+- [README](../README.zh-CN.md) —— WebCodex 能做什么，以及一条命令的首次体验
+- [快速开始](QUICK_START.zh-CN.md) —— 从零到第一次成功完成 AI 开发请求
+- [MCP](MCP.zh-CN.md) —— ChatGPT、Claude、认证方式和其他 MCP 客户端
+- [AI 辅助接入](AI_ONBOARDING.zh-CN.md) —— 让 AI 帮你配置 WebCodex
 
-- [CLI](CLI.zh-CN.md) —— 命令、兼容性术语与凭据
-- [Coding 工作流](CODING_WORKFLOW.zh-CN.md) —— canonical task bootstrap、behavioral guidance、validation 与 closeout
-- [Runner](RUNNER.zh-CN.md) —— 在持有仓库的机器上运维 Runner
+## 我需要 Windows 或长期部署
 
-## 高级部署与集成
+- [部署指南](DEPLOYMENT.zh-CN.md) —— 自托管 Linux Server、Windows/Runner 接入和长期运行
+- [Runner](RUNNER.zh-CN.md) —— 运维仓库所在机器上的执行组件
+- [CLI](CLI.zh-CN.md) —— 命令、配置、凭据和运维参考
 
-- [部署指南](DEPLOYMENT.zh-CN.md) —— 自托管、Server bootstrap 与长期 Runner 接入
-- [认证模型](AUTH_MODEL.zh-CN.md) —— 详细凭据与令牌边界
+## 我需要认证或网络配置
+
+- [MCP](MCP.zh-CN.md) —— Bearer、query-token 兼容方式、OAuth、私有隧道和 MCP 参考
+- [认证模型](AUTH_MODEL.zh-CN.md) —— 详细凭据和权限边界
+- [部署指南](DEPLOYMENT.zh-CN.md) —— 稳定 HTTPS、自托管和生产网络配置
 - [GPT Actions](GPT_ACTIONS.zh-CN.md) —— 可选的 OpenAPI Custom GPT 集成
 
-## 理解 WebCodex
+## 我遇到了问题
 
-- [架构](ARCHITECTURE.md) —— 各组件如何协同
-- [安全](../SECURITY.md) —— 安全模型与策略
+- [故障排查](TROUBLESHOOTING.zh-CN.md) —— 安装、连接、运行和 Runner 问题
+- [安全说明](../SECURITY.md) —— 安全模型和使用建议
 
-## 帮助
+## 我想理解或扩展 WebCodex
 
-- [故障排查](TROUBLESHOOTING.zh-CN.md)
+- [架构](ARCHITECTURE.md) —— 主要组件如何协同
+- [Coding 工作流](CODING_WORKFLOW.zh-CN.md) —— 任务启动、指导、验证和收尾
 
-## 贡献
+## 我想参与开发或发布
 
-- [AGENTS.md](../AGENTS.md) —— 面向 coding/AI agent 的仓库指引
-- [仓库维护](MAINTENANCE.md) —— canonical maintenance queue、依赖更新节奏、PR/CI 约定与双语文档规则
-- [测试策略](TESTING.md) —— 测试策略
-- [发布清单](RELEASE_CHECKLIST.md) —— 发布就绪
+- [AGENTS.md](../AGENTS.md) —— 面向 coding/AI agent 的仓库开发指引
+- [仓库维护](MAINTENANCE.md) —— 维护队列、依赖更新节奏、PR/CI 约定和双语文档规则
+- [测试策略](TESTING.md)
+- [发布清单](RELEASE_CHECKLIST.md)
 - [架构决策](agent/architecture-decisions.md)
-- [Job 可靠性与 Runner 并发](agent/job-reliability-and-concurrency.md) —— Control 重启恢复、observation 语义、共享 Job 容量与工具描述要求
+- [Job 可靠性与 Runner 并发](agent/job-reliability-and-concurrency.md)
 - [权限模型](agent/permission-model.md)
 - [会话模型](agent/session-model.md)
-- [手动多窗口协作](agent/manual-window-collaboration.md) —— 使用现有 Workflow Session message primitive 做 coordinator/worker handoff
+- [手动多窗口协作](agent/manual-window-collaboration.md)
 - [OpenAPI 指南](agent/openapi-guidelines.md)
 - [发布流程](agent/release-process.md)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -25,16 +25,15 @@ You do not need to run `setup`, `doctor`, or `run` first. WebCodex prepares the 
 
 ## 2. Wait for `WebCodex ready`
 
-Keep that terminal open. WebCodex prints the values needed by the MCP client and normally copies the MCP URL to your clipboard.
+Keep that terminal open. WebCodex prints the values needed by the MCP client and normally copies the MCP URL to your clipboard. Press **Enter** in the terminal to open ChatGPT App settings; you can also open **Settings -> Apps -> Create** manually.
 
 ## 3. Add WebCodex to ChatGPT
 
-1. Enable **Developer Mode** in ChatGPT.
-2. Open **Settings -> Apps -> Create**.
-3. Paste the printed **MCP URL**.
-4. For the default share, choose **Access token / API key** or the equivalent Bearer-token option.
-5. Paste the printed temporary **Credential**.
-6. Run **Scan Tools**.
+1. If needed, enable **Developer Mode** and choose **Create** in ChatGPT App settings.
+2. Paste the copied **MCP URL** (or use the URL printed by WebCodex).
+3. For the default share, choose **Access token / API key** or the equivalent Bearer-token option.
+4. Paste the printed temporary **Credential**.
+5. Run **Scan Tools**.
 
 ChatGPT labels can vary by workspace and rollout. The values printed by WebCodex are the source of truth.
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2,227 +2,79 @@
 
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
-This guide gets one local Git repository into ChatGPT through MCP with the fewest
-concepts possible. On Linux/macOS, bare `webcodex` in an interactive Git checkout
-is the shortest first-run entry and dispatches to the normal `webcodex share`
-workflow. Windows does not support the local Server runtime used by `share`;
-Windows users need an existing remote Linux Server and should use
-`webcodex connect <server-url>`
-instead. If no Server exists yet, see [Deployment](DEPLOYMENT.md).
+This page is only the shortest path from a local repository to a first successful AI-assisted development request. You do not need to understand WebCodex internals before starting.
 
 ## Prerequisites
 
-- Node.js 18+ for the npm installer.
-- Git on `PATH` and a Git repository you can safely inspect/edit.
-- No separate `cloudflared` installation is required for the default Linux/macOS
-  temporary public share. WebCodex reuses an explicit/PATH binary or downloads a
-  pinned, verified managed copy when needed.
-  Through the npm wrapper, managed acquisition also inherits npm proxy,
-  `noproxy`, CA, and `strict-ssl` settings; standard proxy/system trust remains
-  the fallback outside npm-specific configuration.
+- Node.js 18 or newer.
+- Git and a repository you are comfortable letting an AI inspect.
+- Linux or macOS for the one-command local `share` flow.
 
-For a one-shot trial without a global install:
+Windows uses a remote Linux WebCodex Server instead of local `share`; start with [MCP setup](MCP.md) or [Deployment](DEPLOYMENT.md).
+
+## 1. Run WebCodex
+
+From the repository you want the AI to use:
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-Or install the CLI once:
+You do not need to run `setup`, `doctor`, or `run` first. WebCodex prepares the temporary connection it needs automatically.
+
+## 2. Wait for `WebCodex ready`
+
+Keep that terminal open. WebCodex prints the values needed by the MCP client and normally copies the MCP URL to your clipboard.
+
+## 3. Add WebCodex to ChatGPT
+
+1. Enable **Developer Mode** in ChatGPT.
+2. Open **Settings -> Apps -> Create**.
+3. Paste the printed **MCP URL**.
+4. For the default share, choose **Access token / API key** or the equivalent Bearer-token option.
+5. Paste the printed temporary **Credential**.
+6. Run **Scan Tools**.
+
+ChatGPT labels can vary by workspace and rollout. The values printed by WebCodex are the source of truth.
+
+### If there is no Bearer/access-token option
+
+If ChatGPT tries OAuth automatically and reports **does not implement OAuth**, or your client has no Bearer-token field, stop the current share and run:
 
 ```bash
-npm install -g @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-The npm wrapper can lazily bootstrap the verified native binaries on first
-execution, so the npx path does not depend on npm preserving postinstall output.
-On Linux/macOS, local MCP debugging with `webcodex share --tunnel none` does not
-need `cloudflared`.
+Paste the complete `/mcp?token=...` URL, choose **No authentication**, and run **Scan Tools** again. The complete URL contains a temporary secret; do not publish or log it. If WebCodex is installed globally, `webcodex share --auth query-token` is equivalent.
 
-## 1. Share the repository
-
-The `npx --yes @yyjeqhc/webcodex` command above already enters this first-run
-path. If you installed the CLI globally instead, run:
-
-```bash
-cd /path/to/your/repository
-webcodex
-# explicit/script-friendly equivalent:
-# webcodex share
-```
-
-Bare `webcodex` only auto-dispatches this way for an interactive Linux/macOS
-terminal inside a Git checkout. Non-interactive invocations and non-repository
-directories still show the normal CLI help. The explicit `share` command remains
-the deterministic entry for scripts.
-
-That single first-run path performs the project setup, starts the local Server +
-Runner, creates a temporary Connector credential, opens a Cloudflare Quick Tunnel, and
-waits for the MCP endpoint to become usable. Do not run `setup`, `doctor`, or
-`run` first unless you specifically want the manual/local workflow described
-later.
-
-The default share is temporary. Keep the terminal open; Ctrl-C stops the local
-runtime, tunnel, URL, and temporary credential.
-
-If `cloudflared` is missing, WebCodex acquires a pinned Cloudflare release into
-private user state before project setup/state creation, verifies the artifact and
-binary, and then continues. Set `WEBCODEX_CLOUDFLARED_BIN` to force a trusted
-binary, or use `--tunnel none` for local-only debugging.
-
-## 2. Add WebCodex to ChatGPT
-
-When the terminal reports **WebCodex ready**, the printed values remain the
-source of truth. For a public share, WebCodex best-effort copies the MCP URL to
-the clipboard but never copies the credential automatically. In an interactive
-terminal, press Enter to open ChatGPT App settings. Then:
-
-1. In ChatGPT, enable **Developer Mode** and go to **Settings -> Apps -> Create**.
-2. Paste the copied **MCP URL**, or use the printed `https://.../mcp` fallback.
-3. For the default share, choose **Access token / API key** (Bearer token).
-4. Paste the printed **Credential (this share only)**.
-5. Run **Scan Tools**.
-
-Use `webcodex share --no-copy-url` to suppress the clipboard attempt.
-
-For the opt-in OpenAI-only transport, configure an OpenAI Secure MCP Tunnel and
-a Restricted Runtime API key with Tunnels Read + Use, export
-`CONTROL_PLANE_TUNNEL_ID` and `CONTROL_PLANE_API_KEY`, then run:
-
-```bash
-webcodex share --tunnel openai
-```
-
-WebCodex auto-resolves pinned verified OpenAI `tunnel-client` v0.0.12 (or a
-matching `WEBCODEX_TUNNEL_CLIENT_BIN` / `PATH` binary), runs its doctor/readiness
-checks, and keeps the temporary WebCodex Bearer credential local. In ChatGPT use
-**Connection: Tunnel** and **No authentication**. The default Cloudflare Quick
-Tunnel path remains unchanged and client-agnostic.
-
-The Console intentionally does not display that credential. If you later open
-`/console`, get connection credentials from the successful CLI output, not from
-the browser page. ChatGPT Developer Mode, custom MCP apps, and write/modify
-actions are separately controlled by the ChatGPT plan, workspace, and admin
-settings; WebCodex cannot enable an action that the client workspace does not
-permit.
-
-## 3. Send a safe first prompt
-
-Start by confirming that the client can see the intended repository without
-making changes:
+## 4. Try a read-only request
 
 ```text
 Inspect this repository and summarize its structure. Do not make changes.
 ```
 
-After that succeeds, ask for a small, reversible change. WebCodex's project-bound
-coding surface handles project identity internally; ordinary users do not need
-to provide runtime project ids or operation ids in prompts.
+A successful answer confirms that the client can reach WebCodex and the intended repository.
 
-## 4. Review work
+## 5. Make a small change
 
-The browser `/console` shows readiness, work queue, task guidance, approvals, and
-review actions. Where a stable result is ready, a human can Accept or Reject it
-from the Console or CLI:
+Once the read-only request works, try a small, reviewable task such as:
 
-```bash
-webcodex task list
-webcodex task show <task-id>
-webcodex task accept <task-id>
-# or: webcodex task reject <task-id>
+```text
+Fix one small issue in this repository and run the relevant tests. Show me what changed.
 ```
 
-The online model cannot accept its own result.
+Use Git or the WebCodex review surfaces to inspect the result before accepting it.
 
-## Existing Server: long-lived connection
+## Done
 
-If an existing hosted Server is intentionally configured for shared-key clients,
-use `connect` with the shared key supplied by its operator instead of temporary
-`share`:
+You now have a working first connection. Keep the WebCodex terminal open while using this temporary share; Ctrl-C ends it.
 
-```bash
-cd /path/to/your/repository
-webcodex connect https://webcodex.example --key-file /private/path/shared-key
-```
+Next steps:
 
-`connect` creates/reuses a local profile, starts a detached Runner, waits until
-the Server can see the Runner and project, then prints the MCP URL,
-authentication type, credential source, ChatGPT hint, and diagnostic details.
-The shared key is a hosted-client credential; it is not the bootstrap
-administrator token of a self-hosted Server.
-
-To remove only this repository from a hosted profile later:
-
-```bash
-webcodex disconnect
-```
-
-If you need a Server first, the recommended Docker Server path is clone-free and
-uses three shell commands; see [Deployment](DEPLOYMENT.md#docker-server-only).
-After that bootstrap, enroll repository machines with a short-lived pairing code
-and `webcodex login`, then explicitly install the reported Runner config. Keep
-the Server `.env` and its bootstrap administrator token on the Server.
-
-## Optional OAuth
-
-Bearer authentication is the simplest trial path. If the MCP client requires
-OAuth, provide its exact callback URL.
-
-Temporary project-bound share:
-
-```bash
-webcodex share --auth oauth \
-  --oauth-redirect-uri https://client.example/callback
-```
-
-Existing hosted Server:
-
-```bash
-webcodex connect https://webcodex.example --auth oauth \
-  --oauth-redirect-uri https://client.example/callback
-```
-
-The CLI prints which values belong in the MCP client and which temporary project
-credential belongs only on the WebCodex authorization page. Advanced OAuth
-scope ceilings, optional Computer permissions, managed-user OAuth, and protocol
-contracts are documented in [MCP](MCP.md) and [Authentication](AUTH_MODEL.md).
-
-## Local-only / manual workflow
-
-These commands remain useful for development and diagnostics, but they are not
-prerequisites for a hosted ChatGPT connection:
-
-```bash
-cd /path/to/your/repository
-webcodex setup     # configure private project state only
-webcodex doctor    # read-only local readiness diagnostics
-webcodex run       # foreground loopback Server + Runner
-# in another terminal:
-webcodex status
-```
-
-`doctor` describes the local/manual runtime and may recommend `webcodex run` when
-that loopback runtime is stopped. Hosted clients cannot reach a loopback-only
-runtime, which is why the normal ChatGPT onboarding starts with `share` instead.
-
-## Troubleshooting
-
-Start with the exact error from `share` or `connect`. For established local
-state, these remain useful:
-
-```bash
-webcodex status
-webcodex doctor
-```
-
-Common examples:
-
-| Symptom | Next action |
-| --- | --- |
-| managed `cloudflared` acquisition fails | Check network/proxy access and retry; alternatively set `WEBCODEX_CLOUDFLARED_BIN` to a trusted binary or use `share --tunnel none` locally |
-| loopback port already in use | Stop the conflicting process and retry |
-| local/manual runtime stopped | `webcodex run` |
-| Runner unavailable on an existing hosted profile | rerun `connect` or inspect `webcodex agent status --profile <profile>` |
-| workspace unavailable | restore the Git project/path |
-
-See [Troubleshooting](TROUBLESHOOTING.md) for the full operational checklist.
+- [ChatGPT, Claude, and authentication options](MCP.md)
+- [Windows and permanent/self-hosted deployment](DEPLOYMENT.md)
+- [CLI reference](CLI.md)
+- [Troubleshooting](TROUBLESHOOTING.md)
+- [Security](../SECURITY.md)
+- [Full documentation index](INDEX.md)

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -25,16 +25,15 @@ npx --yes @yyjeqhc/webcodex
 
 ## 2. 等待 `WebCodex ready`
 
-看到 **WebCodex ready** 后保持终端运行。WebCodex 会打印 MCP 客户端需要的配置，通常也会把 MCP URL 复制到剪贴板。
+看到 **WebCodex ready** 后保持终端运行。WebCodex 会打印 MCP 客户端需要的配置，通常也会把 MCP URL 复制到剪贴板。可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。
 
 ## 3. 在 ChatGPT 中添加 WebCodex
 
-1. 在 ChatGPT 中开启 **Developer Mode**。
-2. 进入 **Settings -> Apps -> Create**。
-3. 粘贴输出的 **MCP URL**。
-4. 默认分享方式选择 **Access token / API key** 或等价的 Bearer 令牌选项。
-5. 填入输出的临时 **Credential**。
-6. 点击 **Scan Tools**。
+1. 如有需要，在 ChatGPT App 设置中开启 **Developer Mode** 并选择 **Create**。
+2. 粘贴已经复制的 **MCP URL**；也可以使用 WebCodex 终端中打印的地址。
+3. 默认分享方式选择 **Access token / API key** 或等价的 Bearer 令牌选项。
+4. 填入输出的临时 **Credential**。
+5. 点击 **Scan Tools**。
 
 不同账号或工作区看到的 ChatGPT 文案可能略有区别，具体 URL 和认证值以 WebCodex 终端输出为准。
 

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -2,201 +2,79 @@
 
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
-本指南用尽可能少的概念，把一个本地 Git 仓库通过 MCP 接入 ChatGPT。在 Linux/macOS
-的交互式 Git checkout 中，裸 `webcodex` 是最短 first-run 入口，并会进入正常的
-`webcodex share` 工作流。Windows 不支持 `share` 所需的本地
-Server runtime；Windows 用户需要已有的远程 Linux Server，并改用
-`webcodex connect <server-url>`。如果还没有 Server，请先看[部署指南](DEPLOYMENT.zh-CN.md)。
+这个页面只做一件事：让一个本地代码仓库尽快完成第一次 AI 开发请求。开始之前不需要理解 WebCodex 的内部架构。
 
 ## 前置条件
 
-- npm installer 需要 Node.js 18+。
-- `PATH` 中有 Git，并准备一个可以安全查看/编辑的 Git 仓库。
-- Linux/macOS 默认临时公网 HTTPS 分享不再要求单独安装 `cloudflared`。WebCodex 会优先
-  复用显式指定或 `PATH` 中的 binary；没有时自动下载固定版本并校验后使用。
-  通过 npm wrapper 启动时，managed 下载还会继承 npm proxy、`noproxy`、CA 与
-  `strict-ssl` 配置；没有 npm-specific 配置时继续使用标准 proxy/系统信任路径。
+- Node.js 18 或更新版本。
+- Git，以及一个可以让 AI 安全查看的代码仓库。
+- 一键本机 `share` 流程需要 Linux 或 macOS。
 
-不全局安装也可以直接试用：
+Windows 需要连接远程 Linux WebCodex Server，不在本机运行 `share`；请从 [MCP 接入](MCP.zh-CN.md)或[部署指南](DEPLOYMENT.zh-CN.md)开始。
+
+## 1. 运行 WebCodex
+
+进入希望 AI 使用的仓库：
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-也可以先全局安装一次：
+第一次使用不需要提前运行 `setup`、`doctor` 或 `run`。WebCodex 会自动准备本次临时连接。
+
+## 2. 等待 `WebCodex ready`
+
+看到 **WebCodex ready** 后保持终端运行。WebCodex 会打印 MCP 客户端需要的配置，通常也会把 MCP URL 复制到剪贴板。
+
+## 3. 在 ChatGPT 中添加 WebCodex
+
+1. 在 ChatGPT 中开启 **Developer Mode**。
+2. 进入 **Settings -> Apps -> Create**。
+3. 粘贴输出的 **MCP URL**。
+4. 默认分享方式选择 **Access token / API key** 或等价的 Bearer 令牌选项。
+5. 填入输出的临时 **Credential**。
+6. 点击 **Scan Tools**。
+
+不同账号或工作区看到的 ChatGPT 文案可能略有区别，具体 URL 和认证值以 WebCodex 终端输出为准。
+
+### 如果找不到 Bearer/访问令牌选项
+
+如果 ChatGPT 自动尝试 OAuth 并出现 **does not implement OAuth**，或者当前客户端根本没有 Bearer 令牌输入框，先结束当前分享，再运行：
 
 ```bash
-npm install -g @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-npm wrapper 在第一次执行时可以 lazy bootstrap 经过校验的 native binary，因此 npx 路径
-不依赖 npm 是否保留 postinstall 产生的文件。在 Linux/macOS 上只做本地 MCP 调试时，
-`webcodex share --tunnel none` 不需要
-`cloudflared`。
+把输出的完整 `/mcp?token=...` 地址粘贴进去，认证选择 **No authentication**，然后再次点击 **Scan Tools**。完整地址包含本次临时密钥，不要公开或写入日志。如果已经全局安装 WebCodex，等价命令是 `webcodex share --auth query-token`。
 
-## 1. 分享当前仓库
-
-前面的 `npx --yes @yyjeqhc/webcodex` 已经会直接进入这条 first-run 路径。如果选择了
-全局安装，再运行：
-
-```bash
-cd /path/to/your/repository
-webcodex
-# 显式/脚本友好的等价入口：
-# webcodex share
-```
-
-裸 `webcodex` 只会在 Linux/macOS + 交互式终端 + Git checkout 中这样自动分发；脚本、
-非交互调用和 repo 外目录仍显示普通 CLI help。需要确定性行为时继续显式使用 `share`。
-
-这一条 first-run 路径会完成项目设置、启动本地 Server + Runner、创建临时 Connector
-credential、打开 Cloudflare Quick Tunnel，并等待 MCP endpoint 可用。除非你明确需要后文的手动/本地
-工作流，否则不要先跑 `setup`、`doctor` 或 `run`。
-
-默认 share 是临时的。保持终端运行；Ctrl-C 会停止本地 runtime 与 tunnel，同时使 URL 和
-临时 credential 失效。
-
-如果缺少 `cloudflared`，WebCodex 会在创建项目 setup/state 之前把固定版本下载到私有用户
-状态目录，校验 artifact 与最终 binary 后继续。可用 `WEBCODEX_CLOUDFLARED_BIN` 强制指定
-可信 binary；仅本地调试时也可以使用 `--tunnel none`。
-
-## 2. 在 ChatGPT 中添加 WebCodex
-
-终端出现 **WebCodex ready** 后，终端中打印的值仍然是 source of truth。公网 share 会
-best-effort 把 MCP URL 复制到剪贴板，但 credential 永远不会自动复制；交互式终端可按
-Enter 打开 ChatGPT App 设置。然后：
-
-1. 在 ChatGPT 开启 **Developer Mode**，进入 **Settings -> Apps -> Create**。
-2. 粘贴已复制的 **MCP URL**；复制失败时使用输出的 `https://.../mcp`。
-3. 默认 share 的认证选择 **Access token / API key**（Bearer token）。
-4. 粘贴输出的 **Credential (this share only)**。
-5. 点击 **Scan Tools**。
-
-如不希望访问剪贴板，使用 `webcodex share --no-copy-url`。
-
-如果只需要 OpenAI 产品访问，可以先创建 OpenAI Secure MCP Tunnel 与仅授予 Tunnels
-Read + Use 的 Restricted Runtime API key，导出 `CONTROL_PLANE_TUNNEL_ID` 和
-`CONTROL_PLANE_API_KEY`，然后运行：
-
-```bash
-webcodex share --tunnel openai
-```
-
-WebCodex 会自动解析固定且经过校验的 OpenAI `tunnel-client` v0.0.12（也可使用匹配的
-`WEBCODEX_TUNNEL_CLIENT_BIN` / `PATH` binary），运行 doctor/readiness，并把临时
-WebCodex Bearer credential 留在本机。ChatGPT 侧使用 **Connection: Tunnel** 与
-**No authentication**。默认 Cloudflare Quick Tunnel 路径保持不变，仍然不绑定特定 MCP client。
-
-Console 故意不显示 credential。以后即使打开 `/console`，认证值也应来自成功的 CLI 首次
-输出，而不是浏览器页面。ChatGPT Developer Mode、custom MCP app 与 write/modify action
-还分别受 ChatGPT 套餐、workspace 和管理员设置控制；客户端 workspace 没有允许的 action，
-WebCodex 不能自行把它开启。
-
-## 3. 发送第一条安全请求
-
-先确认客户端连接的是正确仓库，并且不产生修改：
+## 4. 先试一个只读请求
 
 ```text
 检查这个仓库并总结它的结构。先不要做任何修改。
 ```
 
-确认成功后，再让它完成一个小且可回退的改动。project-bound coding surface 会在内部处理
-项目身份；普通用户不需要在 prompt 中提供 runtime project id 或 operation id。
+能正常得到回答，就说明 ChatGPT 已经能够通过 WebCodex 访问目标仓库。
 
-## 4. 审查结果
+## 5. 再做一个小修改
 
-浏览器 `/console` 可以查看 readiness、工作队列、task guidance、审批与 review action。
-稳定结果准备好后，人类可以在 Console 或 CLI 中 Accept/Reject：
+确认只读请求正常后，可以尝试一个容易审查的小任务：
 
-```bash
-webcodex task list
-webcodex task show <task-id>
-webcodex task accept <task-id>
-# 或：webcodex task reject <task-id>
+```text
+修复这个仓库里的一个小问题，并运行相关测试。告诉我具体改了什么。
 ```
 
-在线模型不能接受自己的结果。
+接受结果之前，用 Git 或 WebCodex 的审查界面检查实际改动。
 
-## 已有 Server：长期连接
+## 完成
 
-如果已有 hosted Server 明确配置为 shared-key 接入，使用 operator 提供的 shared key，
-用 `connect` 替代临时 `share`：
+第一次连接已经成功。使用这次临时分享时保持 WebCodex 终端运行；按 Ctrl-C 会结束本次连接。
 
-```bash
-cd /path/to/your/repository
-webcodex connect https://webcodex.example --key-file /private/path/shared-key
-```
+接下来按需要阅读：
 
-`connect` 创建/复用本地 profile、启动 detached Runner、等待 Server 看见 Runner 与项目，
-然后输出 MCP URL、认证类型、credential 来源、ChatGPT 提示和诊断 Details。这里的 shared
-key 是 hosted client credential，不是自托管 Server 的 bootstrap administrator token。
-
-以后只注销当前仓库：
-
-```bash
-webcodex disconnect
-```
-
-如果还需要先准备 Server，推荐的 Docker Server 路径无需 clone 仓库，只需三条 shell 命令；
-见[部署指南](DEPLOYMENT.zh-CN.md#docker仅-server)。bootstrap 完成后，在 Server 侧创建短期
-pairing code，在仓库机器上执行 `webcodex login`，再显式安装它报告的 Runner config。Server
-`.env` 和 bootstrap administrator token 始终留在 Server 机器上。
-
-## 可选 OAuth
-
-Bearer 是最简单的试用路径。如果 MCP client 要求 OAuth，请提供它的精确 callback URL。
-
-临时 project-bound share：
-
-```bash
-webcodex share --auth oauth \
-  --oauth-redirect-uri https://client.example/callback
-```
-
-已有 hosted Server：
-
-```bash
-webcodex connect https://webcodex.example --auth oauth \
-  --oauth-redirect-uri https://client.example/callback
-```
-
-CLI 会明确哪些值填进 MCP client，哪个临时 project credential 只能填在 WebCodex 授权页。
-高级 OAuth scope ceiling、optional Computer permission、managed-user OAuth 与协议 contract
-见 [MCP](MCP.zh-CN.md) 和[认证模型](AUTH_MODEL.zh-CN.md)。
-
-## 仅本地 / 手动工作流
-
-这些命令仍适合开发与诊断，但不是 hosted ChatGPT 接入的前置条件：
-
-```bash
-cd /path/to/your/repository
-webcodex setup     # 只配置私有项目状态
-webcodex doctor    # 只读本地 readiness 诊断
-webcodex run       # 前台 loopback Server + Runner
-# 另一个终端：
-webcodex status
-```
-
-`doctor` 描述的是本地/手动 runtime；loopback runtime 停止时，它仍可能推荐
-`webcodex run`。Hosted client 无法访问 loopback，因此普通 ChatGPT onboarding 从
-`share` 开始，而不是从 `doctor` 开始。
-
-## 故障排查
-
-优先看 `share` 或 `connect` 返回的精确错误。已有本地状态时也可运行：
-
-```bash
-webcodex status
-webcodex doctor
-```
-
-| 现象 | 下一步 |
-| --- | --- |
-| WebCodex-managed `cloudflared` 获取失败 | 检查网络/代理后重试；也可用 `WEBCODEX_CLOUDFLARED_BIN` 指定可信 binary，或仅本地调试时用 `share --tunnel none` |
-| loopback 端口已被占用 | 停掉冲突进程后重试 |
-| 本地/手动 runtime 未运行 | `webcodex run` |
-| 已有 hosted profile 的 Runner 不可用 | 重跑 `connect` 或检查 `webcodex agent status --profile <profile>` |
-| workspace 不可用 | 恢复 Git 仓库/路径 |
-
-完整检查清单见[故障排查](TROUBLESHOOTING.zh-CN.md)。
+- [ChatGPT、Claude 与认证方式](MCP.zh-CN.md)
+- [Windows 与长期/自托管部署](DEPLOYMENT.zh-CN.md)
+- [CLI 参考](CLI.zh-CN.md)
+- [故障排查](TROUBLESHOOTING.zh-CN.md)
+- [安全说明](../SECURITY.md)
+- [完整文档索引](INDEX.zh-CN.md)

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -17,10 +17,10 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-When it reports **WebCodex ready**, keep the terminal open and add it to ChatGPT:
+When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL** is normally copied to your clipboard; press **Enter** in the terminal to open ChatGPT App settings, or open **Settings -> Apps -> Create** manually. Then:
 
-1. Enable **Developer Mode** and open **Settings -> Apps -> Create**.
-2. Paste the printed **MCP URL**.
+1. Enable **Developer Mode** if needed and choose **Create**.
+2. Paste the copied **MCP URL** (or use the URL printed by WebCodex).
 3. Choose **Access token / API key** (Bearer token) and paste the printed **Credential**.
 4. Run **Scan Tools**.
 
@@ -73,10 +73,10 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-看到 **WebCodex ready** 后保持终端运行，然后在 ChatGPT 中：
+看到 **WebCodex ready** 后保持终端运行。**MCP URL** 通常已经复制到剪贴板；可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。然后：
 
-1. 开启 **Developer Mode**，进入 **Settings -> Apps -> Create**。
-2. 粘贴输出的 **MCP URL**。
+1. 如有需要，开启 **Developer Mode** 并选择 **Create**。
+2. 粘贴已经复制的 **MCP URL**；也可以使用 WebCodex 终端中打印的地址。
 3. 认证选择 **Access token / API key**（Bearer 令牌），并填入输出的临时 **Credential**。
 4. 点击 **Scan Tools**。
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -4,211 +4,121 @@
 
 ## English
 
-WebCodex connects ChatGPT, Claude, and other MCP clients to repositories and
-development tools on your own machines. This npm package installs the native
-`webcodex`, `webcodex-server`, and `webcodex-runner` binaries for supported
-platforms.
+**Connect ChatGPT, Claude, and other AI agents to repositories and developer tools on your own machines.**
+
+WebCodex lets an AI inspect and edit code, run tests and commands, use Git, and work with the development environment that already exists beside your repository.
 
 ### Fastest first connection
 
-Supported platforms are Linux x64/arm64, macOS arm64, Windows x64, and native
-Windows arm64. The installer wrapper requires Node.js 18 or newer. Windows is a
-CLI + Runner client platform in this release: local Server runtime and
-`webcodex share` are unsupported there, so use `webcodex connect <server-url>`
-against a remote Linux Server. The `share` steps below apply to Linux/macOS.
-For the default public flow, WebCodex reuses `WEBCODEX_CLOUDFLARED_BIN` or a
-`cloudflared` on `PATH`, and otherwise downloads a pinned, verified managed copy.
-The managed download reuses npm proxy/`noproxy`/CA/`strict-ssl` configuration when
-launched through this npm wrapper, while standard proxy/system trust remains the
-fallback when npm-specific settings are absent.
-
-Try it without a global install:
+Requires Node.js 18+ and Git. On Linux or macOS:
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-Or install it once and use the same bare first-run entry:
+When it reports **WebCodex ready**, keep the terminal open and add it to ChatGPT:
+
+1. Enable **Developer Mode** and open **Settings -> Apps -> Create**.
+2. Paste the printed **MCP URL**.
+3. Choose **Access token / API key** (Bearer token) and paste the printed **Credential**.
+4. Run **Scan Tools**.
+
+Try:
+
+```text
+Inspect this repository and summarize its structure. Do not make changes.
+```
+
+If ChatGPT does not show a Bearer/access-token option, or reports **does not implement OAuth**, run:
+
+```bash
+npx --yes @yyjeqhc/webcodex share --auth query-token
+```
+
+Paste the complete `/mcp?token=...` URL and choose **No authentication**. Treat the complete URL as a temporary secret. If the package is installed globally, `webcodex share --auth query-token` is equivalent.
+
+### Platforms
+
+- Linux x64/arm64: local one-command `share`, Server, and Runner workflows.
+- macOS arm64: local one-command `share` and Runner workflows.
+- Windows x64/arm64: CLI + Runner against a remote Linux Server; local `share` is not supported in this release.
+
+For Windows, permanent/self-hosted setup, OAuth, private tunnels, proxy settings, and troubleshooting, use the [WebCodex documentation](https://github.com/yyjeqhc/webcodex/tree/main/docs). The [Quick Start](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.md) stays focused on the first successful connection.
+
+### Install globally
 
 ```bash
 npm install -g @yyjeqhc/webcodex
-cd /path/to/your/repository
-webcodex
 ```
 
-If npm/npx did not retain postinstall output, the wrapper lazily runs the same
-verified native installer before launching. Bare `webcodex` auto-dispatches to
-`share` only in an interactive Linux/macOS Git checkout; use explicit
-`webcodex share` for scripts or deterministic dispatch.
+The package exposes the `webcodex` command. WebCodex downloads and verifies the matching native release artifacts for supported platforms and replaces the installed binary set atomically; a failed download, extraction, checksum, or identity check does not replace the previous complete installation.
 
-You do not need to run `setup`, `doctor`, or `run` first. `share` prepares the
-tunnel dependency when needed, configures the project, starts a local Server +
-Runner, opens a temporary Cloudflare Quick Tunnel, and prints the MCP URL and
-temporary credential.
+### Security
 
-When it says **WebCodex ready**, public share best-effort copies the MCP URL but
-never the credential. In an interactive terminal, press Enter to open ChatGPT
-App settings. Then:
-
-1. Enable Developer Mode and go to Settings -> Apps -> Create.
-2. Paste the copied MCP URL, or copy the printed fallback URL.
-3. Choose Access token / API key (Bearer token).
-4. Paste the printed Credential.
-5. Scan Tools.
-6. Try: `Inspect this repository and summarize its structure. Do not make changes.`
-
-Use `webcodex share --no-copy-url` to disable clipboard access.
-
-For MCP clients that cannot set a Bearer header, `webcodex share --auth query-token`
-is an explicit opt-in that prints and copies one sensitive `/mcp?token=...` URL;
-choose No authentication in the client. The token is temporary and share-only,
-but the complete URL must be treated as a secret because query strings may be logged.
-
-The default share is temporary and ends when the command exits. For local-only
-MCP debugging, `webcodex share --tunnel none` does not require `cloudflared`.
-For OpenAI-only private reachability, users who already have an OpenAI Secure MCP
-Tunnel can export `CONTROL_PLANE_TUNNEL_ID` plus a Restricted
-`CONTROL_PLANE_API_KEY` with Tunnels Read + Use and run
-`webcodex share --tunnel openai`. WebCodex resolves pinned verified OpenAI
-`tunnel-client` v0.0.12 and keeps the temporary WebCodex Bearer local; ChatGPT
-uses Connection: Tunnel + No authentication.
-ChatGPT Developer Mode, custom MCP apps, and write/modify actions are controlled
-by the ChatGPT plan, workspace, and admin settings; WebCodex cannot widen those
-client-side permissions.
-
-If you already operate a hosted WebCodex Server configured for shared-key
-clients, use the operator-provided client key with the long-lived path:
-
-```bash
-webcodex connect https://webcodex.example --key-file /private/path/shared-key
-```
-
-`connect` creates a reusable profile and prints the corresponding MCP setup
-values. For a freshly self-hosted Docker Server, keep the bootstrap admin token
-on the Server and enroll repository machines with pairing + `webcodex login`.
-
-### Package integrity
-
-The package exposes one public command, `webcodex`. During installation it
-downloads the matching release artifact, verifies its SHA-256 checksum, checks
-that all three binaries share one version/build identity, and atomically
-replaces the previous complete binary set. A failed download, extraction,
-checksum, or identity check leaves the previous installation intact.
-The artifact download honors npm lifecycle proxy, `noproxy`, `cafile`/`ca`, and
-`strict-ssl` settings, so installations behind the same corporate proxy or CA
-configuration used by npm do not need a separate WebCodex network setup.
-
-`webcodex-server` and `webcodex-runner` are package-local binaries rather than
-separate npm `bin` entries. The public CLI discovers them for `webcodex server`
-and the compatibility `webcodex agent` Runner-management namespace.
-
-### Disclaimer
-
-WebCodex can read and modify files and execute commands inside configured
-project boundaries. Use version control and recoverable backups.
+WebCodex can read and modify files and execute commands inside configured project boundaries. Use version control and keep credentials out of prompts, logs, and Git. See the repository [security guidance](https://github.com/yyjeqhc/webcodex/blob/main/SECURITY.md).
 
 ## 简体中文
 
-WebCodex 把 ChatGPT、Claude 和其他 MCP client 连接到你自己机器上的仓库与开发工具。
-npm package 会为支持的平台安装原生 `webcodex`、`webcodex-server`、
-`webcodex-runner` binaries。
+**把 ChatGPT、Claude 和其他 AI Agent 连接到你自己机器上的代码仓库和开发工具。**
 
-### 最快的第一次接入
+WebCodex 可以让 AI 理解和修改代码、运行测试与命令、检查 Git，并直接使用仓库旁边已经存在的真实开发环境。
 
-支持 Linux x64/arm64、macOS arm64、Windows x64 与原生 Windows arm64；installer
-wrapper 需要 Node.js 18 或更新版本。本版本的 Windows 是 CLI + Runner 客户端平台，
-不支持本地 Server runtime 或 `webcodex share`；Windows 请使用
-`webcodex connect <server-url>` 连接远程 Linux Server。下面的 `share` 步骤适用于
-Linux/macOS。默认公网流程会优先复用 `WEBCODEX_CLOUDFLARED_BIN` 或 `PATH` 中已有的
-`cloudflared`，否则自动下载固定版本、校验后由 WebCodex 管理。
-通过 npm wrapper 启动时，这次 managed 下载会复用 npm proxy、`noproxy`、CA 与
-`strict-ssl` 配置；没有 npm-specific 配置时继续使用标准 proxy/系统信任路径。
+### 最快的第一次连接
 
-无需全局安装即可试用：
+需要 Node.js 18+ 和 Git。Linux 或 macOS 上进入仓库：
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-也可以全局安装后使用同样的裸 first-run 入口：
+看到 **WebCodex ready** 后保持终端运行，然后在 ChatGPT 中：
+
+1. 开启 **Developer Mode**，进入 **Settings -> Apps -> Create**。
+2. 粘贴输出的 **MCP URL**。
+3. 认证选择 **Access token / API key**（Bearer 令牌），并填入输出的临时 **Credential**。
+4. 点击 **Scan Tools**。
+
+第一条可以先只读检查：
+
+```text
+检查这个仓库并总结它的结构。先不要做任何修改。
+```
+
+如果 ChatGPT 没有 Bearer/访问令牌选项，或者出现 **does not implement OAuth**，运行：
+
+```bash
+npx --yes @yyjeqhc/webcodex share --auth query-token
+```
+
+粘贴完整的 `/mcp?token=...` 地址并选择 **No authentication**。完整地址包含本次临时密钥，请按敏感信息处理。如果已经全局安装，也可以使用 `webcodex share --auth query-token`。
+
+### 平台支持
+
+- Linux x64/arm64：支持本机一键 `share`、Server 和 Runner 工作流。
+- macOS arm64：支持本机一键 `share` 和 Runner 工作流。
+- Windows x64/arm64：支持 CLI 和 Runner，连接远程 Linux Server；本版本不支持 Windows 本机 `share`。
+
+Windows、长期/自托管部署、OAuth、私有隧道、代理配置和故障排查见 [WebCodex 文档](https://github.com/yyjeqhc/webcodex/tree/main/docs)。[快速开始](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.zh-CN.md)只保留第一次成功连接所需的步骤。
+
+### 全局安装
 
 ```bash
 npm install -g @yyjeqhc/webcodex
-cd /path/to/your/repository
-webcodex
 ```
 
-如果 npm/npx 没有保留 postinstall 输出，wrapper 会在启动前 lazy 执行同一套经过校验的
-native installer。裸 `webcodex` 只在 Linux/macOS 的交互式 Git checkout 中自动进入
-`share`；脚本或需要确定性分发时继续显式使用 `webcodex share`。
+npm 包对外提供 `webcodex` 命令。安装时会下载并校验当前平台对应的原生发布产物，再原子替换完整的程序文件；下载、解压、校验或版本一致性检查失败时，不会破坏上一份完整安装。
 
-第一次不需要先执行 `setup`、`doctor` 或 `run`。`share` 会在需要时先准备 tunnel 依赖，
-然后配置项目、启动本地 Server + Runner、打开临时 Cloudflare Quick Tunnel，并输出 MCP URL
-与临时 credential。
+### 安全
 
-出现 **WebCodex ready** 后，公网 share 会 best-effort 复制 MCP URL，但绝不会自动复制
-credential；交互式终端可以按 Enter 打开 ChatGPT App 设置。然后：
-
-1. 开启 Developer Mode，进入 Settings -> Apps -> Create。
-2. 粘贴已复制的 MCP URL；失败时使用终端打印的 fallback URL。
-3. 认证选择 Access token / API key（Bearer token）。
-4. 填入输出的 Credential。
-5. Scan Tools。
-6. 第一条可先说：`检查这个仓库并总结它的结构。先不要做任何修改。`
-
-使用 `webcodex share --no-copy-url` 可以关闭剪贴板访问。
-
-如果 MCP client 无法设置 Bearer header，可显式使用 `webcodex share --auth query-token`。
-它会输出并复制一条敏感的 `/mcp?token=...` URL，此时 client 选择 No authentication。
-token 只属于本次临时 share，但整条 URL 都必须当作 secret，因为 query string 可能进入日志。
-
-默认 share 会在命令退出时结束。仅做本地 MCP 调试可用
-`webcodex share --tunnel none`，此时不需要 `cloudflared`。ChatGPT Developer Mode、custom
-MCP app 与 write/modify action 受 ChatGPT 套餐、workspace 和管理员设置控制；WebCodex
-不能扩大这些客户端侧权限。
-
-如果只需要 OpenAI 产品的私有可达性，已经创建 Secure MCP Tunnel 的用户可以导出
-`CONTROL_PLANE_TUNNEL_ID` 与只授予 Tunnels Read + Use 的 Restricted
-`CONTROL_PLANE_API_KEY`，然后运行 `webcodex share --tunnel openai`。WebCodex 会解析固定且
-经过校验的 OpenAI `tunnel-client` v0.0.12，并把临时 WebCodex Bearer 留在本机；ChatGPT
-使用 Connection: Tunnel + No authentication。
-
-如果你已经运营一个明确支持 shared-key client 的 hosted WebCodex Server，使用 operator
-提供的 client key 走长期路径：
-
-```bash
-webcodex connect https://webcodex.example --key-file /private/path/shared-key
-```
-
-`connect` 会创建可复用 profile 并输出对应 MCP 配置。对于刚完成 Docker bootstrap 的自托管
-Server，把 bootstrap admin token 留在 Server，仓库机器通过 pairing + `webcodex login` 接入。
-
-### Package 完整性
-
-package 只暴露一个公共命令 `webcodex`。安装时会下载匹配的 release artifact、校验
-SHA-256、确认三个 binary 版本/build identity 一致，再原子替换旧 binary set。下载、
-解压、checksum 或 identity 校验失败时，旧安装保持不变。
-artifact 下载会继承 npm lifecycle 中的 proxy、`noproxy`、`cafile`/`ca` 与
-`strict-ssl` 配置，因此使用企业代理或私有 CA 时不需要再单独配置 WebCodex 网络层。
-
-`webcodex-server` 与 `webcodex-runner` 是 package-local binaries，不单独作为 npm `bin`
-暴露。公共 CLI 会通过 `webcodex server` 和兼容保留的 `webcodex agent` Runner 管理
-命名空间发现它们。
-
-### 免责声明
-
-WebCodex 能够在配置的项目边界内读取、修改文件并执行命令，请使用版本控制和可恢复备份。
+WebCodex 能在配置的项目范围内读取和修改文件、执行命令。建议使用版本控制，不要把凭据写进提示词、日志或 Git。完整说明见仓库的[安全文档](https://github.com/yyjeqhc/webcodex/blob/main/SECURITY.md)。
 
 ## Development verification / 开发验证
 
 ```bash
 npm --prefix npm/webcodex test
 ```
-
-Release smoke uses the release-control-host-staged package and exact extracted
-binary candidate; see the repository release documentation for the full command.
 
 ## License
 

--- a/npm/webcodex/package.json
+++ b/npm/webcodex/package.json
@@ -1,7 +1,19 @@
 {
   "name": "@yyjeqhc/webcodex",
   "version": "0.3.8",
-  "description": "Thin npm installer/wrapper for WebCodex native binaries.",
+  "description": "Connect ChatGPT, Claude, and other AI agents to repositories and developer tools on your own machines.",
+  "keywords": [
+    "ai",
+    "agent",
+    "coding-agent",
+    "chatgpt",
+    "claude",
+    "mcp",
+    "developer-tools",
+    "self-hosted",
+    "code",
+    "automation"
+  ],
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Separate the new-user path from engineering/operator reference material so WebCodex presents itself as a product that can be tried in one command rather than as a collection of Server/Runner/tunnel concepts.

- rewrite the root README pages around product value, one-command first-run, capabilities, platform support, and goal-oriented documentation links
- preserve the existing interactive onboarding shortcut: after **WebCodex ready**, the MCP URL is normally on the clipboard and pressing **Enter** opens ChatGPT App settings; manual **Settings -> Apps -> Create** remains the fallback
- reduce engineering jargon in the Chinese landing page before first success
- turn both Quick Start pages into a strict zero-to-first-success flow, ending with next-step links instead of long-lived deployment/OAuth/operator reference
- document the real ChatGPT fallback when Bearer/access-token UI is unavailable or OAuth autodiscovery reports `does not implement OAuth`: use `share --auth query-token` and `No authentication`
- keep the npx-only user path self-contained by showing the npx form of the query-token fallback, with the global CLI form only as an equivalent
- shorten the npm package README around `npx --yes @yyjeqhc/webcodex`, supported platforms, first connection, and security; move package integrity below onboarding
- replace the npm package description with the product value proposition and add discovery keywords (`ai`, `agent`, `coding-agent`, `chatgpt`, `claude`, `mcp`, `developer-tools`, `self-hosted`, `code`, `automation`)
- reorganize the documentation indexes by user goal

Detailed networking, OAuth, private tunnel, deployment, authentication, and protocol material remains in the existing MCP/CLI/Deployment/Auth reference docs rather than being deleted.

No logo or screenshots are added in this PR.

## Validation

- branch is based directly on current `main`; the diff contains exactly the intended 8 documentation/package metadata files
- `npm/webcodex/package.json` was fetched back from the branch with the new description/keywords and valid JSON structure
- first-run shortcut wording was restored consistently in the English/Chinese root README, Quick Start, and npm README
- full repository CI provides the package/documentation contract checks for the PR