### PR TITLE
Add durable MCP 2026 Connector Tasks

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -236,15 +236,19 @@ remembered from an earlier request or from `Mcp-Session-Id`.
 
 Only `commands_run` and `checks_run` use task-augmented execution, and only when
 the existing bounded quick-yield returns an execution that is still active. A
-Tasks-capable client receives `resultType: "task"` with the durable execution ID
-as `taskId`; an exact `operation_id` replay resolves to the same execution and
-therefore the same task handle. If the execution is already terminal, or the
-request does not advertise the Tasks extension, the normal `CallToolResult`
-shape is unchanged.
+Tasks-capable client receives `resultType: "task"` only after that exact durable
+execution is materialized as an MCP Task; its execution ID is the `taskId`.
+Once materialized, an exact `operation_id` replay resolves to the same task
+handle even after the execution becomes terminal. If an execution reaches
+terminal state before it was ever materialized, or the request does not
+advertise the Tasks extension, the normal `CallToolResult` shape is unchanged.
 
-Poll with `tasks/get`. `working` is derived from the durable execution; terminal
-polls return the same bounded/redacted Connector execution result and remain
-stable across Server/database reopen. `tasks/update` is accepted for protocol
+Poll with `tasks/get`. `working` is derived from the durable execution. At the
+terminal transition, a materialized Task durably finalizes the bounded/redacted
+Connector result inputs, including the same bounded stdout/stderr tail used by
+the ordinary synchronous result. Terminal polls reconstruct only from that
+durable snapshot, so repeated polls remain stable across Server/database reopen
+and later Runner Job-log loss. `tasks/update` is accepted for protocol
 compatibility, but Connector execution Tasks never enter `input_required`, so
 unknown/already-satisfied input responses are ignored. `tasks/cancel` delegates
 to the existing Connector cancellation path: its ACK means the cancel request
@@ -253,8 +257,9 @@ the task reports a terminal status. There is no `tasks/list` and no task
 notification/subscription surface in this Connector integration.
 
 Task access is re-authorized on every request against the bound project and
-owner. Task IDs do not grant cross-user or cross-project access, do not encode a
-Workflow Session/window/credential, and do not consume terminal-continuation
+owner, and only execution IDs that were actually materialized as MCP Tasks are
+accepted by task methods. Task IDs do not grant cross-user or cross-project
+access, do not encode a Workflow Session/window/credential, and do not consume terminal-continuation
 delivery state. `ttlMs` is `null` (no fabricated expiry authority) and
 `pollIntervalMs` is an advisory two seconds.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -227,6 +227,37 @@ connection, credential, project, or transport header. Older stateful adapter
 contracts may expose a stable `ClientWindow`, but that is not a general MCP
 property and is not Workflow Session or model-context identity.
 
+### Stateless MCP 2026 Tasks extension
+
+For `canonical_connector`, `server/discover` advertises the official
+`io.modelcontextprotocol/tasks` extension. Support is negotiated per request via
+`_meta.io.modelcontextprotocol/clientCapabilities.extensions`; no capability is
+remembered from an earlier request or from `Mcp-Session-Id`.
+
+Only `commands_run` and `checks_run` use task-augmented execution, and only when
+the existing bounded quick-yield returns an execution that is still active. A
+Tasks-capable client receives `resultType: "task"` with the durable execution ID
+as `taskId`; an exact `operation_id` replay resolves to the same execution and
+therefore the same task handle. If the execution is already terminal, or the
+request does not advertise the Tasks extension, the normal `CallToolResult`
+shape is unchanged.
+
+Poll with `tasks/get`. `working` is derived from the durable execution; terminal
+polls return the same bounded/redacted Connector execution result and remain
+stable across Server/database reopen. `tasks/update` is accepted for protocol
+compatibility, but Connector execution Tasks never enter `input_required`, so
+unknown/already-satisfied input responses are ignored. `tasks/cancel` delegates
+to the existing Connector cancellation path: its ACK means the cancel request
+was accepted, not that cancellation is already terminal; continue polling until
+the task reports a terminal status. There is no `tasks/list` and no task
+notification/subscription surface in this Connector integration.
+
+Task access is re-authorized on every request against the bound project and
+owner. Task IDs do not grant cross-user or cross-project access, do not encode a
+Workflow Session/window/credential, and do not consume terminal-continuation
+delivery state. `ttlMs` is `null` (no fabricated expiry authority) and
+`pollIntervalMs` is an advisory two seconds.
+
 ## Golden coding loop
 
 ```text

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -212,22 +212,26 @@ Workflow Session 或 model-context identity。
 `Mcp-Session-Id` 或其他隐藏状态记住能力。
 
 只有 `commands_run` 与 `checks_run` 会使用 task-augmented execution，并且仅限现有的
-有界 quick-yield 返回后 execution 仍处于 active 状态。支持 Tasks 的客户端会收到
-`resultType: "task"`，其中 durable execution ID 直接作为 `taskId`；相同
-`operation_id` 的精确 replay 会复用同一个 execution，因此得到同一个 task handle。
-如果 execution 已经 terminal，或者当前请求没有声明 Tasks extension，原有
-`CallToolResult` 形状完全不变。
+有界 quick-yield 返回后 execution 仍处于 active 状态。只有当这个 exact durable
+execution 已经被持久化标记为 MCP Task 后，支持 Tasks 的客户端才会收到
+`resultType: "task"`；execution ID 直接作为 `taskId`。一旦 materialized，相同
+`operation_id` 的精确 replay 即使发生在 execution terminal 之后，也仍返回同一个 task
+handle。若 execution 在从未 materialize 为 MCP Task 前已经 terminal，或者当前请求没有
+声明 Tasks extension，则原有 `CallToolResult` 形状完全不变。
 
-使用 `tasks/get` 轮询。`working` 直接来自 durable execution truth；terminal poll
-返回同一套有界、脱敏的 Connector execution result，并在 Server/数据库 reopen 后保持
-稳定。`tasks/update` 为协议兼容而接受，但 Connector execution Task 不会进入
+使用 `tasks/get` 轮询。`working` 直接来自 durable execution truth。materialized Task
+进入 terminal 的同一持久化边界会固化有界、脱敏的 Connector result 输入，其中包括与
+普通同步结果相同的 bounded stdout/stderr tail；terminal poll 只从该 durable snapshot
+重建，因此在 Server/数据库 reopen，甚至后续 Runner Job log 已丢失后仍保持稳定。
+`tasks/update` 为协议兼容而接受，但 Connector execution Task 不会进入
 `input_required`，因此未知或已经满足的 input response 会被忽略。`tasks/cancel` 复用
 现有 Connector cancellation：ACK 只表示取消请求已接受，不代表已经 terminal；客户端
 仍应继续轮询直到出现 terminal status。本集成不提供 `tasks/list`，也不实现 task
 notification/subscription。
 
-每次 task 请求都会重新按绑定 project 与 owner 做授权。`taskId` 不能提供跨用户或跨
-project 权限，也不编码 Workflow Session、window、credential，更不会消费 terminal
+每次 task 请求都会重新按绑定 project 与 owner 做授权，并且 task method 只接受真正
+materialized 为 MCP Task 的 execution ID。`taskId` 不能提供跨用户或跨 project 权限，
+也不编码 Workflow Session、window、credential，更不会消费 terminal
 continuation delivery state。`ttlMs` 为 `null`（不伪造 expiry/retry authority），
 `pollIntervalMs` 建议为 2 秒。
 

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -204,6 +204,33 @@ MCP 2026 中，每次 `tools/call` 对聊天/窗口连续性而言都是应用�
 adapter 契约可以显式提供 stable `ClientWindow`，但这不是 MCP 的普遍属性，也不是
 Workflow Session 或 model-context identity。
 
+### Stateless MCP 2026 Tasks extension
+
+对于 `canonical_connector`，`server/discover` 会声明官方
+`io.modelcontextprotocol/tasks` extension。能力只按**当前请求**的
+`_meta.io.modelcontextprotocol/clientCapabilities.extensions` 协商；不会从前一次请求、
+`Mcp-Session-Id` 或其他隐藏状态记住能力。
+
+只有 `commands_run` 与 `checks_run` 会使用 task-augmented execution，并且仅限现有的
+有界 quick-yield 返回后 execution 仍处于 active 状态。支持 Tasks 的客户端会收到
+`resultType: "task"`，其中 durable execution ID 直接作为 `taskId`；相同
+`operation_id` 的精确 replay 会复用同一个 execution，因此得到同一个 task handle。
+如果 execution 已经 terminal，或者当前请求没有声明 Tasks extension，原有
+`CallToolResult` 形状完全不变。
+
+使用 `tasks/get` 轮询。`working` 直接来自 durable execution truth；terminal poll
+返回同一套有界、脱敏的 Connector execution result，并在 Server/数据库 reopen 后保持
+稳定。`tasks/update` 为协议兼容而接受，但 Connector execution Task 不会进入
+`input_required`，因此未知或已经满足的 input response 会被忽略。`tasks/cancel` 复用
+现有 Connector cancellation：ACK 只表示取消请求已接受，不代表已经 terminal；客户端
+仍应继续轮询直到出现 terminal status。本集成不提供 `tasks/list`，也不实现 task
+notification/subscription。
+
+每次 task 请求都会重新按绑定 project 与 owner 做授权。`taskId` 不能提供跨用户或跨
+project 权限，也不编码 Workflow Session、window、credential，更不会消费 terminal
+continuation delivery state。`ttlMs` 为 `null`（不伪造 expiry/retry authority），
+`pollIntervalMs` 建议为 2 秒。
+
 ## 黄金 coding 循环
 
 ```text

--- a/src/connector_runtime/continuation_delivery_tests.rs
+++ b/src/connector_runtime/continuation_delivery_tests.rs
@@ -69,6 +69,7 @@ fn model_execution_projection_never_exposes_terminal_continuation_claim_fence() 
             assertion_evidence: None,
             validated_workspace_sha256: None,
             executor_failure_code: None,
+            mcp_task_output_tail: None,
             now: 21,
         },
     )

