### PR TITLE
Add Windows foreground Server and share tunnel parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5151,6 +5151,7 @@ dependencies = [
  "webcodex-runner-config",
  "webcodex-sandbox",
  "webcodex-workspace",
+ "windows-sys 0.61.2",
  "zip",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,17 @@ rustls-pemfile = "2"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# Narrow Windows-native ACL support for project/share private state and managed
+# tunnel executable caches. This is intentionally not a generic filesystem API.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+] }
+
 # Release binaries ship via the npm wrapper; optimize for size without
 # changing runtime behavior (panic unwinding stays enabled).
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Ask your assistant to inspect a repository, modify code, run tests, use Git, or 
 
 ## Quick start
 
-On Linux or macOS, with Node.js 18+ and Git installed:
+With Node.js 18+ and Git installed on Linux, macOS, or Windows x64:
 
 ```bash
 cd /path/to/your/repository
-npx --yes @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share
 ```
 
 When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL** is normally copied to your clipboard; press **Enter** in the terminal to open ChatGPT App settings, or open **Settings -> Apps -> Create** manually. Then:
@@ -78,7 +78,7 @@ For the internal Server/Runner architecture, protocol surfaces, and authority bo
 
 - **Linux x64/arm64** — local `share`, Server, and Runner workflows.
 - **macOS x64/arm64** — local `share` and Runner workflows.
-- **Windows x64/arm64** — CLI + Runner, plus an explicit local foreground Server via `webcodex server init` and `webcodex server run --env-file <path>`. WebCodex-managed Windows Server services and local `webcodex share` are not supported yet.
+- **Windows x64/arm64** — CLI + Runner, local foreground Server, and explicit `webcodex share --tunnel cloudflare|openai|none`. Windows x64 can auto-manage the pinned Cloudflare Quick Tunnel binary; OpenAI `tunnel-client` is managed on both x64 and arm64. Cloudflare does not publish a Windows ARM64 artifact for the pinned release, so Windows ARM64 Cloudflare sharing requires a trusted explicit/PATH `cloudflared`. WebCodex-managed Windows Server services remain unsupported.
 
 Windows and long-lived deployments are covered in [Deployment](docs/DEPLOYMENT.md) and [MCP](docs/MCP.md).
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For the internal Server/Runner architecture, protocol surfaces, and authority bo
 
 - **Linux x64/arm64** — local `share`, Server, and Runner workflows.
 - **macOS x64/arm64** — local `share` and Runner workflows.
-- **Windows x64/arm64** — CLI + Runner against a remote Linux Server. Local `webcodex share` is not supported on Windows in this release.
+- **Windows x64/arm64** — CLI + Runner, plus an explicit local foreground Server via `webcodex server init` and `webcodex server run --env-file <path>`. WebCodex-managed Windows Server services and local `webcodex share` are not supported yet.
 
 Windows and long-lived deployments are covered in [Deployment](docs/DEPLOYMENT.md) and [MCP](docs/MCP.md).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL** is normally copied to your clipboard; press **Enter** in the terminal to open ChatGPT App settings, or open **Settings -> Apps -> Create** manually. Then:
+When WebCodex reports **WebCodex ready**, keep the terminal open. Linux and macOS normally copy the **MCP URL** to your clipboard and can use **Enter** in an interactive terminal to open ChatGPT App settings. On Windows, copy the printed **MCP URL** manually and open **Settings -> Apps -> Create**. Then:
 
 1. Enable **Developer Mode** if needed and choose **Create**.
 2. Paste the copied **MCP URL** (or use the URL printed by WebCodex).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,7 +78,7 @@ WebCodex
 
 - **Linux x64/arm64** —— 支持本机 `share`、Server 和 Runner 工作流。
 - **macOS x64/arm64** —— 支持本机 `share` 和 Runner 工作流。
-- **Windows x64/arm64** —— 支持 CLI 和 Runner，连接远程 Linux Server；本版本不在 Windows 本机运行 `webcodex share`。
+- **Windows x64/arm64** —— 支持 CLI、Runner，以及显式的本地前台 Server（`webcodex server init` 后执行 `webcodex server run --env-file <path>`）；暂不支持 WebCodex 托管的 Windows Server service，也不支持本机 `webcodex share`。
 
 Windows 接入和长期部署见[部署指南](docs/DEPLOYMENT.zh-CN.md)与 [MCP](docs/MCP.zh-CN.md)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,11 +8,11 @@
 
 ## 快速开始
 
-Linux 或 macOS 上准备好 Node.js 18+ 和 Git，然后进入一个仓库：
+Linux、macOS 或 Windows x64 上准备好 Node.js 18+ 和 Git，然后进入一个仓库：
 
 ```bash
 cd /path/to/your/repository
-npx --yes @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share
 ```
 
 看到 **WebCodex ready** 后保持终端运行。**MCP URL** 通常已经复制到剪贴板；可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。然后：
@@ -78,7 +78,7 @@ WebCodex
 
 - **Linux x64/arm64** —— 支持本机 `share`、Server 和 Runner 工作流。
 - **macOS x64/arm64** —— 支持本机 `share` 和 Runner 工作流。
-- **Windows x64/arm64** —— 支持 CLI、Runner，以及显式的本地前台 Server（`webcodex server init` 后执行 `webcodex server run --env-file <path>`）；暂不支持 WebCodex 托管的 Windows Server service，也不支持本机 `webcodex share`。
+- **Windows x64/arm64** —— 支持 CLI、Runner、本地前台 Server，以及显式 `webcodex share --tunnel cloudflare|openai|none`。Windows x64 可自动管理固定版本的 Cloudflare Quick Tunnel；OpenAI `tunnel-client` 在 x64/arm64 都支持 managed 获取。固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 Windows ARM64 使用 Cloudflare 时需要提供受信任的显式/`PATH` `cloudflared`。WebCodex 托管的 Windows Server service 仍不支持。
 
 Windows 接入和长期部署见[部署指南](docs/DEPLOYMENT.zh-CN.md)与 [MCP](docs/MCP.zh-CN.md)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-看到 **WebCodex ready** 后保持终端运行。**MCP URL** 通常已经复制到剪贴板；可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。然后：
+看到 **WebCodex ready** 后保持终端运行。Linux 与 macOS 通常会自动复制 **MCP URL**，并可在交互终端按 **Enter** 打开 ChatGPT App 设置；Windows 请手动复制终端中打印的 **MCP URL**，并进入 **Settings -> Apps -> Create**。然后：
 
 1. 如有需要，开启 **Developer Mode** 并选择 **Create**。
 2. 粘贴已经复制的 **MCP URL**；也可以使用 WebCodex 终端中打印的地址。

--- a/crates/webcodex-cli/Cargo.toml
+++ b/crates/webcodex-cli/Cargo.toml
@@ -32,6 +32,8 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System_Threading",
 ] }

--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -2453,10 +2453,10 @@ where
 
 /// Windows release boundary, evaluated before any command dispatch.
 ///
-/// Windows supports explicit local foreground Server initialization/execution.
-/// Service-managed Server lifecycle operations, project `share`, and Runner
-/// service install remain unsupported and fail before platform-specific service
-/// logic. `--help` is exempt so help output still renders normally.
+/// Windows supports explicit local foreground Server initialization/execution
+/// and the platform-neutral project `share` path. Service-managed Server lifecycle
+/// operations and Runner service install remain unsupported and fail before
+/// platform-specific service logic. `--help` is exempt so help still renders.
 #[cfg(windows)]
 fn windows_unsupported_platform_action(args: &[String]) -> Option<&'static str> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
@@ -2471,10 +2471,6 @@ fn windows_unsupported_platform_action(args: &[String]) -> Option<&'static str> 
             ),
             _ => None,
         },
