### PR TITLE
Add durable terminal continuation delivery state

### DIFF
--- a/src/connector_runtime/continuation_delivery_tests.rs
+++ b/src/connector_runtime/continuation_delivery_tests.rs
@@ -1,0 +1,92 @@
+use super::execution::execution_projection;
+use super::{ConnectorBinding, ConnectorExecutionReservation, NewConnectorTask};
+use crate::db::ConnectorExecutionObservation;
+use crate::Database;
+
+#[test]
+fn model_execution_projection_never_exposes_terminal_continuation_claim_fence() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("continuation-projection.db")).unwrap();
+    db.ensure_connector_binding(ConnectorBinding {
+        project_id: "wc_proj_projection",
+        project_name: "projection",
+        workspace_id: "wc_ws_projection",
+        executor_ref: "agent:hosted:projection",
+        subject_id: "user:projection",
+        profile: "personal",
+        now: 10,
+    })
+    .unwrap();
+    let task = db
+        .start_connector_task(NewConnectorTask {
+            task_id: "wc_task_projection",
+            run_id: "wc_run_projection",
+            project_id: "wc_proj_projection",
+            workspace_id: "wc_ws_projection",
+            subject_id: "user:projection",
+            goal: "prove claim fence stays internal",
+            mode: "normal",
+            target_executor_ref: "agent:hosted:projection",
+            execution_executor_ref: "agent:hosted:projection",
+            target_root: "/workspace/projection",
+            execution_root: "/workspace/runs/projection",
+            baseline_commit: Some("0123456789abcdef"),
+            baseline_tree: Some("fedcba9876543210"),
+            isolated: true,
+            now: 11,
+        })
+        .unwrap();
+    let execution = match db
+        .reserve_connector_execution(
+            &task,
+            "command",
+            "op-projection",
+            "request-hash",
+            &[],
+            None,
+            None,
+            100,
+            12,
+        )
+        .unwrap()
+    {
+        ConnectorExecutionReservation::Created(execution) => execution,
+        ConnectorExecutionReservation::Existing(_) => unreachable!(),
+    };
+    db.arm_connector_terminal_continuation(&execution.execution_id, 20)
+        .unwrap();
+    db.observe_connector_execution(
+        &execution.execution_id,
+        ConnectorExecutionObservation {
+            executor_status: "completed",
+            stdout_cursor: 1,
+            stderr_cursor: 1,
+            exit_code: Some(0),
+            started_at: Some(20),
+            finished_at: Some(21),
+            check_completed: None,
+            failed_check: None,
+            assertion_evidence: None,
+            validated_workspace_sha256: None,
+            executor_failure_code: None,
+            now: 21,
+        },
+    )
+    .unwrap();
+    let claim = db.claim_next_terminal_continuation().unwrap().unwrap();
+
+    let projection = execution_projection(&claim.execution, 22, None);
+    let serialized = serde_json::to_string(&projection).unwrap();
+    assert!(!serialized.contains(&claim.claim_fence));
+    for forbidden in [
+        "claim_fence",
+        "terminal_continuation_claim_fence",
+        "continuation_delivery_state",
+        "terminal_continuation_delivery_state",
+    ] {
+        assert!(
+            projection.get(forbidden).is_none(),
+            "leaked internal field {forbidden}"
+        );
+    }
+}

