### PR TITLE
Expose effective MCP and Server runtime configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -346,6 +346,16 @@ pub(crate) enum ToolRequestTraceMode {
     Full,
 }
 
+impl ToolRequestTraceMode {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Metadata => "metadata",
+            Self::Full => "full",
+        }
+    }
+}
+
 pub(crate) fn tool_request_trace_mode() -> ToolRequestTraceMode {
     let Ok(value) = std::env::var("WEBCODEX_TOOL_REQUEST_TRACE") else {
         return ToolRequestTraceMode::Off;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,8 +247,8 @@ only for local/trusted-network demos."
     // projection reads this immutable enum from ToolRuntime.
     let model_surface = model_surface::resolve_model_surface(connector_context.as_ref())
         .map_err(std::io::Error::other)?;
-    let runtime_info = Arc::new(tool_runtime::RuntimeInfo::from_env_with_quic_config(
-        &quic_cfg,
+    let runtime_info = Arc::new(tool_runtime::RuntimeInfo::from_config_with_quic_config(
+        &config, &quic_cfg,
     ));
     let runtime_state_dir = config.runtime_state_dir();
     let mut tool_runtime_builder =

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -273,7 +273,7 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation(
                     "getRuntimeStatus",
                     "Get runtime status",
-                    "Read-only runtime health/observability with agent count/online_count/stale_count plus project and Job counts, together with safe allowlisted effective Server configuration. effective_config reports running modes without dumping environment or private state; compact=true only changes this response shape and is distinct from MCP compact schema discovery. Pass exact client_id when validating one Runner deployment/source alignment so unrelated fleet mismatches remain secondary; omit it for fleet-wide investigation.",
+                    "Read-only runtime health/observability with agent count/online_count/stale_count, project/Job counts, and safe allowlisted effective_config. compact=true compacts this response, not MCP schema discovery. Pass exact client_id for one Runner; omit it for fleet-wide status.",
                     "RuntimeStatusRequest",
                     "ToolResult"
                 )

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -273,7 +273,7 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation(
                     "getRuntimeStatus",
                     "Get runtime status",
-                    "Read-only runtime health/observability with agent count/online_count/stale_count plus project and Job counts. Pass exact client_id when validating one Runner deployment/source alignment so unrelated fleet mismatches remain secondary; omit it for fleet-wide investigation.",
+                    "Read-only runtime health/observability with agent count/online_count/stale_count plus project and Job counts, together with safe allowlisted effective Server configuration. effective_config reports running modes without dumping environment or private state; compact=true only changes this response shape and is distinct from MCP compact schema discovery. Pass exact client_id when validating one Runner deployment/source alignment so unrelated fleet mismatches remain secondary; omit it for fleet-wide investigation.",
                     "RuntimeStatusRequest",
                     "ToolResult"
                 )

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -41,7 +41,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                                 "shared_key_enabled": {"type": "boolean", "description": "Whether direct shared-key quick-start authentication is effective for the running Server; false on the project-bound canonical Connector surface."},
                                 "anonymous_enabled": {"type": "boolean", "description": "Whether explicit open-anonymous access is effective for the running Server; false on the project-bound canonical Connector surface."},
                                 "oauth2_enabled": {"type": "boolean", "description": "Whether OAuth2 support was enabled in the running Server configuration."},
-                                "oauth2_shared_key_bridge_enabled": {"type": "boolean", "description": "Whether the OAuth2 shared-key bridge is effective; false whenever OAuth2 itself is disabled or the project-bound canonical Connector surface excludes shared-key auth."}
+                                "oauth2_shared_key_bridge_enabled": {"type": "boolean", "description": "Whether the OAuth2 shared-key bridge is enabled in the running OAuth2 configuration; false whenever OAuth2 itself is disabled. This public OAuth flow is distinct from direct Bearer shared-key authentication."}
                             },
                             "required": ["shared_key_enabled", "anonymous_enabled", "oauth2_enabled", "oauth2_shared_key_bridge_enabled"]
                         },

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -16,6 +16,13 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "Configured MCP model surface: canonical_connector or full_operator_runtime.",
                 ),
             ),
