### PR TITLE
Add durable terminal continuation intent

### DIFF
--- a/src/connector_runtime/execution.rs
+++ b/src/connector_runtime/execution.rs
@@ -200,7 +200,7 @@ impl ExecutionService {
                     self.spawn_monitor(task.clone(), execution.execution_id.clone(), auth.clone());
                 }
                 return self
-                    .wait_for_terminal(&execution.execution_id, self.yield_ms)
+                    .wait_for_terminal_or_arm_continuation(&execution.execution_id, self.yield_ms)
                     .await;
             }
             ConnectorExecutionReservation::Created(execution) => {
@@ -265,7 +265,7 @@ impl ExecutionService {
             return Ok(attached);
         }
         self.spawn_monitor(task, execution.execution_id.clone(), auth);
-        self.wait_for_terminal(&execution.execution_id, self.yield_ms)
+        self.wait_for_terminal_or_arm_continuation(&execution.execution_id, self.yield_ms)
             .await
     }
 
@@ -367,6 +367,19 @@ impl ExecutionService {
             execution,
             heartbeat: false,
         })
+    }
+
+    async fn wait_for_terminal_or_arm_continuation(
+        &self,
+        execution_id: &str,
+        wait_ms: u64,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        let execution = self.wait_for_terminal(execution_id, wait_ms).await?;
+        if execution.is_terminal() {
+            return Ok(execution);
+        }
+        self.db
+            .arm_connector_terminal_continuation(execution_id, chrono::Utc::now().timestamp())
     }
 
     pub(crate) async fn wait_for_terminal(

--- a/src/connector_runtime/execution_tests.rs
+++ b/src/connector_runtime/execution_tests.rs
@@ -1,6 +1,8 @@
 use super::wire_models::sanitize_value;
 use super::*;
-use crate::db::{ConnectorExecutionFailure, ConnectorExecutionObservation};
+use crate::db::{
+    ConnectorExecutionContinuationIntent, ConnectorExecutionFailure, ConnectorExecutionObservation,
+};
 use crate::shell_client::{ShellClientRegistry, ShellJobStartMetadata};
 use crate::shell_protocol::{
     ShellAgentJobUpdateRequest, ShellAgentPollRequest, ShellAgentProjectSummary,
@@ -730,6 +732,116 @@ async fn connector_readiness_uses_registered_agent_capabilities() {
         .findings
         .iter()
         .any(|finding| finding.code == "agent_offline"));
+}
+
+#[tokio::test]
+async fn quick_yield_arms_terminal_continuation_before_return_and_replay_keeps_single_intent() {
+    let fixture = fixture(20).await;
+    let arguments = command_arguments(&fixture, "continuation-yield-1", "sleep 30");
+    let connector = fixture.connector.clone();
+    let owner = fixture.owner.clone();
+    let call =
+        tokio::spawn(
+            async move { call(&connector, &owner, "commands_run", arguments.clone()).await },
+        );
+    let request = next_request(&fixture.registry).await;
+    assert_eq!(request.kind, "start_job");
+    let job_id = request.job_id.unwrap();
+    update_job(&fixture.registry, &job_id, "running", None, None).await;
+
+    let yielded = call.await.unwrap();
+    assert!(yielded.ok, "{}", yielded.body);
+    assert!(matches!(
+        yielded.body["data"]["execution"]["execution_status"].as_str(),
+        Some("queued" | "running")
+    ));
+    let execution_id = yielded.body["data"]["execution"]["execution_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let armed = execution_by_id(&fixture, &execution_id);
+    assert_eq!(
+        armed.continuation_intent,
+        ConnectorExecutionContinuationIntent::ArmedForTerminal
+    );
+    let armed_at = armed
+        .continuation_armed_at
+        .expect("active yielded execution must be durably armed");
+
+    let reopened = Database::open(&fixture._temp.path().join("connector.db")).unwrap();
+    let durable = reopened.connector_execution(&execution_id).unwrap();
+    assert_eq!(durable.continuation_armed_at, Some(armed_at));
+    drop(reopened);
+
+    let replay = fixture
+        .call(
+            "commands_run",
+            command_arguments(&fixture, "continuation-yield-1", "sleep 30"),
+        )
+        .await;
+    assert!(replay.ok, "{}", replay.body);
+    assert_eq!(
+        replay.body["data"]["execution"]["execution_id"],
+        execution_id
+    );
+    assert!(poll(&fixture.registry).await.is_none());
+    assert_eq!(
+        execution_by_id(&fixture, &execution_id).continuation_armed_at,
+        Some(armed_at)
+    );
+
+    update_job(&fixture.registry, &job_id, "completed", None, Some(0)).await;
+    let completed = wait_for_execution(
+        &fixture,
+        Some(&execution_id),
+        Duration::from_secs(10),
+        "armed yielded execution terminal continuation readiness",
+        |execution| execution.state == "succeeded",
+    )
+    .await;
+    assert_eq!(
+        completed.continuation_intent,
+        ConnectorExecutionContinuationIntent::ArmedForTerminal
+    );
+    assert_eq!(completed.continuation_armed_at, Some(armed_at));
+    let ready = fixture
+        .connector
+        .db
+        .terminal_ready_connector_executions()
+        .unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].execution_id, execution_id);
+}
+
+#[tokio::test]
+async fn terminal_before_yield_boundary_is_not_newly_armed() {
+    let fixture = fixture(1_000).await;
+    let arguments = command_arguments(&fixture, "continuation-terminal-1", "printf done");
+    let registry = fixture.registry.clone();
+    let responder = tokio::spawn(async move {
+        let request = next_request(&registry).await;
+        let job_id = request.job_id.unwrap();
+        update_job(&registry, &job_id, "completed", Some("done\n"), Some(0)).await;
+    });
+    let outcome = fixture.call("commands_run", arguments).await;
+    responder.await.unwrap();
+    assert!(outcome.ok, "{}", outcome.body);
+    assert_eq!(
+        outcome.body["data"]["execution"]["execution_status"],
+        "succeeded"
+    );
+    let execution = latest_execution(&fixture);
+    assert_eq!(
+        execution.continuation_intent,
+        ConnectorExecutionContinuationIntent::None
+    );
+    assert_eq!(execution.continuation_armed_at, None);
+    assert!(fixture
+        .connector
+        .db
+        .terminal_ready_connector_executions()
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -20,6 +20,8 @@ mod task_kernel;
 
 pub use self::activity::WorkspaceActivityStore;
 pub(crate) use self::admin_project_lifecycle::AdminProjectAudit;
+#[cfg(test)]
+pub(crate) use self::execution_model::ConnectorExecutionContinuationIntent;
 pub(crate) use self::execution_model::{
     ConnectorExecution, ConnectorExecutionFailure, ConnectorExecutionObservation,
     ConnectorExecutionReservation, MAX_ASSERTION_EVIDENCE_BYTES,
@@ -57,6 +59,10 @@ impl Database {
         self.conn.lock().unwrap()
     }
 }
+
+#[cfg(test)]
+#[path = "db/execution_intent_tests.rs"]
+mod execution_intent_tests;
 
 #[cfg(test)]
 #[path = "db_tests.rs"]

--- a/src/db/execution_intent_tests.rs
+++ b/src/db/execution_intent_tests.rs
@@ -1,0 +1,200 @@
+use super::*;
+
+fn database() -> (tempfile::TempDir, std::path::PathBuf, Database) {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("execution-intent.db");
+    let db = Database::open(&path).unwrap();
+    (temp, path, db)
+}
+
+fn task(db: &Database, suffix: &str) -> ConnectorTaskSnapshot {
+    db.ensure_connector_binding(ConnectorBinding {
+        project_id: "wc_proj_intent",
+        project_name: "intent",
+        workspace_id: "wc_ws_intent",
+        executor_ref: "agent:hosted:intent",
+        subject_id: "user:intent",
+        profile: "personal",
+        now: 10,
+    })
+    .unwrap();
+    db.start_connector_task(NewConnectorTask {
+        task_id: &format!("wc_task_{suffix}"),
+        run_id: &format!("wc_run_{suffix}"),
+        project_id: "wc_proj_intent",
+        workspace_id: "wc_ws_intent",
+        subject_id: "user:intent",
+        goal: "test durable terminal continuation intent",
+        mode: "normal",
+        target_executor_ref: "agent:hosted:intent",
+        execution_executor_ref: "agent:hosted:intent",
+        target_root: "/workspace/intent",
+        execution_root: "/workspace/runs/intent",
+        baseline_commit: Some("0123456789abcdef"),
+        baseline_tree: Some("fedcba9876543210"),
+        isolated: true,
+        now: 11,
+    })
+    .unwrap()
+}
+
+fn reserve(db: &Database, task: &ConnectorTaskSnapshot, operation_id: &str) -> ConnectorExecution {
+    match db
+        .reserve_connector_execution(
+            task,
+            "command",
+            operation_id,
+            "request-hash",
+            &[],
+            None,
+            None,
+            100,
+            12,
+        )
+        .unwrap()
+    {
+        ConnectorExecutionReservation::Created(execution) => execution,
+        ConnectorExecutionReservation::Existing(_) => panic!("expected fresh execution"),
+    }
+}
+
+fn succeed(db: &Database, execution_id: &str, now: i64) -> ConnectorExecution {
+    db.observe_connector_execution(
+        execution_id,
+        ConnectorExecutionObservation {
+            executor_status: "completed",
+            stdout_cursor: 1,
+            stderr_cursor: 1,
+            exit_code: Some(0),
+            started_at: Some(now - 1),
+            finished_at: Some(now),
+            check_completed: None,
+            failed_check: None,
+            assertion_evidence: None,
+            validated_workspace_sha256: None,
+            executor_failure_code: None,
+            now,
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn reservation_is_unarmed_and_arm_is_durable_idempotent_and_replay_stable() {
+    let (_temp, path, db) = database();
+    let task = task(&db, "durable");
+    let execution = reserve(&db, &task, "op-durable");
+    assert_eq!(
+        execution.continuation_intent,
+        ConnectorExecutionContinuationIntent::None
+    );
+    assert_eq!(execution.continuation_armed_at, None);
+
+    let armed = db
+        .arm_connector_terminal_continuation(&execution.execution_id, 20)
+        .unwrap();
+    assert_eq!(
+        armed.continuation_intent,
+        ConnectorExecutionContinuationIntent::ArmedForTerminal
+    );
+    assert_eq!(armed.continuation_armed_at, Some(20));
+    let rearmed = db
+        .arm_connector_terminal_continuation(&execution.execution_id, 30)
+        .unwrap();
+    assert_eq!(rearmed.continuation_armed_at, Some(20));
+
+    let replay = db
+        .reserve_connector_execution(
+            &task,
+            "command",
+            "op-durable",
+            "request-hash",
+            &[],
+            None,
+            None,
+            100,
+            31,
+        )
+        .unwrap();
+    let replay = match replay {
+        ConnectorExecutionReservation::Existing(execution) => execution,
+        ConnectorExecutionReservation::Created(_) => {
+            panic!("exact replay created a second execution")
+        }
+    };
+    assert_eq!(replay.execution_id, execution.execution_id);
+    assert_eq!(replay.continuation_armed_at, Some(20));
+
+    drop(db);
+    let reopened = Database::open(&path).unwrap();
+    let restored = reopened
+        .connector_execution(&execution.execution_id)
+        .unwrap();
+    assert_eq!(
+        restored.continuation_intent,
+        ConnectorExecutionContinuationIntent::ArmedForTerminal
+    );
+    assert_eq!(restored.continuation_armed_at, Some(20));
+}
+
+#[test]
+fn ready_query_requires_both_armed_intent_and_terminal_state() {
+    let (_temp, _path, db) = database();
+    let first_task = task(&db, "armed");
+    let armed = reserve(&db, &first_task, "op-armed");
+    db.arm_connector_terminal_continuation(&armed.execution_id, 20)
+        .unwrap();
+    assert!(db.terminal_ready_connector_executions().unwrap().is_empty());
+
+    let terminal = succeed(&db, &armed.execution_id, 21);
+    assert_eq!(
+        terminal.continuation_intent,
+        ConnectorExecutionContinuationIntent::ArmedForTerminal
+    );
+    let ready = db.terminal_ready_connector_executions().unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].execution_id, armed.execution_id);
+
+    let second_task = task(&db, "unarmed");
+    let unarmed = reserve(&db, &second_task, "op-unarmed");
+    let unarmed = succeed(&db, &unarmed.execution_id, 22);
+    assert_eq!(
+        unarmed.continuation_intent,
+        ConnectorExecutionContinuationIntent::None
+    );
+    let ready = db.terminal_ready_connector_executions().unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].execution_id, armed.execution_id);
+}
+
+#[test]
+fn startup_reconciliation_preserves_armed_intent_and_makes_it_ready() {
+    let (_temp, _path, db) = database();
+    let task = task(&db, "restart");
+    let execution = reserve(&db, &task, "op-restart");
+    db.arm_connector_terminal_continuation(&execution.execution_id, 20)
+        .unwrap();
+
+    let recovery = db
+        .reconcile_connector_executions("wc_proj_intent", 30)
+        .unwrap();
+    assert_eq!(recovery.1, 1);
+    let interrupted = db.connector_execution(&execution.execution_id).unwrap();
+    assert_eq!(interrupted.state, "interrupted");
+    assert_eq!(
+        interrupted.continuation_intent,
+        ConnectorExecutionContinuationIntent::ArmedForTerminal
+    );
+    assert_eq!(interrupted.continuation_armed_at, Some(20));
+    assert_eq!(
+        db.terminal_ready_connector_executions().unwrap()[0].execution_id,
+        execution.execution_id
+    );
+
+    let events = db
+        .connector_task_events(&task.task_id, "wc_proj_intent", "user:intent", 20)
+        .unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "execution_interrupted"));
+}

