### PR TITLE
Run macOS readiness tests before release builds

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -30,7 +30,8 @@ env:
 
 jobs:
   # Stage 1 is deliberately fail-fast and release-artifact-free: prove the exact
-  # source's Linux correctness before spending native/image build minutes.
+  # source's correctness, including native macOS Runner behavior, before spending
+  # any native/image release-build minutes.
   release-contract:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -345,8 +346,84 @@ jobs:
           git diff --check
           test -z "$(git status --porcelain --untracked-files=all)"
 
+  # Native macOS Runner behavior is a correctness gate, not a release-build
+  # side effect. Run both architectures before any expensive release-profile or
+  # disposable image validation starts so a platform-specific test failure stays
+  # cheap and actionable.
+  macos-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: darwin-arm64
+            runner: macos-14
+            host_arch: arm64
+            rust_host: aarch64-apple-darwin
+          - platform: darwin-x64
+            runner: macos-15-intel
+            host_arch: x86_64
+            rust_host: x86_64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Fence exact reviewed main source
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          INPUT_REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          [[ "$INPUT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$INPUT_REQUEST_ID" =~ ^rr_[0-9a-f]{24}$ ]]
+          test "$GITHUB_SHA" = "$INPUT_SOURCE_SHA"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ inputs.source_sha }}
+
+      - name: Verify exact clean checkout
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$INPUT_SOURCE_SHA"
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: macos-ci-${{ matrix.platform }}
+
+      - name: Verify native macOS test host
+        shell: bash
+        env:
+          EXPECTED_HOST_ARCH: ${{ matrix.host_arch }}
+          EXPECTED_RUST_HOST: ${{ matrix.rust_host }}
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = "$EXPECTED_HOST_ARCH"
+          rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+          test "$rust_host" = "$EXPECTED_RUST_HOST"
+
+      - name: Run native macOS Runner tests before release builds
+        run: cargo test --locked -p webcodex-runner -- --nocapture
+
+      - name: Require final macOS test source cleanliness
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check
+          test -z "$(git status --porcelain --untracked-files=all)"
+
   native-linux:
-    needs: [release-contract, core-tests, frontend, e2e, eval]
+    needs: [release-contract, core-tests, frontend, e2e, eval, macos-tests]
     strategy:
       fail-fast: false
       matrix:
@@ -482,7 +559,7 @@ jobs:
           test -z "$(git status --porcelain --untracked-files=all)"
 
   server-image:
-    needs: [release-contract, core-tests, frontend, e2e, eval]
+    needs: [release-contract, core-tests, frontend, e2e, eval, macos-tests]
     strategy:
       fail-fast: false
       matrix:
@@ -640,8 +717,8 @@ jobs:
           git diff --check
           test -z "$(git status --porcelain --untracked-files=all)"
 
-  macos-runner:
-    needs: [release-contract, core-tests, frontend, e2e, eval]
+  native-macos:
+    needs: [release-contract, core-tests, frontend, e2e, eval, macos-tests]
     strategy:
       fail-fast: false
       matrix:
@@ -747,9 +824,6 @@ jobs:
           scripts/package_release_artifact.sh "$dist" >/dev/null
           test -s "$dist/webcodex-v$version-$WEBCODEX_RELEASE_PLATFORM.tar.gz"
 
-      - name: Run native macOS Runner tests
-        run: cargo test --locked -p webcodex-runner -- --nocapture
-
       - name: Require final macOS source cleanliness
         shell: bash
         run: |
@@ -758,7 +832,7 @@ jobs:
           test -z "$(git status --porcelain --untracked-files=all)"
 
   native-windows:
-    needs: [release-contract, core-tests, frontend, e2e, eval]
+    needs: [release-contract, core-tests, frontend, e2e, eval, macos-tests]
     strategy:
       fail-fast: false
       matrix:
@@ -871,7 +945,7 @@ jobs:
           }
 
   summary:
-    needs: [release-contract, core-tests, frontend, e2e, eval, native-linux, server-image, macos-runner, native-windows]
+    needs: [release-contract, core-tests, frontend, e2e, eval, macos-tests, native-linux, server-image, native-macos, native-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Record readiness summary
@@ -884,7 +958,7 @@ jobs:
             echo "### Release readiness passed"
             echo "- source: \`$INPUT_SOURCE_SHA\`"
             echo "- request: \`$INPUT_REQUEST_ID\`"
-            echo "- fail-fast test gate: canonical release contract, complete package-sharded locked Rust suite, frontend, E2E, and eval all passed before release builds"
+            echo "- fail-fast test gate: canonical release contract, complete package-sharded locked Rust suite, frontend, E2E, eval, and native macOS Runner suites all passed before release builds"
             echo "- parallel build gate: native release surfaces and disposable Server images passed"
             echo "- native release-profile validation: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64 passed"
             echo "- disposable Server images: linux/amd64 and linux/arm64 build, runtime, health, and digest-pinned bootstrap generation passed"

--- a/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
@@ -3180,12 +3180,12 @@ for line in sys.stdin:
     }
 
     #[cfg(unix)]
-    fn wait_for_snapshot(
+    fn wait_for_snapshot_until(
         manager: &CodingAgentManager,
         run: &str,
+        deadline: Instant,
         predicate: impl Fn(&CodingAgentRunSnapshot) -> bool,
     ) -> CodingAgentRunSnapshot {
-        let deadline = Instant::now() + Duration::from_secs(5);
         loop {
             let snapshot = manager.runs.lock().unwrap().get(run).unwrap().snapshot();
             if predicate(&snapshot) {
@@ -3197,6 +3197,20 @@ for line in sys.stdin:
             );
             thread::sleep(Duration::from_millis(20));
         }
+    }
+
+    #[cfg(unix)]
+    fn wait_for_snapshot(
+        manager: &CodingAgentManager,
+        run: &str,
+        predicate: impl Fn(&CodingAgentRunSnapshot) -> bool,
+    ) -> CodingAgentRunSnapshot {
+        wait_for_snapshot_until(
+            manager,
+            run,
+            Instant::now() + Duration::from_secs(5),
+            predicate,
+        )
     }
 
     #[cfg(unix)]
@@ -4356,17 +4370,23 @@ for line in sys.stdin:
         let manager = CodingAgentManager::with_store(&cfg, temp.path().join("store")).unwrap();
         let run = "wc_agent_run_promptbackpressure01";
         let started_at = Instant::now();
-        // Leave enough setup budget for a contended macOS hosted runner to reach
-        // the intended blocked ChildStdin state before the total Run deadline.
-        // The assertion below still proves that the blocked write is bounded by
-        // that deadline rather than by the provider ever resuming reads.
-        let started = manager.handle(max_instruction_request(&manager, &root, run, 3), &projects);
+        // Process startup and ACP negotiation are setup for this assertion, not
+        // the behavior under test. Hosted macOS VMs have already demonstrated
+        // that a three-second total budget can expire before the fake provider
+        // reaches the intended blocked ChildStdin state. Use the same bounded
+        // ten-second Run budget as the adjacent blocked-write lifecycle tests;
+        // the assertions below still require the permanently blocked write to
+        // terminate at the total Run deadline and preserve uncertainty/reaping.
+        let started = manager.handle(max_instruction_request(&manager, &root, run, 10), &projects);
         assert!(started.error.is_none(), "{:?}", started.error);
         wait_for_path(&temp.path().join("stdin_stopped.ready"));
         wait_for_prompt_handoff(&manager, run);
-        let snapshot = wait_for_snapshot(&manager, run, |snapshot| snapshot.state.terminal());
+        let observation_deadline = started_at + Duration::from_secs(13);
+        let snapshot = wait_for_snapshot_until(&manager, run, observation_deadline, |snapshot| {
+            snapshot.state.terminal()
+        });
         assert!(
-            started_at.elapsed() < Duration::from_secs(6),
+            Instant::now() < observation_deadline,
             "blocked prompt write escaped the total Run deadline"
         );
         assert_eq!(snapshot.state, CodingAgentRunState::Lost);

--- a/scripts/tests/test_release_readiness.py
+++ b/scripts/tests/test_release_readiness.py
@@ -209,23 +209,36 @@ class WorkflowContractTests(unittest.TestCase):
         )
         self.assertNotIn("cargo test --locked --workspace -- --nocapture", workflow)
 
