### PR TITLE
Decompose MCP into focused domains

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,3 +1,5 @@
+mod tasks;
+
 use crate::action_audit::{ActionAudit, ActionAuditRecord};
 use crate::auth::AuthContext;
 use crate::connector_runtime::{ConnectorRuntime, ConnectorRuntimeSlot, ConnectorTransport};
@@ -33,6 +35,12 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
 
+#[cfg(test)]
+use tasks::{
+    mcp_create_task_result, request_supports_tasks, MCP_MISSING_REQUIRED_CLIENT_CAPABILITY,
+    MCP_TASKS_EXTENSION,
+};
+
 const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 const MCP_CHATGPT_PROTOCOL_VERSION: &str = "2025-11-25";
 const MCP_STATELESS_PROTOCOL_VERSION: &str = "2026-07-28";
@@ -56,7 +64,6 @@ const MAX_MCP_ARTIFACT_EXPORTS: usize = 128;
 const MAX_MCP_ARTIFACT_EXPORTS_PER_CALLER: usize = 16;
 const MCP_ARTIFACT_EXPORT_BUSY_CODE: i64 = -32029;
 const MCP_HEADER_MISMATCH: i64 = -32020;
-const MCP_MISSING_REQUIRED_CLIENT_CAPABILITY: i64 = -32021;
 const MCP_UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
 const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
     MCP_STATELESS_PROTOCOL_VERSION,
@@ -64,8 +71,6 @@ const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
     MCP_PROTOCOL_VERSION,
 ];
 const MCP_UI_EXTENSION: &str = "io.modelcontextprotocol/ui";
-const MCP_TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
-const MCP_TASK_POLL_INTERVAL_MS: u64 = 2_000;
 const MCP_COMPUTER_UI_RESOURCE_URI: &str = "ui://webcodex/computer/v11";
 const MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS: &[&str] = &[
     "ui://webcodex/computer/v1",
@@ -126,19 +131,6 @@ struct McpToolCallParams {
     pub name: String,
     #[serde(default)]
     pub arguments: Value,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct McpTaskParams {
-    pub task_id: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct McpTaskUpdateParams {
-    pub task_id: String,
-    pub input_responses: Value,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -214,17 +206,6 @@ fn request_supports_mcp_apps(params: &Value) -> bool {
             .any(|mime| mime.as_str() == Some(MCP_UI_RESOURCE_MIME_TYPE)),
         None => false,
     }
-}
-
-fn request_supports_tasks(params: &Value) -> bool {
-    request_client_capabilities(params)
-        .and_then(|capabilities| capabilities.get("extensions"))
-        .and_then(|extensions| extensions.get(MCP_TASKS_EXTENSION))
-        .is_some_and(Value::is_object)
-}
-
-fn model_surface_supports_tasks(model_surface: ModelSurface) -> bool {
-    model_surface == ModelSurface::CanonicalConnector
 }
 
 fn model_surface_supports_computer_app(model_surface: ModelSurface) -> bool {
@@ -454,123 +435,6 @@ fn connector_call_tool_result(outcome: crate::connector_runtime::ConnectorCallOu
         "structuredContent": outcome.body,
         "isError": !outcome.ok
     })
-}
-
-fn mcp_task_timestamp(timestamp: i64) -> String {
-    chrono::DateTime::<chrono::Utc>::from_timestamp(timestamp, 0)
-        .map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
-        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string())
-}
-
-fn mcp_task_id_is_valid(task_id: &str) -> bool {
-    task_id.strip_prefix("wc_exec_").is_some_and(|suffix| {
-        suffix.len() == 32 && suffix.bytes().all(|byte| byte.is_ascii_hexdigit())
-    })
-}
-
-fn mcp_task_status(execution: &crate::db::ConnectorExecution) -> &'static str {
-    if execution.state == "cancelled" {
-        "cancelled"
-    } else if execution.is_terminal() {
-        "completed"
-    } else {
-        "working"
-    }
-}
-
-fn mcp_task_base(
-    execution: &crate::db::ConnectorExecution,
-    result_type: &str,
-    status: &str,
-) -> Value {
-    let created_at = execution
-        .mcp_task_materialized_at
-        .unwrap_or(execution.submitted_at);
-    let last_updated_at = execution
-        .mcp_task_result_finalized_at
-        .or(execution.finished_at)
-        .or(execution.last_output_at)
-        .or(execution.started_at)
-        .or(execution.queued_at)
-        .unwrap_or(created_at)
-        .max(created_at);
-    json!({
-        "resultType": result_type,
-        "taskId": execution.execution_id,
-        "status": status,
-        "createdAt": mcp_task_timestamp(created_at),
-        "lastUpdatedAt": mcp_task_timestamp(last_updated_at),
-        "ttlMs": null,
-        "pollIntervalMs": MCP_TASK_POLL_INTERVAL_MS
-    })
-}
-
-fn mcp_create_task_result(execution: &crate::db::ConnectorExecution) -> Value {
-    mcp_task_base(execution, "task", mcp_task_status(execution))
-}
-
-fn mcp_detailed_task_result(
-    execution: &crate::db::ConnectorExecution,
-    call_tool_result: Option<Value>,
-) -> Value {
-    let status = mcp_task_status(execution);
-    let mut result = mcp_task_base(execution, "complete", status);
-    if status == "completed" {
-        if let (Some(object), Some(call_tool_result)) = (result.as_object_mut(), call_tool_result) {
-            object.insert("result".to_string(), call_tool_result);
-        }
-    }
-    result
-}
-
-fn missing_tasks_capability(id: Option<Value>) -> McpOutcome {
-    McpOutcome::BadRequest(rpc_error_with_data(
-        id,
-        MCP_MISSING_REQUIRED_CLIENT_CAPABILITY,
-        "Missing required client capability",
-        json!({
-            "requiredCapabilities": {
-                "extensions": {
-                    MCP_TASKS_EXTENSION: {}
-                }
-            }
-        }),
-    ))
-}
-
-fn mcp_task_connector_error(
-    id: Option<Value>,
-    auth: Option<&AuthContext>,
-    outcome: crate::connector_runtime::ConnectorCallOutcome,
-) -> McpOutcome {
-    if let Some(required_scope) = outcome.required_scope {
-        let description = outcome
-            .body
-            .pointer("/error/message")
-            .and_then(Value::as_str)
-            .unwrap_or("connector credential lacks the required scope")
-            .to_string();
-        return scope_forbidden(auth, Some(required_scope), description);
-    }
-    if outcome.http_status == 404
-        || outcome.body.pointer("/error/code").and_then(Value::as_str) == Some("task_not_found")
-    {
-        return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params: task not found"));
-    }
-    if outcome.protocol_error {
-        let message = outcome
-            .body
-            .pointer("/error/message")
-            .and_then(Value::as_str)
-            .unwrap_or("Invalid task params")
-            .to_string();
-        return McpOutcome::BadRequest(rpc_error(id, -32602, message));
-    }
-    McpOutcome::BadRequest(rpc_error(
-        id,
-        -32603,
-        "Internal error while resolving durable Connector task",
-    ))
 }
 
 /// MCP tools/list payload for the immutable startup-selected model surface.
@@ -2900,13 +2764,8 @@ async fn handle_mcp_request_with_lifecycle(
                             }
                         }
                     })
-                } else if model_surface_supports_tasks(runtime.model_surface()) {
-                    json!({
-                        "tools": { "listChanged": false },
-                        "extensions": {
-                            MCP_TASKS_EXTENSION: {}
-                        }
-                    })
+                } else if tasks::model_surface_supports_tasks(runtime.model_surface()) {
+                    tasks::server_capabilities()
                 } else {
                     json!({ "tools": { "listChanged": false } })
                 },
@@ -3083,137 +2942,21 @@ async fn handle_mcp_request_with_lifecycle(
             }
             rpc_result(id, result)
         }
-        "tasks/get" if stateless_2026 && model_surface_supports_tasks(runtime.model_surface()) => {
-            if !request_supports_tasks(&request.params) {
-                return missing_tasks_capability(id);
-            }
-            let params: McpTaskParams = match serde_json::from_value(request.params) {
-                Ok(params) => params,
-                Err(error) => {
-                    return McpOutcome::BadRequest(rpc_error(
-                        id,
-                        -32602,
-                        format!("Invalid params: {error}"),
-                    ));
-                }
-            };
-            if !mcp_task_id_is_valid(&params.task_id) {
-                return McpOutcome::BadRequest(rpc_error(
-                    id,
-                    -32602,
-                    "Invalid params: task not found",
-                ));
-            }
-            let Some(auth) = auth else {
-                return scope_forbidden(
-                    None,
-                    Some(crate::auth::SCOPE_JOB_RUN),
-                    "connector credential is required for MCP task access",
-                );
-            };
-            if let Some(outcome) = require_mcp_scope(Some(auth), crate::auth::SCOPE_JOB_RUN) {
-                return outcome;
-            }
-            let connector = connector.expect("validated canonical Connector state");
-            match connector
-                .execution_task_result_for_auth(&params.task_id, auth)
-                .await
-            {
-                Ok((_task, execution, outcome)) => {
-                    let call_tool_result = execution
-                        .is_terminal()
-                        .then(|| connector_call_tool_result(outcome));
-                    let result = mcp_detailed_task_result(&execution, call_tool_result);
-                    return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(result, false)));
-                }
-                Err(outcome) => return mcp_task_connector_error(id, Some(auth), outcome),
-            }
-        }
-        "tasks/update"
-            if stateless_2026 && model_surface_supports_tasks(runtime.model_surface()) =>
+        method @ ("tasks/get" | "tasks/update" | "tasks/cancel")
+            if stateless_2026 && tasks::model_surface_supports_tasks(runtime.model_surface()) =>
         {
-            if !request_supports_tasks(&request.params) {
-                return missing_tasks_capability(id);
-            }
-            let params: McpTaskUpdateParams = match serde_json::from_value(request.params) {
-                Ok(params) => params,
-                Err(error) => {
-                    return McpOutcome::BadRequest(rpc_error(
-                        id,
-                        -32602,
-                        format!("Invalid params: {error}"),
-                    ));
-                }
-            };
-            if !mcp_task_id_is_valid(&params.task_id) || !params.input_responses.is_object() {
-                return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params"));
-            }
-            let Some(auth) = auth else {
-                return scope_forbidden(
-                    None,
-                    Some(crate::auth::SCOPE_JOB_RUN),
-                    "connector credential is required for MCP task access",
-                );
-            };
-            if let Some(outcome) = require_mcp_scope(Some(auth), crate::auth::SCOPE_JOB_RUN) {
-                return outcome;
-            }
-            let connector = connector.expect("validated canonical Connector state");
-            if let Err(outcome) = connector
-                .execution_task_result_for_auth(&params.task_id, auth)
-                .await
-            {
-                return mcp_task_connector_error(id, Some(auth), outcome);
-            }
-            // A3 never creates input_required Tasks. Per the Tasks extension,
-            // responses for unknown/already-satisfied input requests are ignored.
-            return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(json!({}), false)));
-        }
-        "tasks/cancel"
-            if stateless_2026 && model_surface_supports_tasks(runtime.model_surface()) =>
-        {
-            if !request_supports_tasks(&request.params) {
-                return missing_tasks_capability(id);
-            }
-            let params: McpTaskParams = match serde_json::from_value(request.params) {
-                Ok(params) => params,
-                Err(error) => {
-                    return McpOutcome::BadRequest(rpc_error(
-                        id,
-                        -32602,
-                        format!("Invalid params: {error}"),
-                    ));
-                }
-            };
-            if !mcp_task_id_is_valid(&params.task_id) {
-                return McpOutcome::BadRequest(rpc_error(
-                    id,
-                    -32602,
-                    "Invalid params: task not found",
-                ));
-            }
-            let Some(auth) = auth else {
-                return scope_forbidden(
-                    None,
-                    Some(crate::auth::SCOPE_JOB_RUN),
-                    "connector credential is required for MCP task access",
-                );
-            };
-            if let Some(outcome) = require_mcp_scope(Some(auth), crate::auth::SCOPE_JOB_RUN) {
-                return outcome;
-            }
-            let connector = connector.expect("validated canonical Connector state");
-            if let Err(outcome) = connector
-                .cancel_execution_task_for_auth(&params.task_id, auth)
-                .await
-            {
-                return mcp_task_connector_error(id, Some(auth), outcome);
-            }
-            return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(json!({}), false)));
+            return tasks::handle_request(
+                method,
+                request.params,
+                id,
+                auth,
+                connector.expect("validated canonical Connector state"),
+            )
+            .await;
         }
         "tools/call" => {
             let tasks_extension_declared =
-                stateless_2026 && request_supports_tasks(&request.params);
+                stateless_2026 && tasks::request_supports_tasks(&request.params);
             let mut params: McpToolCallParams = match serde_json::from_value(request.params) {
                 Ok(params) => params,
                 Err(e) => {
@@ -3394,80 +3137,10 @@ async fn handle_mcp_request_with_lifecycle(
                     lc.dispatch_finished(true, Some(outcome.ok), category);
                 }
                 if task_polling && outcome.ok {
-                    if let Some(execution_id) = outcome
-                        .body
-                        .pointer("/data/execution/execution_id")
-                        .and_then(Value::as_str)
+                    if let Some(task_outcome) =
+                        tasks::promote_connector_tool_call(&id, &outcome, auth, connector).await
                     {
-                        let Some(auth) = auth else {
-                            return scope_forbidden(
-                                None,
-                                Some(crate::auth::SCOPE_JOB_RUN),
-                                "connector credential is required for MCP task access",
-                            );
-                        };
-                        match connector.materialize_execution_task_for_auth(execution_id, auth) {
-                            Ok(execution) if execution.mcp_task_is_materialized() => {
-                                if execution.is_active()
-                                    && !execution.terminal_continuation_is_armed()
-                                {
-                                    return McpOutcome::BadRequest(rpc_error(
-                                        id,
-                                        -32603,
-                                        "active Connector execution is not durably armed for terminal polling",
-                                    ));
-                                }
-                                if execution.is_terminal()
-                                    && !execution.mcp_task_result_is_finalized()
-                                {
-                                    return McpOutcome::BadRequest(rpc_error(
-                                        id,
-                                        -32603,
-                                        "materialized MCP task became terminal before its durable result was finalized",
-                                    ));
-                                }
-                                return McpOutcome::Ok(rpc_result(
-                                    id,
-                                    mcp_stateless_result(mcp_create_task_result(&execution), false),
-                                ));
-                            }
-                            Ok(execution) if execution.is_terminal() => {
-                                let ordinary = match connector
-                                    .ordinary_execution_result_for_auth(execution_id, auth)
-                                    .await
-                                {
-                                    Ok(ordinary) => ordinary,
-                                    Err(task_outcome) => {
-                                        return mcp_task_connector_error(
-                                            id,
-                                            Some(auth),
-                                            task_outcome,
-                                        );
-                                    }
-                                };
-                                let result = connector_call_tool_result(ordinary);
-                                return McpOutcome::Ok(rpc_result(
-                                    id,
-                                    mcp_stateless_result(result, false),
-                                ));
-                            }
-                            Ok(_) => {
-                                return McpOutcome::BadRequest(rpc_error(
-                                    id,
-                                    -32603,
-                                    "active Connector execution was not durably materialized for MCP task polling",
-                                ));
-                            }
-                            Err(task_outcome) => {
-                                return mcp_task_connector_error(id, Some(auth), task_outcome);
-                            }
-                        }
-                    } else if outcome.body["blocking"].as_bool() == Some(true) {
-                        return McpOutcome::BadRequest(rpc_error(
-                            id,
-                            -32603,
-                            "active Connector execution did not expose durable execution identity",
-                        ));
+                        return task_outcome;
                     }
                 }
                 let result = connector_call_tool_result(outcome);

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,3 +1,4 @@
+mod resources;
 mod tasks;
 
 use crate::action_audit::{ActionAudit, ActionAuditRecord};
@@ -18,23 +19,27 @@ use crate::tool_runtime::model_ergonomics_telemetry::{
 use crate::tool_runtime::tool_definition::LOCAL_CODING_TOOL_NAMES;
 #[cfg(test)]
 use crate::tool_runtime::MAX_PROJECT_ARTIFACT_BYTES;
+use crate::tool_runtime::{registered_tool_specs, ToolResult, ToolRuntime, ToolSpec};
+#[cfg(test)]
 use crate::tool_runtime::{
-    registered_tool_specs, validate_project_artifact_export_snapshot,
-    ProjectArtifactExportSnapshot, ToolResult, ToolRuntime, ToolSpec,
+    validate_project_artifact_export_snapshot, ProjectArtifactExportSnapshot,
     MAX_PROJECT_ARTIFACT_EXPORT_BYTES, MAX_READ_PROJECT_ARTIFACT_LENGTH,
 };
-use base64::{engine::general_purpose, Engine as _};
-use futures_util::{future::join_all, stream};
+use base64::engine::general_purpose;
+#[cfg(test)]
+use base64::Engine as _;
+use futures_util::stream;
 use salvo::prelude::*;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
-use std::collections::{HashMap, VecDeque};
-use std::future::Future;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
+#[cfg(test)]
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+#[cfg(test)]
+use tokio::sync::Semaphore;
 
+#[cfg(test)]
+use resources::*;
 #[cfg(test)]
 use tasks::{
     mcp_create_task_result, request_supports_tasks, MCP_MISSING_REQUIRED_CLIENT_CAPABILITY,
@@ -47,22 +52,6 @@ const MCP_STATELESS_PROTOCOL_VERSION: &str = "2026-07-28";
 const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
 const MCP_METHOD_HEADER: &str = "mcp-method";
 const MCP_NAME_HEADER: &str = "mcp-name";
-const MCP_ARTIFACT_EXPORT_URI_PREFIX: &str = "webcodex-artifact://export/";
-const MCP_ARTIFACT_EXPORT_ID_PREFIX: &str = "wc_export_";
-const MCP_SNAPSHOT_RESOURCE_URI_PREFIX: &str = "webcodex-snapshot://view/";
-const MCP_SNAPSHOT_RESOURCE_ID_PREFIX: &str = "wc_snapshot_";
-const MCP_SNAPSHOT_RESOURCE_TTL: Duration = Duration::from_secs(5 * 60);
-const MAX_MCP_SNAPSHOT_RESOURCES: usize = 32;
-const MAX_MCP_SNAPSHOT_RESOURCES_PER_CALLER: usize = 8;
-const MCP_ARTIFACT_EXPORT_TTL: Duration = Duration::from_secs(5 * 60);
-const MCP_ARTIFACT_EXPORT_ADMISSION_TIMEOUT: Duration = Duration::from_secs(5);
-const MCP_ARTIFACT_EXPORT_READ_TIMEOUT: Duration = Duration::from_secs(120);
-const MCP_ARTIFACT_EXPORT_STREAM_TIMEOUT: Duration = Duration::from_secs(10 * 60);
-const MAX_MCP_ARTIFACT_EXPORT_READS: usize = 2;
-const MAX_MCP_ARTIFACT_EXPORT_CHUNK_READS: usize = 4;
-const MAX_MCP_ARTIFACT_EXPORTS: usize = 128;
-const MAX_MCP_ARTIFACT_EXPORTS_PER_CALLER: usize = 16;
-const MCP_ARTIFACT_EXPORT_BUSY_CODE: i64 = -32029;
 const MCP_HEADER_MISMATCH: i64 = -32020;
 const MCP_UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
 const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
@@ -70,27 +59,6 @@ const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
     MCP_CHATGPT_PROTOCOL_VERSION,
     MCP_PROTOCOL_VERSION,
 ];
-const MCP_UI_EXTENSION: &str = "io.modelcontextprotocol/ui";
-const MCP_COMPUTER_UI_RESOURCE_URI: &str = "ui://webcodex/computer/v11";
-const MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS: &[&str] = &[
-    "ui://webcodex/computer/v1",
-    "ui://webcodex/computer/v2",
-    "ui://webcodex/computer/v3",
-    "ui://webcodex/computer/v4",
-    "ui://webcodex/computer/v5",
-    "ui://webcodex/computer/v6",
-    "ui://webcodex/computer/v7",
-    "ui://webcodex/computer/v8",
-    "ui://webcodex/computer/v9",
-    "ui://webcodex/computer/v10",
-];
-// Temporary gray-card diagnostic: force the host to re-read the canonical App
-// resource for every card so resource reuse/cache is not an unobserved variable.
-const MCP_COMPUTER_UI_RESOURCE_TTL_MS: u64 = 0;
-const MCP_COMPUTER_UI_DOMAIN: &str = "https://sg4.yyjeqhc.cn";
-const MCP_UI_RESOURCE_MIME_TYPE: &str = "text/html;profile=mcp-app";
-const MCP_COMPUTER_APP_HTML: &str = include_str!("mcp_computer_app.html");
-
 /// Single source of truth for the JSON-RPC methods advertised by `GET /mcp`.
 /// Must match the dispatch arms in `handle_mcp_request_with_lifecycle`;
 /// pinned by `mcp_info_advertised_methods_match_dispatch`.
@@ -190,26 +158,6 @@ fn request_client_capabilities(params: &Value) -> Option<&Value> {
     params
         .get("_meta")
         .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
-}
-
-fn request_supports_mcp_apps(params: &Value) -> bool {
-    let Some(extension) = request_client_capabilities(params)
-        .and_then(|capabilities| capabilities.get("extensions"))
-        .and_then(|extensions| extensions.get(MCP_UI_EXTENSION))
-        .and_then(Value::as_object)
-    else {
-        return false;
-    };
-    match extension.get("mimeTypes").and_then(Value::as_array) {
-        Some(mime_types) => mime_types
-            .iter()
-            .any(|mime| mime.as_str() == Some(MCP_UI_RESOURCE_MIME_TYPE)),
-        None => false,
-    }
-}
-
-fn model_surface_supports_computer_app(model_surface: ModelSurface) -> bool {
-    model_surface == ModelSurface::FullOperatorRuntime
 }
 
 fn request_client_info_is_valid(params: &Value) -> bool {
@@ -629,507 +577,20 @@ fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, _app_enabled: bool) -> 
     value
 }
 
-fn mcp_computer_app_resource_meta() -> Value {
-    json!({
-        "ui": {
-            "prefersBorder": true,
-            "domain": MCP_COMPUTER_UI_DOMAIN,
-            "csp": {
-                "connectDomains": [],
-                "resourceDomains": []
-            }
-        }
-    })
-}
-
-fn mcp_computer_app_resources_list() -> Value {
-    json!({
-        "resources": [{
-            "uri": MCP_COMPUTER_UI_RESOURCE_URI,
-            "name": "WebCodex Computer",
-            "description": "Minimal read-only WebCodex Computer screenshot card that performs only the standard MCP Apps handshake and renders the native computer_snapshot image.",
-            "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
-            "_meta": mcp_computer_app_resource_meta()
-        }]
-    })
-}
-
-fn is_mcp_computer_app_resource_uri(uri: &str) -> bool {
-    uri == MCP_COMPUTER_UI_RESOURCE_URI || MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS.contains(&uri)
-}
-
-fn mcp_computer_app_resource_read(uri: &str) -> Option<Value> {
-    // ChatGPT can retain an older tool descriptor across connector refreshes.
-    // Keep prior computer App URIs as hidden read aliases so an already-bound
-    // card can fetch the current safe template. resources/list and tools/list
-    // still advertise only the canonical URI above.
-    let supported = is_mcp_computer_app_resource_uri(uri);
-    supported.then(|| {
-        json!({
-            "contents": [{
-                "uri": uri,
-                "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
-                "text": MCP_COMPUTER_APP_HTML,
-                "_meta": mcp_computer_app_resource_meta()
-            }]
-        })
-    })
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum McpArtifactExportCallerBinding {
-    Bootstrap,
-    ApiToken {
-        api_key_id: String,
-    },
-    AgentToken {
-        api_key_id: String,
-    },
-    AccountCredential {
-        user_id: String,
-    },
-    OAuthUser {
-        user_id: String,
-        client_id: String,
-    },
-    OAuthSharedKey {
-        shared_key_hash: String,
-        client_id: String,
-    },
-    SharedKey {
-        shared_key_hash: String,
-    },
-    ProjectCredential {
-        project_grant_id: String,
-    },
-}
-
-fn mcp_artifact_export_caller_binding(
-    auth: Option<&AuthContext>,
-) -> Result<McpArtifactExportCallerBinding, &'static str> {
-    let auth = auth.ok_or("authenticated caller identity is unavailable")?;
-    match auth.kind {
-        crate::auth::AuthKind::Bootstrap => Ok(McpArtifactExportCallerBinding::Bootstrap),
-        crate::auth::AuthKind::ApiToken => auth
-            .api_key_id
-            .as_ref()
-            .filter(|value| !value.is_empty())
-            .cloned()
-            .map(|api_key_id| McpArtifactExportCallerBinding::ApiToken { api_key_id })
-            .ok_or("API token identity is unavailable"),
-        crate::auth::AuthKind::AgentToken => auth
-            .api_key_id
-            .as_ref()
-            .filter(|value| !value.is_empty())
-            .cloned()
-            .map(|api_key_id| McpArtifactExportCallerBinding::AgentToken { api_key_id })
-            .ok_or("agent token identity is unavailable"),
-        crate::auth::AuthKind::AccountCredential => auth
-            .user_id
-            .as_ref()
-            .filter(|value| !value.is_empty())
-            .cloned()
-            .map(|user_id| McpArtifactExportCallerBinding::AccountCredential { user_id })
-            .ok_or("account identity is unavailable"),
-        crate::auth::AuthKind::OAuth2Token => {
-            let client_id = auth
-                .allowed_client_id
-                .as_ref()
-                .filter(|value| !value.is_empty())
-                .cloned()
-                .ok_or("OAuth client identity is unavailable")?;
-            if auth.is_oauth_shared_key_subject() {
-                let shared_key_hash = auth
-                    .shared_key_hash
-                    .as_ref()
-                    .filter(|value| !value.is_empty())
-                    .cloned()
-                    .ok_or("OAuth shared-key subject identity is unavailable")?;
-                Ok(McpArtifactExportCallerBinding::OAuthSharedKey {
-                    shared_key_hash,
-                    client_id,
-                })
-            } else if auth.token_kind.as_deref() == Some("oauth2") {
-                let user_id = auth
-                    .user_id
-                    .as_ref()
-                    .filter(|value| !value.is_empty())
-                    .cloned()
-                    .ok_or("OAuth user identity is unavailable")?;
-                Ok(McpArtifactExportCallerBinding::OAuthUser { user_id, client_id })
-            } else {
-                Err("unsupported OAuth subject identity")
-            }
-        }
-        crate::auth::AuthKind::SharedKey => auth
-            .shared_key_hash
-            .as_ref()
-            .filter(|value| !value.is_empty())
-            .cloned()
-            .map(|shared_key_hash| McpArtifactExportCallerBinding::SharedKey { shared_key_hash })
-            .ok_or("shared-key identity is unavailable"),
-        crate::auth::AuthKind::ProjectCredential => auth
-            .project_grant_id
-            .as_ref()
-            .filter(|value| !value.is_empty())
-            .cloned()
-            .map(
-                |project_grant_id| McpArtifactExportCallerBinding::ProjectCredential {
-                    project_grant_id,
-                },
-            )
-            .ok_or("project credential identity is unavailable"),
-        crate::auth::AuthKind::OpenAnonymous => {
-            Err("anonymous MCP callers cannot create artifact export resources")
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct McpArtifactExportRecord {
-    caller: McpArtifactExportCallerBinding,
-    project: String,
-    snapshot: ProjectArtifactExportSnapshot,
-    expires_at: Instant,
-}
-
-#[derive(Default)]
-struct McpArtifactExportRegistry {
-    entries: HashMap<String, McpArtifactExportRecord>,
-    order: VecDeque<String>,
-}
-
-impl McpArtifactExportRegistry {
-    fn cleanup(&mut self, now: Instant) {
-        self.entries.retain(|_, record| record.expires_at > now);
-        self.order.retain(|id| self.entries.contains_key(id));
-    }
-
-    fn insert(&mut self, record: McpArtifactExportRecord) -> String {
-        self.cleanup(Instant::now());
-        while self
-            .entries
-            .values()
-            .filter(|existing| existing.caller == record.caller)
-            .count()
-            >= MAX_MCP_ARTIFACT_EXPORTS_PER_CALLER
-        {
-            let Some(position) = self.order.iter().position(|id| {
-                self.entries
-                    .get(id)
-                    .is_some_and(|existing| existing.caller == record.caller)
-            }) else {
-                break;
-            };
-            if let Some(id) = self.order.remove(position) {
-                self.entries.remove(&id);
-            }
-        }
-        while self.entries.len() >= MAX_MCP_ARTIFACT_EXPORTS {
-            if let Some(id) = self.order.pop_front() {
-                self.entries.remove(&id);
-            } else {
-                break;
-            }
-        }
-        let id = loop {
-            let candidate = format!(
-                "{MCP_ARTIFACT_EXPORT_ID_PREFIX}{}",
-                uuid::Uuid::new_v4().simple()
-            );
-            if !self.entries.contains_key(&candidate) {
-                break candidate;
-            }
-        };
-        self.order.push_back(id.clone());
-        self.entries.insert(id.clone(), record);
-        format!("{MCP_ARTIFACT_EXPORT_URI_PREFIX}{id}")
-    }
-
-    fn get_for_caller(
-        &mut self,
-        uri: &str,
-        caller: &McpArtifactExportCallerBinding,
-    ) -> Option<McpArtifactExportRecord> {
-        self.cleanup(Instant::now());
-        let id = mcp_artifact_export_id_from_uri(uri)?;
-        self.entries
-            .get(id)
-            .filter(|record| &record.caller == caller)
-            .cloned()
-    }
-}
-
-static MCP_ARTIFACT_EXPORT_REGISTRY: OnceLock<Mutex<McpArtifactExportRegistry>> = OnceLock::new();
-static MCP_ARTIFACT_EXPORT_READ_SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
-
-fn mcp_artifact_export_registry() -> &'static Mutex<McpArtifactExportRegistry> {
-    MCP_ARTIFACT_EXPORT_REGISTRY.get_or_init(|| Mutex::new(McpArtifactExportRegistry::default()))
-}
-
-fn mcp_artifact_export_read_semaphore() -> Arc<Semaphore> {
-    MCP_ARTIFACT_EXPORT_READ_SEMAPHORE
-        .get_or_init(|| Arc::new(Semaphore::new(MAX_MCP_ARTIFACT_EXPORT_READS)))
-        .clone()
-}
-
-fn mcp_artifact_export_id_from_uri(uri: &str) -> Option<&str> {
-    let id = uri.strip_prefix(MCP_ARTIFACT_EXPORT_URI_PREFIX)?;
-    let hex = id.strip_prefix(MCP_ARTIFACT_EXPORT_ID_PREFIX)?;
-    (hex.len() == 32
-        && hex
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()))
-    .then_some(id)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum McpSnapshotResourceKind {
-    Window,
-    Display,
-}
-
-impl McpSnapshotResourceKind {
-    fn from_tool_name(tool_name: &str) -> Option<Self> {
-        match tool_name {
-            "computer_snapshot" => Some(Self::Window),
-            "computer_snapshot_display" => Some(Self::Display),
-            _ => None,
-        }
-    }
-
-    fn name(self, client_id: &str, mime_type: &str) -> String {
-        let extension = match mime_type {
-            "image/png" => "png",
-            "image/webp" => "webp",
-            _ => "jpg",
-        };
-        let kind = match self {
-            Self::Window => "window",
-            Self::Display => "display",
-        };
-        let normalized_client_id: String = client_id
-            .chars()
-            .map(|ch| {
-                if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
-                    ch
-                } else {
-                    '_'
-                }
-            })
-            .collect();
-        let client_id = if normalized_client_id.is_empty() {
-            "computer"
-        } else {
-            normalized_client_id.as_str()
-        };
-        format!("{client_id}-{kind}-snapshot.{extension}")
-    }
-}
-
-#[derive(Debug, Clone)]
-struct McpSnapshotResourceRecord {
-    caller: McpArtifactExportCallerBinding,
-    kind: McpSnapshotResourceKind,
-    bytes: Arc<[u8]>,
-    mime_type: String,
-    expires_at: Instant,
-}
-
-#[derive(Default)]
-struct McpSnapshotResourceRegistry {
-    entries: HashMap<String, McpSnapshotResourceRecord>,
-    order: VecDeque<String>,
-}
-
-impl McpSnapshotResourceRegistry {
-    fn cleanup(&mut self, now: Instant) {
-        self.entries.retain(|_, record| record.expires_at > now);
-        self.order.retain(|id| self.entries.contains_key(id));
-    }
-
-    fn insert(&mut self, record: McpSnapshotResourceRecord) -> String {
-        self.cleanup(Instant::now());
-        while self
-            .entries
-            .values()
-            .filter(|existing| existing.caller == record.caller)
-            .count()
-            >= MAX_MCP_SNAPSHOT_RESOURCES_PER_CALLER
-        {
-            let Some(position) = self.order.iter().position(|id| {
-                self.entries
-                    .get(id)
-                    .is_some_and(|existing| existing.caller == record.caller)
-            }) else {
-                break;
-            };
-            if let Some(id) = self.order.remove(position) {
-                self.entries.remove(&id);
-            }
-        }
-        while self.entries.len() >= MAX_MCP_SNAPSHOT_RESOURCES {
-            if let Some(id) = self.order.pop_front() {
-                self.entries.remove(&id);
-            } else {
-                break;
-            }
-        }
-        let id = loop {
-            let candidate = format!(
-                "{MCP_SNAPSHOT_RESOURCE_ID_PREFIX}{}",
-                uuid::Uuid::new_v4().simple()
-            );
-            if !self.entries.contains_key(&candidate) {
-                break candidate;
-            }
-        };
-        self.order.push_back(id.clone());
-        self.entries.insert(id.clone(), record);
-        format!("{MCP_SNAPSHOT_RESOURCE_URI_PREFIX}{id}")
-    }
-
-    fn get_for_caller(
-        &mut self,
-        uri: &str,
-        caller: &McpArtifactExportCallerBinding,
-    ) -> Option<McpSnapshotResourceRecord> {
-        self.cleanup(Instant::now());
-        let id = mcp_snapshot_resource_id_from_uri(uri)?;
-        self.entries
-            .get(id)
-            .filter(|record| &record.caller == caller)
-            .cloned()
-    }
-}
-
-static MCP_SNAPSHOT_RESOURCE_REGISTRY: OnceLock<Mutex<McpSnapshotResourceRegistry>> =
-    OnceLock::new();
-
-fn mcp_snapshot_resource_registry() -> &'static Mutex<McpSnapshotResourceRegistry> {
-    MCP_SNAPSHOT_RESOURCE_REGISTRY
-        .get_or_init(|| Mutex::new(McpSnapshotResourceRegistry::default()))
-}
-
-fn mcp_snapshot_resource_id_from_uri(uri: &str) -> Option<&str> {
-    let id = uri.strip_prefix(MCP_SNAPSHOT_RESOURCE_URI_PREFIX)?;
-    let hex = id.strip_prefix(MCP_SNAPSHOT_RESOURCE_ID_PREFIX)?;
-    (hex.len() == 32
-        && hex
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()))
-    .then_some(id)
-}
-
-fn mcp_issue_artifact_export(
-    caller: McpArtifactExportCallerBinding,
-    result: &ToolResult,
-) -> Result<(String, ProjectArtifactExportSnapshot), String> {
-    let project = result
-        .output
-        .get("project")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "export result is missing canonical project identity".to_string())?
-        .to_string();
-    let path = result
-        .output
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| "export result is missing artifact path".to_string())?;
-    let snapshot = validate_project_artifact_export_snapshot(path, &result.output)?;
-    if result.output.get("name").and_then(Value::as_str) != Some(snapshot.name.as_str()) {
-        return Err(
-            "export result basename does not match validated artifact metadata".to_string(),
-        );
-    }
-    let record = McpArtifactExportRecord {
-        caller,
-        project,
-        snapshot: snapshot.clone(),
-        expires_at: Instant::now() + MCP_ARTIFACT_EXPORT_TTL,
-    };
-    let uri = mcp_artifact_export_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .insert(record);
-    Ok((uri, snapshot))
-}
-
-fn mcp_artifact_export_tool_result(
-    result: ToolResult,
-    caller: McpArtifactExportCallerBinding,
-) -> Value {
-    if !result.success {
-        return mcp_runtime_tool_result("export_project_artifact", false, result);
-    }
-    let (uri, snapshot) = match mcp_issue_artifact_export(caller, &result) {
-        Ok(value) => value,
-        Err(error) => {
-            return mcp_runtime_tool_result(
-                "export_project_artifact",
-                false,
-                ToolResult::err(format!("cannot frame artifact export resource: {error}")),
-            )
-        }
-    };
-    json!({
-        "content": [{
-            "type": "resource_link",
-            "uri": uri,
-            "name": snapshot.name,
-            "mimeType": snapshot.mime_type,
-            "description": "Short-lived authenticated WebCodex project artifact export. Read this URI with MCP resources/read to retrieve the complete bounded binary."
-        }],
-        "structuredContent": {
-            "success": true,
-            "output": result.output,
-            "error": Value::Null,
-        },
-        "isError": false
-    })
-}
-
-#[cfg(test)]
-fn mcp_expire_artifact_export_for_test(uri: &str) {
-    if let Some(id) = mcp_artifact_export_id_from_uri(uri) {
-        let mut registry = mcp_artifact_export_registry()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(record) = registry.entries.get_mut(id) {
-            record.expires_at = Instant::now();
-        }
-    }
-}
-
 pub(crate) fn mcp_runtime_tool_result(
     tool_name: &str,
     as_image_requested: bool,
     result: ToolResult,
 ) -> Value {
-    mcp_runtime_tool_result_with_snapshot_resource(tool_name, as_image_requested, result, None)
+    resources::mcp_runtime_tool_result_with_snapshot_resource(
+        tool_name,
+        as_image_requested,
+        result,
+        None,
+    )
 }
 
