### PR TITLE
Centralize HTTP route metadata

### DIFF
--- a/src/action_audit_sessions.rs
+++ b/src/action_audit_sessions.rs
@@ -514,32 +514,23 @@ pub fn compute_stats(events: &[ActionEventView]) -> ActionSessionStats {
                 job_ids.insert(id.to_string());
             }
         }
-        match event.endpoint.as_str() {
-            "/api/projects/apply_patch"
-            | "/api/projects/apply_patch_checked"
-            | "/api/projects/write_file" => edit_count += 1,
-            "/api/projects/list"
-            | "/api/projects/read_file"
-            | "/api/projects/list_files"
-            | "/api/projects/search_text" => context_count += 1,
-            "/api/projects/run_job" | "/api/jobs/status" | "/api/jobs/log" | "/api/jobs/tail" => {
-                job_count += 1
-            }
-            "/api/tools/call" => command_count += 1,
-            "/api/runtime/status" => report_count += 1,
-            "/api/artifacts/import"
-            | "/api/projects/delete_files"
-            | "/api/projects/git_restore_paths"
-            | "/api/projects/discard_untracked" => artifact_count += 1,
-            "/api/projects/git_status"
-            | "/api/projects/git_diff"
-            | "/api/projects/git_diff_summary" => git_count += 1,
-            "/api/projects/run_shell"
-            | "/api/shell/clients"
-            | "/api/shell/run"
-            | "/api/shell/file"
-            | "/api/shell/job" => shell_count += 1,
-            _ => {}
+        use crate::route_metadata::AuditClass;
+        match crate::route_metadata::audit_class_for_path(&event.endpoint) {
+            Some(AuditClass::Edit) => edit_count += 1,
+            Some(AuditClass::Context) => context_count += 1,
+            Some(AuditClass::Job) => job_count += 1,
+            Some(AuditClass::Command) => command_count += 1,
+            Some(AuditClass::Report) => report_count += 1,
+            Some(AuditClass::Artifact) => artifact_count += 1,
+            Some(AuditClass::Git) => git_count += 1,
+            Some(AuditClass::Shell) => shell_count += 1,
+            Some(AuditClass::Other) => {}
+            // Historical records can contain endpoints removed before the
+            // canonical route registry existed. Keep only those compatibility
+            // classifications here; current mounted routes must use RouteSpec.
+            None if event.endpoint == "/api/projects/write_file" => edit_count += 1,
+            None if event.endpoint == "/api/shell/clients" => shell_count += 1,
+            None => {}
         }
     }
     ActionSessionStats {

--- a/src/action_audit_sessions.rs
+++ b/src/action_audit_sessions.rs
@@ -592,6 +592,39 @@ mod tests {
     }
 
     #[test]
+    fn compute_stats_preserves_removed_endpoint_categories() {
+        fn event(endpoint: &str) -> ActionEventView {
+            ActionEventView {
+                event_id: "evt".to_string(),
+                session_id: "session".to_string(),
+                started_at: 0,
+                ended_at: 0,
+                duration_ms: 0,
+                endpoint: endpoint.to_string(),
+                operation: None,
+                action_name: "legacy".to_string(),
+                project: None,
+                status: "ok".to_string(),
+                http_status: None,
+                error_summary: None,
+                warning_summary: None,
+                changed_files: Vec::new(),
+                ids: json!({}),
+                summary: json!({}),
+                request_bytes: None,
+                response_bytes: None,
+            }
+        }
+
+        let stats = compute_stats(&[
+            event("/api/projects/write_file"),
+            event("/api/shell/clients"),
+        ]);
+        assert_eq!(stats.edit_count, 1);
+        assert_eq!(stats.shell_count, 1);
+    }
+
+    #[test]
     fn audit_sanitize_value_keeps_non_secret_regular_strings() {
         assert_eq!(
             sanitize_value(&json!({"message": "normal project status update"})),

--- a/src/admin_http.rs
+++ b/src/admin_http.rs
@@ -11,27 +11,19 @@ use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub(crate) const ADMIN_ROUTES: &[&str] = &[
-    "/api/admin/dashboard",
-    "/api/admin/projects/register",
-    "/api/admin/projects/create",
-    "/api/admin/projects/enable",
-    "/api/admin/projects/disable",
-    "/api/admin/projects/unregister",
-];
 const ACTIVITY_LIMIT: usize = 50;
 const ADMIN_BODY_MAX_BYTES: usize = 16 * 1024;
 
 pub(crate) fn routes() -> Router {
-    Router::with_path("admin")
-        .push(Router::with_path("dashboard").post(dashboard))
+    use crate::route_metadata::{api_path, RouteId};
+    Router::new()
+        .push(Router::with_path(api_path(RouteId::AdminDashboard)).post(dashboard))
+        .push(Router::with_path(api_path(RouteId::AdminProjectsRegister)).post(register_project))
+        .push(Router::with_path(api_path(RouteId::AdminProjectsCreate)).post(create_project))
+        .push(Router::with_path(api_path(RouteId::AdminProjectsEnable)).post(enable_project))
+        .push(Router::with_path(api_path(RouteId::AdminProjectsDisable)).post(disable_project))
         .push(
-            Router::with_path("projects")
-                .push(Router::with_path("register").post(register_project))
-                .push(Router::with_path("create").post(create_project))
-                .push(Router::with_path("enable").post(enable_project))
-                .push(Router::with_path("disable").post(disable_project))
-                .push(Router::with_path("unregister").post(unregister_project)),
+            Router::with_path(api_path(RouteId::AdminProjectsUnregister)).post(unregister_project),
         )
 }
 
@@ -709,11 +701,15 @@ mod tests {
 
     #[test]
     fn admin_routes_are_separate_from_console_routes() {
-        assert!(ADMIN_ROUTES
+        let mut admin = crate::route_metadata::routes()
             .iter()
-            .all(|route| route.starts_with("/api/admin/")));
-        assert!(ADMIN_ROUTES
-            .iter()
-            .all(|route| !crate::host_console_http::CONSOLE_ROUTES.contains(route)));
+            .filter(|spec| spec.surface == crate::route_metadata::RouteSurface::Admin);
+        assert!(admin
+            .clone()
+            .all(|spec| spec.path.starts_with("/api/admin/")));
+        assert!(admin.all(|spec| !crate::route_metadata::path_has_surface(
+            spec.path,
+            crate::route_metadata::RouteSurface::HostConsole,
+        )));
     }
 }

--- a/src/agent_tokens_http.rs
+++ b/src/agent_tokens_http.rs
@@ -5,9 +5,9 @@
 //! on agent transport endpoints (`/api/shell/agent/*`, `/api/agents/ws`). They
 //! are intentionally **not** exposed in `/openapi.json` (GPT Actions) because
 //! token creation is sensitive and should be driven by an admin CLI/HTTP
-//! client, not a GPT. The paths are listed in `LEGACY_FORBIDDEN_PATHS` so
-//! tests catch accidental OpenAPI inclusion. All endpoints sit behind the
-//! shared `AuthMiddleware` (Bearer auth) and resolve the caller's
+//! client, not a GPT. Their canonical `RouteSpec` entries are `Hidden`, and
+//! OpenAPI tests derive the exclusion invariant from that metadata. All endpoints
+//! sit behind the shared `AuthMiddleware` (Bearer auth) and resolve the caller's
 //! [`AuthContext`] to enforce the admin/bootstrap-or-self boundary.
 //!
 //! Security properties:

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -213,31 +213,20 @@ pub(crate) fn bearer_or_allowed_query_token(req: &Request) -> Option<String> {
 /// The paths are compared exactly (no prefix match) so a path like
 /// `/api/agent-tokens/create` is correctly rejected for agent tokens even
 /// though it starts with `/api/agent`.
-pub(crate) const AGENT_TRANSPORT_PATHS: &[&str] = &[
-    "/api/shell/agent/register",
-    "/api/shell/agent/poll",
-    "/api/shell/agent/result",
-    "/api/shell/agent/persistent_shell_result",
-    "/api/shell/agent/job_update",
-    "/api/agents/ws",
-];
-
 /// True when `path` is one of the exact agent transport endpoints an agent
 /// token may call. Used by [`AuthMiddleware`] to gate agent tokens centrally.
 pub(crate) fn is_agent_transport_path(path: &str) -> bool {
-    AGENT_TRANSPORT_PATHS.contains(&path)
+    crate::route_metadata::path_has_surface(
+        path,
+        crate::route_metadata::RouteSurface::AgentTransport,
+    )
 }
 
-pub(crate) const ACCOUNT_CONTROL_PATHS: &[&str] = &[
-    "/api/users/me",
-    "/api/tokens/list",
-    "/api/tokens/register_hash",
-    "/api/tokens/revoke",
-    "/api/agent-tokens/register_hash",
-];
-
 pub(crate) fn is_account_control_path(path: &str) -> bool {
-    ACCOUNT_CONTROL_PATHS.contains(&path)
+    crate::route_metadata::path_has_surface(
+        path,
+        crate::route_metadata::RouteSurface::AccountControl,
+    )
 }
 
 /// Enforce that the token kind is permitted on the requested HTTP path.
@@ -325,14 +314,11 @@ pub(crate) fn enforce_project_connector_surface(
 }
 
 fn is_project_console_path(path: &str) -> bool {
-    crate::host_console_http::CONSOLE_ROUTES.contains(&path)
+    crate::route_metadata::path_has_surface(path, crate::route_metadata::RouteSurface::HostConsole)
 }
 
 fn is_project_connector_path(path: &str) -> bool {
-    path == "/api/connector/readiness"
-        || crate::connector_runtime::surface::CAPABILITY_NAMES
-            .iter()
-            .any(|name| crate::connector_runtime::surface::route_for(name) == Some(path))
+    crate::route_metadata::path_has_surface(path, crate::route_metadata::RouteSurface::Connector)
 }
 
 fn project_connector_runtime(

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -85,7 +85,7 @@ pub(crate) use scopes::{is_agent_scope, scopes_to_string, validate_agent_scopes,
 #[cfg(test)]
 pub(crate) use middleware::{
     allow_query_token_for_path, enforce_token_surface, is_account_control_path,
-    is_agent_transport_path, ACCOUNT_CONTROL_PATHS, AGENT_TRANSPORT_PATHS,
+    is_agent_transport_path,
 };
 pub(crate) use middleware::{
     bearer_token, get_config, get_db, json_error, oauth_insufficient_scope_challenge,

--- a/src/auth/scopes.rs
+++ b/src/auth/scopes.rs
@@ -156,6 +156,10 @@ pub(crate) fn scopes_to_string(scopes: &[String]) -> String {
 pub(crate) enum OAuthRouteScopePolicy {
     Public,
     FirstPartyOnly,
+    /// Explicit representation of the historical fail-closed behavior for an
+    /// authenticated route that only bootstrap could traverse because no
+    /// delegated route policy existed.
+    BootstrapOnly,
     AgentSurface,
     Require(&'static str),
     BodyAware(OAuthBodyAwarePolicy),
@@ -183,136 +187,9 @@ pub(crate) fn oauth_route_scope_policy_for_path_method(
     method: &str,
     path: &str,
 ) -> OAuthRouteScopePolicy {
-    let method = method.trim().to_ascii_uppercase();
-    let path = normalize_route_path(path);
-
-    match (method.as_str(), path.as_str()) {
-        (_, "/.well-known/oauth-protected-resource")
-        | (_, "/.well-known/oauth-authorization-server")
-        | (_, "/oauth/token")
-        | (_, "/oauth/revoke")
-        | ("POST", "/oauth/authorize/login")
-        | ("POST", "/oauth/authorize/consent")
-        | ("POST", "/oauth/authorize/bridge") => OAuthRouteScopePolicy::Public,
-        // `/oauth/authorize` is NOT mounted behind `AuthMiddleware` (the
-        // handler does its own Bearer PAT / session cookie validation), so
-        // this `FirstPartyOnly` entry is audit/documentation only — it
-        // records the intended identity boundary but is never enforced by the
-        // middleware for this route.
-        (_, "/oauth/authorize") => OAuthRouteScopePolicy::FirstPartyOnly,
-
-        // First-party OAuth client management API. Only Bootstrap / ApiToken
-        // may call these; OAuth2 access tokens are blocked even with
-        // `account:manage`.
-        ("POST", "/api/oauth/clients/create")
-        | ("POST", "/api/oauth/clients/list")
-        | ("POST", "/api/oauth/clients/update_scopes")
-        | ("POST", "/api/oauth/clients/revoke") => OAuthRouteScopePolicy::FirstPartyOnly,
-        // Narrow hosted-connect bridge provisioning. The route-level scope is
-        // only the ordinary runtime entry gate; the handler additionally
-        // requires AuthKind::SharedKey and the matching connected Runner group.
-        ("POST", "/api/oauth/shared-key-client/provision") => {
-            OAuthRouteScopePolicy::Require(SCOPE_RUNTIME_READ)
-        }
-
-        ("GET", "/mcp") => OAuthRouteScopePolicy::Require(SCOPE_RUNTIME_READ),
-        ("POST", "/mcp") => OAuthRouteScopePolicy::BodyAware(OAuthBodyAwarePolicy::McpToolCall),
-        ("POST", "/api/runtime/status") | ("POST", "/api/tools/list") => {
-            OAuthRouteScopePolicy::Require(SCOPE_RUNTIME_READ)
-        }
-        ("POST", "/api/connector/task/start") => OAuthRouteScopePolicy::Require(SCOPE_RUNTIME_READ),
-        ("POST", "/api/connector/files/read")
-        | ("POST", "/api/connector/files/search")
-        | ("POST", "/api/connector/code/navigate")
-        | ("POST", "/api/connector/code/impact")
-        | ("POST", "/api/connector/task/review") => {
-            OAuthRouteScopePolicy::Require(SCOPE_PROJECT_READ)
-        }
-        ("POST", "/api/connector/edits/apply") | ("POST", "/api/connector/task/finish") => {
-            OAuthRouteScopePolicy::Require(SCOPE_PROJECT_WRITE)
-        }
-        ("POST", "/api/connector/checks/run")
-        | ("POST", "/api/connector/commands/run")
-        | ("POST", "/api/connector/task/cancel") => OAuthRouteScopePolicy::Require(SCOPE_JOB_RUN),
-        ("POST", "/api/tools/call") => {
-            OAuthRouteScopePolicy::BodyAware(OAuthBodyAwarePolicy::RuntimeToolCall)
-        }
-        ("POST", "/api/artifacts/import") => OAuthRouteScopePolicy::Require(SCOPE_PROJECT_WRITE),
-
-        ("POST", "/api/jobs/status")
-        | ("POST", "/api/jobs/log")
-        | ("POST", "/api/jobs/list")
-        | ("POST", "/api/jobs/tail")
-        | ("POST", "/api/shell/jobs/status")
-        | ("POST", "/api/shell/jobs/log")
-        | ("POST", "/api/shell/jobs/list") => OAuthRouteScopePolicy::Require(SCOPE_RUNTIME_READ),
-        ("POST", "/api/jobs/stop") | ("POST", "/api/shell/jobs/stop") => {
-            OAuthRouteScopePolicy::Require(SCOPE_JOB_RUN)
-        }
-
-        ("POST", "/api/runtime-console/overview")
-        | ("POST", "/api/runtime-console/runner")
-        | ("POST", "/api/runtime-console/workflow-session-messages")
-        | ("POST", "/api/runtime-console/workflow-session-observe") => {
-            OAuthRouteScopePolicy::Require(SCOPE_RUNTIME_READ)
-        }
-        ("POST", "/api/runtime-console/workflow-session-post-message")
-        | ("POST", "/api/runtime-console/workflow-session-withdraw-message")
-        | ("POST", "/api/runtime-console/workflow-session-replace-message") => {
-            OAuthRouteScopePolicy::Require(SCOPE_SESSION_COLLABORATE)
-        }
-        ("POST", "/api/runtime-console/projects")
-        | ("POST", "/api/runtime-console/workflow-sessions")
-        | ("POST", "/api/runtime-console/workflow-session")
-        | ("POST", "/api/projects/list")
-        | ("POST", "/api/projects/read_file")
-        | ("POST", "/api/projects/git_status")
-        | ("POST", "/api/projects/git_diff")
-        | ("POST", "/api/projects/git_diff_summary")
-        | ("POST", "/api/projects/list_files")
-        | ("POST", "/api/projects/search_text")
-        | ("POST", "/api/projects/validate_patch") => {
-            OAuthRouteScopePolicy::Require(SCOPE_PROJECT_READ)
-        }
-        ("POST", "/api/projects/register")
-        | ("POST", "/api/projects/create")
-        | ("POST", "/api/projects/unregister")
-        | ("POST", "/api/projects/apply_patch")
-        | ("POST", "/api/projects/apply_patch_checked")
-        | ("POST", "/api/projects/delete_files")
-        | ("POST", "/api/projects/git_restore_paths")
-        | ("POST", "/api/projects/discard_untracked")
-        | ("POST", "/api/shell/file") => OAuthRouteScopePolicy::Require(SCOPE_PROJECT_WRITE),
-        ("POST", "/api/projects/run_shell")
-        | ("POST", "/api/projects/run_job")
-        | ("POST", "/api/shell/run")
-        | ("POST", "/api/shell/job") => OAuthRouteScopePolicy::Require(SCOPE_JOB_RUN),
-
-        ("POST", "/api/users/create")
-        | ("POST", "/api/users/list")
-        | ("POST", "/api/users/me")
-        | ("POST", "/api/tokens/create")
-        | ("POST", "/api/tokens/register_hash")
-        | ("POST", "/api/tokens/list")
-        | ("POST", "/api/tokens/revoke")
-        | ("POST", "/api/agent-tokens/create")
-        | ("POST", "/api/agent-tokens/register_hash")
-        | ("POST", "/api/agent-tokens/list")
-        | ("POST", "/api/agent-tokens/revoke")
-        | ("POST", "/api/pairing/create")
-        | ("POST", "/api/audit/sessions")
-        | ("POST", "/api/audit/session")
-        | ("POST", "/api/audit/stats") => OAuthRouteScopePolicy::Require(SCOPE_ACCOUNT_MANAGE),
-
-        ("POST", "/api/pairing/enroll")
-        | ("POST", "/api/shell/agent/register")
-        | ("POST", "/api/shell/agent/poll")
-        | ("POST", "/api/shell/agent/result")
-        | ("POST", "/api/shell/agent/persistent_shell_result")
-        | ("POST", "/api/shell/agent/job_update")
-        | ("GET", "/api/agents/ws") => OAuthRouteScopePolicy::AgentSurface,
-        _ => OAuthRouteScopePolicy::Unknown,
-    }
+    crate::route_metadata::lookup(method, path)
+        .map(|spec| spec.scope_policy)
+        .unwrap_or(OAuthRouteScopePolicy::Unknown)
 }
 
 pub(crate) fn oauth_scope_policy_for_runtime_tool(tool_name: &str) -> OAuthToolScopePolicy {
@@ -375,21 +252,7 @@ pub(crate) fn required_oauth_scope_for_path_method(
 }
 
 fn pat_account_manage_compatibility_route(method: &str, path: &str) -> bool {
-    matches!(
-        (method, path),
-        ("POST", "/api/users/create")
-            | ("POST", "/api/users/list")
-            | ("POST", "/api/users/me")
-            | ("POST", "/api/tokens/create")
-            | ("POST", "/api/tokens/register_hash")
-            | ("POST", "/api/tokens/list")
-            | ("POST", "/api/tokens/revoke")
-            | ("POST", "/api/agent-tokens/create")
-            | ("POST", "/api/agent-tokens/register_hash")
-            | ("POST", "/api/agent-tokens/list")
-            | ("POST", "/api/agent-tokens/revoke")
-            | ("POST", "/api/pairing/create")
-    )
+    crate::route_metadata::lookup(method, path).is_some_and(|spec| spec.pat_account_manage_compat)
 }
 
 pub(crate) fn enforce_route_scope(
@@ -412,6 +275,13 @@ pub(crate) fn enforce_route_scope(
                 Ok(())
             } else {
                 Err((Some(scope), format!("missing required scope: {}", scope)))
+            }
+        }
+        OAuthRouteScopePolicy::BootstrapOnly => {
+            if ctx.is_bootstrap() {
+                Ok(())
+            } else {
+                Err((None, "route requires bootstrap authority".to_string()))
             }
         }
         OAuthRouteScopePolicy::FirstPartyOnly => {
@@ -441,22 +311,6 @@ pub(crate) fn enforce_route_scope(
                 ))
             }
         }
-    }
-}
-
-fn normalize_route_path(path: &str) -> String {
-    let path = path.trim();
-    let path = path.split('?').next().unwrap_or(path);
-    let path = if path.is_empty() { "/" } else { path };
-    let with_slash = if path.starts_with('/') {
-        path.to_string()
-    } else {
-        format!("/{path}")
-    };
-    if with_slash.len() > 1 {
-        with_slash.trim_end_matches('/').to_string()
-    } else {
-        with_slash
     }
 }
 
@@ -812,88 +666,22 @@ mod tests {
 
     #[test]
     fn oauth_route_policy_authenticated_route_audit() {
-        for (method, path) in [
-            ("POST", "/api/connector/task/start"),
-            ("POST", "/api/connector/files/read"),
-            ("POST", "/api/connector/files/search"),
-            ("POST", "/api/connector/code/navigate"),
-            ("POST", "/api/connector/code/impact"),
-            ("POST", "/api/connector/edits/apply"),
-            ("POST", "/api/connector/checks/run"),
-            ("POST", "/api/connector/commands/run"),
-            ("POST", "/api/connector/task/review"),
-            ("POST", "/api/connector/task/cancel"),
-            ("POST", "/api/connector/task/finish"),
-            ("POST", "/api/tools/list"),
-            ("POST", "/api/tools/call"),
-            ("POST", "/api/artifacts/import"),
-            ("POST", "/api/jobs/status"),
-            ("POST", "/api/jobs/log"),
-            ("POST", "/api/jobs/stop"),
-            ("POST", "/api/jobs/list"),
-            ("POST", "/api/jobs/tail"),
-            ("POST", "/api/projects/list"),
-            ("POST", "/api/projects/register"),
-            ("POST", "/api/projects/create"),
-            ("POST", "/api/projects/read_file"),
-            ("POST", "/api/projects/git_status"),
-            ("POST", "/api/projects/git_diff"),
-            ("POST", "/api/projects/git_diff_summary"),
-            ("POST", "/api/projects/list_files"),
-            ("POST", "/api/projects/search_text"),
-            ("POST", "/api/projects/apply_patch"),
-            ("POST", "/api/projects/validate_patch"),
-            ("POST", "/api/projects/run_shell"),
-            ("POST", "/api/projects/apply_patch_checked"),
-            ("POST", "/api/projects/delete_files"),
-            ("POST", "/api/projects/git_restore_paths"),
-            ("POST", "/api/projects/discard_untracked"),
-            ("POST", "/api/projects/run_job"),
-            ("POST", "/api/runtime/status"),
-            ("POST", "/api/users/create"),
-            ("POST", "/api/users/list"),
-            ("POST", "/api/users/me"),
-            ("POST", "/api/tokens/create"),
-            ("POST", "/api/tokens/register_hash"),
-            ("POST", "/api/tokens/list"),
-            ("POST", "/api/tokens/revoke"),
-            ("POST", "/api/agent-tokens/create"),
-            ("POST", "/api/agent-tokens/register_hash"),
-            ("POST", "/api/agent-tokens/list"),
-            ("POST", "/api/agent-tokens/revoke"),
-            ("POST", "/api/shell/run"),
-            ("POST", "/api/shell/file"),
-            ("POST", "/api/shell/job"),
-            ("POST", "/api/shell/jobs/status"),
-            ("POST", "/api/shell/jobs/log"),
-            ("POST", "/api/shell/jobs/stop"),
-            ("POST", "/api/shell/jobs/list"),
-            ("POST", "/api/shell/agent/register"),
-            ("POST", "/api/shell/agent/poll"),
-            ("POST", "/api/shell/agent/result"),
-            ("POST", "/api/shell/agent/persistent_shell_result"),
-            ("POST", "/api/shell/agent/job_update"),
-            ("GET", "/api/agents/ws"),
-            ("POST", "/api/pairing/enroll"),
-            ("POST", "/api/pairing/create"),
-            ("POST", "/api/audit/sessions"),
-            ("POST", "/api/audit/session"),
-            ("POST", "/api/audit/stats"),
-            ("GET", "/mcp"),
-            ("POST", "/mcp"),
-            ("GET", "/oauth/authorize"),
-            ("POST", "/oauth/authorize/login"),
-            ("POST", "/oauth/authorize/consent"),
-            ("POST", "/api/oauth/clients/create"),
-            ("POST", "/api/oauth/clients/list"),
-            ("POST", "/api/oauth/clients/update_scopes"),
-            ("POST", "/api/oauth/clients/revoke"),
-            ("POST", "/api/oauth/shared-key-client/provision"),
-        ] {
+        for spec in crate::route_metadata::routes()
+            .iter()
+            .filter(|spec| spec.auth == crate::route_metadata::RouteAuth::AuthMiddleware)
+        {
             assert_ne!(
-                oauth_route_scope_policy_for_path_method(method, path),
+                oauth_route_scope_policy_for_path_method(
+                    match spec.method {
+                        crate::route_metadata::RouteMethod::Get => "GET",
+                        crate::route_metadata::RouteMethod::Post => "POST",
+                    },
+                    spec.path,
+                ),
                 OAuthRouteScopePolicy::Unknown,
-                "{method} {path}"
+                "{:?} {}",
+                spec.method,
+                spec.path
             );
         }
     }

--- a/src/auth/tests.rs
+++ b/src/auth/tests.rs
@@ -85,9 +85,10 @@ fn is_agent_transport_path_allows_only_the_six_exact_paths() {
     assert!(!is_agent_transport_path("/api/audit/sessions"));
     assert!(!is_agent_transport_path("/api/users/list"));
     assert!(!is_agent_transport_path("/api/tokens/list"));
-    // Prefix-only matches must not pass (exact match required).
+    // Prefix and trailing-slash aliases must not pass (exact match required).
     assert!(!is_agent_transport_path("/api/shell/agent/register/extra"));
     assert!(!is_agent_transport_path("/api/agents/ws/extra"));
+    assert!(!is_agent_transport_path("/api/agents/ws/"));
     assert!(!is_agent_transport_path(""));
 }
 
@@ -424,6 +425,7 @@ fn account_control_path_allowlist_is_exact() {
     assert!(!is_account_control_path("/api/tools/list"));
     assert!(!is_account_control_path("/mcp"));
     assert!(!is_account_control_path("/api/users/me/extra"));
+    assert!(!is_account_control_path("/api/users/me/"));
 }
 
 #[tokio::test]

--- a/src/auth/tests.rs
+++ b/src/auth/tests.rs
@@ -1139,7 +1139,11 @@ async fn oauth2_verifier_accepts_current_project_share_and_preserves_project_ide
         Some(PROJECT_SHARE_OAUTH_TOKEN_KIND)
     );
     assert!(enforce_project_connector_surface(true, &ctx, "/mcp").is_ok());
-    for path in AGENT_TRANSPORT_PATHS {
+    for path in crate::route_metadata::routes()
+        .iter()
+        .filter(|spec| spec.surface == crate::route_metadata::RouteSurface::AgentTransport)
+        .map(|spec| spec.path)
+    {
         assert!(enforce_token_surface(&ctx, path).is_err());
     }
 }
@@ -1215,9 +1219,18 @@ fn enforce_token_surface_matrix() {
         "/api/projects/list",
         "/mcp",
     ];
-    let lightweight_account_rejected: Vec<&str> = ACCOUNT_CONTROL_PATHS.to_vec();
+    let lightweight_account_rejected: Vec<&str> = crate::route_metadata::routes()
+        .iter()
+        .filter(|spec| spec.surface == crate::route_metadata::RouteSurface::AccountControl)
+        .map(|spec| spec.path)
+        .collect();
     let mut open_rejected = lightweight_account_rejected.clone();
-    open_rejected.extend(AGENT_TRANSPORT_PATHS);
+    open_rejected.extend(
+        crate::route_metadata::routes()
+            .iter()
+            .filter(|spec| spec.surface == crate::route_metadata::RouteSurface::AgentTransport)
+            .map(|spec| spec.path),
+    );
 
     // Rows: (label, ctx, allowed paths, rejected paths, rejection message
     // substring; "" skips the message check). Every rejection must be
@@ -2242,7 +2255,11 @@ async fn auth_middleware_lightweight_empty_and_open_paths() {
 
     let (status, body) = gate_send(&service, "/api/runtime/status", Some("my-key")).await;
     assert_eq!(status, StatusCode::OK, "body: {:?}", body);
-    for path in AGENT_TRANSPORT_PATHS {
+    for path in crate::route_metadata::routes()
+        .iter()
+        .filter(|spec| spec.surface == crate::route_metadata::RouteSurface::AgentTransport)
+        .map(|spec| spec.path)
+    {
         let (status, body) = gate_send(&service, path, Some("my-key")).await;
         assert_eq!(
             status,

--- a/src/connector_runtime/http.rs
+++ b/src/connector_runtime/http.rs
@@ -7,22 +7,23 @@ use serde_json::{json, Value};
 use std::sync::Arc;
 
 pub(crate) fn routes() -> Router {
-    Router::with_path("connector")
-        .push(Router::with_path("readiness").post(readiness))
-        .push(Router::with_path("task/start").post(task_start))
-        .push(Router::with_path("task/list").post(task_list))
-        .push(Router::with_path("task/resume").post(task_resume))
-        .push(Router::with_path("files/list").post(files_list))
-        .push(Router::with_path("files/read").post(files_read))
-        .push(Router::with_path("files/search").post(files_search))
-        .push(Router::with_path("code/navigate").post(code_navigate))
-        .push(Router::with_path("code/impact").post(code_impact))
-        .push(Router::with_path("edits/apply").post(edits_apply))
-        .push(Router::with_path("checks/run").post(checks_run))
-        .push(Router::with_path("commands/run").post(commands_run))
-        .push(Router::with_path("task/review").post(task_review))
-        .push(Router::with_path("task/cancel").post(task_cancel))
-        .push(Router::with_path("task/finish").post(task_finish))
+    use crate::route_metadata::{api_path, RouteId};
+    Router::new()
+        .push(Router::with_path(api_path(RouteId::ConnectorReadiness)).post(readiness))
+        .push(Router::with_path(api_path(RouteId::ConnectorTaskStart)).post(task_start))
+        .push(Router::with_path(api_path(RouteId::ConnectorTaskList)).post(task_list))
+        .push(Router::with_path(api_path(RouteId::ConnectorTaskResume)).post(task_resume))
+        .push(Router::with_path(api_path(RouteId::ConnectorFilesList)).post(files_list))
+        .push(Router::with_path(api_path(RouteId::ConnectorFilesRead)).post(files_read))
+        .push(Router::with_path(api_path(RouteId::ConnectorFilesSearch)).post(files_search))
+        .push(Router::with_path(api_path(RouteId::ConnectorCodeNavigate)).post(code_navigate))
+        .push(Router::with_path(api_path(RouteId::ConnectorCodeImpact)).post(code_impact))
+        .push(Router::with_path(api_path(RouteId::ConnectorEditsApply)).post(edits_apply))
+        .push(Router::with_path(api_path(RouteId::ConnectorChecksRun)).post(checks_run))
+        .push(Router::with_path(api_path(RouteId::ConnectorCommandsRun)).post(commands_run))
+        .push(Router::with_path(api_path(RouteId::ConnectorTaskReview)).post(task_review))
+        .push(Router::with_path(api_path(RouteId::ConnectorTaskCancel)).post(task_cancel))
+        .push(Router::with_path(api_path(RouteId::ConnectorTaskFinish)).post(task_finish))
 }
 
 #[handler]

--- a/src/connector_runtime/surface.rs
+++ b/src/connector_runtime/surface.rs
@@ -429,23 +429,25 @@ pub(crate) fn capability_spec(name: &str) -> Option<ToolSpec> {
 }
 
 pub(crate) fn route_for(name: &str) -> Option<&'static str> {
-    match name {
-        "task_start" => Some("/api/connector/task/start"),
-        "task_list" => Some("/api/connector/task/list"),
-        "task_resume" => Some("/api/connector/task/resume"),
-        "files_list" => Some("/api/connector/files/list"),
-        "files_read" => Some("/api/connector/files/read"),
-        "files_search" => Some("/api/connector/files/search"),
-        "code_navigate" => Some("/api/connector/code/navigate"),
-        "edits_apply" => Some("/api/connector/edits/apply"),
-        "checks_run" => Some("/api/connector/checks/run"),
-        "commands_run" => Some("/api/connector/commands/run"),
-        "task_review" => Some("/api/connector/task/review"),
-        "task_cancel" => Some("/api/connector/task/cancel"),
-        "task_finish" => Some("/api/connector/task/finish"),
-        "code_impact" => Some("/api/connector/code/impact"),
-        _ => None,
-    }
+    use crate::route_metadata::RouteId;
+    let id = match name {
+        "task_start" => RouteId::ConnectorTaskStart,
+        "task_list" => RouteId::ConnectorTaskList,
+        "task_resume" => RouteId::ConnectorTaskResume,
+        "files_list" => RouteId::ConnectorFilesList,
+        "files_read" => RouteId::ConnectorFilesRead,
+        "files_search" => RouteId::ConnectorFilesSearch,
+        "code_navigate" => RouteId::ConnectorCodeNavigate,
+        "edits_apply" => RouteId::ConnectorEditsApply,
+        "checks_run" => RouteId::ConnectorChecksRun,
+        "commands_run" => RouteId::ConnectorCommandsRun,
+        "task_review" => RouteId::ConnectorTaskReview,
+        "task_cancel" => RouteId::ConnectorTaskCancel,
+        "task_finish" => RouteId::ConnectorTaskFinish,
+        "code_impact" => RouteId::ConnectorCodeImpact,
+        _ => return None,
+    };
+    Some(crate::route_metadata::path(id))
 }
 
 pub(crate) fn build_openapi_spec(public_url: String) -> Value {
@@ -626,6 +628,21 @@ mod tests {
             .collect::<BTreeSet<_>>();
         assert_eq!(operations, expected);
         assert_eq!(spec["paths"].as_object().unwrap().len(), 14);
+        let expected_paths = crate::route_metadata::routes()
+            .iter()
+            .filter(|route| {
+                route.openapi_visibility
+                    == crate::route_metadata::OpenApiVisibility::ConnectorActions
+            })
+            .map(|route| route.path.to_string())
+            .collect::<BTreeSet<_>>();
+        let actual_paths = spec["paths"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        assert_eq!(actual_paths, expected_paths);
         let start = &spec["paths"]["/api/connector/task/start"]["post"]["requestBody"]["content"]
             ["application/json"]["schema"];
         assert_eq!(start["properties"]["target_path"]["type"], "string");

--- a/src/host_console_http.rs
+++ b/src/host_console_http.rs
@@ -10,39 +10,28 @@ use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
 
-pub(crate) const CONSOLE_ROUTES: &[&str] = &[
-    "/api/console/readiness",
-    "/api/console/tasks",
-    "/api/console/activity",
-    "/api/console/workflow-sessions",
-    "/api/console/workflow-session",
-    "/api/console/task/review",
-    "/api/console/task/cancel",
-    "/api/console/task/guide",
-    "/api/console/approvals",
-    "/api/console/approval/decide",
-    "/api/console/devices",
-    "/api/console/result/accept",
-    "/api/console/result/reject",
-    "/api/console/connect",
-];
-
 pub(crate) fn routes() -> Router {
-    Router::with_path("console")
-        .push(Router::with_path("readiness").post(readiness))
-        .push(Router::with_path("tasks").post(tasks))
-        .push(Router::with_path("activity").post(activity))
-        .push(Router::with_path("workflow-sessions").post(workflow_sessions))
-        .push(Router::with_path("workflow-session").post(workflow_session))
-        .push(Router::with_path("task/review").post(task_review))
-        .push(Router::with_path("task/cancel").post(task_cancel))
-        .push(Router::with_path("task/guide").post(task_guide))
-        .push(Router::with_path("approvals").post(approvals))
-        .push(Router::with_path("approval/decide").post(approval_decide))
-        .push(Router::with_path("devices").post(devices))
-        .push(Router::with_path("result/accept").post(result_accept))
-        .push(Router::with_path("result/reject").post(result_reject))
-        .push(Router::with_path("connect").post(connect))
+    use crate::route_metadata::{api_path, RouteId};
+    Router::new()
+        .push(Router::with_path(api_path(RouteId::HostConsoleReadiness)).post(readiness))
+        .push(Router::with_path(api_path(RouteId::HostConsoleTasks)).post(tasks))
+        .push(Router::with_path(api_path(RouteId::HostConsoleActivity)).post(activity))
+        .push(
+            Router::with_path(api_path(RouteId::HostConsoleWorkflowSessions))
+                .post(workflow_sessions),
+        )
+        .push(
+            Router::with_path(api_path(RouteId::HostConsoleWorkflowSession)).post(workflow_session),
+        )
+        .push(Router::with_path(api_path(RouteId::HostConsoleTaskReview)).post(task_review))
+        .push(Router::with_path(api_path(RouteId::HostConsoleTaskCancel)).post(task_cancel))
+        .push(Router::with_path(api_path(RouteId::HostConsoleTaskGuide)).post(task_guide))
+        .push(Router::with_path(api_path(RouteId::HostConsoleApprovals)).post(approvals))
+        .push(Router::with_path(api_path(RouteId::HostConsoleApprovalDecide)).post(approval_decide))
+        .push(Router::with_path(api_path(RouteId::HostConsoleDevices)).post(devices))
+        .push(Router::with_path(api_path(RouteId::HostConsoleResultAccept)).post(result_accept))
+        .push(Router::with_path(api_path(RouteId::HostConsoleResultReject)).post(result_reject))
+        .push(Router::with_path(api_path(RouteId::HostConsoleConnect)).post(connect))
 }
 
 fn failure(status: u16, code: &str, message: impl Into<String>) -> ConnectorCallOutcome {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "512"]
 
+use crate::route_metadata::RouteId;
 use salvo::cors::Cors;
 use salvo::prelude::*;
 #[cfg(test)]
@@ -35,6 +36,7 @@ mod openapi;
 mod pairing_http;
 mod project_entry;
 mod projects;
+mod route_metadata;
 mod runtime_console_http;
 mod runtime_http;
 mod server_listener;
@@ -330,121 +332,256 @@ only for local/trusted-network demos."
         }
     }
 
-    let _admin_route_allowlist = admin_http::ADMIN_ROUTES;
     let authed_api_router = Router::new()
         .hoop(AuthMiddleware)
         .push(connector_runtime::http::routes())
         .push(host_console_http::routes())
         .push(runtime_console_http::routes())
         .push(admin_http::routes())
-        .push(Router::with_path("tools/list").post(runtime_http::tools_list))
-        .push(Router::with_path("tools/call").post(runtime_http::tools_call))
         .push(
-            Router::with_path("artifacts/import")
+            Router::with_path(route_metadata::api_path(RouteId::ToolsList))
+                .post(runtime_http::tools_list),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ToolsCall))
+                .post(runtime_http::tools_call),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ArtifactsImport))
                 .post(runtime_http::import_conversation_files_to_project),
         )
-        .push(Router::with_path("jobs/status").post(runtime_http::job_status))
-        .push(Router::with_path("jobs/log").post(runtime_http::job_log))
-        .push(Router::with_path("jobs/stop").post(runtime_http::job_stop))
-        .push(Router::with_path("jobs/list").post(runtime_http::jobs_list))
-        .push(Router::with_path("jobs/tail").post(runtime_http::job_tail))
-        .push(Router::with_path("projects/list").post(runtime_http::projects_list))
-        .push(Router::with_path("projects/register").post(runtime_http::projects_register))
-        .push(Router::with_path("projects/create").post(runtime_http::projects_create))
-        .push(Router::with_path("projects/unregister").post(runtime_http::projects_unregister))
-        .push(Router::with_path("projects/read_file").post(runtime_http::projects_read_file))
-        .push(Router::with_path("projects/git_status").post(runtime_http::projects_git_status))
-        .push(Router::with_path("projects/git_diff").post(runtime_http::projects_git_diff))
         .push(
-            Router::with_path("projects/git_diff_summary")
+            Router::with_path(route_metadata::api_path(RouteId::JobsStatus))
+                .post(runtime_http::job_status),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::JobsLog))
+                .post(runtime_http::job_log),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::JobsStop))
+                .post(runtime_http::job_stop),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::JobsList))
+                .post(runtime_http::jobs_list),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::JobsTail))
+                .post(runtime_http::job_tail),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsList))
+                .post(runtime_http::projects_list),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsRegister))
+                .post(runtime_http::projects_register),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsCreate))
+                .post(runtime_http::projects_create),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsUnregister))
+                .post(runtime_http::projects_unregister),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsReadFile))
+                .post(runtime_http::projects_read_file),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsGitStatus))
+                .post(runtime_http::projects_git_status),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsGitDiff))
+                .post(runtime_http::projects_git_diff),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsGitDiffSummary))
                 .post(runtime_http::projects_git_diff_summary),
         )