-        Some("share") => Some(
-            "`webcodex share` is not supported on Windows yet.\n\
-             Run `webcodex server run` for a local foreground Server or use `webcodex connect` with an existing Server.",
-        ),
         Some("runner") if args.get(1).map(String::as_str) == Some("install") => Some(
             "Automatic Windows Runner startup is not supported yet.\n\
              Use `webcodex connect` or `webcodex runner start --profile <name>.",

--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -16,6 +16,7 @@
 //! execution remains in the separate `webcodex-server` and `webcodex-runner`
 //! binaries.
 
+use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
@@ -258,6 +259,7 @@ struct RunnerInstallServiceOptions {
 struct InternalRunOptions {
     bin: PathBuf,
     args: Vec<String>,
+    env: Vec<(OsString, OsString)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1462,7 +1464,7 @@ fn parse_server_subcommand(args: &[String]) -> CliAction {
         let help = match command {
             "init" => server_init_usage(),
             "install" => server_install_service_usage(),
-            "run" => "Usage: webcodex server run [--help|--version]\n\nRun webcodex-server directly in the foreground.\n",
+            "run" => "Usage: webcodex server run [--env-file PATH] [--help|--version]\n\nRun webcodex-server directly in the foreground. --env-file passes the exact path through WEBCODEX_ENV_FILE; the Server remains the authoritative env-file parser.\n",
             "start" | "stop" | "restart" => "Usage: webcodex server <start|stop|restart>\n",
             "status" => server_status_usage(),
             "logs" => "Usage: webcodex server logs [--lines N] [--since VALUE] [--follow]\n",
@@ -1497,8 +1499,22 @@ fn parse_server_subcommand(args: &[String]) -> CliAction {
 }
 
 fn parse_server_run(args: &[String]) -> Result<InternalRunOptions, String> {
-    if !args.is_empty() {
-        return Err(format!("unknown server run option: {}", args[0]));
+    let mut env_file: Option<PathBuf> = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--env-file" => {
+                if env_file.is_some() {
+                    return Err("--env-file may be specified only once".to_string());
+                }
+                let path = PathBuf::from(next_value(&mut iter, arg)?);
+                if path.as_os_str().is_empty() {
+                    return Err("--env-file cannot be empty".to_string());
+                }
+                env_file = Some(path);
+            }
+            other => return Err(format!("unknown server run option: {other}")),
+        }
     }
     let bin = discover_internal_binary("webcodex-server").ok_or_else(|| {
         "webcodex-server was not found beside webcodex or in an absolute PATH entry".to_string()
@@ -1506,6 +1522,9 @@ fn parse_server_run(args: &[String]) -> Result<InternalRunOptions, String> {
     Ok(InternalRunOptions {
         bin,
         args: Vec::new(),
+        env: env_file
+            .map(|path| vec![(OsString::from("WEBCODEX_ENV_FILE"), path.into_os_string())])
+            .unwrap_or_default(),
     })
 }
 
@@ -1537,6 +1556,7 @@ fn parse_runner_run(args: &[String]) -> Result<InternalRunOptions, String> {
     Ok(InternalRunOptions {
         bin,
         args: vec!["--config".to_string(), config.display().to_string()],
+        env: Vec::new(),
     })
 }
 
@@ -2433,22 +2453,27 @@ where
 
 /// Windows release boundary, evaluated before any command dispatch.
 ///
-/// The supported Windows surface is the CLI + hosted/local-profile Runner
-/// talking to a remote Linux WebCodex Server. Operations that require a
-/// long-running local Windows Server (`webcodex server ...`, `webcodex
-/// share`) or a systemd-style service install (`webcodex runner install`)
-/// fail here with a clear platform message instead of reaching server or
-/// service logic that cannot work on Windows. `--help` is exempt so help
-/// output still renders normally; only real execution is blocked.
+/// Windows supports explicit local foreground Server initialization/execution.
+/// Service-managed Server lifecycle operations, project `share`, and Runner
+/// service install remain unsupported and fail before platform-specific service
+/// logic. `--help` is exempt so help output still renders normally.
 #[cfg(windows)]
 fn windows_unsupported_platform_action(args: &[String]) -> Option<&'static str> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         return None;
     }
     match args.first().map(String::as_str) {
-        Some("server") | Some("share") => Some(
-            "Windows Server runtime is not supported in this release.\n\
-             Use `webcodex connect` with a remote WebCodex Server.",
+        Some("server") => match args.get(1).map(String::as_str) {
+            Some("init") | Some("run") => None,
+            Some("install" | "start" | "stop" | "restart" | "logs" | "uninstall") | None => Some(
+                "Windows service-managed Server lifecycle is not supported yet.\n\
+                 Use `webcodex server run` for foreground operation.",
+            ),
+            _ => None,
+        },
+        Some("share") => Some(
+            "`webcodex share` is not supported on Windows yet.\n\
+             Run `webcodex server run` for a local foreground Server or use `webcodex connect` with an existing Server.",
         ),
         Some("runner") if args.get(1).map(String::as_str) == Some("install") => Some(
             "Automatic Windows Runner startup is not supported yet.\n\
@@ -2660,7 +2685,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
         },
         CliAction::RunnerRun(opts) | CliAction::ServerRun(opts) => {
-            match run_internal_binary(&opts.bin, &opts.args) {
+            match run_internal_binary(&opts.bin, &opts.args, &opts.env) {
                 Ok(code) => std::process::exit(code),
                 Err(stderr) => {
                     eprintln!("{}", stderr);

--- a/crates/webcodex-cli/src/webcodex_cli/server.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/server.rs
@@ -44,8 +44,21 @@ pub(crate) fn run_server_init(opts: ServerInitOptions) -> Result<String, String>
     let token_generated = existing_token.is_none();
     let token = existing_token.unwrap_or_else(generate_bootstrap_token);
     let env_content = render_server_env(&opts, &token);
-    super::write_text_file(&opts.env_file, &env_content, opts.overwrite, true)?;
+    super::system::write_server_secret_text_file(&opts.env_file, &env_content, opts.overwrite)?;
     if opts.json {
+        let next_steps = if cfg!(windows) {
+            json!([
+                "webcodex server run --env-file <path shown in env_file>",
+                "webcodex server status",
+                "configure HTTPS/public URL separately if using GPT Actions"
+            ])
+        } else {
+            json!([
+                "webcodex server install",
+                "webcodex server status",
+                "configure HTTPS/public URL separately if using GPT Actions"
+            ])
+        };
         let summary = json!({
             "env_file": opts.env_file.to_string_lossy(),
             "listen": opts.listen,
@@ -56,11 +69,7 @@ pub(crate) fn run_server_init(opts: ServerInitOptions) -> Result<String, String>
             "token_generated": token_generated,
             "token_prefix": token_prefix(&token),
             "wrote_env_file": true,
-            "next_steps": [
-                "webcodex server install",
-                "webcodex server status",
-                "configure HTTPS/public URL separately if using GPT Actions"
-            ],
+            "next_steps": next_steps,
         });
         return serde_json::to_string_pretty(&summary).map_err(|e| e.to_string());
     }
@@ -76,8 +85,14 @@ pub(crate) fn run_server_init(opts: ServerInitOptions) -> Result<String, String>
     ));
     out.push_str("  shared key:   enabled\n");
     out.push_str("\nNext steps:\n");
-    out.push_str("  - Install and start: `webcodex server install`\n");
-    out.push_str("  - Or run in foreground: `webcodex server run`\n");
+    if cfg!(windows) {
+        out.push_str(
+            "  - Run in foreground: `webcodex server run --env-file <path shown above>`\n",
+        );
+    } else {
+        out.push_str("  - Install and start: `webcodex server install`\n");
+        out.push_str("  - Or run in foreground: `webcodex server run`\n");
+    }
     out.push_str("  - Check it: `webcodex server status`\n");
     out.push_str("\nNo full token was printed. No user or Agent tokens were created.\n");
     Ok(out)

--- a/crates/webcodex-cli/src/webcodex_cli/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/service.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -1696,9 +1697,14 @@ pub(crate) fn run_logs_for_scope(
     )
 }
 
-pub(crate) fn run_internal_binary(path: &Path, args: &[String]) -> Result<i32, String> {
+pub(crate) fn run_internal_binary(
+    path: &Path,
+    args: &[String],
+    env: &[(OsString, OsString)],
+) -> Result<i32, String> {
     let mut command = Command::new(path);
     command.args(args);
+    command.envs(env.iter().cloned());
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;

--- a/crates/webcodex-cli/src/webcodex_cli/system.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/system.rs
@@ -42,25 +42,7 @@ pub(crate) fn write_text_file(
                 .map_err(|e| format!("failed to set permissions on {}: {}", path.display(), e))?;
         }
     }
-    #[cfg(windows)]
-    {
-        if secret {
-            write_windows_secret_text_file(path, content, overwrite)?;
-        } else if overwrite {
-            std::fs::write(path, content)
-                .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
-        } else {
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(path)
-                .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
-            use std::io::Write;
-            file.write_all(content.as_bytes())
-                .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
-        }
-    }
-    #[cfg(all(not(unix), not(windows)))]
+    #[cfg(not(unix))]
     {
         let _ = secret;
         if overwrite {
@@ -78,6 +60,21 @@ pub(crate) fn write_text_file(
         }
     }
     Ok(())
+}
+
+pub(crate) fn write_server_secret_text_file(
+    path: &Path,
+    content: &str,
+    overwrite: bool,
+) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        return write_windows_secret_text_file(path, content, overwrite);
+    }
+    #[cfg(not(windows))]
+    {
+        write_text_file(path, content, overwrite, true)
+    }
 }
 
 #[cfg(windows)]

--- a/crates/webcodex-cli/src/webcodex_cli/system.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/system.rs
@@ -42,7 +42,25 @@ pub(crate) fn write_text_file(
                 .map_err(|e| format!("failed to set permissions on {}: {}", path.display(), e))?;
         }
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        if secret {
+            write_windows_secret_text_file(path, content, overwrite)?;
+        } else if overwrite {
+            std::fs::write(path, content)
+                .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
+        } else {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+                .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
+            use std::io::Write;
+            file.write_all(content.as_bytes())
+                .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
+        }
+    }
+    #[cfg(all(not(unix), not(windows)))]
     {
         let _ = secret;
         if overwrite {
@@ -60,6 +78,278 @@ pub(crate) fn write_text_file(
         }
     }
     Ok(())
+}
+
+#[cfg(windows)]
+fn write_windows_secret_text_file(
+    path: &Path,
+    content: &str,
+    overwrite: bool,
+) -> Result<(), String> {
+    use std::io::{Seek, SeekFrom, Write};
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::GENERIC_WRITE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_REPARSE_POINT,
+        FILE_FLAG_OPEN_REPARSE_POINT,
+    };
+
+    // WRITE_DAC is deliberately requested on the same handle that will receive
+    // the secret. The DACL is hardened before truncation/write, so an ACL
+    // failure cannot leave newly written token material under inherited access.
+    const WRITE_DAC: u32 = 0x0004_0000;
+    let existed = path.exists();
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .write(true)
+        .access_mode(GENERIC_WRITE | WRITE_DAC)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    if overwrite {
+        options.create(true);
+    } else {
+        options.create_new(true);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|e| format!("failed to open secret file {}: {}", path.display(), e))?;
+    let result = (|| {
+        let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+        if unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, &mut info) } == 0 {
+            return Err(format!(
+                "failed to inspect secret file {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        if info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(format!(
+                "refusing to write secret file through a reparse point: {}",
+                path.display()
+            ));
+        }
+        protect_windows_secret_handle(file.as_raw_handle() as _, path)?;
+        file.set_len(0)
+            .map_err(|e| format!("failed to truncate {}: {}", path.display(), e))?;
+        file.seek(SeekFrom::Start(0))
+            .map_err(|e| format!("failed to seek {}: {}", path.display(), e))?;
+        file.write_all(content.as_bytes())
+            .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
+        file.sync_all()
+            .map_err(|e| format!("failed to sync {}: {}", path.display(), e))?;
+        Ok(())
+    })();
+    drop(file);
+    if result.is_err() && !existed {
+        let _ = std::fs::remove_file(path);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn protect_windows_secret_handle(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    path: &Path,
+) -> Result<(), String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+        SetSecurityInfo, SDDL_REVISION_1, SE_FILE_OBJECT,
+    };
+    use windows_sys::Win32::Security::{
+        GetSecurityDescriptorDacl, GetTokenInformation, TokenUser, DACL_SECURITY_INFORMATION,
+        PROTECTED_DACL_SECURITY_INFORMATION, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let mut token = std::ptr::null_mut();
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(format!(
+            "failed to open current Windows token while protecting {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    let result = (|| {
+        let mut required = 0u32;
+        unsafe { GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut required) };
+        if required == 0 {
+            return Err(format!(
+                "failed to size current Windows user identity while protecting {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        let words = (required as usize).div_ceil(std::mem::size_of::<usize>());
+        let mut buffer = vec![0usize; words];
+        if unsafe {
+            GetTokenInformation(
+                token,
+                TokenUser,
+                buffer.as_mut_ptr().cast(),
+                required,
+                &mut required,
+            )
+        } == 0
+        {
+            return Err(format!(
+                "failed to read current Windows user identity while protecting {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        let token_user = unsafe { &*(buffer.as_ptr().cast::<TOKEN_USER>()) };
+        let mut sid_text_ptr = std::ptr::null_mut();
+        if unsafe { ConvertSidToStringSidW(token_user.User.Sid, &mut sid_text_ptr) } == 0 {
+            return Err(format!(
+                "failed to encode current Windows user SID while protecting {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        let sid = unsafe {
+            let mut len = 0usize;
+            while *sid_text_ptr.add(len) != 0 {
+                len += 1;
+            }
+            let value = String::from_utf16_lossy(std::slice::from_raw_parts(sid_text_ptr, len));
+            LocalFree(sid_text_ptr as _);
+            value
+        };
+        let sddl = format!("D:P(A;;FA;;;{sid})(A;;FA;;;SY)");
+        let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut descriptor = std::ptr::null_mut();
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl_wide.as_ptr(),
+                SDDL_REVISION_1,
+                &mut descriptor,
+                std::ptr::null_mut(),
+            )
+        } == 0
+        {
+            return Err(format!(
+                "failed to construct protected Windows ACL for {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        let descriptor_result = (|| {
+            let mut present = 0;
+            let mut defaulted = 0;
+            let mut dacl = std::ptr::null_mut();
+            if unsafe {
+                GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted)
+            } == 0
+                || present == 0
+                || dacl.is_null()
+            {
+                return Err(format!(
+                    "failed to inspect protected Windows ACL for {}: {}",
+                    path.display(),
+                    std::io::Error::last_os_error()
+                ));
+            }
+            let status = unsafe {
+                SetSecurityInfo(
+                    handle,
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    dacl,
+                    std::ptr::null_mut(),
+                )
+            };
+            if status != 0 {
+                return Err(format!(
+                    "failed to protect Windows secret file {}: OS error {}",
+                    path.display(),
+                    status
+                ));
+            }
+            Ok(())
+        })();
+        unsafe { LocalFree(descriptor as _) };
+        descriptor_result
+    })();
+    unsafe { CloseHandle(token) };
+    result
+}
+
+#[cfg(all(test, windows))]
+pub(crate) fn windows_dacl_sddl(path: &Path) -> Result<String, String> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertSecurityDescriptorToStringSecurityDescriptorW, GetSecurityInfo, SDDL_REVISION_1,
+        SE_FILE_OBJECT,
+    };
+    use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+
+    const READ_CONTROL: u32 = 0x0002_0000;
+    let file = std::fs::OpenOptions::new()
+        .access_mode(READ_CONTROL)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|e| {
+            format!(
+                "failed to open {} for ACL inspection: {}",
+                path.display(),
+                e
+            )
+        })?;
+    let mut descriptor = std::ptr::null_mut();
+    let status = unsafe {
+        GetSecurityInfo(
+            file.as_raw_handle() as _,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(format!(
+            "failed to read Windows ACL for {}: OS error {}",
+            path.display(),
+            status
+        ));
+    }
+    let result = (|| {
+        let mut text = std::ptr::null_mut();
+        let mut text_len = 0u32;
+        if unsafe {
+            ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                descriptor,
+                SDDL_REVISION_1,
+                DACL_SECURITY_INFORMATION,
+                &mut text,
+                &mut text_len,
+            )
+        } == 0
+        {
+            return Err(format!(
+                "failed to render Windows ACL for {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        let value = unsafe {
+            let value =
+                String::from_utf16_lossy(std::slice::from_raw_parts(text, text_len as usize));
+            LocalFree(text as _);
+            value
+        };
+        Ok(value)
+    })();
+    unsafe { LocalFree(descriptor as _) };
+    result
 }
 
 pub(crate) fn discover_internal_binary(name: &str) -> Option<PathBuf> {

--- a/crates/webcodex-cli/src/webcodex_cli/system.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/system.rs
@@ -83,6 +83,16 @@ fn write_windows_secret_text_file(
     content: &str,
     overwrite: bool,
 ) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            super::connections::ensure_real_directory_tree(parent).map_err(|error| {
+                format!(
+                    "failed to prepare secret file directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
     use std::io::{Seek, SeekFrom, Write};
     use std::os::windows::fs::OpenOptionsExt;
     use std::os::windows::io::AsRawHandle;

--- a/crates/webcodex-cli/src/webcodex_cli/tests/platform.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/platform.rs
@@ -40,15 +40,6 @@ mod windows_guard {
     }
 
     #[test]
-    fn share_fails_closed_on_windows() {
-        let message = windows_unsupported_platform_action(&args(&["share"]))
-            .expect("share must be blocked on Windows");
-        assert!(message.contains("webcodex share"), "{message}");
-        assert!(message.contains("not supported on Windows"), "{message}");
-        assert!(message.contains("webcodex server run"), "{message}");
-    }
-
-    #[test]
     fn runner_install_fails_closed_on_windows() {
         for command in [
             vec!["runner", "install"],
@@ -89,6 +80,10 @@ mod windows_guard {
             vec!["server", "run"],
             vec!["server", "run", "--env-file", "C:\\temp\\webcodex.env"],
             vec!["server", "status"],
+            vec!["share"],
+            vec!["share", "--tunnel", "cloudflare"],
+            vec!["share", "--tunnel", "openai"],
+            vec!["share", "--tunnel", "none"],
             vec!["connect", "https://server.example.com"],
             vec!["login", "https://server.example.com", "--code", "wc_pair_x"],
             vec!["runner", "status"],

--- a/crates/webcodex-cli/src/webcodex_cli/tests/platform.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/platform.rs
@@ -12,22 +12,28 @@ mod windows_guard {
     }
 
     #[test]
-    fn server_commands_fail_closed_on_windows() {
+    fn managed_server_lifecycle_fails_closed_on_windows() {
         for command in [
             vec!["server"],
-            vec!["server", "run"],
-            vec!["server", "start"],
-            vec!["server", "status"],
             vec!["server", "install"],
+            vec!["server", "start"],
+            vec!["server", "stop"],
+            vec!["server", "restart"],
+            vec!["server", "logs"],
+            vec!["server", "uninstall", "--confirm"],
         ] {
             let message = windows_unsupported_platform_action(&args(&command))
-                .expect("server command must be blocked on Windows");
+                .expect("managed server lifecycle must be blocked on Windows");
             assert!(
-                message.contains("Windows Server runtime is not supported"),
+                message.contains("service-managed Server lifecycle"),
                 "{command:?}: {message}"
             );
             assert!(
-                message.contains("webcodex connect"),
+                message.contains("webcodex server run"),
+                "{command:?}: {message}"
+            );
+            assert!(
+                !message.contains("Server runtime is not supported"),
                 "{command:?}: {message}"
             );
         }
@@ -37,10 +43,9 @@ mod windows_guard {
     fn share_fails_closed_on_windows() {
         let message = windows_unsupported_platform_action(&args(&["share"]))
             .expect("share must be blocked on Windows");
-        assert!(
-            message.contains("Windows Server runtime is not supported"),
-            "{message}"
-        );
+        assert!(message.contains("webcodex share"), "{message}");
+        assert!(message.contains("not supported on Windows"), "{message}");
+        assert!(message.contains("webcodex server run"), "{message}");
     }
 
     #[test]
@@ -80,6 +85,10 @@ mod windows_guard {
     #[test]
     fn supported_windows_commands_are_not_blocked() {
         for command in [
+            vec!["server", "init"],
+            vec!["server", "run"],
+            vec!["server", "run", "--env-file", "C:\\temp\\webcodex.env"],
+            vec!["server", "status"],
             vec!["connect", "https://server.example.com"],
             vec!["login", "https://server.example.com", "--code", "wc_pair_x"],
             vec!["runner", "status"],

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
@@ -321,7 +321,7 @@ fn server_init_json_output_does_not_include_full_token() {
 #[test]
 fn server_init_secret_env_file_has_protected_windows_dacl() {
     let tmp = tempfile::tempdir().unwrap();
-    let env_file = tmp.path().join("webcodex.env");
+    let env_file = tmp.path().join("config/webcodex.env");
     let data_dir = tmp.path().join("data");
     let opts = parse_server_init(&args(&[
         "--listen",

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
@@ -317,6 +317,49 @@ fn server_init_json_output_does_not_include_full_token() {
     assert!(json.get("token").is_none());
 }
 
+#[cfg(windows)]
+#[test]
+fn server_init_secret_env_file_has_protected_windows_dacl() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("webcodex.env");
+    let data_dir = tmp.path().join("data");
+    let opts = parse_server_init(&args(&[
+        "--listen",
+        "127.0.0.1:0",
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--data-dir",
+        data_dir.to_str().unwrap(),
+        "--json",
+    ]))
+    .unwrap();
+    let output = run_server_init(opts).unwrap();
+    let content = std::fs::read_to_string(&env_file).unwrap();
+    let token = parse_env_content_value(&content, "WEBCODEX_TOKEN").unwrap();
+    assert!(!output.contains(&token));
+
+    let sddl = crate::webcodex_cli::system::windows_dacl_sddl(&env_file).unwrap();
+    assert!(sddl.starts_with("D:P"), "DACL must be protected: {sddl}");
+    assert!(sddl.contains(";;;SY)"), "SYSTEM access must remain: {sddl}");
+    assert_eq!(
+        sddl.matches("(A;").count(),
+        2,
+        "only the current user and SYSTEM should have allow ACEs: {sddl}"
+    );
+    assert!(
+        !sddl.contains(";;;WD)"),
+        "Everyone must not retain read access: {sddl}"
+    );
+    assert!(
+        !sddl.contains(";;;BU)"),
+        "Builtin Users must not retain read access: {sddl}"
+    );
+    assert!(
+        !sddl.contains(";;;BA)"),
+        "Builtin Administrators must not receive a direct allow ACE: {sddl}"
+    );
+}
+
 #[test]
 fn server_init_rejects_legacy_full_token_stdout_mode() {
     let result = parse_server_init(&args(&["--output", "-"]));

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
@@ -337,6 +337,16 @@ fn server_init_secret_env_file_has_protected_windows_dacl() {
     let content = std::fs::read_to_string(&env_file).unwrap();
     let token = parse_env_content_value(&content, "WEBCODEX_TOKEN").unwrap();
     assert!(!output.contains(&token));
+    let json: Value = serde_json::from_str(&output).unwrap();
+    let next_steps = json["next_steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(next_steps.contains("server run --env-file"), "{next_steps}");
+    assert!(!next_steps.contains("server install"), "{next_steps}");
 
     let sddl = crate::webcodex_cli::system::windows_dacl_sddl(&env_file).unwrap();
     assert!(sddl.starts_with("D:P"), "DACL must be protected: {sddl}");

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/mod.rs
@@ -1,4 +1,5 @@
 mod env;
 mod init;
+mod run;
 mod service;
 mod status;

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/run.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/run.rs
@@ -1,0 +1,57 @@
+use super::super::support::*;
+
+#[test]
+fn server_run_env_file_is_passed_only_through_child_environment() {
+    let _guard = env_test_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = tmp
+        .path()
+        .join(format!("webcodex-server{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&bin, b"").unwrap();
+    let env_file = tmp.path().join("foreground server.env");
+    let _env = EnvGuard::new().set_os("PATH", tmp.path().as_os_str().to_os_string());
+
+    let opts = parse_server_run(&args(&["--env-file", env_file.to_str().unwrap()])).unwrap();
+    assert_eq!(opts.bin, bin);
+    assert!(opts.args.is_empty());
+    assert_eq!(
+        opts.env,
+        vec![(
+            std::ffi::OsString::from("WEBCODEX_ENV_FILE"),
+            env_file.into_os_string()
+        )]
+    );
+}
+
+#[test]
+fn server_run_without_env_file_preserves_server_startup_discovery() {
+    let _guard = env_test_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = tmp
+        .path()
+        .join(format!("webcodex-server{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&bin, b"").unwrap();
+    let _env = EnvGuard::new().set_os("PATH", tmp.path().as_os_str().to_os_string());
+
+    let opts = parse_server_run(&[]).unwrap();
+    assert_eq!(opts.bin, bin);
+    assert!(opts.args.is_empty());
+    assert!(opts.env.is_empty());
+}
+
+#[test]
+fn server_run_rejects_invalid_env_file_shapes_before_binary_discovery() {
+    let _guard = env_test_guard();
+    let _env = EnvGuard::new().set_os("PATH", std::ffi::OsString::new());
+
+    assert!(parse_server_run(&args(&["--env-file"]))
+        .unwrap_err()
+        .contains("--env-file"));
+    assert_eq!(
+        parse_server_run(&args(&["--env-file", "a", "--env-file", "b"])).unwrap_err(),
+        "--env-file may be specified only once"
+    );
+    assert!(parse_server_run(&args(&["--bogus"]))
+        .unwrap_err()
+        .contains("unknown server run option"));
+}

--- a/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
@@ -171,8 +171,14 @@ fn top_level_help_prioritizes_first_run_without_hiding_advanced_commands() {
     let operator = out.find("Operator / service management:").unwrap();
     assert!(start_here < share && share < connect && connect < operator);
     assert!(out.contains("(no command)"));
-    assert!(out.contains("run `webcodex` inside a Git repo"));
-    assert!(out.contains("Windows -> use `webcodex connect <server-url>`"));
+    assert!(out.contains("Interactive Git repo shortcut for `share` on Linux/macOS"));
+    assert!(
+        out.contains("Share the current project for ChatGPT/MCP over HTTPS (Linux/macOS/Windows)")
+    );
+    assert!(out.contains(
+        "First ChatGPT connection: run explicit `webcodex share` on Linux/macOS/Windows"
+    ));
+    assert!(!out.contains("Windows -> use `webcodex connect <server-url>`"));
     assert!(!out.contains("historical `agent` namespace"));
     assert!(out.contains("agent-tokens create|"));
 }

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -35,7 +35,7 @@ Advanced / compatibility:\n\
 Options:\n\
   -h, --help                    Print help and exit\n\
   -V, --version                 Print version and exit\n\n\
-First ChatGPT connection: Linux/macOS -> run `webcodex` inside a Git repo (or explicit `webcodex share`); Windows -> use `webcodex connect <server-url>` for sharing, or `webcodex server init` + `webcodex server run --env-file <path>` for a local foreground Server.\n"
+First ChatGPT connection: run explicit `webcodex share` on Linux/macOS/Windows. Bare interactive `webcodex` auto-share remains Linux/macOS-only. Windows x64 supports managed Cloudflare; Windows ARM64 Cloudflare requires a trusted explicit/PATH binary.\n"
 }
 
 pub(crate) fn connect_usage() -> &'static str {

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -18,7 +18,7 @@ Account / identity (advanced):\n\
   auth status                   Show login status\n\n\
 Operator / service management:\n\
   server init|install|run|start|stop|restart|status|logs|uninstall\n\
-                                Configure and manage the Server service\n\
+                                Configure/run the Server; managed lifecycle is Linux-only\n\
   runner init|install|run|start|stop|restart|status|logs|uninstall\n\
                                 Manage the Runner lifecycle and service\n\
   ops status|agents|runner|projects|smoke-preflight\n\
@@ -35,7 +35,7 @@ Advanced / compatibility:\n\
 Options:\n\
   -h, --help                    Print help and exit\n\
   -V, --version                 Print version and exit\n\n\
-First ChatGPT connection: Linux/macOS -> run `webcodex` inside a Git repo (or explicit `webcodex share`); Windows -> use `webcodex connect <server-url>` with a remote Linux Server.\n"
+First ChatGPT connection: Linux/macOS -> run `webcodex` inside a Git repo (or explicit `webcodex share`); Windows -> use `webcodex connect <server-url>` for sharing, or `webcodex server init` + `webcodex server run --env-file <path>` for a local foreground Server.\n"
 }
 
 pub(crate) fn connect_usage() -> &'static str {
@@ -268,14 +268,15 @@ pub(crate) fn server_usage() -> &'static str {
     "Usage: webcodex server <COMMAND>\n\n\
 Commands:\n\
   init        Initialize or update Server configuration\n\
-  install     Install, enable, and start the systemd socket/service pair\n\
+  install     Install, enable, and start the Linux systemd socket/service pair\n\
   run         Run webcodex-server directly in the foreground\n\
-  start       Start the listener socket, then the Server service\n\
-  stop        Stop socket activation and the Server service\n\
-  restart     Restart only the Server service while the socket stays active\n\
+  start       Start the Linux listener socket, then the Server service\n\
+  stop        Stop Linux socket activation and the Server service\n\
+  restart     Restart only the Linux Server service while the socket stays active\n\
   status      Check socket/service state, HTTP reachability, and build revisions\n\
-  logs        Read bounded Server service journal logs or explicitly follow them\n\
-  uninstall   Remove only the systemd socket/service pair; requires --confirm\n\n\
+  logs        Read bounded Linux Server service journal logs or explicitly follow them\n\
+  uninstall   Remove only the Linux systemd socket/service pair; requires --confirm\n\n\
+Windows supports `server init` and foreground `server run`; WebCodex-managed Windows Server services are not supported yet.\n\
 For start/stop/restart/logs/uninstall, --service-file PATH targets a custom managed service unit and derives its sibling .socket.\n"
 }
 

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -3,7 +3,7 @@ pub(crate) fn usage() -> &'static str {
 Unified command-line interface for WebCodex.\n\n\
 Start here:\n\
   (no command)                  Interactive Git repo shortcut for `share` on Linux/macOS\n\
-  share                         Share the current project for ChatGPT/MCP over HTTPS (Linux/macOS)\n\
+  share                         Share the current project for ChatGPT/MCP over HTTPS (Linux/macOS/Windows)\n\
   connect                       Connect the current project to an existing Server\n\
   status                        Show concise project coding readiness\n\
   doctor                        Diagnose project readiness\n\n\

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -12,13 +12,15 @@ or OAuth scope ceilings unless the user's chosen path actually requires them.
 
 ## Choose the smallest path
 
-Check the platform before choosing the path. Windows does not support the local
-Server runtime used by `webcodex share`; on Windows, use `connect` when a remote
-Linux Server already exists, or guide the user through Linux Server deployment
-first. Do not recommend `share` on Windows.
+Check the platform before choosing the path. Windows supports the same explicit
+`webcodex share` path as Linux/macOS; do not invent a remote Linux Server as a
+Windows prerequisite. Keep the no-command interactive shortcut Linux/macOS-only.
+On Windows ARM64, explain that the pinned Cloudflare release has no official ARM64
+artifact if the user selects/defaults to Cloudflare; a trusted explicit/PATH
+`cloudflared`, OpenAI tunnel, or local-only `none` is required instead.
 
-1. On Linux/macOS, the user has one local repository and wants to try ChatGPT/MCP
-   now, with no existing WebCodex Server URL: use **`webcodex share`**.
+1. The user has one local repository and wants to try ChatGPT/MCP now, with no
+   existing WebCodex Server URL: use **`webcodex share`**.
 2. The user already has a WebCodex Server URL and wants a persistent repository
    connection: use **`webcodex connect <server>`**.
 3. The user needs separate identity, independent revocation, audit, or managed

--- a/docs/AI_ONBOARDING.zh-CN.md
+++ b/docs/AI_ONBOARDING.zh-CN.md
@@ -11,12 +11,9 @@ ceiling。
 
 ## 选择最小路径
 
-先检查平台再选路径。Windows 不支持 `webcodex share` 所需的本地 Server runtime；
-Windows 已有远程 Linux Server 时使用 `connect`，没有 Server 时先引导用户部署 Linux
-Server。不要在 Windows 上推荐 `share`。
+先检查平台再选路径。Windows 已支持与 Linux/macOS 相同的显式 `webcodex share`，不要再把远程 Linux Server 当成 Windows 前置条件；无子命令的交互式 shortcut 仍只在 Linux/macOS 自动进入 share。Windows ARM64 如果使用默认/显式 Cloudflare，需要说明固定版本 Cloudflare 没有官方 ARM64 artifact，应提供受信任的显式/`PATH` `cloudflared`，或者选择 OpenAI tunnel / 本地 `none`。
 
-1. 在 Linux/macOS 上，用户只有一个本地仓库、想马上试 ChatGPT/MCP，并且没有现成
-   WebCodex Server URL：使用 **`webcodex share`**。
+1. 用户只有一个本地仓库、想马上试 ChatGPT/MCP，并且没有现成 WebCodex Server URL：使用 **`webcodex share`**。
 2. 用户已经有 WebCodex Server URL，需要长期连接：使用
    **`webcodex connect <server>`**。
 3. 用户明确需要独立身份、独立撤销、审计或 managed user：使用 managed identity

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -26,8 +26,9 @@ explicit `share` command remains the deterministic/script-friendly entry. It per
 Server and Runner, and exposes a temporary HTTPS MCP endpoint. For the default
 Quick Tunnel, WebCodex prefers `WEBCODEX_CLOUDFLARED_BIN`, then `cloudflared` on
 `PATH`, and otherwise acquires a pinned, verified managed copy before creating
-project/share state. Windows does not support this local Server/share path; use
-`webcodex connect <server-url>` against a remote Linux Server there.
+project/share state. Windows does not support `share`, but it does support an explicit
+local foreground Server with `webcodex server init` and `webcodex server run --env-file
+<path>`. Use `webcodex connect <server-url>` when connecting the Runner to an existing Server.
 
 ## Command map
 
@@ -109,12 +110,14 @@ keep their detached-process behavior when `--scope` is omitted.
 | --- | --- |
 | `webcodex server init` | Initialize or update the Server env file (creates the bootstrap token) |
 | `webcodex server install` | Install the Linux systemd `webcodex.socket` + `webcodex.service` pair |
-| `webcodex server run` | Run `webcodex-server` in the foreground (direct bind) |
+| `webcodex server run [--env-file PATH]` | Run `webcodex-server` in the foreground (direct bind); `--env-file` passes the exact path via `WEBCODEX_ENV_FILE` |
 | `webcodex server start` / `stop` | Start or stop socket activation and the Server process coherently |
 | `webcodex server restart` | Restart only the Server process; keep the managed listener socket active |
 | `webcodex server status` | Check authoritative socket/service state, HTTP reachability, and build revisions |
 | `webcodex server logs` | Read the Server service journal |
 | `webcodex server uninstall` | Stop, disable, and remove the managed socket/service pair |
+
+On Windows, `server init` and foreground `server run` are supported. The managed service lifecycle (`install`, `start`, `stop`, `restart`, `logs`, `uninstall`) is Linux-only; `share` also remains unavailable on Windows.
 
 `webcodex server install --service-file /path/name.service` derives the sibling
 `/path/name.socket`. Use the same `--service-file` on `start`, `stop`, `restart`,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,15 +20,7 @@ The CLI produces three binaries when built from source:
 `webcodex --help` lists the top-level namespaces. The sections below explain
 what each namespace is for.
 
-For a first ChatGPT connection on Linux/macOS, running bare `webcodex` in an
-interactive Git checkout is a convenience shortcut for `webcodex share`. The
-explicit `share` command remains the deterministic/script-friendly entry. It performs project setup, starts the local
-Server and Runner, and exposes a temporary HTTPS MCP endpoint. For the default
-Quick Tunnel, WebCodex prefers `WEBCODEX_CLOUDFLARED_BIN`, then `cloudflared` on
-`PATH`, and otherwise acquires a pinned, verified managed copy before creating
-project/share state. Windows does not support `share`, but it does support an explicit
-local foreground Server with `webcodex server init` and `webcodex server run --env-file
-<path>`. Use `webcodex connect <server-url>` when connecting the Runner to an existing Server.
+For a first ChatGPT connection, explicit `webcodex share` is the deterministic/script-friendly entry on Linux, macOS, and Windows. Running bare `webcodex` in an interactive Git checkout remains a Linux/macOS-only convenience shortcut; W2 does not change Windows no-command auto-dispatch. `share` performs project setup, starts the local Server and Runner, and exposes a temporary HTTPS MCP endpoint. For the default Quick Tunnel, WebCodex prefers `WEBCODEX_CLOUDFLARED_BIN`, then `cloudflared` on `PATH`, and otherwise acquires a pinned, verified managed copy before creating project/share state. Managed Cloudflare acquisition supports Windows x64; the pinned Cloudflare release has no official Windows ARM64 artifact, so Windows ARM64 Cloudflare use requires a trusted explicit/PATH binary. Managed OpenAI `tunnel-client` supports Windows x64 and arm64.
 
 ## Command map
 
@@ -39,7 +31,7 @@ These commands work on the current Git project.
 | Command | Purpose | Notes |
 | --- | --- | --- |
 | `webcodex` (no command) | Fast interactive first-run shortcut | Only auto-dispatches to `share` on Linux/macOS when stdin/stdout are terminals and the current directory is inside a Git checkout; otherwise normal help is shown. |
-| `webcodex share` | Share the current project for ChatGPT/MCP over HTTPS | Linux/macOS first-run path; includes setup, starts the local Server + Runner, auto-manages verified `cloudflared` when needed, and best-effort copies the public MCP URL. Unavailable on Windows. |
+| `webcodex share` | Share the current project for ChatGPT/MCP over HTTPS | Explicit first-run path on Linux/macOS/Windows; includes setup, local Server + Runner, `cloudflare|openai|none`, managed tunnel acquisition when available, and bounded foreground cleanup. |
 | `webcodex connect <server>` | Connect the current project to an existing Server | Long-lived path when you already have a Server URL; defaults to hosted shared-key. |
 | `webcodex status` | Concise project coding readiness | Short summary; `doctor` is the full diagnostic check. |
 | `webcodex doctor` | Read-only readiness checks for the current project | Diagnostics/manual workflow; reports a stable `next action`. |
@@ -117,7 +109,7 @@ keep their detached-process behavior when `--scope` is omitted.
 | `webcodex server logs` | Read the Server service journal |
 | `webcodex server uninstall` | Stop, disable, and remove the managed socket/service pair |
 
-On Windows, `server init` and foreground `server run` are supported. The managed service lifecycle (`install`, `start`, `stop`, `restart`, `logs`, `uninstall`) is Linux-only; `share` also remains unavailable on Windows.
+On Windows, `server init`, foreground `server run`, and explicit `share` are supported. The managed service lifecycle (`install`, `start`, `stop`, `restart`, `logs`, `uninstall`) remains Linux-only.
 
 `webcodex server install --service-file /path/name.service` derives the sibling
 `/path/name.socket`. Use the same `--service-file` on `start`, `stop`, `restart`,

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -16,14 +16,7 @@ Server API 完成。
 
 `webcodex --help` 会列出顶层命名空间。下面按命名空间说明各自的用途。
 
-在 Linux/macOS 上第一次连接 ChatGPT 时，交互式 Git checkout 中运行裸 `webcodex`
-就是 `webcodex share` 的 convenience shortcut；显式 `share` 仍然是脚本/确定性分发入口。
-它会完成项目设置、启动本地 Server 与 Runner，并暴露临时 HTTPS
-MCP endpoint。默认 Quick Tunnel 会依次优先使用 `WEBCODEX_CLOUDFLARED_BIN`、`PATH`
-中的 `cloudflared`；两者都没有时，会在创建项目/share 状态之前自动获取固定版本、完成
-校验并使用 WebCodex 管理的副本。Windows 仍不支持 `share`，但已经支持显式的本地前台
-Server：先执行 `webcodex server init`，再执行 `webcodex server run --env-file <path>`。
-需要把 Runner 接到已有 Server 时，继续使用 `webcodex connect <server-url>`。
+第一次连接 ChatGPT 时，显式 `webcodex share` 已是 Linux、macOS、Windows 共同的脚本/确定性入口。交互式 Git checkout 中的裸 `webcodex` 自动进入 share 仍只属于 Linux/macOS convenience shortcut；W2 不改变 Windows 无子命令语义。`share` 会完成项目设置、启动本地 Server 与 Runner，并暴露临时 HTTPS MCP endpoint。默认 Quick Tunnel 依次使用 `WEBCODEX_CLOUDFLARED_BIN`、`PATH` 中的 `cloudflared`，否则获取固定版本 managed 副本。Windows x64 支持 managed Cloudflare；固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 ARM64 使用 Cloudflare 时需要受信任的显式/`PATH` binary。OpenAI `tunnel-client` 的 managed 获取支持 Windows x64/arm64。
 
 ## 命令总览
 
@@ -34,7 +27,7 @@ Server：先执行 `webcodex server init`，再执行 `webcodex server run --env
 | 命令 | 用途 | 说明 |
 | --- | --- | --- |
 | `webcodex`（无子命令） | 快速交互式 first-run shortcut | 仅 Linux/macOS + stdin/stdout 为终端 + 当前目录位于 Git checkout 时自动进入 `share`；否则照常显示 help。 |
-| `webcodex share` | 通过 HTTPS 把当前项目接入 ChatGPT/MCP | Linux/macOS 首次使用主路径；包含 setup、启动本地 Server + Runner、按需自动管理经过校验的 `cloudflared`，并 best-effort 复制公网 MCP URL。Windows 不可用。 |
+| `webcodex share` | 通过 HTTPS 把当前项目接入 ChatGPT/MCP | Linux/macOS/Windows 的显式首次使用主路径；包含 setup、本地 Server + Runner、`cloudflare|openai|none`、可用时的 managed tunnel 获取，以及有界前台 cleanup。 |
 | `webcodex connect <server>` | 把当前项目接入已有的 Server | 已经拥有 Server URL 时的长期路径；默认使用 hosted shared-key。 |
 | `webcodex status` | 简洁的项目 coding 就绪状态 | 简短状态；`doctor` 提供完整诊断。 |
 | `webcodex doctor` | 当前项目的只读就绪检查 | 诊断/手动工作流；输出稳定的 `next action`。 |
@@ -110,7 +103,7 @@ detached-process 行为。
 | `webcodex server logs` | 读取 Server service journal |
 | `webcodex server uninstall` | stop/disable/remove 受管 socket/service pair |
 
-Windows 支持 `server init` 与前台 `server run`。受管 service 生命周期（`install`、`start`、`stop`、`restart`、`logs`、`uninstall`）仍只支持 Linux；Windows 上 `share` 也仍不可用。
+Windows 支持 `server init`、前台 `server run` 与显式 `share`。受管 service 生命周期（`install`、`start`、`stop`、`restart`、`logs`、`uninstall`）仍只支持 Linux。
 
 使用 `webcodex server install --service-file /path/name.service` 时，会派生同目录的
 `/path/name.socket`。后续 `start`、`stop`、`restart`、`status`、`logs` 和 `uninstall`

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -21,8 +21,9 @@ Server API 完成。
 它会完成项目设置、启动本地 Server 与 Runner，并暴露临时 HTTPS
 MCP endpoint。默认 Quick Tunnel 会依次优先使用 `WEBCODEX_CLOUDFLARED_BIN`、`PATH`
 中的 `cloudflared`；两者都没有时，会在创建项目/share 状态之前自动获取固定版本、完成
-校验并使用 WebCodex 管理的副本。Windows 不支持这条本地 Server/share 路径，请改用
-`webcodex connect <server-url>` 连接远程 Linux Server。
+校验并使用 WebCodex 管理的副本。Windows 仍不支持 `share`，但已经支持显式的本地前台
+Server：先执行 `webcodex server init`，再执行 `webcodex server run --env-file <path>`。
+需要把 Runner 接到已有 Server 时，继续使用 `webcodex connect <server-url>`。
 
 ## 命令总览
 
@@ -102,12 +103,14 @@ detached-process 行为。
 | --- | --- |
 | `webcodex server init` | 初始化或更新 Server env 文件（创建 bootstrap token） |
 | `webcodex server install` | 安装 Linux systemd `webcodex.socket` + `webcodex.service` pair |
-| `webcodex server run` | 前台运行 `webcodex-server`（direct bind） |
+| `webcodex server run [--env-file PATH]` | 前台运行 `webcodex-server`（direct bind）；`--env-file` 通过 `WEBCODEX_ENV_FILE` 精确传递路径 |
 | `webcodex server start` / `stop` | 一致地启动或停止 socket activation 与 Server process |
 | `webcodex server restart` | 只 restart Server process，保持受管 listener socket active |
 | `webcodex server status` | 检查 authoritative socket/service 状态、HTTP 可达性与构建版本 |
 | `webcodex server logs` | 读取 Server service journal |
 | `webcodex server uninstall` | stop/disable/remove 受管 socket/service pair |
+
+Windows 支持 `server init` 与前台 `server run`。受管 service 生命周期（`install`、`start`、`stop`、`restart`、`logs`、`uninstall`）仍只支持 Linux；Windows 上 `share` 也仍不可用。
 
 使用 `webcodex server install --service-file /path/name.service` 时，会派生同目录的
 `/path/name.socket`。后续 `start`、`stop`、`restart`、`status`、`logs` 和 `uninstall`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,11 +24,7 @@ The documented distribution path is the npm thin installer/wrapper:
 npm install -g @yyjeqhc/webcodex
 ```
 
-Supported package platforms are Linux x64, Linux arm64, macOS x64, macOS arm64,
-Windows x64, and Windows arm64. Windows x64/arm64 support the CLI + Runner workflow
-and an explicit local foreground Server (`webcodex server init`, then `webcodex server run
---env-file <path>`). WebCodex-managed Windows Server services and `webcodex share` are not
-supported yet. The npm wrapper
+Supported package platforms are Linux x64, Linux arm64, macOS x64, macOS arm64, Windows x64, and Windows arm64. Windows supports CLI + Runner, explicit foreground Server, and explicit local `webcodex share --tunnel cloudflare|openai|none`. Windows x64 supports managed Cloudflare acquisition; Windows ARM64 Cloudflare requires a trusted explicit/PATH binary because the pinned upstream release has no official ARM64 artifact. Managed OpenAI `tunnel-client` supports Windows x64/arm64. WebCodex-managed Windows Server services remain unsupported. The npm wrapper
 requires Node.js 18 or newer. Starting with v0.3.5, the native Linux x64
 artifact targets glibc 2.17 or newer.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,8 +26,9 @@ npm install -g @yyjeqhc/webcodex
 
 Supported package platforms are Linux x64, Linux arm64, macOS x64, macOS arm64,
 Windows x64, and Windows arm64. Windows x64/arm64 support the CLI + Runner workflow
-against a remote Linux Server; a long-running Windows Server is not supported.
-The npm wrapper
+and an explicit local foreground Server (`webcodex server init`, then `webcodex server run
+--env-file <path>`). WebCodex-managed Windows Server services and `webcodex share` are not
+supported yet. The npm wrapper
 requires Node.js 18 or newer. Starting with v0.3.5, the native Linux x64
 artifact targets glibc 2.17 or newer.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,7 +24,7 @@ The documented distribution path is the npm thin installer/wrapper:
 npm install -g @yyjeqhc/webcodex
 ```
 
-Supported package platforms are Linux x64, Linux arm64, macOS x64, macOS arm64, Windows x64, and Windows arm64. Windows supports CLI + Runner, explicit foreground Server, and explicit local `webcodex share --tunnel cloudflare|openai|none`. Windows x64 supports managed Cloudflare acquisition; Windows ARM64 Cloudflare requires a trusted explicit/PATH binary because the pinned upstream release has no official ARM64 artifact. Managed OpenAI `tunnel-client` supports Windows x64/arm64. WebCodex-managed Windows Server services remain unsupported. The npm wrapper
+Supported package platforms are Linux x64, Linux arm64, macOS x64, macOS arm64, Windows x64, and Windows arm64. Windows supports CLI + Runner, explicit foreground Server, and explicit local `webcodex share --tunnel cloudflare|openai|none`. Windows x64 supports managed Cloudflare acquisition; Windows ARM64 Cloudflare requires a trusted explicit/PATH binary because the pinned upstream release has no official ARM64 artifact. Managed OpenAI `tunnel-client` supports Windows x64/arm64. WebCodex-managed Windows Server and Runner services remain unsupported; run them explicitly in the foreground instead. The npm wrapper
 requires Node.js 18 or newer. Starting with v0.3.5, the native Linux x64
 artifact targets glibc 2.17 or newer.
 
@@ -36,6 +36,34 @@ export PATH="$PWD/target/release:$PATH"
 ```
 
 This produces `webcodex`, `webcodex-server`, and `webcodex-runner`.
+
+## Windows foreground Server and Runner
+
+The npm package installs all three Windows executables. Windows can run both the Server and Runner directly without Linux, WSL, or a Windows Service. Keep the foreground terminals open while the processes are in use.
+
+On the Windows Server machine, initialize an explicit env file and start the Server from PowerShell:
+
+```powershell
+$envFile = Join-Path $HOME ".config\webcodex\webcodex.env"
+$dataDir = Join-Path $HOME ".local\share\webcodex"
+webcodex server init --listen 127.0.0.1:8080 --data-dir $dataDir --env-file $envFile
+webcodex server run --env-file $envFile
+```
+
+Pass the same `--env-file` explicitly when starting the foreground Server; do not rely on a managed-service default. For a local same-machine enrollment, open another PowerShell window and create a short-lived pairing code:
+
+```powershell
+webcodex pairing create --server-url http://127.0.0.1:8080 --env-file $envFile --username workstation --display-name "Windows Workstation" --ttl-secs 600
+```
+
+Then, on the Windows machine that owns the repositories, redeem only that short-lived code and run the generated Runner config in the foreground:
+
+```powershell
+webcodex login http://127.0.0.1:8080 --code <wc_pair_...> --allowed-root C:\src
+webcodex runner run --config <login-reported-agent-config>
+```
+
+When Server and Runner are on different machines, replace the loopback URL with the Server's reachable HTTPS URL and configure the Server listener/public URL plus a trusted reverse proxy or tunnel as described below. Do not copy the Server bootstrap token or env file to the Runner machine. `webcodex server install/start/stop/restart/logs/uninstall` and `webcodex runner install` remain unsupported on Windows; Ctrl-C or Ctrl-Break ends the foreground runtime.
 
 ## Connect a repository to an existing shared-key Server
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -21,7 +21,7 @@ Runner 机器、连接 MCP/GPT 客户端以及 smoke 检查。第一次连接 Ch
 npm install -g @yyjeqhc/webcodex
 ```
 
-支持 Linux x64、Linux arm64、macOS x64、macOS arm64、Windows x64 与 Windows arm64。Windows 支持 CLI + Runner、显式前台 Server，以及显式本机 `webcodex share --tunnel cloudflare|openai|none`。Windows x64 支持 managed Cloudflare 获取；固定版本 upstream 没有官方 Windows ARM64 artifact，因此 ARM64 使用 Cloudflare 时需要受信任的显式/`PATH` binary。managed OpenAI `tunnel-client` 支持 Windows x64/arm64。WebCodex 仍不支持 Windows Server service 托管生命周期。npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64
+支持 Linux x64、Linux arm64、macOS x64、macOS arm64、Windows x64 与 Windows arm64。Windows 支持 CLI + Runner、显式前台 Server，以及显式本机 `webcodex share --tunnel cloudflare|openai|none`。Windows x64 支持 managed Cloudflare 获取；固定版本 upstream 没有官方 Windows ARM64 artifact，因此 ARM64 使用 Cloudflare 时需要受信任的显式/`PATH` binary。managed OpenAI `tunnel-client` 支持 Windows x64/arm64。WebCodex 仍不支持 Windows Server/Runner service 托管生命周期；Windows 上应显式以前台方式运行。npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64
 native artifact 以
 glibc 2.17 或更新为兼容基线。
 
@@ -33,6 +33,34 @@ export PATH="$PWD/target/release:$PATH"
 ```
 
 这会生成 `webcodex`、`webcodex-server`、`webcodex-runner`。
+
+## Windows 前台 Server 与 Runner
+
+npm 包会同时安装三个 Windows 可执行文件。Windows 不需要 Linux、WSL 或 Windows Service，也可以直接以前台方式运行 Server 与 Runner；使用期间保持对应终端开启即可。
+
+在 Windows Server 机器上，从 PowerShell 初始化显式 env 文件并启动 Server：
+
+```powershell
+$envFile = Join-Path $HOME ".config\webcodex\webcodex.env"
+$dataDir = Join-Path $HOME ".local\share\webcodex"
+webcodex server init --listen 127.0.0.1:8080 --data-dir $dataDir --env-file $envFile
+webcodex server run --env-file $envFile
+```
+
+启动前台 Server 时继续显式传入同一个 `--env-file`，不要依赖受管 service 的默认行为。如果先做同一台机器上的本地接入，再打开一个 PowerShell 窗口创建短期 pairing code：
+
+```powershell
+webcodex pairing create --server-url http://127.0.0.1:8080 --env-file $envFile --username workstation --display-name "Windows Workstation" --ttl-secs 600
+```
+
+然后在持有仓库的 Windows 机器上只兑换该短期 code，并以前台方式运行登录流程生成的 Runner 配置：
+
+```powershell
+webcodex login http://127.0.0.1:8080 --code <wc_pair_...> --allowed-root C:\src
+webcodex runner run --config <login-reported-agent-config>
+```
+
+如果 Server 与 Runner 位于不同机器，把 loopback URL 替换为 Server 可访问的 HTTPS URL，并按下文配置 Server listener/public URL 与受信任的反向代理或 tunnel。不要把 Server bootstrap token 或 env 文件复制到 Runner 机器。Windows 仍不支持 `webcodex server install/start/stop/restart/logs/uninstall` 与 `webcodex runner install`；Ctrl-C 或 Ctrl-Break 会结束前台 runtime。
 
 ## 把仓库接入已有的 shared-key Server
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -22,8 +22,9 @@ npm install -g @yyjeqhc/webcodex
 ```
 
 支持 Linux x64、Linux arm64、macOS x64、macOS arm64、Windows x64 与 Windows arm64。
-Windows x64/arm64 支持针对远程 Linux Server 的 CLI + Runner 工作流；不支持长期
-运行的 Windows Server。npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64
+Windows x64/arm64 支持 CLI + Runner，也支持显式的本地前台 Server：先执行
+`webcodex server init`，再执行 `webcodex server run --env-file <path>`。WebCodex 尚不支持
+Windows Server service 托管生命周期，也不支持 `webcodex share`。npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64
 native artifact 以
 glibc 2.17 或更新为兼容基线。
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -21,10 +21,7 @@ Runner 机器、连接 MCP/GPT 客户端以及 smoke 检查。第一次连接 Ch
 npm install -g @yyjeqhc/webcodex
 ```
 
-支持 Linux x64、Linux arm64、macOS x64、macOS arm64、Windows x64 与 Windows arm64。
-Windows x64/arm64 支持 CLI + Runner，也支持显式的本地前台 Server：先执行
-`webcodex server init`，再执行 `webcodex server run --env-file <path>`。WebCodex 尚不支持
-Windows Server service 托管生命周期，也不支持 `webcodex share`。npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64
+支持 Linux x64、Linux arm64、macOS x64、macOS arm64、Windows x64 与 Windows arm64。Windows 支持 CLI + Runner、显式前台 Server，以及显式本机 `webcodex share --tunnel cloudflare|openai|none`。Windows x64 支持 managed Cloudflare 获取；固定版本 upstream 没有官方 Windows ARM64 artifact，因此 ARM64 使用 Cloudflare 时需要受信任的显式/`PATH` binary。managed OpenAI `tunnel-client` 支持 Windows x64/arm64。WebCodex 仍不支持 Windows Server service 托管生命周期。npm 包装器要求 Node.js 18 或更新。从 v0.3.5 起，Linux x64
 native artifact 以
 glibc 2.17 或更新为兼容基线。
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -10,8 +10,9 @@ reference material, not onboarding prerequisites.
 ## ChatGPT Developer Mode: first connection
 
 The self-contained `share` path below requires a local WebCodex Server and is
-supported on Linux/macOS. Windows users should connect the Runner to an existing
-remote Linux Server with `webcodex connect <server-url>` instead.
+supported on Linux/macOS. Windows does not support `share`; it may run a local Server
+explicitly in the foreground with `webcodex server init` + `webcodex server run --env-file
+<path>`, or connect the Runner to an existing Server with `webcodex connect <server-url>`.
 
 For the default temporary public path, WebCodex reuses an explicit/PATH
 `cloudflared` or downloads its pinned verified managed copy automatically, then run:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -9,10 +9,7 @@ reference material, not onboarding prerequisites.
 
 ## ChatGPT Developer Mode: first connection
 
-The self-contained `share` path below requires a local WebCodex Server and is
-supported on Linux/macOS. Windows does not support `share`; it may run a local Server
-explicitly in the foreground with `webcodex server init` + `webcodex server run --env-file
-<path>`, or connect the Runner to an existing Server with `webcodex connect <server-url>`.
+The self-contained explicit `share` path below is supported on Linux, macOS, and Windows and owns a local foreground Server + Runner for the session. Windows x64 can use the managed default Cloudflare Quick Tunnel; Windows ARM64 needs a trusted explicit/PATH `cloudflared` because the pinned Cloudflare release publishes no official ARM64 artifact. Managed OpenAI `tunnel-client` supports both Windows x64 and arm64.
 
 For the default temporary public path, WebCodex reuses an explicit/PATH
 `cloudflared` or downloads its pinned verified managed copy automatically, then run:

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -8,10 +8,7 @@ reference，不是 onboarding 前置知识。
 
 ## ChatGPT Developer Mode：第一次接入
 
-下面的 self-contained `share` 路径需要本地 WebCodex Server，只支持 Linux/macOS。
-Windows 仍不支持 `share`，但可以用 `webcodex server init` + `webcodex server run --env-file
-<path>` 显式以前台方式运行本地 Server；也可以用 `webcodex connect <server-url>` 把 Runner
-接到已有 Server。
+下面的 self-contained 显式 `share` 路径支持 Linux、macOS 与 Windows，并由当前前台 session 持有本地 Server + Runner。Windows x64 可直接使用 managed 默认 Cloudflare Quick Tunnel；固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 ARM64 需要受信任的显式/`PATH` `cloudflared`。managed OpenAI `tunnel-client` 支持 Windows x64/arm64。
 
 默认临时公网路径会复用显式指定/`PATH` 中的 `cloudflared`，否则由 WebCodex 自动下载并校验
 固定的 managed 副本，然后执行：

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -9,8 +9,9 @@ reference，不是 onboarding 前置知识。
 ## ChatGPT Developer Mode：第一次接入
 
 下面的 self-contained `share` 路径需要本地 WebCodex Server，只支持 Linux/macOS。
-Windows 用户应改用 `webcodex connect <server-url>`，把 Runner 连接到已有的远程
-Linux Server。
+Windows 仍不支持 `share`，但可以用 `webcodex server init` + `webcodex server run --env-file
+<path>` 显式以前台方式运行本地 Server；也可以用 `webcodex connect <server-url>` 把 Runner
+接到已有 Server。
 
 默认临时公网路径会复用显式指定/`PATH` 中的 `cloudflared`，否则由 WebCodex 自动下载并校验
 固定的 managed 副本，然后执行：

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -8,9 +8,9 @@ This page is only the shortest path from a local repository to a first successfu
 
 - Node.js 18 or newer.
 - Git and a repository you are comfortable letting an AI inspect.
-- Linux or macOS for the one-command local `share` flow.
+- Linux, macOS, or Windows x64 for the fully managed default Cloudflare `share` flow.
 
-Windows uses a remote Linux WebCodex Server instead of local `share`; start with [MCP setup](MCP.md) or [Deployment](DEPLOYMENT.md).
+Windows supports explicit local `webcodex share`. On Windows ARM64, the pinned Cloudflare release has no official ARM64 binary, so `--tunnel cloudflare` requires a trusted `WEBCODEX_CLOUDFLARED_BIN`/`PATH` binary; managed OpenAI `tunnel-client` and `--tunnel none` remain available.
 
 ## 1. Run WebCodex
 
@@ -18,7 +18,7 @@ From the repository you want the AI to use:
 
 ```bash
 cd /path/to/your/repository
-npx --yes @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share
 ```
 
 You do not need to run `setup`, `doctor`, or `run` first. The default one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -25,7 +25,7 @@ You do not need to run `setup`, `doctor`, or `run` first. The default one-comman
 
 ## 2. Wait for `WebCodex ready`
 
-Keep that terminal open. WebCodex prints the values needed by the MCP client and normally copies the MCP URL to your clipboard. Press **Enter** in the terminal to open ChatGPT App settings; you can also open **Settings -> Apps -> Create** manually.
+Keep that terminal open. WebCodex prints the values needed by the MCP client. On Linux and macOS it normally copies the MCP URL to your clipboard and an interactive terminal can use **Enter** to open ChatGPT App settings. On Windows, copy the printed MCP URL manually and open **Settings -> Apps -> Create**.
 
 ## 3. Add WebCodex to ChatGPT
 

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -25,7 +25,7 @@ npx --yes @yyjeqhc/webcodex share
 
 ## 2. 等待 `WebCodex ready`
 
-看到 **WebCodex ready** 后保持终端运行。WebCodex 会打印 MCP 客户端需要的配置，通常也会把 MCP URL 复制到剪贴板。可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。
+看到 **WebCodex ready** 后保持终端运行。WebCodex 会打印 MCP 客户端需要的配置。Linux 与 macOS 通常会自动复制 MCP URL，并可在交互终端按 **Enter** 打开 ChatGPT App 设置；Windows 请手动复制终端中打印的 MCP URL，并进入 **Settings -> Apps -> Create**。
 
 ## 3. 在 ChatGPT 中添加 WebCodex
 

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -8,9 +8,9 @@
 
 - Node.js 18 或更新版本。
 - Git，以及一个可以让 AI 安全查看的代码仓库。
-- 一键本机 `share` 流程需要 Linux 或 macOS。
+- Linux、macOS 或 Windows x64 可直接使用完整 managed Cloudflare 本机 `share` 流程。
 
-Windows 需要连接远程 Linux WebCodex Server，不在本机运行 `share`；请从 [MCP 接入](MCP.zh-CN.md)或[部署指南](DEPLOYMENT.zh-CN.md)开始。
+Windows 已支持显式本机 `webcodex share`。固定版本 Cloudflare 没有官方 Windows ARM64 binary，因此 Windows ARM64 使用 `--tunnel cloudflare` 时需要通过 `WEBCODEX_CLOUDFLARED_BIN`/`PATH` 提供受信任 binary；managed OpenAI `tunnel-client` 与 `--tunnel none` 仍可用。
 
 ## 1. 运行 WebCodex
 
@@ -18,7 +18,7 @@ Windows 需要连接远程 Linux WebCodex Server，不在本机运行 `share`；
 
 ```bash
 cd /path/to/your/repository
-npx --yes @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share
 ```
 
 第一次使用不需要提前运行 `setup`、`doctor` 或 `run`。默认的一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -44,7 +44,7 @@ Paste the complete `/mcp?token=...` URL and choose **No authentication**. This f
 
 - Linux x64/arm64: local one-command `share`, Server, and Runner workflows.
 - macOS x64/arm64: local one-command `share` and Runner workflows.
-- Windows x64/arm64: CLI + Runner against a remote Linux Server; local `share` is not supported in this release.
+- Windows x64/arm64: CLI + Runner and an explicit local foreground Server (`webcodex server init`, then `webcodex server run --env-file <path>`); managed Windows Server services and local `share` are not supported yet.
 
 For Windows, permanent/self-hosted setup, OAuth, private tunnels, proxy settings, and troubleshooting, use the [WebCodex documentation](https://github.com/yyjeqhc/webcodex/tree/main/docs). The [Quick Start](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.md) stays focused on the first successful connection.
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -102,7 +102,7 @@ npx --yes @yyjeqhc/webcodex share --auth query-token
 
 - Linux x64/arm64：支持本机一键 `share`、Server 和 Runner 工作流。
 - macOS x64/arm64：支持本机一键 `share` 和 Runner 工作流。
-- Windows x64/arm64：支持 CLI 和 Runner，连接远程 Linux Server；本版本不支持 Windows 本机 `share`。
+- Windows x64/arm64：支持 CLI、Runner，以及显式的本地前台 Server（先执行 `webcodex server init`，再执行 `webcodex server run --env-file <path>`）；暂不支持 WebCodex 托管的 Windows Server service，也不支持本机 `share`。
 
 Windows、长期/自托管部署、OAuth、私有隧道、代理配置和故障排查见 [WebCodex 文档](https://github.com/yyjeqhc/webcodex/tree/main/docs)。[快速开始](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.zh-CN.md)只保留第一次成功连接所需的步骤。
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -10,11 +10,11 @@ WebCodex lets an AI inspect and edit code, run tests and commands, use Git, and 
 
 ### Fastest first connection
 
-Requires Node.js 18+ and Git. On Linux or macOS:
+Requires Node.js 18+ and Git. On Linux, macOS, or Windows x64:
 
 ```bash
 cd /path/to/your/repository
-npx --yes @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share
 ```
 
 When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL** is normally copied to your clipboard; press **Enter** in the terminal to open ChatGPT App settings, or open **Settings -> Apps -> Create** manually. Then:
@@ -44,7 +44,7 @@ Paste the complete `/mcp?token=...` URL and choose **No authentication**. This f
 
 - Linux x64/arm64: local one-command `share`, Server, and Runner workflows.
 - macOS x64/arm64: local one-command `share` and Runner workflows.
-- Windows x64/arm64: CLI + Runner and an explicit local foreground Server (`webcodex server init`, then `webcodex server run --env-file <path>`); managed Windows Server services and local `share` are not supported yet.
+- Windows x64/arm64: CLI + Runner, foreground Server, and explicit local `share` with `cloudflare`, `openai`, or `none`. Windows x64 auto-manages the pinned Cloudflare binary; managed OpenAI `tunnel-client` supports x64 and arm64. The pinned Cloudflare release has no official Windows ARM64 artifact, so ARM64 Cloudflare use requires a trusted explicit/PATH binary. Managed Windows Server services remain unsupported.
 
 For Windows, permanent/self-hosted setup, OAuth, private tunnels, proxy settings, and troubleshooting, use the [WebCodex documentation](https://github.com/yyjeqhc/webcodex/tree/main/docs). The [Quick Start](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.md) stays focused on the first successful connection.
 
@@ -68,11 +68,11 @@ WebCodex 可以让 AI 理解和修改代码、运行测试与命令、检查 Git
 
 ### 最快的第一次连接
 
-需要 Node.js 18+ 和 Git。Linux 或 macOS 上进入仓库：
+需要 Node.js 18+ 和 Git。Linux、macOS 或 Windows x64 上进入仓库：
 
 ```bash
 cd /path/to/your/repository
-npx --yes @yyjeqhc/webcodex
+npx --yes @yyjeqhc/webcodex share
 ```
 
 看到 **WebCodex ready** 后保持终端运行。**MCP URL** 通常已经复制到剪贴板；可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。然后：
@@ -102,7 +102,7 @@ npx --yes @yyjeqhc/webcodex share --auth query-token
 
 - Linux x64/arm64：支持本机一键 `share`、Server 和 Runner 工作流。
 - macOS x64/arm64：支持本机一键 `share` 和 Runner 工作流。
-- Windows x64/arm64：支持 CLI、Runner，以及显式的本地前台 Server（先执行 `webcodex server init`，再执行 `webcodex server run --env-file <path>`）；暂不支持 WebCodex 托管的 Windows Server service，也不支持本机 `share`。
+- Windows x64/arm64：支持 CLI、Runner、前台 Server，以及显式本机 `share --tunnel cloudflare|openai|none`。Windows x64 可自动管理固定版本 Cloudflare；OpenAI `tunnel-client` 的 managed 获取支持 x64/arm64。固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 ARM64 使用 Cloudflare 时需要受信任的显式/`PATH` binary。WebCodex 托管的 Windows Server service 仍不支持。
 
 Windows、长期/自托管部署、OAuth、私有隧道、代理配置和故障排查见 [WebCodex 文档](https://github.com/yyjeqhc/webcodex/tree/main/docs)。[快速开始](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.zh-CN.md)只保留第一次成功连接所需的步骤。
 

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -17,7 +17,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-When WebCodex reports **WebCodex ready**, keep the terminal open. The **MCP URL** is normally copied to your clipboard; press **Enter** in the terminal to open ChatGPT App settings, or open **Settings -> Apps -> Create** manually. Then:
+When WebCodex reports **WebCodex ready**, keep the terminal open. Linux and macOS normally copy the **MCP URL** to your clipboard and can use **Enter** in an interactive terminal to open ChatGPT App settings. On Windows, copy the printed **MCP URL** manually and open **Settings -> Apps -> Create**. Then:
 
 1. Enable **Developer Mode** if needed and choose **Create**.
 2. Paste the copied **MCP URL** (or use the URL printed by WebCodex).
@@ -75,7 +75,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-看到 **WebCodex ready** 后保持终端运行。**MCP URL** 通常已经复制到剪贴板；可以直接在终端按 **Enter** 打开 ChatGPT App 设置，也可以手动进入 **Settings -> Apps -> Create**。然后：
+看到 **WebCodex ready** 后保持终端运行。Linux 与 macOS 通常会自动复制 **MCP URL**，并可在交互终端按 **Enter** 打开 ChatGPT App 设置；Windows 请手动复制终端中打印的 **MCP URL**，并进入 **Settings -> Apps -> Create**。然后：
 
 1. 如有需要，开启 **Developer Mode** 并选择 **Create**。
 2. 粘贴已经复制的 **MCP URL**；也可以使用 WebCodex 终端中打印的地址。

--- a/scripts/npm_install_windows_smoke.ps1
+++ b/scripts/npm_install_windows_smoke.ps1
@@ -373,8 +373,6 @@ try {
     $ShareSmokeRoot = Join-Path $TempRoot "share-none"
     $ShareRepo = Join-Path $ShareSmokeRoot "repo"
     $ShareState = Join-Path $ShareSmokeRoot "state"
-    $ShareStdout = Join-Path $ShareSmokeRoot "share.stdout.log"
-    $ShareStderr = Join-Path $ShareSmokeRoot "share.stderr.log"
     New-Item -ItemType Directory -Force -Path $ShareRepo | Out-Null
     & git -C $ShareRepo init --quiet
     if ($LASTEXITCODE -ne 0) {
@@ -412,22 +410,61 @@ try {
     $ShareCliProcess = $null
     $ShareServerPid = $null
     $ShareRunnerPid = $null
+    $ShareStdoutBuffer = [System.Text.StringBuilder]::new()
+    $ShareStderrBuffer = [System.Text.StringBuilder]::new()
+    $ShareStdoutTask = $null
+    $ShareStderrTask = $null
     $ShareServerExe = Join-Path $VendorBin "webcodex-server.exe"
     $ShareRunnerExe = Join-Path $VendorBin "webcodex-runner.exe"
     try {
         $quotedShareRepo = '"' + $ShareRepo.Replace('"', '\"') + '"'
         $quotedShareState = '"' + $ShareState.Replace('"', '\"') + '"'
-        $ShareCliProcess = Start-Process -FilePath $cli `
-            -ArgumentList @("share", "--root", $quotedShareRepo, "--state-dir", $quotedShareState, "--tunnel", "none", "--no-copy-url") `
-            -RedirectStandardOutput $ShareStdout -RedirectStandardError $ShareStderr `
-            -PassThru -WindowStyle Hidden
+        # Start-Process keeps -RedirectStandardOutput files exclusively open on
+        # Windows PowerShell while the child is alive. Observe the long-lived
+        # share process through redirected pipes instead so readiness can be read
+        # without racing the redirection file handle, and drain stderr in parallel
+        # so neither pipe can block the child.
+        $shareStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $shareStartInfo.FileName = $cli
+        $shareStartInfo.Arguments = "share --root $quotedShareRepo --state-dir $quotedShareState --tunnel none --no-copy-url"
+        $shareStartInfo.UseShellExecute = $false
+        $shareStartInfo.RedirectStandardOutput = $true
+        $shareStartInfo.RedirectStandardError = $true
+        $shareStartInfo.CreateNoWindow = $true
+        $ShareCliProcess = [System.Diagnostics.Process]::new()
+        $ShareCliProcess.StartInfo = $shareStartInfo
+        if (-not $ShareCliProcess.Start()) {
+            throw "could not start webcodex share --tunnel none"
+        }
+        $ShareStdoutTask = $ShareCliProcess.StandardOutput.ReadLineAsync()
+        $ShareStderrTask = $ShareCliProcess.StandardError.ReadLineAsync()
 
         $shareDeadline = [System.Diagnostics.Stopwatch]::StartNew()
         $shareReady = $false
         $shareOutput = ""
         while ($shareDeadline.Elapsed -lt [TimeSpan]::FromSeconds(65)) {
+            while ($null -ne $ShareStdoutTask -and $ShareStdoutTask.IsCompleted) {
+                $line = $ShareStdoutTask.Result
+                if ($null -eq $line) {
+                    $ShareStdoutTask = $null
+                    break
+                }
+                $null = $ShareStdoutBuffer.AppendLine($line)
+                $ShareStdoutTask = $ShareCliProcess.StandardOutput.ReadLineAsync()
+            }
+            while ($null -ne $ShareStderrTask -and $ShareStderrTask.IsCompleted) {
+                $line = $ShareStderrTask.Result
+                if ($null -eq $line) {
+                    $ShareStderrTask = $null
+                    break
+                }
+                $null = $ShareStderrBuffer.AppendLine($line)
+                $ShareStderrTask = $ShareCliProcess.StandardError.ReadLineAsync()
+            }
+            $shareOutput = $ShareStdoutBuffer.ToString()
             if ($ShareCliProcess.HasExited) {
-                throw "webcodex share --tunnel none exited before readiness (exit $($ShareCliProcess.ExitCode))"
+                $shareError = $ShareStderrBuffer.ToString().Trim()
+                throw "webcodex share --tunnel none exited before readiness (exit $($ShareCliProcess.ExitCode)): $shareError"
             }
             $children = @(Get-CimInstance Win32_Process -Filter "ParentProcessId=$($ShareCliProcess.Id)" -ErrorAction SilentlyContinue)
             if ($null -eq $ShareServerPid) {
@@ -438,12 +475,9 @@ try {
                 $runnerChild = $children | Where-Object { $_.Name -eq "webcodex-runner.exe" -and $_.ExecutablePath -eq $ShareRunnerExe } | Select-Object -First 1
                 if ($null -ne $runnerChild) { $ShareRunnerPid = [int]$runnerChild.ProcessId }
             }
-            if (Test-Path -LiteralPath $ShareStdout -PathType Leaf) {
-                $shareOutput = [System.IO.File]::ReadAllText($ShareStdout)
-                if ($shareOutput.Contains("WebCodex ready")) {
-                    $shareReady = $true
-                    break
-                }
+            if ($shareOutput.Contains("WebCodex ready")) {
+                $shareReady = $true
+                break
             }
             Start-Sleep -Milliseconds 100
         }

--- a/scripts/npm_install_windows_smoke.ps1
+++ b/scripts/npm_install_windows_smoke.ps1
@@ -13,6 +13,8 @@
 #   - version and build identity are consistent
 #   - the npm wrapper finds webcodex.exe
 #   - webcodex.exe --version / --help and webcodex-runner.exe --version work
+#   - packaged `server init` + foreground `server run --env-file` reaches HTTP readiness
+#     with an isolated local config/data root and leaves no Server process behind
 #   - an install failure does not break the previous binary set
 #   - staging/temporary files are cleaned up
 #
@@ -216,7 +218,146 @@ try {
     }
 
     # -----------------------------------------------------------------------
-    # 6. An install failure must not break the previous binary set.
+    # 6. Windows foreground Server runtime. Exercise the installed CLI so this
+    #    proves sibling webcodex-server.exe discovery and WEBCODEX_ENV_FILE
+    #    propagation, not merely that the Server binary itself starts.
+    # -----------------------------------------------------------------------
+    $ServerSmokeRoot = Join-Path $TempRoot "foreground-server"
+    $ServerData = Join-Path $ServerSmokeRoot "data"
+    $ServerEnv = Join-Path $ServerSmokeRoot "webcodex.env"
+    $ServerStdout = Join-Path $ServerSmokeRoot "server.stdout.log"
+    $ServerStderr = Join-Path $ServerSmokeRoot "server.stderr.log"
+    New-Item -ItemType Directory -Force -Path $ServerSmokeRoot | Out-Null
+
+    $PortProbe = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $PortProbe.Start()
+    try {
+        $ServerPort = ([System.Net.IPEndPoint]$PortProbe.LocalEndpoint).Port
+    } finally {
+        $PortProbe.Stop()
+    }
+    $Listen = "127.0.0.1:$ServerPort"
+
+    # The explicit env file is the only Server startup-env source for this smoke.
+    # Do not let CI/operator control-plane or tunnel credentials participate.
+    $SensitiveEnvNames = @(
+        "CONTROL_PLANE_API_KEY",
+        "CONTROL_PLANE_TUNNEL_ID",
+        "OPENAI_TUNNEL_TOKEN",
+        "WEBCODEX_ENV_FILE",
+        "WEBCODEX_TOKEN",
+        "WEBCODEX_LISTEN",
+        "WEBCODEX_DATA_DIR"
+    )
+    $SavedSensitiveEnv = @{}
+    foreach ($name in $SensitiveEnvNames) {
+        $item = Get-Item "Env:$name" -ErrorAction SilentlyContinue
+        if ($null -ne $item) { $SavedSensitiveEnv[$name] = $item.Value }
+        Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+    }
+
+    $ServerCliProcess = $null
+    $ServerChildPid = $null
+    $ServerExe = Join-Path $VendorBin "webcodex-server.exe"
+    $BaselineServerPids = @(
+        Get-CimInstance Win32_Process -Filter "Name='webcodex-server.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.ExecutablePath -eq $ServerExe } |
+            Select-Object -ExpandProperty ProcessId
+    )
+    try {
+        $initOutput = @(& $cli server init --listen $Listen --data-dir $ServerData --env-file $ServerEnv --json)
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $ServerEnv -PathType Leaf)) {
+            throw "Windows foreground server init failed with exit code $LASTEXITCODE"
+        }
+        $envText = [System.IO.File]::ReadAllText($ServerEnv)
+        $tokenMatch = [regex]::Match($envText, '(?m)^WEBCODEX_TOKEN=(.+)$')
+        if (-not $tokenMatch.Success -or [string]::IsNullOrWhiteSpace($tokenMatch.Groups[1].Value)) {
+            throw "server init did not write WEBCODEX_TOKEN to the isolated env file"
+        }
+        $secretToken = $tokenMatch.Groups[1].Value.Trim()
+        if (($initOutput -join "`n").Contains($secretToken)) {
+            throw "server init leaked WEBCODEX_TOKEN to stdout"
+        }
+
+        $quotedEnvFile = '"' + $ServerEnv.Replace('"', '\"') + '"'
+        $ServerCliProcess = Start-Process -FilePath $cli `
+            -ArgumentList @("server", "run", "--env-file", $quotedEnvFile) `
+            -RedirectStandardOutput $ServerStdout -RedirectStandardError $ServerStderr `
+            -PassThru -WindowStyle Hidden
+
+        $ready = $false
+        $deadline = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($deadline.Elapsed -lt [TimeSpan]::FromSeconds(20)) {
+            if ($ServerCliProcess.HasExited) {
+                throw "foreground webcodex CLI exited before Server readiness (exit $($ServerCliProcess.ExitCode))"
+            }
+            if ($null -eq $ServerChildPid) {
+                $child = Get-CimInstance Win32_Process -Filter "ParentProcessId=$($ServerCliProcess.Id)" -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -eq "webcodex-server.exe" -and $_.ExecutablePath -eq $ServerExe } |
+                    Select-Object -First 1
+                if ($null -ne $child) { $ServerChildPid = [int]$child.ProcessId }
+            }
+            try {
+                $response = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$ServerPort/openapi.json" -TimeoutSec 1
+                if ($response.StatusCode -eq 200) {
+                    $ready = $true
+                    break
+                }
+            } catch {
+                # Startup connection failures are expected until the one absolute deadline.
+            }
+            Start-Sleep -Milliseconds 100
+        }
+        if (-not $ready) {
+            throw "foreground Windows Server did not reach /openapi.json readiness before the absolute deadline"
+        }
+        while ($null -eq $ServerChildPid -and $deadline.Elapsed -lt [TimeSpan]::FromSeconds(20)) {
+            $child = Get-CimInstance Win32_Process -Filter "ParentProcessId=$($ServerCliProcess.Id)" -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -eq "webcodex-server.exe" -and $_.ExecutablePath -eq $ServerExe } |
+                Select-Object -First 1
+            if ($null -ne $child) {
+                $ServerChildPid = [int]$child.ProcessId
+                break
+            }
+            Start-Sleep -Milliseconds 50
+        }
+        if ($null -eq $ServerChildPid) {
+            throw "foreground CLI readiness succeeded without observing its real webcodex-server.exe child before the same absolute deadline"
+        }
+    } finally {
+        if ($null -ne $ServerChildPid) {
+            Stop-Process -Id $ServerChildPid -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -ne $ServerCliProcess -and -not $ServerCliProcess.HasExited) {
+            Stop-Process -Id $ServerCliProcess.Id -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -ne $ServerCliProcess) {
+            try { $ServerCliProcess.WaitForExit(5000) | Out-Null } catch {}
+        }
+        foreach ($name in $SensitiveEnvNames) {
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+            if ($SavedSensitiveEnv.ContainsKey($name)) {
+                Set-Item "Env:$name" $SavedSensitiveEnv[$name]
+            }
+        }
+        $newServerProcesses = @(
+            Get-CimInstance Win32_Process -Filter "Name='webcodex-server.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.ExecutablePath -eq $ServerExe -and $_.ProcessId -notin $BaselineServerPids }
+        )
+        foreach ($process in $newServerProcesses) {
+            Stop-Process -Id $process.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+        if ($newServerProcesses.Count -gt 0) {
+            Start-Sleep -Milliseconds 200
+            $leftRunning = @($newServerProcesses | Where-Object { Get-Process -Id $_.ProcessId -ErrorAction SilentlyContinue })
+            if ($leftRunning.Count -gt 0) {
+                throw "foreground Windows Server smoke left webcodex-server.exe running"
+            }
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # 7. An install failure must not break the previous binary set.
     # -----------------------------------------------------------------------
     $badArtifacts = [ordered]@{}
     $badArtifacts[$Platform] = [ordered]@{
@@ -249,7 +390,7 @@ try {
     }
 
     # -----------------------------------------------------------------------
-    # 7. Staging/temporary cleanup.
+    # 8. Staging/temporary cleanup.
     # -----------------------------------------------------------------------
     $leftovers = Get-ChildItem -LiteralPath $env:TEMP -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "webcodex-artifact-*" -or $_.Name -like "webcodex-manifest-*" -or $_.Name -like "webcodex-npm-test-*" } |

--- a/scripts/npm_install_windows_smoke.ps1
+++ b/scripts/npm_install_windows_smoke.ps1
@@ -15,6 +15,8 @@
 #   - webcodex.exe --version / --help and webcodex-runner.exe --version work
 #   - packaged `server init` + foreground `server run --env-file` reaches HTTP readiness
 #     with an isolated local config/data root and leaves no Server process behind
+#   - packaged explicit `share --tunnel none` reaches local MCP readiness with
+#     isolated project state and exact tracked Server/Runner children
 #   - an install failure does not break the previous binary set
 #   - staging/temporary files are cleaned up
 #
@@ -364,7 +366,147 @@ try {
     }
 
     # -----------------------------------------------------------------------
-    # 7. An install failure must not break the previous binary set.
+    # 7. Explicit Windows share with no tunnel. This is the deterministic CI
+    #    share lane: installed CLI -> private state -> Server -> Runner -> MCP.
+    #    Public Cloudflare/OpenAI E2E remains native dogfood evidence.
+    # -----------------------------------------------------------------------
+    $ShareSmokeRoot = Join-Path $TempRoot "share-none"
+    $ShareRepo = Join-Path $ShareSmokeRoot "repo"
+    $ShareState = Join-Path $ShareSmokeRoot "state"
+    $ShareStdout = Join-Path $ShareSmokeRoot "share.stdout.log"
+    $ShareStderr = Join-Path $ShareSmokeRoot "share.stderr.log"
+    New-Item -ItemType Directory -Force -Path $ShareRepo | Out-Null
+    & git -C $ShareRepo init --quiet
+    if ($LASTEXITCODE -ne 0) {
+        throw "could not initialize isolated Git repo for Windows share smoke"
+    }
+
+    $ShareEnvNames = @(
+        "CONTROL_PLANE_API_KEY",
+        "CONTROL_PLANE_TUNNEL_ID",
+        "OPENAI_ADMIN_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_TUNNEL_TOKEN",
+        "WEBCODEX_AGENT_BIN",
+        "WEBCODEX_AGENT_TOKEN",
+        "WEBCODEX_CLOUDFLARED_BIN",
+        "WEBCODEX_TUNNEL_CLIENT_BIN",
+        "WEBCODEX_ENV_FILE",
+        "WEBCODEX_ADDR",
+        "WEBCODEX_DATA",
+        "WEBCODEX_TOKEN",
+        "WEBCODEX_SHARED_KEY_ENABLED",
+        "WEBCODEX_ALLOW_ANONYMOUS",
+        "WEBCODEX_PUBLIC_URL",
+        "WEBCODEX_OAUTH2_ENABLED",
+        "WEBCODEX_OAUTH2_ISSUER",
+        "WEBCODEX_OAUTH2_SHARED_KEY_BRIDGE"
+    )
+    $SavedShareEnv = @{}
+    foreach ($name in $ShareEnvNames) {
+        $item = Get-Item "Env:$name" -ErrorAction SilentlyContinue
+        if ($null -ne $item) { $SavedShareEnv[$name] = $item.Value }
+        Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+    }
+
+    $ShareCliProcess = $null
+    $ShareServerPid = $null
+    $ShareRunnerPid = $null
+    $ShareServerExe = Join-Path $VendorBin "webcodex-server.exe"
+    $ShareRunnerExe = Join-Path $VendorBin "webcodex-runner.exe"
+    try {
+        $quotedShareRepo = '"' + $ShareRepo.Replace('"', '\"') + '"'
+        $quotedShareState = '"' + $ShareState.Replace('"', '\"') + '"'
+        $ShareCliProcess = Start-Process -FilePath $cli `
+            -ArgumentList @("share", "--root", $quotedShareRepo, "--state-dir", $quotedShareState, "--tunnel", "none", "--no-copy-url") `
+            -RedirectStandardOutput $ShareStdout -RedirectStandardError $ShareStderr `
+            -PassThru -WindowStyle Hidden
+
+        $shareDeadline = [System.Diagnostics.Stopwatch]::StartNew()
+        $shareReady = $false
+        $shareOutput = ""
+        while ($shareDeadline.Elapsed -lt [TimeSpan]::FromSeconds(65)) {
+            if ($ShareCliProcess.HasExited) {
+                throw "webcodex share --tunnel none exited before readiness (exit $($ShareCliProcess.ExitCode))"
+            }
+            $children = @(Get-CimInstance Win32_Process -Filter "ParentProcessId=$($ShareCliProcess.Id)" -ErrorAction SilentlyContinue)
+            if ($null -eq $ShareServerPid) {
+                $serverChild = $children | Where-Object { $_.Name -eq "webcodex-server.exe" -and $_.ExecutablePath -eq $ShareServerExe } | Select-Object -First 1
+                if ($null -ne $serverChild) { $ShareServerPid = [int]$serverChild.ProcessId }
+            }
+            if ($null -eq $ShareRunnerPid) {
+                $runnerChild = $children | Where-Object { $_.Name -eq "webcodex-runner.exe" -and $_.ExecutablePath -eq $ShareRunnerExe } | Select-Object -First 1
+                if ($null -ne $runnerChild) { $ShareRunnerPid = [int]$runnerChild.ProcessId }
+            }
+            if (Test-Path -LiteralPath $ShareStdout -PathType Leaf) {
+                $shareOutput = [System.IO.File]::ReadAllText($ShareStdout)
+                if ($shareOutput.Contains("WebCodex ready")) {
+                    $shareReady = $true
+                    break
+                }
+            }
+            Start-Sleep -Milliseconds 100
+        }
+        if (-not $shareReady) {
+            throw "Windows share --tunnel none did not become ready before the absolute smoke deadline"
+        }
+        if ($null -eq $ShareServerPid -or $null -eq $ShareRunnerPid) {
+            throw "Windows share readiness did not expose the expected exact Server + Runner child processes"
+        }
+
+        $mcpMatch = [regex]::Match($shareOutput, 'http://127\.0\.0\.1:\d+/mcp')
+        $credentialMatch = [regex]::Match($shareOutput, '(?m)^\d+\. Credential \(this share only\): (.+)$')
+        if (-not $mcpMatch.Success -or -not $credentialMatch.Success) {
+            throw "Windows share output did not contain the local MCP endpoint and temporary Bearer contract"
+        }
+        $shareCredential = $credentialMatch.Groups[1].Value.Trim()
+        if ([string]::IsNullOrWhiteSpace($shareCredential)) {
+            throw "Windows share printed an empty temporary Bearer credential"
+        }
+        $initialize = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"windows-package-smoke","version":"1"}}}'
+        $headers = @{
+            Authorization = "Bearer $shareCredential"
+            Accept = "application/json, text/event-stream"
+            "MCP-Protocol-Version" = "2025-06-18"
+        }
+        $response = Invoke-WebRequest -UseBasicParsing -Method Post -Uri $mcpMatch.Value `
+            -Headers $headers -ContentType "application/json" -Body $initialize -TimeoutSec 3
+        if ($response.StatusCode -ne 200) {
+            throw "Windows share local MCP initialize returned HTTP $($response.StatusCode)"
+        }
+        if (-not (Test-Path -LiteralPath $ShareState -PathType Container)) {
+            throw "Windows share did not create isolated project state"
+        }
+    } finally {
+        # CI termination is containment only; native MSI dogfood separately proves
+        # Ctrl-C/foreground cleanup. Never kill by process name.
+        if ($null -ne $ShareServerPid) {
+            Stop-Process -Id $ShareServerPid -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -ne $ShareRunnerPid) {
+            Stop-Process -Id $ShareRunnerPid -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -ne $ShareCliProcess -and -not $ShareCliProcess.HasExited) {
+            Stop-Process -Id $ShareCliProcess.Id -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -ne $ShareCliProcess) {
+            try { $ShareCliProcess.WaitForExit(5000) | Out-Null } catch {}
+        }
+        foreach ($trackedPid in @($ShareServerPid, $ShareRunnerPid)) {
+            if ($null -ne $trackedPid -and $null -ne (Get-Process -Id $trackedPid -ErrorAction SilentlyContinue)) {
+                throw "Windows share smoke left a tracked child process running"
+            }
+        }
+        foreach ($name in $ShareEnvNames) {
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+            if ($SavedShareEnv.ContainsKey($name)) {
+                Set-Item "Env:$name" $SavedShareEnv[$name]
+            }
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # 8. An install failure must not break the previous binary set.
     # -----------------------------------------------------------------------
     $badArtifacts = [ordered]@{}
     $badArtifacts[$Platform] = [ordered]@{
@@ -397,7 +539,7 @@ try {
     }
 
     # -----------------------------------------------------------------------
-    # 8. Staging/temporary cleanup.
+    # 9. Staging/temporary cleanup.
     # -----------------------------------------------------------------------
     $leftovers = Get-ChildItem -LiteralPath $env:TEMP -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "webcodex-artifact-*" -or $_.Name -like "webcodex-manifest-*" -or $_.Name -like "webcodex-npm-test-*" } |

--- a/scripts/npm_install_windows_smoke.ps1
+++ b/scripts/npm_install_windows_smoke.ps1
@@ -238,16 +238,23 @@ try {
     }
     $Listen = "127.0.0.1:$ServerPort"
 
-    # The explicit env file is the only Server startup-env source for this smoke.
-    # Do not let CI/operator control-plane or tunnel credentials participate.
+    # Process environment wins over env-file values, so clear the canonical
+    # Server keys that could override this smoke's isolated listener/data/auth
+    # state. Also keep operator control-plane/tunnel credentials out of scope.
     $SensitiveEnvNames = @(
         "CONTROL_PLANE_API_KEY",
         "CONTROL_PLANE_TUNNEL_ID",
         "OPENAI_TUNNEL_TOKEN",
         "WEBCODEX_ENV_FILE",
+        "WEBCODEX_ADDR",
+        "WEBCODEX_DATA",
         "WEBCODEX_TOKEN",
-        "WEBCODEX_LISTEN",
-        "WEBCODEX_DATA_DIR"
+        "WEBCODEX_SHARED_KEY_ENABLED",
+        "WEBCODEX_ALLOW_ANONYMOUS",
+        "WEBCODEX_PUBLIC_URL",
+        "WEBCODEX_OAUTH2_ENABLED",
+        "WEBCODEX_OAUTH2_ISSUER",
+        "WEBCODEX_OAUTH2_SHARED_KEY_BRIDGE"
     )
     $SavedSensitiveEnv = @{}
     foreach ($name in $SensitiveEnvNames) {

--- a/scripts/package_release_artifact.ps1
+++ b/scripts/package_release_artifact.ps1
@@ -9,9 +9,10 @@
 #
 #   webcodex.exe webcodex-server.exe webcodex-runner.exe
 #
-# webcodex-server.exe is a supported local foreground runtime on Windows.
-# WebCodex-managed Windows Server service lifecycle and `webcodex share` remain
-# unsupported; packaging this binary does not claim Windows service/Tunnel parity.
+# webcodex-server.exe is a supported local foreground/share runtime on Windows.
+# The three-binary package supports explicit `webcodex share` with Cloudflare,
+# OpenAI Secure MCP Tunnel, or no tunnel. Managed Windows Server service lifecycle
+# remains unsupported and is not implied by packaging these binaries.
 #
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File scripts\package_release_artifact.ps1

--- a/scripts/package_release_artifact.ps1
+++ b/scripts/package_release_artifact.ps1
@@ -9,9 +9,9 @@
 #
 #   webcodex.exe webcodex-server.exe webcodex-runner.exe
 #
-# webcodex-server.exe is packaged to keep the artifact/manifest contract
-# intact; it is NOT a statement that a long-running Windows Server runtime is
-# supported (it is not, in this release).
+# webcodex-server.exe is a supported local foreground runtime on Windows.
+# WebCodex-managed Windows Server service lifecycle and `webcodex share` remain
+# unsupported; packaging this binary does not claim Windows service/Tunnel parity.
 #
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File scripts\package_release_artifact.ps1

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -57,8 +57,10 @@ pub(crate) mod tokens;
 // so that existing `use crate::auth::*` imports continue to work.
 
 pub use context::{AuthContext, AuthError, AuthKind};
+#[cfg(any(not(windows), test))]
+pub(crate) use project_credential::read_protected_secret;
 pub(crate) use project_credential::{
-    read_protected_secret, validate_agent_token as validate_project_agent_token,
+    validate_agent_token as validate_project_agent_token,
     validate_credential as validate_project_credential, ProjectAgentTokenVerifier,
     ProjectCredentialVerifier,
 };

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -19,10 +19,10 @@ mod share_service;
 mod windows_private_state;
 
 use setup_service::{
-    create_private_dir, local_readiness, read_private_value, read_project_agent_token,
-    read_project_credential, read_toml_optional, validate_agent_authentication,
-    validate_existing_registration, validate_existing_runner, validate_product_config,
-    validate_profile, ProjectConfig,
+    create_private_dir, harden_existing_runtime_private_state, local_readiness, read_private_value,
+    read_project_agent_token, read_project_credential, read_toml_optional,
+    validate_agent_authentication, validate_existing_registration, validate_existing_runner,
+    validate_product_config, validate_profile, ProjectConfig,
 };
 pub(crate) use setup_service::{resolve_local_task_state, setup};
 #[cfg(test)]
@@ -740,6 +740,7 @@ pub(super) async fn start_local_runtime(
 ) -> Result<LocalRuntimeHandle, ProductError> {
     let console_assets_dir = resolve_console_assets_directory(options)?;
     let (config, paths) = configured_project(options)?;
+    harden_existing_runtime_private_state(&paths)?;
     ensure_local_runtime_port_available(config.port, runtime_options.port_conflict_action)?;
     let readiness_deadline = runtime_options
         .readiness_deadline
@@ -1159,6 +1160,10 @@ async fn wait_for_ready(
         Some("Run webcodex doctor."),
     ))
 }
+
+#[cfg(all(test, windows))]
+#[path = "project_entry_windows_migration_tests.rs"]
+mod windows_migration_tests;
 
 #[cfg(test)]
 #[path = "project_entry_tests.rs"]

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -19,7 +19,7 @@ mod share_service;
 mod windows_private_state;
 
 use setup_service::{
-    create_private_dir, harden_existing_runtime_private_state, local_readiness, read_private_value,
+    create_private_dir, local_readiness, prepare_runtime_private_state, read_private_value,
     read_project_agent_token, read_project_credential, read_toml_optional,
     validate_agent_authentication, validate_existing_registration, validate_existing_runner,
     validate_product_config, validate_profile, ProjectConfig,
@@ -740,7 +740,7 @@ pub(super) async fn start_local_runtime(
 ) -> Result<LocalRuntimeHandle, ProductError> {
     let console_assets_dir = resolve_console_assets_directory(options)?;
     let (config, paths) = configured_project(options)?;
-    harden_existing_runtime_private_state(&paths)?;
+    prepare_runtime_private_state(&paths)?;
     ensure_local_runtime_port_available(config.port, runtime_options.port_conflict_action)?;
     let readiness_deadline = runtime_options
         .readiness_deadline
@@ -926,11 +926,31 @@ pub(crate) async fn start_runner(options: &ProjectCommandOptions) -> Result<(), 
     started.push_str("\nRunner: online\nCoding access: ready\n\nPress Ctrl-C to stop.");
     println!("{started}");
     let outcome = tokio::select! {
-        _ = tokio::signal::ctrl_c() => Ok(()),
+        _ = wait_for_local_runtime_stop_signal() => Ok(()),
         result = runtime.wait_for_exit() => result,
     };
     runtime.stop().await;
     outcome
+}
+
+#[cfg(not(windows))]
+async fn wait_for_local_runtime_stop_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+#[cfg(windows)]
+async fn wait_for_local_runtime_stop_signal() {
+    let mut ctrl_break = match tokio::signal::windows::ctrl_break() {
+        Ok(signal) => signal,
+        Err(_) => {
+            let _ = tokio::signal::ctrl_c().await;
+            return;
+        }
+    };
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {},
+        _ = ctrl_break.recv() => {},
+    }
 }
 
 fn resolve_console_assets_directory(

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -14,6 +14,9 @@ mod openai_tunnel_service;
 mod setup_service;
 #[path = "project_entry_share.rs"]
 mod share_service;
+#[cfg(windows)]
+#[path = "project_entry_windows.rs"]
+mod windows_private_state;
 
 use setup_service::{
     create_private_dir, local_readiness, read_private_value, read_project_agent_token,
@@ -246,7 +249,7 @@ starting services. `run` is the explicit foreground local runtime step. Its opti
 `--console-assets-dir` enables loopback-only development assets for that run.\n\
 `--auth query-token` is a temporary share-only convenience for MCP clients that\n\
 cannot configure a Bearer header; `--auth oauth` adds project-bound OAuth.\n\
-On Windows, `webcodex share` remains unsupported. Use `webcodex server init` + `webcodex server run --env-file <path>` for a standalone local foreground Server, or `webcodex connect <server-url>` with an existing Server.\n"
+On Windows, explicit `webcodex share` is supported. Managed Cloudflare acquisition is available on Windows x64; Windows ARM64 requires a trusted explicit/PATH cloudflared because the pinned upstream release has no official ARM64 artifact. Managed OpenAI tunnel-client supports Windows x64/arm64.\n"
 }
 
 pub(crate) fn readiness_with_probe(
@@ -650,6 +653,7 @@ pub(super) struct LocalRuntimeOptions {
     pub(super) project_share_oauth: Option<ProjectShareOAuthRuntimeOptions>,
     pub(super) child_environment_remove: Vec<&'static str>,
     pub(super) port_conflict_action: &'static str,
+    pub(super) readiness_deadline: Option<Instant>,
 }
 
 impl Default for LocalRuntimeOptions {
@@ -661,6 +665,7 @@ impl Default for LocalRuntimeOptions {
             project_share_oauth: None,
             child_environment_remove: Vec::new(),
             port_conflict_action: "Stop the conflicting process, then run webcodex run.",
+            readiness_deadline: None,
         }
     }
 }
@@ -736,6 +741,9 @@ pub(super) async fn start_local_runtime(
     let console_assets_dir = resolve_console_assets_directory(options)?;
     let (config, paths) = configured_project(options)?;
     ensure_local_runtime_port_available(config.port, runtime_options.port_conflict_action)?;
+    let readiness_deadline = runtime_options
+        .readiness_deadline
+        .unwrap_or_else(|| Instant::now() + START_TIMEOUT);
     let project_share_oauth = runtime_options.project_share_oauth.clone();
     let mcp_query_token_auth = runtime_options.mcp_query_token_auth;
     let runner_binary = locate_runner_binary().ok_or_else(|| {
@@ -840,7 +848,12 @@ pub(super) async fn start_local_runtime(
             Some("Run webcodex doctor."),
         )
     })?;
-    wait_for_server(&mut server, &local_url, &connector_key).await?;
+    if let Err(error) =
+        wait_for_server(&mut server, &local_url, &connector_key, readiness_deadline).await
+    {
+        stop_child(&mut server).await;
+        return Err(error);
+    }
 
     let runner_log = open_log(&paths.logs.join("agent.log"))?;
     let runner_error = runner_log.try_clone().map_err(io_error)?;
@@ -858,14 +871,31 @@ pub(super) async fn start_local_runtime(
         .stdout(Stdio::from(runner_log))
         .stderr(Stdio::from(runner_error))
         .kill_on_drop(true);
-    let mut runner = runner_command.spawn().map_err(|_| {
-        ProductError::new(
-            "agent_offline",
-            "the local Runner could not start",
-            Some("Run webcodex doctor."),
-        )
-    })?;
-    wait_for_ready(&mut server, &mut runner, options, &config, &connector_key).await?;
+    let mut runner = match runner_command.spawn() {
+        Ok(runner) => runner,
+        Err(_) => {
+            stop_child(&mut server).await;
+            return Err(ProductError::new(
+                "agent_offline",
+                "the local Runner could not start",
+                Some("Run webcodex doctor."),
+            ));
+        }
+    };
+    if let Err(error) = wait_for_ready(
+        &mut server,
+        &mut runner,
+        options,
+        &config,
+        &connector_key,
+        readiness_deadline,
+    )
+    .await
+    {
+        stop_child(&mut runner).await;
+        stop_child(&mut server).await;
+        return Err(error);
+    }
     Ok(LocalRuntimeHandle {
         project_name: config.project_name,
         local_url,
@@ -1019,6 +1049,11 @@ fn open_log(path: &Path) -> Result<File, ProductError> {
         })
 }
 
+async fn stop_child(child: &mut Child) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
 fn io_error(_: std::io::Error) -> ProductError {
     ProductError::new(
         "workspace_unavailable",
@@ -1031,6 +1066,7 @@ async fn wait_for_server(
     server: &mut Child,
     base_url: &str,
     key: &str,
+    deadline: Instant,
 ) -> Result<(), ProductError> {
     let client = reqwest::Client::builder()
         .no_proxy()
@@ -1044,21 +1080,31 @@ async fn wait_for_server(
                 Some("Run webcodex doctor."),
             )
         })?;
-    let deadline = Instant::now() + START_TIMEOUT;
     while Instant::now() < deadline {
         if server.try_wait().ok().flatten().is_some() {
             break;
         }
-        let response = client
-            .post(format!("{base_url}/api/connector/readiness"))
-            .bearer_auth(key)
-            .json(&serde_json::json!({}))
-            .send()
-            .await;
-        if response.is_ok_and(|response| response.status().is_success()) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let response = tokio::time::timeout(
+            remaining,
+            client
+                .post(format!("{base_url}/api/connector/readiness"))
+                .bearer_auth(key)
+                .json(&serde_json::json!({}))
+                .send(),
+        )
+        .await
+        .ok()
+        .and_then(Result::ok);
+        if response.is_some_and(|response| response.status().is_success()) {
             return Ok(());
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(100)),
+        )
+        .await;
     }
     Err(ProductError::new(
         "server_unreachable",
@@ -1073,8 +1119,8 @@ async fn wait_for_ready(
     options: &ProjectCommandOptions,
     config: &ProjectConfig,
     connector_key: &str,
+    deadline: Instant,
 ) -> Result<(), ProductError> {
-    let deadline = Instant::now() + START_TIMEOUT;
     while Instant::now() < deadline {
         if server.try_wait().ok().flatten().is_some() {
             return Err(ProductError::new(
@@ -1090,13 +1136,22 @@ async fn wait_for_ready(
                 Some("Run webcodex doctor."),
             ));
         }
-        if collect_readiness_from_remote(options, config, connector_key)
-            .await
-            .ready
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if tokio::time::timeout(
+            remaining,
+            collect_readiness_from_remote(options, config, connector_key),
+        )
+        .await
+        .is_ok_and(|readiness| readiness.ready)
         {
             return Ok(());
         }
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::time::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(150)),
+        )
+        .await;
     }
     Err(ProductError::new(
         "agent_offline",

--- a/src/project_entry.rs
+++ b/src/project_entry.rs
@@ -246,7 +246,7 @@ starting services. `run` is the explicit foreground local runtime step. Its opti
 `--console-assets-dir` enables loopback-only development assets for that run.\n\
 `--auth query-token` is a temporary share-only convenience for MCP clients that\n\
 cannot configure a Bearer header; `--auth oauth` adds project-bound OAuth.\n\
-On Windows, local Server/share runtime is unsupported; use `webcodex connect <server-url>` with a remote Linux Server.\n"
+On Windows, `webcodex share` remains unsupported. Use `webcodex server init` + `webcodex server run --env-file <path>` for a standalone local foreground Server, or `webcodex connect <server-url>` with an existing Server.\n"
 }
 
 pub(crate) fn readiness_with_probe(

--- a/src/project_entry_cloudflared.rs
+++ b/src/project_entry_cloudflared.rs
@@ -3,8 +3,12 @@ use futures_util::future::join_all;
 use reqwest::header::USER_AGENT;
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+#[cfg(not(windows))]
+use std::fs::OpenOptions;
+use std::fs::{self, File};
+use std::io::Read;
+#[cfg(not(windows))]
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
@@ -371,6 +375,20 @@ fn cloudflared_asset_for(os: &str, arch: &str) -> Result<CloudflaredAsset, Produ
             binary_sha256: "f35c50089cd25f77a4cb5a2152036bc26db15aa31fbe11f7995d2e42a4ed6257",
             gzip_archive: true,
         },
+        ("windows", "x86_64") => CloudflaredAsset {
+            target: "windows-amd64",
+            file_name: "cloudflared-windows-amd64.exe",
+            archive_sha256: "8635da433b6df8194746e88ed9d2589566c20e38bfc2a80e431a348b7c765841",
+            binary_sha256: "8635da433b6df8194746e88ed9d2589566c20e38bfc2a80e431a348b7c765841",
+            gzip_archive: false,
+        },
+        ("windows", "aarch64") => {
+            return Err(ProductError::new(
+                "tunnel_unavailable",
+                format!("automatic cloudflared installation is unavailable on {os}/{arch}: Cloudflare {CLOUDFLARED_VERSION} publishes no Windows ARM64 artifact"),
+                Some("Set WEBCODEX_CLOUDFLARED_BIN to a trusted compatible cloudflared binary, or use webcodex share --tunnel openai / --tunnel none."),
+            ))
+        }
         _ => {
             return Err(ProductError::new(
                 "tunnel_unavailable",
@@ -383,15 +401,20 @@ fn cloudflared_asset_for(os: &str, arch: &str) -> Result<CloudflaredAsset, Produ
 }
 
 fn managed_cloudflared_root() -> Result<PathBuf, ProductError> {
+    let local_app_data = cfg!(windows)
+        .then(|| std::env::var_os("LOCALAPPDATA"))
+        .flatten();
     managed_cloudflared_root_from(
         std::env::var_os("XDG_STATE_HOME").as_deref(),
         std::env::var_os("HOME").as_deref(),
+        local_app_data.as_deref(),
     )
 }
 
 fn managed_cloudflared_root_from(
     xdg_state_home: Option<&OsStr>,
     home: Option<&OsStr>,
+    local_app_data: Option<&OsStr>,
 ) -> Result<PathBuf, ProductError> {
     if let Some(path) = xdg_state_home.filter(|value| !value.is_empty()) {
         let path = PathBuf::from(path);
@@ -407,10 +430,17 @@ fn managed_cloudflared_root_from(
         }
         return Ok(path.join(".local/state/webcodex/tools/cloudflared"));
     }
+    if let Some(path) = local_app_data.filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            return Err(managed_user_root_error("LOCALAPPDATA"));
+        }
+        return Ok(path.join("WebCodex/tools/cloudflared"));
+    }
     Err(ProductError::new(
         "tunnel_unavailable",
         "WebCodex cannot choose a private user directory for managed cloudflared",
-        Some("Set HOME or XDG_STATE_HOME, set WEBCODEX_CLOUDFLARED_BIN, or use webcodex share --tunnel none."),
+        Some("Set HOME/XDG_STATE_HOME, ensure LOCALAPPDATA is available on Windows, set WEBCODEX_CLOUDFLARED_BIN, or use webcodex share --tunnel none."),
     ))
 }
 
@@ -426,6 +456,8 @@ async fn ensure_managed_cloudflared_at(
     url: &str,
 ) -> Result<PathBuf, ProductError> {
     let destination = managed_binary_path(root, asset);
+    let install_dir = destination.parent().ok_or_else(managed_tool_path_error)?;
+    create_private_tool_dir(install_dir)?;
     if managed_binary_is_valid(&destination, asset).await {
         return Ok(destination);
     }
@@ -433,8 +465,6 @@ async fn ensure_managed_cloudflared_at(
     eprintln!(
         "WebCodex: cloudflared was not found; downloading verified Cloudflare Tunnel {CLOUDFLARED_VERSION}..."
     );
-    let install_dir = destination.parent().ok_or_else(managed_tool_path_error)?;
-    create_private_tool_dir(install_dir)?;
     let temporary = install_dir.join(format!(".install-{}", uuid::Uuid::new_v4().simple()));
     create_private_tool_dir(&temporary)?;
 
@@ -485,6 +515,10 @@ async fn managed_binary_is_valid(path: &Path, asset: CloudflaredAsset) -> bool {
     if !metadata.file_type().is_file() {
         return false;
     }
+    #[cfg(windows)]
+    if super::windows_private_state::protect_private_file(path).is_err() {
+        return false;
+    }
     if sha256_file(path).ok().as_deref() != Some(asset.binary_sha256) {
         return false;
     }
@@ -510,6 +544,14 @@ fn create_private_tool_dir(path: &Path) -> Result<(), ProductError> {
             )
         })?;
     }
+    #[cfg(windows)]
+    super::windows_private_state::protect_private_directory(path).map_err(|_| {
+        ProductError::new(
+            "tunnel_unavailable",
+            "WebCodex could not protect its managed cloudflared directory on Windows",
+            Some("Check user-state filesystem permissions and reparse points, then retry webcodex share."),
+        )
+    })?;
     Ok(())
 }
 
@@ -567,27 +609,40 @@ async fn download_cloudflared_asset_with_network(
 }
 
 fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), ProductError> {
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
+    #[cfg(windows)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
+        return super::windows_private_state::write_new_private_file(path, bytes).map_err(|_| {
+            ProductError::new(
+                "tunnel_unavailable",
+                "WebCodex could not securely create the temporary cloudflared download on Windows",
+                Some("Check user-state filesystem permissions and reparse points, then retry webcodex share."),
+            )
+        });
     }
-    let mut file = options.open(path).map_err(|_| {
-        ProductError::new(
-            "tunnel_unavailable",
-            "WebCodex could not create the temporary cloudflared download",
-            Some("Check user-state filesystem permissions, then retry webcodex share."),
-        )
-    })?;
-    file.write_all(bytes).map_err(|_| {
-        ProductError::new(
-            "tunnel_unavailable",
-            "WebCodex could not write the temporary cloudflared download",
-            Some("Check user-state filesystem permissions, then retry webcodex share."),
-        )
-    })
+    #[cfg(not(windows))]
+    {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(path).map_err(|_| {
+            ProductError::new(
+                "tunnel_unavailable",
+                "WebCodex could not create the temporary cloudflared download",
+                Some("Check user-state filesystem permissions, then retry webcodex share."),
+            )
+        })?;
+        file.write_all(bytes).map_err(|_| {
+            ProductError::new(
+                "tunnel_unavailable",
+                "WebCodex could not write the temporary cloudflared download",
+                Some("Check user-state filesystem permissions, then retry webcodex share."),
+            )
+        })
+    }
 }
 
 async fn extract_cloudflared_archive(archive: &Path, directory: &Path) -> Result<(), ProductError> {
@@ -638,6 +693,8 @@ fn verify_sha256(path: &Path, expected: &str, label: &str) -> Result<(), Product
 }
 
 fn make_private_executable(path: &Path) -> Result<(), ProductError> {
+    #[cfg(windows)]
+    let _ = path;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/src/project_entry_cloudflared_tests.rs
+++ b/src/project_entry_cloudflared_tests.rs
@@ -91,9 +91,19 @@ fn release_assets_are_pinned_per_supported_platform() {
         "f35c50089cd25f77a4cb5a2152036bc26db15aa31fbe11f7995d2e42a4ed6257"
     );
 
-    let error = cloudflared_asset_for("windows", "x86_64").unwrap_err();
-    assert_eq!(error.code, "tunnel_unavailable");
-    assert!(error.message.contains("unsupported"));
+    let windows_amd64 = cloudflared_asset_for("windows", "x86_64").unwrap();
+    assert_eq!(windows_amd64.file_name, "cloudflared-windows-amd64.exe");
+    assert_eq!(windows_amd64.target, "windows-amd64");
+    assert_eq!(
+        windows_amd64.binary_sha256,
+        "8635da433b6df8194746e88ed9d2589566c20e38bfc2a80e431a348b7c765841"
+    );
+    assert_eq!(windows_amd64.archive_sha256, windows_amd64.binary_sha256);
+    assert!(!windows_amd64.gzip_archive);
+
+    let windows_arm64 = cloudflared_asset_for("windows", "aarch64").unwrap_err();
+    assert_eq!(windows_arm64.code, "tunnel_unavailable");
+    assert!(windows_arm64.message.contains("no Windows ARM64 artifact"));
 }
 
 #[test]
@@ -125,26 +135,43 @@ fn explicit_override_is_authoritative_then_path_is_used() {
 #[test]
 fn managed_root_prefers_xdg_then_home_and_requires_private_user_base() {
     assert_eq!(
-        managed_cloudflared_root_from(Some(OsStr::new("/state")), Some(OsStr::new("/home/user")))
-            .unwrap(),
+        managed_cloudflared_root_from(
+            Some(OsStr::new("/state")),
+            Some(OsStr::new("/home/user")),
+            Some(OsStr::new("/local")),
+        )
+        .unwrap(),
         PathBuf::from("/state/webcodex/tools/cloudflared")
     );
     assert_eq!(
-        managed_cloudflared_root_from(None, Some(OsStr::new("/home/user"))).unwrap(),
+        managed_cloudflared_root_from(
+            None,
+            Some(OsStr::new("/home/user")),
+            Some(OsStr::new("/local")),
+        )
+        .unwrap(),
         PathBuf::from("/home/user/.local/state/webcodex/tools/cloudflared")
     );
-    let error = managed_cloudflared_root_from(None, None).unwrap_err();
+    assert_eq!(
+        managed_cloudflared_root_from(None, None, Some(OsStr::new("/local"))).unwrap(),
+        PathBuf::from("/local/WebCodex/tools/cloudflared")
+    );
+    let error = managed_cloudflared_root_from(None, None, None).unwrap_err();
     assert_eq!(error.code, "tunnel_unavailable");
     assert!(error.message.contains("private user directory"));
     let relative_xdg = managed_cloudflared_root_from(
         Some(OsStr::new("relative-state")),
         Some(OsStr::new("/home/user")),
+        None,
     )
     .unwrap_err();
     assert!(relative_xdg.message.contains("XDG_STATE_HOME"));
     let relative_home =
-        managed_cloudflared_root_from(None, Some(OsStr::new("relative-home"))).unwrap_err();
+        managed_cloudflared_root_from(None, Some(OsStr::new("relative-home")), None).unwrap_err();
     assert!(relative_home.message.contains("HOME"));
+    let relative_local =
+        managed_cloudflared_root_from(None, None, Some(OsStr::new("relative-local"))).unwrap_err();
+    assert!(relative_local.message.contains("LOCALAPPDATA"));
 }
 
 #[test]

--- a/src/project_entry_openai_tunnel.rs
+++ b/src/project_entry_openai_tunnel.rs
@@ -4,8 +4,12 @@ use super::{
 use reqwest::header::USER_AGENT;
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+#[cfg(not(windows))]
+use std::fs::OpenOptions;
+use std::fs::{self, File};
+use std::io::Read;
+#[cfg(any(not(windows), test))]
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -18,7 +22,6 @@ const TUNNEL_CLIENT_MAX_DOWNLOAD_BYTES: usize = 64 * 1024 * 1024;
 const TUNNEL_CLIENT_MAX_BINARY_BYTES: u64 = 64 * 1024 * 1024;
 const TUNNEL_CLIENT_VERIFY_TIMEOUT: Duration = Duration::from_secs(10);
 const TUNNEL_CLIENT_DOCTOR_TIMEOUT: Duration = Duration::from_secs(30);
-const TUNNEL_CLIENT_READY_TIMEOUT: Duration = Duration::from_secs(45);
 const TUNNEL_CLIENT_READY_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const TUNNEL_CLIENT_HEALTH_URL_BYTES: usize = 512;
 const TUNNEL_CLIENT_OVERRIDE: &str = "WEBCODEX_TUNNEL_CLIENT_BIN";
@@ -29,6 +32,7 @@ struct TunnelClientAsset {
     file_name: &'static str,
     archive_sha256: &'static str,
     binary_sha256: &'static str,
+    member_name: &'static str,
 }
 
 #[derive(Debug)]
@@ -73,8 +77,9 @@ pub(super) async fn start_openai_tunnel(
     mcp_url: &str,
     authorization_file: &Path,
     session_dir: &Path,
+    deadline: Instant,
 ) -> Result<OpenAiTunnel, ProductError> {
-    run_doctor(prerequisites, mcp_url, authorization_file).await?;
+    run_doctor(prerequisites, mcp_url, authorization_file, deadline).await?;
 
     let health_url_file = session_dir.join("openai-tunnel-health-url");
     let log_file = session_dir.join("openai-tunnel.log");
@@ -100,7 +105,7 @@ pub(super) async fn start_openai_tunnel(
         .spawn()
         .map_err(|_| tunnel_runtime_error("OpenAI tunnel-client could not start"))?;
 
-    if let Err(error) = wait_until_ready(&mut child, &health_url_file).await {
+    if let Err(error) = wait_until_ready(&mut child, &health_url_file, deadline).await {
         let _ = child.start_kill();
         let _ = child.wait().await;
         return Err(error);
@@ -134,6 +139,7 @@ async fn run_doctor(
     prerequisites: &OpenAiTunnelPrerequisites,
     mcp_url: &str,
     authorization_file: &Path,
+    deadline: Instant,
 ) -> Result<(), ProductError> {
     let mut command = Command::new(&prerequisites.binary);
     command.arg("doctor");
@@ -146,14 +152,35 @@ async fn run_doctor(
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .kill_on_drop(true);
-    let status = tokio::time::timeout(TUNNEL_CLIENT_DOCTOR_TIMEOUT, command.status())
-        .await
-        .map_err(|_| {
-            tunnel_runtime_error(
-                "OpenAI tunnel-client doctor timed out before validating the connection",
-            )
-        })?
+    let mut child = command
+        .spawn()
         .map_err(|_| tunnel_runtime_error("OpenAI tunnel-client doctor could not start"))?;
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        return Err(tunnel_runtime_error(
+            "OpenAI tunnel-client doctor had no startup budget remaining",
+        ));
+    }
+    let budget = remaining.min(TUNNEL_CLIENT_DOCTOR_TIMEOUT);
+    let status = match tokio::time::timeout(budget, child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(_)) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Err(tunnel_runtime_error(
+                "OpenAI tunnel-client doctor could not be supervised",
+            ));
+        }
+        Err(_) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Err(tunnel_runtime_error(
+                "OpenAI tunnel-client doctor timed out before validating the connection",
+            ));
+        }
+    };
     if !status.success() {
         return Err(ProductError::new(
             "tunnel_unavailable",
@@ -164,7 +191,11 @@ async fn run_doctor(
     Ok(())
 }
 
-async fn wait_until_ready(child: &mut Child, health_url_file: &Path) -> Result<(), ProductError> {
+async fn wait_until_ready(
+    child: &mut Child,
+    health_url_file: &Path,
+    deadline: Instant,
+) -> Result<(), ProductError> {
     let client = reqwest::Client::builder()
         .connect_timeout(TUNNEL_CLIENT_READY_PROBE_TIMEOUT)
         .timeout(TUNNEL_CLIENT_READY_PROBE_TIMEOUT)
@@ -173,7 +204,6 @@ async fn wait_until_ready(child: &mut Child, health_url_file: &Path) -> Result<(
         .map_err(|_| {
             tunnel_runtime_error("WebCodex could not initialize the local tunnel readiness probe")
         })?;
-    let deadline = Instant::now() + TUNNEL_CLIENT_READY_TIMEOUT;
     let mut health_base = None;
 
     loop {
@@ -192,9 +222,17 @@ async fn wait_until_ready(child: &mut Child, health_url_file: &Path) -> Result<(
             health_base = read_loopback_health_url(health_url_file).ok();
         }
         if let Some(base) = health_base.as_ref() {
-            if let Ok(response) = client.get(format!("{base}/readyz")).send().await {
-                if response.status().is_success() {
-                    return Ok(());
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if !remaining.is_zero() {
+                if let Ok(Ok(response)) = tokio::time::timeout(
+                    remaining.min(TUNNEL_CLIENT_READY_PROBE_TIMEOUT),
+                    client.get(format!("{base}/readyz")).send(),
+                )
+                .await
+                {
+                    if response.status().is_success() {
+                        return Ok(());
+                    }
                 }
             }
         }
@@ -206,7 +244,12 @@ async fn wait_until_ready(child: &mut Child, health_url_file: &Path) -> Result<(
                 Some("Check CONTROL_PLANE_TUNNEL_ID, CONTROL_PLANE_API_KEY, Tunnel workspace scope, and local MCP reachability, then retry."),
             ));
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(100)),
+        )
+        .await;
     }
 }
 
@@ -218,6 +261,14 @@ fn read_loopback_health_url(path: &Path) -> Result<String, ProductError> {
             "OpenAI tunnel-client health URL file is invalid",
         ));
     }
+    #[cfg(windows)]
+    let value = super::windows_private_state::read_private_bytes(path)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .ok_or_else(|| {
+            tunnel_runtime_error("OpenAI tunnel-client health URL could not be read securely")
+        })?;
+    #[cfg(not(windows))]
     let value = fs::read_to_string(path)
         .map_err(|_| tunnel_runtime_error("OpenAI tunnel-client health URL could not be read"))?;
     let value = value.trim();
@@ -306,24 +357,42 @@ fn tunnel_client_asset_for(os: &str, arch: &str) -> Result<TunnelClientAsset, Pr
             file_name: "tunnel-client-v0.0.12-linux-amd64.zip",
             archive_sha256: "2bb693bd7b5cd28da7ce09cd9e309529dbb33b7cc9dc0058e62a064688f92c81",
             binary_sha256: "ee9d4a75bc0b42f36f345aa96231e0db1ab00488122f34ebc99d6db055b6603e",
+            member_name: "tunnel-client",
         },
         ("linux", "aarch64") => TunnelClientAsset {
             target: "linux-arm64",
             file_name: "tunnel-client-v0.0.12-linux-arm64.zip",
             archive_sha256: "6813878a3edb82ebebb32fe5a859bc6327a81cce5bc7b635a2313174d26365d6",
             binary_sha256: "0a48e6696de0df5951c013e40be81ce775e6644e209758c48795a0ecbda06406",
+            member_name: "tunnel-client",
         },
         ("macos", "x86_64") => TunnelClientAsset {
             target: "darwin-amd64",
             file_name: "tunnel-client-v0.0.12-darwin-amd64.zip",
             archive_sha256: "33de53aec680faafedc795f8f8268d6861577bddb871cb2d49529c91f88c2009",
             binary_sha256: "4133dab2575223252732a998210c34b7ed96a51765cf5ea835a8e24cf2be1272",
+            member_name: "tunnel-client",
         },
         ("macos", "aarch64") => TunnelClientAsset {
             target: "darwin-arm64",
             file_name: "tunnel-client-v0.0.12-darwin-arm64.zip",
             archive_sha256: "42fb3138dc9c081d5777cb7e8bd1e041cc48b67c4978dbab3c5167ca1aabca02",
             binary_sha256: "b1757220cf4722cec9085ee4a908cf0ee4c1a499a33bd99979b9a9c7669e29b1",
+            member_name: "tunnel-client",
+        },
+        ("windows", "x86_64") => TunnelClientAsset {
+            target: "windows-amd64",
+            file_name: "tunnel-client-v0.0.12-windows-amd64.zip",
+            archive_sha256: "2a2804933924e38a502d62b61f0266cb80d56d65744f4c29876b2bf9c1544356",
+            binary_sha256: "6649169733686805ca16cccd91774594d0c017fd729c37ad4ce1cd18323d9ae8",
+            member_name: "tunnel-client.exe",
+        },
+        ("windows", "aarch64") => TunnelClientAsset {
+            target: "windows-arm64",
+            file_name: "tunnel-client-v0.0.12-windows-arm64.zip",
+            archive_sha256: "65ab54221554481bb1c23b6015b99abe0b7f79b08593f4fb17a9e2e25532281d",
+            binary_sha256: "480684ec1031fc2985c7e87f9d669e7dfda4012a8ecdab21eabe1b5deafdd656",
+            member_name: "tunnel-client.exe",
         },
         _ => {
             return Err(ProductError::new(
@@ -337,15 +406,20 @@ fn tunnel_client_asset_for(os: &str, arch: &str) -> Result<TunnelClientAsset, Pr
 }
 
 fn managed_tunnel_client_root() -> Result<PathBuf, ProductError> {
+    let local_app_data = cfg!(windows)
+        .then(|| std::env::var_os("LOCALAPPDATA"))
+        .flatten();
     managed_tunnel_client_root_from(
         std::env::var_os("XDG_STATE_HOME").as_deref(),
         std::env::var_os("HOME").as_deref(),
+        local_app_data.as_deref(),
     )
 }
 
 fn managed_tunnel_client_root_from(
     xdg_state_home: Option<&OsStr>,
     home: Option<&OsStr>,
+    local_app_data: Option<&OsStr>,
 ) -> Result<PathBuf, ProductError> {
     if let Some(path) = xdg_state_home.filter(|value| !value.is_empty()) {
         let path = PathBuf::from(path);
@@ -361,10 +435,17 @@ fn managed_tunnel_client_root_from(
         }
         return Ok(path.join(".local/state/webcodex/tools/tunnel-client"));
     }
+    if let Some(path) = local_app_data.filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            return Err(managed_user_root_error("LOCALAPPDATA"));
+        }
+        return Ok(path.join("WebCodex/tools/tunnel-client"));
+    }
     Err(ProductError::new(
         "tunnel_unavailable",
         "WebCodex cannot choose a private user directory for managed OpenAI tunnel-client",
-        Some("Set HOME or XDG_STATE_HOME, set WEBCODEX_TUNNEL_CLIENT_BIN, or use another WebCodex tunnel provider."),
+        Some("Set HOME/XDG_STATE_HOME, ensure LOCALAPPDATA is available on Windows, set WEBCODEX_TUNNEL_CLIENT_BIN, or use another WebCodex tunnel provider."),
     ))
 }
 
@@ -379,6 +460,8 @@ async fn ensure_managed_tunnel_client_at(
     asset: TunnelClientAsset,
 ) -> Result<PathBuf, ProductError> {
     let destination = managed_binary_path(root, asset);
+    let install_dir = destination.parent().ok_or_else(managed_tool_path_error)?;
+    create_private_tool_dir(install_dir)?;
     if managed_binary_is_valid(&destination, asset).await {
         return Ok(destination);
     }
@@ -386,8 +469,6 @@ async fn ensure_managed_tunnel_client_at(
     eprintln!(
         "WebCodex: tunnel-client was not found; downloading verified OpenAI tunnel-client {TUNNEL_CLIENT_VERSION}..."
     );
-    let install_dir = destination.parent().ok_or_else(managed_tool_path_error)?;
-    create_private_tool_dir(install_dir)?;
     let temporary = install_dir.join(format!(".install-{}", uuid::Uuid::new_v4().simple()));
     create_private_tool_dir(&temporary)?;
     let result = async {
@@ -396,7 +477,7 @@ async fn ensure_managed_tunnel_client_at(
         download_tunnel_client_asset(&url, &archive).await?;
         verify_sha256(&archive, asset.archive_sha256, "downloaded tunnel-client archive")?;
         let candidate = temporary.join(executable_name("tunnel-client"));
-        extract_tunnel_client(&archive, &candidate)?;
+        extract_tunnel_client(&archive, &candidate, asset.member_name)?;
         verify_sha256(&candidate, asset.binary_sha256, "downloaded tunnel-client binary")?;
         make_private_executable(&candidate)?;
         verify_tunnel_client_version(&candidate).await?;
@@ -423,6 +504,10 @@ async fn managed_binary_is_valid(path: &Path, asset: TunnelClientAsset) -> bool 
         Err(_) => return false,
     };
     if !metadata.file_type().is_file() {
+        return false;
+    }
+    #[cfg(windows)]
+    if super::windows_private_state::protect_private_file(path).is_err() {
         return false;
     }
     if sha256_file(path).ok().as_deref() != Some(asset.binary_sha256) {
@@ -487,13 +572,17 @@ async fn download_tunnel_client_asset(url: &str, destination: &Path) -> Result<(
     write_private_file(destination, &bytes)
 }
 
-fn extract_tunnel_client(archive: &Path, destination: &Path) -> Result<(), ProductError> {
+fn extract_tunnel_client(
+    archive: &Path,
+    destination: &Path,
+    member_name: &str,
+) -> Result<(), ProductError> {
     let file = File::open(archive).map_err(|_| extraction_error("archive could not be opened"))?;
     let mut archive = zip::ZipArchive::new(file)
         .map_err(|_| extraction_error("verified archive is not a valid ZIP file"))?;
-    let mut entry = archive
-        .by_name("tunnel-client")
-        .map_err(|_| extraction_error("verified archive does not contain tunnel-client"))?;
+    let mut entry = archive.by_name(member_name).map_err(|_| {
+        extraction_error("verified archive does not contain the expected tunnel-client executable")
+    })?;
     if !entry.is_file() || entry.size() > TUNNEL_CLIENT_MAX_BINARY_BYTES {
         return Err(extraction_error("tunnel-client archive member is invalid"));
     }
@@ -517,22 +606,35 @@ fn create_private_tool_dir(path: &Path) -> Result<(), ProductError> {
         fs::set_permissions(path, fs::Permissions::from_mode(0o700))
             .map_err(|_| managed_tool_path_error())?;
     }
+    #[cfg(windows)]
+    super::windows_private_state::protect_private_directory(path)
+        .map_err(|_| managed_tool_path_error())?;
     Ok(())
 }
 
 fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), ProductError> {
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
+    #[cfg(windows)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
+        return super::windows_private_state::write_new_private_file(path, bytes)
+            .map_err(|_| managed_tool_path_error());
     }
-    let mut file = options.open(path).map_err(|_| managed_tool_path_error())?;
-    file.write_all(bytes).map_err(|_| managed_tool_path_error())
+    #[cfg(not(windows))]
+    {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(path).map_err(|_| managed_tool_path_error())?;
+        file.write_all(bytes).map_err(|_| managed_tool_path_error())
+    }
 }
 
 fn make_private_executable(path: &Path) -> Result<(), ProductError> {
+    #[cfg(windows)]
+    let _ = path;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/src/project_entry_openai_tunnel_tests.rs
+++ b/src/project_entry_openai_tunnel_tests.rs
@@ -50,26 +50,59 @@ fn official_release_assets_and_extracted_binaries_are_pinned_per_supported_platf
     );
     assert_eq!(darwin_arm64.target, "darwin-arm64");
 
-    let error = tunnel_client_asset_for("windows", "x86_64").unwrap_err();
-    assert_eq!(error.code, "tunnel_unavailable");
-    assert!(error.message.contains("unsupported"));
+    let windows_amd64 = tunnel_client_asset_for("windows", "x86_64").unwrap();
+    assert_eq!(windows_amd64.target, "windows-amd64");
+    assert_eq!(windows_amd64.member_name, "tunnel-client.exe");
+    assert_eq!(
+        windows_amd64.archive_sha256,
+        "2a2804933924e38a502d62b61f0266cb80d56d65744f4c29876b2bf9c1544356"
+    );
+    assert_eq!(
+        windows_amd64.binary_sha256,
+        "6649169733686805ca16cccd91774594d0c017fd729c37ad4ce1cd18323d9ae8"
+    );
+    let windows_arm64 = tunnel_client_asset_for("windows", "aarch64").unwrap();
+    assert_eq!(windows_arm64.target, "windows-arm64");
+    assert_eq!(windows_arm64.member_name, "tunnel-client.exe");
+    assert_eq!(
+        windows_arm64.archive_sha256,
+        "65ab54221554481bb1c23b6015b99abe0b7f79b08593f4fb17a9e2e25532281d"
+    );
+    assert_eq!(
+        windows_arm64.binary_sha256,
+        "480684ec1031fc2985c7e87f9d669e7dfda4012a8ecdab21eabe1b5deafdd656"
+    );
 }
 
 #[test]
 fn managed_root_prefers_private_xdg_then_home() {
     assert_eq!(
-        managed_tunnel_client_root_from(Some(OsStr::new("/state")), Some(OsStr::new("/home/user")))
-            .unwrap(),
+        managed_tunnel_client_root_from(
+            Some(OsStr::new("/state")),
+            Some(OsStr::new("/home/user")),
+            Some(OsStr::new("/local")),
+        )
+        .unwrap(),
         PathBuf::from("/state/webcodex/tools/tunnel-client")
     );
     assert_eq!(
-        managed_tunnel_client_root_from(None, Some(OsStr::new("/home/user"))).unwrap(),
+        managed_tunnel_client_root_from(
+            None,
+            Some(OsStr::new("/home/user")),
+            Some(OsStr::new("/local")),
+        )
+        .unwrap(),
         PathBuf::from("/home/user/.local/state/webcodex/tools/tunnel-client")
     );
-    assert!(managed_tunnel_client_root_from(None, None).is_err());
+    assert_eq!(
+        managed_tunnel_client_root_from(None, None, Some(OsStr::new("/local"))).unwrap(),
+        PathBuf::from("/local/WebCodex/tools/tunnel-client")
+    );
+    assert!(managed_tunnel_client_root_from(None, None, None).is_err());
     assert!(managed_tunnel_client_root_from(
         Some(OsStr::new("relative")),
-        Some(OsStr::new("/home/user"))
+        Some(OsStr::new("/home/user")),
+        None,
     )
     .is_err());
 }
@@ -117,9 +150,31 @@ fn zip_extraction_reads_only_the_exact_tunnel_client_member() {
     archive.finish().unwrap();
 
     let destination = temp.path().join("extracted");
-    extract_tunnel_client(&archive_path, &destination).unwrap();
+    extract_tunnel_client(&archive_path, &destination, "tunnel-client").unwrap();
     assert_eq!(fs::read(&destination).unwrap(), b"expected-binary");
     assert!(!temp.path().join("tunnel-client").exists());
+
+    let windows_archive_path = temp.path().join("windows-client.zip");
+    let file = File::create(&windows_archive_path).unwrap();
+    let mut archive = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default();
+    archive.start_file("../tunnel-client.exe", options).unwrap();
+    archive.write_all(b"wrong-windows").unwrap();
+    archive.start_file("tunnel-client.exe", options).unwrap();
+    archive.write_all(b"expected-windows-binary").unwrap();
+    archive.finish().unwrap();
+    let windows_destination = temp.path().join("extracted.exe");
+    extract_tunnel_client(
+        &windows_archive_path,
+        &windows_destination,
+        "tunnel-client.exe",
+    )
+    .unwrap();
+    assert_eq!(
+        fs::read(&windows_destination).unwrap(),
+        b"expected-windows-binary"
+    );
+    assert!(!temp.path().join("tunnel-client.exe").exists());
 }
 
 #[cfg(unix)]

--- a/src/project_entry_setup.rs
+++ b/src/project_entry_setup.rs
@@ -230,6 +230,7 @@ pub(crate) fn setup(options: &ProjectCommandOptions) -> Result<SetupReport, Prod
     // project/share state. On Windows this replaces inherited broad DACLs with
     // a protected current-user + SYSTEM boundary; on Unix it preserves 0700.
     paths.create()?;
+    harden_existing_runtime_private_state(&paths)?;
     let config = match read_toml_optional::<ProjectConfig>(&paths.config)? {
         Some(existing) => {
             validate_product_config(&expected, &existing)?;
@@ -1057,6 +1058,55 @@ fn read_private_value_with_code(path: &Path, code: &str) -> Result<String, Produ
                 Some("Restore protected private authentication material, then retry."),
             )
         })
+}
+
+pub(super) fn harden_existing_runtime_private_state(
+    paths: &ProjectPaths,
+) -> Result<(), ProductError> {
+    #[cfg(windows)]
+    {
+        for path in [
+            paths.data.join("webcodex.db"),
+            paths.data.join("webcodex.db-wal"),
+            paths.data.join("webcodex.db-shm"),
+            paths.logs.join("server.log"),
+            paths.logs.join("agent.log"),
+        ] {
+            match std::fs::symlink_metadata(&path) {
+                Ok(metadata) => {
+                    if !metadata.file_type().is_file() {
+                        return Err(ProductError::new(
+                            "project_registration_invalid",
+                            "WebCodex refused unsafe existing private Windows runtime state",
+                            Some(
+                                "Remove the unexpected reparse or non-file runtime state, then retry.",
+                            ),
+                        ));
+                    }
+                    super::windows_private_state::protect_private_file(&path).map_err(|_| {
+                        ProductError::new(
+                            "project_registration_invalid",
+                            "WebCodex could not protect existing private Windows runtime state",
+                            Some(
+                                "Check local filesystem permissions and reparse points, then retry.",
+                            ),
+                        )
+                    })?;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(_) => {
+                    return Err(ProductError::new(
+                        "project_registration_invalid",
+                        "WebCodex could not inspect existing private Windows runtime state",
+                        Some("Check local filesystem permissions, then retry."),
+                    ));
+                }
+            }
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = paths;
+    Ok(())
 }
 
 pub(super) fn create_private_dir(path: &Path) -> Result<(), ProductError> {

--- a/src/project_entry_setup.rs
+++ b/src/project_entry_setup.rs
@@ -230,7 +230,7 @@ pub(crate) fn setup(options: &ProjectCommandOptions) -> Result<SetupReport, Prod
     // project/share state. On Windows this replaces inherited broad DACLs with
     // a protected current-user + SYSTEM boundary; on Unix it preserves 0700.
     paths.create()?;
-    harden_existing_runtime_private_state(&paths)?;
+    prepare_runtime_private_state(&paths)?;
     let config = match read_toml_optional::<ProjectConfig>(&paths.config)? {
         Some(existing) => {
             validate_product_config(&expected, &existing)?;
@@ -1058,6 +1058,15 @@ fn read_private_value_with_code(path: &Path, code: &str) -> Result<String, Produ
                 Some("Restore protected private authentication material, then retry."),
             )
         })
+}
+
+pub(super) fn prepare_runtime_private_state(paths: &ProjectPaths) -> Result<(), ProductError> {
+    #[cfg(windows)]
+    {
+        create_private_dir(&paths.data)?;
+        create_private_dir(&paths.logs)?;
+    }
+    harden_existing_runtime_private_state(paths)
 }
 
 pub(super) fn harden_existing_runtime_private_state(

--- a/src/project_entry_setup.rs
+++ b/src/project_entry_setup.rs
@@ -9,7 +9,9 @@ use crate::runner_config::{
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+#[cfg(not(windows))]
 use std::fs::OpenOptions;
+#[cfg(not(windows))]
 use std::io::Write;
 use std::net::TcpListener;
 use std::path::{Component, Path, PathBuf};
@@ -224,6 +226,10 @@ pub(crate) fn resolve_local_task_state(
 
 pub(crate) fn setup(options: &ProjectCommandOptions) -> Result<SetupReport, ProductError> {
     let (mut expected, paths) = ProjectConfig::resolve(options)?;
+    // Establish the private-state boundary before reading or creating any
+    // project/share state. On Windows this replaces inherited broad DACLs with
+    // a protected current-user + SYSTEM boundary; on Unix it preserves 0700.
+    paths.create()?;
     let config = match read_toml_optional::<ProjectConfig>(&paths.config)? {
         Some(existing) => {
             validate_product_config(&expected, &existing)?;
@@ -239,7 +245,6 @@ pub(crate) fn setup(options: &ProjectCommandOptions) -> Result<SetupReport, Prod
     if paths.agent_config.exists() {
         validate_agent_authentication(&config, &paths)?;
     }
-    paths.create()?;
 
     let mut changed = Vec::new();
     if paths.connector_key.is_file() {
@@ -919,22 +924,55 @@ fn state_path_unavailable() -> ProductError {
 }
 
 fn default_state_base() -> Result<PathBuf, ProductError> {
-    if let Some(path) = std::env::var_os("XDG_STATE_HOME").filter(|value| !value.is_empty()) {
+    default_state_base_from(
+        std::env::var_os("XDG_STATE_HOME").as_deref(),
+        std::env::var_os("HOME").as_deref(),
+        if cfg!(windows) {
+            std::env::var_os("LOCALAPPDATA")
+        } else {
+            None
+        }
+        .as_deref(),
+    )
+}
+
+pub(super) fn default_state_base_from(
+    xdg_state_home: Option<&std::ffi::OsStr>,
+    home: Option<&std::ffi::OsStr>,
+    local_app_data: Option<&std::ffi::OsStr>,
+) -> Result<PathBuf, ProductError> {
+    if let Some(path) = xdg_state_home.filter(|value| !value.is_empty()) {
         return Ok(PathBuf::from(path).join("webcodex/projects"));
     }
-    let home = std::env::var_os("HOME")
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            ProductError::new(
-                "project_not_configured",
-                "HOME is unavailable and no --state-dir was provided",
-                Some("Set HOME or pass an absolute --state-dir."),
-            )
-        })?;
-    Ok(PathBuf::from(home).join(".local/state/webcodex/projects"))
+    // Preserve the historical HOME path when it exists. Native Windows shells
+    // commonly lack HOME, so LOCALAPPDATA is the compatibility fallback rather
+    // than a migration of existing profiles.
+    if let Some(path) = home.filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(path).join(".local/state/webcodex/projects"));
+    }
+    if let Some(path) = local_app_data.filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(path).join("WebCodex/state/projects"));
+    }
+    Err(ProductError::new(
+        "project_not_configured",
+        "no private user state directory is available and no --state-dir was provided",
+        Some("Set HOME/XDG_STATE_HOME, ensure LOCALAPPDATA is available on Windows, or pass an absolute --state-dir."),
+    ))
 }
 
 fn read_toml<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, ProductError> {
+    #[cfg(windows)]
+    let content = super::windows_private_state::read_private_bytes(path)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .ok_or_else(|| {
+            ProductError::new(
+                "project_registration_invalid",
+                "a WebCodex configuration file is unreadable or not protected",
+                Some("Restore protected private state, then retry."),
+            )
+        })?;
+    #[cfg(not(windows))]
     let content = std::fs::read_to_string(path).map_err(|_| {
         ProductError::new(
             "project_registration_invalid",
@@ -998,7 +1036,15 @@ pub(super) fn read_project_agent_token(path: &Path) -> Result<String, ProductErr
 }
 
 fn read_private_value_with_code(path: &Path, code: &str) -> Result<String, ProductError> {
-    crate::auth::read_protected_secret(path)
+    #[cfg(windows)]
+    let protected = super::windows_private_state::read_private_bytes(path).and_then(|bytes| {
+        String::from_utf8(bytes)
+            .map(|value| value.trim().to_string())
+            .map_err(|_| "private authentication material is unreadable".to_string())
+    });
+    #[cfg(not(windows))]
+    let protected = crate::auth::read_protected_secret(path);
+    protected
         .and_then(|value| {
             (!value.is_empty())
                 .then_some(value)
@@ -1032,6 +1078,14 @@ pub(super) fn create_private_dir(path: &Path) -> Result<(), ProductError> {
             )
         })?;
     }
+    #[cfg(windows)]
+    super::windows_private_state::protect_private_directory(path).map_err(|_| {
+        ProductError::new(
+            "project_registration_invalid",
+            "WebCodex could not protect its private Windows state directory",
+            Some("Check local filesystem permissions and reparse points, then retry."),
+        )
+    })?;
     Ok(())
 }
 
@@ -1039,25 +1093,49 @@ pub(super) fn write_new_private(path: &Path, content: &[u8]) -> Result<(), Produ
     if let Some(parent) = path.parent() {
         create_private_dir(parent)?;
     }
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
+    #[cfg(windows)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
+        return super::windows_private_state::write_new_private_file(path, content).map_err(
+            |message| {
+                let conflict = message.contains("overwrite");
+                ProductError::new(
+                    "project_registration_invalid",
+                    if conflict {
+                        "WebCodex refused to overwrite existing project state"
+                    } else {
+                        "WebCodex could not securely write private Windows project state"
+                    },
+                    Some(if conflict {
+                        "Resolve the existing state conflict, then retry."
+                    } else {
+                        "Check local filesystem permissions and reparse points, then retry."
+                    }),
+                )
+            },
+        );
     }
-    let mut file = options.open(path).map_err(|_| {
-        ProductError::new(
-            "project_registration_invalid",
-            "WebCodex refused to overwrite existing project state",
-            Some("Resolve the existing state conflict, then retry."),
-        )
-    })?;
-    file.write_all(content).map_err(|_| {
-        ProductError::new(
-            "project_registration_invalid",
-            "WebCodex could not write private project state",
-            Some("Check local filesystem permissions, then retry."),
-        )
-    })
+    #[cfg(not(windows))]
+    {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(path).map_err(|_| {
+            ProductError::new(
+                "project_registration_invalid",
+                "WebCodex refused to overwrite existing project state",
+                Some("Resolve the existing state conflict, then retry."),
+            )
+        })?;
+        file.write_all(content).map_err(|_| {
+            ProductError::new(
+                "project_registration_invalid",
+                "WebCodex could not write private project state",
+                Some("Check local filesystem permissions, then retry."),
+            )
+        })
+    }
 }

--- a/src/project_entry_share.rs
+++ b/src/project_entry_share.rs
@@ -22,7 +22,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-const TUNNEL_START_TIMEOUT: Duration = Duration::from_secs(20);
+const SHARE_START_TIMEOUT: Duration = Duration::from_secs(60);
 const TUNNEL_LOG_LINES: usize = 8;
 const TUNNEL_LOG_LINE_BYTES: usize = 512;
 const TUNNEL_LOG_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -483,6 +483,10 @@ pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductEr
             session_id: crate::auth::generate_project_share_session_id(),
         });
 
+    // All process/network readiness for this share uses one absolute budget.
+    // Managed binary acquisition and local state setup above are preflight, not
+    // readiness stages, and therefore do not reset this deadline.
+    let startup_deadline = Instant::now() + SHARE_START_TIMEOUT;
     let local_url = config.server_url();
     let (public_url, mut cloudflare_tunnel) = match options.tunnel {
         TunnelProvider::CloudflareQuick => {
@@ -490,8 +494,7 @@ pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductEr
                 .as_deref()
                 .ok_or_else(tunnel_runtime_error)?;
             let (url, tunnel) =
-                start_cloudflare_quick_with_binary(binary, &local_url, TUNNEL_START_TIMEOUT)
-                    .await?;
+                start_cloudflare_quick_with_binary(binary, &local_url, startup_deadline).await?;
             (url, Some(tunnel))
         }
         TunnelProvider::OpenAiSecure => (local_url.clone(), None),
@@ -504,7 +507,7 @@ pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductEr
         ),
     };
 
-    let mut runtime = start_local_runtime(
+    let mut runtime = match start_local_runtime(
         &options.project,
         LocalRuntimeOptions {
             public_url: Some(public_url.clone()),
@@ -522,17 +525,44 @@ pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductEr
                 Vec::new()
             },
             port_conflict_action: "Stop the conflicting process, then retry webcodex share.",
+            readiness_deadline: Some(startup_deadline),
         },
     )
-    .await?;
+    .await
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            if let Some(tunnel) = cloudflare_tunnel.as_mut() {
+                tunnel.stop().await;
+            }
+            return Err(error);
+        }
+    };
+
+    if let Some(tunnel) = cloudflare_tunnel.as_mut() {
+        if let Err(error) =
+            wait_for_cloudflare_forwarding(tunnel, &runtime.public_url, startup_deadline).await
+        {
+            runtime.stop().await;
+            tunnel.stop().await;
+            return Err(error);
+        }
+    }
 
     let mut openai_tunnel = if let Some(prerequisites) = openai_prerequisites.as_ref() {
-        let authorization_file = session.write_openai_authorization_file()?;
+        let authorization_file = match session.write_openai_authorization_file() {
+            Ok(path) => path,
+            Err(error) => {
+                runtime.stop().await;
+                return Err(error);
+            }
+        };
         match super::openai_tunnel_service::start_openai_tunnel(
             prerequisites,
             &mcp_url(&runtime.local_url),
             &authorization_file,
             &session.directory,
+            startup_deadline,
         )
         .await
         {
@@ -607,17 +637,17 @@ pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductEr
 
     let outcome = match (cloudflare_tunnel.as_mut(), openai_tunnel.as_mut()) {
         (Some(tunnel), None) => tokio::select! {
-            _ = tokio::signal::ctrl_c() => Ok(()),
+            _ = wait_for_share_stop_signal() => Ok(()),
             result = runtime.wait_for_exit() => result,
             result = tunnel.wait_for_exit() => result,
         },
         (None, Some(tunnel)) => tokio::select! {
-            _ = tokio::signal::ctrl_c() => Ok(()),
+            _ = wait_for_share_stop_signal() => Ok(()),
             result = runtime.wait_for_exit() => result,
             result = tunnel.wait_for_exit() => result,
         },
         (None, None) => tokio::select! {
-            _ = tokio::signal::ctrl_c() => Ok(()),
+            _ = wait_for_share_stop_signal() => Ok(()),
             result = runtime.wait_for_exit() => result,
         },
         (Some(_), Some(_)) => unreachable!("one share cannot own two tunnel providers"),
@@ -635,6 +665,26 @@ pub(crate) async fn share(options: &ShareCommandOptions) -> Result<(), ProductEr
         tunnel.stop().await;
     }
     outcome
+}
+
+#[cfg(not(windows))]
+async fn wait_for_share_stop_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+#[cfg(windows)]
+async fn wait_for_share_stop_signal() {
+    let mut ctrl_break = match tokio::signal::windows::ctrl_break() {
+        Ok(signal) => signal,
+        Err(_) => {
+            let _ = tokio::signal::ctrl_c().await;
+            return;
+        }
+    };
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {},
+        _ = ctrl_break.recv() => {},
+    }
 }
 
 fn share_access_labels(
@@ -749,7 +799,7 @@ fn render_share_oauth_ready(
 async fn start_cloudflare_quick_with_binary(
     binary: &Path,
     local_url: &str,
-    timeout: Duration,
+    deadline: Instant,
 ) -> Result<(String, CloudflareTunnel), ProductError> {
     let mut tunnel_command = Command::new(binary);
     remove_npm_wrapper_network_environment(&mut tunnel_command);
@@ -773,7 +823,6 @@ async fn start_cloudflare_quick_with_binary(
     let (url_tx, mut url_rx) = mpsc::channel(2);
     let stdout_task = spawn_tunnel_reader(stdout, recent.clone(), url_tx.clone());
     let stderr_task = spawn_tunnel_reader(stderr, recent.clone(), url_tx);
-    let deadline = Instant::now() + timeout;
 
     loop {
         if let Some(status) = child.try_wait().map_err(|_| tunnel_runtime_error())? {
@@ -833,6 +882,57 @@ where
             }
         }
     })
+}
+
+async fn wait_for_cloudflare_forwarding(
+    tunnel: &mut CloudflareTunnel,
+    public_url: &str,
+    deadline: Instant,
+) -> Result<(), ProductError> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(2))
+        .timeout(Duration::from_secs(2))
+        .build()
+        .map_err(|_| tunnel_runtime_error())?;
+    let probe_url = format!("{}/openapi.json", public_url.trim_end_matches('/'));
+    loop {
+        if let Some(status) = tunnel
+            .child
+            .try_wait()
+            .map_err(|_| tunnel_runtime_error())?
+        {
+            return Err(ProductError::new(
+                "tunnel_unavailable",
+                format!("Cloudflare Quick Tunnel stopped before public forwarding became ready ({status})"),
+                Some("Check network connectivity and cloudflared, then retry."),
+            ));
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(ProductError::new(
+                "tunnel_unavailable",
+                "Cloudflare Quick Tunnel did not forward the local Server before the share startup timeout",
+                Some("Check network connectivity and cloudflared, then retry."),
+            ));
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        if let Ok(Ok(response)) = tokio::time::timeout(
+            remaining.min(Duration::from_secs(2)),
+            client.get(&probe_url).send(),
+        )
+        .await
+        {
+            if response.status().is_success() {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(150)),
+        )
+        .await;
+    }
 }
 
 // A child can exit before the async readers are scheduled to consume bytes that
@@ -1239,6 +1339,25 @@ mod tests {
             );
         }
         let directory = session.directory.clone();
+        #[cfg(windows)]
+        {
+            for (path, directory) in [
+                (state.join("share"), true),
+                (session.directory.clone(), true),
+                (session.credential_file.clone(), false),
+                (authorization_file.clone(), false),
+            ] {
+                let sddl =
+                    super::super::windows_private_state::dacl_sddl(&path, directory).unwrap();
+                assert!(sddl.starts_with("D:P"), "DACL must be protected: {sddl}");
+                for broad in [";;;WD)", ";;;BU)", ";;;BA)"] {
+                    assert!(
+                        !sddl.contains(broad),
+                        "broad Windows ACE {broad} remained: {sddl}"
+                    );
+                }
+            }
+        }
         drop(session);
         assert!(!directory.exists());
         assert!(!authorization_file.exists());
@@ -1262,7 +1381,7 @@ mod tests {
         let error = start_cloudflare_quick_with_binary(
             &binary,
             "http://127.0.0.1:23456",
-            TUNNEL_TEST_START_TIMEOUT,
+            Instant::now() + TUNNEL_TEST_START_TIMEOUT,
         )
         .await
         .unwrap_err();
@@ -1277,7 +1396,7 @@ mod tests {
         let error = start_cloudflare_quick_with_binary(
             &binary,
             "http://127.0.0.1:23456",
-            Duration::from_millis(100),
+            Instant::now() + Duration::from_millis(100),
         )
         .await
         .unwrap_err();
@@ -1294,7 +1413,7 @@ mod tests {
         let (_url, mut tunnel) = start_cloudflare_quick_with_binary(
             &binary,
             "http://127.0.0.1:23456",
-            TUNNEL_TEST_START_TIMEOUT,
+            Instant::now() + TUNNEL_TEST_START_TIMEOUT,
         )
         .await
         .unwrap();
@@ -1311,7 +1430,7 @@ mod tests {
         let (url, mut tunnel) = start_cloudflare_quick_with_binary(
             &binary,
             "http://127.0.0.1:23456",
-            TUNNEL_TEST_START_TIMEOUT,
+            Instant::now() + TUNNEL_TEST_START_TIMEOUT,
         )
         .await
         .unwrap();

--- a/src/project_entry_tests.rs
+++ b/src/project_entry_tests.rs
@@ -1041,6 +1041,35 @@ fn state_directory_allows_absolute_and_relative_paths_outside_checkout() {
     assert!(resolved.join("project.toml").is_file());
 }
 
+#[test]
+fn default_state_base_preserves_home_and_has_windows_localappdata_fallback() {
+    use std::ffi::OsStr;
+
+    assert_eq!(
+        setup_service::default_state_base_from(
+            Some(OsStr::new("/state")),
+            Some(OsStr::new("/home/user")),
+            Some(OsStr::new("/local")),
+        )
+        .unwrap(),
+        PathBuf::from("/state/webcodex/projects")
+    );
+    assert_eq!(
+        setup_service::default_state_base_from(
+            None,
+            Some(OsStr::new("/home/user")),
+            Some(OsStr::new("/local")),
+        )
+        .unwrap(),
+        PathBuf::from("/home/user/.local/state/webcodex/projects")
+    );
+    assert_eq!(
+        setup_service::default_state_base_from(None, None, Some(OsStr::new("/local"))).unwrap(),
+        PathBuf::from("/local/WebCodex/state/projects")
+    );
+    assert!(setup_service::default_state_base_from(None, None, None).is_err());
+}
+
 #[cfg(unix)]
 #[test]
 fn state_directory_rejects_symlink_that_resolves_into_checkout() {

--- a/src/project_entry_windows.rs
+++ b/src/project_entry_windows.rs
@@ -228,6 +228,23 @@ pub(super) fn set_broad_test_file_dacl(path: &Path) -> Result<(), String> {
 }
 
 #[cfg(test)]
+pub(super) fn set_broad_test_directory_dacl(path: &Path) -> Result<(), String> {
+    let directory = OpenOptions::new()
+        .access_mode(READ_CONTROL | WRITE_DAC)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|_| "could not open Windows test directory for ACL setup".to_string())?;
+    reject_reparse(&directory, "Windows test directory")?;
+    let sid = current_user_sid()?;
+    install_protected_dacl(
+        directory.as_raw_handle() as _,
+        &format!(
+            "D:P(A;OICI;FA;;;{sid})(A;OICI;FA;;;SY)(A;OICI;FA;;;WD)(A;OICI;FA;;;BU)(A;OICI;FA;;;BA)"
+        ),
+    )
+}
+
+#[cfg(test)]
 pub(super) fn dacl_sddl(path: &Path, directory: bool) -> Result<String, String> {
     use windows_sys::Win32::Security::Authorization::{
         ConvertSecurityDescriptorToStringSecurityDescriptorW, GetSecurityInfo,

--- a/src/project_entry_windows.rs
+++ b/src/project_entry_windows.rs
@@ -100,10 +100,7 @@ fn reject_reparse(file: &File, label: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn protect_handle(
-    handle: windows_sys::Win32::Foundation::HANDLE,
-    inherit_children: bool,
-) -> Result<(), String> {
+fn current_user_sid() -> Result<String, String> {
     let mut token = std::ptr::null_mut();
     if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
         return Err("could not inspect the current Windows user identity".to_string());
@@ -142,56 +139,92 @@ fn protect_handle(
             LocalFree(sid_text_ptr as _);
             value
         };
-        let ace_flags = if inherit_children { "OICI" } else { "" };
-        let sddl = format!("D:P(A;{ace_flags};FA;;;{sid})(A;{ace_flags};FA;;;SY)");
-        let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
-        let mut descriptor = std::ptr::null_mut();
-        if unsafe {
-            ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                sddl_wide.as_ptr(),
-                SDDL_REVISION_1,
-                &mut descriptor,
-                std::ptr::null_mut(),
-            )
-        } == 0
-        {
-            return Err("could not construct the protected Windows DACL".to_string());
-        }
-        let descriptor_result = (|| {
-            let mut present = 0;
-            let mut defaulted = 0;
-            let mut dacl = std::ptr::null_mut();
-            if unsafe {
-                GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted)
-            } == 0
-                || present == 0
-                || dacl.is_null()
-            {
-                return Err("could not inspect the protected Windows DACL".to_string());
-            }
-            let status = unsafe {
-                SetSecurityInfo(
-                    handle,
-                    SE_FILE_OBJECT,
-                    DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
-                    std::ptr::null_mut(),
-                    std::ptr::null_mut(),
-                    dacl,
-                    std::ptr::null_mut(),
-                )
-            };
-            if status != 0 {
-                return Err(format!(
-                    "could not install the protected Windows DACL: OS error {status}"
-                ));
-            }
-            Ok(())
-        })();
-        unsafe { LocalFree(descriptor as _) };
-        descriptor_result
+        Ok(sid)
     })();
     unsafe { CloseHandle(token) };
     result
+}
+
+fn install_protected_dacl(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    sddl: &str,
+) -> Result<(), String> {
+    let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut descriptor = std::ptr::null_mut();
+    if unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_wide.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        return Err("could not construct the protected Windows DACL".to_string());
+    }
+    let result = (|| {
+        let mut present = 0;
+        let mut defaulted = 0;
+        let mut dacl = std::ptr::null_mut();
+        if unsafe { GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted) }
+            == 0
+            || present == 0
+            || dacl.is_null()
+        {
+            return Err("could not inspect the protected Windows DACL".to_string());
+        }
+        let status = unsafe {
+            SetSecurityInfo(
+                handle,
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                dacl,
+                std::ptr::null_mut(),
+            )
+        };
+        if status != 0 {
+            return Err(format!(
+                "could not install the protected Windows DACL: OS error {status}"
+            ));
+        }
+        Ok(())
+    })();
+    unsafe { LocalFree(descriptor as _) };
+    result
+}
+
+fn protect_handle(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    inherit_children: bool,
+) -> Result<(), String> {
+    let sid = current_user_sid()?;
+    let ace_flags = if inherit_children { "OICI" } else { "" };
+    install_protected_dacl(
+        handle,
+        &format!("D:P(A;{ace_flags};FA;;;{sid})(A;{ace_flags};FA;;;SY)"),
+    )
+}
+
+#[cfg(test)]
+pub(super) fn current_user_sid_for_test() -> Result<String, String> {
+    current_user_sid()
+}
+
+#[cfg(test)]
+pub(super) fn set_broad_test_file_dacl(path: &Path) -> Result<(), String> {
+    let file = OpenOptions::new()
+        .access_mode(READ_CONTROL | WRITE_DAC)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|_| "could not open Windows test file for ACL setup".to_string())?;
+    reject_reparse(&file, "Windows test file")?;
+    let sid = current_user_sid()?;
+    install_protected_dacl(
+        file.as_raw_handle() as _,
+        &format!("D:P(A;;FA;;;{sid})(A;;FA;;;SY)(A;;FA;;;WD)(A;;FA;;;BU)(A;;FA;;;BA)"),
+    )
 }
 
 #[cfg(test)]

--- a/src/project_entry_windows.rs
+++ b/src/project_entry_windows.rs
@@ -1,0 +1,257 @@
+//! Narrow Windows private-state protection for the project/share product path.
+//!
+//! This module is deliberately scoped to project-entry state and managed tunnel
+//! caches. It is not a generic Windows filesystem-security abstraction.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::os::windows::fs::OpenOptionsExt;
+use std::os::windows::io::AsRawHandle;
+use std::path::Path;
+use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, GENERIC_READ, GENERIC_WRITE};
+use windows_sys::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SetSecurityInfo,
+    SDDL_REVISION_1, SE_FILE_OBJECT,
+};
+use windows_sys::Win32::Security::{
+    GetSecurityDescriptorDacl, GetTokenInformation, TokenUser, DACL_SECURITY_INFORMATION,
+    PROTECTED_DACL_SECURITY_INFORMATION, TOKEN_QUERY, TOKEN_USER,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_REPARSE_POINT,
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+const READ_CONTROL: u32 = 0x0002_0000;
+const WRITE_DAC: u32 = 0x0004_0000;
+
+pub(super) fn protect_private_directory(path: &Path) -> Result<(), String> {
+    let directory = OpenOptions::new()
+        .access_mode(READ_CONTROL | WRITE_DAC)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|_| "could not open the private Windows directory for protection".to_string())?;
+    reject_reparse(&directory, "private Windows directory")?;
+    protect_handle(directory.as_raw_handle() as _, true)
+}
+
+pub(super) fn protect_private_file(path: &Path) -> Result<(), String> {
+    let file = OpenOptions::new()
+        .access_mode(READ_CONTROL | WRITE_DAC)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|_| "could not open the private Windows file for protection".to_string())?;
+    reject_reparse(&file, "private Windows file")?;
+    protect_handle(file.as_raw_handle() as _, false)
+}
+
+pub(super) fn read_private_bytes(path: &Path) -> Result<Vec<u8>, String> {
+    let mut file = OpenOptions::new()
+        .access_mode(GENERIC_READ | READ_CONTROL | WRITE_DAC)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|_| "private authentication material is unreadable".to_string())?;
+    reject_reparse(&file, "private authentication material")?;
+    protect_handle(file.as_raw_handle() as _, false)?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "private authentication material is unreadable".to_string())?;
+    if !metadata.is_file() {
+        return Err("private authentication material is not a regular file".to_string());
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|_| "private authentication material is unreadable".to_string())?;
+    Ok(bytes)
+}
+
+pub(super) fn write_new_private_file(path: &Path, content: &[u8]) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .access_mode(GENERIC_WRITE | READ_CONTROL | WRITE_DAC)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .map_err(|_| "refused to overwrite existing private Windows state".to_string())?;
+    let result = (|| {
+        reject_reparse(&file, "private Windows file")?;
+        protect_handle(file.as_raw_handle() as _, false)?;
+        file.write_all(content)
+            .map_err(|_| "could not write private Windows state".to_string())?;
+        file.sync_all()
+            .map_err(|_| "could not sync private Windows state".to_string())
+    })();
+    drop(file);
+    if result.is_err() {
+        let _ = std::fs::remove_file(path);
+    }
+    result
+}
+
+fn reject_reparse(file: &File, label: &str) -> Result<(), String> {
+    let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, &mut info) } == 0 {
+        return Err(format!("could not inspect {label}"));
+    }
+    if info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(format!("refusing to use {label} through a reparse point"));
+    }
+    Ok(())
+}
+
+fn protect_handle(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    inherit_children: bool,
+) -> Result<(), String> {
+    let mut token = std::ptr::null_mut();
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err("could not inspect the current Windows user identity".to_string());
+    }
+    let result = (|| {
+        let mut required = 0u32;
+        unsafe { GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut required) };
+        if required == 0 {
+            return Err("could not size the current Windows user identity".to_string());
+        }
+        let words = (required as usize).div_ceil(std::mem::size_of::<usize>());
+        let mut buffer = vec![0usize; words];
+        if unsafe {
+            GetTokenInformation(
+                token,
+                TokenUser,
+                buffer.as_mut_ptr().cast(),
+                required,
+                &mut required,
+            )
+        } == 0
+        {
+            return Err("could not read the current Windows user identity".to_string());
+        }
+        let token_user = unsafe { &*(buffer.as_ptr().cast::<TOKEN_USER>()) };
+        let mut sid_text_ptr = std::ptr::null_mut();
+        if unsafe { ConvertSidToStringSidW(token_user.User.Sid, &mut sid_text_ptr) } == 0 {
+            return Err("could not encode the current Windows user identity".to_string());
+        }
+        let sid = unsafe {
+            let mut len = 0usize;
+            while *sid_text_ptr.add(len) != 0 {
+                len += 1;
+            }
+            let value = String::from_utf16_lossy(std::slice::from_raw_parts(sid_text_ptr, len));
+            LocalFree(sid_text_ptr as _);
+            value
+        };
+        let ace_flags = if inherit_children { "OICI" } else { "" };
+        let sddl = format!("D:P(A;{ace_flags};FA;;;{sid})(A;{ace_flags};FA;;;SY)");
+        let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut descriptor = std::ptr::null_mut();
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl_wide.as_ptr(),
+                SDDL_REVISION_1,
+                &mut descriptor,
+                std::ptr::null_mut(),
+            )
+        } == 0
+        {
+            return Err("could not construct the protected Windows DACL".to_string());
+        }
+        let descriptor_result = (|| {
+            let mut present = 0;
+            let mut defaulted = 0;
+            let mut dacl = std::ptr::null_mut();
+            if unsafe {
+                GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted)
+            } == 0
+                || present == 0
+                || dacl.is_null()
+            {
+                return Err("could not inspect the protected Windows DACL".to_string());
+            }
+            let status = unsafe {
+                SetSecurityInfo(
+                    handle,
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    dacl,
+                    std::ptr::null_mut(),
+                )
+            };
+            if status != 0 {
+                return Err(format!(
+                    "could not install the protected Windows DACL: OS error {status}"
+                ));
+            }
+            Ok(())
+        })();
+        unsafe { LocalFree(descriptor as _) };
+        descriptor_result
+    })();
+    unsafe { CloseHandle(token) };
+    result
+}
+
+#[cfg(test)]
+pub(super) fn dacl_sddl(path: &Path, directory: bool) -> Result<String, String> {
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertSecurityDescriptorToStringSecurityDescriptorW, GetSecurityInfo,
+    };
+
+    let flags = FILE_FLAG_OPEN_REPARSE_POINT
+        | if directory {
+            FILE_FLAG_BACKUP_SEMANTICS
+        } else {
+            0
+        };
+    let file = OpenOptions::new()
+        .access_mode(READ_CONTROL)
+        .custom_flags(flags)
+        .open(path)
+        .map_err(|_| "could not open Windows private state for ACL inspection".to_string())?;
+    let mut descriptor = std::ptr::null_mut();
+    let status = unsafe {
+        GetSecurityInfo(
+            file.as_raw_handle() as _,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(format!(
+            "could not read Windows private-state DACL: OS error {status}"
+        ));
+    }
+    let result = (|| {
+        let mut text = std::ptr::null_mut();
+        let mut text_len = 0u32;
+        if unsafe {
+            ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                descriptor,
+                SDDL_REVISION_1,
+                DACL_SECURITY_INFORMATION,
+                &mut text,
+                &mut text_len,
+            )
+        } == 0
+        {
+            return Err("could not render Windows private-state DACL".to_string());
+        }
+        let value = unsafe {
+            let value =
+                String::from_utf16_lossy(std::slice::from_raw_parts(text, text_len as usize));
+            LocalFree(text as _);
+            value
+        };
+        Ok(value)
+    })();
+    unsafe { LocalFree(descriptor as _) };
+    result
+}

--- a/src/project_entry_windows_migration_tests.rs
+++ b/src/project_entry_windows_migration_tests.rs
@@ -1,0 +1,152 @@
+use super::setup_service::{harden_existing_runtime_private_state, ProjectConfig, ProjectPaths};
+use super::windows_private_state::{
+    current_user_sid_for_test, dacl_sddl, set_broad_test_file_dacl,
+};
+use super::ProjectCommandOptions;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn git(args: &[&str], cwd: &Path) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn legacy_paths(name: &str) -> (tempfile::TempDir, ProjectPaths) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join(name);
+    let state = temp.path().join("state");
+    fs::create_dir(&root).unwrap();
+    git(&["init", "-q"], &root);
+    let options = ProjectCommandOptions {
+        root,
+        profile: "personal".to_string(),
+        state_dir: Some(state),
+        json: false,
+        console_assets_dir: None,
+    };
+    let (_, paths) = ProjectConfig::resolve(&options).unwrap();
+    fs::create_dir_all(&paths.data).unwrap();
+    fs::create_dir_all(&paths.logs).unwrap();
+    (temp, paths)
+}
+
+fn assert_hardened(path: &Path, current_user_sid: &str) {
+    let sddl = dacl_sddl(path, false).unwrap();
+    assert!(sddl.starts_with("D:P"), "DACL must be protected: {sddl}");
+    assert!(
+        sddl.contains(&format!(";;;{current_user_sid})")),
+        "current user ACE must remain: {sddl}"
+    );
+    assert!(sddl.contains(";;;SY)"), "SYSTEM ACE must remain: {sddl}");
+    for broad in [";;;WD)", ";;;BU)", ";;;BA)"] {
+        assert!(
+            !sddl.contains(broad),
+            "broad Windows ACE {broad} remained: {sddl}"
+        );
+    }
+}
+
+#[test]
+fn legacy_runtime_file_acls_are_migrated_without_changing_contents() {
+    let (_temp, paths) = legacy_paths("legacy-runtime-acls");
+    let files = [
+        (paths.data.join("webcodex.db"), b"legacy-main-db".as_slice()),
+        (
+            paths.data.join("webcodex.db-wal"),
+            b"legacy-existing-wal".as_slice(),
+        ),
+        (
+            paths.data.join("webcodex.db-shm"),
+            b"legacy-existing-shm".as_slice(),
+        ),
+        (
+            paths.logs.join("server.log"),
+            b"legacy-server-log\n".as_slice(),
+        ),
+        (
+            paths.logs.join("agent.log"),
+            b"legacy-agent-log\n".as_slice(),
+        ),
+    ];
+
+    for (path, content) in &files {
+        fs::write(path, content).unwrap();
+        set_broad_test_file_dacl(path).unwrap();
+        let sddl = dacl_sddl(path, false).unwrap();
+        assert!(
+            sddl.contains(";;;WD)") && sddl.contains(";;;BU)"),
+            "fixture must start with explicit broad ACEs: {sddl}"
+        );
+    }
+    let before = files
+        .iter()
+        .map(|(path, _)| (path.clone(), fs::read(path).unwrap()))
+        .collect::<Vec<(PathBuf, Vec<u8>)>>();
+
+    harden_existing_runtime_private_state(&paths).unwrap();
+
+    let current_user_sid = current_user_sid_for_test().unwrap();
+    for (path, content) in before {
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            content,
+            "migration changed {path:?}"
+        );
+        assert_hardened(&path, &current_user_sid);
+    }
+}
+
+#[test]
+fn legacy_runtime_acl_migration_does_not_create_absent_sqlite_sidecars() {
+    let (_temp, paths) = legacy_paths("legacy-absent-sidecars");
+    let db = paths.data.join("webcodex.db");
+    let server_log = paths.logs.join("server.log");
+    fs::write(&db, b"legacy-db").unwrap();
+    fs::write(&server_log, b"legacy-log\n").unwrap();
+    set_broad_test_file_dacl(&db).unwrap();
+    set_broad_test_file_dacl(&server_log).unwrap();
+    let wal = paths.data.join("webcodex.db-wal");
+    let shm = paths.data.join("webcodex.db-shm");
+    assert!(!wal.exists());
+    assert!(!shm.exists());
+
+    harden_existing_runtime_private_state(&paths).unwrap();
+
+    assert!(!wal.exists(), "migration must not create an absent WAL");
+    assert!(!shm.exists(), "migration must not create an absent SHM");
+    let current_user_sid = current_user_sid_for_test().unwrap();
+    assert_hardened(&db, &current_user_sid);
+    assert_hardened(&server_log, &current_user_sid);
+}
+
+#[test]
+fn legacy_runtime_acl_migration_rejects_direct_reparse_file() {
+    use std::os::windows::fs::symlink_file;
+
+    let (temp, paths) = legacy_paths("legacy-reparse");
+    let target = temp.path().join("outside-runtime-state.db");
+    fs::write(&target, b"must-stay-untouched").unwrap();
+    let link = paths.data.join("webcodex.db");
+    symlink_file(&target, &link).expect("Windows test host must support file symlinks");
+    assert!(fs::symlink_metadata(&link)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+
+    let error = harden_existing_runtime_private_state(&paths).unwrap_err();
+
+    assert_eq!(error.code, "project_registration_invalid");
+    assert!(error
+        .message
+        .contains("unsafe existing private Windows runtime state"));
+    assert_eq!(fs::read(&target).unwrap(), b"must-stay-untouched");
+}

--- a/src/project_entry_windows_migration_tests.rs
+++ b/src/project_entry_windows_migration_tests.rs
@@ -1,6 +1,9 @@
-use super::setup_service::{harden_existing_runtime_private_state, ProjectConfig, ProjectPaths};
+use super::setup_service::{
+    harden_existing_runtime_private_state, prepare_runtime_private_state, ProjectConfig,
+    ProjectPaths,
+};
 use super::windows_private_state::{
-    current_user_sid_for_test, dacl_sddl, set_broad_test_file_dacl,
+    current_user_sid_for_test, dacl_sddl, set_broad_test_directory_dacl, set_broad_test_file_dacl,
 };
 use super::ProjectCommandOptions;
 use std::fs;
@@ -53,6 +56,96 @@ fn assert_hardened(path: &Path, current_user_sid: &str) {
             "broad Windows ACE {broad} remained: {sddl}"
         );
     }
+}
+
+fn assert_hardened_directory(path: &Path, current_user_sid: &str) {
+    let sddl = dacl_sddl(path, true).unwrap();
+    assert!(sddl.starts_with("D:P"), "DACL must be protected: {sddl}");
+    assert_narrow_acl(&sddl, current_user_sid);
+}
+
+fn assert_narrow_acl(sddl: &str, current_user_sid: &str) {
+    assert!(
+        sddl.contains(&format!(";;;{current_user_sid})")),
+        "current user ACE must remain: {sddl}"
+    );
+    assert!(sddl.contains(";;;SY)"), "SYSTEM ACE must remain: {sddl}");
+    for broad in [";;;WD)", ";;;BU)", ";;;BA)"] {
+        assert!(
+            !sddl.contains(broad),
+            "broad Windows ACE {broad} remained: {sddl}"
+        );
+    }
+}
+
+#[test]
+fn legacy_runtime_parent_acls_are_hardened_before_future_children() {
+    let (_temp, paths) = legacy_paths("legacy-runtime-parent-acls");
+    for parent in [&paths.data, &paths.logs] {
+        set_broad_test_directory_dacl(parent).unwrap();
+        let sddl = dacl_sddl(parent, true).unwrap();
+        assert!(
+            sddl.contains(";;;WD)") && sddl.contains(";;;BU)"),
+            "fixture must start with broad inheritable ACEs: {sddl}"
+        );
+        assert!(
+            sddl.contains("OICI"),
+            "fixture broad ACEs must be inheritable: {sddl}"
+        );
+    }
+
+    let runtime_children = [
+        paths.data.join("webcodex.db"),
+        paths.data.join("webcodex.db-wal"),
+        paths.data.join("webcodex.db-shm"),
+        paths.logs.join("server.log"),
+        paths.logs.join("agent.log"),
+    ];
+    for path in &runtime_children {
+        assert!(!path.exists(), "fixture child must start absent: {path:?}");
+    }
+
+    prepare_runtime_private_state(&paths).unwrap();
+
+    let current_user_sid = current_user_sid_for_test().unwrap();
+    assert_hardened_directory(&paths.data, &current_user_sid);
+    assert_hardened_directory(&paths.logs, &current_user_sid);
+    for path in &runtime_children {
+        assert!(
+            !path.exists(),
+            "runtime preflight must not create an absent child: {path:?}"
+        );
+    }
+
+    for path in [
+        paths.data.join("post-preflight-child.bin"),
+        paths.logs.join("post-preflight-child.log"),
+    ] {
+        fs::write(&path, b"created-after-preflight").unwrap();
+        let sddl = dacl_sddl(&path, false).unwrap();
+        assert_narrow_acl(&sddl, &current_user_sid);
+    }
+}
+
+#[test]
+fn runtime_private_state_preflight_rejects_direct_reparse_parent() {
+    use std::os::windows::fs::symlink_dir;
+
+    let (temp, paths) = legacy_paths("legacy-runtime-parent-reparse");
+    fs::remove_dir(&paths.data).unwrap();
+    let target = temp.path().join("outside-runtime-data");
+    fs::create_dir(&target).unwrap();
+    let marker = target.join("marker.txt");
+    fs::write(&marker, b"must-stay-untouched").unwrap();
+    symlink_dir(&target, &paths.data).expect("Windows test host must support directory symlinks");
+
+    let error = prepare_runtime_private_state(&paths).unwrap_err();
+
+    assert_eq!(error.code, "project_registration_invalid");
+    assert!(error
+        .message
+        .contains("protect its private Windows state directory"));
+    assert_eq!(fs::read(&marker).unwrap(), b"must-stay-untouched");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Bring the Windows product path to foreground runtime parity without introducing Windows Service management.

- support `webcodex server init` + foreground `webcodex server run --env-file ...` on Windows
- support explicit Windows `webcodex share` with `cloudflare`, `openai`, and `none`
- package and discover `webcodex.exe`, `webcodex-server.exe`, and `webcodex-runner.exe` together
- add verified managed Windows tunnel acquisition where upstream artifacts exist
- harden Windows private runtime state, including legacy parent/child ACL migration and reparse fail-closed handling
- handle Ctrl-C / Ctrl-Break for foreground local runtime cleanup
- document a copy-paste Windows foreground Server + Runner enrollment path and correct Linux/macOS-only clipboard/browser convenience wording

## Windows user path

A Windows user can now install the npm package, start a Server in one PowerShell window, create/redeem a short-lived pairing code, and run the generated Runner config in another foreground window. Windows Service lifecycle remains intentionally out of scope.

## Limits

- no WebCodex-managed Windows Server or Runner Service yet
- `webcodex server install/start/stop/restart/logs/uninstall` and `webcodex runner install` remain unsupported on Windows
- the pinned Cloudflare release has no official Windows ARM64 binary, so ARM64 Cloudflare use still requires a trusted explicit/PATH binary

## Validation

Rebased branch is based on current `origin/main` `3b3e920d34fc0652ab307a056c39df0d053b1d95`.

Focused validation across the implementation/review sequence included:

- `cargo fmt -- --check`
- `cargo check --all-targets -p webcodex`
- `cargo check --all-targets -p webcodex-cli`
- Windows migration regressions on MSI
- native foreground Server / Runner / MCP initialization dogfood on MSI
- Ctrl-Break graceful cleanup and process-hygiene checks
- npm Windows installer/package smoke for the three executable set and local `share --tunnel none`
- `npm --prefix npm/webcodex test`
- final documentation `git diff --check`

The final documentation-only closeout did not change runtime code.