### PR TITLE
Canonicalize Workflow Session authority lifecycle

### DIFF
--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -126,9 +126,9 @@ Waiting uses process-local notification only as a wake signal; durable revision 
 
 Message observation is not a delivery receipt, not model-context retention, not a subscription/stream, and not an orchestrator wake-up. Room/Discussion, Participant, presence, typing, scheduler/worker-pool, automatic worker spawning, and routing remain future additive capabilities rather than reinterpretations of this cursor.
 
-Authenticated project-scoped Workflow Sessions created by current code also persist an internal canonical authority-group fingerprint. A legacy project-scoped record from before that fence may legitimately have no fingerprint; current project authorization or knowledge of its `session_id` is not enough to claim it. The only automatic compatibility upgrade is a coding continuation/resume whose current caller can reconstruct an exact historical `CurrentSessionKey` and whose pre-existing **durable** binding already points to that exact active Session for the same resolved project. The proof ignores the process-local cache. After all continuation validation succeeds, the canonical fingerprint is written atomically with the instruction/capability/context/binding mutation and enters the same persistence generation. Without that durable proof the legacy Session remains fail-closed.
+Every Workflow Session admitted to the in-memory store carries one canonical creation-time authority-group fingerprint. The ledger keeps only that domain-separated SHA-256 fingerprint under the historical `owner_authority_fingerprint` field; raw user, shared-key, project-grant, credential, or window identity material is never persisted as Session authority. Project authorization and creation-time Session authority are separate checks: access to a project does not authorize another authority group's Session, and a matching Session fingerprint does not bypass project authorization or project equality.
 
-The historical `CurrentSessionKey` and durable binding hash format are unchanged, including their principal-presentation, transport, stable-window, project, and canonical-root components. Consequently a legacy binding created through one presentation (for example direct shared-key) is not rewritten to make a first migration attempt through another presentation match. Once migration succeeds, subsequent Session authorization uses the canonical authority-group fingerprint, so direct shared-key and its OAuth shared-key bridge share the migrated Session normally.
+Persisted rows without an exact lowercase canonical fingerprint, or without an explicit canonical `active`/`closed` lifecycle, are discarded row-locally during restore. A process-local or durable `CurrentSessionKey` binding may select an existing active same-project Session for continuity, but it never grants, repairs, migrates, or upgrades Session authority. After selection, execution/mutation/resume still compares the caller's canonical fingerprint before changing Session state. Direct shared-key and its OAuth shared-key bridge share a Session only because they derive the same canonical authority-group fingerprint, not because a binding bridges their presentation identities.
 
 ### Persistent execution defaults
 
@@ -168,7 +168,7 @@ in-memory store lock. An explicit `{}` clears all execution defaults.
 `update_session_context` requires a project input that the caller may access and
 that resolves exactly to the explicit known active Session project. It never
 uses current-session fallback, never creates an unknown Session, rejects closed,
-archived, project-less, unauthorized, and mismatched Sessions, and has no
+project-less, unauthorized, and mismatched Sessions, and has no
 cross-project escape. The context and event commit together in memory; the JSON
 ledger is then queued to the existing background writer. Persistence failures
 are reported through existing status and logs, and success does not mean a
@@ -423,8 +423,9 @@ remain their own model and do not infer or mutate Workflow Sessions.
 
 ### Current lifecycle contract
 
-- New Workflow Sessions are `active`; older ledgers without a lifecycle field
-  are also read as `active`.
+- New Workflow Sessions are `active`. Persisted Sessions must carry an explicit
+  canonical `active` or `closed` lifecycle; rows with missing or unknown lifecycle
+  values are discarded during restore and never gain mutation authority.
 - `close_session` is the only explicit `active → closed` transition. It requires
   an explicit `session_id`, never uses current-session fallback, and returns
   `unknown_session_id` for malformed or unknown IDs without creating a session.
@@ -437,8 +438,7 @@ remain their own model and do not infer or mutate Workflow Sessions.
   checkpoint create/restore/delete with `session_closed`.
 - `finish_coding_task`, `session_handoff_summary`, and other summary/query tools
   produce closeout information but do not close the session.
-- `archived` is a reserved wire state that current code does not produce. LRU
-  eviction is capacity management, not a lifecycle transition, and removes
+- LRU eviction is capacity management, not a lifecycle transition, and removes
   bindings to the evicted Session.
 - Session modes (`normal`, `inspect`, `read_only`) are execution policy, not
   lifecycle state.

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -694,11 +694,10 @@ impl ToolRuntime {
                 "message": "repository structure overview was unavailable during startup",
             }));
         }