-        .push(Router::with_path("projects/list_files").post(runtime_http::projects_list_files))
-        .push(Router::with_path("projects/search_text").post(runtime_http::projects_search_text))
-        .push(Router::with_path("projects/apply_patch").post(runtime_http::projects_apply_patch))
         .push(
-            Router::with_path("projects/validate_patch")
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsListFiles))
+                .post(runtime_http::projects_list_files),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsSearchText))
+                .post(runtime_http::projects_search_text),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsApplyPatch))
+                .post(runtime_http::projects_apply_patch),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsValidatePatch))
                 .post(runtime_http::projects_validate_patch),
         )
-        .push(Router::with_path("projects/run_shell").post(runtime_http::projects_run_shell))
         .push(
-            Router::with_path("projects/apply_patch_checked")
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsRunShell))
+                .post(runtime_http::projects_run_shell),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsApplyPatchChecked))
                 .post(runtime_http::projects_apply_patch_checked),
         )
-        .push(Router::with_path("projects/delete_files").post(runtime_http::projects_delete_files))
         .push(
-            Router::with_path("projects/git_restore_paths")
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsDeleteFiles))
+                .post(runtime_http::projects_delete_files),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsGitRestorePaths))
                 .post(runtime_http::projects_git_restore_paths),
         )
         .push(
-            Router::with_path("projects/discard_untracked")
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsDiscardUntracked))
                 .post(runtime_http::projects_discard_untracked),
         )
