### PR TITLE
Complete apply_text_edits conflict diagnostics

### DIFF
--- a/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
+++ b/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
@@ -110,6 +110,7 @@ fn file_apply_text_edits_hash_conflict_keeps_every_file_unchanged() {
     std::fs::write(tmp.path().join("a.txt"), "alpha\n").unwrap();
     std::fs::write(tmp.path().join("b.txt"), "beta\n").unwrap();
     let a_hash = sha256_hex_bytes(&std::fs::read(tmp.path().join("a.txt")).unwrap());
+    let b_hash = sha256_hex_bytes(&std::fs::read(tmp.path().join("b.txt")).unwrap());
 
     let out = line_edit_json(handle_file_request(
         &policy,
@@ -117,6 +118,7 @@ fn file_apply_text_edits_hash_conflict_keeps_every_file_unchanged() {
             tmp.path(),
             "a.txt",
             serde_json::json!({
+                "recovery_metadata_version": 1,
                 "changes": [
                     {
                         "kind": "edit",
@@ -137,6 +139,18 @@ fn file_apply_text_edits_hash_conflict_keeps_every_file_unchanged() {
     assert_eq!(out["error_kind"], "sha256_conflict");
     assert_eq!(out["change_index"], 1);
     assert_eq!(out["state_changed"], false);
+    assert_eq!(out["conflict_recovery"]["conflict_kind"], "sha256_mismatch");
+    assert_eq!(out["conflict_recovery"]["direct_retry_safe"], false);
+    assert_eq!(out["conflict_recovery"]["reread_required"], true);
+    assert_eq!(
+        out["conflict_recovery"]["occurrence_selector_supported"],
+        false
+    );
+    assert_eq!(
+        out["conflict_recovery"]["expected_sha256"],
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+    assert_eq!(out["conflict_recovery"]["current_sha256"], b_hash);
     assert_eq!(
         std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
         "alpha\n"
@@ -532,6 +546,8 @@ fn file_apply_text_edits_structured_multiple_match_recovery_is_bounded() {
     assert_eq!(recovery["conflict_kind"], "multiple_matches");
     assert_eq!(recovery["match_count"], 10);
     assert_eq!(recovery["occurrence_selector_supported"], true);
+    assert_eq!(recovery["direct_retry_safe"], true);
+    assert_eq!(recovery["reread_required"], false);
     assert_eq!(recovery["candidate_ranges"].as_array().unwrap().len(), 8);
     assert_eq!(recovery["candidate_ranges"][0]["occurrence"], 1);
     assert_eq!(recovery["candidate_ranges"][0]["start_line"], 2);
@@ -575,6 +591,8 @@ fn file_apply_text_edits_structured_not_found_disables_selector() {
     assert_eq!(recovery["conflict_kind"], "match_not_found");
     assert_eq!(recovery["match_count"], 0);
     assert_eq!(recovery["occurrence_selector_supported"], false);
+    assert_eq!(recovery["direct_retry_safe"], false);
+    assert_eq!(recovery["reread_required"], true);
     assert_eq!(recovery["recovery_action"], "reread_or_refine_match");
     assert_eq!(recovery["candidate_ranges"].as_array().unwrap().len(), 0);
     assert!(!serde_json::to_string(recovery)
@@ -611,6 +629,8 @@ fn file_apply_text_edits_structured_overlap_is_atomic_and_body_free() {
         serde_json::json!([0, 1])
     );
     assert_eq!(recovery["recovery_action"], "refine_edit_batch");
+    assert_eq!(recovery["direct_retry_safe"], true);
+    assert_eq!(recovery["reread_required"], false);
     let serialized = serde_json::to_string(recovery).unwrap();
     assert!(!serialized.contains("SECRET_A"));
     assert!(!serialized.contains("SECRET_B"));
@@ -669,6 +689,8 @@ fn file_apply_text_edits_occurrence_out_of_range_is_actionable_and_atomic() {
     );
     assert_eq!(out["conflict_recovery"]["match_count"], 2);
     assert_eq!(out["conflict_recovery"]["requested_occurrence"], 3);
+    assert_eq!(out["conflict_recovery"]["direct_retry_safe"], true);
+    assert_eq!(out["conflict_recovery"]["reread_required"], false);
     assert!(out["error"]
         .as_str()
         .unwrap()
@@ -682,6 +704,7 @@ fn file_apply_text_edits_sha_conflict_precedes_occurrence_selection() {
     let policy = project_policy(tmp.path());
     let file = tmp.path().join("target.txt");
     std::fs::write(&file, "dup\ndup\n").unwrap();
+    let current_sha256 = sha256_hex_bytes(&std::fs::read(&file).unwrap());
     let out = line_edit_json(handle_file_request(
         &policy,
         &apply_text_edits_request(
@@ -697,6 +720,17 @@ fn file_apply_text_edits_sha_conflict_precedes_occurrence_selection() {
     assert_eq!(out["error_kind"], "sha256_conflict");
     assert_eq!(out["conflict_recovery"]["conflict_kind"], "sha256_mismatch");
     assert_eq!(out["conflict_recovery"]["recovery_action"], "reread_file");
+    assert_eq!(out["conflict_recovery"]["direct_retry_safe"], false);
+    assert_eq!(out["conflict_recovery"]["reread_required"], true);
+    assert_eq!(
+        out["conflict_recovery"]["occurrence_selector_supported"],
+        false
+    );
+    assert_eq!(
+        out["conflict_recovery"]["expected_sha256"],
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+    assert_eq!(out["conflict_recovery"]["current_sha256"], current_sha256);
     assert_eq!(std::fs::read_to_string(&file).unwrap(), "dup\ndup\n");
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -517,20 +517,25 @@ fn edit_plan(
 fn edit_conflict_recovery(error: &EditPlanError) -> Option<serde_json::Value> {
     match error.conflict.as_ref()? {
         EditPlanConflict::Match(conflict) => {
-            let (selector_supported, recovery_action) = match conflict.kind {
-                ApplyTextMatchConflictKind::MultipleMatches => {
-                    (true, "select_occurrence_or_refine_match")
-                }
-                ApplyTextMatchConflictKind::OccurrenceOutOfRange => {
-                    (true, "choose_valid_occurrence_or_refine_match")
-                }
-                ApplyTextMatchConflictKind::MatchNotFound => (false, "reread_or_refine_match"),
-            };
+            let (selector_supported, recovery_action, direct_retry_safe, reread_required) =
+                match conflict.kind {
+                    ApplyTextMatchConflictKind::MultipleMatches => {
+                        (true, "select_occurrence_or_refine_match", true, false)
+                    }
+                    ApplyTextMatchConflictKind::OccurrenceOutOfRange => {
+                        (true, "choose_valid_occurrence_or_refine_match", true, false)
+                    }
+                    ApplyTextMatchConflictKind::MatchNotFound => {
+                        (false, "reread_or_refine_match", false, true)
+                    }
+                };
             let mut recovery = serde_json::json!({
                 "schema_version": 1,
                 "conflict_kind": conflict.kind.as_str(),
                 "match_count": conflict.match_count,
                 "occurrence_selector_supported": selector_supported,
+                "direct_retry_safe": direct_retry_safe,
+                "reread_required": reread_required,
                 "candidate_ranges": conflict.candidate_ranges,
                 "candidates_truncated": conflict.candidates_truncated,
                 "recovery_action": recovery_action,
@@ -547,6 +552,8 @@ fn edit_conflict_recovery(error: &EditPlanError) -> Option<serde_json::Value> {
             "schema_version": 1,
             "conflict_kind": "overlapping_edits",
             "occurrence_selector_supported": false,
+            "direct_retry_safe": true,
+            "reread_required": false,
             "conflicting_edit_indices": [first_edit_index, second_edit_index],
             "recovery_action": "refine_edit_batch",
         })),
@@ -574,13 +581,23 @@ fn edit_conflict_retry_guidance(recovery: Option<&serde_json::Value>) -> &'stati
     }
 }
 
-fn sha256_conflict_recovery() -> serde_json::Value {
-    serde_json::json!({
+fn sha256_conflict_recovery(
+    expected_sha256: Option<&str>,
+    current_sha256: &str,
+) -> serde_json::Value {
+    let mut recovery = serde_json::json!({
         "schema_version": 1,
         "conflict_kind": "sha256_mismatch",
         "occurrence_selector_supported": false,
+        "direct_retry_safe": false,
+        "reread_required": true,
+        "current_sha256": current_sha256,
         "recovery_action": "reread_file",
-    })
+    });
+    if let Some(expected_sha256) = expected_sha256 {
+        recovery["expected_sha256"] = serde_json::json!(expected_sha256);
+    }
+    recovery
 }
 
 fn batch_error(
@@ -1102,7 +1119,13 @@ pub(crate) fn handle_apply_text_edits_file_request(
                         ),
                     });
                     if payload.recovery_metadata_version == Some(1) {
-                        result["conflict_recovery"] = sha256_conflict_recovery();
+                        result["conflict_recovery"] = sha256_conflict_recovery(
+                            change.expected_sha256.as_deref(),
+                            &old_sha256,
+                        );
+                        result["retry_guidance"] = serde_json::json!(
+                            "reread the file to obtain current content and sha256, then retry the whole batch with refreshed guards"
+                        );
                     }
                     return line_edit_stdout(result, start);
                 }
@@ -1136,6 +1159,7 @@ pub(crate) fn handle_apply_text_edits_file_request(
                                     "edit_index": error.edit_index,
                                     "kind": error.edit_kind,
                                     "path": change.path,
+                                    "retry_guidance": retry_guidance,
                                     "error": format!(
                                         "Rejected transactional file batch: {}. No files were modified. Retry guidance: {retry_guidance}",
                                         error.message

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -164,31 +164,56 @@ fn validate_apply_text_edit(
     Ok(())
 }
 
-fn validate_apply_file_change(index: usize, change: &ApplyFileChangeInput) -> Result<(), String> {
-    let expected_hash = || -> Result<(), String> {
+#[derive(Debug)]
+struct ApplyTextEditsPreflightValidationError {
+    message: String,
+    edit_index: Option<usize>,
+}
+
+impl From<String> for ApplyTextEditsPreflightValidationError {
+    fn from(message: String) -> Self {
+        Self {
+            message,
+            edit_index: None,
+        }
+    }
+}
+
+fn validate_apply_file_change(
+    index: usize,
+    change: &ApplyFileChangeInput,
+) -> Result<(), ApplyTextEditsPreflightValidationError> {
+    let expected_hash = || -> Result<(), ApplyTextEditsPreflightValidationError> {
         match change.expected_sha256.as_deref() {
             Some(hash) if is_hex_sha256(hash) => Ok(()),
             _ => Err(format!(
                 "change {index} ({}): expected_sha256 is required and must be 64 lowercase hexadecimal characters",
                 change.kind.as_str()
-            )),
+            )
+            .into()),
         }
     };
     match change.kind {
         ApplyFileChangeKind::Edit => {
             expected_hash()?;
             if change.to_path.is_some() || change.content.is_some() {
-                return Err(format!(
-                    "change {index} (edit): to_path and content are not allowed"
-                ));
+                return Err(
+                    format!("change {index} (edit): to_path and content are not allowed").into(),
+                );
             }
             if change.edits.is_empty() || change.edits.len() > MAX_APPLY_TEXT_EDITS {
                 return Err(format!(
                     "change {index} (edit): edits must contain 1..={MAX_APPLY_TEXT_EDITS} entries"
-                ));
+                )
+                .into());
             }
             for (edit_index, edit) in change.edits.iter().enumerate() {
-                validate_apply_text_edit(index, edit_index, edit)?;
+                if let Err(message) = validate_apply_text_edit(index, edit_index, edit) {
+                    return Err(ApplyTextEditsPreflightValidationError {
+                        message,
+                        edit_index: Some(edit_index),
+                    });
+                }
             }
         }
         ApplyFileChangeKind::Create => {
@@ -198,16 +223,17 @@ fn validate_apply_file_change(index: usize, change: &ApplyFileChangeInput) -> Re
             {
                 return Err(format!(
                     "change {index} (create): to_path, expected_sha256, and edits are not allowed"
-                ));
+                )
+                .into());
             }
             let content = change
                 .content
                 .as_deref()
                 .ok_or_else(|| format!("change {index} (create): content is required"))?;
             if content.contains('\0') {
-                return Err(format!(
-                    "change {index} (create): content cannot contain NUL bytes"
-                ));
+                return Err(
+                    format!("change {index} (create): content cannot contain NUL bytes").into(),
+                );
             }
         }
         ApplyFileChangeKind::Delete => {
@@ -215,7 +241,8 @@ fn validate_apply_file_change(index: usize, change: &ApplyFileChangeInput) -> Re
             if change.to_path.is_some() || change.content.is_some() || !change.edits.is_empty() {
                 return Err(format!(
                     "change {index} (delete): to_path, content, and edits are not allowed"
-                ));
+                )
+                .into());
             }
         }
         ApplyFileChangeKind::Rename => {
@@ -225,14 +252,14 @@ fn validate_apply_file_change(index: usize, change: &ApplyFileChangeInput) -> Re
                 .as_deref()
                 .ok_or_else(|| format!("change {index} (rename): to_path is required"))?;
             if to_path == change.path {
-                return Err(format!(
-                    "change {index} (rename): path and to_path must differ"
-                ));
+                return Err(
+                    format!("change {index} (rename): path and to_path must differ").into(),
+                );
             }
             if change.content.is_some() || !change.edits.is_empty() {
-                return Err(format!(
-                    "change {index} (rename): content and edits are not allowed"
-                ));
+                return Err(
+                    format!("change {index} (rename): content and edits are not allowed").into(),
+                );
             }
         }
     }
@@ -241,7 +268,7 @@ fn validate_apply_file_change(index: usize, change: &ApplyFileChangeInput) -> Re
 
 fn apply_text_edits_agent_stdout_result(stdout: &str) -> ToolResult {
     let stdout = stdout.trim();
-    let obj: Value = match serde_json::from_str(stdout) {
+    let mut obj: Value = match serde_json::from_str(stdout) {
         Ok(value) => value,
         Err(error) => {
             return ToolResult::err(format!(
@@ -251,25 +278,85 @@ fn apply_text_edits_agent_stdout_result(stdout: &str) -> ToolResult {
             ))
         }
     };
-    if let Some(error) = obj.get("error").and_then(Value::as_str) {
+    if let Some(error) = obj.get("error").and_then(Value::as_str).map(str::to_string) {
         let uncertain = obj.get("rollback_complete").and_then(Value::as_bool) == Some(false)
             || obj.get("changed").and_then(Value::as_bool) == Some(true);
         let message = if uncertain {
+            if let Some(output) = obj.as_object_mut() {
+                // A Runner response that admits incomplete rollback or a
+                // changed worktree cannot retain deterministic no-mutation
+                // retry authority from an earlier planning conflict.
+                output.remove("conflict_recovery");
+                output.remove("retry_guidance");
+                output.remove("state_changed");
+            }
             format!(
                 "Edit outcome is uncertain: {error}. Inspect the affected files before issuing another write."
             )
         } else if obj.get("conflict_recovery").is_some_and(Value::is_object) {
-            error.to_string()
+            error.clone()
         } else {
-            recoverable_write_rejection(error)
+            recoverable_write_rejection(&error)
         };
         return ToolResult::err_with_output(message, obj);
     }
     ToolResult::ok(obj)
 }
 
-fn apply_text_edits_preflight_rejection(message: impl Into<String>) -> ToolResult {
-    ToolResult::err_with_output(message, json!({"state_changed": false}))
+fn apply_text_edits_preflight_rejection(
+    message: impl Into<String>,
+    error_kind: &'static str,
+    change_index: Option<usize>,
+    edit_index: Option<usize>,
+    kind: Option<&str>,
+    path: Option<&str>,
+    retry_guidance: &'static str,
+) -> ToolResult {
+    let detail = message.into();
+    let mut output = json!({
+        "state_changed": false,
+        "error_kind": error_kind,
+        "retry_guidance": retry_guidance,
+    });
+    if let Some(change_index) = change_index {
+        output["change_index"] = json!(change_index);
+    }
+    if let Some(edit_index) = edit_index {
+        output["edit_index"] = json!(edit_index);
+    }
+    if let Some(kind) = kind {
+        output["kind"] = json!(kind);
+    }
+    if let Some(path) = path {
+        output["path"] = json!(path);
+    }
+    ToolResult::err_with_output(
+        format!(
+            "Rejected before write: {detail}.\nNo files were modified.\nRetry guidance: {retry_guidance}."
+        ),
+        output,
+    )
+}
+
+fn apply_text_edits_path_policy_rejection(
+    change_index: usize,
+    kind: &str,
+    path: &str,
+    message: String,
+) -> ToolResult {
+    let mut result = super::permissions::edit_path_policy_rejected_result(path, message);
+    if let Some(output) = result.output.as_object_mut() {
+        // The rejected path may itself be absolute or sensitive. Keep exact
+        // change provenance without copying that untrusted path into recovery
+        // metadata.
+        output.remove("path");
+        output.remove("error");
+    }
+    result.output["change_index"] = json!(change_index);
+    result.output["kind"] = json!(kind);
+    result.output["retry_guidance"] =
+        json!("correct the rejected project-relative path and retry the whole batch");
+    result
 }
 
 /// Pure, allocation-only computation of an `apply_text_edits` plan against
@@ -934,37 +1021,94 @@ impl ToolRuntime {
         if changes.is_empty() {
             return apply_text_edits_preflight_rejection(
                 "changes must contain at least one file change",
+                "empty_batch",
+                None,
+                None,
+                None,
+                None,
+                "add at least one valid file change and retry",
             );
         }
         if changes.len() > MAX_APPLY_FILE_CHANGES {
-            return apply_text_edits_preflight_rejection(format!(
-                "too many file changes; maximum is {}",
-                MAX_APPLY_FILE_CHANGES
-            ));
+            return apply_text_edits_preflight_rejection(
+                format!(
+                    "too many file changes; maximum is {}",
+                    MAX_APPLY_FILE_CHANGES
+                ),
+                "batch_too_large",
+                None,
+                None,
+                None,
+                None,
+                "reduce the batch to the supported file-change limit and retry",
+            );
         }
         let mut touched_paths = HashSet::new();
         for (change_index, change) in changes.iter().enumerate() {
             if let Err(error) = validate_edit_file_path(&change.path) {
-                return super::permissions::edit_path_policy_rejected_result(&change.path, error);
+                return apply_text_edits_path_policy_rejection(
+                    change_index,
+                    change.kind.as_str(),
+                    &change.path,
+                    error,
+                );
             }
             if !touched_paths.insert(change.path.as_str()) {
-                return apply_text_edits_preflight_rejection(format!(
-                    "change {change_index} reuses path '{}'; each source/destination path may appear only once",
-                    change.path
-                ));
+                return apply_text_edits_preflight_rejection(
+                    format!(
+                        "change {change_index} reuses path '{}'; each source/destination path may appear only once",
+                        change.path
+                    ),
+                    "path_overlap",
+                    Some(change_index),
+                    None,
+                    Some(change.kind.as_str()),
+                    Some(&change.path),
+                    "correct the duplicate source/destination path and retry the whole batch",
+                );
             }
             if let Some(to_path) = change.to_path.as_deref() {
                 if let Err(error) = validate_edit_file_path(to_path) {
-                    return super::permissions::edit_path_policy_rejected_result(to_path, error);
+                    return apply_text_edits_path_policy_rejection(
+                        change_index,
+                        change.kind.as_str(),
+                        to_path,
+                        error,
+                    );
                 }
                 if !touched_paths.insert(to_path) {
-                    return apply_text_edits_preflight_rejection(format!(
-                        "change {change_index} reuses destination path '{to_path}'; each source/destination path may appear only once"
-                    ));
+                    return apply_text_edits_preflight_rejection(
+                        format!(
+                            "change {change_index} reuses destination path '{to_path}'; each source/destination path may appear only once"
+                        ),
+                        "path_overlap",
+                        Some(change_index),
+                        None,
+                        Some(change.kind.as_str()),
+                        Some(to_path),
+                        "correct the duplicate source/destination path and retry the whole batch",
+                    );
                 }
             }
-            if let Err(message) = validate_apply_file_change(change_index, change) {
-                return apply_text_edits_preflight_rejection(message);
+            if let Err(validation_error) = validate_apply_file_change(change_index, change) {
+                let failed_kind = validation_error
+                    .edit_index
+                    .and_then(|edit_index| change.edits.get(edit_index))
+                    .map(|edit| edit.kind.as_str())
+                    .unwrap_or_else(|| change.kind.as_str());
+                return apply_text_edits_preflight_rejection(
+                    validation_error.message,
+                    if validation_error.edit_index.is_some() {
+                        "invalid_edit"
+                    } else {
+                        "invalid_change"
+                    },
+                    Some(change_index),
+                    validation_error.edit_index,
+                    Some(failed_kind),
+                    Some(&change.path),
+                    "correct the rejected change or edit and retry the whole batch",
+                );
             }
         }
         let requires_occurrence_capability = changes
@@ -980,15 +1124,29 @@ impl ToolRuntime {
         let serialized = match serde_json::to_string(&payload) {
             Ok(serialized) if serialized.len() <= MAX_APPLY_FILE_CHANGES_BYTES => serialized,
             Ok(_) => {
-                return apply_text_edits_preflight_rejection(format!(
-                    "serialized file changes exceed {} bytes",
-                    MAX_APPLY_FILE_CHANGES_BYTES
-                ))
+                return apply_text_edits_preflight_rejection(
+                    format!(
+                        "serialized file changes exceed {} bytes",
+                        MAX_APPLY_FILE_CHANGES_BYTES
+                    ),
+                    "payload_too_large",
+                    None,
+                    None,
+                    None,
+                    None,
+                    "reduce the batch payload size and retry",
+                )
             }
             Err(error) => {
-                return apply_text_edits_preflight_rejection(format!(
-                    "failed to serialize file changes payload: {error}"
-                ))
+                return apply_text_edits_preflight_rejection(
+                    format!("failed to serialize file changes payload: {error}"),
+                    "serialization_failed",
+                    None,
+                    None,
+                    None,
+                    None,
+                    "correct the request payload and retry",
+                )
             }
         };
 
@@ -1080,13 +1238,37 @@ mod tests {
     use super::*;
 
     #[test]
+    fn apply_text_edits_path_policy_recovery_omits_untrusted_path_metadata() {
+        let result = apply_text_edits_path_policy_rejection(
+            2,
+            "edit",
+            "/private/secret.txt",
+            "path must be project-relative".to_string(),
+        );
+
+        assert!(!result.success);
+        assert_eq!(result.output["state_changed"], false);
+        assert_eq!(result.output["error_kind"], "policy_rejected");
+        assert_eq!(result.output["change_index"], 2);
+        assert_eq!(result.output["kind"], "edit");
+        assert!(result.output.get("path").is_none());
+        assert!(result.output.get("error").is_none());
+        assert!(!serde_json::to_string(&result.output)
+            .unwrap()
+            .contains("/private/secret.txt"));
+    }
+
+    #[test]
     fn incomplete_apply_text_edits_rollback_is_not_reported_as_no_write() {
         let result = apply_text_edits_agent_stdout_result(
-            r#"{"changed":true,"rollback_complete":false,"error":"rollback failed"}"#,
+            r#"{"changed":true,"state_changed":false,"rollback_complete":false,"retry_guidance":"retry directly","conflict_recovery":{"schema_version":1,"conflict_kind":"multiple_matches","occurrence_selector_supported":true,"direct_retry_safe":true,"reread_required":false,"recovery_action":"select_occurrence_or_refine_match"},"error":"rollback failed"}"#,
         );
 
         assert!(!result.success);
         assert_eq!(result.output["rollback_complete"], false);
+        assert!(result.output.get("conflict_recovery").is_none());
+        assert!(result.output.get("retry_guidance").is_none());
+        assert!(result.output.get("state_changed").is_none());
         let error = result.error.unwrap();
         assert!(error.contains("uncertain"));
         assert!(!error.contains("No files were modified"));

--- a/src/tool_runtime/registry/output_schemas/edits.rs
+++ b/src/tool_runtime/registry/output_schemas/edits.rs
@@ -20,6 +20,24 @@ fn edit_conflict_recovery_schema() -> Value {
                 "choose_valid_occurrence_or_refine_match", "refine_edit_batch", "reread_file"
             ]},
             "occurrence_selector_supported": {"type": "boolean"},
+            "direct_retry_safe": {
+                "type": "boolean",
+                "description": "True only when a corrected request may be retried against the same observed expected_sha256 without rereading. It never authorizes automatic replay of the rejected payload."
+            },
+            "reread_required": {
+                "type": "boolean",
+                "description": "True when the caller must reread the affected file before another write attempt."
+            },
+            "expected_sha256": {
+                "type": "string",
+                "pattern": "^[a-f0-9]{64}$",
+                "description": "Caller-provided expected sha256 on a sha256 mismatch; hash only, never file content."
+            },
+            "current_sha256": {
+                "type": "string",
+                "pattern": "^[a-f0-9]{64}$",
+                "description": "Current observed file sha256 on a sha256 mismatch; hash only, never file content."
+            },
             "match_count": {"type": "integer", "minimum": 0},
             "requested_occurrence": {"type": "integer", "minimum": 1},
             "candidate_ranges": {
@@ -146,6 +164,34 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             (
                 "changed_paths",
                 schema_type("array", "Paths touched by the edit batch."),
+            ),
+            (
+                "state_changed",
+                schema_type("boolean", "Authoritative no-effect fact for deterministic rejected batches when false."),
+            ),
+            (
+                "error_kind",
+                schema_type("string", "Stable structured rejection/failure kind when unsuccessful."),
+            ),
+            (
+                "change_index",
+                nullable_schema("integer", "Zero-based failed file-change index when known; null or absent for batch-global failures."),
+            ),
+            (
+                "edit_index",
+                nullable_schema("integer", "Zero-based failed text-edit index when known; null or absent when not edit-specific."),
+            ),
+            (
+                "kind",
+                nullable_schema("string", "Failed change or text-edit kind when known."),
+            ),
+            (
+                "path",
+                nullable_schema("string", "Project-relative failed path when known."),
+            ),
+            (
+                "retry_guidance",
+                schema_type("string", "Bounded recovery guidance for a deterministic no-mutation rejection."),
             ),
             (
                 "conflict_recovery",

--- a/src/tool_runtime/tests/apply_text_edits.rs
+++ b/src/tool_runtime/tests/apply_text_edits.rs
@@ -27,10 +27,53 @@ fn apply_text_edits_occurrence_and_recovery_schemas_are_model_visible() {
     let output = &spec.output_schema["properties"]["output"]["properties"]["conflict_recovery"];
     assert_eq!(output["properties"]["schema_version"]["const"], 1);
     assert_eq!(output["properties"]["candidate_ranges"]["maxItems"], 8);
+    assert_eq!(output["properties"]["direct_retry_safe"]["type"], "boolean");
+    assert_eq!(output["properties"]["reread_required"]["type"], "boolean");
+    assert_eq!(
+        output["properties"]["expected_sha256"]["pattern"],
+        "^[a-f0-9]{64}$"
+    );
+    assert_eq!(
+        output["properties"]["current_sha256"]["pattern"],
+        "^[a-f0-9]{64}$"
+    );
+    let output_properties = &spec.output_schema["properties"]["output"]["properties"];
+    assert!(output_properties["change_index"]["anyOf"].is_array());
+    assert!(output_properties["edit_index"]["anyOf"].is_array());
+    assert_eq!(output_properties["state_changed"]["type"], "boolean");
+    assert_eq!(output_properties["retry_guidance"]["type"], "string");
     assert!(output["properties"]["conflict_kind"]["enum"]
         .as_array()
         .unwrap()
         .contains(&serde_json::json!("multiple_matches")));
+
+    let sha_conflict = serde_json::json!({
+        "success": false,
+        "output": {
+            "state_changed": false,
+            "error_kind": "sha256_conflict",
+            "change_index": 0,
+            "kind": "edit",
+            "path": "src/lib.rs",
+            "retry_guidance": "reread the file",
+            "conflict_recovery": {
+                "schema_version": 1,
+                "conflict_kind": "sha256_mismatch",
+                "occurrence_selector_supported": false,
+                "direct_retry_safe": false,
+                "reread_required": true,
+                "expected_sha256": "a".repeat(64),
+                "current_sha256": "b".repeat(64),
+                "recovery_action": "reread_file"
+            }
+        },
+        "error": "sha256 mismatch"
+    });
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+        &sha_conflict,
+        &spec.output_schema,
+    )
+    .unwrap_or_else(|error| panic!("sha conflict recovery must match output schema: {error}"));
 
     let openapi = crate::openapi::build_openapi_spec();
     let occurrence = &openapi["components"]["schemas"]["ToolCallRequest"]["properties"]["changes"]
@@ -449,6 +492,8 @@ async fn apply_text_edits_conflict_then_same_sha_occurrence_retry_needs_no_hidde
                 "conflict_kind": "multiple_matches",
                 "match_count": 2,
                 "occurrence_selector_supported": true,
+                "direct_retry_safe": true,
+                "reread_required": false,
                 "candidate_ranges": [
                     {"occurrence":1,"start_line":1,"end_line":1},
                     {"occurrence":2,"start_line":3,"end_line":3}
@@ -465,6 +510,14 @@ async fn apply_text_edits_conflict_then_same_sha_occurrence_retry_needs_no_hidde
     let conflict = first.await.unwrap();
     assert!(!conflict.success);
     assert_eq!(conflict.output["conflict_recovery"]["match_count"], 2);
+    assert_eq!(
+        conflict.output["conflict_recovery"]["direct_retry_safe"],
+        true
+    );
+    assert_eq!(
+        conflict.output["conflict_recovery"]["reread_required"],
+        false
+    );
     let conflict_error = conflict
         .error
         .as_deref()
@@ -701,13 +754,79 @@ async fn apply_text_edits_legacy_runner_ambiguous_no_occurrence_keeps_legacy_fai
 }
 
 #[tokio::test]
-async fn apply_text_edits_empty_batch_proves_preflight_no_effect() {
+async fn apply_text_edits_server_preflight_reports_exact_failed_edit() {
+    let runtime = test_runtime();
+    let result = runtime
+        .apply_text_edits(
+            "agent:unused:unused".to_string(),
+            vec![
+                edit_change(
+                    "src/first.rs",
+                    &"a".repeat(64),
+                    vec![text_edit(
+                        ApplyTextEditKind::ReplaceExact,
+                        Some("first"),
+                        Some("FIRST"),
+                        None,
+                    )],
+                ),
+                edit_change(
+                    "src/second.rs",
+                    &"b".repeat(64),
+                    vec![text_edit(
+                        ApplyTextEditKind::ReplaceExact,
+                        None,
+                        Some("SECOND"),
+                        None,
+                    )],
+                ),
+            ],
+            None,
+        )
+        .await;
+
+    assert!(!result.success);
+    assert_eq!(result.output["state_changed"], false);
+    assert_eq!(result.output["error_kind"], "invalid_edit");
+    assert_eq!(result.output["change_index"], 1);
+    assert_eq!(result.output["edit_index"], 0);
+    assert_eq!(result.output["kind"], "replace_exact");
+    assert_eq!(result.output["path"], "src/second.rs");
+    assert!(result.output["retry_guidance"]
+        .as_str()
+        .unwrap()
+        .contains("retry the whole batch"));
+    let output_schema = crate::tool_runtime::registry::output_schema_for_tool("apply_text_edits");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+        &serialized,
+        &output_schema,
+    )
+    .unwrap_or_else(|error| panic!("structured preflight must match output schema: {error}"));
+    assert!(result.output.get("conflict_recovery").is_none());
+    assert!(result
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("No files were modified"));
+}
+
+#[tokio::test]
+async fn apply_text_edits_empty_batch_proves_preflight_no_effect_without_fake_indices() {
     let runtime = test_runtime();
     let result = runtime
         .apply_text_edits("agent:unused:unused".to_string(), Vec::new(), None)
         .await;
     assert!(!result.success);
     assert_eq!(result.output["state_changed"], false);
+    assert_eq!(result.output["error_kind"], "empty_batch");
+    for field in ["change_index", "edit_index", "kind", "path"] {
+        assert!(
+            result.output.get(field).is_none(),
+            "{field} must remain absent"
+        );
+    }
+    assert!(result.output["retry_guidance"].is_string());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Complete and normalize `apply_text_edits` recovery v1 so deterministic no-mutation conflicts are explicitly actionable without weakening transactional write safety.

This PR:

- adds optional `direct_retry_safe` / `reread_required` recovery facts while keeping `conflict_recovery.schema_version = 1`
- makes multiple-match / occurrence-out-of-range / corrected-overlap retries explicit under the same authoritative SHA
- makes match-not-found conservative and requires reread
- reports SHA mismatch with hash-only `expected_sha256` + `current_sha256`, `direct_retry_safe=false`, `reread_required=true`, and no occurrence shortcut
- adds structured Server preflight provenance (`error_kind`, exact `change_index` / `edit_index` / kind / validated relative path when known) without fabricating indices for batch-global failures
- strips deterministic retry authority from uncertain post-dispatch / incomplete-rollback outcomes
- preserves whole-batch atomicity: later-change conflicts leave earlier changes unapplied
- keeps occurrence capability fencing and old Runner behavior fail-closed
- keeps recovery metadata bounded and body-free; rejected absolute/sensitive paths are not copied into structured recovery JSON

## Review history

The implementation was independently reviewed at `3c3b529d395d623e2d92688ca35e2505c0975a65` and accepted with no correctness blocker or reviewer-fix commit required.

After PR #193 merged, this branch was rebased onto `main@654f627f042f330f5c60ca7d251aa12a7a4ca15e`. PR #193 changes only closeout/session-test files and does not overlap the five E2 files. `git range-diff` reports the reviewed E2 commit and the rebased commit as patch-equivalent:

`3c3b529d = 797a66b6 Complete apply_text_edits conflict diagnostics`

Current PR head: `797a66b65a4022f4d93fa79b09bea8aa65eac39e`.

## Validation

Post-rebase validation:

- `cargo test 'apply_text_edits_'` — 33/33 pass
- `cargo test 'file_apply_text_edits_' -p webcodex-runner` — 24/24 pass
- `cargo check --all-targets` — pass, 0 warnings / 0 errors
- `cargo fmt -- --check` — pass
- `git diff --check origin/main...HEAD` — pass

The Runner-focused test lane still reports the same three pre-existing warnings in untouched `remote_shell.rs` / `ssh.rs`; E2 introduces no new diagnostics.