-fn mcp_runtime_tool_result_with_snapshot_resource(
-    tool_name: &str,
-    as_image_requested: bool,
-    mut result: ToolResult,
-    snapshot_caller: Option<McpArtifactExportCallerBinding>,
-) -> Value {
-    let native_image_requested = (tool_name == "read_project_artifact" && as_image_requested)
-        || matches!(tool_name, "computer_snapshot" | "computer_snapshot_display");
-    if native_image_requested && result.success {
-        match mcp_native_image_tool_result(tool_name, &mut result, snapshot_caller) {
-            Ok(value) => return value,
-            Err(error) => {
-                result = ToolResult::err(format!(
-                    "cannot frame {tool_name} as MCP image content: {error}"
-                ));
-            }
-        }
-    }
-
+fn mcp_runtime_tool_result_fallback(result: ToolResult) -> Value {
     let text = serde_json::to_string(&json!({
         "success": result.success,
         "output": result.output.clone(),
@@ -1137,12 +598,7 @@ fn mcp_runtime_tool_result_with_snapshot_resource(
     }))
     .unwrap_or_else(|_| "{}".to_string());
     json!({
-        "content": [
-            {
-                "type": "text",
-                "text": text
-            }
-        ],
+        "content": [{ "type": "text", "text": text }],
         "structuredContent": {
             "success": result.success,
             "output": result.output,
@@ -1150,878 +606,6 @@ fn mcp_runtime_tool_result_with_snapshot_resource(
         },
         "isError": !result.success
     })
-}
-
-fn mcp_native_image_tool_result(
-    tool_name: &str,
-    result: &mut ToolResult,
-    snapshot_caller: Option<McpArtifactExportCallerBinding>,
-) -> Result<Value, String> {
-    let data = result
-        .output
-        .get("content_base64")
-        .and_then(Value::as_str)
-        .ok_or_else(|| "missing content_base64".to_string())?
-        .to_string();
-    let mime_type = result
-        .output
-        .get("mime_type")
-        .and_then(Value::as_str)
-        .ok_or_else(|| "missing mime_type".to_string())?
-        .to_string();
-    if !matches!(
-        mime_type.as_str(),
-        "image/png" | "image/jpeg" | "image/webp"
-    ) {
-        return Err(format!("unsupported MIME type '{mime_type}'"));
-    }
-    let decoded = general_purpose::STANDARD
-        .decode(&data)
-        .map_err(|error| format!("invalid image base64: {error}"))?;
-    if decoded.is_empty() || decoded.len() > crate::artifact_policy::MAX_MCP_IMAGE_BYTES {
-        return Err(format!(
-            "image payload exceeds {} decoded bytes",
-            crate::artifact_policy::MAX_MCP_IMAGE_BYTES
-        ));
-    }
-    let detected = if decoded.starts_with(b"\x89PNG\r\n\x1a\n") {
-        Some("image/png")
-    } else if decoded.starts_with(&[0xff, 0xd8, 0xff]) {
-        Some("image/jpeg")
-    } else if decoded.len() >= 12 && decoded.starts_with(b"RIFF") && &decoded[8..12] == b"WEBP" {
-        Some("image/webp")
-    } else {
-        None
-    };
-    if detected != Some(mime_type.as_str()) {
-        return Err("image MIME does not match decoded content".to_string());
-    }
-    let image_label = if tool_name == "computer_snapshot" {
-        result
-            .output
-            .pointer("/surface/surface_id")
-            .and_then(Value::as_str)
-            .unwrap_or("desktop surface")
-    } else if tool_name == "computer_snapshot_display" {
-        result
-            .output
-            .get("display_id")
-            .and_then(Value::as_str)
-            .unwrap_or("full display")
-    } else {
-        result
-            .output
-            .get("path")
-            .and_then(Value::as_str)
-            .unwrap_or("project image")
-    };
-    let file_bytes = result
-        .output
-        .get("file_bytes")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| "missing file_bytes".to_string())?;
-    if file_bytes != decoded.len() as u64 {
-        return Err("file_bytes does not match decoded image payload".to_string());
-    }
-    let sha256 = result
-        .output
-        .get("sha256")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    let metadata_text = if matches!(tool_name, "computer_snapshot" | "computer_snapshot_display") {
-        let width = result
-            .output
-            .get("width")
-            .and_then(Value::as_u64)
-            .unwrap_or(0);
-        let height = result
-            .output
-            .get("height")
-            .and_then(Value::as_u64)
-            .unwrap_or(0);
-        if width == 0 || height == 0 || width > 4096 || height > 4096 {
-            return Err("computer snapshot dimensions are invalid".to_string());
-        }
-        format!("Image {image_label}: {mime_type}, {width}x{height}, {file_bytes} bytes.")
-    } else {
-        format!("Image {image_label}: {mime_type}, {file_bytes} bytes, sha256 {sha256}.")
-    };
-
-    let output = result
-        .output
-        .as_object_mut()
-        .ok_or_else(|| "tool output is not an object".to_string())?;
-    output.remove("content_base64");
-    output.insert("content_delivery".to_string(), json!("mcp_image"));
-    let structured_output = result.output.clone();
-
-    let snapshot_link = snapshot_caller
-        .zip(McpSnapshotResourceKind::from_tool_name(tool_name))
-        .map(|(caller, kind)| {
-            let client_id = result
-                .output
-                .get("client_id")
-                .and_then(Value::as_str)
-                .unwrap_or("computer");
-            let name = kind.name(client_id, &mime_type);
-            let record = McpSnapshotResourceRecord {
-                caller,
-                kind,
-                bytes: Arc::from(decoded.into_boxed_slice()),
-                mime_type: mime_type.clone(),
-                expires_at: Instant::now() + MCP_SNAPSHOT_RESOURCE_TTL,
-            };
-            let uri = mcp_snapshot_resource_registry()
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .insert(record);
-            tracing::info!(
-                target: "webcodex::mcp",
-                tool_name,
-                file_bytes,
-                "mcp_snapshot_resource_link_issued"
-            );
-            json!({
-                "type": "resource_link",
-                "uri": uri,
-                "name": name,
-                "mimeType": mime_type,
-                "size": file_bytes,
-                "description": "Short-lived authenticated WebCodex computer screenshot. No project artifact was created."
-            })
-        });
-    let mut content = Vec::with_capacity(if snapshot_link.is_some() { 3 } else { 2 });
-    if let Some(link) = snapshot_link {
-        content.push(link);
-    }
-    content.push(json!({ "type": "text", "text": metadata_text }));
-    content.push(json!({ "type": "image", "data": data, "mimeType": mime_type }));
-
-    Ok(json!({
-        "content": content,
-        "structuredContent": {
-            "success": true,
-            "output": structured_output,
-            "error": Value::Null,
-        },
-        "isError": false
-    }))
-}
-
-#[derive(Debug)]
-enum McpArtifactExportReadError {
-    Unavailable,
-    Forbidden {
-        required_scope: Option<&'static str>,
-        description: String,
-    },
-    SnapshotChanged,
-    Unsafe,
-    Busy,
-    Timeout,
-}
-
-fn mcp_artifact_export_lookup(
-    uri: &str,
-    auth: Option<&AuthContext>,
-) -> Result<McpArtifactExportRecord, McpArtifactExportReadError> {
-    let caller = mcp_artifact_export_caller_binding(auth)
-        .map_err(|_| McpArtifactExportReadError::Unavailable)?;
-    mcp_artifact_export_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get_for_caller(uri, &caller)
-        .ok_or(McpArtifactExportReadError::Unavailable)
-}
-
-async fn mcp_artifact_export_metadata_recheck(
-    runtime: &ToolRuntime,
-    record: &McpArtifactExportRecord,
-    auth: Option<&AuthContext>,
-) -> Result<ProjectArtifactExportSnapshot, McpArtifactExportReadError> {
-    let result = runtime
-        .read_project_artifact_export_metadata_internal(
-            &record.project,
-            &record.snapshot.path,
-            auth,
-        )
-        .await;
-    if !result.success {
-        return Err(McpArtifactExportReadError::Unavailable);
-    }
-    let snapshot = validate_project_artifact_export_snapshot(&record.snapshot.path, &result.output)
-        .map_err(|_| McpArtifactExportReadError::Unsafe)?;
-    if snapshot != record.snapshot {
-        return Err(McpArtifactExportReadError::SnapshotChanged);
-    }
-    Ok(snapshot)
-}
-
-fn mcp_artifact_export_decode_chunk(
-    record: &McpArtifactExportRecord,
-    offset: usize,
-    length: usize,
-    output: &Value,
-    require_complete_metadata: bool,
-) -> Result<Vec<u8>, McpArtifactExportReadError> {
-    if output.get("error_kind").and_then(Value::as_str) == Some("snapshot_changed") {
-        return Err(McpArtifactExportReadError::SnapshotChanged);
-    }
-    if output.get("error").and_then(Value::as_str).is_some() {
-        return Err(McpArtifactExportReadError::Unsafe);
-    }
-    if output.get("path").and_then(Value::as_str) != Some(record.snapshot.path.as_str())
-        || output.get("file_bytes").and_then(Value::as_u64) != Some(record.snapshot.bytes as u64)
-    {
-        return Err(McpArtifactExportReadError::SnapshotChanged);
-    }
-    if require_complete_metadata
-        && (output.get("mime_type").and_then(Value::as_str)
-            != Some(record.snapshot.mime_type.as_str())
-            || output.get("sha256").and_then(Value::as_str)
-                != Some(record.snapshot.sha256.as_str()))
-    {
-        return Err(McpArtifactExportReadError::SnapshotChanged);
-    }
-    if output.get("offset").and_then(Value::as_u64) != Some(offset as u64) {
-        return Err(McpArtifactExportReadError::Unsafe);
-    }
-    let encoded = output
-        .get("content_base64")
-        .and_then(Value::as_str)
-        .ok_or(McpArtifactExportReadError::Unsafe)?;
-    let decoded = general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|_| McpArtifactExportReadError::Unsafe)?;
-    let bytes_returned = output
-        .get("bytes_returned")
-        .and_then(Value::as_u64)
-        .and_then(|value| usize::try_from(value).ok())
-        .ok_or(McpArtifactExportReadError::Unsafe)?;
-    let next_offset = output
-        .get("next_offset")
-        .and_then(Value::as_u64)
-        .and_then(|value| usize::try_from(value).ok())
-        .ok_or(McpArtifactExportReadError::Unsafe)?;
-    let eof = output
-        .get("eof")
-        .and_then(Value::as_bool)
-        .ok_or(McpArtifactExportReadError::Unsafe)?;
-    let truncated = output
-        .get("truncated")
-        .and_then(Value::as_bool)
-        .ok_or(McpArtifactExportReadError::Unsafe)?;
-    let expected_next = offset
-        .checked_add(decoded.len())
-        .ok_or(McpArtifactExportReadError::Unsafe)?;
-    if decoded.len() != bytes_returned
-        || decoded.len() > length
-        || expected_next != next_offset
-        || next_offset > record.snapshot.bytes
-        || (decoded.is_empty() && offset < record.snapshot.bytes)
-        || eof != (next_offset == record.snapshot.bytes)
-        || truncated == eof
-    {
-        return Err(McpArtifactExportReadError::Unsafe);
-    }
-    Ok(decoded)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum McpArtifactExportChunkRoute {
-    Optimized,
-    Legacy,
-}
-
-async fn mcp_artifact_export_read_optimized_chunk(
-    runtime: &ToolRuntime,
-    record: &McpArtifactExportRecord,
-    auth: Option<&AuthContext>,
-    offset: usize,
-    length: usize,
-) -> Result<Option<Vec<u8>>, McpArtifactExportReadError> {
-    match runtime
-        .read_project_artifact_export_chunk_internal(
-            &record.project,
-            &record.snapshot.path,
-            record.snapshot.bytes,
-            offset,
-            length,
-            auth,
-        )
-        .await
-    {
-        Ok(Some(output)) => {
-            mcp_artifact_export_decode_chunk(record, offset, length, &output, false).map(Some)
-        }
-        Ok(None) => Ok(None),
-        Err(_) => Err(McpArtifactExportReadError::Unavailable),
-    }
-}
-
-async fn mcp_artifact_export_read_legacy_chunk(
-    runtime: &ToolRuntime,
-    record: &McpArtifactExportRecord,
-    auth: Option<&AuthContext>,
-    offset: usize,
-    length: usize,
-) -> Result<Vec<u8>, McpArtifactExportReadError> {
-    let outcome = runtime
-        .call_tool_with_context(
-            KernelToolCallRequest {
-                tool_name: "read_project_artifact".to_string(),
-                arguments: json!({
-                    "project": record.project,
-                    "path": record.snapshot.path,
-                    "encoding": "base64",
-                    "offset": offset,
-                    "length": length,
-                    "max_bytes": length,
-                }),
-            },
-            ToolCallContext {
-                transport: ToolTransport::Mcp,
-                session_id: None,
-                auth,
-                window: None,
-                record_oauth_scope_denials: false,
-                host_file_import_trust: HostFileImportTrust::Untrusted,
-            },
-        )
-        .await;
-    if let Some(error_status) = outcome.error_status {
-        return match error_status {
-            ToolCallErrorStatus::InsufficientScope {
-                required_scope,
-                description,
-            } => Err(McpArtifactExportReadError::Forbidden {
-                required_scope,
-                description,
-            }),
-            ToolCallErrorStatus::InvalidArguments { .. } => Err(McpArtifactExportReadError::Unsafe),
-        };
-    }
-    let result = outcome.result.ok_or(McpArtifactExportReadError::Unsafe)?;
-    if !result.success {
-        return Err(McpArtifactExportReadError::Unavailable);
-    }
-    mcp_artifact_export_decode_chunk(record, offset, length, &result.output, true)
-}
-
-async fn mcp_artifact_export_read_chunk(
-    runtime: &ToolRuntime,
-    record: &McpArtifactExportRecord,
-    auth: Option<&AuthContext>,
-    offset: usize,
-    length: usize,
-) -> Result<(Vec<u8>, McpArtifactExportChunkRoute), McpArtifactExportReadError> {
-    if let Some(chunk) =
-        mcp_artifact_export_read_optimized_chunk(runtime, record, auth, offset, length).await?
-    {
-        return Ok((chunk, McpArtifactExportChunkRoute::Optimized));
-    }
-
-    // Rolling-upgrade compatibility: an old Runner cannot receive the optimized
-    // request kind because capability check + enqueue are atomic. Observe that
-    // route once on the first chunk; the resource read then stays sequential on
-    // this public compatibility path rather than amplifying legacy whole-file
-    // work with Control-side concurrency.
-    let chunk =
-        mcp_artifact_export_read_legacy_chunk(runtime, record, auth, offset, length).await?;
-    Ok((chunk, McpArtifactExportChunkRoute::Legacy))
-}
-
-#[derive(Debug)]
-struct McpArtifactExportStreamPlan {
-    uri: String,
-    record: McpArtifactExportRecord,
-    first_chunk: Vec<u8>,
-    route: Option<McpArtifactExportChunkRoute>,
-    offset: usize,
-    chunks: usize,
-    max_chunks: usize,
-    read_budget: Duration,
-    _permit: OwnedSemaphorePermit,
-}
-
-async fn mcp_artifact_export_with_read_budget<T, F>(
-    runtime: &ToolRuntime,
-    read_budget: &mut Duration,
-    future: F,
-) -> Result<T, McpArtifactExportReadError>
-where
-    F: Future<Output = Result<T, McpArtifactExportReadError>>,
-{
-    if read_budget.is_zero() {
-        return Err(McpArtifactExportReadError::Timeout);
-    }
-    let started = Instant::now();
-    let outcome = tokio::time::timeout(*read_budget, future).await;
-    *read_budget = read_budget.saturating_sub(started.elapsed());
-    match outcome {
-        Ok(result) => result,
-        Err(_) => {
-            runtime.shell_clients.cancel_abandoned_sync_requests().await;
-            Err(McpArtifactExportReadError::Timeout)
-        }
-    }
-}
-
-async fn mcp_artifact_export_stream_plan_with_gate_timeout(
-    runtime: &ToolRuntime,
-    uri: &str,
-    auth: Option<&AuthContext>,
-    gate: Arc<Semaphore>,
-    admission_timeout: Duration,
-    read_timeout: Duration,
-) -> Result<McpArtifactExportStreamPlan, McpArtifactExportReadError> {
-    let record = mcp_artifact_export_lookup(uri, auth)?;
-    if auth.is_some_and(|auth| !auth.has_scope(crate::auth::SCOPE_PROJECT_READ)) {
-        return Err(McpArtifactExportReadError::Forbidden {
-            required_scope: Some(crate::auth::SCOPE_PROJECT_READ),
-            description: format!(
-                "missing required scope: {}",
-                crate::auth::SCOPE_PROJECT_READ
-            ),
-        });
-    }
-    let permit = match tokio::time::timeout(admission_timeout, gate.acquire_owned()).await {
-        Ok(Ok(permit)) => permit,
-        Ok(Err(_)) | Err(_) => return Err(McpArtifactExportReadError::Busy),
-    };
-    let mut read_budget = read_timeout;
-    let snapshot = mcp_artifact_export_with_read_budget(
-        runtime,
-        &mut read_budget,
-        mcp_artifact_export_metadata_recheck(runtime, &record, auth),
-    )
-    .await?;
-    let max_chunks = MAX_PROJECT_ARTIFACT_EXPORT_BYTES
-        .div_ceil(MAX_READ_PROJECT_ARTIFACT_LENGTH)
-        .saturating_add(1);
-    let mut first_chunk = Vec::new();
-    let mut route = None;
-    let mut offset = 0usize;
-    let mut chunks = 0usize;
-    if snapshot.bytes > 0 {
-        let length = snapshot.bytes.min(MAX_READ_PROJECT_ARTIFACT_LENGTH);
-        let (chunk, first_route) = mcp_artifact_export_with_read_budget(
-            runtime,
-            &mut read_budget,
-            mcp_artifact_export_read_chunk(runtime, &record, auth, 0, length),
-        )
-        .await?;
-        offset = chunk.len();
-        if offset == 0 || offset > snapshot.bytes {
-            return Err(McpArtifactExportReadError::Unsafe);
-        }
-        chunks = 1;
-        first_chunk = chunk;
-        route = Some(first_route);
-    }
-    Ok(McpArtifactExportStreamPlan {
-        uri: uri.to_string(),
-        record,
-        first_chunk,
-        route,
-        offset,
-        chunks,
-        max_chunks,
-        read_budget,
-        _permit: permit,
-    })
-}
-
-async fn mcp_artifact_export_stream_plan(
-    runtime: &ToolRuntime,
-    uri: &str,
-    auth: Option<&AuthContext>,
-) -> Result<McpArtifactExportStreamPlan, McpArtifactExportReadError> {
-    mcp_artifact_export_stream_plan_with_gate_timeout(
-        runtime,
-        uri,
-        auth,
-        mcp_artifact_export_read_semaphore(),
-        MCP_ARTIFACT_EXPORT_ADMISSION_TIMEOUT,
-        MCP_ARTIFACT_EXPORT_READ_TIMEOUT,
-    )
-    .await
-}
-
-#[derive(Default)]
-struct McpArtifactExportBase64Encoder {
-    carry: [u8; 3],
-    carry_len: usize,
-}
-
-impl McpArtifactExportBase64Encoder {
-    fn push(&mut self, bytes: &[u8]) -> String {
-        let mut output = String::with_capacity(((bytes.len() + 2) / 3) * 4 + 4);
-        let mut index = 0usize;
-        if self.carry_len > 0 {
-            let needed = 3 - self.carry_len;
-            let take = needed.min(bytes.len());
-            self.carry[self.carry_len..self.carry_len + take].copy_from_slice(&bytes[..take]);
-            self.carry_len += take;
-            index += take;
-            if self.carry_len == 3 {
-                general_purpose::STANDARD.encode_string(&self.carry, &mut output);
-                self.carry_len = 0;
-            }
-        }
-        let remaining = &bytes[index..];
-        let aligned_len = (remaining.len() / 3) * 3;
-        if aligned_len > 0 {
-            general_purpose::STANDARD.encode_string(&remaining[..aligned_len], &mut output);
-        }
-        let tail = &remaining[aligned_len..];
-        if !tail.is_empty() {
-            self.carry[..tail.len()].copy_from_slice(tail);
-            self.carry_len = tail.len();
-        }
-        output
-    }
-
-    fn finish(&mut self) -> String {
-        if self.carry_len == 0 {
-            return String::new();
-        }
-        let output = general_purpose::STANDARD.encode(&self.carry[..self.carry_len]);
-        self.carry_len = 0;
-        output
-    }
-}
-
-type McpArtifactExportStreamFrame = Result<Vec<u8>, std::io::Error>;
-
-fn mcp_artifact_export_stream_prefix(
-    id: &Value,
-    uri: &str,
-    mime_type: &str,
-) -> Result<Vec<u8>, McpArtifactExportReadError> {
-    let mut output = Vec::with_capacity(256);
-    output.extend_from_slice(b"{\"jsonrpc\":\"2.0\",\"id\":");
-    output.extend_from_slice(
-        &serde_json::to_vec(id).map_err(|_| McpArtifactExportReadError::Unsafe)?,
-    );
-    output.extend_from_slice(b",\"result\":{\"contents\":[{\"uri\":");
-    output.extend_from_slice(
-        &serde_json::to_vec(uri).map_err(|_| McpArtifactExportReadError::Unsafe)?,
-    );
-    output.extend_from_slice(b",\"mimeType\":");
-    output.extend_from_slice(
-        &serde_json::to_vec(mime_type).map_err(|_| McpArtifactExportReadError::Unsafe)?,
-    );
-    output.extend_from_slice(b",\"blob\":\"");
-    Ok(output)
-}
-
-fn mcp_artifact_export_stream_suffix() -> Result<Vec<u8>, McpArtifactExportReadError> {
-    let mut output = b"\"}],\"resultType\":\"complete\",\"_meta\":{\"io.modelcontextprotocol/serverInfo\":{\"name\":\"webcodex\",\"version\":".to_vec();
-    output.extend_from_slice(
-        &serde_json::to_vec(env!("CARGO_PKG_VERSION"))
-            .map_err(|_| McpArtifactExportReadError::Unsafe)?,
-    );
-    output.extend_from_slice(b"}}}}");
-    Ok(output)
-}
-
-async fn mcp_artifact_export_send_frame(
-    sender: &mpsc::Sender<McpArtifactExportStreamFrame>,
-    frame: Vec<u8>,
-) -> Result<(), McpArtifactExportReadError> {
-    sender
-        .send(Ok(frame))
-        .await
-        .map_err(|_| McpArtifactExportReadError::Unavailable)
-}
-
-async fn mcp_artifact_export_emit_chunk(
-    sender: &mpsc::Sender<McpArtifactExportStreamFrame>,
-    encoder: &mut McpArtifactExportBase64Encoder,
-    sha256: &mut Sha256,
-    emitted_bytes: &mut usize,
-    expected_bytes: usize,
-    chunk: &[u8],
-) -> Result<(), McpArtifactExportReadError> {
-    *emitted_bytes = emitted_bytes
-        .checked_add(chunk.len())
-        .ok_or(McpArtifactExportReadError::Unsafe)?;
-    if *emitted_bytes > expected_bytes {
-        return Err(McpArtifactExportReadError::Unsafe);
-    }
-    sha256.update(chunk);
-    let encoded = encoder.push(chunk);
-    if !encoded.is_empty() {
-        mcp_artifact_export_send_frame(sender, encoded.into_bytes()).await?;
-    }
-    Ok(())
-}
-
-async fn mcp_artifact_export_stream_transfer(
-    runtime: &ToolRuntime,
-    id: &Value,
-    auth: Option<&AuthContext>,
-    mut plan: McpArtifactExportStreamPlan,
-    sender: mpsc::Sender<McpArtifactExportStreamFrame>,
-) -> Result<(), McpArtifactExportReadError> {
-    let snapshot = plan.record.snapshot.clone();
-    mcp_artifact_export_send_frame(
-        &sender,
-        mcp_artifact_export_stream_prefix(id, &plan.uri, &snapshot.mime_type)?,
-    )
-    .await?;
-
-    let mut encoder = McpArtifactExportBase64Encoder::default();
-    let mut sha256 = Sha256::new();
-    let mut emitted_bytes = 0usize;
-    if !plan.first_chunk.is_empty() {
-        let first_chunk = std::mem::take(&mut plan.first_chunk);
-        mcp_artifact_export_emit_chunk(
-            &sender,
-            &mut encoder,
-            &mut sha256,
-            &mut emitted_bytes,
-            snapshot.bytes,
-            &first_chunk,
-        )
-        .await?;
-    }
-    if emitted_bytes != plan.offset {
-        return Err(McpArtifactExportReadError::Unsafe);
-    }
-
-    match plan.route {
-        Some(McpArtifactExportChunkRoute::Legacy) => {
-            while plan.offset < snapshot.bytes {
-                if plan.chunks >= plan.max_chunks {
-                    return Err(McpArtifactExportReadError::Unsafe);
-                }
-                plan.chunks = plan.chunks.saturating_add(1);
-                let length = (snapshot.bytes - plan.offset).min(MAX_READ_PROJECT_ARTIFACT_LENGTH);
-                let chunk = mcp_artifact_export_with_read_budget(
-                    runtime,
-                    &mut plan.read_budget,
-                    mcp_artifact_export_read_legacy_chunk(
-                        runtime,
-                        &plan.record,
-                        auth,
-                        plan.offset,
-                        length,
-                    ),
-                )
-                .await?;
-                plan.offset = plan
-                    .offset
-                    .checked_add(chunk.len())
-                    .ok_or(McpArtifactExportReadError::Unsafe)?;
-                mcp_artifact_export_emit_chunk(
-                    &sender,
-                    &mut encoder,
-                    &mut sha256,
-                    &mut emitted_bytes,
-                    snapshot.bytes,
-                    &chunk,
-                )
-                .await?;
-            }
-        }
-        Some(McpArtifactExportChunkRoute::Optimized) => {
-            while plan.offset < snapshot.bytes {
-                let mut batch = Vec::with_capacity(MAX_MCP_ARTIFACT_EXPORT_CHUNK_READS);
-                let mut batch_offset = plan.offset;
-                while batch.len() < MAX_MCP_ARTIFACT_EXPORT_CHUNK_READS
-                    && batch_offset < snapshot.bytes
-                {
-                    if plan.chunks >= plan.max_chunks {
-                        return Err(McpArtifactExportReadError::Unsafe);
-                    }
-                    plan.chunks = plan.chunks.saturating_add(1);
-                    let length =
-                        (snapshot.bytes - batch_offset).min(MAX_READ_PROJECT_ARTIFACT_LENGTH);
-                    batch.push((batch_offset, length));
-                    batch_offset = batch_offset
-                        .checked_add(length)
-                        .ok_or(McpArtifactExportReadError::Unsafe)?;
-                }
-                let runtime_ref = runtime;
-                let record = &plan.record;
-                let results =
-                    mcp_artifact_export_with_read_budget(runtime, &mut plan.read_budget, async {
-                        Ok(
-                            join_all(batch.iter().map(|&(batch_offset, length)| async move {
-                                mcp_artifact_export_read_optimized_chunk(
-                                    runtime_ref,
-                                    record,
-                                    auth,
-                                    batch_offset,
-                                    length,
-                                )
-                                .await
-                            }))
-                            .await,
-                        )
-                    })
-                    .await?;
-
-                // Drain the full bounded batch before surfacing an offset-ordered
-                // error. This preserves the existing no-abandoned-request rule.
-                for ((requested_offset, _), result) in batch.into_iter().zip(results) {
-                    if requested_offset != plan.offset {
-                        return Err(McpArtifactExportReadError::Unsafe);
-                    }
-                    let chunk = result?.ok_or(McpArtifactExportReadError::Unavailable)?;
-                    plan.offset = plan
-                        .offset
-                        .checked_add(chunk.len())
-                        .ok_or(McpArtifactExportReadError::Unsafe)?;
-                    mcp_artifact_export_emit_chunk(
-                        &sender,
-                        &mut encoder,
-                        &mut sha256,
-                        &mut emitted_bytes,
-                        snapshot.bytes,
-                        &chunk,
-                    )
-                    .await?;
-                }
-            }
-        }
-        None => {}
-    }
-
-    if emitted_bytes != snapshot.bytes || plan.offset != snapshot.bytes {
-        return Err(McpArtifactExportReadError::Unsafe);
-    }
-    let final_sha256 = format!("{:x}", sha256.finalize());
-    if final_sha256 != snapshot.sha256 {
-        // Bytes may already have reached the HTTP peer. Fail closed by never
-        // emitting the base64 tail or closing JSON suffix, so a changed file
-        // cannot become a syntactically valid successful MCP resource result.
-        return Err(McpArtifactExportReadError::SnapshotChanged);
-    }
-    let tail = encoder.finish();
-    if !tail.is_empty() {
-        mcp_artifact_export_send_frame(&sender, tail.into_bytes()).await?;
-    }
-    mcp_artifact_export_send_frame(&sender, mcp_artifact_export_stream_suffix()?).await?;
-    Ok(())
-}
-
-fn mcp_artifact_export_stream_io_error(error: &McpArtifactExportReadError) -> std::io::Error {
-    let message = match error {
-        McpArtifactExportReadError::SnapshotChanged => {
-            "artifact export stream failed snapshot integrity validation"
-        }
-        McpArtifactExportReadError::Timeout => "artifact export stream timed out",
-        _ => "artifact export stream failed",
-    };
-    std::io::Error::other(message)
-}
-
-#[cfg(test)]
-async fn mcp_artifact_export_collect_stream_response(
-    runtime: &ToolRuntime,
-    id: &Value,
-    auth: Option<&AuthContext>,
-    plan: McpArtifactExportStreamPlan,
-) -> Result<Value, McpArtifactExportReadError> {
-    let (sender, mut receiver) = mpsc::channel::<McpArtifactExportStreamFrame>(1);
-    let transfer = mcp_artifact_export_stream_transfer(runtime, id, auth, plan, sender);
-    let collect = async {
-        let mut body = Vec::new();
-        while let Some(frame) = receiver.recv().await {
-            let frame = frame.map_err(|_| McpArtifactExportReadError::Unsafe)?;
-            body.extend_from_slice(&frame);
-        }
-        Ok::<Vec<u8>, McpArtifactExportReadError>(body)
-    };
-    let (transfer_result, body_result) = tokio::join!(transfer, collect);
-    transfer_result?;
-    serde_json::from_slice(&body_result?).map_err(|_| McpArtifactExportReadError::Unsafe)
-}
-
-#[cfg(test)]
-async fn mcp_artifact_export_resource_read_with_gate_timeout(
-    runtime: &ToolRuntime,
-    uri: &str,
-    auth: Option<&AuthContext>,
-    gate: Arc<Semaphore>,
-    admission_timeout: Duration,
-    read_timeout: Duration,
-) -> Result<Value, McpArtifactExportReadError> {
-    let plan = mcp_artifact_export_stream_plan_with_gate_timeout(
-        runtime,
-        uri,
-        auth,
-        gate,
-        admission_timeout,
-        read_timeout,
-    )
-    .await?;
-    let response =
-        mcp_artifact_export_collect_stream_response(runtime, &Value::Null, auth, plan).await?;
-    response
-        .get("result")
-        .cloned()
-        .ok_or(McpArtifactExportReadError::Unsafe)
-}
-
-#[cfg(test)]
-async fn mcp_artifact_export_resource_read_with_gate(
-    runtime: &ToolRuntime,
-    uri: &str,
-    auth: Option<&AuthContext>,
-    gate: Arc<Semaphore>,
-    admission_timeout: Duration,
-) -> Result<Value, McpArtifactExportReadError> {
-    mcp_artifact_export_resource_read_with_gate_timeout(
-        runtime,
-        uri,
-        auth,
-        gate,
-        admission_timeout,
-        MCP_ARTIFACT_EXPORT_READ_TIMEOUT,
-    )
-    .await
-}
-
-fn mcp_artifact_export_read_error_outcome(
-    id: Option<Value>,
-    auth: Option<&AuthContext>,
-    error: McpArtifactExportReadError,
-) -> McpOutcome {
-    match error {
-        McpArtifactExportReadError::Forbidden {
-            required_scope,
-            description,
-        } => scope_forbidden(auth, required_scope, description),
-        McpArtifactExportReadError::Unavailable => McpOutcome::BadRequest(rpc_error(
-            id,
-            -32602,
-            "Artifact export resource is unavailable",
-        )),
-        McpArtifactExportReadError::SnapshotChanged => McpOutcome::BadRequest(rpc_error(
-            id,
-            -32602,
-            "Exported artifact no longer matches its snapshot",
-        )),
-        McpArtifactExportReadError::Unsafe => McpOutcome::BadRequest(rpc_error(
-            id,
-            -32603,
-            "Artifact export resource failed bounded safety validation",
-        )),
-        McpArtifactExportReadError::Busy => McpOutcome::BadRequest(rpc_error(
-            id,
-            MCP_ARTIFACT_EXPORT_BUSY_CODE,
-            "Artifact export is temporarily busy; retry later",
-        )),
-        McpArtifactExportReadError::Timeout => McpOutcome::BadRequest(rpc_error(
-            id,
-            -32603,
-            "Artifact export resource read timed out",
-        )),
-    }
 }
 
 /// Outcome of handling a single MCP JSON-RPC request.
@@ -2037,7 +621,7 @@ enum McpOutcome {
     /// incrementally by the HTTP wrapper without whole-file aggregation.
     ArtifactExportStream {
         id: Value,
-        plan: McpArtifactExportStreamPlan,
+        plan: resources::McpArtifactExportStreamPlan,
     },
     /// A JSON-RPC protocol error. HTTP 400 with the error body.
     BadRequest(Value),
@@ -2243,12 +827,12 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
             .params
             .get("uri")
             .and_then(Value::as_str)
-            .filter(|uri| is_mcp_computer_app_resource_uri(uri))
+            .filter(|uri| resources::is_mcp_computer_app_resource_uri(uri))
             .map(str::to_string)
     } else {
         None
     };
-    let computer_app_ui_capability_present = request_supports_mcp_apps(&request.params);
+    let computer_app_ui_capability_present = resources::request_supports_mcp_apps(&request.params);
     // Computer App resource delivery is part of gray-card diagnosis, but its
     // durable projection must remain metadata-only. Never persist App HTML,
     // screenshot/tool-result content, tool arguments, window titles, or other
@@ -2510,38 +1094,8 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
             guard.response_serialized(200, None, Some(true), None, "artifact_export_stream");
             res.status_code(StatusCode::OK);
             let _ = res.add_header("content-type", "application/json", true);
-            let (sender, receiver) = mpsc::channel::<McpArtifactExportStreamFrame>(1);
-            let error_sender = sender.clone();
-            let stream_runtime = runtime.clone();
-            let stream_auth = auth.clone();
-            tokio::spawn(async move {
-                let transfer = mcp_artifact_export_stream_transfer(
-                    &stream_runtime,
-                    &id,
-                    stream_auth.as_ref(),
-                    plan,
-                    sender,
-                );
-                match tokio::time::timeout(MCP_ARTIFACT_EXPORT_STREAM_TIMEOUT, transfer).await {
-                    Ok(Ok(())) => {}
-                    Ok(Err(error)) => {
-                        let _ = error_sender
-                            .send(Err(mcp_artifact_export_stream_io_error(&error)))
-                            .await;
-                    }
-                    Err(_) => {
-                        stream_runtime
-                            .shell_clients
-                            .cancel_abandoned_sync_requests()
-                            .await;
-                        let _ = error_sender
-                            .send(Err(std::io::Error::other(
-                                "artifact export stream exceeded bounded transfer timeout",
-                            )))
-                            .await;
-                    }
-                }
-            });
+            let receiver =
+                resources::start_artifact_export_stream(runtime.clone(), id, auth.clone(), plan);
             let response_stream = stream::unfold(receiver, |mut receiver| async move {
                 receiver.recv().await.map(|frame| (frame, receiver))
             });
@@ -2639,9 +1193,13 @@ async fn handle_mcp_request(
     .await;
     match outcome {
         McpOutcome::ArtifactExportStream { id, plan } => {
-            match mcp_artifact_export_collect_stream_response(runtime, &id, auth, plan).await {
+            match resources::mcp_artifact_export_collect_stream_response(runtime, &id, auth, plan)
+                .await
+            {
                 Ok(body) => McpOutcome::Ok(body),
-                Err(error) => mcp_artifact_export_read_error_outcome(Some(id), auth, error),
+                Err(error) => {
+                    resources::mcp_artifact_export_read_error_outcome(Some(id), auth, error)
+                }
             }
         }
         outcome => outcome,
@@ -2660,31 +1218,17 @@ async fn handle_mcp_request_with_lifecycle(
     mut model_ergonomics_out: Option<&mut Option<ModelErgonomicsRecord>>,
 ) -> McpOutcome {
     let stateless_2026 = protocol_era == McpProtocolEra::Stateless2026;
-    let artifact_export_resource_read = stateless_2026
+    let resource_read_bypasses_runtime_read = stateless_2026
         && request.method == "resources/read"
-        && request
-            .params
-            .get("uri")
-            .and_then(Value::as_str)
-            .is_some_and(|uri| uri.starts_with(MCP_ARTIFACT_EXPORT_URI_PREFIX));
-    let snapshot_resource_read = stateless_2026
-        && request.method == "resources/read"
-        && request
-            .params
-            .get("uri")
-            .and_then(Value::as_str)
-            .is_some_and(|uri| uri.starts_with(MCP_SNAPSHOT_RESOURCE_URI_PREFIX));
-    let mcp_app_enabled = stateless_2026
-        && model_surface_supports_computer_app(runtime.model_surface())
-        && request_supports_mcp_apps(&request.params);
+        && resources::resource_read_bypasses_runtime_read(&request.params);
+    let mcp_app_enabled =
+        resources::mcp_app_enabled(stateless_2026, runtime.model_surface(), &request.params);
 
     if auth.is_some()
         && (matches!(
             request.method.as_str(),
             "server/discover" | "tools/list" | "resources/list"
-        ) || (request.method == "resources/read"
-            && !artifact_export_resource_read
-            && !snapshot_resource_read)
+        ) || (request.method == "resources/read" && !resource_read_bypasses_runtime_read)
             || (!stateless_2026
                 && matches!(
                     request.method.as_str(),
@@ -2754,16 +1298,8 @@ async fn handle_mcp_request_with_lifecycle(
                     MCP_CHATGPT_PROTOCOL_VERSION,
                     MCP_PROTOCOL_VERSION
                 ],
-                "capabilities": if model_surface_supports_computer_app(runtime.model_surface()) {
-                    json!({
-                        "tools": { "listChanged": false },
-                        "resources": { "listChanged": false, "subscribe": false },
-                        "extensions": {
-                            MCP_UI_EXTENSION: {
-                                "mimeTypes": [MCP_UI_RESOURCE_MIME_TYPE]
-                            }
-                        }
-                    })
+                "capabilities": if resources::model_surface_supports_computer_app(runtime.model_surface()) {
+                    resources::server_capabilities()
                 } else if tasks::model_surface_supports_tasks(runtime.model_surface()) {
                     tasks::server_capabilities()
                 } else {
@@ -2801,7 +1337,7 @@ async fn handle_mcp_request_with_lifecycle(
                     mcp_tools_list_payload_with_features_for_auth(
                         runtime.model_surface(),
                         crate::config::mcp_compact_schemas_enabled(),
-                        model_surface_supports_computer_app(runtime.model_surface()),
+                        resources::model_surface_supports_computer_app(runtime.model_surface()),
                         true,
                         auth,
                     )
@@ -2809,7 +1345,7 @@ async fn handle_mcp_request_with_lifecycle(
                     mcp_tools_list_payload_with_compact_and_app(
                         runtime.model_surface(),
                         crate::config::mcp_compact_schemas_enabled(),
-                        model_surface_supports_computer_app(runtime.model_surface()),
+                        resources::model_surface_supports_computer_app(runtime.model_surface()),
                     )
                 }
             } else if oauth_scope_projection {
@@ -2841,106 +1377,17 @@ async fn handle_mcp_request_with_lifecycle(
             )
         }
         "resources/list" if stateless_2026 => {
-            let result = if mcp_app_enabled {
-                mcp_computer_app_resources_list()
-            } else {
-                json!({ "resources": [] })
-            };
-            rpc_result(id, mcp_stateless_result(result, true))
+            return resources::handle_list(id, mcp_app_enabled);
         }
         "resources/read" if stateless_2026 => {
-            let Some(uri) = request.params.get("uri").and_then(Value::as_str) else {
-                return McpOutcome::BadRequest(rpc_error(
-                    id,
-                    -32602,
-                    "Invalid params: uri is required",
-                ));
-            };
-            if uri.starts_with(MCP_ARTIFACT_EXPORT_URI_PREFIX) {
-                let response_id = id.clone().unwrap_or(Value::Null);
-                let plan = match mcp_artifact_export_stream_plan(runtime, uri, auth).await {
-                    Ok(plan) => plan,
-                    Err(error) => return mcp_artifact_export_read_error_outcome(id, auth, error),
-                };
-                return McpOutcome::ArtifactExportStream {
-                    id: response_id,
-                    plan,
-                };
-            }
-            if uri.starts_with(MCP_SNAPSHOT_RESOURCE_URI_PREFIX) {
-                let caller = match mcp_artifact_export_caller_binding(auth) {
-                    Ok(caller) => caller,
-                    Err(_) => {
-                        return McpOutcome::BadRequest(rpc_error(
-                            id,
-                            -32602,
-                            format!("Resource not found: {uri}"),
-                        ))
-                    }
-                };
-                let record = mcp_snapshot_resource_registry()
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .get_for_caller(uri, &caller);
-                let Some(record) = record else {
-                    return McpOutcome::BadRequest(rpc_error(
-                        id,
-                        -32602,
-                        format!("Resource not found: {uri}"),
-                    ));
-                };
-                for scope in match record.kind {
-                    McpSnapshotResourceKind::Window => &[crate::auth::SCOPE_COMPUTER_READ][..],
-                    McpSnapshotResourceKind::Display => &[
-                        crate::auth::SCOPE_COMPUTER_READ,
-                        crate::auth::SCOPE_COMPUTER_DISPLAY_READ,
-                    ][..],
-                } {
-                    if let Some(outcome) = require_mcp_scope(auth, scope) {
-                        return outcome;
-                    }
-                }
-                tracing::info!(
-                    target: "webcodex::mcp",
-                    resource_kind = ?record.kind,
-                    file_bytes = record.bytes.len(),
-                    "mcp_snapshot_resource_read"
-                );
-                let result = json!({
-                    "contents": [{
-                        "uri": uri,
-                        "mimeType": record.mime_type,
-                        "blob": general_purpose::STANDARD.encode(record.bytes.as_ref())
-                    }]
-                });
-                return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(result, true)));
-            }
-            // Tool descriptors on the full-operator surface advertise the App
-            // resource independently of whether a later resource fetch repeats
-            // the UI client-capability metadata. Keep resources/list negotiated,
-            // but allow a client to dereference an already-advertised resource.
-            if !model_surface_supports_computer_app(runtime.model_surface()) {
-                return McpOutcome::BadRequest(rpc_error(
-                    id,
-                    -32602,
-                    "MCP App resource is unavailable on this model surface",
-                ));
-            }
-            let Some(result) = mcp_computer_app_resource_read(uri) else {
-                return McpOutcome::BadRequest(rpc_error(
-                    id,
-                    -32602,
-                    format!("Resource not found: {uri}"),
-                ));
-            };
-            let mut result = mcp_stateless_result(result, true);
-            // The canonical URI uses the current delivery TTL policy (temporarily
-            // zero during gray-card diagnosis). Hidden legacy aliases always stay
-            // zero-TTL because they intentionally serve the current HTML.
-            if uri == MCP_COMPUTER_UI_RESOURCE_URI {
-                result["ttlMs"] = Value::from(MCP_COMPUTER_UI_RESOURCE_TTL_MS);
-            }
-            rpc_result(id, result)
+            return resources::handle_read(
+                runtime,
+                request.params,
+                id,
+                auth,
+                runtime.model_surface(),
+            )
+            .await;
         }
         method @ ("tasks/get" | "tasks/update" | "tasks/cancel")
             if stateless_2026 && tasks::model_surface_supports_tasks(runtime.model_surface()) =>
@@ -3026,17 +1473,15 @@ async fn handle_mcp_request_with_lifecycle(
             // shared ToolRuntime kernel; preserve those failed attempts in generic
             // telemetry without creating a second record for normal kernel calls.
             let mut pre_kernel_model_ergonomics = ModelErgonomicsTimer::start(&params.name);
-            let artifact_export_caller = if params.name == "export_project_artifact" {
-                if !stateless_2026 || runtime.model_surface() != ModelSurface::FullOperatorRuntime {
-                    return McpOutcome::BadRequest(rpc_error(
-                        id,
-                        -32602,
-                        "export_project_artifact requires the stateless-2026 full-operator MCP surface",
-                    ));
-                }
-                match mcp_artifact_export_caller_binding(auth) {
-                    Ok(caller) => Some(caller),
-                    Err(error) => {
+            let resource_tool_call = match resources::prepare_tool_call(
+                &params.name,
+                stateless_2026,
+                runtime.model_surface(),
+                auth,
+            ) {
+                Ok(context) => context,
+                Err(error) => {
+                    if error.records_model_ergonomics_failure() {
                         if let (Some(slot), Some(timer)) = (
                             model_ergonomics_out.as_deref_mut(),
                             pre_kernel_model_ergonomics.take(),
@@ -3047,25 +1492,9 @@ async fn handle_mcp_request_with_lifecycle(
                                     .record_for_pre_result_failure("invalid_arguments"),
                             );
                         }
-                        return McpOutcome::BadRequest(rpc_error(
-                            id,
-                            -32602,
-                            format!("export_project_artifact cannot bind this caller: {error}"),
-                        ));
                     }
+                    return McpOutcome::BadRequest(rpc_error(id, -32602, error.message()));
                 }
-            } else {
-                None
-            };
-            let snapshot_resource_caller = if stateless_2026
-                && runtime.model_surface() == ModelSurface::FullOperatorRuntime
-                && matches!(
-                    params.name.as_str(),
-                    "computer_snapshot" | "computer_snapshot_display"
-                ) {
-                mcp_artifact_export_caller_binding(auth).ok()
-            } else {
-                None
             };
             if runtime.model_surface() == ModelSurface::CanonicalConnector {
                 let connector = connector.expect("validated canonical Connector state");
@@ -3349,19 +1778,12 @@ async fn handle_mcp_request_with_lifecycle(
                     lc.dispatch_finished(true, Some(false), category);
                 }
             }
-            let result = if params.name == "export_project_artifact" {
-                mcp_artifact_export_tool_result(
-                    result,
-                    artifact_export_caller.expect("validated artifact export caller binding"),
-                )
-            } else {
-                mcp_runtime_tool_result_with_snapshot_resource(
-                    &params.name,
-                    as_image_requested,
-                    result,
-                    snapshot_resource_caller,
-                )
-            };
+            let result = resources::adapt_tool_result(
+                &params.name,
+                as_image_requested,
+                result,
+                resource_tool_call,
+            );
             let model_ergonomics = model_ergonomics_completion.as_ref().and_then(|completion| {
                 result
                     .get("structuredContent")

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,36 +1,53 @@
+mod http_metadata;
+mod protocol;
 mod resources;
+mod response;
 mod tasks;
+mod tools;
 
 use crate::action_audit::{ActionAudit, ActionAuditRecord};
 use crate::auth::AuthContext;
-use crate::connector_runtime::{ConnectorRuntime, ConnectorRuntimeSlot, ConnectorTransport};
+use crate::connector_runtime::{ConnectorRuntime, ConnectorRuntimeSlot};
 use crate::json_error;
 use crate::model_surface::ModelSurface;
 use crate::tool_request_trace::{
     estimate_json_bytes, jsonrpc_id_safe, new_trace_id, scope_active_trace, ToolRequestLifecycle,
 };
-use crate::tool_runtime::kernel::{
-    check_runtime_tool_scope, HostFileImportTrust, ToolCallContext, ToolCallErrorStatus,
-    ToolCallRequest as KernelToolCallRequest, ToolTransport,
-};
+use crate::tool_runtime::kernel::HostFileImportTrust;
 use crate::tool_runtime::model_ergonomics_telemetry::{
     ModelErgonomicsRecord, ModelErgonomicsTimer,
 };
-use crate::tool_runtime::tool_definition::LOCAL_CODING_TOOL_NAMES;
+#[cfg(test)]
+use crate::tool_runtime::registered_tool_specs;
+#[cfg(test)]
+use crate::tool_runtime::ToolResult;
+use crate::tool_runtime::ToolRuntime;
 #[cfg(test)]
 use crate::tool_runtime::MAX_PROJECT_ARTIFACT_BYTES;
-use crate::tool_runtime::{registered_tool_specs, ToolResult, ToolRuntime, ToolSpec};
 #[cfg(test)]
 use crate::tool_runtime::{
     validate_project_artifact_export_snapshot, ProjectArtifactExportSnapshot,
     MAX_PROJECT_ARTIFACT_EXPORT_BYTES, MAX_READ_PROJECT_ARTIFACT_LENGTH,
 };
-use base64::engine::general_purpose;
 #[cfg(test)]
 use base64::Engine as _;
 use futures_util::stream;
+use http_metadata::{request_header, validate_http_protocol, MCP_PROTOCOL_VERSION_HEADER};
+#[cfg(test)]
+use http_metadata::{
+    MCP_HEADER_MISMATCH, MCP_METHOD_HEADER, MCP_NAME_HEADER, MCP_UNSUPPORTED_PROTOCOL_VERSION,
+};
+#[cfg(test)]
+use protocol::{
+    inferred_protocol_era, request_protocol_version, MCP_CHATGPT_PROTOCOL_VERSION,
+    MCP_SUPPORTED_PROTOCOL_VERSIONS,
+};
+use protocol::{
+    JsonRpcRequest, McpProtocolEra, MCP_INFO_METHODS, MCP_PROTOCOL_VERSION,
+    MCP_STATELESS_PROTOCOL_VERSION,
+};
+use response::{rpc_error, rpc_result};
 use salvo::prelude::*;
-use serde::Deserialize;
 use serde_json::{json, Value};
 use std::sync::Arc;
 #[cfg(test)]
@@ -45,34 +62,15 @@ use tasks::{
     mcp_create_task_result, request_supports_tasks, MCP_MISSING_REQUIRED_CLIENT_CAPABILITY,
     MCP_TASKS_EXTENSION,
 };
-
-const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
-const MCP_CHATGPT_PROTOCOL_VERSION: &str = "2025-11-25";
-const MCP_STATELESS_PROTOCOL_VERSION: &str = "2026-07-28";
-const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
-const MCP_METHOD_HEADER: &str = "mcp-method";
-const MCP_NAME_HEADER: &str = "mcp-name";
-const MCP_HEADER_MISMATCH: i64 = -32020;
-const MCP_UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
-const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
-    MCP_STATELESS_PROTOCOL_VERSION,
-    MCP_CHATGPT_PROTOCOL_VERSION,
-    MCP_PROTOCOL_VERSION,
-];
-/// Single source of truth for the JSON-RPC methods advertised by `GET /mcp`.
-/// Must match the dispatch arms in `handle_mcp_request_with_lifecycle`;
-/// pinned by `mcp_info_advertised_methods_match_dispatch`.
-const MCP_INFO_METHODS: &[&str] = &[
-    "server/discover",
-    "initialize",
-    "ping",
-    "tools/list",
-    "tools/call",
-    "resources/list",
-    "resources/read",
-    "notifications/initialized",
-];
-const MCP_RESERVED_SESSION_ID_FIELD: &str = "_session_id";
+#[cfg(test)]
+use tools::{
+    add_stateless_workflow_recorder_metadata, mcp_host_file_import_trust_decision_from_state,
+    mcp_host_file_import_trust_from_state, mcp_tools_list_payload_with_compact,
+    mcp_tools_list_payload_with_compact_and_app, strip_stateless_ack_session_context_revision,
+    strip_stateless_ack_session_message_ids, strip_stateless_session_message_resolution,
+    take_last_mcp_host_file_import_trust_decision, HostFileImportTrustReason, McpToolCallParams,
+    MCP_RESERVED_SESSION_ID_FIELD,
+};
 
 /// Hard upper bound on a single MCP JSON-RPC dispatch, applied in `mcp_post`.
 ///
@@ -82,30 +80,6 @@ const MCP_RESERVED_SESSION_ID_FIELD: &str = "_session_id";
 /// an otherwise-permanently-silent HTTP request into an explicit JSON-RPC
 /// error the client can surface.
 const MCP_DISPATCH_HARD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(150);
-
-#[derive(Debug, Deserialize)]
-struct JsonRpcRequest {
-    #[serde(default)]
-    jsonrpc: Option<String>,
-    pub method: String,
-    #[serde(default)]
-    pub params: Value,
-    #[serde(default)]
-    pub id: Option<Value>,
-}
-
-#[derive(Debug, Deserialize)]
-struct McpToolCallParams {
-    pub name: String,
-    #[serde(default)]
-    pub arguments: Value,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum McpProtocolEra {
-    Legacy,
-    Stateless2026,
-}
 
 fn runtime(depot: &Depot) -> Option<Arc<ToolRuntime>> {
     depot.obtain::<Arc<ToolRuntime>>().ok().cloned()
@@ -136,476 +110,13 @@ fn validate_model_surface_state(
     }
 }
 
-fn tool_name_from_params(params: &Value) -> Option<String> {
-    params
-        .get("name")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-}
-
-fn project_from_tool_call_params(params: &Value) -> Option<String> {
-    params["arguments"]["project"].as_str().map(str::to_string)
-}
-
-fn request_protocol_version(params: &Value) -> Option<&str> {
-    params
-        .get("_meta")
-        .and_then(|meta| meta.get("io.modelcontextprotocol/protocolVersion"))
-        .and_then(Value::as_str)
-}
-
-fn request_client_capabilities(params: &Value) -> Option<&Value> {
-    params
-        .get("_meta")
-        .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
-}
-
-fn request_client_info_is_valid(params: &Value) -> bool {
-    let Some(meta) = params.get("_meta").and_then(Value::as_object) else {
-        return true;
-    };
-    let Some(client_info) = meta.get("io.modelcontextprotocol/clientInfo") else {
-        return true;
-    };
-    let Some(client_info) = client_info.as_object() else {
-        return false;
-    };
-    client_info.get("name").is_some_and(Value::is_string)
-        && client_info.get("version").is_some_and(Value::is_string)
-}
-
-fn request_header<'a>(req: &'a Request, name: &str) -> Option<&'a str> {
-    req.headers()
-        .get(name)
-        .and_then(|value| value.to_str().ok())
-}
-
-fn decode_mcp_name_header(value: &str) -> Result<String, ()> {
-    let Some(encoded) = value
-        .strip_prefix("=?base64?")
-        .and_then(|value| value.strip_suffix("?="))
-    else {
-        return Ok(value.to_string());
-    };
-    let bytes = base64::Engine::decode(&general_purpose::STANDARD, encoded).map_err(|_| ())?;
-    String::from_utf8(bytes).map_err(|_| ())
-}
-
-fn request_mcp_name(request: &JsonRpcRequest) -> Option<Option<&str>> {
-    match request.method.as_str() {
-        "tools/call" | "prompts/get" => Some(request.params.get("name").and_then(Value::as_str)),
-        "resources/read" => Some(request.params.get("uri").and_then(Value::as_str)),
-        "tasks/get" | "tasks/update" | "tasks/cancel" => {
-            Some(request.params.get("taskId").and_then(Value::as_str))
-        }
-        _ => None,
-    }
-}
-
-fn header_mismatch(id: Option<Value>, message: impl Into<String>) -> Value {
-    rpc_error(id, MCP_HEADER_MISMATCH, message)
-}
-
-fn unsupported_protocol_version(id: Option<Value>, requested: &str) -> Value {
-    rpc_error_with_data(
-        id,
-        MCP_UNSUPPORTED_PROTOCOL_VERSION,
-        format!("Unsupported MCP protocol version: {requested}"),
-        json!({
-            "supported": MCP_SUPPORTED_PROTOCOL_VERSIONS,
-            "requested": requested,
-        }),
-    )
-}
-
 #[cfg(test)]
-fn inferred_protocol_era(request: &JsonRpcRequest) -> McpProtocolEra {
-    if request_protocol_version(&request.params) == Some(MCP_STATELESS_PROTOCOL_VERSION) {
-        McpProtocolEra::Stateless2026
-    } else {
-        McpProtocolEra::Legacy
-    }
-}
-
-fn legacy_initialize_protocol_version(params: &Value) -> &'static str {
-    match params.get("protocolVersion").and_then(Value::as_str) {
-        Some(MCP_CHATGPT_PROTOCOL_VERSION) => MCP_CHATGPT_PROTOCOL_VERSION,
-        Some(MCP_PROTOCOL_VERSION) => MCP_PROTOCOL_VERSION,
-        _ => MCP_PROTOCOL_VERSION,
-    }
-}
-
-/// Validate the HTTP-only request metadata introduced by MCP 2026-07-28.
-/// Requests with no modern markers retain the existing 2025-06-18 behavior.
-fn validate_http_protocol(
-    req: &Request,
-    request: &JsonRpcRequest,
-) -> Result<McpProtocolEra, Value> {
-    let id = request.id.clone();
-    let header_version = request_header(req, MCP_PROTOCOL_VERSION_HEADER);
-    let body_version = request_protocol_version(&request.params);
-
-    if let (Some(header), Some(body)) = (header_version, body_version) {
-        if header != body {
-            return Err(header_mismatch(
-                id.clone(),
-                format!(
-                    "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} header value '{header}' does not match params._meta protocolVersion '{body}'"
-                ),
-            ));
-        }
-    }
-
-    for requested in [header_version, body_version].into_iter().flatten() {
-        if !MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
-            return Err(unsupported_protocol_version(id.clone(), requested));
-        }
-    }
-
-    let stateless = header_version == Some(MCP_STATELESS_PROTOCOL_VERSION)
-        || body_version == Some(MCP_STATELESS_PROTOCOL_VERSION);
-    if !stateless {
-        return Ok(McpProtocolEra::Legacy);
-    }
-
-    if header_version != Some(MCP_STATELESS_PROTOCOL_VERSION) {
-        return Err(header_mismatch(
-            id,
-            format!(
-                "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} is required and must equal {MCP_STATELESS_PROTOCOL_VERSION}"
-            ),
-        ));
-    }
-    if body_version != Some(MCP_STATELESS_PROTOCOL_VERSION) {
-        return Err(header_mismatch(
-            id,
-            format!(
-                "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} does not match params._meta protocolVersion"
-            ),
-        ));
-    }
-    if request.id.is_some() {
-        if !request_client_capabilities(&request.params).is_some_and(Value::is_object) {
-            return Err(rpc_error(
-                id.clone(),
-                -32602,
-                "Invalid params: MCP 2026-07-28 requests require params._meta clientCapabilities",
-            ));
-        }
-        if !request_client_info_is_valid(&request.params) {
-            return Err(rpc_error(
-                id,
-                -32602,
-                "Invalid params: params._meta clientInfo must contain string name and version fields when present",
-            ));
-        }
-    }
-
-    match request_header(req, MCP_METHOD_HEADER) {
-        Some(method) if method == request.method => {}
-        Some(method) => {
-            return Err(header_mismatch(
-                id,
-                format!(
-                    "Header mismatch: Mcp-Method header value '{method}' does not match body value '{}'",
-                    request.method
-                ),
-            ));
-        }
-        None => {
-            return Err(header_mismatch(
-                id,
-                "Header mismatch: required Mcp-Method header is missing or malformed",
-            ));
-        }
-    }
-
-    if let Some(body_name) = request_mcp_name(request) {
-        let header_name = request_header(req, MCP_NAME_HEADER)
-            .and_then(|value| decode_mcp_name_header(value).ok());
-        match (header_name.as_deref(), body_name) {
-            (Some(header), Some(body)) if header == body => {}
-            (Some(header), Some(body)) => {
-                return Err(header_mismatch(
-                    id,
-                    format!(
-                        "Header mismatch: Mcp-Name header value '{header}' does not match body value '{body}'"
-                    ),
-                ));
-            }
-            _ => {
-                return Err(header_mismatch(
-                    id,
-                    "Header mismatch: required Mcp-Name header is missing, malformed, or has no matching body value",
-                ));
-            }
-        }
-    }
-
-    Ok(McpProtocolEra::Stateless2026)
-}
-
-fn mcp_stateless_result(mut result: Value, cacheable: bool) -> Value {
-    let Some(object) = result.as_object_mut() else {
-        return result;
-    };
-    object
-        .entry("resultType".to_string())
-        .or_insert_with(|| Value::String("complete".to_string()));
-    if cacheable {
-        object
-            .entry("ttlMs".to_string())
-            .or_insert_with(|| Value::from(0));
-        object
-            .entry("cacheScope".to_string())
-            .or_insert_with(|| Value::String("private".to_string()));
-    }
-    let meta = object
-        .entry("_meta".to_string())
-        .or_insert_with(|| json!({}));
-    if let Some(meta_object) = meta.as_object_mut() {
-        meta_object
-            .entry("io.modelcontextprotocol/serverInfo".to_string())
-            .or_insert_with(|| {
-                json!({
-                    "name": "webcodex",
-                    "version": env!("CARGO_PKG_VERSION")
-                })
-            });
-    }
-    result
-}
-
-fn connector_call_tool_result(outcome: crate::connector_runtime::ConnectorCallOutcome) -> Value {
-    let text = serde_json::to_string(&outcome.body).unwrap_or_else(|_| "{}".to_string());
-    json!({
-        "content": [{ "type": "text", "text": text }],
-        "structuredContent": outcome.body,
-        "isError": !outcome.ok
-    })
-}
-
-/// MCP tools/list payload for the immutable startup-selected model surface.
-///
-/// Env adapter: resolves the `WEBCODEX_MCP_COMPACT_SCHEMAS` switch and
-/// delegates to the pure renderer.
-fn mcp_tools_list_payload(model_surface: ModelSurface) -> Value {
-    mcp_tools_list_payload_with_compact(model_surface, crate::config::mcp_compact_schemas_enabled())
-}
-
-/// Pure tools/list rendering with an explicit compact switch; no env access.
-/// Production resolves the switch from the env adapter above; tests pass an
-/// explicit bool so they never need process-global env. The schema shape is
-/// identical to the adapter path: `compact` only omits `outputSchema`.
-fn mcp_tools_list_payload_with_compact(model_surface: ModelSurface, compact: bool) -> Value {
-    mcp_tools_list_payload_with_features(model_surface, compact, false, false)
-}
-
-fn mcp_tools_list_payload_with_compact_and_app(
-    model_surface: ModelSurface,
-    compact: bool,
-    app_enabled: bool,
-) -> Value {
-    mcp_tools_list_payload_with_features(model_surface, compact, app_enabled, true)
-}
-
-fn mcp_tools_list_payload_with_features(
-    model_surface: ModelSurface,
-    compact: bool,
-    app_enabled: bool,
-    artifact_export_enabled: bool,
-) -> Value {
-    mcp_tools_list_payload_with_features_for_auth(
-        model_surface,
-        compact,
-        app_enabled,
-        artifact_export_enabled,
-        None,
-    )
-}
-
-fn mcp_tools_list_payload_with_features_for_auth(
-    model_surface: ModelSurface,
-    compact: bool,
-    app_enabled: bool,
-    artifact_export_enabled: bool,
-    auth: Option<&AuthContext>,
-) -> Value {
-    let specs = match model_surface {
-        ModelSurface::CanonicalConnector => crate::connector_runtime::surface::capability_specs(),
-        ModelSurface::LocalCoding => crate::model_surface::local_coding_tool_specs(),
-        ModelSurface::FullOperatorRuntime => registered_tool_specs(),
-    };
-    let oauth_scope_projection = auth.is_some_and(AuthContext::is_oauth_token);
-    let tools: Vec<Value> = specs
-        .into_iter()
-        .filter(|spec| artifact_export_enabled || spec.name != "export_project_artifact")
-        .filter(|spec| {
-            !oauth_scope_projection || check_runtime_tool_scope(auth, &spec.name).is_ok()
-        })
-        .map(|spec| mcp_tool_spec_json(spec, compact, app_enabled))
-        .collect();
-    json!({ "tools": tools })
-}
-
-fn adapt_computer_snapshot_output_schema_for_mcp(spec: &mut ToolSpec) {
-    let properties = spec
-        .output_schema
-        .pointer_mut("/properties/output/properties")
-        .and_then(Value::as_object_mut)
-        .expect("computer_snapshot output schema properties");
-    properties.remove("content_base64");
-    properties.insert(
-        "content_delivery".to_string(),
-        json!({
-            "type": "string",
-            "const": "mcp_image",
-            "description": "MCP native-image delivery marker; binary image bytes are carried in the image ContentBlock rather than structuredContent."
-        }),
-    );
-}
-
-fn add_stateless_workflow_recorder_metadata(payload: &mut Value, model_surface: ModelSurface) {
-    if matches!(model_surface, ModelSurface::CanonicalConnector) {
-        return;
-    }
-    let Some(tools) = payload.get_mut("tools").and_then(Value::as_array_mut) else {
-        return;
-    };
-    for tool in tools {
-        let Some(properties) = tool
-            .pointer_mut("/inputSchema/properties")
-            .and_then(Value::as_object_mut)
-        else {
-            continue;
-        };
-        properties.insert(
-            crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD.to_string(),
-            json!({
-                "type": "string",
-                "pattern": "^wc_sess_[A-Za-z0-9_]+$",
-                "description": "MCP wrapper metadata only. Optional explicit existing Workflow Session that records this tools/call and supplies trusted collaboration provenance. It is distinct from any concrete tool business session_id, grants no authority, and is removed before concrete tool parsing."
-            }),
-        );
-        properties.insert(
-            crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD.to_string(),
-            json!({
-                "type": "array",
-                "maxItems": crate::tool_runtime::sessions::MAX_TOOL_CALL_ACK_MESSAGE_IDS,
-                "items": {
-                    "type": "string",
-                    "pattern": "^wc_msg_[A-Za-z0-9_]+$"
-                },
-                "description": "MCP wrapper metadata only. ACK means the current model context still remembers the referenced open Session message. Repeat ACK ids on subsequent calls while remembered. If omitted later, unresolved ACK-required guidance may be returned again. ACK does not resolve the message."
-            }),
-        );
-        properties.insert(
-            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD.to_string(),
-            json!({
-                "type": "object",
-                "description": "MCP wrapper metadata only. After one non-todo message in recording_session_id is already handled, resolve it and attach bounded resolution text on this same WebCodex call instead of making a separate resolve call. For requires_ack guidance, include the same message_id in ack_session_message_ids on this request. The target is always the exact recording Session and this object is removed before concrete tool parsing. Do not use it to predict whether the current tool call will succeed; todo completion still uses complete_session_message.",
-                "properties": {
-                    "message_id": {
-                        "type": "string",
-                        "pattern": "^wc_msg_[A-Za-z0-9_]+$"
-                    },
-                    "resolution": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": crate::tool_runtime::sessions::MAX_MESSAGE_RESOLUTION_CHARS
-                    }
-                },
-                "required": ["message_id", "resolution"],
-                "additionalProperties": false
-            }),
-        );
-        if matches!(model_surface, ModelSurface::FullOperatorRuntime) {
-            properties.insert(
-                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD
-                    .to_string(),
-                json!({
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "Echo the latest Session context revision still present in the current model context. Omit it when unknown. If it is missing or behind the Session's model-facing continuity watermark, the tool still executes normally and the result may include bounded Session recovery context."
-                }),
-            );
-        }
-    }
-}
-
-fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, _app_enabled: bool) -> Value {
-    let tool_name = spec.name.clone();
-    if matches!(
-        tool_name.as_str(),
-        "computer_snapshot" | "computer_snapshot_display"
-    ) {
-        adapt_computer_snapshot_output_schema_for_mcp(&mut spec);
-    }
-    if tool_name == "read_project_artifact" {
-        if let Some(properties) = spec.input_schema["properties"].as_object_mut() {
-            properties.insert(
-                "as_image".to_string(),
-                json!({
-                    "type": "boolean",
-                    "description": "MCP-only. When true, read one complete PNG, JPEG, or WebP up to 1 MiB and return it as native image content. Cannot be combined with offset, length, or max_bytes."
-                }),
-            );
-        }
-        spec.description.push_str(
-            " Over MCP, set as_image=true to return one complete PNG, JPEG, or WebP as native image content; ordinary calls keep the existing chunked base64 response.",
-        );
-    }
-    let mut value = if compact {
-        json!({
-            "name": spec.name,
-            "description": spec.description,
-            "inputSchema": spec.input_schema,
-            "annotations": spec.annotations,
-        })
-    } else {
-        // Match ToolSpec's camelCase serde so default behavior is unchanged.
-        serde_json::to_value(spec).unwrap_or_else(|_| json!({}))
-    };
-    if tool_name == "import_conversation_files_to_project" {
-        if let Some(object) = value.as_object_mut() {
-            object.insert(
-                "_meta".to_string(),
-                json!({"openai/fileParams": ["openaiFileIdRefs"]}),
-            );
-        }
-    }
-    value
-}
-
 pub(crate) fn mcp_runtime_tool_result(
     tool_name: &str,
     as_image_requested: bool,
     result: ToolResult,
 ) -> Value {
-    resources::mcp_runtime_tool_result_with_snapshot_resource(
-        tool_name,
-        as_image_requested,
-        result,
-        None,
-    )
-}
-
-fn mcp_runtime_tool_result_fallback(result: ToolResult) -> Value {
-    let text = serde_json::to_string(&json!({
-        "success": result.success,
-        "output": result.output.clone(),
-        "error": result.error.clone(),
-    }))
-    .unwrap_or_else(|_| "{}".to_string());
-    json!({
-        "content": [{ "type": "text", "text": text }],
-        "structuredContent": {
-            "success": result.success,
-            "output": result.output,
-            "error": result.error,
-        },
-        "isError": !result.success
-    })
+    tools::mcp_runtime_tool_result(tool_name, as_image_requested, result)
 }
 
 /// Outcome of handling a single MCP JSON-RPC request.
@@ -638,13 +149,6 @@ enum McpOutcome {
         body: Value,
         required_scope: Option<&'static str>,
     },
-}
-
-fn mcp_protocol_era_label(protocol_era: McpProtocolEra) -> &'static str {
-    match protocol_era {
-        McpProtocolEra::Legacy => "legacy",
-        McpProtocolEra::Stateless2026 => "stateless_2026",
-    }
 }
 
 fn log_mcp_computer_app_resource_delivery(
@@ -680,7 +184,7 @@ fn log_mcp_computer_app_resource_outcome(
     };
     log_mcp_computer_app_resource_delivery(
         uri,
-        mcp_protocol_era_label(protocol_era),
+        protocol::era_label(protocol_era),
         ui_capability_present,
         http_status,
         mcp_error_code,
@@ -817,7 +321,7 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
     guard.set_jsonrpc_id(jsonrpc_id_safe(request.id.as_ref()));
     guard.set_method(request.method.clone());
     let tool_name = if request.method == "tools/call" {
-        tool_name_from_params(&request.params)
+        tools::tool_name_from_params(&request.params)
     } else {
         None
     };
@@ -911,7 +415,7 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
         Some((
             ActionAudit::start(req, depot, "/mcp", "toolsCall"),
             tool_name.clone().unwrap_or_else(|| "unknown".to_string()),
-            project_from_tool_call_params(&request.params),
+            tools::project_from_tool_call_params(&request.params),
         ))
     } else {
         None
@@ -936,14 +440,14 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
     };
 
     let auth = depot.obtain::<crate::auth::AuthContext>().ok().cloned();
-    let host_file_import_trust =
-        if tool_name.as_deref() == Some("import_conversation_files_to_project") {
-            let decision = mcp_host_file_import_trust_decision(depot, auth.as_ref());
-            log_mcp_host_file_import_trust_decision(auth.as_ref(), &decision);
-            decision.trust
-        } else {
-            HostFileImportTrust::Untrusted
-        };
+    let config = crate::auth::get_config(depot);
+    let db = crate::auth::get_db(depot);
+    let host_file_import_trust = tools::host_file_import_trust_for_call(
+        tool_name.as_deref(),
+        auth.as_ref(),
+        config.as_deref(),
+        db.as_deref(),
+    );
     // Defense-in-depth backstop: every tool bounds its own agent/subprocess
     // waits at <= 124s, so this outer limit never preempts a legitimate inner
     // timeout. It only fires if a dispatch path hangs without a bound (the
@@ -997,13 +501,13 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
             if let Some(uri) = computer_app_resource_uri.as_deref() {
                 log_mcp_computer_app_resource_delivery(
                     uri,
-                    mcp_protocol_era_label(protocol_era),
+                    protocol::era_label(protocol_era),
                     computer_app_ui_capability_present,
                     500,
                     Some(-32000),
                 );
                 record_computer_app_resource_audit(
-                    mcp_protocol_era_label(protocol_era),
+                    protocol::era_label(protocol_era),
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Some(-32000),
                 );
@@ -1046,7 +550,7 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
             McpOutcome::Forbidden { .. } => (StatusCode::FORBIDDEN, None),
         };
         record_computer_app_resource_audit(
-            mcp_protocol_era_label(protocol_era),
+            protocol::era_label(protocol_era),
             status,
             mcp_error_code,
         );
@@ -1287,94 +791,24 @@ async fn handle_mcp_request_with_lifecycle(
         // requests. WebCodex supports the stateless tools path required by
         // modern clients while retaining the initialized 2025 tool-only
         // session lifecycle used by 2025-06-18 and ChatGPT 2025-11-25 clients.
-        "server/discover" if stateless_2026 => rpc_result(
-            id,
-            json!({
-                "resultType": "complete",
-                "ttlMs": 0,
-                "cacheScope": "private",
-                "supportedVersions": [
-                    MCP_STATELESS_PROTOCOL_VERSION,
-                    MCP_CHATGPT_PROTOCOL_VERSION,
-                    MCP_PROTOCOL_VERSION
-                ],
-                "capabilities": if resources::model_surface_supports_computer_app(runtime.model_surface()) {
+        "server/discover" if stateless_2026 => {
+            let capabilities =
+                if resources::model_surface_supports_computer_app(runtime.model_surface()) {
                     resources::server_capabilities()
                 } else if tasks::model_surface_supports_tasks(runtime.model_surface()) {
                     tasks::server_capabilities()
                 } else {
                     json!({ "tools": { "listChanged": false } })
-                },
-                "_meta": {
-                    "io.modelcontextprotocol/serverInfo": {
-                        "name": "webcodex",
-                        "version": env!("CARGO_PKG_VERSION")
-                    }
-                }
-            }),
-        ),
+                };
+            rpc_result(id, protocol::server_discover_payload(capabilities))
+        }
         "initialize" if !stateless_2026 => rpc_result(
             id,
-            json!({
-                "protocolVersion": legacy_initialize_protocol_version(&request.params),
-                "capabilities": {
-                    "tools": {
-                        "listChanged": false
-                    }
-                },
-                "serverInfo": {
-                    "name": "webcodex",
-                    "version": env!("CARGO_PKG_VERSION"),
-                    "modelSurface": runtime.model_surface().name()
-                }
-            }),
+            protocol::legacy_initialize_payload(&request.params, runtime.model_surface().name()),
         ),
         "ping" if !stateless_2026 => rpc_result(id, json!({})),
         "tools/list" => {
-            let oauth_scope_projection = auth.is_some_and(AuthContext::is_oauth_token);
-            let mut result = if stateless_2026 {
-                if oauth_scope_projection {
-                    mcp_tools_list_payload_with_features_for_auth(
-                        runtime.model_surface(),
-                        crate::config::mcp_compact_schemas_enabled(),
-                        resources::model_surface_supports_computer_app(runtime.model_surface()),
-                        true,
-                        auth,
-                    )
-                } else {
-                    mcp_tools_list_payload_with_compact_and_app(
-                        runtime.model_surface(),
-                        crate::config::mcp_compact_schemas_enabled(),
-                        resources::model_surface_supports_computer_app(runtime.model_surface()),
-                    )
-                }
-            } else if oauth_scope_projection {
-                mcp_tools_list_payload_with_features_for_auth(
-                    runtime.model_surface(),
-                    crate::config::mcp_compact_schemas_enabled(),
-                    false,
-                    false,
-                    auth,
-                )
-            } else {
-                mcp_tools_list_payload(runtime.model_surface())
-            };
-            if stateless_2026 {
-                add_stateless_workflow_recorder_metadata(&mut result, runtime.model_surface());
-            }
-            if crate::mcp_gateway::authorized(auth) {
-                if let Some(tools) = result.get_mut("tools").and_then(Value::as_array_mut) {
-                    tools.push(crate::mcp_gateway::tool_spec());
-                }
-            }
-            rpc_result(
-                id,
-                if stateless_2026 {
-                    mcp_stateless_result(result, true)
-                } else {
-                    result
-                },
-            )
+            return tools::handle_list(runtime, id, auth, stateless_2026);
         }
         "resources/list" if stateless_2026 => {
             return resources::handle_list(id, mcp_app_enabled);
@@ -1402,404 +836,19 @@ async fn handle_mcp_request_with_lifecycle(
             .await;
         }
         "tools/call" => {
-            let tasks_extension_declared =
-                stateless_2026 && tasks::request_supports_tasks(&request.params);
-            let mut params: McpToolCallParams = match serde_json::from_value(request.params) {
-                Ok(params) => params,
-                Err(e) => {
-                    return McpOutcome::BadRequest(rpc_error(
-                        id,
-                        -32602,
-                        format!("Invalid params: {}", e),
-                    ));
-                }
-            };
-            if let Some(lc) = lifecycle.as_deref() {
-                lc.capture_payload("raw_arguments", &params.arguments);
-            }
-            // Emit dispatch_started only after params parse succeeds and before
-            // ToolRuntime work begins.
-            if let Some(lc) = lifecycle.as_deref_mut() {
-                lc.set_tool_name(Some(params.name.clone()));
-                lc.dispatch_started();
-            }
-            if params.name == crate::mcp_gateway::MCP_TOOL_NAME {
-                if let Some(outcome) = require_mcp_scope(auth, crate::auth::SCOPE_MCP_LOCAL) {
-                    if let Some(lc) = lifecycle.as_deref() {
-                        lc.dispatch_failed("forbidden");
-                        lc.dispatch_finished(false, Some(false), "forbidden");
-                    }
-                    return outcome;
-                }
-                if let Some(lc) = lifecycle.as_deref() {
-                    lc.capture_payload("effective_arguments", &params.arguments);
-                }
-                let result = crate::mcp_gateway::call(runtime, params.arguments, auth).await;
-                let ok = result.get("isError").and_then(Value::as_bool) != Some(true);
-                if let Some(lc) = lifecycle.as_deref() {
-                    lc.dispatch_finished(true, Some(ok), if ok { "success" } else { "tool_error" });
-                }
-                return McpOutcome::Ok(rpc_result(
-                    id,
-                    if stateless_2026 {
-                        mcp_stateless_result(result, false)
-                    } else {
-                        result
-                    },
-                ));
-            }
-            // The local_coding model surface rejects tools it does not
-            // advertise at the MCP boundary, before ToolRuntime dispatch. The
-            // full operator runtime and the canonical Connector keep their
-            // existing behavior unchanged.
-            if runtime.model_surface() == ModelSurface::LocalCoding
-                && !LOCAL_CODING_TOOL_NAMES.contains(&params.name.as_str())
-            {
-                if let Some(lc) = lifecycle.as_deref() {
-                    lc.dispatch_failed("surface_denied");
-                    lc.dispatch_finished(false, Some(false), "surface_denied");
-                }
-                return McpOutcome::BadRequest(rpc_error(
-                    id,
-                    -32602,
-                    format!(
-                        "tool '{}' is not available on the local_coding MCP surface; the full operator runtime must be selected explicitly with WEBCODEX_MCP_MODEL_SURFACE=full-operator-v1",
-                        params.name
-                    ),
-                ));
-            }
-            // From here on, the MCP boundary has established a model-visible runtime
-            // tool identity. A few MCP-only validations still happen before the
-            // shared ToolRuntime kernel; preserve those failed attempts in generic
-            // telemetry without creating a second record for normal kernel calls.
-            let mut pre_kernel_model_ergonomics = ModelErgonomicsTimer::start(&params.name);
-            let resource_tool_call = match resources::prepare_tool_call(
-                &params.name,
-                stateless_2026,
-                runtime.model_surface(),
-                auth,
-            ) {
-                Ok(context) => context,
-                Err(error) => {
-                    if error.records_model_ergonomics_failure() {
-                        if let (Some(slot), Some(timer)) = (
-                            model_ergonomics_out.as_deref_mut(),
-                            pre_kernel_model_ergonomics.take(),
-                        ) {
-                            *slot = Some(
-                                timer
-                                    .finish()
-                                    .record_for_pre_result_failure("invalid_arguments"),
-                            );
-                        }
-                    }
-                    return McpOutcome::BadRequest(rpc_error(id, -32602, error.message()));
-                }
-            };
-            if runtime.model_surface() == ModelSurface::CanonicalConnector {
-                let connector = connector.expect("validated canonical Connector state");
-                if !stateless_2026 && params.name == "task_start" && window.is_none() {
-                    if let Some(lc) = lifecycle.as_deref() {
-                        lc.dispatch_failed("window_identity_unavailable");
-                        lc.dispatch_finished(false, Some(false), "window_identity_unavailable");
-                    }
-                    return McpOutcome::BadRequest(rpc_error(
-                        id,
-                        -32600,
-                        "MCP session identity is unavailable; initialize the connection before starting or continuing project work",
-                    ));
-                }
-                if let Some(lc) = lifecycle.as_deref() {
-                    lc.capture_payload("effective_arguments", &params.arguments);
-                }
-                let task_polling = tasks_extension_declared
-                    && matches!(params.name.as_str(), "commands_run" | "checks_run");
-                let outcome = if task_polling {
-                    connector
-                        .call_for_window_with_task_polling(
-                            &params.name,
-                            params.arguments,
-                            auth,
-                            ConnectorTransport::Mcp,
-                            window,
-                        )
-                        .await
-                } else {
-                    connector
-                        .call_for_window(
-                            &params.name,
-                            params.arguments,
-                            auth,
-                            ConnectorTransport::Mcp,
-                            window,
-                        )
-                        .await
-                };
-                if let Some(required_scope) = outcome.required_scope {
-                    if let Some(lc) = lifecycle.as_deref() {
-                        lc.dispatch_failed("forbidden");
-                        lc.dispatch_finished(false, Some(false), "forbidden");
-                    }
-                    let description = outcome
-                        .body
-                        .pointer("/error/message")
-                        .and_then(Value::as_str)
-                        .unwrap_or("connector credential lacks the required scope")
-                        .to_string();
-                    return scope_forbidden(auth, Some(required_scope), description);
-                }
-                if outcome.protocol_error {
-                    if let Some(lc) = lifecycle.as_deref() {
-                        lc.dispatch_failed("invalid_arguments");
-                        lc.dispatch_finished(false, Some(false), "invalid_arguments");
-                    }
-                    let message = outcome
-                        .body
-                        .pointer("/error/message")
-                        .and_then(Value::as_str)
-                        .unwrap_or("invalid connector capability arguments")
-                        .to_string();
-                    return McpOutcome::BadRequest(rpc_error(id, -32602, message));
-                }
-                if let Some(lc) = lifecycle.as_deref() {
-                    let category = if outcome.ok { "success" } else { "tool_error" };
-                    lc.dispatch_finished(true, Some(outcome.ok), category);
-                }
-                if task_polling && outcome.ok {
-                    if let Some(task_outcome) =
-                        tasks::promote_connector_tool_call(&id, &outcome, auth, connector).await
-                    {
-                        return task_outcome;
-                    }
-                }
-                let result = connector_call_tool_result(outcome);
-                return McpOutcome::Ok(rpc_result(
-                    id,
-                    if stateless_2026 {
-                        mcp_stateless_result(result, false)
-                    } else {
-                        result
-                    },
-                ));
-            }
-            let session_id = match strip_reserved_session_id(&mut params.arguments) {
-                Ok(session_id) => session_id,
-                Err(message) => {
-                    if let Some(lc) = lifecycle.as_deref() {
-                        lc.dispatch_failed("invalid_arguments");
-                        lc.dispatch_finished(false, Some(false), "invalid_arguments");
-                    }
-                    if let (Some(slot), Some(timer)) = (
-                        model_ergonomics_out.as_deref_mut(),
-                        pre_kernel_model_ergonomics.take(),
-                    ) {
-                        *slot = Some(
-                            timer
-                                .finish()
-                                .record_for_pre_result_failure("invalid_arguments"),
-                        );
-                    }
-                    return McpOutcome::BadRequest(rpc_error(id, -32602, message));
-                }
-            };
-            let ack_session_message_ids = if stateless_2026 {
-                match strip_stateless_ack_session_message_ids(&mut params.arguments) {
-                    Ok(ids) => ids,
-                    Err(message) => {
-                        if let Some(lc) = lifecycle.as_deref() {
-                            lc.dispatch_failed("invalid_arguments");
-                            lc.dispatch_finished(false, Some(false), "invalid_arguments");
-                        }
-                        if let (Some(slot), Some(timer)) = (
-                            model_ergonomics_out.as_deref_mut(),
-                            pre_kernel_model_ergonomics.take(),
-                        ) {
-                            *slot = Some(
-                                timer
-                                    .finish()
-                                    .record_for_pre_result_failure("invalid_arguments"),
-                            );
-                        }
-                        return McpOutcome::BadRequest(rpc_error(id, -32602, message));
-                    }
-                }
-            } else {
-                Vec::new()
-            };
-            let session_message_resolution = if stateless_2026 {
-                if let Some(arguments) = params.arguments.as_object_mut() {
-                    arguments.remove(
-                        crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_INTERNAL_FIELD,
-                    );
-                }
-                match strip_stateless_session_message_resolution(&mut params.arguments) {
-                    Ok(value) => value,
-                    Err(message) => {
-                        if let Some(lc) = lifecycle.as_deref() {
-                            lc.dispatch_failed("invalid_arguments");
-                            lc.dispatch_finished(false, Some(false), "invalid_arguments");
-                        }
-                        if let (Some(slot), Some(timer)) = (
-                            model_ergonomics_out.as_deref_mut(),
-                            pre_kernel_model_ergonomics.take(),
-                        ) {
-                            *slot = Some(
-                                timer
-                                    .finish()
-                                    .record_for_pre_result_failure("invalid_arguments"),
-                            );
-                        }
-                        return McpOutcome::BadRequest(rpc_error(id, -32602, message));
-                    }
-                }
-            } else {
-                None
-            };
-            if session_message_resolution.is_some() && session_id.is_none() {
-                let message = format!(
-                    "field '{}' requires '{}' for the exact target Workflow Session",
-                    crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD,
-                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,
-                );
-                if let Some(lc) = lifecycle.as_deref() {
-                    lc.dispatch_failed("invalid_arguments");
-                    lc.dispatch_finished(false, Some(false), "invalid_arguments");
-                }
-                return McpOutcome::BadRequest(rpc_error(id, -32602, message));
-            }
-            if let (Some(arguments), Some(resolution)) =
-                (params.arguments.as_object_mut(), session_message_resolution)
-            {
-                arguments.insert(
-                    crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_INTERNAL_FIELD
-                        .to_string(),
-                    json!(resolution),
-                );
-            }
-            if !ack_session_message_ids.is_empty() {
-                if let Some(arguments) = params.arguments.as_object_mut() {
-                    arguments.insert(
-                        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_INTERNAL_FIELD
-                            .to_string(),
-                        json!(ack_session_message_ids),
-                    );
-                }
-            }
-            let context_continuity_capable = stateless_2026
-                && matches!(runtime.model_surface(), ModelSurface::FullOperatorRuntime);
-            if context_continuity_capable {
-                if let Some(arguments) = params.arguments.as_object_mut() {
-                    arguments.remove(
-                        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
-                    );
-                }
-                let context_revision =
-                    strip_stateless_ack_session_context_revision(&mut params.arguments);
-                if let (Some(arguments), Some(context_revision)) =
-                    (params.arguments.as_object_mut(), context_revision)
-                {
-                    arguments.insert(
-                        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD
-                            .to_string(),
-                        context_revision,
-                    );
-                }
-            }
-            if let Some(lc) = lifecycle.as_deref() {
-                lc.capture_payload("effective_arguments", &params.arguments);
-            }
-            let as_image_requested = params.name == "read_project_artifact"
-                && params.arguments.get("as_image").and_then(Value::as_bool) == Some(true);
-            let outcome = runtime
-                .call_tool_with_context_protocol_capability(
-                    KernelToolCallRequest {
-                        tool_name: params.name.clone(),
-                        arguments: params.arguments,
-                    },
-                    ToolCallContext {
-                        transport: ToolTransport::Mcp,
-                        session_id: session_id.as_deref(),
-                        auth,
-                        window,
-                        record_oauth_scope_denials: false,
-                        host_file_import_trust,
-                    },
-                    context_continuity_capable,
-                )
-                .await;
-            let model_ergonomics_completion = outcome.model_ergonomics;
-            let result = match outcome.error_status {
-                Some(ToolCallErrorStatus::InsufficientScope {
-                    required_scope,
-                    description,
-                }) => {
-                    if let Some(lc) = lifecycle.as_deref() {
-                        lc.dispatch_failed("forbidden");
-                        lc.dispatch_finished(false, Some(false), "forbidden");
-                    }
-                    if let (Some(slot), Some(completion)) = (
-                        model_ergonomics_out.as_deref_mut(),
-                        model_ergonomics_completion.as_ref(),
-                    ) {
-                        *slot =
-                            Some(completion.record_for_pre_result_failure("insufficient_scope"));
-                    }
-                    return scope_forbidden(auth, required_scope, description);
-                }
-                Some(ToolCallErrorStatus::InvalidArguments { message }) => {
-                    if let Some(lc) = lifecycle.as_deref() {
-                        lc.dispatch_failed("invalid_arguments");
-                        lc.dispatch_finished(false, Some(false), "invalid_arguments");
-                    }
-                    if let (Some(slot), Some(completion)) = (
-                        model_ergonomics_out.as_deref_mut(),
-                        model_ergonomics_completion.as_ref(),
-                    ) {
-                        *slot = Some(completion.record_for_pre_result_failure("invalid_arguments"));
-                    }
-                    return McpOutcome::BadRequest(rpc_error(id, -32602, message));
-                }
-                None => outcome
-                    .result
-                    .expect("tool kernel outcome without error must include result"),
-            };
-            debug_assert_eq!(outcome.success, result.success);
-            if let Some(lc) = lifecycle.as_deref() {
-                // Protocol layer produced a JSON-RPC result (not -32xxx).
-                // Tool kernel success is independent (isError / structuredContent).
-                let category = if result.success {
-                    "success"
-                } else {
-                    "tool_error"
-                };
-                if result.success {
-                    lc.dispatch_finished(true, Some(true), category);
-                } else {
-                    lc.dispatch_finished(true, Some(false), category);
-                }
-            }
-            let result = resources::adapt_tool_result(
-                &params.name,
-                as_image_requested,
-                result,
-                resource_tool_call,
-            );
-            let model_ergonomics = model_ergonomics_completion.as_ref().and_then(|completion| {
-                result
-                    .get("structuredContent")
-                    .and_then(|structured| completion.record_for_structured_content(structured))
-            });
-            if let Some(slot) = model_ergonomics_out.as_deref_mut() {
-                *slot = model_ergonomics;
-            }
-            return McpOutcome::Ok(rpc_result(
+            return tools::handle_call(
+                runtime,
+                connector,
+                request.params,
                 id,
-                if stateless_2026 {
-                    mcp_stateless_result(result, false)
-                } else {
-                    result
-                },
-            ));
+                auth,
+                stateless_2026,
+                host_file_import_trust,
+                window,
+                lifecycle.as_deref_mut(),
+                model_ergonomics_out.as_deref_mut(),
+            )
+            .await;
         }
         "notifications/initialized" if !stateless_2026 => rpc_result(id, json!({})),
         _ => {
@@ -1814,249 +863,6 @@ async fn handle_mcp_request_with_lifecycle(
     McpOutcome::Ok(response)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HostFileImportTrustReason {
-    Trusted,
-    MissingConfig,
-    MissingDatabase,
-    MissingAuth,
-    NotOAuthToken,
-    MissingAllowedClientId,
-    OAuthDisabled,
-    ClientIdNotConfigured,
-    ClientRegistrationMissingOrRevoked,
-    ClientRegistrationLookupFailed,
-}
-
-impl HostFileImportTrustReason {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Trusted => "trusted",
-            Self::MissingConfig => "missing_config",
-            Self::MissingDatabase => "missing_database",
-            Self::MissingAuth => "missing_auth",
-            Self::NotOAuthToken => "not_oauth_token",
-            Self::MissingAllowedClientId => "missing_allowed_client_id",
-            Self::OAuthDisabled => "oauth_disabled",
-            Self::ClientIdNotConfigured => "client_id_not_configured",
-            Self::ClientRegistrationMissingOrRevoked => "client_registration_missing_or_revoked",
-            Self::ClientRegistrationLookupFailed => "client_registration_lookup_failed",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct HostFileImportTrustDecision {
-    trust: HostFileImportTrust,
-    reason: HostFileImportTrustReason,
-    config_present: bool,
-    database_present: bool,
-    oauth_enabled: bool,
-    configured_trusted_client_count: usize,
-    client_id_configured: Option<bool>,
-    active_client_registration_found: Option<bool>,
-}
-
-#[cfg(test)]
-static LAST_MCP_HOST_FILE_IMPORT_TRUST_DECISION: std::sync::OnceLock<
-    std::sync::Mutex<Option<HostFileImportTrustDecision>>,
-> = std::sync::OnceLock::new();
-
-#[cfg(test)]
-fn take_last_mcp_host_file_import_trust_decision() -> Option<HostFileImportTrustDecision> {
-    LAST_MCP_HOST_FILE_IMPORT_TRUST_DECISION
-        .get_or_init(|| std::sync::Mutex::new(None))
-        .lock()
-        .unwrap()
-        .take()
-}
-
-impl HostFileImportTrustDecision {
-    fn unavailable(reason: HostFileImportTrustReason) -> Self {
-        Self {
-            trust: HostFileImportTrust::Untrusted,
-            reason,
-            config_present: false,
-            database_present: false,
-            oauth_enabled: false,
-            configured_trusted_client_count: 0,
-            client_id_configured: None,
-            active_client_registration_found: None,
-        }
-    }
-
-    fn from_config(reason: HostFileImportTrustReason, config: &crate::Config) -> Self {
-        Self {
-            trust: HostFileImportTrust::Untrusted,
-            reason,
-            config_present: true,
-            database_present: false,
-            oauth_enabled: config.oauth2.enabled,
-            configured_trusted_client_count: config.oauth2.trusted_mcp_file_client_ids.len(),
-            client_id_configured: None,
-            active_client_registration_found: None,
-        }
-    }
-}
-
-fn mcp_host_file_import_trust_decision_from_state(
-    config: &crate::Config,
-    db: &crate::Database,
-    auth: Option<&AuthContext>,
-) -> HostFileImportTrustDecision {
-    let base = HostFileImportTrustDecision {
-        trust: HostFileImportTrust::Untrusted,
-        reason: HostFileImportTrustReason::MissingAuth,
-        config_present: true,
-        database_present: true,
-        oauth_enabled: config.oauth2.enabled,
-        configured_trusted_client_count: config.oauth2.trusted_mcp_file_client_ids.len(),
-        client_id_configured: None,
-        active_client_registration_found: None,
-    };
-    let Some(auth) = auth else {
-        return base;
-    };
-    if !auth.is_oauth_token() {
-        return HostFileImportTrustDecision {
-            reason: HostFileImportTrustReason::NotOAuthToken,
-            ..base
-        };
-    }
-    let Some(client_id) = auth
-        .allowed_client_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|client_id| !client_id.is_empty())
-    else {
-        return HostFileImportTrustDecision {
-            reason: HostFileImportTrustReason::MissingAllowedClientId,
-            ..base
-        };
-    };
-    if !config.oauth2.enabled {
-        return HostFileImportTrustDecision {
-            reason: HostFileImportTrustReason::OAuthDisabled,
-            ..base
-        };
-    }
-    let client_id_configured = config
-        .oauth2
-        .trusted_mcp_file_client_ids
-        .iter()
-        .any(|trusted_client_id| trusted_client_id == client_id);
-    if !client_id_configured {
-        return HostFileImportTrustDecision {
-            reason: HostFileImportTrustReason::ClientIdNotConfigured,
-            client_id_configured: Some(false),
-            ..base
-        };
-    }
-    match db.get_oauth_client_by_client_id(client_id) {
-        Ok(Some(client)) if client.client_id == client_id => HostFileImportTrustDecision {
-            trust: HostFileImportTrust::TrustedOAuthClient,
-            reason: HostFileImportTrustReason::Trusted,
-            client_id_configured: Some(true),
-            active_client_registration_found: Some(true),
-            ..base
-        },
-        Ok(_) => HostFileImportTrustDecision {
-            reason: HostFileImportTrustReason::ClientRegistrationMissingOrRevoked,
-            client_id_configured: Some(true),
-            active_client_registration_found: Some(false),
-            ..base
-        },
-        Err(_) => HostFileImportTrustDecision {
-            reason: HostFileImportTrustReason::ClientRegistrationLookupFailed,
-            client_id_configured: Some(true),
-            active_client_registration_found: None,
-            ..base
-        },
-    }
-}
-
-#[cfg(test)]
-fn mcp_host_file_import_trust_from_state(
-    config: &crate::Config,
-    db: &crate::Database,
-    auth: Option<&AuthContext>,
-) -> HostFileImportTrust {
-    mcp_host_file_import_trust_decision_from_state(config, db, auth).trust
-}
-
-fn mcp_host_file_import_trust_decision(
-    depot: &Depot,
-    auth: Option<&AuthContext>,
-) -> HostFileImportTrustDecision {
-    let Some(config) = crate::auth::get_config(depot) else {
-        return HostFileImportTrustDecision::unavailable(HostFileImportTrustReason::MissingConfig);
-    };
-    let Some(db) = crate::auth::get_db(depot) else {
-        return HostFileImportTrustDecision::from_config(
-            HostFileImportTrustReason::MissingDatabase,
-            config.as_ref(),
-        );
-    };
-    mcp_host_file_import_trust_decision_from_state(config.as_ref(), db.as_ref(), auth)
-}
-
-fn mcp_auth_kind_classification(auth: Option<&AuthContext>) -> &'static str {
-    match auth.map(|auth| auth.kind) {
-        None => "none",
-        Some(crate::auth::AuthKind::OAuth2Token) => "oauth2",
-        Some(crate::auth::AuthKind::ApiToken) => "api_token",
-        Some(crate::auth::AuthKind::Bootstrap) => "bootstrap",
-        Some(crate::auth::AuthKind::AgentToken) => "agent_token",
-        Some(crate::auth::AuthKind::AccountCredential) => "account_credential",
-        Some(crate::auth::AuthKind::SharedKey) => "shared_key",
-        Some(crate::auth::AuthKind::ProjectCredential) => "project_credential",
-        Some(crate::auth::AuthKind::OpenAnonymous) => "open_anonymous",
-    }
-}
-
-fn mcp_token_kind_classification(auth: Option<&AuthContext>) -> &'static str {
-    match auth.and_then(|auth| auth.token_kind.as_deref()) {
-        None => "none",
-        Some("oauth2") => "oauth2",
-        Some("oauth2_shared_key") => "oauth2_shared_key",
-        Some("oauth2_project") => "oauth2_project",
-        Some("user") => "user",
-        Some("agent") => "agent",
-        Some(_) => "other",
-    }
-}
-
-fn log_mcp_host_file_import_trust_decision(
-    auth: Option<&AuthContext>,
-    decision: &HostFileImportTrustDecision,
-) {
-    #[cfg(test)]
-    {
-        *LAST_MCP_HOST_FILE_IMPORT_TRUST_DECISION
-            .get_or_init(|| std::sync::Mutex::new(None))
-            .lock()
-            .unwrap() = Some(*decision);
-    }
-    let allowed_client_id_present = auth
-        .and_then(|auth| auth.allowed_client_id.as_deref())
-        .is_some_and(|client_id| !client_id.trim().is_empty());
-    tracing::info!(
-        target: "webcodex::mcp",
-        trust = decision.trust.is_trusted(),
-        reason = decision.reason.as_str(),
-        auth_kind = mcp_auth_kind_classification(auth),
-        token_kind = mcp_token_kind_classification(auth),
-        allowed_client_id_present,
-        config_present = decision.config_present,
-        database_present = decision.database_present,
-        oauth_enabled = decision.oauth_enabled,
-        configured_trusted_client_count = decision.configured_trusted_client_count,
-        client_id_configured = ?decision.client_id_configured,
-        active_client_registration_found = ?decision.active_client_registration_found,
-        "mcp_host_file_import_trust_decision"
-    );
-}
-
 fn require_mcp_scope(auth: Option<&AuthContext>, scope: &'static str) -> Option<McpOutcome> {
     let auth = auth?;
     if auth.has_scope(scope) {
@@ -2069,169 +875,6 @@ fn require_mcp_scope(auth: Option<&AuthContext>, scope: &'static str) -> Option<
     ))
 }
 
-fn strip_reserved_session_id(arguments: &mut Value) -> Result<Option<String>, String> {
-    let Some(object) = arguments.as_object_mut() else {
-        return Ok(None);
-    };
-    let canonical =
-        object.remove(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD);
-    let legacy = object.remove(MCP_RESERVED_SESSION_ID_FIELD);
-
-    let canonical = match canonical {
-        None => None,
-        Some(Value::String(value)) => {
-            let value = value.trim();
-            if value.is_empty() {
-                return Err(format!(
-                    "field '{}' must be a non-empty string",
-                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
-                ));
-            }
-            Some(value.to_string())
-        }
-        Some(_) => {
-            return Err(format!(
-                "field '{}' must be a non-empty string",
-                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
-            ));
-        }
-    };
-    let legacy = legacy
-        .and_then(|value| value.as_str().map(str::to_string))
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
-
-    if let (Some(canonical), Some(legacy)) = (&canonical, &legacy) {
-        if canonical != legacy {
-            return Err(format!(
-                "fields '{}' and '{}' must identify the same Workflow Session when both are provided",
-                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,
-                MCP_RESERVED_SESSION_ID_FIELD
-            ));
-        }
-    }
-    Ok(canonical.or(legacy))
-}
-
-fn strip_stateless_ack_session_message_ids(arguments: &mut Value) -> Result<Vec<String>, String> {
-    let Some(object) = arguments.as_object_mut() else {
-        return Ok(Vec::new());
-    };
-    let Some(value) =
-        object.remove(crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD)
-    else {
-        return Ok(Vec::new());
-    };
-    let Value::Array(values) = value else {
-        return Err(format!(
-            "field '{}' must be an array of wc_msg_* ids",
-            crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD
-        ));
-    };
-    if values.len() > crate::tool_runtime::sessions::MAX_TOOL_CALL_ACK_MESSAGE_IDS {
-        return Err(format!(
-            "field '{}' accepts at most {} message ids",
-            crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD,
-            crate::tool_runtime::sessions::MAX_TOOL_CALL_ACK_MESSAGE_IDS
-        ));
-    }
-    let mut normalized = Vec::with_capacity(values.len());
-    let mut seen = std::collections::HashSet::new();
-    for value in values {
-        let Value::String(value) = value else {
-            return Err(format!(
-                "field '{}' must contain only wc_msg_* strings",
-                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD
-            ));
-        };
-        let value = value.trim();
-        let valid = value.strip_prefix("wc_msg_").is_some_and(|suffix| {
-            !suffix.is_empty()
-                && suffix
-                    .as_bytes()
-                    .iter()
-                    .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-        });
-        if !valid {
-            return Err(format!(
-                "field '{}' must contain only valid wc_msg_* ids",
-                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD
-            ));
-        }
-        if seen.insert(value.to_string()) {
-            normalized.push(value.to_string());
-        }
-    }
-    Ok(normalized)
-}
-
-fn strip_stateless_session_message_resolution(
-    arguments: &mut Value,
-) -> Result<Option<crate::tool_runtime::sessions::ToolCallSessionMessageResolution>, String> {
-    let Some(object) = arguments.as_object_mut() else {
-        return Ok(None);
-    };
-    let Some(value) =
-        object.remove(crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD)
-    else {
-        return Ok(None);
-    };
-    let Value::Object(mut fields) = value else {
-        return Err(format!(
-            "field '{}' must be an object with message_id and resolution",
-            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD
-        ));
-    };
-    if fields.len() != 2 || !fields.contains_key("message_id") || !fields.contains_key("resolution")
-    {
-        return Err(format!(
-            "field '{}' accepts exactly message_id and resolution",
-            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD
-        ));
-    }
-    let Some(Value::String(message_id)) = fields.remove("message_id") else {
-        return Err("session_message_resolution.message_id must be a wc_msg_* string".to_string());
-    };
-    let message_id = message_id.trim().to_string();
-    let valid_message_id = message_id.strip_prefix("wc_msg_").is_some_and(|suffix| {
-        !suffix.is_empty()
-            && suffix
-                .as_bytes()
-                .iter()
-                .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-    });
-    if !valid_message_id {
-        return Err(
-            "session_message_resolution.message_id must be a valid wc_msg_* id".to_string(),
-        );
-    }
-    let Some(Value::String(resolution)) = fields.remove("resolution") else {
-        return Err("session_message_resolution.resolution must be a string".to_string());
-    };
-    let resolution = resolution.trim().to_string();
-    if resolution.is_empty() {
-        return Err("session_message_resolution.resolution must not be empty".to_string());
-    }
-    if resolution.chars().count() > crate::tool_runtime::sessions::MAX_MESSAGE_RESOLUTION_CHARS {
-        return Err(format!(
-            "session_message_resolution.resolution exceeds {} chars",
-            crate::tool_runtime::sessions::MAX_MESSAGE_RESOLUTION_CHARS
-        ));
-    }
-    Ok(Some(
-        crate::tool_runtime::sessions::ToolCallSessionMessageResolution {
-            message_id,
-            resolution,
-        },
-    ))
-}
-
-fn strip_stateless_ack_session_context_revision(arguments: &mut Value) -> Option<Value> {
-    arguments
-        .as_object_mut()?
-        .remove(crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD)
-}
-
 fn scope_forbidden(
     auth: Option<&AuthContext>,
     required_scope: Option<&'static str>,
@@ -2241,42 +884,6 @@ fn scope_forbidden(
         body: crate::auth::scope_forbidden_body(auth, description),
         required_scope,
     }
-}
-
-fn rpc_result(id: Option<Value>, result: Value) -> Value {
-    json!({
-        "jsonrpc": "2.0",
-        "id": id.unwrap_or(Value::Null),
-        "result": result,
-    })
-}
-
-fn rpc_error(id: Option<Value>, code: i64, message: impl Into<String>) -> Value {
-    json!({
-        "jsonrpc": "2.0",
-        "id": id.unwrap_or(Value::Null),
-        "error": {
-            "code": code,
-            "message": message.into(),
-        }
-    })
-}
-
-fn rpc_error_with_data(
-    id: Option<Value>,
-    code: i64,
-    message: impl Into<String>,
-    data: Value,
-) -> Value {
-    json!({
-        "jsonrpc": "2.0",
-        "id": id.unwrap_or(Value::Null),
-        "error": {
-            "code": code,
-            "message": message.into(),
-            "data": data,
-        }
-    })
 }
 
 #[cfg(test)]

--- a/src/mcp/http_metadata.rs
+++ b/src/mcp/http_metadata.rs
@@ -1,0 +1,169 @@
+use super::protocol::{
+    request_client_capabilities, request_client_info_is_valid, request_protocol_version,
+    JsonRpcRequest, McpProtocolEra, MCP_STATELESS_PROTOCOL_VERSION,
+    MCP_SUPPORTED_PROTOCOL_VERSIONS,
+};
+use super::response::{rpc_error, rpc_error_with_data};
+use base64::engine::general_purpose;
+use salvo::prelude::Request;
+use serde_json::{json, Value};
+
+pub(super) const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+pub(super) const MCP_METHOD_HEADER: &str = "mcp-method";
+pub(super) const MCP_NAME_HEADER: &str = "mcp-name";
+pub(super) const MCP_HEADER_MISMATCH: i64 = -32020;
+pub(super) const MCP_UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
+
+pub(super) fn request_header<'a>(req: &'a Request, name: &str) -> Option<&'a str> {
+    req.headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+}
+
+fn decode_mcp_name_header(value: &str) -> Result<String, ()> {
+    let Some(encoded) = value
+        .strip_prefix("=?base64?")
+        .and_then(|value| value.strip_suffix("?="))
+    else {
+        return Ok(value.to_string());
+    };
+    let bytes = base64::Engine::decode(&general_purpose::STANDARD, encoded).map_err(|_| ())?;
+    String::from_utf8(bytes).map_err(|_| ())
+}
+
+fn request_mcp_name(request: &JsonRpcRequest) -> Option<Option<&str>> {
+    match request.method.as_str() {
+        "tools/call" | "prompts/get" => Some(request.params.get("name").and_then(Value::as_str)),
+        "resources/read" => Some(request.params.get("uri").and_then(Value::as_str)),
+        "tasks/get" | "tasks/update" | "tasks/cancel" => {
+            Some(request.params.get("taskId").and_then(Value::as_str))
+        }
+        _ => None,
+    }
+}
+
+fn header_mismatch(id: Option<Value>, message: impl Into<String>) -> Value {
+    rpc_error(id, MCP_HEADER_MISMATCH, message)
+}
+
+fn unsupported_protocol_version(id: Option<Value>, requested: &str) -> Value {
+    rpc_error_with_data(
+        id,
+        MCP_UNSUPPORTED_PROTOCOL_VERSION,
+        format!("Unsupported MCP protocol version: {requested}"),
+        json!({
+            "supported": MCP_SUPPORTED_PROTOCOL_VERSIONS,
+            "requested": requested,
+        }),
+    )
+}
+
+/// Validate the HTTP-only request metadata introduced by MCP 2026-07-28.
+/// Requests with no modern markers retain the existing 2025-06-18 behavior.
+pub(super) fn validate_http_protocol(
+    req: &Request,
+    request: &JsonRpcRequest,
+) -> Result<McpProtocolEra, Value> {
+    let id = request.id.clone();
+    let header_version = request_header(req, MCP_PROTOCOL_VERSION_HEADER);
+    let body_version = request_protocol_version(&request.params);
+
+    if let (Some(header), Some(body)) = (header_version, body_version) {
+        if header != body {
+            return Err(header_mismatch(
+                id.clone(),
+                format!(
+                    "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} header value '{header}' does not match params._meta protocolVersion '{body}'"
+                ),
+            ));
+        }
+    }
+
+    for requested in [header_version, body_version].into_iter().flatten() {
+        if !MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
+            return Err(unsupported_protocol_version(id.clone(), requested));
+        }
+    }
+
+    let stateless = header_version == Some(MCP_STATELESS_PROTOCOL_VERSION)
+        || body_version == Some(MCP_STATELESS_PROTOCOL_VERSION);
+    if !stateless {
+        return Ok(McpProtocolEra::Legacy);
+    }
+
+    if header_version != Some(MCP_STATELESS_PROTOCOL_VERSION) {
+        return Err(header_mismatch(
+            id,
+            format!(
+                "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} is required and must equal {MCP_STATELESS_PROTOCOL_VERSION}"
+            ),
+        ));
+    }
+    if body_version != Some(MCP_STATELESS_PROTOCOL_VERSION) {
+        return Err(header_mismatch(
+            id,
+            format!(
+                "Header mismatch: {MCP_PROTOCOL_VERSION_HEADER} does not match params._meta protocolVersion"
+            ),
+        ));
+    }
+    if request.id.is_some() {
+        if !request_client_capabilities(&request.params).is_some_and(Value::is_object) {
+            return Err(rpc_error(
+                id.clone(),
+                -32602,
+                "Invalid params: MCP 2026-07-28 requests require params._meta clientCapabilities",
+            ));
+        }
+        if !request_client_info_is_valid(&request.params) {
+            return Err(rpc_error(
+                id,
+                -32602,
+                "Invalid params: params._meta clientInfo must contain string name and version fields when present",
+            ));
+        }
+    }
+
+    match request_header(req, MCP_METHOD_HEADER) {
+        Some(method) if method == request.method => {}
+        Some(method) => {
+            return Err(header_mismatch(
+                id,
+                format!(
+                    "Header mismatch: Mcp-Method header value '{method}' does not match body value '{}'",
+                    request.method
+                ),
+            ));
+        }
+        None => {
+            return Err(header_mismatch(
+                id,
+                "Header mismatch: required Mcp-Method header is missing or malformed",
+            ));
+        }
+    }
+
+    if let Some(body_name) = request_mcp_name(request) {
+        let header_name = request_header(req, MCP_NAME_HEADER)
+            .and_then(|value| decode_mcp_name_header(value).ok());
+        match (header_name.as_deref(), body_name) {
+            (Some(header), Some(body)) if header == body => {}
+            (Some(header), Some(body)) => {
+                return Err(header_mismatch(
+                    id,
+                    format!(
+                        "Header mismatch: Mcp-Name header value '{header}' does not match body value '{body}'"
+                    ),
+                ));
+            }
+            _ => {
+                return Err(header_mismatch(
+                    id,
+                    "Header mismatch: required Mcp-Name header is missing, malformed, or has no matching body value",
+                ));
+            }
+        }
+    }
+
+    Ok(McpProtocolEra::Stateless2026)
+}

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -1,0 +1,127 @@
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub(super) const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
+pub(super) const MCP_CHATGPT_PROTOCOL_VERSION: &str = "2025-11-25";
+pub(super) const MCP_STATELESS_PROTOCOL_VERSION: &str = "2026-07-28";
+pub(super) const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
+    MCP_STATELESS_PROTOCOL_VERSION,
+    MCP_CHATGPT_PROTOCOL_VERSION,
+    MCP_PROTOCOL_VERSION,
+];
+/// Single source of truth for the JSON-RPC methods advertised by `GET /mcp`.
+/// Must match the facade router; pinned by `mcp_info_advertised_methods_match_dispatch`.
+pub(super) const MCP_INFO_METHODS: &[&str] = &[
+    "server/discover",
+    "initialize",
+    "ping",
+    "tools/list",
+    "tools/call",
+    "resources/list",
+    "resources/read",
+    "notifications/initialized",
+];
+
+#[derive(Debug, Deserialize)]
+pub(super) struct JsonRpcRequest {
+    #[serde(default)]
+    pub(super) jsonrpc: Option<String>,
+    pub(super) method: String,
+    #[serde(default)]
+    pub(super) params: Value,
+    #[serde(default)]
+    pub(super) id: Option<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum McpProtocolEra {
+    Legacy,
+    Stateless2026,
+}
+
+pub(super) fn request_protocol_version(params: &Value) -> Option<&str> {
+    params
+        .get("_meta")
+        .and_then(|meta| meta.get("io.modelcontextprotocol/protocolVersion"))
+        .and_then(Value::as_str)
+}
+
+pub(super) fn request_client_capabilities(params: &Value) -> Option<&Value> {
+    params
+        .get("_meta")
+        .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
+}
+
+pub(super) fn request_client_info_is_valid(params: &Value) -> bool {
+    let Some(meta) = params.get("_meta").and_then(Value::as_object) else {
+        return true;
+    };
+    let Some(client_info) = meta.get("io.modelcontextprotocol/clientInfo") else {
+        return true;
+    };
+    let Some(client_info) = client_info.as_object() else {
+        return false;
+    };
+    client_info.get("name").is_some_and(Value::is_string)
+        && client_info.get("version").is_some_and(Value::is_string)
+}
+
+#[cfg(test)]
+pub(super) fn inferred_protocol_era(request: &JsonRpcRequest) -> McpProtocolEra {
+    if request_protocol_version(&request.params) == Some(MCP_STATELESS_PROTOCOL_VERSION) {
+        McpProtocolEra::Stateless2026
+    } else {
+        McpProtocolEra::Legacy
+    }
+}
+
+pub(super) fn legacy_initialize_protocol_version(params: &Value) -> &'static str {
+    match params.get("protocolVersion").and_then(Value::as_str) {
+        Some(MCP_CHATGPT_PROTOCOL_VERSION) => MCP_CHATGPT_PROTOCOL_VERSION,
+        Some(MCP_PROTOCOL_VERSION) => MCP_PROTOCOL_VERSION,
+        _ => MCP_PROTOCOL_VERSION,
+    }
+}
+
+pub(super) fn server_discover_payload(capabilities: Value) -> Value {
+    json!({
+        "resultType": "complete",
+        "ttlMs": 0,
+        "cacheScope": "private",
+        "supportedVersions": [
+            MCP_STATELESS_PROTOCOL_VERSION,
+            MCP_CHATGPT_PROTOCOL_VERSION,
+            MCP_PROTOCOL_VERSION
+        ],
+        "capabilities": capabilities,
+        "_meta": {
+            "io.modelcontextprotocol/serverInfo": {
+                "name": "webcodex",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        }
+    })
+}
+
+pub(super) fn legacy_initialize_payload(params: &Value, model_surface_name: &str) -> Value {
+    json!({
+        "protocolVersion": legacy_initialize_protocol_version(params),
+        "capabilities": {
+            "tools": {
+                "listChanged": false
+            }
+        },
+        "serverInfo": {
+            "name": "webcodex",
+            "version": env!("CARGO_PKG_VERSION"),
+            "modelSurface": model_surface_name
+        }
+    })
+}
+
+pub(super) fn era_label(protocol_era: McpProtocolEra) -> &'static str {
+    match protocol_era {
+        McpProtocolEra::Legacy => "legacy",
+        McpProtocolEra::Stateless2026 => "stateless_2026",
+    }
+}

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -1,7 +1,8 @@
-use super::{
-    mcp_runtime_tool_result_fallback, mcp_stateless_result, request_client_capabilities,
-    require_mcp_scope, rpc_error, rpc_result, scope_forbidden, McpOutcome,
+use super::protocol::request_client_capabilities;
+use super::response::{
+    mcp_runtime_tool_result_fallback, mcp_stateless_result, rpc_error, rpc_result,
 };
+use super::{require_mcp_scope, scope_forbidden, McpOutcome};
 use crate::auth::AuthContext;
 use crate::model_surface::ModelSurface;
 use crate::tool_runtime::kernel::{
@@ -955,15 +956,15 @@ pub(super) async fn mcp_artifact_export_read_chunk(
 
 #[derive(Debug)]
 pub(super) struct McpArtifactExportStreamPlan {
-    pub(super) uri: String,
-    pub(super) record: McpArtifactExportRecord,
-    pub(super) first_chunk: Vec<u8>,
-    pub(super) route: Option<McpArtifactExportChunkRoute>,
-    pub(super) offset: usize,
-    pub(super) chunks: usize,
-    pub(super) max_chunks: usize,
-    pub(super) read_budget: Duration,
-    pub(super) _permit: OwnedSemaphorePermit,
+    uri: String,
+    record: McpArtifactExportRecord,
+    first_chunk: Vec<u8>,
+    route: Option<McpArtifactExportChunkRoute>,
+    offset: usize,
+    chunks: usize,
+    max_chunks: usize,
+    read_budget: Duration,
+    _permit: OwnedSemaphorePermit,
 }
 
 pub(super) async fn mcp_artifact_export_with_read_budget<T, F>(
@@ -1644,31 +1645,38 @@ pub(super) fn prepare_tool_call(
     })
 }
 
+pub(super) enum McpResourceToolResultAdaptation {
+    Framed(Value),
+    Unhandled(ToolResult),
+}
+
 pub(super) fn adapt_tool_result(
     tool_name: &str,
     as_image_requested: bool,
     result: ToolResult,
     context: McpResourceToolCallContext,
-) -> Value {
+) -> McpResourceToolResultAdaptation {
     if tool_name == "export_project_artifact" {
-        return mcp_artifact_export_tool_result(
+        return McpResourceToolResultAdaptation::Framed(mcp_artifact_export_tool_result(
             result,
             context
                 .artifact_export_caller
                 .expect("validated artifact export caller binding"),
-        );
+        ));
     }
     if matches!(tool_name, "computer_snapshot" | "computer_snapshot_display")
         || (tool_name == "read_project_artifact" && as_image_requested)
     {
-        return mcp_runtime_tool_result_with_snapshot_resource(
-            tool_name,
-            as_image_requested,
-            result,
-            context.snapshot_resource_caller,
+        return McpResourceToolResultAdaptation::Framed(
+            mcp_runtime_tool_result_with_snapshot_resource(
+                tool_name,
+                as_image_requested,
+                result,
+                context.snapshot_resource_caller,
+            ),
         );
     }
-    super::mcp_runtime_tool_result(tool_name, as_image_requested, result)
+    McpResourceToolResultAdaptation::Unhandled(result)
 }
 
 pub(super) fn start_artifact_export_stream(

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -1,0 +1,1703 @@
+use super::{
+    mcp_runtime_tool_result_fallback, mcp_stateless_result, request_client_capabilities,
+    require_mcp_scope, rpc_error, rpc_result, scope_forbidden, McpOutcome,
+};
+use crate::auth::AuthContext;
+use crate::model_surface::ModelSurface;
+use crate::tool_runtime::kernel::{
+    HostFileImportTrust, ToolCallContext, ToolCallErrorStatus,
+    ToolCallRequest as KernelToolCallRequest, ToolTransport,
+};
+use crate::tool_runtime::{
+    validate_project_artifact_export_snapshot, ProjectArtifactExportSnapshot, ToolResult,
+    ToolRuntime, MAX_PROJECT_ARTIFACT_EXPORT_BYTES, MAX_READ_PROJECT_ARTIFACT_LENGTH,
+};
+use base64::{engine::general_purpose, Engine as _};
+use futures_util::future::join_all;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+
+pub(super) const MCP_ARTIFACT_EXPORT_URI_PREFIX: &str = "webcodex-artifact://export/";
+pub(super) const MCP_ARTIFACT_EXPORT_ID_PREFIX: &str = "wc_export_";
+pub(super) const MCP_SNAPSHOT_RESOURCE_URI_PREFIX: &str = "webcodex-snapshot://view/";
+pub(super) const MCP_SNAPSHOT_RESOURCE_ID_PREFIX: &str = "wc_snapshot_";
+pub(super) const MCP_SNAPSHOT_RESOURCE_TTL: Duration = Duration::from_secs(5 * 60);
+pub(super) const MAX_MCP_SNAPSHOT_RESOURCES: usize = 32;
+pub(super) const MAX_MCP_SNAPSHOT_RESOURCES_PER_CALLER: usize = 8;
+pub(super) const MCP_ARTIFACT_EXPORT_TTL: Duration = Duration::from_secs(5 * 60);
+pub(super) const MCP_ARTIFACT_EXPORT_ADMISSION_TIMEOUT: Duration = Duration::from_secs(5);
+pub(super) const MCP_ARTIFACT_EXPORT_READ_TIMEOUT: Duration = Duration::from_secs(120);
+pub(super) const MCP_ARTIFACT_EXPORT_STREAM_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+pub(super) const MAX_MCP_ARTIFACT_EXPORT_READS: usize = 2;
+pub(super) const MAX_MCP_ARTIFACT_EXPORT_CHUNK_READS: usize = 4;
+pub(super) const MAX_MCP_ARTIFACT_EXPORTS: usize = 128;
+pub(super) const MAX_MCP_ARTIFACT_EXPORTS_PER_CALLER: usize = 16;
+pub(super) const MCP_ARTIFACT_EXPORT_BUSY_CODE: i64 = -32029;
+pub(super) const MCP_UI_EXTENSION: &str = "io.modelcontextprotocol/ui";
+pub(super) const MCP_COMPUTER_UI_RESOURCE_URI: &str = "ui://webcodex/computer/v11";
+pub(super) const MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS: &[&str] = &[
+    "ui://webcodex/computer/v1",
+    "ui://webcodex/computer/v2",
+    "ui://webcodex/computer/v3",
+    "ui://webcodex/computer/v4",
+    "ui://webcodex/computer/v5",
+    "ui://webcodex/computer/v6",
+    "ui://webcodex/computer/v7",
+    "ui://webcodex/computer/v8",
+    "ui://webcodex/computer/v9",
+    "ui://webcodex/computer/v10",
+];
+// Temporary gray-card diagnostic: force the host to re-read the canonical App
+// resource for every card so resource reuse/cache is not an unobserved variable.
+pub(super) const MCP_COMPUTER_UI_RESOURCE_TTL_MS: u64 = 0;
+pub(super) const MCP_COMPUTER_UI_DOMAIN: &str = "https://sg4.yyjeqhc.cn";
+pub(super) const MCP_UI_RESOURCE_MIME_TYPE: &str = "text/html;profile=mcp-app";
+pub(super) const MCP_COMPUTER_APP_HTML: &str = include_str!("../mcp_computer_app.html");
+
+pub(super) fn request_supports_mcp_apps(params: &Value) -> bool {
+    let Some(extension) = request_client_capabilities(params)
+        .and_then(|capabilities| capabilities.get("extensions"))
+        .and_then(|extensions| extensions.get(MCP_UI_EXTENSION))
+        .and_then(Value::as_object)
+    else {
+        return false;
+    };
+    match extension.get("mimeTypes").and_then(Value::as_array) {
+        Some(mime_types) => mime_types
+            .iter()
+            .any(|mime| mime.as_str() == Some(MCP_UI_RESOURCE_MIME_TYPE)),
+        None => false,
+    }
+}
+
+pub(super) fn model_surface_supports_computer_app(model_surface: ModelSurface) -> bool {
+    model_surface == ModelSurface::FullOperatorRuntime
+}
+
+pub(super) fn mcp_computer_app_resource_meta() -> Value {
+    json!({
+        "ui": {
+            "prefersBorder": true,
+            "domain": MCP_COMPUTER_UI_DOMAIN,
+            "csp": {
+                "connectDomains": [],
+                "resourceDomains": []
+            }
+        }
+    })
+}
+
+pub(super) fn mcp_computer_app_resources_list() -> Value {
+    json!({
+        "resources": [{
+            "uri": MCP_COMPUTER_UI_RESOURCE_URI,
+            "name": "WebCodex Computer",
+            "description": "Minimal read-only WebCodex Computer screenshot card that performs only the standard MCP Apps handshake and renders the native computer_snapshot image.",
+            "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
+            "_meta": mcp_computer_app_resource_meta()
+        }]
+    })
+}
+
+pub(super) fn is_mcp_computer_app_resource_uri(uri: &str) -> bool {
+    uri == MCP_COMPUTER_UI_RESOURCE_URI || MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS.contains(&uri)
+}
+
+pub(super) fn mcp_computer_app_resource_read(uri: &str) -> Option<Value> {
+    // ChatGPT can retain an older tool descriptor across connector refreshes.
+    // Keep prior computer App URIs as hidden read aliases so an already-bound
+    // card can fetch the current safe template. resources/list and tools/list
+    // still advertise only the canonical URI above.
+    let supported = is_mcp_computer_app_resource_uri(uri);
+    supported.then(|| {
+        json!({
+            "contents": [{
+                "uri": uri,
+                "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
+                "text": MCP_COMPUTER_APP_HTML,
+                "_meta": mcp_computer_app_resource_meta()
+            }]
+        })
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum McpArtifactExportCallerBinding {
+    Bootstrap,
+    ApiToken {
+        api_key_id: String,
+    },
+    AgentToken {
+        api_key_id: String,
+    },
+    AccountCredential {
+        user_id: String,
+    },
+    OAuthUser {
+        user_id: String,
+        client_id: String,
+    },
+    OAuthSharedKey {
+        shared_key_hash: String,
+        client_id: String,
+    },
+    SharedKey {
+        shared_key_hash: String,
+    },
+    ProjectCredential {
+        project_grant_id: String,
+    },
+}
+
+pub(super) fn mcp_artifact_export_caller_binding(
+    auth: Option<&AuthContext>,
+) -> Result<McpArtifactExportCallerBinding, &'static str> {
+    let auth = auth.ok_or("authenticated caller identity is unavailable")?;
+    match auth.kind {
+        crate::auth::AuthKind::Bootstrap => Ok(McpArtifactExportCallerBinding::Bootstrap),
+        crate::auth::AuthKind::ApiToken => auth
+            .api_key_id
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .map(|api_key_id| McpArtifactExportCallerBinding::ApiToken { api_key_id })
+            .ok_or("API token identity is unavailable"),
+        crate::auth::AuthKind::AgentToken => auth
+            .api_key_id
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .map(|api_key_id| McpArtifactExportCallerBinding::AgentToken { api_key_id })
+            .ok_or("agent token identity is unavailable"),
+        crate::auth::AuthKind::AccountCredential => auth
+            .user_id
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .map(|user_id| McpArtifactExportCallerBinding::AccountCredential { user_id })
+            .ok_or("account identity is unavailable"),
+        crate::auth::AuthKind::OAuth2Token => {
+            let client_id = auth
+                .allowed_client_id
+                .as_ref()
+                .filter(|value| !value.is_empty())
+                .cloned()
+                .ok_or("OAuth client identity is unavailable")?;
+            if auth.is_oauth_shared_key_subject() {
+                let shared_key_hash = auth
+                    .shared_key_hash
+                    .as_ref()
+                    .filter(|value| !value.is_empty())
+                    .cloned()
+                    .ok_or("OAuth shared-key subject identity is unavailable")?;
+                Ok(McpArtifactExportCallerBinding::OAuthSharedKey {
+                    shared_key_hash,
+                    client_id,
+                })
+            } else if auth.token_kind.as_deref() == Some("oauth2") {
+                let user_id = auth
+                    .user_id
+                    .as_ref()
+                    .filter(|value| !value.is_empty())
+                    .cloned()
+                    .ok_or("OAuth user identity is unavailable")?;
+                Ok(McpArtifactExportCallerBinding::OAuthUser { user_id, client_id })
+            } else {
+                Err("unsupported OAuth subject identity")
+            }
+        }
+        crate::auth::AuthKind::SharedKey => auth
+            .shared_key_hash
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .map(|shared_key_hash| McpArtifactExportCallerBinding::SharedKey { shared_key_hash })
+            .ok_or("shared-key identity is unavailable"),
+        crate::auth::AuthKind::ProjectCredential => auth
+            .project_grant_id
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .map(
+                |project_grant_id| McpArtifactExportCallerBinding::ProjectCredential {
+                    project_grant_id,
+                },
+            )
+            .ok_or("project credential identity is unavailable"),
+        crate::auth::AuthKind::OpenAnonymous => {
+            Err("anonymous MCP callers cannot create artifact export resources")
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct McpArtifactExportRecord {
+    pub(super) caller: McpArtifactExportCallerBinding,
+    pub(super) project: String,
+    pub(super) snapshot: ProjectArtifactExportSnapshot,
+    pub(super) expires_at: Instant,
+}
+
+#[derive(Default)]
+pub(super) struct McpArtifactExportRegistry {
+    pub(super) entries: HashMap<String, McpArtifactExportRecord>,
+    pub(super) order: VecDeque<String>,
+}
+
+impl McpArtifactExportRegistry {
+    pub(super) fn cleanup(&mut self, now: Instant) {
+        self.entries.retain(|_, record| record.expires_at > now);
+        self.order.retain(|id| self.entries.contains_key(id));
+    }
+
+    pub(super) fn insert(&mut self, record: McpArtifactExportRecord) -> String {
+        self.cleanup(Instant::now());
+        while self
+            .entries
+            .values()
+            .filter(|existing| existing.caller == record.caller)
+            .count()
+            >= MAX_MCP_ARTIFACT_EXPORTS_PER_CALLER
+        {
+            let Some(position) = self.order.iter().position(|id| {
+                self.entries
+                    .get(id)
+                    .is_some_and(|existing| existing.caller == record.caller)
+            }) else {
+                break;
+            };
+            if let Some(id) = self.order.remove(position) {
+                self.entries.remove(&id);
+            }
+        }
+        while self.entries.len() >= MAX_MCP_ARTIFACT_EXPORTS {
+            if let Some(id) = self.order.pop_front() {
+                self.entries.remove(&id);
+            } else {
+                break;
+            }
+        }
+        let id = loop {
+            let candidate = format!(
+                "{MCP_ARTIFACT_EXPORT_ID_PREFIX}{}",
+                uuid::Uuid::new_v4().simple()
+            );
+            if !self.entries.contains_key(&candidate) {
+                break candidate;
+            }
+        };
+        self.order.push_back(id.clone());
+        self.entries.insert(id.clone(), record);
+        format!("{MCP_ARTIFACT_EXPORT_URI_PREFIX}{id}")
+    }
+
+    pub(super) fn get_for_caller(
+        &mut self,
+        uri: &str,
+        caller: &McpArtifactExportCallerBinding,
+    ) -> Option<McpArtifactExportRecord> {
+        self.cleanup(Instant::now());
+        let id = mcp_artifact_export_id_from_uri(uri)?;
+        self.entries
+            .get(id)
+            .filter(|record| &record.caller == caller)
+            .cloned()
+    }
+}
+
+pub(super) static MCP_ARTIFACT_EXPORT_REGISTRY: OnceLock<Mutex<McpArtifactExportRegistry>> =
+    OnceLock::new();
+pub(super) static MCP_ARTIFACT_EXPORT_READ_SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+
+pub(super) fn mcp_artifact_export_registry() -> &'static Mutex<McpArtifactExportRegistry> {
+    MCP_ARTIFACT_EXPORT_REGISTRY.get_or_init(|| Mutex::new(McpArtifactExportRegistry::default()))
+}
+
+pub(super) fn mcp_artifact_export_read_semaphore() -> Arc<Semaphore> {
+    MCP_ARTIFACT_EXPORT_READ_SEMAPHORE
+        .get_or_init(|| Arc::new(Semaphore::new(MAX_MCP_ARTIFACT_EXPORT_READS)))
+        .clone()
+}
+
+pub(super) fn mcp_artifact_export_id_from_uri(uri: &str) -> Option<&str> {
+    let id = uri.strip_prefix(MCP_ARTIFACT_EXPORT_URI_PREFIX)?;
+    let hex = id.strip_prefix(MCP_ARTIFACT_EXPORT_ID_PREFIX)?;
+    (hex.len() == 32
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()))
+    .then_some(id)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum McpSnapshotResourceKind {
+    Window,
+    Display,
+}
+
+impl McpSnapshotResourceKind {
+    pub(super) fn from_tool_name(tool_name: &str) -> Option<Self> {
+        match tool_name {
+            "computer_snapshot" => Some(Self::Window),
+            "computer_snapshot_display" => Some(Self::Display),
+            _ => None,
+        }
+    }
+
+    pub(super) fn name(self, client_id: &str, mime_type: &str) -> String {
+        let extension = match mime_type {
+            "image/png" => "png",
+            "image/webp" => "webp",
+            _ => "jpg",
+        };
+        let kind = match self {
+            Self::Window => "window",
+            Self::Display => "display",
+        };
+        let normalized_client_id: String = client_id
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                    ch
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        let client_id = if normalized_client_id.is_empty() {
+            "computer"
+        } else {
+            normalized_client_id.as_str()
+        };
+        format!("{client_id}-{kind}-snapshot.{extension}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct McpSnapshotResourceRecord {
+    pub(super) caller: McpArtifactExportCallerBinding,
+    pub(super) kind: McpSnapshotResourceKind,
+    pub(super) bytes: Arc<[u8]>,
+    pub(super) mime_type: String,
+    pub(super) expires_at: Instant,
+}
+
+#[derive(Default)]
+pub(super) struct McpSnapshotResourceRegistry {
+    pub(super) entries: HashMap<String, McpSnapshotResourceRecord>,
+    pub(super) order: VecDeque<String>,
+}
+
+impl McpSnapshotResourceRegistry {
+    pub(super) fn cleanup(&mut self, now: Instant) {
+        self.entries.retain(|_, record| record.expires_at > now);
+        self.order.retain(|id| self.entries.contains_key(id));
+    }
+
+    pub(super) fn insert(&mut self, record: McpSnapshotResourceRecord) -> String {
+        self.cleanup(Instant::now());
+        while self
+            .entries
+            .values()
+            .filter(|existing| existing.caller == record.caller)
+            .count()
+            >= MAX_MCP_SNAPSHOT_RESOURCES_PER_CALLER
+        {
+            let Some(position) = self.order.iter().position(|id| {
+                self.entries
+                    .get(id)
+                    .is_some_and(|existing| existing.caller == record.caller)
+            }) else {
+                break;
+            };
+            if let Some(id) = self.order.remove(position) {
+                self.entries.remove(&id);
+            }
+        }
+        while self.entries.len() >= MAX_MCP_SNAPSHOT_RESOURCES {
+            if let Some(id) = self.order.pop_front() {
+                self.entries.remove(&id);
+            } else {
+                break;
+            }
+        }
+        let id = loop {
+            let candidate = format!(
+                "{MCP_SNAPSHOT_RESOURCE_ID_PREFIX}{}",
+                uuid::Uuid::new_v4().simple()
+            );
+            if !self.entries.contains_key(&candidate) {
+                break candidate;
+            }
+        };
+        self.order.push_back(id.clone());
+        self.entries.insert(id.clone(), record);
+        format!("{MCP_SNAPSHOT_RESOURCE_URI_PREFIX}{id}")
+    }
+
+    pub(super) fn get_for_caller(
+        &mut self,
+        uri: &str,
+        caller: &McpArtifactExportCallerBinding,
+    ) -> Option<McpSnapshotResourceRecord> {
+        self.cleanup(Instant::now());
+        let id = mcp_snapshot_resource_id_from_uri(uri)?;
+        self.entries
+            .get(id)
+            .filter(|record| &record.caller == caller)
+            .cloned()
+    }
+}
+
+pub(super) static MCP_SNAPSHOT_RESOURCE_REGISTRY: OnceLock<Mutex<McpSnapshotResourceRegistry>> =
+    OnceLock::new();
+
+pub(super) fn mcp_snapshot_resource_registry() -> &'static Mutex<McpSnapshotResourceRegistry> {
+    MCP_SNAPSHOT_RESOURCE_REGISTRY
+        .get_or_init(|| Mutex::new(McpSnapshotResourceRegistry::default()))
+}
+
+pub(super) fn mcp_snapshot_resource_id_from_uri(uri: &str) -> Option<&str> {
+    let id = uri.strip_prefix(MCP_SNAPSHOT_RESOURCE_URI_PREFIX)?;
+    let hex = id.strip_prefix(MCP_SNAPSHOT_RESOURCE_ID_PREFIX)?;
+    (hex.len() == 32
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()))
+    .then_some(id)
+}
+
+pub(super) fn mcp_issue_artifact_export(
+    caller: McpArtifactExportCallerBinding,
+    result: &ToolResult,
+) -> Result<(String, ProjectArtifactExportSnapshot), String> {
+    let project = result
+        .output
+        .get("project")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "export result is missing canonical project identity".to_string())?
+        .to_string();
+    let path = result
+        .output
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "export result is missing artifact path".to_string())?;
+    let snapshot = validate_project_artifact_export_snapshot(path, &result.output)?;
+    if result.output.get("name").and_then(Value::as_str) != Some(snapshot.name.as_str()) {
+        return Err(
+            "export result basename does not match validated artifact metadata".to_string(),
+        );
+    }
+    let record = McpArtifactExportRecord {
+        caller,
+        project,
+        snapshot: snapshot.clone(),
+        expires_at: Instant::now() + MCP_ARTIFACT_EXPORT_TTL,
+    };
+    let uri = mcp_artifact_export_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(record);
+    Ok((uri, snapshot))
+}
+
+pub(super) fn mcp_artifact_export_tool_result(
+    result: ToolResult,
+    caller: McpArtifactExportCallerBinding,
+) -> Value {
+    if !result.success {
+        return mcp_runtime_tool_result_fallback(result);
+    }
+    let (uri, snapshot) = match mcp_issue_artifact_export(caller, &result) {
+        Ok(value) => value,
+        Err(error) => {
+            return mcp_runtime_tool_result_fallback(ToolResult::err(format!(
+                "cannot frame artifact export resource: {error}"
+            )))
+        }
+    };
+    json!({
+        "content": [{
+            "type": "resource_link",
+            "uri": uri,
+            "name": snapshot.name,
+            "mimeType": snapshot.mime_type,
+            "description": "Short-lived authenticated WebCodex project artifact export. Read this URI with MCP resources/read to retrieve the complete bounded binary."
+        }],
+        "structuredContent": {
+            "success": true,
+            "output": result.output,
+            "error": Value::Null,
+        },
+        "isError": false
+    })
+}
+
+#[cfg(test)]
+pub(super) fn mcp_expire_artifact_export_for_test(uri: &str) {
+    if let Some(id) = mcp_artifact_export_id_from_uri(uri) {
+        let mut registry = mcp_artifact_export_registry()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(record) = registry.entries.get_mut(id) {
+            record.expires_at = Instant::now();
+        }
+    }
+}
+
+pub(super) fn mcp_runtime_tool_result_with_snapshot_resource(
+    tool_name: &str,
+    as_image_requested: bool,
+    mut result: ToolResult,
+    snapshot_caller: Option<McpArtifactExportCallerBinding>,
+) -> Value {
+    let native_image_requested = (tool_name == "read_project_artifact" && as_image_requested)
+        || matches!(tool_name, "computer_snapshot" | "computer_snapshot_display");
+    if native_image_requested && result.success {
+        match mcp_native_image_tool_result(tool_name, &mut result, snapshot_caller) {
+            Ok(value) => return value,
+            Err(error) => {
+                result = ToolResult::err(format!(
+                    "cannot frame {tool_name} as MCP image content: {error}"
+                ));
+            }
+        }
+    }
+
+    mcp_runtime_tool_result_fallback(result)
+}
+
+pub(super) fn mcp_native_image_tool_result(
+    tool_name: &str,
+    result: &mut ToolResult,
+    snapshot_caller: Option<McpArtifactExportCallerBinding>,
+) -> Result<Value, String> {
+    let data = result
+        .output
+        .get("content_base64")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "missing content_base64".to_string())?
+        .to_string();
+    let mime_type = result
+        .output
+        .get("mime_type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "missing mime_type".to_string())?
+        .to_string();
+    if !matches!(
+        mime_type.as_str(),
+        "image/png" | "image/jpeg" | "image/webp"
+    ) {
+        return Err(format!("unsupported MIME type '{mime_type}'"));
+    }
+    let decoded = general_purpose::STANDARD
+        .decode(&data)
+        .map_err(|error| format!("invalid image base64: {error}"))?;
+    if decoded.is_empty() || decoded.len() > crate::artifact_policy::MAX_MCP_IMAGE_BYTES {
+        return Err(format!(
+            "image payload exceeds {} decoded bytes",
+            crate::artifact_policy::MAX_MCP_IMAGE_BYTES
+        ));
+    }
+    let detected = if decoded.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Some("image/png")
+    } else if decoded.starts_with(&[0xff, 0xd8, 0xff]) {
+        Some("image/jpeg")
+    } else if decoded.len() >= 12 && decoded.starts_with(b"RIFF") && &decoded[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else {
+        None
+    };
+    if detected != Some(mime_type.as_str()) {
+        return Err("image MIME does not match decoded content".to_string());
+    }
+    let image_label = if tool_name == "computer_snapshot" {
+        result
+            .output
+            .pointer("/surface/surface_id")
+            .and_then(Value::as_str)
+            .unwrap_or("desktop surface")
+    } else if tool_name == "computer_snapshot_display" {
+        result
+            .output
+            .get("display_id")
+            .and_then(Value::as_str)
+            .unwrap_or("full display")
+    } else {
+        result
+            .output
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or("project image")
+    };
+    let file_bytes = result
+        .output
+        .get("file_bytes")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| "missing file_bytes".to_string())?;
+    if file_bytes != decoded.len() as u64 {
+        return Err("file_bytes does not match decoded image payload".to_string());
+    }
+    let sha256 = result
+        .output
+        .get("sha256")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let metadata_text = if matches!(tool_name, "computer_snapshot" | "computer_snapshot_display") {
+        let width = result
+            .output
+            .get("width")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let height = result
+            .output
+            .get("height")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if width == 0 || height == 0 || width > 4096 || height > 4096 {
+            return Err("computer snapshot dimensions are invalid".to_string());
+        }
+        format!("Image {image_label}: {mime_type}, {width}x{height}, {file_bytes} bytes.")
+    } else {
+        format!("Image {image_label}: {mime_type}, {file_bytes} bytes, sha256 {sha256}.")
+    };
+
+    let output = result
+        .output
+        .as_object_mut()
+        .ok_or_else(|| "tool output is not an object".to_string())?;
+    output.remove("content_base64");
+    output.insert("content_delivery".to_string(), json!("mcp_image"));
+    let structured_output = result.output.clone();
+
+    let snapshot_link = snapshot_caller
+        .zip(McpSnapshotResourceKind::from_tool_name(tool_name))
+        .map(|(caller, kind)| {
+            let client_id = result
+                .output
+                .get("client_id")
+                .and_then(Value::as_str)
+                .unwrap_or("computer");
+            let name = kind.name(client_id, &mime_type);
+            let record = McpSnapshotResourceRecord {
+                caller,
+                kind,
+                bytes: Arc::from(decoded.into_boxed_slice()),
+                mime_type: mime_type.clone(),
+                expires_at: Instant::now() + MCP_SNAPSHOT_RESOURCE_TTL,
+            };
+            let uri = mcp_snapshot_resource_registry()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(record);
+            tracing::info!(
+                target: "webcodex::mcp",
+                tool_name,
+                file_bytes,
+                "mcp_snapshot_resource_link_issued"
+            );
+            json!({
+                "type": "resource_link",
+                "uri": uri,
+                "name": name,
+                "mimeType": mime_type,
+                "size": file_bytes,
+                "description": "Short-lived authenticated WebCodex computer screenshot. No project artifact was created."
+            })
+        });
+    let mut content = Vec::with_capacity(if snapshot_link.is_some() { 3 } else { 2 });
+    if let Some(link) = snapshot_link {
+        content.push(link);
+    }
+    content.push(json!({ "type": "text", "text": metadata_text }));
+    content.push(json!({ "type": "image", "data": data, "mimeType": mime_type }));
+
+    Ok(json!({
+        "content": content,
+        "structuredContent": {
+            "success": true,
+            "output": structured_output,
+            "error": Value::Null,
+        },
+        "isError": false
+    }))
+}
+
+#[derive(Debug)]
+pub(super) enum McpArtifactExportReadError {
+    Unavailable,
+    Forbidden {
+        required_scope: Option<&'static str>,
+        description: String,
+    },
+    SnapshotChanged,
+    Unsafe,
+    Busy,
+    Timeout,
+}
+
+pub(super) fn mcp_artifact_export_lookup(
+    uri: &str,
+    auth: Option<&AuthContext>,
+) -> Result<McpArtifactExportRecord, McpArtifactExportReadError> {
+    let caller = mcp_artifact_export_caller_binding(auth)
+        .map_err(|_| McpArtifactExportReadError::Unavailable)?;
+    mcp_artifact_export_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get_for_caller(uri, &caller)
+        .ok_or(McpArtifactExportReadError::Unavailable)
+}
+
+pub(super) async fn mcp_artifact_export_metadata_recheck(
+    runtime: &ToolRuntime,
+    record: &McpArtifactExportRecord,
+    auth: Option<&AuthContext>,
+) -> Result<ProjectArtifactExportSnapshot, McpArtifactExportReadError> {
+    let result = runtime
+        .read_project_artifact_export_metadata_internal(
+            &record.project,
+            &record.snapshot.path,
+            auth,
+        )
+        .await;
+    if !result.success {
+        return Err(McpArtifactExportReadError::Unavailable);
+    }
+    let snapshot = validate_project_artifact_export_snapshot(&record.snapshot.path, &result.output)
+        .map_err(|_| McpArtifactExportReadError::Unsafe)?;
+    if snapshot != record.snapshot {
+        return Err(McpArtifactExportReadError::SnapshotChanged);
+    }
+    Ok(snapshot)
+}
+
+pub(super) fn mcp_artifact_export_decode_chunk(
+    record: &McpArtifactExportRecord,
+    offset: usize,
+    length: usize,
+    output: &Value,
+    require_complete_metadata: bool,
+) -> Result<Vec<u8>, McpArtifactExportReadError> {
+    if output.get("error_kind").and_then(Value::as_str) == Some("snapshot_changed") {
+        return Err(McpArtifactExportReadError::SnapshotChanged);
+    }
+    if output.get("error").and_then(Value::as_str).is_some() {
+        return Err(McpArtifactExportReadError::Unsafe);
+    }
+    if output.get("path").and_then(Value::as_str) != Some(record.snapshot.path.as_str())
+        || output.get("file_bytes").and_then(Value::as_u64) != Some(record.snapshot.bytes as u64)
+    {
+        return Err(McpArtifactExportReadError::SnapshotChanged);
+    }
+    if require_complete_metadata
+        && (output.get("mime_type").and_then(Value::as_str)
+            != Some(record.snapshot.mime_type.as_str())
+            || output.get("sha256").and_then(Value::as_str)
+                != Some(record.snapshot.sha256.as_str()))
+    {
+        return Err(McpArtifactExportReadError::SnapshotChanged);
+    }
+    if output.get("offset").and_then(Value::as_u64) != Some(offset as u64) {
+        return Err(McpArtifactExportReadError::Unsafe);
+    }
+    let encoded = output
+        .get("content_base64")
+        .and_then(Value::as_str)
+        .ok_or(McpArtifactExportReadError::Unsafe)?;
+    let decoded = general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| McpArtifactExportReadError::Unsafe)?;
+    let bytes_returned = output
+        .get("bytes_returned")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or(McpArtifactExportReadError::Unsafe)?;
+    let next_offset = output
+        .get("next_offset")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or(McpArtifactExportReadError::Unsafe)?;
+    let eof = output
+        .get("eof")
+        .and_then(Value::as_bool)
+        .ok_or(McpArtifactExportReadError::Unsafe)?;
+    let truncated = output
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .ok_or(McpArtifactExportReadError::Unsafe)?;
+    let expected_next = offset
+        .checked_add(decoded.len())
+        .ok_or(McpArtifactExportReadError::Unsafe)?;
+    if decoded.len() != bytes_returned
+        || decoded.len() > length
+        || expected_next != next_offset
+        || next_offset > record.snapshot.bytes
+        || (decoded.is_empty() && offset < record.snapshot.bytes)
+        || eof != (next_offset == record.snapshot.bytes)
+        || truncated == eof
+    {
+        return Err(McpArtifactExportReadError::Unsafe);
+    }
+    Ok(decoded)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum McpArtifactExportChunkRoute {
+    Optimized,
+    Legacy,
+}
+
+pub(super) async fn mcp_artifact_export_read_optimized_chunk(
+    runtime: &ToolRuntime,
+    record: &McpArtifactExportRecord,
+    auth: Option<&AuthContext>,
+    offset: usize,
+    length: usize,
+) -> Result<Option<Vec<u8>>, McpArtifactExportReadError> {
+    match runtime
+        .read_project_artifact_export_chunk_internal(
+            &record.project,
+            &record.snapshot.path,
+            record.snapshot.bytes,
+            offset,
+            length,
+            auth,
+        )
+        .await
+    {
+        Ok(Some(output)) => {
+            mcp_artifact_export_decode_chunk(record, offset, length, &output, false).map(Some)
+        }
+        Ok(None) => Ok(None),
+        Err(_) => Err(McpArtifactExportReadError::Unavailable),
+    }
+}
+
+pub(super) async fn mcp_artifact_export_read_legacy_chunk(
+    runtime: &ToolRuntime,
+    record: &McpArtifactExportRecord,
+    auth: Option<&AuthContext>,
+    offset: usize,
+    length: usize,
+) -> Result<Vec<u8>, McpArtifactExportReadError> {
+    let outcome = runtime
+        .call_tool_with_context(
+            KernelToolCallRequest {
+                tool_name: "read_project_artifact".to_string(),
+                arguments: json!({
+                    "project": record.project,
+                    "path": record.snapshot.path,
+                    "encoding": "base64",
+                    "offset": offset,
+                    "length": length,
+                    "max_bytes": length,
+                }),
+            },
+            ToolCallContext {
+                transport: ToolTransport::Mcp,
+                session_id: None,
+                auth,
+                window: None,
+                record_oauth_scope_denials: false,
+                host_file_import_trust: HostFileImportTrust::Untrusted,
+            },
+        )
+        .await;
+    if let Some(error_status) = outcome.error_status {
+        return match error_status {
+            ToolCallErrorStatus::InsufficientScope {
+                required_scope,
+                description,
+            } => Err(McpArtifactExportReadError::Forbidden {
+                required_scope,
+                description,
+            }),
+            ToolCallErrorStatus::InvalidArguments { .. } => Err(McpArtifactExportReadError::Unsafe),
+        };
+    }
+    let result = outcome.result.ok_or(McpArtifactExportReadError::Unsafe)?;
+    if !result.success {
+        return Err(McpArtifactExportReadError::Unavailable);
+    }
+    mcp_artifact_export_decode_chunk(record, offset, length, &result.output, true)
+}
+
+pub(super) async fn mcp_artifact_export_read_chunk(
+    runtime: &ToolRuntime,
+    record: &McpArtifactExportRecord,
+    auth: Option<&AuthContext>,
+    offset: usize,
+    length: usize,
+) -> Result<(Vec<u8>, McpArtifactExportChunkRoute), McpArtifactExportReadError> {
+    if let Some(chunk) =
+        mcp_artifact_export_read_optimized_chunk(runtime, record, auth, offset, length).await?
+    {
+        return Ok((chunk, McpArtifactExportChunkRoute::Optimized));
+    }
+
+    // Rolling-upgrade compatibility: an old Runner cannot receive the optimized
+    // request kind because capability check + enqueue are atomic. Observe that
+    // route once on the first chunk; the resource read then stays sequential on
+    // this public compatibility path rather than amplifying legacy whole-file
+    // work with Control-side concurrency.
+    let chunk =
+        mcp_artifact_export_read_legacy_chunk(runtime, record, auth, offset, length).await?;
+    Ok((chunk, McpArtifactExportChunkRoute::Legacy))
+}
+
+#[derive(Debug)]
+pub(super) struct McpArtifactExportStreamPlan {
+    pub(super) uri: String,
+    pub(super) record: McpArtifactExportRecord,
+    pub(super) first_chunk: Vec<u8>,
+    pub(super) route: Option<McpArtifactExportChunkRoute>,
+    pub(super) offset: usize,
+    pub(super) chunks: usize,
+    pub(super) max_chunks: usize,
+    pub(super) read_budget: Duration,
+    pub(super) _permit: OwnedSemaphorePermit,
+}
+
+pub(super) async fn mcp_artifact_export_with_read_budget<T, F>(
+    runtime: &ToolRuntime,
+    read_budget: &mut Duration,
+    future: F,
+) -> Result<T, McpArtifactExportReadError>
+where
+    F: Future<Output = Result<T, McpArtifactExportReadError>>,
+{
+    if read_budget.is_zero() {
+        return Err(McpArtifactExportReadError::Timeout);
+    }
+    let started = Instant::now();
+    let outcome = tokio::time::timeout(*read_budget, future).await;
+    *read_budget = read_budget.saturating_sub(started.elapsed());
+    match outcome {
+        Ok(result) => result,
+        Err(_) => {
+            runtime.shell_clients.cancel_abandoned_sync_requests().await;
+            Err(McpArtifactExportReadError::Timeout)
+        }
+    }
+}
+
+pub(super) async fn mcp_artifact_export_stream_plan_with_gate_timeout(
+    runtime: &ToolRuntime,
+    uri: &str,
+    auth: Option<&AuthContext>,
+    gate: Arc<Semaphore>,
+    admission_timeout: Duration,
+    read_timeout: Duration,
+) -> Result<McpArtifactExportStreamPlan, McpArtifactExportReadError> {
+    let record = mcp_artifact_export_lookup(uri, auth)?;
+    if auth.is_some_and(|auth| !auth.has_scope(crate::auth::SCOPE_PROJECT_READ)) {
+        return Err(McpArtifactExportReadError::Forbidden {
+            required_scope: Some(crate::auth::SCOPE_PROJECT_READ),
+            description: format!(
+                "missing required scope: {}",
+                crate::auth::SCOPE_PROJECT_READ
+            ),
+        });
+    }
+    let permit = match tokio::time::timeout(admission_timeout, gate.acquire_owned()).await {
+        Ok(Ok(permit)) => permit,
+        Ok(Err(_)) | Err(_) => return Err(McpArtifactExportReadError::Busy),
+    };
+    let mut read_budget = read_timeout;
+    let snapshot = mcp_artifact_export_with_read_budget(
+        runtime,
+        &mut read_budget,
+        mcp_artifact_export_metadata_recheck(runtime, &record, auth),
+    )
+    .await?;
+    let max_chunks = MAX_PROJECT_ARTIFACT_EXPORT_BYTES
+        .div_ceil(MAX_READ_PROJECT_ARTIFACT_LENGTH)
+        .saturating_add(1);
+    let mut first_chunk = Vec::new();
+    let mut route = None;
+    let mut offset = 0usize;
+    let mut chunks = 0usize;
+    if snapshot.bytes > 0 {
+        let length = snapshot.bytes.min(MAX_READ_PROJECT_ARTIFACT_LENGTH);
+        let (chunk, first_route) = mcp_artifact_export_with_read_budget(
+            runtime,
+            &mut read_budget,
+            mcp_artifact_export_read_chunk(runtime, &record, auth, 0, length),
+        )
+        .await?;
+        offset = chunk.len();
+        if offset == 0 || offset > snapshot.bytes {
+            return Err(McpArtifactExportReadError::Unsafe);
+        }
+        chunks = 1;
+        first_chunk = chunk;
+        route = Some(first_route);
+    }
+    Ok(McpArtifactExportStreamPlan {
+        uri: uri.to_string(),
+        record,
+        first_chunk,
+        route,
+        offset,
+        chunks,
+        max_chunks,
+        read_budget,
+        _permit: permit,
+    })
+}
+
+pub(super) async fn mcp_artifact_export_stream_plan(
+    runtime: &ToolRuntime,
+    uri: &str,
+    auth: Option<&AuthContext>,
+) -> Result<McpArtifactExportStreamPlan, McpArtifactExportReadError> {
+    mcp_artifact_export_stream_plan_with_gate_timeout(
+        runtime,
+        uri,
+        auth,
+        mcp_artifact_export_read_semaphore(),
+        MCP_ARTIFACT_EXPORT_ADMISSION_TIMEOUT,
+        MCP_ARTIFACT_EXPORT_READ_TIMEOUT,
+    )
+    .await
+}
+
+#[derive(Default)]
+pub(super) struct McpArtifactExportBase64Encoder {
+    pub(super) carry: [u8; 3],
+    pub(super) carry_len: usize,
+}
+
+impl McpArtifactExportBase64Encoder {
+    pub(super) fn push(&mut self, bytes: &[u8]) -> String {
+        let mut output = String::with_capacity(((bytes.len() + 2) / 3) * 4 + 4);
+        let mut index = 0usize;
+        if self.carry_len > 0 {
+            let needed = 3 - self.carry_len;
+            let take = needed.min(bytes.len());
+            self.carry[self.carry_len..self.carry_len + take].copy_from_slice(&bytes[..take]);
+            self.carry_len += take;
+            index += take;
+            if self.carry_len == 3 {
+                general_purpose::STANDARD.encode_string(&self.carry, &mut output);
+                self.carry_len = 0;
+            }
+        }
+        let remaining = &bytes[index..];
+        let aligned_len = (remaining.len() / 3) * 3;
+        if aligned_len > 0 {
+            general_purpose::STANDARD.encode_string(&remaining[..aligned_len], &mut output);
+        }
+        let tail = &remaining[aligned_len..];
+        if !tail.is_empty() {
+            self.carry[..tail.len()].copy_from_slice(tail);
+            self.carry_len = tail.len();
+        }
+        output
+    }
+
+    pub(super) fn finish(&mut self) -> String {
+        if self.carry_len == 0 {
+            return String::new();
+        }
+        let output = general_purpose::STANDARD.encode(&self.carry[..self.carry_len]);
+        self.carry_len = 0;
+        output
+    }
+}
+
+pub(super) type McpArtifactExportStreamFrame = Result<Vec<u8>, std::io::Error>;
+
+pub(super) fn mcp_artifact_export_stream_prefix(
+    id: &Value,
+    uri: &str,
+    mime_type: &str,
+) -> Result<Vec<u8>, McpArtifactExportReadError> {
+    let mut output = Vec::with_capacity(256);
+    output.extend_from_slice(b"{\"jsonrpc\":\"2.0\",\"id\":");
+    output.extend_from_slice(
+        &serde_json::to_vec(id).map_err(|_| McpArtifactExportReadError::Unsafe)?,
+    );
+    output.extend_from_slice(b",\"result\":{\"contents\":[{\"uri\":");
+    output.extend_from_slice(
+        &serde_json::to_vec(uri).map_err(|_| McpArtifactExportReadError::Unsafe)?,
+    );
+    output.extend_from_slice(b",\"mimeType\":");
+    output.extend_from_slice(
+        &serde_json::to_vec(mime_type).map_err(|_| McpArtifactExportReadError::Unsafe)?,
+    );
+    output.extend_from_slice(b",\"blob\":\"");
+    Ok(output)
+}
+
+pub(super) fn mcp_artifact_export_stream_suffix() -> Result<Vec<u8>, McpArtifactExportReadError> {
+    let mut output = b"\"}],\"resultType\":\"complete\",\"_meta\":{\"io.modelcontextprotocol/serverInfo\":{\"name\":\"webcodex\",\"version\":".to_vec();
+    output.extend_from_slice(
+        &serde_json::to_vec(env!("CARGO_PKG_VERSION"))
+            .map_err(|_| McpArtifactExportReadError::Unsafe)?,
+    );
+    output.extend_from_slice(b"}}}}");
+    Ok(output)
+}
+
+pub(super) async fn mcp_artifact_export_send_frame(
+    sender: &mpsc::Sender<McpArtifactExportStreamFrame>,
+    frame: Vec<u8>,
+) -> Result<(), McpArtifactExportReadError> {
+    sender
+        .send(Ok(frame))
+        .await
+        .map_err(|_| McpArtifactExportReadError::Unavailable)
+}
+
+pub(super) async fn mcp_artifact_export_emit_chunk(
+    sender: &mpsc::Sender<McpArtifactExportStreamFrame>,
+    encoder: &mut McpArtifactExportBase64Encoder,
+    sha256: &mut Sha256,
+    emitted_bytes: &mut usize,
+    expected_bytes: usize,
+    chunk: &[u8],
+) -> Result<(), McpArtifactExportReadError> {
+    *emitted_bytes = emitted_bytes
+        .checked_add(chunk.len())
+        .ok_or(McpArtifactExportReadError::Unsafe)?;
+    if *emitted_bytes > expected_bytes {
+        return Err(McpArtifactExportReadError::Unsafe);
+    }
+    sha256.update(chunk);
+    let encoded = encoder.push(chunk);
+    if !encoded.is_empty() {
+        mcp_artifact_export_send_frame(sender, encoded.into_bytes()).await?;
+    }
+    Ok(())
+}
+
+pub(super) async fn mcp_artifact_export_stream_transfer(
+    runtime: &ToolRuntime,
+    id: &Value,
+    auth: Option<&AuthContext>,
+    mut plan: McpArtifactExportStreamPlan,
+    sender: mpsc::Sender<McpArtifactExportStreamFrame>,
+) -> Result<(), McpArtifactExportReadError> {
+    let snapshot = plan.record.snapshot.clone();
+    mcp_artifact_export_send_frame(
+        &sender,
+        mcp_artifact_export_stream_prefix(id, &plan.uri, &snapshot.mime_type)?,
+    )
+    .await?;
+
+    let mut encoder = McpArtifactExportBase64Encoder::default();
+    let mut sha256 = Sha256::new();
+    let mut emitted_bytes = 0usize;
+    if !plan.first_chunk.is_empty() {
+        let first_chunk = std::mem::take(&mut plan.first_chunk);
+        mcp_artifact_export_emit_chunk(
+            &sender,
+            &mut encoder,
+            &mut sha256,
+            &mut emitted_bytes,
+            snapshot.bytes,
+            &first_chunk,
+        )
+        .await?;
+    }
+    if emitted_bytes != plan.offset {
+        return Err(McpArtifactExportReadError::Unsafe);
+    }
+
+    match plan.route {
+        Some(McpArtifactExportChunkRoute::Legacy) => {
+            while plan.offset < snapshot.bytes {
+                if plan.chunks >= plan.max_chunks {
+                    return Err(McpArtifactExportReadError::Unsafe);
+                }
+                plan.chunks = plan.chunks.saturating_add(1);
+                let length = (snapshot.bytes - plan.offset).min(MAX_READ_PROJECT_ARTIFACT_LENGTH);
+                let chunk = mcp_artifact_export_with_read_budget(
+                    runtime,
+                    &mut plan.read_budget,
+                    mcp_artifact_export_read_legacy_chunk(
+                        runtime,
+                        &plan.record,
+                        auth,
+                        plan.offset,
+                        length,
+                    ),
+                )
+                .await?;
+                plan.offset = plan
+                    .offset
+                    .checked_add(chunk.len())
+                    .ok_or(McpArtifactExportReadError::Unsafe)?;
+                mcp_artifact_export_emit_chunk(
+                    &sender,
+                    &mut encoder,
+                    &mut sha256,
+                    &mut emitted_bytes,
+                    snapshot.bytes,
+                    &chunk,
+                )
+                .await?;
+            }
+        }
+        Some(McpArtifactExportChunkRoute::Optimized) => {
+            while plan.offset < snapshot.bytes {
+                let mut batch = Vec::with_capacity(MAX_MCP_ARTIFACT_EXPORT_CHUNK_READS);
+                let mut batch_offset = plan.offset;
+                while batch.len() < MAX_MCP_ARTIFACT_EXPORT_CHUNK_READS
+                    && batch_offset < snapshot.bytes
+                {
+                    if plan.chunks >= plan.max_chunks {
+                        return Err(McpArtifactExportReadError::Unsafe);
+                    }
+                    plan.chunks = plan.chunks.saturating_add(1);
+                    let length =
+                        (snapshot.bytes - batch_offset).min(MAX_READ_PROJECT_ARTIFACT_LENGTH);
+                    batch.push((batch_offset, length));
+                    batch_offset = batch_offset
+                        .checked_add(length)
+                        .ok_or(McpArtifactExportReadError::Unsafe)?;
+                }
+                let runtime_ref = runtime;
+                let record = &plan.record;
+                let results =
+                    mcp_artifact_export_with_read_budget(runtime, &mut plan.read_budget, async {
+                        Ok(
+                            join_all(batch.iter().map(|&(batch_offset, length)| async move {
+                                mcp_artifact_export_read_optimized_chunk(
+                                    runtime_ref,
+                                    record,
+                                    auth,
+                                    batch_offset,
+                                    length,
+                                )
+                                .await
+                            }))
+                            .await,
+                        )
+                    })
+                    .await?;
+
+                // Drain the full bounded batch before surfacing an offset-ordered
+                // error. This preserves the existing no-abandoned-request rule.
+                for ((requested_offset, _), result) in batch.into_iter().zip(results) {
+                    if requested_offset != plan.offset {
+                        return Err(McpArtifactExportReadError::Unsafe);
+                    }
+                    let chunk = result?.ok_or(McpArtifactExportReadError::Unavailable)?;
+                    plan.offset = plan
+                        .offset
+                        .checked_add(chunk.len())
+                        .ok_or(McpArtifactExportReadError::Unsafe)?;
+                    mcp_artifact_export_emit_chunk(
+                        &sender,
+                        &mut encoder,
+                        &mut sha256,
+                        &mut emitted_bytes,
+                        snapshot.bytes,
+                        &chunk,
+                    )
+                    .await?;
+                }
+            }
+        }
+        None => {}
+    }
+
+    if emitted_bytes != snapshot.bytes || plan.offset != snapshot.bytes {
+        return Err(McpArtifactExportReadError::Unsafe);
+    }
+    let final_sha256 = format!("{:x}", sha256.finalize());
+    if final_sha256 != snapshot.sha256 {
+        // Bytes may already have reached the HTTP peer. Fail closed by never
+        // emitting the base64 tail or closing JSON suffix, so a changed file
+        // cannot become a syntactically valid successful MCP resource result.
+        return Err(McpArtifactExportReadError::SnapshotChanged);
+    }
+    let tail = encoder.finish();
+    if !tail.is_empty() {
+        mcp_artifact_export_send_frame(&sender, tail.into_bytes()).await?;
+    }
+    mcp_artifact_export_send_frame(&sender, mcp_artifact_export_stream_suffix()?).await?;
+    Ok(())
+}
+
+pub(super) fn mcp_artifact_export_stream_io_error(
+    error: &McpArtifactExportReadError,
+) -> std::io::Error {
+    let message = match error {
+        McpArtifactExportReadError::SnapshotChanged => {
+            "artifact export stream failed snapshot integrity validation"
+        }
+        McpArtifactExportReadError::Timeout => "artifact export stream timed out",
+        _ => "artifact export stream failed",
+    };
+    std::io::Error::other(message)
+}
+
+#[cfg(test)]
+pub(super) async fn mcp_artifact_export_collect_stream_response(
+    runtime: &ToolRuntime,
+    id: &Value,
+    auth: Option<&AuthContext>,
+    plan: McpArtifactExportStreamPlan,
+) -> Result<Value, McpArtifactExportReadError> {
+    let (sender, mut receiver) = mpsc::channel::<McpArtifactExportStreamFrame>(1);
+    let transfer = mcp_artifact_export_stream_transfer(runtime, id, auth, plan, sender);
+    let collect = async {
+        let mut body = Vec::new();
+        while let Some(frame) = receiver.recv().await {
+            let frame = frame.map_err(|_| McpArtifactExportReadError::Unsafe)?;
+            body.extend_from_slice(&frame);
+        }
+        Ok::<Vec<u8>, McpArtifactExportReadError>(body)
+    };
+    let (transfer_result, body_result) = tokio::join!(transfer, collect);
+    transfer_result?;
+    serde_json::from_slice(&body_result?).map_err(|_| McpArtifactExportReadError::Unsafe)
+}
+
+#[cfg(test)]
+pub(super) async fn mcp_artifact_export_resource_read_with_gate_timeout(
+    runtime: &ToolRuntime,
+    uri: &str,
+    auth: Option<&AuthContext>,
+    gate: Arc<Semaphore>,
+    admission_timeout: Duration,
+    read_timeout: Duration,
+) -> Result<Value, McpArtifactExportReadError> {
+    let plan = mcp_artifact_export_stream_plan_with_gate_timeout(
+        runtime,
+        uri,
+        auth,
+        gate,
+        admission_timeout,
+        read_timeout,
+    )
+    .await?;
+    let response =
+        mcp_artifact_export_collect_stream_response(runtime, &Value::Null, auth, plan).await?;
+    response
+        .get("result")
+        .cloned()
+        .ok_or(McpArtifactExportReadError::Unsafe)
+}
+
+#[cfg(test)]
+pub(super) async fn mcp_artifact_export_resource_read_with_gate(
+    runtime: &ToolRuntime,
+    uri: &str,
+    auth: Option<&AuthContext>,
+    gate: Arc<Semaphore>,
+    admission_timeout: Duration,
+) -> Result<Value, McpArtifactExportReadError> {
+    mcp_artifact_export_resource_read_with_gate_timeout(
+        runtime,
+        uri,
+        auth,
+        gate,
+        admission_timeout,
+        MCP_ARTIFACT_EXPORT_READ_TIMEOUT,
+    )
+    .await
+}
+
+pub(super) fn mcp_artifact_export_read_error_outcome(
+    id: Option<Value>,
+    auth: Option<&AuthContext>,
+    error: McpArtifactExportReadError,
+) -> McpOutcome {
+    match error {
+        McpArtifactExportReadError::Forbidden {
+            required_scope,
+            description,
+        } => scope_forbidden(auth, required_scope, description),
+        McpArtifactExportReadError::Unavailable => McpOutcome::BadRequest(rpc_error(
+            id,
+            -32602,
+            "Artifact export resource is unavailable",
+        )),
+        McpArtifactExportReadError::SnapshotChanged => McpOutcome::BadRequest(rpc_error(
+            id,
+            -32602,
+            "Exported artifact no longer matches its snapshot",
+        )),
+        McpArtifactExportReadError::Unsafe => McpOutcome::BadRequest(rpc_error(
+            id,
+            -32603,
+            "Artifact export resource failed bounded safety validation",
+        )),
+        McpArtifactExportReadError::Busy => McpOutcome::BadRequest(rpc_error(
+            id,
+            MCP_ARTIFACT_EXPORT_BUSY_CODE,
+            "Artifact export is temporarily busy; retry later",
+        )),
+        McpArtifactExportReadError::Timeout => McpOutcome::BadRequest(rpc_error(
+            id,
+            -32603,
+            "Artifact export resource read timed out",
+        )),
+    }
+}
+
+pub(super) fn server_capabilities() -> Value {
+    json!({
+        "tools": { "listChanged": false },
+        "resources": { "listChanged": false, "subscribe": false },
+        "extensions": {
+            MCP_UI_EXTENSION: {
+                "mimeTypes": [MCP_UI_RESOURCE_MIME_TYPE]
+            }
+        }
+    })
+}
+
+pub(super) fn mcp_app_enabled(
+    stateless_2026: bool,
+    model_surface: ModelSurface,
+    params: &Value,
+) -> bool {
+    stateless_2026
+        && model_surface_supports_computer_app(model_surface)
+        && request_supports_mcp_apps(params)
+}
+
+pub(super) fn is_artifact_export_resource_uri(uri: &str) -> bool {
+    uri.starts_with(MCP_ARTIFACT_EXPORT_URI_PREFIX)
+}
+
+pub(super) fn is_snapshot_resource_uri(uri: &str) -> bool {
+    uri.starts_with(MCP_SNAPSHOT_RESOURCE_URI_PREFIX)
+}
+
+pub(super) fn resource_read_bypasses_runtime_read(params: &Value) -> bool {
+    params
+        .get("uri")
+        .and_then(Value::as_str)
+        .is_some_and(|uri| is_artifact_export_resource_uri(uri) || is_snapshot_resource_uri(uri))
+}
+
+pub(super) fn handle_list(id: Option<Value>, app_enabled: bool) -> McpOutcome {
+    let result = if app_enabled {
+        mcp_computer_app_resources_list()
+    } else {
+        json!({ "resources": [] })
+    };
+    McpOutcome::Ok(rpc_result(id, mcp_stateless_result(result, true)))
+}
+
+pub(super) async fn handle_read(
+    runtime: &ToolRuntime,
+    params: Value,
+    id: Option<Value>,
+    auth: Option<&AuthContext>,
+    model_surface: ModelSurface,
+) -> McpOutcome {
+    let Some(uri) = params.get("uri").and_then(Value::as_str) else {
+        return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params: uri is required"));
+    };
+    if is_artifact_export_resource_uri(uri) {
+        let response_id = id.clone().unwrap_or(Value::Null);
+        let plan = match mcp_artifact_export_stream_plan(runtime, uri, auth).await {
+            Ok(plan) => plan,
+            Err(error) => return mcp_artifact_export_read_error_outcome(id, auth, error),
+        };
+        return McpOutcome::ArtifactExportStream {
+            id: response_id,
+            plan,
+        };
+    }
+    if is_snapshot_resource_uri(uri) {
+        let caller = match mcp_artifact_export_caller_binding(auth) {
+            Ok(caller) => caller,
+            Err(_) => {
+                return McpOutcome::BadRequest(rpc_error(
+                    id,
+                    -32602,
+                    format!("Resource not found: {uri}"),
+                ));
+            }
+        };
+        let record = mcp_snapshot_resource_registry()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get_for_caller(uri, &caller);
+        let Some(record) = record else {
+            return McpOutcome::BadRequest(rpc_error(
+                id,
+                -32602,
+                format!("Resource not found: {uri}"),
+            ));
+        };
+        for scope in match record.kind {
+            McpSnapshotResourceKind::Window => &[crate::auth::SCOPE_COMPUTER_READ][..],
+            McpSnapshotResourceKind::Display => &[
+                crate::auth::SCOPE_COMPUTER_READ,
+                crate::auth::SCOPE_COMPUTER_DISPLAY_READ,
+            ][..],
+        } {
+            if let Some(outcome) = require_mcp_scope(auth, scope) {
+                return outcome;
+            }
+        }
+        tracing::info!(
+            target: "webcodex::mcp",
+            resource_kind = ?record.kind,
+            file_bytes = record.bytes.len(),
+            "mcp_snapshot_resource_read"
+        );
+        let result = json!({
+            "contents": [{
+                "uri": uri,
+                "mimeType": record.mime_type,
+                "blob": general_purpose::STANDARD.encode(record.bytes.as_ref())
+            }]
+        });
+        return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(result, true)));
+    }
+
+    // Tool descriptors advertise the App resource independently of whether a
+    // later resource fetch repeats UI client-capability metadata.
+    if !model_surface_supports_computer_app(model_surface) {
+        return McpOutcome::BadRequest(rpc_error(
+            id,
+            -32602,
+            "MCP App resource is unavailable on this model surface",
+        ));
+    }
+    let Some(result) = mcp_computer_app_resource_read(uri) else {
+        return McpOutcome::BadRequest(rpc_error(id, -32602, format!("Resource not found: {uri}")));
+    };
+    let mut result = mcp_stateless_result(result, true);
+    if uri == MCP_COMPUTER_UI_RESOURCE_URI {
+        result["ttlMs"] = Value::from(MCP_COMPUTER_UI_RESOURCE_TTL_MS);
+    }
+    McpOutcome::Ok(rpc_result(id, result))
+}
+
+#[derive(Debug, Default)]
+pub(super) struct McpResourceToolCallContext {
+    artifact_export_caller: Option<McpArtifactExportCallerBinding>,
+    snapshot_resource_caller: Option<McpArtifactExportCallerBinding>,
+}
+
+#[derive(Debug)]
+pub(super) enum McpResourceToolCallPrepareError {
+    UnsupportedExportSurface,
+    ArtifactCallerBinding(&'static str),
+}
+
+impl McpResourceToolCallPrepareError {
+    pub(super) fn message(&self) -> String {
+        match self {
+            Self::UnsupportedExportSurface => {
+                "export_project_artifact requires the stateless-2026 full-operator MCP surface"
+                    .to_string()
+            }
+            Self::ArtifactCallerBinding(error) => {
+                format!("export_project_artifact cannot bind this caller: {error}")
+            }
+        }
+    }
+
+    pub(super) fn records_model_ergonomics_failure(&self) -> bool {
+        matches!(self, Self::ArtifactCallerBinding(_))
+    }
+}
+
+pub(super) fn prepare_tool_call(
+    tool_name: &str,
+    stateless_2026: bool,
+    model_surface: ModelSurface,
+    auth: Option<&AuthContext>,
+) -> Result<McpResourceToolCallContext, McpResourceToolCallPrepareError> {
+    let artifact_export_caller = if tool_name == "export_project_artifact" {
+        if !stateless_2026 || model_surface != ModelSurface::FullOperatorRuntime {
+            return Err(McpResourceToolCallPrepareError::UnsupportedExportSurface);
+        }
+        Some(
+            mcp_artifact_export_caller_binding(auth)
+                .map_err(McpResourceToolCallPrepareError::ArtifactCallerBinding)?,
+        )
+    } else {
+        None
+    };
+    let snapshot_resource_caller = if stateless_2026
+        && model_surface == ModelSurface::FullOperatorRuntime
+        && matches!(tool_name, "computer_snapshot" | "computer_snapshot_display")
+    {
+        mcp_artifact_export_caller_binding(auth).ok()
+    } else {
+        None
+    };
+    Ok(McpResourceToolCallContext {
+        artifact_export_caller,
+        snapshot_resource_caller,
+    })
+}
+
+pub(super) fn adapt_tool_result(
+    tool_name: &str,
+    as_image_requested: bool,
+    result: ToolResult,
+    context: McpResourceToolCallContext,
+) -> Value {
+    if tool_name == "export_project_artifact" {
+        return mcp_artifact_export_tool_result(
+            result,
+            context
+                .artifact_export_caller
+                .expect("validated artifact export caller binding"),
+        );
+    }
+    if matches!(tool_name, "computer_snapshot" | "computer_snapshot_display")
+        || (tool_name == "read_project_artifact" && as_image_requested)
+    {
+        return mcp_runtime_tool_result_with_snapshot_resource(
+            tool_name,
+            as_image_requested,
+            result,
+            context.snapshot_resource_caller,
+        );
+    }
+    super::mcp_runtime_tool_result(tool_name, as_image_requested, result)
+}
+
+pub(super) fn start_artifact_export_stream(
+    runtime: Arc<ToolRuntime>,
+    id: Value,
+    auth: Option<AuthContext>,
+    plan: McpArtifactExportStreamPlan,
+) -> mpsc::Receiver<McpArtifactExportStreamFrame> {
+    let (sender, receiver) = mpsc::channel::<McpArtifactExportStreamFrame>(1);
+    let error_sender = sender.clone();
+    tokio::spawn(async move {
+        let transfer =
+            mcp_artifact_export_stream_transfer(&runtime, &id, auth.as_ref(), plan, sender);
+        match tokio::time::timeout(MCP_ARTIFACT_EXPORT_STREAM_TIMEOUT, transfer).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                let _ = error_sender
+                    .send(Err(mcp_artifact_export_stream_io_error(&error)))
+                    .await;
+            }
+            Err(_) => {
+                runtime.shell_clients.cancel_abandoned_sync_requests().await;
+                let _ = error_sender
+                    .send(Err(std::io::Error::other(
+                        "artifact export stream exceeded bounded transfer timeout",
+                    )))
+                    .await;
+            }
+        }
+    });
+    receiver
+}

--- a/src/mcp/response.rs
+++ b/src/mcp/response.rs
@@ -1,0 +1,97 @@
+use crate::connector_runtime::ConnectorCallOutcome;
+use crate::tool_runtime::ToolResult;
+use serde_json::{json, Value};
+
+pub(super) fn mcp_stateless_result(mut result: Value, cacheable: bool) -> Value {
+    let Some(object) = result.as_object_mut() else {
+        return result;
+    };
+    object
+        .entry("resultType".to_string())
+        .or_insert_with(|| Value::String("complete".to_string()));
+    if cacheable {
+        object
+            .entry("ttlMs".to_string())
+            .or_insert_with(|| Value::from(0));
+        object
+            .entry("cacheScope".to_string())
+            .or_insert_with(|| Value::String("private".to_string()));
+    }
+    let meta = object
+        .entry("_meta".to_string())
+        .or_insert_with(|| json!({}));
+    if let Some(meta_object) = meta.as_object_mut() {
+        meta_object
+            .entry("io.modelcontextprotocol/serverInfo".to_string())
+            .or_insert_with(|| {
+                json!({
+                    "name": "webcodex",
+                    "version": env!("CARGO_PKG_VERSION")
+                })
+            });
+    }
+    result
+}
+
+pub(super) fn connector_call_tool_result(outcome: ConnectorCallOutcome) -> Value {
+    let text = serde_json::to_string(&outcome.body).unwrap_or_else(|_| "{}".to_string());
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "structuredContent": outcome.body,
+        "isError": !outcome.ok
+    })
+}
+
+pub(super) fn mcp_runtime_tool_result_fallback(result: ToolResult) -> Value {
+    let text = serde_json::to_string(&json!({
+        "success": result.success,
+        "output": result.output.clone(),
+        "error": result.error.clone(),
+    }))
+    .unwrap_or_else(|_| "{}".to_string());
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "structuredContent": {
+            "success": result.success,
+            "output": result.output,
+            "error": result.error,
+        },
+        "isError": !result.success
+    })
+}
+
+pub(super) fn rpc_result(id: Option<Value>, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id.unwrap_or(Value::Null),
+        "result": result,
+    })
+}
+
+pub(super) fn rpc_error(id: Option<Value>, code: i64, message: impl Into<String>) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id.unwrap_or(Value::Null),
+        "error": {
+            "code": code,
+            "message": message.into(),
+        }
+    })
+}
+
+pub(super) fn rpc_error_with_data(
+    id: Option<Value>,
+    code: i64,
+    message: impl Into<String>,
+    data: Value,
+) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id.unwrap_or(Value::Null),
+        "error": {
+            "code": code,
+            "message": message.into(),
+            "data": data,
+        }
+    })
+}

