### PR TITLE
Reconcile canonical closeout evidence

### DIFF
--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -15,7 +15,7 @@ use super::continuation_feedback::{
 use super::handoff::{
     actionable_unexpected_failure_count, apply_compact_workflow_outcomes, closeout_work_projection,
     compact_jobs, compact_review_evidence, compact_tool_failures, compact_validation,
-    project_tool_failure_actionability, review_evidence_summary_for_session,
+    reconcile_closeout_evidence, review_evidence_summary_for_session,
     validation_has_cargo_test_zero_tests,
 };
 use super::handoff_brief::{build_handoff_brief, HandoffBriefInput};
@@ -1425,12 +1425,6 @@ impl ToolRuntime {
         let workspace = workspace_payload_from_show_changes(&changes_result.output);
         append_workspace_warnings(&workspace, &mut final_warnings);
 
-        let validation = if include_validation_summary {
-            self.validation_summary_for_session_with_jobs(&session_summary, 10, auth)
-                .await
-        } else {
-            skipped_validation_summary()
-        };
         let permissions = permission_summary_from_events(
             &session_summary.events,
             super::permissions::DEFAULT_PERMISSION_RECENT_LIMIT,
@@ -1507,10 +1501,28 @@ impl ToolRuntime {
         } else {
             Value::Null
         };
-        let closeout_session_summary = self
+        // Reconcile from the freshest post-inspection ledger snapshot. Validation
+        // materialization may itself append authoritative terminal evidence, so
+        // refresh once more after deriving validation before classifying tool
+        // failure actionability.
+        let closeout_pre_validation_summary = self
             .sessions
             .summary(&session_id, Some(FINISH_SESSION_EVENT_LIMIT))
             .unwrap_or_else(|| session_summary.clone());
+        let validation = if include_validation_summary {
+            self.validation_summary_for_session_with_jobs(
+                &closeout_pre_validation_summary,
+                10,
+                auth,
+            )
+            .await
+        } else {
+            skipped_validation_summary()
+        };
+        let closeout_session_summary = self
+            .sessions
+            .summary(&session_id, Some(FINISH_SESSION_EVENT_LIMIT))
+            .unwrap_or(closeout_pre_validation_summary);
         let review_evidence = review_evidence_summary_for_session(&closeout_session_summary);
         let (work_performed, changed_paths) =
             closeout_work_projection(&closeout_session_summary.events);
@@ -1559,7 +1571,7 @@ impl ToolRuntime {
             "validation": validation,
             "continuation_feedback": continuation_feedback,
             "permissions": permissions,
-            "tool_failures": tool_failure_summary_from_events(&session_summary.events, 10),
+            "tool_failures": tool_failure_summary_from_events(&closeout_session_summary.events, 10),
             "review_evidence": review_evidence,
             "work_performed": work_performed,
             "changed_paths": changed_paths,
@@ -1575,11 +1587,13 @@ impl ToolRuntime {
             output["session_project"] = json!(mismatch.session_project);
             output["request_project"] = json!(mismatch.request_project);
         }
-        output["tool_failures"] = project_tool_failure_actionability(
+        let reconciliation = reconcile_closeout_evidence(
             output.get("tool_failures").unwrap_or(&Value::Null),
-            &session_summary.events,
+            &closeout_session_summary.events,
             output.get("validation").unwrap_or(&Value::Null),
         );
+        output["tool_failures"] = reconciliation.tool_failures;
+        output["validation"] = reconciliation.validation;
         output["suggested_next_actions"] = json!(finish_suggested_next_actions(&output));
         output["handoff_brief"] = build_handoff_brief(HandoffBriefInput {
             session_summary: &closeout_session_summary,
@@ -2617,38 +2631,14 @@ fn compact_finish_output(decision: &Value) -> Value {
 }
 
 fn compact_finish_validation(validation: &Value) -> Value {
-    let latest_status = validation
-        .get("latest_status")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    let successes = validation
-        .get("successes")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let unresolved_failure_count = validation
-        .pointer("/unresolved_failures/count")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    // Full validation history intentionally remains `mixed` after a failure is
-    // resolved. Summary-only closeout instead reports the current authoritative
-    // state so resolved history does not masquerade as an open validation
-    // problem while the dedicated resolved count still preserves that history.
-    let status = if latest_status == "passed" && successes > 0 && unresolved_failure_count == 0 {
-        "passed"
-    } else {
-        validation
-            .get("status")
-            .and_then(Value::as_str)
-            .unwrap_or("not_run")
-    };
     json!({
-        "status": status,
+        "status": validation.get("status").cloned().unwrap_or_else(|| json!("not_run")),
         "reason": validation.get("reason").cloned().unwrap_or(Value::Null),
-        "latest_status": latest_status,
-        "successes": successes,
+        "latest_status": validation.get("latest_status").cloned().unwrap_or_else(|| json!("unknown")),
+        "successes": validation.get("successes").and_then(Value::as_u64).unwrap_or(0),
         "failures": validation.get("failures").and_then(Value::as_u64).unwrap_or(0),
         "resolved_failure_count": validation.pointer("/resolved_failures/count").and_then(Value::as_u64).unwrap_or(0),
-        "unresolved_failure_count": unresolved_failure_count,
+        "unresolved_failure_count": validation.pointer("/unresolved_failures/count").and_then(Value::as_u64).unwrap_or(0),
         "cargo_test_zero_tests_run": validation_has_cargo_test_zero_tests(validation),
     })
 }

--- a/src/tool_runtime/handoff.rs
+++ b/src/tool_runtime/handoff.rs
@@ -318,11 +318,15 @@ impl ToolRuntime {
                 .unwrap_or(0)
                 > 0,
         });
-        output["tool_failures"] = project_tool_failure_actionability(
+        let reconciliation = reconcile_closeout_evidence(
             output.get("tool_failures").unwrap_or(&Value::Null),
             &summary.events,
             &feedback_validation,
         );
+        output["tool_failures"] = reconciliation.tool_failures;
+        if include_validation {
+            output["validation"] = reconciliation.validation;
+        }
 
         // --- bounded suggested next actions ---
         output["suggested_next_actions"] = json!(handoff_suggested_next_actions(&output));
@@ -958,12 +962,15 @@ fn compact_workflow_outcomes(
         .pointer("/unresolved_failures/count")
         .and_then(Value::as_u64)
         .unwrap_or(0);
-    let evidence_history_status = match validation_status {
-        Some("mixed") if validation_historical_failures_resolved(validation) => "mixed_resolved",
-        Some("mixed") => "mixed_unresolved",
-        Some("failed") => "failed",
-        _ if validation_historical_failures_unresolved(validation) => "mixed_unresolved",
-        _ => "clean",
+    let evidence_history_status = if validation_historical_failures_resolved(validation) {
+        "mixed_resolved"
+    } else {
+        match validation_status {
+            Some("mixed") => "mixed_unresolved",
+            Some("failed") => "failed",
+            _ if validation_historical_failures_unresolved(validation) => "mixed_unresolved",
+            _ => "clean",
+        }
     };
 
     match validation_status {
@@ -1017,6 +1024,12 @@ fn compact_workflow_outcomes(
         }
         Some("failed") => {}
         Some(_) => {}
+    }
+    if validation_historical_failures_resolved(validation) {
+        push_unique(
+            &mut informational_notes,
+            "historical validation failures were resolved by later successful validation",
+        );
     }
     if unresolved_failure_count > 0 && !matches!(validation_status, Some("failed" | "mixed")) {
         push_unique(
@@ -1136,18 +1149,28 @@ pub(crate) fn actionable_unexpected_failure_count(tool_failures: &Value) -> u64 
         .unwrap_or_else(|| count_field(tool_failures, "unexpected_count"))
 }
 
-pub(crate) fn project_tool_failure_actionability(
+#[derive(Debug, Clone)]
+pub(crate) struct CloseoutEvidenceReconciliation {
+    pub(crate) validation: Value,
+    pub(crate) tool_failures: Value,
+}
+
+/// Reconcile immutable ledger history into the single current closeout view used
+/// by both handoff and finish projections. Raw failure counts and validation
+/// events remain intact; only their current actionability/status is projected.
+pub(crate) fn reconcile_closeout_evidence(
     tool_failures: &Value,
     events: &[SessionEvent],
     validation: &Value,
-) -> Value {
+) -> CloseoutEvidenceReconciliation {
+    let validation = reconcile_closeout_validation(validation);
     let mut projected = tool_failures.clone();
     let raw_unexpected = count_field(tool_failures, "unexpected_count");
     let historical_non_actionable = events
         .iter()
         .filter(|event| unexpected_failure_event(event))
         .filter(|event| {
-            is_resolved_unexpected_validation_failure(event, validation)
+            is_resolved_unexpected_validation_failure(event, &validation)
                 || unexpected_failure_is_proven_non_actionable(event)
         })
         .count() as u64;
@@ -1155,6 +1178,28 @@ pub(crate) fn project_tool_failure_actionability(
     projected["historical_non_actionable_count"] = json!(historical_non_actionable);
     projected["actionable_unexpected_count"] =
         json!(raw_unexpected.saturating_sub(historical_non_actionable));
+    CloseoutEvidenceReconciliation {
+        validation,
+        tool_failures: projected,
+    }
+}
+
+fn reconcile_closeout_validation(validation: &Value) -> Value {
+    let mut projected = validation.clone();
+    let current_validation_passed = validation.get("latest_status").and_then(Value::as_str)
+        == Some("passed")
+        && validation
+            .get("successes")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            > 0
+        && validation
+            .pointer("/unresolved_failures/count")
+            .and_then(Value::as_u64)
+            == Some(0);
+    if projected.is_object() && current_validation_passed {
+        projected["status"] = json!("passed");
+    }
     projected
 }
 
@@ -1172,14 +1217,29 @@ fn is_resolved_unexpected_validation_failure(event: &SessionEvent, validation: &
     if !unexpected_failure_event(event) {
         return false;
     }
+    let event_project = event
+        .resolved_project
+        .as_deref()
+        .or(event.project.as_deref());
     validation
         .pointer("/resolved_failures/events")
         .and_then(Value::as_array)
         .is_some_and(|resolved| {
             resolved.iter().any(|resolved| {
-                resolved.get("tool_name").and_then(Value::as_str) == Some(event.tool_name.as_str())
+                // Membership in resolved_failures is decided upstream by the
+                // canonical validation identity. The remaining fields only
+                // correlate that already-resolved validation fact back to its
+                // immutable source Session event; they never infer resolution.
+                resolved
+                    .get("identity")
+                    .and_then(Value::as_str)
+                    .is_some_and(|identity| !identity.is_empty())
+                    && resolved.get("success").and_then(Value::as_bool) == Some(false)
+                    && resolved.get("tool_name").and_then(Value::as_str)
+                        == Some(event.tool_name.as_str())
                     && resolved.get("session_id").and_then(Value::as_str)
                         == Some(event.session_id.as_str())
+                    && resolved.get("project").and_then(Value::as_str) == event_project
                     && resolved.get("completed_at").and_then(Value::as_i64) == event.finished_at
             })
         })

--- a/src/tool_runtime/handoff.rs
+++ b/src/tool_runtime/handoff.rs
@@ -28,7 +28,7 @@ use crate::auth::AuthContext;
 
 const DEFAULT_HANDOFF_LIMIT: usize = 20;
 const MAX_HANDOFF_LIMIT: usize = 100;
-const HANDOFF_VALIDATION_SESSION_EVENT_LIMIT: usize = 200;
+const HANDOFF_CLOSEOUT_SESSION_EVENT_LIMIT: usize = 200;
 const MAX_RECENT_FAILED_TOOLS: usize = 10;
 const MAX_RECENT_PROGRESS: usize = 10;
 const MAX_RECENT_DECISIONS: usize = 10;
@@ -98,11 +98,18 @@ impl ToolRuntime {
             }
         }
 
-        // --- session basic info + events ---
+        // --- session basic info + display-bounded events ---
         let summary = match self.sessions.summary(&session_id, Some(limit)) {
             Some(summary) => summary,
             None => return super::unknown_session_result(&session_id),
         };
+        // Canonical closeout evidence must not depend on the caller's display
+        // limit. Reuse one fixed bounded Session snapshot for validation,
+        // tool-failure actionability, review evidence, and outcome projection.
+        let closeout_session = self
+            .sessions
+            .summary(&session_id, Some(HANDOFF_CLOSEOUT_SESSION_EVENT_LIMIT))
+            .unwrap_or_else(|| summary.clone());
 
         // --- message board state ---
         let (discussion, guidance_available) =
@@ -166,8 +173,7 @@ impl ToolRuntime {
             .collect();
 
         let failed_tool_calls = recent_failed_tools.len();
-        let tool_failures =
-            tool_failure_summary_from_events(&summary.events, MAX_RECENT_FAILED_TOOLS);
+        let tool_failures = handoff_tool_failure_summary(&summary.events, &closeout_session.events);
         let expected_failed_tool_calls = output_recent(&tool_failures, "recent_expected");
         let unexpected_failed_tool_calls = output_recent(&tool_failures, "recent_unexpected");
         let expectation_mismatches = output_recent(&tool_failures, "recent_mismatches");
@@ -248,7 +254,7 @@ impl ToolRuntime {
             "unexpected_failed_tool_calls": unexpected_failed_tool_calls,
             "expectation_mismatches": expectation_mismatches,
             "unexpected_success_tool_calls": unexpected_success_tool_calls,
-            "review_evidence": review_evidence_summary_for_session(&summary),
+            "review_evidence": review_evidence_summary_for_session(&closeout_session),
             "jobs": jobs,
             "warnings": warnings,
         });
@@ -272,20 +278,14 @@ impl ToolRuntime {
         }
 
         // --- optional ledger-derived validation summary ---
-        // The continuation feedback projection uses an *independent* bounded
-        // evidence snapshot capped at the full validation evidence limit, not the
-        // caller's display `limit`, so a small display limit cannot shrink the
-        // attempt boundary detection. The validation summary itself is only built
-        // when requested; when it is not, the feedback validation is reported as
-        // explicitly unavailable (`validation_not_requested`) rather than
+        // Validation shares the independent fixed closeout snapshot above, so
+        // caller display limits cannot shrink attempt-boundary detection or any
+        // canonical closeout classification. When validation is not requested,
+        // continuation feedback reports it as explicitly unavailable rather than
         // masquerading as `not_run`.
-        let feedback_session = self
-            .sessions
-            .summary(&session_id, Some(HANDOFF_VALIDATION_SESSION_EVENT_LIMIT))
-            .unwrap_or_else(|| summary.clone());
         let feedback_validation: Value = if include_validation {
             self.validation_summary_for_session_with_jobs(
-                &feedback_session,
+                &closeout_session,
                 DEFAULT_HANDOFF_LIMIT,
                 auth,
             )
@@ -306,7 +306,7 @@ impl ToolRuntime {
         // metadata already gathered here; never re-runs validation, mutates the
         // ledger, refreshes activity, or consumes guidance.
         output["continuation_feedback"] = continuation_feedback_value(ContinuationFeedbackInput {
-            session_summary: &feedback_session,
+            session_summary: &closeout_session,
             validation: &feedback_validation,
             jobs: output.get("jobs").unwrap_or(&Value::Null),
             discussion: &discussion,
@@ -320,7 +320,7 @@ impl ToolRuntime {
         });
         let reconciliation = reconcile_closeout_evidence(
             output.get("tool_failures").unwrap_or(&Value::Null),
-            &summary.events,
+            &closeout_session.events,
             &feedback_validation,
         );
         output["tool_failures"] = reconciliation.tool_failures;
@@ -331,7 +331,7 @@ impl ToolRuntime {
         // --- bounded suggested next actions ---
         output["suggested_next_actions"] = json!(handoff_suggested_next_actions(&output));
         output["handoff_brief"] = build_handoff_brief(HandoffBriefInput {
-            session_summary: &feedback_session,
+            session_summary: &closeout_session,
             continuation_feedback: output.get("continuation_feedback").unwrap_or(&Value::Null),
             workspace_requested: include_workspace,
             workspace: output.get("workspace"),
@@ -575,6 +575,26 @@ fn bound_chars(value: &str, max_chars: usize) -> String {
         out.push(ch);
     }
     out
+}
+
+fn handoff_tool_failure_summary(
+    display_events: &[SessionEvent],
+    closeout_events: &[SessionEvent],
+) -> Value {
+    let display = tool_failure_summary_from_events(display_events, MAX_RECENT_FAILED_TOOLS);
+    let mut canonical = tool_failure_summary_from_events(closeout_events, MAX_RECENT_FAILED_TOOLS);
+    // Counts and actionability are canonical closeout facts, while bounded
+    // recent lists remain presentation-only and respect the caller display
+    // window exactly as before.
+    for key in [
+        "recent_expected",
+        "recent_unexpected",
+        "recent_mismatches",
+        "recent_unexpected_successes",
+    ] {
+        canonical[key] = output_recent(&display, key);
+    }
+    canonical
 }
 
 fn output_recent(tool_failures: &Value, key: &str) -> Value {

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -2487,11 +2487,12 @@ fn failure_history_legacy_event_without_effect_evidence_restores_conservatively(
         .find(|event| event.kind == "tool_call_finished")
         .unwrap();
     assert!(finished.effect_evidence.is_none());
-    let projected = crate::tool_runtime::handoff::project_tool_failure_actionability(
+    let projected = crate::tool_runtime::handoff::reconcile_closeout_evidence(
         &json!({"unexpected_count": 1}),
         &summary.events,
         &json!({}),
-    );
+    )
+    .tool_failures;
     assert_eq!(projected["historical_non_actionable_count"], 0);
     assert_eq!(projected["actionable_unexpected_count"], 1);
 }

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -1892,10 +1892,18 @@ async fn finish_coding_task_summary_only_passes_with_resolved_unexpected_cargo_f
     let full = finish_coding_task_with_agent(
         &fixture.runtime,
         fixture.client_id,
-        fixture.project,
-        fixture.session_id,
-        fixture.auth,
+        fixture.project.clone(),
+        fixture.session_id.clone(),
+        fixture.auth.clone(),
         false,
+    )
+    .await;
+    let handoff = session_handoff_summary_only_with_agent(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project.clone(),
+        fixture.session_id.clone(),
+        fixture.auth.clone(),
     )
     .await;
 
@@ -1913,7 +1921,17 @@ async fn finish_coding_task_summary_only_passes_with_resolved_unexpected_cargo_f
     );
     assert_eq!(result.output["validation"]["status"], "passed");
     assert_eq!(result.output["validation"]["latest_status"], "passed");
-    assert_eq!(full.output["validation"]["status"], "mixed");
+    assert_eq!(full.output["validation"]["status"], "passed");
+    assert!(handoff.success, "{:?}", handoff.error);
+    assert_eq!(handoff.output["validation"]["status"], "passed");
+    assert_eq!(
+        handoff.output["validation"]["resolved_failures"]["count"],
+        result.output["validation"]["resolved_failure_count"]
+    );
+    assert_eq!(
+        handoff.output["validation"]["unresolved_failures"]["count"],
+        result.output["validation"]["unresolved_failure_count"]
+    );
     assert_eq!(result.output["validation"]["resolved_failure_count"], 1);
     assert_eq!(result.output["validation"]["unresolved_failure_count"], 0);
     assert_eq!(result.output["task_outcome"]["status"], "pass");
@@ -1932,6 +1950,27 @@ async fn finish_coding_task_summary_only_passes_with_resolved_unexpected_cargo_f
         "review unexpected failed tool calls before proceeding",
     );
     assert_eq!(full.output["task_outcome"], result.output["task_outcome"]);
+    for key in [
+        "expected_count",
+        "unexpected_count",
+        "historical_non_actionable_count",
+        "actionable_unexpected_count",
+        "expectation_mismatch_count",
+        "unexpected_success_count",
+    ] {
+        assert_eq!(
+            handoff.output["tool_failures"][key], result.output["tool_failures"][key],
+            "tool failure parity for {key}"
+        );
+    }
+    assert_eq!(
+        handoff.output["task_outcome"],
+        result.output["task_outcome"]
+    );
+    assert_eq!(
+        handoff.output["evidence_integrity"],
+        result.output["evidence_integrity"]
+    );
     assert!(full.output["advisories"].is_array());
     assert!(full.output["evidence_history"].is_object());
     assert!(full.output["informational_notes"].is_array());
@@ -3230,6 +3269,42 @@ async fn finish_coding_task_with_agent(
     });
     service_agent_task_until_finished(runtime, client_id, &task, "finish_coding_task summary_only")
         .await;
+    task.await.unwrap()
+}
+
+async fn session_handoff_summary_only_with_agent(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: String,
+    session_id: String,
+    auth: AuthContext,
+) -> ToolResult {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::SessionHandoffSummary {
+                        session_id,
+                        project: Some(project),
+                        include_workspace: Some(true),
+                        include_checkpoints: Some(false),
+                        include_validation: Some(true),
+                        summary_only: true,
+                        limit: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    service_agent_task_until_finished(
+        runtime,
+        client_id,
+        &task,
+        "session_handoff_summary summary_only",
+    )
+    .await;
     task.await.unwrap()
 }
 

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -1880,6 +1880,22 @@ async fn finish_coding_task_summary_only_passes_with_resolved_unexpected_cargo_f
         true,
         json!({"exit_code": 0}),
     );
+    // Push the resolved validation pair beyond the default 20-event handoff
+    // display window. Canonical closeout evidence must still retain the raw
+    // failure and its later same-identity resolution.
+    for index in 0..12 {
+        record_coding_task_tool_event(
+            &fixture.runtime,
+            &fixture.session_id,
+            "read_file",
+            json!({
+                "project": fixture.project.clone(),
+                "path": format!("src/display-padding-{index}.rs")
+            }),
+            true,
+            json!({}),
+        );
+    }
 
     let result = finish_coding_task_summary_only_with_agent(
         &fixture.runtime,
@@ -1986,6 +2002,146 @@ async fn finish_coding_task_summary_only_passes_with_resolved_unexpected_cargo_f
     );
     assert_finish_uses_canonical_outcomes(&result.output);
     assert_finish_uses_canonical_outcomes(&full.output);
+}
+
+#[tokio::test]
+async fn handoff_display_limit_does_not_change_canonical_started_shell_failure_closeout() {
+    let fixture = finish_summary_fixture("coding-handoff-display-limit-started-shell").await;
+
+    record_coding_task_tool_event(
+        &fixture.runtime,
+        &fixture.session_id,
+        "run_shell",
+        json!({
+            "project": fixture.project.clone(),
+            "command": "false",
+            "purpose": "operation"
+        }),
+        false,
+        json!({
+            "failure_kind": "process_exit",
+            "exit_code": 1,
+            "state_changed": false,
+            "command_started": true,
+            "command_completed": true,
+            "execution_state": "completed"
+        }),
+    );
+    for index in 0..12 {
+        record_coding_task_tool_event(
+            &fixture.runtime,
+            &fixture.session_id,
+            "read_file",
+            json!({
+                "project": fixture.project.clone(),
+                "path": format!("src/benign-padding-{index}.rs")
+            }),
+            true,
+            json!({}),
+        );
+    }
+    record_coding_task_tool_event(
+        &fixture.runtime,
+        &fixture.session_id,
+        "cargo_check",
+        json!({"project": fixture.project.clone()}),
+        true,
+        json!({"exit_code": 0}),
+    );
+
+    let handoff_default = session_handoff_summary_only_with_agent_limit(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project.clone(),
+        fixture.session_id.clone(),
+        fixture.auth.clone(),
+        None,
+    )
+    .await;
+    let handoff_narrow = session_handoff_summary_only_with_agent_limit(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project.clone(),
+        fixture.session_id.clone(),
+        fixture.auth.clone(),
+        Some(1),
+    )
+    .await;
+    let handoff_wide = session_handoff_summary_only_with_agent_limit(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project.clone(),
+        fixture.session_id.clone(),
+        fixture.auth.clone(),
+        Some(100),
+    )
+    .await;
+    let finish = finish_coding_task_summary_only_with_agent(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project,
+        fixture.session_id,
+        fixture.auth,
+    )
+    .await;
+
+    assert!(finish.success, "{:?}", finish.error);
+    for handoff in [&handoff_default, &handoff_narrow, &handoff_wide] {
+        assert!(handoff.success, "{:?}", handoff.error);
+        for key in [
+            "expected_count",
+            "unexpected_count",
+            "historical_non_actionable_count",
+            "actionable_unexpected_count",
+            "expectation_mismatch_count",
+            "unexpected_success_count",
+        ] {
+            assert_eq!(
+                handoff.output["tool_failures"][key], finish.output["tool_failures"][key],
+                "canonical tool-failure count changed for {key}: {}",
+                handoff.output
+            );
+        }
+        assert_eq!(
+            handoff.output["validation"]["status"], finish.output["validation"]["status"],
+            "canonical validation status changed with handoff display limit"
+        );
+        assert_eq!(
+            handoff.output["task_outcome"], finish.output["task_outcome"],
+            "canonical task_outcome changed with handoff display limit"
+        );
+        assert_eq!(
+            handoff.output["evidence_integrity"], finish.output["evidence_integrity"],
+            "canonical evidence_integrity changed with handoff display limit"
+        );
+    }
+
+    assert_eq!(finish.output["tool_failures"]["unexpected_count"], 1);
+    assert_eq!(
+        finish.output["tool_failures"]["historical_non_actionable_count"],
+        0
+    );
+    assert_eq!(
+        finish.output["tool_failures"]["actionable_unexpected_count"],
+        1
+    );
+    assert_eq!(finish.output["validation"]["status"], "passed");
+    assert_eq!(finish.output["task_outcome"]["status"], "fail");
+    assert_eq!(finish.output["task_outcome"]["blocking"], true);
+    assert_eq!(finish.output["evidence_integrity"]["status"], "clean");
+    assert_reason_list_contains(
+        &finish.output["task_outcome"],
+        "blocking_reasons",
+        "unexpected_tool_failures",
+    );
+    assert_eq!(
+        handoff_default.output["verdict"],
+        handoff_narrow.output["verdict"]
+    );
+    assert_eq!(
+        handoff_default.output["verdict"],
+        handoff_wide.output["verdict"]
+    );
 }
 
 #[tokio::test]
@@ -3279,6 +3435,20 @@ async fn session_handoff_summary_only_with_agent(
     session_id: String,
     auth: AuthContext,
 ) -> ToolResult {
+    session_handoff_summary_only_with_agent_limit(
+        runtime, client_id, project, session_id, auth, None,
+    )
+    .await
+}
+
+async fn session_handoff_summary_only_with_agent_limit(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: String,
+    session_id: String,
+    auth: AuthContext,
+    limit: Option<usize>,
+) -> ToolResult {
     let task = tokio::spawn({
         let runtime = runtime.clone();
         async move {
@@ -3291,7 +3461,7 @@ async fn session_handoff_summary_only_with_agent(
                         include_checkpoints: Some(false),
                         include_validation: Some(true),
                         summary_only: true,
-                        limit: None,
+                        limit,
                     },
                     Some(&auth),
                 )

--- a/src/tool_runtime/tests/handoff.rs
+++ b/src/tool_runtime/tests/handoff.rs
@@ -2284,6 +2284,7 @@ async fn session_handoff_summary_only_passes_with_resolved_unexpected_cargo_test
         result.output["tool_failures"]["actionable_unexpected_count"],
         0
     );
+    assert_eq!(result.output["validation"]["status"], "passed");
     assert_eq!(result.output["validation"]["latest_status"], "passed");
     assert_eq!(
         result.output["validation"]["historical_failures"]["resolved"],
@@ -2336,6 +2337,23 @@ async fn session_handoff_summary_only_passes_with_resolved_unexpected_cargo_test
         VALIDATION_IDENTITY_REUSE_ACTION,
     );
     assert_eq!(full.output["task_outcome"], result.output["task_outcome"]);
+    assert_eq!(
+        full.output["validation"]["status"],
+        result.output["validation"]["status"]
+    );
+    for key in [
+        "expected_count",
+        "unexpected_count",
+        "historical_non_actionable_count",
+        "actionable_unexpected_count",
+        "expectation_mismatch_count",
+        "unexpected_success_count",
+    ] {
+        assert_eq!(
+            full.output["tool_failures"][key], result.output["tool_failures"][key],
+            "full/summary tool failure projection must agree for {key}"
+        );
+    }
     assert_eq!(full.output["verdict"], result.output["verdict"]);
     assert_eq!(
         full.output["evidence_history"],


### PR DESCRIPTION
## Summary

Unify coding-task closeout truth across `finish_coding_task` and `session_handoff_summary` without deleting immutable failure history.

This PR:

- introduces one canonical closeout reconciliation path for tool failures + validation evidence
- treats later success on the same validation identity as resolved historical evidence instead of an active blocker
- keeps started process / `outcome_unknown` / missing effect proof fail-closed
- separates handoff display limits from canonical closeout evidence
- keeps recent/display lists bounded by the caller limit while canonical counts, actionability, validation, `task_outcome`, `evidence_integrity`, and verdict use the fixed 200-event closeout snapshot
- preserves finish/handoff parity for both actionable started failures and resolved same-identity validation

## Review history

Fresh independent review found one display-limit parity blocker in the initial E1 implementation. The follow-up commit fixes that boundary; the final reviewed state was accepted with no remaining correctness blocker.

After PR #192 merged, this branch was rebased onto `main@4bfde8ce`. `git range-diff` reports both E1 commits as patch-equivalent to the reviewed commits; no integration changes were introduced by the rebase.

## Validation

Post-rebase focused validation:

- `handoff_display_limit_does_not_change_canonical_started_shell_failure_closeout`: 1/1 pass
- `failure_history_`: 6/6 pass

The reviewed pre-rebase state also passed the focused finish/handoff suites, formatting, all-targets check, and diff hygiene. CI should provide the final merged-main gate.