--- a/src/connector_runtime/execution.rs
+++ b/src/connector_runtime/execution.rs
@@ -291,6 +291,12 @@ impl ExecutionService {
         match self.dispatch_cancel(&task, &execution, &auth).await {
             CancelDispatch::ReferencePending => return Ok(Some(execution)),
             CancelDispatch::Failed => {
+                if let Some(output_tail) = self.bounded_output_tail(&execution, &auth).await {
+                    let _ = self.db.record_connector_mcp_task_output_tail(
+                        &execution.execution_id,
+                        &output_tail,
+                    );
+                }
                 execution = self.db.finish_connector_execution(
                     &execution.execution_id,
                     ConnectorExecutionFailure::Unknown("cancel_transport_unknown"),
@@ -436,27 +442,36 @@ impl ExecutionService {
         }
     }
 
+    pub(super) async fn bounded_output_tail(
+        &self,
+        execution: &ConnectorExecution,
+        auth: &AuthContext,
+    ) -> Option<Value> {
+        let job_id = execution.executor_reference.as_deref()?;
+        self.tools
+            .shell_clients
+            .job_log_for_auth(Some(auth), job_id, None, None, Some(200), None, None)
+            .await
+            .ok()
+            .map(|(_, stdout, stderr, _, _, _)| {
+                json!({
+                    "stdout": stdout.unwrap_or_default(),
+                    "stderr": stderr.unwrap_or_default(),
+                    "bounded": true
+                })
+            })
+    }
+
     pub(crate) async fn projection(
         &self,
         execution: &ConnectorExecution,
         auth: &AuthContext,
         include_output_tail: bool,
     ) -> Value {
-        let output_tail = match (include_output_tail, execution.executor_reference.as_deref()) {
-            (true, Some(job_id)) => self
-                .tools
-                .shell_clients
-                .job_log_for_auth(Some(auth), job_id, None, None, Some(200), None, None)
-                .await
-                .ok()
-                .map(|(_, stdout, stderr, _, _, _)| {
-                    json!({
-                        "stdout": stdout.unwrap_or_default(),
-                        "stderr": stderr.unwrap_or_default(),
-                        "bounded": true
-                    })
-                }),
-            _ => None,
+        let output_tail = if include_output_tail {
+            self.bounded_output_tail(execution, auth).await
+        } else {
+            None
         };
         execution_projection(execution, chrono::Utc::now().timestamp(), output_tail)
     }
@@ -472,10 +487,14 @@ impl ExecutionService {
         } else {
             chrono::Utc::now().timestamp()
         };
-        // MCP Tasks polling must remain durable and replay-stable even if the
-        // Runner later drops retained Job logs. The same bounded execution
-        // projection is reused, but optional live output tails are omitted.
-        execution_projection(execution, projection_at, None)
+        // MCP Tasks polling never re-reads Runner logs. Once terminal, the
+        // exact bounded/redacted tail captured at the durable terminal boundary
+        // is part of the replay-stable task result.
+        let output_tail = execution
+            .mcp_task_result_is_finalized()
+            .then(|| execution.mcp_task_output_tail.clone())
+            .flatten();
+        execution_projection(execution, projection_at, output_tail)
     }
 }
 

--- a/src/connector_runtime/execution.rs
+++ b/src/connector_runtime/execution.rs
@@ -460,6 +460,23 @@ impl ExecutionService {
         };
         execution_projection(execution, chrono::Utc::now().timestamp(), output_tail)
     }
+
+    pub(crate) fn durable_task_projection(&self, execution: &ConnectorExecution) -> Value {
+        let projection_at = if execution.is_terminal() {
+            execution
+                .finished_at
+                .or(execution.last_output_at)
+                .or(execution.started_at)
+                .or(execution.queued_at)
+                .unwrap_or(execution.submitted_at)
+        } else {
+            chrono::Utc::now().timestamp()
+        };
+        // MCP Tasks polling must remain durable and replay-stable even if the
+        // Runner later drops retained Job logs. The same bounded execution
+        // projection is reused, but optional live output tails are omitted.
+        execution_projection(execution, projection_at, None)
+    }
 }
 
 pub(crate) fn execution_projection(

--- a/src/connector_runtime/execution/monitor.rs
+++ b/src/connector_runtime/execution/monitor.rs
@@ -191,6 +191,22 @@ impl ExecutionService {
             )
             .await
             .map_err(|error| ("executor_status_unavailable", error))?;
+        let executor_failure_code = job.error.as_deref().and_then(executor_failure_code);
+        let terminal_candidate = executor_failure_code.is_some()
+            || matches!(
+                job.status.as_str(),
+                "completed" | "stopped" | "cancelled" | "timeout" | "timed_out" | "lost" | "failed"
+            );
+        let mcp_task_output_tail = if terminal_candidate {
+            self.bounded_output_tail(&execution, auth).await
+        } else {
+            None
+        };
+        if let Some(output_tail) = mcp_task_output_tail.as_ref() {
+            self.db
+                .record_connector_mcp_task_output_tail(execution_id, output_tail)
+                .map_err(|error| ("task_store_error", error.to_string()))?;
+        }
         if job.status == "lost" {
             return Err((
                 "executor_status_unavailable",
@@ -207,7 +223,6 @@ impl ExecutionService {
         let progress = job.validation_progress.as_ref();
         let check_completed = progress.map(|progress| progress.completed);
         let failed_check = progress.and_then(|progress| progress.failed_step.as_deref());
-        let executor_failure_code = job.error.as_deref().and_then(executor_failure_code);
         let assertion_evidence = if execution.kind == "check" && failed_check.is_some() {
             let (_, full_stdout, full_stderr, _, _, _) = self
                 .tools
@@ -291,6 +306,7 @@ impl ExecutionService {
                     assertion_evidence: assertion_evidence.as_ref(),
                     validated_workspace_sha256: validated_workspace_sha256.as_deref(),
                     executor_failure_code,
+                    mcp_task_output_tail: mcp_task_output_tail.as_ref(),
                     now: chrono::Utc::now().timestamp(),
                 },
             )

--- a/src/connector_runtime/execution_tests.rs
+++ b/src/connector_runtime/execution_tests.rs
@@ -436,6 +436,7 @@ fn executor_status_observation<'a>(
         assertion_evidence: None,
         validated_workspace_sha256: None,
         executor_failure_code: None,
+        mcp_task_output_tail: None,
         now,
     }
 }
@@ -847,6 +848,20 @@ async fn mcp_task_polling_quick_yield_replays_exact_armed_execution() {
     assert!(armed.is_active());
     assert!(armed.terminal_continuation_is_armed());
 
+    let before_materialization = fixture
+        .connector
+        .execution_task_result_for_auth(&execution_id, &fixture.owner)
+        .await;
+    let Err(before_materialization) = before_materialization else {
+        panic!("an armed execution is not an MCP Task until materialization");
+    };
+    assert_eq!(before_materialization.http_status, 404);
+    let materialized_execution = fixture
+        .connector
+        .materialize_execution_task_for_auth(&execution_id, &fixture.owner)
+        .unwrap();
+    assert!(materialized_execution.mcp_task_is_materialized());
+
     let (_task, materialized, working_outcome) = fixture
         .connector
         .execution_task_result_for_auth(&execution_id, &fixture.owner)
@@ -889,13 +904,20 @@ async fn mcp_task_polling_quick_yield_replays_exact_armed_execution() {
     assert!(poll(&fixture.registry).await.is_none());
     assert!(execution_by_id(&fixture, &execution_id).terminal_continuation_is_armed());
 
-    update_job(&fixture.registry, &job_id, "completed", None, Some(0)).await;
+    update_job(
+        &fixture.registry,
+        &job_id,
+        "completed",
+        Some("durable task tail\n"),
+        Some(0),
+    )
+    .await;
     let completed = wait_for_execution(
         &fixture,
         Some(&execution_id),
         Duration::from_secs(10),
         "MCP task-polling execution completion",
-        |execution| execution.state == "succeeded",
+        |execution| execution.state == "succeeded" && execution.mcp_task_result_is_finalized(),
     )
     .await;
     let (_task, terminal, terminal_outcome) = fixture
@@ -906,6 +928,17 @@ async fn mcp_task_polling_quick_yield_replays_exact_armed_execution() {
     assert_eq!(terminal.execution_id, completed.execution_id);
     assert!(!terminal.is_active());
     assert_eq!(terminal_outcome.body["blocking"], false);
+    assert_eq!(
+        terminal.mcp_task_output_tail.as_ref().unwrap()["stdout"],
+        "durable task tail\n"
+    );
+    assert!(fixture
+        .connector
+        .db
+        .terminal_ready_connector_executions()
+        .unwrap()
+        .iter()
+        .all(|ready| ready.execution_id != execution_id));
 }
 
 #[tokio::test]
@@ -985,6 +1018,7 @@ async fn mcp_tools_call_tasks_extension_switches_only_active_command_results_to_
         execution_by_id(&fixture, &execution_id).terminal_continuation_is_armed(),
         true
     );
+    assert!(execution_by_id(&fixture, &execution_id).mcp_task_is_materialized());
 
     let mut no_capability = salvo::test::TestClient::post("http://localhost/mcp")
         .bearer_auth(PROJECT_CREDENTIAL)
@@ -1016,6 +1050,11 @@ async fn mcp_tools_call_tasks_extension_switches_only_active_command_results_to_
         no_capability_body["result"]["structuredContent"]["blocking"],
         true
     );
+    let guided = fixture.connector.host_guide(
+        &fixture.task_id,
+        "task polling must not consume this guidance",
+    );
+    assert!(guided.ok, "{}", guided.body);
 
     let mut replay = salvo::test::TestClient::post("http://localhost/mcp")
         .bearer_auth(PROJECT_CREDENTIAL)
@@ -1044,13 +1083,20 @@ async fn mcp_tools_call_tasks_extension_switches_only_active_command_results_to_
     assert_eq!(replay_body["result"]["taskId"], execution_id);
     assert!(poll(&fixture.registry).await.is_none());
 
-    update_job(&fixture.registry, &job_id, "completed", None, Some(0)).await;
+    update_job(
+        &fixture.registry,
+        &job_id,
+        "completed",
+        Some("http durable final\n"),
+        Some(0),
+    )
+    .await;
     wait_for_execution(
         &fixture,
         Some(&execution_id),
         Duration::from_secs(10),
         "MCP task-augmented HTTP execution completion",
-        |execution| execution.state == "succeeded",
+        |execution| execution.state == "succeeded" && execution.mcp_task_result_is_finalized(),
     )
     .await;
 
@@ -1077,12 +1123,142 @@ async fn mcp_tools_call_tasks_extension_switches_only_active_command_results_to_
         .send(service.as_ref())
         .await;
     let terminal_body: Value = terminal.take_json().await.unwrap();
-    assert_eq!(terminal_body["result"]["resultType"], "complete");
-    assert!(terminal_body["result"].get("taskId").is_none());
+    assert_eq!(terminal_body["result"]["resultType"], "task");
+    assert_eq!(terminal_body["result"]["taskId"], execution_id);
+    assert_eq!(terminal_body["result"]["status"], "completed");
+    assert!(poll(&fixture.registry).await.is_none());
+
+    let mut polled = salvo::test::TestClient::post("http://localhost/mcp")
+        .bearer_auth(PROJECT_CREDENTIAL)
+        .add_header("mcp-protocol-version", PROTOCOL_VERSION, true)
+        .add_header("mcp-method", "tasks/get", true)
+        .add_header("mcp-name", &execution_id, true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 405,
+            "method": "tasks/get",
+            "params": {
+                "taskId": execution_id,
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "extensions": { TASKS_EXTENSION: {} }
+                    }
+                }
+            }
+        }))
+        .send(service.as_ref())
+        .await;
+    let polled_body: Value = polled.take_json().await.unwrap();
+    assert_eq!(polled_body["result"]["status"], "completed");
     assert_eq!(
-        terminal_body["result"]["structuredContent"]["data"]["execution"]["execution_status"],
+        polled_body["result"]["result"]["structuredContent"]["data"]["execution"]["output_tail"]
+            ["stdout"],
+        "http durable final\n"
+    );
+    let review = fixture
+        .call("task_review", json!({ "task_id": fixture.task_id }))
+        .await;
+    assert!(review.ok, "{}", review.body);
+    assert_eq!(
+        review.body["data"]["guidance"][0]["message"],
+        "task polling must not consume this guidance"
+    );
+}
+
+#[tokio::test]
+async fn mcp_tools_call_tasks_extension_keeps_terminal_before_yield_ordinary() {
+    const PROJECT_CREDENTIAL: &str =
+        "webcodex_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const PROTOCOL_VERSION: &str = "2026-07-28";
+    const TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
+
+    let fixture = fixture(1_000).await;
+    let mcp_runtime = Arc::new(
+        ToolRuntime::new_for_tests_with_shell_clients(fixture.registry.clone())
+            .with_model_surface(crate::model_surface::ModelSurface::CanonicalConnector),
+    );
+    let service = Arc::new(salvo::Service::new(
+        salvo::Router::new()
+            .hoop(salvo::affix_state::inject(
+                crate::test_support::test_config(Some("secret")),
+            ))
+            .hoop(salvo::affix_state::inject(fixture.connector.db.clone()))
+            .hoop(salvo::affix_state::inject(mcp_runtime))
+            .hoop(salvo::affix_state::inject(ConnectorRuntimeSlot(Some(
+                fixture.connector.clone(),
+            ))))
+            .push(
+                salvo::Router::with_path("mcp")
+                    .hoop(crate::AuthMiddleware)
+                    .post(crate::mcp::mcp_post),
+            ),
+    ));
+    let arguments = command_arguments(&fixture, "mcp-http-sync-terminal-1", "printf sync");
+    let service_for_call = service.clone();
+    let call = tokio::spawn(async move {
+        salvo::test::TestClient::post("http://localhost/mcp")
+            .bearer_auth(PROJECT_CREDENTIAL)
+            .add_header("mcp-protocol-version", PROTOCOL_VERSION, true)
+            .add_header("mcp-method", "tools/call", true)
+            .add_header("mcp-name", "commands_run", true)
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 406,
+                "method": "tools/call",
+                "params": {
+                    "name": "commands_run",
+                    "arguments": arguments,
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+                        "io.modelcontextprotocol/clientCapabilities": {
+                            "extensions": { TASKS_EXTENSION: {} }
+                        }
+                    }
+                }
+            }))
+            .send(service_for_call.as_ref())
+            .await
+    });
+    let request = next_request(&fixture.registry).await;
+    let job_id = request.job_id.unwrap();
+    let guided = fixture.connector.host_guide(
+        &fixture.task_id,
+        "ordinary fallback must carry this guidance",
+    );
+    assert!(guided.ok, "{}", guided.body);
+    update_job(
+        &fixture.registry,
+        &job_id,
+        "completed",
+        Some("sync terminal\n"),
+        Some(0),
+    )
+    .await;
+
+    let mut response = call.await.unwrap();
+    let body: Value = response.take_json().await.unwrap();
+    assert_eq!(body["result"]["resultType"], "complete");
+    assert!(body["result"].get("taskId").is_none());
+    assert_eq!(
+        body["result"]["structuredContent"]["data"]["execution"]["execution_status"],
         "succeeded"
     );
+    assert_eq!(
+        body["result"]["structuredContent"]["data"]["execution"]["output_tail"]["stdout"],
+        "sync terminal\n"
+    );
+    assert_eq!(
+        body["result"]["structuredContent"]["data"]["guidance"][0]["message"],
+        "ordinary fallback must carry this guidance"
+    );
+    let execution_id = body["result"]["structuredContent"]["data"]["execution"]["execution_id"]
+        .as_str()
+        .unwrap();
+    let execution = execution_by_id(&fixture, execution_id);
+    assert!(!execution.mcp_task_is_materialized());
+    assert!(!execution.mcp_task_result_is_finalized());
+    assert!(poll(&fixture.registry).await.is_none());
 }
 
 #[tokio::test]
@@ -2085,6 +2261,7 @@ async fn terminal_validation_success_without_progress_fails_closed() {
                 assertion_evidence: None,
                 validated_workspace_sha256: None,
                 executor_failure_code: None,
+                mcp_task_output_tail: None,
                 now: 4,
             },
         )
@@ -3633,6 +3810,7 @@ async fn nonzero_exit_keeps_submission_and_execution_outcomes_separate() {
                     assertion_evidence: None,
                     validated_workspace_sha256: None,
                     executor_failure_code: None,
+                    mcp_task_output_tail: None,
                     now,
                 },
             )

--- a/src/connector_runtime/execution_tests.rs
+++ b/src/connector_runtime/execution_tests.rs
@@ -12,6 +12,7 @@ use crate::shell_protocol::{
 };
 use crate::tool_runtime::validation_profile::{RecipeId, SemanticCheck};
 use crate::tool_runtime::ApplyFileChangeInput;
+use salvo::test::ResponseExt;
 use std::time::{Duration, Instant};
 
 #[tokio::test]
@@ -811,6 +812,277 @@ async fn quick_yield_arms_terminal_continuation_before_return_and_replay_keeps_s
         .unwrap();
     assert_eq!(ready.len(), 1);
     assert_eq!(ready[0].execution_id, execution_id);
