### PR TITLE
Avoid macOS host check pipefail races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,8 @@ jobs:
           EXPECTED_RUST_HOST: ${{ matrix.rust_host }}
         run: |
           test "$(uname -m)" = "$EXPECTED_HOST_ARCH"
-          rustc -vV | grep -Fxq "host: $EXPECTED_RUST_HOST"
+          rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+          test "$rust_host" = "$EXPECTED_RUST_HOST"
       - name: Check macOS release production surfaces
         run: cargo check --locked -p webcodex -p webcodex-cli -p webcodex-runner
       - name: Run native macOS Runner tests

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -365,8 +365,9 @@ jobs:
             echo "Expected native macOS host $EXPECTED_HOST_ARCH, got $(uname -m)." >&2
             exit 1
           fi
-          if ! rustc -vV | grep -Fxq "host: $EXPECTED_RUST_HOST"; then
-            echo "Expected native Rust host $EXPECTED_RUST_HOST." >&2
+          rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+          if [ "$rust_host" != "$EXPECTED_RUST_HOST" ]; then
+            echo "Expected native Rust host $EXPECTED_RUST_HOST, got $rust_host." >&2
             rustc -vV >&2
             exit 1
           fi
@@ -390,9 +391,9 @@ jobs:
               echo "Unexpected $name release identity: $output" >&2
               exit 1
             fi
-            if ! file "$binary" | grep -Fq "$EXPECTED_FILE_ARCH"; then
-              echo "Unexpected Mach-O architecture for $binary" >&2
-              file "$binary" >&2
+            file_output="$(file "$binary")"
+            if [[ "$file_output" != *"$EXPECTED_FILE_ARCH"* ]]; then
+              echo "Unexpected Mach-O architecture for $binary: $file_output" >&2
               exit 1
             fi
           done

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -722,8 +722,9 @@ jobs:
             echo "Expected native macOS host $EXPECTED_HOST_ARCH, got $(uname -m)." >&2
             exit 1
           fi
-          if ! rustc -vV | grep -Fxq "host: $EXPECTED_RUST_HOST"; then
-            echo "Expected native Rust host $EXPECTED_RUST_HOST." >&2
+          rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+          if [ "$rust_host" != "$EXPECTED_RUST_HOST" ]; then
+            echo "Expected native Rust host $EXPECTED_RUST_HOST, got $rust_host." >&2
             rustc -vV >&2
             exit 1
           fi
@@ -738,7 +739,8 @@ jobs:
             output="$($binary --version)"
             expected="$name $version (commit $short_commit, dirty=false, built_at=$built_at)"
             test "$output" = "$expected"
-            file "$binary" | grep -Fq "$EXPECTED_FILE_ARCH"
+            file_output="$(file "$binary")"
+            [[ "$file_output" == *"$EXPECTED_FILE_ARCH"* ]]
           done
           dist="$(mktemp -d)"
           trap 'rm -rf "$dist"' EXIT

--- a/scripts/tests/test_release_publication.py
+++ b/scripts/tests/test_release_publication.py
@@ -538,6 +538,8 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("platform: darwin-x64", workflow)
         self.assertIn("runner: macos-15-intel", workflow)
         self.assertIn("rust_host: x86_64-apple-darwin", workflow)
+        self.assertNotIn('rustc -vV | grep -Fxq "host:', workflow)
+        self.assertNotIn('file "$binary" | grep -Fq "$EXPECTED_FILE_ARCH"', workflow)
 
     def test_server_image_publication_is_separate_and_multi_arch(self) -> None:
         candidate = Path(".github/workflows/release-build.yml").read_text(encoding="utf-8")

--- a/scripts/tests/test_release_readiness.py
+++ b/scripts/tests/test_release_readiness.py
@@ -168,6 +168,8 @@ class WorkflowContractTests(unittest.TestCase):
             self.assertIn(platform, workflow)
         self.assertIn("runner: macos-15-intel", workflow)
         self.assertIn("rust_host: x86_64-apple-darwin", workflow)
+        self.assertNotIn('rustc -vV | grep -Fxq "host:', workflow)
+        self.assertNotIn('file "$binary" | grep -Fq "$EXPECTED_FILE_ARCH"', workflow)
         self.assertGreaterEqual(workflow.count("cargo build --locked --release"), 3)
         self.assertIn("quay.io/pypa/manylinux2014_x86_64", workflow)
         self.assertIn("quay.io/pypa/manylinux2014_aarch64", workflow)
@@ -246,6 +248,11 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("rust_host: x86_64-apple-darwin", macos)
         self.assertIn("contains(github.event.pull_request.labels.*.name, 'run-ci')", macos)
         self.assertIn("if: always()", aggregate)
+
+    def test_macos_ci_host_check_does_not_use_quiet_grep_under_pipefail(self) -> None:
+        workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertNotIn('rustc -vV | grep -Fxq "host:', workflow)
+        self.assertIn("rust_host=\"$(rustc -vV | sed -n 's/^host: //p')\"", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix a false-negative macOS native-host gate caused by `grep -q` terminating early under Bash `pipefail`
- capture the complete `rustc -vV` output before comparing the native Rust host in ordinary CI, release readiness, and formal release builds
- capture Mach-O `file` output before architecture matching in readiness/build so the adjacent check cannot hit the same early-consumer pattern
- add release workflow contract regressions that reject the old quiet-grep pipelines

## Failure evidence
Release-readiness run 32960717487 failed both `darwin-arm64` and `darwin-x64` at the host check even though the diagnostic immediately printed the exact expected host (`aarch64-apple-darwin` / `x86_64-apple-darwin`). With `set -o pipefail`, `grep -q` may exit after matching `host:` while `rustc -vV` is still writing later lines, causing the producer to receive SIGPIPE and the whole pipeline to be reported as failed.

The failed readiness run was cancelled after diagnosis because it could no longer satisfy the release gate.

## Validation
- `python3 -m unittest scripts.tests.test_release_readiness scripts.tests.test_release_publication`: 33/33 passed
- `actionlint` on `ci.yml`, `release-readiness.yml`, and `release-build.yml`: passed
- `git diff --check`: passed

No product/runtime code, tag, release, npm publication, image publication, or deployment changes.