### PR TITLE
Prepare WebCodex v0.3.9 release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing annotated release tag (v0.3.8) or verification tag (release-build-test-*)
+        description: Existing annotated release tag (v0.3.9) or verification tag (release-build-test-*)
         required: true
         type: string
       request_id:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing published immutable release tag (v0.3.8)
+        description: Existing published immutable release tag (v0.3.9)
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "base64",
@@ -5157,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-admin"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "reqwest 0.12.28",
  "serde_json",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-agent-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "toml 0.8.23",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "fs2",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-persistent-shell"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64",
  "libc",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-process"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "libc",
  "tempfile",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-runner"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "agent-client-protocol-schema",
  "base64",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-sandbox"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "landlock",
  "tempfile",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "webcodex-workspace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL*
 3. Choose **Access token / API key** (or the equivalent Bearer-token option) and paste the printed **Credential**.
 4. Run **Scan Tools**.
 
+Developer Mode, custom MCP Apps, and write/modify actions depend on your ChatGPT plan, workspace, and administrator policy. WebCodex cannot enable capabilities the client does not grant.
+
 Try a read-only first request:
 
 ```text
@@ -34,9 +36,9 @@ If ChatGPT does not show a Bearer/access-token option, or tries OAuth discovery 
 npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-Paste the complete `/mcp?token=...` URL and choose **No authentication**. That URL contains a temporary secret, so do not publish or log it. If WebCodex is installed globally, the equivalent command is `webcodex share --auth query-token`. See the [Quick Start](docs/QUICK_START.md) and [MCP setup guide](docs/MCP.md) for details and other clients.
+Paste the complete `/mcp?token=...` URL and choose **No authentication**. This fallback requires WebCodex 0.3.9 or later. That URL contains a temporary secret, so do not publish or log it. If WebCodex is installed globally, the equivalent command is `webcodex share --auth query-token`. See the [Quick Start](docs/QUICK_START.md) and [MCP setup guide](docs/MCP.md) for details and other clients.
 
-WebCodex automatically prepares the temporary connection it needs. Advanced networking, OAuth, private tunnels, and self-hosting options are documented separately.
+The default one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits. Advanced networking, OAuth, private tunnels, and self-hosting options are documented separately.
 
 ## What can it do?
 
@@ -88,7 +90,7 @@ If you want to keep the CLI installed:
 npm install -g @yyjeqhc/webcodex
 ```
 
-If you already have a hosted WebCodex Server, `webcodex connect <server-url>` connects the current repository using the authentication configured by that Server.
+If an operator has provided a shared key for an existing hosted WebCodex Server, use `webcodex connect <server-url>`. For a newly deployed self-hosted Server, keep the bootstrap administrator token on the Server and use the [Deployment](docs/DEPLOYMENT.md) guide's short-lived pairing code + `webcodex login` enrollment flow.
 
 For production/self-hosted deployment, Windows enrollment, OAuth, private tunnels, proxy/CA configuration, and other operator workflows, use the documentation below rather than the first-run path.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,8 @@ npx --yes @yyjeqhc/webcodex
 3. 认证选择 **Access token / API key**（或等价的 Bearer 令牌选项），再填入输出的临时 **Credential**。
 4. 点击 **Scan Tools**。
 
+Developer Mode、自定义 MCP App 和写入/修改操作是否可用取决于 ChatGPT 套餐、workspace 与管理员策略；WebCodex 无法启用客户端未授予的权限。
+
 第一条消息可以先只读检查：
 
 ```text
@@ -34,9 +36,9 @@ npx --yes @yyjeqhc/webcodex
 npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-把输出的完整 `/mcp?token=...` 地址粘贴到 ChatGPT，并选择 **No authentication**。这条地址包含本次临时密钥，不要公开、转发或记录到日志中。如果已经全局安装 WebCodex，也可以使用等价命令 `webcodex share --auth query-token`。更多客户端配置见[快速开始](docs/QUICK_START.zh-CN.md)和 [MCP 接入指南](docs/MCP.zh-CN.md)。
+把输出的完整 `/mcp?token=...` 地址粘贴到 ChatGPT，并选择 **No authentication**。这个 fallback 需要 WebCodex 0.3.9 或更新版本。这条地址包含本次临时密钥，不要公开、转发或记录到日志中。如果已经全局安装 WebCodex，也可以使用等价命令 `webcodex share --auth query-token`。更多客户端配置见[快速开始](docs/QUICK_START.zh-CN.md)和 [MCP 接入指南](docs/MCP.zh-CN.md)。
 
-WebCodex 会自动准备临时连接所需的组件。代理网络、OAuth、私有隧道、自托管等高级配置都放在单独的文档中，不是第一次使用的前置条件。
+默认的一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。代理网络、OAuth、私有隧道、自托管等高级配置都放在单独的文档中，不是第一次使用的前置条件。
 
 ## 能做什么？
 
@@ -88,7 +90,7 @@ Windows 接入和长期部署见[部署指南](docs/DEPLOYMENT.zh-CN.md)与 [MCP
 npm install -g @yyjeqhc/webcodex
 ```
 