-        build_gate_dependency = "    needs: [release-contract, core-tests, frontend, e2e, eval]\n"
-        # Linux native, Server image, macOS, and Windows builds all wait for the
-        # complete test gate, while frontend/E2E/eval have no upstream build gate.
+        build_gate_dependency = (
+            "    needs: [release-contract, core-tests, frontend, e2e, eval, macos-tests]\n"
+        )
+        # Every expensive native/image build waits for the complete test gate,
+        # including both native macOS Runner suites. Test jobs themselves have
+        # no upstream build gate and therefore fan out immediately.
         self.assertEqual(workflow.count(build_gate_dependency), 4)
-        for test_job in ("frontend", "e2e", "eval"):
+        for test_job in ("frontend", "e2e", "eval", "macos-tests"):
             start = workflow.index(f"  {test_job}:\n")
             end = workflow.find("\n  ", start + 1)
             block = workflow[start:] if end == -1 else workflow[start:end]
             self.assertNotIn("    needs:", block)
+        macos_tests_start = workflow.index("  macos-tests:\n")
+        macos_tests_end = workflow.index("  native-linux:\n", macos_tests_start)
+        macos_tests = workflow[macos_tests_start:macos_tests_end]
+        native_macos_start = workflow.index("  native-macos:\n")
         self.assertIn(
-            "needs: [release-contract, core-tests, frontend, e2e, eval, native-linux, server-image, macos-runner, native-windows]",
+            "run: cargo test --locked -p webcodex-runner -- --nocapture",
+            macos_tests,
+        )
+        self.assertNotIn("cargo build --locked --release", macos_tests)
+        native_macos_end = workflow.index("  native-windows:\n", native_macos_start)
+        native_macos = workflow[native_macos_start:native_macos_end]
+        self.assertIn("cargo build --locked --release", native_macos)
+        self.assertNotIn("cargo test --locked -p webcodex-runner", native_macos)
+        self.assertIn(
+            "needs: [release-contract, core-tests, frontend, e2e, eval, macos-tests, native-linux, server-image, native-macos, native-windows]",
             workflow,
         )
-        self.assertNotIn(
-            "needs: [readiness, native-linux, server-image, macos-runner, native-windows]",
-            workflow,
-        )
+        self.assertNotIn("macos-runner", workflow)
 
     def test_owner_prs_run_complete_linux_ci_before_merge(self) -> None:
         workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- keep the blocked-max-prompt-write deadline/reap regression enabled, but stop conflating hosted-macOS ACP startup latency with the blocked-write semantic deadline
- give that real-process fixture the same bounded 10-second total Run budget as the adjacent cancel/shutdown blocked-write lifecycle tests and observe terminal state against one absolute deadline
- split pre-tag macOS correctness from release-profile validation: `macos-tests` runs ARM64 + Intel Runner suites before any native/image release build can start
- rename the build-only macOS readiness lane to `native-macos`; Linux native, Windows native, Server-image, and macOS release builds all depend on successful native macOS tests

## Failure evidence
Release-readiness run `32963640081` passed the Intel `darwin-x64` native release build, then failed only `webcodex_runner::coding_agent::tests::blocked_max_prompt_write_respects_total_deadline_and_reaps_tree` while waiting for the fake provider's `stdin_stopped.ready` marker. The same Intel hosted platform had already passed the complete Runner suite in the preceding Intel-support and pipefail-fix PRs.

The fixture had previously been widened from a 1-second to a 3-second total Run budget in #156 specifically for contended hosted macOS. A 3-second total deadline can still expire during process startup / ACP initialize / session-new before the fake provider reaches the intended blocked ChildStdin state. This change does not skip or ignore the test and does not weaken the product deadline/reaping assertions.

## Validation
- focused blocked-write deadline/reap regression: 1/1 passed; real test duration ~10.04s
- `cargo test --locked -p webcodex-runner`: 812 passed, 0 failed, 4 ignored
- `python3 -m unittest scripts.tests.test_release_readiness`: 14/14 passed
- `bash scripts/test_python_tooling.sh`: 81/81 passed
- `actionlint .github/workflows/release-readiness.yml`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

No release tag, GitHub Release, npm publication, image publication, deployment, or runtime/product behavior change.