--- a/src/db/execution_model.rs
+++ b/src/db/execution_model.rs
@@ -3,6 +3,33 @@ use serde_json::Value;
 
 pub(crate) const MAX_ASSERTION_EVIDENCE_BYTES: usize = 16 * 1024;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectorExecutionContinuationIntent {
+    None,
+    ArmedForTerminal,
+}
+
+impl ConnectorExecutionContinuationIntent {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::ArmedForTerminal => "armed_for_terminal",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "none" => Ok(Self::None),
+            "armed_for_terminal" => Ok(Self::ArmedForTerminal),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                rusqlite::types::Type::Text,
+                format!("unsupported connector continuation intent: {other}").into(),
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ConnectorExecution {
     pub execution_id: String,
@@ -35,6 +62,8 @@ pub(crate) struct ConnectorExecution {
     pub validated_workspace_sha256: Option<String>,
     pub failed_check: Option<String>,
     pub assertion_evidence: Option<Value>,
+    pub continuation_intent: ConnectorExecutionContinuationIntent,
+    pub continuation_armed_at: Option<i64>,
 }
 
 impl ConnectorExecution {
@@ -277,7 +306,8 @@ pub(super) const EXECUTION_COLUMNS: &str =
     exit_code, failure_source, failure_code, terminal_reason, operation_id, request_sha256, \
     executor_reference, first_status_failure_at, last_successful_observation_at, \
     status_failure_code, check_plan, check_recipe_json, check_completed, check_workspace_sha256, \
-    validated_workspace_sha256, failed_check, assertion_evidence_json";
+    validated_workspace_sha256, failed_check, assertion_evidence_json, \
+    terminal_continuation_intent, terminal_continuation_armed_at";
 
 pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<ConnectorExecution> {
     let cursor = |index| {
@@ -340,6 +370,11 @@ pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<Connect
                 })
             })
             .transpose()?,
+        continuation_intent: ConnectorExecutionContinuationIntent::from_db(
+            &row.get::<_, String>(30)?,
+            30,
+        )?,
+        continuation_armed_at: row.get(31)?,
     })
 }
 

