### PR TITLE
Stabilize large MCP integration test stacks

### DIFF
--- a/src/mcp_tests/http_transport.rs
+++ b/src/mcp_tests/http_transport.rs
@@ -248,8 +248,29 @@ async fn start_stateless_observation_session(
         .to_string()
 }
 
-#[tokio::test]
-async fn stateless_full_trace_preserves_raw_context_ack_and_records_effective_internal_ack() {
+#[test]
+fn stateless_full_trace_preserves_raw_context_ack_and_records_effective_internal_ack() {
+    // Full tracing retains the request/response trees plus decoded trace payloads.
+    // Keep this integration fixture off the default libtest stack for the same
+    // reason as the larger stateless MCP continuity/observation fixtures below.
+    std::thread::Builder::new()
+        .name("mcp-stateless-full-trace".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build stateless full-trace test runtime")
+                .block_on(
+                    stateless_full_trace_preserves_raw_context_ack_and_records_effective_internal_ack_body(),
+                );
+        })
+        .expect("spawn stateless full-trace test thread")
+        .join()
+        .expect("stateless full-trace test thread panicked");
+}
+
+async fn stateless_full_trace_preserves_raw_context_ack_and_records_effective_internal_ack_body() {
     let trace_root = tempfile::tempdir().unwrap();
     let mut env = crate::test_support::TestEnvGuard::new();
     env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
@@ -1051,8 +1072,31 @@ async fn http_mcp_2026_request_scoped_ack_redelivers_until_durable_resolution_bo
     assert!(!audit.contains("handled through ordinary list_tools wrapper metadata"));
 }
 
-#[tokio::test]
-async fn http_mcp_2026_session_context_revision_recovers_missing_stale_and_invalid_ack() {
+#[test]
+fn http_mcp_2026_session_context_revision_recovers_missing_stale_and_invalid_ack() {
+    // Like the neighboring request-scoped ACK and observation fixtures, this
+    // end-to-end continuity test keeps several large MCP response trees alive
+    // across awaits. The default libtest stack can overflow only in the full
+    // workspace suite, so isolate the fixture on the same bounded larger stack
+    // without changing production request handling or the release gate.
+    std::thread::Builder::new()
+        .name("mcp-session-context-continuity".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build session context continuity test runtime")
+                .block_on(
+                    http_mcp_2026_session_context_revision_recovers_missing_stale_and_invalid_ack_body(),
+                );
+        })
+        .expect("spawn session context continuity test thread")
+        .join()
+        .expect("session context continuity test thread panicked");
+}
+
+async fn http_mcp_2026_session_context_revision_recovers_missing_stale_and_invalid_ack_body() {
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
     let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));


### PR DESCRIPTION
## Summary

Close the v0.3.9 exact-source release-readiness blocker without changing runtime behavior.

The full workspace suite exposed libtest-stack overflows in two large stateless MCP integration fixtures. Both tests pass in isolation, and this file already uses the same bounded 8 MiB test-thread pattern for neighboring request-scoped ACK and stateless observation fixtures.

This change moves only the two observed large fixtures onto dedicated 8 MiB test threads with current-thread Tokio runtimes:

- `http_mcp_2026_session_context_revision_recovers_missing_stale_and_invalid_ack`
- `stateless_full_trace_preserves_raw_context_ack_and_records_effective_internal_ack`

Assertions, MCP request paths, production runtime behavior, and the release gate are unchanged.

## Evidence

- v0.3.9 readiness run `32940062189`: all five native gates and both disposable Server-image gates passed; canonical release check passed; full workspace aborted with a stack overflow in the session-context continuity fixture.
- The continuity fixture passed 1/1 in isolation on the exact failed source.
- After isolating it, the full workspace suite progressed beyond that point and exposed the same stack overflow in the full-trace fixture.
- After isolating both fixtures, full workspace progressed through the root `webcodex` test binary without either stack overflow; a later unrelated Runner timing test failed on Special (`structured_process_job_handoff_observation_does_not_reset_the_original_total_timeout`) and then passed 1/1 in focused rerun.
- `cargo fmt -- --check` passed.
- `git diff --check` passed.

This is a release-blocker test-harness stabilization only; no v0.3.9 feature or runtime behavior is added.