### PR TITLE
Establish Runner protocol generation baseline

### DIFF
--- a/crates/webcodex-agent-config/src/lib.rs
+++ b/crates/webcodex-agent-config/src/lib.rs
@@ -287,6 +287,9 @@ pub fn generated_agent_config_toml(opts: &AgentInitOptions) -> Result<String, St
             // ACP autonomous coding is a runtime-only capability and must not be
             // silently enabled by generated legacy agent config.
             coding_agent_runs: false,
+            // Protocol generation is a live Runner registration fact, never a
+            // static generated-config capability.
+            agent_protocol_generation: None,
         },
         policy: GeneratedAgentPolicy {
             allow_raw_shell: true,

--- a/crates/webcodex-core/src/shell_protocol.rs
+++ b/crates/webcodex-core/src/shell_protocol.rs
@@ -132,6 +132,30 @@ pub const AGENT_PROTOCOL_VERSION_QUIC_V1: &str = "quic-v1";
 /// compatibility metadata rather than a distinct canonical protocol generation.
 pub const AGENT_PROTOCOL_VERSION_QUIC_V2: &str = "quic-v2";
 
+/// Raw additive protocol-generation advertisement carried by Runner registration.
+///
+/// This wire type deliberately permits future/unsupported numeric values so a new
+/// peer can be rejected explicitly at Server ingress instead of being truncated or
+/// guessed into a supported generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentProtocolGenerationNumber(u16);
+
+impl AgentProtocolGenerationNumber {
+    pub const fn new(value: u16) -> Self {
+        Self(value)
+    }
+
+    pub const fn get(self) -> u16 {
+        self.0
+    }
+}
+
+pub const AGENT_PROTOCOL_GENERATION_LEGACY_V1: AgentProtocolGenerationNumber =
+    AgentProtocolGenerationNumber::new(1);
+pub const AGENT_PROTOCOL_GENERATION_V2: AgentProtocolGenerationNumber =
+    AgentProtocolGenerationNumber::new(2);
+
 /// Canonical compatibility identity for the agent request/response grammar.
 ///
 /// All six historical transport x `v1`/`v2` labels below describe the same
@@ -376,6 +400,35 @@ pub fn shell_computer_request_payload_max_bytes(kind: &str) -> usize {
 }
 pub const SHELL_CLIENT_CAPABILITY_JOB_STATE_RECONCILIATION: &str = "job_state_reconciliation";
 pub const SHELL_CLIENT_CAPABILITY_CODING_AGENT_RUNS: &str = "coding_agent_runs";
+/// Capabilities guaranteed by every Runner that explicitly advertises protocol
+/// generation 2. These are protocol facts shared with the Runner so its legacy
+/// bool projection remains compatible with older Servers. Server authority still
+/// uses its typed RunnerFeature classification and verifies this list cannot drift.
+pub const AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES: &[&str] = &[
+    SHELL_CLIENT_CAPABILITY_FILE_READ,
+    SHELL_CLIENT_CAPABILITY_FILE_WRITE,
+    SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_CHUNK_READ,
+    SHELL_CLIENT_CAPABILITY_ARTIFACT_EXPORT_STREAMING_METADATA,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_FILE_DELETE,
+    SHELL_CLIENT_CAPABILITY_APPLY_TEXT_EDIT_OCCURRENCE,
+    SHELL_CLIENT_CAPABILITY_JOBS,
+    SHELL_CLIENT_CAPABILITY_ASYNC_JOBS,
+    SHELL_CLIENT_CAPABILITY_ASYNC_SHELL_JOBS,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_VALIDATION_ARGV,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_CARGO_TEST_COUNT_ASSERTION,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_JSON,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_TOOL,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_PACKAGES,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD,
+    SHELL_CLIENT_CAPABILITY_INTERNAL_POSIX_SCRIPT,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_EXECUTION_JOBS,
+    SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION,
+    SHELL_CLIENT_CAPABILITY_LSP_CALL_HIERARCHY,
+    SHELL_CLIENT_CAPABILITY_PROJECT_LIFECYCLE,
+    SHELL_CLIENT_CAPABILITY_PROJECT_PATH_REGISTRATION,
+];
+
 pub const SHELL_CLIENT_CAPABILITY_NAMES: &[&str] = &[
     SHELL_CLIENT_CAPABILITY_SHELL,
     SHELL_CLIENT_CAPABILITY_FILE_READ,
@@ -641,6 +694,15 @@ pub struct ShellClientCapabilities {
     /// Missing on older Runners is false and is never inferred from shell/MCP.
     #[serde(default, skip_serializing_if = "is_false")]
     pub coding_agent_runs: bool,
+    /// Registration-only compatibility envelope for explicit protocol generation.
+    ///
+    /// This is deliberately nested under the historically additive capabilities
+    /// object because stable v0.3.8 rejects unknown *top-level* registration
+    /// fields but ignores unknown nested capability fields. It is not a
+    /// RunnerFeature and Server ingress removes it before retaining the legacy
+    /// capability projection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_protocol_generation: Option<AgentProtocolGenerationNumber>,
 }
 
 /// Bounded, non-secret status for the agent's active configuration generation.
@@ -716,6 +778,7 @@ impl Default for ShellClientCapabilities {
             computer_text_input: false,
             job_state_reconciliation: false,
             coding_agent_runs: false,
+            agent_protocol_generation: None,
         }
     }
 }
@@ -3276,6 +3339,7 @@ mod envelope_tests {
                 computer_text_input: false,
                 job_state_reconciliation: false,
                 coding_agent_runs: false,
+                agent_protocol_generation: None,
             }),
             projects: None,
             agent_protocol_version: Some(AGENT_PROTOCOL_VERSION_WEBSOCKET_V1.to_string()),
@@ -3335,25 +3399,63 @@ mod envelope_tests {
     }
 
     #[test]