+}
+
+#[tokio::test]
+async fn mcp_task_polling_quick_yield_replays_exact_armed_execution() {
+    let fixture = fixture(20).await;
+    let arguments = command_arguments(&fixture, "mcp-task-yield-1", "sleep 30");
+    let connector = fixture.connector.clone();
+    let owner = fixture.owner.clone();
+    let call_arguments = arguments.clone();
+    let call = tokio::spawn(async move {
+        connector
+            .call_for_window_with_task_polling(
+                "commands_run",
+                call_arguments,
+                Some(&owner),
+                ConnectorTransport::Mcp,
+                None,
+            )
+            .await
+    });
+    let request = next_request(&fixture.registry).await;
+    assert_eq!(request.kind, "start_job");
+    let job_id = request.job_id.unwrap();
+    update_job(&fixture.registry, &job_id, "running", None, None).await;
+
+    let yielded = call.await.unwrap();
+    assert!(yielded.ok, "{}", yielded.body);
+    let execution_id = yielded.body["data"]["execution"]["execution_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let armed = execution_by_id(&fixture, &execution_id);
+    assert!(armed.is_active());
+    assert!(armed.terminal_continuation_is_armed());
+
+    let (_task, materialized, working_outcome) = fixture
+        .connector
+        .execution_task_result_for_auth(&execution_id, &fixture.owner)
+        .await
+        .unwrap();
+    assert_eq!(materialized.execution_id, execution_id);
+    assert!(materialized.is_active());
+    assert_eq!(
+        working_outcome.body["data"]["execution"]["execution_id"],
+        execution_id
+    );
+    assert_eq!(working_outcome.body["blocking"], true);
+
+    let foreign = tests::auth("foreign-grant");
+    let denied = fixture
+        .connector
+        .execution_task_result_for_auth(&execution_id, &foreign)
+        .await;
+    let Err(denied) = denied else {
+        panic!("foreign project credential must not resolve an execution task id");
+    };
+    assert_eq!(denied.http_status, 404);
+    assert!(!denied.body.to_string().contains(&execution_id));
+
+    let replay = fixture
+        .connector
+        .call_for_window_with_task_polling(
+            "commands_run",
+            arguments,
+            Some(&fixture.owner),
+            ConnectorTransport::Mcp,
+            None,
+        )
+        .await;
+    assert!(replay.ok, "{}", replay.body);
+    assert_eq!(
+        replay.body["data"]["execution"]["execution_id"],
+        execution_id
+    );
+    assert!(poll(&fixture.registry).await.is_none());
+    assert!(execution_by_id(&fixture, &execution_id).terminal_continuation_is_armed());
+
+    update_job(&fixture.registry, &job_id, "completed", None, Some(0)).await;
+    let completed = wait_for_execution(
+        &fixture,
+        Some(&execution_id),
+        Duration::from_secs(10),
+        "MCP task-polling execution completion",
+        |execution| execution.state == "succeeded",
+    )
+    .await;
+    let (_task, terminal, terminal_outcome) = fixture
+        .connector
+        .execution_task_result_for_auth(&execution_id, &fixture.owner)
+        .await
+        .unwrap();
+    assert_eq!(terminal.execution_id, completed.execution_id);
+    assert!(!terminal.is_active());
+    assert_eq!(terminal_outcome.body["blocking"], false);
+}
+
+#[tokio::test]
+async fn mcp_tools_call_tasks_extension_switches_only_active_command_results_to_tasks() {
+    const PROJECT_CREDENTIAL: &str =
+        "webcodex_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const PROTOCOL_VERSION: &str = "2026-07-28";
+    const TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
+
+    let fixture = fixture(20).await;
+    let mcp_runtime = Arc::new(
+        ToolRuntime::new_for_tests_with_shell_clients(fixture.registry.clone())
+            .with_model_surface(crate::model_surface::ModelSurface::CanonicalConnector),
+    );
+    let service = Arc::new(salvo::Service::new(
+        salvo::Router::new()
+            .hoop(salvo::affix_state::inject(
+                crate::test_support::test_config(Some("secret")),
+            ))
+            .hoop(salvo::affix_state::inject(fixture.connector.db.clone()))
+            .hoop(salvo::affix_state::inject(mcp_runtime))
+            .hoop(salvo::affix_state::inject(ConnectorRuntimeSlot(Some(
+                fixture.connector.clone(),
+            ))))
+            .push(
+                salvo::Router::with_path("mcp")
+                    .hoop(crate::AuthMiddleware)
+                    .post(crate::mcp::mcp_post),
+            ),
+    ));
+    let arguments = command_arguments(&fixture, "mcp-http-task-yield-1", "sleep 30");
+
+    let service_for_call = service.clone();
+    let first_arguments = arguments.clone();
+    let first_call = tokio::spawn(async move {
+        salvo::test::TestClient::post("http://localhost/mcp")
+            .bearer_auth(PROJECT_CREDENTIAL)
+            .add_header("mcp-protocol-version", PROTOCOL_VERSION, true)
+            .add_header("mcp-method", "tools/call", true)
+            .add_header("mcp-name", "commands_run", true)
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 401,
+                "method": "tools/call",
+                "params": {
+                    "name": "commands_run",
+                    "arguments": first_arguments,
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+                        "io.modelcontextprotocol/clientCapabilities": {
+                            "extensions": { TASKS_EXTENSION: {} }
+                        }
+                    }
+                }
+            }))
+            .send(service_for_call.as_ref())
+            .await
+    });
+    let request = next_request(&fixture.registry).await;
+    assert_eq!(request.kind, "start_job");
+    let job_id = request.job_id.unwrap();
+    update_job(&fixture.registry, &job_id, "running", None, None).await;
+
+    let mut first = first_call.await.unwrap();
+    assert_eq!(
+        first.status_code.unwrap_or(salvo::http::StatusCode::OK),
+        salvo::http::StatusCode::OK
+    );
+    let first_body: Value = first.take_json().await.unwrap();
+    assert_eq!(first_body["result"]["resultType"], "task");
+    assert_eq!(first_body["result"]["status"], "working");
+    let execution_id = first_body["result"]["taskId"]
+        .as_str()
+        .expect("active task-augmented call must expose durable execution id")
+        .to_string();
+    assert_eq!(
+        execution_by_id(&fixture, &execution_id).terminal_continuation_is_armed(),
+        true
+    );
+
+    let mut no_capability = salvo::test::TestClient::post("http://localhost/mcp")
+        .bearer_auth(PROJECT_CREDENTIAL)
+        .add_header("mcp-protocol-version", PROTOCOL_VERSION, true)
+        .add_header("mcp-method", "tools/call", true)
+        .add_header("mcp-name", "commands_run", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 402,
+            "method": "tools/call",
+            "params": {
+                "name": "commands_run",
+                "arguments": arguments.clone(),
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        }))
+        .send(service.as_ref())
+        .await;
+    let no_capability_body: Value = no_capability.take_json().await.unwrap();
+    assert_eq!(no_capability_body["result"]["resultType"], "complete");
+    assert_eq!(
+        no_capability_body["result"]["structuredContent"]["data"]["execution"]["execution_id"],
+        execution_id
+    );
+    assert_eq!(
+        no_capability_body["result"]["structuredContent"]["blocking"],
+        true
+    );
+
+    let mut replay = salvo::test::TestClient::post("http://localhost/mcp")
+        .bearer_auth(PROJECT_CREDENTIAL)
+        .add_header("mcp-protocol-version", PROTOCOL_VERSION, true)
+        .add_header("mcp-method", "tools/call", true)
+        .add_header("mcp-name", "commands_run", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 403,
+            "method": "tools/call",
+            "params": {
+                "name": "commands_run",
+                "arguments": arguments.clone(),
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "extensions": { TASKS_EXTENSION: {} }
+                    }
+                }
+            }
+        }))
+        .send(service.as_ref())
+        .await;
+    let replay_body: Value = replay.take_json().await.unwrap();
+    assert_eq!(replay_body["result"]["resultType"], "task");
+    assert_eq!(replay_body["result"]["taskId"], execution_id);
+    assert!(poll(&fixture.registry).await.is_none());
+
+    update_job(&fixture.registry, &job_id, "completed", None, Some(0)).await;
+    wait_for_execution(
+        &fixture,
+        Some(&execution_id),
+        Duration::from_secs(10),
+        "MCP task-augmented HTTP execution completion",
+        |execution| execution.state == "succeeded",
+    )
+    .await;
+
+    let mut terminal = salvo::test::TestClient::post("http://localhost/mcp")
+        .bearer_auth(PROJECT_CREDENTIAL)
+        .add_header("mcp-protocol-version", PROTOCOL_VERSION, true)
+        .add_header("mcp-method", "tools/call", true)
+        .add_header("mcp-name", "commands_run", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 404,
+            "method": "tools/call",
+            "params": {
+                "name": "commands_run",
+                "arguments": arguments,
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "extensions": { TASKS_EXTENSION: {} }
+                    }
+                }
+            }
+        }))
+        .send(service.as_ref())
+        .await;
+    let terminal_body: Value = terminal.take_json().await.unwrap();
+    assert_eq!(terminal_body["result"]["resultType"], "complete");
+    assert!(terminal_body["result"].get("taskId").is_none());
+    assert_eq!(
+        terminal_body["result"]["structuredContent"]["data"]["execution"]["execution_status"],
+        "succeeded"
+    );
 }
 
 #[tokio::test]

