### PR TITLE
Add Project Memory lifecycle and provenance

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -29,11 +29,12 @@ pub(crate) use self::execution_model::{
 };
 pub(crate) use self::memory::{
     canonicalize_memory_tags, memory_catalog_revision, valid_memory_catalog_revision,
-    validate_memory_query, validate_memory_revision, MemoryPriority, MemorySetInput,
-    MemoryStoreError, ProjectMemoryRecord, MAX_MEMORY_BODY_BYTES, MAX_MEMORY_BOOTSTRAP_BYTES,
-    MAX_MEMORY_KEY_CHARS, MAX_MEMORY_QUERY_CHARS, MAX_MEMORY_SEARCH_LIMIT,
-    MAX_MEMORY_SEARCH_RESULT_BYTES, MAX_MEMORY_SUMMARY_CHARS, MAX_MEMORY_TAGS,
-    MAX_MEMORY_TAG_CHARS,
+    validate_memory_query, validate_memory_revision, validate_memory_scope_id,
+    MemoryPrincipalAttribution, MemoryPriority, MemoryScopeAttribution, MemorySetInput,
+    MemoryStoreError, ProjectMemoryRecord, ProjectMemoryScopeRecord, MAX_MEMORY_BODY_BYTES,
+    MAX_MEMORY_BOOTSTRAP_BYTES, MAX_MEMORY_KEY_CHARS, MAX_MEMORY_QUERY_CHARS,
+    MAX_MEMORY_SCOPE_LIST_LIMIT, MAX_MEMORY_SEARCH_LIMIT, MAX_MEMORY_SEARCH_RESULT_BYTES,
+    MAX_MEMORY_SUMMARY_CHARS, MAX_MEMORY_TAGS, MAX_MEMORY_TAG_CHARS,
 };
 #[cfg(test)]
 pub(crate) use self::memory::{

--- a/src/db.rs
+++ b/src/db.rs
@@ -31,15 +31,15 @@ pub(crate) use self::memory::{
     canonicalize_memory_tags, memory_catalog_revision, valid_memory_catalog_revision,
     validate_memory_query, validate_memory_revision, validate_memory_scope_id,
     MemoryPrincipalAttribution, MemoryPriority, MemoryScopeAttribution, MemorySetInput,
-    MemoryStoreError, ProjectMemoryRecord, ProjectMemoryScopeRecord, MAX_MEMORY_BODY_BYTES,
-    MAX_MEMORY_BOOTSTRAP_BYTES, MAX_MEMORY_KEY_CHARS, MAX_MEMORY_QUERY_CHARS,
-    MAX_MEMORY_SCOPE_LIST_LIMIT, MAX_MEMORY_SEARCH_LIMIT, MAX_MEMORY_SEARCH_RESULT_BYTES,
-    MAX_MEMORY_SUMMARY_CHARS, MAX_MEMORY_TAGS, MAX_MEMORY_TAG_CHARS,
+    MemoryStoreError, ProjectMemoryRecord, ProjectMemoryScopeRecord, MAX_MEMORIES_GLOBAL,
+    MAX_MEMORY_BODY_BYTES, MAX_MEMORY_BOOTSTRAP_BYTES, MAX_MEMORY_KEY_CHARS,
+    MAX_MEMORY_QUERY_CHARS, MAX_MEMORY_SCOPE_LIST_LIMIT, MAX_MEMORY_SEARCH_LIMIT,
+    MAX_MEMORY_SEARCH_RESULT_BYTES, MAX_MEMORY_SUMMARY_CHARS, MAX_MEMORY_TAGS,
+    MAX_MEMORY_TAG_CHARS,
 };
 #[cfg(test)]
 pub(crate) use self::memory::{
-    validate_memory_body, validate_memory_key, validate_memory_summary, MAX_MEMORIES_GLOBAL,
-    MAX_MEMORIES_PER_PROJECT,
+    validate_memory_body, validate_memory_key, validate_memory_summary, MAX_MEMORIES_PER_PROJECT,
 };
 pub use self::oauth::RotateResult;
 pub(crate) use self::task_kernel::{

--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -15,12 +15,35 @@ pub(crate) const MAX_MEMORY_QUERY_CHARS: usize = 200;
 pub(crate) const MAX_MEMORY_SEARCH_LIMIT: usize = 50;
 pub(crate) const MAX_MEMORY_BOOTSTRAP_BYTES: usize = 8 * 1024;
 pub(crate) const MAX_MEMORY_SEARCH_RESULT_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_MEMORY_SCOPE_LIST_LIMIT: usize = 100;
 
 const MEMORY_ID_PREFIX: &str = "wc_mem_";
 const MEMORY_DEFINITION_HASH_PREFIX: &str = "wc_memdef_";
 const MEMORY_REVISION_PREFIX: &str = "wc_memrev_";
 const MEMORY_CATALOG_REVISION_PREFIX: &str = "wc_memcat_";
+const MEMORY_ROOT_FINGERPRINT_PREFIX: &str = "wc_memroot_";
+const MEMORY_PRINCIPAL_DIGEST_PREFIX: &str = "wc_memprincipal_";
 const MAX_MEMORY_TAGS_JSON_BYTES: usize = 4 * 1024;
+const MEMORY_PROVENANCE_KINDS: &[&str] = &[
+    MEMORY_PROVENANCE_LEGACY,
+    "dev",
+    "bootstrap",
+    "api_token",
+    "user",
+    "agent_token",
+    "account_credential",
+    "oauth2",
+    "shared-key",
+    "project-credential",
+    "open",
+];
+const MAX_MEMORY_PRINCIPAL_KIND_CHARS: usize = 64;
+const MAX_MEMORY_PROJECT_RUNTIME_ID_CHARS: usize = 512;
+const MAX_MEMORY_RUNNER_CLIENT_ID_CHARS: usize = 128;
+
+pub(crate) const MEMORY_SCOPE_IDENTITY_ATTRIBUTED: &str = "attributed";
+pub(crate) const MEMORY_SCOPE_IDENTITY_LEGACY: &str = "legacy_unattributed";
+pub(crate) const MEMORY_PROVENANCE_LEGACY: &str = "legacy_unattributed";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -69,12 +92,55 @@ pub(crate) struct ProjectMemoryRecord {
     /// Canonical model-relevant definition identity. Internal durable metadata;
     /// it is deliberately distinct from the model-facing CAS state revision.
     pub(crate) definition_hash: String,
+    pub(crate) created_by_kind: String,
+    pub(crate) created_by_principal_digest: Option<String>,
+    pub(crate) updated_by_kind: String,
+    pub(crate) updated_by_principal_digest: Option<String>,
     /// Monotonic generation within the current memory_id incarnation.
     pub(crate) generation: u64,
     /// Opaque state-generation ETag used for read/update/delete CAS.
     pub(crate) revision: String,
     pub(crate) created_at_unix_ms: i64,
     pub(crate) updated_at_unix_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemoryPrincipalAttribution {
+    pub(crate) kind: String,
+    pub(crate) principal_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemoryScopeAttribution {
+    pub(crate) project_runtime_id: String,
+    pub(crate) runner_client_id: String,
+    pub(crate) root_fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectMemoryScopeRecord {
+    pub(crate) memory_scope_id: String,
+    pub(crate) identity_state: String,
+    pub(crate) project_runtime_id: Option<String>,
+    pub(crate) runner_client_id: Option<String>,
+    pub(crate) root_fingerprint: Option<String>,
+    pub(crate) created_at_unix_ms: i64,
+    pub(crate) last_mutated_at_unix_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectMemoryScopeSnapshot {
+    pub(crate) scope: ProjectMemoryScopeRecord,
+    pub(crate) memories: Vec<ProjectMemoryRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemoryScopePurgeOutcome {
+    pub(crate) memory_scope_id: String,
+    pub(crate) catalog_revision: Option<String>,
+    pub(crate) purged_count: usize,
+    pub(crate) purged: bool,
+    pub(crate) state_changed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -118,6 +184,7 @@ pub(crate) enum MemoryStoreError {
     NotFound,
     Changed { current_revision: String },
     ExpectedRevisionRequired { current_revision: String },
+    ScopeChanged { current_catalog_revision: String },
     ProjectCapacityExceeded,
     GlobalCapacityExceeded,
     DatabaseUnavailable,
@@ -138,6 +205,7 @@ impl MemoryStoreError {
             Self::NotFound => "memory_not_found",
             Self::Changed { .. } => "memory_changed",
             Self::ExpectedRevisionRequired { .. } => "memory_expected_revision_required",
+            Self::ScopeChanged { .. } => "memory_scope_changed",
             Self::ProjectCapacityExceeded => "memory_project_capacity_exceeded",
             Self::GlobalCapacityExceeded => "memory_global_capacity_exceeded",
             Self::DatabaseUnavailable => "memory_store_unavailable",
@@ -148,6 +216,15 @@ impl MemoryStoreError {
         match self {
             Self::Changed { current_revision }
             | Self::ExpectedRevisionRequired { current_revision } => Some(current_revision),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn current_catalog_revision(&self) -> Option<&str> {
+        match self {
+            Self::ScopeChanged {
+                current_catalog_revision,
+            } => Some(current_catalog_revision),
             _ => None,
         }
     }
@@ -238,6 +315,54 @@ fn valid_lower_hex_prefixed(value: &str, prefix: &str, hex_len: usize) -> bool {
         && value[prefix.len()..]
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+pub(crate) fn validate_memory_scope_id(value: &str) -> Result<(), MemoryStoreError> {
+    validate_scope(value)
+}
+
+pub(crate) fn valid_memory_root_fingerprint(value: &str) -> bool {
+    valid_lower_hex_prefixed(value, MEMORY_ROOT_FINGERPRINT_PREFIX, 64)
+}
+
+pub(crate) fn valid_memory_principal_digest(value: &str) -> bool {
+    valid_lower_hex_prefixed(value, MEMORY_PRINCIPAL_DIGEST_PREFIX, 64)
+}
+
+fn valid_bounded_identity_text(value: &str, maximum: usize) -> bool {
+    !value.is_empty() && value.chars().count() <= maximum && !value.chars().any(char::is_control)
+}
+fn valid_memory_principal_kind(value: &str) -> bool {
+    MEMORY_PROVENANCE_KINDS.contains(&value)
+}
+
+fn validate_principal_attribution(
+    attribution: &MemoryPrincipalAttribution,
+) -> Result<(), MemoryStoreError> {
+    if attribution.kind == MEMORY_PROVENANCE_LEGACY
+        || !valid_bounded_identity_text(&attribution.kind, MAX_MEMORY_PRINCIPAL_KIND_CHARS)
+        || !valid_memory_principal_kind(&attribution.kind)
+        || !valid_memory_principal_digest(&attribution.principal_digest)
+    {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    Ok(())
+}
+
+fn validate_scope_attribution(
+    attribution: &MemoryScopeAttribution,
+) -> Result<(), MemoryStoreError> {
+    if !valid_bounded_identity_text(
+        &attribution.project_runtime_id,
+        MAX_MEMORY_PROJECT_RUNTIME_ID_CHARS,
+    ) || !valid_bounded_identity_text(
+        &attribution.runner_client_id,
+        MAX_MEMORY_RUNNER_CLIENT_ID_CHARS,
+    ) || !valid_memory_root_fingerprint(&attribution.root_fingerprint)
+    {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    Ok(())
 }
 
 fn validate_memory_id(value: &str) -> Result<(), MemoryStoreError> {
@@ -361,6 +486,176 @@ fn parse_canonical_tags_json(tags_json: &str) -> Result<Vec<String>, MemoryStore
     Ok(tags)
 }
 
+fn validate_provenance_pair(kind: &str, digest: Option<&str>) -> Result<(), MemoryStoreError> {
+    if !valid_bounded_identity_text(kind, MAX_MEMORY_PRINCIPAL_KIND_CHARS)
+        || !valid_memory_principal_kind(kind)
+    {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    if kind == MEMORY_PROVENANCE_LEGACY {
+        if digest.is_some() {
+            return Err(MemoryStoreError::DatabaseUnavailable);
+        }
+        return Ok(());
+    }
+    if !digest.is_some_and(valid_memory_principal_digest) {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    Ok(())
+}
+
+fn parse_scope_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ProjectMemoryScopeRecord> {
+    // Reject malformed or hostile persisted metadata before materializing its
+    // TEXT values. Scope inventory is bounded by Memory cardinality, and each
+    // descriptor must also remain bounded independently.
+    if row.get::<_, i64>(7)? != ("wc_memscope_".len() + 64) as i64 {
+        return Err(corrupt_row(
+            0,
+            rusqlite::types::Type::Text,
+            "invalid Memory scope id length",
+        ));
+    }
+    for (length_column, value_column, maximum, message) in [
+        (
+            8,
+            1,
+            MEMORY_SCOPE_IDENTITY_LEGACY.len(),
+            "invalid Memory scope identity_state length",
+        ),
+        (
+            9,
+            2,
+            MAX_MEMORY_PROJECT_RUNTIME_ID_CHARS,
+            "invalid Memory project attribution length",
+        ),
+        (
+            10,
+            3,
+            MAX_MEMORY_RUNNER_CLIENT_ID_CHARS,
+            "invalid Memory Runner attribution length",
+        ),
+    ] {
+        let length = row.get::<_, i64>(length_column)?;
+        if length < 0 || length > maximum as i64 {
+            return Err(corrupt_row(
+                value_column,
+                rusqlite::types::Type::Text,
+                message,
+            ));
+        }
+    }
+    let root_length = row.get::<_, i64>(11)?;
+    if root_length != 0 && root_length != (MEMORY_ROOT_FINGERPRINT_PREFIX.len() + 64) as i64 {
+        return Err(corrupt_row(
+            4,
+            rusqlite::types::Type::Text,
+            "invalid Memory root attribution length",
+        ));
+    }
+
+    let memory_scope_id: String = row.get(0)?;
+    let identity_state: String = row.get(1)?;
+    let project_runtime_id: Option<String> = row.get(2)?;
+    let runner_client_id: Option<String> = row.get(3)?;
+    let root_fingerprint: Option<String> = row.get(4)?;
+    let created_at_unix_ms: i64 = row.get(5)?;
+    let last_mutated_at_unix_ms: i64 = row.get(6)?;
+    validate_scope(&memory_scope_id)
+        .map_err(|_| corrupt_row(0, rusqlite::types::Type::Text, "invalid Memory scope id"))?;
+    validate_timestamp_pair(created_at_unix_ms, last_mutated_at_unix_ms).map_err(|_| {
+        corrupt_row(
+            5,
+            rusqlite::types::Type::Integer,
+            "invalid Memory scope timestamps",
+        )
+    })?;
+    match identity_state.as_str() {
+        MEMORY_SCOPE_IDENTITY_LEGACY
+            if project_runtime_id.is_none()
+                && runner_client_id.is_none()
+                && root_fingerprint.is_none() => {}
+        MEMORY_SCOPE_IDENTITY_ATTRIBUTED => {
+            let attributed = MemoryScopeAttribution {
+                project_runtime_id: project_runtime_id.clone().ok_or_else(|| {
+                    corrupt_row(
+                        2,
+                        rusqlite::types::Type::Null,
+                        "missing Memory project attribution",
+                    )
+                })?,
+                runner_client_id: runner_client_id.clone().ok_or_else(|| {
+                    corrupt_row(
+                        3,
+                        rusqlite::types::Type::Null,
+                        "missing Memory Runner attribution",
+                    )
+                })?,
+                root_fingerprint: root_fingerprint.clone().ok_or_else(|| {
+                    corrupt_row(
+                        4,
+                        rusqlite::types::Type::Null,
+                        "missing Memory root attribution",
+                    )
+                })?,
+            };
+            validate_scope_attribution(&attributed).map_err(|_| {
+                corrupt_row(
+                    2,
+                    rusqlite::types::Type::Text,
+                    "invalid Memory scope attribution",
+                )
+            })?;
+        }
+        _ => {
+            return Err(corrupt_row(
+                1,
+                rusqlite::types::Type::Text,
+                "invalid Memory scope identity_state",
+            ))
+        }
+    }
+    Ok(ProjectMemoryScopeRecord {
+        memory_scope_id,
+        identity_state,
+        project_runtime_id,
+        runner_client_id,
+        root_fingerprint,
+        created_at_unix_ms,
+        last_mutated_at_unix_ms,
+    })
+}
+
+const SELECT_SCOPE: &str = "SELECT memory_scope_id, identity_state, project_runtime_id,
+    runner_client_id, root_fingerprint, created_at_unix_ms, last_mutated_at_unix_ms,
+    length(memory_scope_id), length(identity_state), COALESCE(length(project_runtime_id), 0),
+    COALESCE(length(runner_client_id), 0), COALESCE(length(root_fingerprint), 0)
+    FROM project_memory_scopes";
+
+fn get_scope_record(
+    conn: &rusqlite::Connection,
+    memory_scope_id: &str,
+) -> Result<Option<ProjectMemoryScopeRecord>, MemoryStoreError> {
+    conn.query_row(
+        &format!("{SELECT_SCOPE} WHERE memory_scope_id = ?1"),
+        params![memory_scope_id],
+        parse_scope_row,
+    )
+    .optional()
+    .map_err(|_| MemoryStoreError::DatabaseUnavailable)
+}
+
+fn validate_scope_record_for_memories(
+    conn: &rusqlite::Connection,
+    memory_scope_id: &str,
+    has_memories: bool,
+) -> Result<Option<ProjectMemoryScopeRecord>, MemoryStoreError> {
+    let scope = get_scope_record(conn, memory_scope_id)?;
+    if scope.is_some() != has_memories {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    Ok(scope)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn validate_legacy_memory_row_lengths(
     memory_id_chars: i64,
@@ -439,6 +734,80 @@ pub(super) fn validate_legacy_memory_row_identity(
     Ok((definition_hash, revision))
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(super) fn validate_current_memory_v2_row_lengths(
+    memory_id_chars: i64,
+    memory_scope_chars: i64,
+    memory_key_chars: i64,
+    summary_chars: i64,
+    body_bytes: i64,
+    priority_chars: i64,
+    tags_json_bytes: i64,
+    definition_hash_chars: i64,
+    revision_chars: i64,
+) -> Result<(), MemoryStoreError> {
+    validate_legacy_memory_row_lengths(
+        memory_id_chars,
+        memory_scope_chars,
+        memory_key_chars,
+        summary_chars,
+        body_bytes,
+        priority_chars,
+        tags_json_bytes,
+        revision_chars,
+    )?;
+    if definition_hash_chars != (MEMORY_DEFINITION_HASH_PREFIX.len() + 64) as i64 {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn validate_current_memory_v2_row_identity(
+    memory_id: &str,
+    memory_scope_id: &str,
+    memory_key: &str,
+    summary: &str,
+    body: &str,
+    priority: &str,
+    bootstrap_raw: i64,
+    tags_json: &str,
+    definition_hash: &str,
+    generation_raw: i64,
+    revision: &str,
+    created_at_unix_ms: i64,
+    updated_at_unix_ms: i64,
+) -> Result<(), MemoryStoreError> {
+    validate_memory_id(memory_id)?;
+    validate_scope(memory_scope_id)?;
+    validate_memory_key(memory_key).map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+    validate_memory_summary(summary).map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+    validate_memory_body(body).map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+    let priority =
+        MemoryPriority::parse(priority).map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+    let bootstrap = match bootstrap_raw {
+        0 => false,
+        1 => true,
+        _ => return Err(MemoryStoreError::DatabaseUnavailable),
+    };
+    let tags = parse_canonical_tags_json(tags_json)?;
+    validate_memory_definition_hash(definition_hash)?;
+    let generation = u64::try_from(generation_raw)
+        .ok()
+        .filter(|generation| *generation >= 1)
+        .ok_or(MemoryStoreError::DatabaseUnavailable)?;
+    validate_memory_revision(revision).map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+    validate_timestamp_pair(created_at_unix_ms, updated_at_unix_ms)?;
+    if memory_definition_hash(memory_key, summary, body, priority, bootstrap, &tags)
+        != definition_hash
+        || memory_state_revision(memory_scope_id, memory_id, generation, definition_hash)
+            != revision
+    {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    Ok(())
+}
+
 pub(crate) fn memory_catalog_revision(records: &[ProjectMemoryRecord]) -> String {
     let mut pairs = records
         .iter()
@@ -482,10 +851,10 @@ fn parse_row(
     // large TEXT values into Rust Strings. This is a local Memory-store bound,
     // not a generic DB streaming abstraction.
     let exact_lengths = [
-        (13, MEMORY_ID_PREFIX.len() + 32),
-        (14, "wc_memscope_".len() + 64),
-        (20, MEMORY_DEFINITION_HASH_PREFIX.len() + 64),
-        (21, MEMORY_REVISION_PREFIX.len() + 64),
+        (17, MEMORY_ID_PREFIX.len() + 32),
+        (18, "wc_memscope_".len() + 64),
+        (24, MEMORY_DEFINITION_HASH_PREFIX.len() + 64),
+        (25, MEMORY_REVISION_PREFIX.len() + 64),
     ];
     for (column, expected) in exact_lengths {
         if row.get::<_, i64>(column)? != expected as i64 {
@@ -497,11 +866,15 @@ fn parse_row(
         }
     }
     let bounded_lengths = [
-        (15, MAX_MEMORY_KEY_CHARS),
-        (16, MAX_MEMORY_SUMMARY_CHARS),
-        (17, MAX_MEMORY_BODY_BYTES),
-        (18, 6usize),
-        (19, MAX_MEMORY_TAGS_JSON_BYTES),
+        (19, MAX_MEMORY_KEY_CHARS),
+        (20, MAX_MEMORY_SUMMARY_CHARS),
+        (21, MAX_MEMORY_BODY_BYTES),
+        (22, 6usize),
+        (23, MAX_MEMORY_TAGS_JSON_BYTES),
+        (26, MAX_MEMORY_PRINCIPAL_KIND_CHARS),
+        (27, MEMORY_PRINCIPAL_DIGEST_PREFIX.len() + 64),
+        (28, MAX_MEMORY_PRINCIPAL_KIND_CHARS),
+        (29, MEMORY_PRINCIPAL_DIGEST_PREFIX.len() + 64),
     ];
     for (column, maximum) in bounded_lengths {
         let length = row.get::<_, i64>(column)?;
@@ -527,6 +900,10 @@ fn parse_row(
     let revision: String = row.get(10)?;
     let created_at_unix_ms: i64 = row.get(11)?;
     let updated_at_unix_ms: i64 = row.get(12)?;
+    let created_by_kind: String = row.get(13)?;
+    let created_by_principal_digest: Option<String> = row.get(14)?;
+    let updated_by_kind: String = row.get(15)?;
+    let updated_by_principal_digest: Option<String> = row.get(16)?;
 
     validate_memory_id(&memory_id)
         .map_err(|_| corrupt_row(0, rusqlite::types::Type::Text, "invalid memory_id"))?;
@@ -590,6 +967,24 @@ fn parse_row(
             "invalid Memory timestamps",
         )
     })?;
+    validate_provenance_pair(&created_by_kind, created_by_principal_digest.as_deref()).map_err(
+        |_| {
+            corrupt_row(
+                13,
+                rusqlite::types::Type::Text,
+                "invalid Memory created provenance",
+            )
+        },
+    )?;
+    validate_provenance_pair(&updated_by_kind, updated_by_principal_digest.as_deref()).map_err(
+        |_| {
+            corrupt_row(
+                15,
+                rusqlite::types::Type::Text,
+                "invalid Memory updated provenance",
+            )
+        },
+    )?;
 
     let expected_definition =
         memory_definition_hash(&memory_key, &summary, &body, priority, bootstrap, &tags);
@@ -619,6 +1014,10 @@ fn parse_row(
         bootstrap,
         tags,
         definition_hash,
+        created_by_kind,
+        created_by_principal_digest,
+        updated_by_kind,
+        updated_by_principal_digest,
         generation,
         revision,
         created_at_unix_ms,
@@ -629,10 +1028,109 @@ fn parse_row(
 const SELECT_RECORD: &str =
     "SELECT memory_id, memory_scope_id, memory_key, summary, body, priority, bootstrap, tags_json,
             definition_hash, generation, revision, created_at_unix_ms, updated_at_unix_ms,
+            created_by_kind, created_by_principal_digest, updated_by_kind, updated_by_principal_digest,
             length(memory_id), length(memory_scope_id), length(memory_key), length(summary),
             length(CAST(body AS BLOB)), length(priority), length(CAST(tags_json AS BLOB)),
-            length(definition_hash), length(revision)
+            length(definition_hash), length(revision), length(created_by_kind),
+            COALESCE(length(created_by_principal_digest), 0), length(updated_by_kind),
+            COALESCE(length(updated_by_principal_digest), 0)
      FROM project_memories";
+
+fn list_project_memories_with_conn(
+    conn: &rusqlite::Connection,
+    memory_scope_id: &str,
+) -> Result<Vec<ProjectMemoryRecord>, MemoryStoreError> {
+    let mut statement = conn
+        .prepare(&format!(
+            "{SELECT_RECORD} WHERE memory_scope_id = ?1 ORDER BY memory_key ASC LIMIT ?2"
+        ))
+        .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+    let records = statement
+        .query_map(
+            params![memory_scope_id, (MAX_MEMORIES_PER_PROJECT + 1) as i64],
+            |row| parse_row(row, memory_scope_id),
+        )
+        .map_err(|_| MemoryStoreError::DatabaseUnavailable)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+    if records.len() > MAX_MEMORIES_PER_PROJECT {
+        return Err(MemoryStoreError::DatabaseUnavailable);
+    }
+    validate_scope_record_for_memories(conn, memory_scope_id, !records.is_empty())?;
+    Ok(records)
+}
+
+fn ensure_scope_for_mutation(
+    tx: &rusqlite::Transaction<'_>,
+    memory_scope_id: &str,
+    attribution: &MemoryScopeAttribution,
+    now: i64,
+    allow_create: bool,
+) -> Result<(), MemoryStoreError> {
+    validate_scope_attribution(attribution)?;
+    match get_scope_record(tx, memory_scope_id)? {
+        Some(scope) if scope.identity_state == MEMORY_SCOPE_IDENTITY_ATTRIBUTED => {
+            if scope.project_runtime_id.as_deref() != Some(attribution.project_runtime_id.as_str())
+                || scope.runner_client_id.as_deref() != Some(attribution.runner_client_id.as_str())
+                || scope.root_fingerprint.as_deref() != Some(attribution.root_fingerprint.as_str())
+            {
+                return Err(MemoryStoreError::DatabaseUnavailable);
+            }
+            let changed = tx
+                .execute(
+                    "UPDATE project_memory_scopes SET last_mutated_at_unix_ms = ?1
+                     WHERE memory_scope_id = ?2",
+                    params![now, memory_scope_id],
+                )
+                .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+            if changed != 1 {
+                return Err(MemoryStoreError::DatabaseUnavailable);
+            }
+        }
+        Some(scope) if scope.identity_state == MEMORY_SCOPE_IDENTITY_LEGACY => {
+            let changed = tx
+                .execute(
+                    "UPDATE project_memory_scopes
+                     SET identity_state = ?1, project_runtime_id = ?2, runner_client_id = ?3,
+                         root_fingerprint = ?4, last_mutated_at_unix_ms = ?5
+                     WHERE memory_scope_id = ?6 AND identity_state = ?7",
+                    params![
+                        MEMORY_SCOPE_IDENTITY_ATTRIBUTED,
+                        attribution.project_runtime_id,
+                        attribution.runner_client_id,
+                        attribution.root_fingerprint,
+                        now,
+                        memory_scope_id,
+                        MEMORY_SCOPE_IDENTITY_LEGACY,
+                    ],
+                )
+                .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+            if changed != 1 {
+                return Err(MemoryStoreError::DatabaseUnavailable);
+            }
+        }
+        Some(_) => return Err(MemoryStoreError::DatabaseUnavailable),
+        None if allow_create => {
+            tx.execute(
+                "INSERT INTO project_memory_scopes
+                 (memory_scope_id, identity_state, project_runtime_id, runner_client_id,
+                  root_fingerprint, created_at_unix_ms, last_mutated_at_unix_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+                params![
+                    memory_scope_id,
+                    MEMORY_SCOPE_IDENTITY_ATTRIBUTED,
+                    attribution.project_runtime_id,
+                    attribution.runner_client_id,
+                    attribution.root_fingerprint,
+                    now,
+                ],
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        }
+        None => return Err(MemoryStoreError::DatabaseUnavailable),
+    }
+    Ok(())
+}
 
 impl Database {
     pub(crate) fn list_project_memories(
@@ -641,23 +1139,7 @@ impl Database {
     ) -> Result<Vec<ProjectMemoryRecord>, MemoryStoreError> {
         validate_scope(memory_scope_id)?;
         let conn = self.conn.lock().unwrap();
-        let mut statement = conn
-            .prepare(&format!(
-                "{SELECT_RECORD} WHERE memory_scope_id = ?1 ORDER BY memory_key ASC LIMIT ?2"
-            ))
-            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
-        let records = statement
-            .query_map(
-                params![memory_scope_id, (MAX_MEMORIES_PER_PROJECT + 1) as i64],
-                |row| parse_row(row, memory_scope_id),
-            )
-            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
-        if records.len() > MAX_MEMORIES_PER_PROJECT {
-            return Err(MemoryStoreError::DatabaseUnavailable);
-        }
-        Ok(records)
+        list_project_memories_with_conn(&conn, memory_scope_id)
     }
 
     pub(crate) fn get_project_memory(
@@ -668,21 +1150,35 @@ impl Database {
         validate_scope(memory_scope_id)?;
         validate_memory_key(memory_key)?;
         let conn = self.conn.lock().unwrap();
-        conn.query_row(
-            &format!("{SELECT_RECORD} WHERE memory_scope_id = ?1 AND memory_key = ?2"),
-            params![memory_scope_id, memory_key],
-            |row| parse_row(row, memory_scope_id),
-        )
-        .optional()
-        .map_err(|_| MemoryStoreError::DatabaseUnavailable)
+        let record = conn
+            .query_row(
+                &format!("{SELECT_RECORD} WHERE memory_scope_id = ?1 AND memory_key = ?2"),
+                params![memory_scope_id, memory_key],
+                |row| parse_row(row, memory_scope_id),
+            )
+            .optional()
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM project_memories WHERE memory_scope_id = ?1",
+                params![memory_scope_id],
+                |row| row.get(0),
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        validate_scope_record_for_memories(&conn, memory_scope_id, count > 0)?;
+        Ok(record)
     }
 
-    pub(crate) fn set_project_memory(
+    pub(crate) fn set_project_memory_attributed(
         &self,
         memory_scope_id: &str,
+        scope_attribution: &MemoryScopeAttribution,
+        principal: &MemoryPrincipalAttribution,
         mut input: MemorySetInput,
     ) -> Result<MemorySetOutcome, MemoryStoreError> {
         validate_scope(memory_scope_id)?;
+        validate_scope_attribution(scope_attribution)?;
+        validate_principal_attribution(principal)?;
         validate_memory_key(&input.memory_key)?;
         validate_memory_summary(&input.summary)?;
         validate_memory_body(&input.body)?;
@@ -711,6 +1207,14 @@ impl Database {
             )
             .optional()
             .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        let scope_memory_count: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM project_memories WHERE memory_scope_id = ?1",
+                params![memory_scope_id],
+                |row| row.get(0),
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        validate_scope_record_for_memories(&tx, memory_scope_id, scope_memory_count > 0)?;
 
         if let Some(existing) = existing {
             match input.expected_revision.as_deref() {
@@ -746,6 +1250,7 @@ impl Database {
                 }
                 Some(_) => {}
             }
+            ensure_scope_for_mutation(&tx, memory_scope_id, scope_attribution, now, false)?;
             let old_revision = existing.revision.clone();
             let generation = existing
                 .generation
@@ -765,8 +1270,9 @@ impl Database {
                     "UPDATE project_memories
                      SET summary = ?1, body = ?2, priority = ?3, bootstrap = ?4,
                          tags_json = ?5, definition_hash = ?6, generation = ?7,
-                         revision = ?8, updated_at_unix_ms = ?9
-                     WHERE memory_scope_id = ?10 AND memory_key = ?11 AND revision = ?12",
+                         revision = ?8, updated_at_unix_ms = ?9,
+                         updated_by_kind = ?10, updated_by_principal_digest = ?11
+                     WHERE memory_scope_id = ?12 AND memory_key = ?13 AND revision = ?14",
                     params![
                         input.summary,
                         input.body,
@@ -777,6 +1283,8 @@ impl Database {
                         generation as i64,
                         requested_revision,
                         now,
+                        principal.kind,
+                        principal.principal_digest,
                         memory_scope_id,
                         input.memory_key,
                         old_revision,
@@ -826,6 +1334,13 @@ impl Database {
         if global_count >= MAX_MEMORIES_GLOBAL as i64 {
             return Err(MemoryStoreError::GlobalCapacityExceeded);
         }
+        ensure_scope_for_mutation(
+            &tx,
+            memory_scope_id,
+            scope_attribution,
+            now,
+            project_count == 0,
+        )?;
         let memory_id = format!("{MEMORY_ID_PREFIX}{}", uuid::Uuid::new_v4().simple());
         let generation = 1u64;
         let requested_revision = memory_state_revision(
@@ -839,8 +1354,9 @@ impl Database {
         tx.execute(
             "INSERT INTO project_memories
              (memory_id, memory_scope_id, memory_key, summary, body, priority, bootstrap,
-              tags_json, definition_hash, generation, revision, created_at_unix_ms, updated_at_unix_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)",
+              tags_json, definition_hash, generation, revision, created_at_unix_ms, updated_at_unix_ms,
+              created_by_kind, created_by_principal_digest, updated_by_kind, updated_by_principal_digest)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12, ?13, ?14, ?13, ?14)",
             params![
                 memory_id,
                 memory_scope_id,
@@ -854,6 +1370,8 @@ impl Database {
                 generation as i64,
                 requested_revision,
                 now,
+                principal.kind,
+                principal.principal_digest,
             ],
         )
         .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
@@ -874,15 +1392,18 @@ impl Database {
         })
     }
 
-    pub(crate) fn delete_project_memory(
+    pub(crate) fn delete_project_memory_attributed(
         &self,
         memory_scope_id: &str,
+        scope_attribution: &MemoryScopeAttribution,
         memory_key: &str,
         expected_revision: &str,
     ) -> Result<MemoryDeleteOutcome, MemoryStoreError> {
         validate_scope(memory_scope_id)?;
+        validate_scope_attribution(scope_attribution)?;
         validate_memory_key(memory_key)?;
         validate_memory_revision(expected_revision)?;
+        let now = chrono::Utc::now().timestamp_millis();
         let mut conn = self.conn.lock().unwrap();
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -895,6 +1416,14 @@ impl Database {
             )
             .optional()
             .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        let scope_memory_count: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM project_memories WHERE memory_scope_id = ?1",
+                params![memory_scope_id],
+                |row| row.get(0),
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        validate_scope_record_for_memories(&tx, memory_scope_id, scope_memory_count > 0)?;
         let Some(existing) = existing else {
             tx.commit()
                 .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
@@ -910,6 +1439,7 @@ impl Database {
                 current_revision: existing.revision,
             });
         }
+        ensure_scope_for_mutation(&tx, memory_scope_id, scope_attribution, now, false)?;
         let deleted = tx
             .execute(
                 "DELETE FROM project_memories
@@ -922,12 +1452,227 @@ impl Database {
                 current_revision: expected_revision.to_string(),
             });
         }
+        let remaining: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM project_memories WHERE memory_scope_id = ?1",
+                params![memory_scope_id],
+                |row| row.get(0),
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        if remaining == 0 {
+            let removed_scope = tx
+                .execute(
+                    "DELETE FROM project_memory_scopes WHERE memory_scope_id = ?1",
+                    params![memory_scope_id],
+                )
+                .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+            if removed_scope != 1 {
+                return Err(MemoryStoreError::DatabaseUnavailable);
+            }
+        }
         tx.commit()
             .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
         Ok(MemoryDeleteOutcome {
             memory_id: Some(existing.memory_id),
             revision: Some(existing.revision),
             deleted: true,
+            state_changed: true,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_project_memory(
+        &self,
+        memory_scope_id: &str,
+        input: MemorySetInput,
+    ) -> Result<MemorySetOutcome, MemoryStoreError> {
+        let scope_attribution = MemoryScopeAttribution {
+            project_runtime_id: "agent:test:memory".to_string(),
+            runner_client_id: "test-runner".to_string(),
+            root_fingerprint: format!("wc_memroot_{}", "0".repeat(64)),
+        };
+        let principal = MemoryPrincipalAttribution {
+            kind: "dev".to_string(),
+            principal_digest: format!("wc_memprincipal_{}", "1".repeat(64)),
+        };
+        self.set_project_memory_attributed(memory_scope_id, &scope_attribution, &principal, input)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn delete_project_memory(
+        &self,
+        memory_scope_id: &str,
+        memory_key: &str,
+        expected_revision: &str,
+    ) -> Result<MemoryDeleteOutcome, MemoryStoreError> {
+        let scope_attribution = MemoryScopeAttribution {
+            project_runtime_id: "agent:test:memory".to_string(),
+            runner_client_id: "test-runner".to_string(),
+            root_fingerprint: format!("wc_memroot_{}", "0".repeat(64)),
+        };
+        self.delete_project_memory_attributed(
+            memory_scope_id,
+            &scope_attribution,
+            memory_key,
+            expected_revision,
+        )
+    }
+
+    pub(crate) fn list_project_memory_scopes(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(usize, Vec<ProjectMemoryScopeSnapshot>), MemoryStoreError> {
+        if limit == 0 || limit > MAX_MEMORY_SCOPE_LIST_LIMIT {
+            return Err(MemoryStoreError::InvalidLimit);
+        }
+        // Scope cardinality is globally bounded by Memory cardinality. Clamp a
+        // hostile/out-of-range page offset before converting usize to SQLite's
+        // signed integer representation; callers still observe the effective
+        // offset normalized against total below.
+        let offset = offset.min(MAX_MEMORIES_GLOBAL);
+        let conn = self.conn.lock().unwrap();
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM project_memory_scopes", [], |row| {
+                row.get(0)
+            })
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        if total < 0 || total as usize > MAX_MEMORIES_GLOBAL {
+            return Err(MemoryStoreError::DatabaseUnavailable);
+        }
+        let (memory_total, distinct_scope_total): (i64, i64) = conn
+            .query_row(
+                "SELECT COUNT(*), COUNT(DISTINCT memory_scope_id) FROM project_memories",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        if memory_total < 0
+            || memory_total as usize > MAX_MEMORIES_GLOBAL
+            || distinct_scope_total < 0
+            || distinct_scope_total != total
+        {
+            // A Memory row without its one scope-metadata row would otherwise
+            // disappear from lifecycle inventory while still consuming global
+            // capacity. Treat either direction of drift as store corruption.
+            return Err(MemoryStoreError::DatabaseUnavailable);
+        }
+        let mut statement = conn
+            .prepare(&format!(
+                "{SELECT_SCOPE} ORDER BY memory_scope_id ASC LIMIT ?1 OFFSET ?2"
+            ))
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        let scopes = statement
+            .query_map(params![limit as i64, offset as i64], parse_scope_row)
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        let mut snapshots = Vec::with_capacity(scopes.len());
+        for scope in scopes {
+            let memories = list_project_memories_with_conn(&conn, &scope.memory_scope_id)?;
+            if memories.is_empty() {
+                return Err(MemoryStoreError::DatabaseUnavailable);
+            }
+            snapshots.push(ProjectMemoryScopeSnapshot { scope, memories });
+        }
+        Ok((total as usize, snapshots))
+    }
+
+    pub(crate) fn get_project_memory_scope(
+        &self,
+        memory_scope_id: &str,
+    ) -> Result<Option<ProjectMemoryScopeSnapshot>, MemoryStoreError> {
+        validate_scope(memory_scope_id)?;
+        let conn = self.conn.lock().unwrap();
+        let Some(scope) = get_scope_record(&conn, memory_scope_id)? else {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM project_memories WHERE memory_scope_id = ?1",
+                    params![memory_scope_id],
+                    |row| row.get(0),
+                )
+                .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+            if count != 0 {
+                return Err(MemoryStoreError::DatabaseUnavailable);
+            }
+            return Ok(None);
+        };
+        let memories = list_project_memories_with_conn(&conn, memory_scope_id)?;
+        if memories.is_empty() {
+            return Err(MemoryStoreError::DatabaseUnavailable);
+        }
+        Ok(Some(ProjectMemoryScopeSnapshot { scope, memories }))
+    }
+
+    pub(crate) fn purge_project_memory_scope(
+        &self,
+        memory_scope_id: &str,
+        expected_catalog_revision: &str,
+    ) -> Result<MemoryScopePurgeOutcome, MemoryStoreError> {
+        validate_scope(memory_scope_id)?;
+        if !valid_memory_catalog_revision(expected_catalog_revision) {
+            return Err(MemoryStoreError::InvalidRevision);
+        }
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        let Some(_scope) = get_scope_record(&tx, memory_scope_id)? else {
+            let count: i64 = tx
+                .query_row(
+                    "SELECT COUNT(*) FROM project_memories WHERE memory_scope_id = ?1",
+                    params![memory_scope_id],
+                    |row| row.get(0),
+                )
+                .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+            if count != 0 {
+                return Err(MemoryStoreError::DatabaseUnavailable);
+            }
+            tx.commit()
+                .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+            return Ok(MemoryScopePurgeOutcome {
+                memory_scope_id: memory_scope_id.to_string(),
+                catalog_revision: None,
+                purged_count: 0,
+                purged: false,
+                state_changed: false,
+            });
+        };
+        let records = list_project_memories_with_conn(&tx, memory_scope_id)?;
+        if records.is_empty() {
+            return Err(MemoryStoreError::DatabaseUnavailable);
+        }
+        let current_catalog_revision = memory_catalog_revision(&records);
+        if current_catalog_revision != expected_catalog_revision {
+            return Err(MemoryStoreError::ScopeChanged {
+                current_catalog_revision,
+            });
+        }
+        let purged_count = tx
+            .execute(
+                "DELETE FROM project_memories WHERE memory_scope_id = ?1",
+                params![memory_scope_id],
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        if purged_count != records.len() {
+            return Err(MemoryStoreError::DatabaseUnavailable);
+        }
+        let removed_scope = tx
+            .execute(
+                "DELETE FROM project_memory_scopes WHERE memory_scope_id = ?1",
+                params![memory_scope_id],
+            )
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        if removed_scope != 1 {
+            return Err(MemoryStoreError::DatabaseUnavailable);
+        }
+        tx.commit()
+            .map_err(|_| MemoryStoreError::DatabaseUnavailable)?;
+        Ok(MemoryScopePurgeOutcome {
+            memory_scope_id: memory_scope_id.to_string(),
+            catalog_revision: Some(current_catalog_revision),
+            purged_count,
+            purged: true,
             state_changed: true,
         })
     }

--- a/src/db/memory_tests.rs
+++ b/src/db/memory_tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::db::memory::{
-    legacy_memory_revision_v1, memory_definition_hash, memory_state_revision, MemoryPriority,
-    MemorySetInput,
+    legacy_memory_revision_v1, memory_definition_hash, memory_state_revision,
+    MemoryPrincipalAttribution, MemoryPriority, MemoryScopeAttribution, MemorySetInput,
+    MEMORY_PROVENANCE_LEGACY, MEMORY_SCOPE_IDENTITY_ATTRIBUTED, MEMORY_SCOPE_IDENTITY_LEGACY,
 };
 use rusqlite::{params, Connection};
 use std::sync::{Arc, Barrier};
@@ -20,6 +21,47 @@ fn input(key: &str, summary: &str) -> MemorySetInput {
         tags: vec!["architecture".to_string(), "stable".to_string()],
         expected_revision: None,
     }
+}
+
+fn scope_attribution(project: &str, runner: &str, hex: char) -> MemoryScopeAttribution {
+    MemoryScopeAttribution {
+        project_runtime_id: project.to_string(),
+        runner_client_id: runner.to_string(),
+        root_fingerprint: format!("wc_memroot_{}", hex.to_string().repeat(64)),
+    }
+}
+
+fn principal(kind: &str, hex: char) -> MemoryPrincipalAttribution {
+    MemoryPrincipalAttribution {
+        kind: kind.to_string(),
+        principal_digest: format!("wc_memprincipal_{}", hex.to_string().repeat(64)),
+    }
+}
+
+fn create_current_v2_memory_schema(conn: &Connection) {
+    conn.execute_batch(
+        "CREATE TABLE project_memories (
+            memory_id TEXT PRIMARY KEY,
+            memory_scope_id TEXT NOT NULL,
+            memory_key TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            body TEXT NOT NULL,
+            priority TEXT NOT NULL CHECK(priority IN ('high', 'normal', 'low')),
+            bootstrap INTEGER NOT NULL CHECK(bootstrap IN (0, 1)),
+            tags_json TEXT NOT NULL,
+            definition_hash TEXT NOT NULL,
+            generation INTEGER NOT NULL CHECK(generation >= 1),
+            revision TEXT NOT NULL,
+            created_at_unix_ms INTEGER NOT NULL,
+            updated_at_unix_ms INTEGER NOT NULL,
+            UNIQUE(memory_scope_id, memory_key)
+        );
+        CREATE INDEX idx_project_memories_scope_key
+            ON project_memories(memory_scope_id, memory_key);
+        CREATE INDEX idx_project_memories_scope_bootstrap
+            ON project_memories(memory_scope_id, bootstrap, priority, memory_key);",
+    )
+    .unwrap();
 }
 
 #[test]
@@ -75,6 +117,30 @@ fn memory_create_retry_cas_update_delete_and_restart_are_durable() {
         .unwrap();
     assert_eq!(durable.revision, updated.record.revision);
     assert_eq!(durable.summary, "Use canary deploys.");
+    assert_eq!(durable.created_by_kind, "dev");
+    assert_eq!(durable.updated_by_kind, "dev");
+    assert!(durable.created_by_principal_digest.is_some());
+    assert_eq!(
+        durable.created_by_principal_digest,
+        durable.updated_by_principal_digest
+    );
+    let durable_scope = reopened
+        .get_project_memory_scope(&scope)
+        .unwrap()
+        .expect("attributed scope must survive reopen");
+    assert_eq!(
+        durable_scope.scope.identity_state,
+        MEMORY_SCOPE_IDENTITY_ATTRIBUTED
+    );
+    assert_eq!(
+        durable_scope.scope.project_runtime_id.as_deref(),
+        Some("agent:test:memory")
+    );
+    assert_eq!(
+        durable_scope.scope.runner_client_id.as_deref(),
+        Some("test-runner")
+    );
+    assert_eq!(durable_scope.memories.len(), 1);
 
     assert_eq!(
         reopened
@@ -191,14 +257,30 @@ fn memory_global_capacity_is_hard_and_does_not_evict() {
                 "INSERT INTO project_memories
                  (memory_id, memory_scope_id, memory_key, summary, body, priority, bootstrap,
                   tags_json, definition_hash, generation, revision,
-                  created_at_unix_ms, updated_at_unix_ms)
-                 VALUES (?1, ?2, ?3, 's', '', 'normal', 0, '[]', ?4, 1, ?5, 1, 1)",
+                  created_at_unix_ms, updated_at_unix_ms,
+                  created_by_kind, created_by_principal_digest,
+                  updated_by_kind, updated_by_principal_digest)
+                 VALUES (?1, ?2, ?3, 's', '', 'normal', 0, '[]', ?4, 1, ?5, 1, 1,
+                         'dev', ?6, 'dev', ?6)",
                 params![
                     memory_id,
                     memory_scope_id,
                     memory_key,
                     definition_hash,
-                    revision
+                    revision,
+                    format!("wc_memprincipal_{}", "1".repeat(64))
+                ],
+            )
+            .unwrap();
+            tx.execute(
+                "INSERT INTO project_memory_scopes
+                 (memory_scope_id, identity_state, project_runtime_id, runner_client_id,
+                  root_fingerprint, created_at_unix_ms, last_mutated_at_unix_ms)
+                 VALUES (?1, 'attributed', ?2, 'test-runner', ?3, 1, 1)",
+                params![
+                    memory_scope_id,
+                    format!("agent:test:global-{index}"),
+                    format!("wc_memroot_{:064x}", index + 1),
                 ],
             )
             .unwrap();
@@ -218,6 +300,31 @@ fn memory_global_capacity_is_hard_and_does_not_evict() {
             row.get(0)
         })
         .unwrap();
+    assert_eq!(total as usize, MAX_MEMORIES_GLOBAL);
+
+    let reclaim_scope = format!("wc_memscope_{:064x}", 100);
+    let reclaim = db
+        .get_project_memory_scope(&reclaim_scope)
+        .unwrap()
+        .unwrap();
+    let reclaim_catalog = memory_catalog_revision(&reclaim.memories);
+    let purged = db
+        .purge_project_memory_scope(&reclaim_scope, &reclaim_catalog)
+        .unwrap();
+    assert!(purged.purged && purged.state_changed);
+    assert_eq!(purged.purged_count, 1);
+    assert!(
+        db.set_project_memory(&new_scope, input("new", "capacity recovered"))
+            .unwrap()
+            .created
+    );
+    let recovered_total: i64 = db
+        .conn_for_tests()
+        .query_row("SELECT COUNT(*) FROM project_memories", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(recovered_total as usize, MAX_MEMORIES_GLOBAL);
     assert_eq!(total as usize, MAX_MEMORIES_GLOBAL);
 }
 
@@ -637,6 +744,559 @@ fn corrupted_persisted_memory_rows_fail_closed_before_projection() {
             "{label} list"
         );
     }
+}
+
+#[test]
+fn current_205_rows_migrate_scope_metadata_and_legacy_provenance_without_revision_churn() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("memory-v2.db");
+    let raw = Connection::open(&path).unwrap();
+    create_current_v2_memory_schema(&raw);
+    let memory_scope_id = scope('a');
+    let mut expected_revisions = Vec::new();
+    for (index, (key, summary, created, updated)) in [
+        ("policy-a", "first", 10_i64, 20_i64),
+        ("policy-b", "second", 30_i64, 40_i64),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let memory_id = format!("wc_mem_{:032x}", index + 1);
+        let definition_hash =
+            memory_definition_hash(key, summary, "body", MemoryPriority::Normal, false, &[]);
+        let revision = memory_state_revision(&memory_scope_id, &memory_id, 1, &definition_hash);
+        raw.execute(
+            "INSERT INTO project_memories
+             (memory_id, memory_scope_id, memory_key, summary, body, priority, bootstrap,
+              tags_json, definition_hash, generation, revision,
+              created_at_unix_ms, updated_at_unix_ms)
+             VALUES (?1, ?2, ?3, ?4, 'body', 'normal', 0, '[]', ?5, 1, ?6, ?7, ?8)",
+            params![
+                memory_id,
+                memory_scope_id,
+                key,
+                summary,
+                definition_hash,
+                revision,
+                created,
+                updated,
+            ],
+        )
+        .unwrap();
+        expected_revisions.push((key.to_string(), revision));
+    }
+    drop(raw);
+
+    let db = Database::open(&path).unwrap();
+    let snapshot = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .expect("migrated scope");
+    assert_eq!(snapshot.scope.identity_state, MEMORY_SCOPE_IDENTITY_LEGACY);
+    assert!(snapshot.scope.project_runtime_id.is_none());
+    assert!(snapshot.scope.runner_client_id.is_none());
+    assert!(snapshot.scope.root_fingerprint.is_none());
+    assert_eq!(snapshot.scope.created_at_unix_ms, 10);
+    assert_eq!(snapshot.scope.last_mutated_at_unix_ms, 40);
+    assert_eq!(snapshot.memories.len(), 2);
+    for (key, revision) in expected_revisions {
+        let record = snapshot
+            .memories
+            .iter()
+            .find(|record| record.memory_key == key)
+            .unwrap();
+        assert_eq!(
+            record.revision, revision,
+            "migration must preserve #205 state ETag"
+        );
+        assert_eq!(record.generation, 1);
+        assert_eq!(record.created_by_kind, MEMORY_PROVENANCE_LEGACY);
+        assert_eq!(record.updated_by_kind, MEMORY_PROVENANCE_LEGACY);
+        assert!(record.created_by_principal_digest.is_none());
+        assert!(record.updated_by_principal_digest.is_none());
+    }
+    drop(db);
+
+    let reopened = Database::open(&path).unwrap();
+    let durable = reopened
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(durable.scope.identity_state, MEMORY_SCOPE_IDENTITY_LEGACY);
+    assert_eq!(durable.memories.len(), 2);
+}
+
+#[test]
+fn malformed_current_205_row_migration_rolls_back_without_trusting_provenance() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("memory-v2-corrupt.db");
+    let raw = Connection::open(&path).unwrap();
+    create_current_v2_memory_schema(&raw);
+    let memory_scope_id = scope('b');
+    let memory_id = "wc_mem_0123456789abcdef0123456789abcdef";
+    let definition_hash = memory_definition_hash(
+        "policy",
+        "summary",
+        "body",
+        MemoryPriority::Normal,
+        false,
+        &[],
+    );
+    raw.execute(
+        "INSERT INTO project_memories
+         (memory_id, memory_scope_id, memory_key, summary, body, priority, bootstrap,
+          tags_json, definition_hash, generation, revision, created_at_unix_ms, updated_at_unix_ms)
+         VALUES (?1, ?2, 'policy', 'summary', 'body', 'normal', 0, '[]', ?3, 1, ?4, 1, 1)",
+        params![
+            memory_id,
+            memory_scope_id,
+            definition_hash,
+            format!("wc_memrev_{}", "0".repeat(64)),
+        ],
+    )
+    .unwrap();
+    drop(raw);
+
+    assert!(Database::open(&path).is_err());
+    let raw = Connection::open(&path).unwrap();
+    let columns = raw
+        .prepare("PRAGMA table_info(project_memories)")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert!(!columns.iter().any(|column| column == "created_by_kind"));
+    let scope_table_count: i64 = raw
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='project_memory_scopes'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(scope_table_count, 0);
+}
+
+#[test]
+fn attributed_scope_and_provenance_track_real_mutations_without_noop_churn() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("memory.db");
+    let db = Database::open(&path).unwrap();
+    let memory_scope_id = scope('c');
+    let scope_meta = scope_attribution("agent:runner:demo", "runner", 'a');
+    let creator = principal("shared-key", '1');
+    let updater = principal("oauth2", '2');
+
+    let created = db
+        .set_project_memory_attributed(
+            &memory_scope_id,
+            &scope_meta,
+            &creator,
+            input("policy-a", "original"),
+        )
+        .unwrap();
+    assert_eq!(created.record.created_by_kind, creator.kind);
+    assert_eq!(created.record.updated_by_kind, creator.kind);
+    assert_eq!(
+        created.record.created_by_principal_digest.as_deref(),
+        Some(creator.principal_digest.as_str())
+    );
+    let first_scope = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap()
+        .scope;
+    assert_eq!(first_scope.identity_state, MEMORY_SCOPE_IDENTITY_ATTRIBUTED);
+    assert_eq!(
+        first_scope.project_runtime_id.as_deref(),
+        Some(scope_meta.project_runtime_id.as_str())
+    );
+    assert_eq!(
+        first_scope.runner_client_id.as_deref(),
+        Some(scope_meta.runner_client_id.as_str())
+    );
+    assert_eq!(
+        first_scope.root_fingerprint.as_deref(),
+        Some(scope_meta.root_fingerprint.as_str())
+    );
+
+    let noop = db
+        .set_project_memory_attributed(
+            &memory_scope_id,
+            &scope_meta,
+            &updater,
+            input("policy-a", "original"),
+        )
+        .unwrap();
+    assert!(!noop.state_changed);
+    assert_eq!(noop.record.updated_by_kind, creator.kind);
+    assert_eq!(noop.record.revision, created.record.revision);
+    let after_noop_scope = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap()
+        .scope;
+    assert_eq!(
+        after_noop_scope.last_mutated_at_unix_ms,
+        first_scope.last_mutated_at_unix_ms
+    );
+
+    let second = db
+        .set_project_memory_attributed(
+            &memory_scope_id,
+            &scope_meta,
+            &creator,
+            input("policy-b", "second"),
+        )
+        .unwrap();
+    let shared_scope = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(shared_scope.memories.len(), 2);
+
+    let mut update = input("policy-a", "changed");
+    update.expected_revision = Some(created.record.revision.clone());
+    let changed = db
+        .set_project_memory_attributed(&memory_scope_id, &scope_meta, &updater, update)
+        .unwrap();
+    assert!(changed.state_changed);
+    assert_eq!(changed.record.created_by_kind, creator.kind);
+    assert_eq!(changed.record.updated_by_kind, updater.kind);
+    assert_eq!(
+        changed.record.created_by_principal_digest,
+        created.record.created_by_principal_digest
+    );
+    assert_eq!(
+        changed.record.updated_by_principal_digest.as_deref(),
+        Some(updater.principal_digest.as_str())
+    );
+
+    // Scope attribution and provenance are durable Control data, not process
+    // memory. Reopening the same SQLite store must preserve them exactly.
+    drop(db);
+    let db = Database::open(&path).unwrap();
+    let restarted = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        restarted.scope.identity_state,
+        MEMORY_SCOPE_IDENTITY_ATTRIBUTED
+    );
+    let restarted_policy = restarted
+        .memories
+        .iter()
+        .find(|record| record.memory_key == "policy-a")
+        .unwrap();
+    assert_eq!(restarted_policy.created_by_kind, creator.kind);
+    assert_eq!(restarted_policy.updated_by_kind, updater.kind);
+    assert_eq!(
+        restarted_policy.updated_by_principal_digest.as_deref(),
+        Some(updater.principal_digest.as_str())
+    );
+
+    db.delete_project_memory_attributed(
+        &memory_scope_id,
+        &scope_meta,
+        "policy-b",
+        &second.record.revision,
+    )
+    .unwrap();
+    assert_eq!(
+        db.get_project_memory_scope(&memory_scope_id)
+            .unwrap()
+            .unwrap()
+            .memories
+            .len(),
+        1
+    );
+    db.delete_project_memory_attributed(
+        &memory_scope_id,
+        &scope_meta,
+        "policy-a",
+        &changed.record.revision,
+    )
+    .unwrap();
+    assert!(db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn legacy_scope_is_attributed_only_by_real_mutation_and_reads_remain_read_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("legacy-scope.db");
+    let raw = Connection::open(&path).unwrap();
+    create_current_v2_memory_schema(&raw);
+    let memory_scope_id = scope('d');
+    let memory_id = "wc_mem_11111111111111111111111111111111";
+    let definition_hash = memory_definition_hash(
+        "policy",
+        "summary",
+        "body",
+        MemoryPriority::Normal,
+        false,
+        &[],
+    );
+    let revision = memory_state_revision(&memory_scope_id, memory_id, 1, &definition_hash);
+    raw.execute(
+        "INSERT INTO project_memories VALUES (?1, ?2, 'policy', 'summary', 'body', 'normal', 0, '[]', ?3, 1, ?4, 10, 20)",
+        params![memory_id, memory_scope_id, definition_hash, revision],
+    )
+    .unwrap();
+    drop(raw);
+    let db = Database::open(&path).unwrap();
+    let before = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(before.scope.identity_state, MEMORY_SCOPE_IDENTITY_LEGACY);
+
+    let _ = db.list_project_memories(&memory_scope_id).unwrap();
+    let _ = db.get_project_memory(&memory_scope_id, "policy").unwrap();
+    let after_reads = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(after_reads.scope, before.scope);
+
+    let scope_meta = scope_attribution("agent:runner:demo", "runner", 'b');
+    let current = principal("shared-key", '3');
+    let noop = db
+        .set_project_memory_attributed(
+            &memory_scope_id,
+            &scope_meta,
+            &current,
+            MemorySetInput {
+                memory_key: "policy".to_string(),
+                summary: "summary".to_string(),
+                body: "body".to_string(),
+                priority: MemoryPriority::Normal,
+                bootstrap: false,
+                tags: vec![],
+                expected_revision: None,
+            },
+        )
+        .unwrap();
+    assert!(!noop.state_changed);
+    assert_eq!(
+        db.get_project_memory_scope(&memory_scope_id)
+            .unwrap()
+            .unwrap()
+            .scope
+            .identity_state,
+        MEMORY_SCOPE_IDENTITY_LEGACY
+    );
+
+    let mut real_update = MemorySetInput {
+        memory_key: "policy".to_string(),
+        summary: "changed".to_string(),
+        body: "body".to_string(),
+        priority: MemoryPriority::Normal,
+        bootstrap: false,
+        tags: vec![],
+        expected_revision: Some(revision),
+    };
+    let updated = db
+        .set_project_memory_attributed(&memory_scope_id, &scope_meta, &current, real_update.clone())
+        .unwrap();
+    real_update.expected_revision = Some(updated.record.revision.clone());
+    let after = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(after.scope.identity_state, MEMORY_SCOPE_IDENTITY_ATTRIBUTED);
+    assert_eq!(after.memories[0].created_by_kind, MEMORY_PROVENANCE_LEGACY);
+    assert_eq!(after.memories[0].updated_by_kind, current.kind);
+}
+
+#[test]
+fn purge_is_catalog_fenced_atomic_and_desired_state_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = Database::open(&tmp.path().join("purge.db")).unwrap();
+    let memory_scope_id = scope('e');
+    let scope_meta = scope_attribution("agent:runner:detached", "runner", 'c');
+    let actor = principal("bootstrap", '4');
+    let first = db
+        .set_project_memory_attributed(&memory_scope_id, &scope_meta, &actor, input("a", "A"))
+        .unwrap();
+    let second = db
+        .set_project_memory_attributed(&memory_scope_id, &scope_meta, &actor, input("b", "B"))
+        .unwrap();
+    let initial = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    let stale_catalog = memory_catalog_revision(&initial.memories);
+
+    let mut update = input("a", "A2");
+    update.expected_revision = Some(first.record.revision);
+    let updated = db
+        .set_project_memory_attributed(&memory_scope_id, &scope_meta, &actor, update)
+        .unwrap();
+    assert_eq!(
+        db.purge_project_memory_scope(&memory_scope_id, &stale_catalog)
+            .unwrap_err()
+            .code(),
+        "memory_scope_changed"
+    );
+    assert_eq!(
+        db.get_project_memory_scope(&memory_scope_id)
+            .unwrap()
+            .unwrap()
+            .memories
+            .len(),
+        2
+    );
+
+    let before_recreate = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    let recreate_stale = memory_catalog_revision(&before_recreate.memories);
+    db.delete_project_memory_attributed(
+        &memory_scope_id,
+        &scope_meta,
+        "b",
+        &second.record.revision,
+    )
+    .unwrap();
+    let recreated = db
+        .set_project_memory_attributed(&memory_scope_id, &scope_meta, &actor, input("b", "B"))
+        .unwrap();
+    assert_ne!(recreated.record.memory_id, second.record.memory_id);
+    assert_eq!(
+        db.purge_project_memory_scope(&memory_scope_id, &recreate_stale)
+            .unwrap_err()
+            .code(),
+        "memory_scope_changed"
+    );
+
+    let current = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    let current_catalog = memory_catalog_revision(&current.memories);
+    db.conn_for_tests()
+        .execute_batch(
+            "CREATE TRIGGER fail_scope_metadata_delete BEFORE DELETE ON project_memory_scopes
+             BEGIN SELECT RAISE(ABORT, 'forced scope purge failure'); END;",
+        )
+        .unwrap();
+    assert_eq!(
+        db.purge_project_memory_scope(&memory_scope_id, &current_catalog)
+            .unwrap_err()
+            .code(),
+        "memory_store_unavailable"
+    );
+    let after_failed_purge = db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(after_failed_purge.memories.len(), 2);
+    db.conn_for_tests()
+        .execute_batch("DROP TRIGGER fail_scope_metadata_delete;")
+        .unwrap();
+    let purged = db
+        .purge_project_memory_scope(&memory_scope_id, &current_catalog)
+        .unwrap();
+    assert!(purged.purged && purged.state_changed);
+    assert_eq!(purged.purged_count, 2);
+    assert!(db
+        .get_project_memory_scope(&memory_scope_id)
+        .unwrap()
+        .is_none());
+    assert!(db
+        .get_project_memory(&memory_scope_id, "a")
+        .unwrap()
+        .is_none());
+    let repeated = db
+        .purge_project_memory_scope(&memory_scope_id, &current_catalog)
+        .unwrap();
+    assert!(!repeated.purged && !repeated.state_changed);
+    assert_eq!(repeated.purged_count, 0);
+    let _ = updated;
+}
+
+#[test]
+fn corrupted_scope_or_provenance_metadata_fails_closed() {
+    for (label, corrupt) in [
+        (
+            "scope_identity",
+            "PRAGMA ignore_check_constraints = ON;
+             UPDATE project_memory_scopes SET identity_state = 'bogus';
+             PRAGMA ignore_check_constraints = OFF;",
+        ),
+        (
+            "scope_root",
+            "UPDATE project_memory_scopes SET root_fingerprint = 'wc_memroot_bad';",
+        ),
+        (
+            "scope_project_too_long",
+            "UPDATE project_memory_scopes SET project_runtime_id = printf('%0513d', 0);",
+        ),
+        (
+            "scope_runner_too_long",
+            "UPDATE project_memory_scopes SET runner_client_id = printf('%0129d', 0);",
+        ),
+        (
+            "scope_timestamps",
+            "UPDATE project_memory_scopes
+             SET last_mutated_at_unix_ms = created_at_unix_ms - 1;",
+        ),
+        (
+            "provenance_digest",
+            "UPDATE project_memories
+             SET created_by_kind = 'shared-key', created_by_principal_digest = NULL;",
+        ),
+        (
+            "provenance_kind",
+            "UPDATE project_memories SET created_by_kind = 'bogus';",
+        ),
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(&tmp.path().join(format!("{label}.db"))).unwrap();
+        let memory_scope_id = scope('f');
+        db.set_project_memory(&memory_scope_id, input("policy", "summary"))
+            .unwrap();
+        db.conn_for_tests().execute_batch(corrupt).unwrap();
+        assert_eq!(
+            db.get_project_memory_scope(&memory_scope_id)
+                .unwrap_err()
+                .code(),
+            "memory_store_unavailable",
+            "{label} scope"
+        );
+        assert_eq!(
+            db.list_project_memories(&memory_scope_id)
+                .unwrap_err()
+                .code(),
+            "memory_store_unavailable",
+            "{label} memory"
+        );
+    }
+}
+
+#[test]
+fn lifecycle_scope_list_fails_closed_when_scope_metadata_is_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = Database::open(&tmp.path().join("missing-scope-row.db")).unwrap();
+    let memory_scope_id = scope('e');
+    db.set_project_memory(&memory_scope_id, input("policy", "summary"))
+        .unwrap();
+    db.conn_for_tests()
+        .execute(
+            "DELETE FROM project_memory_scopes WHERE memory_scope_id = ?1",
+            params![memory_scope_id],
+        )
+        .unwrap();
+    assert_eq!(
+        db.list_project_memory_scopes(0, 10).unwrap_err().code(),
+        "memory_store_unavailable",
+        "lifecycle inventory must not silently omit Memory rows whose scope metadata is missing"
+    );
 }
 
 #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -633,7 +633,35 @@ impl Database {
             "created_at_unix_ms",
             "updated_at_unix_ms",
         ];
-        const CREATE_V2_TABLE: &str = "
+        const V3_COLUMNS: &[&str] = &[
+            "memory_id",
+            "memory_scope_id",
+            "memory_key",
+            "summary",
+            "body",
+            "priority",
+            "bootstrap",
+            "tags_json",
+            "definition_hash",
+            "generation",
+            "revision",
+            "created_at_unix_ms",
+            "updated_at_unix_ms",
+            "created_by_kind",
+            "created_by_principal_digest",
+            "updated_by_kind",
+            "updated_by_principal_digest",
+        ];
+        const SCOPE_COLUMNS: &[&str] = &[
+            "memory_scope_id",
+            "identity_state",
+            "project_runtime_id",
+            "runner_client_id",
+            "root_fingerprint",
+            "created_at_unix_ms",
+            "last_mutated_at_unix_ms",
+        ];
+        const CREATE_V3_TABLE: &str = "
             CREATE TABLE project_memories (
                 memory_id TEXT PRIMARY KEY,
                 memory_scope_id TEXT NOT NULL,
@@ -648,7 +676,32 @@ impl Database {
                 revision TEXT NOT NULL,
                 created_at_unix_ms INTEGER NOT NULL,
                 updated_at_unix_ms INTEGER NOT NULL,
+                created_by_kind TEXT NOT NULL,
+                created_by_principal_digest TEXT,
+                updated_by_kind TEXT NOT NULL,
+                updated_by_principal_digest TEXT,
                 UNIQUE(memory_scope_id, memory_key)
+            );";
+        const CREATE_SCOPE_TABLE: &str = "
+            CREATE TABLE project_memory_scopes (
+                memory_scope_id TEXT PRIMARY KEY,
+                identity_state TEXT NOT NULL CHECK(identity_state IN ('attributed', 'legacy_unattributed')),
+                project_runtime_id TEXT,
+                runner_client_id TEXT,
+                root_fingerprint TEXT,
+                created_at_unix_ms INTEGER NOT NULL,
+                last_mutated_at_unix_ms INTEGER NOT NULL,
+                CHECK(
+                    (identity_state = 'legacy_unattributed'
+                        AND project_runtime_id IS NULL
+                        AND runner_client_id IS NULL
+                        AND root_fingerprint IS NULL)
+                    OR
+                    (identity_state = 'attributed'
+                        AND project_runtime_id IS NOT NULL
+                        AND runner_client_id IS NOT NULL
+                        AND root_fingerprint IS NOT NULL)
+                )
             );";
         const CREATE_INDEXES: &str = "
             CREATE INDEX IF NOT EXISTS idx_project_memories_scope_key
@@ -660,6 +713,8 @@ impl Database {
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .context("begin project Memory schema migration")?;
         let columns = table_columns(&transaction, "project_memories")?;
+        let fresh = columns.is_empty();
+        let mut backfill_scope_metadata = false;
         let matches_columns = |expected: &[&str]| {
             columns
                 .iter()
@@ -669,9 +724,10 @@ impl Database {
 
         if columns.is_empty() {
             transaction
-                .execute_batch(CREATE_V2_TABLE)
-                .context("create project Memory v2 table")?;
+                .execute_batch(CREATE_V3_TABLE)
+                .context("create project Memory v3 table")?;
         } else if matches_columns(V1_COLUMNS) {
+            backfill_scope_metadata = true;
             // Current #203 schema. Rebuild instead of ALTERing nullable columns:
             // every legacy row must be validated before it can acquire trusted
             // v2 definition/state identities, and any failure rolls back the
@@ -682,8 +738,8 @@ impl Database {
                  ALTER TABLE project_memories RENAME TO project_memories_v1;",
             )?;
             transaction
-                .execute_batch(CREATE_V2_TABLE)
-                .context("create project Memory v2 table during migration")?;
+                .execute_batch(CREATE_V3_TABLE)
+                .context("create project Memory v3 table during migration")?;
 
             let rows = {
                 let mut statement = transaction.prepare(
@@ -763,8 +819,11 @@ impl Database {
                     "INSERT INTO project_memories
                      (memory_id, memory_scope_id, memory_key, summary, body, priority, bootstrap,
                       tags_json, definition_hash, generation, revision,
-                      created_at_unix_ms, updated_at_unix_ms)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10, ?11, ?12)",
+                      created_at_unix_ms, updated_at_unix_ms,
+                      created_by_kind, created_by_principal_digest,
+                      updated_by_kind, updated_by_principal_digest)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10, ?11, ?12,
+                             'legacy_unattributed', NULL, 'legacy_unattributed', NULL)",
                     rusqlite::params![
                         memory_id,
                         memory_scope_id,
@@ -782,8 +841,105 @@ impl Database {
                 )?;
             }
             transaction.execute_batch("DROP TABLE project_memories_v1;")?;
-        } else if !matches_columns(V2_COLUMNS) {
+        } else if matches_columns(V2_COLUMNS) {
+            backfill_scope_metadata = true;
+            {
+                let mut statement = transaction.prepare(
+                    "SELECT memory_id, memory_scope_id, memory_key, summary, body, priority,
+                            bootstrap, tags_json, definition_hash, generation, revision,
+                            created_at_unix_ms, updated_at_unix_ms,
+                            length(memory_id), length(memory_scope_id), length(memory_key),
+                            length(summary), length(CAST(body AS BLOB)), length(priority),
+                            length(CAST(tags_json AS BLOB)), length(definition_hash), length(revision)
+                     FROM project_memories ORDER BY memory_scope_id, memory_key",
+                )?;
+                statement
+                    .query_map([], |row| {
+                        super::memory::validate_current_memory_v2_row_lengths(
+                            row.get::<_, i64>(13)?,
+                            row.get::<_, i64>(14)?,
+                            row.get::<_, i64>(15)?,
+                            row.get::<_, i64>(16)?,
+                            row.get::<_, i64>(17)?,
+                            row.get::<_, i64>(18)?,
+                            row.get::<_, i64>(19)?,
+                            row.get::<_, i64>(20)?,
+                            row.get::<_, i64>(21)?,
+                        )
+                        .map_err(|_| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                13,
+                                rusqlite::types::Type::Integer,
+                                "current Memory row exceeds bounded shape".into(),
+                            )
+                        })?;
+                        super::memory::validate_current_memory_v2_row_identity(
+                            &row.get::<_, String>(0)?,
+                            &row.get::<_, String>(1)?,
+                            &row.get::<_, String>(2)?,
+                            &row.get::<_, String>(3)?,
+                            &row.get::<_, String>(4)?,
+                            &row.get::<_, String>(5)?,
+                            row.get::<_, i64>(6)?,
+                            &row.get::<_, String>(7)?,
+                            &row.get::<_, String>(8)?,
+                            row.get::<_, i64>(9)?,
+                            &row.get::<_, String>(10)?,
+                            row.get::<_, i64>(11)?,
+                            row.get::<_, i64>(12)?,
+                        )
+                        .map_err(|_| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                0,
+                                rusqlite::types::Type::Text,
+                                "malformed #205 project Memory row".into(),
+                            )
+                        })?;
+                        Ok(())
+                    })?
+                    .collect::<Result<Vec<_>, _>>()?;
+            }
+            transaction.execute_batch(
+                "ALTER TABLE project_memories
+                    ADD COLUMN created_by_kind TEXT NOT NULL DEFAULT 'legacy_unattributed';
+                 ALTER TABLE project_memories
+                    ADD COLUMN created_by_principal_digest TEXT;
+                 ALTER TABLE project_memories
+                    ADD COLUMN updated_by_kind TEXT NOT NULL DEFAULT 'legacy_unattributed';
+                 ALTER TABLE project_memories
+                    ADD COLUMN updated_by_principal_digest TEXT;",
+            )?;
+        } else if !matches_columns(V3_COLUMNS) {
             anyhow::bail!("unsupported project Memory schema shape");
+        }
+
+        let scope_columns = table_columns(&transaction, "project_memory_scopes")?;
+        let scope_shape_matches = scope_columns
+            .iter()
+            .map(String::as_str)
+            .eq(SCOPE_COLUMNS.iter().copied());
+        if scope_columns.is_empty() {
+            if !fresh && !backfill_scope_metadata {
+                anyhow::bail!("project Memory scope metadata is missing");
+            }
+            transaction
+                .execute_batch(CREATE_SCOPE_TABLE)
+                .context("create project Memory scope metadata table")?;
+        } else if !scope_shape_matches {
+            anyhow::bail!("unsupported project Memory scope schema shape");
+        }
+
+        if backfill_scope_metadata {
+            transaction.execute(
+                "INSERT INTO project_memory_scopes
+                 (memory_scope_id, identity_state, project_runtime_id, runner_client_id,
+                  root_fingerprint, created_at_unix_ms, last_mutated_at_unix_ms)
+                 SELECT memory_scope_id, 'legacy_unattributed', NULL, NULL, NULL,
+                        MIN(created_at_unix_ms), MAX(updated_at_unix_ms)
+                 FROM project_memories
+                 GROUP BY memory_scope_id",
+                [],
+            )?;
         }
 
         transaction

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -181,6 +181,8 @@ fn memory_tools_are_stateless_full_operator_only_scope_filtered_and_schema_stati
         "memory_read",
         "memory_set",
         "memory_delete",
+        "memory_scope_list",
+        "memory_scope_purge",
     ] {
         assert!(!generic_names.iter().any(|generic| generic == name));
     }
@@ -238,6 +240,13 @@ fn memory_tools_are_stateless_full_operator_only_scope_filtered_and_schema_stati
         crate::auth::SCOPE_MEMORY_MANAGE,
     ]);
     let full = render(Some(&full_auth));
+    // Project Memory manage authority is not global lifecycle authority.
+    assert!(!memory_names(&full).contains(&"memory_scope_list".to_string()));
+    assert!(!memory_names(&full).contains(&"memory_scope_purge".to_string()));
+    let admin_auth = oauth(&[crate::auth::SCOPE_ADMIN]);
+    let admin = render(Some(&admin_auth));
+    assert!(memory_names(&admin).contains(&"memory_scope_list".to_string()));
+    assert!(memory_names(&admin).contains(&"memory_scope_purge".to_string()));
     assert_eq!(
         memory_names(&full),
         vec![
@@ -334,7 +343,12 @@ fn memory_tools_are_stateless_full_operator_only_scope_filtered_and_schema_stati
             .into_iter()
             .map(|spec| spec.name)
             .collect::<Vec<_>>(),
-        vec!["memory_set", "memory_delete"]
+        vec![
+            "memory_set",
+            "memory_delete",
+            "memory_scope_list",
+            "memory_scope_purge"
+        ]
     );
 
     for surface in [ModelSurface::CanonicalConnector, ModelSurface::LocalCoding] {

--- a/src/shell_client/agents.rs
+++ b/src/shell_client/agents.rs
@@ -1237,6 +1237,38 @@ impl ShellClientRegistry {
             .collect()
     }
 
+    /// Hold the authoritative Runner/Project registry snapshot stable while one
+    /// bounded synchronous Control operation decides against that inventory.
+    /// This is intentionally narrow: callers must not await inside `f`.
+    pub(crate) async fn with_client_semantic_views_for_auth_locked<R>(
+        &self,
+        auth: Option<&crate::auth::AuthContext>,
+        f: impl FnOnce(Vec<ShellClientSemanticView>) -> R,
+    ) -> R {
+        let now = now_ts();
+        let mut inner = self.inner.lock().await;
+        self.prune_expired_shared_key_clients_locked(&mut inner, now);
+        for client in inner.clients.values_mut() {
+            expire_staging(client, now);
+        }
+        let mut ids = inner.clients.keys().cloned().collect::<Vec<_>>();
+        ids.sort();
+        let views = ids
+            .into_iter()
+            .filter(|id| {
+                inner
+                    .clients
+                    .get(id)
+                    .map(|client| shell_client_visible_to_auth(auth, client))
+                    .unwrap_or(false)
+            })
+            .filter_map(|id| Self::client_semantic_view_locked(&inner, &id))
+            .collect();
+        let result = f(views);
+        drop(inner);
+        result
+    }
+
     pub async fn get_client_view(&self, client_id: &str) -> Option<ShellClientView> {
         let now = now_ts();
         let mut inner = self.inner.lock().await;

--- a/src/shell_client/agents.rs
+++ b/src/shell_client/agents.rs
@@ -1237,13 +1237,34 @@ impl ShellClientRegistry {
             .collect()
     }
 
-    /// Hold the authoritative Runner/Project registry snapshot stable while one
-    /// bounded synchronous Control operation decides against that inventory.
-    /// This is intentionally narrow: callers must not await inside `f`.
-    pub(crate) async fn with_client_semantic_views_for_auth_locked<R>(
+    /// Return a complete canonical Runner/Project observation only when both
+    /// caller-supplied cardinality bounds hold. `None` means the observation is
+    /// incomplete and must never support a negative authority conclusion.
+    pub(crate) async fn list_bounded_client_semantic_views_for_auth(
         &self,
         auth: Option<&crate::auth::AuthContext>,
-        f: impl FnOnce(Vec<ShellClientSemanticView>) -> R,
+        max_clients: usize,
+        max_projects: usize,
+    ) -> Option<Vec<ShellClientSemanticView>> {
+        let now = now_ts();
+        let mut inner = self.inner.lock().await;
+        self.prune_expired_shared_key_clients_locked(&mut inner, now);
+        for client in inner.clients.values_mut() {
+            expire_staging(client, now);
+        }
+        Self::bounded_client_semantic_views_for_auth_locked(&inner, auth, max_clients, max_projects)
+    }
+
+    /// Hold one bounded authoritative Runner/Project registry observation stable
+    /// while a synchronous Control operation decides against it. `None` is an
+    /// incomplete observation; callers must fail closed. Callers must not await
+    /// inside `f`.
+    pub(crate) async fn with_bounded_client_semantic_views_for_auth_locked<R>(
+        &self,
+        auth: Option<&crate::auth::AuthContext>,
+        max_clients: usize,
+        max_projects: usize,
+        f: impl FnOnce(Option<Vec<ShellClientSemanticView>>) -> R,
     ) -> R {
         let now = now_ts();
         let mut inner = self.inner.lock().await;
@@ -1251,19 +1272,12 @@ impl ShellClientRegistry {
         for client in inner.clients.values_mut() {
             expire_staging(client, now);
         }
-        let mut ids = inner.clients.keys().cloned().collect::<Vec<_>>();
-        ids.sort();
-        let views = ids
-            .into_iter()
-            .filter(|id| {
-                inner
-                    .clients
-                    .get(id)
-                    .map(|client| shell_client_visible_to_auth(auth, client))
-                    .unwrap_or(false)
-            })
-            .filter_map(|id| Self::client_semantic_view_locked(&inner, &id))
-            .collect();
+        let views = Self::bounded_client_semantic_views_for_auth_locked(
+            &inner,
+            auth,
+            max_clients,
+            max_projects,
+        );
         let result = f(views);
         drop(inner);
         result
@@ -1427,6 +1441,36 @@ impl ShellClientRegistry {
             .get(client_id)
             .ok_or_else(|| format!("unknown shell client: {}", client_id))?;
         assert_shell_client_access(auth, client)
+    }
+
+    fn bounded_client_semantic_views_for_auth_locked(
+        inner: &ShellClientRegistryInner,
+        auth: Option<&crate::auth::AuthContext>,
+        max_clients: usize,
+        max_projects: usize,
+    ) -> Option<Vec<ShellClientSemanticView>> {
+        // Check the backing registry before allocating/sorting identifiers. This
+        // is conservative for non-admin callers, but lifecycle tools are
+        // administrator-only and a conservative incomplete result is fail-closed.
+        if inner.clients.len() > max_clients {
+            return None;
+        }
+        let mut ids = Vec::with_capacity(inner.clients.len());
+        let mut project_count = 0usize;
+        for (id, client) in &inner.clients {
+            if !shell_client_visible_to_auth(auth, client) {
+                continue;
+            }
+            project_count = project_count.checked_add(client.projects.len())?;
+            if project_count > max_projects {
+                return None;
+            }
+            ids.push(id.clone());
+        }
+        ids.sort();
+        ids.into_iter()
+            .map(|id| Self::client_semantic_view_locked(inner, &id))
+            .collect()
     }
 
     fn client_semantic_view_locked(

--- a/src/shell_client/mod_tests/project_projection.rs
+++ b/src/shell_client/mod_tests/project_projection.rs
@@ -1,6 +1,51 @@
 use super::*;
 
 #[tokio::test]
+async fn bounded_semantic_inventory_fails_closed_on_client_or_project_overflow() {
+    let registry = ShellClientRegistry::default();
+    for index in 0..2 {
+        registry
+            .register(runner_registration(
+                &format!("bounded-{index}"),
+                &format!("bounded-instance-{index}"),
+                vec![project_summary(
+                    &format!("project-{index}"),
+                    &format!("/tmp/project-{index}"),
+                )],
+            ))
+            .await
+            .unwrap();
+    }
+    let admin = auth_context(None, true);
+    assert_eq!(
+        registry
+            .list_bounded_client_semantic_views_for_auth(Some(&admin), 2, 2)
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert!(registry
+        .list_bounded_client_semantic_views_for_auth(Some(&admin), 1, 2)
+        .await
+        .is_none());
+    assert!(registry
+        .list_bounded_client_semantic_views_for_auth(Some(&admin), 2, 1)
+        .await
+        .is_none());
+    let locked_count = registry
+        .with_bounded_client_semantic_views_for_auth_locked(Some(&admin), 2, 2, |views| {
+            views.map(|views| views.len())
+        })
+        .await;
+    assert_eq!(locked_count, Some(2));
+    let locked_overflow = registry
+        .with_bounded_client_semantic_views_for_auth_locked(Some(&admin), 1, 2, |views| views)
+        .await;
+    assert!(locked_overflow.is_none());
+}
+
+#[tokio::test]
 async fn project_cardinality_does_not_reject_runner_liveness_or_dynamic_upsert() {
     let registry = ShellClientRegistry::default();
     let shared = crate::auth::shared_key::shared_key_context("project-scale-shared");

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -1618,6 +1618,7 @@ impl ToolRuntime {
                     bootstrap,
                     tags,
                     expected_revision,
+                    auth,
                 )
             }
 
@@ -1632,6 +1633,19 @@ impl ToolRuntime {
                     None => return ToolResult::err("memory_delete requires a resolved Project"),
                 };
                 self.memory_delete(&project, memory_key, expected_revision)
+            }
+
+            ToolCall::MemoryScopeList { offset, limit } => {
+                self.memory_scope_list(auth, offset, limit).await
+            }
+
+            ToolCall::MemoryScopePurge {
+                memory_scope_id,
+                expected_catalog_revision,
+                confirm,
+            } => {
+                self.memory_scope_purge(auth, memory_scope_id, expected_catalog_revision, confirm)
+                    .await
             }
 
             call @ ToolCall::ImportConversationFilesToProject { .. } => {

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -97,13 +97,17 @@ pub(crate) fn check_runtime_tool_scope(
     let policy = crate::auth::scopes::oauth_scope_policy_for_runtime_tool(tool_name);
     let Some(auth) = auth else {
         // Preserve historical unauthenticated compatibility for unrelated
-        // internal tools, but Memory authority is intentionally never inferred
-        // from surface presence or a missing credential.
-        let required_memory_scope = match policy {
+        // internal tools, but explicit Memory and administrator authority is
+        // intentionally never inferred from surface presence or a missing
+        // credential. This derives only from the canonical ToolDefinition
+        // authority policy; it is not a tool-name registry.
+        let required_explicit_scope = match policy {
             OAuthToolScopePolicy::Require(scope)
                 if matches!(
                     scope,
-                    crate::auth::SCOPE_MEMORY_READ | crate::auth::SCOPE_MEMORY_MANAGE
+                    crate::auth::SCOPE_MEMORY_READ
+                        | crate::auth::SCOPE_MEMORY_MANAGE
+                        | crate::auth::SCOPE_ADMIN
                 ) =>
             {
                 Some(scope)
@@ -111,12 +115,14 @@ pub(crate) fn check_runtime_tool_scope(
             OAuthToolScopePolicy::RequireAll(scopes) => scopes.iter().copied().find(|scope| {
                 matches!(
                     *scope,
-                    crate::auth::SCOPE_MEMORY_READ | crate::auth::SCOPE_MEMORY_MANAGE
+                    crate::auth::SCOPE_MEMORY_READ
+                        | crate::auth::SCOPE_MEMORY_MANAGE
+                        | crate::auth::SCOPE_ADMIN
                 )
             }),
             _ => None,
         };
-        if let Some(scope) = required_memory_scope {
+        if let Some(scope) = required_explicit_scope {
             return Err(ToolCallErrorStatus::InsufficientScope {
                 required_scope: Some(scope),
                 description: format!("missing required scope: {scope}"),

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -65,8 +65,9 @@ pub(crate) struct ToolProtocolCapabilities {
     pub(crate) context_sidecar: bool,
     pub(crate) skill_runtime: bool,
     pub(crate) skill_management: bool,
-    /// Protocol-surface support for the Control-owned Memory runtime. Read vs
-    /// manage authority is expressed only by canonical credential scopes.
+    /// Protocol-surface support for the Control-owned Memory runtime. Per-tool
+    /// read, manage, and administrator authority comes only from canonical
+    /// ToolDefinition metadata.
     pub(crate) memory_surface: bool,
 }
 
@@ -266,8 +267,8 @@ impl ToolRuntime {
         // inner business ledger pairs inherit it, but it never affects execution.
         recorder_metadata.assign_logical_invocation();
         // Project Memory tools are kernel-known but globally model-hidden. One
-        // explicit protocol-surface capability gates all four tools; canonical
-        // memory:read/manage + project scopes below decide caller authority.
+        // explicit protocol-surface capability gates all six fixed tools; their
+        // canonical ToolDefinition authority decides caller access below.
         if (super::memory::is_memory_runtime_tool_name(&request.tool_name)
             || super::memory::is_memory_management_tool_name(&request.tool_name))
             && !capabilities.memory_surface

--- a/src/tool_runtime/memory.rs
+++ b/src/tool_runtime/memory.rs
@@ -107,7 +107,6 @@ impl MemoryScopeCurrentStatus {
 struct MemoryInventoryObservation {
     current_projects: BTreeMap<String, String>,
     client_inventory_complete: BTreeMap<String, bool>,
-    global_inventory_complete: bool,
 }
 
 fn memory_inventory_observation(
@@ -137,12 +136,9 @@ fn memory_inventory_observation(
             }
         }
     }
-    let global_inventory_complete =
-        !views.is_empty() && client_inventory_complete.values().all(|complete| *complete);
     MemoryInventoryObservation {
         current_projects,
         client_inventory_complete,
-        global_inventory_complete,
     }
 }
 
@@ -157,15 +153,14 @@ fn memory_scope_current_status(
         return MemoryScopeCurrentStatus::Current;
     }
     let Some(client_id) = scope.runner_client_id.as_deref() else {
-        // Legacy opaque scopes cannot target one Runner for a negative check. A
-        // complete non-empty current Server inventory can still prove that no
-        // currently registered Project has this exact scope identity. Empty,
-        // pending, degraded, or collision-ambiguous observations remain unknown.
-        return if inventory.global_inventory_complete {
-            MemoryScopeCurrentStatus::NotCurrent
-        } else {
-            MemoryScopeCurrentStatus::Unknown
-        };
+        // Legacy opaque scopes have no persisted owning Runner identity. An exact
+        // current scope match above proves `current`, but absence from this
+        // process-local registry can never prove `not_current`: after Server
+        // restart or while another Runner is absent, unrelated complete
+        // inventories are not a durable global Runner roster. Keep destructive
+        // lifecycle decisions fail-closed until a real Memory mutation safely
+        // upgrades the scope to attributed metadata.
+        return MemoryScopeCurrentStatus::Unknown;
     };
     if inventory.client_inventory_complete.get(client_id) == Some(&true) {
         MemoryScopeCurrentStatus::NotCurrent

--- a/src/tool_runtime/memory.rs
+++ b/src/tool_runtime/memory.rs
@@ -1,12 +1,16 @@
 use super::project_resolution::ResolvedProject;
 use super::{ToolResult, ToolRuntime};
+use crate::auth::AuthContext;
 use crate::db::{
     canonicalize_memory_tags, memory_catalog_revision, valid_memory_catalog_revision,
-    validate_memory_query, MemoryPriority, MemorySetInput, MemoryStoreError, ProjectMemoryRecord,
-    MAX_MEMORY_BOOTSTRAP_BYTES, MAX_MEMORY_SEARCH_LIMIT, MAX_MEMORY_SEARCH_RESULT_BYTES,
+    validate_memory_query, validate_memory_scope_id, MemoryPrincipalAttribution, MemoryPriority,
+    MemoryScopeAttribution, MemorySetInput, MemoryStoreError, ProjectMemoryRecord,
+    ProjectMemoryScopeRecord, MAX_MEMORY_BOOTSTRAP_BYTES, MAX_MEMORY_SCOPE_LIST_LIMIT,
+    MAX_MEMORY_SEARCH_LIMIT, MAX_MEMORY_SEARCH_RESULT_BYTES,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 
 const DEFAULT_MEMORY_SEARCH_LIMIT: usize = 20;
 
@@ -15,21 +19,176 @@ pub(crate) fn is_memory_runtime_tool_name(name: &str) -> bool {
 }
 
 pub(crate) fn is_memory_management_tool_name(name: &str) -> bool {
-    matches!(name, "memory_set" | "memory_delete")
+    matches!(
+        name,
+        "memory_set" | "memory_delete" | "memory_scope_list" | "memory_scope_purge"
+    )
 }
 
-pub(crate) fn memory_scope_id(project: &ResolvedProject) -> String {
+fn memory_hash_field(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value);
+}
+
+fn memory_scope_id_from_parts(project_runtime_id: &str, client_id: &str, root: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"webcodex-project-memory-scope-v1\0");
     for value in [
-        project.resolved_id.as_bytes(),
-        project.config.client_id.as_bytes(),
-        project.config.path.as_bytes(),
+        project_runtime_id.as_bytes(),
+        client_id.as_bytes(),
+        root.as_bytes(),
     ] {
-        hasher.update((value.len() as u64).to_be_bytes());
-        hasher.update(value);
+        memory_hash_field(&mut hasher, value);
     }
     format!("wc_memscope_{:x}", hasher.finalize())
+}
+
+pub(crate) fn memory_scope_id(project: &ResolvedProject) -> String {
+    memory_scope_id_from_parts(
+        &project.resolved_id,
+        &project.config.client_id,
+        &project.config.path,
+    )
+}
+
+pub(crate) fn memory_root_fingerprint(root: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex-project-memory-root-v1\0");
+    memory_hash_field(&mut hasher, root.as_bytes());
+    format!("wc_memroot_{:x}", hasher.finalize())
+}
+
+fn memory_scope_attribution(project: &ResolvedProject) -> MemoryScopeAttribution {
+    MemoryScopeAttribution {
+        project_runtime_id: project.resolved_id.clone(),
+        runner_client_id: project.config.client_id.clone(),
+        root_fingerprint: memory_root_fingerprint(&project.config.path),
+    }
+}
+
+pub(crate) fn memory_principal_attribution(
+    auth: Option<&AuthContext>,
+) -> Result<MemoryPrincipalAttribution, &'static str> {
+    let (kind, stable_principal_id) = super::session_context::runtime_observation_principal(auth)
+        .map_err(|_| "memory_principal_unavailable")?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex-project-memory-principal-v1\0");
+    memory_hash_field(&mut hasher, kind.as_bytes());
+    memory_hash_field(&mut hasher, stable_principal_id.as_bytes());
+    Ok(MemoryPrincipalAttribution {
+        kind,
+        principal_digest: format!("wc_memprincipal_{:x}", hasher.finalize()),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemoryScopeCurrentStatus {
+    Current,
+    NotCurrent,
+    Unknown,
+}
+
+impl MemoryScopeCurrentStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::NotCurrent => "not_current",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct MemoryInventoryObservation {
+    current_projects: BTreeMap<String, String>,
+    client_inventory_complete: BTreeMap<String, bool>,
+    global_inventory_complete: bool,
+}
+
+fn memory_inventory_observation(
+    views: &[crate::shell_client::ShellClientSemanticView],
+) -> MemoryInventoryObservation {
+    let mut current_projects = BTreeMap::new();
+    let mut client_inventory_complete = BTreeMap::new();
+    for semantic in views {
+        let client_id = &semantic.view.client_id;
+        let complete = semantic
+            .view
+            .project_inventory
+            .as_ref()
+            .is_some_and(|status| status.sync_state == "complete");
+        client_inventory_complete.insert(client_id.clone(), complete);
+        for project in &semantic.view.projects {
+            let runtime_id =
+                super::project_resolution::agent_project_runtime_id(client_id, &project.id);
+            let scope = memory_scope_id_from_parts(&runtime_id, client_id, &project.path);
+            if current_projects.insert(scope, runtime_id).is_some() {
+                // A domain collision or duplicated authoritative identity makes
+                // negative lifecycle conclusions unsafe for every affected scope.
+                client_inventory_complete.insert(client_id.clone(), false);
+            }
+        }
+    }
+    let global_inventory_complete =
+        !views.is_empty() && client_inventory_complete.values().all(|complete| *complete);
+    MemoryInventoryObservation {
+        current_projects,
+        client_inventory_complete,
+        global_inventory_complete,
+    }
+}
+
+fn memory_scope_current_status(
+    scope: &ProjectMemoryScopeRecord,
+    inventory: &MemoryInventoryObservation,
+) -> MemoryScopeCurrentStatus {
+    if inventory
+        .current_projects
+        .contains_key(&scope.memory_scope_id)
+    {
+        return MemoryScopeCurrentStatus::Current;
+    }
+    let Some(client_id) = scope.runner_client_id.as_deref() else {
+        // Legacy opaque scopes cannot target one Runner for a negative check. A
+        // complete non-empty current Server inventory can still prove that no
+        // currently registered Project has this exact scope identity. Empty,
+        // pending, degraded, or collision-ambiguous observations remain unknown.
+        return if inventory.global_inventory_complete {
+            MemoryScopeCurrentStatus::NotCurrent
+        } else {
+            MemoryScopeCurrentStatus::Unknown
+        };
+    };
+    if inventory.client_inventory_complete.get(client_id) == Some(&true) {
+        MemoryScopeCurrentStatus::NotCurrent
+    } else {
+        // Missing Runner records, pending/degraded inventory, and Server restart
+        // gaps are not evidence of permanent detachment.
+        MemoryScopeCurrentStatus::Unknown
+    }
+}
+
+fn memory_lifecycle_error(kind: &str, extra: Value) -> ToolResult {
+    let mut output = json!({
+        "error_kind": kind,
+        "state_changed": false,
+    });
+    if let (Some(target), Some(extra)) = (output.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+    ToolResult::err_with_output(kind.to_string(), output)
+}
+
+fn memory_lifecycle_store_error(error: MemoryStoreError) -> ToolResult {
+    let mut extra = json!({});
+    if let (Some(revision), Some(object)) =
+        (error.current_catalog_revision(), extra.as_object_mut())
+    {
+        object.insert("current_catalog_revision".to_string(), json!(revision));
+    }
+    memory_lifecycle_error(error.code(), extra)
 }
 
 fn memory_descriptor(
@@ -245,6 +404,10 @@ impl ToolRuntime {
             "revision": record.revision,
             "created_at_unix_ms": record.created_at_unix_ms,
             "updated_at_unix_ms": record.updated_at_unix_ms,
+            "provenance": {
+                "created_by_kind": record.created_by_kind,
+                "updated_by_kind": record.updated_by_kind,
+            },
         }))
     }
 
@@ -259,11 +422,17 @@ impl ToolRuntime {
         bootstrap: Option<bool>,
         tags: Option<Vec<String>>,
         expected_revision: Option<String>,
+        auth: Option<&AuthContext>,
     ) -> ToolResult {
         let Some(db) = self.memory_db.as_deref() else {
             return memory_simple_error(project, "memory_store_unavailable", json!({}));
         };
         let scope = memory_scope_id(project);
+        let scope_attribution = memory_scope_attribution(project);
+        let principal = match memory_principal_attribution(auth) {
+            Ok(principal) => principal,
+            Err(kind) => return memory_simple_error(project, kind, json!({})),
+        };
         // memory_set is a full canonical definition update for the required
         // summary. Omitted optional fields preserve current values only on an
         // explicit CAS update; without expected_revision they retain create
@@ -311,8 +480,10 @@ impl ToolRuntime {
                 .unwrap_or_default(),
             None => Vec::new(),
         };
-        let outcome = match db.set_project_memory(
+        let outcome = match db.set_project_memory_attributed(
             &scope,
+            &scope_attribution,
+            &principal,
             MemorySetInput {
                 memory_key,
                 summary,
@@ -347,7 +518,13 @@ impl ToolRuntime {
             return memory_simple_error(project, "memory_store_unavailable", json!({}));
         };
         let scope = memory_scope_id(project);
-        let outcome = match db.delete_project_memory(&scope, &memory_key, &expected_revision) {
+        let scope_attribution = memory_scope_attribution(project);
+        let outcome = match db.delete_project_memory_attributed(
+            &scope,
+            &scope_attribution,
+            &memory_key,
+            &expected_revision,
+        ) {
             Ok(outcome) => outcome,
             Err(error) => return memory_error(project, error),
         };
@@ -359,6 +536,156 @@ impl ToolRuntime {
             "deleted": outcome.deleted,
             "state_changed": outcome.state_changed,
         }))
+    }
+
+    pub(crate) async fn memory_scope_list(
+        &self,
+        auth: Option<&AuthContext>,
+        offset: Option<usize>,
+        limit: Option<usize>,
+    ) -> ToolResult {
+        let Some(db) = self.memory_db.as_deref() else {
+            return memory_lifecycle_error("memory_store_unavailable", json!({}));
+        };
+        let offset = offset.unwrap_or(0);
+        let limit = limit.unwrap_or(50);
+        if !(1..=MAX_MEMORY_SCOPE_LIST_LIMIT).contains(&limit) {
+            return memory_lifecycle_store_error(MemoryStoreError::InvalidLimit);
+        }
+        let (total_count, snapshots) = match db.list_project_memory_scopes(offset, limit) {
+            Ok(value) => value,
+            Err(error) => return memory_lifecycle_store_error(error),
+        };
+        let views = self
+            .shell_clients
+            .list_client_semantic_views_for_auth(auth)
+            .await;
+        let inventory = memory_inventory_observation(&views);
+        let normalized_offset = offset.min(total_count);
+        let mut scopes = Vec::with_capacity(snapshots.len());
+        for snapshot in snapshots {
+            let status = memory_scope_current_status(&snapshot.scope, &inventory);
+            let catalog_revision = memory_catalog_revision(&snapshot.memories);
+            let memory_count = snapshot.memories.len();
+            let bootstrap_count = snapshot
+                .memories
+                .iter()
+                .filter(|memory| memory.bootstrap)
+                .count();
+            let oldest_memory_created_at_unix_ms = snapshot
+                .memories
+                .iter()
+                .map(|memory| memory.created_at_unix_ms)
+                .min()
+                .expect("scope snapshots are non-empty");
+            let latest_memory_updated_at_unix_ms = snapshot
+                .memories
+                .iter()
+                .map(|memory| memory.updated_at_unix_ms)
+                .max()
+                .expect("scope snapshots are non-empty");
+            let current_project_runtime_id = inventory
+                .current_projects
+                .get(&snapshot.scope.memory_scope_id)
+                .cloned();
+            scopes.push(json!({
+                "memory_scope_id": snapshot.scope.memory_scope_id,
+                "identity_state": snapshot.scope.identity_state,
+                "current_status": status.as_str(),
+                "project_runtime_id": snapshot.scope.project_runtime_id,
+                "runner_client_id": snapshot.scope.runner_client_id,
+                "root_fingerprint": snapshot.scope.root_fingerprint,
+                "current_project_runtime_id": current_project_runtime_id,
+                "memory_count": memory_count,
+                "bootstrap_count": bootstrap_count,
+                "catalog_revision": catalog_revision,
+                "oldest_memory_created_at_unix_ms": oldest_memory_created_at_unix_ms,
+                "latest_memory_updated_at_unix_ms": latest_memory_updated_at_unix_ms,
+                "scope_created_at_unix_ms": snapshot.scope.created_at_unix_ms,
+                "scope_last_mutated_at_unix_ms": snapshot.scope.last_mutated_at_unix_ms,
+            }));
+        }
+        let next = normalized_offset + scopes.len();
+        let truncated = next < total_count;
+        ToolResult::ok(json!({
+            "total_count": total_count,
+            "returned_count": scopes.len(),
+            "offset": normalized_offset,
+            "next_offset": truncated.then_some(next),
+            "truncated": truncated,
+            "scopes": scopes,
+        }))
+    }
+
+    pub(crate) async fn memory_scope_purge(
+        &self,
+        auth: Option<&AuthContext>,
+        memory_scope_id: String,
+        expected_catalog_revision: String,
+        confirm: bool,
+    ) -> ToolResult {
+        if !confirm {
+            return memory_lifecycle_error(
+                "memory_scope_confirmation_required",
+                json!({"memory_scope_id": memory_scope_id}),
+            );
+        }
+        if let Err(error) = validate_memory_scope_id(&memory_scope_id) {
+            return memory_lifecycle_store_error(error);
+        }
+        if !valid_memory_catalog_revision(&expected_catalog_revision) {
+            return memory_lifecycle_error(
+                "memory_catalog_revision_invalid",
+                json!({"memory_scope_id": memory_scope_id}),
+            );
+        }
+        let Some(db) = self.memory_db.as_deref() else {
+            return memory_lifecycle_error("memory_store_unavailable", json!({}));
+        };
+        let scope_record = match db.get_project_memory_scope(&memory_scope_id) {
+            Ok(None) => {
+                return ToolResult::ok(json!({
+                    "memory_scope_id": memory_scope_id,
+                    "catalog_revision": Value::Null,
+                    "purged_count": 0,
+                    "purged": false,
+                    "state_changed": false,
+                }))
+            }
+            Ok(Some(scope)) => scope,
+            Err(error) => return memory_lifecycle_store_error(error),
+        };
+
+        self.shell_clients
+            .with_client_semantic_views_for_auth_locked(auth, |views| {
+                let inventory = memory_inventory_observation(&views);
+                match memory_scope_current_status(&scope_record.scope, &inventory) {
+                    MemoryScopeCurrentStatus::Current => {
+                        return memory_lifecycle_error(
+                            "memory_scope_current",
+                            json!({"memory_scope_id": memory_scope_id}),
+                        )
+                    }
+                    MemoryScopeCurrentStatus::Unknown => {
+                        return memory_lifecycle_error(
+                            "memory_scope_status_unknown",
+                            json!({"memory_scope_id": memory_scope_id}),
+                        )
+                    }
+                    MemoryScopeCurrentStatus::NotCurrent => {}
+                }
+                match db.purge_project_memory_scope(&memory_scope_id, &expected_catalog_revision) {
+                    Ok(outcome) => ToolResult::ok(json!({
+                        "memory_scope_id": outcome.memory_scope_id,
+                        "catalog_revision": outcome.catalog_revision,
+                        "purged_count": outcome.purged_count,
+                        "purged": outcome.purged,
+                        "state_changed": outcome.state_changed,
+                    })),
+                    Err(error) => memory_lifecycle_store_error(error),
+                }
+            })
+            .await
     }
 
     pub(crate) fn memory_bootstrap_context_projection(
@@ -461,6 +788,10 @@ mod tests {
             bootstrap: false,
             tags: Vec::new(),
             definition_hash: format!("wc_memdef_{}", "a".repeat(64)),
+            created_by_kind: "test".to_string(),
+            created_by_principal_digest: Some(format!("wc_memprincipal_{}", "1".repeat(64))),
+            updated_by_kind: "test".to_string(),
+            updated_by_principal_digest: Some(format!("wc_memprincipal_{}", "1".repeat(64))),
             generation: 1,
             revision: format!("wc_memrev_{}", "a".repeat(64)),
             created_at_unix_ms: 1,

--- a/src/tool_runtime/memory.rs
+++ b/src/tool_runtime/memory.rs
@@ -5,14 +5,19 @@ use crate::db::{
     canonicalize_memory_tags, memory_catalog_revision, valid_memory_catalog_revision,
     validate_memory_query, validate_memory_scope_id, MemoryPrincipalAttribution, MemoryPriority,
     MemoryScopeAttribution, MemorySetInput, MemoryStoreError, ProjectMemoryRecord,
-    ProjectMemoryScopeRecord, MAX_MEMORY_BOOTSTRAP_BYTES, MAX_MEMORY_SCOPE_LIST_LIMIT,
-    MAX_MEMORY_SEARCH_LIMIT, MAX_MEMORY_SEARCH_RESULT_BYTES,
+    ProjectMemoryScopeRecord, MAX_MEMORIES_GLOBAL, MAX_MEMORY_BOOTSTRAP_BYTES,
+    MAX_MEMORY_SCOPE_LIST_LIMIT, MAX_MEMORY_SEARCH_LIMIT, MAX_MEMORY_SEARCH_RESULT_BYTES,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 const DEFAULT_MEMORY_SEARCH_LIMIT: usize = 20;
+/// Independent cap for lifecycle inventory projection. Project summaries are
+/// separately capped by the global Memory row ceiling below; exceeding either
+/// bound makes status unknown rather than turning a partial view into deletion
+/// authority.
+const MAX_MEMORY_SCOPE_INVENTORY_CLIENTS: usize = 1_024;
 
 pub(crate) fn is_memory_runtime_tool_name(name: &str) -> bool {
     matches!(name, "memory_search" | "memory_read")
@@ -106,8 +111,11 @@ struct MemoryInventoryObservation {
 }
 
 fn memory_inventory_observation(
-    views: &[crate::shell_client::ShellClientSemanticView],
+    views: Option<&[crate::shell_client::ShellClientSemanticView]>,
 ) -> MemoryInventoryObservation {
+    let Some(views) = views else {
+        return MemoryInventoryObservation::default();
+    };
     let mut current_projects = BTreeMap::new();
     let mut client_inventory_complete = BTreeMap::new();
     for semantic in views {
@@ -558,9 +566,13 @@ impl ToolRuntime {
         };
         let views = self
             .shell_clients
-            .list_client_semantic_views_for_auth(auth)
+            .list_bounded_client_semantic_views_for_auth(
+                auth,
+                MAX_MEMORY_SCOPE_INVENTORY_CLIENTS,
+                MAX_MEMORIES_GLOBAL,
+            )
             .await;
-        let inventory = memory_inventory_observation(&views);
+        let inventory = memory_inventory_observation(views.as_deref());
         let normalized_offset = offset.min(total_count);
         let mut scopes = Vec::with_capacity(snapshots.len());
         for snapshot in snapshots {
@@ -657,34 +669,41 @@ impl ToolRuntime {
         };
 
         self.shell_clients
-            .with_client_semantic_views_for_auth_locked(auth, |views| {
-                let inventory = memory_inventory_observation(&views);
-                match memory_scope_current_status(&scope_record.scope, &inventory) {
-                    MemoryScopeCurrentStatus::Current => {
-                        return memory_lifecycle_error(
-                            "memory_scope_current",
-                            json!({"memory_scope_id": memory_scope_id}),
-                        )
+            .with_bounded_client_semantic_views_for_auth_locked(
+                auth,
+                MAX_MEMORY_SCOPE_INVENTORY_CLIENTS,
+                MAX_MEMORIES_GLOBAL,
+                |views| {
+                    let inventory = memory_inventory_observation(views.as_deref());
+                    match memory_scope_current_status(&scope_record.scope, &inventory) {
+                        MemoryScopeCurrentStatus::Current => {
+                            return memory_lifecycle_error(
+                                "memory_scope_current",
+                                json!({"memory_scope_id": memory_scope_id}),
+                            )
+                        }
+                        MemoryScopeCurrentStatus::Unknown => {
+                            return memory_lifecycle_error(
+                                "memory_scope_status_unknown",
+                                json!({"memory_scope_id": memory_scope_id}),
+                            )
+                        }
+                        MemoryScopeCurrentStatus::NotCurrent => {}
                     }
-                    MemoryScopeCurrentStatus::Unknown => {
-                        return memory_lifecycle_error(
-                            "memory_scope_status_unknown",
-                            json!({"memory_scope_id": memory_scope_id}),
-                        )
+                    match db
+                        .purge_project_memory_scope(&memory_scope_id, &expected_catalog_revision)
+                    {
+                        Ok(outcome) => ToolResult::ok(json!({
+                            "memory_scope_id": outcome.memory_scope_id,
+                            "catalog_revision": outcome.catalog_revision,
+                            "purged_count": outcome.purged_count,
+                            "purged": outcome.purged,
+                            "state_changed": outcome.state_changed,
+                        })),
+                        Err(error) => memory_lifecycle_store_error(error),
                     }
-                    MemoryScopeCurrentStatus::NotCurrent => {}
-                }
-                match db.purge_project_memory_scope(&memory_scope_id, &expected_catalog_revision) {
-                    Ok(outcome) => ToolResult::ok(json!({
-                        "memory_scope_id": outcome.memory_scope_id,
-                        "catalog_revision": outcome.catalog_revision,
-                        "purged_count": outcome.purged_count,
-                        "purged": outcome.purged,
-                        "state_changed": outcome.state_changed,
-                    })),
-                    Err(error) => memory_lifecycle_store_error(error),
-                }
-            })
+                },
+            )
             .await
     }
 
@@ -775,6 +794,37 @@ mod tests {
         assert!(a.starts_with("wc_memscope_"));
         assert!(!a.contains("registered"));
         assert!(!a.contains("runner"));
+    }
+
+    #[test]
+    fn incomplete_bounded_inventory_never_proves_not_current() {
+        let attributed = ProjectMemoryScopeRecord {
+            memory_scope_id: format!("wc_memscope_{}", "a".repeat(64)),
+            identity_state: "attributed".to_string(),
+            project_runtime_id: Some("agent:runner:demo".to_string()),
+            runner_client_id: Some("runner".to_string()),
+            root_fingerprint: Some(format!("wc_memroot_{}", "b".repeat(64))),
+            created_at_unix_ms: 1,
+            last_mutated_at_unix_ms: 1,
+        };
+        let legacy = ProjectMemoryScopeRecord {
+            memory_scope_id: format!("wc_memscope_{}", "c".repeat(64)),
+            identity_state: "legacy_unattributed".to_string(),
+            project_runtime_id: None,
+            runner_client_id: None,
+            root_fingerprint: None,
+            created_at_unix_ms: 1,
+            last_mutated_at_unix_ms: 1,
+        };
+        let incomplete = memory_inventory_observation(None);
+        assert_eq!(
+            memory_scope_current_status(&attributed, &incomplete),
+            MemoryScopeCurrentStatus::Unknown
+        );
+        assert_eq!(
+            memory_scope_current_status(&legacy, &incomplete),
+            MemoryScopeCurrentStatus::Unknown
+        );
     }
 
     #[test]

--- a/src/tool_runtime/registry/input_schemas.rs
+++ b/src/tool_runtime/registry/input_schemas.rs
@@ -89,8 +89,8 @@ pub(super) use lsp::{
     lsp_status_input_schema, workspace_symbols_input_schema,
 };
 pub(super) use memory::{
-    memory_delete_input_schema, memory_read_input_schema, memory_search_input_schema,
-    memory_set_input_schema,
+    memory_delete_input_schema, memory_read_input_schema, memory_scope_list_input_schema,
+    memory_scope_purge_input_schema, memory_search_input_schema, memory_set_input_schema,
 };
 pub(super) use patches::{apply_patch_checked_input_schema, apply_patch_input_schema};
 pub(crate) use projects::{

--- a/src/tool_runtime/registry/input_schemas/memory.rs
+++ b/src/tool_runtime/registry/input_schemas/memory.rs
@@ -1,8 +1,9 @@
 use serde_json::{json, Value};
 
 use crate::db::{
-    MAX_MEMORY_BODY_BYTES, MAX_MEMORY_KEY_CHARS, MAX_MEMORY_QUERY_CHARS, MAX_MEMORY_SEARCH_LIMIT,
-    MAX_MEMORY_SUMMARY_CHARS, MAX_MEMORY_TAGS, MAX_MEMORY_TAG_CHARS,
+    MAX_MEMORY_BODY_BYTES, MAX_MEMORY_KEY_CHARS, MAX_MEMORY_QUERY_CHARS,
+    MAX_MEMORY_SCOPE_LIST_LIMIT, MAX_MEMORY_SEARCH_LIMIT, MAX_MEMORY_SUMMARY_CHARS,
+    MAX_MEMORY_TAGS, MAX_MEMORY_TAG_CHARS,
 };
 
 fn memory_key_schema() -> Value {
@@ -103,6 +104,41 @@ pub(crate) fn memory_delete_input_schema() -> Value {
             "session_id": {"type":"string"}
         },
         "required": ["project", "memory_key", "expected_revision"],
+        "additionalProperties": false
+    })
+}
+
+pub(crate) fn memory_scope_list_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "offset": {"type":"integer","minimum":0},
+            "limit": {"type":"integer","minimum":1,"maximum":MAX_MEMORY_SCOPE_LIST_LIMIT}
+        },
+        "additionalProperties": false
+    })
+}
+
+pub(crate) fn memory_scope_purge_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "memory_scope_id": {
+                "type":"string",
+                "pattern":"^wc_memscope_[0-9a-f]{64}$",
+                "description":"Opaque Control-owned project Memory scope identity from memory_scope_list. It contains no native root path."
+            },
+            "expected_catalog_revision": {
+                "type":"string",
+                "pattern":"^wc_memcat_[0-9a-f]{64}$",
+                "description":"Required scope-content CAS fence from memory_scope_list. Any Memory add/update/delete/recreate makes a prior value stale."
+            },
+            "confirm": {
+                "type":"boolean",
+                "description":"Must be true. Confirmation never overrides current or unknown scope status."
+            }
+        },
+        "required": ["memory_scope_id", "expected_catalog_revision", "confirm"],
         "additionalProperties": false
     })
 }

--- a/src/tool_runtime/registry/output_schemas/memory.rs
+++ b/src/tool_runtime/registry/output_schemas/memory.rs
@@ -21,6 +21,43 @@ fn descriptor_schema() -> Value {
     })
 }
 
+fn provenance_schema() -> Value {
+    json!({
+        "type":"object",
+        "properties": {
+            "created_by_kind": {"type":"string"},
+            "updated_by_kind": {"type":"string"}
+        },
+        "required":["created_by_kind","updated_by_kind"],
+        "additionalProperties":false,
+        "description":"Coarse durable attribution only. Principal digests and raw principal identities are never exposed here."
+    })
+}
+
+fn memory_scope_descriptor_schema() -> Value {
+    json!({
+        "type":"object",
+        "properties": {
+            "memory_scope_id":{"type":"string","pattern":"^wc_memscope_[0-9a-f]{64}$"},
+            "identity_state":{"type":"string","enum":["attributed","legacy_unattributed"]},
+            "current_status":{"type":"string","enum":["current","not_current","unknown"]},
+            "project_runtime_id":{"type":["string","null"]},
+            "runner_client_id":{"type":["string","null"]},
+            "root_fingerprint":{"type":["string","null"],"pattern":"^wc_memroot_[0-9a-f]{64}$"},
+            "current_project_runtime_id":{"type":["string","null"]},
+            "memory_count":{"type":"integer","minimum":1},
+            "bootstrap_count":{"type":"integer","minimum":0},
+            "catalog_revision":{"type":"string","pattern":"^wc_memcat_[0-9a-f]{64}$"},
+            "oldest_memory_created_at_unix_ms":{"type":"integer"},
+            "latest_memory_updated_at_unix_ms":{"type":"integer"},
+            "scope_created_at_unix_ms":{"type":"integer"},
+            "scope_last_mutated_at_unix_ms":{"type":"integer"}
+        },
+        "required":["memory_scope_id","identity_state","current_status","project_runtime_id","runner_client_id","root_fingerprint","current_project_runtime_id","memory_count","bootstrap_count","catalog_revision","oldest_memory_created_at_unix_ms","latest_memory_updated_at_unix_ms","scope_created_at_unix_ms","scope_last_mutated_at_unix_ms"],
+        "additionalProperties":false
+    })
+}
+
 pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
     match name {
         "memory_search" => Some(wrapped_output_schema(vec![
@@ -121,6 +158,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 schema_type("integer", "Last changed timestamp."),
             ),
             (
+                "provenance",
+                provenance_schema(),
+            ),
+            (
                 "error_kind",
                 schema_type("string", "Stable error/guard code."),
             ),
@@ -204,6 +245,25 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 "current_revision",
                 schema_type("string", "Current revision on stale delete CAS."),
             ),
+        ])),
+        "memory_scope_list" => Some(wrapped_output_schema(vec![
+            ("total_count", schema_type("integer", "Total durable Memory scope count.")),
+            ("returned_count", schema_type("integer", "Scope descriptors returned in this page.")),
+            ("offset", schema_type("integer", "Effective page offset.")),
+            ("next_offset", nullable_schema("integer", "Next offset when more scopes remain.")),
+            ("truncated", schema_type("boolean", "Whether more scopes remain.")),
+            ("scopes", array_schema(memory_scope_descriptor_schema(), "Bounded operator scope metadata; never native roots or Memory content.")),
+            ("error_kind", schema_type("string", "Stable lifecycle/store error code.")),
+            ("state_changed", schema_type("boolean", "Always false for list failures.")),
+        ])),
+        "memory_scope_purge" => Some(wrapped_output_schema(vec![
+            ("memory_scope_id", schema_type("string", "Opaque Memory scope identity.")),
+            ("catalog_revision", nullable_schema("string", "Purged catalog revision, or null when already absent.")),
+            ("current_catalog_revision", schema_type("string", "Current catalog revision when the CAS fence is stale.")),
+            ("purged_count", schema_type("integer", "Number of Memory rows atomically deleted.")),
+            ("purged", schema_type("boolean", "Whether this call purged an existing scope.")),
+            ("state_changed", schema_type("boolean", "Whether durable Memory state changed.")),
+            ("error_kind", schema_type("string", "Stable lifecycle/CAS/safety error code.")),
         ])),
         _ => None,
     }

--- a/src/tool_runtime/registry/tool_specs.rs
+++ b/src/tool_runtime/registry/tool_specs.rs
@@ -40,13 +40,19 @@ pub(crate) fn memory_runtime_tool_specs() -> Vec<ToolSpec> {
         .collect()
 }
 
-/// Fixed project Memory management contract. Durable Memory cardinality never
-/// changes this schema set; execution additionally requires the independent
-/// management capability, project:write scope, and permission evaluator.
+/// Fixed project Memory mutation plus global Memory lifecycle contract. Durable
+/// Memory/scope cardinality never changes this schema set. Each tool's canonical
+/// ToolDefinition authority distinguishes project-scoped memory:manage from
+/// admin-only lifecycle inspection/purge; permission evaluation remains independent.
 pub(crate) fn memory_management_tool_specs() -> Vec<ToolSpec> {
     memory::tool_specs()
         .into_iter()
-        .filter(|spec| matches!(spec.name.as_str(), "memory_set" | "memory_delete"))
+        .filter(|spec| {
+            matches!(
+                spec.name.as_str(),
+                "memory_set" | "memory_delete" | "memory_scope_list" | "memory_scope_purge"
+            )
+        })
         .collect()
 }
 

--- a/src/tool_runtime/registry/tool_specs/memory.rs
+++ b/src/tool_runtime/registry/tool_specs/memory.rs
@@ -1,6 +1,6 @@
 use super::super::input_schemas::{
-    memory_delete_input_schema, memory_read_input_schema, memory_search_input_schema,
-    memory_set_input_schema,
+    memory_delete_input_schema, memory_read_input_schema, memory_scope_list_input_schema,
+    memory_scope_purge_input_schema, memory_search_input_schema, memory_set_input_schema,
 };
 use super::tool_spec;
 use crate::tool_runtime::tool_spec::ToolSpec;
@@ -26,6 +26,16 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
             "memory_delete",
             "CAS-delete one explicit durable project Memory by memory_key and current state revision / ETag in expected_revision. An already-absent key is desired-state idempotent (deleted=false) but is not proof that an earlier deletion succeeded; delete+recreate has a different incarnation and revision. Requires project:write plus memory:manage and the normal permission gate.",
             memory_delete_input_schema(),
+        ),
+        tool_spec(
+            "memory_scope_list",
+            "Admin-only paginated inventory of durable Control-owned project Memory scopes. Reports attributed/legacy identity metadata, current/not_current/unknown status from fresh authoritative Project inventory, counts, timestamps, opaque root fingerprints, and catalog CAS revisions; never returns native roots or Memory content.",
+            memory_scope_list_input_schema(),
+        ),
+        tool_spec(
+            "memory_scope_purge",
+            "Admin-only destructive purge of one explicitly non-current project Memory scope. Requires confirm=true, current_status=not_current under a fresh authoritative Project inventory fence, and the exact current catalog revision. Current or unknown scopes fail closed. Reconcile a lost response with memory_scope_list; an already-absent scope is desired-state no-op, not proof of who performed an earlier purge.",
+            memory_scope_purge_input_schema(),
         ),
     ]
 }

--- a/src/tool_runtime/sessions/events.rs
+++ b/src/tool_runtime/sessions/events.rs
@@ -1058,6 +1058,28 @@ pub(super) fn context_result_summary_for_tool_result(
                 "state_changed",
             ],
         ),
+        "memory_scope_list" => selected(
+            output,
+            &[
+                "total_count",
+                "returned_count",
+                "truncated",
+                "error_kind",
+                "state_changed",
+            ],
+        ),
+        "memory_scope_purge" => selected(
+            output,
+            &[
+                "memory_scope_id",
+                "catalog_revision",
+                "current_catalog_revision",
+                "purged_count",
+                "purged",
+                "error_kind",
+                "state_changed",
+            ],
+        ),
         "skill_list" => selected(
             output,
             &[

--- a/src/tool_runtime/sessions/events.rs
+++ b/src/tool_runtime/sessions/events.rs
@@ -1075,7 +1075,6 @@ pub(super) fn context_result_summary_for_tool_result(
                 "catalog_revision",
                 "current_catalog_revision",
                 "purged_count",
-                "purged",
                 "error_kind",
                 "state_changed",
             ],

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -712,6 +712,7 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
     let memory_id = "wc_mem_0123456789abcdef0123456789abcdef";
     let revision = format!("wc_memrev_{}", "a".repeat(64));
     let catalog_revision = format!("wc_memcat_{}", "b".repeat(64));
+    let private_principal_digest = format!("wc_memprincipal_{}", "c".repeat(64));
 
     let set_args = super::super::ToolCall::MemorySet {
         project: project.to_string(),
@@ -819,7 +820,13 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
             "tags": [private_tag],
             "revision": revision,
             "created_at_unix_ms": 1,
-            "updated_at_unix_ms": 2
+            "updated_at_unix_ms": 2,
+            "provenance": {
+                "created_by_kind": "user",
+                "updated_by_kind": "oauth2",
+                "created_by_principal_digest": private_principal_digest,
+                "updated_by_principal_digest": private_principal_digest
+            }
         }),
         None,
         None,
@@ -827,7 +834,13 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
 
     let restored = flush_and_restore(&store, ledger.clone());
     let raw = std::fs::read_to_string(&ledger).unwrap();
-    for private in [private_query, private_summary, private_body, private_tag] {
+    for private in [
+        private_query,
+        private_summary,
+        private_body,
+        private_tag,
+        private_principal_digest.as_str(),
+    ] {
         assert!(!raw.contains(private), "ledger leaked {private}");
     }
     assert!(raw.contains(memory_id));
@@ -838,7 +851,13 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
 
     let recovery =
         serde_json::to_string(&restored.summary(&session.session_id, Some(30)).unwrap()).unwrap();
-    for private in [private_query, private_summary, private_body, private_tag] {
+    for private in [
+        private_query,
+        private_summary,
+        private_body,
+        private_tag,
+        private_principal_digest.as_str(),
+    ] {
         assert!(!recovery.contains(private), "recovery leaked {private}");
     }
 }

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -713,6 +713,9 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
     let revision = format!("wc_memrev_{}", "a".repeat(64));
     let catalog_revision = format!("wc_memcat_{}", "b".repeat(64));
     let private_principal_digest = format!("wc_memprincipal_{}", "c".repeat(64));
+    let scope_id = format!("wc_memscope_{}", "d".repeat(64));
+    let private_root_fingerprint = format!("wc_memroot_{}", "e".repeat(64));
+    let private_native_root = "/PRIVATE/NATIVE/MEMORY/ROOT";
 
     let set_args = super::super::ToolCall::MemorySet {
         project: project.to_string(),
@@ -832,6 +835,72 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
         None,
     );
 
+    let scope_list_start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Mcp,
+        "memory_scope_list",
+        &json!({"offset": 0, "limit": 50}),
+    );
+    store.record_model_facing_tool_call_finished(
+        scope_list_start,
+        true,
+        &json!({
+            "total_count": 1,
+            "returned_count": 1,
+            "offset": 0,
+            "next_offset": null,
+            "truncated": false,
+            "scopes": [{
+                "memory_scope_id": scope_id,
+                "identity_state": "attributed",
+                "current_status": "not_current",
+                "project_runtime_id": project,
+                "runner_client_id": "private-runner",
+                "root_fingerprint": private_root_fingerprint,
+                "catalog_revision": catalog_revision,
+                "summary": private_summary,
+                "body": private_body,
+                "native_root": private_native_root,
+                "principal_digest": private_principal_digest
+            }]
+        }),
+        None,
+        None,
+    );
+
+    let purge_args = super::super::ToolCall::MemoryScopePurge {
+        memory_scope_id: scope_id.clone(),
+        expected_catalog_revision: catalog_revision.clone(),
+        confirm: true,
+    }
+    .session_log_arguments();
+    assert!(purge_args.get("confirm").is_none());
+    let purge_start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Mcp,
+        "memory_scope_purge",
+        &purge_args,
+    );
+    store.record_model_facing_tool_call_finished(
+        purge_start,
+        true,
+        &json!({
+            "memory_scope_id": scope_id,
+            "catalog_revision": catalog_revision,
+            "purged_count": 1,
+            "purged": true,
+            "state_changed": true,
+            "summary": private_summary,
+            "body": private_body,
+            "tags": [private_tag],
+            "native_root": private_native_root,
+            "root_fingerprint": private_root_fingerprint,
+            "principal_digest": private_principal_digest
+        }),
+        None,
+        None,
+    );
+
     let restored = flush_and_restore(&store, ledger.clone());
     let raw = std::fs::read_to_string(&ledger).unwrap();
     for private in [
@@ -840,14 +909,21 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
         private_body,
         private_tag,
         private_principal_digest.as_str(),
+        private_root_fingerprint.as_str(),
+        private_native_root,
     ] {
         assert!(!raw.contains(private), "ledger leaked {private}");
     }
     assert!(raw.contains(memory_id));
     assert!(raw.contains(&revision));
     assert!(raw.contains(&catalog_revision));
+    assert!(raw.contains(&scope_id));
     assert!(raw.contains("returned_body_bytes"));
+    assert!(raw.contains("purged_count"));
     assert!(!raw.contains("\"memories\""));
+    assert!(!raw.contains("\"scopes\""));
+    assert!(!raw.contains("\"confirm\""));
+    assert!(!raw.contains("\"purged\""));
 
     let recovery =
         serde_json::to_string(&restored.summary(&session.session_id, Some(30)).unwrap()).unwrap();
@@ -857,6 +933,8 @@ fn memory_body_summary_query_and_tags_never_enter_durable_session_ledger_or_reco
         private_body,
         private_tag,
         private_principal_digest.as_str(),
+        private_root_fingerprint.as_str(),
+        private_native_root,
     ] {
         assert!(!recovery.contains(private), "recovery leaked {private}");
     }

--- a/src/tool_runtime/tests/memory.rs
+++ b/src/tool_runtime/tests/memory.rs
@@ -1553,9 +1553,11 @@ async fn memory_scope_legacy_exact_match_is_current_without_read_side_attributio
     let persisted = db.get_project_memory_scope(&scope_id).unwrap().unwrap();
     assert_eq!(persisted.scope.identity_state, "legacy_unattributed");
     assert!(persisted.scope.project_runtime_id.is_none());
-    // The same legacy scope becomes safely purgeable only after a non-empty,
-    // fully synchronized current Server inventory proves there is no exact
-    // Project scope match. No durable attribution is guessed in the process.
+    // Once the exact match disappears, this legacy scope has no persisted owning
+    // Runner identity. Even a complete inventory for the currently registered
+    // Runner cannot prove that an absent Runner does not own the opaque scope, so
+    // destructive lifecycle state remains fail-closed until a real mutation
+    // safely attributes it.
     register_agent_projects(
         &runtime,
         client_id,
@@ -1567,7 +1569,7 @@ async fn memory_scope_legacy_exact_match_is_current_without_read_side_attributio
     let detached = runtime.memory_scope_list(Some(&admin), None, None).await;
     let detached_scope = &detached.output["scopes"][0];
     assert_eq!(detached_scope["identity_state"], "legacy_unattributed");
-    assert_eq!(detached_scope["current_status"], "not_current");
+    assert_eq!(detached_scope["current_status"], "unknown");
     let catalog_revision = detached_scope["catalog_revision"]
         .as_str()
         .unwrap()
@@ -1575,8 +1577,74 @@ async fn memory_scope_legacy_exact_match_is_current_without_read_side_attributio
     let purged = runtime
         .memory_scope_purge(Some(&admin), scope_id.clone(), catalog_revision, true)
         .await;
-    assert!(purged.success, "{}", purged.output);
-    assert!(db.get_project_memory_scope(&scope_id).unwrap().is_none());
+    assert!(!purged.success);
+    assert_eq!(purged.output["error_kind"], "memory_scope_status_unknown");
+    assert!(db.get_project_memory_scope(&scope_id).unwrap().is_some());
+}
+
+#[tokio::test]
+async fn legacy_scope_missing_owner_stays_unknown_with_unrelated_complete_inventory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = Arc::new(crate::Database::open(&tmp.path().join("webcodex.db")).unwrap());
+    let runtime = ToolRuntime::new_for_tests()
+        .with_memory_database(db.clone())
+        .with_permission_evaluator(PermissionEvaluator::with_mode(AuthorityMode::TrustedAgent));
+    let admin = bootstrap_auth_context();
+    let project = resolved(
+        &crate::tool_runtime::agent_project_runtime_id("legacy-owner", "demo"),
+        "legacy-owner",
+        "/registered/legacy-owner",
+    );
+    assert!(
+        set(
+            &runtime,
+            &project,
+            "legacy-owner-policy",
+            "Owner may be absent after restart.",
+            "body",
+            "normal",
+            false,
+            &[],
+            None,
+        )
+        .success
+    );
+    let scope_id = super::super::memory::memory_scope_id(&project);
+    {
+        let conn = db.conn_for_tests();
+        conn.execute(
+            "UPDATE project_memory_scopes
+             SET identity_state = 'legacy_unattributed', project_runtime_id = NULL,
+                 runner_client_id = NULL, root_fingerprint = NULL
+             WHERE memory_scope_id = ?1",
+            rusqlite::params![scope_id],
+        )
+        .unwrap();
+    }
+
+    // A different Runner can have a fully complete inventory while the true
+    // legacy owner has not reconnected to this Server epoch. That observation is
+    // not a complete global Runner roster and must never authorize deletion.
+    register_agent_projects(
+        &runtime,
+        "unrelated-runner",
+        None,
+        ShellClientCapabilities::default(),
+        Vec::new(),
+    )
+    .await;
+    let listed = runtime.memory_scope_list(Some(&admin), None, None).await;
+    assert!(listed.success, "{}", listed.output);
+    let scope = &listed.output["scopes"][0];
+    assert_eq!(scope["identity_state"], "legacy_unattributed");
+    assert_eq!(scope["current_status"], "unknown");
+    let catalog_revision = scope["catalog_revision"].as_str().unwrap().to_string();
+    let purged = runtime
+        .memory_scope_purge(Some(&admin), scope_id.clone(), catalog_revision, true)
+        .await;
+    assert!(!purged.success);
+    assert_eq!(purged.output["error_kind"], "memory_scope_status_unknown");
+    assert!(db.get_project_memory_scope(&scope_id).unwrap().is_some());
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/memory.rs
+++ b/src/tool_runtime/tests/memory.rs
@@ -12,7 +12,9 @@ use super::super::{ToolResult, ToolRuntime};
 use super::support::*;
 use crate::db::{memory_catalog_revision, MemoryPriority, MAX_MEMORY_BOOTSTRAP_BYTES};
 use crate::projects::ProjectConfig;
+use crate::shell_protocol::{ShellClientCapabilities, ShellClientRegisterRequest};
 use serde_json::json;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 fn resolved(id: &str, client: &str, root: &str) -> ResolvedProject {
@@ -111,6 +113,31 @@ async fn list_files_with_session_context(
         .unwrap_or_else(|| panic!("list_project_files failed: {:?}", outcome.error_status))
 }
 
+fn set_raw(
+    runtime: &ToolRuntime,
+    project: &ResolvedProject,
+    memory_key: String,
+    summary: String,
+    body: Option<String>,
+    priority: Option<String>,
+    bootstrap: Option<bool>,
+    tags: Option<Vec<String>>,
+    expected_revision: Option<String>,
+) -> ToolResult {
+    let auth = shared_key_auth_context("memory-test-writer");
+    runtime.memory_set(
+        project,
+        memory_key,
+        summary,
+        body,
+        priority,
+        bootstrap,
+        tags,
+        expected_revision,
+        Some(&auth),
+    )
+}
+
 fn set(
     runtime: &ToolRuntime,
     project: &ResolvedProject,
@@ -122,7 +149,8 @@ fn set(
     tags: &[&str],
     expected_revision: Option<String>,
 ) -> ToolResult {
-    runtime.memory_set(
+    set_raw(
+        runtime,
         project,
         key.to_string(),
         summary.to_string(),
@@ -177,7 +205,8 @@ fn memory_runtime_search_read_cas_pagination_and_project_scope_are_explicit() {
     // A response-lost create retry is interpreted using create defaults, not
     // whatever optional fields a concurrent writer has since installed. Only an
     // explicit expected_revision turns omitted optional fields into "preserve".
-    let default_create = runtime.memory_set(
+    let default_create = set_raw(
+        &runtime,
         &project_a,
         "create-retry-defaults".to_string(),
         "Stable create intent.".to_string(),
@@ -192,7 +221,8 @@ fn memory_runtime_search_read_cas_pagination_and_project_scope_are_explicit() {
         .as_str()
         .unwrap()
         .to_string();
-    let intervening = runtime.memory_set(
+    let intervening = set_raw(
+        &runtime,
         &project_a,
         "create-retry-defaults".to_string(),
         "Stable create intent.".to_string(),
@@ -204,7 +234,8 @@ fn memory_runtime_search_read_cas_pagination_and_project_scope_are_explicit() {
     );
     assert!(intervening.success);
     let intervening_revision = intervening.output["revision"].as_str().unwrap().to_string();
-    let retried_create = runtime.memory_set(
+    let retried_create = set_raw(
+        &runtime,
         &project_a,
         "create-retry-defaults".to_string(),
         "Stable create intent.".to_string(),
@@ -417,7 +448,8 @@ fn memory_set_cas_update_preserves_omitted_optional_fields() {
     assert!(created.success);
     let original_revision = created.output["revision"].as_str().unwrap().to_string();
 
-    let updated = runtime.memory_set(
+    let updated = set_raw(
+        &runtime,
         &project,
         "preserve-fields".to_string(),
         "updated summary".to_string(),
@@ -437,7 +469,8 @@ fn memory_set_cas_update_preserves_omitted_optional_fields() {
     assert_eq!(read.output["bootstrap"], true);
     assert_eq!(read.output["tags"], json!(["one", "two"]));
 
-    let no_change = runtime.memory_set(
+    let no_change = set_raw(
+        &runtime,
         &project,
         "preserve-fields".to_string(),
         "updated summary".to_string(),
@@ -1155,6 +1188,819 @@ async fn memory_surface_scopes_and_permission_are_independent_authority() {
 }
 
 #[tokio::test]
+async fn memory_scope_lifecycle_is_offline_safe_unregister_explicit_and_purge_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = Arc::new(crate::Database::open(&tmp.path().join("webcodex.db")).unwrap());
+    let runtime = ToolRuntime::new_for_tests()
+        .with_memory_database(db.clone())
+        .with_permission_evaluator(PermissionEvaluator::with_mode(AuthorityMode::TrustedAgent));
+    let admin = bootstrap_auth_context();
+    let client_id = "memory-lifecycle";
+    let root = tempfile::tempdir().unwrap();
+    let root_text = root.path().to_string_lossy().to_string();
+    let revision = format!("sha256:{}", "a".repeat(64));
+    let mut summary = registered_project("demo", &root_text);
+    summary.revision = Some(revision.clone());
+    register_agent_projects(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            project_lifecycle: true,
+            ..Default::default()
+        },
+        vec![summary.clone()],
+    )
+    .await;
+    let project_id = crate::tool_runtime::agent_project_runtime_id(client_id, "demo");
+    let project = runtime
+        .resolve_project_input_for_auth(&project_id, Some(&admin))
+        .await
+        .unwrap();
+    let created = set(
+        &runtime,
+        &project,
+        "lifecycle-policy",
+        "Preserve explicit Memory lifecycle.",
+        "PRIVATE_LIFECYCLE_BODY",
+        "high",
+        true,
+        &["lifecycle"],
+        None,
+    );
+    assert!(created.success, "{}", created.output);
+    let scope_id = super::super::memory::memory_scope_id(&project);
+
+    let before_read_only = db
+        .get_project_memory_scope(&scope_id)
+        .unwrap()
+        .unwrap()
+        .scope
+        .last_mutated_at_unix_ms;
+    assert!(
+        runtime
+            .memory_read(&project, "lifecycle-policy".to_string(), None)
+            .success
+    );
+    assert!(
+        runtime
+            .memory_search(&project, None, None, None, None, None)
+            .success
+    );
+    runtime
+        .memory_bootstrap_context_projection(&project)
+        .unwrap();
+    let current = runtime.memory_scope_list(Some(&admin), None, None).await;
+    assert!(current.success, "{}", current.output);
+    let current_scope = current.output["scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|scope| scope["memory_scope_id"] == scope_id)
+        .unwrap();
+    assert_eq!(current_scope["current_status"], "current");
+    assert_eq!(current_scope["project_runtime_id"], project_id);
+    assert_eq!(current_scope["runner_client_id"], client_id);
+    assert_eq!(
+        current_scope["root_fingerprint"],
+        super::super::memory::memory_root_fingerprint(&root_text)
+    );
+    assert!(!current.output.to_string().contains(&root_text));
+    assert!(!current
+        .output
+        .to_string()
+        .contains("PRIVATE_LIFECYCLE_BODY"));
+    assert_eq!(
+        db.get_project_memory_scope(&scope_id)
+            .unwrap()
+            .unwrap()
+            .scope
+            .last_mutated_at_unix_ms,
+        before_read_only,
+        "read/search/bootstrap/scope-list must not mutate scope metadata"
+    );
+    let catalog_revision = current_scope["catalog_revision"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let current_purge = runtime
+        .memory_scope_purge(
+            Some(&admin),
+            scope_id.clone(),
+            catalog_revision.clone(),
+            true,
+        )
+        .await;
+    assert!(!current_purge.success);
+    assert_eq!(current_purge.output["error_kind"], "memory_scope_current");
+    assert!(db
+        .get_project_memory(&scope_id, "lifecycle-policy")
+        .unwrap()
+        .is_some());
+
+    runtime
+        .shell_clients
+        .reconcile_disconnect(client_id, &format!("inst-{client_id}"))
+        .await;
+    let offline = runtime.memory_scope_list(Some(&admin), None, None).await;
+    let offline_scope = offline.output["scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|scope| scope["memory_scope_id"] == scope_id)
+        .unwrap();
+    assert_eq!(offline_scope["current_status"], "current");
+    assert!(db
+        .get_project_memory(&scope_id, "lifecycle-policy")
+        .unwrap()
+        .is_some());
+
+    // Restore the same Runner registration, then explicitly unregister only the
+    // Project registration. Memory must remain until a separate lifecycle purge.
+    register_agent_projects(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities {
+            project_lifecycle: true,
+            ..Default::default()
+        },
+        vec![summary],
+    )
+    .await;
+    let unregister = tokio::spawn({
+        let runtime = runtime.clone();
+        let admin = admin.clone();
+        let project_id = project_id.clone();
+        let revision = revision.clone();
+        async move {
+            runtime
+                .unregister_project(project_id, revision, Some(&admin))
+                .await
+        }
+    });
+    let request = wait_for_agent_request_for_client(&runtime, client_id).await;
+    assert_eq!(request.kind, "project_lifecycle_unregister");
+    complete_patch_agent_request_for_instance(
+        &runtime,
+        client_id,
+        &format!("inst-{client_id}"),
+        &request.request_id,
+        0,
+        &json!({
+            "operation": "unregister",
+            "agent_project_id": "demo",
+            "outcome": "unregistered",
+            "changed": true,
+            "revision": serde_json::Value::Null
+        })
+        .to_string(),
+        "",
+    )
+    .await;
+    assert!(unregister.await.unwrap().success);
+    assert!(
+        runtime
+            .memory_read(&project, "lifecycle-policy".to_string(), None)
+            .success
+    );
+
+    let detached = runtime.memory_scope_list(Some(&admin), None, None).await;
+    let detached_scope = detached.output["scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|scope| scope["memory_scope_id"] == scope_id)
+        .unwrap();
+    assert_eq!(detached_scope["current_status"], "not_current");
+    let detached_revision = detached_scope["catalog_revision"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let purged = runtime
+        .memory_scope_purge(Some(&admin), scope_id.clone(), detached_revision, true)
+        .await;
+    assert!(purged.success, "{}", purged.output);
+    assert_eq!(purged.output["purged_count"], 1);
+    assert_eq!(purged.output["state_changed"], true);
+    assert!(db.get_project_memory_scope(&scope_id).unwrap().is_none());
+    assert!(
+        !runtime
+            .memory_read(&project, "lifecycle-policy".to_string(), None)
+            .success
+    );
+}
+
+#[tokio::test]
+async fn memory_scope_same_project_id_new_root_does_not_migrate_old_memory() {
+    let (runtime, _tmp) = runtime_with_memory();
+    let admin = bootstrap_auth_context();
+    let client_id = "memory-root-change";
+    let root_a = tempfile::tempdir().unwrap();
+    let root_b = tempfile::tempdir().unwrap();
+    let root_a_text = root_a.path().to_string_lossy().to_string();
+    let root_b_text = root_b.path().to_string_lossy().to_string();
+    register_agent_projects(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities::default(),
+        vec![registered_project("demo", &root_a_text)],
+    )
+    .await;
+    let project_id = crate::tool_runtime::agent_project_runtime_id(client_id, "demo");
+    let project_a = runtime
+        .resolve_project_input_for_auth(&project_id, Some(&admin))
+        .await
+        .unwrap();
+    assert!(
+        set(
+            &runtime,
+            &project_a,
+            "root-policy",
+            "Root A only.",
+            "old root body",
+            "normal",
+            false,
+            &[],
+            None,
+        )
+        .success
+    );
+    let scope_a = super::super::memory::memory_scope_id(&project_a);
+
+    register_agent_projects(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities::default(),
+        vec![registered_project("demo", &root_b_text)],
+    )
+    .await;
+    let project_b = runtime
+        .resolve_project_input_for_auth(&project_id, Some(&admin))
+        .await
+        .unwrap();
+    let scope_b = super::super::memory::memory_scope_id(&project_b);
+    assert_ne!(scope_a, scope_b);
+    assert!(
+        !runtime
+            .memory_read(&project_b, "root-policy".to_string(), None)
+            .success
+    );
+    let before_new_memory = runtime.memory_scope_list(Some(&admin), None, None).await;
+    let old = before_new_memory.output["scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|scope| scope["memory_scope_id"] == scope_a)
+        .unwrap();
+    assert_eq!(old["current_status"], "not_current");
+    assert_eq!(
+        old["root_fingerprint"],
+        super::super::memory::memory_root_fingerprint(&root_a_text)
+    );
+
+    assert!(
+        set(
+            &runtime,
+            &project_b,
+            "root-policy",
+            "Root B only.",
+            "new root body",
+            "normal",
+            false,
+            &[],
+            None,
+        )
+        .success
+    );
+    let after = runtime.memory_scope_list(Some(&admin), None, None).await;
+    let scopes = after.output["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 2);
+    assert_eq!(
+        scopes
+            .iter()
+            .find(|scope| scope["memory_scope_id"] == scope_a)
+            .unwrap()["current_status"],
+        "not_current"
+    );
+    assert_eq!(
+        scopes
+            .iter()
+            .find(|scope| scope["memory_scope_id"] == scope_b)
+            .unwrap()["current_status"],
+        "current"
+    );
+}
+
+#[tokio::test]
+async fn memory_scope_legacy_exact_match_is_current_without_read_side_attribution() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = Arc::new(crate::Database::open(&tmp.path().join("webcodex.db")).unwrap());
+    let runtime = ToolRuntime::new_for_tests()
+        .with_memory_database(db.clone())
+        .with_permission_evaluator(PermissionEvaluator::with_mode(AuthorityMode::TrustedAgent));
+    let admin = bootstrap_auth_context();
+    let client_id = "memory-legacy-current";
+    let root = tempfile::tempdir().unwrap();
+    let root_text = root.path().to_string_lossy().to_string();
+    let project_id = crate::tool_runtime::agent_project_runtime_id(client_id, "demo");
+    let project = resolved(&project_id, client_id, &root_text);
+    assert!(
+        set(
+            &runtime,
+            &project,
+            "legacy-current",
+            "Exact current match remains discoverable.",
+            "body",
+            "normal",
+            false,
+            &[],
+            None,
+        )
+        .success
+    );
+    let scope_id = super::super::memory::memory_scope_id(&project);
+    {
+        let conn = db.conn_for_tests();
+        conn.execute(
+            "UPDATE project_memory_scopes
+             SET identity_state = 'legacy_unattributed', project_runtime_id = NULL,
+                 runner_client_id = NULL, root_fingerprint = NULL
+             WHERE memory_scope_id = ?1",
+            rusqlite::params![scope_id],
+        )
+        .unwrap();
+    }
+    register_agent_projects(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities::default(),
+        vec![registered_project("demo", &root_text)],
+    )
+    .await;
+    let listed = runtime.memory_scope_list(Some(&admin), None, None).await;
+    assert!(listed.success, "{}", listed.output);
+    let scope = &listed.output["scopes"][0];
+    assert_eq!(scope["identity_state"], "legacy_unattributed");
+    assert_eq!(scope["current_status"], "current");
+    assert_eq!(scope["current_project_runtime_id"], project_id);
+    assert!(scope["project_runtime_id"].is_null());
+    assert!(scope["runner_client_id"].is_null());
+    assert!(scope["root_fingerprint"].is_null());
+    let persisted = db.get_project_memory_scope(&scope_id).unwrap().unwrap();
+    assert_eq!(persisted.scope.identity_state, "legacy_unattributed");
+    assert!(persisted.scope.project_runtime_id.is_none());
+    // The same legacy scope becomes safely purgeable only after a non-empty,
+    // fully synchronized current Server inventory proves there is no exact
+    // Project scope match. No durable attribution is guessed in the process.
+    register_agent_projects(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities::default(),
+        Vec::new(),
+    )
+    .await;
+    let detached = runtime.memory_scope_list(Some(&admin), None, None).await;
+    let detached_scope = &detached.output["scopes"][0];
+    assert_eq!(detached_scope["identity_state"], "legacy_unattributed");
+    assert_eq!(detached_scope["current_status"], "not_current");
+    let catalog_revision = detached_scope["catalog_revision"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let purged = runtime
+        .memory_scope_purge(Some(&admin), scope_id.clone(), catalog_revision, true)
+        .await;
+    assert!(purged.success, "{}", purged.output);
+    assert!(db.get_project_memory_scope(&scope_id).unwrap().is_none());
+}
+
+#[tokio::test]
+async fn memory_scope_missing_or_incomplete_inventory_is_unknown_until_complete() {
+    let (runtime, _tmp) = runtime_with_memory();
+    let admin = bootstrap_auth_context();
+    let client_id = "memory-incomplete";
+    let project = resolved(
+        &crate::tool_runtime::agent_project_runtime_id(client_id, "demo"),
+        client_id,
+        "/registered/missing-at-runtime",
+    );
+    assert!(
+        set(
+            &runtime,
+            &project,
+            "unknown-policy",
+            "Unknown until inventory proves absence.",
+            "body",
+            "normal",
+            false,
+            &[],
+            None,
+        )
+        .success
+    );
+    let scope_id = super::super::memory::memory_scope_id(&project);
+    let first = runtime.memory_scope_list(Some(&admin), None, None).await;
+    let first_scope = first.output["scopes"].as_array().unwrap()[0].clone();
+    assert_eq!(first_scope["current_status"], "unknown");
+    let catalog_revision = first_scope["catalog_revision"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let denied = runtime
+        .memory_scope_purge(
+            Some(&admin),
+            scope_id.clone(),
+            catalog_revision.clone(),
+            true,
+        )
+        .await;
+    assert!(!denied.success);
+    assert_eq!(denied.output["error_kind"], "memory_scope_status_unknown");
+
+    runtime
+        .shell_clients
+        .register(ShellClientRegisterRequest {
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: None,
+            job_inventory: None,
+            coding_agent_providers: None,
+            coding_agent_inventory: None,
+            client_id: client_id.to_string(),
+            agent_instance_id: format!("inst-{client_id}"),
+            display_name: None,
+            owner: None,
+            hostname: None,
+            host_context: None,
+            capabilities: Some(ShellClientCapabilities::default()),
+            projects: None,
+            agent_protocol_version: Some("polling-v1".to_string()),
+            policy: None,
+        })
+        .await
+        .unwrap();
+    let pending = runtime.memory_scope_list(Some(&admin), None, None).await;
+    assert_eq!(pending.output["scopes"][0]["current_status"], "unknown");
+
+    register_agent_projects(
+        &runtime,
+        client_id,
+        None,
+        ShellClientCapabilities::default(),
+        Vec::new(),
+    )
+    .await;
+    let complete = runtime.memory_scope_list(Some(&admin), None, None).await;
+    assert_eq!(
+        complete.output["scopes"][0]["current_status"],
+        "not_current"
+    );
+    let purged = runtime
+        .memory_scope_purge(Some(&admin), scope_id, catalog_revision, true)
+        .await;
+    assert!(purged.success, "{}", purged.output);
+}
+
+#[test]
+fn memory_provenance_digest_is_stable_private_and_updates_only_on_real_content_change() {
+    let (runtime, _tmp) = runtime_with_memory();
+    let project = resolved(
+        "agent:runner:provenance",
+        "runner",
+        "/registered/provenance",
+    );
+    let creator = auth_context(Some("alice"), false);
+    let creator_again = creator.clone();
+    let other = auth_context(Some("bob"), false);
+    let mut other_kind_same_id = creator.clone();
+    other_kind_same_id.kind = crate::auth::AuthKind::OAuth2Token;
+    other_kind_same_id.token_kind = Some("oauth2".to_string());
+
+    let creator_attr = super::super::memory::memory_principal_attribution(Some(&creator)).unwrap();
+    assert_eq!(
+        creator_attr,
+        super::super::memory::memory_principal_attribution(Some(&creator_again)).unwrap()
+    );
+    assert_ne!(
+        creator_attr.principal_digest,
+        super::super::memory::memory_principal_attribution(Some(&other))
+            .unwrap()
+            .principal_digest
+    );
+    let other_kind_attr =
+        super::super::memory::memory_principal_attribution(Some(&other_kind_same_id)).unwrap();
+    assert_ne!(
+        creator_attr.principal_digest,
+        other_kind_attr.principal_digest
+    );
+    assert!(!creator_attr.principal_digest.contains("key-alice"));
+
+    let created = runtime.memory_set(
+        &project,
+        "provenance".to_string(),
+        "Initial guidance".to_string(),
+        Some("body".to_string()),
+        Some("normal".to_string()),
+        Some(true),
+        Some(Vec::new()),
+        None,
+        Some(&creator),
+    );
+    assert!(created.success);
+    let created_revision = created.output["revision"].as_str().unwrap().to_string();
+    let scope_id = super::super::memory::memory_scope_id(&project);
+    let stored_created = runtime
+        .memory_db
+        .as_ref()
+        .unwrap()
+        .get_project_memory(&scope_id, "provenance")
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored_created.created_by_kind, creator.principal_kind());
+    assert_eq!(
+        stored_created.created_by_principal_digest.as_deref(),
+        Some(creator_attr.principal_digest.as_str())
+    );
+    assert_eq!(
+        stored_created.updated_by_principal_digest,
+        stored_created.created_by_principal_digest
+    );
+    let persisted_provenance: (String, Option<String>, String, Option<String>) = runtime
+        .memory_db
+        .as_ref()
+        .unwrap()
+        .conn_for_tests()
+        .query_row(
+            "SELECT created_by_kind, created_by_principal_digest,
+                    updated_by_kind, updated_by_principal_digest
+             FROM project_memories WHERE memory_scope_id = ?1 AND memory_key = 'provenance'",
+            rusqlite::params![scope_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    let persisted_provenance_text = format!("{persisted_provenance:?}");
+    assert!(!persisted_provenance_text.contains("key-alice"));
+    assert!(!persisted_provenance_text.contains("user-alice"));
+
+    let read = runtime.memory_read(&project, "provenance".to_string(), None);
+    assert_eq!(
+        read.output["provenance"]["created_by_kind"],
+        creator.principal_kind()
+    );
+    assert_eq!(
+        read.output["provenance"]["updated_by_kind"],
+        creator.principal_kind()
+    );
+    let read_text = read.output.to_string();
+    assert!(!read_text.contains("wc_memprincipal_"));
+    assert!(!read_text.contains("key-alice"));
+    let search_text = runtime
+        .memory_search(&project, None, None, None, None, None)
+        .output
+        .to_string();
+    let bootstrap_text = runtime
+        .memory_bootstrap_context_projection(&project)
+        .unwrap()
+        .to_string();
+    assert!(!search_text.contains("wc_memprincipal_"));
+    assert!(!bootstrap_text.contains("wc_memprincipal_"));
+
+    let no_op_other = runtime.memory_set(
+        &project,
+        "provenance".to_string(),
+        "Initial guidance".to_string(),
+        Some("body".to_string()),
+        Some("normal".to_string()),
+        Some(true),
+        Some(Vec::new()),
+        None,
+        Some(&other),
+    );
+    assert!(no_op_other.success);
+    assert_eq!(no_op_other.output["state_changed"], false);
+    assert_eq!(no_op_other.output["revision"], created_revision);
+    let after_no_op = runtime
+        .memory_db
+        .as_ref()
+        .unwrap()
+        .get_project_memory(&scope_id, "provenance")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after_no_op.updated_by_principal_digest,
+        stored_created.updated_by_principal_digest
+    );
+
+    let updated = runtime.memory_set(
+        &project,
+        "provenance".to_string(),
+        "Updated guidance".to_string(),
+        Some("body".to_string()),
+        Some("normal".to_string()),
+        Some(true),
+        Some(Vec::new()),
+        Some(created_revision),
+        Some(&other_kind_same_id),
+    );
+    assert!(updated.success);
+    assert_eq!(updated.output["state_changed"], true);
+    let updated_revision = updated.output["revision"].as_str().unwrap().to_string();
+    let stored_updated = runtime
+        .memory_db
+        .as_ref()
+        .unwrap()
+        .get_project_memory(&scope_id, "provenance")
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored_updated.created_by_kind, creator.principal_kind());
+    assert_eq!(
+        stored_updated.created_by_principal_digest,
+        stored_created.created_by_principal_digest
+    );
+    assert_eq!(stored_updated.updated_by_kind, "oauth2");
+    assert_eq!(
+        stored_updated.updated_by_principal_digest.as_deref(),
+        Some(other_kind_attr.principal_digest.as_str())
+    );
+    let no_op_cas = runtime.memory_set(
+        &project,
+        "provenance".to_string(),
+        "Updated guidance".to_string(),
+        Some("body".to_string()),
+        Some("normal".to_string()),
+        Some(true),
+        Some(Vec::new()),
+        Some(updated_revision.clone()),
+        Some(&creator),
+    );
+    assert!(no_op_cas.success);
+    assert_eq!(no_op_cas.output["state_changed"], false);
+    assert_eq!(no_op_cas.output["revision"], updated_revision);
+    assert_eq!(
+        runtime
+            .memory_db
+            .as_ref()
+            .unwrap()
+            .get_project_memory(&scope_id, "provenance")
+            .unwrap()
+            .unwrap()
+            .updated_by_principal_digest,
+        stored_updated.updated_by_principal_digest
+    );
+    let final_read = runtime.memory_read(&project, "provenance".to_string(), None);
+    assert_eq!(final_read.output["provenance"]["created_by_kind"], "user");
+    assert_eq!(final_read.output["provenance"]["updated_by_kind"], "oauth2");
+}
+
+#[tokio::test]
+async fn memory_scope_lifecycle_authority_surface_and_permission_are_independent() {
+    let (runtime, _tmp) = runtime_with_memory();
+    let admin = bootstrap_auth_context();
+    let non_admin = shared_key_auth_context("memory-lifecycle-nonadmin");
+    for tool in ["memory_scope_list", "memory_scope_purge"] {
+        assert!(matches!(
+            check_runtime_tool_scope(None, tool),
+            Err(ToolCallErrorStatus::InsufficientScope {
+                required_scope: Some(crate::auth::SCOPE_ADMIN),
+                ..
+            })
+        ));
+        assert!(matches!(
+            check_runtime_tool_scope(Some(&non_admin), tool),
+            Err(ToolCallErrorStatus::InsufficientScope {
+                required_scope: Some(crate::auth::SCOPE_ADMIN),
+                ..
+            })
+        ));
+        assert!(check_runtime_tool_scope(Some(&admin), tool).is_ok());
+    }
+    let context = |auth| ToolCallContext {
+        transport: ToolTransport::Mcp,
+        session_id: None,
+        auth,
+        window: None,
+        record_oauth_scope_denials: false,
+        host_file_import_trust: HostFileImportTrust::Untrusted,
+    };
+    let hidden = runtime
+        .call_tool_with_protocol_capabilities(
+            ToolCallRequest {
+                tool_name: "memory_scope_list".to_string(),
+                arguments: json!({}),
+            },
+            context(Some(&admin)),
+            Default::default(),
+        )
+        .await;
+    assert!(matches!(
+        hidden.error_status,
+        Some(ToolCallErrorStatus::InvalidArguments { .. })
+    ));
+    let denied = runtime
+        .call_tool_with_protocol_capabilities(
+            ToolCallRequest {
+                tool_name: "memory_scope_list".to_string(),
+                arguments: json!({}),
+            },
+            context(Some(&non_admin)),
+            ToolProtocolCapabilities {
+                memory_surface: true,
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(matches!(
+        denied.error_status,
+        Some(ToolCallErrorStatus::InsufficientScope {
+            required_scope: Some(crate::auth::SCOPE_ADMIN),
+            ..
+        })
+    ));
+    let allowed = runtime
+        .call_tool_with_protocol_capabilities(
+            ToolCallRequest {
+                tool_name: "memory_scope_list".to_string(),
+                arguments: json!({}),
+            },
+            context(Some(&admin)),
+            ToolProtocolCapabilities {
+                memory_surface: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .result
+        .expect("admin lifecycle list result");
+    assert!(allowed.success);
+    assert_eq!(allowed.output["total_count"], 0);
+
+    let restricted_tmp = tempfile::tempdir().unwrap();
+    let restricted_db =
+        Arc::new(crate::Database::open(&restricted_tmp.path().join("webcodex.db")).unwrap());
+    let eval_count = Arc::new(AtomicUsize::new(0));
+    let restricted = ToolRuntime::new_for_tests()
+        .with_memory_database(restricted_db.clone())
+        .with_permission_evaluator(
+            PermissionEvaluator::with_mode(AuthorityMode::Restricted)
+                .with_eval_counter(eval_count.clone()),
+        );
+    let detached_project = resolved(
+        "agent:missing:restricted-memory",
+        "missing",
+        "/registered/restricted-memory",
+    );
+    assert!(
+        set(
+            &restricted,
+            &detached_project,
+            "restricted-purge",
+            "Must still pass permission evaluation.",
+            "body",
+            "normal",
+            false,
+            &[],
+            None,
+        )
+        .success
+    );
+    let scope_id = super::super::memory::memory_scope_id(&detached_project);
+    let catalog_revision =
+        memory_catalog_revision(&restricted_db.list_project_memories(&scope_id).unwrap());
+    let before_eval = eval_count.load(Ordering::SeqCst);
+    let outcome = restricted
+        .call_tool_with_protocol_capabilities(
+            ToolCallRequest {
+                tool_name: "memory_scope_purge".to_string(),
+                arguments: json!({
+                    "memory_scope_id": scope_id,
+                    "expected_catalog_revision": catalog_revision,
+                    "confirm": true
+                }),
+            },
+            context(Some(&admin)),
+            ToolProtocolCapabilities {
+                memory_surface: true,
+                ..Default::default()
+            },
+        )
+        .await;
+    let result = outcome.result.expect("permission denial is a tool result");
+    assert!(!result.success);
+    assert_eq!(result.output["error_kind"], "permission_denied");
+    assert_eq!(result.output["permission"]["status"], "denied");
+    assert_eq!(eval_count.load(Ordering::SeqCst), before_eval + 1);
+    assert!(restricted_db
+        .get_project_memory_scope(&super::super::memory::memory_scope_id(&detached_project))
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
 async fn session_and_skill_observations_do_not_automatically_create_memory() {
     let (runtime, _tmp) = runtime_with_memory();
     let root = tempfile::tempdir().unwrap();
@@ -1295,6 +2141,10 @@ fn memory_catalog_revision_depends_only_on_key_revision_pairs() {
             bootstrap: false,
             tags: tags.clone(),
             definition_hash: format!("wc_memdef_{}", "b".repeat(64)),
+            created_by_kind: "test".to_string(),
+            created_by_principal_digest: Some(format!("wc_memprincipal_{}", "1".repeat(64))),
+            updated_by_kind: "test".to_string(),
+            updated_by_principal_digest: Some(format!("wc_memprincipal_{}", "1".repeat(64))),
             generation: 1,
             revision: format!("wc_memrev_{}", "b".repeat(64)),
             created_at_unix_ms: 1,
@@ -1309,6 +2159,10 @@ fn memory_catalog_revision_depends_only_on_key_revision_pairs() {
             bootstrap: true,
             tags,
             definition_hash: format!("wc_memdef_{}", "a".repeat(64)),
+            created_by_kind: "test".to_string(),
+            created_by_principal_digest: Some(format!("wc_memprincipal_{}", "2".repeat(64))),
+            updated_by_kind: "test".to_string(),
+            updated_by_principal_digest: Some(format!("wc_memprincipal_{}", "2".repeat(64))),
             generation: 1,
             revision: format!("wc_memrev_{}", "a".repeat(64)),
             created_at_unix_ms: 2,

--- a/src/tool_runtime/tests/schema/definitions.rs
+++ b/src/tool_runtime/tests/schema/definitions.rs
@@ -230,6 +230,8 @@ fn tool_call_parser_name_gate_matches_tool_definitions() {
         "memory_read",
         "memory_set",
         "memory_delete",
+        "memory_scope_list",
+        "memory_scope_purge",
     ]
     .into_iter()
     .collect();

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -580,7 +580,7 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
             copy_keys(
                 obj,
                 &mut out,
-                &["memory_scope_id", "expected_catalog_revision", "confirm"],
+                &["memory_scope_id", "expected_catalog_revision"],
             );
         }
         "skill_list" => {
@@ -1270,7 +1270,6 @@ pub(crate) fn session_log_result_for_tool(tool_name: &str, output: &Value) -> Va
             "catalog_revision": output.get("catalog_revision").cloned().unwrap_or(Value::Null),
             "current_catalog_revision": output.get("current_catalog_revision").cloned().unwrap_or(Value::Null),
             "purged_count": output.get("purged_count").cloned().unwrap_or(Value::Null),
-            "purged": output.get("purged").cloned().unwrap_or(Value::Null),
             "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
             "state_changed": output.get("state_changed").cloned().unwrap_or(Value::Null),
         }),
@@ -2282,6 +2281,27 @@ mod computer_privacy_tests {
         let private_native_root = "/PRIVATE/NATIVE/MEMORY/ROOT";
         let scope_id = format!("wc_memscope_{}", "c".repeat(64));
         let catalog_revision = format!("wc_memcat_{}", "e".repeat(64));
+        let purge_args = session_log_arguments_for_tool_request(
+            "memory_scope_purge",
+            &json!({
+                "memory_scope_id": scope_id,
+                "expected_catalog_revision": catalog_revision,
+                "confirm": true,
+                "body": private_body,
+            }),
+        );
+        assert_eq!(purge_args["memory_scope_id"], scope_id);
+        assert_eq!(purge_args["expected_catalog_revision"], catalog_revision);
+        assert!(purge_args.get("confirm").is_none());
+        assert!(!purge_args.to_string().contains(private_body));
+        let typed_purge = ToolCall::MemoryScopePurge {
+            memory_scope_id: scope_id.clone(),
+            expected_catalog_revision: catalog_revision.clone(),
+            confirm: true,
+        }
+        .session_log_arguments();
+        assert!(typed_purge.get("confirm").is_none());
+
         let scope_list = session_log_result_for_tool(
             "memory_scope_list",
             &json!({
@@ -2338,6 +2358,7 @@ mod computer_privacy_tests {
         assert_eq!(purge["memory_scope_id"], scope_id);
         assert_eq!(purge["catalog_revision"], catalog_revision);
         assert_eq!(purge["purged_count"], 1);
+        assert!(purge.get("purged").is_none());
         assert_eq!(purge["state_changed"], true);
         for private in [
             private_summary,
@@ -3742,13 +3763,12 @@ impl ToolCall {
             Self::MemoryScopePurge {
                 memory_scope_id,
                 expected_catalog_revision,
-                confirm,
+                ..
             } => session_log_arguments_for_tool_request(
                 "memory_scope_purge",
                 &serde_json::json!({
                     "memory_scope_id": memory_scope_id,
                     "expected_catalog_revision": expected_catalog_revision,
-                    "confirm": confirm,
                 }),
             ),
             Self::SkillList {

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -573,6 +573,16 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
                 &["project", "memory_key", "expected_revision", "session_id"],
             );
         }
+        "memory_scope_list" => {
+            copy_keys(obj, &mut out, &["offset", "limit"]);
+        }
+        "memory_scope_purge" => {
+            copy_keys(
+                obj,
+                &mut out,
+                &["memory_scope_id", "expected_catalog_revision", "confirm"],
+            );
+        }
         "skill_list" => {
             copy_keys(
                 obj,
@@ -1245,6 +1255,22 @@ pub(crate) fn session_log_result_for_tool(tool_name: &str, output: &Value) -> Va
             "memory_key": output.get("memory_key").cloned().unwrap_or(Value::Null),
             "revision": output.get("revision").cloned().unwrap_or(Value::Null),
             "deleted": output.get("deleted").cloned().unwrap_or(Value::Null),
+            "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
+            "state_changed": output.get("state_changed").cloned().unwrap_or(Value::Null),
+        }),
+        "memory_scope_list" => serde_json::json!({
+            "total_count": output.get("total_count").cloned().unwrap_or(Value::Null),
+            "returned_count": output.get("returned_count").cloned().unwrap_or(Value::Null),
+            "truncated": output.get("truncated").cloned().unwrap_or(Value::Null),
+            "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
+            "state_changed": output.get("state_changed").cloned().unwrap_or(Value::Null),
+        }),
+        "memory_scope_purge" => serde_json::json!({
+            "memory_scope_id": output.get("memory_scope_id").cloned().unwrap_or(Value::Null),
+            "catalog_revision": output.get("catalog_revision").cloned().unwrap_or(Value::Null),
+            "current_catalog_revision": output.get("current_catalog_revision").cloned().unwrap_or(Value::Null),
+            "purged_count": output.get("purged_count").cloned().unwrap_or(Value::Null),
+            "purged": output.get("purged").cloned().unwrap_or(Value::Null),
             "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
             "state_changed": output.get("state_changed").cloned().unwrap_or(Value::Null),
         }),
@@ -2252,6 +2278,79 @@ mod computer_privacy_tests {
                 "body": private_body
             }),
         );
+        let private_principal_digest = format!("wc_memprincipal_{}", "d".repeat(64));
+        let private_native_root = "/PRIVATE/NATIVE/MEMORY/ROOT";
+        let scope_id = format!("wc_memscope_{}", "c".repeat(64));
+        let catalog_revision = format!("wc_memcat_{}", "e".repeat(64));
+        let scope_list = session_log_result_for_tool(
+            "memory_scope_list",
+            &json!({
+                "total_count": 1,
+                "returned_count": 1,
+                "truncated": false,
+                "scopes": [{
+                    "memory_scope_id": scope_id,
+                    "identity_state": "attributed",
+                    "current_status": "not_current",
+                    "catalog_revision": catalog_revision,
+                    "memory_count": 1,
+                    "summary": private_summary,
+                    "body": private_body,
+                    "tags": [private_tag],
+                    "native_root": private_native_root,
+                    "principal_digest": private_principal_digest
+                }]
+            }),
+        );
+        let scope_list_text = scope_list.to_string();
+        assert_eq!(scope_list["total_count"], 1);
+        assert_eq!(scope_list["returned_count"], 1);
+        assert!(scope_list.get("scopes").is_none());
+        for private in [
+            private_summary,
+            private_body,
+            private_tag,
+            private_native_root,
+            private_principal_digest.as_str(),
+        ] {
+            assert!(
+                !scope_list_text.contains(private),
+                "scope-list audit leaked {private}"
+            );
+        }
+
+        let purge = session_log_result_for_tool(
+            "memory_scope_purge",
+            &json!({
+                "memory_scope_id": scope_id,
+                "catalog_revision": catalog_revision,
+                "purged_count": 1,
+                "purged": true,
+                "state_changed": true,
+                "summary": private_summary,
+                "body": private_body,
+                "tags": [private_tag],
+                "native_root": private_native_root,
+                "principal_digest": private_principal_digest
+            }),
+        );
+        let purge_text = purge.to_string();
+        assert_eq!(purge["memory_scope_id"], scope_id);
+        assert_eq!(purge["catalog_revision"], catalog_revision);
+        assert_eq!(purge["purged_count"], 1);
+        assert_eq!(purge["state_changed"], true);
+        for private in [
+            private_summary,
+            private_body,
+            private_tag,
+            private_native_root,
+            private_principal_digest.as_str(),
+        ] {
+            assert!(
+                !purge_text.contains(private),
+                "purge audit leaked {private}"
+            );
+        }
         assert!(!delete_result.to_string().contains(private_body));
     }
 
@@ -3634,6 +3733,22 @@ impl ToolCall {
                     "memory_key": memory_key,
                     "expected_revision": expected_revision,
                     "session_id": session_id,
+                }),
+            ),
+            Self::MemoryScopeList { offset, limit } => session_log_arguments_for_tool_request(
+                "memory_scope_list",
+                &serde_json::json!({"offset": offset, "limit": limit}),
+            ),
+            Self::MemoryScopePurge {
+                memory_scope_id,
+                expected_catalog_revision,
+                confirm,
+            } => session_log_arguments_for_tool_request(
+                "memory_scope_purge",
+                &serde_json::json!({
+                    "memory_scope_id": memory_scope_id,
+                    "expected_catalog_revision": expected_catalog_revision,
+                    "confirm": confirm,
                 }),
             ),
             Self::SkillList {

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -1063,6 +1063,22 @@ pub enum ToolCall {
         session_id: Option<String>,
     },
 
+    /// Admin-only paginated inventory of durable project Memory scopes.
+    MemoryScopeList {
+        #[serde(default)]
+        offset: Option<usize>,
+        #[serde(default)]
+        limit: Option<usize>,
+    },
+
+    /// Admin-only explicit purge of one non-current durable Memory scope.
+    MemoryScopePurge {
+        memory_scope_id: String,
+        expected_catalog_revision: String,
+        #[serde(default)]
+        confirm: bool,
+    },
+
     /// Start an async background job (long-running commands, codex CLI, etc.).
     RunJob {
         project: String,
@@ -2317,6 +2333,8 @@ impl ToolCall {
             Self::MemoryRead { .. } => "memory_read",
             Self::MemorySet { .. } => "memory_set",
             Self::MemoryDelete { .. } => "memory_delete",
+            Self::MemoryScopeList { .. } => "memory_scope_list",
+            Self::MemoryScopePurge { .. } => "memory_scope_purge",
             Self::RunJob { .. } => "run_job",
             Self::StopJob { .. } => "stop_job",
             Self::JobStatus { .. } => "job_status",

--- a/src/tool_runtime/tool_definition/memory.rs
+++ b/src/tool_runtime/tool_definition/memory.rs
@@ -4,7 +4,7 @@ use crate::auth::scopes::{MEMORY_MANAGE_SCOPES, MEMORY_READ_SCOPES};
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath,
     ToolRisk::{MemoryManage, ReadOnly},
-    PROJECT_READ, PROJECT_WRITE, TOOL_PROVIDER_CONTROL,
+    ADMIN, PROJECT_READ, PROJECT_WRITE, TOOL_PROVIDER_CONTROL,
 };
 
 /// Fixed Control-owned project Memory runtime contract. These tools remain
@@ -74,5 +74,31 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             false,
         ),
         MEMORY_MANAGE_SCOPES,
+    ),
+    def(
+        "memory_scope_list",
+        ModelHidden,
+        TOOL_CATEGORY_RUNTIME,
+        None,
+        TOOL_PROVIDER_CONTROL,
+        ReadOnly,
+        Some(ADMIN),
+        false,
+        NoPath,
+        false,
+        false,
+    ),
+    def(
+        "memory_scope_purge",
+        ModelHidden,
+        TOOL_CATEGORY_RUNTIME,
+        None,
+        TOOL_PROVIDER_CONTROL,
+        MemoryManage,
+        Some(ADMIN),
+        false,
+        NoPath,
+        true,
+        false,
     ),
 ];


### PR DESCRIPTION
## Summary

- add Control-owned durable lifecycle metadata for Project Memory scopes without changing `memory_scope_id`
- add admin-only `memory_scope_list` / `memory_scope_purge` with bounded authoritative inventory, `current` / `not_current` / `unknown` lifecycle status, catalog CAS, and transactional purge
- add durable Memory creator/updater provenance while keeping principal digests private and model-facing provenance coarse-grained
- integrate lifecycle authority through the canonical `ToolDefinition` registry and keep ordinary ActionAudit / Session projections metadata-only

## Lifecycle safety

- Runner offline, Project unregister, root changes, and Server restart do not automatically delete or migrate Memory
- purge requires a fresh `not_current` proof under the authoritative Runner/Project registry lock plus the exact catalog revision
- `legacy_unattributed` scopes may be recognized as `current` by exact scope match, but process-local registry absence cannot prove them `not_current`; destructive purge therefore remains fail closed until attribution is safely established by a real Memory mutation
- scope/provenance metadata remains bounded by the existing global Memory cardinality ceiling

## Validation

- `cargo fmt -- --check`
- `cargo check --all-targets`
- `cargo test --lib`
- focused Memory lifecycle, persistence/migration, authority, MCP schema, privacy, and provenance suites
- `git diff --check`

Rebased onto current `origin/main` (`bfbb32a4`, #208) before PR creation.