-        // Explicit resume may need the exact historical durable binding as a
-        // legacy authority-upgrade proof even when the caller does not want to
-        // bind this request as current. Building the key does not itself create
-        // or refresh any binding; `bind_current` remains the sole mutation gate.
-        let continuity_key = if bind_current || resume_requested {
+        // Current-session identity is only needed when this request intends to
+        // bind a Session as current. Explicit resume is authorized independently
+        // by project equality plus the Session's canonical creation-time authority.
+        let continuity_key = if bind_current {
             match current_session_key(
                 auth,
                 transport,
@@ -767,24 +766,21 @@ impl ToolRuntime {
         let binding_available = bind_current && continuity_key.is_some();
         let write_scope_verified =
             auth.is_none_or(|auth| auth.has_scope(crate::auth::SCOPE_PROJECT_WRITE));
-        let authority_fingerprint = match auth {
-            None => None,
-            Some(auth) => match workflow_session_authority_fingerprint(Some(auth)) {
-                Ok(fingerprint) => Some(fingerprint),
-                Err(_) => {
-                    return attach_project_resolution(
-                        ToolResult::err_with_output(
-                            "authenticated caller has no canonical Workflow Session authority identity",
-                            json!({
-                                "error_kind": "session_authority_identity_unavailable",
-                                "failure_kind": "session_authority_denied",
-                                "state_changed": false,
-                            }),
-                        ),
-                        &project_resolution,
-                    );
-                }
-            },
+        let authority_fingerprint = match workflow_session_authority_fingerprint(auth) {
+            Ok(fingerprint) => fingerprint,
+            Err(_) => {
+                return attach_project_resolution(
+                    ToolResult::err_with_output(
+                        "caller has no canonical Workflow Session authority identity",
+                        json!({
+                            "error_kind": "session_authority_identity_unavailable",
+                            "failure_kind": "session_authority_denied",
+                            "state_changed": false,
+                        }),
+                    ),
+                    &project_resolution,
+                );
+            }
         };
         let session_outcome = match self.sessions.ensure_coding_session(
             sessions::CodingSessionRequest {
@@ -837,7 +833,6 @@ impl ToolRuntime {
             }) => {
                 let error_kind = match lifecycle {
                     sessions::SessionLifecycle::Closed => "session_closed",
-                    sessions::SessionLifecycle::Archived => "session_archived",
                     sessions::SessionLifecycle::Active => "session_lifecycle_denied",
                 };
                 return attach_project_resolution(
@@ -888,24 +883,6 @@ impl ToolRuntime {
                             "failure_kind": "session_authority_denied",
                             "session_id": session_id,
                             "resume_requested": true,
-                            "state_changed": false,
-                        }),
-                    ),
-                    &project_resolution,
-                );
-            }
-            Err(sessions::CodingSessionError::LegacySessionAuthorityUnverifiable {
-                session_id,
-            }) => {
-                return attach_project_resolution(
-                    ToolResult::err_with_output(
-                        "legacy_session_authority_unverifiable",
-                        json!({
-                            "error_kind": "legacy_session_authority_unverifiable",
-                            "failure_kind": "session_authority_denied",
-                            "reason_code": "legacy_session_authority_unverifiable",
-                            "session_id": session_id,
-                            "resume_requested": resume_requested,
                             "state_changed": false,
                         }),
                     ),

--- a/src/tool_runtime/registry/input_schemas/sessions.rs
+++ b/src/tool_runtime/registry/input_schemas/sessions.rs
@@ -12,12 +12,11 @@ pub(crate) fn session_mode_schema(description: &str) -> Value {
 
 /// Workflow session lifecycle wire values.
 ///
-/// Phase 2: create yields `active`; explicit `close_session` yields `closed`.
-/// `archived` remains reserved for later phases. Missing ledger field → active.
+/// Create yields `active`; explicit `close_session` yields `closed`.
 pub(crate) fn session_lifecycle_schema(description: &str) -> Value {
     json!({
         "type": "string",
-        "enum": ["active", "closed", "archived"],
+        "enum": ["active", "closed"],
         "description": description,
     })
 }

--- a/src/tool_runtime/registry/output_schemas/common.rs
+++ b/src/tool_runtime/registry/output_schemas/common.rs
@@ -589,7 +589,7 @@ pub(crate) fn handoff_brief_schema(description: &str) -> Value {
                     },
                     "lifecycle": {
                         "type": "string",
-                        "enum": ["active", "closed", "archived"]
+                        "enum": ["active", "closed"]
                     },
                     "mode": {
                         "type": "string",

--- a/src/tool_runtime/registry/output_schemas/sessions.rs
+++ b/src/tool_runtime/registry/output_schemas/sessions.rs
@@ -184,7 +184,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 "already_closed",
                 schema_type(
                     "boolean",
-                    "True when the session was already closed (or archived); no new transition event was recorded.",
+                    "True when the session was already closed; no new transition event was recorded.",
                 ),
             ),
             (

--- a/src/tool_runtime/session_context.rs
+++ b/src/tool_runtime/session_context.rs
@@ -187,7 +187,7 @@ pub(crate) fn session_guard_denied_result(
     .with_recovery(RecoveryKind::NoAction, None)
 }
 
-/// Lifecycle denial for Closed/Archived workflow sessions (write/shell/mutation).
+/// Lifecycle denial for Closed workflow sessions (write/shell/mutation).
 pub(crate) fn session_lifecycle_denied_result(
     session_id: &str,
     tool_name: &str,
@@ -196,7 +196,6 @@ pub(crate) fn session_lifecycle_denied_result(
     let lifecycle = denial.lifecycle.as_str();
     let error_kind = match denial.lifecycle {
         sessions::SessionLifecycle::Closed => "session_closed",
-        sessions::SessionLifecycle::Archived => "session_archived",
         sessions::SessionLifecycle::Active => "session_lifecycle_denied",
     };
     let mut output = json!({
@@ -368,21 +367,15 @@ pub(crate) fn session_message_error_result(
             }),
         )
         .with_recovery(RecoveryKind::RetrySame, None),
-        sessions::SessionMessageError::SessionClosed { lifecycle } => {
-            let error_kind = match lifecycle {
-                sessions::SessionLifecycle::Archived => "session_archived",
-                _ => "session_closed",
-            };
-            ToolResult::err_with_output(
-                format!("{error_kind}: session message mutation blocked"),
-                json!({
-                    "error_kind": error_kind,
-                    "session_id": session_id,
-                    "lifecycle": lifecycle.as_str(),
-                }),
-            )
-            .with_recovery(RecoveryKind::NoAction, None)
-        }
+        sessions::SessionMessageError::SessionClosed { lifecycle } => ToolResult::err_with_output(
+            "session_closed: session message mutation blocked",
+            json!({
+                "error_kind": "session_closed",
+                "session_id": session_id,
+                "lifecycle": lifecycle.as_str(),
+            }),
+        )
+        .with_recovery(RecoveryKind::NoAction, None),
         sessions::SessionMessageError::InvalidInput(message) => ToolResult::err_with_output(
             message.clone(),
             json!({
@@ -868,73 +861,6 @@ fn hash_workflow_session_authority(domain: &[u8], kind: &str, id: &str) -> Strin
     hasher.update(b"\0");
     hasher.update(id.as_bytes());
     format!("{:x}", hasher.finalize())
-}
-
-/// Compatibility verifier for project-less Sessions written by c3a09275.
-/// New Sessions always use the canonical authority-group fingerprint above.
-pub(crate) fn legacy_workflow_session_owner_fingerprint(
-    auth: Option<&AuthContext>,
-) -> Result<String, String> {
-    let (principal_kind, principal_id) = match auth {
-        None => ("dev".to_string(), "dev".to_string()),
-        Some(auth) if auth.is_open_anonymous() => {
-            return Err(
-                "project-less Workflow Session requires a distinct stable caller identity"
-                    .to_string(),
-            );
-        }
-        Some(auth) if auth.is_bootstrap => (
-            "bootstrap".to_string(),
-            auth.user_id
-                .as_deref()
-                .or(auth.username.as_deref())
-                .unwrap_or("bootstrap")
-                .to_string(),
-        ),
-        Some(auth) if auth.is_oauth_shared_key_subject() => (
-            auth.principal_kind().to_string(),
-            stable_workflow_authority_id(
-                auth.shared_key_hash.as_deref(),
-                "OAuth shared-key subject has no stable identity",
-            )?,
-        ),
-        Some(auth) if auth.is_oauth_project_subject() => (
-            auth.principal_kind().to_string(),
-            stable_workflow_authority_id(
-                auth.project_grant_id.as_deref(),
-                "OAuth project subject has no stable identity",
-            )?,
-        ),
-        Some(auth) if auth.is_oauth_token() => (
-            auth.principal_kind().to_string(),
-            auth.user_id
-                .as_deref()
-                .or(auth.username.as_deref())
-                .or(auth.api_key_id.as_deref())
-                .map(str::to_string)
-                .ok_or_else(|| "OAuth caller has no stable owner identity".to_string())?,
-        ),
-        Some(auth) if auth.is_shared_key() => (
-            auth.principal_kind().to_string(),
-            stable_workflow_authority_id(
-                auth.shared_key_hash.as_deref(),
-                "shared-key caller has no stable owner identity",
-            )?,
-        ),
-        Some(auth) if auth.is_project_credential() => (
-            auth.principal_kind().to_string(),
-            stable_workflow_authority_id(
-                auth.project_grant_id.as_deref(),
-                "project credential has no stable owner identity",
-            )?,
-        ),
-        Some(auth) => current_session_principal(Some(auth))?,
-    };
-    Ok(hash_workflow_session_authority(
-        b"webcodex.workflow-session-owner.v1\0",
-        &principal_kind,
-        &principal_id,
-    ))
 }
 
 pub(crate) fn current_session_key(

--- a/src/tool_runtime/session_tools.rs
+++ b/src/tool_runtime/session_tools.rs
@@ -1,8 +1,7 @@
 //! Runtime handlers for session and current-session tool calls.
 
 use super::session_context::{
-    current_session_key, current_session_unavailable_result,
-    legacy_workflow_session_owner_fingerprint, session_authority_denied_result,
+    current_session_key, current_session_unavailable_result, session_authority_denied_result,
     session_lifecycle_denied_result, session_message_error_result,
     session_project_mismatch_no_escape_result, unknown_session_result,
     workflow_session_authority_fingerprint, SessionProjectMismatch,
@@ -226,7 +225,7 @@ impl ToolRuntime {
             );
         }
         let owner_authority_fingerprint = match workflow_session_authority_fingerprint(auth) {
-            Ok(fingerprint) => Some(fingerprint),
+            Ok(fingerprint) => fingerprint,
             Err(_) => {
                 return ToolResult::err_with_output(
                     "session_authority_identity_unavailable",
@@ -252,7 +251,7 @@ impl ToolRuntime {
                 },
             ),
         )
-        .with_owner_authority_fingerprint(owner_authority_fingerprint)
+        .with_owner_authority_fingerprint(Some(owner_authority_fingerprint))
         .with_project_instructions(project_instructions.clone())
         .with_execution_context(execution_context.unwrap_or_default());
         let summary = match self.sessions.start_session_with_options(options) {
@@ -426,68 +425,50 @@ impl ToolRuntime {
             return Err(unknown_session_result(session_id));
         };
         if let Some(project) = project {
-            // The trusted local/dev dispatcher remains an explicit compatibility
-            // path. Every authenticated caller must satisfy both current project
-            // authorization and the immutable creation-time authority fence.
-            let Some(auth) = auth else {
-                return Ok(None);
+            // Project authorization and immutable creation-time Session authority
+            // are independent checks. Local/dev has no credential project check,
+            // but still has the same canonical authority fence as every caller.
+            let resolved = if let Some(auth) = auth {
+                let resolved = match self
+                    .resolve_project_input_for_auth(&project, Some(auth))
+                    .await
+                {
+                    Ok(resolved) => resolved,
+                    Err(err) => return Err(err.into_tool_result()),
+                };
+                if resolved.resolved_id != project {
+                    return Err(session_project_mismatch_no_escape_result(
+                        session_id,
+                        tool_name,
+                        &SessionProjectMismatch {
+                            session_project: project,
+                            request_project: resolved.resolved_id,
+                        },
+                    ));
+                }
+                Some(resolved)
+            } else {
+                None
             };
-            let resolved = match self
-                .resolve_project_input_for_auth(&project, Some(auth))
-                .await
-            {
-                Ok(resolved) => resolved,
-                Err(err) => return Err(err.into_tool_result()),
-            };
-            if resolved.resolved_id != project {
-                return Err(session_project_mismatch_no_escape_result(
-                    session_id,
-                    tool_name,
-                    &SessionProjectMismatch {
-                        session_project: project,
-                        request_project: resolved.resolved_id,
-                    },
-                ));
-            }
-            let caller_fingerprint = workflow_session_authority_fingerprint(Some(auth))
+            let caller_fingerprint = workflow_session_authority_fingerprint(auth)
                 .map_err(|_| session_authority_denied_result(session_id, tool_name))?;
             #[cfg(test)]
-            let synthetic_test_fixture = owner_authority_fingerprint.as_deref()
-                == Some(sessions::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT);
+            let synthetic_test_fixture = owner_authority_fingerprint
+                == sessions::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT;
             #[cfg(not(test))]
             let synthetic_test_fixture = false;
-            if !synthetic_test_fixture
-                && owner_authority_fingerprint.as_deref() != Some(caller_fingerprint.as_str())
-            {
+            if !synthetic_test_fixture && owner_authority_fingerprint != caller_fingerprint {
                 return Err(session_authority_denied_result(session_id, tool_name));
             }
-            return Ok(Some(resolved));
+            return Ok(resolved);
         }
 
-        // Project-less Sessions remain available to the trusted local/dev path.
-        // Authenticated callers must match the durable hashed authority. c3a09275
-        // ledgers are accepted only when the same caller matches their legacy
-        // owner fingerprint; a missing fingerprint still fails closed.
-        let Some(auth) = auth else {
-            return Ok(None);
-        };
-        if auth.is_open_anonymous() {
+        if auth.is_some_and(AuthContext::is_open_anonymous) {
             return Err(session_authority_denied_result(session_id, tool_name));
         }
-        let caller_fingerprint = workflow_session_authority_fingerprint(Some(auth))
+        let caller_fingerprint = workflow_session_authority_fingerprint(auth)
             .map_err(|_| session_authority_denied_result(session_id, tool_name))?;
-        let canonical_match =
-            owner_authority_fingerprint.as_deref() == Some(caller_fingerprint.as_str());
-        let legacy_match = if canonical_match {
-            false
-        } else {
-            legacy_workflow_session_owner_fingerprint(Some(auth))
-                .ok()
-                .is_some_and(|fingerprint| {
-                    owner_authority_fingerprint.as_deref() == Some(fingerprint.as_str())
-                })
-        };
-        if !canonical_match && !legacy_match {
+        if owner_authority_fingerprint != caller_fingerprint {
             return Err(session_authority_denied_result(session_id, tool_name));
         }
         Ok(None)

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -4,7 +4,7 @@ use super::super::project_instructions::{
     ProjectInstructionsSnapshot, ProjectInstructionsSummarySnapshot,
 };
 use super::super::tool_inputs::{ExecutionShell, SessionMode};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{value::RawValue, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, VecDeque};
@@ -249,26 +249,22 @@ impl CurrentSessionKey {
 
 /// Workflow session lifecycle state.
 ///
-/// Wire values use snake_case (`"active"`, `"closed"`, `"archived"`). Missing
-/// ledger fields default to [`SessionLifecycle::Active`] so pre-lifecycle JSON
-/// remains readable without migration.
+/// Canonical wire values are `"active"` and `"closed"`. Lifecycle is explicit
+/// persisted authority: missing or unknown persisted values are rejected row-local
+/// during restore and never become an active mutable Session.
 ///
-/// Transitions (Phase 2):
+/// Transitions:
 /// - Create always yields [`SessionLifecycle::Active`].
 /// - Explicit `close_session` may transition `Active → Closed`.
-/// - `Closed → Active` is not allowed (no reopen in this phase).
-/// - `Archived` is a reserved wire state and is never produced by the store.
+/// - `Closed → Active` is not allowed.
 ///
 /// LRU eviction remains capacity management, not a lifecycle transition.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum SessionLifecycle {
-    #[default]
     Active,
     /// Explicitly closed; query remains allowed, mutations are denied.
     Closed,
-    /// Reserved wire state. Not produced; treated like Closed for denial.
-    Archived,
 }
 
 impl SessionLifecycle {
@@ -281,17 +277,30 @@ impl SessionLifecycle {
         match self {
             Self::Active => "active",
             Self::Closed => "closed",
-            Self::Archived => "archived",
         }
     }
+}
+
+fn deserialize_persisted_session_lifecycle<'de, D>(
+    deserializer: D,
+) -> Result<Option<SessionLifecycle>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    Ok(match value.as_str() {
+        Some("active") => Some(SessionLifecycle::Active),
+        Some("closed") => Some(SessionLifecycle::Closed),
+        _ => None,
+    })
 }
 
 /// Result of an explicit close attempt on a known session.
 #[derive(Debug, Clone)]
 pub(crate) struct SessionCloseOutcome {
     pub(crate) summary: SessionSummary,
-    /// True when the session was already `Closed` (or `Archived`); no new
-    /// transition event was recorded.
+    /// True when the session was already `Closed`; no new transition event was
+    /// recorded.
     pub(crate) already_closed: bool,
 }
 
@@ -312,16 +321,15 @@ pub(super) struct SessionRecord {
     pub(super) session_id: String,
     pub(super) project: Option<String>,
     /// Domain-separated SHA-256 of the canonical creation-time authority group.
-    /// The historical field name is retained for ledger compatibility; the raw
-    /// authority identity is never stored. Restore may use a private noncanonical
-    /// marker for a malformed persisted value so it remains distinguishable from
-    /// a genuinely absent legacy field and permanently fails authorization.
-    pub(super) owner_authority_fingerprint: Option<String>,
+    /// The historical field name is retained only in persistence; in-memory
+    /// mutable/queryable Sessions always carry a canonical fingerprint and never
+    /// retain raw authority identity material.
+    pub(super) owner_authority_fingerprint: String,
     pub(super) title: Option<String>,
     pub(super) mode: SessionMode,
     pub(super) guards: SessionGuards,
     pub(super) execution_context: SessionExecutionContext,
-    /// Explicit lifecycle; always set in memory. Default on load: Active.
+    /// Explicit canonical lifecycle; always set in memory.
     pub(super) lifecycle: SessionLifecycle,
     pub(super) created_at: i64,
     pub(super) updated_at: i64,
@@ -383,7 +391,7 @@ pub(super) enum StoredSession {
 pub(super) struct ColdSessionRecord {
     pub(super) session_id: String,
     pub(super) project: Option<String>,
-    pub(super) owner_authority_fingerprint: Option<String>,
+    pub(super) owner_authority_fingerprint: String,
     pub(super) mode: SessionMode,
     pub(super) guards: SessionGuards,
     pub(super) lifecycle: SessionLifecycle,
@@ -408,10 +416,10 @@ impl StoredSession {
         }
     }
 
-    pub(super) fn owner_authority_fingerprint(&self) -> Option<&str> {
+    pub(super) fn owner_authority_fingerprint(&self) -> &str {
         match self {
-            Self::Hot(record) => record.owner_authority_fingerprint.as_deref(),
-            Self::Cold(record) => record.owner_authority_fingerprint.as_deref(),
+            Self::Hot(record) => record.owner_authority_fingerprint.as_str(),
+            Self::Cold(record) => record.owner_authority_fingerprint.as_str(),
         }
     }
 
@@ -525,9 +533,9 @@ impl SessionCreateOptions {
 pub(crate) struct CodingSessionRequest {
     pub(crate) key: Option<CurrentSessionKey>,
     pub(crate) project: String,
-    /// Canonical creation-time authority fence for authenticated callers.
-    /// `None` is reserved for the trusted local/dev path.
-    pub(crate) authority_fingerprint: Option<String>,
+    /// Canonical creation-time authority fence for every caller, including the
+    /// canonical local/dev authority group.
+    pub(crate) authority_fingerprint: String,
     pub(crate) resume_session_id: Option<String>,
     pub(crate) instruction: Option<String>,
     pub(crate) mode: SessionMode,
@@ -574,9 +582,6 @@ pub(crate) enum CodingSessionError {
         request_project: String,
     },
     ResumeAuthorityMismatch {
-        session_id: String,
-    },
-    LegacySessionAuthorityUnverifiable {
         session_id: String,
     },
     ResumeNewSessionConflict,
@@ -701,9 +706,9 @@ pub(super) struct DurableCurrentBinding {
 pub(super) struct PersistedSessionRecord {
     pub(super) session_id: String,
     pub(super) project: Option<String>,
-    /// Additive v1 field. c3a09275 used it only for project-less ownership;
-    /// current writers store the canonical authority-group fingerprint for every
-    /// authenticated Session. The historical name keeps ledger compatibility.
+    /// Historical field name retained for JSON compatibility. Canonical writers
+    /// always store a domain-separated authority-group fingerprint; missing or
+    /// malformed values are rejected row-local during restore.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) owner_authority_fingerprint: Option<String>,
     pub(super) title: Option<String>,
@@ -712,9 +717,15 @@ pub(super) struct PersistedSessionRecord {
     /// Additive ledger-v1 field. Older ledgers restore an empty context.
     #[serde(default)]
     pub(super) execution_context: SessionExecutionContext,
-    /// Optional on disk for ledger compatibility; missing → Active.
-    #[serde(default)]
-    pub(super) lifecycle: SessionLifecycle,
+    /// Canonical writers always persist an explicit lifecycle. Missing, unknown,
+    /// or removed values deserialize as `None` so restore can discard only that
+    /// row instead of poisoning the whole ledger.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_persisted_session_lifecycle",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(super) lifecycle: Option<SessionLifecycle>,
     pub(super) created_at: i64,
     pub(super) updated_at: i64,
     pub(super) events: Vec<Arc<SessionEvent>>,
@@ -1352,8 +1363,8 @@ pub(crate) enum SessionMessageError {
         current: SessionAssignmentCurrentState,
     },
     PersistenceUncertain,
-    /// Message-board mutation denied because the workflow session is closed
-    /// (or archived). Query tools remain available.
+    /// Message-board mutation denied because the workflow session is closed.
+    /// Query tools remain available.
     SessionClosed {
         lifecycle: SessionLifecycle,
     },

--- a/src/tool_runtime/sessions/persistence.rs
+++ b/src/tool_runtime/sessions/persistence.rs
@@ -60,12 +60,12 @@ impl PersistedSessionRecord {
         Self {
             session_id: record.session_id.clone(),
             project: record.project.clone(),
-            owner_authority_fingerprint: record.owner_authority_fingerprint.clone(),
+            owner_authority_fingerprint: Some(record.owner_authority_fingerprint.clone()),
             title: record.title.clone(),
             mode: record.mode,
             guards: record.guards,
             execution_context: record.execution_context.clone(),
-            lifecycle: record.lifecycle,
+            lifecycle: Some(record.lifecycle),
             created_at: record.created_at,
             updated_at: record.updated_at,
             events,
@@ -93,12 +93,13 @@ impl PersistedSessionRecord {
     pub(super) fn still_matches_record(&self, record: &SessionRecord) -> bool {
         self.session_id == record.session_id
             && self.project == record.project
-            && self.owner_authority_fingerprint == record.owner_authority_fingerprint
+            && self.owner_authority_fingerprint.as_deref()
+                == Some(record.owner_authority_fingerprint.as_str())
             && self.title == record.title
             && self.mode == record.mode
             && self.guards == record.guards
             && self.execution_context == record.execution_context
-            && self.lifecycle == record.lifecycle
+            && self.lifecycle == Some(record.lifecycle)
             && self.created_at == record.created_at
             && self.updated_at == record.updated_at
             && self.events_observed == record.events_observed
@@ -136,6 +137,12 @@ impl PersistedSessionRecord {
         if !is_valid_session_id(&session_id) {
             return None;
         }
+        // Canonical authority and lifecycle are required before any restored row
+        // can enter the in-memory Session store. Missing, malformed, unknown, or
+        // removed historical values fail closed by discarding only this row.
+        let owner_authority_fingerprint =
+            sanitize_owner_authority_fingerprint(self.owner_authority_fingerprint)?;
+        let lifecycle = self.lifecycle?;
         let events: VecDeque<Arc<SessionEvent>> = self
             .events
             .into_iter()
@@ -327,8 +334,6 @@ impl PersistedSessionRecord {
             .max()
             .unwrap_or(0);
         let project = self.project.map(|value| bound_summary_string(value.trim()));
-        let owner_authority_fingerprint =
-            sanitize_owner_authority_fingerprint(self.owner_authority_fingerprint);
         let execution_context = if project.is_some() {
             self.execution_context.sanitized_for_restore()
         } else {
@@ -342,8 +347,7 @@ impl PersistedSessionRecord {
             mode: self.mode,
             guards: SessionGuards::effective(self.mode, self.guards),
             execution_context,
-            // Missing ledger field deserializes via #[serde(default)] → Active.
-            lifecycle: self.lifecycle,
+            lifecycle,
             created_at: self.created_at,
             updated_at: self.updated_at.max(self.created_at),
             events,
@@ -385,25 +389,9 @@ fn sanitize_materialized_validation_job_ids(values: Vec<String>) -> VecDeque<Str
     newest.into()
 }
 
-// Preserve the distinction between a genuinely absent legacy field and a
-// present-but-malformed value without retaining attacker-controlled material.
-// The marker is internal ledger state, is never a valid canonical fingerprint,
-// and therefore remains permanently fail-closed across subsequent rewrites.
-const INVALID_OWNER_AUTHORITY_FINGERPRINT_MARKER: &str =
-    "invalid_persisted_workflow_session_authority_fingerprint";
-
 fn sanitize_owner_authority_fingerprint(value: Option<String>) -> Option<String> {
     let value = value?;
-    let normalized = value.trim().to_ascii_lowercase();
-    if normalized.len() == 64
-        && normalized
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    {
-        Some(normalized)
-    } else {
-        Some(INVALID_OWNER_AUTHORITY_FINGERPRINT_MARKER.to_string())
-    }
+    is_lower_hex_sha256(&value).then_some(value)
 }
 
 pub(super) fn cold_session_from_record(
@@ -423,16 +411,28 @@ pub(super) fn cold_session_from_persisted(
     persisted: &PersistedSessionRecord,
     project_instructions: Option<ProjectInstructionsSummarySnapshot>,
 ) -> Result<ColdSessionRecord, serde_json::Error> {
+    let owner_authority_fingerprint =
+        sanitize_owner_authority_fingerprint(persisted.owner_authority_fingerprint.clone())
+            .ok_or_else(|| {
+                serde_json::Error::io(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "persisted Session is missing canonical authority",
+                ))
+            })?;
+    let lifecycle = persisted.lifecycle.ok_or_else(|| {
+        serde_json::Error::io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "persisted Session is missing canonical lifecycle",
+        ))
+    })?;
     let raw = Arc::from(serde_json::value::to_raw_value(persisted)?);
     Ok(ColdSessionRecord {
         session_id: persisted.session_id.clone(),
         project: persisted.project.clone(),
-        owner_authority_fingerprint: sanitize_owner_authority_fingerprint(
-            persisted.owner_authority_fingerprint.clone(),
-        ),
+        owner_authority_fingerprint,
         mode: persisted.mode,
         guards: persisted.guards,
-        lifecycle: persisted.lifecycle,
+        lifecycle,
         updated_at: persisted.updated_at,
         context_revision: persisted.context_revision,
         project_instructions,

--- a/src/tool_runtime/sessions/store.rs
+++ b/src/tool_runtime/sessions/store.rs
@@ -456,19 +456,6 @@ impl SessionStore {
     }
 
     #[cfg(test)]
-    pub(crate) fn insert_process_local_binding_only_for_test(
-        &self,
-        key: CurrentSessionKey,
-        session_id: &str,
-    ) {
-        self.inner
-            .lock()
-            .expect("session store mutex poisoned")
-            .current_sessions
-            .insert(key, session_id.to_string());
-    }
-
-    #[cfg(test)]
     pub(crate) fn hot_payload_entry_count_for_test(&self, session_id: &str) -> Option<usize> {
         self.inner
             .lock()
@@ -528,11 +515,10 @@ impl SessionStore {
     ) -> Result<SessionSummary, String> {
         opts.execution_context = opts.execution_context.validated()?;
         #[cfg(test)]
-        if opts.project.is_some() && opts.owner_authority_fingerprint.is_none() {
-            // cfg(test)-only callers often build a synthetic project Session
-            // directly, without an AuthContext. Mark those fixtures explicitly;
-            // real runtime creation supplies a canonical fingerprint before this
-            // point, so production missing-fingerprint records still fail closed.
+        if opts.owner_authority_fingerprint.is_none() {
+            // Direct store fixtures do not have an AuthContext. Give them an
+            // explicit cfg(test)-only authority so production invariants never
+            // depend on an optional creation-time fingerprint.
             opts.owner_authority_fingerprint =
                 Some(super::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT.to_string());
         }
@@ -545,7 +531,9 @@ impl SessionStore {
         let session_id = format!("{SESSION_ID_PREFIX}{}", uuid::Uuid::new_v4().simple());
         let now = now_ts();
         let guards = SessionGuards::effective(opts.mode, opts.guards);
-        let owner_authority_fingerprint = opts.owner_authority_fingerprint;
+        let owner_authority_fingerprint = opts.owner_authority_fingerprint.ok_or_else(|| {
+            "Workflow Session creation requires a canonical authority fingerprint".to_string()
+        })?;
         let record = SessionRecord {
             session_id: session_id.clone(),
             project: opts.project,
@@ -651,48 +639,25 @@ impl SessionStore {
                 None
             };
 
-            let legacy_authority_upgrade = if let (Some(session_id), Some(authority_fingerprint)) = (
-                reusable_session_id.as_deref(),
-                request.authority_fingerprint.as_deref(),
-            ) {
+            if let Some(session_id) = reusable_session_id.as_deref() {
                 let stored_fingerprint = inner
                     .sessions
                     .get(session_id)
-                    .and_then(StoredSession::owner_authority_fingerprint);
+                    .expect("reusable session must exist")
+                    .owner_authority_fingerprint();
                 #[cfg(test)]
-                let synthetic_test_fixture = stored_fingerprint
-                    == Some(super::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT);
+                let synthetic_test_fixture =
+                    stored_fingerprint == super::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT;
                 #[cfg(not(test))]
                 let synthetic_test_fixture = false;
-                if synthetic_test_fixture {
-                    false
-                } else if let Some(stored_fingerprint) = stored_fingerprint {
-                    if stored_fingerprint != authority_fingerprint {
-                        return Err(CodingSessionError::ResumeAuthorityMismatch {
-                            session_id: session_id.to_string(),
-                        });
-                    }
-                    false
-                } else {
-                    let Some(key) = request.key.as_ref() else {
-                        return Err(CodingSessionError::LegacySessionAuthorityUnverifiable {
-                            session_id: session_id.to_string(),
-                        });
-                    };
-                    if !inner.legacy_project_session_authority_upgrade_proof(
-                        session_id,
-                        key,
-                        &request.project,
-                    ) {
-                        return Err(CodingSessionError::LegacySessionAuthorityUnverifiable {
-                            session_id: session_id.to_string(),
-                        });
-                    }
-                    true
+                if !synthetic_test_fixture
+                    && stored_fingerprint != request.authority_fingerprint.as_str()
+                {
+                    return Err(CodingSessionError::ResumeAuthorityMismatch {
+                        session_id: session_id.to_string(),
+                    });
                 }
-            } else {
-                false
-            };
+            }
 
             if let Some(session_id) = reusable_session_id {
                 let (previous_mode, previous_guards, previous_execution_context) = {
@@ -769,12 +734,6 @@ impl SessionStore {
                         .get_mut(&session_id)
                         .and_then(StoredSession::hot_mut)
                         .expect("active reusable session must stay hot before commit");
-                    if legacy_authority_upgrade {
-                        // The exact durable binding proof and every other fallible
-                        // continuation check completed above. Commit the canonical
-                        // fence with the same Session mutation/persistence generation.
-                        record.owner_authority_fingerprint = request.authority_fingerprint.clone();
-                    }
                     record.mode = request.mode;
                     record.guards = next_guards;
                     record.execution_context = next_execution_context;
@@ -1062,7 +1021,7 @@ impl SessionStore {
     pub(crate) fn session_target_authority(
         &self,
         session_id: &str,
-    ) -> Option<(Option<String>, Option<String>)> {
+    ) -> Option<(Option<String>, String)> {
         let inner = self.inner.lock().expect("session store mutex poisoned");
         inner.session_target_authority(session_id)
     }
@@ -1193,7 +1152,7 @@ impl SessionStore {
 
     /// Authoritative lifecycle check used by dispatch/kernel before mutation.
     ///
-    /// Closed/Archived sessions deny write-like, shell-like, and a small set of
+    /// Closed sessions deny write-like, shell-like, and a small set of
     /// session-local mutations (messages, checkpoint create/restore/delete).
     /// Query tools and pure reads remain allowed. `close_session` itself is
     /// never denied so repeated close stays idempotent.
@@ -2262,7 +2221,7 @@ impl SessionStore {
 ///
 /// Map fields stay private; sibling modules must use these helpers so create,
 /// bind, message, and event mutations cannot bypass the store.
-/// Tools blocked on Closed/Archived workflow sessions.
+/// Tools blocked on Closed workflow sessions.
 ///
 /// Query and pure-read tools remain allowed. Message-board mutations and
 /// session-scoped checkpoint mutations are blocked even when metadata marks
@@ -2692,7 +2651,7 @@ impl SessionStoreInner {
             .map(StoredSession::lifecycle)
             .ok_or(SessionCloseError::UnknownSession)?;
         match lifecycle {
-            SessionLifecycle::Closed | SessionLifecycle::Archived => {
+            SessionLifecycle::Closed => {
                 self.remove_bindings_for_session(session_id);
                 let Some(record) = self.sessions.get(session_id).and_then(StoredSession::hot)
                 else {
@@ -2810,27 +2769,6 @@ impl SessionStoreInner {
             .remove(&key.durable_binding_key())
             .is_some();
         process_local_removed || durable_removed
-    }
-
-    fn legacy_project_session_authority_upgrade_proof(
-        &self,
-        session_id: &str,
-        key: &CurrentSessionKey,
-        expected_project: &str,
-    ) -> bool {
-        if key.resolved_project != expected_project {
-            return false;
-        }
-        let legacy_session_matches = self.sessions.get(session_id).is_some_and(|record| {
-            record.lifecycle().allows_mutation()
-                && record.project() == Some(expected_project)
-                && record.owner_authority_fingerprint().is_none()
-        });
-        legacy_session_matches
-            && self
-                .durable_current_bindings
-                .get(&key.durable_binding_key())
-                .is_some_and(|binding| binding.session_id == session_id)
     }
 
     fn reusable_current_session_id(
@@ -3633,11 +3571,11 @@ impl SessionStoreInner {
     pub(super) fn session_target_authority(
         &self,
         session_id: &str,
-    ) -> Option<(Option<String>, Option<String>)> {
+    ) -> Option<(Option<String>, String)> {
         self.sessions.get(session_id).map(|record| {
             (
                 record.project().map(str::to_string),
-                record.owner_authority_fingerprint().map(str::to_string),
+                record.owner_authority_fingerprint().to_string(),
             )
         })
     }

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -735,7 +735,7 @@ fn coding_session_context_precommit_failure_leaves_memory_unchanged() {
         CodingSessionRequest {
             key: None,
             project: "agent:oe:private-drop".to_string(),
-            authority_fingerprint: None,
+            authority_fingerprint: TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT.to_string(),
             resume_session_id,
             instruction: Some("continue".to_string()),
             mode: SessionMode::Normal,
@@ -903,7 +903,7 @@ fn update_session_execution_context_sets_clears_and_rejects_invalid_states() {
 }
 
 #[test]
-fn archived_session_rejects_execution_context_update() {
+fn removed_lifecycle_value_is_discarded_instead_of_restored_active() {
     let tmp = tempfile::tempdir().unwrap();
     let ledger = tmp.path().join("sessions.json");
     std::fs::write(
@@ -911,9 +911,10 @@ fn archived_session_rejects_execution_context_update() {
         serde_json::to_vec_pretty(&json!({
             "version": SESSION_LEDGER_VERSION,
             "sessions": [{
-                "session_id": "wc_sess_archivedcontext01",
+                "session_id": "wc_sess_removedlifecycle01",
                 "project": "agent:oe:private-drop",
-                "title": "archived",
+                "owner_authority_fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "title": "removed lifecycle",
                 "mode": "normal",
                 "guards": {
                     "deny_write_tools": false,
@@ -931,17 +932,16 @@ fn archived_session_rejects_execution_context_update() {
     )
     .unwrap();
     let store = SessionStore::with_persistence(ledger, 10, 10);
+    assert!(store.summary("wc_sess_removedlifecycle01", None).is_none());
     assert_eq!(
         store
             .update_execution_context(
-                "wc_sess_archivedcontext01",
+                "wc_sess_removedlifecycle01",
                 SessionExecutionContext::default(),
                 SessionTransport::Api,
             )
             .unwrap_err(),
-        SessionExecutionContextUpdateError::SessionNotActive {
-            lifecycle: SessionLifecycle::Archived
-        }
+        SessionExecutionContextUpdateError::UnknownSession
     );
 }
 
@@ -3759,7 +3759,7 @@ fn ledger_round_trip_preserves_session_state_events_and_messages() {
     assert!(restored.current_session(&key).is_none());
 }
 
-// --- Workflow session lifecycle (Phase 1: field + ledger default only) ---
+// --- Workflow Session lifecycle: explicit Active/Closed authority ---
 
 #[test]
 fn new_session_defaults_lifecycle_to_active() {
@@ -3796,7 +3796,7 @@ fn persisted_ledger_writes_and_reads_lifecycle_active() {
 }
 
 #[test]
-fn durable_current_binding_legacy_ledger_without_bindings_loads_session_as_active() {
+fn durable_current_binding_legacy_ledger_without_lifecycle_is_discarded() {
     let tmp = tempfile::tempdir().unwrap();
     let ledger_path = tmp.path().join("sessions.json");
     // Pre-lifecycle JSON shape: no `lifecycle` key on the session record.
@@ -3819,22 +3819,17 @@ fn durable_current_binding_legacy_ledger_without_bindings_loads_session_as_activ
     });
     std::fs::write(&ledger_path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
 
-    // Missing field must not fail serde (#[serde(default)] → Active).
+    // Missing lifecycle/authority is tolerated at JSON decode but never inferred
+    // into an active in-memory Session.
     let restored = persistent_store(ledger_path);
     let status = restored.status();
-    assert_eq!(status.restored_sessions, 1);
+    assert_eq!(status.restored_sessions, 0);
     assert_eq!(status.durable_binding_count, 0);
     assert_eq!(status.restored_binding_count, 0);
-    assert_eq!(status.discarded_binding_count, 0);
     assert_eq!(status.last_persist_error, None);
-
-    let summary = restored
+    assert!(restored
         .summary("wc_sess_legacylifecycle01", Some(10))
-        .unwrap();
-    assert_eq!(summary.lifecycle, SessionLifecycle::Active);
-    assert_eq!(summary.project.as_deref(), Some("proj-legacy"));
-    assert_eq!(summary.title.as_deref(), Some("old row"));
-    assert_eq!(summary.mode, SessionMode::Normal);
+        .is_none());
 }
 
 #[test]
@@ -3960,11 +3955,12 @@ fn durable_current_binding_restore_enforces_bounded_count() {
 }
 
 #[test]
-fn persisted_session_record_serde_defaults_missing_lifecycle() {
-    // Direct serde check: omit lifecycle entirely; deserialize succeeds as Active.
+fn persisted_session_record_missing_lifecycle_is_fail_closed() {
+    // Deserialize the row without poisoning the ledger, but never infer Active.
     let json = r#"{
         "session_id": "wc_sess_serde_default_ok",
         "project": null,
+        "owner_authority_fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "title": null,
         "mode": "normal",
         "guards": {"deny_write_tools": false, "deny_shell_tools": false},
@@ -3974,7 +3970,26 @@ fn persisted_session_record_serde_defaults_missing_lifecycle() {
         "messages": []
     }"#;
     let record: PersistedSessionRecord = serde_json::from_str(json).unwrap();
-    assert_eq!(record.lifecycle, SessionLifecycle::Active);
+    assert_eq!(record.lifecycle, None);
+    let malformed = json.replace(
+        "\"created_at\": 10,",
+        "\"lifecycle\": {\"removed\": true}, \"created_at\": 10,",
+    );
+    let malformed_record: PersistedSessionRecord = serde_json::from_str(&malformed).unwrap();
+    assert_eq!(malformed_record.lifecycle, None);
+    let uppercase_authority = json.replace(
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    );
+    let uppercase_record: PersistedSessionRecord =
+        serde_json::from_str(&uppercase_authority).unwrap();
+    assert!(uppercase_record.into_record(10).is_none());
+    let padded_authority = json.replace(
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        " bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ",
+    );
+    let padded_record: PersistedSessionRecord = serde_json::from_str(&padded_authority).unwrap();
+    assert!(padded_record.into_record(10).is_none());
     assert!(record.session_id.starts_with(SESSION_ID_PREFIX));
 
     let ledger_json = format!(
@@ -3985,12 +4000,16 @@ fn persisted_session_record_serde_defaults_missing_lifecycle() {
     let ledger: PersistedSessionLedger = serde_json::from_str(&ledger_json).unwrap();
     assert_eq!(ledger.version, SESSION_LEDGER_VERSION);
     assert_eq!(ledger.sessions.len(), 1);
-    assert_eq!(
-        ledger.sessions[0].hot().unwrap().lifecycle,
-        SessionLifecycle::Active
-    );
+    assert_eq!(ledger.sessions[0].hot().unwrap().lifecycle, None);
     assert!(ledger.durable_current_bindings.records.is_empty());
     assert_eq!(ledger.durable_current_bindings.malformed_count, 0);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger_path = tmp.path().join("missing-lifecycle.json");
+    std::fs::write(&ledger_path, ledger_json).unwrap();
+    let restored = SessionStore::with_persistence(ledger_path, 10, 10);
+    assert!(restored.summary("wc_sess_serde_default_ok", None).is_none());
+    assert_eq!(restored.status().restored_sessions, 0);
 }
 
 #[test]
@@ -4004,14 +4023,9 @@ fn session_lifecycle_wire_values_are_snake_case() {
         json!("closed")
     );
     assert_eq!(
-        serde_json::to_value(SessionLifecycle::Archived).unwrap(),
-        json!("archived")
-    );
-    assert_eq!(
         serde_json::from_value::<SessionLifecycle>(json!("active")).unwrap(),
         SessionLifecycle::Active
     );
-    assert_eq!(SessionLifecycle::default(), SessionLifecycle::Active);
 }
 
 // --- Workflow session lifecycle (Phase 2: explicit close) ---

--- a/src/tool_runtime/tests/collaboration.rs
+++ b/src/tool_runtime/tests/collaboration.rs
@@ -11,6 +11,7 @@ use crate::auth::AuthContext;
 use crate::client_window::ClientWindow;
 use crate::shell_protocol::ShellClientCapabilities;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 async fn call_with_recorder(
@@ -1904,27 +1905,54 @@ async fn projectless_owner_fingerprint_survives_restart_without_raw_principal_ma
 }
 
 #[tokio::test]
-async fn legacy_persisted_projectless_session_without_owner_fails_closed_for_authenticated_caller()
-{
+async fn legacy_projectless_owner_hash_is_not_accepted_after_restart() {
     let dir = tempfile::tempdir().unwrap();
     let ledger = dir.path().join("sessions.json");
-    let store = sessions::SessionStore::with_persistence(
-        &ledger,
-        sessions::DEFAULT_MAX_SESSIONS,
-        sessions::DEFAULT_MAX_EVENTS_PER_SESSION,
-    );
-    let legacy = store.start_session(None, Some("legacy project-less".to_string()));
-    store.flush_persistence();
-    let persisted = std::fs::read_to_string(&ledger).unwrap();
-    assert!(!persisted.contains("owner_authority_fingerprint"));
-    drop(store);
-
-    let runtime = test_runtime().with_session_ledger(&ledger);
     let alice = shared_key_auth_context("legacy-owner-alice");
-    let denied = call_with_recorder(
+    let runtime = test_runtime().with_session_ledger(&ledger);
+    let started = call_with_recorder(
         &runtime,
+        "start_session",
+        json!({"title": "canonical project-less Session"}),
+        None,
+        &alice,
+        None,
+    )
+    .await;
+    assert!(started.success, "{:?}", started.error);
+    let session_id = started.output["session_id"].as_str().unwrap().to_string();
+    runtime.sessions.flush_persistence();
+    drop(runtime);
+
+    let authority_id = alice.shared_key_hash.as_deref().unwrap();
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex.workflow-session-owner.v1\0");
+    hasher.update(alice.principal_kind().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(authority_id.as_bytes());
+    let legacy_fingerprint = format!("{:x}", hasher.finalize());
+    let canonical_fingerprint =
+        super::super::session_context::workflow_session_authority_fingerprint(Some(&alice))
+            .unwrap();
+    assert_ne!(legacy_fingerprint, canonical_fingerprint);
+
+    let mut persisted: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
+    let row = persisted["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|row| row["session_id"] == session_id)
+        .unwrap();
+    row["owner_authority_fingerprint"] = Value::String(legacy_fingerprint);
+    std::fs::write(&ledger, serde_json::to_vec_pretty(&persisted).unwrap()).unwrap();
+
+    let restored = test_runtime().with_session_ledger(&ledger);
+    assert!(restored.sessions.summary(&session_id, None).is_some());
+    let denied = call_with_recorder(
+        &restored,
         "session_summary",
-        json!({"session_id": legacy.session_id}),
+        json!({"session_id": session_id}),
         None,
         &alice,
         None,
@@ -1932,10 +1960,6 @@ async fn legacy_persisted_projectless_session_without_owner_fails_closed_for_aut
     .await;
     assert!(!denied.success);
     assert_eq!(denied.output["error_kind"], "session_authority_denied");
-
-    // The trusted local/dev path retains compatibility for legacy project-less
-    // records; the new authenticated boundary is the fail-closed change.
-    assert!(runtime.sessions.summary(&legacy.session_id, None).is_some());
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/continuation_feedback.rs
+++ b/src/tool_runtime/tests/continuation_feedback.rs
@@ -2278,7 +2278,8 @@ fn add_instruction(runtime: &ToolRuntime, session_id: &str, instruction: &str, m
         .ensure_coding_session(sessions::CodingSessionRequest {
             key: None,
             project: "test-project".to_string(),
-            authority_fingerprint: None,
+            authority_fingerprint: sessions::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT
+                .to_string(),
             resume_session_id: Some(session_id.to_string()),
             instruction: Some(instruction.to_string()),
             mode,
@@ -2404,7 +2405,8 @@ fn add_instruction_for(
         .ensure_coding_session(sessions::CodingSessionRequest {
             key: None,
             project: project.to_string(),
-            authority_fingerprint: None,
+            authority_fingerprint: sessions::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT
+                .to_string(),
             resume_session_id: Some(session_id.to_string()),
             instruction: Some(instruction.to_string()),
             mode,

--- a/src/tool_runtime/tests/handoff_brief.rs
+++ b/src/tool_runtime/tests/handoff_brief.rs
@@ -44,7 +44,9 @@ fn add_instruction_for_project(
         .ensure_coding_session(CodingSessionRequest {
             key: None,
             project: project.to_string(),
-            authority_fingerprint: None,
+            authority_fingerprint:
+                crate::tool_runtime::sessions::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT
+                    .to_string(),
             resume_session_id: Some(session_id.to_string()),
             instruction: Some(instruction.to_string()),
             mode: SessionMode::Normal,

--- a/src/tool_runtime/tests/reconnect.rs
+++ b/src/tool_runtime/tests/reconnect.rs
@@ -510,21 +510,13 @@ async fn durable_current_binding_restores_same_window_after_restart() {
 }
 
 #[tokio::test]
-async fn legacy_project_session_authority_migrates_via_work_on_project_and_persists() {
+async fn canonical_project_session_explicit_resume_survives_restart() {
     let dir = tempfile::tempdir().unwrap();
     let ledger = dir.path().join("sessions.json");
     let project_root = dir.path().join("proj");
     std::fs::create_dir_all(&project_root).unwrap();
     init_git_repo(&project_root);
-    let alice = shared_key_auth_context("legacy-migration-alice");
-    let alice_oauth = oauth_bridge_auth_context(
-        "legacy-migration-alice",
-        &[
-            crate::auth::SCOPE_RUNTIME_READ,
-            crate::auth::SCOPE_PROJECT_READ,
-            crate::auth::SCOPE_PROJECT_WRITE,
-        ],
-    );
+    let alice = shared_key_auth_context("canonical-restart-alice");
     let expected_fingerprint =
         super::super::session_context::workflow_session_authority_fingerprint(Some(&alice))
             .unwrap();
@@ -532,7 +524,7 @@ async fn legacy_project_session_authority_migrates_via_work_on_project_and_persi
     let runtime1 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
     let project = register_agent_project_at_path_with_auth(
         &runtime1,
-        "legacy-migration-agent",
+        "canonical-restart-agent",
         "proj",
         &project_root,
         &alice,
@@ -540,10 +532,10 @@ async fn legacy_project_session_authority_migrates_via_work_on_project_and_persi
     .await;
     let started = dispatch_start_coding_task_in_window(
         &runtime1,
-        "legacy-migration-agent",
-        coding_start_call(&project, "legacy root", SessionMode::Normal, false),
+        "canonical-restart-agent",
+        coding_start_call(&project, "canonical root", SessionMode::Normal, false),
         Some(&alice),
-        "legacy-migration-window",
+        "canonical-restart-window",
     )
     .await;
     assert!(started.success, "{:?}", started.error);
@@ -552,174 +544,55 @@ async fn legacy_project_session_authority_migrates_via_work_on_project_and_persi
         .unwrap()
         .to_string();
     runtime1.sessions.flush_persistence();
-    drop(runtime1);
-    rewrite_persisted_session_as_legacy(&ledger, &session_id, true);
-    assert_eq!(
-        persisted_session_authority_fingerprint(&ledger, &session_id),
-        None
-    );
-
-    let runtime2 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
-    register_agent_project_at_path_with_auth(
-        &runtime2,
-        "legacy-migration-agent",
-        "proj",
-        &project_root,
-        &alice,
-    )
-    .await;
-    assert_eq!(runtime2.sessions.process_local_binding_count_for_test(), 0);
-    assert_eq!(runtime2.sessions.status().restored_binding_count, 1);
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        None
-    );
-
-    let denied_before_migration = runtime2
-        .dispatch_with_auth(
-            ToolCall::SessionSummary {
-                session_id: session_id.clone(),
-                limit: None,
-            },
-            Some(&alice),
-        )
-        .await;
-    assert!(!denied_before_migration.success);
-    assert_eq!(
-        denied_before_migration.output["error_kind"],
-        "session_authority_denied"
-    );
-
-    // The old durable CurrentSessionKey is intentionally presentation-specific.
-    // Canonical shared-key grouping applies only after this one-time migration.
-    let oauth_first = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-migration-agent",
-        work_on_project_resume_call(&project, "oauth cannot claim legacy binding", &session_id),
-        Some(&alice_oauth),
-        "legacy-migration-window",
-    )
-    .await;
-    assert!(!oauth_first.success);
-    assert_eq!(
-        oauth_first.output["error_kind"],
-        "legacy_session_authority_unverifiable"
-    );
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        None
-    );
-
-    let migrated = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-migration-agent",
-        work_on_project_resume_call(&project, "legacy migration continuation", &session_id),
-        Some(&alice),
-        "legacy-migration-window",
-    )
-    .await;
-    assert!(migrated.success, "{:?}", migrated.error);
-    assert_eq!(
-        runtime2
-            .sessions
-            .active_session_count_for_test(Some(&project)),
-        1
-    );
-    let authority = runtime2
-        .sessions
-        .session_target_authority(&session_id)
-        .unwrap();
-    assert_eq!(authority.0.as_deref(), Some(project.as_str()));
-    assert_eq!(authority.1.as_deref(), Some(expected_fingerprint.as_str()));
-    let summary = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    assert_eq!(
-        summary
-            .events
-            .iter()
-            .filter(|event| event.kind == "task_instruction")
-            .count(),
-        2
-    );
-
-    let discussion = runtime2
-        .dispatch_with_auth(
-            ToolCall::SessionDiscussionSummary {
-                session_id: session_id.clone(),
-                limit: Some(10),
-            },
-            Some(&alice),
-        )
-        .await;
-    assert!(discussion.success, "{:?}", discussion.error);
-    runtime2.sessions.flush_persistence();
     assert_eq!(
         persisted_session_authority_fingerprint(&ledger, &session_id).as_deref(),
         Some(expected_fingerprint.as_str())
     );
-    drop(runtime2);
+    drop(runtime1);
 
-    let runtime3 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
+    let runtime2 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
     register_agent_project_at_path_with_auth(
-        &runtime3,
-        "legacy-migration-agent",
+        &runtime2,
+        "canonical-restart-agent",
         "proj",
         &project_root,
         &alice,
     )
     .await;
+    assert_eq!(runtime2.sessions.status().restored_sessions, 1);
+    let resumed = dispatch_start_coding_task_in_window(
+        &runtime2,
+        "canonical-restart-agent",
+        coding_resume_call(&project, "explicit canonical resume", &session_id, false),
+        Some(&alice),
+        "canonical-restart-window",
+    )
+    .await;
+    assert!(resumed.success, "{:?}", resumed.error);
+    assert_eq!(resumed.output["session"]["session_id"], session_id);
     assert_eq!(
-        runtime3
+        runtime2
             .sessions
             .session_target_authority(&session_id)
             .unwrap()
-            .1
-            .as_deref(),
-        Some(expected_fingerprint.as_str())
+            .1,
+        expected_fingerprint
     );
-    let alice_read = runtime3
-        .dispatch_with_auth(
-            ToolCall::SessionSummary {
-                session_id: session_id.clone(),
-                limit: None,
-            },
-            Some(&alice),
-        )
-        .await;
-    assert!(alice_read.success, "{:?}", alice_read.error);
-
-    let oauth_read = runtime3
-        .dispatch_with_auth(
-            ToolCall::SessionSummary {
-                session_id,
-                limit: None,
-            },
-            Some(&alice_oauth),
-        )
-        .await;
-    assert!(oauth_read.success, "{:?}", oauth_read.error);
 }
 
 #[tokio::test]
-async fn legacy_project_session_authority_requires_historical_durable_binding() {
+async fn missing_authority_with_exact_durable_binding_is_discarded_without_upgrade() {
     let dir = tempfile::tempdir().unwrap();
     let ledger = dir.path().join("sessions.json");
     let project_root = dir.path().join("proj");
     std::fs::create_dir_all(&project_root).unwrap();
     init_git_repo(&project_root);
-    let alice = shared_key_auth_context("legacy-no-proof-alice");
+    let alice = shared_key_auth_context("missing-authority-alice");
 
     let runtime1 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
     let project = register_agent_project_at_path_with_auth(
         &runtime1,
-        "legacy-no-proof-agent",
+        "missing-authority-agent",
         "proj",
         &project_root,
         &alice,
@@ -727,10 +600,10 @@ async fn legacy_project_session_authority_requires_historical_durable_binding() 
     .await;
     let started = dispatch_start_coding_task_in_window(
         &runtime1,
-        "legacy-no-proof-agent",
-        coding_start_call(&project, "legacy root", SessionMode::Normal, false),
+        "missing-authority-agent",
+        coding_start_call(&project, "canonical root", SessionMode::Normal, false),
         Some(&alice),
-        "legacy-no-proof-window",
+        "missing-authority-window",
     )
     .await;
     assert!(started.success, "{:?}", started.error);
@@ -740,77 +613,61 @@ async fn legacy_project_session_authority_requires_historical_durable_binding() 
         .to_string();
     runtime1.sessions.flush_persistence();
     drop(runtime1);
-    rewrite_persisted_session_as_legacy(&ledger, &session_id, false);
 
+    rewrite_persisted_session_as_legacy(&ledger, &session_id, true);
+    let legacy_bytes = std::fs::read(&ledger).unwrap();
     let runtime2 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
     register_agent_project_at_path_with_auth(
         &runtime2,
-        "legacy-no-proof-agent",
+        "missing-authority-agent",
         "proj",
         &project_root,
         &alice,
     )
     .await;
-    assert_eq!(runtime2.sessions.status().durable_binding_count, 0);
-    let process_local_key = super::super::session_context::current_session_key(
-        Some(&alice),
-        crate::tool_runtime::sessions::SessionTransport::Mcp,
-        &project,
-        &project_root.to_string_lossy(),
-        Some(&ClientWindow::for_test("legacy-no-proof-window")),
-    )
-    .unwrap();
-    runtime2
+    let status = runtime2.sessions.status();
+    assert_eq!(status.restored_sessions, 0);
+    assert_eq!(status.restored_binding_count, 0);
+    assert!(status.discarded_binding_count >= 1);
+    assert!(runtime2.sessions.summary(&session_id, None).is_none());
+    assert!(runtime2
         .sessions
-        .insert_process_local_binding_only_for_test(process_local_key, &session_id);
-    assert_eq!(runtime2.sessions.process_local_binding_count_for_test(), 1);
-    assert_eq!(runtime2.sessions.status().durable_binding_count, 0);
-    let before = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
+        .session_target_authority(&session_id)
+        .is_none());
+
     let denied = dispatch_start_coding_task_in_window(
         &runtime2,
-        "legacy-no-proof-agent",
-        coding_resume_call(&project, "must not claim by id", &session_id, false),
+        "missing-authority-agent",
+        coding_resume_call(&project, "must not upgrade", &session_id, false),
         Some(&alice),
-        "legacy-no-proof-window",
+        "missing-authority-window",
     )
     .await;
     assert!(!denied.success);
-    assert_eq!(
-        denied.output["error_kind"],
-        "legacy_session_authority_unverifiable"
-    );
-    assert_eq!(denied.output["state_changed"], false);
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        None
-    );
-    let after = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    assert_eq!(after.events.len(), before.events.len());
+    assert_eq!(denied.output["error_kind"], "unknown_session_id");
     assert_eq!(
         runtime2
             .sessions
             .active_session_count_for_test(Some(&project)),
-        1
+        0
     );
+    runtime2.sessions.flush_persistence();
+    assert_eq!(std::fs::read(&ledger).unwrap(), legacy_bytes);
 }
 
 #[tokio::test]
-async fn legacy_project_session_authority_malformed_fingerprint_is_not_migratable() {
+async fn malformed_persisted_authority_is_discarded_fail_closed() {
     let dir = tempfile::tempdir().unwrap();
     let ledger = dir.path().join("sessions.json");
     let project_root = dir.path().join("proj");
     std::fs::create_dir_all(&project_root).unwrap();
     init_git_repo(&project_root);
-    let alice = shared_key_auth_context("legacy-malformed-alice");
+    let alice = shared_key_auth_context("malformed-authority-alice");
 
     let runtime1 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
     let project = register_agent_project_at_path_with_auth(
         &runtime1,
-        "legacy-malformed-agent",
+        "malformed-authority-agent",
         "proj",
         &project_root,
         &alice,
@@ -818,10 +675,10 @@ async fn legacy_project_session_authority_malformed_fingerprint_is_not_migratabl
     .await;
     let started = dispatch_start_coding_task_in_window(
         &runtime1,
-        "legacy-malformed-agent",
-        coding_start_call(&project, "malformed root", SessionMode::Normal, false),
+        "malformed-authority-agent",
+        coding_start_call(&project, "canonical root", SessionMode::Normal, false),
         Some(&alice),
-        "legacy-malformed-window",
+        "malformed-authority-window",
     )
     .await;
     assert!(started.success, "{:?}", started.error);
@@ -834,374 +691,12 @@ async fn legacy_project_session_authority_malformed_fingerprint_is_not_migratabl
     rewrite_persisted_session_with_malformed_authority(&ledger, &session_id);
 
     let runtime2 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
-    register_agent_project_at_path_with_auth(
-        &runtime2,
-        "legacy-malformed-agent",
-        "proj",
-        &project_root,
-        &alice,
-    )
-    .await;
-    let restored_authority = runtime2
-        .sessions
-        .session_target_authority(&session_id)
-        .unwrap()
-        .1;
-    assert!(restored_authority.is_some());
-    assert_ne!(
-        restored_authority.as_deref(),
-        Some(
-            super::super::session_context::workflow_session_authority_fingerprint(Some(&alice))
-                .unwrap()
-                .as_str()
-        )
-    );
-    let before = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    let denied = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-malformed-agent",
-        coding_resume_call(&project, "must not migrate malformed", &session_id, false),
-        Some(&alice),
-        "legacy-malformed-window",
-    )
-    .await;
-    assert!(!denied.success);
-    assert_eq!(denied.output["error_kind"], "session_authority_denied");
-    assert_eq!(denied.output["state_changed"], false);
-    let after = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    assert_eq!(after.events.len(), before.events.len());
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        restored_authority
-    );
-    runtime2.sessions.flush_persistence();
-    drop(runtime2);
-
-    let runtime3 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
-    assert!(runtime3
-        .sessions
-        .session_target_authority(&session_id)
-        .unwrap()
-        .1
-        .is_some());
-}
-
-#[tokio::test]
-async fn legacy_project_session_authority_binding_proof_is_window_and_transport_exact() {
-    let dir = tempfile::tempdir().unwrap();
-    let ledger = dir.path().join("sessions.json");
-    let project_root = dir.path().join("proj");
-    std::fs::create_dir_all(&project_root).unwrap();
-    init_git_repo(&project_root);
-    let alice = shared_key_auth_context("legacy-exact-proof-alice");
-
-    let runtime1 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
-    let project = register_agent_project_at_path_with_auth(
-        &runtime1,
-        "legacy-exact-proof-agent",
-        "proj",
-        &project_root,
-        &alice,
-    )
-    .await;
-    let started = dispatch_start_coding_task_in_window(
-        &runtime1,
-        "legacy-exact-proof-agent",
-        coding_start_call(&project, "legacy root", SessionMode::Normal, false),
-        Some(&alice),
-        "legacy-exact-window",
-    )
-    .await;
-    assert!(started.success, "{:?}", started.error);
-    let session_id = started.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    runtime1.sessions.flush_persistence();
-    drop(runtime1);
-    rewrite_persisted_session_as_legacy(&ledger, &session_id, true);
-
-    let runtime2 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
-    register_agent_project_at_path_with_auth(
-        &runtime2,
-        "legacy-exact-proof-agent",
-        "proj",
-        &project_root,
-        &alice,
-    )
-    .await;
-    let before = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    let wrong_window = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-exact-proof-agent",
-        coding_resume_call(&project, "wrong window", &session_id, false),
-        Some(&alice),
-        "legacy-other-window",
-    )
-    .await;
-    assert!(!wrong_window.success);
-    assert_eq!(
-        wrong_window.output["error_kind"],
-        "legacy_session_authority_unverifiable"
-    );
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        None
-    );
-
-    let wrong_transport = dispatch_start_coding_task_in_window_with_transport(
-        &runtime2,
-        "legacy-exact-proof-agent",
-        coding_resume_call(&project, "wrong transport", &session_id, false),
-        Some(&alice),
-        "legacy-exact-window",
-        crate::tool_runtime::sessions::SessionTransport::Api,
-    )
-    .await;
-    assert!(!wrong_transport.success);
-    assert_eq!(
-        wrong_transport.output["error_kind"],
-        "legacy_session_authority_unverifiable"
-    );
-    let after_denials = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    assert_eq!(after_denials.events.len(), before.events.len());
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        None
-    );
-
-    let exact = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-exact-proof-agent",
-        coding_resume_call(&project, "exact historical proof", &session_id, false),
-        Some(&alice),
-        "legacy-exact-window",
-    )
-    .await;
-    assert!(exact.success, "{:?}", exact.error);
-    assert_eq!(exact.output["session"]["session_id"], session_id);
+    assert_eq!(runtime2.sessions.status().restored_sessions, 0);
+    assert!(runtime2.sessions.summary(&session_id, None).is_none());
     assert!(runtime2
         .sessions
         .session_target_authority(&session_id)
-        .unwrap()
-        .1
-        .is_some());
-}
-
-#[tokio::test]
-async fn legacy_project_session_authority_upgrade_is_atomic_with_failed_continuation() {
-    let dir = tempfile::tempdir().unwrap();
-    let ledger = dir.path().join("sessions.json");
-    let project_root = dir.path().join("proj");
-    std::fs::create_dir_all(&project_root).unwrap();
-    init_git_repo(&project_root);
-    let alice = shared_key_auth_context("legacy-atomic-alice");
-
-    let runtime1 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
-    let project = register_agent_project_at_path_with_auth(
-        &runtime1,
-        "legacy-atomic-agent",
-        "proj",
-        &project_root,
-        &alice,
-    )
-    .await;
-    let started = dispatch_start_coding_task_in_window(
-        &runtime1,
-        "legacy-atomic-agent",
-        coding_start_call(&project, "legacy root", SessionMode::Normal, false),
-        Some(&alice),
-        "legacy-atomic-window",
-    )
-    .await;
-    assert!(started.success, "{:?}", started.error);
-    let session_id = started.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    runtime1.sessions.flush_persistence();
-    drop(runtime1);
-    rewrite_persisted_session_as_legacy(&ledger, &session_id, true);
-    let ledger_before_failure = std::fs::read(&ledger).unwrap();
-
-    let runtime2 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
-    register_agent_project_at_path_with_auth(
-        &runtime2,
-        "legacy-atomic-agent",
-        "proj",
-        &project_root,
-        &alice,
-    )
-    .await;
-    let before = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    runtime2
-        .sessions
-        .fail_next_coding_continuity_precommit_for_test();
-    let failed = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-atomic-agent",
-        coding_resume_call(&project, "atomic migration", &session_id, false),
-        Some(&alice),
-        "legacy-atomic-window",
-    )
-    .await;
-    assert!(!failed.success);
-    assert_eq!(
-        failed.output["error_kind"],
-        "coding_continuity_commit_failed"
-    );
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        None
-    );
-    let after_failure = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    assert_eq!(after_failure.events.len(), before.events.len());
-    assert_eq!(runtime2.sessions.status().durable_binding_count, 1);
-    runtime2.sessions.flush_persistence();
-    assert_eq!(std::fs::read(&ledger).unwrap(), ledger_before_failure);
-
-    let retried = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-atomic-agent",
-        coding_resume_call(&project, "atomic migration", &session_id, false),
-        Some(&alice),
-        "legacy-atomic-window",
-    )
-    .await;
-    assert!(retried.success, "{:?}", retried.error);
-    assert!(runtime2
-        .sessions
-        .session_target_authority(&session_id)
-        .unwrap()
-        .1
-        .is_some());
-    let after_retry = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    assert_eq!(
-        after_retry
-            .events
-            .iter()
-            .filter(|event| event.instruction.as_deref() == Some("atomic migration"))
-            .count(),
-        1
-    );
-}
-
-#[tokio::test]
-async fn legacy_project_session_authority_rejects_recycled_project_without_exact_binding() {
-    let dir = tempfile::tempdir().unwrap();
-    let ledger = dir.path().join("sessions.json");
-    let project_root = dir.path().join("proj");
-    std::fs::create_dir_all(&project_root).unwrap();
-    init_git_repo(&project_root);
-    let shell_clients = Arc::new(
-        crate::shell_client::ShellClientRegistry::with_shared_key_limits_for_test(4, 8, 1),
-    );
-    let alice = shared_key_auth_context("legacy-recycled-authority-a");
-    let bob = shared_key_auth_context("legacy-recycled-authority-b");
-
-    let runtime1 = ToolRuntime::new_for_tests_with_shell_clients(shell_clients.clone())
-        .with_session_ledger(&ledger);
-    let project = register_agent_project_at_path_with_auth(
-        &runtime1,
-        "legacy-recycled-client",
-        "recycled-project",
-        &project_root,
-        &alice,
-    )
-    .await;
-    let started = dispatch_start_coding_task_in_window(
-        &runtime1,
-        "legacy-recycled-client",
-        coding_start_call(&project, "legacy recycled root", SessionMode::Normal, false),
-        Some(&alice),
-        "legacy-recycled-window",
-    )
-    .await;
-    assert!(started.success, "{:?}", started.error);
-    let session_id = started.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    runtime1.sessions.flush_persistence();
-    drop(runtime1);
-    rewrite_persisted_session_as_legacy(&ledger, &session_id, true);
-
-    let runtime2 = ToolRuntime::new_for_tests_with_shell_clients(shell_clients.clone())
-        .with_session_ledger(&ledger);
-    let expired_at = chrono::Utc::now().timestamp() - 100;
-    shell_clients
-        .set_last_seen_for_test("legacy-recycled-client", expired_at)
-        .await;
-    let _ = shell_clients.list_clients_for_auth(Some(&alice)).await;
-    assert!(shell_clients
-        .get_client_view("legacy-recycled-client")
-        .await
         .is_none());
-    let recycled_project = register_agent_project_at_path_with_auth(
-        &runtime2,
-        "legacy-recycled-client",
-        "recycled-project",
-        &project_root,
-        &bob,
-    )
-    .await;
-    assert_eq!(recycled_project, project);
-
-    let before = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    let denied_resume = dispatch_start_coding_task_in_window(
-        &runtime2,
-        "legacy-recycled-client",
-        coding_resume_call(&project, "Bob must not claim", &session_id, false),
-        Some(&bob),
-        "legacy-recycled-window",
-    )
-    .await;
-    assert!(!denied_resume.success);
-    assert_eq!(
-        denied_resume.output["error_kind"],
-        "legacy_session_authority_unverifiable"
-    );
-    assert_eq!(denied_resume.output["state_changed"], false);
-
-    let denied_read = runtime2
-        .dispatch_with_auth(
-            ToolCall::SessionSummary {
-                session_id: session_id.clone(),
-                limit: None,
-            },
-            Some(&bob),
-        )
-        .await;
-    assert!(!denied_read.success);
-    assert_eq!(denied_read.output["error_kind"], "session_authority_denied");
-    assert_eq!(
-        runtime2
-            .sessions
-            .session_target_authority(&session_id)
-            .unwrap()
-            .1,
-        None
-    );
-    let after = runtime2.sessions.summary(&session_id, Some(20)).unwrap();
-    assert_eq!(after.events.len(), before.events.len());
-    assert_eq!(after.messages.total, before.messages.total);
-    assert_eq!(after.lifecycle, before.lifecycle);
 }
 
 #[tokio::test]
@@ -1997,18 +1492,6 @@ fn coding_resume_call(
         bind_current,
         new_session: false,
         execution_context: None,
-    }
-}
-
-fn work_on_project_resume_call(project: &str, instruction: &str, session_id: &str) -> ToolCall {
-    ToolCall::WorkOnProject {
-        project: project.to_string(),
-        client_id: None,
-        path: None,
-        instruction: instruction.to_string(),
-        include_project_instructions: true,
-        include_workflow_guidance: true,
-        session_id: Some(session_id.to_string()),
     }
 }
 


### PR DESCRIPTION
## Summary

Canonicalize the Workflow Session authority and lifecycle contract for the 0.4 development line.

- remove legacy project-less owner-hash verification
- remove durable-current-binding authority upgrade and `LegacySessionAuthorityUnverifiable`
- require canonical creation-time authority for mutable/restored Sessions
- make durable current bindings continuity selection only, never authority proof
- collapse lifecycle to `active | closed` and reject missing/unknown/removed lifecycle rows fail-closed
- preserve canonical v0.3.9-shaped active/closed rows, project authorization separation, privacy, collaboration and continuity semantics

## Validation

Fresh independent review accepted the commit as-is.

- focused implementation suite: 79/79 passed
- reviewer-selected authority/lifecycle restart and negative regressions: 10/10 passed
- `cargo check --all-targets`
- `cargo fmt -- --check`
- `git diff --check`
- clean worktree, 0 conflicts, 0 active Jobs