--- a/src/mcp/tasks.rs
+++ b/src/mcp/tasks.rs
@@ -1,0 +1,364 @@
+use super::{
+    connector_call_tool_result, mcp_stateless_result, request_client_capabilities,
+    require_mcp_scope, rpc_error, rpc_error_with_data, rpc_result, scope_forbidden, McpOutcome,
+};
+use crate::auth::{AuthContext, SCOPE_JOB_RUN};
+use crate::connector_runtime::{ConnectorCallOutcome, ConnectorRuntime};
+use crate::db::ConnectorExecution;
+use crate::model_surface::ModelSurface;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub(super) const MCP_TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
+pub(super) const MCP_MISSING_REQUIRED_CLIENT_CAPABILITY: i64 = -32021;
+const MCP_TASK_POLL_INTERVAL_MS: u64 = 2_000;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct McpTaskParams {
+    task_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct McpTaskUpdateParams {
+    task_id: String,
+    input_responses: Value,
+}
+
+pub(super) fn request_supports_tasks(params: &Value) -> bool {
+    request_client_capabilities(params)
+        .and_then(|capabilities| capabilities.get("extensions"))
+        .and_then(|extensions| extensions.get(MCP_TASKS_EXTENSION))
+        .is_some_and(Value::is_object)
+}
+
+pub(super) fn model_surface_supports_tasks(model_surface: ModelSurface) -> bool {
+    model_surface == ModelSurface::CanonicalConnector
+}
+
+pub(super) fn server_capabilities() -> Value {
+    json!({
+        "tools": { "listChanged": false },
+        "extensions": {
+            MCP_TASKS_EXTENSION: {}
+        }
+    })
+}
+
+fn mcp_task_timestamp(timestamp: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(timestamp, 0)
+        .map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string())
+}
+
+fn mcp_task_id_is_valid(task_id: &str) -> bool {
+    task_id.strip_prefix("wc_exec_").is_some_and(|suffix| {
+        suffix.len() == 32 && suffix.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
+
+fn mcp_task_status(execution: &ConnectorExecution) -> &'static str {
+    if execution.state == "cancelled" {
+        "cancelled"
+    } else if execution.is_terminal() {
+        "completed"
+    } else {
+        "working"
+    }
+}
+
+fn mcp_task_base(execution: &ConnectorExecution, result_type: &str, status: &str) -> Value {
+    let created_at = execution
+        .mcp_task_materialized_at
+        .unwrap_or(execution.submitted_at);
+    let last_updated_at = execution
+        .mcp_task_result_finalized_at
+        .or(execution.finished_at)
+        .or(execution.last_output_at)
+        .or(execution.started_at)
+        .or(execution.queued_at)
+        .unwrap_or(created_at)
+        .max(created_at);
+    json!({
+        "resultType": result_type,
+        "taskId": execution.execution_id,
+        "status": status,
+        "createdAt": mcp_task_timestamp(created_at),
+        "lastUpdatedAt": mcp_task_timestamp(last_updated_at),
+        "ttlMs": null,
+        "pollIntervalMs": MCP_TASK_POLL_INTERVAL_MS
+    })
+}
+
+pub(super) fn mcp_create_task_result(execution: &ConnectorExecution) -> Value {
+    mcp_task_base(execution, "task", mcp_task_status(execution))
+}
+
+fn mcp_detailed_task_result(
+    execution: &ConnectorExecution,
+    call_tool_result: Option<Value>,
+) -> Value {
+    let status = mcp_task_status(execution);
+    let mut result = mcp_task_base(execution, "complete", status);
+    if status == "completed" {
+        if let (Some(object), Some(call_tool_result)) = (result.as_object_mut(), call_tool_result) {
+            object.insert("result".to_string(), call_tool_result);
+        }
+    }
+    result
+}
+
+fn missing_tasks_capability(id: Option<Value>) -> McpOutcome {
+    McpOutcome::BadRequest(rpc_error_with_data(
+        id,
+        MCP_MISSING_REQUIRED_CLIENT_CAPABILITY,
+        "Missing required client capability",
+        json!({
+            "requiredCapabilities": {
+                "extensions": {
+                    MCP_TASKS_EXTENSION: {}
+                }
+            }
+        }),
+    ))
+}
+
+fn mcp_task_connector_error(
+    id: Option<Value>,
+    auth: Option<&AuthContext>,
+    outcome: ConnectorCallOutcome,
+) -> McpOutcome {
+    if let Some(required_scope) = outcome.required_scope {
+        let description = outcome
+            .body
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap_or("connector credential lacks the required scope")
+            .to_string();
+        return scope_forbidden(auth, Some(required_scope), description);
+    }
+    if outcome.http_status == 404
+        || outcome.body.pointer("/error/code").and_then(Value::as_str) == Some("task_not_found")
+    {
+        return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params: task not found"));
+    }
+    if outcome.protocol_error {
+        let message = outcome
+            .body
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap_or("Invalid task params")
+            .to_string();
+        return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+    }
+    McpOutcome::BadRequest(rpc_error(
+        id,
+        -32603,
+        "Internal error while resolving durable Connector task",
+    ))
+}
+
+fn require_task_auth(auth: Option<&AuthContext>) -> Result<&AuthContext, McpOutcome> {
+    let Some(auth) = auth else {
+        return Err(scope_forbidden(
+            None,
+            Some(SCOPE_JOB_RUN),
+            "connector credential is required for MCP task access",
+        ));
+    };
+    if let Some(outcome) = require_mcp_scope(Some(auth), SCOPE_JOB_RUN) {
+        return Err(outcome);
+    }
+    Ok(auth)
+}
+
+pub(super) async fn handle_request(
+    method: &str,
+    params: Value,
+    id: Option<Value>,
+    auth: Option<&AuthContext>,
+    connector: &ConnectorRuntime,
+) -> McpOutcome {
+    if !request_supports_tasks(&params) {
+        return missing_tasks_capability(id);
+    }
+
+    match method {
+        "tasks/get" => {
+            let params: McpTaskParams = match serde_json::from_value(params) {
+                Ok(params) => params,
+                Err(error) => {
+                    return McpOutcome::BadRequest(rpc_error(
+                        id,
+                        -32602,
+                        format!("Invalid params: {error}"),
+                    ));
+                }
+            };
+            if !mcp_task_id_is_valid(&params.task_id) {
+                return McpOutcome::BadRequest(rpc_error(
+                    id,
+                    -32602,
+                    "Invalid params: task not found",
+                ));
+            }
+            let auth = match require_task_auth(auth) {
+                Ok(auth) => auth,
+                Err(outcome) => return outcome,
+            };
+            match connector
+                .execution_task_result_for_auth(&params.task_id, auth)
+                .await
+            {
+                Ok((_task, execution, outcome)) => {
+                    let call_tool_result = execution
+                        .is_terminal()
+                        .then(|| connector_call_tool_result(outcome));
+                    let result = mcp_detailed_task_result(&execution, call_tool_result);
+                    McpOutcome::Ok(rpc_result(id, mcp_stateless_result(result, false)))
+                }
+                Err(outcome) => mcp_task_connector_error(id, Some(auth), outcome),
+            }
+        }
+        "tasks/update" => {
+            let params: McpTaskUpdateParams = match serde_json::from_value(params) {
+                Ok(params) => params,
+                Err(error) => {
+                    return McpOutcome::BadRequest(rpc_error(
+                        id,
+                        -32602,
+                        format!("Invalid params: {error}"),
+                    ));
+                }
+            };
+            if !mcp_task_id_is_valid(&params.task_id) || !params.input_responses.is_object() {
+                return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params"));
+            }
+            let auth = match require_task_auth(auth) {
+                Ok(auth) => auth,
+                Err(outcome) => return outcome,
+            };
+            if let Err(outcome) = connector
+                .execution_task_result_for_auth(&params.task_id, auth)
+                .await
+            {
+                return mcp_task_connector_error(id, Some(auth), outcome);
+            }
+            // A3 never creates input_required Tasks. Per the Tasks extension,
+            // responses for unknown/already-satisfied input requests are ignored.
+            McpOutcome::Ok(rpc_result(id, mcp_stateless_result(json!({}), false)))
+        }
+        "tasks/cancel" => {
+            let params: McpTaskParams = match serde_json::from_value(params) {
+                Ok(params) => params,
+                Err(error) => {
+                    return McpOutcome::BadRequest(rpc_error(
+                        id,
+                        -32602,
+                        format!("Invalid params: {error}"),
+                    ));
+                }
+            };
+            if !mcp_task_id_is_valid(&params.task_id) {
+                return McpOutcome::BadRequest(rpc_error(
+                    id,
+                    -32602,
+                    "Invalid params: task not found",
+                ));
+            }
+            let auth = match require_task_auth(auth) {
+                Ok(auth) => auth,
+                Err(outcome) => return outcome,
+            };
+            if let Err(outcome) = connector
+                .cancel_execution_task_for_auth(&params.task_id, auth)
+                .await
+            {
+                return mcp_task_connector_error(id, Some(auth), outcome);
+            }
+            McpOutcome::Ok(rpc_result(id, mcp_stateless_result(json!({}), false)))
+        }
+        _ => unreachable!("validated MCP Tasks method: {method}"),
+    }
+}
+
+/// Promote a successful task-polling Connector tools/call outcome into an MCP Task.
+/// Returns `None` only when the Connector result is an ordinary non-blocking result
+/// with no durable execution identity, so the caller can render its normal tools/call response.
+pub(super) async fn promote_connector_tool_call(
+    id: &Option<Value>,
+    outcome: &ConnectorCallOutcome,
+    auth: Option<&AuthContext>,
+    connector: &ConnectorRuntime,
+) -> Option<McpOutcome> {
+    let Some(execution_id) = outcome
+        .body
+        .pointer("/data/execution/execution_id")
+        .and_then(Value::as_str)
+    else {
+        return (outcome.body["blocking"].as_bool() == Some(true)).then(|| {
+            McpOutcome::BadRequest(rpc_error(
+                id.clone(),
+                -32603,
+                "active Connector execution did not expose durable execution identity",
+            ))
+        });
+    };
+
+    let Some(auth) = auth else {
+        return Some(scope_forbidden(
+            None,
+            Some(SCOPE_JOB_RUN),
+            "connector credential is required for MCP task access",
+        ));
+    };
+
+    Some(
+        match connector.materialize_execution_task_for_auth(execution_id, auth) {
+            Ok(execution) if execution.mcp_task_is_materialized() => {
+                if execution.is_active() && !execution.terminal_continuation_is_armed() {
+                    return Some(McpOutcome::BadRequest(rpc_error(
+                        id.clone(),
+                        -32603,
+                        "active Connector execution is not durably armed for terminal polling",
+                    )));
+                }
+                if execution.is_terminal() && !execution.mcp_task_result_is_finalized() {
+                    return Some(McpOutcome::BadRequest(rpc_error(
+                        id.clone(),
+                        -32603,
+                        "materialized MCP task became terminal before its durable result was finalized",
+                    )));
+                }
+                McpOutcome::Ok(rpc_result(
+                    id.clone(),
+                    mcp_stateless_result(mcp_create_task_result(&execution), false),
+                ))
+            }
+            Ok(execution) if execution.is_terminal() => {
+                let ordinary = match connector
+                    .ordinary_execution_result_for_auth(execution_id, auth)
+                    .await
+                {
+                    Ok(ordinary) => ordinary,
+                    Err(task_outcome) => {
+                        return Some(mcp_task_connector_error(
+                            id.clone(),
+                            Some(auth),
+                            task_outcome,
+                        ));
+                    }
+                };
+                let result = connector_call_tool_result(ordinary);
+                McpOutcome::Ok(rpc_result(id.clone(), mcp_stateless_result(result, false)))
+            }
+            Ok(_) => McpOutcome::BadRequest(rpc_error(
+                id.clone(),
+                -32603,
+                "active Connector execution was not durably materialized for MCP task polling",
+            )),
+            Err(task_outcome) => mcp_task_connector_error(id.clone(), Some(auth), task_outcome),
+        },
+    )
+}

--- a/src/mcp/tasks.rs
+++ b/src/mcp/tasks.rs
@@ -1,7 +1,8 @@
-use super::{
-    connector_call_tool_result, mcp_stateless_result, request_client_capabilities,
-    require_mcp_scope, rpc_error, rpc_error_with_data, rpc_result, scope_forbidden, McpOutcome,
+use super::protocol::request_client_capabilities;
+use super::response::{
+    connector_call_tool_result, mcp_stateless_result, rpc_error, rpc_error_with_data, rpc_result,
 };
+use super::{require_mcp_scope, scope_forbidden, McpOutcome};
 use crate::auth::{AuthContext, SCOPE_JOB_RUN};
 use crate::connector_runtime::{ConnectorCallOutcome, ConnectorRuntime};
 use crate::db::ConnectorExecution;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,0 +1,1142 @@
+use super::resources;
+use super::response::{
+    connector_call_tool_result, mcp_runtime_tool_result_fallback, mcp_stateless_result, rpc_error,
+    rpc_result,
+};
+use super::tasks;
+use super::{require_mcp_scope, scope_forbidden, McpOutcome};
+use crate::auth::AuthContext;
+use crate::connector_runtime::{ConnectorRuntime, ConnectorTransport};
+use crate::model_surface::ModelSurface;
+use crate::tool_request_trace::ToolRequestLifecycle;
+use crate::tool_runtime::kernel::{
+    check_runtime_tool_scope, HostFileImportTrust, ToolCallContext, ToolCallErrorStatus,
+    ToolCallRequest as KernelToolCallRequest, ToolTransport,
+};
+use crate::tool_runtime::model_ergonomics_telemetry::{
+    ModelErgonomicsRecord, ModelErgonomicsTimer,
+};
+use crate::tool_runtime::tool_definition::LOCAL_CODING_TOOL_NAMES;
+#[cfg(test)]
+use crate::tool_runtime::ToolResult;
+use crate::tool_runtime::{registered_tool_specs, ToolRuntime, ToolSpec};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub(super) const MCP_RESERVED_SESSION_ID_FIELD: &str = "_session_id";
+
+#[derive(Debug, Deserialize)]
+pub(super) struct McpToolCallParams {
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) arguments: Value,
+}
+
+pub(super) fn tool_name_from_params(params: &Value) -> Option<String> {
+    params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+pub(super) fn project_from_tool_call_params(params: &Value) -> Option<String> {
+    params["arguments"]["project"].as_str().map(str::to_string)
+}
+
+/// MCP tools/list payload for the immutable startup-selected model surface.
+///
+/// Env adapter: resolves the `WEBCODEX_MCP_COMPACT_SCHEMAS` switch and
+/// delegates to the pure renderer.
+fn mcp_tools_list_payload(model_surface: ModelSurface) -> Value {
+    mcp_tools_list_payload_with_compact(model_surface, crate::config::mcp_compact_schemas_enabled())
+}
+
+/// Pure tools/list rendering with an explicit compact switch; no env access.
+/// Production resolves the switch from the env adapter above; tests pass an
+/// explicit bool so they never need process-global env. The schema shape is
+/// identical to the adapter path: `compact` only omits `outputSchema`.
+pub(super) fn mcp_tools_list_payload_with_compact(
+    model_surface: ModelSurface,
+    compact: bool,
+) -> Value {
+    mcp_tools_list_payload_with_features(model_surface, compact, false, false)
+}
+
+pub(super) fn mcp_tools_list_payload_with_compact_and_app(
+    model_surface: ModelSurface,
+    compact: bool,
+    app_enabled: bool,
+) -> Value {
+    mcp_tools_list_payload_with_features(model_surface, compact, app_enabled, true)
+}
+
+fn mcp_tools_list_payload_with_features(
+    model_surface: ModelSurface,
+    compact: bool,
+    app_enabled: bool,
+    artifact_export_enabled: bool,
+) -> Value {
+    mcp_tools_list_payload_with_features_for_auth(
+        model_surface,
+        compact,
+        app_enabled,
+        artifact_export_enabled,
+        None,
+    )
+}
+
+fn mcp_tools_list_payload_with_features_for_auth(
+    model_surface: ModelSurface,
+    compact: bool,
+    app_enabled: bool,
+    artifact_export_enabled: bool,
+    auth: Option<&AuthContext>,
+) -> Value {
+    let specs = match model_surface {
+        ModelSurface::CanonicalConnector => crate::connector_runtime::surface::capability_specs(),
+        ModelSurface::LocalCoding => crate::model_surface::local_coding_tool_specs(),
+        ModelSurface::FullOperatorRuntime => registered_tool_specs(),
+    };
+    let oauth_scope_projection = auth.is_some_and(AuthContext::is_oauth_token);
+    let tools: Vec<Value> = specs
+        .into_iter()
+        .filter(|spec| artifact_export_enabled || spec.name != "export_project_artifact")
+        .filter(|spec| {
+            !oauth_scope_projection || check_runtime_tool_scope(auth, &spec.name).is_ok()
+        })
+        .map(|spec| mcp_tool_spec_json(spec, compact, app_enabled))
+        .collect();
+    json!({ "tools": tools })
+}
+
+fn adapt_computer_snapshot_output_schema_for_mcp(spec: &mut ToolSpec) {
+    let properties = spec
+        .output_schema
+        .pointer_mut("/properties/output/properties")
+        .and_then(Value::as_object_mut)
+        .expect("computer_snapshot output schema properties");
+    properties.remove("content_base64");
+    properties.insert(
+        "content_delivery".to_string(),
+        json!({
+            "type": "string",
+            "const": "mcp_image",
+            "description": "MCP native-image delivery marker; binary image bytes are carried in the image ContentBlock rather than structuredContent."
+        }),
+    );
+}
+
+pub(super) fn add_stateless_workflow_recorder_metadata(
+    payload: &mut Value,
+    model_surface: ModelSurface,
+) {
+    if matches!(model_surface, ModelSurface::CanonicalConnector) {
+        return;
+    }
+    let Some(tools) = payload.get_mut("tools").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for tool in tools {
+        let Some(properties) = tool
+            .pointer_mut("/inputSchema/properties")
+            .and_then(Value::as_object_mut)
+        else {
+            continue;
+        };
+        properties.insert(
+            crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD.to_string(),
+            json!({
+                "type": "string",
+                "pattern": "^wc_sess_[A-Za-z0-9_]+$",
+                "description": "MCP wrapper metadata only. Optional explicit existing Workflow Session that records this tools/call and supplies trusted collaboration provenance. It is distinct from any concrete tool business session_id, grants no authority, and is removed before concrete tool parsing."
+            }),
+        );
+        properties.insert(
+            crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD.to_string(),
+            json!({
+                "type": "array",
+                "maxItems": crate::tool_runtime::sessions::MAX_TOOL_CALL_ACK_MESSAGE_IDS,
+                "items": {
+                    "type": "string",
+                    "pattern": "^wc_msg_[A-Za-z0-9_]+$"
+                },
+                "description": "MCP wrapper metadata only. ACK means the current model context still remembers the referenced open Session message. Repeat ACK ids on subsequent calls while remembered. If omitted later, unresolved ACK-required guidance may be returned again. ACK does not resolve the message."
+            }),
+        );
+        properties.insert(
+            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD.to_string(),
+            json!({
+                "type": "object",
+                "description": "MCP wrapper metadata only. After one non-todo message in recording_session_id is already handled, resolve it and attach bounded resolution text on this same WebCodex call instead of making a separate resolve call. For requires_ack guidance, include the same message_id in ack_session_message_ids on this request. The target is always the exact recording Session and this object is removed before concrete tool parsing. Do not use it to predict whether the current tool call will succeed; todo completion still uses complete_session_message.",
+                "properties": {
+                    "message_id": {
+                        "type": "string",
+                        "pattern": "^wc_msg_[A-Za-z0-9_]+$"
+                    },
+                    "resolution": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": crate::tool_runtime::sessions::MAX_MESSAGE_RESOLUTION_CHARS
+                    }
+                },
+                "required": ["message_id", "resolution"],
+                "additionalProperties": false
+            }),
+        );
+        if matches!(model_surface, ModelSurface::FullOperatorRuntime) {
+            properties.insert(
+                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD
+                    .to_string(),
+                json!({
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Echo the latest Session context revision still present in the current model context. Omit it when unknown. If it is missing or behind the Session's model-facing continuity watermark, the tool still executes normally and the result may include bounded Session recovery context."
+                }),
+            );
+        }
+    }
+}
+
+fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, _app_enabled: bool) -> Value {
+    let tool_name = spec.name.clone();
+    if matches!(
+        tool_name.as_str(),
+        "computer_snapshot" | "computer_snapshot_display"
+    ) {
+        adapt_computer_snapshot_output_schema_for_mcp(&mut spec);
+    }
+    if tool_name == "read_project_artifact" {
+        if let Some(properties) = spec.input_schema["properties"].as_object_mut() {
+            properties.insert(
+                "as_image".to_string(),
+                json!({
+                    "type": "boolean",
+                    "description": "MCP-only. When true, read one complete PNG, JPEG, or WebP up to 1 MiB and return it as native image content. Cannot be combined with offset, length, or max_bytes."
+                }),
+            );
+        }
+        spec.description.push_str(
+            " Over MCP, set as_image=true to return one complete PNG, JPEG, or WebP as native image content; ordinary calls keep the existing chunked base64 response.",
+        );
+    }
+    let mut value = if compact {
+        json!({
+            "name": spec.name,
+            "description": spec.description,
+            "inputSchema": spec.input_schema,
+            "annotations": spec.annotations,
+        })
+    } else {
+        // Match ToolSpec's camelCase serde so default behavior is unchanged.
+        serde_json::to_value(spec).unwrap_or_else(|_| json!({}))
+    };
+    if tool_name == "import_conversation_files_to_project" {
+        if let Some(object) = value.as_object_mut() {
+            object.insert(
+                "_meta".to_string(),
+                json!({"openai/fileParams": ["openaiFileIdRefs"]}),
+            );
+        }
+    }
+    value
+}
+
+#[cfg(test)]
+pub(super) fn mcp_runtime_tool_result(
+    tool_name: &str,
+    as_image_requested: bool,
+    result: ToolResult,
+) -> Value {
+    if tool_name == "export_project_artifact" {
+        return mcp_runtime_tool_result_fallback(result);
+    }
+    match resources::adapt_tool_result(
+        tool_name,
+        as_image_requested,
+        result,
+        resources::McpResourceToolCallContext::default(),
+    ) {
+        resources::McpResourceToolResultAdaptation::Framed(value) => value,
+        resources::McpResourceToolResultAdaptation::Unhandled(result) => {
+            mcp_runtime_tool_result_fallback(result)
+        }
+    }
+}
+
+pub(super) fn handle_list(
+    runtime: &ToolRuntime,
+    id: Option<Value>,
+    auth: Option<&AuthContext>,
+    stateless_2026: bool,
+) -> McpOutcome {
+    let oauth_scope_projection = auth.is_some_and(AuthContext::is_oauth_token);
+    let mut result = if stateless_2026 {
+        if oauth_scope_projection {
+            mcp_tools_list_payload_with_features_for_auth(
+                runtime.model_surface(),
+                crate::config::mcp_compact_schemas_enabled(),
+                resources::model_surface_supports_computer_app(runtime.model_surface()),
+                true,
+                auth,
+            )
+        } else {
+            mcp_tools_list_payload_with_compact_and_app(
+                runtime.model_surface(),
+                crate::config::mcp_compact_schemas_enabled(),
+                resources::model_surface_supports_computer_app(runtime.model_surface()),
+            )
+        }
+    } else if oauth_scope_projection {
+        mcp_tools_list_payload_with_features_for_auth(
+            runtime.model_surface(),
+            crate::config::mcp_compact_schemas_enabled(),
+            false,
+            false,
+            auth,
+        )
+    } else {
+        mcp_tools_list_payload(runtime.model_surface())
+    };
+    if stateless_2026 {
+        add_stateless_workflow_recorder_metadata(&mut result, runtime.model_surface());
+    }
+    if crate::mcp_gateway::authorized(auth) {
+        if let Some(tools) = result.get_mut("tools").and_then(Value::as_array_mut) {
+            tools.push(crate::mcp_gateway::tool_spec());
+        }
+    }
+    McpOutcome::Ok(rpc_result(
+        id,
+        if stateless_2026 {
+            mcp_stateless_result(result, true)
+        } else {
+            result
+        },
+    ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum HostFileImportTrustReason {
+    Trusted,
+    MissingConfig,
+    MissingDatabase,
+    MissingAuth,
+    NotOAuthToken,
+    MissingAllowedClientId,
+    OAuthDisabled,
+    ClientIdNotConfigured,
+    ClientRegistrationMissingOrRevoked,
+    ClientRegistrationLookupFailed,
+}
+
+impl HostFileImportTrustReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::MissingConfig => "missing_config",
+            Self::MissingDatabase => "missing_database",
+            Self::MissingAuth => "missing_auth",
+            Self::NotOAuthToken => "not_oauth_token",
+            Self::MissingAllowedClientId => "missing_allowed_client_id",
+            Self::OAuthDisabled => "oauth_disabled",
+            Self::ClientIdNotConfigured => "client_id_not_configured",
+            Self::ClientRegistrationMissingOrRevoked => "client_registration_missing_or_revoked",
+            Self::ClientRegistrationLookupFailed => "client_registration_lookup_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct HostFileImportTrustDecision {
+    pub(super) trust: HostFileImportTrust,
+    pub(super) reason: HostFileImportTrustReason,
+    config_present: bool,
+    database_present: bool,
+    oauth_enabled: bool,
+    configured_trusted_client_count: usize,
+    pub(super) client_id_configured: Option<bool>,
+    pub(super) active_client_registration_found: Option<bool>,
+}
+
+#[cfg(test)]
+static LAST_MCP_HOST_FILE_IMPORT_TRUST_DECISION: std::sync::OnceLock<
+    std::sync::Mutex<Option<HostFileImportTrustDecision>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+pub(super) fn take_last_mcp_host_file_import_trust_decision() -> Option<HostFileImportTrustDecision>
+{
+    LAST_MCP_HOST_FILE_IMPORT_TRUST_DECISION
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .unwrap()
+        .take()
+}
+
+impl HostFileImportTrustDecision {
+    fn unavailable(reason: HostFileImportTrustReason) -> Self {
+        Self {
+            trust: HostFileImportTrust::Untrusted,
+            reason,
+            config_present: false,
+            database_present: false,
+            oauth_enabled: false,
+            configured_trusted_client_count: 0,
+            client_id_configured: None,
+            active_client_registration_found: None,
+        }
+    }
+
+    fn from_config(reason: HostFileImportTrustReason, config: &crate::Config) -> Self {
+        Self {
+            trust: HostFileImportTrust::Untrusted,
+            reason,
+            config_present: true,
+            database_present: false,
+            oauth_enabled: config.oauth2.enabled,
+            configured_trusted_client_count: config.oauth2.trusted_mcp_file_client_ids.len(),
+            client_id_configured: None,
+            active_client_registration_found: None,
+        }
+    }
+}
+
+pub(super) fn mcp_host_file_import_trust_decision_from_state(
+    config: &crate::Config,
+    db: &crate::Database,
+    auth: Option<&AuthContext>,
+) -> HostFileImportTrustDecision {
+    let base = HostFileImportTrustDecision {
+        trust: HostFileImportTrust::Untrusted,
+        reason: HostFileImportTrustReason::MissingAuth,
+        config_present: true,
+        database_present: true,
+        oauth_enabled: config.oauth2.enabled,
+        configured_trusted_client_count: config.oauth2.trusted_mcp_file_client_ids.len(),
+        client_id_configured: None,
+        active_client_registration_found: None,
+    };
+    let Some(auth) = auth else {
+        return base;
+    };
+    if !auth.is_oauth_token() {
+        return HostFileImportTrustDecision {
+            reason: HostFileImportTrustReason::NotOAuthToken,
+            ..base
+        };
+    }
+    let Some(client_id) = auth
+        .allowed_client_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|client_id| !client_id.is_empty())
+    else {
+        return HostFileImportTrustDecision {
+            reason: HostFileImportTrustReason::MissingAllowedClientId,
+            ..base
+        };
+    };
+    if !config.oauth2.enabled {
+        return HostFileImportTrustDecision {
+            reason: HostFileImportTrustReason::OAuthDisabled,
+            ..base
+        };
+    }
+    let client_id_configured = config
+        .oauth2
+        .trusted_mcp_file_client_ids
+        .iter()
+        .any(|trusted_client_id| trusted_client_id == client_id);
+    if !client_id_configured {
+        return HostFileImportTrustDecision {
+            reason: HostFileImportTrustReason::ClientIdNotConfigured,
+            client_id_configured: Some(false),
+            ..base
+        };
+    }
+    match db.get_oauth_client_by_client_id(client_id) {
+        Ok(Some(client)) if client.client_id == client_id => HostFileImportTrustDecision {
+            trust: HostFileImportTrust::TrustedOAuthClient,
+            reason: HostFileImportTrustReason::Trusted,
+            client_id_configured: Some(true),
+            active_client_registration_found: Some(true),
+            ..base
+        },
+        Ok(_) => HostFileImportTrustDecision {
+            reason: HostFileImportTrustReason::ClientRegistrationMissingOrRevoked,
+            client_id_configured: Some(true),
+            active_client_registration_found: Some(false),
+            ..base
+        },
+        Err(_) => HostFileImportTrustDecision {
+            reason: HostFileImportTrustReason::ClientRegistrationLookupFailed,
+            client_id_configured: Some(true),
+            active_client_registration_found: None,
+            ..base
+        },
+    }
+}
+
+#[cfg(test)]
+pub(super) fn mcp_host_file_import_trust_from_state(
+    config: &crate::Config,
+    db: &crate::Database,
+    auth: Option<&AuthContext>,
+) -> HostFileImportTrust {
+    mcp_host_file_import_trust_decision_from_state(config, db, auth).trust
+}
+
+pub(super) fn host_file_import_trust_for_call(
+    tool_name: Option<&str>,
+    auth: Option<&AuthContext>,
+    config: Option<&crate::Config>,
+    db: Option<&crate::Database>,
+) -> HostFileImportTrust {
+    if tool_name != Some("import_conversation_files_to_project") {
+        return HostFileImportTrust::Untrusted;
+    }
+    let decision = match config {
+        None => HostFileImportTrustDecision::unavailable(HostFileImportTrustReason::MissingConfig),
+        Some(config) => match db {
+            None => HostFileImportTrustDecision::from_config(
+                HostFileImportTrustReason::MissingDatabase,
+                config,
+            ),
+            Some(db) => mcp_host_file_import_trust_decision_from_state(config, db, auth),
+        },
+    };
+    log_mcp_host_file_import_trust_decision(auth, &decision);
+    decision.trust
+}
+
+fn mcp_auth_kind_classification(auth: Option<&AuthContext>) -> &'static str {
+    match auth.map(|auth| auth.kind) {
+        None => "none",
+        Some(crate::auth::AuthKind::OAuth2Token) => "oauth2",
+        Some(crate::auth::AuthKind::ApiToken) => "api_token",
+        Some(crate::auth::AuthKind::Bootstrap) => "bootstrap",
+        Some(crate::auth::AuthKind::AgentToken) => "agent_token",
+        Some(crate::auth::AuthKind::AccountCredential) => "account_credential",
+        Some(crate::auth::AuthKind::SharedKey) => "shared_key",
+        Some(crate::auth::AuthKind::ProjectCredential) => "project_credential",
+        Some(crate::auth::AuthKind::OpenAnonymous) => "open_anonymous",
+    }
+}
+
+fn mcp_token_kind_classification(auth: Option<&AuthContext>) -> &'static str {
+    match auth.and_then(|auth| auth.token_kind.as_deref()) {
+        None => "none",
+        Some("oauth2") => "oauth2",
+        Some("oauth2_shared_key") => "oauth2_shared_key",
+        Some("oauth2_project") => "oauth2_project",
+        Some("user") => "user",
+        Some("agent") => "agent",
+        Some(_) => "other",
+    }
+}
+
+fn log_mcp_host_file_import_trust_decision(
+    auth: Option<&AuthContext>,
+    decision: &HostFileImportTrustDecision,
+) {
+    #[cfg(test)]
+    {
+        *LAST_MCP_HOST_FILE_IMPORT_TRUST_DECISION
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .unwrap() = Some(*decision);
+    }
+    let allowed_client_id_present = auth
+        .and_then(|auth| auth.allowed_client_id.as_deref())
+        .is_some_and(|client_id| !client_id.trim().is_empty());
+    tracing::info!(
+        target: "webcodex::mcp",
+        trust = decision.trust.is_trusted(),
+        reason = decision.reason.as_str(),
+        auth_kind = mcp_auth_kind_classification(auth),
+        token_kind = mcp_token_kind_classification(auth),
+        allowed_client_id_present,
+        config_present = decision.config_present,
+        database_present = decision.database_present,
+        oauth_enabled = decision.oauth_enabled,
+        configured_trusted_client_count = decision.configured_trusted_client_count,
+        client_id_configured = ?decision.client_id_configured,
+        active_client_registration_found = ?decision.active_client_registration_found,
+        "mcp_host_file_import_trust_decision"
+    );
+}
+
+pub(super) fn strip_reserved_session_id(arguments: &mut Value) -> Result<Option<String>, String> {
+    let Some(object) = arguments.as_object_mut() else {
+        return Ok(None);
+    };
+    let canonical =
+        object.remove(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD);
+    let legacy = object.remove(MCP_RESERVED_SESSION_ID_FIELD);
+
+    let canonical = match canonical {
+        None => None,
+        Some(Value::String(value)) => {
+            let value = value.trim();
+            if value.is_empty() {
+                return Err(format!(
+                    "field '{}' must be a non-empty string",
+                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
+                ));
+            }
+            Some(value.to_string())
+        }
+        Some(_) => {
+            return Err(format!(
+                "field '{}' must be a non-empty string",
+                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
+            ));
+        }
+    };
+    let legacy = legacy
+        .and_then(|value| value.as_str().map(str::to_string))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if let (Some(canonical), Some(legacy)) = (&canonical, &legacy) {
+        if canonical != legacy {
+            return Err(format!(
+                "fields '{}' and '{}' must identify the same Workflow Session when both are provided",
+                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,
+                MCP_RESERVED_SESSION_ID_FIELD
+            ));
+        }
+    }
+    Ok(canonical.or(legacy))
+}
+
+pub(super) fn strip_stateless_ack_session_message_ids(
+    arguments: &mut Value,
+) -> Result<Vec<String>, String> {
+    let Some(object) = arguments.as_object_mut() else {
+        return Ok(Vec::new());
+    };
+    let Some(value) =
+        object.remove(crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD)
+    else {
+        return Ok(Vec::new());
+    };
+    let Value::Array(values) = value else {
+        return Err(format!(
+            "field '{}' must be an array of wc_msg_* ids",
+            crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD
+        ));
+    };
+    if values.len() > crate::tool_runtime::sessions::MAX_TOOL_CALL_ACK_MESSAGE_IDS {
+        return Err(format!(
+            "field '{}' accepts at most {} message ids",
+            crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD,
+            crate::tool_runtime::sessions::MAX_TOOL_CALL_ACK_MESSAGE_IDS
+        ));
+    }
+    let mut normalized = Vec::with_capacity(values.len());
+    let mut seen = std::collections::HashSet::new();
+    for value in values {
+        let Value::String(value) = value else {
+            return Err(format!(
+                "field '{}' must contain only wc_msg_* strings",
+                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD
+            ));
+        };
+        let value = value.trim();
+        let valid = value.strip_prefix("wc_msg_").is_some_and(|suffix| {
+            !suffix.is_empty()
+                && suffix
+                    .as_bytes()
+                    .iter()
+                    .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+        });
+        if !valid {
+            return Err(format!(
+                "field '{}' must contain only valid wc_msg_* ids",
+                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD
+            ));
+        }
+        if seen.insert(value.to_string()) {
+            normalized.push(value.to_string());
+        }
+    }
+    Ok(normalized)
+}
+
+pub(super) fn strip_stateless_session_message_resolution(
+    arguments: &mut Value,
+) -> Result<Option<crate::tool_runtime::sessions::ToolCallSessionMessageResolution>, String> {
+    let Some(object) = arguments.as_object_mut() else {
+        return Ok(None);
+    };
+    let Some(value) =
+        object.remove(crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD)
+    else {
+        return Ok(None);
+    };
+    let Value::Object(mut fields) = value else {
+        return Err(format!(
+            "field '{}' must be an object with message_id and resolution",
+            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD
+        ));
+    };
+    if fields.len() != 2 || !fields.contains_key("message_id") || !fields.contains_key("resolution")
+    {
+        return Err(format!(
+            "field '{}' accepts exactly message_id and resolution",
+            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD
+        ));
+    }
+    let Some(Value::String(message_id)) = fields.remove("message_id") else {
+        return Err("session_message_resolution.message_id must be a wc_msg_* string".to_string());
+    };
+    let message_id = message_id.trim().to_string();
+    let valid_message_id = message_id.strip_prefix("wc_msg_").is_some_and(|suffix| {
+        !suffix.is_empty()
+            && suffix
+                .as_bytes()
+                .iter()
+                .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+    });
+    if !valid_message_id {
+        return Err(
+            "session_message_resolution.message_id must be a valid wc_msg_* id".to_string(),
+        );
+    }
+    let Some(Value::String(resolution)) = fields.remove("resolution") else {
+        return Err("session_message_resolution.resolution must be a string".to_string());
+    };
+    let resolution = resolution.trim().to_string();
+    if resolution.is_empty() {
+        return Err("session_message_resolution.resolution must not be empty".to_string());
+    }
+    if resolution.chars().count() > crate::tool_runtime::sessions::MAX_MESSAGE_RESOLUTION_CHARS {
+        return Err(format!(
+            "session_message_resolution.resolution exceeds {} chars",
+            crate::tool_runtime::sessions::MAX_MESSAGE_RESOLUTION_CHARS
+        ));
+    }
+    Ok(Some(
+        crate::tool_runtime::sessions::ToolCallSessionMessageResolution {
+            message_id,
+            resolution,
+        },
+    ))
+}
+
+pub(super) fn strip_stateless_ack_session_context_revision(arguments: &mut Value) -> Option<Value> {
+    arguments
+        .as_object_mut()?
+        .remove(crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD)
+}
+
+pub(super) async fn handle_call(
+    runtime: &ToolRuntime,
+    connector: Option<&ConnectorRuntime>,
+    request_params: Value,
+    id: Option<Value>,
+    auth: Option<&AuthContext>,
+    stateless_2026: bool,
+    host_file_import_trust: HostFileImportTrust,
+    window: Option<&crate::client_window::ClientWindow>,
+    mut lifecycle: Option<&mut ToolRequestLifecycle>,
+    mut model_ergonomics_out: Option<&mut Option<ModelErgonomicsRecord>>,
+) -> McpOutcome {
+    let tasks_extension_declared = stateless_2026 && tasks::request_supports_tasks(&request_params);
+    let mut params: McpToolCallParams = match serde_json::from_value(request_params) {
+        Ok(params) => params,
+        Err(e) => {
+            return McpOutcome::BadRequest(rpc_error(id, -32602, format!("Invalid params: {}", e)));
+        }
+    };
+    if let Some(lc) = lifecycle.as_deref() {
+        lc.capture_payload("raw_arguments", &params.arguments);
+    }
+    // Emit dispatch_started only after params parse succeeds and before
+    // ToolRuntime work begins.
+    if let Some(lc) = lifecycle.as_deref_mut() {
+        lc.set_tool_name(Some(params.name.clone()));
+        lc.dispatch_started();
+    }
+    if params.name == crate::mcp_gateway::MCP_TOOL_NAME {
+        if let Some(outcome) = require_mcp_scope(auth, crate::auth::SCOPE_MCP_LOCAL) {
+            if let Some(lc) = lifecycle.as_deref() {
+                lc.dispatch_failed("forbidden");
+                lc.dispatch_finished(false, Some(false), "forbidden");
+            }
+            return outcome;
+        }
+        if let Some(lc) = lifecycle.as_deref() {
+            lc.capture_payload("effective_arguments", &params.arguments);
+        }
+        let result = crate::mcp_gateway::call(runtime, params.arguments, auth).await;
+        let ok = result.get("isError").and_then(Value::as_bool) != Some(true);
+        if let Some(lc) = lifecycle.as_deref() {
+            lc.dispatch_finished(true, Some(ok), if ok { "success" } else { "tool_error" });
+        }
+        return McpOutcome::Ok(rpc_result(
+            id,
+            if stateless_2026 {
+                mcp_stateless_result(result, false)
+            } else {
+                result
+            },
+        ));
+    }
+    // The local_coding model surface rejects tools it does not
+    // advertise at the MCP boundary, before ToolRuntime dispatch. The
+    // full operator runtime and the canonical Connector keep their
+    // existing behavior unchanged.
+    if runtime.model_surface() == ModelSurface::LocalCoding
+        && !LOCAL_CODING_TOOL_NAMES.contains(&params.name.as_str())
+    {
+        if let Some(lc) = lifecycle.as_deref() {
+            lc.dispatch_failed("surface_denied");
+            lc.dispatch_finished(false, Some(false), "surface_denied");
+        }
+        return McpOutcome::BadRequest(rpc_error(
+            id,
+            -32602,
+            format!(
+                "tool '{}' is not available on the local_coding MCP surface; the full operator runtime must be selected explicitly with WEBCODEX_MCP_MODEL_SURFACE=full-operator-v1",
+                params.name
+            ),
+        ));
+    }
+    // From here on, the MCP boundary has established a model-visible runtime
+    // tool identity. A few MCP-only validations still happen before the
+    // shared ToolRuntime kernel; preserve those failed attempts in generic
+    // telemetry without creating a second record for normal kernel calls.
+    let mut pre_kernel_model_ergonomics = ModelErgonomicsTimer::start(&params.name);
+    let resource_tool_call = match resources::prepare_tool_call(
+        &params.name,
+        stateless_2026,
+        runtime.model_surface(),
+        auth,
+    ) {
+        Ok(context) => context,
+        Err(error) => {
+            if error.records_model_ergonomics_failure() {
+                if let (Some(slot), Some(timer)) = (
+                    model_ergonomics_out.as_deref_mut(),
+                    pre_kernel_model_ergonomics.take(),
+                ) {
+                    *slot = Some(
+                        timer
+                            .finish()
+                            .record_for_pre_result_failure("invalid_arguments"),
+                    );
+                }
+            }
+            return McpOutcome::BadRequest(rpc_error(id, -32602, error.message()));
+        }
+    };
+    if runtime.model_surface() == ModelSurface::CanonicalConnector {
+        let connector = connector.expect("validated canonical Connector state");
+        if !stateless_2026 && params.name == "task_start" && window.is_none() {
+            if let Some(lc) = lifecycle.as_deref() {
+                lc.dispatch_failed("window_identity_unavailable");
+                lc.dispatch_finished(false, Some(false), "window_identity_unavailable");
+            }
+            return McpOutcome::BadRequest(rpc_error(
+                id,
+                -32600,
+                "MCP session identity is unavailable; initialize the connection before starting or continuing project work",
+            ));
+        }
+        if let Some(lc) = lifecycle.as_deref() {
+            lc.capture_payload("effective_arguments", &params.arguments);
+        }
+        let task_polling = tasks_extension_declared
+            && matches!(params.name.as_str(), "commands_run" | "checks_run");
+        let outcome = if task_polling {
+            connector
+                .call_for_window_with_task_polling(
+                    &params.name,
+                    params.arguments,
+                    auth,
+                    ConnectorTransport::Mcp,
+                    window,
+                )
+                .await
+        } else {
+            connector
+                .call_for_window(
+                    &params.name,
+                    params.arguments,
+                    auth,
+                    ConnectorTransport::Mcp,
+                    window,
+                )
+                .await
+        };
+        if let Some(required_scope) = outcome.required_scope {
+            if let Some(lc) = lifecycle.as_deref() {
+                lc.dispatch_failed("forbidden");
+                lc.dispatch_finished(false, Some(false), "forbidden");
+            }
+            let description = outcome
+                .body
+                .pointer("/error/message")
+                .and_then(Value::as_str)
+                .unwrap_or("connector credential lacks the required scope")
+                .to_string();
+            return scope_forbidden(auth, Some(required_scope), description);
+        }
+        if outcome.protocol_error {
+            if let Some(lc) = lifecycle.as_deref() {
+                lc.dispatch_failed("invalid_arguments");
+                lc.dispatch_finished(false, Some(false), "invalid_arguments");
+            }
+            let message = outcome
+                .body
+                .pointer("/error/message")
+                .and_then(Value::as_str)
+                .unwrap_or("invalid connector capability arguments")
+                .to_string();
+            return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+        }
+        if let Some(lc) = lifecycle.as_deref() {
+            let category = if outcome.ok { "success" } else { "tool_error" };
+            lc.dispatch_finished(true, Some(outcome.ok), category);
+        }
+        if task_polling && outcome.ok {
+            if let Some(task_outcome) =
+                tasks::promote_connector_tool_call(&id, &outcome, auth, connector).await
+            {
+                return task_outcome;
+            }
+        }
+        let result = connector_call_tool_result(outcome);
+        return McpOutcome::Ok(rpc_result(
+            id,
+            if stateless_2026 {
+                mcp_stateless_result(result, false)
+            } else {
+                result
+            },
+        ));
+    }
+    let session_id = match strip_reserved_session_id(&mut params.arguments) {
+        Ok(session_id) => session_id,
+        Err(message) => {
+            if let Some(lc) = lifecycle.as_deref() {
+                lc.dispatch_failed("invalid_arguments");
+                lc.dispatch_finished(false, Some(false), "invalid_arguments");
+            }
+            if let (Some(slot), Some(timer)) = (
+                model_ergonomics_out.as_deref_mut(),
+                pre_kernel_model_ergonomics.take(),
+            ) {
+                *slot = Some(
+                    timer
+                        .finish()
+                        .record_for_pre_result_failure("invalid_arguments"),
+                );
+            }
+            return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+        }
+    };
+    let ack_session_message_ids = if stateless_2026 {
+        match strip_stateless_ack_session_message_ids(&mut params.arguments) {
+            Ok(ids) => ids,
+            Err(message) => {
+                if let Some(lc) = lifecycle.as_deref() {
+                    lc.dispatch_failed("invalid_arguments");
+                    lc.dispatch_finished(false, Some(false), "invalid_arguments");
+                }
+                if let (Some(slot), Some(timer)) = (
+                    model_ergonomics_out.as_deref_mut(),
+                    pre_kernel_model_ergonomics.take(),
+                ) {
+                    *slot = Some(
+                        timer
+                            .finish()
+                            .record_for_pre_result_failure("invalid_arguments"),
+                    );
+                }
+                return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+            }
+        }
+    } else {
+        Vec::new()
+    };
+    let session_message_resolution = if stateless_2026 {
+        if let Some(arguments) = params.arguments.as_object_mut() {
+            arguments.remove(
+                crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_INTERNAL_FIELD,
+            );
+        }
+        match strip_stateless_session_message_resolution(&mut params.arguments) {
+            Ok(value) => value,
+            Err(message) => {
+                if let Some(lc) = lifecycle.as_deref() {
+                    lc.dispatch_failed("invalid_arguments");
+                    lc.dispatch_finished(false, Some(false), "invalid_arguments");
+                }
+                if let (Some(slot), Some(timer)) = (
+                    model_ergonomics_out.as_deref_mut(),
+                    pre_kernel_model_ergonomics.take(),
+                ) {
+                    *slot = Some(
+                        timer
+                            .finish()
+                            .record_for_pre_result_failure("invalid_arguments"),
+                    );
+                }
+                return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+            }
+        }
+    } else {
+        None
+    };
+    if session_message_resolution.is_some() && session_id.is_none() {
+        let message = format!(
+            "field '{}' requires '{}' for the exact target Workflow Session",
+            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD,
+            crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,
+        );
+        if let Some(lc) = lifecycle.as_deref() {
+            lc.dispatch_failed("invalid_arguments");
+            lc.dispatch_finished(false, Some(false), "invalid_arguments");
+        }
+        return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+    }
+    if let (Some(arguments), Some(resolution)) =
+        (params.arguments.as_object_mut(), session_message_resolution)
+    {
+        arguments.insert(
+            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_INTERNAL_FIELD
+                .to_string(),
+            json!(resolution),
+        );
+    }
+    if !ack_session_message_ids.is_empty() {
+        if let Some(arguments) = params.arguments.as_object_mut() {
+            arguments.insert(
+                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_INTERNAL_FIELD
+                    .to_string(),
+                json!(ack_session_message_ids),
+            );
+        }
+    }
+    let context_continuity_capable =
+        stateless_2026 && matches!(runtime.model_surface(), ModelSurface::FullOperatorRuntime);
+    if context_continuity_capable {
+        if let Some(arguments) = params.arguments.as_object_mut() {
+            arguments.remove(
+                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
+            );
+        }
+        let context_revision = strip_stateless_ack_session_context_revision(&mut params.arguments);
+        if let (Some(arguments), Some(context_revision)) =
+            (params.arguments.as_object_mut(), context_revision)
+        {
+            arguments.insert(
+                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD
+                    .to_string(),
+                context_revision,
+            );
+        }
+    }
+    if let Some(lc) = lifecycle.as_deref() {
+        lc.capture_payload("effective_arguments", &params.arguments);
+    }
+    let as_image_requested = params.name == "read_project_artifact"
+        && params.arguments.get("as_image").and_then(Value::as_bool) == Some(true);
+    let outcome = runtime
+        .call_tool_with_context_protocol_capability(
+            KernelToolCallRequest {
+                tool_name: params.name.clone(),
+                arguments: params.arguments,
+            },
+            ToolCallContext {
+                transport: ToolTransport::Mcp,
+                session_id: session_id.as_deref(),
+                auth,
+                window,
+                record_oauth_scope_denials: false,
+                host_file_import_trust,
+            },
+            context_continuity_capable,
+        )
+        .await;
+    let model_ergonomics_completion = outcome.model_ergonomics;
+    let result = match outcome.error_status {
+        Some(ToolCallErrorStatus::InsufficientScope {
+            required_scope,
+            description,
+        }) => {
+            if let Some(lc) = lifecycle.as_deref() {
+                lc.dispatch_failed("forbidden");
+                lc.dispatch_finished(false, Some(false), "forbidden");
+            }
+            if let (Some(slot), Some(completion)) = (
+                model_ergonomics_out.as_deref_mut(),
+                model_ergonomics_completion.as_ref(),
+            ) {
+                *slot = Some(completion.record_for_pre_result_failure("insufficient_scope"));
+            }
+            return scope_forbidden(auth, required_scope, description);
+        }
+        Some(ToolCallErrorStatus::InvalidArguments { message }) => {
+            if let Some(lc) = lifecycle.as_deref() {
+                lc.dispatch_failed("invalid_arguments");
+                lc.dispatch_finished(false, Some(false), "invalid_arguments");
+            }
+            if let (Some(slot), Some(completion)) = (
+                model_ergonomics_out.as_deref_mut(),
+                model_ergonomics_completion.as_ref(),
+            ) {
+                *slot = Some(completion.record_for_pre_result_failure("invalid_arguments"));
+            }
+            return McpOutcome::BadRequest(rpc_error(id, -32602, message));
+        }
+        None => outcome
+            .result
+            .expect("tool kernel outcome without error must include result"),
+    };
+    debug_assert_eq!(outcome.success, result.success);
+    if let Some(lc) = lifecycle.as_deref() {
+        // Protocol layer produced a JSON-RPC result (not -32xxx).
+        // Tool kernel success is independent (isError / structuredContent).
+        let category = if result.success {
+            "success"
+        } else {
+            "tool_error"
+        };
+        if result.success {
+            lc.dispatch_finished(true, Some(true), category);
+        } else {
+            lc.dispatch_finished(true, Some(false), category);
+        }
+    }
+    let result = match resources::adapt_tool_result(
+        &params.name,
+        as_image_requested,
+        result,
+        resource_tool_call,
+    ) {
+        resources::McpResourceToolResultAdaptation::Framed(value) => value,
+        resources::McpResourceToolResultAdaptation::Unhandled(result) => {
+            mcp_runtime_tool_result_fallback(result)
+        }
+    };
+    let model_ergonomics = model_ergonomics_completion.as_ref().and_then(|completion| {
+        result
+            .get("structuredContent")
+            .and_then(|structured| completion.record_for_structured_content(structured))
+    });
+    if let Some(slot) = model_ergonomics_out.as_deref_mut() {
+        *slot = model_ergonomics;
+    }
+    return McpOutcome::Ok(rpc_result(
+        id,
+        if stateless_2026 {
+            mcp_stateless_result(result, false)
+        } else {
+            result
+        },
+    ));
+}