-如果已经有 WebCodex Server，使用 `webcodex connect <server-url>` 把当前仓库接入该服务，并按照服务端配置的认证方式连接。
+对于 operator 提供 shared key 的已有 hosted WebCodex Server，使用 `webcodex connect <server-url>`；新部署的自托管 Server 应把 bootstrap administrator token 留在 Server 侧，并按[部署指南](docs/DEPLOYMENT.zh-CN.md)使用短期 pairing code + `webcodex login` 完成 enrollment。
 
 生产环境、自托管、Windows 接入、OAuth、私有隧道、代理/私有 CA 等运维配置请直接查看下面的专题文档，不需要在第一次体验前理解这些概念。
 
@@ -116,7 +118,7 @@ export PATH="$PWD/target/release:$PATH"
 
 ## 参与贡献
 
-欢迎提交贡献，也欢迎使用 WebCodex 或其他 coding agent 辅助开发。Bug 报告、开发流程与 PR 说明见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+欢迎提交贡献，也欢迎使用 WebCodex 或其他 coding agent 辅助开发。Bug 报告、开发流程与 PR 说明见 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)。
 
 ## 致谢
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -21,7 +21,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-You do not need to run `setup`, `doctor`, or `run` first. WebCodex prepares the temporary connection it needs automatically.
+You do not need to run `setup`, `doctor`, or `run` first. The default one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits.
 
 ## 2. Wait for `WebCodex ready`
 
@@ -35,7 +35,7 @@ Keep that terminal open. WebCodex prints the values needed by the MCP client and
 4. Paste the printed temporary **Credential**.
 5. Run **Scan Tools**.
 
-ChatGPT labels can vary by workspace and rollout. The values printed by WebCodex are the source of truth.
+ChatGPT labels can vary by workspace and rollout. Developer Mode, custom MCP Apps, and write/modify actions also depend on your ChatGPT plan, workspace, and administrator policy; WebCodex cannot enable capabilities the client does not grant. The values printed by WebCodex are the source of truth.
 
 ### If there is no Bearer/access-token option
 
@@ -45,7 +45,7 @@ If ChatGPT tries OAuth automatically and reports **does not implement OAuth**, o
 npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-Paste the complete `/mcp?token=...` URL, choose **No authentication**, and run **Scan Tools** again. The complete URL contains a temporary secret; do not publish or log it. If WebCodex is installed globally, `webcodex share --auth query-token` is equivalent.
+Paste the complete `/mcp?token=...` URL, choose **No authentication**, and run **Scan Tools** again. This fallback requires WebCodex 0.3.9 or later. The complete URL contains a temporary secret; do not publish or log it. If WebCodex is installed globally, `webcodex share --auth query-token` is equivalent.
 
 ## 4. Try a read-only request
 

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -21,7 +21,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex
 ```
 
-第一次使用不需要提前运行 `setup`、`doctor` 或 `run`。WebCodex 会自动准备本次临时连接。
+第一次使用不需要提前运行 `setup`、`doctor` 或 `run`。默认的一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。
 
 ## 2. 等待 `WebCodex ready`
 
@@ -35,7 +35,7 @@ npx --yes @yyjeqhc/webcodex
 4. 填入输出的临时 **Credential**。
 5. 点击 **Scan Tools**。
 
-不同账号或工作区看到的 ChatGPT 文案可能略有区别，具体 URL 和认证值以 WebCodex 终端输出为准。
+不同账号或工作区看到的 ChatGPT 文案可能略有区别。Developer Mode、自定义 MCP App 和写入/修改操作是否可用也取决于 ChatGPT 套餐、workspace 与管理员策略；WebCodex 无法启用客户端未授予的权限。具体 URL 和认证值以 WebCodex 终端输出为准。
 
 ### 如果找不到 Bearer/访问令牌选项
 
@@ -45,7 +45,7 @@ npx --yes @yyjeqhc/webcodex
 npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-把输出的完整 `/mcp?token=...` 地址粘贴进去，认证选择 **No authentication**，然后再次点击 **Scan Tools**。完整地址包含本次临时密钥，不要公开或写入日志。如果已经全局安装 WebCodex，等价命令是 `webcodex share --auth query-token`。
+把输出的完整 `/mcp?token=...` 地址粘贴进去，认证选择 **No authentication**，然后再次点击 **Scan Tools**。这个 fallback 需要 WebCodex 0.3.9 或更新版本。完整地址包含本次临时密钥，不要公开或写入日志。如果已经全局安装 WebCodex，等价命令是 `webcodex share --auth query-token`。
 
 ## 4. 先试一个只读请求
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -24,6 +24,8 @@ When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL*
 3. Choose **Access token / API key** (Bearer token) and paste the printed **Credential**.
 4. Run **Scan Tools**.
 
+The default one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits. Developer Mode, custom MCP Apps, and write/modify actions depend on your ChatGPT plan, workspace, and administrator policy; WebCodex cannot enable capabilities the client does not grant.
+
 Try:
 
 ```text