-        .push(Router::with_path("projects/run_job").post(runtime_http::projects_run_job))
-        .push(Router::with_path("runtime/status").post(runtime_http::runtime_status))
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ProjectsRunJob))
+                .post(runtime_http::projects_run_job),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::RuntimeStatus))
+                .post(runtime_http::runtime_status),
+        )
         // Phase 2e-3: first-party OAuth client management API. Behind
         // AuthMiddleware; route policy is FirstPartyOnly so OAuth2 access
         // tokens are rejected even with account:manage.
-        .push(Router::with_path("oauth/clients/create").post(oauth_http::oauth_clients_create))
-        .push(Router::with_path("oauth/clients/list").post(oauth_http::oauth_clients_list))
         .push(
-            Router::with_path("oauth/clients/update_scopes")
+            Router::with_path(route_metadata::api_path(RouteId::OAuthClientsCreate))
+                .post(oauth_http::oauth_clients_create),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::OAuthClientsList))
+                .post(oauth_http::oauth_clients_list),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::OAuthClientsUpdateScopes))
                 .post(oauth_http::oauth_clients_update_scopes),
         )
-        .push(Router::with_path("oauth/clients/revoke").post(oauth_http::oauth_clients_revoke))
         .push(
-            Router::with_path("oauth/shared-key-client/provision")
-                .post(oauth_http::oauth_shared_key_client_provision),
+            Router::with_path(route_metadata::api_path(RouteId::OAuthClientsRevoke))
+                .post(oauth_http::oauth_clients_revoke),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(
+                RouteId::OAuthSharedKeyClientProvision,
+            ))
+            .post(oauth_http::oauth_shared_key_client_provision),
         )
         // Phase 2 multi-user auth: user + personal API token management.
         // REST-only admin/self-management surface; intentionally NOT
         // exposed in /openapi.json (GPT Actions) because token creation is
         // sensitive. All behind the shared AuthMiddleware Bearer auth.