--- a/src/db/executions.rs
+++ b/src/db/executions.rs
@@ -3,8 +3,9 @@
 
 use super::execution_model::{
     execution_event_kind, latest_execution, latest_execution_by_kind, load_execution,
-    load_execution_by_operation, observed_state, ConnectorExecution, ConnectorExecutionFailure,
-    ConnectorExecutionObservation, ConnectorExecutionReservation,
+    load_execution_by_operation, observed_state, ConnectorExecution,
+    ConnectorExecutionContinuationIntent, ConnectorExecutionFailure, ConnectorExecutionObservation,
+    ConnectorExecutionReservation, EXECUTION_COLUMNS,
 };
 use super::task_kernel::{
     expire_task_approvals, insert_event, load_task, require_running, touch_task,
@@ -124,6 +125,55 @@ impl Database {
     ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
         let conn = self.conn.lock().unwrap();
         load_execution(&conn, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)
+    }
+
+    pub(crate) fn arm_connector_terminal_continuation(
+        &self,
+        execution_id: &str,
+        now: i64,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let execution =
+            load_execution(&tx, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
+        if execution.is_terminal()
+            || execution.continuation_intent
+                == ConnectorExecutionContinuationIntent::ArmedForTerminal
+        {
+            tx.commit()?;
+            return Ok(execution);
+        }
+        tx.execute(
+            "UPDATE wc_executions
+             SET terminal_continuation_intent = ?1,
+                 terminal_continuation_armed_at = COALESCE(terminal_continuation_armed_at, ?2)
+             WHERE id = ?3 AND state IN ('accepted','queued','starting','running','cancel_requested')",
+            params![
+                ConnectorExecutionContinuationIntent::ArmedForTerminal.as_str(),
+                now,
+                execution_id
+            ],
+        )?;
+        commit_execution(tx, execution_id)
+    }
+
+    // A1 intentionally stops at a durable read boundary; the A2 host adapter
+    // will become the first production consumer of this query.
+    #[allow(dead_code)]
+    pub(crate) fn terminal_ready_connector_executions(
+        &self,
+    ) -> Result<Vec<ConnectorExecution>, ConnectorTaskStoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut statement = conn.prepare(&format!(
+            "SELECT {EXECUTION_COLUMNS} FROM wc_executions
+             WHERE terminal_continuation_intent = 'armed_for_terminal'
+               AND state NOT IN ('accepted','queued','starting','running','cancel_requested')
+             ORDER BY finished_at ASC, submitted_at ASC, id ASC"
+        ))?;
+        let executions = statement
+            .query_map([], super::execution_model::map_execution)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(executions)
     }
 
     pub(crate) fn latest_connector_execution(

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -461,6 +461,9 @@ impl Database {
                 validated_workspace_sha256 TEXT,
                 failed_check TEXT,
                 assertion_evidence_json TEXT,
+                terminal_continuation_intent TEXT NOT NULL DEFAULT 'none'
+                    CHECK(terminal_continuation_intent IN ('none', 'armed_for_terminal')),
+                terminal_continuation_armed_at INTEGER,
                 UNIQUE(task_id, run_id, operation_id),
                 CHECK(
                     (kind = 'command' AND check_plan IS NULL)
@@ -953,6 +956,11 @@ impl Database {
             ("validated_workspace_sha256", "TEXT"),
             ("failed_check", "TEXT"),
             ("assertion_evidence_json", "TEXT"),
+            (
+                "terminal_continuation_intent",
+                "TEXT NOT NULL DEFAULT 'none' CHECK(terminal_continuation_intent IN ('none', 'armed_for_terminal'))",
+            ),
+            ("terminal_continuation_armed_at", "INTEGER"),
         ] {
             if !columns.iter().any(|existing| existing == column) {
                 conn.execute(
@@ -987,6 +995,37 @@ fn restore_foreign_keys(conn: &Connection) -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod connector_execution_column_tests {
+    use super::*;
+
+    #[test]
+    fn legacy_execution_rows_migrate_to_unarmed_terminal_continuation() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE wc_executions (id TEXT PRIMARY KEY, state TEXT NOT NULL);
+             INSERT INTO wc_executions (id, state) VALUES ('legacy', 'succeeded');",
+        )
+        .unwrap();
+
+        Database::ensure_connector_execution_columns(&conn).unwrap();
+        Database::ensure_connector_execution_columns(&conn).unwrap();
+
+        let restored: (String, Option<i64>, String) = conn
+            .query_row(
+                "SELECT terminal_continuation_intent, terminal_continuation_armed_at, state
+                 FROM wc_executions WHERE id = 'legacy'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            restored,
+            ("none".to_string(), None, "succeeded".to_string())
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Establish the A1 durable boundary for terminal continuation without introducing claim, consume, wakeup, or delivery semantics.

- persist execution-scoped `none` / `armed_for_terminal` continuation intent
- persist the first arm timestamp idempotently
- arm before returning an active quick-yield response
- preserve intent across exact operation replay and DB reopen
- preserve armed intent through startup reconciliation so interrupted terminal executions remain continuation-ready
- expose a read-only terminal-ready query for future A2 consumption
- migrate legacy execution rows to unarmed continuation state

## Correctness boundaries

- terminal-before-yield does not acquire a new continuation intent
- active-yield cannot return successfully unless the arm mutation has durably committed
- exact replay reuses the same execution and first arm timestamp
- terminal-ready requires both an armed intent and terminal execution state
- A1 does not implement claim/consume/ACK/retry/wakeup/delivery or host-specific continuation

## Validation

Fresh independent review accepted the change with no reviewer fixes required.

- `cargo fmt -- --check`
- `cargo check --all-targets`
- focused execution-intent durability/replay/restart tests
- focused quick-yield / terminal-boundary / migration tests
- clean worktree and hygiene closeout