+            (
+                "mcp_compact_schemas",
+                schema_type(
+                    "boolean",
+                    "Whether MCP tools/list omits outputSchema while retaining tool names, descriptions, inputSchema, and annotations.",
+                ),
+            ),
             ("version", schema_type("string", "Runtime version.")),
             (
                 "focus",

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -20,8 +20,39 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 "mcp_compact_schemas",
                 schema_type(
                     "boolean",
-                    "Whether MCP tools/list omits outputSchema while retaining tool names, descriptions, inputSchema, and annotations.",
+                    "Whether MCP tools/list omits outputSchema while retaining tool names, descriptions, inputSchema, and annotations. This is MCP discovery schema compaction, not runtime_status compact=true response shaping or GPT Action response compaction.",
                 ),
+            ),
+            (
+                "effective_config",
+                json!({
+                    "type": "object",
+                    "description": "Safe allowlisted effective configuration of the running Server. This is distinct from runtime_status compact=true response shaping and from health or transport state.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "action_compact_responses": {
+                            "type": "boolean",
+                            "description": "Whether the GPT Action/API adapter returns its compact response projection."
+                        },
+                        "auth": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "shared_key_enabled": {"type": "boolean", "description": "Whether direct shared-key quick-start authentication is effective for the running authenticated Server."},
+                                "anonymous_enabled": {"type": "boolean", "description": "Whether explicit open-anonymous access is effective for the running authenticated Server."},
+                                "oauth2_enabled": {"type": "boolean", "description": "Whether OAuth2 support was enabled in the running Server configuration."},
+                                "oauth2_shared_key_bridge_enabled": {"type": "boolean", "description": "Whether the OAuth2 shared-key bridge is effective; false whenever OAuth2 itself is disabled."}
+                            },
+                            "required": ["shared_key_enabled", "anonymous_enabled", "oauth2_enabled", "oauth2_shared_key_bridge_enabled"]
+                        },
+                        "tool_request_trace_mode": {
+                            "type": "string",
+                            "enum": ["off", "metadata", "full"],
+                            "description": "Effective bounded tool-request trace mode; no trace paths, request bodies, headers, or environment values are exposed."
+                        }
+                    },
+                    "required": ["action_compact_responses", "auth", "tool_request_trace_mode"]
+                }),
             ),
             ("version", schema_type("string", "Runtime version.")),
             (

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -38,10 +38,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
-                                "shared_key_enabled": {"type": "boolean", "description": "Whether direct shared-key quick-start authentication is effective for the running authenticated Server."},
-                                "anonymous_enabled": {"type": "boolean", "description": "Whether explicit open-anonymous access is effective for the running authenticated Server."},
+                                "shared_key_enabled": {"type": "boolean", "description": "Whether direct shared-key quick-start authentication is effective for the running Server; false on the project-bound canonical Connector surface."},
+                                "anonymous_enabled": {"type": "boolean", "description": "Whether explicit open-anonymous access is effective for the running Server; false on the project-bound canonical Connector surface."},
                                 "oauth2_enabled": {"type": "boolean", "description": "Whether OAuth2 support was enabled in the running Server configuration."},
-                                "oauth2_shared_key_bridge_enabled": {"type": "boolean", "description": "Whether the OAuth2 shared-key bridge is effective; false whenever OAuth2 itself is disabled."}
+                                "oauth2_shared_key_bridge_enabled": {"type": "boolean", "description": "Whether the OAuth2 shared-key bridge is effective; false whenever OAuth2 itself is disabled or the project-bound canonical Connector surface excludes shared-key auth."}
                             },
                             "required": ["shared_key_enabled", "anonymous_enabled", "oauth2_enabled", "oauth2_shared_key_bridge_enabled"]
                         },

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -85,8 +85,7 @@ impl ToolRuntime {
                     && self.runtime_info.auth_enabled
                     && crate::auth::allow_anonymous_enabled(),
                 "oauth2_enabled": self.runtime_info.oauth2_enabled,
-                "oauth2_shared_key_bridge_enabled": lightweight_auth_available
-                    && self.runtime_info.oauth2_shared_key_bridge_enabled,
+                "oauth2_shared_key_bridge_enabled": self.runtime_info.oauth2_shared_key_bridge_enabled,
             },
             "tool_request_trace_mode": crate::config::tool_request_trace_mode().as_str(),
         })

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -73,15 +73,20 @@ impl RuntimeInfo {
 
 impl ToolRuntime {
     fn effective_config_status(&self) -> Value {
+        let lightweight_auth_available =
+            self.model_surface() != crate::model_surface::ModelSurface::CanonicalConnector;
         json!({
             "action_compact_responses": crate::config::action_compact_responses_enabled(),
             "auth": {
-                "shared_key_enabled": self.runtime_info.auth_enabled
+                "shared_key_enabled": lightweight_auth_available
+                    && self.runtime_info.auth_enabled
                     && crate::auth::shared_key_enabled(),
-                "anonymous_enabled": self.runtime_info.auth_enabled
+                "anonymous_enabled": lightweight_auth_available
+                    && self.runtime_info.auth_enabled
                     && crate::auth::allow_anonymous_enabled(),
                 "oauth2_enabled": self.runtime_info.oauth2_enabled,
-                "oauth2_shared_key_bridge_enabled": self.runtime_info.oauth2_shared_key_bridge_enabled,
+                "oauth2_shared_key_bridge_enabled": lightweight_auth_available
+                    && self.runtime_info.oauth2_shared_key_bridge_enabled,
             },
             "tool_request_trace_mode": crate::config::tool_request_trace_mode().as_str(),
         })

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -25,8 +25,8 @@ pub(crate) struct ListAgentsOptions {
 }
 
 /// Lightweight runtime metadata injected into `ToolRuntime` so observability
-/// tools (e.g. `runtime_status`) can report auth/public-url state without the
-/// runtime holding a full `Config` (which would couple it to HTTP/fs details).
+/// tools (e.g. `runtime_status`) can report bounded auth/OAuth/public-url state
+/// without the runtime holding a full `Config` (which would couple it to HTTP/fs details).
 ///
 /// `configured_public_url` is `None` when `WEBCODEX_PUBLIC_URL` is unset; the
 /// observability output reports this as `null` so a deployer can immediately
@@ -35,22 +35,25 @@ pub(crate) struct ListAgentsOptions {
 pub struct RuntimeInfo {
     pub auth_enabled: bool,
     pub configured_public_url: Option<String>,
+    pub oauth2_enabled: bool,
+    pub oauth2_shared_key_bridge_enabled: bool,
     pub quic: Option<std::sync::Arc<std::sync::Mutex<crate::config::QuicRuntimeStatus>>>,
 }
 
 impl RuntimeInfo {
-    /// Build `RuntimeInfo` from the process environment. Reads
-    /// `WEBCODEX_TOKEN` (presence) and `WEBCODEX_PUBLIC_URL`.
+    /// Build test runtime metadata from the same parsed `Config` used by
+    /// production startup, plus the public URL and QUIC runtime configuration.
     #[cfg(test)]
     pub fn from_env() -> Self {
-        Self::from_env_with_quic_config(&crate::config::QuicServerConfig::from_env())
+        let config = crate::config::Config::from_env();
+        Self::from_config_with_quic_config(&config, &crate::config::QuicServerConfig::from_env())
     }
 
-    pub fn from_env_with_quic_config(quic_cfg: &crate::config::QuicServerConfig) -> Self {
-        let auth_enabled = std::env::var("WEBCODEX_TOKEN")
-            .ok()
-            .map(|v| !v.trim().is_empty())
-            .unwrap_or(false);
+    pub fn from_config_with_quic_config(
+        config: &crate::config::Config,
+        quic_cfg: &crate::config::QuicServerConfig,
+    ) -> Self {
+        let auth_enabled = config.is_auth_enabled();
         let configured_public_url = std::env::var("WEBCODEX_PUBLIC_URL")
             .ok()
             .map(|s| s.trim().trim_end_matches('/').to_string())
@@ -58,6 +61,9 @@ impl RuntimeInfo {
         Self {
             auth_enabled,
             configured_public_url,
+            oauth2_enabled: config.oauth2.enabled,
+            oauth2_shared_key_bridge_enabled: config.oauth2.enabled
+                && config.oauth2.shared_key_bridge_enabled,
             quic: Some(std::sync::Arc::new(std::sync::Mutex::new(
                 quic_cfg.runtime_status(),
             ))),
@@ -66,6 +72,21 @@ impl RuntimeInfo {
 }
 
 impl ToolRuntime {
+    fn effective_config_status(&self) -> Value {
+        json!({
+            "action_compact_responses": crate::config::action_compact_responses_enabled(),
+            "auth": {
+                "shared_key_enabled": self.runtime_info.auth_enabled
+                    && crate::auth::shared_key_enabled(),
+                "anonymous_enabled": self.runtime_info.auth_enabled
+                    && crate::auth::allow_anonymous_enabled(),
+                "oauth2_enabled": self.runtime_info.oauth2_enabled,
+                "oauth2_shared_key_bridge_enabled": self.runtime_info.oauth2_shared_key_bridge_enabled,
+            },
+            "tool_request_trace_mode": crate::config::tool_request_trace_mode().as_str(),
+        })
+    }
+
     pub(crate) async fn list_agents(&self, auth: Option<&AuthContext>) -> ToolResult {
         self.list_agents_with_options(auth, ListAgentsOptions::default())
             .await
@@ -452,6 +473,7 @@ impl ToolRuntime {
             "service": "webcodex",
             "model_surface": self.model_surface().name(),
             "mcp_compact_schemas": crate::config::mcp_compact_schemas_enabled(),
+            "effective_config": self.effective_config_status(),
             "version": env!("CARGO_PKG_VERSION"),
             "build": crate::build_info::runtime_build_info(),
             "server_time": now,
@@ -644,6 +666,7 @@ impl ToolRuntime {
             "service": "webcodex",
             "model_surface": self.model_surface().name(),
             "mcp_compact_schemas": crate::config::mcp_compact_schemas_enabled(),
+            "effective_config": self.effective_config_status(),
             "version": env!("CARGO_PKG_VERSION"),
             "build": server_build,
             "server_time": now,
@@ -692,6 +715,9 @@ pub(crate) fn compact_runtime_status(status: &Value) -> Value {
                 .cloned()
                 .unwrap_or_else(|| json!(crate::model_surface::MODEL_SURFACE_LOCAL_CODING)),
             "mcp_compact_schemas": status.get("mcp_compact_schemas").cloned().unwrap_or_else(|| json!(false)),
+            "effective_config": status.get("effective_config").cloned().unwrap_or(Value::Null),
+            "auth_enabled": status.get("auth_enabled").cloned().unwrap_or_else(|| json!(false)),
+            "configured_public_url": status.get("configured_public_url").cloned().unwrap_or(Value::Null),
             "version": status.get("version").cloned().unwrap_or(Value::Null),
             "focus": status.get("focus").cloned().unwrap_or(Value::Null),
             "server": status.get("server").cloned().unwrap_or(Value::Null),
@@ -719,6 +745,9 @@ pub(crate) fn compact_runtime_status(status: &Value) -> Value {
             .cloned()
             .unwrap_or_else(|| json!(crate::model_surface::MODEL_SURFACE_LOCAL_CODING)),
         "mcp_compact_schemas": status.get("mcp_compact_schemas").cloned().unwrap_or_else(|| json!(false)),
+        "effective_config": status.get("effective_config").cloned().unwrap_or(Value::Null),
+        "auth_enabled": status.get("auth_enabled").cloned().unwrap_or_else(|| json!(false)),
+        "configured_public_url": status.get("configured_public_url").cloned().unwrap_or(Value::Null),
         "version": status.get("version").cloned().unwrap_or(Value::Null),
         "build": {
             "version": status.get("version").cloned().unwrap_or(Value::Null),
@@ -1460,6 +1489,8 @@ impl Default for RuntimeInfo {
         Self {
             auth_enabled: false,
             configured_public_url: None,
+            oauth2_enabled: false,
+            oauth2_shared_key_bridge_enabled: false,
             quic: Some(std::sync::Arc::new(std::sync::Mutex::new(
                 crate::config::QuicServerConfig::default().runtime_status(),
             ))),

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -451,6 +451,7 @@ impl ToolRuntime {
         let mut output = json!({
             "service": "webcodex",
             "model_surface": self.model_surface().name(),
+            "mcp_compact_schemas": crate::config::mcp_compact_schemas_enabled(),
             "version": env!("CARGO_PKG_VERSION"),
             "build": crate::build_info::runtime_build_info(),
             "server_time": now,
@@ -642,6 +643,7 @@ impl ToolRuntime {
         ToolResult::ok(json!({
             "service": "webcodex",
             "model_surface": self.model_surface().name(),
+            "mcp_compact_schemas": crate::config::mcp_compact_schemas_enabled(),
             "version": env!("CARGO_PKG_VERSION"),
             "build": server_build,
             "server_time": now,
@@ -689,6 +691,7 @@ pub(crate) fn compact_runtime_status(status: &Value) -> Value {
                 .get("model_surface")
                 .cloned()
                 .unwrap_or_else(|| json!(crate::model_surface::MODEL_SURFACE_LOCAL_CODING)),
+            "mcp_compact_schemas": status.get("mcp_compact_schemas").cloned().unwrap_or_else(|| json!(false)),
             "version": status.get("version").cloned().unwrap_or(Value::Null),
             "focus": status.get("focus").cloned().unwrap_or(Value::Null),
             "server": status.get("server").cloned().unwrap_or(Value::Null),
@@ -715,6 +718,7 @@ pub(crate) fn compact_runtime_status(status: &Value) -> Value {
             .get("model_surface")
             .cloned()
             .unwrap_or_else(|| json!(crate::model_surface::MODEL_SURFACE_LOCAL_CODING)),
+        "mcp_compact_schemas": status.get("mcp_compact_schemas").cloned().unwrap_or_else(|| json!(false)),
         "version": status.get("version").cloned().unwrap_or(Value::Null),
         "build": {
             "version": status.get("version").cloned().unwrap_or(Value::Null),

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -2232,12 +2232,36 @@ async fn runtime_status_defaults_to_local_coding_surface() {
 
 #[tokio::test]
 async fn runtime_status_reports_canonical_connector_surface_when_configured() {
-    let runtime =
-        test_runtime().with_model_surface(crate::model_surface::ModelSurface::CanonicalConnector);
+    let mut env = crate::test_support::TestEnvGuard::new();
+    env.set("WEBCODEX_SHARED_KEY_ENABLED", "true");
+    env.set("WEBCODEX_ALLOW_ANONYMOUS", "true");
+    let runtime = runtime_with_info(RuntimeInfo {
+        auth_enabled: true,
+        oauth2_enabled: true,
+        oauth2_shared_key_bridge_enabled: true,
+        ..RuntimeInfo::default()
+    })
+    .with_model_surface(crate::model_surface::ModelSurface::CanonicalConnector);
     let full = runtime.dispatch(runtime_status_call()).await;
     assert_eq!(
         full.output["model_surface"],
         crate::model_surface::MODEL_SURFACE_CANONICAL_CONNECTOR
+    );
+    assert_eq!(
+        full.output["effective_config"]["auth"]["shared_key_enabled"],
+        false
+    );
+    assert_eq!(
+        full.output["effective_config"]["auth"]["anonymous_enabled"],
+        false
+    );
+    assert_eq!(
+        full.output["effective_config"]["auth"]["oauth2_enabled"],
+        true
+    );
+    assert_eq!(
+        full.output["effective_config"]["auth"]["oauth2_shared_key_bridge_enabled"],
+        false
     );
     let compact = runtime
         .dispatch(ToolCall::from_tool_name("runtime_status", json!({"compact": true})).unwrap())

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1552,6 +1552,17 @@ fn runtime_status_input_schema_exposes_compact_flags() {
     assert!(compact_schemas["description"]
         .as_str()
         .is_some_and(|description| description.contains("omits outputSchema")));
+    let effective_config = &output_schema["properties"]["output"]["properties"]["effective_config"];
+    assert_eq!(effective_config["type"], "object");
+    assert_eq!(effective_config["additionalProperties"], false);
+    assert_eq!(
+        effective_config["properties"]["auth"]["additionalProperties"],
+        false
+    );
+    assert_eq!(
+        effective_config["properties"]["tool_request_trace_mode"]["enum"],
+        json!(["off", "metadata", "full"])
+    );
 
     let openapi = crate::openapi::build_openapi_spec();
     let tool_call_properties = openapi["components"]["schemas"]["ToolCallRequest"]["properties"]
@@ -2131,6 +2142,82 @@ async fn runtime_status_includes_build_metadata() {
 }
 
 #[tokio::test]
+async fn runtime_status_preserves_allowlisted_effective_config_across_projections() {
+    let mut env = crate::test_support::TestEnvGuard::new();
+    env.set("WEBCODEX_ACTION_COMPACT_RESPONSES", "true");
+    env.set("WEBCODEX_SHARED_KEY_ENABLED", "true");
+    env.set("WEBCODEX_ALLOW_ANONYMOUS", "true");
+    env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+
+    let runtime = runtime_with_info(RuntimeInfo {
+        auth_enabled: true,
+        configured_public_url: Some("https://runtime.example.com".to_string()),
+        oauth2_enabled: true,
+        oauth2_shared_key_bridge_enabled: true,
+        ..RuntimeInfo::default()
+    });
+    register_agent(
+        &runtime,
+        "effective-config-agent",
+        None,
+        ShellClientCapabilities::default(),
+    )
+    .await;
+
+    let full = runtime.dispatch(runtime_status_call()).await;
+    assert!(full.success, "{:?}", full.error);
+    let config = &full.output["effective_config"];
+    let config_object = config.as_object().expect("effective_config object");
+    assert_eq!(
+        config_object.len(),
+        3,
+        "effective_config must stay allowlisted"
+    );
+    assert_eq!(config["action_compact_responses"], true);
+    assert_eq!(config["tool_request_trace_mode"], "full");
+    let auth = config["auth"].as_object().expect("effective auth object");
+    assert_eq!(auth.len(), 4, "effective auth facts must stay allowlisted");
+    assert_eq!(auth["shared_key_enabled"], true);
+    assert_eq!(auth["anonymous_enabled"], true);
+    assert_eq!(auth["oauth2_enabled"], true);
+    assert_eq!(auth["oauth2_shared_key_bridge_enabled"], true);
+
+    let focused = runtime
+        .dispatch(
+            ToolCall::from_tool_name(
+                "runtime_status",
+                json!({"client_id": "effective-config-agent"}),
+            )
+            .unwrap(),
+        )
+        .await;
+    assert!(focused.success, "{:?}", focused.error);
+    assert_eq!(focused.output["effective_config"], *config);
+    assert_eq!(focused.output["auth_enabled"], full.output["auth_enabled"]);
+    assert_eq!(
+        focused.output["configured_public_url"],
+        full.output["configured_public_url"]
+    );
+
+    for arguments in [
+        json!({"compact": true}),
+        json!({"summary_only": true}),
+        json!({"client_id": "effective-config-agent", "compact": true}),
+    ] {
+        let compact = runtime
+            .dispatch(ToolCall::from_tool_name("runtime_status", arguments).unwrap())
+            .await;
+        assert!(compact.success, "{:?}", compact.error);
+        assert_eq!(compact.output["effective_config"], *config);
+        assert_eq!(compact.output["auth_enabled"], full.output["auth_enabled"]);
+        assert_eq!(
+            compact.output["configured_public_url"],
+            full.output["configured_public_url"]
+        );
+    }
+}
+
+#[tokio::test]
 async fn runtime_status_defaults_to_local_coding_surface() {
     // ToolRuntime::new_for_tests defaults to local_coding; keep this as a real
     // default-constructor check rather than overriding the value under test.
@@ -2204,6 +2291,9 @@ async fn runtime_status_compact_and_summary_only_return_sanitized_summary() {
             crate::config::mcp_compact_schemas_enabled(),
             "arguments: {arguments}"
         );
+        assert!(summary["effective_config"].is_object());
+        assert_eq!(summary["auth_enabled"], false);
+        assert!(summary["configured_public_url"].is_null());
         for pointer in [
             "/service",
             "/version",
@@ -2284,6 +2374,8 @@ async fn runtime_status_does_not_expose_tokens_or_secrets() {
     let info = RuntimeInfo {
         auth_enabled: true,
         configured_public_url: Some("https://example.com".to_string()),
+        oauth2_enabled: true,
+        oauth2_shared_key_bridge_enabled: true,
         quic: Some(Arc::new(std::sync::Mutex::new(
             crate::config::QuicServerConfig::default().runtime_status(),
         ))),
@@ -2350,6 +2442,8 @@ async fn runtime_status_quic_enabled_error_is_sanitized() {
         auth_enabled: false,
         configured_public_url: None,
         quic: Some(status),
+        oauth2_enabled: false,
+        oauth2_shared_key_bridge_enabled: false,
     });
     let result = runtime.dispatch(runtime_status_call()).await;
     assert!(result.success);
@@ -2379,6 +2473,8 @@ async fn runtime_status_quic_started_reports_listen_and_alpn() {
         auth_enabled: false,
         configured_public_url: None,
         quic: Some(status),
+        oauth2_enabled: false,
+        oauth2_shared_key_bridge_enabled: false,
     });
     let result = runtime.dispatch(runtime_status_call()).await;
     assert!(result.success);
@@ -2396,6 +2492,8 @@ async fn runtime_status_auth_enabled_reflects_runtime_info() {
     let runtime = runtime_with_info(RuntimeInfo {
         auth_enabled: false,
         configured_public_url: None,
+        oauth2_enabled: false,
+        oauth2_shared_key_bridge_enabled: false,
         quic: Some(Arc::new(std::sync::Mutex::new(
             crate::config::QuicServerConfig::default().runtime_status(),
         ))),
@@ -2408,6 +2506,8 @@ async fn runtime_status_auth_enabled_reflects_runtime_info() {
     let runtime = runtime_with_info(RuntimeInfo {
         auth_enabled: true,
         configured_public_url: Some("https://webcodex.example.com".to_string()),
+        oauth2_enabled: true,
+        oauth2_shared_key_bridge_enabled: true,
         quic: Some(Arc::new(std::sync::Mutex::new(
             crate::config::QuicServerConfig::default().runtime_status(),
         ))),
@@ -2422,28 +2522,12 @@ async fn runtime_status_auth_enabled_reflects_runtime_info() {
 }
 
 #[test]
-fn runtime_info_from_env_reads_webcodex_public_url() {
-    let _guard = crate::admin_cli::TEST_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let previous = ["WEBCODEX_TOKEN", "WEBCODEX_PUBLIC_URL"]
-        .into_iter()
-        .map(|name| (name, std::env::var_os(name)))
-        .collect::<Vec<_>>();
-    struct RestoreEnv(Vec<(&'static str, Option<std::ffi::OsString>)>);
-    impl Drop for RestoreEnv {
-        fn drop(&mut self) {
-            for (name, value) in self.0.drain(..).rev() {
-                match value {
-                    Some(value) => std::env::set_var(name, value),
-                    None => std::env::remove_var(name),
-                }
-            }
-        }
-    }
-    let _restore = RestoreEnv(previous);
-    std::env::set_var("WEBCODEX_TOKEN", "token");
-    std::env::set_var("WEBCODEX_PUBLIC_URL", "https://new.example.com");
+fn runtime_info_from_env_reads_effective_server_config() {
+    let mut env = crate::test_support::TestEnvGuard::new();
+    env.set("WEBCODEX_TOKEN", "token");
+    env.set("WEBCODEX_PUBLIC_URL", "https://new.example.com");
+    env.set("WEBCODEX_OAUTH2_ENABLED", "true");
+    env.set("WEBCODEX_OAUTH2_SHARED_KEY_BRIDGE", "true");
 
     let info = RuntimeInfo::from_env();
     assert!(info.auth_enabled);
@@ -2451,6 +2535,13 @@ fn runtime_info_from_env_reads_webcodex_public_url() {
         info.configured_public_url.as_deref(),
         Some("https://new.example.com")
     );
+    assert!(info.oauth2_enabled);
+    assert!(info.oauth2_shared_key_bridge_enabled);
+
+    env.set("WEBCODEX_OAUTH2_ENABLED", "false");
+    let info = RuntimeInfo::from_env();
+    assert!(!info.oauth2_enabled);
+    assert!(!info.oauth2_shared_key_bridge_enabled);
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1546,6 +1546,12 @@ fn runtime_status_input_schema_exposes_compact_flags() {
         .expect("runtime_status agents output description");
     assert!(agents_description.contains("stale_count"));
     assert!(!agents_description.contains("offline_count"));
+    let compact_schemas =
+        &output_schema["properties"]["output"]["properties"]["mcp_compact_schemas"];
+    assert_eq!(compact_schemas["type"], "boolean");
+    assert!(compact_schemas["description"]
+        .as_str()
+        .is_some_and(|description| description.contains("omits outputSchema")));
 
     let openapi = crate::openapi::build_openapi_spec();
     let tool_call_properties = openapi["components"]["schemas"]["ToolCallRequest"]["properties"]
@@ -2113,6 +2119,10 @@ async fn runtime_status_includes_build_metadata() {
         result.output["model_surface"],
         crate::model_surface::MODEL_SURFACE_FULL_OPERATOR_RUNTIME
     );
+    assert_eq!(
+        result.output["mcp_compact_schemas"],
+        crate::config::mcp_compact_schemas_enabled()
+    );
     let build = &result.output["build"];
     assert!(build.is_object());
     assert!(build.get("git_commit").is_some());
@@ -2148,6 +2158,10 @@ async fn runtime_status_reports_canonical_connector_surface_when_configured() {
     assert_eq!(
         compact.output["model_surface"],
         crate::model_surface::MODEL_SURFACE_CANONICAL_CONNECTOR
+    );
+    assert_eq!(
+        compact.output["mcp_compact_schemas"],
+        crate::config::mcp_compact_schemas_enabled()
     );
 }
 
@@ -2185,6 +2199,11 @@ async fn runtime_status_compact_and_summary_only_return_sanitized_summary() {
         assert!(result.success, "{:?}", result.error);
         let summary = &result.output;
         assert_eq!(summary["compact"], true, "arguments: {arguments}");
+        assert_eq!(
+            summary["mcp_compact_schemas"],
+            crate::config::mcp_compact_schemas_enabled(),
+            "arguments: {arguments}"
+        );
         for pointer in [
             "/service",
             "/version",

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -2261,7 +2261,7 @@ async fn runtime_status_reports_canonical_connector_surface_when_configured() {
     );
     assert_eq!(
         full.output["effective_config"]["auth"]["oauth2_shared_key_bridge_enabled"],
-        false
+        true
     );
     let compact = runtime
         .dispatch(ToolCall::from_tool_name("runtime_status", json!({"compact": true})).unwrap())
@@ -2273,6 +2273,10 @@ async fn runtime_status_reports_canonical_connector_surface_when_configured() {
     assert_eq!(
         compact.output["mcp_compact_schemas"],
         crate::config::mcp_compact_schemas_enabled()
+    );
+    assert_eq!(
+        compact.output["effective_config"]["auth"]["oauth2_shared_key_bridge_enabled"],
+        true
     );
 }
 

--- a/src/tool_runtime/tests/schema/outputs.rs
+++ b/src/tool_runtime/tests/schema/outputs.rs
@@ -1158,6 +1158,7 @@ fn key_tool_output_schemas_include_expected_fields() {
         "build",
         "auth_enabled",
         "configured_public_url",
+        "effective_config",
         "agents",
         "projects",
         "jobs",


### PR DESCRIPTION
## Summary

Make `runtime_status` the authoritative read-only surface for safe effective Server configuration facts.

This stack:
- exposes whether MCP discovery is running with compact schemas
- adds a strictly allowlisted `effective_config` projection
- preserves the same Server configuration truth across full, focused, compact, and summary runtime-status views
- makes direct shared-key and anonymous observability Connector-aware
- keeps the public OAuth shared-key bridge independent from direct Bearer shared-key availability

## Effective configuration

`effective_config` exposes only:
- `action_compact_responses`
- auth booleans for direct shared key, anonymous, OAuth2, and the OAuth shared-key bridge
- `tool_request_trace_mode` as `off | metadata | full`

It does not expose raw environment variables, credentials, paths, OAuth client ids, headers, request bodies, trace directories, or other private state. The canonical output schema keeps `additionalProperties: false` for the configuration objects.

## Semantics

OAuth2/bridge state comes from the parsed Server `Config` snapshot used at startup. Other fields reuse the same canonical accessors as their live runtime paths.

On the project-bound canonical Connector surface, direct shared-key and anonymous auth are reported false because those request paths are fenced there. The OAuth shared-key bridge remains independently observable because it is a public OAuth authorization flow rather than the direct Bearer shared-key path.

## Validation

- focused `cargo test runtime_status -p webcodex`: 32 passed, 0 failed
- `cargo check -p webcodex`: pass, 0 warnings/errors
- `cargo fmt -- --check`: pass
- `git diff --check`: pass
- final workspace clean

The final implementation also received fresh independent review plus bounded reviewer fixes for effective auth semantics.