-        .push(Router::with_path("users/create").post(users_http::users_create))
-        .push(Router::with_path("users/list").post(users_http::users_list))
-        .push(Router::with_path("users/me").post(users_http::users_me))
-        .push(Router::with_path("tokens/create").post(users_http::tokens_create))
-        .push(Router::with_path("tokens/register_hash").post(users_http::tokens_register_hash))
-        .push(Router::with_path("tokens/list").post(users_http::tokens_list))
-        .push(Router::with_path("tokens/revoke").post(users_http::tokens_revoke))
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::UsersCreate))
+                .post(users_http::users_create),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::UsersList))
+                .post(users_http::users_list),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::UsersMe))
+                .post(users_http::users_me),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::TokensCreate))
+                .post(users_http::tokens_create),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::TokensRegisterHash))
+                .post(users_http::tokens_register_hash),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::TokensList))
+                .post(users_http::tokens_list),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::TokensRevoke))
+                .post(users_http::tokens_revoke),
+        )
         // Phase 3 agent token management: REST-only admin/self-management
         // surface for agent tokens bound to an owner + allowed_client_id.
         // Intentionally NOT exposed in /openapi.json (GPT Actions) because
         // token creation is sensitive. All behind the shared AuthMiddleware
         // Bearer auth. Agent tokens themselves are rejected from these
         // endpoints so a leaked agent token cannot mint more tokens.
-        .push(Router::with_path("agent-tokens/create").post(agent_tokens_http::agent_tokens_create))
         .push(
-            Router::with_path("agent-tokens/register_hash")
+            Router::with_path(route_metadata::api_path(RouteId::AgentTokensCreate))
+                .post(agent_tokens_http::agent_tokens_create),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::AgentTokensRegisterHash))
                 .post(agent_tokens_http::agent_tokens_register_hash),
         )
-        .push(Router::with_path("agent-tokens/list").post(agent_tokens_http::agent_tokens_list))
-        .push(Router::with_path("agent-tokens/revoke").post(agent_tokens_http::agent_tokens_revoke))
-        .push(Router::with_path("shell/run").post(shell_run))
-        .push(Router::with_path("shell/file").post(shell_file_op))
-        .push(Router::with_path("shell/job").post(shell_job))
-        .push(Router::with_path("shell/jobs/status").post(shell_job_status))
-        .push(Router::with_path("shell/jobs/log").post(shell_job_log))
-        .push(Router::with_path("shell/jobs/stop").post(shell_job_stop))
-        .push(Router::with_path("shell/jobs/list").post(shell_jobs_list))
-        .push(Router::with_path("shell/agent/register").post(shell_agent_register))
-        .push(Router::with_path("shell/agent/poll").post(shell_agent_poll))
-        .push(Router::with_path("shell/agent/result").post(shell_agent_result))
         .push(
-            Router::with_path("shell/agent/persistent_shell_result")
-                .post(shell_agent_persistent_shell_result),
+            Router::with_path(route_metadata::api_path(RouteId::AgentTokensList))
+                .post(agent_tokens_http::agent_tokens_list),
         )
-        .push(Router::with_path("shell/agent/job_update").post(shell_agent_job_update))
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::AgentTokensRevoke))
+                .post(agent_tokens_http::agent_tokens_revoke),
+        )
+        .push(Router::with_path(route_metadata::api_path(RouteId::ShellRun)).post(shell_run))
+        .push(Router::with_path(route_metadata::api_path(RouteId::ShellFile)).post(shell_file_op))
+        .push(Router::with_path(route_metadata::api_path(RouteId::ShellJob)).post(shell_job))
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellJobsStatus))
+                .post(shell_job_status),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellJobsLog)).post(shell_job_log),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellJobsStop))
+                .post(shell_job_stop),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellJobsList))
+                .post(shell_jobs_list),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellAgentRegister))
+                .post(shell_agent_register),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellAgentPoll))
+                .post(shell_agent_poll),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellAgentResult))
+                .post(shell_agent_result),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(
+                RouteId::ShellAgentPersistentShellResult,
+            ))
+            .post(shell_agent_persistent_shell_result),
+        )
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::ShellAgentJobUpdate))
+                .post(shell_agent_job_update),
+        )
         // WebSocket agent transport (preferred long-lived connection).
         // Polling endpoints above remain as fallback. Bearer auth is
         // enforced by the shared AuthMiddleware hoop.
-        .push(Router::with_path("agents/ws").get(agent_ws::agent_ws));
+        .push(
+            Router::with_path(route_metadata::api_path(RouteId::AgentsWs)).get(agent_ws::agent_ws),
+        );
 
     let api_router = Router::with_path("api")