### PR DESCRIPTION
## Summary

Complete the first 0.4 MCP architecture decomposition as three focused commits:

1. **M1 — Tasks domain**
   - extract MCP Tasks request/projection/promotion logic into `src/mcp/tasks.rs`
   - keep Tasks as an adapter over the existing Connector execution source of truth

2. **M2 — Resources domain**
   - extract artifact export resources, snapshot resources, Computer App resources, resource-link adaptation, and bounded artifact streaming into `src/mcp/resources.rs`
   - preserve caller isolation, scope rechecks, integrity validation, bounded registries, backpressure, and incremental HTTP streaming

3. **M3 — Facade/core boundary closure**
   - add `src/mcp/protocol.rs`, `src/mcp/http_metadata.rs`, `src/mcp/response.rs`, and `src/mcp/tools.rs`
   - reduce `src/mcp.rs` to the HTTP facade, outer lifecycle/audit/timeout/stream rendering, `McpOutcome`, and thin method routing
   - remove the Resources -> parent generic-result callback seam and make the artifact stream plan opaque

This is an architectural refactor of the 0.4 development line. It intentionally preserves current MCP behavior while establishing cleaner ownership and dependency direction. The demonstrated outer `Box::pin`, hard dispatch timeout, and real bounded incremental artifact streaming remain unchanged.