@@ -36,7 +38,7 @@ If ChatGPT does not show a Bearer/access-token option, or reports **does not imp
 npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-Paste the complete `/mcp?token=...` URL and choose **No authentication**. Treat the complete URL as a temporary secret. If the package is installed globally, `webcodex share --auth query-token` is equivalent.
+Paste the complete `/mcp?token=...` URL and choose **No authentication**. This fallback requires WebCodex 0.3.9 or later. Treat the complete URL as a temporary secret. If the package is installed globally, `webcodex share --auth query-token` is equivalent.
 
 ### Platforms
 
@@ -80,6 +82,8 @@ npx --yes @yyjeqhc/webcodex
 3. 认证选择 **Access token / API key**（Bearer 令牌），并填入输出的临时 **Credential**。
 4. 点击 **Scan Tools**。
 
+默认的一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。Developer Mode、自定义 MCP App 和写入/修改操作是否可用取决于 ChatGPT 套餐、workspace 与管理员策略；WebCodex 无法启用客户端未授予的权限。
+
 第一条可以先只读检查：
 
 ```text
@@ -92,7 +96,7 @@ npx --yes @yyjeqhc/webcodex
 npx --yes @yyjeqhc/webcodex share --auth query-token
 ```
 
-粘贴完整的 `/mcp?token=...` 地址并选择 **No authentication**。完整地址包含本次临时密钥，请按敏感信息处理。如果已经全局安装，也可以使用 `webcodex share --auth query-token`。
+粘贴完整的 `/mcp?token=...` 地址并选择 **No authentication**。这个 fallback 需要 WebCodex 0.3.9 或更新版本。完整地址包含本次临时密钥，请按敏感信息处理。如果已经全局安装，也可以使用 `webcodex share --auth query-token`。
 
 ### 平台支持
 

--- a/npm/webcodex/manifest.example.json
+++ b/npm/webcodex/manifest.example.json
@@ -1,25 +1,25 @@
 {
-  "version": "0.3.8",
+  "version": "0.3.9",
   "binaries": ["webcodex", "webcodex-server", "webcodex-runner"],
   "artifacts": {
     "linux-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-linux-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-linux-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "linux-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-linux-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-linux-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "darwin-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-darwin-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-darwin-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "win32-x64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-win32-x64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-win32-x64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     },
     "win32-arm64": {
-      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.8/webcodex-v0.3.8-win32-arm64.tar.gz",
+      "url": "https://github.com/yyjeqhc/webcodex/releases/download/v0.3.9/webcodex-v0.3.9-win32-arm64.tar.gz",
       "sha256": "REPLACE_WITH_RELEASE_ARTIFACT_SHA256"
     }
   }