--- a/src/connector_runtime/execution.rs
+++ b/src/connector_runtime/execution.rs
@@ -155,7 +155,7 @@ impl ExecutionService {
         project_id: &str,
         now: i64,
     ) -> Result<(usize, usize), ConnectorTaskStoreError> {
-        self.db.reconcile_connector_executions(project_id, now)
+        self.db.reconcile_connector_startup(project_id, now)
     }
 
     pub(crate) fn reserve(

--- a/src/connector_runtime/mod.rs
+++ b/src/connector_runtime/mod.rs
@@ -6,6 +6,8 @@
 //! executor project id or workflow-session state.
 
 mod context;
+#[cfg(test)]
+mod continuation_delivery_tests;
 mod execution;
 #[cfg(test)]
 pub(crate) mod execution_tests;

--- a/src/db.rs
+++ b/src/db.rs
@@ -61,6 +61,10 @@ impl Database {
 }
 
 #[cfg(test)]
+#[path = "db/continuation_delivery_tests.rs"]
+mod continuation_delivery_tests;
+
+#[cfg(test)]
 #[path = "db/execution_intent_tests.rs"]
 mod execution_intent_tests;
 

--- a/src/db/continuation_delivery_tests.rs
+++ b/src/db/continuation_delivery_tests.rs
@@ -1,0 +1,595 @@
+use super::execution_model::ConnectorTerminalContinuationDeliveryState;
+use super::*;
+use std::sync::{Arc, Barrier};
+
+fn database() -> (tempfile::TempDir, std::path::PathBuf, Database) {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("continuation-delivery.db");
+    let db = Database::open(&path).unwrap();
+    (temp, path, db)
+}
+
+fn task(db: &Database, suffix: &str) -> ConnectorTaskSnapshot {
+    db.ensure_connector_binding(ConnectorBinding {
+        project_id: "wc_proj_delivery",
+        project_name: "delivery",
+        workspace_id: "wc_ws_delivery",
+        executor_ref: "agent:hosted:delivery",
+        subject_id: "user:delivery",
+        profile: "personal",
+        now: 10,
+    })
+    .unwrap();
+    db.start_connector_task(NewConnectorTask {
+        task_id: &format!("wc_task_{suffix}"),
+        run_id: &format!("wc_run_{suffix}"),
+        project_id: "wc_proj_delivery",
+        workspace_id: "wc_ws_delivery",
+        subject_id: "user:delivery",
+        goal: "test durable terminal continuation delivery",
+        mode: "normal",
+        target_executor_ref: "agent:hosted:delivery",
+        execution_executor_ref: "agent:hosted:delivery",
+        target_root: "/workspace/delivery",
+        execution_root: &format!("/workspace/runs/{suffix}"),
+        baseline_commit: Some("0123456789abcdef"),
+        baseline_tree: Some("fedcba9876543210"),
+        isolated: true,
+        now: 11,
+    })
+    .unwrap()
+}
+
+fn reserve(db: &Database, task: &ConnectorTaskSnapshot, operation_id: &str) -> ConnectorExecution {
+    match db
+        .reserve_connector_execution(
+            task,
+            "command",
+            operation_id,
+            "request-hash",
+            &[],
+            None,
+            None,
+            100,
+            12,
+        )
+        .unwrap()
+    {
+        ConnectorExecutionReservation::Created(execution) => execution,
+        ConnectorExecutionReservation::Existing(_) => panic!("expected a fresh execution"),
+    }
+}
+
+fn succeed(db: &Database, execution_id: &str, now: i64) -> ConnectorExecution {
+    db.observe_connector_execution(
+        execution_id,
+        ConnectorExecutionObservation {
+            executor_status: "completed",
+            stdout_cursor: 1,
+            stderr_cursor: 1,
+            exit_code: Some(0),
+            started_at: Some(now - 1),
+            finished_at: Some(now),
+            check_completed: None,
+            failed_check: None,
+            assertion_evidence: None,
+            validated_workspace_sha256: None,
+            executor_failure_code: None,
+            now,
+        },
+    )
+    .unwrap()
+}
+
+fn armed_terminal(
+    db: &Database,
+    suffix: &str,
+    operation_id: &str,
+    armed_at: i64,
+    finished_at: i64,
+) -> ConnectorExecution {
+    let task = task(db, suffix);
+    let execution = reserve(db, &task, operation_id);
+    db.arm_connector_terminal_continuation(&execution.execution_id, armed_at)
+        .unwrap();
+    succeed(db, &execution.execution_id, finished_at)
+}
+
+fn stored_fence(db: &Database, execution_id: &str) -> Option<String> {
+    db.conn_for_tests()
+        .query_row(
+            "SELECT terminal_continuation_claim_fence FROM wc_executions WHERE id = ?1",
+            rusqlite::params![execution_id],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+fn assert_stale(result: Result<ConnectorExecution, ConnectorTaskStoreError>) {
+    match result {
+        Err(ConnectorTaskStoreError::InvalidState(message)) => {
+            assert!(message.contains("claim fence is stale"), "{message}");
+        }
+        _ => panic!("stale claim fence unexpectedly mutated delivery state"),
+    }
+}
+
+#[test]
+fn readiness_requires_armed_terminal_unclaimed_and_claim_is_exactly_once() {
+    let (_temp, _path, db) = database();
+
+    let unarmed_task = task(&db, "unarmed");
+    let unarmed = reserve(&db, &unarmed_task, "op-unarmed");
+    succeed(&db, &unarmed.execution_id, 20);
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+
+    let active_task = task(&db, "active");
+    let active = reserve(&db, &active_task, "op-active");
+    db.arm_connector_terminal_continuation(&active.execution_id, 21)
+        .unwrap();
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+
+    let terminal = succeed(&db, &active.execution_id, 22);
+    assert_eq!(
+        terminal.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Unclaimed
+    );
+    let claim = db
+        .claim_next_terminal_continuation()
+        .unwrap()
+        .expect("armed terminal unclaimed execution must be claimable");
+    assert_eq!(claim.execution.execution_id, active.execution_id);
+    assert_eq!(
+        claim.execution.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Claimed
+    );
+    assert!(claim.claim_fence.starts_with("wc_claim_"));
+    assert!(claim.claim_fence.len() <= 80);
+    assert_eq!(
+        stored_fence(&db, &active.execution_id).as_deref(),
+        Some(claim.claim_fence.as_str())
+    );
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+}
+
+#[test]
+fn concurrent_database_handles_create_only_one_live_claim() {
+    let (_temp, path, db) = database();
+    let terminal = armed_terminal(&db, "concurrent", "op-concurrent", 20, 21);
+    let execution_id = terminal.execution_id.clone();
+    drop(db);
+
+    let barrier = Arc::new(Barrier::new(3));
+    let mut workers = Vec::new();
+    for _ in 0..2 {
+        let path = path.clone();
+        let barrier = barrier.clone();
+        workers.push(std::thread::spawn(move || {
+            let db = Database::open(&path).unwrap();
+            barrier.wait();
+            db.claim_next_terminal_continuation()
+                .map(|claim| claim.map(|claim| (claim.execution.execution_id, claim.claim_fence)))
+                .map_err(|error| error.to_string())
+        }));
+    }
+    barrier.wait();
+    let outcomes = workers
+        .into_iter()
+        .map(|worker| worker.join().unwrap().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outcomes.iter().filter(|outcome| outcome.is_some()).count(),
+        1
+    );
+    assert_eq!(
+        outcomes.iter().filter(|outcome| outcome.is_none()).count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .flatten()
+            .next()
+            .map(|claim| claim.0.as_str()),
+        Some(execution_id.as_str())
+    );
+
+    let reopened = Database::open(&path).unwrap();
+    let durable = reopened.connector_execution(&execution_id).unwrap();
+    assert_eq!(
+        durable.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Claimed
+    );
+}
+
+#[test]
+fn release_rotates_fence_and_stale_claimant_cannot_mutate_new_claim() {
+    let (_temp, _path, db) = database();
+    let terminal = armed_terminal(&db, "stale", "op-stale", 20, 21);
+    let first = db.claim_next_terminal_continuation().unwrap().unwrap();
+    assert_eq!(first.execution.execution_id, terminal.execution_id);
+
+    let released = db
+        .release_terminal_continuation_claim(&terminal.execution_id, &first.claim_fence)
+        .unwrap();
+    assert_eq!(
+        released.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Unclaimed
+    );
+    assert_eq!(stored_fence(&db, &terminal.execution_id), None);
+
+    let second = db.claim_next_terminal_continuation().unwrap().unwrap();
+    assert_ne!(second.claim_fence, first.claim_fence);
+    assert_stale(
+        db.release_terminal_continuation_claim(&terminal.execution_id, &first.claim_fence),
+    );
+    assert_stale(
+        db.begin_terminal_continuation_dispatch(&terminal.execution_id, &first.claim_fence),
+    );
+    assert_stale(
+        db.complete_terminal_continuation_delivery(&terminal.execution_id, &first.claim_fence),
+    );
+    assert_stale(
+        db.mark_terminal_continuation_delivery_unknown(&terminal.execution_id, &first.claim_fence),
+    );
+
+    let dispatching = db
+        .begin_terminal_continuation_dispatch(&terminal.execution_id, &second.claim_fence)
+        .unwrap();
+    assert_eq!(
+        dispatching.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Dispatching
+    );
+    assert_eq!(
+        stored_fence(&db, &terminal.execution_id).as_deref(),
+        Some(second.claim_fence.as_str())
+    );
+    assert!(matches!(
+        db.release_terminal_continuation_claim(&terminal.execution_id, &second.claim_fence),
+        Err(ConnectorTaskStoreError::InvalidState(_))
+    ));
+}
+
+#[test]
+fn delivered_and_delivery_unknown_are_terminal_delivery_truths() {
+    let (_temp, path, db) = database();
+    let delivered_execution = armed_terminal(&db, "delivered", "op-delivered", 20, 21);
+    let delivered_claim = db.claim_next_terminal_continuation().unwrap().unwrap();
+    db.begin_terminal_continuation_dispatch(
+        &delivered_execution.execution_id,
+        &delivered_claim.claim_fence,
+    )
+    .unwrap();
+    let delivered = db
+        .complete_terminal_continuation_delivery(
+            &delivered_execution.execution_id,
+            &delivered_claim.claim_fence,
+        )
+        .unwrap();
+    assert_eq!(
+        delivered.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Delivered
+    );
+    assert_eq!(stored_fence(&db, &delivered.execution_id), None);
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+
+    let unknown_execution = armed_terminal(&db, "unknown", "op-unknown", 30, 31);
+    let unknown_claim = db.claim_next_terminal_continuation().unwrap().unwrap();
+    db.begin_terminal_continuation_dispatch(
+        &unknown_execution.execution_id,
+        &unknown_claim.claim_fence,
+    )
+    .unwrap();
+    let unknown = db
+        .mark_terminal_continuation_delivery_unknown(
+            &unknown_execution.execution_id,
+            &unknown_claim.claim_fence,
+        )
+        .unwrap();
+    assert_eq!(
+        unknown.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::DeliveryUnknown
+    );
+    assert_eq!(stored_fence(&db, &unknown.execution_id), None);
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+
+    let delivered_id = delivered.execution_id.clone();
+    let unknown_id = unknown.execution_id.clone();
+    drop(db);
+    let reopened = Database::open(&path).unwrap();
+    assert_eq!(
+        reopened
+            .connector_execution(&delivered_id)
+            .unwrap()
+            .continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Delivered
+    );
+    assert_eq!(
+        reopened
+            .connector_execution(&unknown_id)
+            .unwrap()
+            .continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::DeliveryUnknown
+    );
+    reopened
+        .reconcile_connector_startup("wc_proj_delivery", 40)
+        .unwrap();
+    assert_eq!(
+        reopened
+            .connector_execution(&delivered_id)
+            .unwrap()
+            .continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Delivered
+    );
+    assert_eq!(
+        reopened
+            .connector_execution(&unknown_id)
+            .unwrap()
+            .continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::DeliveryUnknown
+    );
+    assert!(reopened
+        .claim_next_terminal_continuation()
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn reopen_preserves_claim_and_dispatch_uncertainty_fence() {
+    let (_temp, path, db) = database();
+    let terminal = armed_terminal(&db, "reopen", "op-reopen", 20, 21);
+    let claim = db.claim_next_terminal_continuation().unwrap().unwrap();
+    let execution_id = terminal.execution_id.clone();
+    let fence = claim.claim_fence.clone();
+    drop(db);
+
+    let reopened = Database::open(&path).unwrap();
+    let claimed = reopened.connector_execution(&execution_id).unwrap();
+    assert_eq!(
+        claimed.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Claimed
+    );
+    assert_eq!(
+        stored_fence(&reopened, &execution_id).as_deref(),
+        Some(fence.as_str())
+    );
+    reopened
+        .begin_terminal_continuation_dispatch(&execution_id, &fence)
+        .unwrap();
+    drop(reopened);
+
+    let reopened = Database::open(&path).unwrap();
+    let dispatching = reopened.connector_execution(&execution_id).unwrap();
+    assert_eq!(
+        dispatching.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Dispatching
+    );
+    assert_eq!(
+        stored_fence(&reopened, &execution_id).as_deref(),
+        Some(fence.as_str())
+    );
+}
+
+#[test]
+fn startup_reconciliation_releases_claimed_but_quarantines_dispatching() {
+    let (_temp, _path, db) = database();
+    let claimed_execution = armed_terminal(&db, "restart-claimed", "op-restart-claimed", 20, 21);
+    let dispatching_execution =
+        armed_terminal(&db, "restart-dispatching", "op-restart-dispatching", 30, 31);
+
+    let claimed = db.claim_next_terminal_continuation().unwrap().unwrap();
+    assert_eq!(
+        claimed.execution.execution_id,
+        claimed_execution.execution_id
+    );
+    let dispatching = db.claim_next_terminal_continuation().unwrap().unwrap();
+    assert_eq!(
+        dispatching.execution.execution_id,
+        dispatching_execution.execution_id
+    );
+    db.begin_terminal_continuation_dispatch(
+        &dispatching_execution.execution_id,
+        &dispatching.claim_fence,
+    )
+    .unwrap();
+
+    db.reconcile_connector_executions("wc_proj_delivery", 39)
+        .unwrap();
+    assert_eq!(
+        db.connector_execution(&claimed_execution.execution_id)
+            .unwrap()
+            .continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Claimed
+    );
+    assert_eq!(
+        db.connector_execution(&dispatching_execution.execution_id)
+            .unwrap()
+            .continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Dispatching
+    );
+
+    db.reconcile_connector_startup("wc_proj_delivery", 40)
+        .unwrap();
+
+    let safely_released = db
+        .connector_execution(&claimed_execution.execution_id)
+        .unwrap();
+    assert_eq!(safely_released.state, "succeeded");
+    assert_eq!(
+        safely_released.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Unclaimed
+    );
+    assert_eq!(stored_fence(&db, &claimed_execution.execution_id), None);
+
+    let uncertain = db
+        .connector_execution(&dispatching_execution.execution_id)
+        .unwrap();
+    assert_eq!(uncertain.state, "succeeded");
+    assert_eq!(
+        uncertain.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::DeliveryUnknown
+    );
+    assert_eq!(stored_fence(&db, &dispatching_execution.execution_id), None);
+
+    let reclaimed = db.claim_next_terminal_continuation().unwrap().unwrap();
+    assert_eq!(
+        reclaimed.execution.execution_id,
+        claimed_execution.execution_id
+    );
+    assert_ne!(reclaimed.claim_fence, claimed.claim_fence);
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+}
+
+#[test]
+fn inconsistent_delivery_state_and_fence_fail_closed() {
+    let (_temp, _path, db) = database();
+    let terminal = armed_terminal(&db, "inconsistent", "op-inconsistent", 20, 21);
+
+    db.conn_for_tests()
+        .execute_batch(&format!(
+            "PRAGMA ignore_check_constraints = ON;
+             UPDATE wc_executions
+             SET terminal_continuation_claim_fence = 'orphan-fence'
+             WHERE id = '{}';
+             PRAGMA ignore_check_constraints = OFF;",
+            terminal.execution_id
+        ))
+        .unwrap();
+    assert!(db.terminal_ready_connector_executions().unwrap().is_empty());
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+
+    db.conn_for_tests()
+        .execute_batch(&format!(
+            "PRAGMA ignore_check_constraints = ON;
+             UPDATE wc_executions
+             SET terminal_continuation_delivery_state = 'claimed',
+                 terminal_continuation_claim_fence = NULL
+             WHERE id = '{}';
+             PRAGMA ignore_check_constraints = OFF;",
+            terminal.execution_id
+        ))
+        .unwrap();
+    let active_task = task(&db, "inconsistent-active");
+    let active = reserve(&db, &active_task, "op-inconsistent-active");
+    db.arm_connector_terminal_continuation(&active.execution_id, 22)
+        .unwrap();
+    db.conn_for_tests()
+        .execute(
+            "UPDATE wc_executions
+             SET terminal_continuation_delivery_state = 'claimed',
+                 terminal_continuation_claim_fence = 'corrupt-active-fence'
+             WHERE id = ?1",
+            rusqlite::params![active.execution_id],
+        )
+        .unwrap();
+
+    db.reconcile_connector_startup("wc_proj_delivery", 30)
+        .unwrap();
+    let stranded = db.connector_execution(&terminal.execution_id).unwrap();
+    assert_eq!(
+        stranded.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Claimed
+    );
+    assert_eq!(stored_fence(&db, &terminal.execution_id), None);
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+
+    let recovered_active = db.connector_execution(&active.execution_id).unwrap();
+    assert_eq!(recovered_active.state, "interrupted");
+    assert_eq!(
+        recovered_active.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Claimed
+    );
+    assert_eq!(
+        stored_fence(&db, &active.execution_id).as_deref(),
+        Some("corrupt-active-fence")
+    );
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+}
+
+#[test]
+fn unknown_persisted_delivery_state_fails_closed_and_is_not_claimable() {
+    let (_temp, _path, db) = database();
+    let terminal = armed_terminal(&db, "corrupt", "op-corrupt", 20, 21);
+    db.conn_for_tests()
+        .execute_batch(&format!(
+            "PRAGMA ignore_check_constraints = ON;
+             UPDATE wc_executions
+             SET terminal_continuation_delivery_state = 'future_state'
+             WHERE id = '{}';
+             PRAGMA ignore_check_constraints = OFF;",
+            terminal.execution_id
+        ))
+        .unwrap();
+
+    assert!(db.claim_next_terminal_continuation().unwrap().is_none());
+    assert!(db.connector_execution(&terminal.execution_id).is_err());
+}
+
+#[test]
+fn pre_a2_armed_terminal_row_migrates_unclaimed_and_remains_claimable() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("pre-a2.db");
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE wc_executions (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            task_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            state TEXT NOT NULL,
+            submitted_at INTEGER NOT NULL,
+            queued_at INTEGER,
+            queue_deadline INTEGER NOT NULL,
+            started_at INTEGER,
+            last_output_at INTEGER,
+            finished_at INTEGER,
+            stdout_cursor INTEGER NOT NULL DEFAULT 1,
+            stderr_cursor INTEGER NOT NULL DEFAULT 1,
+            exit_code INTEGER,
+            failure_source TEXT,
+            failure_code TEXT,
+            terminal_reason TEXT,
+            operation_id TEXT NOT NULL,
+            request_sha256 TEXT NOT NULL,
+            executor_reference TEXT,
+            first_status_failure_at INTEGER,
+            last_successful_observation_at INTEGER,
+            status_failure_code TEXT,
+            check_plan TEXT,
+            check_recipe_json TEXT,
+            check_completed INTEGER NOT NULL DEFAULT 0,
+            check_workspace_sha256 TEXT,
+            validated_workspace_sha256 TEXT,
+            failed_check TEXT,
+            assertion_evidence_json TEXT,
+            terminal_continuation_intent TEXT NOT NULL DEFAULT 'none',
+            terminal_continuation_armed_at INTEGER
+         );
+         INSERT INTO wc_executions (
+            id, kind, task_id, run_id, state, submitted_at, queue_deadline,
+            operation_id, request_sha256, finished_at, exit_code,
+            terminal_continuation_intent, terminal_continuation_armed_at
+         ) VALUES (
+            'wc_exec_pre_a2', 'command', 'wc_task_pre_a2', 'wc_run_pre_a2',
+            'succeeded', 10, 100, 'op-pre-a2', 'hash', 20, 0,
+            'armed_for_terminal', 15
+         );",
+    )
+    .unwrap();
+    drop(conn);
+
+    let db = Database::open(&path).unwrap();
+    let migrated = db.connector_execution("wc_exec_pre_a2").unwrap();
+    assert_eq!(
+        migrated.continuation_intent,
+        ConnectorExecutionContinuationIntent::ArmedForTerminal
+    );
+    assert_eq!(migrated.continuation_armed_at, Some(15));
+    assert_eq!(
+        migrated.continuation_delivery_state,
+        ConnectorTerminalContinuationDeliveryState::Unclaimed
+    );
+    assert_eq!(stored_fence(&db, "wc_exec_pre_a2"), None);
+    let claim = db.claim_next_terminal_continuation().unwrap().unwrap();
+    assert_eq!(claim.execution.execution_id, "wc_exec_pre_a2");
+}

--- a/src/db/execution_model.rs
+++ b/src/db/execution_model.rs
@@ -30,6 +30,51 @@ impl ConnectorExecutionContinuationIntent {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectorTerminalContinuationDeliveryState {
+    Unclaimed,
+    Claimed,
+    Dispatching,
+    Delivered,
+    DeliveryUnknown,
+}
+
+impl ConnectorTerminalContinuationDeliveryState {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unclaimed => "unclaimed",
+            Self::Claimed => "claimed",
+            Self::Dispatching => "dispatching",
+            Self::Delivered => "delivered",
+            Self::DeliveryUnknown => "delivery_unknown",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "unclaimed" => Ok(Self::Unclaimed),
+            "claimed" => Ok(Self::Claimed),
+            "dispatching" => Ok(Self::Dispatching),
+            "delivered" => Ok(Self::Delivered),
+            "delivery_unknown" => Ok(Self::DeliveryUnknown),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                rusqlite::types::Type::Text,
+                format!("unsupported connector terminal continuation delivery state: {other}")
+                    .into(),
+            )),
+        }
+    }
+}
+
+// A2 stops at the durable claim/delivery boundary; the next host-adapter slice
+// will become the first production reader of the returned claim handle.
+#[allow(dead_code)]
+pub(crate) struct ConnectorTerminalContinuationClaim {
+    pub execution: ConnectorExecution,
+    pub claim_fence: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ConnectorExecution {
     pub execution_id: String,
@@ -64,6 +109,7 @@ pub(crate) struct ConnectorExecution {
     pub assertion_evidence: Option<Value>,
     pub continuation_intent: ConnectorExecutionContinuationIntent,
     pub continuation_armed_at: Option<i64>,
+    pub continuation_delivery_state: ConnectorTerminalContinuationDeliveryState,
 }
 
 impl ConnectorExecution {
@@ -307,7 +353,8 @@ pub(super) const EXECUTION_COLUMNS: &str =
     executor_reference, first_status_failure_at, last_successful_observation_at, \
     status_failure_code, check_plan, check_recipe_json, check_completed, check_workspace_sha256, \
     validated_workspace_sha256, failed_check, assertion_evidence_json, \
-    terminal_continuation_intent, terminal_continuation_armed_at";
+    terminal_continuation_intent, terminal_continuation_armed_at, \
+    terminal_continuation_delivery_state";
 
 pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<ConnectorExecution> {
     let cursor = |index| {
@@ -375,6 +422,10 @@ pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<Connect
             30,
         )?,
         continuation_armed_at: row.get(31)?,
+        continuation_delivery_state: ConnectorTerminalContinuationDeliveryState::from_db(
+            &row.get::<_, String>(32)?,
+            32,
+        )?,
     })
 }
 

--- a/src/db/executions.rs
+++ b/src/db/executions.rs
@@ -5,14 +5,21 @@ use super::execution_model::{
     execution_event_kind, latest_execution, latest_execution_by_kind, load_execution,
     load_execution_by_operation, observed_state, ConnectorExecution,
     ConnectorExecutionContinuationIntent, ConnectorExecutionFailure, ConnectorExecutionObservation,
-    ConnectorExecutionReservation, EXECUTION_COLUMNS,
+    ConnectorExecutionReservation, ConnectorTerminalContinuationClaim,
+    ConnectorTerminalContinuationDeliveryState, EXECUTION_COLUMNS,
 };
 use super::task_kernel::{
     expire_task_approvals, insert_event, load_task, require_running, touch_task,
 };
 use super::{ConnectorTaskSnapshot, ConnectorTaskStoreError, Database};
-use rusqlite::{params, Transaction};
+use rusqlite::{params, OptionalExtension, Transaction, TransactionBehavior};
 use serde_json::json;
+
+const TERMINAL_CONTINUATION_READY_PREDICATE: &str =
+    "terminal_continuation_intent = 'armed_for_terminal' \
+     AND state NOT IN ('accepted','queued','starting','running','cancel_requested') \
+     AND terminal_continuation_delivery_state = 'unclaimed' \
+     AND terminal_continuation_claim_fence IS NULL";
 
 impl Database {
     pub(crate) fn reserve_connector_execution(
@@ -157,8 +164,8 @@ impl Database {
         commit_execution(tx, execution_id)
     }
 
-    // A1 intentionally stops at a durable read boundary; the A2 host adapter
-    // will become the first production consumer of this query.
+    // Ready remains derived: A1 intent + terminal execution truth + unclaimed
+    // delivery state. No second durable ready bit exists.
     #[allow(dead_code)]
     pub(crate) fn terminal_ready_connector_executions(
         &self,
@@ -166,14 +173,182 @@ impl Database {
         let conn = self.conn.lock().unwrap();
         let mut statement = conn.prepare(&format!(
             "SELECT {EXECUTION_COLUMNS} FROM wc_executions
-             WHERE terminal_continuation_intent = 'armed_for_terminal'
-               AND state NOT IN ('accepted','queued','starting','running','cancel_requested')
+             WHERE {TERMINAL_CONTINUATION_READY_PREDICATE}
              ORDER BY finished_at ASC, submitted_at ASC, id ASC"
         ))?;
         let executions = statement
             .query_map([], super::execution_model::map_execution)?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(executions)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn claim_next_terminal_continuation(
+        &self,
+    ) -> Result<Option<ConnectorTerminalContinuationClaim>, ConnectorTaskStoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        // Serialize the select+claim decision across independent DB handles as
+        // well as this process-local mutex. A second claimant observes the
+        // committed Claimed state instead of selecting the same ready row.
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let candidate = tx
+            .query_row(
+                &format!(
+                    "SELECT {EXECUTION_COLUMNS} FROM wc_executions
+                     WHERE {TERMINAL_CONTINUATION_READY_PREDICATE}
+                     ORDER BY finished_at ASC, submitted_at ASC, id ASC
+                     LIMIT 1"
+                ),
+                [],
+                super::execution_model::map_execution,
+            )
+            .optional()?;
+        let Some(candidate) = candidate else {
+            tx.commit()?;
+            return Ok(None);
+        };
+        let claim_fence = format!("wc_claim_{}", uuid::Uuid::new_v4().simple());
+        let updated = tx.execute(
+            &format!(
+                "UPDATE wc_executions
+                 SET terminal_continuation_delivery_state = ?1,
+                     terminal_continuation_claim_fence = ?2
+                 WHERE id = ?3 AND {TERMINAL_CONTINUATION_READY_PREDICATE}"
+            ),
+            params![
+                ConnectorTerminalContinuationDeliveryState::Claimed.as_str(),
+                claim_fence,
+                candidate.execution_id
+            ],
+        )?;
+        if updated != 1 {
+            return Err(ConnectorTaskStoreError::InvalidState(
+                "terminal continuation claim lost its ready state".to_string(),
+            ));
+        }
+        let execution = load_execution(&tx, &candidate.execution_id)?
+            .ok_or(ConnectorTaskStoreError::NotFound)?;
+        tx.commit()?;
+        Ok(Some(ConnectorTerminalContinuationClaim {
+            execution,
+            claim_fence,
+        }))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn release_terminal_continuation_claim(
+        &self,
+        execution_id: &str,
+        claim_fence: &str,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        self.transition_terminal_continuation_delivery(
+            execution_id,
+            claim_fence,
+            ConnectorTerminalContinuationDeliveryState::Claimed,
+            ConnectorTerminalContinuationDeliveryState::Unclaimed,
+            true,
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn begin_terminal_continuation_dispatch(
+        &self,
+        execution_id: &str,
+        claim_fence: &str,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        self.transition_terminal_continuation_delivery(
+            execution_id,
+            claim_fence,
+            ConnectorTerminalContinuationDeliveryState::Claimed,
+            ConnectorTerminalContinuationDeliveryState::Dispatching,
+            false,
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn complete_terminal_continuation_delivery(
+        &self,
+        execution_id: &str,
+        claim_fence: &str,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        self.transition_terminal_continuation_delivery(
+            execution_id,
+            claim_fence,
+            ConnectorTerminalContinuationDeliveryState::Dispatching,
+            ConnectorTerminalContinuationDeliveryState::Delivered,
+            true,
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn mark_terminal_continuation_delivery_unknown(
+        &self,
+        execution_id: &str,
+        claim_fence: &str,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        self.transition_terminal_continuation_delivery(
+            execution_id,
+            claim_fence,
+            ConnectorTerminalContinuationDeliveryState::Dispatching,
+            ConnectorTerminalContinuationDeliveryState::DeliveryUnknown,
+            true,
+        )
+    }
+
+    fn transition_terminal_continuation_delivery(
+        &self,
+        execution_id: &str,
+        claim_fence: &str,
+        expected: ConnectorTerminalContinuationDeliveryState,
+        next: ConnectorTerminalContinuationDeliveryState,
+        clear_fence: bool,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let execution =
+            load_execution(&tx, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
+        let stored_fence = tx.query_row(
+            "SELECT terminal_continuation_claim_fence FROM wc_executions WHERE id = ?1",
+            params![execution_id],
+            |row| row.get::<_, Option<String>>(0),
+        )?;
+        if stored_fence.as_deref() != Some(claim_fence) {
+            return Err(ConnectorTaskStoreError::InvalidState(
+                "terminal continuation claim fence is stale".to_string(),
+            ));
+        }
+        if execution.continuation_delivery_state != expected {
+            return Err(ConnectorTaskStoreError::InvalidState(
+                "terminal continuation delivery transition is not allowed from the current state"
+                    .to_string(),
+            ));
+        }
+        let updated = if clear_fence {
+            tx.execute(
+                "UPDATE wc_executions
+                 SET terminal_continuation_delivery_state = ?1,
+                     terminal_continuation_claim_fence = NULL
+                 WHERE id = ?2
+                   AND terminal_continuation_delivery_state = ?3
+                   AND terminal_continuation_claim_fence = ?4",
+                params![next.as_str(), execution_id, expected.as_str(), claim_fence],
+            )?
+        } else {
+            tx.execute(
+                "UPDATE wc_executions
+                 SET terminal_continuation_delivery_state = ?1
+                 WHERE id = ?2
+                   AND terminal_continuation_delivery_state = ?3
+                   AND terminal_continuation_claim_fence = ?4",
+                params![next.as_str(), execution_id, expected.as_str(), claim_fence],
+            )?
+        };
+        if updated != 1 {
+            return Err(ConnectorTaskStoreError::InvalidState(
+                "terminal continuation claim fence is no longer current".to_string(),
+            ));
+        }
+        commit_execution(tx, execution_id)
     }
 
     pub(crate) fn latest_connector_execution(
@@ -583,13 +758,61 @@ impl Database {
         Ok(latest_execution(&conn, task_id)?.filter(ConnectorExecution::blocks_finish))
     }
 
+    pub(crate) fn reconcile_connector_startup(
+        &self,
+        project_id: &str,
+        now: i64,
+    ) -> Result<(usize, usize), ConnectorTaskStoreError> {
+        self.reconcile_connector_executions_inner(project_id, now, true)
+    }
+
+    #[cfg(test)]
     pub(crate) fn reconcile_connector_executions(
         &self,
         project_id: &str,
         now: i64,
     ) -> Result<(usize, usize), ConnectorTaskStoreError> {
+        self.reconcile_connector_executions_inner(project_id, now, false)
+    }
+
+    fn reconcile_connector_executions_inner(
+        &self,
+        project_id: &str,
+        now: i64,
+        recover_terminal_continuation_delivery: bool,
+    ) -> Result<(usize, usize), ConnectorTaskStoreError> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
+        if recover_terminal_continuation_delivery {
+            let claimed_released = tx.execute(
+                "UPDATE wc_executions
+                     SET terminal_continuation_delivery_state = 'unclaimed',
+                         terminal_continuation_claim_fence = NULL
+                     WHERE terminal_continuation_delivery_state = 'claimed'
+                       AND terminal_continuation_claim_fence IS NOT NULL
+                       AND terminal_continuation_intent = 'armed_for_terminal'
+                       AND state NOT IN ('accepted','queued','starting','running','cancel_requested')
+                       AND task_id IN (SELECT id FROM wc_tasks WHERE project_id = ?1)",
+                params![project_id],
+            )?;
+            let dispatching_uncertain = tx.execute(
+                "UPDATE wc_executions
+                     SET terminal_continuation_delivery_state = 'delivery_unknown',
+                         terminal_continuation_claim_fence = NULL
+                     WHERE terminal_continuation_delivery_state = 'dispatching'
+                       AND task_id IN (SELECT id FROM wc_tasks WHERE project_id = ?1)",
+                params![project_id],
+            )?;
+            if claimed_released > 0 || dispatching_uncertain > 0 {
+                tracing::warn!(
+                    project_id,
+                    claimed_released,
+                    dispatching_uncertain,
+                    "Reconciled terminal continuation delivery state after restart"
+                );
+            }
+        }
+
         let recoveries = {
             let mut statement = tx.prepare(
                 "SELECT r.id, t.id,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -464,6 +464,22 @@ impl Database {
                 terminal_continuation_intent TEXT NOT NULL DEFAULT 'none'
                     CHECK(terminal_continuation_intent IN ('none', 'armed_for_terminal')),
                 terminal_continuation_armed_at INTEGER,
+                terminal_continuation_delivery_state TEXT NOT NULL DEFAULT 'unclaimed'
+                    CHECK(terminal_continuation_delivery_state IN (
+                        'unclaimed', 'claimed', 'dispatching', 'delivered', 'delivery_unknown'
+                    )),
+                terminal_continuation_claim_fence TEXT
+                    CHECK(terminal_continuation_claim_fence IS NULL OR (
+                        length(terminal_continuation_claim_fence) BETWEEN 1 AND 80
+                    )),
+                CHECK(
+                    (terminal_continuation_delivery_state = 'unclaimed'
+                        AND terminal_continuation_claim_fence IS NULL)
+                    OR (terminal_continuation_delivery_state IN ('claimed', 'dispatching')
+                        AND terminal_continuation_claim_fence IS NOT NULL)
+                    OR (terminal_continuation_delivery_state IN ('delivered', 'delivery_unknown')
+                        AND terminal_continuation_claim_fence IS NULL)
+                ),
                 UNIQUE(task_id, run_id, operation_id),
                 CHECK(
                     (kind = 'command' AND check_plan IS NULL)
@@ -961,6 +977,14 @@ impl Database {
                 "TEXT NOT NULL DEFAULT 'none' CHECK(terminal_continuation_intent IN ('none', 'armed_for_terminal'))",
             ),
             ("terminal_continuation_armed_at", "INTEGER"),
+            (
+                "terminal_continuation_delivery_state",
+                "TEXT NOT NULL DEFAULT 'unclaimed' CHECK(terminal_continuation_delivery_state IN ('unclaimed', 'claimed', 'dispatching', 'delivered', 'delivery_unknown'))",
+            ),
+            (
+                "terminal_continuation_claim_fence",
+                "TEXT CHECK(terminal_continuation_claim_fence IS NULL OR (length(terminal_continuation_claim_fence) BETWEEN 1 AND 80))",
+            ),
         ] {
             if !columns.iter().any(|existing| existing == column) {
                 conn.execute(
@@ -1013,17 +1037,32 @@ mod connector_execution_column_tests {
         Database::ensure_connector_execution_columns(&conn).unwrap();
         Database::ensure_connector_execution_columns(&conn).unwrap();
 
-        let restored: (String, Option<i64>, String) = conn
+        let restored: (String, Option<i64>, String, String, Option<String>) = conn
             .query_row(
-                "SELECT terminal_continuation_intent, terminal_continuation_armed_at, state
+                "SELECT terminal_continuation_intent, terminal_continuation_armed_at, state,
+                        terminal_continuation_delivery_state, terminal_continuation_claim_fence
                  FROM wc_executions WHERE id = 'legacy'",
                 [],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
             )
             .unwrap();
         assert_eq!(
             restored,
-            ("none".to_string(), None, "succeeded".to_string())
+            (
+                "none".to_string(),
+                None,
+                "succeeded".to_string(),
+                "unclaimed".to_string(),
+                None,
+            )
         );
     }
 }


### PR DESCRIPTION
## Summary

Builds on the merged A1 terminal-continuation intent and adds the focused A2 durable delivery state machine for Connector executions.

- adds `Unclaimed -> Claimed -> Dispatching -> Delivered / DeliveryUnknown`
- makes terminal-continuation claim atomic across independent SQLite handles with an immediate transaction
- adds opaque stale-worker claim fences and fenced transitions
- releases `Claimed` only during startup recovery, while quarantining `Dispatching` as `DeliveryUnknown`
- keeps `Ready` derived from execution terminal truth + armed intent + unclaimed delivery state
- keeps claim fences and delivery state internal; no model/public/log projection
- preserves A1 replay/restart semantics and does not implement host wakeup/callback delivery yet

## Correctness boundaries

`Claimed` means no external delivery side effect has started and is therefore safe to release on process startup. `Dispatching` means an external side effect may have started; restart converts it to `DeliveryUnknown` and never treats timeout/restart as retry authority.

## Validation

Fresh independent review passed with no reviewer fix required.

- `cargo test 'continuation_delivery_tests'` — 10/10
- `cargo test 'execution_intent_tests'` — 3/3
- `cargo test 'terminal_continuation'` — 3/3
- `cargo check --all-targets`
- `cargo fmt -- --check`
- diff/worktree hygiene clean

Exact reviewed head: `18fbc32f279dba94a1139e5e37773cc5cbb019f0`.