-        .push(Router::with_path("pairing/enroll").post(pairing_http::pairing_enroll))
         .push(
-            authed_api_router
-                .push(Router::with_path("pairing/create").post(pairing_http::pairing_create)),
+            Router::with_path(route_metadata::api_path(RouteId::PairingEnroll))
+                .post(pairing_http::pairing_enroll),
+        )
+        .push(
+            authed_api_router.push(
+                Router::with_path(route_metadata::api_path(RouteId::PairingCreate))
+                    .post(pairing_http::pairing_create),
+            ),
         );
 
     let openapi_router = Router::with_path("openapi.json").get(openapi_json);
@@ -498,44 +635,81 @@ only for local/trusted-network demos."
         // OAuth2 token, revocation, and discovery endpoints — public, no
         // AuthMiddleware. Token/revoke clients authenticate via
         // client_id + client_secret in the form body.
-        .push(Router::with_path("oauth/token").post(oauth_http::oauth_token))
-        .push(Router::with_path("oauth/revoke").post(oauth_http::oauth_revoke))
+        .push(
+            Router::with_path(route_metadata::root_path(RouteId::OAuthToken))
+                .post(oauth_http::oauth_token),
+        )
+        .push(
+            Router::with_path(route_metadata::root_path(RouteId::OAuthRevoke))
+                .post(oauth_http::oauth_revoke),
+        )
         // /oauth/authorize is NOT behind AuthMiddleware: the handler accepts
         // either a first-party Bearer token (Bootstrap / PAT, backward
         // compatible direct code issuance) or a short-lived authorize
         // session cookie set by the login form. login/consent do their own
         // token/session validation.
         .push(
-            Router::with_path("oauth/authorize")
-                .get(oauth_http::oauth_authorize)
-                .push(Router::with_path("login").post(oauth_http::oauth_authorize_login))
-                .push(Router::with_path("consent").post(oauth_http::oauth_authorize_consent))
-                .push(Router::with_path("bridge").post(oauth_http::oauth_authorize_bridge))
-                .push(Router::with_path("project").post(oauth_http::oauth_authorize_project)),
+            Router::new()
+                .push(
+                    Router::with_path(route_metadata::root_path(RouteId::OAuthAuthorize))
+                        .get(oauth_http::oauth_authorize),
+                )
+                .push(
+                    Router::with_path(route_metadata::root_path(RouteId::OAuthAuthorizeLogin))
+                        .post(oauth_http::oauth_authorize_login),
+                )
+                .push(
+                    Router::with_path(route_metadata::root_path(RouteId::OAuthAuthorizeConsent))
+                        .post(oauth_http::oauth_authorize_consent),
+                )
+                .push(
+                    Router::with_path(route_metadata::root_path(RouteId::OAuthAuthorizeBridge))
+                        .post(oauth_http::oauth_authorize_bridge),
+                )
+                .push(
+                    Router::with_path(route_metadata::root_path(RouteId::OAuthAuthorizeProject))
+                        .post(oauth_http::oauth_authorize_project),
+                ),
         )
         .push(
-            Router::with_path(".well-known/oauth-protected-resource")
-                .get(oauth_http::oauth_metadata),
+            Router::with_path(route_metadata::root_path(
+                RouteId::WellKnownProtectedResource,
+            ))
+            .get(oauth_http::oauth_metadata),
         )
         .push(
-            Router::with_path(".well-known/oauth-authorization-server")
-                .get(oauth_http::oauth_authorization_server_metadata),
+            Router::with_path(route_metadata::root_path(
+                RouteId::WellKnownAuthorizationServer,
+            ))
+            .get(oauth_http::oauth_authorization_server_metadata),
         )
         .push(
-            Router::with_path("mcp")
-                .hoop(AuthMiddleware)
-                .get(mcp::mcp_info)
-                .post(mcp::mcp_post),
+            Router::with_path(route_metadata::shared_root_path(
+                RouteId::McpGet,
+                RouteId::McpPost,
+            ))
+            .hoop(AuthMiddleware)
+            .get(mcp::mcp_info)
+            .post(mcp::mcp_post),
         );
 
     // Read-only audit query API. Admin/debug surface only: NOT part of the
     // GPT Actions OpenAPI schema. All endpoints are POST + Bearer auth.
     router = router.push(
-        Router::with_path("api/audit")
+        Router::new()
             .hoop(AuthMiddleware)
-            .push(Router::with_path("sessions").post(audit_http::audit_sessions))
-            .push(Router::with_path("session").post(audit_http::audit_session))
-            .push(Router::with_path("stats").post(audit_http::audit_stats)),
+            .push(
+                Router::with_path(route_metadata::root_path(RouteId::AuditSessions))
+                    .post(audit_http::audit_sessions),
+            )
+            .push(
+                Router::with_path(route_metadata::root_path(RouteId::AuditSession))
+                    .post(audit_http::audit_session),
+            )
+            .push(
+                Router::with_path(route_metadata::root_path(RouteId::AuditStats))
+                    .post(audit_http::audit_stats),
+            ),
     );
     tracing::info!("Server started successfully!");
     let port = addr.split(':').next_back().unwrap_or("8080");

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -145,10 +145,9 @@ const GPT_ACTION_OPS: &[&str] = &[
     "callRuntimeTool",
 ];
 