--- a/npm/webcodex/package.json
+++ b/npm/webcodex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yyjeqhc/webcodex",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Connect ChatGPT, Claude, and other AI agents to repositories and developer tools on your own machines.",
   "keywords": [
     "ai",

--- a/npm/webcodex/test/self-test.js
+++ b/npm/webcodex/test/self-test.js
@@ -209,7 +209,7 @@ async function expectInstallFailure(action, destination, tempRoot, pattern) {
 }
 
 async function main() {
-  assert.strictEqual(packageJson.version, "0.3.8");
+  assert.strictEqual(packageJson.version, "0.3.9");
   assert.deepStrictEqual(packageJson.bin, { webcodex: "bin/webcodex.js" });
   assert.deepStrictEqual(install.RUNTIME_BINARIES, ["webcodex", "webcodex-server", "webcodex-runner"]);
   assert.deepStrictEqual(install.SUPPORTED_PLATFORM_KEYS, ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"]);

--- a/src/mcp_tests/runtime_tools.rs
+++ b/src/mcp_tests/runtime_tools.rs
@@ -4,8 +4,14 @@ use super::*;
 // runtime_status via MCP tools/list and tools/call
 // =========================================================================
 
+// This test asserts the default full tools/list schema, including outputSchema.
+// Serialize it with other process-global compact-schema env tests so a concurrent
+// WEBCODEX_MCP_COMPACT_SCHEMAS mutation cannot change the observed contract.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn mcp_tools_list_exposes_canonical_coding_bootstrap_and_runtime_status_ux_flags() {
+    let mut env = crate::test_support::TestEnvGuard::new();
+    env.remove("WEBCODEX_MCP_COMPACT_SCHEMAS");
     let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(
         &runtime,


### PR DESCRIPTION
## Summary

Prepare WebCodex v0.3.9 from the current post-#172 `main`.

- bump the current workspace/npm/release-manifest identity from 0.3.8 to 0.3.9 while preserving frozen v0.3.8 previous-stable compatibility fixtures
- update release workflow input examples and npm artifact URLs for v0.3.9
- close the remaining first-run documentation gaps: temporary public HTTPS MCP endpoint lifetime, ChatGPT plan/workspace/admin capability boundaries, hosted shared-key `connect` versus self-hosted pairing + `webcodex login`, and the Chinese contribution link
- serialize the default MCP `tools/list` schema test against the process-global compact-schema env switch after `release_check` exposed a test race; runtime behavior is unchanged

No v0.4.0 architecture work is included.

## Release notes draft

### Highlights

- streamlined first-run onboarding and npm package discovery, including `share --auth query-token` as the temporary-share fallback for MCP clients without Bearer-token UI
- expanded hosted and MCP connectivity, including managed OAuth/connect paths and the local MCP gateway
- matured Workflow Session collaboration with canonical `work_on_project`, handoff/message observation, edit/withdraw/resolve flows, context ACK continuity, and Runtime Console collaboration surfaces
- improved Windows/Runner operations with lifecycle/bootstrap hardening, persistent execution, replacement readiness, SSH resource parity, and stronger status/readiness integrity
- hardened Server operations and release delivery with graceful Linux listener continuity, systemd rollback/lifecycle fixes, multi-architecture Server images, recoverable clone-free bootstrap, and disposable Server-image release readiness
- improved long-running execution/recovery, ACP durability, model-facing recovery metadata, bounded response economy, and release tooling

### Compatibility and upgrade notes

- `runtime:read` remains observe-only for Workflow Sessions. Session post/resolve/complete/replace/withdraw/close operations require `session:collaborate`.
- Direct shared-key and normal pairing/full-interactive paths include `session:collaborate`. Existing PATs that only carry `runtime:read` must be reissued with `session:collaborate` if they modify Session collaboration state.
- Existing OAuth clients do not automatically widen an omitted/legacy scope ceiling. Operators that add `session:collaborate` to a client ceiling must reauthorize that client; a real ceiling change revokes existing access/refresh tokens and outstanding authorization codes.
- `webcodex share --auth query-token` is the new temporary-share `/mcp?token=...` fallback; the complete URL is a sensitive temporary credential. It is distinct from the deprecated Runner WebSocket `/api/agents/ws?token=...` compatibility path; first-party Runners use `Authorization: Bearer`.
- Hosted Servers with an operator-provided shared key use `webcodex connect`. Fresh self-hosted Servers keep the bootstrap administrator token on the Server and enroll repository machines with a short-lived pairing code + `webcodex login`.
- v0.3.8 remains the frozen previous-stable wire/rolling-compatibility fixture for v0.3.9 validation.

### Known client/platform boundaries

- local one-command `webcodex share` remains a Linux/macOS path; Windows uses CLI + Runner against a remote Linux Server
- ChatGPT Developer Mode, custom MCP Apps, and write/modify actions depend on plan/workspace/administrator policy; WebCodex cannot enable capabilities the client does not grant

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `npm --prefix npm/webcodex test`
- `python3 scripts/check_markdown_links.py` — 46 files / 293 local links / 0 missing
- `git diff --check`
- `cargo test --locked -p webcodex --lib mcp -- --nocapture` — 162 passed, 0 failed
- `bash scripts/release_check.sh` — all 12 stages passed, including all-target checks, focused metadata/schema/OpenAPI/MCP tests, Python tooling, npm existing-binary release smoke, Markdown links, and static safety checks

The initial canonical release check exposed a process-global compact-schema test race: the affected test passed in isolation on both exact `main` and this branch, then the explicit `TestEnvGuard` closure made the full 162-test MCP group and complete release check pass. No runtime behavior changed.

Formal exact-source `release-readiness` intentionally remains post-merge and is not run by this PR. No tag, GitHub Release, npm publication, GHCR publication, or deployment is performed here.