### PR TITLE
Migrate Runner capability decisions to canonical semantics

### DIFF
--- a/src/admin_project_lifecycle.rs
+++ b/src/admin_project_lifecycle.rs
@@ -1,6 +1,6 @@
 use crate::auth::AuthContext;
 use crate::db::AdminProjectAudit;
-use crate::shell_client::ShellClientRegistry;
+use crate::shell_client::{RunnerFeature, ShellClientRegistry};
 use crate::shell_protocol::ShellAgentProjectSummary;
 use crate::tool_runtime::{ToolResult, ToolRuntime};
 use crate::Database;
@@ -264,16 +264,16 @@ impl AdminProjectLifecycleService {
         }
         let client = runtime
             .shell_clients
-            .get_client_view_for_auth(&client_id, auth)
+            .get_client_semantic_view_for_auth(&client_id, auth)
             .await
             .ok_or_else(|| api_error(503, "agent_unavailable"))?;
-        if !client.connected || client.status != "online" {
+        if !client.view.connected || client.view.status != "online" {
             return Err(api_error(503, "agent_unavailable"));
         }
-        if !client.capabilities.project_lifecycle {
+        if !client.supports(RunnerFeature::ProjectLifecycle) {
             return Err(api_error(409, "unsupported_runner_version"));
         }
-        let project = client.projects.iter().find(|p| p.id == project_id);
+        let project = client.view.projects.iter().find(|p| p.id == project_id);
         if action != "unregister" && project.is_none() {
             return Err(api_error(404, "project_not_found"));
         }
@@ -348,7 +348,7 @@ impl AdminProjectLifecycleService {
                 .shell_clients
                 .remove_client_project_for_instance(
                     &client_id,
-                    &client.agent_instance_id,
+                    &client.view.agent_instance_id,
                     &project_id,
                 )
                 .await
@@ -374,7 +374,11 @@ impl AdminProjectLifecycleService {
             };
             if runtime
                 .shell_clients
-                .upsert_client_project_for_instance(&client_id, &client.agent_instance_id, summary)
+                .upsert_client_project_for_instance(
+                    &client_id,
+                    &client.view.agent_instance_id,
+                    summary,
+                )
                 .await
                 .is_err()
             {
@@ -866,6 +870,67 @@ mod tests {
             limit: None,
             codex: None,
         }
+    }
+
+    #[tokio::test]
+    async fn project_lifecycle_capability_gate_uses_canonical_runner_semantics() {
+        let registry = Arc::new(ShellClientRegistry::default());
+        let revision = format!("sha256:{}", "b".repeat(64));
+        let target = "agent:lifecycle-legacy:demo";
+        registry
+            .register(ShellClientRegisterRequest {
+                client_id: "lifecycle-legacy".to_string(),
+                agent_instance_id: "instance-lifecycle-legacy".to_string(),
+                display_name: None,
+                owner: Some("alice".to_string()),
+                hostname: None,
+                host_context: None,
+                capabilities: Some(ShellClientCapabilities {
+                    project_lifecycle: false,
+                    ..Default::default()
+                }),
+                projects: Some(vec![ShellAgentProjectSummary {
+                    id: "demo".to_string(),
+                    name: Some("demo".to_string()),
+                    path: "/tmp/demo".to_string(),
+                    allow_patch: true,
+                    kind: None,
+                    description: None,
+                    hooks: Vec::new(),
+                    disabled: false,
+                    revision: Some(revision.clone()),
+                    git_branch: None,
+                    git_head: None,
+                    git_dirty: None,
+                    updated_at: 1,
+                    shell_profile: None,
+                }]),
+                agent_protocol_version: Some("polling-v1".to_string()),
+                policy: None,
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: None,
+                job_inventory: None,
+                coding_agent_providers: None,
+                coding_agent_inventory: None,
+            })
+            .await
+            .unwrap();
+
+        let runtime = ToolRuntime::new_for_tests_with_shell_clients(registry);
+        let error = AdminProjectLifecycleService::mutate_authorized_core(
+            &runtime,
+            Some(&user_auth("alice")),
+            "disable",
+            target,
+            &revision,
+            "c3b_test",
+            true,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.status, 409);
+        assert_eq!(error.body["error"]["code"], "unsupported_runner_version");
     }
 
     #[tokio::test]

--- a/src/connector_runtime/mod.rs
+++ b/src/connector_runtime/mod.rs
@@ -67,6 +67,7 @@ use crate::project_context::{
     capture_project_context, compare_project_context, ContextRefreshSummary,
     ProjectContextFingerprint,
 };
+use crate::shell_client::RunnerFeature;
 use crate::shell_protocol::{
     SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS,
     SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_JSON,
@@ -301,32 +302,32 @@ impl ConnectorRuntime {
         let Some(agent) = self
             .tools
             .shell_clients
-            .get_client_view_for_auth(client_id, Some(auth))
+            .get_client_semantic_view_for_auth(client_id, Some(auth))
             .await
         else {
             return Some(self.observed_readiness(RemoteProbe::AgentOffline));
         };
-        if agent.status != "online" || !agent.connected {
+        if agent.view.status != "online" || !agent.view.connected {
             return Some(self.observed_readiness(RemoteProbe::AgentOffline));
         }
         if !agent
+            .view
             .projects
             .iter()
             .any(|project| project.id == project_id && !project.disabled)
         {
             return Some(self.observed_readiness(RemoteProbe::ProjectMissing));
         }
-        let capabilities = &agent.capabilities;
-        if !(capabilities.shell
-            && capabilities.file_read
-            && capabilities.file_write
-            && capabilities.jobs
-            && capabilities.async_jobs
-            && capabilities.async_shell_jobs)
+        if !(agent.supports(RunnerFeature::Shell)
+            && agent.supports(RunnerFeature::FileRead)
+            && agent.supports(RunnerFeature::FileWrite)
+            && agent.supports(RunnerFeature::Jobs)
+            && agent.supports(RunnerFeature::AsyncJobs)
+            && agent.supports(RunnerFeature::AsyncShellJobs))
         {
             return Some(self.observed_readiness(RemoteProbe::RequiredCapabilityMissing));
         }
-        if !capabilities.structured_validation_argv {
+        if !agent.supports(RunnerFeature::StructuredValidationArgv) {
             return Some(self.observed_readiness(RemoteProbe::StructuredValidationMissing));
         }
         Some(self.observed_readiness(RemoteProbe::Ready))

--- a/src/oauth_http/shared_key_bridge.rs
+++ b/src/oauth_http/shared_key_bridge.rs
@@ -9,7 +9,7 @@ use crate::auth::{
     SCOPE_SESSION_COLLABORATE,
 };
 use crate::models::OAuthAuthorizationCodeRecord;
-use crate::shell_protocol::ShellClientCapabilities;
+use crate::shell_client::{RunnerFeature, RunnerFeatureSet};
 
 use super::{
     apply_oauth_no_store_headers, authorize_bridge_html, decoded_authorize_param, form_field,
@@ -309,15 +309,19 @@ impl BridgeAuthorizeValidated {
     }
 }
 
-fn bridge_permission_capable(permission_id: &str, capabilities: &ShellClientCapabilities) -> bool {
+fn bridge_permission_capable(permission_id: &str, features: &RunnerFeatureSet) -> bool {
     match permission_id {
         "launch" => {
-            capabilities.computer_application_discovery && capabilities.computer_application_launch
+            features.supports(RunnerFeature::ComputerApplicationDiscovery)
+                && features.supports(RunnerFeature::ComputerApplicationLaunch)
         }
-        "display" => capabilities.computer_display_observe,
-        "pointer" => capabilities.computer_display_observe && capabilities.computer_pointer_control,
-        "clipboard_read" => capabilities.computer_clipboard_read,
-        "clipboard_write" => capabilities.computer_clipboard_write,
+        "display" => features.supports(RunnerFeature::ComputerDisplayObserve),
+        "pointer" => {
+            features.supports(RunnerFeature::ComputerDisplayObserve)
+                && features.supports(RunnerFeature::ComputerPointerControl)
+        }
+        "clipboard_read" => features.supports(RunnerFeature::ComputerClipboardRead),
+        "clipboard_write" => features.supports(RunnerFeature::ComputerClipboardWrite),
         _ => false,
     }
 }
@@ -333,7 +337,7 @@ async fn bridge_permission_views(
     let capabilities = match (registry, validated.client.owner_shared_key_hash.as_deref()) {
         (Some(registry), Some(owner_hash)) => {
             registry
-                .connected_shared_key_group_capabilities(owner_hash)
+                .connected_shared_key_group_feature_sets(owner_hash)
                 .await
         }
         _ => Vec::new(),

--- a/src/shell_client/agents.rs
+++ b/src/shell_client/agents.rs
@@ -9,7 +9,9 @@ use super::reconciliation::{
     validate_job_inventory, validate_job_inventory_without_project_membership,
 };
 use super::requests::resolve_disconnected_sync_requests_locked;
-use super::state::{NotifierEntry, ShellClientRecord, ShellClientRegistryInner};
+use super::state::{
+    NotifierEntry, ShellClientRecord, ShellClientRegistryInner, ShellClientSemanticView,
+};
 use super::validation::{
     normalize_project_summaries, normalize_required_agent_protocol_version,
     normalize_tool_providers, trim_string, validate_agent_instance_id, validate_id,
@@ -21,8 +23,8 @@ use super::{
 };
 use crate::mcp_gateway::validate_providers;
 use crate::shell_protocol::{
-    normalize_agent_protocol_semantics, AgentProjectInventoryStrategy, ShellClientCapabilities,
-    ShellClientRegisterRequest, ShellClientView, JOB_INVENTORY_MAX_ACTIVE_JOBS,
+    normalize_agent_protocol_semantics, AgentProjectInventoryStrategy, ShellClientRegisterRequest,
+    ShellClientView, JOB_INVENTORY_MAX_ACTIVE_JOBS,
 };
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
@@ -1043,10 +1045,11 @@ impl ShellClientRegistry {
             inner.notifiers.remove(client_id);
         }
         let now = now_ts();
-        let recoverable = inner
-            .clients
-            .get(client_id)
-            .is_some_and(|client| client.capabilities.job_state_reconciliation);
+        let recoverable = inner.clients.get(client_id).is_some_and(|client| {
+            client
+                .runner_features
+                .supports(RunnerFeature::JobStateReconciliation)
+        });
         if let Some(client) = inner.clients.get_mut(client_id) {
             client.last_seen = offline_last_seen(now);
             client.disconnected_at = Some(now);
@@ -1178,14 +1181,14 @@ impl ShellClientRegistry {
         })
     }
 
-    /// Return capability snapshots for the currently-online Runners in one exact
-    /// shared-key authorization group. Callers must evaluate each snapshot as a
-    /// whole; combining capabilities across different Runners would overstate
+    /// Return canonical feature snapshots for currently-online Runners in one
+    /// exact shared-key authorization group. Callers must evaluate each set as
+    /// a whole; combining features across different Runners would overstate
     /// executable authority.
-    pub(crate) async fn connected_shared_key_group_capabilities(
+    pub(crate) async fn connected_shared_key_group_feature_sets(
         &self,
         shared_key_hash: &str,
-    ) -> Vec<ShellClientCapabilities> {
+    ) -> Vec<RunnerFeatureSet> {
         let now = now_ts();
         let mut inner = self.inner.lock().await;
         self.prune_expired_shared_key_clients_locked(&mut inner, now);
@@ -1198,7 +1201,31 @@ impl ShellClientRegistry {
                     Some(ShellClientAuthGroup::SharedKey(group)) if group == shared_key_hash
                 ) && now.saturating_sub(client.last_seen) <= CLIENT_ONLINE_WINDOW_SECS
             })
-            .map(|client| client.capabilities.clone())
+            .map(|client| client.runner_features.clone())
+            .collect()
+    }
+
+    pub(crate) async fn list_client_semantic_views_for_auth(
+        &self,
+        auth: Option<&crate::auth::AuthContext>,
+    ) -> Vec<ShellClientSemanticView> {
+        let now = now_ts();
+        let mut inner = self.inner.lock().await;
+        self.prune_expired_shared_key_clients_locked(&mut inner, now);
+        for client in inner.clients.values_mut() {
+            expire_staging(client, now);
+        }
+        let mut ids = inner.clients.keys().cloned().collect::<Vec<_>>();
+        ids.sort();
+        ids.into_iter()
+            .filter(|id| {
+                inner
+                    .clients
+                    .get(id)
+                    .map(|client| shell_client_visible_to_auth(auth, client))
+                    .unwrap_or(false)
+            })
+            .filter_map(|id| Self::client_semantic_view_locked(&inner, &id))
             .collect()
     }
 
@@ -1242,6 +1269,49 @@ impl ShellClientRegistry {
             return None;
         }
         Self::client_view_locked(&inner, client_id)
+    }
+
+    pub(crate) async fn get_client_semantic_view(
+        &self,
+        client_id: &str,
+    ) -> Option<ShellClientSemanticView> {
+        let now = now_ts();
+        let mut inner = self.inner.lock().await;
+        self.prune_expired_shared_key_clients_locked(&mut inner, now);
+        if let Some(client) = inner.clients.get_mut(client_id) {
+            expire_staging(client, now);
+        }
+        Self::client_semantic_view_locked(&inner, client_id)
+    }
+
+    pub(crate) async fn get_client_semantic_view_for_auth(
+        &self,
+        client_id: &str,
+        auth: Option<&crate::auth::AuthContext>,
+    ) -> Option<ShellClientSemanticView> {
+        let mut inner = self.inner.lock().await;
+        self.prune_expired_shared_key_clients_locked(&mut inner, now_ts());
+        let client = inner.clients.get(client_id)?;
+        if !shell_client_visible_to_auth(auth, client) {
+            return None;
+        }
+        Self::client_semantic_view_locked(&inner, client_id)
+    }
+
+    pub(crate) async fn get_client_semantic_view_checked_for_auth(
+        &self,
+        client_id: &str,
+        auth: Option<&crate::auth::AuthContext>,
+    ) -> Result<ShellClientSemanticView, String> {
+        let mut inner = self.inner.lock().await;
+        self.prune_expired_shared_key_clients_locked(&mut inner, now_ts());
+        let client = inner
+            .clients
+            .get(client_id)
+            .ok_or_else(|| format!("unknown shell client: {client_id}"))?;
+        assert_shell_client_access(auth, client)?;
+        Self::client_semantic_view_locked(&inner, client_id)
+            .ok_or_else(|| format!("unknown shell client: {client_id}"))
     }
 
     pub(crate) async fn coding_agent_run_for_client_for_auth(
@@ -1317,6 +1387,18 @@ impl ShellClientRegistry {
             .get(client_id)
             .ok_or_else(|| format!("unknown shell client: {}", client_id))?;
         assert_shell_client_access(auth, client)
+    }
+
+    fn client_semantic_view_locked(
+        inner: &ShellClientRegistryInner,
+        client_id: &str,
+    ) -> Option<ShellClientSemanticView> {
+        let runner_features = inner.clients.get(client_id)?.runner_features.clone();
+        let view = Self::client_view_locked(inner, client_id)?;
+        Some(ShellClientSemanticView {
+            view,
+            runner_features,
+        })
     }
 
     fn client_view_locked(

--- a/src/shell_client/job_updates.rs
+++ b/src/shell_client/job_updates.rs
@@ -12,7 +12,7 @@ use super::requests::{
 use super::state::{DetachedIdempotencyIntent, ShellJobRecord, ShellJobVisibility};
 use super::validation::{validate_agent_instance_id, validate_id, validate_run_request};
 use super::{
-    now_ts, ShellClientRegistry, DETACHED_IDEMPOTENCY_CONFLICT,
+    now_ts, RunnerFeature, ShellClientRegistry, DETACHED_IDEMPOTENCY_CONFLICT,
     DETACHED_IDEMPOTENCY_RECOVERY_PREFIX,
 };
 use crate::shell_protocol::{
@@ -859,19 +859,29 @@ impl ShellClientRegistry {
         if auth.is_some() {
             assert_shell_client_access(auth, client)?;
         }
-        if !(client.capabilities.async_jobs || client.capabilities.async_shell_jobs) {
+        if !(client.runner_features.supports(RunnerFeature::AsyncJobs)
+            || client
+                .runner_features
+                .supports(RunnerFeature::AsyncShellJobs))
+        {
             return Err(format!(
                 "agent client {} does not support async shell jobs",
                 client_id
             ));
         }
-        if structured_metadata.is_some() && !client.capabilities.structured_execution_jobs {
+        if structured_metadata.is_some()
+            && !client
+                .runner_features
+                .supports(RunnerFeature::StructuredExecutionJobs)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {client_id} does not support structured_execution_jobs"
             ));
         }
         if request.kind == "start_detached_process_job"
-            && !client.capabilities.detached_process_jobs
+            && !client
+                .runner_features
+                .supports(RunnerFeature::DetachedProcessJobs)
         {
             return Err(format!(
                 "capability_unavailable: agent client {client_id} does not support detached_process_jobs"
@@ -883,7 +893,9 @@ impl ShellClientRegistry {
                     .to_string(),
             );
         }
-        if metadata.ssh_resource.is_some() && !client.capabilities.ssh_shell {
+        if metadata.ssh_resource.is_some()
+            && !client.runner_features.supports(RunnerFeature::SshShell)
+        {
             return Err(format!(
                 "agent_capability_unavailable: agent client {} does not support ssh_shell",
                 client_id
@@ -893,7 +905,10 @@ impl ShellClientRegistry {
             if mode != crate::command_sandbox::INSPECT_SANDBOX_MODE {
                 return Err(format!("unknown sandbox mode '{mode}'"));
             }
-            if !client.capabilities.sandbox_inspect_commands {
+            if !client
+                .runner_features
+                .supports(RunnerFeature::SandboxInspectCommands)
+            {
                 return Err(format!(
                     "{}: agent client {} cannot enforce the inspect sandbox",
                     crate::shell_protocol::SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS,
@@ -901,7 +916,11 @@ impl ShellClientRegistry {
                 ));
             }
         }
-        if !validation_steps.is_empty() && !client.capabilities.structured_validation_argv {
+        if !validation_steps.is_empty()
+            && !client
+                .runner_features
+                .supports(RunnerFeature::StructuredValidationArgv)
+        {
             return Err(format!(
                 "structured_validation_unavailable: agent client {} does not support structured argv validation jobs",
                 client_id
@@ -911,7 +930,9 @@ impl ShellClientRegistry {
             .as_ref()
             .and_then(|metadata| metadata.minimum_tests)
             .is_some()
-            && !client.capabilities.structured_cargo_test_count_assertion
+            && !client
+                .runner_features
+                .supports(RunnerFeature::StructuredCargoTestCountAssertion)
         {
             return Err(format!(
                 "structured_cargo_test_count_assertion_unavailable: agent client {} does not support durable Cargo test-count assertions",
@@ -921,7 +942,9 @@ impl ShellClientRegistry {
         if validation_steps
             .iter()
             .any(crate::shell_protocol::ShellJobValidationStep::is_structured_go_test_json)
-            && !client.capabilities.structured_go_test_json
+            && !client
+                .runner_features
+                .supports(RunnerFeature::StructuredGoTestJson)
         {
             return Err(format!(
                 "structured_go_test_json_unavailable: agent client {} does not support machine-readable Go test validation",
@@ -930,7 +953,9 @@ impl ShellClientRegistry {
         }
         if validation_steps.iter().any(|step| {
             step.is_structured_go_test_json() && step.args.as_slice() != ["test", "-json", "./..."]
-        }) && !client.capabilities.structured_go_test_packages
+        }) && !client
+            .runner_features
+            .supports(RunnerFeature::StructuredGoTestPackages)
         {
             return Err(format!(
                 "structured_go_test_packages_unavailable: agent client {} does not support focused Go package validation argv",
@@ -940,7 +965,9 @@ impl ShellClientRegistry {
         if validation
             .as_ref()
             .is_some_and(|metadata| metadata.tool == "go_test")
-            && !client.capabilities.structured_go_test_tool
+            && !client
+                .runner_features
+                .supports(RunnerFeature::StructuredGoTestTool)
         {
             return Err(format!(
                 "structured_go_test_tool_unavailable: agent client {} does not support the first-class go_test validation contract",
@@ -1867,10 +1894,11 @@ impl ShellClientRegistry {
         // Reject job updates from a stale/replaced instance before refreshing
         // liveness or mutating job state.
         assert_active_instance_locked(&inner, &body.client_id, &body.agent_instance_id)?;
-        let sequenced = inner
-            .clients
-            .get(&body.client_id)
-            .is_some_and(|client| client.capabilities.job_state_reconciliation);
+        let sequenced = inner.clients.get(&body.client_id).is_some_and(|client| {
+            client
+                .runner_features
+                .supports(RunnerFeature::JobStateReconciliation)
+        });
         let incoming_seq = if sequenced {
             Some(
                 body.update_seq

--- a/src/shell_client/jobs.rs
+++ b/src/shell_client/jobs.rs
@@ -1,5 +1,8 @@
 use super::state::{ShellClientRegistryInner, ShellJobLogState, ShellJobRecord};
-use super::{now_ts, CLIENT_ONLINE_WINDOW_SECS, MAX_OUTPUT_BYTES, MAX_QUEUED_REQUESTS_PER_CLIENT};
+use super::{
+    now_ts, RunnerFeature, CLIENT_ONLINE_WINDOW_SECS, MAX_OUTPUT_BYTES,
+    MAX_QUEUED_REQUESTS_PER_CLIENT,
+};
 use crate::shell_protocol::{
     ShellAgentJobResult, ShellAgentShellJobResult, ShellAgentShellRequest,
     ShellCommandExecutionState, ShellJobInfo, ShellJobStreamSnapshot,
@@ -716,10 +719,11 @@ pub(super) fn refresh_job_status_locked(inner: &mut ShellClientRegistryInner, jo
     if client_is_connected_locked(inner, &client_id) {
         return;
     }
-    let recoverable = inner
-        .clients
-        .get(&client_id)
-        .is_some_and(|client| client.capabilities.job_state_reconciliation);
+    let recoverable = inner.clients.get(&client_id).is_some_and(|client| {
+        client
+            .runner_features
+            .supports(RunnerFeature::JobStateReconciliation)
+    });
     if let Some(job) = inner.jobs_by_id.get_mut(job_id) {
         if recoverable {
             begin_job_recovery(job, now_ts(), "runner_transport_stale");

--- a/src/shell_client/mod.rs
+++ b/src/shell_client/mod.rs
@@ -65,7 +65,7 @@ pub(crate) use projects::ShellClientLookupError;
 pub(crate) use reconciliation::recovery_timeout_sweep;
 pub(crate) use requests::EnqueueLspError;
 use state::ShellClientRegistryInner;
-pub(crate) use state::ShellJobVisibility;
+pub(crate) use state::{ShellClientSemanticView, ShellJobVisibility};
 use validation::sha256_hex;
 #[cfg(test)]
 use validation::{validate_file_request, validate_run_request, MAX_RUN_STDIN_BYTES};

--- a/src/shell_client/mod_tests/capabilities.rs
+++ b/src/shell_client/mod_tests/capabilities.rs
@@ -172,6 +172,68 @@ async fn shell_client_view_preserves_legacy_capability_wire_projection() {
     assert!(serialized.get("feature_classification").is_none());
 }
 
+#[tokio::test]
+async fn semantic_snapshot_keeps_identity_state_and_features_atomic_across_replacement() {
+    let registry = ShellClientRegistry::default();
+
+    let mut first_capabilities = wire_capabilities_with_only(None);
+    first_capabilities.file_read = true;
+    first_capabilities.structured_process_argv = true;
+    first_capabilities.lsp_read_only_navigation = true;
+    first_capabilities.computer_observe = true;
+    let mut first = runner_registration("semantic-snapshot", "inst-a", Vec::new());
+    first.capabilities = Some(first_capabilities);
+    registry.register(first).await.unwrap();
+
+    let first_snapshot = registry
+        .get_client_semantic_view("semantic-snapshot")
+        .await
+        .unwrap();
+    assert_eq!(first_snapshot.view.agent_instance_id, "inst-a");
+    assert!(first_snapshot.view.connected);
+    assert!(first_snapshot.supports(RunnerFeature::FileRead));
+    assert!(first_snapshot.supports(RunnerFeature::StructuredProcessArgv));
+    assert!(first_snapshot.supports(RunnerFeature::LspReadOnlyNavigation));
+    assert!(first_snapshot.supports(RunnerFeature::ComputerObserve));
+    assert!(!first_snapshot.supports(RunnerFeature::FileWrite));
+    assert!(!first_snapshot.supports(RunnerFeature::ComputerTextInput));
+
+    registry
+        .set_last_seen_for_test(
+            "semantic-snapshot",
+            now_ts() - CLIENT_ONLINE_WINDOW_SECS - 1,
+        )
+        .await;
+    let mut replacement_capabilities = wire_capabilities_with_only(None);
+    replacement_capabilities.file_write = true;
+    replacement_capabilities.structured_script_payload = true;
+    replacement_capabilities.lsp_call_hierarchy = true;
+    replacement_capabilities.computer_text_input = true;
+    let mut replacement = runner_registration("semantic-snapshot", "inst-b", Vec::new());
+    replacement.capabilities = Some(replacement_capabilities);
+    registry.register(replacement).await.unwrap();
+
+    let replacement_snapshot = registry
+        .get_client_semantic_view("semantic-snapshot")
+        .await
+        .unwrap();
+    assert_eq!(replacement_snapshot.view.agent_instance_id, "inst-b");
+    assert!(replacement_snapshot.view.connected);
+    assert!(!replacement_snapshot.supports(RunnerFeature::FileRead));
+    assert!(replacement_snapshot.supports(RunnerFeature::FileWrite));
+    assert!(replacement_snapshot.supports(RunnerFeature::StructuredScriptPayload));
+    assert!(replacement_snapshot.supports(RunnerFeature::LspCallHierarchy));
+    assert!(replacement_snapshot.supports(RunnerFeature::ComputerTextInput));
+
+    // The prior immutable observation remains internally coherent rather than
+    // being paired with feature truth from the replacement process.
+    assert_eq!(first_snapshot.view.agent_instance_id, "inst-a");
+    assert!(first_snapshot.supports(RunnerFeature::FileRead));
+    assert!(!first_snapshot.supports(RunnerFeature::FileWrite));
+    assert!(first_snapshot.supports(RunnerFeature::ComputerObserve));
+    assert!(!first_snapshot.supports(RunnerFeature::ComputerTextInput));
+}
+
 async fn register_structured_delete_state(
     registry: &ShellClientRegistry,
     client_id: &str,

--- a/src/shell_client/mod_tests/capabilities.rs
+++ b/src/shell_client/mod_tests/capabilities.rs
@@ -234,6 +234,58 @@ async fn semantic_snapshot_keeps_identity_state_and_features_atomic_across_repla
     assert!(!first_snapshot.supports(RunnerFeature::ComputerTextInput));
 }
 
+#[tokio::test]
+async fn project_operation_enqueue_rechecks_canonical_features_after_reregistration() {
+    let registry = ShellClientRegistry::default();
+    let mut initial_capabilities = wire_capabilities_with_only(None);
+    initial_capabilities.project_path_registration = true;
+    initial_capabilities.project_lifecycle = true;
+    let mut initial = runner_registration("project-feature-fence", "inst-a", Vec::new());
+    initial.capabilities = Some(initial_capabilities);
+    registry.register(initial).await.unwrap();
+
+    // Hold the old semantic observation to model the ToolRuntime preflight, then
+    // allow the same process to re-register without these non-sticky features.
+    let stale_preflight = registry
+        .get_client_semantic_view("project-feature-fence")
+        .await
+        .unwrap();
+    assert!(stale_preflight.supports(RunnerFeature::ProjectPathRegistration));
+    assert!(stale_preflight.supports(RunnerFeature::ProjectLifecycle));
+
+    let mut downgraded = runner_registration("project-feature-fence", "inst-a", Vec::new());
+    downgraded.capabilities = Some(wire_capabilities_with_only(None));
+    registry.register(downgraded).await.unwrap();
+
+    let path_error = registry
+        .enqueue_project_op(
+            "project-feature-fence".to_string(),
+            "resolve_or_register_project",
+            "{}".to_string(),
+            "test".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        path_error.contains("project_path_registration"),
+        "{path_error}"
+    );
+
+    let lifecycle_error = registry
+        .enqueue_project_op(
+            "project-feature-fence".to_string(),
+            "project_lifecycle_disable",
+            "{}".to_string(),
+            "test".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        lifecycle_error.contains("project_lifecycle"),
+        "{lifecycle_error}"
+    );
+}
+
 async fn register_structured_delete_state(
     registry: &ShellClientRegistry,
     client_id: &str,

--- a/src/shell_client/mod_tests/protocol.rs
+++ b/src/shell_client/mod_tests/protocol.rs
@@ -420,7 +420,7 @@ async fn client_supports_reflects_registered_capabilities() {
             client_id: "ghost".to_string()
         }
     );
-    let err = registry.get_client_capabilities("ghost").await.unwrap_err();
+    let err = registry.get_client_feature_set("ghost").await.unwrap_err();
     assert_eq!(
         err,
         ShellClientLookupError::UnknownClient {

--- a/src/shell_client/polling.rs
+++ b/src/shell_client/polling.rs
@@ -5,7 +5,7 @@ use super::jobs::{
 use super::project_inventory::apply_legacy_refresh;
 use super::requests::{remove_pending_request_locked, take_pending_request_locked};
 use super::validation::{validate_agent_instance_id, validate_id};
-use super::{now_ts, ShellClientRegistry};
+use super::{now_ts, RunnerFeature, ShellClientRegistry};
 use crate::mcp_gateway::{
     validate_response as validate_mcp_gateway_response, McpGatewayDispatchState, McpGatewayResponse,
 };
@@ -253,10 +253,14 @@ impl ShellClientRegistry {
                         Some(client) if client.owner != pending.expected_client_owner => Some(
                             "stale_authority: target Runner owner changed before dispatch".to_string(),
                         ),
-                        Some(client) if !client.capabilities.file_write => Some(
+                        Some(client)
+                            if !client.runner_features.supports(RunnerFeature::FileWrite) =>
+                        {
+                            Some(
                             "stale_authority: target Runner no longer advertises file_write before dispatch"
                                 .to_string(),
-                        ),
+                            )
+                        }
                         Some(client)
                             if client.projects.iter().any(|project| {
                                 !project.disabled

--- a/src/shell_client/projects.rs
+++ b/src/shell_client/projects.rs
@@ -3,8 +3,8 @@ use super::project_inventory::reconcile_dynamic_projection;
 #[cfg(test)]
 use super::validation::validate_id;
 use super::validation::validate_project_summary;
-use super::ShellClientRegistry;
-use crate::shell_protocol::{ShellAgentProjectSummary, ShellClientCapabilities};
+use super::{RunnerFeatureSet, ShellClientRegistry};
+use crate::shell_protocol::ShellAgentProjectSummary;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,12 +38,13 @@ fn upsert_project_summary(
 }
 
 impl ShellClientRegistry {
-    /// Return the capabilities advertised by a registered agent client.
-    /// Returns a typed lookup error when the client is not registered.
-    pub(crate) async fn get_client_capabilities(
+    /// Return an immutable clone of the canonical feature truth for one
+    /// registered Runner. This is an internal semantic query, never a wire
+    /// projection.
+    pub(crate) async fn get_client_feature_set(
         &self,
         client_id: &str,
-    ) -> Result<ShellClientCapabilities, ShellClientLookupError> {
+    ) -> Result<RunnerFeatureSet, ShellClientLookupError> {
         self.prune_expired_shared_key_clients().await;
         let inner = self.inner.lock().await;
         let client =
@@ -53,7 +54,7 @@ impl ShellClientRegistry {
                 .ok_or_else(|| ShellClientLookupError::UnknownClient {
                     client_id: client_id.to_string(),
                 })?;
-        Ok(client.capabilities.clone())
+        Ok(client.runner_features.clone())
     }
 
     /// Check whether a registered agent client supports a named capability.

--- a/src/shell_client/requests.rs
+++ b/src/shell_client/requests.rs
@@ -9,7 +9,7 @@ use super::validation::{
     validate_file_request, validate_id, validate_process_request, validate_run_request,
     validate_script_enqueue_request,
 };
-use super::{now_ts, ShellClientRegistry, CLIENT_ONLINE_WINDOW_SECS};
+use super::{now_ts, RunnerFeature, ShellClientRegistry, CLIENT_ONLINE_WINDOW_SECS};
 use crate::lsp_bridge::{AgentLspPayload, AgentLspRequest, AGENT_LSP_REQUEST_KIND};
 use crate::mcp_gateway::{
     validate_request as validate_mcp_gateway_request, McpGatewayDispatchState, McpGatewayRequest,
@@ -21,20 +21,8 @@ use crate::shell_protocol::{
     ShellRunResponse, ShellScriptPayload, RAW_SHELL_COMMAND_MAX_BYTES,
     SHELL_CLIENT_CAPABILITY_APPLY_TEXT_EDIT_OCCURRENCE,
     SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ,
-    SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE, SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE, SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE, SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION, SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE, SHELL_CLIENT_CAPABILITY_FILE_READ,
+    SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA, SHELL_CLIENT_CAPABILITY_FILE_READ,
     SHELL_CLIENT_CAPABILITY_FILE_WRITE, SHELL_CLIENT_CAPABILITY_INTERNAL_POSIX_SCRIPT,
-    SHELL_CLIENT_CAPABILITY_LSP_CALL_HIERARCHY, SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION,
     SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL, SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS,
     SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL, SHELL_CLIENT_CAPABILITY_STRUCTURED_FILE_DELETE,
     SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV,
@@ -402,7 +390,10 @@ impl ShellClientRegistry {
         let Some(client) = inner.clients.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
         };
-        if !client.capabilities.apply_text_edit_occurrence {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::ApplyTextEditOccurrence)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_APPLY_TEXT_EDIT_OCCURRENCE}",
                 body.client_id
@@ -485,7 +476,7 @@ impl ShellClientRegistry {
             .get(&body.client_id)
             .ok_or_else(|| format!("unknown shell client: {}", body.client_id))?;
         assert_shell_client_access(auth, current)?;
-        if !current.capabilities.file_write {
+        if !current.runner_features.supports(RunnerFeature::FileWrite) {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_FILE_WRITE}",
                 body.client_id
@@ -573,19 +564,25 @@ impl ShellClientRegistry {
             return Err(format!("unknown shell client: {}", body.client_id));
         };
         assert_shell_client_access(auth, client)?;
-        if !client.capabilities.file_read {
+        if !client.runner_features.supports(RunnerFeature::FileRead) {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_FILE_READ}",
                 body.client_id
             ));
         }
-        if !client.capabilities.artifact_export_chunk_read {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::ArtifactExportChunkRead)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ}",
                 body.client_id
             ));
         }
-        if !client.capabilities.artifact_export_streaming_metadata {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::ArtifactExportStreamingMetadata)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA}",
                 body.client_id
@@ -656,13 +653,16 @@ impl ShellClientRegistry {
             return Err(format!("unknown shell client: {}", body.client_id));
         };
         assert_shell_client_access(auth, client)?;
-        if !client.capabilities.file_read {
+        if !client.runner_features.supports(RunnerFeature::FileRead) {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_FILE_READ}",
                 body.client_id
             ));
         }
-        if !client.capabilities.artifact_export_chunk_read {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::ArtifactExportChunkRead)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ}",
                 body.client_id
@@ -740,7 +740,10 @@ impl ShellClientRegistry {
         let Some(client) = inner.clients.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
         };
-        if !client.capabilities.structured_file_delete {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::StructuredFileDelete)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {} does not support {SHELL_CLIENT_CAPABILITY_STRUCTURED_FILE_DELETE}",
                 body.client_id
@@ -823,7 +826,10 @@ impl ShellClientRegistry {
         let Some(client) = inner.clients.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
         };
-        if !client.capabilities.structured_process_argv {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::StructuredProcessArgv)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {client_id} does not support {SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV}"
             ));
@@ -832,7 +838,10 @@ impl ShellClientRegistry {
             if mode != crate::command_sandbox::INSPECT_SANDBOX_MODE {
                 return Err(format!("unknown sandbox mode '{mode}'"));
             }
-            if !client.capabilities.sandbox_inspect_commands {
+            if !client
+                .runner_features
+                .supports(RunnerFeature::SandboxInspectCommands)
+            {
                 return Err(format!(
                     "{}: agent client {} cannot enforce the inspect sandbox",
                     SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS, client_id
@@ -907,7 +916,10 @@ impl ShellClientRegistry {
         let Some(client) = inner.clients.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
         };
-        if !client.capabilities.structured_script_payload {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::StructuredScriptPayload)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {client_id} does not support {SHELL_CLIENT_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD}"
             ));
@@ -916,7 +928,10 @@ impl ShellClientRegistry {
             if mode != crate::command_sandbox::INSPECT_SANDBOX_MODE {
                 return Err(format!("unknown sandbox mode '{mode}'"));
             }
-            if !client.capabilities.sandbox_inspect_commands {
+            if !client
+                .runner_features
+                .supports(RunnerFeature::SandboxInspectCommands)
+            {
                 return Err(format!(
                     "{}: agent client {} cannot enforce the inspect sandbox",
                     SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS, client_id
@@ -1000,7 +1015,10 @@ impl ShellClientRegistry {
         let Some(client) = inner.clients.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
         };
-        if !client.capabilities.internal_posix_script {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::InternalPosixScript)
+        {
             return Err(format!(
                 "capability_unavailable: agent client {client_id} does not support {SHELL_CLIENT_CAPABILITY_INTERNAL_POSIX_SCRIPT}"
             ));
@@ -1009,7 +1027,10 @@ impl ShellClientRegistry {
             if mode != crate::command_sandbox::INSPECT_SANDBOX_MODE {
                 return Err(format!("unknown sandbox mode '{mode}'"));
             }
-            if !client.capabilities.sandbox_inspect_commands {
+            if !client
+                .runner_features
+                .supports(RunnerFeature::SandboxInspectCommands)
+            {
                 return Err(format!(
                     "{}: agent client {} cannot enforce the inspect sandbox",
                     SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS, client_id
@@ -1113,7 +1134,7 @@ impl ShellClientRegistry {
             let Some(client) = inner.clients.get(&body.client_id) else {
                 return Err(format!("unknown shell client: {}", body.client_id));
             };
-            if !client.capabilities.ssh_shell {
+            if !client.runner_features.supports(RunnerFeature::SshShell) {
                 return Err(format!(
                     "agent_capability_unavailable: agent client {} does not support ssh_shell",
                     body.client_id
@@ -1127,7 +1148,10 @@ impl ShellClientRegistry {
             let Some(client) = inner.clients.get(&body.client_id) else {
                 return Err(format!("unknown shell client: {}", body.client_id));
             };
-            if !client.capabilities.sandbox_inspect_commands {
+            if !client
+                .runner_features
+                .supports(RunnerFeature::SandboxInspectCommands)
+            {
                 return Err(format!(
                     "{}: agent client {} cannot enforce the inspect sandbox",
                     SHELL_CLIENT_CAPABILITY_SANDBOX_INSPECT_COMMANDS, body.client_id
@@ -1361,7 +1385,10 @@ impl ShellClientRegistry {
             .ok_or_else(|| "exact Runner is unavailable".to_string())?;
         assert_shell_client_access(auth, client)
             .map_err(|_| "exact Runner is unavailable".to_string())?;
-        if !client.capabilities.coding_agent_runs {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::CodingAgentRuns)
+        {
             return Err("exact Runner does not support CodingAgentRun".to_string());
         }
         if client.agent_instance_id != expected_agent_instance_id {
@@ -1481,7 +1508,10 @@ impl ShellClientRegistry {
         let Some(client) = inner.clients.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
         };
-        if !client.capabilities.persistent_shell {
+        if !client
+            .runner_features
+            .supports(RunnerFeature::PersistentShell)
+        {
             return Err(format!(
                 "agent_capability_unavailable: agent client {client_id} does not support {SHELL_CLIENT_CAPABILITY_PERSISTENT_SHELL}"
             ));
@@ -1492,7 +1522,9 @@ impl ShellClientRegistry {
         if job_context
             .as_ref()
             .is_some_and(|ctx| ctx.ssh_resource.is_some())
-            && !client.capabilities.ssh_persistent_shell
+            && !client
+                .runner_features
+                .supports(RunnerFeature::SshPersistentShell)
         {
             return Err(format!(
                 "agent_capability_unavailable: agent client {client_id} does not support {SHELL_CLIENT_CAPABILITY_SSH_PERSISTENT_SHELL}"
@@ -1598,35 +1630,31 @@ impl ShellClientRegistry {
         timeout_secs: u64,
     ) -> Result<(String, oneshot::Receiver<ShellRunResponse>), String> {
         validate_id(&client_id, "client_id")?;
-        let required_capabilities: &[&str] = match kind {
-            "computer_list_applications" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY]
-            }
-            "computer_launch_application" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH],
+        let required_features: &[RunnerFeature] = match kind {
+            "computer_list_applications" => &[RunnerFeature::ComputerApplicationDiscovery],
+            "computer_launch_application" => &[RunnerFeature::ComputerApplicationLaunch],
             "computer_list_displays" | "computer_snapshot_display" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE]
+                &[RunnerFeature::ComputerDisplayObserve]
             }
-            "computer_read_clipboard" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ],
-            "computer_write_clipboard" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE],
-            "computer_list_windows" | "computer_snapshot" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE]
-            }
+            "computer_read_clipboard" => &[RunnerFeature::ComputerClipboardRead],
+            "computer_write_clipboard" => &[RunnerFeature::ComputerClipboardWrite],
+            "computer_list_windows" | "computer_snapshot" => &[RunnerFeature::ComputerObserve],
             "computer_snapshot_region" => &[
-                SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE,
-                SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION,
+                RunnerFeature::ComputerObserve,
+                RunnerFeature::ComputerSnapshotRegion,
             ],
             "computer_accessibility_status" | "computer_accessibility_tree" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE]
+                &[RunnerFeature::ComputerAccessibilityObserve]
             }
-            "computer_element_state" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE],
-            "computer_control" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL],
-            "computer_scroll_to_element" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT],
-            "computer_key_input" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT],
+            "computer_element_state" => &[RunnerFeature::ComputerElementState],
+            "computer_control" => &[RunnerFeature::ComputerControl],
+            "computer_scroll_to_element" => &[RunnerFeature::ComputerScrollToElement],
+            "computer_key_input" => &[RunnerFeature::ComputerKeyInput],
             "computer_pointer_move" | "computer_pointer_click" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL]
+                &[RunnerFeature::ComputerPointerControl]
             }
-            "computer_activate_window" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE],
-            "computer_input_text" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT],
+            "computer_activate_window" => &[RunnerFeature::ComputerWindowActivate],
+            "computer_input_text" => &[RunnerFeature::ComputerTextInput],
             _ => return Err("invalid computer request kind".to_string()),
         };
         if payload.len() > shell_computer_request_payload_max_bytes(kind) || payload.contains('\0')
@@ -1671,13 +1699,14 @@ impl ShellClientRegistry {
             .get(&client_id)
             .ok_or_else(|| format!("unknown shell client: {client_id}"))?;
         assert_shell_client_access(auth, current)?;
-        if let Some(required_capability) = required_capabilities
+        if let Some(required_feature) = required_features
             .iter()
             .copied()
-            .find(|capability| !current.runner_features.supports_wire_name(capability))
+            .find(|feature| !current.runner_features.supports(*feature))
         {
             return Err(format!(
-                "agent client {client_id} does not support {required_capability}"
+                "agent client {client_id} does not support {}",
+                required_feature.as_wire_name()
             ));
         }
         enqueue_pending_request_locked(
@@ -1707,12 +1736,12 @@ impl ShellClientRegistry {
             .map_err(|message| EnqueueLspError::InvalidRequest { message })?;
         // Capability gate before enqueue so old agents never receive unknown
         // LSP kinds that could fall into shell fallback.
-        let required_capability =
-            if matches!(&payload.request, AgentLspRequest::CallHierarchy { .. }) {
-                SHELL_CLIENT_CAPABILITY_LSP_CALL_HIERARCHY
-            } else {
-                SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION
-            };
+        let required_feature = if matches!(&payload.request, AgentLspRequest::CallHierarchy { .. })
+        {
+            RunnerFeature::LspCallHierarchy
+        } else {
+            RunnerFeature::LspReadOnlyNavigation
+        };
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
         let request = ShellAgentShellRequest {
@@ -1755,13 +1784,10 @@ impl ShellClientRegistry {
                 .ok_or_else(|| EnqueueLspError::UnknownClient {
                     client_id: client_id.clone(),
                 })?;
-        if !current
-            .runner_features
-            .supports_wire_name(required_capability)
-        {
+        if !current.runner_features.supports(required_feature) {
             return Err(EnqueueLspError::UnsupportedCapability {
                 client_id,
-                capability: required_capability,
+                capability: required_feature.as_wire_name(),
             });
         }
         enqueue_pending_request_locked(

--- a/src/shell_client/requests.rs
+++ b/src/shell_client/requests.rs
@@ -1572,6 +1572,14 @@ impl ShellClientRegistry {
         if payload.contains('\0') {
             return Err("project op payload must not contain NUL".to_string());
         }
+        let required_feature = match kind {
+            "resolve_or_register_project" => Some(RunnerFeature::ProjectPathRegistration),
+            "project_lifecycle_enable"
+            | "project_lifecycle_disable"
+            | "project_lifecycle_unregister" => Some(RunnerFeature::ProjectLifecycle),
+            "register_project" | "create_project" => None,
+            _ => unreachable!("project op kind validated above"),
+        };
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
         let request = ShellAgentShellRequest {
@@ -1604,6 +1612,18 @@ impl ShellClientRegistry {
             persistent_shell: None,
         };
         let mut inner = self.inner.lock().await;
+        if let Some(required_feature) = required_feature {
+            let client = inner
+                .clients
+                .get(&client_id)
+                .ok_or_else(|| format!("unknown shell client: {client_id}"))?;
+            if !client.runner_features.supports(required_feature) {
+                return Err(format!(
+                    "capability_unavailable: agent client {client_id} does not support {}",
+                    required_feature.as_wire_name()
+                ));
+            }
+        }
         enqueue_pending_request_locked(
             &mut inner,
             &client_id,

--- a/src/shell_client/state.rs
+++ b/src/shell_client/state.rs
@@ -1,10 +1,10 @@
 use super::auth::ShellClientAuthGroup;
-use super::{AgentTransport, RunnerFeatureSet};
+use super::{AgentTransport, RunnerFeature, RunnerFeatureSet};
 use crate::mcp_gateway::McpGatewayResponse;
 use crate::shell_protocol::{
     AgentBuildInfo, AgentHostContext, AgentPolicySummary, AgentProtocolSemantics,
     PersistentShellResult, ShellAgentProjectSummary, ShellAgentShellRequest,
-    ShellClientCapabilities, ShellCommandExecutionState, ShellJobCodexMetadata,
+    ShellClientCapabilities, ShellClientView, ShellCommandExecutionState, ShellJobCodexMetadata,
     ShellJobStructuredExecutionMetadata, ShellJobValidationProgress, ShellProcessArgv,
     ShellProjectInventoryStatus, ShellRunResponse, JOB_INVENTORY_MAX_TERMINAL_JOBS,
     JOB_TERMINAL_RETENTION_SECS,
@@ -55,8 +55,9 @@ pub(super) struct ShellClientRecord {
     /// Bounded Runner-configured planning metadata. This is not policy or live
     /// state and is replaced by each successful registration.
     pub(super) host_context: Option<AgentHostContext>,
-    /// Accepted legacy wire snapshot retained for compatibility projection and
-    /// C3b's explicitly inventoried downstream consumers.
+    /// Accepted legacy wire snapshot retained only for wire-compatible public
+    /// projection and diagnostics. Server capability authority lives in
+    /// `runner_features` below.
     pub(super) capabilities: ShellClientCapabilities,
     /// Canonical Server capability truth normalized once from `capabilities`
     /// during registration. This set has no independent mutation path.
@@ -112,6 +113,32 @@ pub(super) struct ShellClientRecord {
     /// the same runner instance.
     pub(super) projected_structured_terminal_suppressions:
         VecDeque<ProjectedStructuredTerminalSuppression>,
+}
+
+/// Internal-only atomic observation of one active Runner record.
+///
+/// `view` preserves the existing compatibility/diagnostic projection while
+/// feature decisions use the canonical set cloned from the same registry lock.
+/// This type is never serialized or exposed through the wire protocol.
+#[derive(Debug, Clone)]
+pub(crate) struct ShellClientSemanticView {
+    pub(crate) view: ShellClientView,
+    pub(super) runner_features: RunnerFeatureSet,
+}
+
+impl ShellClientSemanticView {
+    pub(crate) fn supports(&self, feature: RunnerFeature) -> bool {
+        self.runner_features.supports(feature)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_public_view_for_test(view: ShellClientView) -> Self {
+        let runner_features = RunnerFeatureSet::from_wire(&view.capabilities);
+        Self {
+            view,
+            runner_features,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -18,7 +18,7 @@ use super::validation_profile::{
 };
 use super::{ExecutionPurpose, ToolRuntime};
 use crate::auth::AuthContext;
-use crate::shell_client::ShellJobStartMetadata;
+use crate::shell_client::{RunnerFeature, ShellJobStartMetadata};
 use crate::shell_protocol::{
     ShellCommandExecutionState, ShellJobOpRequest, ShellJobValidationMetadata,
     ShellJobValidationStep,
@@ -801,8 +801,8 @@ impl ToolRuntime {
                     ));
                 }
             };
-            let capabilities = match self.shell_clients.get_client_capabilities(client_id).await {
-                Ok(capabilities) => capabilities,
+            let features = match self.shell_clients.get_client_feature_set(client_id).await {
+                Ok(features) => features,
                 Err(error) => {
                     return ToolResult::err(command_rejected_message(
                         error.to_string(),
@@ -810,14 +810,14 @@ impl ToolRuntime {
                     ));
                 }
             };
-            let async_handoff_available = (capabilities.async_jobs
-                || capabilities.async_shell_jobs)
-                && capabilities.structured_validation_argv;
+            let async_handoff_available = (features.supports(RunnerFeature::AsyncJobs)
+                || features.supports(RunnerFeature::AsyncShellJobs))
+                && features.supports(RunnerFeature::StructuredValidationArgv);
             if tool_name == "cargo_test"
                 && request.minimum_tests.is_some()
                 && timeout_secs > SYNC_VALIDATION_WAIT_SECS
                 && async_handoff_available
-                && !capabilities.structured_cargo_test_count_assertion
+                && !features.supports(RunnerFeature::StructuredCargoTestCountAssertion)
             {
                 return ToolResult::err_with_output(
                     command_rejected_message(
@@ -836,7 +836,7 @@ impl ToolRuntime {
                     }),
                 );
             }
-            if tool_name == "go_test" && !capabilities.structured_go_test_json {
+            if tool_name == "go_test" && !features.supports(RunnerFeature::StructuredGoTestJson) {
                 return ToolResult::err_with_output(
                     command_rejected_message(
                         "capability_unavailable: this Runner does not advertise structured_go_test_json",
@@ -852,7 +852,7 @@ impl ToolRuntime {
                     }),
                 );
             }
-            if tool_name == "go_test" && !capabilities.structured_go_test_tool {
+            if tool_name == "go_test" && !features.supports(RunnerFeature::StructuredGoTestTool) {
                 return ToolResult::err_with_output(
                     command_rejected_message(
                         "capability_unavailable: this Runner does not advertise structured_go_test_tool",
@@ -870,7 +870,7 @@ impl ToolRuntime {
             }
             if tool_name == "go_test"
                 && options.go_packages.is_some()
-                && !capabilities.structured_go_test_packages
+                && !features.supports(RunnerFeature::StructuredGoTestPackages)
             {
                 return ToolResult::err_with_output(
                     command_rejected_message(

--- a/src/tool_runtime/coding_agent.rs
+++ b/src/tool_runtime/coding_agent.rs
@@ -1,5 +1,6 @@
 use super::{RecoveryKind, ToolResult, ToolRuntime};
 use crate::auth::{AuthContext, AuthKind};
+use crate::shell_client::RunnerFeature;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::Utc;
 use serde_json::{json, Value};
@@ -263,10 +264,10 @@ impl ToolRuntime {
         };
         let client = match self
             .shell_clients
-            .get_client_view_for_auth(&client_id, auth)
+            .get_client_semantic_view_for_auth(&client_id, auth)
             .await
         {
-            Some(client) if client.connected => client,
+            Some(client) if client.view.connected => client,
             _ => {
                 return coding_agent_error(
                     "coding_agent_runner_unavailable",
@@ -277,7 +278,7 @@ impl ToolRuntime {
                 )
             }
         };
-        if !client.capabilities.coding_agent_runs {
+        if !client.supports(RunnerFeature::CodingAgentRuns) {
             return coding_agent_error(
                 "coding_agent_unsupported",
                 "exact Project Runner does not advertise CodingAgentRun",
@@ -286,6 +287,7 @@ impl ToolRuntime {
                 Some(&run_id),
             );
         }
+        let client = client.view;
         let providers = client.coding_agent_providers.as_deref().unwrap_or(&[]);
         let provider = match providers
             .iter()

--- a/src/tool_runtime/computer_tools.rs
+++ b/src/tool_runtime/computer_tools.rs
@@ -4,19 +4,8 @@ use super::tool_call::ComputerSnapshotRegion;
 use super::{RecoveryKind, RecoveryTool, ToolCall, ToolResult, ToolRuntime};
 use crate::artifact_policy::MAX_MCP_IMAGE_BYTES;
 use crate::auth::AuthContext;
-use crate::shell_protocol::{
-    ShellCommandExecutionState, ShellFileOpRequest,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE, SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE, SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE, SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION, SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT,
-    SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE,
-};
+use crate::shell_client::RunnerFeature;
+use crate::shell_protocol::{ShellCommandExecutionState, ShellFileOpRequest};
 use base64::{engine::general_purpose, Engine as _};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -1011,19 +1000,26 @@ impl ToolRuntime {
     }
 
     async fn computer_list_targets(&self, auth: Option<&AuthContext>) -> ToolResult {
-        let clients = self.shell_clients.list_clients_for_auth(auth).await;
+        let clients = self
+            .shell_clients
+            .list_client_semantic_views_for_auth(auth)
+            .await;
         let mut total_count = 0usize;
         let mut targets = Vec::new();
         for client in clients {
-            let computer_observe = client.capabilities.computer_observe;
-            let computer_application_discovery = client.capabilities.computer_application_discovery;
-            let computer_application_launch = client.capabilities.computer_application_launch;
-            let computer_display_observe = client.capabilities.computer_display_observe;
-            let computer_pointer_control = client.capabilities.computer_pointer_control;
-            let computer_clipboard_read = client.capabilities.computer_clipboard_read;
-            let computer_clipboard_write = client.capabilities.computer_clipboard_write;
-            let computer_snapshot_region = client.capabilities.computer_snapshot_region;
-            let computer_accessibility_observe = client.capabilities.computer_accessibility_observe;
+            let computer_observe = client.supports(RunnerFeature::ComputerObserve);
+            let computer_application_discovery =
+                client.supports(RunnerFeature::ComputerApplicationDiscovery);
+            let computer_application_launch =
+                client.supports(RunnerFeature::ComputerApplicationLaunch);
+            let computer_display_observe = client.supports(RunnerFeature::ComputerDisplayObserve);
+            let computer_pointer_control = client.supports(RunnerFeature::ComputerPointerControl);
+            let computer_clipboard_read = client.supports(RunnerFeature::ComputerClipboardRead);
+            let computer_clipboard_write = client.supports(RunnerFeature::ComputerClipboardWrite);
+            let computer_snapshot_region = client.supports(RunnerFeature::ComputerSnapshotRegion);
+            let computer_accessibility_observe =
+                client.supports(RunnerFeature::ComputerAccessibilityObserve);
+            let view = client.view;
             if !computer_observe
                 && !computer_accessibility_observe
                 && !computer_application_discovery
@@ -1040,9 +1036,9 @@ impl ToolRuntime {
                 continue;
             }
             targets.push(json!({
-                "client_id": client.client_id,
-                "display_name": client.display_name,
-                "connected": client.connected,
+                "client_id": view.client_id,
+                "display_name": view.display_name,
+                "connected": view.connected,
                 "capabilities": {
                     "computer_observe": computer_observe,
                     "computer_application_discovery": computer_application_discovery,
@@ -1131,96 +1127,94 @@ impl ToolRuntime {
             }
             return computer_error("invalid_client", "client_id is invalid");
         }
-        let required_capabilities: &[&str] = match kind {
-            "computer_list_applications" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_DISCOVERY]
-            }
-            "computer_launch_application" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_APPLICATION_LAUNCH],
+        let required_features: &[RunnerFeature] = match kind {
+            "computer_list_applications" => &[RunnerFeature::ComputerApplicationDiscovery],
+            "computer_launch_application" => &[RunnerFeature::ComputerApplicationLaunch],
             "computer_list_displays" | "computer_snapshot_display" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_DISPLAY_OBSERVE]
+                &[RunnerFeature::ComputerDisplayObserve]
             }
-            "computer_read_clipboard" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_READ],
-            "computer_write_clipboard" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_CLIPBOARD_WRITE],
+            "computer_read_clipboard" => &[RunnerFeature::ComputerClipboardRead],
+            "computer_write_clipboard" => &[RunnerFeature::ComputerClipboardWrite],
             "computer_pointer_move" | "computer_pointer_click" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_POINTER_CONTROL]
+                &[RunnerFeature::ComputerPointerControl]
             }
-            "computer_list_windows" | "computer_snapshot" => {
-                &[SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE]
-            }
+            "computer_list_windows" | "computer_snapshot" => &[RunnerFeature::ComputerObserve],
             "computer_snapshot_region" => &[
-                SHELL_CLIENT_CAPABILITY_COMPUTER_OBSERVE,
-                SHELL_CLIENT_CAPABILITY_COMPUTER_SNAPSHOT_REGION,
+                RunnerFeature::ComputerObserve,
+                RunnerFeature::ComputerSnapshotRegion,
             ],
             "computer_accessibility_status" | "computer_accessibility_tree" => {
-                &[crate::shell_protocol::SHELL_CLIENT_CAPABILITY_COMPUTER_ACCESSIBILITY_OBSERVE]
+                &[RunnerFeature::ComputerAccessibilityObserve]
             }
-            "computer_element_state" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_ELEMENT_STATE],
-            "computer_control" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_CONTROL],
-            "computer_scroll_to_element" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_SCROLL_TO_ELEMENT],
-            "computer_key_input" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_KEY_INPUT],
-            "computer_activate_window" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_WINDOW_ACTIVATE],
-            "computer_input_text" => &[SHELL_CLIENT_CAPABILITY_COMPUTER_TEXT_INPUT],
+            "computer_element_state" => &[RunnerFeature::ComputerElementState],
+            "computer_control" => &[RunnerFeature::ComputerControl],
+            "computer_scroll_to_element" => &[RunnerFeature::ComputerScrollToElement],
+            "computer_key_input" => &[RunnerFeature::ComputerKeyInput],
+            "computer_activate_window" => &[RunnerFeature::ComputerWindowActivate],
+            "computer_input_text" => &[RunnerFeature::ComputerTextInput],
             _ => return computer_error("invalid_request", "unsupported computer request kind"),
         };
-        for required_capability in required_capabilities {
-            match self
-                .shell_clients
-                .client_supports_for_auth(client_id, required_capability, auth)
-                .await
-            {
-                Ok(true) => {}
-                Ok(false) => {
-                    if is_application_launch {
-                        return computer_application_effect_not_started(
-                            "capability_unavailable",
-                            &format!("target Runner does not support {required_capability}"),
-                            expected_application_id.as_deref().unwrap_or_default(),
-                        );
-                    }
-                    if let Some(context) = pointer_context.as_ref() {
-                        return computer_pointer_effect_not_started(
-                            "capability_unavailable",
-                            &format!("target Runner does not support {required_capability}"),
-                            context,
-                        );
-                    }
-                    if let Some(context) = clipboard_write_context.as_ref() {
-                        return computer_clipboard_write_not_started(
-                            "capability_unavailable",
-                            &format!("target Runner does not support {required_capability}"),
-                            context,
-                        );
-                    }
-                    return computer_error(
-                        "capability_unavailable",
-                        &format!("target Runner does not support {required_capability}"),
-                    );
-                }
-                Err(_error) if is_application_launch => {
-                    return computer_application_effect_not_started(
-                        "client_access_denied",
-                        "caller cannot access the target Runner for application launch",
-                        expected_application_id.as_deref().unwrap_or_default(),
-                    );
-                }
-                Err(_error) if is_pointer => {
-                    return computer_pointer_effect_not_started(
-                        "client_access_denied",
-                        "caller cannot access the target Runner for pointer control",
-                        pointer_context.as_ref().expect("pointer context"),
-                    );
-                }
-                Err(_error) if is_clipboard_write => {
-                    return computer_clipboard_write_not_started(
-                        "client_access_denied",
-                        "caller cannot access the target Runner for clipboard write",
-                        clipboard_write_context
-                            .as_ref()
-                            .expect("clipboard write context"),
-                    );
-                }
-                Err(error) => return computer_error("client_access_denied", &error),
+        let client = match self
+            .shell_clients
+            .get_client_semantic_view_checked_for_auth(client_id, auth)
+            .await
+        {
+            Ok(client) => client,
+            Err(_error) if is_application_launch => {
+                return computer_application_effect_not_started(
+                    "client_access_denied",
+                    "caller cannot access the target Runner for application launch",
+                    expected_application_id.as_deref().unwrap_or_default(),
+                );
             }
+            Err(_error) if is_pointer => {
+                return computer_pointer_effect_not_started(
+                    "client_access_denied",
+                    "caller cannot access the target Runner for pointer control",
+                    pointer_context.as_ref().expect("pointer context"),
+                );
+            }
+            Err(_error) if is_clipboard_write => {
+                return computer_clipboard_write_not_started(
+                    "client_access_denied",
+                    "caller cannot access the target Runner for clipboard write",
+                    clipboard_write_context
+                        .as_ref()
+                        .expect("clipboard write context"),
+                );
+            }
+            Err(error) => return computer_error("client_access_denied", &error),
+        };
+        for required_feature in required_features {
+            if client.supports(*required_feature) {
+                continue;
+            }
+            let required_capability = required_feature.as_wire_name();
+            if is_application_launch {
+                return computer_application_effect_not_started(
+                    "capability_unavailable",
+                    &format!("target Runner does not support {required_capability}"),
+                    expected_application_id.as_deref().unwrap_or_default(),
+                );
+            }
+            if let Some(context) = pointer_context.as_ref() {
+                return computer_pointer_effect_not_started(
+                    "capability_unavailable",
+                    &format!("target Runner does not support {required_capability}"),
+                    context,
+                );
+            }
+            if let Some(context) = clipboard_write_context.as_ref() {
+                return computer_clipboard_write_not_started(
+                    "capability_unavailable",
+                    &format!("target Runner does not support {required_capability}"),
+                    context,
+                );
+            }
+            return computer_error(
+                "capability_unavailable",
+                &format!("target Runner does not support {required_capability}"),
+            );
         }
         let expected_element_id = payload
             .get("element_id")

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -517,9 +517,11 @@ impl ToolRuntime {
             // the legacy shell path instead of receiving an unknown file op.
             let supports_structured_delete = self
                 .shell_clients
-                .get_client_capabilities(&client_id)
+                .get_client_feature_set(&client_id)
                 .await
-                .map(|caps| caps.structured_file_delete)
+                .map(|features| {
+                    features.supports(crate::shell_client::RunnerFeature::StructuredFileDelete)
+                })
                 .unwrap_or(false);
             if supports_structured_delete {
                 return self

--- a/src/tool_runtime/lsp_tools.rs
+++ b/src/tool_runtime/lsp_tools.rs
@@ -10,7 +10,7 @@ use crate::lsp_bridge::{
     LspStatusResult, WorkspaceSymbolsResult, MAX_CALL_HIERARCHY_CALL_SITES_PER_EDGE,
     MAX_CALL_HIERARCHY_ROOTS,
 };
-use crate::shell_client::EnqueueLspError;
+use crate::shell_client::{EnqueueLspError, RunnerFeature};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -205,26 +205,30 @@ impl ToolRuntime {
             Ok(id) => id.to_string(),
             Err(e) => return ToolResult::err(e),
         };
-        let Some(client) = self.shell_clients.get_client_view(&client_id).await else {
+        let Some(client) = self
+            .shell_clients
+            .get_client_semantic_view(&client_id)
+            .await
+        else {
             return ToolResult::err(format!(
                 "{}: agent is not connected",
                 error_codes::AGENT_CAPABILITY_UNAVAILABLE
             ));
         };
-        if !client.connected {
+        if !client.view.connected {
             return ToolResult::err(format!(
                 "{}: agent is not connected",
                 error_codes::AGENT_CAPABILITY_UNAVAILABLE
             ));
         }
         let call_hierarchy = matches!(&request, AgentLspRequest::CallHierarchy { .. });
-        if call_hierarchy && !client.capabilities.lsp_call_hierarchy {
+        if call_hierarchy && !client.supports(RunnerFeature::LspCallHierarchy) {
             return ToolResult::err(format!(
                 "{}: agent does not support lsp_call_hierarchy",
                 error_codes::AGENT_CAPABILITY_UNAVAILABLE
             ));
         }
-        if !call_hierarchy && !client.capabilities.lsp_read_only_navigation {
+        if !call_hierarchy && !client.supports(RunnerFeature::LspReadOnlyNavigation) {
             return ToolResult::err(format!(
                 "{}: agent does not support lsp_read_only_navigation",
                 error_codes::AGENT_CAPABILITY_UNAVAILABLE

--- a/src/tool_runtime/process.rs
+++ b/src/tool_runtime/process.rs
@@ -17,8 +17,8 @@ use super::tool_audit::run_process_validation_identity;
 use super::{ExecutionPurpose, ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
 use crate::shell_client::{
-    process_preview, ShellJobStartMetadata, ShellJobVisibility, StructuredJobExecution,
-    DETACHED_IDEMPOTENCY_CONFLICT, DETACHED_IDEMPOTENCY_RECOVERY_PREFIX,
+    process_preview, RunnerFeature, ShellJobStartMetadata, ShellJobVisibility,
+    StructuredJobExecution, DETACHED_IDEMPOTENCY_CONFLICT, DETACHED_IDEMPOTENCY_RECOVERY_PREFIX,
 };
 use crate::shell_protocol::{
     validate_process_argv, ShellCommandExecutionState, ShellJobInfo, ShellJobOpRequest,
@@ -465,8 +465,8 @@ impl ToolRuntime {
         };
         let resolved_cwd =
             project_relative_agent_cwd(&proj, &effective_cwd).unwrap_or_else(|_| ".".to_string());
-        let capabilities = match self.shell_clients.get_client_capabilities(&client_id).await {
-            Ok(capabilities) => capabilities,
+        let features = match self.shell_clients.get_client_feature_set(&client_id).await {
+            Ok(features) => features,
             Err(error) => {
                 return process_tool_failure_result(
                     command_rejected_message(
@@ -478,10 +478,11 @@ impl ToolRuntime {
                 )
             }
         };
-        if !capabilities.detached_process_jobs
-            || !capabilities.structured_process_argv
-            || !capabilities.structured_execution_jobs
-            || !(capabilities.async_jobs || capabilities.async_shell_jobs)
+        if !features.supports(RunnerFeature::DetachedProcessJobs)
+            || !features.supports(RunnerFeature::StructuredProcessArgv)
+            || !features.supports(RunnerFeature::StructuredExecutionJobs)
+            || !(features.supports(RunnerFeature::AsyncJobs)
+                || features.supports(RunnerFeature::AsyncShellJobs))
         {
             return process_tool_failure_result(
                 command_rejected_message(
@@ -711,8 +712,8 @@ impl ToolRuntime {
             };
             let resolved_cwd = project_relative_agent_cwd(&proj, &effective_cwd)
                 .unwrap_or_else(|_| ".".to_string());
-            let capabilities = match self.shell_clients.get_client_capabilities(&client_id).await {
-                Ok(capabilities) => capabilities,
+            let features = match self.shell_clients.get_client_feature_set(&client_id).await {
+                Ok(features) => features,
                 Err(error) => {
                     let mut result = process_tool_failure_result(
                         command_rejected_message(
@@ -739,8 +740,9 @@ impl ToolRuntime {
                 }
             };
             let async_handoff_available = allow_async_handoff
-                && capabilities.structured_execution_jobs
-                && (capabilities.async_jobs || capabilities.async_shell_jobs);
+                && features.supports(RunnerFeature::StructuredExecutionJobs)
+                && (features.supports(RunnerFeature::AsyncJobs)
+                    || features.supports(RunnerFeature::AsyncShellJobs));
             if !async_handoff_available
                 && timeout > STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS
             {

--- a/src/tool_runtime/projects.rs
+++ b/src/tool_runtime/projects.rs
@@ -20,8 +20,9 @@ use std::time::Duration;
 use super::tool_result::{RecoveryKind, ToolResult};
 use super::{agent_project_runtime_id, ToolRuntime};
 use crate::auth::AuthContext;
+use crate::shell_client::{RunnerFeature, ShellClientSemanticView};
 use crate::shell_protocol::{
-    ShellAgentProjectSummary, ShellClientView, SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION,
+    ShellAgentProjectSummary, SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION,
 };
 
 /// Maximum time the runtime waits for an agent project-op response. Project
@@ -104,21 +105,22 @@ fn validate_list_projects_options(
 }
 
 fn project_candidates(
-    clients: &[ShellClientView],
+    clients: &[ShellClientSemanticView],
     options: &ListProjectsOptions,
     query: Option<&str>,
 ) -> Vec<ProjectCandidate> {
     let mut candidates = Vec::new();
     for (client_index, client) in clients.iter().enumerate() {
+        let view = &client.view;
         if options
             .client_id
             .as_deref()
-            .is_some_and(|expected| client.client_id != expected)
+            .is_some_and(|expected| view.client_id != expected)
         {
             continue;
         }
-        for (project_index, project) in client.projects.iter().enumerate() {
-            let runtime_id = agent_project_runtime_id(&client.client_id, &project.id);
+        for (project_index, project) in view.projects.iter().enumerate() {
+            let runtime_id = agent_project_runtime_id(&view.client_id, &project.id);
             if options
                 .project
                 .as_deref()
@@ -155,8 +157,11 @@ impl ToolRuntime {
             Ok(validated) => validated,
             Err(result) => return result,
         };
-        let clients = self.shell_clients.list_clients_for_auth(auth).await;
-        self.list_projects_from_visible_clients(auth, &options, query.as_deref(), limit, &clients)
+        let clients = self
+            .shell_clients
+            .list_client_semantic_views_for_auth(auth)
+            .await;
+        self.list_projects_from_semantic_clients(auth, &options, query.as_deref(), limit, &clients)
             .await
     }
 
@@ -165,23 +170,34 @@ impl ToolRuntime {
         &self,
         auth: Option<&AuthContext>,
         options: ListProjectsOptions,
-        clients: &[ShellClientView],
+        clients: &[crate::shell_protocol::ShellClientView],
     ) -> ToolResult {
         let (query, limit) = match validate_list_projects_options(&options) {
             Ok(validated) => validated,
             Err(result) => return result,
         };
-        self.list_projects_from_visible_clients(auth, &options, query.as_deref(), limit, clients)
-            .await
+        let semantic_clients = clients
+            .iter()
+            .cloned()
+            .map(ShellClientSemanticView::from_public_view_for_test)
+            .collect::<Vec<_>>();
+        self.list_projects_from_semantic_clients(
+            auth,
+            &options,
+            query.as_deref(),
+            limit,
+            &semantic_clients,
+        )
+        .await
     }
 
-    async fn list_projects_from_visible_clients(
+    async fn list_projects_from_semantic_clients(
         &self,
         auth: Option<&AuthContext>,
         options: &ListProjectsOptions,
         query: Option<&str>,
         limit: Option<usize>,
-        clients: &[ShellClientView],
+        clients: &[ShellClientSemanticView],
     ) -> ToolResult {
         let mut candidates = project_candidates(clients, options, query);
         let matched_count = candidates.len();
@@ -212,18 +228,19 @@ impl ToolRuntime {
                 capabilities,
             ) = {
                 let client = &clients[client_index];
-                let project = &client.projects[project_index];
-                let shell_profiles = client
+                let view = &client.view;
+                let project = &view.projects[project_index];
+                let shell_profiles = view
                     .policy
                     .as_ref()
                     .and_then(|policy| policy.shell_profiles.as_ref());
                 let (resolved_shell_profile, shell_profile_status) =
                     resolve_project_shell_profile(project.shell_profile.as_deref(), shell_profiles);
                 (
-                    client.client_id.clone(),
-                    client.status.clone(),
-                    client.connected,
-                    client.last_seen,
+                    view.client_id.clone(),
+                    view.status.clone(),
+                    view.connected,
+                    view.last_seen,
                     project.clone(),
                     resolved_shell_profile,
                     shell_profile_status,
@@ -452,7 +469,7 @@ impl ToolRuntime {
         }
         if let Some(client) = self
             .shell_clients
-            .get_client_view_for_auth(&client_id, auth)
+            .get_client_semantic_view_for_auth(&client_id, auth)
             .await
         {
             if let Err(error) = self
@@ -462,7 +479,7 @@ impl ToolRuntime {
             {
                 return ToolResult::err(error);
             }
-            if !client.capabilities.project_path_registration {
+            if !client.supports(RunnerFeature::ProjectPathRegistration) {
                 return ToolResult::err_with_output(
                     "agent_capability_unavailable: the selected Runner does not support project path registration; upgrade the Runner or use an existing registered project id",
                     json!({
@@ -759,13 +776,14 @@ fn smoke_marker_present(project: &crate::shell_protocol::ShellAgentProjectSummar
 }
 
 fn smoke_project_capabilities(
-    client: &crate::shell_protocol::ShellClientView,
+    client: &ShellClientSemanticView,
     project: &crate::shell_protocol::ShellAgentProjectSummary,
 ) -> Value {
-    let git_available = project_git_available(client, project);
+    let git_available = project_git_available(&client.view, project);
     let safe_smoke_project =
-        project.allow_patch && client.connected && smoke_marker_present(project);
-    let supports_artifact_smoke = client.capabilities.file_read && client.capabilities.file_write;
+        project.allow_patch && client.view.connected && smoke_marker_present(project);
+    let supports_artifact_smoke =
+        client.supports(RunnerFeature::FileRead) && client.supports(RunnerFeature::FileWrite);
     let supports_cleanup_verification =
         supports_artifact_smoke || git_available.is_some_and(|available| available);
     let recommended_for_smoke = safe_smoke_project

--- a/src/tool_runtime/script.rs
+++ b/src/tool_runtime/script.rs
@@ -19,7 +19,8 @@ use super::tool_audit::run_script_validation_identity;
 use super::{ExecutionPurpose, ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
 use crate::shell_client::{
-    script_preview, ShellJobStartMetadata, ShellJobVisibility, StructuredJobExecution,
+    script_preview, RunnerFeature, ShellJobStartMetadata, ShellJobVisibility,
+    StructuredJobExecution,
 };
 use crate::shell_protocol::{
     validate_script_request, ShellCommandExecutionState, ShellJobOpRequest, ShellScriptLanguage,
@@ -151,8 +152,8 @@ impl ToolRuntime {
             };
             let resolved_cwd = project_relative_agent_cwd(&proj, &effective_cwd)
                 .unwrap_or_else(|_| ".".to_string());
-            let capabilities = match self.shell_clients.get_client_capabilities(&client_id).await {
-                Ok(capabilities) => capabilities,
+            let features = match self.shell_clients.get_client_feature_set(&client_id).await {
+                Ok(features) => features,
                 Err(error) => {
                     let mut result = process_tool_failure_result(
                         command_rejected_message(
@@ -179,8 +180,9 @@ impl ToolRuntime {
                     return result;
                 }
             };
-            let async_handoff_available = capabilities.structured_execution_jobs
-                && (capabilities.async_jobs || capabilities.async_shell_jobs);
+            let async_handoff_available = features.supports(RunnerFeature::StructuredExecutionJobs)
+                && (features.supports(RunnerFeature::AsyncJobs)
+                    || features.supports(RunnerFeature::AsyncShellJobs));
             if !async_handoff_available
                 && timeout > STRUCTURED_EXECUTION_LEGACY_SYNC_TIMEOUT_MAX_SECS
             {

--- a/src/tool_runtime/semantic_navigation.rs
+++ b/src/tool_runtime/semantic_navigation.rs
@@ -11,7 +11,7 @@ use crate::lsp_bridge::{
     parse_agent_lsp_result_envelope, AgentLspPayload, AgentLspRequest, LspAvailabilityStatus,
     LspStatusResult,
 };
-use crate::shell_client::EnqueueLspError;
+use crate::shell_client::{EnqueueLspError, RunnerFeature};
 use serde::Serialize;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -306,19 +306,23 @@ impl ToolRuntime {
                 )
             }
         };
-        let Some(client) = self.shell_clients.get_client_view(&client_id).await else {
+        let Some(client) = self
+            .shell_clients
+            .get_client_semantic_view(&client_id)
+            .await
+        else {
             return SemanticNavigationStartupSummary::unsupported(
                 SemanticNavigationStartupStatus::AgentUnavailable,
                 SemanticNavigationReasonCode::AgentNotConnected,
             );
         };
-        if !client.connected {
+        if !client.view.connected {
             return SemanticNavigationStartupSummary::unsupported(
                 SemanticNavigationStartupStatus::AgentUnavailable,
                 SemanticNavigationReasonCode::AgentNotConnected,
             );
         }
-        if !client.capabilities.lsp_read_only_navigation {
+        if !client.supports(RunnerFeature::LspReadOnlyNavigation) {
             return SemanticNavigationStartupSummary::unsupported(
                 SemanticNavigationStartupStatus::AgentCapabilityUnavailable,
                 SemanticNavigationReasonCode::LspCapabilityNotAdvertised,

--- a/src/tool_runtime/shell.rs
+++ b/src/tool_runtime/shell.rs
@@ -17,7 +17,9 @@ use super::structured_execution::{
 use super::tool_result::ToolResult;
 use super::{ExecutionPurpose, ExecutionShell, ToolRuntime};
 use crate::auth::AuthContext;
-use crate::shell_client::{command_preview, ShellJobStartMetadata, ShellJobVisibility};
+use crate::shell_client::{
+    command_preview, RunnerFeature, ShellJobStartMetadata, ShellJobVisibility,
+};
 use crate::shell_protocol::{
     ShellCommandExecutionState, ShellJobInfo, ShellJobOpRequest, ShellRunRequest, ShellRunResponse,
 };
@@ -660,11 +662,12 @@ impl ToolRuntime {
             let async_handoff_available =
                 if timeout > DEFAULT_RUN_SHELL_TIMEOUT_SECS && ssh_resource.is_none() {
                     self.shell_clients
-                        .get_client_capabilities(&client_id)
+                        .get_client_feature_set(&client_id)
                         .await
-                        .is_ok_and(|capabilities| {
-                            capabilities.shell
-                                && (capabilities.async_jobs || capabilities.async_shell_jobs)
+                        .is_ok_and(|features| {
+                            features.supports(RunnerFeature::Shell)
+                                && (features.supports(RunnerFeature::AsyncJobs)
+                                    || features.supports(RunnerFeature::AsyncShellJobs))
                         })
                 } else {
                     false

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -414,6 +414,40 @@ async fn register_agent_projects_for_auth(
 }
 
 #[tokio::test]
+async fn coding_agent_start_uses_canonical_runner_capability_gate() {
+    let runtime = test_runtime();
+    register_agent_with_projects(
+        &runtime,
+        "coding-capability-gate",
+        None,
+        ShellClientCapabilities::default(),
+        vec![registered_project("demo", "/tmp/coding-capability-gate")],
+    )
+    .await;
+    let project = agent_project_runtime_id("coding-capability-gate", "demo");
+
+    let result = runtime
+        .coding_agent_start(
+            project,
+            "codex".to_string(),
+            "c3b-canonical-capability-gate".to_string(),
+            "prove capability admission".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+    assert!(!result.success);
+    assert_eq!(result.output["error_kind"], "coding_agent_unsupported");
+    assert!(result
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("does not advertise CodingAgentRun")));
+}
+
+#[tokio::test]
 async fn list_projects_returns_agent_registered_projects_without_server_config() {
     let runtime = test_runtime();
     register_agent_with_projects(


### PR DESCRIPTION
## Summary

- make `RunnerFeatureSet` the Server business/authority source for Runner capabilities
- add internal atomic semantic snapshots so identity/state/capabilities cannot split across reconnects
- keep `ShellClientCapabilities` as registration/projection compatibility DTO, with no wire schema change or generation baseline
- recheck project path/lifecycle capabilities under the registry lock immediately before project-operation enqueue

## Validation

- capability suite: 12/12 passed
- same-instance regressions: 14/14 passed
- Project lifecycle regressions: 3/3 passed
- Project path registration positive path passed
- shared-key Computer launch dependency regression passed
- Computer target capability regression passed
- frozen v0.3.8 registration fixture passed
- `cargo fmt -- --check` passed
- `cargo check --all-targets` passed with 0 errors / 0 warnings

No Runner wire schema, protocol-generation baseline, public capability JSON, deploy, restart, or release changes.