## Architecture invariants

- no second MCP task/execution lifecycle, database table, registry, cache, monitor, or cancellation model
- Tasks continue to project the existing Connector execution truth
- Resources reuse existing ToolRuntime/auth/artifact truth
- `tools` may depend on Tasks/Resources; Tasks/Resources do not depend back on `tools`
- protocol/header interpretation is separated from ToolRuntime/Connector business logic
- generic JSON-RPC/MCP framing is shared without introducing a generic streaming/framework layer
- artifact HTTP delivery remains bounded and incremental; no whole-file aggregation
- existing authority, privacy, audit, and model-surface behavior is preserved

## Validation

Fresh independent review accepted M1, M2, and M3 without reviewer-fix commits.

Reviewer-selected post-M3 validation:

- MCP protocol: **15/15 PASS**
- MCP HTTP transport: **26/26 PASS**
- MCP tools: **27/27 PASS**
- artifact export/resources: **21/21 PASS**
- Connector Tasks HTTP: **3/3 PASS**
- advertised-method/router parity: **1/1 PASS**
- `cargo check --all-targets`: PASS, 0 warnings / 0 errors
- `cargo fmt -- --check`: PASS
- M3 `git diff --check`: PASS
- full M1..M3 `git diff --check`: PASS
- worktree/hygiene clean, conflicts 0, active Jobs 0

No deployment or release changes are included.