### PR TITLE
Close Linux managed onboarding gaps

### DIFF
--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -42,20 +42,21 @@ use webcodex_cli::{
     default_client_output_dir_for_profile, default_device_name, default_server_paths,
     disconnect_usage, discover_internal_binary, is_effective_root, login_usage, logout_usage,
     ops_agents_usage, ops_projects_usage, ops_runner_usage, ops_smoke_preflight_usage,
-    ops_status_usage, ops_usage, pairing_create_usage, pairing_usage, render_token_generate,
-    run_agent_token_create_local, run_client_enroll, run_connect, run_disconnect,
-    run_hosted_log_writer, run_internal_binary, run_login, run_logout, run_ops_command,
-    run_pairing_create, run_runner_install_service, run_runner_service, run_runner_status,
-    run_server_init, run_server_install_service, run_server_service, run_server_status,
-    run_setup_single_user, run_status, run_token_create_local, runner_init_usage,
-    runner_install_service_usage, runner_service_file_for_scope, runner_status_usage, runner_usage,
-    server_init_usage, server_install_service_usage, server_status_usage, server_usage,
-    service_unit_name, status_usage, system_user_home, system_user_is_root, usage,
-    validate_client_profile, validate_service_file_scope, write_connect_result, write_secret_file,
-    write_text_file, ConnectAuth, ConnectOptions, DisconnectOptions, LoginOptions, LogoutOptions,
-    OpsCommand, OpsCommonOptions, OpsRunnerOptions, OpsSmokePreflightOptions, ServerStatusOptions,
-    ServiceControl, StatusOptions, DEFAULT_LOG_LINES, RUNNER_SERVICE_UNIT, SERVER_SERVICE_FILE,
-    SERVER_SERVICE_UNIT,
+    ops_status_usage, ops_usage, pairing_create_usage, pairing_usage, project_register_usage,
+    read_env_file_value, render_token_generate, run_agent_token_create_local, run_client_enroll,
+    run_connect, run_disconnect, run_hosted_log_writer, run_internal_binary, run_login, run_logout,
+    run_ops_command, run_pairing_create, run_project_register, run_runner_install_service,
+    run_runner_service, run_runner_status, run_server_init, run_server_install_service,
+    run_server_service, run_server_status, run_setup_single_user, run_status,
+    run_token_create_local, runner_init_usage, runner_install_service_usage,
+    runner_service_file_for_scope, runner_status_usage, runner_usage, server_init_usage,
+    server_install_service_usage, server_status_usage, server_usage, service_unit_name,
+    status_usage, system_user_home, system_user_is_root, usage, validate_client_profile,
+    validate_service_file_scope, write_connect_result, write_secret_file, write_text_file,
+    ConnectAuth, ConnectOptions, DisconnectOptions, LoginOptions, LogoutOptions, OpsCommand,
+    OpsCommonOptions, OpsRunnerOptions, OpsSmokePreflightOptions, ProjectRegisterOptions,
+    ServerStatusOptions, ServiceControl, StatusOptions, DEFAULT_LOG_LINES, RUNNER_SERVICE_UNIT,
+    SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT,
 };
 const SETUP_GPT_SCOPES: &[&str] = &[
     "runtime:read",
@@ -105,6 +106,7 @@ fn default_runner_service_scope(effective_root: bool) -> ServiceScope {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CliAction {
     Project(Vec<String>),
+    ProjectRegister(ProjectRegisterOptions),
     Connect(ConnectOptions),
     Disconnect(DisconnectOptions),
     HostedLogWriter(PathBuf),
@@ -357,6 +359,7 @@ where
         }
         "connect" => parse_connect(&args[1..]),
         "disconnect" => parse_disconnect(&args[1..]),
+        "project" => parse_project_subcommand(&args[1..]),
         "__hosted-log-writer" => {
             if args.len() == 2 {
                 CliAction::HostedLogWriter(PathBuf::from(&args[1]))
@@ -649,6 +652,75 @@ fn parse_disconnect(args: &[String]) -> CliAction {
     })
 }
 
+fn parse_project_subcommand(args: &[String]) -> CliAction {
+    match args.first().map(String::as_str) {
+        Some("register") => {
+            if args[1..]
+                .iter()
+                .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+            {
+                return CliAction::Exit {
+                    code: 0,
+                    stdout: project_register_usage().to_string(),
+                    stderr: String::new(),
+                };
+            }
+            let mut config = None;
+            let mut project = None;
+            let mut json = false;
+            let mut index = 1;
+            while index < args.len() {
+                match args[index].as_str() {
+                    "--config" => {
+                        index += 1;
+                        match args.get(index) {
+                            Some(value) => config = Some(PathBuf::from(value)),
+                            None => {
+                                return cli_parse_error("--config requires a value".to_string())
+                            }
+                        }
+                    }
+                    "--json" => json = true,
+                    other if other.starts_with('-') => {
+                        return cli_parse_error(format!("unknown project register option: {other}"))
+                    }
+                    value => {
+                        if project.is_some() {
+                            return cli_parse_error(format!(
+                                "unexpected project register argument: {value}"
+                            ));
+                        }
+                        project = Some(PathBuf::from(value));
+                    }
+                }
+                index += 1;
+            }
+            let Some(config) = config else {
+                return cli_parse_error("project register requires --config PATH".to_string());
+            };
+            let Some(project) = project else {
+                return cli_parse_error(
+                    "project register requires an existing workspace path".to_string(),
+                );
+            };
+            CliAction::ProjectRegister(ProjectRegisterOptions {
+                config,
+                project,
+                json,
+            })
+        }
+        Some("--help" | "-h") => CliAction::Exit {
+            code: 0,
+            stdout: project_register_usage().to_string(),
+            stderr: String::new(),
+        },
+        Some(other) => cli_parse_error(format!("unknown project subcommand: {other}")),
+        None => cli_parse_error(
+            "missing project subcommand; try `webcodex project register --help`".to_string(),
+        ),
+    }
+}
+
 fn parse_auth_subcommand(args: &[String]) -> CliAction {
     match args.first().map(String::as_str) {
         Some("status") => parse_status(&args[1..]),
@@ -689,6 +761,7 @@ fn parse_login(args: &[String]) -> CliAction {
     let mut base_dir: Option<PathBuf> = None;
     let mut transport = TRANSPORT_WEBSOCKET.to_string();
     let mut allowed_roots: Vec<PathBuf> = Vec::new();
+    let mut project: Option<PathBuf> = None;
     let mut overwrite = false;
     let mut json = false;
     let mut print_mcp_config = false;
@@ -727,6 +800,10 @@ fn parse_login(args: &[String]) -> CliAction {
             "--allowed-root" => match take(&mut index) {
                 Some(value) => allowed_roots.push(PathBuf::from(value)),
                 None => return cli_parse_error("--allowed-root requires a value".to_string()),
+            },
+            "--project" => match take(&mut index) {
+                Some(value) => project = Some(PathBuf::from(value)),
+                None => return cli_parse_error("--project requires a value".to_string()),
             },
             "--overwrite" => overwrite = true,
             "--json" => json = true,
@@ -774,6 +851,7 @@ fn parse_login(args: &[String]) -> CliAction {
         base_dir,
         transport,
         allowed_roots,
+        project,
         overwrite,
         json,
         print_mcp_config,
@@ -2025,12 +2103,13 @@ fn parse_runner_status_with_identity(
 }
 
 fn parse_server_install_service(args: &[String]) -> Result<ServerInstallServiceOptions, String> {
-    let mut env_file = PathBuf::from("/etc/webcodex/webcodex.env");
+    let defaults = default_server_paths()?;
+    let mut env_file = defaults.env_file;
     let mut bin: Option<PathBuf> = None;
     let mut service_file = PathBuf::from("/etc/systemd/system/webcodex.service");
     let mut user = None;
     let mut group = None;
-    let mut working_directory = PathBuf::from("/var/lib/webcodex");
+    let mut working_directory: Option<PathBuf> = None;
     let mut overwrite = false;
     let mut dry_run = false;
     let mut output_stdout = false;
@@ -2044,7 +2123,9 @@ fn parse_server_install_service(args: &[String]) -> Result<ServerInstallServiceO
             "--service-file" => service_file = PathBuf::from(next_value(&mut iter, arg)?),
             "--user" => user = Some(next_value(&mut iter, arg)?),
             "--group" => group = Some(next_value(&mut iter, arg)?),
-            "--working-directory" => working_directory = PathBuf::from(next_value(&mut iter, arg)?),
+            "--working-directory" => {
+                working_directory = Some(PathBuf::from(next_value(&mut iter, arg)?))
+            }
             "--overwrite" => overwrite = true,
             "--dry-run" => dry_run = true,
             "--no-start" => no_start = true,
@@ -2063,6 +2144,20 @@ fn parse_server_install_service(args: &[String]) -> Result<ServerInstallServiceO
         Some(path) => path,
         None => return Err("--bin is required because webcodex-server was not found beside webcodex or in an absolute PATH entry".to_string()),
     };
+    let working_directory = match working_directory {
+        Some(path) => path,
+        None if env_file.exists() => match read_env_file_value(&env_file, "WEBCODEX_DATA")? {
+            Some(value) if !value.trim().is_empty() => PathBuf::from(value.trim()),
+            Some(_) => {
+                return Err(format!(
+                    "{} defines an empty WEBCODEX_DATA; pass --working-directory explicitly",
+                    env_file.display()
+                ))
+            }
+            None => defaults.data_dir,
+        },
+        None => defaults.data_dir,
+    };
     if env_file.as_os_str().is_empty() {
         return Err("--env-file cannot be empty".to_string());
     }
@@ -2074,6 +2169,9 @@ fn parse_server_install_service(args: &[String]) -> Result<ServerInstallServiceO
     }
     if working_directory.as_os_str().is_empty() {
         return Err("--working-directory cannot be empty".to_string());
+    }
+    if !working_directory.is_absolute() {
+        return Err("--working-directory must be an absolute path".to_string());
     }
     Ok(ServerInstallServiceOptions {
         env_file,
@@ -2093,6 +2191,7 @@ fn parse_server_install_service(args: &[String]) -> Result<ServerInstallServiceO
 fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
     let mut opts = ServerStatusOptions {
         url: "http://127.0.0.1:8080".to_string(),
+        url_explicit: false,
         server_http: ServerHttpOptions::default(),
         env_file: Some(default_server_paths()?.env_file),
         env_file_explicit: false,
@@ -2103,7 +2202,10 @@ fn parse_server_status(args: &[String]) -> Result<ServerStatusOptions, String> {
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
-            "--url" => opts.url = next_value(&mut iter, arg)?,
+            "--url" => {
+                opts.url = next_value(&mut iter, arg)?;
+                opts.url_explicit = true;
+            }
             "--proxy" => opts.server_http.proxy = Some(next_value(&mut iter, arg)?),
             "--no-system-proxy" => opts.server_http.no_system_proxy = true,
             "--env-file" => {
@@ -2501,6 +2603,19 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             std::process::exit(output.code);
         }
+        CliAction::ProjectRegister(opts) => match run_project_register(opts) {
+            Ok(stdout) => {
+                print!("{}", stdout);
+                if !stdout.ends_with('\n') {
+                    println!();
+                }
+                std::process::exit(0);
+            }
+            Err(stderr) => {
+                eprintln!("{}", stderr);
+                std::process::exit(1);
+            }
+        },
         CliAction::Connect(opts) => match run_connect(opts).await {
             Ok(result) => {
                 let stdout = std::io::stdout();

--- a/crates/webcodex-cli/src/webcodex_cli/connect/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/mod.rs
@@ -3,7 +3,7 @@ mod oauth;
 mod output;
 mod probe;
 mod process;
-mod profile;
+pub(crate) mod profile;
 mod shared_key_oauth;
 
 pub(crate) use disconnect::{run_disconnect, DisconnectOptions};

--- a/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/connect/profile.rs
@@ -60,9 +60,9 @@ pub(super) struct ExistingAgentConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub(super) struct ProjectFile {
-    pub(super) id: String,
-    pub(super) path: String,
+pub(crate) struct ProjectFile {
+    pub(crate) id: String,
+    pub(crate) path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     shell_profile: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -283,7 +283,7 @@ pub(super) fn read_existing_agent_config(
         .map_err(|error| format!("failed to parse agent config {}: {error}", path.display()))
 }
 
-pub(super) fn read_project_files(
+pub(crate) fn read_project_files(
     projects_dir: &Path,
 ) -> Result<Vec<(PathBuf, ProjectFile)>, String> {
     let entries = match std::fs::read_dir(projects_dir) {
@@ -447,7 +447,7 @@ pub(super) fn ensure_private_directory(path: &Path) -> Result<PathBuf, String> {
     Ok(path)
 }
 
-pub(super) fn atomic_write(path: &Path, content: &[u8], secret: bool) -> Result<bool, String> {
+pub(crate) fn atomic_write(path: &Path, content: &[u8], secret: bool) -> Result<bool, String> {
     if path.exists() {
         validate_existing_regular_file(path)?;
         let existing = std::fs::read(path)
@@ -512,11 +512,11 @@ pub(super) fn protect_secret_file(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-pub(super) fn render_project_file(project: &ProjectFile) -> Result<String, String> {
+pub(crate) fn render_project_file(project: &ProjectFile) -> Result<String, String> {
     toml::to_string(project).map_err(|error| format!("failed to render project config: {error}"))
 }
 
-pub(super) fn resolve_project(
+pub(crate) fn resolve_project(
     projects_dir: &Path,
     canonical_project: &Path,
     explicit_id: Option<&str>,

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -24,7 +24,10 @@ use super::connections::{
     list_connections, resolve_connection_parent, user_slug, Connection, ConnectionPaths,
     INTERNAL_DIR_PREFIX,
 };
-use super::{is_effective_root, shell_command, validate_user_api_token};
+use super::{
+    is_effective_root, register_existing_project, shell_command, validate_user_api_token,
+    ProjectRegistration,
+};
 
 /// Device name reported to the server. The hostname is what a person would call
 /// this machine; `--device` overrides it.
@@ -295,6 +298,7 @@ pub(crate) struct LoginOptions {
     pub(crate) base_dir: PathBuf,
     pub(crate) transport: String,
     pub(crate) allowed_roots: Vec<PathBuf>,
+    pub(crate) project: Option<PathBuf>,
     pub(crate) overwrite: bool,
     pub(crate) json: bool,
     pub(crate) print_mcp_config: bool,
@@ -584,6 +588,8 @@ pub(crate) fn render_login_result(
     server_url: &str,
     username: &str,
     device: &str,
+    registration: Option<&ProjectRegistration>,
+    allowed_roots: &[PathBuf],
     effective_root: bool,
     json: bool,
     print_mcp_config: bool,
@@ -617,18 +623,43 @@ pub(crate) fn render_login_result(
     };
     let foreground_command = foreground_argv.as_ref().map(|argv| shell_command(argv));
     let runner_install_command = runner_install_argv.as_ref().map(|argv| shell_command(argv));
+    let runtime_project = registration.map(|project| format!("agent:{device}:{}", project.id));
+    let register_command = format!(
+        "{} <existing-workspace>",
+        shell_command(&[
+            "webcodex".to_string(),
+            "project".to_string(),
+            "register".to_string(),
+            "--config".to_string(),
+            paths.agent_config.to_string_lossy().into_owned(),
+        ])
+    );
 
     // JSON output carries only safe metadata; never a full token. The
     // `--print-mcp-config` path is text-only and mutually exclusive with `--json`
     // (enforced at parse time), so the two cannot both apply here.
     if json {
         let mut next_steps = Vec::new();
+        if registration.is_none() {
+            next_steps.push(register_command.clone());
+        }
         if let Some(command) = &foreground_command {
             next_steps.push(command.clone());
         }
         if let Some(command) = &runner_install_command {
             next_steps.push(command.clone());
         }
+        let registered_projects = registration
+            .iter()
+            .map(|project| {
+                serde_json::json!({
+                    "id": project.id,
+                    "path": project.path.to_string_lossy(),
+                    "record": project.record_path.to_string_lossy(),
+                    "runtime_project": format!("agent:{device}:{}", project.id),
+                })
+            })
+            .collect::<Vec<_>>();
         let summary = serde_json::json!({
             "server_url": server_url,
             "username": username,
@@ -637,6 +668,13 @@ pub(crate) fn render_login_result(
             "dir": paths.dir.to_string_lossy(),
             "user_token_file": paths.user_token.to_string_lossy(),
             "agent_config": paths.agent_config.to_string_lossy(),
+            "projects_registry": paths.projects_dir.to_string_lossy(),
+            "allowed_roots": allowed_roots.iter().map(|root| root.to_string_lossy().to_string()).collect::<Vec<_>>(),
+            "project_registration": {
+                "registered": registration.is_some(),
+                "count": registered_projects.len(),
+            },
+            "registered_projects": registered_projects,
             "credential_usage": {
                 "webcodex-user-token": "GPT Actions, MCP, and REST/project APIs",
                 "agent_config_token": "Runner transport only",
@@ -688,14 +726,36 @@ pub(crate) fn render_login_result(
         _ => return Err("inconsistent login Runner guidance state".to_string()),
     };
 
+    let allowed_roots_text = if allowed_roots.is_empty() {
+        "    (none)\n".to_string()
+    } else {
+        allowed_roots
+            .iter()
+            .map(|root| format!("    {}\n", root.display()))
+            .collect::<String>()
+    };
+    let project_guidance = if let (Some(project), Some(runtime_project)) =
+        (registration, runtime_project)
+    {
+        format!(
+            "Registered project:\n  id:   {}\n  path: {}\n\nAfter the Runner starts, WebCodex should expose:\n  {}\n",
+            project.id,
+            project.path.display(),
+            runtime_project,
+        )
+    } else {
+        format!(
+            "Project registration: none\n\nNo project is registered yet.\n--allowed-root controls where projects may be registered; it does not register a workspace.\nRegister an existing workspace before using project-bound coding tools:\n  {register_command}\n\nRunner access is configured, but project-bound tools remain unavailable until a project is registered.\n"
+        )
+    };
+
     Ok(format!(
-        "Logged in to {server_url} as {username} ({device}).\n\n  \
-         MCP endpoint: {server_url}/mcp\n  \
-         user token file: {} (GPT Actions, MCP, and REST/project APIs)\n  \
-         agent config:   {} (contains Runner transport credentials only)\n\n\
-         {}",
+        "Login succeeded.\n\n  server:            {server_url}\n  username:          {username}\n  device/client_id:  {device}\n  MCP endpoint:      {server_url}/mcp\n  user token file:   {} (GPT Actions, MCP, and REST/project APIs)\n  agent config:      {} (contains Runner transport credentials only)\n  projects registry: {} (Runner project registry, not a workspace root)\n\nAllowed roots (registration authority):\n{}\n{}\n{}",
         paths.user_token.display(),
         paths.agent_config.display(),
+        paths.projects_dir.display(),
+        allowed_roots_text,
+        project_guidance,
         next_step_guidance,
     ))
 }
@@ -892,21 +952,73 @@ pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
     let server_url = canonical.url.clone();
     let parent = resolve_connection_parent(&opts.base_dir, &canonical)?;
 
-    // The device name is settled here, after the target directory has been
-    // verified but before the one-time code is spent: `resolve_device_name`
-    // generates and validates the client_id, and creates `.device-id` in the
-    // verified base (the server directory's parent). Every local problem —
-    // an invalid explicit `--device`, a planted `.device-id` — fails now.
+    // The device name and effective filesystem authority are settled before the
+    // one-shot pairing code is redeemed. In particular, a missing HOME with no
+    // explicit roots must not consume the code and fail only while rendering the
+    // Runner config later.
     let base = parent
         .parent()
         .ok_or_else(|| format!("{} has no parent directory", parent.display()))?;
     let device = resolve_device_name(base, &opts)?;
+    let mut output_allowed_roots =
+        webcodex_runner_config::effective_allowed_roots(&opts.allowed_roots, false)?;
 
-    let identity = redeem_pairing_code(&server_url, &opts, &device).await?;
+    // When --project is present, even the project record is fully validated and
+    // staged before redemption. The staging directory contains no credentials at
+    // this point, so any path/policy/registry write failure leaves the one-shot
+    // pairing code untouched.
+    let mut prestaged: Option<(PathBuf, ProjectRegistration)> = None;
+    if let Some(project) = &opts.project {
+        let staging = create_staging_dir(&parent)?;
+        let staged_projects_dir = staging.join("projects.d");
+        match register_existing_project(
+            &staged_projects_dir,
+            project,
+            &output_allowed_roots,
+            false,
+            None,
+        ) {
+            Ok((registration, roots)) => {
+                output_allowed_roots = roots;
+                prestaged = Some((staging, registration));
+            }
+            Err(error) => {
+                let residue = discard_internal_dir(&staging);
+                return Err(match residue {
+                    None => error,
+                    Some(path) => format!(
+                        "{error}; non-secret project-registration staging data remains at {} and may be deleted",
+                        path.display()
+                    ),
+                });
+            }
+        }
+    }
+
+    let identity = match redeem_pairing_code(&server_url, &opts, &device).await {
+        Ok(identity) => identity,
+        Err(error) => {
+            if let Some((staging, _)) = prestaged.as_ref() {
+                let residue = discard_internal_dir(staging);
+                return Err(match residue {
+                    None => error,
+                    Some(path) => format!(
+                        "{error}; non-secret project-registration staging data remains at {} and may be deleted",
+                        path.display()
+                    ),
+                });
+            }
+            return Err(error);
+        }
+    };
     let user = user_slug(&identity.username)?;
     let paths = ConnectionPaths::new(parent.join(user));
 
-    let staging = create_staging_dir(&parent)?;
+    let (staging, mut registration) = if let Some((staging, registration)) = prestaged {
+        (staging, Some(registration))
+    } else {
+        (create_staging_dir(&parent)?, None)
+    };
     let now = chrono::Utc::now().to_rfc3339();
     if let Err(error) = stage_connection(
         &staging,
@@ -922,15 +1034,22 @@ pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
     }
 
     match publish_connection(&staging, &paths.dir, opts.overwrite)? {
-        PublishOutcome::Published => render_login_result(
-            &paths,
-            &server_url,
-            &identity.username,
-            &device,
-            effective_root,
-            opts.json,
-            opts.print_mcp_config,
-        ),
+        PublishOutcome::Published => {
+            if let Some(project) = registration.as_mut() {
+                project.record_path = paths.projects_dir.join(format!("{}.toml", project.id));
+            }
+            render_login_result(
+                &paths,
+                &server_url,
+                &identity.username,
+                &device,
+                registration.as_ref(),
+                &output_allowed_roots,
+                effective_root,
+                opts.json,
+                opts.print_mcp_config,
+            )
+        }
         // The pairing code was spent but the destination was taken; the fresh
         // credentials are real and are parked for recovery. Never emit a token
         // here, even with `--print-mcp-config` — there is no published
@@ -1033,6 +1152,7 @@ mod tests {
             transport: "websocket".to_string(),
             allowed_roots: Vec::new(),
             overwrite,
+            project: None,
             json: false,
             print_mcp_config: false,
         }
@@ -1180,6 +1300,7 @@ mod tests {
         assert!(paths.agent_config.is_file());
         assert!(paths.user_token.is_file());
         assert!(paths.projects_dir.is_dir());
+        assert_eq!(std::fs::read_dir(&paths.projects_dir).unwrap().count(), 0);
         // The agent token has exactly one home.
         assert!(!paths.dir.join("webcodex-runner-token").exists());
         let agent_config = std::fs::read_to_string(&paths.agent_config).unwrap();
@@ -1202,6 +1323,52 @@ mod tests {
 
         assert_no_internal_residue(base);
         assert_no_internal_residue(paths.dir.parent().unwrap());
+    }
+
+    #[test]
+    fn allowed_root_without_project_remains_policy_only() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let base = temp.path().join("config");
+        let allowed_root = temp.path().join("workspaces");
+        std::fs::create_dir_all(&allowed_root).unwrap();
+        let mut opts = login_opts(&base, "https://api.example.com", false);
+        opts.allowed_roots = vec![allowed_root.clone()];
+        let canonical = canonical_server_url(&opts.server_url).unwrap();
+        let identity = identity();
+        let parent = resolve_connection_parent(&base, &canonical).unwrap();
+        let paths = ConnectionPaths::new(parent.join(user_slug(&identity.username).unwrap()));
+        let staging = create_staging_dir(&parent).unwrap();
+        stage_connection(
+            &staging,
+            &paths.projects_dir,
+            &opts,
+            &canonical.url,
+            &identity,
+            &opts.device,
+            "t",
+        )
+        .unwrap();
+        assert_eq!(
+            publish_connection(&staging, &paths.dir, false).unwrap(),
+            PublishOutcome::Published
+        );
+        assert_eq!(std::fs::read_dir(&paths.projects_dir).unwrap().count(), 0);
+        let agent_config = std::fs::read_to_string(&paths.agent_config).unwrap();
+        let parsed: toml::Value = toml::from_str(&agent_config).unwrap();
+        assert_eq!(
+            PathBuf::from(parsed["projects_dir"].as_str().unwrap())
+                .canonicalize()
+                .unwrap(),
+            paths.projects_dir.canonicalize().unwrap()
+        );
+        assert_ne!(
+            paths.projects_dir.canonicalize().unwrap(),
+            allowed_root.canonicalize().unwrap()
+        );
+        assert_eq!(
+            parsed["policy"]["allowed_roots"].as_array().unwrap()[0].as_str(),
+            allowed_root.to_str()
+        );
     }
 
     #[cfg(unix)]
@@ -1966,6 +2133,7 @@ mod tests {
             transport: "websocket".to_string(),
             allowed_roots: Vec::new(),
             overwrite: false,
+            project: None,
             json: false,
             print_mcp_config: false,
         };
@@ -1981,6 +2149,138 @@ mod tests {
         assert_eq!(value["pairing_code"], CODE);
         assert!(output.contains(device), "{output}");
         assert!(base.join(DEVICE_ID_FILE).is_file());
+    }
+
+    #[tokio::test]
+    async fn login_project_registers_existing_workspace_into_published_registry() {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 16384];
+            let length = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..length]);
+            let body = request.split("\r\n\r\n").nth(1).unwrap();
+            let value: serde_json::Value = serde_json::from_str(body).unwrap();
+            assert_eq!(value["pairing_code"], CODE);
+            assert_eq!(value["allow_cwd_anywhere"], false);
+            assert_eq!(value["allowed_roots"].as_array().unwrap().len(), 1);
+            let body = serde_json::json!({
+                "username": "alice",
+                "user_token": USER_TOKEN,
+                "agent_token": AGENT_TOKEN,
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let base = temp.path().join("config");
+        let allowed_root = temp.path().join("workspaces");
+        let project = allowed_root.join("my-repo");
+        std::fs::create_dir_all(&project).unwrap();
+        let opts = LoginOptions {
+            server_url: format!("http://{address}"),
+            server_http: ServerHttpOptions {
+                proxy: None,
+                no_system_proxy: true,
+            },
+            code: CODE.to_string(),
+            device: "project-device".to_string(),
+            device_explicit: true,
+            base_dir: base.clone(),
+            transport: "websocket".to_string(),
+            allowed_roots: vec![allowed_root.clone()],
+            project: Some(project.clone()),
+            overwrite: false,
+            json: true,
+            print_mcp_config: false,
+        };
+        let output = run_login(opts).await.unwrap();
+        server.join().unwrap();
+
+        let value: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(value["project_registration"]["registered"], true);
+        assert_eq!(value["project_registration"]["count"], 1);
+        assert_eq!(value["registered_projects"][0]["id"], "my-repo");
+        assert_eq!(
+            value["registered_projects"][0]["runtime_project"],
+            "agent:project-device:my-repo"
+        );
+        assert!(!output.contains(USER_TOKEN));
+        assert!(!output.contains(AGENT_TOKEN));
+
+        let connections = all_connections(&base);
+        assert_eq!(connections.len(), 1);
+        let paths = &connections[0].paths;
+        let records =
+            crate::webcodex_cli::connect::profile::read_project_files(&paths.projects_dir).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].1.id, "my-repo");
+        assert_eq!(
+            PathBuf::from(&records[0].1.path).canonicalize().unwrap(),
+            project.canonicalize().unwrap()
+        );
+        assert!(records[0].0.starts_with(&paths.projects_dir));
+        assert!(value["registered_projects"][0]["record"]
+            .as_str()
+            .unwrap()
+            .starts_with(paths.projects_dir.to_str().unwrap()));
+        let agent_config = std::fs::read_to_string(&paths.agent_config).unwrap();
+        let parsed: toml::Value = toml::from_str(&agent_config).unwrap();
+        assert_eq!(
+            PathBuf::from(parsed["projects_dir"].as_str().unwrap())
+                .canonicalize()
+                .unwrap(),
+            paths.projects_dir.canonicalize().unwrap()
+        );
+        assert_no_internal_residue(paths.dir.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn login_project_outside_allowed_roots_fails_before_redemption() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let base = temp.path().join("config");
+        let allowed_root = temp.path().join("allowed");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&allowed_root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let opts = LoginOptions {
+            server_url: format!("http://{address}"),
+            server_http: ServerHttpOptions {
+                proxy: None,
+                no_system_proxy: true,
+            },
+            code: CODE.to_string(),
+            device: "project-device".to_string(),
+            device_explicit: true,
+            base_dir: base.clone(),
+            transport: "websocket".to_string(),
+            allowed_roots: vec![allowed_root],
+            project: Some(outside),
+            overwrite: false,
+            json: false,
+            print_mcp_config: false,
+        };
+        let error = run_login(opts).await.unwrap_err();
+        assert!(
+            error.contains("outside the Runner allowed_roots"),
+            "{error}"
+        );
+        let canonical = canonical_server_url(&format!("http://{address}")).unwrap();
+        let parent = resolve_connection_parent(&base, &canonical).unwrap();
+        assert_no_internal_residue(&parent);
     }
 
     #[test]
@@ -2152,6 +2452,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             false,
             false,
             false,
@@ -2172,6 +2474,9 @@ mod tests {
             "{text}"
         );
         assert!(text.contains("Runner transport credentials only"), "{text}");
+        assert!(text.contains("Project registration: none"), "{text}");
+        assert!(text.contains("--allowed-root controls where projects may be registered; it does not register a workspace"), "{text}");
+        assert!(text.contains("projects registry"), "{text}");
         assert!(
             (!cfg!(windows) && text.contains("webcodex runner install --scope user --config"))
                 || (cfg!(windows) && !text.contains("webcodex runner install")),
@@ -2193,6 +2498,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             false,
             true,
             false,
@@ -2206,6 +2513,13 @@ mod tests {
             Some("https://api.example.com/mcp")
         );
         assert!(json_value.get("credential_usage").is_some(), "{json}");
+        assert_eq!(json_value["project_registration"]["registered"], false);
+        assert_eq!(json_value["project_registration"]["count"], 0);
+        assert_eq!(json_value["registered_projects"], serde_json::json!([]));
+        assert_eq!(
+            json_value["projects_registry"],
+            paths.projects_dir.to_string_lossy().as_ref()
+        );
         assert_eq!(
             json_value
                 .get("user_token_file")
@@ -2222,7 +2536,7 @@ mod tests {
                 json_value["runner_install_reason"],
                 serde_json::json!(WINDOWS_RUNNER_INSTALL_REASON)
             );
-            assert_eq!(json_value["next_steps"].as_array().unwrap().len(), 1);
+            assert_eq!(json_value["next_steps"].as_array().unwrap().len(), 2);
         }
         assert!(!json.contains(USER_TOKEN), "json leaked a token");
         assert!(!json.contains(AGENT_TOKEN), "json leaked a token");
@@ -2251,6 +2565,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             false,
             false,
             false,
@@ -2272,6 +2588,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             false,
             true,
             false,
@@ -2301,13 +2619,17 @@ mod tests {
         } else {
             assert!(value["runner_install_reason"].is_null());
         }
+        assert!(value["next_steps"][0]
+            .as_str()
+            .unwrap()
+            .contains("webcodex project register"));
         assert_eq!(
-            value["next_steps"][0].as_str().unwrap(),
+            value["next_steps"][1].as_str().unwrap(),
             shell_command(&foreground_argv)
         );
         assert_eq!(
             value["next_steps"]
-                .get(1)
+                .get(2)
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or(""),
             if cfg!(windows) {
@@ -2355,6 +2677,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             true,
             false,
             false,
@@ -2397,6 +2721,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             true,
             true,
             false,
@@ -2414,7 +2740,11 @@ mod tests {
         let foreground_reason = value["foreground_reason"].as_str().unwrap();
         assert!(foreground_reason.contains("login ran as root"));
         assert!(foreground_reason.contains("project commands as root"));
-        assert_eq!(value["next_steps"], serde_json::json!([]));
+        assert_eq!(value["next_steps"].as_array().unwrap().len(), 1);
+        assert!(value["next_steps"][0]
+            .as_str()
+            .unwrap()
+            .contains("webcodex project register"));
         assert!(!json_text.contains("--allow-root-runner"));
         assert!(!json_text.contains("webcodex runner install --scope user"));
         assert!(!json_text.contains(USER_TOKEN), "root json leaked a token");
@@ -2432,6 +2762,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             false,
             false,
             true,
@@ -2460,6 +2792,8 @@ mod tests {
             "https://api.example.com",
             "alice",
             "laptop",
+            None,
+            &[],
             false,
             false,
             true,

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -2274,9 +2274,47 @@ mod tests {
             print_mcp_config: false,
         };
         let error = run_login(opts).await.unwrap_err();
+        assert!(error.contains("outside allowed_roots"), "{error}");
+        let canonical = canonical_server_url(&format!("http://{address}")).unwrap();
+        let parent = resolve_connection_parent(&base, &canonical).unwrap();
+        assert_no_internal_residue(&parent);
+    }
+
+    #[tokio::test]
+    async fn login_project_rejects_unauthorized_dangerous_root_before_redemption() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let base = temp.path().join("config");
+        let allowed_root = temp.path().join("allowed");
+        std::fs::create_dir_all(&allowed_root).unwrap();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        #[cfg(windows)]
+        let dangerous_project = PathBuf::from(r"C:\");
+        #[cfg(not(windows))]
+        let dangerous_project = PathBuf::from("/etc");
+        let opts = LoginOptions {
+            server_url: format!("http://{address}"),
+            server_http: ServerHttpOptions {
+                proxy: None,
+                no_system_proxy: true,
+            },
+            code: CODE.to_string(),
+            device: "project-device".to_string(),
+            device_explicit: true,
+            base_dir: base.clone(),
+            transport: "websocket".to_string(),
+            allowed_roots: vec![allowed_root],
+            project: Some(dangerous_project),
+            overwrite: false,
+            json: false,
+            print_mcp_config: false,
+        };
+        let error = run_login(opts).await.unwrap_err();
+        assert!(error.contains("outside allowed_roots"), "{error}");
         assert!(
-            error.contains("outside the Runner allowed_roots"),
-            "{error}"
+            !error.contains("failed to send"),
+            "path policy must fail before the one-shot pairing request: {error}"
         );
         let canonical = canonical_server_url(&format!("http://{address}")).unwrap();
         let parent = resolve_connection_parent(&base, &canonical).unwrap();

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -2230,10 +2230,12 @@ mod tests {
             project.canonicalize().unwrap()
         );
         assert!(records[0].0.starts_with(&paths.projects_dir));
-        assert!(value["registered_projects"][0]["record"]
-            .as_str()
-            .unwrap()
-            .starts_with(paths.projects_dir.to_str().unwrap()));
+        let reported_record =
+            PathBuf::from(value["registered_projects"][0]["record"].as_str().unwrap());
+        assert_eq!(
+            reported_record.canonicalize().unwrap(),
+            records[0].0.canonicalize().unwrap()
+        );
         let agent_config = std::fs::read_to_string(&paths.agent_config).unwrap();
         let parsed: toml::Value = toml::from_str(&agent_config).unwrap();
         assert_eq!(

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -2321,6 +2321,47 @@ mod tests {
         assert_no_internal_residue(&parent);
     }
 
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn login_project_rejects_raw_unc_before_redemption_or_canonicalization() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let base = temp.path().join("config");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let unc = PathBuf::from(r"\\server\share\webcodex-unreachable-repo");
+        let opts = LoginOptions {
+            server_url: format!("http://{address}"),
+            server_http: ServerHttpOptions {
+                proxy: None,
+                no_system_proxy: true,
+            },
+            code: CODE.to_string(),
+            device: "project-device".to_string(),
+            device_explicit: true,
+            base_dir: base.clone(),
+            transport: "websocket".to_string(),
+            allowed_roots: vec![unc.clone()],
+            project: Some(unc),
+            overwrite: false,
+            json: false,
+            print_mcp_config: false,
+        };
+        let error = run_login(opts).await.unwrap_err();
+        assert!(error.contains("not on a local disk drive"), "{error}");
+        assert!(
+            !error.contains("does not exist or cannot be resolved"),
+            "raw UNC ingress must fail before project canonicalization: {error}"
+        );
+        assert!(
+            !error.contains("failed to send"),
+            "raw UNC ingress must fail before the one-shot pairing request: {error}"
+        );
+        let canonical = canonical_server_url(&format!("http://{address}")).unwrap();
+        let parent = resolve_connection_parent(&base, &canonical).unwrap();
+        assert_no_internal_residue(&parent);
+    }
+
     #[test]
     fn explicit_device_wins_verbatim_without_a_suffix() {
         let temp = tempfile::TempDir::new().unwrap();

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod ops;
 pub(crate) mod output;
 pub(crate) mod pairing;
 pub(crate) mod profiles;
+pub(crate) mod project;
 pub(crate) mod runner_service;
 pub(crate) mod server;
 pub(crate) mod service;
@@ -88,6 +89,9 @@ pub(crate) use profiles::{
 };
 #[cfg(test)]
 pub(crate) use profiles::{client_output_dir_for_profile, CLIENT_PROFILE_ERROR};
+pub(crate) use project::{
+    register_existing_project, run_project_register, ProjectRegisterOptions, ProjectRegistration,
+};
 #[cfg(all(test, unix))]
 pub(crate) use runner_service::render_runner_systemd_unit;
 pub(crate) use runner_service::{
@@ -109,8 +113,9 @@ pub(crate) use service::{
 };
 pub(crate) use setup::run_setup_single_user;
 pub(crate) use system::{
-    discover_internal_binary, read_optional_token, read_optional_user_api_token, system_user_home,
-    system_user_is_root, validate_user_api_token, write_secret_file, write_text_file,
+    discover_internal_binary, read_optional_token, read_optional_user_api_token,
+    system_group_exists, system_user_exists, system_user_home, system_user_is_root,
+    validate_user_api_token, write_secret_file, write_text_file,
 };
 #[cfg(test)]
 pub(crate) use token_commands::resolve_account_credential;
@@ -122,9 +127,10 @@ pub(crate) use tokens::{
 pub(crate) use usage::{
     client_enroll_usage, client_usage, connect_usage, disconnect_usage, login_usage, logout_usage,
     ops_agents_usage, ops_projects_usage, ops_runner_usage, ops_smoke_preflight_usage,
-    ops_status_usage, ops_usage, pairing_create_usage, pairing_usage, runner_init_usage,
-    runner_install_service_usage, runner_status_usage, runner_usage, server_init_usage,
-    server_install_service_usage, server_status_usage, server_usage, status_usage, usage,
+    ops_status_usage, ops_usage, pairing_create_usage, pairing_usage, project_register_usage,
+    runner_init_usage, runner_install_service_usage, runner_status_usage, runner_usage,
+    server_init_usage, server_install_service_usage, server_status_usage, server_usage,
+    status_usage, usage,
 };
 
 #[cfg(test)]

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -153,14 +153,20 @@ fn read_registration_config(path: &Path) -> Result<RegistrationAgentConfig, Stri
         .map_err(|error| format!("failed to parse agent config {}: {error}", path.display()))
 }
 
+fn registration_projects_dir(config: &RegistrationAgentConfig) -> Result<PathBuf, String> {
+    config.projects_dir.clone().map(Ok).unwrap_or_else(|| {
+        webcodex_runner_config::paths::default_client_config_base_dir()
+            .map(|base| base.join("projects.d"))
+    })
+}
+
 pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<String, String> {
     let config = read_registration_config(&opts.config)?;
-    let projects_dir = config.projects_dir.ok_or_else(|| {
-        format!(
-            "agent config {} does not define projects_dir; projects_dir is the Runner project registry directory, not the workspace root",
-            opts.config.display()
-        )
-    })?;
+    // Mirror Runner config loading exactly: a minimal agent.toml may omit
+    // projects_dir, in which case the Runner materializes the shared per-user
+    // config-base projects.d path. The local registration CLI must write to that
+    // same registry rather than rejecting a config the Runner itself accepts.
+    let projects_dir = registration_projects_dir(&config)?;
     let (registration, roots) = register_existing_project(
         &projects_dir,
         &opts.project,
@@ -182,7 +188,7 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
                 "allow_cwd_anywhere": config.policy.allow_cwd_anywhere,
                 "allowed_roots": roots.iter().map(|root| root.to_string_lossy().to_string()).collect::<Vec<_>>(),
             },
-            "runner_reload_required": true,
+            "runner_reload_required": !registration.already_registered,
         }))
         .map_err(|error| error.to_string());
     }
@@ -191,8 +197,15 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
         "--config".to_string(),
         opts.config.to_string_lossy().into_owned(),
     ]);
+    let reload_guidance = if registration.already_registered {
+        "The project registry was unchanged; no Runner reload is required.\n".to_string()
+    } else {
+        format!(
+            "Restart or reload the existing Runner that uses this config so the registry change is loaded.\nIf it is a foreground Runner, stop that existing process first, then run:\n  {runner_command}\nIf it is installed as a service, use the matching `webcodex runner restart ...` command instead; do not start a second foreground Runner with the same client_id.\n"
+        )
+    };
     Ok(format!(
-        "Project {}.\n\n  id:                {}\n  path:              {}\n  agent config:      {}\n  projects registry: {}\n  project record:    {}\n\nAllowed roots are registration authority; they are not workspace registrations.\nRestart the Runner using this config (or start it if stopped) so the registry change is loaded:\n  {}\n",
+        "Project {}.\n\n  id:                {}\n  path:              {}\n  agent config:      {}\n  projects registry: {}\n  project record:    {}\n\nAllowed roots are registration authority; they are not workspace registrations.\n{}",
         if registration.already_registered {
             "already registered"
         } else {
@@ -203,7 +216,7 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
         opts.config.display(),
         projects_dir.display(),
         registration.record_path.display(),
-        runner_command,
+        reload_guidance,
     ))
 }
 
@@ -242,6 +255,7 @@ mod tests {
         let first: serde_json::Value = serde_json::from_str(&first).unwrap();
         assert_eq!(first["project"]["id"], "demo");
         assert_eq!(first["project"]["already_registered"], false);
+        assert_eq!(first["runner_reload_required"], true);
         assert!(registry.join("demo.toml").is_file());
         assert!(!first.to_string().contains("secret-not-printed"));
 
@@ -254,6 +268,19 @@ mod tests {
         let second: serde_json::Value = serde_json::from_str(&second).unwrap();
         assert_eq!(second["project"]["id"], "demo");
         assert_eq!(second["project"]["already_registered"], true);
+        assert_eq!(second["runner_reload_required"], false);
+    }
+
+    #[test]
+    fn omitted_projects_dir_uses_the_same_default_as_runner_config_loading() {
+        let config = RegistrationAgentConfig {
+            projects_dir: None,
+            policy: RegistrationPolicy::default(),
+        };
+        let expected = webcodex_runner_config::paths::default_client_config_base_dir()
+            .unwrap()
+            .join("projects.d");
+        assert_eq!(registration_projects_dir(&config).unwrap(), expected);
     }
 
     #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -66,16 +66,11 @@ fn validate_project_authority(
     allow_cwd_anywhere: bool,
 ) -> Result<Vec<PathBuf>, String> {
     let roots = effective_canonical_roots(configured_roots, allow_cwd_anywhere)?;
-    if !allow_cwd_anywhere
-        && !roots
-            .iter()
-            .any(|root| webcodex_runner_config::paths::path_is_within(project, root))
-    {
-        return Err(format!(
-            "project {} is outside the Runner allowed_roots; --allowed-root controls registration authority and does not register a workspace",
-            project.display()
-        ));
-    }
+    webcodex_runner_config::paths::validate_project_path_policy(
+        project,
+        &roots,
+        allow_cwd_anywhere,
+    )?;
     Ok(roots)
 }
 
@@ -224,16 +219,29 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
 mod tests {
     use super::*;
 
-    fn config(path: &Path, projects_dir: &Path, root: &Path) {
+    fn config_with_policy(
+        path: &Path,
+        projects_dir: &Path,
+        roots: &[PathBuf],
+        allow_cwd_anywhere: bool,
+    ) {
+        let roots = roots
+            .iter()
+            .map(|root| format!("{:?}", root.to_string_lossy()))
+            .collect::<Vec<_>>()
+            .join(", ");
         std::fs::write(
             path,
             format!(
-                "server_url = \"https://example.test\"\ntoken = \"secret-not-printed\"\nclient_id = \"client\"\nprojects_dir = {:?}\n\n[policy]\nallowed_roots = [{:?}]\n",
+                "server_url = \"https://example.test\"\ntoken = \"secret-not-printed\"\nclient_id = \"client\"\nprojects_dir = {:?}\n\n[policy]\nallow_cwd_anywhere = {allow_cwd_anywhere}\nallowed_roots = [{roots}]\n",
                 projects_dir.to_string_lossy(),
-                root.to_string_lossy()
             ),
         )
         .unwrap();
+    }
+
+    fn config(path: &Path, projects_dir: &Path, root: &Path) {
+        config_with_policy(path, projects_dir, &[root.to_path_buf()], false);
     }
 
     #[test]
@@ -299,11 +307,75 @@ mod tests {
             json: false,
         })
         .unwrap_err();
-        assert!(
-            error.contains("outside the Runner allowed_roots"),
-            "{error}"
-        );
+        assert!(error.contains("outside allowed_roots"), "{error}");
         assert!(!registry.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cwd_anywhere_rejects_dangerous_root_without_mutating_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        let _guard = crate::webcodex_cli::test_support::env_test_guard();
+        let _env = crate::webcodex_cli::test_support::EnvGuard::new()
+            .set_os("HOME", home.as_os_str().to_os_string());
+        let registry = tmp.path().join("registry");
+        let config_path = tmp.path().join("agent.toml");
+        config_with_policy(&config_path, &registry, &[], true);
+
+        let error = run_project_register(ProjectRegisterOptions {
+            config: config_path,
+            project: PathBuf::from("/etc"),
+            json: true,
+        })
+        .unwrap_err();
+        assert!(error.contains("dangerous system root"), "{error}");
+        assert!(
+            !registry.exists(),
+            "policy failure must not mutate registry"
+        );
+    }
+
+    #[test]
+    fn cwd_anywhere_still_allows_an_ordinary_directory_outside_explicit_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let authority = tmp.path().join("authority");
+        let project = tmp.path().join("ordinary-project");
+        let registry = tmp.path().join("registry");
+        std::fs::create_dir_all(&authority).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        let config_path = tmp.path().join("agent.toml");
+        config_with_policy(&config_path, &registry, &[authority], true);
+
+        let output = run_project_register(ProjectRegisterOptions {
+            config: config_path,
+            project,
+            json: true,
+        })
+        .unwrap();
+        let output: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(output["project"]["already_registered"], false);
+        assert!(registry.join("ordinary-project.toml").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_dangerous_root_authority_allows_intentional_registration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = tmp.path().join("registry");
+        let config_path = tmp.path().join("agent.toml");
+        config_with_policy(&config_path, &registry, &[PathBuf::from("/etc")], true);
+
+        let output = run_project_register(ProjectRegisterOptions {
+            config: config_path,
+            project: PathBuf::from("/etc"),
+            json: true,
+        })
+        .unwrap();
+        let output: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(output["project"]["id"], "etc");
+        assert!(registry.join("etc.toml").is_file());
     }
 
     #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -1,0 +1,301 @@
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use super::connect::profile::{atomic_write, render_project_file, resolve_project};
+use super::shell_command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectRegisterOptions {
+    pub(crate) config: PathBuf,
+    pub(crate) project: PathBuf,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectRegistration {
+    pub(crate) id: String,
+    pub(crate) path: PathBuf,
+    pub(crate) record_path: PathBuf,
+    pub(crate) already_registered: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RegistrationPolicy {
+    #[serde(default)]
+    allow_cwd_anywhere: bool,
+    #[serde(default)]
+    allowed_roots: Vec<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistrationAgentConfig {
+    projects_dir: Option<PathBuf>,
+    #[serde(default)]
+    policy: RegistrationPolicy,
+}
+
+fn canonical_existing_directory(path: &Path, label: &str) -> Result<PathBuf, String> {
+    let canonical = path.canonicalize().map_err(|error| {
+        format!(
+            "{label} {} does not exist or cannot be resolved: {error}",
+            path.display()
+        )
+    })?;
+    if !canonical.is_dir() {
+        return Err(format!(
+            "{label} {} is not a directory",
+            canonical.display()
+        ));
+    }
+    Ok(canonical)
+}
+
+fn effective_canonical_roots(
+    configured: &[PathBuf],
+    allow_cwd_anywhere: bool,
+) -> Result<Vec<PathBuf>, String> {
+    webcodex_runner_config::effective_allowed_roots(configured, allow_cwd_anywhere)?
+        .into_iter()
+        .map(|root| canonical_existing_directory(&root, "allowed root"))
+        .collect()
+}
+
+fn validate_project_authority(
+    project: &Path,
+    configured_roots: &[PathBuf],
+    allow_cwd_anywhere: bool,
+) -> Result<Vec<PathBuf>, String> {
+    let roots = effective_canonical_roots(configured_roots, allow_cwd_anywhere)?;
+    if !allow_cwd_anywhere
+        && !roots
+            .iter()
+            .any(|root| webcodex_runner_config::paths::path_is_within(project, root))
+    {
+        return Err(format!(
+            "project {} is outside the Runner allowed_roots; --allowed-root controls registration authority and does not register a workspace",
+            project.display()
+        ));
+    }
+    Ok(roots)
+}
+
+fn ensure_registry_directory(path: &Path) -> Result<(), String> {
+    if !path.is_absolute() {
+        return Err(format!(
+            "projects_dir {} must be an absolute path; projects_dir is the Runner project registry directory, not a workspace root",
+            path.display()
+        ));
+    }
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.is_symlink() || !metadata.is_dir() {
+                return Err(format!(
+                    "projects_dir {} is not a real directory; projects_dir is the Runner project registry directory, not a workspace root",
+                    path.display()
+                ));
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(path).map_err(|error| {
+                format!("failed to create projects_dir {}: {error}", path.display())
+            })?;
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect projects_dir {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn register_existing_project(
+    projects_dir: &Path,
+    project: &Path,
+    configured_roots: &[PathBuf],
+    allow_cwd_anywhere: bool,
+    explicit_id: Option<&str>,
+) -> Result<(ProjectRegistration, Vec<PathBuf>), String> {
+    let canonical_project = canonical_existing_directory(project, "project path")?;
+    let roots =
+        validate_project_authority(&canonical_project, configured_roots, allow_cwd_anywhere)?;
+    ensure_registry_directory(projects_dir)?;
+    let (record_path, project_file, already_registered) =
+        resolve_project(projects_dir, &canonical_project, explicit_id)?;
+    if !already_registered {
+        let content = render_project_file(&project_file)?;
+        atomic_write(&record_path, content.as_bytes(), false)?;
+    }
+    Ok((
+        ProjectRegistration {
+            id: project_file.id,
+            path: canonical_project,
+            record_path,
+            already_registered,
+        },
+        roots,
+    ))
+}
+
+fn read_registration_config(path: &Path) -> Result<RegistrationAgentConfig, String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| format!("failed to inspect agent config {}: {error}", path.display()))?;
+    if metadata.is_symlink() || !metadata.is_file() {
+        return Err(format!(
+            "agent config {} is not a regular file",
+            path.display()
+        ));
+    }
+    let content = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read agent config {}: {error}", path.display()))?;
+    toml::from_str(&content)
+        .map_err(|error| format!("failed to parse agent config {}: {error}", path.display()))
+}
+
+pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<String, String> {
+    let config = read_registration_config(&opts.config)?;
+    let projects_dir = config.projects_dir.ok_or_else(|| {
+        format!(
+            "agent config {} does not define projects_dir; projects_dir is the Runner project registry directory, not the workspace root",
+            opts.config.display()
+        )
+    })?;
+    let (registration, roots) = register_existing_project(
+        &projects_dir,
+        &opts.project,
+        &config.policy.allowed_roots,
+        config.policy.allow_cwd_anywhere,
+        None,
+    )?;
+    if opts.json {
+        return serde_json::to_string_pretty(&serde_json::json!({
+            "agent_config": opts.config.to_string_lossy(),
+            "projects_dir": projects_dir.to_string_lossy(),
+            "project": {
+                "id": registration.id,
+                "path": registration.path.to_string_lossy(),
+                "record": registration.record_path.to_string_lossy(),
+                "already_registered": registration.already_registered,
+            },
+            "policy": {
+                "allow_cwd_anywhere": config.policy.allow_cwd_anywhere,
+                "allowed_roots": roots.iter().map(|root| root.to_string_lossy().to_string()).collect::<Vec<_>>(),
+            },
+            "runner_reload_required": true,
+        }))
+        .map_err(|error| error.to_string());
+    }
+    let runner_command = shell_command(&[
+        "webcodex-runner".to_string(),
+        "--config".to_string(),
+        opts.config.to_string_lossy().into_owned(),
+    ]);
+    Ok(format!(
+        "Project {}.\n\n  id:                {}\n  path:              {}\n  agent config:      {}\n  projects registry: {}\n  project record:    {}\n\nAllowed roots are registration authority; they are not workspace registrations.\nRestart the Runner using this config (or start it if stopped) so the registry change is loaded:\n  {}\n",
+        if registration.already_registered {
+            "already registered"
+        } else {
+            "registered"
+        },
+        registration.id,
+        registration.path.display(),
+        opts.config.display(),
+        projects_dir.display(),
+        registration.record_path.display(),
+        runner_command,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(path: &Path, projects_dir: &Path, root: &Path) {
+        std::fs::write(
+            path,
+            format!(
+                "server_url = \"https://example.test\"\ntoken = \"secret-not-printed\"\nclient_id = \"client\"\nprojects_dir = {:?}\n\n[policy]\nallowed_roots = [{:?}]\n",
+                projects_dir.to_string_lossy(),
+                root.to_string_lossy()
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn register_existing_directory_is_idempotent_and_respects_registry_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let project = root.join("demo");
+        let registry = tmp.path().join("registry");
+        std::fs::create_dir_all(&project).unwrap();
+        let config_path = tmp.path().join("agent.toml");
+        config(&config_path, &registry, &root);
+
+        let first = run_project_register(ProjectRegisterOptions {
+            config: config_path.clone(),
+            project: project.clone(),
+            json: true,
+        })
+        .unwrap();
+        let first: serde_json::Value = serde_json::from_str(&first).unwrap();
+        assert_eq!(first["project"]["id"], "demo");
+        assert_eq!(first["project"]["already_registered"], false);
+        assert!(registry.join("demo.toml").is_file());
+        assert!(!first.to_string().contains("secret-not-printed"));
+
+        let second = run_project_register(ProjectRegisterOptions {
+            config: config_path,
+            project,
+            json: true,
+        })
+        .unwrap();
+        let second: serde_json::Value = serde_json::from_str(&second).unwrap();
+        assert_eq!(second["project"]["id"], "demo");
+        assert_eq!(second["project"]["already_registered"], true);
+    }
+
+    #[test]
+    fn outside_allowed_roots_is_rejected_without_registry_mutation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let outside = tmp.path().join("outside");
+        let registry = tmp.path().join("registry");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let config_path = tmp.path().join("agent.toml");
+        config(&config_path, &registry, &root);
+        let error = run_project_register(ProjectRegisterOptions {
+            config: config_path,
+            project: outside,
+            json: false,
+        })
+        .unwrap_err();
+        assert!(
+            error.contains("outside the Runner allowed_roots"),
+            "{error}"
+        );
+        assert!(!registry.exists());
+    }
+
+    #[test]
+    fn different_paths_with_same_basename_get_stable_collision_suffix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let one = root.join("one/demo");
+        let two = root.join("two/demo");
+        let registry = tmp.path().join("registry");
+        std::fs::create_dir_all(&one).unwrap();
+        std::fs::create_dir_all(&two).unwrap();
+        let first = register_existing_project(&registry, &one, &[root.clone()], false, None)
+            .unwrap()
+            .0;
+        let second = register_existing_project(&registry, &two, &[root], false, None)
+            .unwrap()
+            .0;
+        assert_eq!(first.id, "demo");
+        assert!(second.id.starts_with("demo-"), "{}", second.id);
+        assert_ne!(first.id, second.id);
+    }
+}

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -112,6 +112,7 @@ pub(crate) fn register_existing_project(
     allow_cwd_anywhere: bool,
     explicit_id: Option<&str>,
 ) -> Result<(ProjectRegistration, Vec<PathBuf>), String> {
+    webcodex_runner_config::paths::validate_project_path_ingress(project)?;
     let canonical_project = canonical_existing_directory(project, "project path")?;
     let roots =
         validate_project_authority(&canonical_project, configured_roots, allow_cwd_anywhere)?;
@@ -308,6 +309,39 @@ mod tests {
         })
         .unwrap_err();
         assert!(error.contains("outside allowed_roots"), "{error}");
+        assert!(!registry.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn raw_unc_is_rejected_before_canonicalization_even_when_explicitly_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = tmp.path().join("registry");
+        let unc = PathBuf::from(r"\\server\share\webcodex-unreachable-repo");
+
+        let error =
+            register_existing_project(&registry, &unc, &[unc.clone()], true, None).unwrap_err();
+        assert!(error.contains("not on a local disk drive"), "{error}");
+        assert!(
+            !error.contains("does not exist or cannot be resolved"),
+            "raw UNC ingress must fail before canonicalization: {error}"
+        );
+        assert!(!registry.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn raw_local_disk_path_proceeds_to_project_canonicalization() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = tmp.path().join("registry");
+        let missing = PathBuf::from(r"C:\webcodex-definitely-missing-p2-regression\repo");
+
+        let error = register_existing_project(&registry, &missing, &[], true, None).unwrap_err();
+        assert!(
+            error.contains("does not exist or cannot be resolved"),
+            "local-disk ingress should proceed to canonicalization: {error}"
+        );
+        assert!(!error.contains("not on a local disk drive"), "{error}");
         assert!(!registry.exists());
     }
 

--- a/crates/webcodex-cli/src/webcodex_cli/server.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/server.rs
@@ -10,16 +10,18 @@ use crate::{
 
 use super::{
     compare_build_commits, control_server_unit_pair, encode_exec_program, encode_unit_path_value,
-    fetch_runtime_status, generate_bootstrap_token, install_server_unit_pair,
+    fetch_runtime_status, generate_bootstrap_token, install_server_unit_pair, is_effective_root,
     local_cli_build_metadata, query_systemd_service_status, query_systemd_socket_status,
     read_env_file_value, render_build_metadata_block, render_server_env, run_logs,
-    runtime_build_metadata, server_status_revision_check, service_unit_name, token_prefix,
-    uninstall_server_unit_pair, validate_systemd_identity, SERVER_SERVICE_UNIT, SERVER_SOCKET_UNIT,
+    runtime_build_metadata, server_status_revision_check, service_unit_name, shell_command,
+    system_group_exists, system_user_exists, token_prefix, uninstall_server_unit_pair,
+    validate_systemd_identity, SERVER_SERVICE_UNIT, SERVER_SOCKET_UNIT,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ServerStatusOptions {
     pub(crate) url: String,
+    pub(crate) url_explicit: bool,
     pub(crate) server_http: ServerHttpOptions,
     pub(crate) env_file: Option<PathBuf>,
     pub(crate) env_file_explicit: bool,
@@ -35,6 +37,18 @@ pub(crate) fn run_server_init(opts: ServerInitOptions) -> Result<String, String>
             opts.env_file.display()
         ));
     }
+    std::fs::create_dir_all(&opts.data_dir).map_err(|error| {
+        format!(
+            "failed to create Server data directory {}: {error}",
+            opts.data_dir.display()
+        )
+    })?;
+    if !opts.data_dir.is_dir() {
+        return Err(format!(
+            "Server data path {} is not a directory",
+            opts.data_dir.display()
+        ));
+    }
     let existing_token = if opts.env_file.exists() {
         read_env_file_value(&opts.env_file, "WEBCODEX_TOKEN")?
             .filter(|token| !token.trim().is_empty())
@@ -45,20 +59,39 @@ pub(crate) fn run_server_init(opts: ServerInitOptions) -> Result<String, String>
     let token = existing_token.unwrap_or_else(generate_bootstrap_token);
     let env_content = render_server_env(&opts, &token);
     super::system::write_server_secret_text_file(&opts.env_file, &env_content, opts.overwrite)?;
+    let foreground_command = shell_command(&[
+        "webcodex".to_string(),
+        "server".to_string(),
+        "run".to_string(),
+        "--env-file".to_string(),
+        opts.env_file.to_string_lossy().into_owned(),
+    ]);
+    let status_command = shell_command(&[
+        "webcodex".to_string(),
+        "server".to_string(),
+        "status".to_string(),
+        "--env-file".to_string(),
+        opts.env_file.to_string_lossy().into_owned(),
+    ]);
+    let install_command = (cfg!(target_os = "linux") && is_effective_root()).then(|| {
+        shell_command(&[
+            "webcodex".to_string(),
+            "server".to_string(),
+            "install".to_string(),
+            "--env-file".to_string(),
+            opts.env_file.to_string_lossy().into_owned(),
+            "--working-directory".to_string(),
+            opts.data_dir.to_string_lossy().into_owned(),
+        ])
+    });
     if opts.json {
-        let next_steps = if cfg!(windows) {
-            json!([
-                "webcodex server run --env-file <path shown in env_file>",
-                "webcodex server status",
-                "configure HTTPS/public URL separately if using GPT Actions"
-            ])
-        } else {
-            json!([
-                "webcodex server install",
-                "webcodex server status",
-                "configure HTTPS/public URL separately if using GPT Actions"
-            ])
-        };
+        let mut next_steps = Vec::new();
+        if let Some(command) = &install_command {
+            next_steps.push(command.clone());
+        }
+        next_steps.push(foreground_command.clone());
+        next_steps.push(status_command.clone());
+        next_steps.push("configure HTTPS/public URL separately if using GPT Actions".to_string());
         let summary = json!({
             "env_file": opts.env_file.to_string_lossy(),
             "listen": opts.listen,
@@ -85,15 +118,20 @@ pub(crate) fn run_server_init(opts: ServerInitOptions) -> Result<String, String>
     ));
     out.push_str("  shared key:   enabled\n");
     out.push_str("\nNext steps:\n");
-    if cfg!(windows) {
-        out.push_str(
-            "  - Run in foreground: `webcodex server run --env-file <path shown above>`\n",
-        );
+    if let Some(command) = install_command {
+        out.push_str(&format!("  - Install and start: `{command}`\n"));
+        out.push_str(&format!(
+            "  - Or run in foreground: `{foreground_command}`\n"
+        ));
     } else {
-        out.push_str("  - Install and start: `webcodex server install`\n");
-        out.push_str("  - Or run in foreground: `webcodex server run`\n");
+        out.push_str(&format!("  - Run in foreground: `{foreground_command}`\n"));
+        if cfg!(target_os = "linux") {
+            out.push_str("  - System service installation is root-only; non-root onboarding uses the foreground Server flow.\n");
+        } else {
+            out.push_str("  - Managed systemd Server installation is Linux-only.\n");
+        }
     }
-    out.push_str("  - Check it: `webcodex server status`\n");
+    out.push_str(&format!("  - Check it: `{status_command}`\n"));
     out.push_str("\nNo full token was printed. No user or Agent tokens were created.\n");
     Ok(out)
 }
@@ -130,10 +168,83 @@ fn configured_socket_addr(env_file: &Path) -> Result<String, String> {
     Ok(addr.to_string())
 }
 
+fn preflight_server_install(opts: &ServerInstallServiceOptions) -> Result<(), String> {
+    let binary = std::fs::metadata(&opts.bin).map_err(|_| {
+        format!(
+            "cannot install WebCodex Server: binary {} does not exist",
+            opts.bin.display()
+        )
+    })?;
+    if !binary.is_file() {
+        return Err(format!(
+            "cannot install WebCodex Server: binary {} is not a regular file",
+            opts.bin.display()
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if binary.permissions().mode() & 0o111 == 0 {
+            return Err(format!(
+                "cannot install WebCodex Server: binary {} is not executable",
+                opts.bin.display()
+            ));
+        }
+    }
+    let working = std::fs::metadata(&opts.working_directory).map_err(|_| {
+        format!(
+            "cannot install WebCodex Server: WorkingDirectory {} does not exist\n\nCreate it or pass --working-directory <existing-directory>.",
+            opts.working_directory.display()
+        )
+    })?;
+    if !working.is_dir() {
+        return Err(format!(
+            "cannot install WebCodex Server: WorkingDirectory {} is not a directory",
+            opts.working_directory.display()
+        ));
+    }
+    let env = std::fs::metadata(&opts.env_file).map_err(|_| {
+        format!(
+            "cannot install WebCodex Server: env file {} does not exist",
+            opts.env_file.display()
+        )
+    })?;
+    if !env.is_file() {
+        return Err(format!(
+            "cannot install WebCodex Server: env file {} is not a regular file",
+            opts.env_file.display()
+        ));
+    }
+    std::fs::File::open(&opts.env_file).map_err(|error| {
+        format!(
+            "cannot install WebCodex Server: env file {} is not readable: {error}",
+            opts.env_file.display()
+        )
+    })?;
+    if let Some(user) = &opts.user {
+        if !system_user_exists(user) {
+            return Err(format!(
+                "cannot install WebCodex Server: User={user} does not name a local account"
+            ));
+        }
+    }
+    if let Some(group) = &opts.group {
+        if !system_group_exists(group) {
+            return Err(format!(
+                "cannot install WebCodex Server: Group={group} does not name a local group"
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn run_server_install_service(
     opts: ServerInstallServiceOptions,
 ) -> Result<String, String> {
     let service_unit = service_unit_name(&opts.service_file, SERVER_SERVICE_UNIT);
+    if !opts.output_stdout && !opts.dry_run {
+        preflight_server_install(&opts)?;
+    }
     let socket_file = server_socket_file(&opts.service_file)?;
     let socket_unit = service_unit_name(&socket_file, SERVER_SOCKET_UNIT);
     let rendered_service = render_systemd_unit(&opts, &socket_unit)?;
@@ -146,6 +257,7 @@ pub(crate) fn run_server_install_service(
                 "socket_file": socket_file.to_string_lossy(),
                 "env_file": opts.env_file.to_string_lossy(),
                 "bin": opts.bin.to_string_lossy(),
+                "working_directory": opts.working_directory.to_string_lossy(),
                 "service_unit": service_unit,
                 "socket_unit": socket_unit,
                 "listen": listen,
@@ -184,6 +296,7 @@ pub(crate) fn run_server_install_service(
             "env_file": opts.env_file.to_string_lossy(),
             "bin": opts.bin.to_string_lossy(),
             "service_unit": service_unit,
+            "working_directory": opts.working_directory.to_string_lossy(),
             "socket_unit": socket_unit,
             "listen": listen,
             "enabled": true,
@@ -192,13 +305,15 @@ pub(crate) fn run_server_install_service(
         .map_err(|e| e.to_string());
     }
     Ok(format!(
-        "Server socket/service pair installed.\n\n  service file: {}\n  socket file:  {}\n  service unit: {}\n  socket unit:  {}\n  listen:       {}\n  binary:       {}\n  enabled:      yes\n  started:      {}\n",
+        "Server socket/service pair installed.\n\n  service file:      {}\n  socket file:       {}\n  service unit:      {}\n  socket unit:       {}\n  binary:            {}\n  env file:          {}\n  working directory: {}\n  listen:            {}\n  enabled:           yes\n  started:           {}\n",
         opts.service_file.display(),
         socket_file.display(),
         service_unit,
         socket_unit,
-        listen,
         opts.bin.display(),
+        opts.env_file.display(),
+        opts.working_directory.display(),
+        listen,
         if result.started { "yes" } else { "no (--no-start)" }
     ))
 }
@@ -334,14 +449,54 @@ fn resolve_status_token(opts: &ServerStatusOptions) -> Result<Option<String>, St
     Ok(None)
 }
 
+pub(crate) fn derive_server_status_url(opts: &ServerStatusOptions) -> Result<String, String> {
+    if opts.url_explicit {
+        return Ok(opts.url.clone());
+    }
+    let Some(env_file) = &opts.env_file else {
+        return Ok(opts.url.clone());
+    };
+    if !env_file.exists() {
+        if opts.env_file_explicit {
+            return Err(format!("env file {} does not exist", env_file.display()));
+        }
+        return Ok(opts.url.clone());
+    }
+    let Some(value) = read_env_file_value(env_file, "WEBCODEX_ADDR")? else {
+        return Ok(opts.url.clone());
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(format!(
+            "{} defines an empty WEBCODEX_ADDR",
+            env_file.display()
+        ));
+    }
+    let mut addr = value.parse::<SocketAddr>().map_err(|error| {
+        format!(
+            "WEBCODEX_ADDR {value:?} from {} is not a fixed IP socket address: {error}",
+            env_file.display()
+        )
+    })?;
+    if addr.ip().is_unspecified() {
+        addr.set_ip(if addr.is_ipv4() {
+            std::net::Ipv4Addr::LOCALHOST.into()
+        } else {
+            std::net::Ipv6Addr::LOCALHOST.into()
+        });
+    }
+    Ok(format!("http://{addr}"))
+}
+
 pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<String, String> {
+    let probe_url = derive_server_status_url(&opts)?;
     let service_unit = service_unit_name(&opts.service_file, SERVER_SERVICE_UNIT);
     let socket_file = server_socket_file(&opts.service_file)?;
     let socket_unit = service_unit_name(&socket_file, SERVER_SOCKET_UNIT);
     let systemd = query_systemd_service_status(&service_unit);
     let socket = query_systemd_socket_status(&socket_unit);
     let token = resolve_status_token(&opts)?;
-    let http = fetch_runtime_status(&opts.url, &opts.server_http, token.as_deref()).await?;
+    let http = fetch_runtime_status(&probe_url, &opts.server_http, token.as_deref()).await?;
     let output = http.output.as_ref();
     let auth_enabled = output.and_then(|v| v.get("auth_enabled")).cloned();
     let configured_public_url = output
@@ -363,6 +518,7 @@ pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<Strin
     if opts.json {
         let summary = json!({
             "http_reachable": http.reachable,
+            "probe_url": probe_url,
             "http_status_code": http.status_code,
             "http_content_type": http.content_type,
             "http_error": http.error,
@@ -404,6 +560,7 @@ pub(crate) async fn run_server_status(opts: ServerStatusOptions) -> Result<Strin
     }
     let mut out = String::new();
     out.push_str("Server status:\n\n");
+    out.push_str(&format!("  HTTP probe:            {}\n", probe_url));
     out.push_str(&format!(
         "  HTTP reachable:        {}\n",
         if http.reachable { "yes" } else { "no" }

--- a/crates/webcodex-cli/src/webcodex_cli/system.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/system.rs
@@ -470,9 +470,103 @@ pub(crate) fn system_user_is_root(user: &str) -> bool {
     status == 0 && !result.is_null() && unsafe { record.assume_init().pw_uid == 0 }
 }
 
+#[cfg(unix)]
+pub(crate) fn system_user_exists(user: &str) -> bool {
+    use std::ffi::CString;
+
+    let initial_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    let size = if initial_size > 0 {
+        usize::try_from(initial_size)
+            .unwrap_or(16 * 1024)
+            .clamp(1024, 1024 * 1024)
+    } else {
+        16 * 1024
+    };
+    let mut buffer = vec![0_u8; size];
+    let mut record = std::mem::MaybeUninit::<libc::passwd>::uninit();
+    let mut result = std::ptr::null_mut();
+    if let Ok(uid) = user.parse::<libc::uid_t>() {
+        return unsafe {
+            libc::getpwuid_r(
+                uid,
+                record.as_mut_ptr(),
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+                &mut result,
+            ) == 0
+                && !result.is_null()
+        };
+    }
+    let Ok(user) = CString::new(user) else {
+        return false;
+    };
+    unsafe {
+        libc::getpwnam_r(
+            user.as_ptr(),
+            record.as_mut_ptr(),
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        ) == 0
+            && !result.is_null()
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn system_group_exists(group: &str) -> bool {
+    use std::ffi::CString;
+
+    let initial_size = unsafe { libc::sysconf(libc::_SC_GETGR_R_SIZE_MAX) };
+    let size = if initial_size > 0 {
+        usize::try_from(initial_size)
+            .unwrap_or(16 * 1024)
+            .clamp(1024, 1024 * 1024)
+    } else {
+        16 * 1024
+    };
+    let mut buffer = vec![0_u8; size];
+    let mut record = std::mem::MaybeUninit::<libc::group>::uninit();
+    let mut result = std::ptr::null_mut();
+    if let Ok(gid) = group.parse::<libc::gid_t>() {
+        return unsafe {
+            libc::getgrgid_r(
+                gid,
+                record.as_mut_ptr(),
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+                &mut result,
+            ) == 0
+                && !result.is_null()
+        };
+    }
+    let Ok(group) = CString::new(group) else {
+        return false;
+    };
+    unsafe {
+        libc::getgrnam_r(
+            group.as_ptr(),
+            record.as_mut_ptr(),
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        ) == 0
+            && !result.is_null()
+    }
+}
+
 #[cfg(not(unix))]
 pub(crate) fn system_user_home(_user: &str) -> Option<PathBuf> {
     None
+}
+
+#[cfg(not(unix))]
+pub(crate) fn system_user_exists(_user: &str) -> bool {
+    true
+}
+
+#[cfg(not(unix))]
+pub(crate) fn system_group_exists(_group: &str) -> bool {
+    true
 }
 
 #[cfg(not(unix))]

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/init.rs
@@ -248,6 +248,29 @@ fn server_init_writes_env_file_and_0600_permissions() {
     ]))
     .unwrap();
     let output = run_server_init(opts).unwrap();
+    assert!(data_dir.is_dir(), "server init must create WEBCODEX_DATA");
+    let foreground = crate::webcodex_cli::shell_command(&[
+        "webcodex".to_string(),
+        "server".to_string(),
+        "run".to_string(),
+        "--env-file".to_string(),
+        env_file.to_string_lossy().into_owned(),
+    ]);
+    assert!(output.contains(&foreground), "{output}");
+    if cfg!(target_os = "linux") && is_effective_root() {
+        let install = crate::webcodex_cli::shell_command(&[
+            "webcodex".to_string(),
+            "server".to_string(),
+            "install".to_string(),
+            "--env-file".to_string(),
+            env_file.to_string_lossy().into_owned(),
+            "--working-directory".to_string(),
+            data_dir.to_string_lossy().into_owned(),
+        ]);
+        assert!(output.contains(&install), "{output}");
+    } else {
+        assert!(!output.contains("webcodex server install"), "{output}");
+    }
     let content = std::fs::read_to_string(&env_file).unwrap();
     assert!(content.contains("WEBCODEX_ADDR=127.0.0.1:9090\n"));
     assert!(content.contains(&format!("WEBCODEX_DATA={}\n", data_dir.display())));

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -116,21 +116,200 @@ fn explicitly_allowed_root_runner_is_visibly_marked() {
 #[cfg(unix)]
 #[test]
 fn install_service_refuses_overwrite_unless_requested() {
+    // Preflight is intentionally satisfied here so this remains an overwrite test.
+    use std::os::unix::fs::PermissionsExt;
+
     let tmp = tempfile::tempdir().unwrap();
     let service_file = tmp.path().join("webcodex.service");
     let env_file = server_env(&tmp);
+    let binary = tmp.path().join("webcodex-server");
+    std::fs::write(&binary, "test binary").unwrap();
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
     std::fs::write(&service_file, "old").unwrap();
     let opts = parse_server_install_service(&args(&[
         "--bin",
-        "/usr/local/bin/webcodex-server",
+        binary.to_str().unwrap(),
         "--env-file",
         env_file.to_str().unwrap(),
+        "--working-directory",
+        tmp.path().to_str().unwrap(),
         "--service-file",
         service_file.to_str().unwrap(),
     ]))
     .unwrap();
     let err = run_server_install_service(opts).unwrap_err();
     assert!(err.contains("already exists"));
+}
+
+#[cfg(unix)]
+#[test]
+fn server_install_working_directory_follows_env_data_unless_explicit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("server.env");
+    let data_dir = tmp.path().join("custom-data");
+    std::fs::write(
+        &env_file,
+        format!(
+            "WEBCODEX_ADDR=127.0.0.1:9090\nWEBCODEX_DATA={}\n",
+            data_dir.display()
+        ),
+    )
+    .unwrap();
+    let from_env = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--bin",
+        "/usr/local/bin/webcodex-server",
+        "--dry-run",
+    ]))
+    .unwrap();
+    assert_eq!(from_env.working_directory, data_dir);
+
+    let explicit = tmp.path().join("explicit-data");
+    let overridden = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--bin",
+        "/usr/local/bin/webcodex-server",
+        "--working-directory",
+        explicit.to_str().unwrap(),
+        "--dry-run",
+    ]))
+    .unwrap();
+    assert_eq!(overridden.working_directory, explicit);
+}
+
+#[cfg(unix)]
+#[test]
+fn server_install_preflight_rejects_missing_workdir_before_service_mutation() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("server.env");
+    let missing_workdir = tmp.path().join("missing-data");
+    std::fs::write(
+        &env_file,
+        format!(
+            "WEBCODEX_ADDR=127.0.0.1:9090\nWEBCODEX_DATA={}\n",
+            missing_workdir.display()
+        ),
+    )
+    .unwrap();
+    let binary = tmp.path().join("webcodex-server");
+    std::fs::write(&binary, "test binary").unwrap();
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let service_file = tmp.path().join("webcodex.service");
+    let opts = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--bin",
+        binary.to_str().unwrap(),
+        "--service-file",
+        service_file.to_str().unwrap(),
+    ]))
+    .unwrap();
+    let error = run_server_install_service(opts).unwrap_err();
+    assert!(error.contains("WorkingDirectory"), "{error}");
+    assert!(error.contains("does not exist"), "{error}");
+    assert!(
+        !service_file.exists(),
+        "preflight must precede unit mutation"
+    );
+    assert!(!service_file.with_extension("socket").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn server_install_preflight_rejects_missing_and_non_executable_binary() {
+    // Binary checks are local and must fail before systemd is contacted.
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = server_env(&tmp);
+    let service_file = tmp.path().join("webcodex.service");
+    let missing = tmp.path().join("missing-server");
+    let missing_opts = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--bin",
+        missing.to_str().unwrap(),
+        "--working-directory",
+        tmp.path().to_str().unwrap(),
+        "--service-file",
+        service_file.to_str().unwrap(),
+    ]))
+    .unwrap();
+    let error = run_server_install_service(missing_opts).unwrap_err();
+    assert!(error.contains("binary"), "{error}");
+    assert!(error.contains("does not exist"), "{error}");
+    assert!(!service_file.exists());
+
+    let binary = tmp.path().join("not-executable-server");
+    std::fs::write(&binary, "test binary").unwrap();
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let non_exec_opts = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--bin",
+        binary.to_str().unwrap(),
+        "--working-directory",
+        tmp.path().to_str().unwrap(),
+        "--service-file",
+        service_file.to_str().unwrap(),
+    ]))
+    .unwrap();
+    let error = run_server_install_service(non_exec_opts).unwrap_err();
+    assert!(error.contains("not executable"), "{error}");
+    assert!(!service_file.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn server_install_preflight_rejects_unknown_user_and_group() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = server_env(&tmp);
+    let binary = tmp.path().join("webcodex-server");
+    std::fs::write(&binary, "test binary").unwrap();
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let service_file = tmp.path().join("webcodex.service");
+
+    let unknown_user = "webcodex-o1-user-that-must-not-exist";
+    let user_opts = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--bin",
+        binary.to_str().unwrap(),
+        "--working-directory",
+        tmp.path().to_str().unwrap(),
+        "--service-file",
+        service_file.to_str().unwrap(),
+        "--user",
+        unknown_user,
+    ]))
+    .unwrap();
+    let error = run_server_install_service(user_opts).unwrap_err();
+    assert!(error.contains(&format!("User={unknown_user}")), "{error}");
+    assert!(!service_file.exists());
+
+    let unknown_group = "webcodex-o1-group-that-must-not-exist";
+    let group_opts = parse_server_install_service(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--bin",
+        binary.to_str().unwrap(),
+        "--working-directory",
+        tmp.path().to_str().unwrap(),
+        "--service-file",
+        service_file.to_str().unwrap(),
+        "--group",
+        unknown_group,
+    ]))
+    .unwrap();
+    let error = run_server_install_service(group_opts).unwrap_err();
+    assert!(error.contains(&format!("Group={unknown_group}")), "{error}");
+    assert!(!service_file.exists());
 }
 
 /// Unix-only: systemd service unit semantics with Unix absolute-path

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/status.rs
@@ -106,6 +106,53 @@ fn server_status_accepts_custom_service_file() {
     );
 }
 
+#[test]
+fn server_status_url_defaults_from_env_and_maps_wildcards_to_loopback() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("webcodex.env");
+    for (listen, expected) in [
+        ("127.0.0.1:9090", "http://127.0.0.1:9090"),
+        ("0.0.0.0:9091", "http://127.0.0.1:9091"),
+        ("[::1]:9092", "http://[::1]:9092"),
+        ("[::]:9093", "http://[::1]:9093"),
+    ] {
+        std::fs::write(
+            &env_file,
+            format!("WEBCODEX_ADDR={listen}\nWEBCODEX_TOKEN=hidden\n"),
+        )
+        .unwrap();
+        let opts = parse_server_status(&args(&["--env-file", env_file.to_str().unwrap()])).unwrap();
+        assert!(!opts.url_explicit);
+        assert_eq!(
+            crate::webcodex_cli::server::derive_server_status_url(&opts).unwrap(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn server_status_explicit_url_wins_over_env_address() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("webcodex.env");
+    std::fs::write(
+        &env_file,
+        "WEBCODEX_ADDR=not-a-socket\nWEBCODEX_TOKEN=hidden\n",
+    )
+    .unwrap();
+    let opts = parse_server_status(&args(&[
+        "--env-file",
+        env_file.to_str().unwrap(),
+        "--url",
+        "http://127.0.0.1:9191",
+    ]))
+    .unwrap();
+    assert!(opts.url_explicit);
+    assert_eq!(
+        crate::webcodex_cli::server::derive_server_status_url(&opts).unwrap(),
+        "http://127.0.0.1:9191"
+    );
+}
+
 #[tokio::test]
 async fn server_status_parses_env_token_posts_and_does_not_print_token() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/usage.rs
@@ -79,6 +79,13 @@ fn cli_version_output_includes_build_metadata() {
 #[test]
 fn project_doctor_and_hosted_connect_dispatch() {
     assert!(matches!(
+        cli_action(["project", "register", "--config", "/tmp/agent.toml", "/tmp/repo"]),
+        CliAction::ProjectRegister(opts)
+            if opts.config == std::path::PathBuf::from("/tmp/agent.toml")
+                && opts.project == std::path::PathBuf::from("/tmp/repo")
+                && !opts.json
+    ));
+    assert!(matches!(
         cli_action(["doctor"]),
         CliAction::Project(args) if args == ["doctor"]
     ));
@@ -121,6 +128,32 @@ fn webcodex_cli_help_mentions_management_commands() {
         }
         other => panic!("expected help exit, got {other:?}"),
     }
+}
+
+#[test]
+fn project_register_and_login_project_help_explain_registry_vs_authority() {
+    let project_help = cli_exit(["project", "register", "--help"]).unwrap();
+    assert!(project_help.contains("projects_dir is the Runner project registry directory"));
+    assert!(project_help.contains("allowed_roots is the filesystem authority boundary"));
+    let login_help = cli_exit(["login", "--help"]).unwrap();
+    assert!(login_help.contains("--project PATH"));
+    assert!(login_help.contains("does not register a workspace"));
+
+    assert!(matches!(
+        cli_action([
+            "login",
+            "https://example.test",
+            "--code",
+            "wc_pair_example",
+            "--allowed-root",
+            "/tmp",
+            "--project",
+            "/tmp/repo",
+        ]),
+        CliAction::Login(opts)
+            if opts.allowed_roots == vec![std::path::PathBuf::from("/tmp")]
+                && opts.project == Some(std::path::PathBuf::from("/tmp/repo"))
+    ));
 }
 
 #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -11,6 +11,7 @@ Project (local/manual):\n\
   setup                         Configure the current Git project without starting it\n\
   run                           Run the project-bound Server and Runner locally\n\
   disconnect                    Disconnect a local project from its hosted Server\n\
+  project register              Register an existing workspace in a Runner projects registry\n\
   task                          Review tasks and make host-local decisions\n\n\
 Account / identity (advanced):\n\
   login                         Log this device into a server (one-time pairing code)\n\
@@ -83,6 +84,17 @@ unregistered through the Server first; an offline hosted Runner is updated local
 Options:\n\
   --project PATH             Local project directory [default: .]\n\
   --profile NAME             Select an exact hosted profile when more than one matches\n\
+  -h, --help                 Print help and exit\n"
+}
+
+pub(crate) fn project_register_usage() -> &'static str {
+    "Usage: webcodex project register --config PATH <PROJECT> [OPTIONS]\n\n\
+Register one existing workspace in the projects_dir referenced by a Runner agent.toml.\n\
+projects_dir is the Runner project registry directory, not the workspace root.\n\
+allowed_roots is the filesystem authority boundary for registration; it does not register a workspace.\n\n\
+Options:\n\
+  --config PATH              Runner agent.toml containing projects_dir and policy\n\
+  --json                     Print machine-readable output\n\
   -h, --help                 Print help and exit\n"
 }
 
@@ -423,7 +435,8 @@ pub(crate) fn login_usage() -> &'static str {
      \x20\x20--proxy http://HOST:PORT Explicit proxy override for this CLI request\n\
      \x20\x20--no-system-proxy   Ignore proxy environment and connect directly\n\
      \x20\x20--device NAME        Name for this device [default: hostname + local suffix]\n\
-     \x20\x20--allowed-root PATH  Repeatable project root the agent may touch\n\
+     \x20\x20--allowed-root PATH  Repeatable registration authority root; does not register a workspace\n\
+     \x20\x20--project PATH       Existing workspace to register with this login\n\
      \x20\x20--transport NAME     websocket|polling|quic|auto [default: websocket]\n\
      \x20\x20--dir PATH           Where connections are stored [default: root /etc/webcodex;\n\
      \x20\x20                       non-root ~/.config/webcodex]\n\

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -89,11 +89,12 @@ Options:\n\
 
 pub(crate) fn project_register_usage() -> &'static str {
     "Usage: webcodex project register --config PATH <PROJECT> [OPTIONS]\n\n\
-Register one existing workspace in the projects_dir referenced by a Runner agent.toml.\n\
-projects_dir is the Runner project registry directory, not the workspace root.\n\
+Register one existing workspace in the projects_dir used by a Runner agent.toml.\n\
+projects_dir is the Runner project registry directory, not the workspace root; when omitted,\n\
+the same per-user default as Runner config loading is used.\n\
 allowed_roots is the filesystem authority boundary for registration; it does not register a workspace.\n\n\
 Options:\n\
-  --config PATH              Runner agent.toml containing projects_dir and policy\n\
+  --config PATH              Runner agent.toml whose registry and policy should be used\n\
   --json                     Print machine-readable output\n\
   -h, --help                 Print help and exit\n"
 }

--- a/crates/webcodex-runner-config/src/paths.rs
+++ b/crates/webcodex-runner-config/src/paths.rs
@@ -241,6 +241,26 @@ pub fn is_windows_local_disk_path(path: &Path) -> bool {
     }
 }
 
+/// Validate the raw project path before any canonicalization or filesystem I/O.
+///
+/// On Windows only local disk paths (`Disk` / `VerbatimDisk`) may proceed.
+/// UNC, verbatim UNC, device namespace, and other non-local prefixes fail
+/// closed. Non-Windows platforms have no corresponding raw-prefix fence.
+pub fn validate_project_path_ingress(path: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    if !is_windows_local_disk_path(path) {
+        return Err(format!(
+            "path {} is not on a local disk drive; UNC and other Windows network/device paths are not supported for projects",
+            path.to_string_lossy()
+        ));
+    }
+
+    #[cfg(not(windows))]
+    let _ = path;
+
+    Ok(())
+}
+
 /// System directories that must never become project roots through the broad
 /// `allow_cwd_anywhere` relaxation. An explicit allowed root still authorizes
 /// these paths intentionally. Windows non-local-disk paths are rejected before
@@ -298,14 +318,7 @@ pub fn validate_project_path_policy(
     allow_cwd_anywhere: bool,
 ) -> Result<(), String> {
     let path_str = canonical_path.to_string_lossy();
-
-    #[cfg(windows)]
-    if !is_windows_local_disk_path(canonical_path) {
-        return Err(format!(
-            "path {} is not on a local disk drive; UNC and other Windows network/device paths are not supported for projects",
-            path_str
-        ));
-    }
+    validate_project_path_ingress(canonical_path)?;
 
     if canonical_allowed_roots
         .iter()
@@ -677,6 +690,8 @@ mod tests {
                 is_windows_local_disk_path(Path::new(accepted)),
                 "{accepted} must be accepted as a local disk path"
             );
+            validate_project_path_ingress(Path::new(accepted))
+                .expect("local-disk ingress must proceed without filesystem access");
         }
         // Everything else is fail-closed, whatever it starts with.
         for rejected in [
@@ -692,6 +707,8 @@ mod tests {
                 !is_windows_local_disk_path(Path::new(rejected)),
                 "{rejected} must be rejected as a non-local-disk path"
             );
+            let error = validate_project_path_ingress(Path::new(rejected)).unwrap_err();
+            assert!(error.contains("not on a local disk drive"), "{error}");
         }
     }
 

--- a/crates/webcodex-runner-config/src/paths.rs
+++ b/crates/webcodex-runner-config/src/paths.rs
@@ -241,6 +241,111 @@ pub fn is_windows_local_disk_path(path: &Path) -> bool {
     }
 }
 
+/// System directories that must never become project roots through the broad
+/// `allow_cwd_anywhere` relaxation. An explicit allowed root still authorizes
+/// these paths intentionally. Windows non-local-disk paths are rejected before
+/// this list is considered, so a UNC allowed root cannot bypass that boundary.
+const DANGEROUS_PROJECT_ROOTS: &[&str] = &[
+    "/",
+    "/etc",
+    "/bin",
+    "/sbin",
+    "/usr",
+    "/var",
+    #[cfg(target_os = "macos")]
+    "/private/etc",
+    #[cfg(target_os = "macos")]
+    "/private/var",
+    "/proc",
+    "/sys",
+    "/dev",
+    "/run",
+    "/boot",
+    #[cfg(windows)]
+    "C:\\Windows",
+    #[cfg(windows)]
+    "C:\\Program Files",
+    #[cfg(windows)]
+    "C:\\Program Files (x86)",
+];
+
+#[cfg(windows)]
+fn is_windows_drive_root(canonical_path: &Path) -> bool {
+    let mut components = canonical_path.components();
+    matches!(
+        (components.next(), components.next()),
+        (
+            Some(std::path::Component::Prefix(_)),
+            Some(std::path::Component::RootDir)
+        ) if components.next().is_none()
+    )
+}
+
+#[cfg(not(windows))]
+fn is_windows_drive_root(_canonical_path: &Path) -> bool {
+    false
+}
+
+/// Authoritative pure path-policy check for Runner project registration.
+///
+/// `canonical_path` and `canonical_allowed_roots` must already be canonicalized
+/// by the caller. Windows non-local-disk paths always fail. Explicit local roots
+/// authorize first; otherwise `allow_cwd_anywhere` relaxes only ordinary paths,
+/// never dangerous system roots or Windows drive roots.
+pub fn validate_project_path_policy(
+    canonical_path: &Path,
+    canonical_allowed_roots: &[PathBuf],
+    allow_cwd_anywhere: bool,
+) -> Result<(), String> {
+    let path_str = canonical_path.to_string_lossy();
+
+    #[cfg(windows)]
+    if !is_windows_local_disk_path(canonical_path) {
+        return Err(format!(
+            "path {} is not on a local disk drive; UNC and other Windows network/device paths are not supported for projects",
+            path_str
+        ));
+    }
+
+    if canonical_allowed_roots
+        .iter()
+        .any(|root| path_is_within(canonical_path, root))
+    {
+        return Ok(());
+    }
+
+    if !allow_cwd_anywhere {
+        return Err(format!(
+            "path {} is outside allowed_roots and allow_cwd_anywhere is false",
+            path_str
+        ));
+    }
+
+    for dangerous in DANGEROUS_PROJECT_ROOTS {
+        let dangerous_root = Path::new(dangerous);
+        let is_dangerous = if dangerous_root == Path::new("/") {
+            paths_equal(canonical_path, dangerous_root)
+        } else {
+            path_is_within(canonical_path, dangerous_root)
+        };
+        if is_dangerous {
+            return Err(format!(
+                "path {} is under a dangerous system root; register it under an explicit allowed_roots entry if intended",
+                path_str
+            ));
+        }
+    }
+
+    if is_windows_drive_root(canonical_path) {
+        return Err(format!(
+            "path {} is a Windows drive root; register it under an explicit allowed_roots entry if intended",
+            path_str
+        ));
+    }
+
+    Ok(())
+}
+
 /// Stable filesystem-independent identity string for a path, used for project
 /// id hashing and registry comparisons.
 ///
@@ -588,6 +693,38 @@ mod tests {
                 "{rejected} must be rejected as a non-local-disk path"
             );
         }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn project_path_policy_keeps_dangerous_roots_fail_closed_under_cwd_anywhere() {
+        let error = validate_project_path_policy(Path::new("/etc"), &[], true).unwrap_err();
+        assert!(error.contains("dangerous system root"), "{error}");
+
+        validate_project_path_policy(Path::new("/tmp/webcodex-project"), &[], true)
+            .expect("ordinary paths remain allowed by allow_cwd_anywhere");
+
+        validate_project_path_policy(Path::new("/etc"), &[PathBuf::from("/etc")], true)
+            .expect("an explicit allowed root must intentionally authorize /etc");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn project_path_policy_preserves_windows_local_disk_and_drive_root_fences() {
+        let unc = Path::new(r"\\server\share\repo");
+        let error =
+            validate_project_path_policy(unc, &[PathBuf::from(r"\\server\share\repo")], true)
+                .unwrap_err();
+        assert!(error.contains("not on a local disk drive"), "{error}");
+
+        let drive_root = Path::new(r"C:\");
+        let error = validate_project_path_policy(drive_root, &[], true).unwrap_err();
+        assert!(error.contains("Windows drive root"), "{error}");
+        validate_project_path_policy(drive_root, &[PathBuf::from(r"C:\")], true)
+            .expect("an explicit local-disk root must authorize the drive root");
+
+        validate_project_path_policy(Path::new(r"C:\Users\alice\repo"), &[], true)
+            .expect("ordinary local-disk paths remain allowed by allow_cwd_anywhere");
     }
 
     #[test]

--- a/crates/webcodex-runner-config/src/paths.rs
+++ b/crates/webcodex-runner-config/src/paths.rs
@@ -241,18 +241,30 @@ pub fn is_windows_local_disk_path(path: &Path) -> bool {
     }
 }
 
+#[cfg(windows)]
+fn windows_non_local_project_path_error(path: &Path) -> String {
+    format!(
+        "path {} is not on a local disk drive; UNC and other Windows network/device paths are not supported for projects",
+        path.to_string_lossy()
+    )
+}
+
 /// Validate the raw project path before any canonicalization or filesystem I/O.
 ///
-/// On Windows only local disk paths (`Disk` / `VerbatimDisk`) may proceed.
-/// UNC, verbatim UNC, device namespace, and other non-local prefixes fail
-/// closed. Non-Windows platforms have no corresponding raw-prefix fence.
+/// On Windows an explicit local-disk prefix (`Disk` / `VerbatimDisk`) may
+/// proceed, while explicit UNC, verbatim UNC, device namespace, and other
+/// unsupported prefixes fail closed. Paths with no prefix (including relative
+/// paths) proceed to canonicalization, where the canonical path policy requires
+/// a local disk. Non-Windows platforms have no corresponding raw-prefix fence.
 pub fn validate_project_path_ingress(path: &Path) -> Result<(), String> {
     #[cfg(windows)]
-    if !is_windows_local_disk_path(path) {
-        return Err(format!(
-            "path {} is not on a local disk drive; UNC and other Windows network/device paths are not supported for projects",
-            path.to_string_lossy()
-        ));
+    if let Some(std::path::Component::Prefix(prefix)) = path.components().next() {
+        if !matches!(
+            prefix.kind(),
+            std::path::Prefix::Disk(_) | std::path::Prefix::VerbatimDisk(_)
+        ) {
+            return Err(windows_non_local_project_path_error(path));
+        }
     }
 
     #[cfg(not(windows))]
@@ -318,7 +330,11 @@ pub fn validate_project_path_policy(
     allow_cwd_anywhere: bool,
 ) -> Result<(), String> {
     let path_str = canonical_path.to_string_lossy();
-    validate_project_path_ingress(canonical_path)?;
+
+    #[cfg(windows)]
+    if !is_windows_local_disk_path(canonical_path) {
+        return Err(windows_non_local_project_path_error(canonical_path));
+    }
 
     if canonical_allowed_roots
         .iter()
@@ -678,8 +694,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_local_disk_prefix_classification_is_grammar_based() {
-        // Local disk paths, plain and canonicalized.
+    fn windows_local_disk_prefix_classification_is_strict_for_canonical_paths() {
         for accepted in [
             r"C:\repo",
             r"c:\repo",
@@ -690,23 +705,46 @@ mod tests {
                 is_windows_local_disk_path(Path::new(accepted)),
                 "{accepted} must be accepted as a local disk path"
             );
-            validate_project_path_ingress(Path::new(accepted))
-                .expect("local-disk ingress must proceed without filesystem access");
         }
-        // Everything else is fail-closed, whatever it starts with.
-        for rejected in [
+
+        for non_local_or_uncanonical in [
             r"\\server\share\repo",
             r"\\?\UNC\server\share\repo",
-            r"\\server\share",
             r"\\.\device\repo",
             r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
             r"\repo",
             r"repo",
+            ".",
         ] {
             assert!(
-                !is_windows_local_disk_path(Path::new(rejected)),
-                "{rejected} must be rejected as a non-local-disk path"
+                !is_windows_local_disk_path(Path::new(non_local_or_uncanonical)),
+                "{non_local_or_uncanonical} must not satisfy the strict canonical local-disk predicate"
             );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_raw_project_ingress_rejects_only_explicit_non_local_prefixes() {
+        for allowed in [
+            r"C:\repo",
+            r"\\?\C:\repo",
+            ".",
+            r"repo",
+            r"some\repo",
+            r"\repo",
+        ] {
+            validate_project_path_ingress(Path::new(allowed)).unwrap_or_else(|error| {
+                panic!("{allowed} must proceed to canonicalization: {error}")
+            });
+        }
+
+        for rejected in [
+            r"\\server\share\repo",
+            r"\\?\UNC\server\share\repo",
+            r"\\.\device\repo",
+            r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
+        ] {
             let error = validate_project_path_ingress(Path::new(rejected)).unwrap_err();
             assert!(error.contains("not on a local disk drive"), "{error}");
         }
@@ -728,11 +766,20 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn project_path_policy_preserves_windows_local_disk_and_drive_root_fences() {
-        let unc = Path::new(r"\\server\share\repo");
-        let error =
-            validate_project_path_policy(unc, &[PathBuf::from(r"\\server\share\repo")], true)
-                .unwrap_err();
-        assert!(error.contains("not on a local disk drive"), "{error}");
+        for non_local in [
+            r"\\server\share\repo",
+            r"\\?\UNC\server\share\repo",
+            r"\\.\device\repo",
+            r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
+        ] {
+            let error = validate_project_path_policy(
+                Path::new(non_local),
+                &[PathBuf::from(non_local)],
+                true,
+            )
+            .unwrap_err();
+            assert!(error.contains("not on a local disk drive"), "{error}");
+        }
 
         let drive_root = Path::new(r"C:\");
         let error = validate_project_path_policy(drive_root, &[], true).unwrap_err();

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -706,57 +706,6 @@ impl RunnerProjectCache {
     }
 }
 
-/// System directories that must never be used as a project root unless they are
-/// explicitly under an `allowed_roots` entry. Even when `allow_cwd_anywhere`
-/// is true, these roots are rejected to prevent accidental registration of
-/// critical system paths.
-///
-/// On Windows the Unix entries can never match (a canonical Windows path has a
-/// drive prefix) and the Windows entries guard the OS/Program Files trees; any
-/// drive root (`C:\`, `D:\`, ...) is rejected by `is_windows_drive_root`.
-const DANGEROUS_PROJECT_ROOTS: &[&str] = &[
-    "/",
-    "/etc",
-    "/bin",
-    "/sbin",
-    "/usr",
-    "/var",
-    // macOS canonicalizes the public `/etc` and `/var` aliases through
-    // `/private`; policy is evaluated after canonicalization, so fence those
-    // canonical spellings as the same dangerous roots.
-    #[cfg(target_os = "macos")]
-    "/private/etc",
-    #[cfg(target_os = "macos")]
-    "/private/var",
-    "/proc",
-    "/sys",
-    "/dev",
-    "/run",
-    "/boot",
-    #[cfg(windows)]
-    "C:\\Windows",
-    #[cfg(windows)]
-    "C:\\Program Files",
-    #[cfg(windows)]
-    "C:\\Program Files (x86)",
-];
-
-/// True when `canonical_path` is a drive root like `C:\` (any drive letter).
-#[cfg(windows)]
-fn is_windows_drive_root(canonical_path: &Path) -> bool {
-    let mut components = canonical_path.components();
-    matches!(
-        (components.next(), components.next()),
-        (Some(std::path::Component::Prefix(_)), Some(std::path::Component::RootDir))
-            if components.next().is_none()
-    )
-}
-
-#[cfg(not(windows))]
-fn is_windows_drive_root(_canonical_path: &Path) -> bool {
-    false
-}
-
 /// Windows-only fail-closed rule: project roots must be on a local disk drive
 /// (`C:\repo`, `D:\repo`, or the canonicalized `\\?\C:\repo` form). UNC
 /// (`\\server\share\repo`), verbatim-UNC (`\\?\UNC\...`), device-namespace
@@ -897,67 +846,24 @@ fn validate_project_op_description(desc: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Check whether a canonicalized project path is allowed by the Runner policy.
-/// Returns Ok(()) if the path is safe, Err otherwise.
-///
-/// - If `allow_cwd_anywhere` is false, the path must be under an explicit
-///   `allowed_roots` entry.
-/// - If `allow_cwd_anywhere` is true, the path is allowed unless it is one of
-///   the `DANGEROUS_PROJECT_ROOTS` (and not under an explicit `allowed_roots`).
+/// Thin Runner adapter over the shared authoritative project-path policy.
+/// Runner config loading has already materialized HOME-derived effective roots;
+/// this layer only canonicalizes currently usable roots before applying the
+/// same pure path semantics used by local onboarding.
 pub(crate) fn validate_project_path_policy(
     policy: &RunnerPolicy,
     canonical_path: &Path,
 ) -> Result<(), String> {
-    let path_str = canonical_path.to_string_lossy().to_string();
-    // Backstop: registration handlers reject non-local-disk paths with the
-    // dedicated `unc_project_path_unsupported` code before this function is
-    // reached, but the policy check itself must never bless one either (for
-    // example through an `allowed_roots` entry that names a UNC share).
-    #[cfg(windows)]
-    if !webcodex_runner_config::paths::is_windows_local_disk_path(canonical_path) {
-        return Err(format!(
-            "path {} is not on a local disk drive; UNC and other Windows network/device paths are not supported for projects",
-            path_str
-        ));
-    }
-    // If under an explicit allowed_root, always allow.
-    for root in &policy.allowed_roots {
-        if let Ok(canonical_root) = canonicalize_existing(root) {
-            // Case-insensitive component-wise containment on Windows so
-            // `C:\Users\Alice` roots match `c:\users\alice\proj` projects.
-            if webcodex_runner_config::paths::path_is_within(canonical_path, &canonical_root) {
-                return Ok(());
-            }
-        }
-    }
-    if !policy.allow_cwd_anywhere {
-        return Err(format!(
-            "path {} is outside allowed_roots and allow_cwd_anywhere is false",
-            path_str
-        ));
-    }
-    // allow_cwd_anywhere is true: reject dangerous system roots.
-    for &dangerous in DANGEROUS_PROJECT_ROOTS {
-        let dangerous_root = Path::new(dangerous);
-        let is_dangerous = if dangerous_root == Path::new("/") {
-            paths_equal(canonical_path, dangerous_root)
-        } else {
-            webcodex_runner_config::paths::path_is_within(canonical_path, dangerous_root)
-        };
-        if is_dangerous {
-            return Err(format!(
-                "path {} is under a dangerous system root; register it under an explicit allowed_roots entry if intended",
-                path_str
-            ));
-        }
-    }
-    if is_windows_drive_root(canonical_path) {
-        return Err(format!(
-            "path {} is a Windows drive root; register it under an explicit allowed_roots entry if intended",
-            path_str
-        ));
-    }
-    Ok(())
+    let canonical_roots = policy
+        .allowed_roots
+        .iter()
+        .filter_map(|root| canonicalize_existing(root).ok())
+        .collect::<Vec<_>>();
+    webcodex_runner_config::paths::validate_project_path_policy(
+        canonical_path,
+        &canonical_roots,
+        policy.allow_cwd_anywhere,
+    )
 }
 
 #[derive(Debug, Clone)]

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -713,21 +713,12 @@ impl RunnerProjectCache {
 /// the stable `unc_project_path_unsupported` error before any filesystem
 /// access happens.
 ///
-/// The classification is grammar-based — the shared
-/// `webcodex_runner_config::paths::is_windows_local_disk_path` parses the
-/// Windows path prefix — never a string `starts_with` check.
-#[cfg(windows)]
+/// The shared `webcodex_runner_config::paths::validate_project_path_ingress`
+/// owns the grammar-based prefix rule; it never falls back to a string
+/// `starts_with` check.
 fn validate_windows_project_root(path: &Path) -> Result<(), &'static str> {
-    if webcodex_runner_config::paths::is_windows_local_disk_path(path) {
-        Ok(())
-    } else {
-        Err("unc_project_path_unsupported")
-    }
-}
-
-#[cfg(not(windows))]
-fn validate_windows_project_root(_path: &Path) -> Result<(), &'static str> {
-    Ok(())
+    webcodex_runner_config::paths::validate_project_path_ingress(path)
+        .map_err(|_| "unc_project_path_unsupported")
 }
 
 /// Escape a string for use as a TOML basic string (double-quoted). NUL is

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -103,10 +103,13 @@ ordinary user that will run project commands:
 
 ```bash
 webcodex login https://webcodex.example --code <wc_pair_...> \
-  --allowed-root "$HOME/git"
+  --allowed-root "$HOME/git" \
+  --project "$HOME/git/my-repo"
 webcodex runner install --scope user \
   --config <login-reported-agent-config>
 ```
+
+`--allowed-root` is only the filesystem authority boundary for future project registration; it does not register a workspace. `projects_dir` in `agent.toml` is the Runner's project-registry directory, not a source checkout. If login is intentionally done without `--project`, register the actual workspace later with `webcodex project register --config <login-reported-agent-config> /path/to/repo` before expecting project-bound tools.
 
 Use `share --auth oauth` or `connect --auth oauth` only when the client requires
 OAuth and the exact callback URL is known. Do not collapse OAuth client secrets,

--- a/docs/AI_ONBOARDING.zh-CN.md
+++ b/docs/AI_ONBOARDING.zh-CN.md
@@ -89,10 +89,13 @@ webcodex disconnect
 
 ```bash
 webcodex login https://webcodex.example --code <wc_pair_...> \
-  --allowed-root "$HOME/git"
+  --allowed-root "$HOME/git" \
+  --project "$HOME/git/my-repo"
 webcodex runner install --scope user \
   --config <login-reported-agent-config>
 ```
+
+`--allowed-root` 只定义后续 Project 注册可使用的文件系统 authority boundary，并不会注册工作区；`agent.toml` 中的 `projects_dir` 是 Runner 的 Project registry 目录，也不是源码工作区。如果有意先只做 login、不传 `--project`，应在使用 project-bound tools 前执行 `webcodex project register --config <login-reported-agent-config> /path/to/repo` 注册实际工作区。
 
 只有 MCP client 要求 OAuth 且精确 callback URL 已知时，才使用 `share --auth oauth` 或
 `connect --auth oauth`。不要把 OAuth client secret、shared key、Project Credential、PAT、

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -69,7 +69,8 @@ not advertised by ordinary MCP/GPT Actions model discovery.
 
 | Command | Purpose | Notes |
 | --- | --- | --- |
-| `webcodex login <server-url> --code <wc_pair_...>` | Log this device into a Server with a pairing code | Primary client entry. Writes the user token and `agent.toml`. |
+| `webcodex login <server-url> --code <wc_pair_...> [--project PATH]` | Log this device into a Server with a pairing code | Primary client entry. `--allowed-root` is registration authority; `--project` registers an actual existing workspace. |
+| `webcodex project register --config PATH <PROJECT>` | Register an existing workspace in a Runner registry | Uses `projects_dir` from `agent.toml`; no Server connection is required to persist the local record. |
 | `webcodex pairing create` | Server/admin side: create a short-lived pairing code | Needs server bootstrap/admin auth. |
 | `webcodex client enroll` | Advanced client enrollment with explicit `--client-id` | Advanced; ordinary users should use `login`, which derives the client id and publishes the canonical per-server/user connection layout in one step. |
 | `webcodex logout <server-url>` | Remove this device's credentials for a Server | |
@@ -100,8 +101,8 @@ keep their detached-process behavior when `--scope` is omitted.
 
 | Command | Purpose |
 | --- | --- |
-| `webcodex server init` | Initialize or update the Server env file (creates the bootstrap token) |
-| `webcodex server install` | Install the Linux systemd `webcodex.socket` + `webcodex.service` pair |
+| `webcodex server init` | Initialize/update the Server env file and selected data directory (creates the bootstrap token) |
+| `webcodex server install` | Install the Linux systemd `webcodex.socket` + `webcodex.service` pair; default WorkingDirectory follows selected env `WEBCODEX_DATA` |
 | `webcodex server run [--env-file PATH]` | Run `webcodex-server` in the foreground (direct bind); `--env-file` passes the exact path via `WEBCODEX_ENV_FILE` |
 | `webcodex server start` / `stop` | Start or stop socket activation and the Server process coherently |
 | `webcodex server restart` | Restart only the Server process; keep the managed listener socket active |
@@ -115,6 +116,8 @@ On Windows, `server init`, foreground `server run`, and explicit `share` are sup
 `/path/name.socket`. Use the same `--service-file` on `start`, `stop`, `restart`,
 `status`, `logs`, and `uninstall` to manage or inspect that custom pair; omitting
 it targets the default `webcodex.service` / `webcodex.socket` pair.
+
+For Runner config terminology, `projects_dir` is the directory of Project registry TOML files, not a workspace root. `[policy].allowed_roots` bounds which filesystem paths may be registered; a Project record names the actual workspace.
 
 ### Operations (read-only operator checks)
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -63,7 +63,8 @@ Cloudflare Quick Tunnel 的公网 origin 仍然是临时的。如需稳定 HTTPS
 
 | 命令 | 用途 | 说明 |
 | --- | --- | --- |
-| `webcodex login <server-url> --code <wc_pair_...>` | 用 pairing code 把本机接入 Server | 主要客户端入口，写入 user token 与 `agent.toml`。 |
+| `webcodex login <server-url> --code <wc_pair_...> [--project PATH]` | 用 pairing code 把本机接入 Server | 主要客户端入口；`--allowed-root` 是注册 authority，`--project` 才注册实际 existing workspace。 |
+| `webcodex project register --config PATH <PROJECT>` | 在 Runner registry 中注册 existing workspace | 使用 `agent.toml` 中的 `projects_dir`；持久化本地 record 不要求 Server 在线。 |
 | `webcodex pairing create` | Server/admin 侧：创建短期 pairing code | 需要 server bootstrap/admin 认证。 |
 | `webcodex client enroll` | 高级客户端接入，可显式指定 `--client-id` | 高级入口；普通用户应使用 `login`，它会自动派生 client id 并一步写入规范的 server/user 本地连接布局。 |
 | `webcodex logout <server-url>` | 移除本机对某 Server 的凭据 | |
@@ -94,8 +95,8 @@ detached-process 行为。
 
 | 命令 | 用途 |
 | --- | --- |
-| `webcodex server init` | 初始化或更新 Server env 文件（创建 bootstrap token） |
-| `webcodex server install` | 安装 Linux systemd `webcodex.socket` + `webcodex.service` pair |
+| `webcodex server init` | 初始化/更新 Server env 文件与所选 data directory（创建 bootstrap token） |
+| `webcodex server install` | 安装 Linux systemd `webcodex.socket` + `webcodex.service` pair；默认 WorkingDirectory 跟随所选 env 的 `WEBCODEX_DATA` |
 | `webcodex server run [--env-file PATH]` | 前台运行 `webcodex-server`（direct bind）；`--env-file` 通过 `WEBCODEX_ENV_FILE` 精确传递路径 |
 | `webcodex server start` / `stop` | 一致地启动或停止 socket activation 与 Server process |
 | `webcodex server restart` | 只 restart Server process，保持受管 listener socket active |
@@ -109,6 +110,8 @@ Windows 支持 `server init`、前台 `server run` 与显式 `share`。受管 se
 `/path/name.socket`。后续 `start`、`stop`、`restart`、`status`、`logs` 和 `uninstall`
 应传入相同的 `--service-file` 来管理或检查该自定义 pair；省略时仍操作默认的
 `webcodex.service` / `webcodex.socket` pair。
+
+Runner 配置术语中，`projects_dir` 是 Project registry TOML 文件目录，不是 workspace root；`[policy].allowed_roots` 只限制哪些文件系统路径可以注册，Project record 才指向实际 workspace。
 
 ### 运维（只读操作检查）
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -120,17 +120,19 @@ sudo webcodex server init \
   --public-url https://your-domain.example
 ```
 
-`server init` creates only the server-side bootstrap/admin token. It does not
-create user API tokens or agent tokens.
+`server init` creates the selected data directory and the server-side bootstrap/admin token. It does not create user API tokens or agent tokens. Its next-step guidance preserves the exact env/data paths supplied above.
 
 Install and start the managed systemd socket/service pair:
 
 ```bash
 sudo webcodex server install \
   --env-file /etc/webcodex/webcodex.env \
+  --working-directory /var/lib/webcodex \
   --bin /usr/local/bin/webcodex-server
 webcodex server status --env-file /etc/webcodex/webcodex.env
 ```
+
+When `--working-directory` is omitted, `server install` uses `WEBCODEX_DATA` from the selected env file before falling back to the platform default. Install preflight rejects a missing/non-executable binary, missing working directory, unreadable env file, or unknown explicit User/Group before mutating systemd. `server status` likewise derives its default local HTTP probe from that env file's `WEBCODEX_ADDR`; an explicit `--url` still wins.
 
 The managed Linux layout is intentionally split: `webcodex.socket` owns the
 fixed `WEBCODEX_ADDR` listener, while `webcodex.service` owns only the Server
@@ -234,7 +236,8 @@ project commands (do not use `sudo`):
 
 ```bash
 webcodex login https://your-domain.example --code <wc_pair_...> \
-  --allowed-root "$HOME/git"
+  --allowed-root "$HOME/git" \
+  --project "$HOME/git/my-repo"
 webcodex runner install --scope user \
   --config <login-reported-agent-config>
 webcodex runner status --scope user \
@@ -243,10 +246,7 @@ webcodex ops status --server-url https://your-domain.example \
   --token-file <login-reported-webcodex-user-token> --strict
 ```
 
-`webcodex login` is the primary client entry: it derives a unique device name,
-redeems the pairing code, and writes the client-side `webcodex-user-token` and
-an `agent.toml`. `webcodex client enroll` remains the advanced alternative for
-an explicit client id or custom output directory.
+`webcodex login` is the primary client entry: it derives a unique device name, redeems the pairing code, and writes the client-side `webcodex-user-token` and an `agent.toml`. `--allowed-root` grants registration authority only; `--project` names the actual existing workspace to register. The generated `projects_dir` is a registry directory, not the workspace root. If login is performed without `--project`, use `webcodex project register --config <login-reported-agent-config> /path/to/repo` before project-bound work. `webcodex client enroll` remains the advanced alternative for an explicit client id or custom output directory.
 
 The pairing code is created server/admin-side:
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -108,17 +108,19 @@ sudo webcodex server init \
   --public-url https://your-domain.example
 ```
 
-`server init` 只创建 server 侧 bootstrap/admin token。它不创建 user API token
-或 agent token。
+`server init` 会创建所选 data directory 与 server 侧 bootstrap/admin token；它不创建 user API token 或 agent token。后续 guidance 会保留上面实际传入的 env/data 路径。
 
 安装并启动受管 systemd socket/service pair：
 
 ```bash
 sudo webcodex server install \
   --env-file /etc/webcodex/webcodex.env \
+  --working-directory /var/lib/webcodex \
   --bin /usr/local/bin/webcodex-server
 webcodex server status --env-file /etc/webcodex/webcodex.env
 ```
+
+省略 `--working-directory` 时，`server install` 会优先读取所选 env 文件中的 `WEBCODEX_DATA`，再回退到平台默认值。安装前会在任何 systemd mutation 之前拒绝缺失/不可执行 binary、缺失 WorkingDirectory、不可读 env file 或不存在的显式 User/Group。`server status` 也会默认从同一 env 的 `WEBCODEX_ADDR` 派生本地 HTTP probe；显式 `--url` 始终优先。
 
 受管 Linux 部署会明确拆分职责：`webcodex.socket` 持有固定的
 `WEBCODEX_ADDR` listener，`webcodex.service` 只持有 Server process。该结构建立后，
@@ -206,7 +208,8 @@ named Cloudflare Tunnel 也是有效入口。同一 hostname 必须承载普通 
 
 ```bash
 webcodex login https://your-domain.example --code <wc_pair_...> \
-  --allowed-root "$HOME/git"
+  --allowed-root "$HOME/git" \
+  --project "$HOME/git/my-repo"
 webcodex runner install --scope user \
   --config <login-reported-agent-config>
 webcodex runner status --scope user \
@@ -215,9 +218,7 @@ webcodex ops status --server-url https://your-domain.example \
   --token-file <login-reported-webcodex-user-token> --strict
 ```
 
-`webcodex login` 是主要客户端入口：它自动派生唯一设备名、兑换 pairing code，并
-写入客户端侧 `webcodex-user-token` 与 `agent.toml`。需要显式 client id 或自定义
-输出目录时，`webcodex client enroll` 仍是高级替代方案。
+`webcodex login` 是主要客户端入口：它自动派生唯一设备名、兑换 pairing code，并写入客户端侧 `webcodex-user-token` 与 `agent.toml`。`--allowed-root` 只授予 Project 注册 authority，`--project` 才表示要注册的实际 existing workspace；生成的 `projects_dir` 是 registry 而不是 workspace root。如果 login 时没有传 `--project`，应在 project-bound 工作前执行 `webcodex project register --config <login-reported-agent-config> /path/to/repo`。需要显式 client id 或自定义输出目录时，`webcodex client enroll` 仍是高级替代方案。
 
 pairing code 由 server/admin 侧创建：
 


### PR DESCRIPTION
## Summary

Close the Linux first-run / managed onboarding gaps exposed by real install and workspace-registration failures.

This PR makes the native onboarding path coherent from Server init/install through login, Runner startup, Project registration, and status diagnostics:

- add `webcodex login --project PATH` while keeping `--allowed-root` strictly as registration authority
- add `webcodex project register --config PATH <PROJECT>` for local existing-workspace registration
- clearly distinguish `projects_dir` (Runner registry), `allowed_roots` (authority), and the actual Project/workspace
- preserve one-shot pairing transactionality by validating/staging project registration before redemption where possible
- derive Server install `WorkingDirectory` from selected `WEBCODEX_DATA` unless explicitly overridden
- preflight Server binary, env file, working directory, and explicit User/Group before systemd mutation
- preserve exact env/data choices in `server init` next-step guidance
- derive default `server status` probe URL from `WEBCODEX_ADDR`, including wildcard/IPv6 handling
- improve first-run/help/docs output without exposing credentials

## Independent review fixes

A fresh independent review found two small local-registration consistency/UX issues and fixed them in a follow-up commit:

- minimal Runner configs that omit `projects_dir` now use the same per-user default registry path as Runner config loading instead of being rejected by `webcodex project register`
- idempotent re-registration now reports that no Runner reload is required; when a registry change does require reload, guidance explicitly avoids starting a duplicate foreground Runner if the existing Runner is service-managed

## Validation

- `cargo fmt --check`
- focused login / `login --project` / allowed-root regressions
- focused local project registration tests
- focused Server init/install/status regressions
- `cargo test -p webcodex-cli` — 327 passed, 0 failed after reviewer fix
- focused CLI usage tests — 21 passed, 0 failed
- `cargo check -p webcodex-cli --all-targets`
- `cargo check -p webcodex-runner --all-targets`
- `git diff --check`

No Runner transport, auth/token authority, MCP protocol, Docker bootstrap, Windows Service, launchd, automatic root scanning, or Project runtime semantics are changed.