### PR TITLE
Classify Runner capability semantics

### DIFF
--- a/src/shell_client/agents.rs
+++ b/src/shell_client/agents.rs
@@ -16,8 +16,8 @@ use super::validation::{
     validate_optional_field, validate_project_summary_batch,
 };
 use super::{
-    now_ts, AgentTransport, ShellClientRegistry, CLIENT_ONLINE_WINDOW_SECS,
-    MAX_RETIRED_INSTANCES_PER_CLIENT,
+    now_ts, AgentTransport, RunnerFeature, RunnerFeatureSet, ShellClientRegistry,
+    CLIENT_ONLINE_WINDOW_SECS, MAX_RETIRED_INSTANCES_PER_CLIENT,
 };
 use crate::mcp_gateway::validate_providers;
 use crate::shell_protocol::{
@@ -107,6 +107,25 @@ fn validate_coding_agent_registration(
                 .to_string(),
         ),
     }
+}
+
+fn reject_same_instance_feature_downgrade(
+    existing: Option<&ShellClientRecord>,
+    agent_instance_id: &str,
+    incoming: &RunnerFeatureSet,
+    feature: RunnerFeature,
+) -> Result<(), String> {
+    if existing.is_some_and(|existing| {
+        existing.agent_instance_id == agent_instance_id
+            && existing.runner_features.supports(feature)
+            && !incoming.supports(feature)
+    }) {
+        return Err(format!(
+            "same runner instance cannot downgrade {} capability",
+            feature.as_wire_name()
+        ));
+    }
+    Ok(())
 }
 
 struct StreamingSessionRegistration {
@@ -229,12 +248,13 @@ impl ShellClientRegistry {
         let client_id = body.client_id.trim().to_string();
         let agent_instance_id = body.agent_instance_id.trim().to_string();
         let capabilities = body.capabilities.clone().unwrap_or_default();
+        let runner_features = RunnerFeatureSet::from_wire(&capabilities);
         let job_inventory = body.job_inventory.clone();
         let coding_agent_providers = body.coding_agent_providers.clone();
         let coding_agent_inventory = body.coding_agent_inventory.clone();
         validate_coding_agent_registration(
             &client_id,
-            capabilities.coding_agent_runs,
+            runner_features.supports(RunnerFeature::CodingAgentRuns),
             coding_agent_providers.as_deref(),
             coding_agent_inventory.as_ref(),
         )?;
@@ -293,6 +313,7 @@ impl ShellClientRegistry {
             hostname: trim_string(body.hostname),
             host_context,
             capabilities: capabilities.clone(),
+            runner_features: runner_features.clone(),
             projects,
             project_inventory,
             last_seen: now,
@@ -318,7 +339,7 @@ impl ShellClientRegistry {
             projected_structured_terminal_suppressions: VecDeque::new(),
         };
         match (
-            capabilities.job_state_reconciliation,
+            runner_features.supports(RunnerFeature::JobStateReconciliation),
             job_inventory.as_ref(),
         ) {
             (true, Some(inventory)) => {
@@ -403,25 +424,18 @@ impl ShellClientRegistry {
                 client_id
             ));
         }
-        if inner.clients.get(&client_id).is_some_and(|existing| {
-            existing.agent_instance_id == agent_instance_id
-                && existing.capabilities.job_state_reconciliation
-                && !capabilities.job_state_reconciliation
-        }) {
-            return Err(
-                "same runner instance cannot downgrade job_state_reconciliation capability"
-                    .to_string(),
-            );
-        }
-        if inner.clients.get(&client_id).is_some_and(|existing| {
-            existing.agent_instance_id == agent_instance_id
-                && existing.capabilities.coding_agent_runs
-                && !capabilities.coding_agent_runs
-        }) {
-            return Err(
-                "same runner instance cannot downgrade coding_agent_runs capability".to_string(),
-            );
-        }
+        reject_same_instance_feature_downgrade(
+            inner.clients.get(&client_id),
+            &agent_instance_id,
+            &runner_features,
+            RunnerFeature::JobStateReconciliation,
+        )?;
+        reject_same_instance_feature_downgrade(
+            inner.clients.get(&client_id),
+            &agent_instance_id,
+            &runner_features,
+            RunnerFeature::CodingAgentRuns,
+        )?;
         if inner.clients.get(&client_id).is_some_and(|existing| {
             existing.agent_instance_id == agent_instance_id
                 && existing.coding_agent_providers != coding_agent_providers
@@ -437,42 +451,30 @@ impl ShellClientRegistry {
         // the current record so a queued structured delete is never handed to a
         // registration that cannot understand it. false -> false, false -> true
         // and true -> true reconnects remain allowed.
-        if inner.clients.get(&client_id).is_some_and(|existing| {
-            existing.agent_instance_id == agent_instance_id
-                && existing.capabilities.structured_file_delete
-                && !capabilities.structured_file_delete
-        }) {
-            return Err(
-                "same runner instance cannot downgrade structured_file_delete capability"
-                    .to_string(),
-            );
-        }
+        reject_same_instance_feature_downgrade(
+            inner.clients.get(&client_id),
+            &agent_instance_id,
+            &runner_features,
+            RunnerFeature::StructuredFileDelete,
+        )?;
         // Occurrence enforcement is effect semantics, not optional response
         // metadata. A same-process reconnect cannot withdraw it while an
         // occurrence-bearing edit admitted for that process may still be queued.
-        if inner.clients.get(&client_id).is_some_and(|existing| {
-            existing.agent_instance_id == agent_instance_id
-                && existing.capabilities.apply_text_edit_occurrence
-                && !capabilities.apply_text_edit_occurrence
-        }) {
-            return Err(
-                "same runner instance cannot downgrade apply_text_edit_occurrence capability"
-                    .to_string(),
-            );
-        }
+        reject_same_instance_feature_downgrade(
+            inner.clients.get(&client_id),
+            &agent_instance_id,
+            &runner_features,
+            RunnerFeature::ApplyTextEditOccurrence,
+        )?;
         // The dedicated internal-POSIX request kind is also binary support.
         // A same-process reconnect cannot withdraw it while queued requests may
         // still target that exact instance.
-        if inner.clients.get(&client_id).is_some_and(|existing| {
-            existing.agent_instance_id == agent_instance_id
-                && existing.capabilities.internal_posix_script
-                && !capabilities.internal_posix_script
-        }) {
-            return Err(
-                "same runner instance cannot downgrade internal_posix_script capability"
-                    .to_string(),
-            );
-        }
+        reject_same_instance_feature_downgrade(
+            inner.clients.get(&client_id),
+            &agent_instance_id,
+            &runner_features,
+            RunnerFeature::InternalPosixScript,
+        )?;
         if inner.clients.get(&client_id).is_some_and(|existing| {
             existing.agent_instance_id == agent_instance_id
                 && existing
@@ -491,26 +493,18 @@ impl ShellClientRegistry {
         // This optimized export request kind is process-lifetime binary support.
         // Reject same-instance downgrade so a request already admitted for this
         // process is never handed to a registration claiming it cannot decode it.
-        if inner.clients.get(&client_id).is_some_and(|existing| {
-            existing.agent_instance_id == agent_instance_id
-                && existing.capabilities.artifact_export_chunk_read
-                && !capabilities.artifact_export_chunk_read
-        }) {
-            return Err(
-                "same runner instance cannot downgrade artifact_export_chunk_read capability"
-                    .to_string(),
-            );
-        }
-        if inner.clients.get(&client_id).is_some_and(|existing| {
-            existing.agent_instance_id == agent_instance_id
-                && existing.capabilities.artifact_export_streaming_metadata
-                && !capabilities.artifact_export_streaming_metadata
-        }) {
-            return Err(
-                "same runner instance cannot downgrade artifact_export_streaming_metadata capability"
-                    .to_string(),
-            );
-        }
+        reject_same_instance_feature_downgrade(
+            inner.clients.get(&client_id),
+            &agent_instance_id,
+            &runner_features,
+            RunnerFeature::ArtifactExportChunkRead,
+        )?;
+        reject_same_instance_feature_downgrade(
+            inner.clients.get(&client_id),
+            &agent_instance_id,
+            &runner_features,
+            RunnerFeature::ArtifactExportStreamingMetadata,
+        )?;
         // Enforce the agent instance lease. `client_id` is the unique active
         // agent identity: at most one agent process may be online for it at a
         // time.

--- a/src/shell_client/capabilities.rs
+++ b/src/shell_client/capabilities.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeSet;
 ///
 /// These identities never infer support from protocol generation, transport,
 /// host OS, or any other Server-side observation. A feature enters
-/// [`RunnerFeatureSet`] only when the accepted registration explicitly
-/// advertises its corresponding legacy wire boolean.
+/// [`RunnerFeatureSet`] only through the accepted registration's effective wire
+/// semantics, including the historical `shell` missing-field default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum RunnerFeature {
     Shell,
@@ -107,7 +107,7 @@ const ALL_RUNNER_FEATURES: [RunnerFeature; 46] = [
 ];
 
 /// Whether a feature could ever become a frozen protocol-generation baseline,
-/// or must permanently depend on explicit Runner advertisement.
+/// or must permanently depend on accepted Runner registration semantics.
 ///
 /// `GenerationEligible` is classification only. C3a defines no generation
 /// baseline and grants no feature merely because a Runner uses a supported
@@ -116,7 +116,7 @@ const ALL_RUNNER_FEATURES: [RunnerFeature; 46] = [
 #[allow(dead_code)]
 pub(crate) enum RunnerFeatureInference {
     GenerationEligible,
-    ExplicitOnly,
+    RegistrationRequired,
 }
 
 impl RunnerFeature {
@@ -329,7 +329,7 @@ impl RunnerFeature {
             | Self::ComputerScrollToElement
             | Self::ComputerKeyInput
             | Self::ComputerWindowActivate
-            | Self::ComputerTextInput => RunnerFeatureInference::ExplicitOnly,
+            | Self::ComputerTextInput => RunnerFeatureInference::RegistrationRequired,
         }
     }
 
@@ -393,24 +393,25 @@ impl RunnerFeature {
 ///
 /// There is intentionally no public mutation API. Every set is rebuilt from the
 /// corresponding immutable wire snapshot at registration ingress, so canonical
-/// semantics cannot acquire features independently from Runner advertisement.
+/// semantics cannot acquire features independently from accepted registration
+/// semantics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RunnerFeatureSet {
-    explicit_features: BTreeSet<RunnerFeature>,
+    effective_features: BTreeSet<RunnerFeature>,
 }
 
 impl RunnerFeatureSet {
     pub(crate) fn from_wire(capabilities: &ShellClientCapabilities) -> Self {
-        let explicit_features = RunnerFeature::all()
+        let effective_features = RunnerFeature::all()
             .iter()
             .copied()
             .filter(|feature| feature.advertised_by(capabilities))
             .collect();
-        Self { explicit_features }
+        Self { effective_features }
     }
 
     pub(crate) fn supports(&self, feature: RunnerFeature) -> bool {
-        self.explicit_features.contains(&feature)
+        self.effective_features.contains(&feature)
     }
 
     pub(crate) fn supports_wire_name(&self, capability: &str) -> bool {

--- a/src/shell_client/capabilities.rs
+++ b/src/shell_client/capabilities.rs
@@ -1,0 +1,419 @@
+use crate::shell_protocol::{self as wire, ShellClientCapabilities};
+use std::collections::BTreeSet;
+
+/// Canonical Server-side identity for one Runner-advertised wire capability.
+///
+/// These identities never infer support from protocol generation, transport,
+/// host OS, or any other Server-side observation. A feature enters
+/// [`RunnerFeatureSet`] only when the accepted registration explicitly
+/// advertises its corresponding legacy wire boolean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum RunnerFeature {
+    Shell,
+    FileRead,
+    FileWrite,
+    ArtifactExportChunkRead,
+    ArtifactExportStreamingMetadata,
+    StructuredFileDelete,
+    ApplyTextEditOccurrence,
+    Git,
+    Jobs,
+    AsyncJobs,
+    AsyncShellJobs,
+    SshShell,
+    PersistentShell,
+    SshPersistentShell,
+    StructuredValidationArgv,
+    StructuredCargoTestCountAssertion,
+    StructuredGoTestJson,
+    StructuredGoTestTool,
+    StructuredGoTestPackages,
+    StructuredProcessArgv,
+    StructuredScriptPayload,
+    InternalPosixScript,
+    StructuredExecutionJobs,
+    DetachedProcessJobs,
+    LspReadOnlyNavigation,
+    LspCallHierarchy,
+    SandboxInspectCommands,
+    ProjectLifecycle,
+    ProjectPathRegistration,
+    ComputerObserve,
+    ComputerApplicationDiscovery,
+    ComputerApplicationLaunch,
+    ComputerDisplayObserve,
+    ComputerPointerControl,
+    ComputerClipboardRead,
+    ComputerClipboardWrite,
+    ComputerSnapshotRegion,
+    ComputerAccessibilityObserve,
+    ComputerElementState,
+    JobStateReconciliation,
+    CodingAgentRuns,
+    ComputerControl,
+    ComputerScrollToElement,
+    ComputerKeyInput,
+    ComputerWindowActivate,
+    ComputerTextInput,
+}
+
+const ALL_RUNNER_FEATURES: [RunnerFeature; 46] = [
+    RunnerFeature::Shell,
+    RunnerFeature::FileRead,
+    RunnerFeature::FileWrite,
+    RunnerFeature::ArtifactExportChunkRead,
+    RunnerFeature::ArtifactExportStreamingMetadata,
+    RunnerFeature::StructuredFileDelete,
+    RunnerFeature::ApplyTextEditOccurrence,
+    RunnerFeature::Git,
+    RunnerFeature::Jobs,
+    RunnerFeature::AsyncJobs,
+    RunnerFeature::AsyncShellJobs,
+    RunnerFeature::SshShell,
+    RunnerFeature::PersistentShell,
+    RunnerFeature::SshPersistentShell,
+    RunnerFeature::StructuredValidationArgv,
+    RunnerFeature::StructuredCargoTestCountAssertion,
+    RunnerFeature::StructuredGoTestJson,
+    RunnerFeature::StructuredGoTestTool,
+    RunnerFeature::StructuredGoTestPackages,
+    RunnerFeature::StructuredProcessArgv,
+    RunnerFeature::StructuredScriptPayload,
+    RunnerFeature::InternalPosixScript,
+    RunnerFeature::StructuredExecutionJobs,
+    RunnerFeature::DetachedProcessJobs,
+    RunnerFeature::LspReadOnlyNavigation,
+    RunnerFeature::LspCallHierarchy,
+    RunnerFeature::SandboxInspectCommands,
+    RunnerFeature::ProjectLifecycle,
+    RunnerFeature::ProjectPathRegistration,
+    RunnerFeature::ComputerObserve,
+    RunnerFeature::ComputerApplicationDiscovery,
+    RunnerFeature::ComputerApplicationLaunch,
+    RunnerFeature::ComputerDisplayObserve,
+    RunnerFeature::ComputerPointerControl,
+    RunnerFeature::ComputerClipboardRead,
+    RunnerFeature::ComputerClipboardWrite,
+    RunnerFeature::ComputerSnapshotRegion,
+    RunnerFeature::ComputerAccessibilityObserve,
+    RunnerFeature::ComputerElementState,
+    RunnerFeature::JobStateReconciliation,
+    RunnerFeature::CodingAgentRuns,
+    RunnerFeature::ComputerControl,
+    RunnerFeature::ComputerScrollToElement,
+    RunnerFeature::ComputerKeyInput,
+    RunnerFeature::ComputerWindowActivate,
+    RunnerFeature::ComputerTextInput,
+];
+
+/// Whether a feature could ever become a frozen protocol-generation baseline,
+/// or must permanently depend on explicit Runner advertisement.
+///
+/// `GenerationEligible` is classification only. C3a defines no generation
+/// baseline and grants no feature merely because a Runner uses a supported
+/// protocol generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum RunnerFeatureInference {
+    GenerationEligible,
+    ExplicitOnly,
+}
+
+impl RunnerFeature {
+    pub(crate) const fn all() -> &'static [Self] {
+        &ALL_RUNNER_FEATURES
+    }
+
+    pub(crate) const fn as_wire_name(self) -> &'static str {
+        match self {
+            Self::Shell => wire::SHELL_CLIENT_CAPABILITY_SHELL,
+            Self::FileRead => wire::SHELL_CLIENT_CAPABILITY_FILE_READ,
+            Self::FileWrite => wire::SHELL_CLIENT_CAPABILITY_FILE_WRITE,
+            Self::ArtifactExportChunkRead => {
+                wire::SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ
+            }
+            Self::ArtifactExportStreamingMetadata => {
+                wire::SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA
+            }
+            Self::StructuredFileDelete => wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_FILE_DELETE,
+            Self::ApplyTextEditOccurrence => {
+                wire::SHELL_CLIENT_CAPABILITY_APPLY_TEXT_EDIT_OCCURRENCE
+            }
+            Self::Git => wire::SHELL_CLIENT_CAPABILITY_GIT,
+            Self::Jobs => wire::SHELL_CLIENT_CAPABILITY_JOBS,
+            Self::AsyncJobs => wire::SHELL_CLIENT_CAPABILITY_ASYNC_JOBS,
+            Self::AsyncShellJobs => wire::SHELL_CLIENT_CAPABILITY_ASYNC_SHELL_JOBS,
+            Self::SshShell => wire::SHELL_CLIENT_CAPABILITY_SSH_SHELL,
+            Self::PersistentShell => wire::SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL,
+            Self::SshPersistentShell => wire::SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL,
+            Self::StructuredValidationArgv => {
+                wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_VALIDATION_ARGV
+            }
+            Self::StructuredCargoTestCountAssertion => {
+                wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_CARGO_TEST_COUNT_ASSERTION
+            }
+            Self::StructuredGoTestJson => wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_JSON,
+            Self::StructuredGoTestTool => wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_TOOL,
+            Self::StructuredGoTestPackages => {
+                wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_PACKAGES
+            }
+            Self::StructuredProcessArgv => wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV,
+            Self::StructuredScriptPayload => {
+                wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD
+            }
+            Self::InternalPosixScript => wire::SHELL_CLIENT_CAPABILITY_INTERNAL_POSIX_SCRIPT,
+            Self::StructuredExecutionJobs => {
+                wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_EXECUTION_JOBS
+            }
+            Self::DetachedProcessJobs => wire::SHELL_CLIENT_CAPABILITY_DETACHED_PROCESS_JOBS,
+            Self::LspReadOnlyNavigation => wire::SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION,
+            Self::LspCallHierarchy => wire::SHELL_CLIENT_CAPABILITY_LSP_CALL_HIERARCHY,
+            Self::SandboxInspectCommands => wire::SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS,
+            Self::ProjectLifecycle => wire::SHELL_CLIENT_CAPABILITY_PROJECT_LIFECYCLE,
+            Self::ProjectPathRegistration => {
+                wire::SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION
+            }
+            Self::ComputerObserve => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE,
+            Self::ComputerApplicationDiscovery => {
+                wire::SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY
+            }
+            Self::ComputerApplicationLaunch => {
+                wire::SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH
+            }
+            Self::ComputerDisplayObserve => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE,
+            Self::ComputerPointerControl => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL,
+            Self::ComputerClipboardRead => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ,
+            Self::ComputerClipboardWrite => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE,
+            Self::ComputerSnapshotRegion => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION,
+            Self::ComputerAccessibilityObserve => {
+                wire::SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE
+            }
+            Self::ComputerElementState => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE,
+            Self::JobStateReconciliation => wire::SHELL_CLIENT_CAPABILITY_JOB_STATE_RECONCILIATION,
+            Self::CodingAgentRuns => wire::SHELL_CLIENT_CAPABILITY_CODING_AGENT_RUNS,
+            Self::ComputerControl => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL,
+            Self::ComputerScrollToElement => {
+                wire::SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT
+            }
+            Self::ComputerKeyInput => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT,
+            Self::ComputerWindowActivate => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE,
+            Self::ComputerTextInput => wire::SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT,
+        }
+    }
+
+    pub(crate) fn from_wire_name(name: &str) -> Option<Self> {
+        Some(match name {
+            wire::SHELL_CLIENT_CAPABILITY_SHELL => Self::Shell,
+            wire::SHELL_CLIENT_CAPABILITY_FILE_READ => Self::FileRead,
+            wire::SHELL_CLIENT_CAPABILITY_FILE_WRITE => Self::FileWrite,
+            wire::SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ => {
+                Self::ArtifactExportChunkRead
+            }
+            wire::SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA => {
+                Self::ArtifactExportStreamingMetadata
+            }
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_FILE_DELETE => Self::StructuredFileDelete,
+            wire::SHELL_CLIENT_CAPABILITY_APPLY_TEXT_EDIT_OCCURRENCE => {
+                Self::ApplyTextEditOccurrence
+            }
+            wire::SHELL_CLIENT_CAPABILITY_GIT => Self::Git,
+            wire::SHELL_CLIENT_CAPABILITY_JOBS => Self::Jobs,
+            wire::SHELL_CLIENT_CAPABILITY_ASYNC_JOBS => Self::AsyncJobs,
+            wire::SHELL_CLIENT_CAPABILITY_ASYNC_SHELL_JOBS => Self::AsyncShellJobs,
+            wire::SHELL_CLIENT_CAPABILITY_SSH_SHELL => Self::SshShell,
+            wire::SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL => Self::PersistentShell,
+            wire::SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL => Self::SshPersistentShell,
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_VALIDATION_ARGV => {
+                Self::StructuredValidationArgv
+            }
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_CARGO_TEST_COUNT_ASSERTION => {
+                Self::StructuredCargoTestCountAssertion
+            }
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_JSON => Self::StructuredGoTestJson,
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_TOOL => Self::StructuredGoTestTool,
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_PACKAGES => {
+                Self::StructuredGoTestPackages
+            }
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV => Self::StructuredProcessArgv,
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD => {
+                Self::StructuredScriptPayload
+            }
+            wire::SHELL_CLIENT_CAPABILITY_INTERNAL_POSIX_SCRIPT => Self::InternalPosixScript,
+            wire::SHELL_CLIENT_CAPABILITY_STRUCTURED_EXECUTION_JOBS => {
+                Self::StructuredExecutionJobs
+            }
+            wire::SHELL_CLIENT_CAPABILITY_DETACHED_PROCESS_JOBS => Self::DetachedProcessJobs,
+            wire::SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION => Self::LspReadOnlyNavigation,
+            wire::SHELL_CLIENT_CAPABILITY_LSP_CALL_HIERARCHY => Self::LspCallHierarchy,
+            wire::SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS => Self::SandboxInspectCommands,
+            wire::SHELL_CLIENT_CAPABILITY_PROJECT_LIFECYCLE => Self::ProjectLifecycle,
+            wire::SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION => {
+                Self::ProjectPathRegistration
+            }
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE => Self::ComputerObserve,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY => {
+                Self::ComputerApplicationDiscovery
+            }
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH => {
+                Self::ComputerApplicationLaunch
+            }
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE => Self::ComputerDisplayObserve,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL => Self::ComputerPointerControl,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ => Self::ComputerClipboardRead,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE => Self::ComputerClipboardWrite,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION => Self::ComputerSnapshotRegion,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE => {
+                Self::ComputerAccessibilityObserve
+            }
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE => Self::ComputerElementState,
+            wire::SHELL_CLIENT_CAPABILITY_JOB_STATE_RECONCILIATION => Self::JobStateReconciliation,
+            wire::SHELL_CLIENT_CAPABILITY_CODING_AGENT_RUNS => Self::CodingAgentRuns,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL => Self::ComputerControl,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT => {
+                Self::ComputerScrollToElement
+            }
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT => Self::ComputerKeyInput,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE => Self::ComputerWindowActivate,
+            wire::SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT => Self::ComputerTextInput,
+            _ => return None,
+        })
+    }
+
+    /// Classification only; this method is deliberately not consulted by
+    /// [`RunnerFeatureSet::from_wire`].
+    #[allow(dead_code)]
+    pub(crate) const fn inference(self) -> RunnerFeatureInference {
+        match self {
+            Self::FileRead
+            | Self::FileWrite
+            | Self::ArtifactExportChunkRead
+            | Self::ArtifactExportStreamingMetadata
+            | Self::StructuredFileDelete
+            | Self::ApplyTextEditOccurrence
+            | Self::Jobs
+            | Self::AsyncJobs
+            | Self::AsyncShellJobs
+            | Self::StructuredValidationArgv
+            | Self::StructuredCargoTestCountAssertion
+            | Self::StructuredGoTestJson
+            | Self::StructuredGoTestTool
+            | Self::StructuredGoTestPackages
+            | Self::StructuredProcessArgv
+            | Self::StructuredScriptPayload
+            | Self::InternalPosixScript
+            | Self::StructuredExecutionJobs
+            | Self::LspReadOnlyNavigation
+            | Self::LspCallHierarchy
+            | Self::ProjectLifecycle
+            | Self::ProjectPathRegistration => RunnerFeatureInference::GenerationEligible,
+            Self::Shell
+            | Self::Git
+            | Self::SshShell
+            | Self::PersistentShell
+            | Self::SshPersistentShell
+            | Self::DetachedProcessJobs
+            | Self::SandboxInspectCommands
+            | Self::ComputerObserve
+            | Self::ComputerApplicationDiscovery
+            | Self::ComputerApplicationLaunch
+            | Self::ComputerDisplayObserve
+            | Self::ComputerPointerControl
+            | Self::ComputerClipboardRead
+            | Self::ComputerClipboardWrite
+            | Self::ComputerSnapshotRegion
+            | Self::ComputerAccessibilityObserve
+            | Self::ComputerElementState
+            | Self::JobStateReconciliation
+            | Self::CodingAgentRuns
+            | Self::ComputerControl
+            | Self::ComputerScrollToElement
+            | Self::ComputerKeyInput
+            | Self::ComputerWindowActivate
+            | Self::ComputerTextInput => RunnerFeatureInference::ExplicitOnly,
+        }
+    }
+
+    fn advertised_by(self, capabilities: &ShellClientCapabilities) -> bool {
+        match self {
+            Self::Shell => capabilities.shell,
+            Self::FileRead => capabilities.file_read,
+            Self::FileWrite => capabilities.file_write,
+            Self::ArtifactExportChunkRead => capabilities.artifact_export_chunk_read,
+            Self::ArtifactExportStreamingMetadata => {
+                capabilities.artifact_export_streaming_metadata
+            }
+            Self::StructuredFileDelete => capabilities.structured_file_delete,
+            Self::ApplyTextEditOccurrence => capabilities.apply_text_edit_occurrence,
+            Self::Git => capabilities.git,
+            Self::Jobs => capabilities.jobs,
+            Self::AsyncJobs => capabilities.async_jobs,
+            Self::AsyncShellJobs => capabilities.async_shell_jobs,
+            Self::SshShell => capabilities.ssh_shell,
+            Self::PersistentShell => capabilities.persistent_shell,
+            Self::SshPersistentShell => capabilities.ssh_persistent_shell,
+            Self::StructuredValidationArgv => capabilities.structured_validation_argv,
+            Self::StructuredCargoTestCountAssertion => {
+                capabilities.structured_cargo_test_count_assertion
+            }
+            Self::StructuredGoTestJson => capabilities.structured_go_test_json,
+            Self::StructuredGoTestTool => capabilities.structured_go_test_tool,
+            Self::StructuredGoTestPackages => capabilities.structured_go_test_packages,
+            Self::StructuredProcessArgv => capabilities.structured_process_argv,
+            Self::StructuredScriptPayload => capabilities.structured_script_payload,
+            Self::InternalPosixScript => capabilities.internal_posix_script,
+            Self::StructuredExecutionJobs => capabilities.structured_execution_jobs,
+            Self::DetachedProcessJobs => capabilities.detached_process_jobs,
+            Self::LspReadOnlyNavigation => capabilities.lsp_read_only_navigation,
+            Self::LspCallHierarchy => capabilities.lsp_call_hierarchy,
+            Self::SandboxInspectCommands => capabilities.sandbox_inspect_commands,
+            Self::ProjectLifecycle => capabilities.project_lifecycle,
+            Self::ProjectPathRegistration => capabilities.project_path_registration,
+            Self::ComputerObserve => capabilities.computer_observe,
+            Self::ComputerApplicationDiscovery => capabilities.computer_application_discovery,
+            Self::ComputerApplicationLaunch => capabilities.computer_application_launch,
+            Self::ComputerDisplayObserve => capabilities.computer_display_observe,
+            Self::ComputerPointerControl => capabilities.computer_pointer_control,
+            Self::ComputerClipboardRead => capabilities.computer_clipboard_read,
+            Self::ComputerClipboardWrite => capabilities.computer_clipboard_write,
+            Self::ComputerSnapshotRegion => capabilities.computer_snapshot_region,
+            Self::ComputerAccessibilityObserve => capabilities.computer_accessibility_observe,
+            Self::ComputerElementState => capabilities.computer_element_state,
+            Self::JobStateReconciliation => capabilities.job_state_reconciliation,
+            Self::CodingAgentRuns => capabilities.coding_agent_runs,
+            Self::ComputerControl => capabilities.computer_control,
+            Self::ComputerScrollToElement => capabilities.computer_scroll_to_element,
+            Self::ComputerKeyInput => capabilities.computer_key_input,
+            Self::ComputerWindowActivate => capabilities.computer_window_activate,
+            Self::ComputerTextInput => capabilities.computer_text_input,
+        }
+    }
+}
+
+/// Canonical Server-side capability truth for one accepted Runner registration.
+///
+/// There is intentionally no public mutation API. Every set is rebuilt from the
+/// corresponding immutable wire snapshot at registration ingress, so canonical
+/// semantics cannot acquire features independently from Runner advertisement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RunnerFeatureSet {
+    explicit_features: BTreeSet<RunnerFeature>,
+}
+
+impl RunnerFeatureSet {
+    pub(crate) fn from_wire(capabilities: &ShellClientCapabilities) -> Self {
+        let explicit_features = RunnerFeature::all()
+            .iter()
+            .copied()
+            .filter(|feature| feature.advertised_by(capabilities))
+            .collect();
+        Self { explicit_features }
+    }
+
+    pub(crate) fn supports(&self, feature: RunnerFeature) -> bool {
+        self.explicit_features.contains(&feature)
+    }
+
+    pub(crate) fn supports_wire_name(&self, capability: &str) -> bool {
+        RunnerFeature::from_wire_name(capability).is_some_and(|feature| self.supports(feature))
+    }
+}

--- a/src/shell_client/mod.rs
+++ b/src/shell_client/mod.rs
@@ -25,6 +25,7 @@ use tokio::sync::Notify;
 
 mod agents;
 mod auth;
+mod capabilities;
 mod handlers;
 mod job_updates;
 mod jobs;
@@ -46,6 +47,9 @@ pub(crate) use auth::{
     effective_register_owner, enforce_agent_transport, enforce_register_owner,
     requested_by_from_auth, require_agent_transport_scope,
 };
+#[cfg(test)]
+pub(crate) use capabilities::RunnerFeatureInference;
+pub(crate) use capabilities::{RunnerFeature, RunnerFeatureSet};
 pub use handlers::{
     shell_agent_job_update, shell_agent_persistent_shell_result, shell_agent_poll,
     shell_agent_register, shell_agent_result,

--- a/src/shell_client/mod_tests.rs
+++ b/src/shell_client/mod_tests.rs
@@ -177,6 +177,9 @@ mod auth_owner;
 #[path = "mod_tests/protocol.rs"]
 mod protocol;
 
+#[path = "mod_tests/capabilities.rs"]
+mod capabilities;
+
 #[path = "mod_tests/polling.rs"]
 mod polling;
 

--- a/src/shell_client/mod_tests/capabilities.rs
+++ b/src/shell_client/mod_tests/capabilities.rs
@@ -1,0 +1,343 @@
+use super::*;
+use std::collections::BTreeSet;
+
+fn wire_capabilities_with_only(feature: Option<RunnerFeature>) -> ShellClientCapabilities {
+    let mut value = serde_json::Map::new();
+    // `shell` is the one historical true-by-default field. Pin it false so an
+    // omitted field really means false in this all-false/individual-true fixture.
+    value.insert("shell".to_string(), serde_json::Value::Bool(false));
+    if let Some(feature) = feature {
+        value.insert(
+            feature.as_wire_name().to_string(),
+            serde_json::Value::Bool(true),
+        );
+    }
+    serde_json::from_value(serde_json::Value::Object(value)).unwrap()
+}
+
+#[test]
+fn canonical_runner_feature_inventory_matches_wire_names_exactly() {
+    let wire_names = SHELL_CLIENT_CAPABILITY_NAMES
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let canonical_names = RunnerFeature::all()
+        .iter()
+        .map(|feature| feature.as_wire_name())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(wire_names.len(), SHELL_CLIENT_CAPABILITY_NAMES.len());
+    assert_eq!(canonical_names.len(), RunnerFeature::all().len());
+    assert_eq!(canonical_names, wire_names);
+}
+
+#[test]
+fn canonical_runner_feature_wire_names_round_trip() {
+    for feature in RunnerFeature::all() {
+        assert_eq!(
+            RunnerFeature::from_wire_name(feature.as_wire_name()),
+            Some(*feature),
+            "{}",
+            feature.as_wire_name()
+        );
+    }
+    assert_eq!(RunnerFeature::from_wire_name("future_runner_feature"), None);
+}
+
+#[test]
+fn canonical_runner_feature_set_tracks_each_individual_wire_bool() {
+    let all_false = RunnerFeatureSet::from_wire(&wire_capabilities_with_only(None));
+    for feature in RunnerFeature::all() {
+        assert!(!all_false.supports(*feature), "{}", feature.as_wire_name());
+    }
+
+    for advertised in RunnerFeature::all() {
+        let semantics =
+            RunnerFeatureSet::from_wire(&wire_capabilities_with_only(Some(*advertised)));
+        for observed in RunnerFeature::all() {
+            assert_eq!(
+                semantics.supports(*observed),
+                observed == advertised,
+                "advertised={} observed={}",
+                advertised.as_wire_name(),
+                observed.as_wire_name()
+            );
+        }
+    }
+}
+
+#[test]
+fn capability_classification_keeps_environment_dependent_features_explicit_only() {
+    for feature in [
+        RunnerFeature::Shell,
+        RunnerFeature::Git,
+        RunnerFeature::SshShell,
+        RunnerFeature::PersistentShell,
+        RunnerFeature::SshPersistentShell,
+        RunnerFeature::DetachedProcessJobs,
+        RunnerFeature::SandboxInspectCommands,
+        RunnerFeature::ComputerObserve,
+        RunnerFeature::ComputerControl,
+        RunnerFeature::ComputerTextInput,
+        RunnerFeature::JobStateReconciliation,
+        RunnerFeature::CodingAgentRuns,
+    ] {
+        assert_eq!(
+            feature.inference(),
+            RunnerFeatureInference::ExplicitOnly,
+            "{}",
+            feature.as_wire_name()
+        );
+    }
+
+    for feature in [
+        RunnerFeature::FileRead,
+        RunnerFeature::StructuredProcessArgv,
+        RunnerFeature::LspReadOnlyNavigation,
+        RunnerFeature::ProjectLifecycle,
+    ] {
+        assert_eq!(
+            feature.inference(),
+            RunnerFeatureInference::GenerationEligible,
+            "{}",
+            feature.as_wire_name()
+        );
+    }
+}
+
+#[test]
+fn missing_additive_wire_fields_remain_false_in_canonical_semantics() {
+    let legacy: ShellClientCapabilities = serde_json::from_str(r#"{}"#).unwrap();
+    let semantics = RunnerFeatureSet::from_wire(&legacy);
+
+    assert!(semantics.supports(RunnerFeature::Shell));
+    for feature in RunnerFeature::all() {
+        if *feature != RunnerFeature::Shell {
+            assert!(!semantics.supports(*feature), "{}", feature.as_wire_name());
+        }
+    }
+    assert!(!semantics.supports_wire_name("future_runner_feature"));
+}
+
+#[tokio::test]
+async fn current_protocol_generation_never_infers_explicit_only_host_features() {
+    let registry = ShellClientRegistry::default();
+    let mut registration = runner_registration("no-inference", "inst-a", Vec::new());
+    registration.agent_protocol_version = Some(AGENT_PROTOCOL_VERSION_POLLING_V1.to_string());
+    registration.capabilities = Some(wire_capabilities_with_only(None));
+    registry.register(registration).await.unwrap();
+
+    for feature in [
+        RunnerFeature::SshShell,
+        RunnerFeature::SandboxInspectCommands,
+        RunnerFeature::ComputerObserve,
+        RunnerFeature::ComputerControl,
+        RunnerFeature::ComputerTextInput,
+        RunnerFeature::CodingAgentRuns,
+    ] {
+        assert!(
+            !registry
+                .client_supports("no-inference", feature.as_wire_name())
+                .await
+                .unwrap(),
+            "{} must require explicit Runner advertisement",
+            feature.as_wire_name()
+        );
+    }
+    assert!(!registry
+        .client_supports("no-inference", "future_runner_feature")
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn shell_client_view_preserves_legacy_capability_wire_projection() {
+    let registry = ShellClientRegistry::default();
+    let mut advertised = wire_capabilities_with_only(None);
+    advertised.file_read = true;
+    advertised.structured_process_argv = true;
+    advertised.computer_control = true;
+
+    let mut registration = runner_registration("projection", "inst-a", Vec::new());
+    registration.capabilities = Some(advertised.clone());
+    let view = registry.register(registration).await.unwrap();
+
+    assert_eq!(view.capabilities, advertised);
+    let serialized = serde_json::to_value(&view.capabilities).unwrap();
+    assert_eq!(serialized["shell"], false);
+    assert_eq!(serialized["file_read"], true);
+    assert_eq!(serialized["structured_process_argv"], true);
+    assert_eq!(serialized["computer_control"], true);
+    assert!(serialized.get("features").is_none());
+    assert!(serialized.get("feature_classification").is_none());
+}
+
+async fn register_structured_delete_state(
+    registry: &ShellClientRegistry,
+    client_id: &str,
+    instance_id: &str,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut capabilities = wire_capabilities_with_only(None);
+    capabilities.structured_file_delete = enabled;
+    let mut registration = runner_registration(client_id, instance_id, Vec::new());
+    registration.capabilities = Some(capabilities);
+    registry.register(registration).await.map(|_| ())
+}
+
+#[tokio::test]
+async fn coding_agent_registration_consistency_uses_canonical_feature_semantics() {
+    let registry = ShellClientRegistry::default();
+
+    let mut metadata_without_feature = runner_registration("coding-metadata", "inst-a", Vec::new());
+    metadata_without_feature.capabilities = Some(wire_capabilities_with_only(None));
+    metadata_without_feature.coding_agent_providers =
+        Some(vec![webcodex_core::coding_agent::CodingAgentProvider {
+            provider_id: "codex".to_string(),
+            provider_instance_id: "provider-a".to_string(),
+            name: "Codex".to_string(),
+        }]);
+    metadata_without_feature.coding_agent_inventory =
+        Some(webcodex_core::coding_agent::CodingAgentRunInventory::default());
+    let error = registry
+        .register(metadata_without_feature)
+        .await
+        .unwrap_err();
+    assert!(
+        error.contains("requires coding_agent_runs capability"),
+        "{error}"
+    );
+
+    let mut feature_without_metadata = runner_registration("coding-feature", "inst-a", Vec::new());
+    feature_without_metadata.capabilities = Some(wire_capabilities_with_only(Some(
+        RunnerFeature::CodingAgentRuns,
+    )));
+    let error = registry
+        .register(feature_without_metadata)
+        .await
+        .unwrap_err();
+    assert!(
+        error.contains("requires non-empty provider inventory and Run inventory"),
+        "{error}"
+    );
+}
+
+async fn register_sticky_feature_state(
+    registry: &ShellClientRegistry,
+    client_id: &str,
+    instance_id: &str,
+    feature: RunnerFeature,
+    enabled: bool,
+) -> Result<(), String> {
+    let capabilities = if enabled {
+        wire_capabilities_with_only(Some(feature))
+    } else {
+        wire_capabilities_with_only(None)
+    };
+    let mut registration = runner_registration(client_id, instance_id, Vec::new());
+    registration.capabilities = Some(capabilities);
+
+    if feature == RunnerFeature::JobStateReconciliation && enabled {
+        registration.job_inventory = Some(crate::shell_protocol::ShellJobInventory {
+            active_complete: true,
+            jobs: Vec::new(),
+        });
+    }
+    if feature == RunnerFeature::CodingAgentRuns && enabled {
+        registration.coding_agent_providers =
+            Some(vec![webcodex_core::coding_agent::CodingAgentProvider {
+                provider_id: "codex".to_string(),
+                provider_instance_id: "provider-sticky".to_string(),
+                name: "Codex".to_string(),
+            }]);
+        registration.coding_agent_inventory =
+            Some(webcodex_core::coding_agent::CodingAgentRunInventory::default());
+    }
+
+    registry.register(registration).await.map(|_| ())
+}
+
+#[tokio::test]
+async fn all_seven_sticky_features_reject_same_instance_downgrade() {
+    for feature in [
+        RunnerFeature::JobStateReconciliation,
+        RunnerFeature::CodingAgentRuns,
+        RunnerFeature::StructuredFileDelete,
+        RunnerFeature::ApplyTextEditOccurrence,
+        RunnerFeature::InternalPosixScript,
+        RunnerFeature::ArtifactExportChunkRead,
+        RunnerFeature::ArtifactExportStreamingMetadata,
+    ] {
+        let registry = ShellClientRegistry::default();
+        let client_id = format!("sticky-{}", feature.as_wire_name());
+        register_sticky_feature_state(&registry, &client_id, "inst-a", feature, true)
+            .await
+            .unwrap();
+        let error = register_sticky_feature_state(&registry, &client_id, "inst-a", feature, false)
+            .await
+            .unwrap_err();
+        assert!(
+            error.contains(&format!("cannot downgrade {}", feature.as_wire_name())),
+            "feature={} error={error}",
+            feature.as_wire_name()
+        );
+        assert!(
+            registry
+                .client_supports(&client_id, feature.as_wire_name())
+                .await
+                .unwrap(),
+            "rejected downgrade must preserve {}",
+            feature.as_wire_name()
+        );
+    }
+}
+
+#[tokio::test]
+async fn canonical_sticky_feature_fence_preserves_allowed_reconnect_transitions() {
+    let false_false = ShellClientRegistry::default();
+    register_structured_delete_state(&false_false, "ff", "inst-a", false)
+        .await
+        .unwrap();
+    register_structured_delete_state(&false_false, "ff", "inst-a", false)
+        .await
+        .unwrap();
+
+    let false_true = ShellClientRegistry::default();
+    register_structured_delete_state(&false_true, "ft", "inst-a", false)
+        .await
+        .unwrap();
+    register_structured_delete_state(&false_true, "ft", "inst-a", true)
+        .await
+        .unwrap();
+
+    let true_true = ShellClientRegistry::default();
+    register_structured_delete_state(&true_true, "tt", "inst-a", true)
+        .await
+        .unwrap();
+    register_structured_delete_state(&true_true, "tt", "inst-a", true)
+        .await
+        .unwrap();
+
+    let true_false = ShellClientRegistry::default();
+    register_structured_delete_state(&true_false, "tf", "inst-a", true)
+        .await
+        .unwrap();
+    let error = register_structured_delete_state(&true_false, "tf", "inst-a", false)
+        .await
+        .unwrap_err();
+    assert!(error.contains("cannot downgrade structured_file_delete"));
+
+    let replacement = ShellClientRegistry::default();
+    register_structured_delete_state(&replacement, "replacement", "inst-a", true)
+        .await
+        .unwrap();
+    replacement
+        .set_last_seen_for_test("replacement", now_ts() - CLIENT_ONLINE_WINDOW_SECS - 1)
+        .await;
+    register_structured_delete_state(&replacement, "replacement", "inst-b", false)
+        .await
+        .unwrap();
+    let view = replacement.get_client_view("replacement").await.unwrap();
+    assert_eq!(view.agent_instance_id, "inst-b");
+    assert!(!view.capabilities.structured_file_delete);
+}

--- a/src/shell_client/mod_tests/capabilities.rs
+++ b/src/shell_client/mod_tests/capabilities.rs
@@ -67,7 +67,7 @@ fn canonical_runner_feature_set_tracks_each_individual_wire_bool() {
 }
 
 #[test]
-fn capability_classification_keeps_environment_dependent_features_explicit_only() {
+fn capability_classification_keeps_environment_dependent_features_registration_required() {
     for feature in [
         RunnerFeature::Shell,
         RunnerFeature::Git,
@@ -84,7 +84,7 @@ fn capability_classification_keeps_environment_dependent_features_explicit_only(
     ] {
         assert_eq!(
             feature.inference(),
-            RunnerFeatureInference::ExplicitOnly,
+            RunnerFeatureInference::RegistrationRequired,
             "{}",
             feature.as_wire_name()
         );
@@ -120,7 +120,7 @@ fn missing_additive_wire_fields_remain_false_in_canonical_semantics() {
 }
 
 #[tokio::test]
-async fn current_protocol_generation_never_infers_explicit_only_host_features() {
+async fn current_protocol_generation_never_infers_registration_required_host_features() {
     let registry = ShellClientRegistry::default();
     let mut registration = runner_registration("no-inference", "inst-a", Vec::new());
     registration.agent_protocol_version = Some(AGENT_PROTOCOL_VERSION_POLLING_V1.to_string());

--- a/src/shell_client/projects.rs
+++ b/src/shell_client/projects.rs
@@ -4,41 +4,7 @@ use super::project_inventory::reconcile_dynamic_projection;
 use super::validation::validate_id;
 use super::validation::validate_project_summary;
 use super::ShellClientRegistry;
-use crate::shell_protocol::{
-    ShellAgentProjectSummary, ShellClientCapabilities,
-    SHELL_CLIENT_CAPABILITY_APPLY_TEXT_EDIT_OCCURRENCE,
-    SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ,
-    SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA, SHELL_CLIENT_CAPABILITY_ASYNC_JOBS,
-    SHELL_CLIENT_CAPABILITY_ASYNC_SHELL_JOBS, SHELL_CLIENT_CAPABILITY_CODING_AGENT_RUNS,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE, SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE, SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE, SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION, SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE,
-    SHELL_CLIENT_CAPABILITY_DETACHED_PROCESS_JOBS, SHELL_CLIENT_CAPABILITY_FILE_READ,
-    SHELL_CLIENT_CAPABILITY_FILE_WRITE, SHELL_CLIENT_CAPABILITY_GIT,
-    SHELL_CLIENT_CAPABILITY_INTERNAL_POSIX_SCRIPT, SHELL_CLIENT_CAPABILITY_JOBS,
-    SHELL_CLIENT_CAPABILITY_JOB_STATE_RECONCILIATION, SHELL_CLIENT_CAPABILITY_LSP_CALL_HIERARCHY,
-    SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION, SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL,
-    SHELL_CLIENT_CAPABILITY_PROJECT_LIFECYCLE, SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION,
-    SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS, SHELL_CLIENT_CAPABILITY_SHELL,
-    SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL, SHELL_CLIENT_CAPABILITY_SSH_SHELL,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_CARGO_TEST_COUNT_ASSERTION,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_EXECUTION_JOBS,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_FILE_DELETE,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_JSON,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_PACKAGES,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_TOOL,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD,
-    SHELL_CLIENT_CAPABILITY_STRUCTURED_VALIDATION_ARGV,
-};
+use crate::shell_protocol::{ShellAgentProjectSummary, ShellClientCapabilities};
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,66 +23,6 @@ impl fmt::Display for ShellClientLookupError {
 }
 
 impl std::error::Error for ShellClientLookupError {}
-
-pub(super) fn capability_enabled(caps: &ShellClientCapabilities, capability: &str) -> bool {
-    match capability {
-        SHELL_CLIENT_CAPABILITY_SHELL => caps.shell,
-        SHELL_CLIENT_CAPABILITY_FILE_READ => caps.file_read,
-        SHELL_CLIENT_CAPABILITY_FILE_WRITE => caps.file_write,
-        SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ => caps.artifact_export_chunk_read,
-        SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA => {
-            caps.artifact_export_streaming_metadata
-        }
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_FILE_DELETE => caps.structured_file_delete,
-        SHELL_CLIENT_CAPABILITY_APPLY_TEXT_EDIT_OCCURRENCE => caps.apply_text_edit_occurrence,
-        SHELL_CLIENT_CAPABILITY_GIT => caps.git,
-        SHELL_CLIENT_CAPABILITY_JOBS => caps.jobs,
-        SHELL_CLIENT_CAPABILITY_ASYNC_JOBS => caps.async_jobs,
-        SHELL_CLIENT_CAPABILITY_ASYNC_SHELL_JOBS => caps.async_shell_jobs,
-        SHELL_CLIENT_CAPABILITY_SSH_SHELL => caps.ssh_shell,
-        SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL => caps.persistent_shell,
-        SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL => caps.ssh_persistent_shell,
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_VALIDATION_ARGV => caps.structured_validation_argv,
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_CARGO_TEST_COUNT_ASSERTION => {
-            caps.structured_cargo_test_count_assertion
-        }
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_JSON => caps.structured_go_test_json,
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_TOOL => caps.structured_go_test_tool,
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_PACKAGES => caps.structured_go_test_packages,
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV => caps.structured_process_argv,
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD => caps.structured_script_payload,
-        SHELL_CLIENT_CAPABILITY_INTERNAL_POSIX_SCRIPT => caps.internal_posix_script,
-        SHELL_CLIENT_CAPABILITY_STRUCTURED_EXECUTION_JOBS => caps.structured_execution_jobs,
-        SHELL_CLIENT_CAPABILITY_DETACHED_PROCESS_JOBS => caps.detached_process_jobs,
-        SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION => caps.lsp_read_only_navigation,
-        SHELL_CLIENT_CAPABILITY_LSP_CALL_HIERARCHY => caps.lsp_call_hierarchy,
-        SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS => caps.sandbox_inspect_commands,
-        SHELL_CLIENT_CAPABILITY_PROJECT_LIFECYCLE => caps.project_lifecycle,
-        SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION => caps.project_path_registration,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE => caps.computer_observe,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY => {
-            caps.computer_application_discovery
-        }
-        SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH => caps.computer_application_launch,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE => caps.computer_display_observe,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ => caps.computer_clipboard_read,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE => caps.computer_clipboard_write,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL => caps.computer_pointer_control,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION => caps.computer_snapshot_region,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE => {
-            caps.computer_accessibility_observe
-        }
-        SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE => caps.computer_element_state,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL => caps.computer_control,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT => caps.computer_scroll_to_element,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT => caps.computer_key_input,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE => caps.computer_window_activate,
-        SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT => caps.computer_text_input,
-        SHELL_CLIENT_CAPABILITY_JOB_STATE_RECONCILIATION => caps.job_state_reconciliation,
-        SHELL_CLIENT_CAPABILITY_CODING_AGENT_RUNS => caps.coding_agent_runs,
-        _ => false,
-    }
-}
 
 fn upsert_project_summary(
     projects: &mut Vec<ShellAgentProjectSummary>,
@@ -169,8 +75,16 @@ impl ShellClientRegistry {
         client_id: &str,
         capability: &str,
     ) -> Result<bool, ShellClientLookupError> {
-        let caps = self.get_client_capabilities(client_id).await?;
-        Ok(capability_enabled(&caps, capability))
+        self.prune_expired_shared_key_clients().await;
+        let inner = self.inner.lock().await;
+        let client =
+            inner
+                .clients
+                .get(client_id)
+                .ok_or_else(|| ShellClientLookupError::UnknownClient {
+                    client_id: client_id.to_string(),
+                })?;
+        Ok(client.runner_features.supports_wire_name(capability))
     }
 
     pub(crate) async fn client_supports_for_auth(
@@ -186,7 +100,7 @@ impl ShellClientRegistry {
             .get(client_id)
             .ok_or_else(|| format!("unknown shell client: {}", client_id))?;
         assert_shell_client_access(auth, client)?;
-        Ok(capability_enabled(&client.capabilities, capability))
+        Ok(client.runner_features.supports_wire_name(capability))
     }
 
     /// Test-only accessor for projects registered to a shell client.

--- a/src/shell_client/requests.rs
+++ b/src/shell_client/requests.rs
@@ -3,7 +3,7 @@ use super::jobs::{
     command_preview, ensure_dispatch_supported_locked, ensure_queue_capacity_locked,
     request_preview, PendingRequestEnqueueError,
 };
-use super::projects::{capability_enabled, ShellClientLookupError};
+use super::projects::ShellClientLookupError;
 use super::state::{CodingAgentDispatchFence, PendingShellRequest, ShellClientRegistryInner};
 use super::validation::{
     validate_file_request, validate_id, validate_process_request, validate_run_request,
@@ -1674,7 +1674,7 @@ impl ShellClientRegistry {
         if let Some(required_capability) = required_capabilities
             .iter()
             .copied()
-            .find(|capability| !capability_enabled(&current.capabilities, capability))
+            .find(|capability| !current.runner_features.supports_wire_name(capability))
         {
             return Err(format!(
                 "agent client {client_id} does not support {required_capability}"
@@ -1755,7 +1755,10 @@ impl ShellClientRegistry {
                 .ok_or_else(|| EnqueueLspError::UnknownClient {
                     client_id: client_id.clone(),
                 })?;
-        if !capability_enabled(&current.capabilities, required_capability) {
+        if !current
+            .runner_features
+            .supports_wire_name(required_capability)
+        {
             return Err(EnqueueLspError::UnsupportedCapability {
                 client_id,
                 capability: required_capability,

--- a/src/shell_client/state.rs
+++ b/src/shell_client/state.rs
@@ -1,5 +1,5 @@
 use super::auth::ShellClientAuthGroup;
-use super::AgentTransport;
+use super::{AgentTransport, RunnerFeatureSet};
 use crate::mcp_gateway::McpGatewayResponse;
 use crate::shell_protocol::{
     AgentBuildInfo, AgentHostContext, AgentPolicySummary, AgentProtocolSemantics,
@@ -55,7 +55,12 @@ pub(super) struct ShellClientRecord {
     /// Bounded Runner-configured planning metadata. This is not policy or live
     /// state and is replaced by each successful registration.
     pub(super) host_context: Option<AgentHostContext>,
+    /// Accepted legacy wire snapshot retained for compatibility projection and
+    /// C3b's explicitly inventoried downstream consumers.
     pub(super) capabilities: ShellClientCapabilities,
+    /// Canonical Server capability truth normalized once from `capabilities`
+    /// during registration. This set has no independent mutation path.
+    pub(super) runner_features: RunnerFeatureSet,
     pub(super) projects: Vec<ShellAgentProjectSummary>,
     /// Authoritative project snapshot plus bounded in-progress staging. A
     /// staging failure never changes liveness or partially publishes projects.


### PR DESCRIPTION
## Summary

- add Server-owned `RunnerFeature` / `RunnerFeatureSet` as the canonical semantic capability boundary for all 46 legacy Runner capability booleans
- normalize accepted Runner registration capabilities exactly once at ingress, with no protocol-generation inference
- migrate registration consistency checks, named capability lookup, and the seven same-instance downgrade fences to canonical feature semantics
- keep legacy `ShellClientCapabilities` projection intact for compatibility/diagnostics and leave remaining downstream raw-bool consumers for C3b
- clarify that canonical truth follows accepted registration effective semantics, including the historical missing `shell` => true default

## Compatibility / correctness

- no wire schema or Runner construction changes
- no generation baseline introduced
- environment/runtime-dependent features remain registration-required
- v0.3.8 registration compatibility is preserved
- public `ShellClientView.capabilities` remains the legacy bool DTO

## Validation

- `cargo test "shell_client::tests::capabilities::"` — 10 passed
- focused `same_instance_` suite — 14 passed
- `latest_stable_v038_registration_fixtures_are_accepted` — passed
- `cargo fmt -- --check` — passed
- `cargo check --all-targets` — passed, 0 errors / 0 warnings
- `git diff --check` — passed