-/// Legacy and non-GPT-Actions paths that must never appear in
-/// `/openapi.json`. The GPT Actions surface is intentionally small and
-/// POST-only; removed legacy `/api/codex/*` paths must stay absent from the
-/// GPT-importable schema.
+/// Removed or non-route resources that must never appear in `/openapi.json`.
+/// Current HTTP-route visibility is owned by `route_metadata`; this list keeps
+/// only historical endpoints and browser/static resources with no RouteSpec.
 #[cfg(test)]
 const LEGACY_FORBIDDEN_PATHS: &[&str] = &[
     "/api/messages",
@@ -167,64 +166,8 @@ const LEGACY_FORBIDDEN_PATHS: &[&str] = &[
     "/api/codex/report",
     "/api/codex/projects",
     "/api/codex/run",
-    "/api/shell/run",
-    "/api/shell/job",
-    "/api/shell/file",
-    "/api/shell/jobs/status",
-    "/api/shell/jobs/log",
-    "/api/shell/jobs/stop",
-    "/api/jobs/stop",
-    "/api/shell/jobs/list",
-    "/api/shell/agent/register",
-    "/api/shell/agent/poll",
-    "/api/shell/agent/result",
-    "/api/shell/agent/persistent_shell_result",
-    "/api/shell/agent/job_update",
-    // Retained whole-file write tool stays runtime-only through
-    // callRuntimeTool / MCP tools/call; it must not be promoted to a
-    // dedicated GPT Action. The legacy single-purpose edit tools
-    // (replace_in_file, replace_exact_block, insert_before_pattern,
-    // insert_after_pattern, replace_line_range, insert_at_line,
-    // delete_line_range) were removed entirely, so they have no paths.
     "/api/projects/write_file",
-    "/api/audit/sessions",
-    "/api/audit/session",
-    "/api/audit/stats",
-    // Phase 2 multi-user auth: user/token management is REST-only admin/self
-    // surface. Token creation is sensitive and must not be GPT-importable, so
-    // these paths are deliberately excluded from /openapi.json.
-    "/api/users/create",
-    "/api/users/list",
-    "/api/users/me",
-    "/api/tokens/create",
-    "/api/tokens/register_hash",
-    "/api/tokens/list",
-    "/api/tokens/revoke",
-    // Phase 3 agent token management: same REST-only admin/self surface, also
-    // excluded from GPT Actions. Agent tokens are bound to an owner and an
-    // allowed_client_id and are only used by the webcodex-runner transport.
-    "/api/agent-tokens/create",
-    "/api/agent-tokens/register_hash",
-    "/api/agent-tokens/list",
-    "/api/agent-tokens/revoke",
-    // Pairing/enrollment creates temporary credentials and enrollment tokens.
-    // It is REST-only for CLI/admin flows and must not be GPT-importable.
-    "/api/pairing/create",
-    "/api/pairing/enroll",
-    "/mcp",
     "/openapi.json",
-    // Browser console shells and their browser-only Runtime Console API are
-    // intentionally NOT GPT Actions and must never appear in /openapi.json.
-    "/api/runtime-console/overview",
-    "/api/runtime-console/runner",
-    "/api/runtime-console/projects",
-    "/api/runtime-console/workflow-sessions",
-    "/api/runtime-console/workflow-session",
-    "/api/runtime-console/workflow-session-messages",
-    "/api/runtime-console/workflow-session-observe",
-    "/api/runtime-console/workflow-session-post-message",
-    "/api/runtime-console/workflow-session-withdraw-message",
-    "/api/runtime-console/workflow-session-replace-message",
     "/runtime",
     "/runtime/app.js",
     "/runtime/styles.css",
@@ -243,7 +186,7 @@ pub async fn openapi_json(depot: &mut Depot, res: &mut Response) {
 }
 
 pub(crate) fn build_openapi_spec() -> Value {
-    json!({
+    let mut spec = json!({
         "openapi": "3.1.0",
         "info": {
             "title": "WebCodex Runtime API",
@@ -907,7 +850,16 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "bearerAuth": []
             }
         ]
-    })
+    });
+    spec["paths"]
+        .as_object_mut()
+        .expect("OpenAPI paths object")
+        .retain(|path, _| {
+            crate::route_metadata::lookup("POST", path).is_some_and(|route| {
+                route.openapi_visibility == crate::route_metadata::OpenApiVisibility::PublicActions
+            })
+        });
+    spec
 }
 
 fn operation(

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -197,6 +197,37 @@ fn openapi_does_not_expose_any_legacy_or_non_gpt_action_paths() {
 }
 
 #[test]
+fn openapi_route_visibility_matches_canonical_metadata() {
+    use std::collections::BTreeSet;
+
+    let spec = build_openapi_spec();
+    let actual = spec["paths"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let expected = crate::route_metadata::routes()
+        .iter()
+        .filter(|route| {
+            route.openapi_visibility == crate::route_metadata::OpenApiVisibility::PublicActions
+        })
+        .map(|route| route.path.to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected);
+
+    for route in crate::route_metadata::routes().iter().filter(|route| {
+        route.openapi_visibility == crate::route_metadata::OpenApiVisibility::Hidden
+    }) {
+        assert!(
+            !actual.contains(route.path),
+            "hidden route leaked: {}",
+            route.path
+        );
+    }
+}
+
+#[test]
 fn openapi_phase3_exposes_validate_patch_as_dedicated_action() {
     // Phase 3: validate_patch is now promoted to a dedicated GPT Action
     // (validateProjectPatch) so a custom GPT can dry-run patches without

--- a/src/route_metadata.rs
+++ b/src/route_metadata.rs
@@ -1586,13 +1586,15 @@ pub(crate) fn lookup(method: &str, path: &str) -> Option<&'static RouteSpec> {
         .find(|spec| spec.method.matches(method) && spec.path == path)
 }
 
+/// Exact path-only lookup for consumers whose historical contract was an
+/// allowlist over `Request::uri().path()` or a persisted audit endpoint.
+/// Method-aware scope lookup below intentionally keeps its older benign
+/// normalization; path-only security gates must not gain new aliases here.
 pub(crate) fn lookup_path(path: &str) -> Option<&'static RouteSpec> {
-    let path = normalize_path(path);
     ROUTES.iter().find(|spec| spec.path == path)
 }
 
 pub(crate) fn path_has_surface(path: &str, surface: RouteSurface) -> bool {
-    let path = normalize_path(path);
     ROUTES
         .iter()
         .any(|spec| spec.path == path && spec.surface == surface)
@@ -1682,6 +1684,13 @@ mod tests {
         assert!(lookup("GET", "/api/runtime/status").is_none());
         assert!(lookup("POST", "/api/future/authenticated-route").is_none());
         assert!(lookup("POST", "/api/runtime/status/extra").is_none());
+
+        // Path-only surface/audit consumers replaced exact historical
+        // allowlists and must not inherit the scope lookup's normalization.
+        assert!(lookup_path("/api/runtime/status").is_some());
+        assert!(lookup_path("/api/runtime/status/").is_none());
+        assert!(path_has_surface("/api/agents/ws", AgentTransport));
+        assert!(!path_has_surface("/api/agents/ws/", AgentTransport));
     }
 
     #[test]
@@ -1785,11 +1794,12 @@ mod tests {
     }
 
     #[test]
-    fn audit_class_is_unambiguous_per_canonical_path() {
-        let mut classes = BTreeMap::new();
+    fn path_only_metadata_is_unambiguous_per_canonical_path() {
+        let mut metadata = BTreeMap::new();
         for spec in routes() {
-            match classes.insert(spec.path, spec.audit_class) {
-                Some(existing) => assert_eq!(existing, spec.audit_class, "{}", spec.path),
+            let path_only = (spec.surface, spec.audit_class);
+            match metadata.insert(spec.path, path_only) {
+                Some(existing) => assert_eq!(existing, path_only, "{}", spec.path),
                 None => {}
             }
         }

--- a/src/route_metadata.rs
+++ b/src/route_metadata.rs
@@ -1,0 +1,1821 @@
+//! Canonical declarative metadata for mounted HTTP routes.
+//!
+//! Handler mounting stays explicit in the owning HTTP modules. This registry owns
+//! the security- and surface-relevant metadata that previously drifted across
+//! auth, OpenAPI, console, audit, and test-only route tables.
+
+use crate::auth::scopes::{
+    OAuthBodyAwarePolicy, OAuthRouteScopePolicy, SCOPE_ACCOUNT_MANAGE, SCOPE_JOB_RUN,
+    SCOPE_PROJECT_READ, SCOPE_PROJECT_WRITE, SCOPE_RUNTIME_READ, SCOPE_SESSION_COLLABORATE,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RouteMethod {
+    Get,
+    Post,
+}
+
+impl RouteMethod {
+    pub(crate) fn matches(self, method: &str) -> bool {
+        match self {
+            Self::Get => method.trim().eq_ignore_ascii_case("GET"),
+            Self::Post => method.trim().eq_ignore_ascii_case("POST"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RouteAuth {
+    /// No bearer AuthMiddleware. The endpoint is intentionally public at the
+    /// HTTP route layer (it may still validate protocol credentials in-body).
+    Public,
+    /// No bearer AuthMiddleware because the handler owns its current identity
+    /// or short-lived authorization contract.
+    HandlerManaged,
+    /// Mounted behind the shared bearer AuthMiddleware.
+    AuthMiddleware,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RouteSurface {
+    OAuth,
+    Mcp,
+    RuntimeApi,
+    Connector,
+    HostConsole,
+    RuntimeConsole,
+    Admin,
+    Audit,
+    AccountManagement,
+    AccountControl,
+    Pairing,
+    AgentTransport,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum OpenApiVisibility {
+    /// The normal server `/openapi.json` GPT Actions surface.
+    PublicActions,
+    /// The project-hosted Connector OpenAPI surface.
+    ConnectorActions,
+    Hidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum AuditClass {
+    Other,
+    Edit,
+    Context,
+    Job,
+    Command,
+    Report,
+    Artifact,
+    Git,
+    Shell,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RouteId {
+    WellKnownProtectedResource,
+    WellKnownAuthorizationServer,
+    OAuthToken,
+    OAuthRevoke,
+    OAuthAuthorize,
+    OAuthAuthorizeLogin,
+    OAuthAuthorizeConsent,
+    OAuthAuthorizeBridge,
+    OAuthAuthorizeProject,
+    PairingEnroll,
+    McpGet,
+    McpPost,
+    ConnectorReadiness,
+    ConnectorTaskStart,
+    ConnectorTaskList,
+    ConnectorTaskResume,
+    ConnectorFilesList,
+    ConnectorFilesRead,
+    ConnectorFilesSearch,
+    ConnectorCodeNavigate,
+    ConnectorCodeImpact,
+    ConnectorEditsApply,
+    ConnectorChecksRun,
+    ConnectorCommandsRun,
+    ConnectorTaskReview,
+    ConnectorTaskCancel,
+    ConnectorTaskFinish,
+    HostConsoleReadiness,
+    HostConsoleTasks,
+    HostConsoleActivity,
+    HostConsoleWorkflowSessions,
+    HostConsoleWorkflowSession,
+    HostConsoleTaskReview,
+    HostConsoleTaskCancel,
+    HostConsoleTaskGuide,
+    HostConsoleApprovals,
+    HostConsoleApprovalDecide,
+    HostConsoleDevices,
+    HostConsoleResultAccept,
+    HostConsoleResultReject,
+    HostConsoleConnect,
+    RuntimeConsoleOverview,
+    RuntimeConsoleRunner,
+    RuntimeConsoleProjects,
+    RuntimeConsoleWorkflowSessions,
+    RuntimeConsoleWorkflowSession,
+    RuntimeConsoleWorkflowSessionMessages,
+    RuntimeConsoleWorkflowSessionObserve,
+    RuntimeConsoleWorkflowSessionPostMessage,
+    RuntimeConsoleWorkflowSessionWithdrawMessage,
+    RuntimeConsoleWorkflowSessionReplaceMessage,
+    AdminDashboard,
+    AdminProjectsRegister,
+    AdminProjectsCreate,
+    AdminProjectsEnable,
+    AdminProjectsDisable,
+    AdminProjectsUnregister,
+    ToolsList,
+    ToolsCall,
+    ArtifactsImport,
+    JobsStatus,
+    JobsLog,
+    JobsStop,
+    JobsList,
+    JobsTail,
+    ProjectsList,
+    ProjectsRegister,
+    ProjectsCreate,
+    ProjectsUnregister,
+    ProjectsReadFile,
+    ProjectsGitStatus,
+    ProjectsGitDiff,
+    ProjectsGitDiffSummary,
+    ProjectsListFiles,
+    ProjectsSearchText,
+    ProjectsApplyPatch,
+    ProjectsValidatePatch,
+    ProjectsRunShell,
+    ProjectsApplyPatchChecked,
+    ProjectsDeleteFiles,
+    ProjectsGitRestorePaths,
+    ProjectsDiscardUntracked,
+    ProjectsRunJob,
+    RuntimeStatus,
+    OAuthClientsCreate,
+    OAuthClientsList,
+    OAuthClientsUpdateScopes,
+    OAuthClientsRevoke,
+    OAuthSharedKeyClientProvision,
+    UsersCreate,
+    UsersList,
+    UsersMe,
+    TokensCreate,
+    TokensRegisterHash,
+    TokensList,
+    TokensRevoke,
+    AgentTokensCreate,
+    AgentTokensRegisterHash,
+    AgentTokensList,
+    AgentTokensRevoke,
+    PairingCreate,
+    ShellRun,
+    ShellFile,
+    ShellJob,
+    ShellJobsStatus,
+    ShellJobsLog,
+    ShellJobsStop,
+    ShellJobsList,
+    ShellAgentRegister,
+    ShellAgentPoll,
+    ShellAgentResult,
+    ShellAgentPersistentShellResult,
+    ShellAgentJobUpdate,
+    AgentsWs,
+    AuditSessions,
+    AuditSession,
+    AuditStats,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RouteSpec {
+    pub(crate) id: RouteId,
+    pub(crate) method: RouteMethod,
+    pub(crate) path: &'static str,
+    pub(crate) scope_policy: OAuthRouteScopePolicy,
+    pub(crate) surface: RouteSurface,
+    pub(crate) openapi_visibility: OpenApiVisibility,
+    pub(crate) audit_class: AuditClass,
+    pub(crate) auth: RouteAuth,
+    /// Preserve the exact legacy PAT compatibility exception for account:manage
+    /// routes without maintaining a second method/path allowlist.
+    pub(crate) pat_account_manage_compat: bool,
+}
+
+const fn route(
+    id: RouteId,
+    method: RouteMethod,
+    path: &'static str,
+    scope_policy: OAuthRouteScopePolicy,
+    surface: RouteSurface,
+    openapi_visibility: OpenApiVisibility,
+    audit_class: AuditClass,
+    auth: RouteAuth,
+    pat_account_manage_compat: bool,
+) -> RouteSpec {
+    RouteSpec {
+        id,
+        method,
+        path,
+        scope_policy,
+        surface,
+        openapi_visibility,
+        audit_class,
+        auth,
+        pat_account_manage_compat,
+    }
+}
+
+use AuditClass::*;
+use OAuthRouteScopePolicy::*;
+use OpenApiVisibility::*;
+use RouteAuth::{AuthMiddleware, HandlerManaged};
+use RouteId::*;
+use RouteMethod::*;
+use RouteSurface::*;
+
+pub(crate) const ROUTES: &[RouteSpec] = &[
+    route(
+        WellKnownProtectedResource,
+        Get,
+        "/.well-known/oauth-protected-resource",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        RouteAuth::Public,
+        false,
+    ),
+    route(
+        WellKnownAuthorizationServer,
+        Get,
+        "/.well-known/oauth-authorization-server",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        RouteAuth::Public,
+        false,
+    ),
+    route(
+        OAuthToken,
+        Post,
+        "/oauth/token",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        RouteAuth::Public,
+        false,
+    ),
+    route(
+        OAuthRevoke,
+        Post,
+        "/oauth/revoke",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        RouteAuth::Public,
+        false,
+    ),
+    route(
+        OAuthAuthorize,
+        Get,
+        "/oauth/authorize",
+        FirstPartyOnly,
+        OAuth,
+        Hidden,
+        Other,
+        HandlerManaged,
+        false,
+    ),
+    route(
+        OAuthAuthorizeLogin,
+        Post,
+        "/oauth/authorize/login",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        HandlerManaged,
+        false,
+    ),
+    route(
+        OAuthAuthorizeConsent,
+        Post,
+        "/oauth/authorize/consent",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        HandlerManaged,
+        false,
+    ),
+    route(
+        OAuthAuthorizeBridge,
+        Post,
+        "/oauth/authorize/bridge",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        HandlerManaged,
+        false,
+    ),
+    route(
+        OAuthAuthorizeProject,
+        Post,
+        "/oauth/authorize/project",
+        Public,
+        OAuth,
+        Hidden,
+        Other,
+        HandlerManaged,
+        false,
+    ),
+    route(
+        PairingEnroll,
+        Post,
+        "/api/pairing/enroll",
+        AgentSurface,
+        Pairing,
+        Hidden,
+        Other,
+        HandlerManaged,
+        false,
+    ),
+    route(
+        McpGet,
+        Get,
+        "/mcp",
+        Require(SCOPE_RUNTIME_READ),
+        Mcp,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        McpPost,
+        Post,
+        "/mcp",
+        BodyAware(OAuthBodyAwarePolicy::McpToolCall),
+        Mcp,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    // Project Connector. Four recovery/discovery routes historically had no
+    // ordinary delegated scope entry; BootstrapOnly makes that existing
+    // fail-closed behavior explicit while project-credential handling remains
+    // owned by the specialized Connector gate.
+    route(
+        ConnectorReadiness,
+        Post,
+        "/api/connector/readiness",
+        BootstrapOnly,
+        Connector,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorTaskStart,
+        Post,
+        "/api/connector/task/start",
+        Require(SCOPE_RUNTIME_READ),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorTaskList,
+        Post,
+        "/api/connector/task/list",
+        BootstrapOnly,
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorTaskResume,
+        Post,
+        "/api/connector/task/resume",
+        BootstrapOnly,
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorFilesList,
+        Post,
+        "/api/connector/files/list",
+        BootstrapOnly,
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorFilesRead,
+        Post,
+        "/api/connector/files/read",
+        Require(SCOPE_PROJECT_READ),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorFilesSearch,
+        Post,
+        "/api/connector/files/search",
+        Require(SCOPE_PROJECT_READ),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorCodeNavigate,
+        Post,
+        "/api/connector/code/navigate",
+        Require(SCOPE_PROJECT_READ),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorCodeImpact,
+        Post,
+        "/api/connector/code/impact",
+        Require(SCOPE_PROJECT_READ),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorEditsApply,
+        Post,
+        "/api/connector/edits/apply",
+        Require(SCOPE_PROJECT_WRITE),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorChecksRun,
+        Post,
+        "/api/connector/checks/run",
+        Require(SCOPE_JOB_RUN),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorCommandsRun,
+        Post,
+        "/api/connector/commands/run",
+        Require(SCOPE_JOB_RUN),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorTaskReview,
+        Post,
+        "/api/connector/task/review",
+        Require(SCOPE_PROJECT_READ),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorTaskCancel,
+        Post,
+        "/api/connector/task/cancel",
+        Require(SCOPE_JOB_RUN),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ConnectorTaskFinish,
+        Post,
+        "/api/connector/task/finish",
+        Require(SCOPE_PROJECT_WRITE),
+        Connector,
+        ConnectorActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    // Browser host console. These routes were deliberately reachable through
+    // the specialized project credential bypass and bootstrap, but had no
+    // ordinary route-scope entry. Preserve that exact production authority.
+    route(
+        HostConsoleReadiness,
+        Post,
+        "/api/console/readiness",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleTasks,
+        Post,
+        "/api/console/tasks",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleActivity,
+        Post,
+        "/api/console/activity",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleWorkflowSessions,
+        Post,
+        "/api/console/workflow-sessions",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleWorkflowSession,
+        Post,
+        "/api/console/workflow-session",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleTaskReview,
+        Post,
+        "/api/console/task/review",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleTaskCancel,
+        Post,
+        "/api/console/task/cancel",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleTaskGuide,
+        Post,
+        "/api/console/task/guide",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleApprovals,
+        Post,
+        "/api/console/approvals",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleApprovalDecide,
+        Post,
+        "/api/console/approval/decide",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleDevices,
+        Post,
+        "/api/console/devices",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleResultAccept,
+        Post,
+        "/api/console/result/accept",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleResultReject,
+        Post,
+        "/api/console/result/reject",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        HostConsoleConnect,
+        Post,
+        "/api/console/connect",
+        BootstrapOnly,
+        HostConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleOverview,
+        Post,
+        "/api/runtime-console/overview",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleRunner,
+        Post,
+        "/api/runtime-console/runner",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleProjects,
+        Post,
+        "/api/runtime-console/projects",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleWorkflowSessions,
+        Post,
+        "/api/runtime-console/workflow-sessions",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleWorkflowSession,
+        Post,
+        "/api/runtime-console/workflow-session",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleWorkflowSessionMessages,
+        Post,
+        "/api/runtime-console/workflow-session-messages",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleWorkflowSessionObserve,
+        Post,
+        "/api/runtime-console/workflow-session-observe",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleWorkflowSessionPostMessage,
+        Post,
+        "/api/runtime-console/workflow-session-post-message",
+        Require(SCOPE_SESSION_COLLABORATE),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleWorkflowSessionWithdrawMessage,
+        Post,
+        "/api/runtime-console/workflow-session-withdraw-message",
+        Require(SCOPE_SESSION_COLLABORATE),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeConsoleWorkflowSessionReplaceMessage,
+        Post,
+        "/api/runtime-console/workflow-session-replace-message",
+        Require(SCOPE_SESSION_COLLABORATE),
+        RuntimeConsole,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    // Admin handlers impose their own admin identity check. Production route
+    // scope previously admitted only bootstrap because these paths were unknown;
+    // keep that behavior explicit rather than widening authority in this cleanup.
+    route(
+        AdminDashboard,
+        Post,
+        "/api/admin/dashboard",
+        BootstrapOnly,
+        Admin,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AdminProjectsRegister,
+        Post,
+        "/api/admin/projects/register",
+        BootstrapOnly,
+        Admin,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AdminProjectsCreate,
+        Post,
+        "/api/admin/projects/create",
+        BootstrapOnly,
+        Admin,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AdminProjectsEnable,
+        Post,
+        "/api/admin/projects/enable",
+        BootstrapOnly,
+        Admin,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AdminProjectsDisable,
+        Post,
+        "/api/admin/projects/disable",
+        BootstrapOnly,
+        Admin,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AdminProjectsUnregister,
+        Post,
+        "/api/admin/projects/unregister",
+        BootstrapOnly,
+        Admin,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ToolsList,
+        Post,
+        "/api/tools/list",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        PublicActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ToolsCall,
+        Post,
+        "/api/tools/call",
+        BodyAware(OAuthBodyAwarePolicy::RuntimeToolCall),
+        RuntimeApi,
+        PublicActions,
+        Command,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ArtifactsImport,
+        Post,
+        "/api/artifacts/import",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Artifact,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        JobsStatus,
+        Post,
+        "/api/jobs/status",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        PublicActions,
+        Job,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        JobsLog,
+        Post,
+        "/api/jobs/log",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        PublicActions,
+        Job,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        JobsStop,
+        Post,
+        "/api/jobs/stop",
+        Require(SCOPE_JOB_RUN),
+        RuntimeApi,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        JobsList,
+        Post,
+        "/api/jobs/list",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        PublicActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        JobsTail,
+        Post,
+        "/api/jobs/tail",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        PublicActions,
+        Job,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsList,
+        Post,
+        "/api/projects/list",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Context,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsRegister,
+        Post,
+        "/api/projects/register",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsCreate,
+        Post,
+        "/api/projects/create",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsUnregister,
+        Post,
+        "/api/projects/unregister",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsReadFile,
+        Post,
+        "/api/projects/read_file",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Context,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsGitStatus,
+        Post,
+        "/api/projects/git_status",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Git,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsGitDiff,
+        Post,
+        "/api/projects/git_diff",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Git,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsGitDiffSummary,
+        Post,
+        "/api/projects/git_diff_summary",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Git,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsListFiles,
+        Post,
+        "/api/projects/list_files",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Context,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsSearchText,
+        Post,
+        "/api/projects/search_text",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Context,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsApplyPatch,
+        Post,
+        "/api/projects/apply_patch",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Edit,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsValidatePatch,
+        Post,
+        "/api/projects/validate_patch",
+        Require(SCOPE_PROJECT_READ),
+        RuntimeApi,
+        PublicActions,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsRunShell,
+        Post,
+        "/api/projects/run_shell",
+        Require(SCOPE_JOB_RUN),
+        RuntimeApi,
+        PublicActions,
+        Shell,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsApplyPatchChecked,
+        Post,
+        "/api/projects/apply_patch_checked",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Edit,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsDeleteFiles,
+        Post,
+        "/api/projects/delete_files",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Artifact,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsGitRestorePaths,
+        Post,
+        "/api/projects/git_restore_paths",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Artifact,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsDiscardUntracked,
+        Post,
+        "/api/projects/discard_untracked",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        PublicActions,
+        Artifact,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ProjectsRunJob,
+        Post,
+        "/api/projects/run_job",
+        Require(SCOPE_JOB_RUN),
+        RuntimeApi,
+        PublicActions,
+        Job,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        RuntimeStatus,
+        Post,
+        "/api/runtime/status",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        PublicActions,
+        Report,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        OAuthClientsCreate,
+        Post,
+        "/api/oauth/clients/create",
+        FirstPartyOnly,
+        OAuth,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        OAuthClientsList,
+        Post,
+        "/api/oauth/clients/list",
+        FirstPartyOnly,
+        OAuth,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        OAuthClientsUpdateScopes,
+        Post,
+        "/api/oauth/clients/update_scopes",
+        FirstPartyOnly,
+        OAuth,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        OAuthClientsRevoke,
+        Post,
+        "/api/oauth/clients/revoke",
+        FirstPartyOnly,
+        OAuth,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        OAuthSharedKeyClientProvision,
+        Post,
+        "/api/oauth/shared-key-client/provision",
+        Require(SCOPE_RUNTIME_READ),
+        OAuth,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        UsersCreate,
+        Post,
+        "/api/users/create",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountManagement,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        UsersList,
+        Post,
+        "/api/users/list",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountManagement,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        UsersMe,
+        Post,
+        "/api/users/me",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountControl,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        TokensCreate,
+        Post,
+        "/api/tokens/create",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountManagement,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        TokensRegisterHash,
+        Post,
+        "/api/tokens/register_hash",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountControl,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        TokensList,
+        Post,
+        "/api/tokens/list",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountControl,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        TokensRevoke,
+        Post,
+        "/api/tokens/revoke",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountControl,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        AgentTokensCreate,
+        Post,
+        "/api/agent-tokens/create",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountManagement,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        AgentTokensRegisterHash,
+        Post,
+        "/api/agent-tokens/register_hash",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountControl,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        AgentTokensList,
+        Post,
+        "/api/agent-tokens/list",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountManagement,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        AgentTokensRevoke,
+        Post,
+        "/api/agent-tokens/revoke",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        AccountManagement,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        PairingCreate,
+        Post,
+        "/api/pairing/create",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        Pairing,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        true,
+    ),
+    route(
+        ShellRun,
+        Post,
+        "/api/shell/run",
+        Require(SCOPE_JOB_RUN),
+        RuntimeApi,
+        Hidden,
+        Shell,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellFile,
+        Post,
+        "/api/shell/file",
+        Require(SCOPE_PROJECT_WRITE),
+        RuntimeApi,
+        Hidden,
+        Shell,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellJob,
+        Post,
+        "/api/shell/job",
+        Require(SCOPE_JOB_RUN),
+        RuntimeApi,
+        Hidden,
+        Shell,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellJobsStatus,
+        Post,
+        "/api/shell/jobs/status",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellJobsLog,
+        Post,
+        "/api/shell/jobs/log",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellJobsStop,
+        Post,
+        "/api/shell/jobs/stop",
+        Require(SCOPE_JOB_RUN),
+        RuntimeApi,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellJobsList,
+        Post,
+        "/api/shell/jobs/list",
+        Require(SCOPE_RUNTIME_READ),
+        RuntimeApi,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellAgentRegister,
+        Post,
+        "/api/shell/agent/register",
+        AgentSurface,
+        AgentTransport,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellAgentPoll,
+        Post,
+        "/api/shell/agent/poll",
+        AgentSurface,
+        AgentTransport,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellAgentResult,
+        Post,
+        "/api/shell/agent/result",
+        AgentSurface,
+        AgentTransport,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellAgentPersistentShellResult,
+        Post,
+        "/api/shell/agent/persistent_shell_result",
+        AgentSurface,
+        AgentTransport,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        ShellAgentJobUpdate,
+        Post,
+        "/api/shell/agent/job_update",
+        AgentSurface,
+        AgentTransport,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AgentsWs,
+        Get,
+        "/api/agents/ws",
+        AgentSurface,
+        AgentTransport,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AuditSessions,
+        Post,
+        "/api/audit/sessions",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        Audit,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AuditSession,
+        Post,
+        "/api/audit/session",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        Audit,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+    route(
+        AuditStats,
+        Post,
+        "/api/audit/stats",
+        Require(SCOPE_ACCOUNT_MANAGE),
+        Audit,
+        Hidden,
+        Other,
+        AuthMiddleware,
+        false,
+    ),
+];
+
+#[allow(dead_code)]
+pub(crate) fn routes() -> &'static [RouteSpec] {
+    ROUTES
+}
+
+pub(crate) fn spec(id: RouteId) -> &'static RouteSpec {
+    ROUTES
+        .iter()
+        .find(|spec| spec.id == id)
+        .unwrap_or_else(|| panic!("RouteId {id:?} has no canonical RouteSpec"))
+}
+
+pub(crate) fn path(id: RouteId) -> &'static str {
+    spec(id).path
+}
+
+/// Path relative to the production `/api` parent router.
+pub(crate) fn api_path(id: RouteId) -> &'static str {
+    spec(id)
+        .path
+        .strip_prefix("/api/")
+        .unwrap_or_else(|| panic!("RouteId {id:?} is not an /api route"))
+}
+
+/// Path relative to the root Salvo router.
+pub(crate) fn root_path(id: RouteId) -> &'static str {
+    spec(id).path.trim_start_matches('/')
+}
+
+/// Return one root-relative path after proving two method-specific specs share
+/// the same canonical path (used for one Salvo Router with GET + POST handlers).
+pub(crate) fn shared_root_path(first: RouteId, second: RouteId) -> &'static str {
+    let first_path = spec(first).path;
+    assert_eq!(first_path, spec(second).path, "shared route path mismatch");
+    first_path.trim_start_matches('/')
+}
+
+pub(crate) fn lookup(method: &str, path: &str) -> Option<&'static RouteSpec> {
+    let path = normalize_path(path);
+    ROUTES
+        .iter()
+        .find(|spec| spec.method.matches(method) && spec.path == path)
+}
+
+pub(crate) fn lookup_path(path: &str) -> Option<&'static RouteSpec> {
+    let path = normalize_path(path);
+    ROUTES.iter().find(|spec| spec.path == path)
+}
+
+pub(crate) fn path_has_surface(path: &str, surface: RouteSurface) -> bool {
+    let path = normalize_path(path);
+    ROUTES
+        .iter()
+        .any(|spec| spec.path == path && spec.surface == surface)
+}
+
+pub(crate) fn audit_class_for_path(path: &str) -> Option<AuditClass> {
+    lookup_path(path).map(|spec| spec.audit_class)
+}
+
+fn normalize_path(path: &str) -> String {
+    let path = path.trim();
+    let path = path.split('?').next().unwrap_or(path);
+    let path = if path.is_empty() { "/" } else { path };
+    let with_slash = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    if with_slash.len() > 1 {
+        with_slash.trim_end_matches('/').to_string()
+    } else {
+        with_slash
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn production_prefix(source: &'static str) -> &'static str {
+        source.split("#[cfg(test)]").next().unwrap_or(source)
+    }
+
+    fn mounted_route_sources() -> [&'static str; 5] {
+        [
+            include_str!("lib.rs"),
+            production_prefix(include_str!("connector_runtime/http.rs")),
+            production_prefix(include_str!("host_console_http.rs")),
+            production_prefix(include_str!("runtime_console_http.rs")),
+            production_prefix(include_str!("admin_http.rs")),
+        ]
+    }
+
+    fn exact_route_id_reference_count(source: &str, needle: &str) -> usize {
+        source
+            .match_indices(needle)
+            .filter(|(index, _)| {
+                source[*index + needle.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || ch == '_'))
+            })
+            .count()
+    }
+
+    #[test]
+    fn canonical_route_metadata_has_unique_method_path_pairs() {
+        let mut seen = BTreeSet::new();
+        let mut ids = BTreeSet::new();
+        for spec in routes() {
+            assert!(spec.path.starts_with('/'), "{:?}: {}", spec.id, spec.path);
+            assert!(
+                ids.insert(spec.id as usize),
+                "duplicate RouteId: {:?}",
+                spec.id
+            );
+            assert!(
+                seen.insert((spec.method as u8, spec.path)),
+                "duplicate canonical route metadata for {:?} {}",
+                spec.method,
+                spec.path
+            );
+        }
+        assert_eq!(lookup("GET", "/mcp").unwrap().id, McpGet);
+        assert_eq!(lookup("POST", "/mcp").unwrap().id, McpPost);
+    }
+
+    #[test]
+    fn canonical_lookup_normalizes_only_benign_request_path_variants() {
+        assert_eq!(
+            lookup(" post ", "api/runtime/status/?ignored=1")
+                .unwrap()
+                .id,
+            RuntimeStatus
+        );
+        assert!(lookup("GET", "/api/runtime/status").is_none());
+        assert!(lookup("POST", "/api/future/authenticated-route").is_none());
+        assert!(lookup("POST", "/api/runtime/status/extra").is_none());
+    }
+
+    #[test]
+    fn authenticated_mounts_reference_each_canonical_spec_exactly_once() {
+        let sources = mounted_route_sources();
+        let combined = sources.concat();
+        for spec in routes().iter().filter(|spec| spec.auth == AuthMiddleware) {
+            let needle = format!("RouteId::{:?}", spec.id);
+            assert_eq!(
+                exact_route_id_reference_count(&combined, &needle),
+                1,
+                "authenticated mount must reference {needle} exactly once"
+            );
+        }
+    }
+
+    #[test]
+    fn authenticated_mount_blocks_do_not_reintroduce_literal_route_paths() {
+        for (name, source) in [
+            (
+                "connector",
+                production_prefix(include_str!("connector_runtime/http.rs")),
+            ),
+            (
+                "host-console",
+                production_prefix(include_str!("host_console_http.rs")),
+            ),
+            (
+                "runtime-console",
+                production_prefix(include_str!("runtime_console_http.rs")),
+            ),
+            ("admin", production_prefix(include_str!("admin_http.rs"))),
+        ] {
+            assert!(
+                !source.contains("Router::with_path(\""),
+                "{name} authenticated mount reintroduced a literal route path"
+            );
+        }
+
+        let lib = include_str!("lib.rs");
+        assert_eq!(
+            lib.matches(".hoop(AuthMiddleware)").count(),
+            3,
+            "a new AuthMiddleware root must be covered by the canonical route inventory invariant"
+        );
+        let authed = lib
+            .split_once("let authed_api_router")
+            .unwrap()
+            .1
+            .split_once("let api_router")
+            .unwrap()
+            .0;
+        assert!(
+            !authed.contains("Router::with_path(\""),
+            "main authenticated /api mount reintroduced a literal route path"
+        );
+        let oauth_mcp = lib
+            .split_once("// OAuth2 token, revocation, and discovery endpoints")
+            .unwrap()
+            .1
+            .split_once("// Read-only audit query API")
+            .unwrap()
+            .0;
+        assert!(
+            !oauth_mcp.contains("Router::with_path(\""),
+            "OAuth/MCP mounts must use canonical RouteId-backed paths"
+        );
+        let audit = lib
+            .split_once("// Read-only audit query API")
+            .unwrap()
+            .1
+            .split_once("tracing::info!(\"Server started successfully!\")")
+            .unwrap()
+            .0;
+        assert!(
+            !audit.contains("Router::with_path(\""),
+            "audit authenticated mounts must use canonical RouteId-backed paths"
+        );
+    }
+
+    #[test]
+    fn runtime_console_mutations_are_never_runtime_read_routes() {
+        let mutations = [
+            RuntimeConsoleWorkflowSessionPostMessage,
+            RuntimeConsoleWorkflowSessionWithdrawMessage,
+            RuntimeConsoleWorkflowSessionReplaceMessage,
+        ];
+        for id in mutations {
+            assert_eq!(
+                spec(id).scope_policy,
+                Require(SCOPE_SESSION_COLLABORATE),
+                "{id:?} must retain mutation-capable Session authority"
+            );
+        }
+        for spec in routes()
+            .iter()
+            .filter(|spec| spec.surface == RuntimeConsole)
+        {
+            assert_eq!(spec.openapi_visibility, Hidden, "{:?}", spec.id);
+        }
+    }
+
+    #[test]
+    fn audit_class_is_unambiguous_per_canonical_path() {
+        let mut classes = BTreeMap::new();
+        for spec in routes() {
+            match classes.insert(spec.path, spec.audit_class) {
+                Some(existing) => assert_eq!(existing, spec.audit_class, "{}", spec.path),
+                None => {}
+            }
+        }
+    }
+
+    #[test]
+    fn audit_class_preserves_existing_http_stats_semantics() {
+        for (path, class) in [
+            ("/api/projects/apply_patch", Edit),
+            ("/api/projects/read_file", Context),
+            ("/api/projects/run_job", Job),
+            ("/api/tools/call", Command),
+            ("/api/runtime/status", Report),
+            ("/api/artifacts/import", Artifact),
+            ("/api/projects/git_diff", Git),
+            ("/api/projects/run_shell", Shell),
+        ] {
+            assert_eq!(audit_class_for_path(path), Some(class), "{path}");
+        }
+        assert_eq!(
+            audit_class_for_path("/api/connector/edits/apply"),
+            Some(Other)
+        );
+        assert_eq!(
+            audit_class_for_path("/api/runtime-console/projects"),
+            Some(Other)
+        );
+    }
+}

--- a/src/runtime_console_http.rs
+++ b/src/runtime_console_http.rs
@@ -35,24 +35,42 @@ const MAX_MESSAGE_LIMIT: usize = 100;
 const MAX_OBSERVATION_TOKEN_CHARS: usize = 192;
 
 pub(crate) fn routes() -> Router {
-    Router::with_path("runtime-console")
-        .push(Router::with_path("overview").post(overview))
-        .push(Router::with_path("runner").post(runner))
-        .push(Router::with_path("projects").post(projects))
-        .push(Router::with_path("workflow-sessions").post(workflow_sessions))
-        .push(Router::with_path("workflow-session").post(workflow_session))
-        .push(Router::with_path("workflow-session-messages").post(workflow_session_messages))
-        .push(Router::with_path("workflow-session-observe").post(workflow_session_observe))
+    use crate::route_metadata::{api_path, RouteId};
+    Router::new()
+        .push(Router::with_path(api_path(RouteId::RuntimeConsoleOverview)).post(overview))
+        .push(Router::with_path(api_path(RouteId::RuntimeConsoleRunner)).post(runner))
+        .push(Router::with_path(api_path(RouteId::RuntimeConsoleProjects)).post(projects))
         .push(
-            Router::with_path("workflow-session-post-message").post(workflow_session_post_message),
+            Router::with_path(api_path(RouteId::RuntimeConsoleWorkflowSessions))
+                .post(workflow_sessions),
         )
         .push(
-            Router::with_path("workflow-session-withdraw-message")
-                .post(workflow_session_withdraw_message),
+            Router::with_path(api_path(RouteId::RuntimeConsoleWorkflowSession))
+                .post(workflow_session),
         )
         .push(
-            Router::with_path("workflow-session-replace-message")
-                .post(workflow_session_replace_message),
+            Router::with_path(api_path(RouteId::RuntimeConsoleWorkflowSessionMessages))
+                .post(workflow_session_messages),
+        )
+        .push(
+            Router::with_path(api_path(RouteId::RuntimeConsoleWorkflowSessionObserve))
+                .post(workflow_session_observe),
+        )
+        .push(
+            Router::with_path(api_path(RouteId::RuntimeConsoleWorkflowSessionPostMessage))
+                .post(workflow_session_post_message),
+        )
+        .push(
+            Router::with_path(api_path(
+                RouteId::RuntimeConsoleWorkflowSessionWithdrawMessage,
+            ))
+            .post(workflow_session_withdraw_message),
+        )
+        .push(
+            Router::with_path(api_path(
+                RouteId::RuntimeConsoleWorkflowSessionReplaceMessage,
+            ))
+            .post(workflow_session_replace_message),
         )
 }
 
@@ -3038,10 +3056,11 @@ mod tests {
         assert!(body.contains("refresh retained messages before retrying"));
 
         let openapi = crate::openapi::build_openapi_spec();
-        for path in [
-            "/api/runtime-console/workflow-session-withdraw-message",
-            "/api/runtime-console/workflow-session-replace-message",
+        for id in [
+            crate::route_metadata::RouteId::RuntimeConsoleWorkflowSessionWithdrawMessage,
+            crate::route_metadata::RouteId::RuntimeConsoleWorkflowSessionReplaceMessage,
         ] {
+            let path = crate::route_metadata::path(id);
             assert!(
                 openapi["paths"].get(path).is_none(),
                 "{path} leaked into OpenAPI"

--- a/src/users_http.rs
+++ b/src/users_http.rs
@@ -2,9 +2,9 @@
 //!
 //! These are REST-only admin/self-management surfaces. They are intentionally
 //! **not** exposed in `/openapi.json` (GPT Actions) because token creation is
-//! sensitive and should be driven by an admin CLI/HTTP client, not a GPT. The
-//! paths are listed in `LEGACY_FORBIDDEN_PATHS` so tests catch accidental
-//! OpenAPI inclusion. All endpoints sit behind the shared `AuthMiddleware`
+//! sensitive and should be driven by an admin CLI/HTTP client, not a GPT. Their
+//! canonical `RouteSpec` entries are `Hidden`, and OpenAPI tests derive the
+//! exclusion invariant from that metadata. All endpoints sit behind `AuthMiddleware`
 //! (Bearer auth) and resolve the caller's [`AuthContext`] to enforce the
 //! admin/bootstrap-or-self boundary.
 //!


### PR DESCRIPTION
## Summary

- add a canonical typed `RouteSpec` registry for HTTP route metadata
- derive auth scope policy, route surfaces, OpenAPI visibility, Connector paths, and audit classification from that registry while keeping handler mounting explicit
- preserve existing bootstrap-only, PAT account-management compatibility, Runtime Console collaboration scopes, and historical audit statistics semantics
- preserve exact path matching for credential/surface allowlists so RouteSpec adoption does not introduce trailing-slash aliases

## Validation

- `cargo fmt -- --check`
- RouteSpec invariants: 7/7 passed
- OAuth route policy tests: 12/12 passed
- `cargo check --all-targets`: passed with 0 errors / 0 warnings
- rebased cleanly onto `main@9210e9b0342517ba7af15b2078ee708d49f96724` (`v0.3.9`)

No handler framework or routing DSL is introduced; Salvo route mounting remains explicit.