--- a/src/connector_runtime/mod.rs
+++ b/src/connector_runtime/mod.rs
@@ -49,14 +49,15 @@ pub(crate) use projections::{
 pub(crate) use wire_models::{TaskCancelInput, TaskReviewInput};
 
 use crate::auth::{
-    AuthContext, ProjectAgentTokenVerifier, ProjectCredentialVerifier, SCOPE_PROJECT_WRITE,
+    AuthContext, ProjectAgentTokenVerifier, ProjectCredentialVerifier, SCOPE_JOB_RUN,
+    SCOPE_PROJECT_WRITE,
 };
 use crate::client_window::ClientWindow;
 use crate::connector_runtime::workspace::{
     LocalResultDecision, PreparedWorkspace, WorkspaceManager,
 };
 use crate::db::{
-    ConnectorApprovalGate, ConnectorBinding, ConnectorEditOperationGate,
+    ConnectorApprovalGate, ConnectorBinding, ConnectorEditOperationGate, ConnectorExecution,
     ConnectorExecutionReservation, ConnectorTaskContinuation, ConnectorTaskResult,
     ConnectorTaskSnapshot, ConnectorTaskStoreError, ConnectorWorkspaceTransition,
     NewConnectorResult, NewConnectorTask,
@@ -426,6 +427,101 @@ impl ConnectorRuntime {
         )
     }
 
+    fn execution_task_not_found() -> ConnectorCallOutcome {
+        store_error_outcome(ConnectorTaskStoreError::NotFound, None)
+    }
+
+    fn execution_task_for_auth(
+        &self,
+        execution_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(ConnectorTaskSnapshot, ConnectorExecution), ConnectorCallOutcome> {
+        if !auth.has_scope(SCOPE_JOB_RUN) {
+            return Err(ConnectorCallOutcome::scope_denied(SCOPE_JOB_RUN));
+        }
+        if !self.project_access_allowed(auth) {
+            return Err(Self::execution_task_not_found());
+        }
+        let subject_id = stable_subject_id(auth).map_err(|_| Self::execution_task_not_found())?;
+        self.db
+            .connector_execution_for_subject(execution_id, &self.context.project_id, &subject_id)
+            .map_err(|error| match error {
+                ConnectorTaskStoreError::NotFound => Self::execution_task_not_found(),
+                other => store_error_outcome(other, None),
+            })
+    }
+
+    pub(crate) async fn execution_task_result_for_auth(
+        &self,
+        execution_id: &str,
+        auth: &AuthContext,
+    ) -> Result<
+        (
+            ConnectorTaskSnapshot,
+            ConnectorExecution,
+            ConnectorCallOutcome,
+        ),
+        ConnectorCallOutcome,
+    > {
+        let (mut task, execution) = self.execution_task_for_auth(execution_id, auth)?;
+        // A Connector task may have been resumed into a later run. MCP task
+        // identity is the exact durable execution, so never project a newer
+        // run id onto an older execution handle.
+        task.run_id = execution.run_id.clone();
+        let execution_event_cursor = self
+            .db
+            .connector_execution_event_cursor(&execution)
+            .map_err(|error| store_error_outcome(error, Some(&task)))?;
+        let projection = self.executions.durable_task_projection(&execution);
+        let outcome = ConnectorCallOutcome::success_blocking_at(
+            &task,
+            execution_event_cursor,
+            json!({ "execution": projection }),
+            execution.blocks_finish(),
+        );
+        Ok((task, execution, outcome))
+    }
+
+    pub(crate) async fn cancel_execution_task_for_auth(
+        &self,
+        execution_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(), ConnectorCallOutcome> {
+        let (task, execution) = self.execution_task_for_auth(execution_id, auth)?;
+        if execution.is_terminal() {
+            return Ok(());
+        }
+        let task_lock = self.task_lock(&task.task_id);
+        let _task_guard = task_lock.lock().await;
+        let (task, execution) = self.execution_task_for_auth(execution_id, auth)?;
+        if execution.is_terminal() {
+            return Ok(());
+        }
+        if task.run_id != execution.run_id {
+            return Err(Self::execution_task_not_found());
+        }
+        let current = self
+            .db
+            .latest_connector_execution(
+                &task.task_id,
+                &self.context.project_id,
+                &task.owner_subject_id,
+                None,
+            )
+            .map_err(|error| store_error_outcome(error, Some(&task)))?;
+        if current
+            .as_ref()
+            .is_none_or(|current| current.execution_id != execution.execution_id)
+        {
+            return Err(Self::execution_task_not_found());
+        }
+        self.executions
+            .cancel_task(task.clone(), None, auth.clone())
+            .await
+            .map(|_| ())
+            .map_err(|error| store_error_outcome(error, Some(&task)))
+    }
+
     #[cfg(test)]
     pub(crate) async fn call(
         &self,
@@ -445,6 +541,31 @@ impl ConnectorRuntime {
         auth: Option<&AuthContext>,
         transport: ConnectorTransport,
         window: Option<&ClientWindow>,
+    ) -> ConnectorCallOutcome {
+        self.call_for_window_inner(capability, arguments, auth, transport, window, false)
+            .await
+    }
+
+    pub(crate) async fn call_for_window_with_task_polling(
+        &self,
+        capability: &str,
+        arguments: Value,
+        auth: Option<&AuthContext>,
+        transport: ConnectorTransport,
+        window: Option<&ClientWindow>,
+    ) -> ConnectorCallOutcome {
+        self.call_for_window_inner(capability, arguments, auth, transport, window, true)
+            .await
+    }
+
+    async fn call_for_window_inner(
+        &self,
+        capability: &str,
+        arguments: Value,
+        auth: Option<&AuthContext>,
+        transport: ConnectorTransport,
+        window: Option<&ClientWindow>,
+        defer_active_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         if surface::capability_spec(capability).is_none() {
             return ConnectorCallOutcome::error(
@@ -568,12 +689,26 @@ impl ConnectorRuntime {
                     .await
             }
             "checks_run" => {
-                self.checks_run(arguments, &subject_id, auth, transport, now)
-                    .await
+                self.checks_run(
+                    arguments,
+                    &subject_id,
+                    auth,
+                    transport,
+                    now,
+                    defer_active_execution_guidance,
+                )
+                .await
             }
             "commands_run" => {
-                self.commands_run(arguments, &subject_id, auth, transport, now)
-                    .await
+                self.commands_run(
+                    arguments,
+                    &subject_id,
+                    auth,
+                    transport,
+                    now,
+                    defer_active_execution_guidance,
+                )
+                .await
             }
             "task_review" => {
                 self.task_review(arguments, &subject_id, auth, transport, true)
@@ -1749,6 +1884,7 @@ impl ConnectorRuntime {
         auth: &AuthContext,
         _transport: ConnectorTransport,
         now: i64,
+        defer_active_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         let input: ChecksRunInput = match parse_input("checks_run", arguments) {
             Ok(input) => input,
@@ -1965,6 +2101,7 @@ impl ConnectorRuntime {
                 .await,
             &task,
             auth,
+            defer_active_execution_guidance,
         )
         .await
     }
@@ -1976,6 +2113,7 @@ impl ConnectorRuntime {
         auth: &AuthContext,
         _transport: ConnectorTransport,
         now: i64,
+        defer_active_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         let input: CommandsRunInput = match parse_input("commands_run", arguments) {
             Ok(input) => input,
@@ -2164,6 +2302,7 @@ impl ConnectorRuntime {
                 .await,
             &task,
             auth,
+            defer_active_execution_guidance,
         )
         .await
     }
@@ -2173,6 +2312,7 @@ impl ConnectorRuntime {
         result: Result<crate::db::ConnectorExecution, ConnectorTaskStoreError>,
         task: &ConnectorTaskSnapshot,
         auth: &AuthContext,
+        defer_active_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         let current = self
             .task(&task.task_id, &task.owner_subject_id)
@@ -2181,7 +2321,9 @@ impl ConnectorRuntime {
             Ok(execution) => {
                 let projection = self.executions.projection(&execution, auth, true).await;
                 let mut data = json!({ "execution": projection });
-                self.attach_pending_guidance(&current, &mut data);
+                if !defer_active_execution_guidance || execution.is_terminal() {
+                    self.attach_pending_guidance(&current, &mut data);
+                }
                 ConnectorCallOutcome::success_blocking_at(
                     &current,
                     current.event_cursor,

--- a/src/connector_runtime/mod.rs
+++ b/src/connector_runtime/mod.rs
@@ -431,7 +431,7 @@ impl ConnectorRuntime {
         store_error_outcome(ConnectorTaskStoreError::NotFound, None)
     }
 
-    fn execution_task_for_auth(
+    fn execution_for_auth(
         &self,
         execution_id: &str,
         auth: &AuthContext,
@@ -451,6 +451,61 @@ impl ConnectorRuntime {
             })
     }
 
+    fn execution_task_for_auth(
+        &self,
+        execution_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(ConnectorTaskSnapshot, ConnectorExecution), ConnectorCallOutcome> {
+        let (task, execution) = self.execution_for_auth(execution_id, auth)?;
+        if !execution.mcp_task_is_materialized() {
+            return Err(Self::execution_task_not_found());
+        }
+        Ok((task, execution))
+    }
+
+    pub(crate) async fn ordinary_execution_result_for_auth(
+        &self,
+        execution_id: &str,
+        auth: &AuthContext,
+    ) -> Result<ConnectorCallOutcome, ConnectorCallOutcome> {
+        let (mut task, execution) = self.execution_for_auth(execution_id, auth)?;
+        task.run_id = execution.run_id.clone();
+        let projection = self.executions.projection(&execution, auth, true).await;
+        let mut data = json!({ "execution": projection });
+        self.attach_pending_guidance(&task, &mut data);
+        Ok(ConnectorCallOutcome::success_blocking_at(
+            &task,
+            task.event_cursor,
+            data,
+            execution.blocks_finish(),
+        ))
+    }
+
+    pub(crate) fn materialize_execution_task_for_auth(
+        &self,
+        execution_id: &str,
+        auth: &AuthContext,
+    ) -> Result<ConnectorExecution, ConnectorCallOutcome> {
+        if !auth.has_scope(SCOPE_JOB_RUN) {
+            return Err(ConnectorCallOutcome::scope_denied(SCOPE_JOB_RUN));
+        }
+        if !self.project_access_allowed(auth) {
+            return Err(Self::execution_task_not_found());
+        }
+        let subject_id = stable_subject_id(auth).map_err(|_| Self::execution_task_not_found())?;
+        self.db
+            .materialize_connector_execution_mcp_task_for_subject(
+                execution_id,
+                &self.context.project_id,
+                &subject_id,
+                chrono::Utc::now().timestamp(),
+            )
+            .map_err(|error| match error {
+                ConnectorTaskStoreError::NotFound => Self::execution_task_not_found(),
+                other => store_error_outcome(other, None),
+            })
+    }
+
     pub(crate) async fn execution_task_result_for_auth(
         &self,
         execution_id: &str,
@@ -464,6 +519,15 @@ impl ConnectorRuntime {
         ConnectorCallOutcome,
     > {
         let (mut task, execution) = self.execution_task_for_auth(execution_id, auth)?;
+        if execution.is_terminal() && !execution.mcp_task_result_is_finalized() {
+            return Err(store_error_outcome(
+                ConnectorTaskStoreError::InvalidState(
+                    "materialized MCP task is terminal before its durable result was finalized"
+                        .to_string(),
+                ),
+                Some(&task),
+            ));
+        }
         // A Connector task may have been resumed into a later run. MCP task
         // identity is the exact durable execution, so never project a newer
         // run id onto an older execution handle.
@@ -565,7 +629,7 @@ impl ConnectorRuntime {
         auth: Option<&AuthContext>,
         transport: ConnectorTransport,
         window: Option<&ClientWindow>,
-        defer_active_execution_guidance: bool,
+        defer_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         if surface::capability_spec(capability).is_none() {
             return ConnectorCallOutcome::error(
@@ -695,7 +759,7 @@ impl ConnectorRuntime {
                     auth,
                     transport,
                     now,
-                    defer_active_execution_guidance,
+                    defer_execution_guidance,
                 )
                 .await
             }
@@ -706,7 +770,7 @@ impl ConnectorRuntime {
                     auth,
                     transport,
                     now,
-                    defer_active_execution_guidance,
+                    defer_execution_guidance,
                 )
                 .await
             }
@@ -1884,7 +1948,7 @@ impl ConnectorRuntime {
         auth: &AuthContext,
         _transport: ConnectorTransport,
         now: i64,
-        defer_active_execution_guidance: bool,
+        defer_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         let input: ChecksRunInput = match parse_input("checks_run", arguments) {
             Ok(input) => input,
@@ -2101,7 +2165,7 @@ impl ConnectorRuntime {
                 .await,
             &task,
             auth,
-            defer_active_execution_guidance,
+            defer_execution_guidance,
         )
         .await
     }
@@ -2113,7 +2177,7 @@ impl ConnectorRuntime {
         auth: &AuthContext,
         _transport: ConnectorTransport,
         now: i64,
-        defer_active_execution_guidance: bool,
+        defer_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         let input: CommandsRunInput = match parse_input("commands_run", arguments) {
             Ok(input) => input,
@@ -2302,7 +2366,7 @@ impl ConnectorRuntime {
                 .await,
             &task,
             auth,
-            defer_active_execution_guidance,
+            defer_execution_guidance,
         )
         .await
     }
@@ -2312,7 +2376,7 @@ impl ConnectorRuntime {
         result: Result<crate::db::ConnectorExecution, ConnectorTaskStoreError>,
         task: &ConnectorTaskSnapshot,
         auth: &AuthContext,
-        defer_active_execution_guidance: bool,
+        defer_execution_guidance: bool,
     ) -> ConnectorCallOutcome {
         let current = self
             .task(&task.task_id, &task.owner_subject_id)
@@ -2321,7 +2385,7 @@ impl ConnectorRuntime {
             Ok(execution) => {
                 let projection = self.executions.projection(&execution, auth, true).await;
                 let mut data = json!({ "execution": projection });
-                if !defer_active_execution_guidance || execution.is_terminal() {
+                if !defer_execution_guidance {
                     self.attach_pending_guidance(&current, &mut data);
                 }
                 ConnectorCallOutcome::success_blocking_at(

--- a/src/db/continuation_delivery_tests.rs
+++ b/src/db/continuation_delivery_tests.rs
@@ -75,6 +75,7 @@ fn succeed(db: &Database, execution_id: &str, now: i64) -> ConnectorExecution {
             assertion_evidence: None,
             validated_workspace_sha256: None,
             executor_failure_code: None,
+            mcp_task_output_tail: None,
             now,
         },
     )

--- a/src/db/execution_intent_tests.rs
+++ b/src/db/execution_intent_tests.rs
@@ -73,6 +73,7 @@ fn succeed(db: &Database, execution_id: &str, now: i64) -> ConnectorExecution {
             assertion_evidence: None,
             validated_workspace_sha256: None,
             executor_failure_code: None,
+            mcp_task_output_tail: None,
             now,
         },
     )
@@ -135,6 +136,73 @@ fn reservation_is_unarmed_and_arm_is_durable_idempotent_and_replay_stable() {
         ConnectorExecutionContinuationIntent::ArmedForTerminal
     );
     assert_eq!(restored.continuation_armed_at, Some(20));
+}
+
+#[test]
+fn mcp_task_materialization_and_terminal_result_finalize_durably_together() {
+    let (_temp, path, db) = database();
+    let task = task(&db, "mcp-final");
+    let execution = reserve(&db, &task, "op-mcp-final");
+    db.arm_connector_terminal_continuation(&execution.execution_id, 20)
+        .unwrap();
+    let materialized = db
+        .materialize_connector_execution_mcp_task_for_subject(
+            &execution.execution_id,
+            "wc_proj_intent",
+            "user:intent",
+            21,
+        )
+        .unwrap();
+    assert_eq!(materialized.mcp_task_materialized_at, Some(21));
+    assert_eq!(materialized.mcp_task_result_finalized_at, None);
+
+    let tail = serde_json::json!({
+        "stdout": "durable stdout\n",
+        "stderr": "durable stderr\n",
+        "bounded": true
+    });
+    let terminal = db
+        .observe_connector_execution(
+            &execution.execution_id,
+            ConnectorExecutionObservation {
+                executor_status: "completed",
+                stdout_cursor: 2,
+                stderr_cursor: 2,
+                exit_code: Some(0),
+                started_at: Some(22),
+                finished_at: Some(23),
+                check_completed: None,
+                failed_check: None,
+                assertion_evidence: None,
+                validated_workspace_sha256: None,
+                executor_failure_code: None,
+                mcp_task_output_tail: Some(&tail),
+                now: 23,
+            },
+        )
+        .unwrap();
+    assert_eq!(terminal.state, "succeeded");
+    assert_eq!(terminal.mcp_task_result_finalized_at, Some(23));
+    assert_eq!(terminal.mcp_task_output_tail.as_ref(), Some(&tail));
+
+    drop(db);
+    let reopened = Database::open(&path).unwrap();
+    let restored = reopened
+        .connector_execution(&execution.execution_id)
+        .unwrap();
+    assert_eq!(restored.mcp_task_materialized_at, Some(21));
+    assert_eq!(restored.mcp_task_result_finalized_at, Some(23));
+    assert_eq!(restored.mcp_task_output_tail.as_ref(), Some(&tail));
+    let replay = reopened
+        .materialize_connector_execution_mcp_task_for_subject(
+            &execution.execution_id,
+            "wc_proj_intent",
+            "user:intent",
+            30,
+        )
+        .unwrap();
+    assert_eq!(replay.mcp_task_materialized_at, Some(21));
+    assert_eq!(replay.mcp_task_result_finalized_at, Some(23));
 }
 
 #[test]

--- a/src/db/execution_model.rs
+++ b/src/db/execution_model.rs
@@ -2,6 +2,10 @@ use rusqlite::{params, OptionalExtension};
 use serde_json::Value;
 
 pub(crate) const MAX_ASSERTION_EVIDENCE_BYTES: usize = 16 * 1024;
+// Two already-bounded 256 KiB UTF-8 streams can expand substantially under
+// JSON escaping. Keep the persisted MCP task snapshot hard-bounded while
+// allowing any ordinary Connector output-tail projection to serialize.
+pub(crate) const MAX_MCP_TASK_OUTPUT_TAIL_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ConnectorExecutionContinuationIntent {
@@ -110,6 +114,9 @@ pub(crate) struct ConnectorExecution {
     pub continuation_intent: ConnectorExecutionContinuationIntent,
     pub continuation_armed_at: Option<i64>,
     pub continuation_delivery_state: ConnectorTerminalContinuationDeliveryState,
+    pub mcp_task_materialized_at: Option<i64>,
+    pub mcp_task_result_finalized_at: Option<i64>,
+    pub mcp_task_output_tail: Option<Value>,
 }
 
 impl ConnectorExecution {
@@ -131,6 +138,14 @@ impl ConnectorExecution {
     pub(crate) fn terminal_continuation_is_armed(&self) -> bool {
         self.continuation_intent == ConnectorExecutionContinuationIntent::ArmedForTerminal
             && self.continuation_armed_at.is_some()
+    }
+
+    pub(crate) fn mcp_task_is_materialized(&self) -> bool {
+        self.mcp_task_materialized_at.is_some()
+    }
+
+    pub(crate) fn mcp_task_result_is_finalized(&self) -> bool {
+        self.mcp_task_result_finalized_at.is_some()
     }
 
     pub(crate) fn blocks_finish(&self) -> bool {
@@ -187,6 +202,7 @@ pub(crate) struct ConnectorExecutionObservation<'a> {
     pub assertion_evidence: Option<&'a Value>,
     pub validated_workspace_sha256: Option<&'a str>,
     pub executor_failure_code: Option<&'static str>,
+    pub mcp_task_output_tail: Option<&'a Value>,
     pub now: i64,
 }
 
@@ -359,7 +375,8 @@ pub(super) const EXECUTION_COLUMNS: &str =
     status_failure_code, check_plan, check_recipe_json, check_completed, check_workspace_sha256, \
     validated_workspace_sha256, failed_check, assertion_evidence_json, \
     terminal_continuation_intent, terminal_continuation_armed_at, \
-    terminal_continuation_delivery_state";
+    terminal_continuation_delivery_state, mcp_task_materialized_at, \
+    mcp_task_result_finalized_at, mcp_task_output_tail_json";
 
 pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<ConnectorExecution> {
     let cursor = |index| {
@@ -431,6 +448,20 @@ pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<Connect
             &row.get::<_, String>(32)?,
             32,
         )?,
+        mcp_task_materialized_at: row.get(33)?,
+        mcp_task_result_finalized_at: row.get(34)?,
+        mcp_task_output_tail: row
+            .get::<_, Option<String>>(35)?
+            .map(|output_tail| {
+                serde_json::from_str(&output_tail).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        35,
+                        rusqlite::types::Type::Text,
+                        Box::new(error),
+                    )
+                })
+            })
+            .transpose()?,
     })
 }
 

--- a/src/db/execution_model.rs
+++ b/src/db/execution_model.rs
@@ -128,6 +128,11 @@ impl ConnectorExecution {
         !self.is_active()
     }
 
+    pub(crate) fn terminal_continuation_is_armed(&self) -> bool {
+        self.continuation_intent == ConnectorExecutionContinuationIntent::ArmedForTerminal
+            && self.continuation_armed_at.is_some()
+    }
+
     pub(crate) fn blocks_finish(&self) -> bool {
         self.is_active() || self.state == "unknown"
     }

--- a/src/db/executions.rs
+++ b/src/db/executions.rs
@@ -6,7 +6,7 @@ use super::execution_model::{
     load_execution_by_operation, observed_state, ConnectorExecution,
     ConnectorExecutionContinuationIntent, ConnectorExecutionFailure, ConnectorExecutionObservation,
     ConnectorExecutionReservation, ConnectorTerminalContinuationClaim,
-    ConnectorTerminalContinuationDeliveryState, EXECUTION_COLUMNS,
+    ConnectorTerminalContinuationDeliveryState, EXECUTION_COLUMNS, MAX_MCP_TASK_OUTPUT_TAIL_BYTES,
 };
 use super::task_kernel::{
     expire_task_approvals, insert_event, load_task, require_running, touch_task,
@@ -18,8 +18,27 @@ use serde_json::json;
 const TERMINAL_CONTINUATION_READY_PREDICATE: &str =
     "terminal_continuation_intent = 'armed_for_terminal' \
      AND state NOT IN ('accepted','queued','starting','running','cancel_requested') \
+     AND mcp_task_materialized_at IS NULL \
      AND terminal_continuation_delivery_state = 'unclaimed' \
      AND terminal_continuation_claim_fence IS NULL";
+
+fn serialize_mcp_task_output_tail(
+    output_tail: Option<&serde_json::Value>,
+) -> Result<Option<String>, ConnectorTaskStoreError> {
+    let serialized = output_tail
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|error| ConnectorTaskStoreError::InvalidState(error.to_string()))?;
+    if serialized
+        .as_ref()
+        .is_some_and(|value| value.len() > MAX_MCP_TASK_OUTPUT_TAIL_BYTES)
+    {
+        return Err(ConnectorTaskStoreError::InvalidState(
+            "MCP task output tail exceeds its durable size limit".to_string(),
+        ));
+    }
+    Ok(serialized)
+}
 
 impl Database {
     pub(crate) fn reserve_connector_execution(
@@ -146,6 +165,70 @@ impl Database {
         let task = load_task(&conn, &execution.task_id, project_id, subject_id)?
             .ok_or(ConnectorTaskStoreError::NotFound)?;
         Ok((task, execution))
+    }
+
+    pub(crate) fn materialize_connector_execution_mcp_task_for_subject(
+        &self,
+        execution_id: &str,
+        project_id: &str,
+        subject_id: &str,
+        now: i64,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let execution =
+            load_execution(&tx, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
+        load_task(&tx, &execution.task_id, project_id, subject_id)?
+            .ok_or(ConnectorTaskStoreError::NotFound)?;
+        if execution.mcp_task_is_materialized() || execution.is_terminal() {
+            tx.commit()?;
+            return Ok(execution);
+        }
+        if !execution.terminal_continuation_is_armed() {
+            return Err(ConnectorTaskStoreError::InvalidState(
+                "active Connector execution is not durably armed for MCP task polling".to_string(),
+            ));
+        }
+        tx.execute(
+            "UPDATE wc_executions
+             SET mcp_task_materialized_at = COALESCE(mcp_task_materialized_at, ?1)
+             WHERE id = ?2
+               AND state IN ('accepted','queued','starting','running','cancel_requested')
+               AND terminal_continuation_intent = 'armed_for_terminal'
+               AND terminal_continuation_armed_at IS NOT NULL",
+            params![now, execution_id],
+        )?;
+        commit_execution(tx, execution_id)
+    }
+
+    pub(crate) fn record_connector_mcp_task_output_tail(
+        &self,
+        execution_id: &str,
+        output_tail: &serde_json::Value,
+    ) -> Result<ConnectorExecution, ConnectorTaskStoreError> {
+        let output_tail_json = serialize_mcp_task_output_tail(Some(output_tail))?
+            .expect("serializing a provided MCP task output tail returns Some");
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let execution =
+            load_execution(&tx, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
+        if !execution.mcp_task_is_materialized()
+            || execution.mcp_task_result_is_finalized()
+            || execution.is_terminal()
+        {
+            tx.commit()?;
+            return Ok(execution);
+        }
+        tx.execute(
+            "UPDATE wc_executions
+             SET mcp_task_output_tail_json = ?1
+             WHERE id = ?2
+               AND mcp_task_materialized_at IS NOT NULL
+               AND mcp_task_result_finalized_at IS NULL
+               AND state IN ('accepted','queued','starting','running','cancel_requested')",
+            params![output_tail_json, execution_id],
+        )?;
+        commit_execution(tx, execution_id)
     }
 
     pub(crate) fn connector_execution_event_cursor(
@@ -577,6 +660,8 @@ impl Database {
             .map(serde_json::to_string)
             .transpose()
             .map_err(|error| ConnectorTaskStoreError::InvalidState(error.to_string()))?;
+        let mcp_task_output_tail_json =
+            serialize_mcp_task_output_tail(observation.mcp_task_output_tail)?;
         if evidence_json
             .as_ref()
             .is_some_and(|evidence| evidence.len() > super::MAX_ASSERTION_EVIDENCE_BYTES)
@@ -637,7 +722,16 @@ impl Database {
                         AND ?10 = 'check'
                         THEN ?16 ELSE assertion_evidence_json END,
                     validated_workspace_sha256 = CASE WHEN ?1 = 'succeeded' AND kind = 'check'
-                        THEN ?17 ELSE NULL END
+                        THEN ?17 ELSE NULL END,
+                    mcp_task_output_tail_json = CASE
+                        WHEN mcp_task_materialized_at IS NOT NULL AND ?18 IS NOT NULL THEN ?18
+                        ELSE mcp_task_output_tail_json
+                    END,
+                    mcp_task_result_finalized_at = CASE
+                        WHEN ?7 AND mcp_task_materialized_at IS NOT NULL
+                        THEN COALESCE(mcp_task_result_finalized_at, ?5)
+                        ELSE mcp_task_result_finalized_at
+                    END
                     WHERE id = ?13",
             params![
                 state,
@@ -656,7 +750,8 @@ impl Database {
                 observation.check_completed.map(|count| count as i64),
                 observation.failed_check,
                 evidence_json,
-                validated_workspace
+                validated_workspace,
+                mcp_task_output_tail_json
             ],
         )?;
         if state_changed {
@@ -721,7 +816,12 @@ impl Database {
                 "UPDATE wc_executions SET state = ?1,
                         cancel_requested_at = COALESCE(cancel_requested_at, ?2),
                         terminal_reason = 'user_cancelled',
-                        finished_at = CASE WHEN ?3 THEN ?2 ELSE finished_at END
+                        finished_at = CASE WHEN ?3 THEN ?2 ELSE finished_at END,
+                        mcp_task_result_finalized_at = CASE
+                            WHEN ?3 AND mcp_task_materialized_at IS NOT NULL
+                            THEN COALESCE(mcp_task_result_finalized_at, ?2)
+                            ELSE mcp_task_result_finalized_at
+                        END
                  WHERE id = ?4",
                 params![state, now, immediate, execution.execution_id],
             )?;
@@ -877,7 +977,13 @@ impl Database {
                 tx.execute(
                     "UPDATE wc_executions SET state = 'interrupted', finished_at = ?1,
                      failure_source = 'runtime', failure_code = 'executor_handle_unverified',
-                     terminal_reason = 'runtime_restarted' WHERE id = ?2",
+                     terminal_reason = 'runtime_restarted',
+                     mcp_task_result_finalized_at = CASE
+                         WHEN mcp_task_materialized_at IS NOT NULL
+                         THEN COALESCE(mcp_task_result_finalized_at, ?1)
+                         ELSE mcp_task_result_finalized_at
+                     END
+                     WHERE id = ?2",
                     params![now, execution_id],
                 )?;
                 append_execution_event(&tx, &execution, "interrupted", now)?;
@@ -939,7 +1045,12 @@ impl Database {
         tx.execute(
             "UPDATE wc_executions SET state = ?1, finished_at = ?2, exit_code = ?3,
                         failure_source = ?4, failure_code = ?5, terminal_reason = ?6,
-                        assertion_evidence_json = COALESCE(?7, assertion_evidence_json)
+                        assertion_evidence_json = COALESCE(?7, assertion_evidence_json),
+                        mcp_task_result_finalized_at = CASE
+                            WHEN mcp_task_materialized_at IS NOT NULL
+                            THEN COALESCE(mcp_task_result_finalized_at, ?2)
+                            ELSE mcp_task_result_finalized_at
+                        END
              WHERE id = ?8",
             params![
                 state,

--- a/src/db/executions.rs
+++ b/src/db/executions.rs
@@ -134,6 +134,42 @@ impl Database {
         load_execution(&conn, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)
     }
 
+    pub(crate) fn connector_execution_for_subject(
+        &self,
+        execution_id: &str,
+        project_id: &str,
+        subject_id: &str,
+    ) -> Result<(ConnectorTaskSnapshot, ConnectorExecution), ConnectorTaskStoreError> {
+        let conn = self.conn.lock().unwrap();
+        let execution =
+            load_execution(&conn, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
+        let task = load_task(&conn, &execution.task_id, project_id, subject_id)?
+            .ok_or(ConnectorTaskStoreError::NotFound)?;
+        Ok((task, execution))
+    }
+
+    pub(crate) fn connector_execution_event_cursor(
+        &self,
+        execution: &ConnectorExecution,
+    ) -> Result<i64, ConnectorTaskStoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT MAX(sequence)
+             FROM wc_task_events
+             WHERE task_id = ?1
+               AND run_id = ?2
+               AND kind LIKE 'execution_%'
+               AND json_extract(payload_json, '$.execution_id') = ?3",
+            params![execution.task_id, execution.run_id, execution.execution_id],
+            |row| row.get::<_, Option<i64>>(0),
+        )?
+        .ok_or_else(|| {
+            ConnectorTaskStoreError::InvalidState(
+                "durable execution has no matching execution event cursor".to_string(),
+            )
+        })
+    }
+
     pub(crate) fn arm_connector_terminal_continuation(
         &self,
         execution_id: &str,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -472,6 +472,9 @@ impl Database {
                     CHECK(terminal_continuation_claim_fence IS NULL OR (
                         length(terminal_continuation_claim_fence) BETWEEN 1 AND 80
                     )),
+                mcp_task_materialized_at INTEGER,
+                mcp_task_result_finalized_at INTEGER,
+                mcp_task_output_tail_json TEXT,
                 CHECK(
                     (terminal_continuation_delivery_state = 'unclaimed'
                         AND terminal_continuation_claim_fence IS NULL)
@@ -480,9 +483,6 @@ impl Database {
                     OR (terminal_continuation_delivery_state IN ('delivered', 'delivery_unknown')
                         AND terminal_continuation_claim_fence IS NULL)
                 ),
-                mcp_task_materialized_at INTEGER,
-                mcp_task_result_finalized_at INTEGER,
-                mcp_task_output_tail_json TEXT,
                 UNIQUE(task_id, run_id, operation_id),
                 CHECK(
                     (kind = 'command' AND check_plan IS NULL)

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -480,6 +480,9 @@ impl Database {
                     OR (terminal_continuation_delivery_state IN ('delivered', 'delivery_unknown')
                         AND terminal_continuation_claim_fence IS NULL)
                 ),
+                mcp_task_materialized_at INTEGER,
+                mcp_task_result_finalized_at INTEGER,
+                mcp_task_output_tail_json TEXT,
                 UNIQUE(task_id, run_id, operation_id),
                 CHECK(
                     (kind = 'command' AND check_plan IS NULL)
@@ -985,6 +988,9 @@ impl Database {
                 "terminal_continuation_claim_fence",
                 "TEXT CHECK(terminal_continuation_claim_fence IS NULL OR (length(terminal_continuation_claim_fence) BETWEEN 1 AND 80))",
             ),
+            ("mcp_task_materialized_at", "INTEGER"),
+            ("mcp_task_result_finalized_at", "INTEGER"),
+            ("mcp_task_output_tail_json", "TEXT"),
         ] {
             if !columns.iter().any(|existing| existing == column) {
                 conn.execute(
@@ -1037,10 +1043,21 @@ mod connector_execution_column_tests {
         Database::ensure_connector_execution_columns(&conn).unwrap();
         Database::ensure_connector_execution_columns(&conn).unwrap();
 
-        let restored: (String, Option<i64>, String, String, Option<String>) = conn
+        let restored: (
+            String,
+            Option<i64>,
+            String,
+            String,
+            Option<String>,
+            Option<i64>,
+            Option<i64>,
+            Option<String>,
+        ) = conn
             .query_row(
                 "SELECT terminal_continuation_intent, terminal_continuation_armed_at, state,
-                        terminal_continuation_delivery_state, terminal_continuation_claim_fence
+                        terminal_continuation_delivery_state, terminal_continuation_claim_fence,
+                        mcp_task_materialized_at, mcp_task_result_finalized_at,
+                        mcp_task_output_tail_json
                  FROM wc_executions WHERE id = 'legacy'",
                 [],
                 |row| {
@@ -1050,6 +1067,9 @@ mod connector_execution_column_tests {
                         row.get(2)?,
                         row.get(3)?,
                         row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
                     ))
                 },
             )
@@ -1061,6 +1081,9 @@ mod connector_execution_column_tests {
                 None,
                 "succeeded".to_string(),
                 "unclaimed".to_string(),
+                None,
+                None,
+                None,
                 None,
             )
         );

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2511,11 +2511,15 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
         };
     let mut model_ergonomics = None;
     let active_trace_id = guard.active_trace_id();
+    // Keep the complete MCP dispatch future off the current thread's stack. The
+    // handler state spans every method arm (including Connector task polling),
+    // so nesting it inline under tracing + timeout can exhaust the default
+    // ~2 MiB libtest/Tokio worker stack even when a request takes another arm.
     let outcome = match tokio::time::timeout(
         MCP_DISPATCH_HARD_TIMEOUT,
         scope_active_trace(
             active_trace_id,
-            handle_mcp_request_with_lifecycle(
+            Box::pin(handle_mcp_request_with_lifecycle(
                 &runtime,
                 connector.as_deref(),
                 request,
@@ -2525,7 +2529,7 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
                 window.identity.as_ref(),
                 Some(&mut guard),
                 Some(&mut model_ergonomics),
-            ),
+            )),
         ),
     )
     .await

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -467,22 +467,36 @@ fn mcp_task_id_is_valid(task_id: &str) -> bool {
     })
 }
 
+fn mcp_task_status(execution: &crate::db::ConnectorExecution) -> &'static str {
+    if execution.state == "cancelled" {
+        "cancelled"
+    } else if execution.is_terminal() {
+        "completed"
+    } else {
+        "working"
+    }
+}
+
 fn mcp_task_base(
     execution: &crate::db::ConnectorExecution,
     result_type: &str,
     status: &str,
 ) -> Value {
+    let created_at = execution
+        .mcp_task_materialized_at
+        .unwrap_or(execution.submitted_at);
     let last_updated_at = execution
-        .finished_at
+        .mcp_task_result_finalized_at
+        .or(execution.finished_at)
         .or(execution.last_output_at)
         .or(execution.started_at)
         .or(execution.queued_at)
-        .unwrap_or(execution.submitted_at);
+        .unwrap_or(created_at);
     json!({
         "resultType": result_type,
         "taskId": execution.execution_id,
         "status": status,
-        "createdAt": mcp_task_timestamp(execution.submitted_at),
+        "createdAt": mcp_task_timestamp(created_at),
         "lastUpdatedAt": mcp_task_timestamp(last_updated_at),
         "ttlMs": null,
         "pollIntervalMs": MCP_TASK_POLL_INTERVAL_MS
@@ -490,20 +504,14 @@ fn mcp_task_base(
 }
 
 fn mcp_create_task_result(execution: &crate::db::ConnectorExecution) -> Value {
-    mcp_task_base(execution, "task", "working")
+    mcp_task_base(execution, "task", mcp_task_status(execution))
 }
 
 fn mcp_detailed_task_result(
     execution: &crate::db::ConnectorExecution,
     call_tool_result: Option<Value>,
 ) -> Value {
-    let status = if execution.state == "cancelled" {
-        "cancelled"
-    } else if execution.is_terminal() {
-        "completed"
-    } else {
-        "working"
-    };
+    let status = mcp_task_status(execution);
     let mut result = mcp_task_base(execution, "complete", status);
     if status == "completed" {
         if let (Some(object), Some(call_tool_result)) = (result.as_object_mut(), call_tool_result) {
@@ -3392,16 +3400,24 @@ async fn handle_mcp_request_with_lifecycle(
                                 "connector credential is required for MCP task access",
                             );
                         };
-                        match connector
-                            .execution_task_result_for_auth(execution_id, auth)
-                            .await
-                        {
-                            Ok((_task, execution, _)) if execution.is_active() => {
-                                if !execution.terminal_continuation_is_armed() {
+                        match connector.materialize_execution_task_for_auth(execution_id, auth) {
+                            Ok(execution) if execution.mcp_task_is_materialized() => {
+                                if execution.is_active()
+                                    && !execution.terminal_continuation_is_armed()
+                                {
                                     return McpOutcome::BadRequest(rpc_error(
                                         id,
                                         -32603,
                                         "active Connector execution is not durably armed for terminal polling",
+                                    ));
+                                }
+                                if execution.is_terminal()
+                                    && !execution.mcp_task_result_is_finalized()
+                                {
+                                    return McpOutcome::BadRequest(rpc_error(
+                                        id,
+                                        -32603,
+                                        "materialized MCP task became terminal before its durable result was finalized",
                                     ));
                                 }
                                 return McpOutcome::Ok(rpc_result(
@@ -3409,7 +3425,33 @@ async fn handle_mcp_request_with_lifecycle(
                                     mcp_stateless_result(mcp_create_task_result(&execution), false),
                                 ));
                             }
-                            Ok(_) => {}
+                            Ok(execution) if execution.is_terminal() => {
+                                let ordinary = match connector
+                                    .ordinary_execution_result_for_auth(execution_id, auth)
+                                    .await
+                                {
+                                    Ok(ordinary) => ordinary,
+                                    Err(task_outcome) => {
+                                        return mcp_task_connector_error(
+                                            id,
+                                            Some(auth),
+                                            task_outcome,
+                                        );
+                                    }
+                                };
+                                let result = connector_call_tool_result(ordinary);
+                                return McpOutcome::Ok(rpc_result(
+                                    id,
+                                    mcp_stateless_result(result, false),
+                                ));
+                            }
+                            Ok(_) => {
+                                return McpOutcome::BadRequest(rpc_error(
+                                    id,
+                                    -32603,
+                                    "active Connector execution was not durably materialized for MCP task polling",
+                                ));
+                            }
                             Err(task_outcome) => {
                                 return mcp_task_connector_error(id, Some(auth), task_outcome);
                             }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -56,6 +56,7 @@ const MAX_MCP_ARTIFACT_EXPORTS: usize = 128;
 const MAX_MCP_ARTIFACT_EXPORTS_PER_CALLER: usize = 16;
 const MCP_ARTIFACT_EXPORT_BUSY_CODE: i64 = -32029;
 const MCP_HEADER_MISMATCH: i64 = -32020;
+const MCP_MISSING_REQUIRED_CLIENT_CAPABILITY: i64 = -32021;
 const MCP_UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
 const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
     MCP_STATELESS_PROTOCOL_VERSION,
@@ -491,7 +492,8 @@ fn mcp_task_base(
         .or(execution.last_output_at)
         .or(execution.started_at)
         .or(execution.queued_at)
-        .unwrap_or(created_at);
+        .unwrap_or(created_at)
+        .max(created_at);
     json!({
         "resultType": result_type,
         "taskId": execution.execution_id,
@@ -524,7 +526,7 @@ fn mcp_detailed_task_result(
 fn missing_tasks_capability(id: Option<Value>) -> McpOutcome {
     McpOutcome::BadRequest(rpc_error_with_data(
         id,
-        -32003,
+        MCP_MISSING_REQUIRED_CLIENT_CAPABILITY,
         "Missing required client capability",
         json!({
             "requiredCapabilities": {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -63,6 +63,8 @@ const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
     MCP_PROTOCOL_VERSION,
 ];
 const MCP_UI_EXTENSION: &str = "io.modelcontextprotocol/ui";
+const MCP_TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
+const MCP_TASK_POLL_INTERVAL_MS: u64 = 2_000;
 const MCP_COMPUTER_UI_RESOURCE_URI: &str = "ui://webcodex/computer/v11";
 const MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS: &[&str] = &[
     "ui://webcodex/computer/v1",
@@ -123,6 +125,19 @@ struct McpToolCallParams {
     pub name: String,
     #[serde(default)]
     pub arguments: Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct McpTaskParams {
+    pub task_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct McpTaskUpdateParams {
+    pub task_id: String,
+    pub input_responses: Value,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -200,6 +215,17 @@ fn request_supports_mcp_apps(params: &Value) -> bool {
     }
 }
 
+fn request_supports_tasks(params: &Value) -> bool {
+    request_client_capabilities(params)
+        .and_then(|capabilities| capabilities.get("extensions"))
+        .and_then(|extensions| extensions.get(MCP_TASKS_EXTENSION))
+        .is_some_and(Value::is_object)
+}
+
+fn model_surface_supports_tasks(model_surface: ModelSurface) -> bool {
+    model_surface == ModelSurface::CanonicalConnector
+}
+
 fn model_surface_supports_computer_app(model_surface: ModelSurface) -> bool {
     model_surface == ModelSurface::FullOperatorRuntime
 }
@@ -239,6 +265,9 @@ fn request_mcp_name(request: &JsonRpcRequest) -> Option<Option<&str>> {
     match request.method.as_str() {
         "tools/call" | "prompts/get" => Some(request.params.get("name").and_then(Value::as_str)),
         "resources/read" => Some(request.params.get("uri").and_then(Value::as_str)),
+        "tasks/get" | "tasks/update" | "tasks/cancel" => {
+            Some(request.params.get("taskId").and_then(Value::as_str))
+        }
         _ => None,
     }
 }
@@ -415,6 +444,123 @@ fn mcp_stateless_result(mut result: Value, cacheable: bool) -> Value {
             });
     }
     result
+}
+
+fn connector_call_tool_result(outcome: crate::connector_runtime::ConnectorCallOutcome) -> Value {
+    let text = serde_json::to_string(&outcome.body).unwrap_or_else(|_| "{}".to_string());
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "structuredContent": outcome.body,
+        "isError": !outcome.ok
+    })
+}
+
+fn mcp_task_timestamp(timestamp: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(timestamp, 0)
+        .map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string())
+}
+
+fn mcp_task_id_is_valid(task_id: &str) -> bool {
+    task_id.strip_prefix("wc_exec_").is_some_and(|suffix| {
+        suffix.len() == 32 && suffix.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
+
+fn mcp_task_base(
+    execution: &crate::db::ConnectorExecution,
+    result_type: &str,
+    status: &str,
+) -> Value {
+    let last_updated_at = execution
+        .finished_at
+        .or(execution.last_output_at)
+        .or(execution.started_at)
+        .or(execution.queued_at)
+        .unwrap_or(execution.submitted_at);
+    json!({
+        "resultType": result_type,
+        "taskId": execution.execution_id,
+        "status": status,
+        "createdAt": mcp_task_timestamp(execution.submitted_at),
+        "lastUpdatedAt": mcp_task_timestamp(last_updated_at),
+        "ttlMs": null,
+        "pollIntervalMs": MCP_TASK_POLL_INTERVAL_MS
+    })
+}
+
+fn mcp_create_task_result(execution: &crate::db::ConnectorExecution) -> Value {
+    mcp_task_base(execution, "task", "working")
+}
+
+fn mcp_detailed_task_result(
+    execution: &crate::db::ConnectorExecution,
+    call_tool_result: Option<Value>,
+) -> Value {
+    let status = if execution.state == "cancelled" {
+        "cancelled"
+    } else if execution.is_terminal() {
+        "completed"
+    } else {
+        "working"
+    };
+    let mut result = mcp_task_base(execution, "complete", status);
+    if status == "completed" {
+        if let (Some(object), Some(call_tool_result)) = (result.as_object_mut(), call_tool_result) {
+            object.insert("result".to_string(), call_tool_result);
+        }
+    }
+    result
+}
+
+fn missing_tasks_capability(id: Option<Value>) -> McpOutcome {
+    McpOutcome::BadRequest(rpc_error_with_data(
+        id,
+        -32003,
+        "Missing required client capability",
+        json!({
+            "requiredCapabilities": {
+                "extensions": {
+                    MCP_TASKS_EXTENSION: {}
+                }
+            }
+        }),
+    ))
+}
+
+fn mcp_task_connector_error(
+    id: Option<Value>,
+    auth: Option<&AuthContext>,
+    outcome: crate::connector_runtime::ConnectorCallOutcome,
+) -> McpOutcome {
+    if let Some(required_scope) = outcome.required_scope {
+        let description = outcome
+            .body
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap_or("connector credential lacks the required scope")
+            .to_string();
+        return scope_forbidden(auth, Some(required_scope), description);
+    }
+    if outcome.http_status == 404
+        || outcome.body.pointer("/error/code").and_then(Value::as_str) == Some("task_not_found")
+    {
+        return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params: task not found"));
+    }
+    if outcome.protocol_error {
+        let message = outcome
+            .body
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap_or("Invalid task params")
+            .to_string();
+        return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+    }
+    McpOutcome::BadRequest(rpc_error(
+        id,
+        -32603,
+        "Internal error while resolving durable Connector task",
+    ))
 }
 
 /// MCP tools/list payload for the immutable startup-selected model surface.
@@ -2740,6 +2886,13 @@ async fn handle_mcp_request_with_lifecycle(
                             }
                         }
                     })
+                } else if model_surface_supports_tasks(runtime.model_surface()) {
+                    json!({
+                        "tools": { "listChanged": false },
+                        "extensions": {
+                            MCP_TASKS_EXTENSION: {}
+                        }
+                    })
                 } else {
                     json!({ "tools": { "listChanged": false } })
                 },
@@ -2916,7 +3069,137 @@ async fn handle_mcp_request_with_lifecycle(
             }
             rpc_result(id, result)
         }
+        "tasks/get" if stateless_2026 && model_surface_supports_tasks(runtime.model_surface()) => {
+            if !request_supports_tasks(&request.params) {
+                return missing_tasks_capability(id);
+            }
+            let params: McpTaskParams = match serde_json::from_value(request.params) {
+                Ok(params) => params,
+                Err(error) => {
+                    return McpOutcome::BadRequest(rpc_error(
+                        id,
+                        -32602,
+                        format!("Invalid params: {error}"),
+                    ));
+                }
+            };
+            if !mcp_task_id_is_valid(&params.task_id) {
+                return McpOutcome::BadRequest(rpc_error(
+                    id,
+                    -32602,
+                    "Invalid params: task not found",
+                ));
+            }
+            let Some(auth) = auth else {
+                return scope_forbidden(
+                    None,
+                    Some(crate::auth::SCOPE_JOB_RUN),
+                    "connector credential is required for MCP task access",
+                );
+            };
+            if let Some(outcome) = require_mcp_scope(Some(auth), crate::auth::SCOPE_JOB_RUN) {
+                return outcome;
+            }
+            let connector = connector.expect("validated canonical Connector state");
+            match connector
+                .execution_task_result_for_auth(&params.task_id, auth)
+                .await
+            {
+                Ok((_task, execution, outcome)) => {
+                    let call_tool_result = execution
+                        .is_terminal()
+                        .then(|| connector_call_tool_result(outcome));
+                    let result = mcp_detailed_task_result(&execution, call_tool_result);
+                    return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(result, false)));
+                }
+                Err(outcome) => return mcp_task_connector_error(id, Some(auth), outcome),
+            }
+        }
+        "tasks/update"
+            if stateless_2026 && model_surface_supports_tasks(runtime.model_surface()) =>
+        {
+            if !request_supports_tasks(&request.params) {
+                return missing_tasks_capability(id);
+            }
+            let params: McpTaskUpdateParams = match serde_json::from_value(request.params) {
+                Ok(params) => params,
+                Err(error) => {
+                    return McpOutcome::BadRequest(rpc_error(
+                        id,
+                        -32602,
+                        format!("Invalid params: {error}"),
+                    ));
+                }
+            };
+            if !mcp_task_id_is_valid(&params.task_id) || !params.input_responses.is_object() {
+                return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params"));
+            }
+            let Some(auth) = auth else {
+                return scope_forbidden(
+                    None,
+                    Some(crate::auth::SCOPE_JOB_RUN),
+                    "connector credential is required for MCP task access",
+                );
+            };
+            if let Some(outcome) = require_mcp_scope(Some(auth), crate::auth::SCOPE_JOB_RUN) {
+                return outcome;
+            }
+            let connector = connector.expect("validated canonical Connector state");
+            if let Err(outcome) = connector
+                .execution_task_result_for_auth(&params.task_id, auth)
+                .await
+            {
+                return mcp_task_connector_error(id, Some(auth), outcome);
+            }
+            // A3 never creates input_required Tasks. Per the Tasks extension,
+            // responses for unknown/already-satisfied input requests are ignored.
+            return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(json!({}), false)));
+        }
+        "tasks/cancel"
+            if stateless_2026 && model_surface_supports_tasks(runtime.model_surface()) =>
+        {
+            if !request_supports_tasks(&request.params) {
+                return missing_tasks_capability(id);
+            }
+            let params: McpTaskParams = match serde_json::from_value(request.params) {
+                Ok(params) => params,
+                Err(error) => {
+                    return McpOutcome::BadRequest(rpc_error(
+                        id,
+                        -32602,
+                        format!("Invalid params: {error}"),
+                    ));
+                }
+            };
+            if !mcp_task_id_is_valid(&params.task_id) {
+                return McpOutcome::BadRequest(rpc_error(
+                    id,
+                    -32602,
+                    "Invalid params: task not found",
+                ));
+            }
+            let Some(auth) = auth else {
+                return scope_forbidden(
+                    None,
+                    Some(crate::auth::SCOPE_JOB_RUN),
+                    "connector credential is required for MCP task access",
+                );
+            };
+            if let Some(outcome) = require_mcp_scope(Some(auth), crate::auth::SCOPE_JOB_RUN) {
+                return outcome;
+            }
+            let connector = connector.expect("validated canonical Connector state");
+            if let Err(outcome) = connector
+                .cancel_execution_task_for_auth(&params.task_id, auth)
+                .await
+            {
+                return mcp_task_connector_error(id, Some(auth), outcome);
+            }
+            return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(json!({}), false)));
+        }
         "tools/call" => {
+            let tasks_extension_declared =
+                stateless_2026 && request_supports_tasks(&request.params);
             let mut params: McpToolCallParams = match serde_json::from_value(request.params) {
                 Ok(params) => params,
                 Err(e) => {
@@ -3043,15 +3326,29 @@ async fn handle_mcp_request_with_lifecycle(
                 if let Some(lc) = lifecycle.as_deref() {
                     lc.capture_payload("effective_arguments", &params.arguments);
                 }
-                let outcome = connector
-                    .call_for_window(
-                        &params.name,
-                        params.arguments,
-                        auth,
-                        ConnectorTransport::Mcp,
-                        window,
-                    )
-                    .await;
+                let task_polling = tasks_extension_declared
+                    && matches!(params.name.as_str(), "commands_run" | "checks_run");
+                let outcome = if task_polling {
+                    connector
+                        .call_for_window_with_task_polling(
+                            &params.name,
+                            params.arguments,
+                            auth,
+                            ConnectorTransport::Mcp,
+                            window,
+                        )
+                        .await
+                } else {
+                    connector
+                        .call_for_window(
+                            &params.name,
+                            params.arguments,
+                            auth,
+                            ConnectorTransport::Mcp,
+                            window,
+                        )
+                        .await
+                };
                 if let Some(required_scope) = outcome.required_scope {
                     if let Some(lc) = lifecycle.as_deref() {
                         lc.dispatch_failed("forbidden");
@@ -3082,13 +3379,50 @@ async fn handle_mcp_request_with_lifecycle(
                     let category = if outcome.ok { "success" } else { "tool_error" };
                     lc.dispatch_finished(true, Some(outcome.ok), category);
                 }
-                let text =
-                    serde_json::to_string(&outcome.body).unwrap_or_else(|_| "{}".to_string());
-                let result = json!({
-                    "content": [{ "type": "text", "text": text }],
-                    "structuredContent": outcome.body,
-                    "isError": !outcome.ok
-                });
+                if task_polling && outcome.ok {
+                    if let Some(execution_id) = outcome
+                        .body
+                        .pointer("/data/execution/execution_id")
+                        .and_then(Value::as_str)
+                    {
+                        let Some(auth) = auth else {
+                            return scope_forbidden(
+                                None,
+                                Some(crate::auth::SCOPE_JOB_RUN),
+                                "connector credential is required for MCP task access",
+                            );
+                        };
+                        match connector
+                            .execution_task_result_for_auth(execution_id, auth)
+                            .await
+                        {
+                            Ok((_task, execution, _)) if execution.is_active() => {
+                                if !execution.terminal_continuation_is_armed() {
+                                    return McpOutcome::BadRequest(rpc_error(
+                                        id,
+                                        -32603,
+                                        "active Connector execution is not durably armed for terminal polling",
+                                    ));
+                                }
+                                return McpOutcome::Ok(rpc_result(
+                                    id,
+                                    mcp_stateless_result(mcp_create_task_result(&execution), false),
+                                ));
+                            }
+                            Ok(_) => {}
+                            Err(task_outcome) => {
+                                return mcp_task_connector_error(id, Some(auth), task_outcome);
+                            }
+                        }
+                    } else if outcome.body["blocking"].as_bool() == Some(true) {
+                        return McpOutcome::BadRequest(rpc_error(
+                            id,
+                            -32603,
+                            "active Connector execution did not expose durable execution identity",
+                        ));
+                    }
+                }
+                let result = connector_call_tool_result(outcome);
                 return McpOutcome::Ok(rpc_result(
                     id,
                     if stateless_2026 {

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -103,6 +103,38 @@ fn mcp_2026_params(mut params: Value) -> Value {
     params
 }
 
+fn mcp_2026_tasks_params(mut params: Value) -> Value {
+    params
+        .as_object_mut()
+        .expect("MCP params must be an object")
+        .insert(
+            "_meta".to_string(),
+            json!({
+                "io.modelcontextprotocol/protocolVersion": MCP_STATELESS_PROTOCOL_VERSION,
+                "io.modelcontextprotocol/clientCapabilities": {
+                    "extensions": {
+                        MCP_TASKS_EXTENSION: {}
+                    }
+                }
+            }),
+        );
+    params
+}
+
+#[test]
+fn mcp_2026_tasks_capability_is_request_scoped_and_shape_strict() {
+    assert!(!request_supports_tasks(&mcp_2026_params(json!({}))));
+    assert!(request_supports_tasks(&mcp_2026_tasks_params(json!({}))));
+
+    let mut malformed = mcp_2026_params(json!({}));
+    malformed["_meta"]["io.modelcontextprotocol/clientCapabilities"] = json!({
+        "extensions": {
+            MCP_TASKS_EXTENSION: true
+        }
+    });
+    assert!(!request_supports_tasks(&malformed));
+}
+
 fn mcp_2026_ui_params(mut params: Value) -> Value {
     params
         .as_object_mut()

--- a/src/mcp_tests/project_connector.rs
+++ b/src/mcp_tests/project_connector.rs
@@ -64,7 +64,7 @@ fn build_connector_test_router(
         .push(Router::with_path("openapi.json").get(crate::openapi::openapi_json))
 }
 
-fn seed_mcp_execution(
+fn seed_armed_mcp_execution(
     db: &crate::Database,
     project_root: &std::path::Path,
 ) -> crate::db::ConnectorExecution {
@@ -121,6 +121,20 @@ fn seed_mcp_execution(
         .unwrap();
     db.arm_connector_terminal_continuation(&execution.execution_id, 14)
         .unwrap()
+}
+
+fn seed_mcp_execution(
+    db: &crate::Database,
+    project_root: &std::path::Path,
+) -> crate::db::ConnectorExecution {
+    let execution = seed_armed_mcp_execution(db, project_root);
+    db.materialize_connector_execution_mcp_task_for_subject(
+        &execution.execution_id,
+        CONNECTOR_TEST_PROJECT_ID,
+        CONNECTOR_TEST_SUBJECT_ID,
+        15,
+    )
+    .unwrap()
 }
 
 async fn mcp_2026_task_request(
@@ -608,6 +622,8 @@ async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen(
 
     let execution = seed_mcp_execution(&db, &project);
     let task_id = execution.execution_id.clone();
+    assert!(execution.mcp_task_is_materialized());
+    assert_eq!(execution.mcp_task_materialized_at, Some(15));
     let create = mcp_create_task_result(&execution);
     assert_eq!(create["resultType"], "task");
     assert_eq!(create["taskId"], task_id);
@@ -679,12 +695,34 @@ async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen(
         Err(crate::db::ConnectorTaskStoreError::NotFound)
     ));
 
-    db.finish_connector_execution(
-        &task_id,
-        crate::db::ConnectorExecutionFailure::Submission("mcp_task_test_terminal"),
-        20,
-    )
-    .unwrap();
+    let durable_tail = json!({
+        "stdout": "durable terminal stdout\n",
+        "stderr": "durable terminal stderr\n",
+        "bounded": true
+    });
+    let finalized = db
+        .observe_connector_execution(
+            &task_id,
+            crate::db::ConnectorExecutionObservation {
+                executor_status: "failed",
+                stdout_cursor: 2,
+                stderr_cursor: 2,
+                exit_code: Some(7),
+                started_at: Some(13),
+                finished_at: Some(20),
+                check_completed: None,
+                failed_check: None,
+                assertion_evidence: None,
+                validated_workspace_sha256: None,
+                executor_failure_code: None,
+                mcp_task_output_tail: Some(&durable_tail),
+                now: 20,
+            },
+        )
+        .unwrap();
+    assert_eq!(finalized.state, "failed");
+    assert_eq!(finalized.mcp_task_result_finalized_at, Some(20));
+    assert_eq!(finalized.mcp_task_output_tail.as_ref(), Some(&durable_tail));
     let mut completed = mcp_2026_task_request(
         &service,
         CONNECTOR_TEST_CREDENTIAL,
@@ -701,6 +739,10 @@ async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen(
         completed_body["result"]["result"]["structuredContent"]["data"]["execution"]
             ["execution_status"],
         "failed"
+    );
+    assert_eq!(
+        completed_body["result"]["result"]["structuredContent"]["data"]["execution"]["output_tail"],
+        durable_tail
     );
 
     let mut replayed = mcp_2026_task_request(
@@ -736,6 +778,77 @@ async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen(
     assert_eq!(effective_status(&after_restart), StatusCode::OK);
     let after_restart_body: Value = after_restart.take_json().await.unwrap();
     assert_eq!(after_restart_body["result"], completed_body["result"]);
+}
+
+#[tokio::test]
+async fn http_project_connector_2026_tasks_reject_unmaterialized_execution_ids() {
+    let config = test_config(Some("secret"));
+    let (tmp, db) = test_db();
+    let project = tmp.path().join("connector-2026-unmaterialized-task");
+    crate::connector_runtime::tests::init_repo(&project);
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::CanonicalConnector));
+    let service = Service::new(build_connector_test_router(
+        config,
+        db.clone(),
+        runtime,
+        &project,
+    ));
+    let execution = seed_armed_mcp_execution(&db, &project);
+    let execution_id = execution.execution_id.clone();
+    assert!(!execution.mcp_task_is_materialized());
+
+    for (method, params) in [
+        ("tasks/get", json!({ "taskId": execution_id })),
+        (
+            "tasks/update",
+            json!({ "taskId": execution_id, "inputResponses": {} }),
+        ),
+        ("tasks/cancel", json!({ "taskId": execution_id })),
+    ] {
+        let mut response = mcp_2026_task_request(
+            &service,
+            CONNECTOR_TEST_CREDENTIAL,
+            method,
+            &execution_id,
+            mcp_2026_tasks_params(params),
+        )
+        .await;
+        assert_eq!(effective_status(&response), StatusCode::BAD_REQUEST);
+        let body: Value = response.take_json().await.unwrap();
+        assert_eq!(body["error"]["code"], -32602, "{method}: {body}");
+    }
+
+    let terminal = db
+        .finish_connector_execution(
+            &execution_id,
+            crate::db::ConnectorExecutionFailure::Submission("terminal_before_materialization"),
+            20,
+        )
+        .unwrap();
+    assert!(terminal.is_terminal());
+    assert!(!terminal.mcp_task_is_materialized());
+    assert!(!terminal.mcp_task_result_is_finalized());
+    let rematerialize = db
+        .materialize_connector_execution_mcp_task_for_subject(
+            &execution_id,
+            CONNECTOR_TEST_PROJECT_ID,
+            CONNECTOR_TEST_SUBJECT_ID,
+            21,
+        )
+        .unwrap();
+    assert!(!rematerialize.mcp_task_is_materialized());
+
+    let mut response = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &execution_id,
+        mcp_2026_tasks_params(json!({ "taskId": execution_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&response), StatusCode::BAD_REQUEST);
+    let body: Value = response.take_json().await.unwrap();
+    assert_eq!(body["error"]["code"], -32602);
 }
 
 #[tokio::test]
@@ -801,6 +914,7 @@ async fn http_project_connector_2026_tasks_cancel_reuses_execution_cancellation(
             assertion_evidence: None,
             validated_workspace_sha256: None,
             executor_failure_code: None,
+            mcp_task_output_tail: None,
             now: 21,
         },
     )

--- a/src/mcp_tests/project_connector.rs
+++ b/src/mcp_tests/project_connector.rs
@@ -1,14 +1,18 @@
 use super::*;
 
+const CONNECTOR_TEST_PROJECT_ID: &str = "wc_proj_1234567890";
+const CONNECTOR_TEST_WORKSPACE_ID: &str = "wc_ws_1234567890";
+const CONNECTOR_TEST_GRANT_ID: &str = "wc_pgrant_3333333333333333";
+const CONNECTOR_TEST_SUBJECT_ID: &str = "project:wc_pgrant_3333333333333333";
+const CONNECTOR_TEST_CREDENTIAL: &str =
+    "webcodex_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
 fn build_connector_test_router(
     config: Arc<crate::Config>,
     db: Arc<crate::Database>,
     runtime: Arc<ToolRuntime>,
     project_root: &std::path::Path,
 ) -> Router {
-    const PROJECT_GRANT_ID: &str = "wc_pgrant_3333333333333333";
-    const PROJECT_CREDENTIAL: &str =
-        "webcodex_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     let state_root = project_root
         .parent()
         .expect("connector test project parent")
@@ -17,9 +21,9 @@ fn build_connector_test_router(
         runtime.clone(),
         db.clone(),
         crate::connector_runtime::ConnectorContext {
-            project_id: "wc_proj_1234567890".to_string(),
+            project_id: CONNECTOR_TEST_PROJECT_ID.to_string(),
             project_name: "demo".to_string(),
-            workspace_id: "wc_ws_1234567890".to_string(),
+            workspace_id: CONNECTOR_TEST_WORKSPACE_ID.to_string(),
             executor_project: "agent:hosted:demo".to_string(),
             executor_root: project_root.to_string_lossy().to_string(),
             runs_root: state_root.join("runs").to_string_lossy().to_string(),
@@ -29,11 +33,11 @@ fn build_connector_test_router(
                 .to_string_lossy()
                 .to_string(),
             profile: "personal".to_string(),
-            project_grant_id: PROJECT_GRANT_ID.to_string(),
+            project_grant_id: CONNECTOR_TEST_GRANT_ID.to_string(),
         },
         crate::auth::ProjectCredentialVerifier::new(
-            PROJECT_GRANT_ID.to_string(),
-            PROJECT_CREDENTIAL,
+            CONNECTOR_TEST_GRANT_ID.to_string(),
+            CONNECTOR_TEST_CREDENTIAL,
         )
         .unwrap(),
     )
@@ -58,6 +62,91 @@ fn build_connector_test_router(
                 .push(Router::with_path("tools/call").post(crate::runtime_http::tools_call)),
         )
         .push(Router::with_path("openapi.json").get(crate::openapi::openapi_json))
+}
+
+fn seed_mcp_execution(
+    db: &crate::Database,
+    project_root: &std::path::Path,
+) -> crate::db::ConnectorExecution {
+    db.ensure_connector_binding(crate::db::ConnectorBinding {
+        project_id: CONNECTOR_TEST_PROJECT_ID,
+        project_name: "demo",
+        workspace_id: CONNECTOR_TEST_WORKSPACE_ID,
+        executor_ref: "agent:hosted:demo",
+        subject_id: CONNECTOR_TEST_SUBJECT_ID,
+        profile: "personal",
+        now: 10,
+    })
+    .unwrap();
+    let task_id = format!("wc_task_{}", uuid::Uuid::new_v4().simple());
+    let run_id = format!("wc_run_{}", uuid::Uuid::new_v4().simple());
+    let root = project_root.to_string_lossy().into_owned();
+    let task = db
+        .start_connector_task(crate::db::NewConnectorTask {
+            task_id: &task_id,
+            run_id: &run_id,
+            project_id: CONNECTOR_TEST_PROJECT_ID,
+            workspace_id: CONNECTOR_TEST_WORKSPACE_ID,
+            subject_id: CONNECTOR_TEST_SUBJECT_ID,
+            goal: "exercise MCP 2026 durable task polling",
+            mode: "read_only",
+            target_executor_ref: "agent:hosted:demo",
+            execution_executor_ref: "agent:hosted:demo",
+            target_root: &root,
+            execution_root: &root,
+            baseline_commit: None,
+            baseline_tree: None,
+            isolated: false,
+            now: 11,
+        })
+        .unwrap();
+    let execution = match db
+        .reserve_connector_execution(
+            &task,
+            "command",
+            "mcp-task-op",
+            "mcp-task-request-hash",
+            &[],
+            None,
+            None,
+            120,
+            12,
+        )
+        .unwrap()
+    {
+        crate::db::ConnectorExecutionReservation::Created(execution) => execution,
+        crate::db::ConnectorExecutionReservation::Existing(_) => unreachable!(),
+    };
+    db.start_connector_execution(&execution.execution_id, 13)
+        .unwrap();
+    db.arm_connector_terminal_continuation(&execution.execution_id, 14)
+        .unwrap()
+}
+
+async fn mcp_2026_task_request(
+    service: &Service,
+    user_token: &str,
+    method: &str,
+    task_id: &str,
+    params: Value,
+) -> salvo::Response {
+    TestClient::post("http://localhost/mcp")
+        .bearer_auth(user_token)
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, method, true)
+        .add_header(MCP_NAME_HEADER, task_id, true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 300,
+            "method": method,
+            "params": params
+        }))
+        .send(service)
+        .await
 }
 
 #[tokio::test]
@@ -477,4 +566,281 @@ async fn http_project_connector_2026_uses_explicit_task_ids_without_transport_wi
         resumed_body["result"]["structuredContent"]["data"]["continuity"]["window_rebound"],
         false
     );
+}
+
+#[tokio::test]
+async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen() {
+    let config = test_config(Some("secret"));
+    let (tmp, db) = test_db();
+    let db_path = tmp.path().join("test.db");
+    let project = tmp.path().join("connector-2026-task-project");
+    crate::connector_runtime::tests::init_repo(&project);
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::CanonicalConnector));
+    let service = Service::new(build_connector_test_router(
+        config,
+        db.clone(),
+        runtime,
+        &project,
+    ));
+
+    let mut discover = TestClient::post("http://localhost/mcp")
+        .bearer_auth(CONNECTOR_TEST_CREDENTIAL)
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "server/discover", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 299,
+            "method": "server/discover",
+            "params": mcp_2026_params(json!({}))
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&discover), StatusCode::OK);
+    let discover_body: Value = discover.take_json().await.unwrap();
+    assert_eq!(
+        discover_body["result"]["capabilities"]["extensions"][MCP_TASKS_EXTENSION],
+        json!({})
+    );
+
+    let execution = seed_mcp_execution(&db, &project);
+    let task_id = execution.execution_id.clone();
+    let create = mcp_create_task_result(&execution);
+    assert_eq!(create["resultType"], "task");
+    assert_eq!(create["taskId"], task_id);
+    assert_eq!(create["status"], "working");
+
+    let mut missing_capability = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &task_id,
+        mcp_2026_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(
+        effective_status(&missing_capability),
+        StatusCode::BAD_REQUEST
+    );
+    let missing_body: Value = missing_capability.take_json().await.unwrap();
+    assert_eq!(missing_body["error"]["code"], -32003);
+    assert_eq!(
+        missing_body["error"]["data"]["requiredCapabilities"]["extensions"][MCP_TASKS_EXTENSION],
+        json!({})
+    );
+
+    let mut working = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&working), StatusCode::OK);
+    assert!(working
+        .headers
+        .get(crate::client_window::MCP_SESSION_HEADER)
+        .is_none());
+    let working_body: Value = working.take_json().await.unwrap();
+    assert_eq!(working_body["result"]["resultType"], "complete");
+    assert_eq!(working_body["result"]["taskId"], task_id);
+    assert_eq!(working_body["result"]["status"], "working");
+    assert!(working_body["result"].get("result").is_none());
+
+    let mut updated = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/update",
+        &task_id,
+        mcp_2026_tasks_params(json!({
+            "taskId": task_id,
+            "inputResponses": { "unused": { "resultType": "complete" } }
+        })),
+    )
+    .await;
+    assert_eq!(effective_status(&updated), StatusCode::OK);
+    let updated_body: Value = updated.take_json().await.unwrap();
+    assert_eq!(updated_body["result"]["resultType"], "complete");
+    assert!(updated_body["result"].get("taskId").is_none());
+    assert!(matches!(
+        db.connector_execution_for_subject(
+            &task_id,
+            CONNECTOR_TEST_PROJECT_ID,
+            "project:foreign-grant"
+        ),
+        Err(crate::db::ConnectorTaskStoreError::NotFound)
+    ));
+    assert!(matches!(
+        db.connector_execution_for_subject(&task_id, "wc_proj_foreign", CONNECTOR_TEST_SUBJECT_ID),
+        Err(crate::db::ConnectorTaskStoreError::NotFound)
+    ));
+
+    db.finish_connector_execution(
+        &task_id,
+        crate::db::ConnectorExecutionFailure::Submission("mcp_task_test_terminal"),
+        20,
+    )
+    .unwrap();
+    let mut completed = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&completed), StatusCode::OK);
+    let completed_body: Value = completed.take_json().await.unwrap();
+    assert_eq!(completed_body["result"]["status"], "completed");
+    assert_eq!(completed_body["result"]["taskId"], task_id);
+    assert_eq!(
+        completed_body["result"]["result"]["structuredContent"]["data"]["execution"]
+            ["execution_status"],
+        "failed"
+    );
+
+    let mut replayed = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&replayed), StatusCode::OK);
+    let replayed_body: Value = replayed.take_json().await.unwrap();
+    assert_eq!(replayed_body["result"], completed_body["result"]);
+
+    drop(service);
+    drop(db);
+    let reopened_db = Arc::new(crate::Database::open(&db_path).unwrap());
+    let reopened_runtime = Arc::new(test_runtime_with_surface(ModelSurface::CanonicalConnector));
+    let reopened_service = Service::new(build_connector_test_router(
+        test_config(Some("secret")),
+        reopened_db,
+        reopened_runtime,
+        &project,
+    ));
+    let mut after_restart = mcp_2026_task_request(
+        &reopened_service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&after_restart), StatusCode::OK);
+    let after_restart_body: Value = after_restart.take_json().await.unwrap();
+    assert_eq!(after_restart_body["result"], completed_body["result"]);
+}
+
+#[tokio::test]
+async fn http_project_connector_2026_tasks_cancel_reuses_execution_cancellation() {
+    let config = test_config(Some("secret"));
+    let (tmp, db) = test_db();
+    let project = tmp.path().join("connector-2026-task-cancel");
+    crate::connector_runtime::tests::init_repo(&project);
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::CanonicalConnector));
+    let service = Service::new(build_connector_test_router(
+        config,
+        db.clone(),
+        runtime,
+        &project,
+    ));
+    let execution = seed_mcp_execution(&db, &project);
+    let task_id = execution.execution_id.clone();
+
+    let mut cancelled = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/cancel",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&cancelled), StatusCode::OK);
+    let cancelled_body: Value = cancelled.take_json().await.unwrap();
+    assert_eq!(cancelled_body["result"]["resultType"], "complete");
+
+    let mut observed = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&observed), StatusCode::OK);
+    let observed_body: Value = observed.take_json().await.unwrap();
+    assert_eq!(observed_body["result"]["status"], "working");
+    assert_eq!(
+        observed_body["result"]["result"].is_null(),
+        true,
+        "cancel ACK must not claim terminal cancellation"
+    );
+    assert_eq!(
+        db.connector_execution(&task_id).unwrap().state,
+        "cancel_requested"
+    );
+
+    db.observe_connector_execution(
+        &task_id,
+        crate::db::ConnectorExecutionObservation {
+            executor_status: "cancelled",
+            stdout_cursor: 1,
+            stderr_cursor: 1,
+            exit_code: None,
+            started_at: None,
+            finished_at: Some(21),
+            check_completed: None,
+            failed_check: None,
+            assertion_evidence: None,
+            validated_workspace_sha256: None,
+            executor_failure_code: None,
+            now: 21,
+        },
+    )
+    .unwrap();
+    let mut terminal = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&terminal), StatusCode::OK);
+    let terminal_body: Value = terminal.take_json().await.unwrap();
+    assert_eq!(terminal_body["result"]["status"], "cancelled");
+    assert!(terminal_body["result"].get("result").is_none());
+
+    let mut repeated_cancel = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/cancel",
+        &task_id,
+        mcp_2026_tasks_params(json!({ "taskId": task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&repeated_cancel), StatusCode::OK);
+    let repeated_body: Value = repeated_cancel.take_json().await.unwrap();
+    assert_eq!(repeated_body["result"]["resultType"], "complete");
+
+    let unknown_task_id = "wc_exec_ffffffffffffffffffffffffffffffff";
+    let mut missing = mcp_2026_task_request(
+        &service,
+        CONNECTOR_TEST_CREDENTIAL,
+        "tasks/get",
+        unknown_task_id,
+        mcp_2026_tasks_params(json!({ "taskId": unknown_task_id })),
+    )
+    .await;
+    assert_eq!(effective_status(&missing), StatusCode::BAD_REQUEST);
+    let missing_body: Value = missing.take_json().await.unwrap();
+    assert_eq!(missing_body["error"]["code"], -32602);
+    assert!(!missing_body.to_string().contains(&task_id));
 }

--- a/src/mcp_tests/project_connector.rs
+++ b/src/mcp_tests/project_connector.rs
@@ -628,6 +628,7 @@ async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen(
     assert_eq!(create["resultType"], "task");
     assert_eq!(create["taskId"], task_id);
     assert_eq!(create["status"], "working");
+    assert_eq!(create["lastUpdatedAt"], create["createdAt"]);
 
     let mut missing_capability = mcp_2026_task_request(
         &service,
@@ -642,7 +643,10 @@ async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen(
         StatusCode::BAD_REQUEST
     );
     let missing_body: Value = missing_capability.take_json().await.unwrap();
-    assert_eq!(missing_body["error"]["code"], -32003);
+    assert_eq!(
+        missing_body["error"]["code"],
+        MCP_MISSING_REQUIRED_CLIENT_CAPABILITY
+    );
     assert_eq!(
         missing_body["error"]["data"]["requiredCapabilities"]["extensions"][MCP_TASKS_EXTENSION],
         json!({})

--- a/src/mcp_tests/protocol.rs
+++ b/src/mcp_tests/protocol.rs
@@ -168,6 +168,27 @@ async fn mcp_legacy_server_discover_is_method_not_found() {
 }
 
 #[tokio::test]
+async fn mcp_legacy_protocol_does_not_expose_tasks_extension_methods() {
+    let runtime = test_runtime();
+    for method in ["tasks/get", "tasks/update", "tasks/cancel"] {
+        let outcome = handle_mcp_request(
+            &runtime,
+            rpc(
+                method,
+                Some(Value::from(62)),
+                json!({ "taskId": "wc_exec_ffffffffffffffffffffffffffffffff" }),
+            ),
+            None,
+        )
+        .await;
+        match outcome {
+            McpOutcome::BadRequest(value) => assert_eq!(value["error"]["code"], -32601),
+            other => panic!("legacy {method} must be method-not-found, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
 async fn mcp_stateless_tools_list_uses_2026_result_shape() {
     let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let outcome = handle_mcp_request(


### PR DESCRIPTION
## Summary
- add the MCP 2026-07-28 `io.modelcontextprotocol/tasks` extension to the Canonical Connector for `commands_run` and `checks_run`
- durably materialize a Task before returning its handle; the exact durable execution remains the `taskId` across active and terminal `operation_id` replay
- persist terminal bounded stdout/stderr plus the final-result marker with execution terminal truth so `tasks/get` survives Runner log cleanup and Server reopen
- keep terminal-before-materialization calls as ordinary `CallToolResult`; only materialized executions are addressable through `tasks/get`, `tasks/update`, or `tasks/cancel`
- keep Tasks capability request-scoped and preserve legacy/2025 behavior
- do not consume pending guidance during Task polling/replay; ordinary synchronous fallback retains the existing guidance-delivery path

## Rebase integration
Rebased onto `main@f655c4be` after #190 added durable terminal-continuation delivery state. Materialized MCP Tasks are excluded from the host terminal-continuation claim queue (`mcp_task_materialized_at IS NULL`) so a terminal execution cannot later be double-delivered through both MCP Tasks polling and the host continuation-delivery path.

The rebase also preserves both #190 delivery-state columns and A3 Task-result columns in the same execution record, including additive legacy migration behavior.

## Validation
- `cargo test 'mcp_tools_call_tasks_extension'` — 2/2
- `cargo test 'mcp_task_polling_quick_yield_replays_exact_armed_execution'` — 1/1
- `cargo test 'mcp_task_materialization_and_terminal_result_finalize_durably_together'` — 1/1
- `cargo test 'http_project_connector_2026_tasks'` — 3/3
- `cargo test 'continuation_delivery'` — 10/10
- `cargo check --all-targets` — 0 warnings / 0 errors
- `cargo fmt -- --check`
- `git diff --check`

No deployment, restart, merge, or release is included in this PR creation step.