-    fn current_websocket_register_remains_latest_stable_v038_envelope_readable() {
+    fn additive_protocol_generation_is_ignored_by_frozen_pre_c4_envelope_shape() {
+        #[allow(dead_code)]
+        #[derive(Deserialize)]
+        struct LatestPreC4RegisterRequest {
+            client_id: String,
+            agent_instance_id: String,
+            #[serde(default)]
+            display_name: Option<String>,
+            #[serde(default)]
+            owner: Option<String>,
+            #[serde(default)]
+            hostname: Option<String>,
+            #[serde(default)]
+            capabilities: Option<serde_json::Value>,
+            #[serde(default)]
+            host_context: Option<AgentHostContext>,
+            #[serde(default)]
+            projects: Option<Vec<ShellAgentProjectSummary>>,
+            #[serde(default)]
+            agent_protocol_version: Option<String>,
+            #[serde(default)]
+            policy: Option<AgentPolicySummary>,
+            #[serde(default)]
+            process_started_at: Option<i64>,
+            #[serde(default)]
+            build: Option<AgentBuildInfo>,
+            #[serde(default)]
+            job_concurrency_limit: Option<usize>,
+            #[serde(default)]
+            job_inventory: Option<ShellJobInventory>,
+            #[serde(default)]
+            coding_agent_providers: Option<Vec<crate::coding_agent::CodingAgentProvider>>,
+            #[serde(default)]
+            coding_agent_inventory: Option<crate::coding_agent::CodingAgentRunInventory>,
+        }
+
         #[derive(Deserialize)]
         #[serde(tag = "type", rename_all = "snake_case")]
-        enum LatestStableV038Envelope {
+        enum LatestPreC4Envelope {
             Register {
                 #[serde(flatten)]
-                payload: ShellClientRegisterRequest,
+                payload: LatestPreC4RegisterRequest,
                 #[serde(default)]
                 auth_token: Option<String>,
             },
         }
 
-        let json = AgentEnvelope::Register {
-            payload: sample_register(),
-        }
-        .to_json()
-        .unwrap();
-        match serde_json::from_str::<LatestStableV038Envelope>(&json).unwrap() {
-            LatestStableV038Envelope::Register {
+        let mut payload = sample_register();
+        payload
+            .capabilities
+            .as_mut()
+            .unwrap()
+            .agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
+        let json = AgentEnvelope::Register { payload }.to_json().unwrap();
+        assert!(json.contains(r#""agent_protocol_generation":2"#));
+        match serde_json::from_str::<LatestPreC4Envelope>(&json).unwrap() {
+            LatestPreC4Envelope::Register {
                 payload,
                 auth_token,
             } => {
@@ -3362,9 +3464,31 @@ mod envelope_tests {
                     payload.agent_protocol_version.as_deref(),
                     Some(AGENT_PROTOCOL_VERSION_WEBSOCKET_V1)
                 );
+                assert_eq!(payload.capabilities.unwrap()["file_read"], true);
                 assert!(auth_token.is_none());
             }
         }
+    }
+
+    #[test]
+    fn raw_protocol_generation_number_preserves_future_wire_values_for_ingress_rejection() {
+        let mut payload = sample_register();
+        payload
+            .capabilities
+            .as_mut()
+            .unwrap()
+            .agent_protocol_generation = Some(AgentProtocolGenerationNumber::new(u16::MAX));
+        let json = serde_json::to_string(&payload).unwrap();
+        let decoded: ShellClientRegisterRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            decoded
+                .capabilities
+                .unwrap()
+                .agent_protocol_generation
+                .unwrap()
+                .get(),
+            u16::MAX
+        );
     }
 
     #[test]

--- a/crates/webcodex-core/src/shell_protocol.rs
+++ b/crates/webcodex-core/src/shell_protocol.rs
@@ -697,10 +697,11 @@ pub struct ShellClientCapabilities {
     /// Registration-only compatibility envelope for explicit protocol generation.
     ///
     /// This is deliberately nested under the historically additive capabilities
-    /// object because stable v0.3.8 rejects unknown *top-level* registration
-    /// fields but ignores unknown nested capability fields. It is not a
-    /// RunnerFeature and Server ingress removes it before retaining the legacy
-    /// capability projection.
+    /// object so the current -> latest-stable compatibility contract keeps the
+    /// top-level registration shape unchanged. Stable v0.3.8 itself also ignores
+    /// unknown top-level struct fields, so nesting is a conservative compatibility
+    /// policy rather than a parser requirement. It is not a RunnerFeature and
+    /// Server ingress removes it before retaining the legacy capability projection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_protocol_generation: Option<AgentProtocolGenerationNumber>,
 }

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -31,10 +31,10 @@ use shell_protocol::{
     ShellClientRegisterResponse, ShellCommandExecutionState, ShellJobContext, ShellJobInventory,
     ShellJobLogSnapshot, ShellJobSnapshot, ShellJobStreamSnapshot, ShellJobValidationProgress,
     ShellJobValidationStep, ShellProfileSummaryEntry, ShellProfilesSummary,
-    ShellProjectInventoryPage, ShellProjectInventoryStatus, AGENT_PROTOCOL_VERSION_POLLING_V1,
-    AGENT_PROTOCOL_VERSION_POLLING_V2, JOB_INVENTORY_MAX_ACTIVE_JOBS,
-    JOB_INVENTORY_MAX_SERIALIZED_BYTES, JOB_INVENTORY_MAX_TERMINAL_JOBS,
-    JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS,
+    ShellProjectInventoryPage, ShellProjectInventoryStatus, AGENT_PROTOCOL_GENERATION_V2,
+    AGENT_PROTOCOL_VERSION_POLLING_V1, AGENT_PROTOCOL_VERSION_POLLING_V2,
+    JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_SERIALIZED_BYTES,
+    JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS,
     PROJECT_INVENTORY_INLINE_MAX_SUMMARIES, PROJECT_INVENTORY_PAGE_MAX_SERIALIZED_BYTES,
     VALIDATION_STEP_SPAWN_FAILED_CODE, VALIDATION_STEP_WAIT_FAILED_CODE,
     VALIDATION_TOOL_UNAVAILABLE_CODE,
@@ -44,7 +44,8 @@ use shell_protocol::{
 use agent_init::{TRANSPORT_AUTO, TRANSPORT_POLLING, TRANSPORT_QUIC, TRANSPORT_WEBSOCKET};
 #[cfg(test)]
 use shell_protocol::{
-    AgentEnvelope, AGENT_PROTOCOL_VERSION_QUIC_V1, AGENT_PROTOCOL_VERSION_WEBSOCKET_V1,
+    AgentEnvelope, AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES,
+    AGENT_PROTOCOL_VERSION_QUIC_V1, AGENT_PROTOCOL_VERSION_WEBSOCKET_V1,
 };
 #[cfg(test)]
 use std::collections::BTreeMap;
@@ -2139,6 +2140,7 @@ fn build_register_request_with_provider_status(
 ) {
     let hot = runtime.snapshot();
     let mut capabilities = agent_register_capabilities(cfg);
+    capabilities.agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
     let coding_agent_providers = runtime
         .coding_agents()
         .map(|manager| manager.providers())

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -1207,6 +1207,13 @@ fn generated_agent_instance_id_is_non_empty_uuid_like() {
         Some(AGENT_PROTOCOL_VERSION_POLLING_V1),
         "first-party registration builders must always declare protocol identity"
     );
+    assert_eq!(
+        body.capabilities
+            .as_ref()
+            .and_then(|capabilities| capabilities.agent_protocol_generation),
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+        "current Runner registration must explicitly declare protocol generation 2"
+    );
 }
 
 fn ws_sink(client_id: &str) -> (AgentSink, tokio::sync::mpsc::Receiver<AgentEnvelope>) {

--- a/crates/webcodex-runner/src/main_tests/compatibility.rs
+++ b/crates/webcodex-runner/src/main_tests/compatibility.rs
@@ -3,12 +3,14 @@ use serde::Deserialize;
 use serde_json::Value;
 use tokio_tungstenite::tungstenite::http::header::AUTHORIZATION;
 
-/// Frozen top-level registration representation from latest stable v0.3.8.
-/// `deny_unknown_fields` intentionally turns any new mandatory top-level wire
-/// field into an explicit rolling-compatibility review instead of silently
-/// widening the guaranteed current -> latest-stable contract. Nested additive
-/// capability/policy content remains opaque because v0.3.8 serde accepts those
-/// additions and current capability semantics are independently fail-closed.
+/// Conservative top-level registration-shape guard based on latest stable v0.3.8.
+///
+/// The real v0.3.8 serde struct ignores unknown top-level fields. This local
+/// `deny_unknown_fields` is intentionally stricter so a future top-level expansion
+/// receives explicit rolling-compatibility review instead of silently widening the
+/// guaranteed current -> latest-stable contract. Nested additive capability/policy
+/// content remains opaque because v0.3.8 serde accepts those additions and current
+/// capability semantics are independently fail-closed.
 #[derive(Deserialize)]
 struct LatestStableV038Capabilities {
     #[serde(default)]
@@ -19,7 +21,7 @@ struct LatestStableV038Capabilities {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct LatestStableV038RegisterRequest {
+struct ConservativeV038RegisterShape {
     client_id: String,
     agent_instance_id: String,
     #[serde(default, rename = "display_name")]
@@ -49,7 +51,7 @@ struct LatestStableV038RegisterRequest {
 }
 
 #[test]
-fn current_runner_registration_is_readable_by_latest_stable_v038_top_level_parser() {
+fn current_runner_registration_preserves_conservative_v038_top_level_shape() {
     let tmp = tempfile::tempdir().unwrap();
     let cfg = test_config(tmp.path().join("config/projects.d"));
     for protocol in [
@@ -62,7 +64,7 @@ fn current_runner_registration_is_readable_by_latest_stable_v038_top_level_parse
         assert_eq!(json_value["capabilities"]["agent_protocol_generation"], 2);
         assert!(json_value.get("agent_protocol_generation").is_none());
         let json = serde_json::to_vec(&current).unwrap();
-        let stable: LatestStableV038RegisterRequest = serde_json::from_slice(&json).unwrap();
+        let stable: ConservativeV038RegisterShape = serde_json::from_slice(&json).unwrap();
         assert_eq!(stable.client_id, cfg.client_id);
         assert_eq!(stable.agent_instance_id, "inst-current");
         assert_eq!(stable.agent_protocol_version.as_deref(), Some(protocol));

--- a/crates/webcodex-runner/src/main_tests/compatibility.rs
+++ b/crates/webcodex-runner/src/main_tests/compatibility.rs
@@ -10,6 +10,14 @@ use tokio_tungstenite::tungstenite::http::header::AUTHORIZATION;
 /// capability/policy content remains opaque because v0.3.8 serde accepts those
 /// additions and current capability semantics are independently fail-closed.
 #[derive(Deserialize)]
+struct LatestStableV038Capabilities {
+    #[serde(default)]
+    file_read: bool,
+    #[serde(default)]
+    structured_process_argv: bool,
+}
+
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct LatestStableV038RegisterRequest {
     client_id: String,
@@ -21,7 +29,7 @@ struct LatestStableV038RegisterRequest {
     #[serde(default, rename = "hostname")]
     _hostname: Option<Value>,
     #[serde(default)]
-    capabilities: Option<Value>,
+    capabilities: Option<LatestStableV038Capabilities>,
     #[serde(default, rename = "host_context")]
     _host_context: Option<Value>,
     #[serde(default)]
@@ -50,12 +58,17 @@ fn current_runner_registration_is_readable_by_latest_stable_v038_top_level_parse
         AGENT_PROTOCOL_VERSION_QUIC_V1,
     ] {
         let current = build_register_request(&cfg, Vec::new(), protocol, "inst-current", 0);
+        let json_value = serde_json::to_value(&current).unwrap();
+        assert_eq!(json_value["capabilities"]["agent_protocol_generation"], 2);
+        assert!(json_value.get("agent_protocol_generation").is_none());
         let json = serde_json::to_vec(&current).unwrap();
         let stable: LatestStableV038RegisterRequest = serde_json::from_slice(&json).unwrap();
         assert_eq!(stable.client_id, cfg.client_id);
         assert_eq!(stable.agent_instance_id, "inst-current");
         assert_eq!(stable.agent_protocol_version.as_deref(), Some(protocol));
-        assert!(stable.capabilities.is_some());
+        let capabilities = stable.capabilities.expect("stable nested capabilities");
+        assert!(capabilities.file_read);
+        assert!(capabilities.structured_process_argv);
         assert!(stable.projects.is_some());
     }
 }

--- a/crates/webcodex-runner/src/main_tests/registration.rs
+++ b/crates/webcodex-runner/src/main_tests/registration.rs
@@ -122,6 +122,102 @@ fn mcp_gateway_register_request_projects_bounded_provider_inventory_without_loca
 }
 
 #[test]
+fn current_runner_registration_advertises_v2_and_complete_generation_baseline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = test_config(tmp.path().join("config/projects.d"));
+    let body = build_register_request(
+        &cfg,
+        Vec::new(),
+        AGENT_PROTOCOL_VERSION_POLLING_V1,
+        "baseline-instance",
+        0,
+    );
+    assert_eq!(
+        body.capabilities
+            .as_ref()
+            .and_then(|capabilities| capabilities.agent_protocol_generation),
+        Some(AGENT_PROTOCOL_GENERATION_V2)
+    );
+
+    let capabilities = serde_json::to_value(body.capabilities.as_ref().unwrap()).unwrap();
+    assert_eq!(
+        AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES.len(),
+        22
+    );
+    for capability in AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES {
+        assert_eq!(
+            capabilities
+                .get(*capability)
+                .and_then(serde_json::Value::as_bool),
+            Some(true),
+            "current Runner must advertise V2 baseline capability {capability}"
+        );
+    }
+}
+
+#[test]
+fn current_v2_registration_is_additive_for_latest_pre_c4_server_shape() {
+    #[allow(dead_code)]
+    #[derive(serde::Deserialize)]
+    struct LatestPreC4RegisterRequest {
+        client_id: String,
+        agent_instance_id: String,
+        #[serde(default)]
+        display_name: Option<String>,
+        #[serde(default)]
+        owner: Option<String>,
+        #[serde(default)]
+        hostname: Option<String>,
+        #[serde(default)]
+        capabilities: Option<serde_json::Value>,
+        #[serde(default)]
+        host_context: Option<shell_protocol::AgentHostContext>,
+        #[serde(default)]
+        projects: Option<Vec<ShellAgentProjectSummary>>,
+        #[serde(default)]
+        agent_protocol_version: Option<String>,
+        #[serde(default)]
+        policy: Option<AgentPolicySummary>,
+        #[serde(default)]
+        process_started_at: Option<i64>,
+        #[serde(default)]
+        build: Option<shell_protocol::AgentBuildInfo>,
+        #[serde(default)]
+        job_concurrency_limit: Option<usize>,
+        #[serde(default)]
+        job_inventory: Option<ShellJobInventory>,
+        #[serde(default)]
+        coding_agent_providers: Option<Vec<webcodex_core::coding_agent::CodingAgentProvider>>,
+        #[serde(default)]
+        coding_agent_inventory: Option<webcodex_core::coding_agent::CodingAgentRunInventory>,
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = test_config(tmp.path().join("config/projects.d"));
+    let body = build_register_request(
+        &cfg,
+        Vec::new(),
+        AGENT_PROTOCOL_VERSION_WEBSOCKET_V1,
+        "pre-c4-compat-instance",
+        0,
+    );
+    let json = serde_json::to_value(&body).unwrap();
+    assert!(json.get("agent_protocol_generation").is_none());
+    assert_eq!(json["capabilities"]["agent_protocol_generation"], 2);
+
+    let old: LatestPreC4RegisterRequest = serde_json::from_value(json).unwrap();
+    assert_eq!(old.client_id, cfg.client_id);
+    assert_eq!(old.agent_instance_id, "pre-c4-compat-instance");
+    assert_eq!(
+        old.agent_protocol_version.as_deref(),
+        Some(AGENT_PROTOCOL_VERSION_WEBSOCKET_V1)
+    );
+    let capabilities = old.capabilities.expect("legacy bool capability projection");
+    assert_eq!(capabilities["file_read"], true);
+    assert_eq!(capabilities["structured_process_argv"], true);
+}
+
+#[test]
 fn computer_register_request_announces_platform_capability_and_protocol_version() {
     let tmp = tempfile::tempdir().unwrap();
     let mut cfg = test_config(tmp.path().join("config/projects.d"));
@@ -163,6 +259,12 @@ fn computer_register_request_announces_platform_capability_and_protocol_version(
             "version mismatch for {expected_str}"
         );
         assert_eq!(body.agent_protocol_version.as_deref(), Some(expected_str));
+        assert_eq!(
+            body.capabilities
+                .as_ref()
+                .and_then(|capabilities| capabilities.agent_protocol_generation),
+            Some(AGENT_PROTOCOL_GENERATION_V2)
+        );
     }
     // Also verify capabilities are advertised (check once for polling).
     let body = build_register_request(

--- a/src/agent_quic.rs
+++ b/src/agent_quic.rs
@@ -626,6 +626,7 @@ mod tests {
                     computer_text_input: false,
                     job_state_reconciliation: false,
                     coding_agent_runs: false,
+                    agent_protocol_generation: None,
                 }),
                 projects: None,
                 agent_protocol_version: Some(protocol.to_string()),

--- a/src/agent_ws.rs
+++ b/src/agent_ws.rs
@@ -414,6 +414,7 @@ mod tests {
                     computer_text_input: false,
                     job_state_reconciliation: false,
                     coding_agent_runs: false,
+                    agent_protocol_generation: None,
                 }),
                 projects: None,
                 agent_protocol_version: Some(

--- a/src/connector_runtime/connector_runtime_tests.rs
+++ b/src/connector_runtime/connector_runtime_tests.rs
@@ -112,6 +112,7 @@ async fn register_agent_with_lsp_capabilities(
                     computer_text_input: false,
                     job_state_reconciliation: false,
                     coding_agent_runs: false,
+                    agent_protocol_generation: None,
                 }),
                 projects: Some(vec![ShellAgentProjectSummary {
                     id: project_id.to_string(),

--- a/src/shell_client/agents.rs
+++ b/src/shell_client/agents.rs
@@ -18,13 +18,13 @@ use super::validation::{
     validate_optional_field, validate_project_summary_batch,
 };
 use super::{
-    now_ts, AgentTransport, RunnerFeature, RunnerFeatureSet, ShellClientRegistry,
-    CLIENT_ONLINE_WINDOW_SECS, MAX_RETIRED_INSTANCES_PER_CLIENT,
+    now_ts, AcceptedRunnerProtocol, AgentTransport, RunnerFeature, RunnerFeatureSet,
+    ShellClientRegistry, CLIENT_ONLINE_WINDOW_SECS, MAX_RETIRED_INSTANCES_PER_CLIENT,
 };
 use crate::mcp_gateway::validate_providers;
 use crate::shell_protocol::{
-    normalize_agent_protocol_semantics, AgentProjectInventoryStrategy, ShellClientRegisterRequest,
-    ShellClientView, JOB_INVENTORY_MAX_ACTIVE_JOBS,
+    AgentProjectInventoryStrategy, ShellClientRegisterRequest, ShellClientView,
+    JOB_INVENTORY_MAX_ACTIVE_JOBS,
 };
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
@@ -249,8 +249,16 @@ impl ShellClientRegistry {
 
         let client_id = body.client_id.trim().to_string();
         let agent_instance_id = body.agent_instance_id.trim().to_string();
-        let capabilities = body.capabilities.clone().unwrap_or_default();
-        let runner_features = RunnerFeatureSet::from_wire(&capabilities);
+        let agent_protocol_version =
+            normalize_required_agent_protocol_version(body.agent_protocol_version.as_deref())?;
+        let mut capabilities = body.capabilities.clone().unwrap_or_default();
+        let announced_generation = capabilities.agent_protocol_generation.take();
+        let accepted_protocol = AcceptedRunnerProtocol::try_from_registration(
+            &agent_protocol_version,
+            announced_generation,
+        )?;
+        let runner_features =
+            RunnerFeatureSet::try_from_registration(accepted_protocol, &capabilities)?;
         let job_inventory = body.job_inventory.clone();
         let coding_agent_providers = body.coding_agent_providers.clone();
         let coding_agent_inventory = body.coding_agent_inventory.clone();
@@ -262,14 +270,8 @@ impl ShellClientRegistry {
         )?;
         let coding_agent_providers = coding_agent_providers.unwrap_or_default();
         let coding_agent_inventory = coding_agent_inventory.unwrap_or_default();
-        let agent_protocol_version =
-            normalize_required_agent_protocol_version(body.agent_protocol_version.as_deref())?;
-        let agent_protocol_semantics = normalize_agent_protocol_semantics(&agent_protocol_version);
-        if !agent_protocol_semantics.compatibility.is_supported() {
-            return Err("agent_protocol_version is unsupported".to_string());
-        }
         let paged_project_inventory = matches!(
-            agent_protocol_semantics.project_inventory,
+            accepted_protocol.project_inventory(),
             AgentProjectInventoryStrategy::Paged
         );
         let host_context = body
@@ -324,7 +326,7 @@ impl ShellClientRegistry {
                 .as_ref()
                 .map(|session| session.transport)
                 .unwrap_or(AgentTransport::Polling),
-            agent_protocol_semantics,
+            accepted_protocol,
             policy,
             auth_group: auth.and_then(ShellClientAuthGroup::from_auth),
             registered_at: now,
@@ -425,6 +427,12 @@ impl ShellClientRegistry {
                 "agent client {} instance was replaced and cannot reclaim the lease",
                 client_id
             ));
+        }
+        if inner.clients.get(&client_id).is_some_and(|existing| {
+            existing.agent_instance_id == agent_instance_id
+                && existing.accepted_protocol.generation() != accepted_protocol.generation()
+        }) {
+            return Err("same runner instance cannot change protocol generation".to_string());
         }
         reject_same_instance_feature_downgrade(
             inner.clients.get(&client_id),
@@ -1431,7 +1439,7 @@ impl ShellClientRegistry {
             project_inventory: Some(client.project_inventory.status.clone()),
             agent_protocol_version: client.agent_protocol_version.clone(),
             transport: client.transport.as_str().to_string(),
-            agent_protocol_semantics: client.agent_protocol_semantics,
+            agent_protocol_semantics: client.accepted_protocol.compatibility_semantics(),
             policy: client.policy.clone(),
             registered_at: client.registered_at,
             connected_at: client.connected_at,

--- a/src/shell_client/capabilities.rs
+++ b/src/shell_client/capabilities.rs
@@ -1,3 +1,4 @@
+use super::protocol::{AcceptedRunnerProtocol, RunnerProtocolGeneration};
 use crate::shell_protocol::{self as wire, ShellClientCapabilities};
 use std::collections::BTreeSet;
 
@@ -109,11 +110,10 @@ const ALL_RUNNER_FEATURES: [RunnerFeature; 46] = [
 /// Whether a feature could ever become a frozen protocol-generation baseline,
 /// or must permanently depend on accepted Runner registration semantics.
 ///
-/// `GenerationEligible` is classification only. C3a defines no generation
-/// baseline and grants no feature merely because a Runner uses a supported
-/// protocol generation.
+/// C4 freezes `GenerationEligible` as the protocol-generation-2 baseline.
+/// `RegistrationRequired` features remain governed only by accepted Runner
+/// registration semantics for every generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum RunnerFeatureInference {
     GenerationEligible,
     RegistrationRequired,
@@ -279,9 +279,6 @@ impl RunnerFeature {
         })
     }
 
-    /// Classification only; this method is deliberately not consulted by
-    /// [`RunnerFeatureSet::from_wire`].
-    #[allow(dead_code)]
     pub(crate) const fn inference(self) -> RunnerFeatureInference {
         match self {
             Self::FileRead
@@ -401,7 +398,50 @@ pub(crate) struct RunnerFeatureSet {
 }
 
 impl RunnerFeatureSet {
-    pub(crate) fn from_wire(capabilities: &ShellClientCapabilities) -> Self {
+    /// Normalize one already-supported registration into canonical feature truth.
+    ///
+    /// LegacyV1 has no generation baseline and therefore preserves historical
+    /// effective wire semantics exactly. Generation 2 requires every frozen
+    /// baseline capability to remain true in the legacy bool projection during
+    /// the rolling-compatibility window; contradictions reject registration
+    /// instead of being silently ORed with the baseline. RegistrationRequired
+    /// features are never inferred from generation.
+    pub(crate) fn try_from_registration(
+        protocol: AcceptedRunnerProtocol,
+        capabilities: &ShellClientCapabilities,
+    ) -> Result<Self, String> {
+        let mut effective_features = BTreeSet::new();
+        for feature in RunnerFeature::all().iter().copied() {
+            let advertised = feature.advertised_by(capabilities);
+            match protocol.generation() {
+                RunnerProtocolGeneration::LegacyV1 => {
+                    if advertised {
+                        effective_features.insert(feature);
+                    }
+                }
+                RunnerProtocolGeneration::V2 => match feature.inference() {
+                    RunnerFeatureInference::GenerationEligible => {
+                        if !advertised {
+                            return Err(format!(
+                                "runner generation baseline capability mismatch: {}",
+                                feature.as_wire_name()
+                            ));
+                        }
+                        effective_features.insert(feature);
+                    }
+                    RunnerFeatureInference::RegistrationRequired => {
+                        if advertised {
+                            effective_features.insert(feature);
+                        }
+                    }
+                },
+            }
+        }
+        Ok(Self { effective_features })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_legacy_wire_for_test(capabilities: &ShellClientCapabilities) -> Self {
         let effective_features = RunnerFeature::all()
             .iter()
             .copied()

--- a/src/shell_client/mod.rs
+++ b/src/shell_client/mod.rs
@@ -32,6 +32,7 @@ mod jobs;
 mod polling;
 mod project_inventory;
 mod projects;
+mod protocol;
 mod reconciliation;
 #[cfg(test)]
 mod reconciliation_tests;
@@ -62,6 +63,9 @@ pub(crate) use jobs::{
 };
 #[cfg(test)]
 pub(crate) use projects::ShellClientLookupError;
+pub(crate) use protocol::AcceptedRunnerProtocol;
+#[cfg(test)]
+pub(crate) use protocol::RunnerProtocolGeneration;
 pub(crate) use reconciliation::recovery_timeout_sweep;
 pub(crate) use requests::EnqueueLspError;
 use state::ShellClientRegistryInner;

--- a/src/shell_client/mod_tests.rs
+++ b/src/shell_client/mod_tests.rs
@@ -1,8 +1,11 @@
 use super::*;
 use crate::shell_protocol::{
-    ShellCommandExecutionState, AGENT_PROTOCOL_VERSION_POLLING_V1,
-    AGENT_PROTOCOL_VERSION_POLLING_V2, AGENT_PROTOCOL_VERSION_QUIC_V1,
-    AGENT_PROTOCOL_VERSION_WEBSOCKET_V1, SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_PACKAGES,
+    AgentProtocolGenerationNumber, ShellCommandExecutionState, AGENT_PROTOCOL_GENERATION_LEGACY_V1,
+    AGENT_PROTOCOL_GENERATION_V2, AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES,
+    AGENT_PROTOCOL_VERSION_POLLING_V1, AGENT_PROTOCOL_VERSION_POLLING_V2,
+    AGENT_PROTOCOL_VERSION_QUIC_V1, AGENT_PROTOCOL_VERSION_QUIC_V2,
+    AGENT_PROTOCOL_VERSION_WEBSOCKET_V1, AGENT_PROTOCOL_VERSION_WEBSOCKET_V2,
+    SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_PACKAGES,
     SHELL_CLIENT_CAPABILITY_STRUCTURED_GO_TEST_TOOL,
 };
 
@@ -119,6 +122,17 @@ fn runner_registration(
         agent_protocol_version: Some(AGENT_PROTOCOL_VERSION_POLLING_V1.to_string()),
         policy: None,
     }
+}
+
+fn v2_baseline_capabilities() -> ShellClientCapabilities {
+    let mut value = serde_json::Map::new();
+    // Shell is historical true-by-default but remains RegistrationRequired in
+    // every generation, so pin it false in the baseline-only fixture.
+    value.insert("shell".to_string(), serde_json::Value::Bool(false));
+    for capability in AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES {
+        value.insert((*capability).to_string(), serde_json::Value::Bool(true));
+    }
+    serde_json::from_value(serde_json::Value::Object(value)).unwrap()
 }
 
 fn async_job_capabilities() -> ShellClientCapabilities {

--- a/src/shell_client/mod_tests/capabilities.rs
+++ b/src/shell_client/mod_tests/capabilities.rs
@@ -15,6 +15,19 @@ fn wire_capabilities_with_only(feature: Option<RunnerFeature>) -> ShellClientCap
     serde_json::from_value(serde_json::Value::Object(value)).unwrap()
 }
 
+fn with_wire_feature(
+    capabilities: &ShellClientCapabilities,
+    feature: RunnerFeature,
+    enabled: bool,
+) -> ShellClientCapabilities {
+    let mut value = serde_json::to_value(capabilities).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert(feature.as_wire_name().to_string(), enabled.into());
+    serde_json::from_value(value).unwrap()
+}
+
 #[test]
 fn canonical_runner_feature_inventory_matches_wire_names_exactly() {
     let wire_names = SHELL_CLIENT_CAPABILITY_NAMES
@@ -46,14 +59,15 @@ fn canonical_runner_feature_wire_names_round_trip() {
 
 #[test]
 fn canonical_runner_feature_set_tracks_each_individual_wire_bool() {
-    let all_false = RunnerFeatureSet::from_wire(&wire_capabilities_with_only(None));
+    let all_false = RunnerFeatureSet::from_legacy_wire_for_test(&wire_capabilities_with_only(None));
     for feature in RunnerFeature::all() {
         assert!(!all_false.supports(*feature), "{}", feature.as_wire_name());
     }
 
     for advertised in RunnerFeature::all() {
-        let semantics =
-            RunnerFeatureSet::from_wire(&wire_capabilities_with_only(Some(*advertised)));
+        let semantics = RunnerFeatureSet::from_legacy_wire_for_test(&wire_capabilities_with_only(
+            Some(*advertised),
+        ));
         for observed in RunnerFeature::all() {
             assert_eq!(
                 semantics.supports(*observed),
@@ -106,9 +120,145 @@ fn capability_classification_keeps_environment_dependent_features_registration_r
 }
 
 #[test]
+fn v2_baseline_exactly_matches_generation_eligible_classification() {
+    let baseline = AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let generation_eligible = RunnerFeature::all()
+        .iter()
+        .copied()
+        .filter(|feature| feature.inference() == RunnerFeatureInference::GenerationEligible)
+        .map(RunnerFeature::as_wire_name)
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(baseline.len(), 22);
+    assert_eq!(
+        baseline.len(),
+        AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES.len()
+    );
+    assert_eq!(baseline, generation_eligible);
+    for feature in RunnerFeature::all() {
+        if feature.inference() == RunnerFeatureInference::RegistrationRequired {
+            assert!(
+                !baseline.contains(feature.as_wire_name()),
+                "{}",
+                feature.as_wire_name()
+            );
+        }
+    }
+}
+
+#[test]
+fn legacy_v1_generation_baseline_is_empty_and_preserves_wire_truth() {
+    for generation in [None, Some(AGENT_PROTOCOL_GENERATION_LEGACY_V1)] {
+        let protocol = AcceptedRunnerProtocol::try_from_registration(
+            AGENT_PROTOCOL_VERSION_POLLING_V1,
+            generation,
+        )
+        .unwrap();
+        assert_eq!(protocol.generation(), RunnerProtocolGeneration::LegacyV1);
+
+        let none =
+            RunnerFeatureSet::try_from_registration(protocol, &wire_capabilities_with_only(None))
+                .unwrap();
+        for feature in RunnerFeature::all()
+            .iter()
+            .copied()
+            .filter(|feature| feature.inference() == RunnerFeatureInference::GenerationEligible)
+        {
+            assert!(!none.supports(feature), "{}", feature.as_wire_name());
+            let advertised = RunnerFeatureSet::try_from_registration(
+                protocol,
+                &wire_capabilities_with_only(Some(feature)),
+            )
+            .unwrap();
+            assert!(advertised.supports(feature), "{}", feature.as_wire_name());
+        }
+    }
+}
+
+#[test]
+fn v2_generation_baseline_requires_legacy_projection_without_silent_or() {
+    let protocol = AcceptedRunnerProtocol::try_from_registration(
+        AGENT_PROTOCOL_VERSION_POLLING_V1,
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    )
+    .unwrap();
+    let baseline = v2_baseline_capabilities();
+    let accepted = RunnerFeatureSet::try_from_registration(protocol, &baseline).unwrap();
+
+    let missing = wire_capabilities_with_only(None);
+    assert_eq!(
+        RunnerFeatureSet::try_from_registration(protocol, &missing).unwrap_err(),
+        "runner generation baseline capability mismatch: file_read"
+    );
+
+    for feature in RunnerFeature::all()
+        .iter()
+        .copied()
+        .filter(|feature| feature.inference() == RunnerFeatureInference::GenerationEligible)
+    {
+        assert!(accepted.supports(feature), "{}", feature.as_wire_name());
+        let contradictory = with_wire_feature(&baseline, feature, false);
+        let error = RunnerFeatureSet::try_from_registration(protocol, &contradictory).unwrap_err();
+        assert_eq!(
+            error,
+            format!(
+                "runner generation baseline capability mismatch: {}",
+                feature.as_wire_name()
+            )
+        );
+    }
+}
+
+#[test]
+fn v2_registration_required_features_are_never_inferred_from_generation() {
+    let protocol = AcceptedRunnerProtocol::try_from_registration(
+        AGENT_PROTOCOL_VERSION_POLLING_V1,
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    )
+    .unwrap();
+    let baseline = v2_baseline_capabilities();
+    let baseline_only = RunnerFeatureSet::try_from_registration(protocol, &baseline).unwrap();
+
+    for feature in RunnerFeature::all()
+        .iter()
+        .copied()
+        .filter(|feature| feature.inference() == RunnerFeatureInference::RegistrationRequired)
+    {
+        assert!(
+            !baseline_only.supports(feature),
+            "{}",
+            feature.as_wire_name()
+        );
+        let explicitly_advertised = with_wire_feature(&baseline, feature, true);
+        let accepted =
+            RunnerFeatureSet::try_from_registration(protocol, &explicitly_advertised).unwrap();
+        assert!(accepted.supports(feature), "{}", feature.as_wire_name());
+    }
+
+    for feature in [
+        RunnerFeature::SshShell,
+        RunnerFeature::SandboxInspectCommands,
+        RunnerFeature::ComputerObserve,
+        RunnerFeature::ComputerControl,
+        RunnerFeature::ComputerTextInput,
+        RunnerFeature::JobStateReconciliation,
+        RunnerFeature::CodingAgentRuns,
+    ] {
+        assert_eq!(
+            feature.inference(),
+            RunnerFeatureInference::RegistrationRequired
+        );
+        assert!(!baseline_only.supports(feature));
+    }
+}
+
+#[test]
 fn missing_additive_wire_fields_remain_false_in_canonical_semantics() {
     let legacy: ShellClientCapabilities = serde_json::from_str(r#"{}"#).unwrap();
-    let semantics = RunnerFeatureSet::from_wire(&legacy);
+    let semantics = RunnerFeatureSet::from_legacy_wire_for_test(&legacy);
 
     assert!(semantics.supports(RunnerFeature::Shell));
     for feature in RunnerFeature::all() {
@@ -124,7 +274,9 @@ async fn current_protocol_generation_never_infers_registration_required_host_fea
     let registry = ShellClientRegistry::default();
     let mut registration = runner_registration("no-inference", "inst-a", Vec::new());
     registration.agent_protocol_version = Some(AGENT_PROTOCOL_VERSION_POLLING_V1.to_string());
-    registration.capabilities = Some(wire_capabilities_with_only(None));
+    let mut capabilities = v2_baseline_capabilities();
+    capabilities.agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
+    registration.capabilities = Some(capabilities);
     registry.register(registration).await.unwrap();
 
     for feature in [
@@ -170,6 +322,24 @@ async fn shell_client_view_preserves_legacy_capability_wire_projection() {
     assert_eq!(serialized["computer_control"], true);
     assert!(serialized.get("features").is_none());
     assert!(serialized.get("feature_classification").is_none());
+}
+
+#[tokio::test]
+async fn v2_generation_advertisement_never_enters_public_capability_projection() {
+    let registry = ShellClientRegistry::default();
+    let mut capabilities = v2_baseline_capabilities();
+    capabilities.agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
+    capabilities.computer_control = true;
+
+    let mut registration = runner_registration("v2-projection", "inst-v2", Vec::new());
+    registration.capabilities = Some(capabilities);
+    let view = registry.register(registration).await.unwrap();
+
+    assert!(view.capabilities.agent_protocol_generation.is_none());
+    assert!(view.capabilities.computer_control);
+    let serialized = serde_json::to_value(&view.capabilities).unwrap();
+    assert!(serialized.get("agent_protocol_generation").is_none());
+    assert_eq!(serialized["computer_control"], true);
 }
 
 #[tokio::test]

--- a/src/shell_client/mod_tests/protocol.rs
+++ b/src/shell_client/mod_tests/protocol.rs
@@ -1,6 +1,267 @@
 use super::*;
 
 #[test]
+fn protocol_generation_inventory_matrix_keeps_three_dimensions_orthogonal() {
+    let labels = [
+        (
+            AGENT_PROTOCOL_VERSION_POLLING_V1,
+            crate::shell_protocol::AgentProjectInventoryStrategy::Inline,
+        ),
+        (
+            AGENT_PROTOCOL_VERSION_POLLING_V2,
+            crate::shell_protocol::AgentProjectInventoryStrategy::Paged,
+        ),
+        (
+            AGENT_PROTOCOL_VERSION_WEBSOCKET_V1,
+            crate::shell_protocol::AgentProjectInventoryStrategy::Inline,
+        ),
+        (
+            AGENT_PROTOCOL_VERSION_WEBSOCKET_V2,
+            crate::shell_protocol::AgentProjectInventoryStrategy::Paged,
+        ),
+        (
+            AGENT_PROTOCOL_VERSION_QUIC_V1,
+            crate::shell_protocol::AgentProjectInventoryStrategy::Inline,
+        ),
+        (
+            AGENT_PROTOCOL_VERSION_QUIC_V2,
+            crate::shell_protocol::AgentProjectInventoryStrategy::Paged,
+        ),
+    ];
+
+    for (label, inventory) in labels {
+        for (wire_generation, generation) in [
+            (None, RunnerProtocolGeneration::LegacyV1),
+            (
+                Some(AGENT_PROTOCOL_GENERATION_LEGACY_V1),
+                RunnerProtocolGeneration::LegacyV1,
+            ),
+            (
+                Some(AGENT_PROTOCOL_GENERATION_V2),
+                RunnerProtocolGeneration::V2,
+            ),
+        ] {
+            let accepted =
+                AcceptedRunnerProtocol::try_from_registration(label, wire_generation).unwrap();
+            assert_eq!(accepted.generation(), generation, "{label}");
+            assert_eq!(accepted.project_inventory(), inventory, "{label}");
+        }
+    }
+
+    let legacy_paged =
+        AcceptedRunnerProtocol::try_from_registration(AGENT_PROTOCOL_VERSION_WEBSOCKET_V2, None)
+            .unwrap();
+    assert_eq!(
+        legacy_paged.generation(),
+        RunnerProtocolGeneration::LegacyV1
+    );
+    assert_eq!(
+        legacy_paged.project_inventory(),
+        crate::shell_protocol::AgentProjectInventoryStrategy::Paged
+    );
+
+    let v2_inline = AcceptedRunnerProtocol::try_from_registration(
+        AGENT_PROTOCOL_VERSION_WEBSOCKET_V1,
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    )
+    .unwrap();
+    assert_eq!(v2_inline.generation(), RunnerProtocolGeneration::V2);
+    assert_eq!(
+        v2_inline.project_inventory(),
+        crate::shell_protocol::AgentProjectInventoryStrategy::Inline
+    );
+}
+
+#[test]
+fn unsupported_protocol_generation_and_unknown_legacy_label_fail_closed() {
+    for raw in [0, 3, u16::MAX] {
+        let error = AcceptedRunnerProtocol::try_from_registration(
+            AGENT_PROTOCOL_VERSION_POLLING_V1,
+            Some(AgentProtocolGenerationNumber::new(raw)),
+        )
+        .unwrap_err();
+        assert_eq!(error, "agent_protocol_generation is unsupported");
+    }
+
+    let error = AcceptedRunnerProtocol::try_from_registration(
+        "future-v2",
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    )
+    .unwrap_err();
+    assert_eq!(error, "agent_protocol_version is unsupported");
+}
+
+fn generation_registration(
+    client_id: &str,
+    instance_id: &str,
+    generation: Option<AgentProtocolGenerationNumber>,
+) -> ShellClientRegisterRequest {
+    let mut registration = runner_registration(client_id, instance_id, Vec::new());
+    let mut capabilities = v2_baseline_capabilities();
+    capabilities.agent_protocol_generation = generation;
+    registration.capabilities = Some(capabilities);
+    registration
+}
+
+#[tokio::test]
+async fn registration_rejects_unknown_generation_before_creating_a_record() {
+    let registry = ShellClientRegistry::default();
+    let error = registry
+        .register(generation_registration(
+            "unknown-generation",
+            "inst-a",
+            Some(AgentProtocolGenerationNumber::new(3)),
+        ))
+        .await
+        .unwrap_err();
+    assert_eq!(error, "agent_protocol_generation is unsupported");
+    assert!(registry
+        .get_client_view("unknown-generation")
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn registration_rejects_v2_baseline_contradiction_before_creating_a_record() {
+    let registry = ShellClientRegistry::default();
+    let mut registration = generation_registration(
+        "v2-contradiction",
+        "inst-a",
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    );
+    registration
+        .capabilities
+        .as_mut()
+        .unwrap()
+        .structured_process_argv = false;
+
+    let error = registry.register(registration).await.unwrap_err();
+    assert_eq!(
+        error,
+        "runner generation baseline capability mismatch: structured_process_argv"
+    );
+    assert!(registry.get_client_view("v2-contradiction").await.is_none());
+}
+
+#[tokio::test]
+async fn same_instance_protocol_generation_is_stable_but_same_generation_reconnects_remain_valid() {
+    let legacy = ShellClientRegistry::default();
+    legacy
+        .register(generation_registration("legacy-stable", "inst-a", None))
+        .await
+        .unwrap();
+    legacy
+        .register(generation_registration(
+            "legacy-stable",
+            "inst-a",
+            Some(AGENT_PROTOCOL_GENERATION_LEGACY_V1),
+        ))
+        .await
+        .unwrap();
+
+    let v2 = ShellClientRegistry::default();
+    v2.register(generation_registration(
+        "v2-stable",
+        "inst-a",
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    ))
+    .await
+    .unwrap();
+    v2.register(generation_registration(
+        "v2-stable",
+        "inst-a",
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    ))
+    .await
+    .unwrap();
+
+    for (client_id, from, to) in [
+        ("legacy-to-v2", None, Some(AGENT_PROTOCOL_GENERATION_V2)),
+        ("v2-to-legacy", Some(AGENT_PROTOCOL_GENERATION_V2), None),
+    ] {
+        let registry = ShellClientRegistry::default();
+        registry
+            .register(generation_registration(client_id, "inst-a", from))
+            .await
+            .unwrap();
+        let error = registry
+            .register(generation_registration(client_id, "inst-a", to))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error,
+            "same runner instance cannot change protocol generation"
+        );
+    }
+}
+
+#[tokio::test]
+async fn same_instance_inventory_strategy_change_does_not_trip_generation_fence() {
+    let registry = ShellClientRegistry::default();
+    let mut inline = generation_registration(
+        "inventory-change",
+        "inst-a",
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    );
+    inline.agent_protocol_version = Some(AGENT_PROTOCOL_VERSION_POLLING_V1.to_string());
+    registry.register(inline).await.unwrap();
+
+    let mut paged = generation_registration(
+        "inventory-change",
+        "inst-a",
+        Some(AGENT_PROTOCOL_GENERATION_V2),
+    );
+    paged.agent_protocol_version = Some(AGENT_PROTOCOL_VERSION_POLLING_V2.to_string());
+    registry.register(paged).await.unwrap();
+
+    let inner = registry.inner.lock().await;
+    let record = inner.clients.get("inventory-change").unwrap();
+    assert_eq!(
+        record.accepted_protocol.generation(),
+        RunnerProtocolGeneration::V2
+    );
+    assert_eq!(
+        record.accepted_protocol.project_inventory(),
+        crate::shell_protocol::AgentProjectInventoryStrategy::Paged
+    );
+}
+
+#[tokio::test]
+async fn different_process_replacement_may_change_protocol_generation_in_either_direction() {
+    for (client_id, from, to, expected) in [
+        (
+            "replace-legacy-v2",
+            None,
+            Some(AGENT_PROTOCOL_GENERATION_V2),
+            RunnerProtocolGeneration::V2,
+        ),
+        (
+            "replace-v2-legacy",
+            Some(AGENT_PROTOCOL_GENERATION_V2),
+            None,
+            RunnerProtocolGeneration::LegacyV1,
+        ),
+    ] {
+        let registry = ShellClientRegistry::default();
+        registry
+            .register(generation_registration(client_id, "inst-a", from))
+            .await
+            .unwrap();
+        registry
+            .set_last_seen_for_test(client_id, now_ts() - CLIENT_ONLINE_WINDOW_SECS - 1)
+            .await;
+        registry
+            .register(generation_registration(client_id, "inst-b", to))
+            .await
+            .unwrap();
+        let inner = registry.inner.lock().await;
+        let record = inner.clients.get(client_id).unwrap();
+        assert_eq!(record.agent_instance_id, "inst-b");
+        assert_eq!(record.accepted_protocol.generation(), expected);
+    }
+}
+
+#[test]
 fn protocol_async_capability_defaults_false() {
     let capabilities = ShellClientCapabilities::default();
     assert!(!capabilities.async_jobs);
@@ -105,6 +366,7 @@ async fn latest_stable_v038_registration_fixtures_are_accepted() {
         );
         let registration: ShellClientRegisterRequest = serde_json::from_str(&fixture).unwrap();
         let caps = registration.capabilities.as_ref().unwrap();
+        assert!(caps.agent_protocol_generation.is_none());
         assert!(caps.shell);
         assert!(caps.file_read);
         assert!(!caps.computer_text_input);
@@ -129,6 +391,53 @@ async fn latest_stable_v038_registration_fixtures_are_accepted() {
         assert_eq!(view.agent_protocol_version, protocol);
         assert_eq!(view.transport, transport_label);
     }
+}
+
+#[tokio::test]
+async fn latest_stable_v039_missing_generation_remains_legacy_even_with_v2_inventory_suffix() {
+    let fixture = r#"{
+        "client_id":"compat-v039",
+        "agent_instance_id":"inst-v039",
+        "capabilities":{"shell":true,"file_read":true,"structured_process_argv":false},
+        "projects":[],
+        "agent_protocol_version":"websocket-v2",
+        "build":{"version":"0.3.9","git_dirty":false}
+    }"#;
+    let registration: ShellClientRegisterRequest = serde_json::from_str(fixture).unwrap();
+    assert!(registration
+        .capabilities
+        .as_ref()
+        .is_some_and(|caps| caps.agent_protocol_generation.is_none()));
+
+    let registry = ShellClientRegistry::default();
+    registry
+        .register_streaming_session(
+            registration,
+            None,
+            "connection-v039",
+            AgentTransport::WebSocket,
+            Arc::new(Notify::new()),
+        )
+        .await
+        .unwrap();
+    let view = registry.get_client_view("compat-v039").await.unwrap();
+    assert_eq!(view.transport, TRANSPORT_WEBSOCKET);
+    assert_eq!(
+        view.agent_protocol_semantics.project_inventory,
+        crate::shell_protocol::AgentProjectInventoryStrategy::Paged
+    );
+    assert!(!registry
+        .client_supports(
+            "compat-v039",
+            crate::shell_protocol::SHELL_CLIENT_CAPABILITY_STRUCTURED_PROCESS_ARGV
+        )
+        .await
+        .unwrap());
+    let inner = registry.inner.lock().await;
+    assert_eq!(
+        inner.clients["compat-v039"].accepted_protocol.generation(),
+        RunnerProtocolGeneration::LegacyV1
+    );
 }
 
 #[tokio::test]
@@ -475,6 +784,7 @@ async fn coding_agent_run_lookup_is_exact_when_bound_and_ambiguous_when_unbound(
                 host_context: None,
                 capabilities: Some(ShellClientCapabilities {
                     coding_agent_runs: true,
+                    agent_protocol_generation: None,
                     ..Default::default()
                 }),
                 projects: None,
@@ -655,6 +965,7 @@ async fn client_supports_recognizes_all_protocol_capability_names() {
                 computer_text_input: true,
                 job_state_reconciliation: true,
                 coding_agent_runs: true,
+                agent_protocol_generation: None,
             }),
             projects: None,
             agent_protocol_version: Some("polling-v1".to_string()),

--- a/src/shell_client/project_inventory.rs
+++ b/src/shell_client/project_inventory.rs
@@ -356,7 +356,7 @@ impl ShellClientRegistry {
         client.last_seen = now;
         expire_staging(client, now);
         if !matches!(
-            client.agent_protocol_semantics.project_inventory,
+            client.accepted_protocol.project_inventory(),
             AgentProjectInventoryStrategy::Paged
         ) {
             note_nonfatal_error(client, "project_inventory_paging_not_negotiated");

--- a/src/shell_client/protocol.rs
+++ b/src/shell_client/protocol.rs
@@ -1,0 +1,66 @@
+use crate::shell_protocol::{
+    normalize_agent_protocol_semantics, AgentProjectInventoryStrategy, AgentProtocolCompatibility,
+    AgentProtocolGenerationNumber, AgentProtocolSemantics, AGENT_PROTOCOL_GENERATION_LEGACY_V1,
+    AGENT_PROTOCOL_GENERATION_V2,
+};
+
+/// Closed Server-internal generation identity for an accepted Runner.
+/// Unsupported wire numbers never enter this type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RunnerProtocolGeneration {
+    LegacyV1,
+    V2,
+}
+
+/// Supported protocol semantics captured once at registration ingress.
+///
+/// The legacy label remains separately available for diagnostics, while this
+/// value is the only accepted generation/inventory semantic state stored in a
+/// successful Runner record. Transport remains an independent ingress fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AcceptedRunnerProtocol {
+    generation: RunnerProtocolGeneration,
+    project_inventory: AgentProjectInventoryStrategy,
+}
+
+impl AcceptedRunnerProtocol {
+    pub(crate) fn try_from_registration(
+        agent_protocol_version: &str,
+        generation_number: Option<AgentProtocolGenerationNumber>,
+    ) -> Result<Self, String> {
+        let legacy = normalize_agent_protocol_semantics(agent_protocol_version);
+        if !legacy.compatibility.is_supported() {
+            return Err("agent_protocol_version is unsupported".to_string());
+        }
+        let generation = match generation_number {
+            None => RunnerProtocolGeneration::LegacyV1,
+            Some(value) if value == AGENT_PROTOCOL_GENERATION_LEGACY_V1 => {
+                RunnerProtocolGeneration::LegacyV1
+            }
+            Some(value) if value == AGENT_PROTOCOL_GENERATION_V2 => RunnerProtocolGeneration::V2,
+            Some(_) => return Err("agent_protocol_generation is unsupported".to_string()),
+        };
+        Ok(Self {
+            generation,
+            project_inventory: legacy.project_inventory,
+        })
+    }
+
+    pub(crate) const fn generation(self) -> RunnerProtocolGeneration {
+        self.generation
+    }
+
+    pub(crate) const fn project_inventory(self) -> AgentProjectInventoryStrategy {
+        self.project_inventory
+    }
+
+    /// Compatibility projection for existing internal/public diagnostic views.
+    /// Every successful accepted protocol currently uses the same V1 wire grammar;
+    /// generation and inventory remain separate semantic dimensions.
+    pub(crate) const fn compatibility_semantics(self) -> AgentProtocolSemantics {
+        AgentProtocolSemantics {
+            compatibility: AgentProtocolCompatibility::V1,
+            project_inventory: self.project_inventory,
+        }
+    }
+}

--- a/src/shell_client/state.rs
+++ b/src/shell_client/state.rs
@@ -1,13 +1,12 @@
 use super::auth::ShellClientAuthGroup;
-use super::{AgentTransport, RunnerFeature, RunnerFeatureSet};
+use super::{AcceptedRunnerProtocol, AgentTransport, RunnerFeature, RunnerFeatureSet};
 use crate::mcp_gateway::McpGatewayResponse;
 use crate::shell_protocol::{
-    AgentBuildInfo, AgentHostContext, AgentPolicySummary, AgentProtocolSemantics,
-    PersistentShellResult, ShellAgentProjectSummary, ShellAgentShellRequest,
-    ShellClientCapabilities, ShellClientView, ShellCommandExecutionState, ShellJobCodexMetadata,
-    ShellJobStructuredExecutionMetadata, ShellJobValidationProgress, ShellProcessArgv,
-    ShellProjectInventoryStatus, ShellRunResponse, JOB_INVENTORY_MAX_TERMINAL_JOBS,
-    JOB_TERMINAL_RETENTION_SECS,
+    AgentBuildInfo, AgentHostContext, AgentPolicySummary, PersistentShellResult,
+    ShellAgentProjectSummary, ShellAgentShellRequest, ShellClientCapabilities, ShellClientView,
+    ShellCommandExecutionState, ShellJobCodexMetadata, ShellJobStructuredExecutionMetadata,
+    ShellJobValidationProgress, ShellProcessArgv, ShellProjectInventoryStatus, ShellRunResponse,
+    JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_TERMINAL_RETENTION_SECS,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::AtomicU64;
@@ -68,9 +67,10 @@ pub(super) struct ShellClientRecord {
     pub(super) project_inventory: ProjectInventoryState,
     pub(super) last_seen: i64,
     pub(super) agent_protocol_version: String,
-    /// Canonical semantics normalized once from the announced compatibility
-    /// label. Runtime/business logic must not reinterpret the raw string above.
-    pub(super) agent_protocol_semantics: AgentProtocolSemantics,
+    /// Supported generation + project-inventory semantics accepted once at
+    /// registration ingress. Unsupported raw generation/label states cannot be
+    /// represented in a successful record.
+    pub(super) accepted_protocol: AcceptedRunnerProtocol,
     /// Authoritative transport from the concrete ingress path. External
     /// projections serialize this typed state as `polling`, `websocket`, or `quic`.
     pub(super) transport: AgentTransport,
@@ -133,7 +133,7 @@ impl ShellClientSemanticView {
 
     #[cfg(test)]
     pub(crate) fn from_public_view_for_test(view: ShellClientView) -> Self {
-        let runner_features = RunnerFeatureSet::from_wire(&view.capabilities);
+        let runner_features = RunnerFeatureSet::from_legacy_wire_for_test(&view.capabilities);
         Self {
             view,
             runner_features,

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -399,6 +399,7 @@ async fn register_agent_projects_for_auth(
                     computer_text_input: false,
                     job_state_reconciliation: false,
                     coding_agent_runs: false,
+                    agent_protocol_generation: None,
                 }),
                 projects: Some(vec![registered_project(
                     project_id,


### PR DESCRIPTION
## Summary

- add an explicit raw Runner protocol-generation advertisement in the additive capability envelope and normalize accepted generation into a closed Server-internal type
- freeze an exact generation-2 baseline of 22 unconditional Runner features while preserving an empty LegacyV1 baseline and explicit advertisement for environment-dependent capabilities
- fail closed on unsupported generations and V2 baseline contradictions, keep generation stable for one `agent_instance_id`, and preserve cross-process replacement semantics
- keep transport, project-inventory strategy, and protocol generation orthogonal
- preserve old Runner -> new Server compatibility and current Runner -> latest-stable compatibility while conservatively keeping the top-level registration shape unchanged

## Validation

- rebased cleanly onto `main@0fce603bd4b369358b45e304a828446d258f57a5` (#187)
- pre/post-rebase combined patch-id unchanged: `384939533e471d007ffa96e505129568ca8a0669`
- `cargo fmt -- --check`
- `cargo test -p webcodex protocol_generation --lib` — 5/5 passed
- `cargo test -p webcodex-runner current_runner_registration --bin webcodex-runner` — 2/2 passed
- `cargo check --all-targets` — 0 warnings / 0 errors
- `git diff --check 0fce603bd4b369358b45e304a828446d258f57a5..HEAD`

The three warnings emitted by the Runner test target are existing test-build SSH warnings and are unchanged by this slice. No deploy, restart, merge, or release is part of this PR.