### PR TITLE
Reframe onboarding around full WebCodex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,39 +6,24 @@
 
 Ask your assistant to inspect a repository, modify code, run tests, use Git, or investigate a failure. Your repository stays on the machine where it already lives; you do not need to move the project into a hosted workspace just to use an AI coding agent.
 
-## Quick start
+## Start using WebCodex
 
-With Node.js 18+ and Git installed on Linux, macOS, or Windows x64:
+### Everyday development: full WebCodex (recommended)
+
+If you want ChatGPT to keep using your real development environment, start with a **regular Server + Runner**. This is the full development experience: durable access to multiple projects plus project exploration, editing, Git, commands, tests, long-running work, and code navigation. Public HTTPS, Cloudflare Tunnel, and OpenAI Secure MCP Tunnel are only ways for ChatGPT to reach the Server; they do not switch you into a different restricted experience.
+
+Follow the [Full Setup guide](docs/PERSONAL_SETUP.md) for installation, one-time login, project selection, Runner startup, and ChatGPT connection. You do not need to learn internal identity, registry, or token details before the first successful setup.
+
+### Just trying it for a few minutes: temporary share
+
+To quickly see whether WebCodex fits your workflow, run this inside one repository:
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-When WebCodex reports **WebCodex ready**, keep the terminal open. Linux and macOS normally copy the **MCP URL** to your clipboard and can use **Enter** in an interactive terminal to open ChatGPT App settings. On Windows, copy the printed **MCP URL** manually and open **Settings -> Apps -> Create**. Then:
-
-1. Enable **Developer Mode** if needed and choose **Create**.
-2. Paste the copied **MCP URL** (or use the URL printed by WebCodex).
-3. Choose **Access token / API key** (or the equivalent Bearer-token option) and paste the printed **Credential**.
-4. Run **Scan Tools**.
-
-Developer Mode, custom MCP Apps, and write/modify actions depend on your ChatGPT plan, workspace, and administrator policy. WebCodex cannot enable capabilities the client does not grant.
-
-Try a read-only first request:
-
-```text
-Inspect this repository and summarize its structure. Do not make changes.
-```
-
-If ChatGPT does not show a Bearer/access-token option, or tries OAuth discovery and reports **does not implement OAuth**, use:
-
-```bash
-npx --yes @yyjeqhc/webcodex share --auth query-token
-```
-
-Paste the complete `/mcp?token=...` URL and choose **No authentication**. This fallback requires WebCodex 0.3.9 or later. That URL contains a temporary secret, so do not publish or log it. If WebCodex is installed globally, the equivalent command is `webcodex share --auth query-token`. See the [Quick Start](docs/QUICK_START.md) and [MCP setup guide](docs/MCP.md) for details and other clients.
-
-The default one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits. Advanced networking, OAuth, private tunnels, and self-hosting options are documented separately.
+`share` starts a temporary, single-project, restricted WebCodex environment and prints the ChatGPT connection values. The endpoint and temporary credential stop working when the command exits. It is intended for trials and short-lived sharing, not as the default full daily setup. See the [Quick Trial](docs/QUICK_START.md) for the exact steps.
 
 ## What can it do?
 
@@ -82,23 +67,18 @@ For the internal Server/Runner architecture, protocol surfaces, and authority bo
 
 Windows and long-lived deployments are covered in [Deployment](docs/DEPLOYMENT.md) and [MCP](docs/MCP.md).
 
-## Long-lived and advanced setup
+## Existing Servers and advanced setup
 
-If you want to keep the CLI installed:
+If someone already provides the WebCodex Server and connection credential, use that existing Server. For a normal personal installation, follow the [Full Setup guide](docs/PERSONAL_SETUP.md). Use [Deployment](docs/DEPLOYMENT.md) later for production hosting, multiple users, systemd/Docker, OAuth, proxies, and private CAs.
 
-```bash
-npm install -g @yyjeqhc/webcodex
-```
-
-If an operator has provided a shared key for an existing hosted WebCodex Server, use `webcodex connect <server-url>`. For a newly deployed self-hosted Server, keep the bootstrap administrator token on the Server and use the [Deployment](docs/DEPLOYMENT.md) guide's short-lived pairing code + `webcodex login` enrollment flow.
-
-For production/self-hosted deployment, Windows enrollment, OAuth, private tunnels, proxy/CA configuration, and other operator workflows, use the documentation below rather than the first-run path.
+Those are follow-up operating concerns, not concepts a first-time user should have to learn before WebCodex works.
 
 ## Documentation
 
-- [Quick Start](docs/QUICK_START.md) — from zero to the first successful AI connection
+- [Full Setup](docs/PERSONAL_SETUP.md) — recommended daily use: a regular Server + Runner + your projects
+- [Quick Trial](docs/QUICK_START.md) — temporarily try one repository with `share`
 - [MCP](docs/MCP.md) — ChatGPT, Claude, authentication choices, and MCP reference
-- [Deployment](docs/DEPLOYMENT.md) — self-hosting, permanent Servers, and machine enrollment
+- [Deployment](docs/DEPLOYMENT.md) — production, self-hosting, and advanced operations
 - [Troubleshooting](docs/TROUBLESHOOTING.md) — connection and runtime problems
 - [CLI](docs/CLI.md) — command and credential reference
 - [AI-assisted setup](docs/AI_ONBOARDING.md) — have an AI agent help configure WebCodex

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,39 +6,24 @@
 
 你可以直接让 AI 理解项目、修改代码、运行测试、检查 Git 或排查问题。仓库仍然留在原来的机器上，不需要为了使用 WebCodex 把整个项目搬到托管环境里。
 
-## 快速开始
+## 开始使用
 
-Linux、macOS 或 Windows x64 上准备好 Node.js 18+ 和 Git，然后进入一个仓库：
+### 日常使用：完整 WebCodex（推荐）
+
+如果你准备让 ChatGPT 长期使用自己的开发环境，推荐从 **普通 Server + Runner** 开始。这是 WebCodex 的完整开发体验：可以长期连接多个项目，并使用项目探索、编辑、Git、命令、测试、长任务和代码导航能力。公网 HTTPS、Cloudflare Tunnel 或 OpenAI Secure MCP Tunnel 只是 ChatGPT 到 Server 的连接方式，不会把你切换到另一套受限体验。
+
+按照[完整使用指南](docs/PERSONAL_SETUP.zh-CN.md)完成安装、一次性登录、项目选择、Runner 启动和 ChatGPT 连接即可。第一次成功使用前，不需要理解内部身份、注册表或令牌细节。
+
+### 只想先试几分钟：临时分享
+
+如果你只是想快速看看 WebCodex 是否适合自己，可以在一个仓库里运行：
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-看到 **WebCodex ready** 后保持终端运行。Linux 与 macOS 通常会自动复制 **MCP URL**，并可在交互终端按 **Enter** 打开 ChatGPT App 设置；Windows 请手动复制终端中打印的 **MCP URL**，并进入 **Settings -> Apps -> Create**。然后：
-
-1. 如有需要，开启 **Developer Mode** 并选择 **Create**。
-2. 粘贴已经复制的 **MCP URL**；也可以使用 WebCodex 终端中打印的地址。
-3. 认证选择 **Access token / API key**（或等价的 Bearer 令牌选项），再填入输出的临时 **Credential**。
-4. 点击 **Scan Tools**。
-
-Developer Mode、自定义 MCP App 和写入/修改操作是否可用取决于 ChatGPT 套餐、workspace 与管理员策略；WebCodex 无法启用客户端未授予的权限。
-
-第一条消息可以先只读检查：
-
-```text
-检查这个仓库并总结它的结构。先不要做任何修改。
-```
-
-如果 ChatGPT 没有显示 Bearer/访问令牌选项，或者自动尝试 OAuth 后出现 **does not implement OAuth**，直接运行：
-
-```bash
-npx --yes @yyjeqhc/webcodex share --auth query-token
-```
-
-把输出的完整 `/mcp?token=...` 地址粘贴到 ChatGPT，并选择 **No authentication**。这个 fallback 需要 WebCodex 0.3.9 或更新版本。这条地址包含本次临时密钥，不要公开、转发或记录到日志中。如果已经全局安装 WebCodex，也可以使用等价命令 `webcodex share --auth query-token`。更多客户端配置见[快速开始](docs/QUICK_START.zh-CN.md)和 [MCP 接入指南](docs/MCP.zh-CN.md)。
-
-默认的一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。代理网络、OAuth、私有隧道、自托管等高级配置都放在单独的文档中，不是第一次使用的前置条件。
+`share` 会临时启动单项目、受限的 WebCodex 环境并给出 ChatGPT 连接信息；关闭命令后连接和临时凭据都会失效。它适合试用和临时分享，不是日常完整体验的默认部署方式。详细步骤见[快速试用](docs/QUICK_START.zh-CN.md)。
 
 ## 能做什么？
 
@@ -82,23 +67,18 @@ WebCodex
 
 Windows 接入和长期部署见[部署指南](docs/DEPLOYMENT.zh-CN.md)与 [MCP](docs/MCP.zh-CN.md)。
 
-## 长期使用与高级配置
+## 已有 Server 与高级配置
 
-希望长期保留命令行工具时可以全局安装：
+如果已经有人为你提供 WebCodex Server 和接入凭据，可以直接使用已有 Server；普通个人完整安装见[完整使用指南](docs/PERSONAL_SETUP.zh-CN.md)。生产环境、多用户、systemd/Docker、OAuth、代理/私有 CA 等运维内容再查看[部署指南](docs/DEPLOYMENT.zh-CN.md)。
 
-```bash
-npm install -g @yyjeqhc/webcodex
-```
-
-对于 operator 提供 shared key 的已有 hosted WebCodex Server，使用 `webcodex connect <server-url>`；新部署的自托管 Server 应把 bootstrap administrator token 留在 Server 侧，并按[部署指南](docs/DEPLOYMENT.zh-CN.md)使用短期 pairing code + `webcodex login` 完成 enrollment。
-
-生产环境、自托管、Windows 接入、OAuth、私有隧道、代理/私有 CA 等运维配置请直接查看下面的专题文档，不需要在第一次体验前理解这些概念。
+这些是后续配置，不应该成为第一次使用 WebCodex 的概念负担。
 
 ## 文档
 
-- [快速开始](docs/QUICK_START.zh-CN.md) —— 从零到第一次成功连接 AI
+- [完整使用指南](docs/PERSONAL_SETUP.zh-CN.md) —— 日常使用推荐：普通 Server + Runner + 你的项目
+- [快速试用](docs/QUICK_START.zh-CN.md) —— 用 `share` 临时体验一个仓库
 - [MCP](docs/MCP.zh-CN.md) —— ChatGPT、Claude、认证方式和 MCP 参考
-- [部署指南](docs/DEPLOYMENT.zh-CN.md) —— 自托管、长期 Server 和机器接入
+- [部署指南](docs/DEPLOYMENT.zh-CN.md) —— 生产、自托管和高级运维
 - [故障排查](docs/TROUBLESHOOTING.zh-CN.md) —— 连接和运行问题
 - [CLI](docs/CLI.zh-CN.md) —— 命令与凭据参考
 - [AI 辅助接入](docs/AI_ONBOARDING.zh-CN.md) —— 让 AI 帮你配置 WebCodex

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -6,35 +6,37 @@ This guide is for an AI coding agent helping a **user** connect a repository to
 WebCodex or operate an existing deployment. It is not [`AGENTS.md`](../AGENTS.md),
 which governs development of WebCodex itself.
 
-The default user goal is: **"let ChatGPT work with this repository."** Do not
-introduce Server deployment, client ids, runtime project ids, PATs, Runner tokens,
-or OAuth scope ceilings unless the user's chosen path actually requires them.
+Treat the default user goal as: **"let ChatGPT use my development environment normally."** Unless the user explicitly asks only for a temporary trial, prefer the full regular Server + Runner coding experience instead of treating `share` as WebCodex itself.
 
-## Choose the smallest path
+Before the first successful setup, keep the user-facing vocabulary to: **WebCodex service, Runner (the machine that runs code), Project, one-time login code, and ChatGPT connection**. Do not front-load `client_id`, runtime project ids, `projects_dir`, PATs, Runner tokens, scope ceilings, or Connector surfaces.
 
-Check the platform before choosing the path. Windows supports the same explicit
-`webcodex share` path as Linux/macOS; do not invent a remote Linux Server as a
-Windows prerequisite. Keep the no-command interactive shortcut Linux/macOS-only.
-On Windows ARM64, explain that the pinned Cloudflare release has no official ARM64
-artifact if the user selects/defaults to Cloudflare; a trusted explicit/PATH
-`cloudflared`, OpenAI tunnel, or local-only `none` is required instead.
+## First choose the experience
 
-1. The user has one local repository and wants to try ChatGPT/MCP now, with no
-   existing WebCodex Server URL: use **`webcodex share`**.
-2. The user already has a WebCodex Server URL and wants a persistent repository
-   connection: use **`webcodex connect <server>`**.
-3. The user needs separate identity, independent revocation, audit, or managed
-   users: use the managed identity path (`webcodex login` / managed OAuth).
-4. The user needs infrastructure control, private networking, stable HTTPS, or
-   their own identity system: use [Deployment](DEPLOYMENT.md).
+1. The user wants normal/daily/long-lived WebCodex use, or did not explicitly ask for a temporary trial: use the [Full Setup guide](PERSONAL_SETUP.md) with a regular Server + Runner.
+2. The user explicitly wants a few-minute, zero-commitment trial of one repository: use **`webcodex share`**. It is temporary, single-project, and more restricted.
+3. The user already has a WebCodex Server URL: use the enrollment method that Server actually provides. Fresh managed self-hosting uses pairing + `webcodex login`; use `webcodex connect <server>` only when an operator explicitly supplied a shared-key credential.
+4. Move to [Deployment](DEPLOYMENT.md) only for production hosting, multiple users, OAuth, systemd/Docker, private CAs, and similar operator concerns.
 
-Do not invent `https://your-server.example` as a prerequisite for a new user.
+Windows can run a foreground Server and Runner directly. Do not redirect Windows users to a remote Linux host by default, and do not switch them to `share` merely because they need a Tunnel. **A Tunnel solves reachability; it does not choose the WebCodex coding permission model.**
 
-## First-time ChatGPT path: `share`
+## Default: full setup
 
-Verify Git and the target repository. For the default public share, WebCodex
-reuses `WEBCODEX_CLOUDFLARED_BIN` / `PATH` or automatically downloads its pinned,
-verified managed `cloudflared`; do not ask a first-time user to install it first.
+Use the [Full Setup guide](PERSONAL_SETUP.md) as the user-facing source of truth. Help the user complete these observable steps:
+
+- install WebCodex;
+- start a regular Server;
+- choose one reachability path to that Server (public HTTPS, Cloudflare, OpenAI Tunnel, etc.);
+- create a one-time login code;
+- run `webcodex login ... --project <repo>`;
+- start the Runner;
+- use `--print-mcp-config` or the selected Tunnel guide to add WebCodex to ChatGPT;
+- verify one read and one small edit using the full coding experience.
+
+Do not copy systemd socket details, OAuth scopes, token taxonomy, registry paths, or similar Deployment reference material into this ordinary user path before it is needed.
+
+## Temporary trial: `share`
+
+Only make `share` the main path after the user explicitly chooses a quick temporary trial:
 
 ```bash
 npm install -g @yyjeqhc/webcodex
@@ -42,32 +44,9 @@ cd /path/to/your/repository
 webcodex share
 ```
 
-`share` performs project setup itself. Do not teach `setup → doctor → run → stop
-run → share` as the onboarding sequence.
+`share` performs temporary project setup and owns the Server/Runner/Tunnel for that run. When the CLI reports **WebCodex ready**, have the human follow its ChatGPT connection output. Developer Mode, custom MCP apps, and write/modify actions still depend on the ChatGPT plan, workspace, and admin policy.
 
-When the CLI reports **WebCodex ready**, tell the human to keep that terminal open
-and follow the printed **What to do next** section. Before promising write access,
-remember that ChatGPT Developer Mode, custom MCP apps, and write/modify actions
-are controlled by the user's ChatGPT plan, workspace, and admin settings; these
-client-side permissions are separate from WebCodex authorization:
-
-- ChatGPT Developer Mode → create an MCP custom app.
-- paste the printed MCP URL.
-- select the authentication type printed by the CLI.
-- the **human** pastes the printed credential into ChatGPT.
-- Scan Tools.
-- first prompt: `Inspect this repository and summarize its structure. Do not make changes.`
-
-For local-only debugging, `webcodex share --tunnel none` avoids the Cloudflare
-Quick Tunnel and does not require `cloudflared`.
-
-When the user explicitly wants OpenAI-only private reachability and already has
-an OpenAI Secure MCP Tunnel, use `webcodex share --tunnel openai`. Require
-`CONTROL_PLANE_TUNNEL_ID` and a Restricted `CONTROL_PLANE_API_KEY` with Tunnels
-Read + Use. In ChatGPT choose Connection: Tunnel and No authentication; WebCodex
-keeps its temporary Bearer local and injects it through `tunnel-client`. Do not
-ask the human to paste that local credential into ChatGPT. Keep Cloudflare Quick
-as the ordinary zero-Platform-setup default.
+Use `webcodex share --tunnel none` only for a local-only temporary trial, and `webcodex share --tunnel openai` for an explicitly selected OpenAI Tunnel temporary share. Do not infer from those temporary share modes that a regular Server + Runner has the same restrictions.
 
 ## Existing shared-key Server path: `connect`
 
@@ -109,7 +88,7 @@ webcodex runner install --scope user \
   --config <login-reported-agent-config>
 ```
 
-`--allowed-root` is only the filesystem authority boundary for future project registration; it does not register a workspace. `projects_dir` in `agent.toml` is the Runner's project-registry directory, not a source checkout. If login is intentionally done without `--project`, register the actual workspace later with `webcodex project register --config <login-reported-agent-config> /path/to/repo` before expecting project-bound tools.
+For ordinary users, explain only that `--project` is the actual project and `--allowed-root` is a parent directory from which more projects may be added later. Do not require manual edits to `agent.toml` or `projects.d`; reserve registry/authority internals for troubleshooting and reference material. If login intentionally omitted `--project`, add it later with `webcodex project register --config <login-reported-agent-config> /path/to/repo`.
 
 Use `share --auth oauth` or `connect --auth oauth` only when the client requires
 OAuth and the exact callback URL is known. Do not collapse OAuth client secrets,
@@ -146,11 +125,7 @@ Do **not** read back, print, log, commit, or echo into chat:
 - full `agent.toml` contents or Server env files;
 - `Authorization` headers.
 
-When a credential must be entered into ChatGPT/Claude, identify the source
-precisely and ask the **human** to copy it. The successful `share`/`connect` output
-is the preferred first-disclosure source. If a stored value must be recovered,
-point the user to the exact protected file/field without echoing it yourself.
-Status/log commands intentionally do not reveal secrets.
+When a credential must be entered into ChatGPT/Claude, identify the source precisely and ask the **human** to copy it. Prefer connection details explicitly produced by the current flow, such as `login --print-mcp-config` for full setup or the successful disclosure from a temporary `share` / existing-Server `connect`. If a stored value must be recovered, point the user to the exact protected file/field without echoing it yourself. Status/log commands intentionally do not reveal secrets.
 
 Never substitute a `wc_agent_*` Runner token for an MCP token, never use a
 bootstrap `WEBCODEX_TOKEN` as an MCP credential, and never assume offline

--- a/docs/AI_ONBOARDING.zh-CN.md
+++ b/docs/AI_ONBOARDING.zh-CN.md
@@ -5,28 +5,37 @@
 本文面向帮助**用户**把仓库接入 WebCodex 或操作已有部署的 AI coding agent。它不是
 [`AGENTS.md`](../AGENTS.md)；后者约束的是 WebCodex 自身开发。
 
-默认用户目标应理解为：**“让 ChatGPT 操作这个仓库。”** 除非用户选择的路径确实需要，
-不要提前引入 Server 部署、client id、runtime project id、PAT、Runner token 或 OAuth scope
-ceiling。
+默认用户目标应理解为：**“让 ChatGPT 正常使用我的开发环境。”** 除非用户明确说只想临时试用，否则优先帮助他获得普通 Server + Runner 的完整 coding 体验，而不是默认把 `share` 当成 WebCodex 本体。
 
-## 选择最小路径
+第一次成功前，把用户需要理解的词汇压缩到：**WebCodex 服务、Runner（运行代码的机器）、Project（项目）、一次性登录码、ChatGPT 连接**。不要提前解释 `client_id`、runtime project id、`projects_dir`、PAT、Runner token、scope ceiling、Connector surface 等内部术语。
 
-先检查平台再选路径。Windows 已支持与 Linux/macOS 相同的显式 `webcodex share`，不要再把远程 Linux Server 当成 Windows 前置条件；无子命令的交互式 shortcut 仍只在 Linux/macOS 自动进入 share。Windows ARM64 如果使用默认/显式 Cloudflare，需要说明固定版本 Cloudflare 没有官方 ARM64 artifact，应提供受信任的显式/`PATH` `cloudflared`，或者选择 OpenAI tunnel / 本地 `none`。
+## 先判断用户要哪种体验
 
-1. 用户只有一个本地仓库、想马上试 ChatGPT/MCP，并且没有现成 WebCodex Server URL：使用 **`webcodex share`**。
-2. 用户已经有 WebCodex Server URL，需要长期连接：使用
-   **`webcodex connect <server>`**。
-3. 用户明确需要独立身份、独立撤销、审计或 managed user：使用 managed identity
-   （`webcodex login` / managed OAuth）。
-4. 用户需要基础设施控制、内网、稳定 HTTPS 或自有身份系统：使用
-   [部署指南](DEPLOYMENT.zh-CN.md)。
+1. 用户想正常/长期/日常使用 WebCodex，或没有明确要求“只临时试一下”：使用[完整使用指南](PERSONAL_SETUP.zh-CN.md)，建立普通 Server + Runner。
+2. 用户明确只想几分钟体验一个仓库、不想配置长期 runtime：使用 **`webcodex share`**。这是临时、单项目、受限体验。
+3. 用户已经有 WebCodex Server URL：优先使用该 Server 已提供的正常 enrollment 方式；自托管 managed Server 用 pairing + `webcodex login`，只有 operator 明确提供 shared-key credential 时才使用 `webcodex connect <server>`。
+4. 用户需要生产托管、多用户、OAuth、systemd/Docker、私有 CA 等运维能力：再进入[部署指南](DEPLOYMENT.zh-CN.md)。
 
-不要把虚构的 `https://your-server.example` 当作全新用户的前置条件。
+Windows 可以直接运行前台 Server 和 Runner；不要因为平台是 Windows 就把用户推到远程 Linux，也不要因为需要 Tunnel 就切换成 `share`。**Tunnel 解决网络可达性，不决定 WebCodex 的 coding 权限模式。**
 
-## 第一次 ChatGPT 接入：`share`
+## 默认：完整使用
 
-先确认 Git 和目标仓库。默认公网 share 会复用 `WEBCODEX_CLOUDFLARED_BIN` / `PATH`，
-没有时由 WebCodex 自动下载并校验固定的 managed `cloudflared`；不要要求第一次用户先手动安装。
+完整路径的用户说明以[完整使用指南](PERSONAL_SETUP.zh-CN.md)为准。AI 应优先帮助用户完成这些可观察步骤：
+
+- 安装 WebCodex；
+- 启动普通 Server；
+- 选择公网 HTTPS / Cloudflare / OpenAI Tunnel 等一种到 Server 的连接方式；
+- 创建一次性登录码；
+- `webcodex login ... --project <repo>`；
+- 启动 Runner；
+- 按 `--print-mcp-config` 或 Tunnel 指南把连接加入 ChatGPT；
+- 用一次读取和一次小修改验证完整 coding 体验。
+
+不要把 Deployment reference 中的 systemd socket、OAuth scope、token 类型、registry 路径等内容提前搬进这条普通用户流程。
+
+## 临时试用：`share`
+
+只有用户明确选择快速临时体验时，才把 `share` 作为主路径：
 
 ```bash
 npm install -g @yyjeqhc/webcodex
@@ -34,29 +43,9 @@ cd /path/to/your/repository
 webcodex share
 ```
 
-`share` 自己会完成项目 setup。不要把
-`setup → doctor → run → 停掉 run → share` 教成 onboarding 主流程。
+`share` 自己完成临时项目 setup，并启动本次会话拥有的 Server/Runner/Tunnel。CLI 显示 **WebCodex ready** 后，让人类按输出配置 ChatGPT。Developer Mode、custom MCP app 与 write/modify action 仍受 ChatGPT 套餐、workspace 和管理员设置控制。
 
-CLI 显示 **WebCodex ready** 后，让人类保持终端运行，并按 **What to do next**。不要在未确认
-前承诺 write 能力：ChatGPT Developer Mode、custom MCP app 与 write/modify action 受用户的
-ChatGPT 套餐、workspace 和管理员设置控制，这些客户端侧权限与 WebCodex authorization 是
-两层独立边界：
-
-- ChatGPT Developer Mode → 创建 MCP custom app；
-- 粘贴输出的 MCP URL；
-- 选择 CLI 输出的认证类型；
-- 由**人类**把输出的 credential 粘贴到 ChatGPT；
-- Scan Tools；
-- 第一条：`检查这个仓库并总结它的结构。先不要做任何修改。`
-
-仅做本地调试时可用 `webcodex share --tunnel none`，不启动 Cloudflare Quick Tunnel，也不
-需要 `cloudflared`。
-
-如果用户明确只需要 OpenAI 产品的私有可达性，并且已经创建 OpenAI Secure MCP Tunnel，
-使用 `webcodex share --tunnel openai`。要求 `CONTROL_PLANE_TUNNEL_ID` 和只授予 Tunnels
-Read + Use 的 Restricted `CONTROL_PLANE_API_KEY`。ChatGPT 侧选择 Connection: Tunnel +
-No authentication；WebCodex 临时 Bearer 留在本机，由 `tunnel-client` 注入，不要让人类把它
-粘贴到 ChatGPT。普通零 Platform 配置的 first-run 默认仍然是 Cloudflare Quick。
+仅本地调试可用 `webcodex share --tunnel none`；明确使用 OpenAI Secure MCP Tunnel 的临时分享可用 `webcodex share --tunnel openai`。这些都是 `share` 的临时模式，不要据此推断普通 Server + Runner 也受同样的临时限制。
 
 ## 已有 shared-key Server：`connect`
 
@@ -95,7 +84,7 @@ webcodex runner install --scope user \
   --config <login-reported-agent-config>
 ```
 
-`--allowed-root` 只定义后续 Project 注册可使用的文件系统 authority boundary，并不会注册工作区；`agent.toml` 中的 `projects_dir` 是 Runner 的 Project registry 目录，也不是源码工作区。如果有意先只做 login、不传 `--project`，应在使用 project-bound tools 前执行 `webcodex project register --config <login-reported-agent-config> /path/to/repo` 注册实际工作区。
+面向普通用户只解释：`--project` 是实际项目，`--allowed-root` 是以后允许继续添加项目的父目录。不要要求用户手工编辑 `agent.toml` 或 `projects.d`；只有排障或 reference 场景才解释 registry/authority 的内部表示。如果 login 时没有传 `--project`，再用 `webcodex project register --config <login-reported-agent-config> /path/to/repo` 添加项目。
 
 只有 MCP client 要求 OAuth 且精确 callback URL 已知时，才使用 `share --auth oauth` 或
 `connect --auth oauth`。不要把 OAuth client secret、shared key、Project Credential、PAT、
@@ -116,8 +105,7 @@ Runner token 或 bootstrap administrator token 合并成一个概念。
 - `webcodex status` 与 `webcodex doctor` 输出；
 - token 文件的位置，但不是其内容。
 
-`doctor` 是本地/手动 runtime 诊断。即使它推荐 `webcodex run`，也不要把这解释成 hosted
-ChatGPT 的前置条件；第一次 hosted-chat 路径用 `share`。
+`doctor` 是本地/手动 runtime 诊断，不是普通 ChatGPT 接入的必经仪式。根据用户目标选择完整 Server + Runner 或临时 `share`，不要机械地把诊断命令堆进 onboarding。
 
 ## Secret 仍由人类控制
 
@@ -129,9 +117,7 @@ ChatGPT 的前置条件；第一次 hosted-chat 路径用 `share`。
 - 完整 `agent.toml` 或 Server env 文件；
 - `Authorization` header。
 
-需要把 credential 填进 ChatGPT/Claude 时，要准确说明来源并让**人类**复制。首次优先使用
-成功的 `share`/`connect` disclosure；若必须恢复已保存的值，只指出精确受保护文件/字段，
-不要由 AI 自己回显。status/log 命令故意不显示 secret。
+需要把 credential 填进 ChatGPT/Claude 时，要准确说明来源并让**人类**复制。优先使用当前流程显式产生的连接信息，例如完整使用中的 `login --print-mcp-config`，或临时 `share` / 已有 Server `connect` 的成功 disclosure。若必须恢复已保存的值，只指出精确受保护文件/字段，不要由 AI 自己回显。status/log 命令故意不显示 secret。
 
 永远不要用 `wc_agent_*` Runner token 替代 MCP token，不要把 bootstrap
 `WEBCODEX_TOKEN` 当作 MCP credential，也不要假设 `webcodex token generate` 的离线素材

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,8 +44,10 @@ WebCodex exposes the same runtime through several thin adapters:
 - **Console** — a read-only browser view of project readiness and review.
 
 All adapters share the same Server, project registration, authentication, and
-policy boundaries. The project-bound Connector is the canonical project-first
-path; generic Servers expose their configured runtime surfaces instead.
+policy boundaries. A regular Server is the normal long-lived coding runtime and
+exposes its configured runtime surface. The project-bound Connector is the
+isolated project-first adapter used by flows such as `webcodex run` and
+`webcodex share`; it is intentionally a different, narrower execution contract.
 
 ## Project registration
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,10 +17,9 @@ The CLI produces three binaries when built from source:
 - `webcodex-runner` — the Runner process that executes project work (started
   and supervised with `webcodex runner ...`).
 
-`webcodex --help` lists the top-level namespaces. The sections below explain
-what each namespace is for.
+`webcodex --help` lists the top-level namespaces. The sections below explain what each namespace is for. This is the complete CLI reference; ordinary users do not need to understand every command, credential, or internal configuration field before their first successful setup.
 
-For a first ChatGPT connection, explicit `webcodex share` is the deterministic/script-friendly entry on Linux, macOS, and Windows. Running bare `webcodex` in an interactive Git checkout remains a Linux/macOS-only convenience shortcut; W2 does not change Windows no-command auto-dispatch. `share` performs project setup, starts the local Server and Runner, and exposes a temporary HTTPS MCP endpoint. For the default Quick Tunnel, WebCodex prefers `WEBCODEX_CLOUDFLARED_BIN`, then `cloudflared` on `PATH`, and otherwise acquires a pinned, verified managed copy before creating project/share state. Managed Cloudflare acquisition supports Windows x64; the pinned Cloudflare release has no official Windows ARM64 artifact, so Windows ARM64 Cloudflare use requires a trusted explicit/PATH binary. Managed OpenAI `tunnel-client` supports Windows x64 and arm64.
+For everyday development, follow the [Full Setup guide](PERSONAL_SETUP.md) and use a regular Server + Runner. `webcodex share` is the explicit **temporary one-project trial/share** entry on Linux, macOS, and Windows; it prepares the temporary project environment, Server, Runner, and optional Tunnel for that foreground run and ends when the process exits. Running bare `webcodex` in an interactive Git checkout remains a Linux/macOS convenience shortcut into that same temporary `share` flow.
 
 ## Command map
 
@@ -30,8 +29,8 @@ These commands work on the current Git project.
 
 | Command | Purpose | Notes |
 | --- | --- | --- |
-| `webcodex` (no command) | Fast interactive first-run shortcut | Only auto-dispatches to `share` on Linux/macOS when stdin/stdout are terminals and the current directory is inside a Git checkout; otherwise normal help is shown. |
-| `webcodex share` | Share the current project for ChatGPT/MCP over HTTPS | Explicit first-run path on Linux/macOS/Windows; includes setup, local Server + Runner, `cloudflare|openai|none`, managed tunnel acquisition when available, and bounded foreground cleanup. |
+| `webcodex` (no command) | Interactive temporary-share shortcut | Only auto-dispatches to `share` on Linux/macOS when stdin/stdout are terminals and the current directory is inside a Git checkout; otherwise normal help is shown. |
+| `webcodex share` | Temporarily share the current project with ChatGPT/MCP | Quick trial/short-lived sharing path on Linux/macOS/Windows; includes temporary setup, local Server + Runner, `cloudflare|openai|none`, and bounded foreground cleanup. Use `PERSONAL_SETUP` for full daily use. |
 | `webcodex connect <server>` | Connect the current project to an existing Server | Long-lived path when you already have a Server URL; defaults to hosted shared-key. |
 | `webcodex status` | Concise project coding readiness | Short summary; `doctor` is the full diagnostic check. |
 | `webcodex doctor` | Read-only readiness checks for the current project | Diagnostics/manual workflow; reports a stable `next action`. |
@@ -69,8 +68,8 @@ not advertised by ordinary MCP/GPT Actions model discovery.
 
 | Command | Purpose | Notes |
 | --- | --- | --- |
-| `webcodex login <server-url> --code <wc_pair_...> [--project PATH]` | Log this device into a Server with a pairing code | Primary client entry. `--allowed-root` is registration authority; `--project` registers an actual existing workspace. |
-| `webcodex project register --config PATH <PROJECT>` | Register an existing workspace in a Runner registry | Uses `projects_dir` from `agent.toml`; no Server connection is required to persist the local record. |
+| `webcodex login <server-url> --code <wc_pair_...> [--project PATH]` | Log this device into a Server with a one-time code | Normal managed enrollment entry. `--project` selects the actual project, `--allowed-root` names a parent from which more projects may be added later, and `--print-mcp-config` explicitly prints sensitive ChatGPT MCP connection values. |
+| `webcodex project register --config PATH <PROJECT>` | Add another project to an existing Runner | Persists that Runner's project configuration without requiring the Server to be online; follow the command output if an already-running Runner needs a reload. |
 | `webcodex pairing create` | Server/admin side: create a short-lived pairing code | Needs server bootstrap/admin auth. |
 | `webcodex client enroll` | Advanced client enrollment with explicit `--client-id` | Advanced; ordinary users should use `login`, which derives the client id and publishes the canonical per-server/user connection layout in one step. |
 | `webcodex logout <server-url>` | Remove this device's credentials for a Server | |
@@ -329,14 +328,24 @@ and `wc_oat_*` access tokens are delegated credentials; see
 
 ## Common examples
 
-First ChatGPT/MCP connection:
+Full everyday use: first follow the [Full Setup guide](PERSONAL_SETUP.md) to start a regular Server, then enroll the project machine and start its Runner:
+
+```bash
+webcodex login https://your-server.example --code <wc_pair_...> \
+  --allowed-root "$HOME/git" \
+  --project "$HOME/git/my-repo" \
+  --print-mcp-config
+webcodex runner run --config <login-reported-agent-config>
+```
+
+To try one repository temporarily:
 
 ```bash
 cd /path/to/your/repository
 webcodex share
 ```
 
-Local/manual workflow:
+Local/manual project-bound workflow (advanced/diagnostic):
 
 ```bash
 webcodex setup

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -14,9 +14,9 @@ Server API 完成。
 - `webcodex-runner` —— 实际执行项目工作的 Runner 进程（用
   `webcodex runner ...` 启动与托管）。
 
-`webcodex --help` 会列出顶层命名空间。下面按命名空间说明各自的用途。
+`webcodex --help` 会列出顶层命名空间。下面按命名空间说明各自的用途。本文是完整 CLI reference，不要求普通用户在第一次成功使用前理解所有命令、凭据或内部配置字段。
 
-第一次连接 ChatGPT 时，显式 `webcodex share` 已是 Linux、macOS、Windows 共同的脚本/确定性入口。交互式 Git checkout 中的裸 `webcodex` 自动进入 share 仍只属于 Linux/macOS convenience shortcut；W2 不改变 Windows 无子命令语义。`share` 会完成项目设置、启动本地 Server 与 Runner，并暴露临时 HTTPS MCP endpoint。默认 Quick Tunnel 依次使用 `WEBCODEX_CLOUDFLARED_BIN`、`PATH` 中的 `cloudflared`，否则获取固定版本 managed 副本。Windows x64 支持 managed Cloudflare；固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 ARM64 使用 Cloudflare 时需要受信任的显式/`PATH` binary。OpenAI `tunnel-client` 的 managed 获取支持 Windows x64/arm64。
+日常使用推荐按[完整使用指南](PERSONAL_SETUP.zh-CN.md)建立普通 Server + Runner。`webcodex share` 则是 Linux、macOS、Windows 上用于**临时试用/分享一个项目**的显式入口；它会为本次前台运行准备临时项目环境、Server、Runner 和可选 Tunnel，退出即结束。Linux/macOS 在交互式 Git checkout 中运行裸 `webcodex` 自动进入 `share`，也只是这个临时试用的 convenience shortcut。
 
 ## 命令总览
 
@@ -26,8 +26,8 @@ Server API 完成。
 
 | 命令 | 用途 | 说明 |
 | --- | --- | --- |
-| `webcodex`（无子命令） | 快速交互式 first-run shortcut | 仅 Linux/macOS + stdin/stdout 为终端 + 当前目录位于 Git checkout 时自动进入 `share`；否则照常显示 help。 |
-| `webcodex share` | 通过 HTTPS 把当前项目接入 ChatGPT/MCP | Linux/macOS/Windows 的显式首次使用主路径；包含 setup、本地 Server + Runner、`cloudflare|openai|none`、可用时的 managed tunnel 获取，以及有界前台 cleanup。 |
+| `webcodex`（无子命令） | 临时分享的交互式快捷方式 | 仅 Linux/macOS + stdin/stdout 为终端 + 当前目录位于 Git checkout 时自动进入 `share`；否则照常显示 help。 |
+| `webcodex share` | 临时把当前项目接入 ChatGPT/MCP | Linux/macOS/Windows 的快速试用/短期分享路径；包含临时 setup、本地 Server + Runner、`cloudflare|openai|none` 和有界前台 cleanup。日常完整使用见 `PERSONAL_SETUP`。 |
 | `webcodex connect <server>` | 把当前项目接入已有的 Server | 已经拥有 Server URL 时的长期路径；默认使用 hosted shared-key。 |
 | `webcodex status` | 简洁的项目 coding 就绪状态 | 简短状态；`doctor` 提供完整诊断。 |
 | `webcodex doctor` | 当前项目的只读就绪检查 | 诊断/手动工作流；输出稳定的 `next action`。 |
@@ -63,8 +63,8 @@ Cloudflare Quick Tunnel 的公网 origin 仍然是临时的。如需稳定 HTTPS
 
 | 命令 | 用途 | 说明 |
 | --- | --- | --- |
-| `webcodex login <server-url> --code <wc_pair_...> [--project PATH]` | 用 pairing code 把本机接入 Server | 主要客户端入口；`--allowed-root` 是注册 authority，`--project` 才注册实际 existing workspace。 |
-| `webcodex project register --config PATH <PROJECT>` | 在 Runner registry 中注册 existing workspace | 使用 `agent.toml` 中的 `projects_dir`；持久化本地 record 不要求 Server 在线。 |
+| `webcodex login <server-url> --code <wc_pair_...> [--project PATH]` | 用一次性登录码把本机接入 Server | 普通 managed 接入入口；`--project` 选择实际项目，`--allowed-root` 指定以后允许添加项目的父目录；`--print-mcp-config` 可显式打印敏感的 ChatGPT MCP 连接信息。 |
+| `webcodex project register --config PATH <PROJECT>` | 给现有 Runner 再添加一个项目 | 写入该 Runner 的项目配置；不要求 Server 在线即可持久化，运行中的 Runner 是否需 reload 以命令输出为准。 |
 | `webcodex pairing create` | Server/admin 侧：创建短期 pairing code | 需要 server bootstrap/admin 认证。 |
 | `webcodex client enroll` | 高级客户端接入，可显式指定 `--client-id` | 高级入口；普通用户应使用 `login`，它会自动派生 client id 并一步写入规范的 server/user 本地连接布局。 |
 | `webcodex logout <server-url>` | 移除本机对某 Server 的凭据 | |
@@ -297,14 +297,24 @@ WebCodex 把 bootstrap 管理、账号接入、runtime API 访问与 Runner 连�
 
 ## 常用示例
 
-第一次连接 ChatGPT/MCP：
+日常完整使用：先按[完整使用指南](PERSONAL_SETUP.zh-CN.md)启动普通 Server，再在项目机器上完成一次性登录并启动 Runner：
+
+```bash
+webcodex login https://your-server.example --code <wc_pair_...> \
+  --allowed-root "$HOME/git" \
+  --project "$HOME/git/my-repo" \
+  --print-mcp-config
+webcodex runner run --config <login-reported-agent-config>
+```
+
+只想临时试用一个仓库：
 
 ```bash
 cd /path/to/your/repository
 webcodex share
 ```
 
-Local/manual 工作流：
+Local/manual project-bound 工作流（高级/诊断）：
 
 ```bash
 webcodex setup
@@ -324,11 +334,9 @@ webcodex runner status --profile <profile>
 webcodex runner logs --profile <profile> --lines 100
 ```
 
-Managed 接入：
+Linux 上把已经验证过的 Runner 改为 user service：
 
 ```bash
-webcodex login https://your-server.example --code <wc_pair_...> \
-  --allowed-root "$HOME/git"
 webcodex runner install --scope user --config <login-reported-agent-config>
 webcodex runner status --scope user --config <login-reported-agent-config>
 webcodex ops status --server-url https://your-server.example \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,10 +2,7 @@
 
 [English](DEPLOYMENT.md) | [简体中文](DEPLOYMENT.zh-CN.md)
 
-This guide covers self-hosting WebCodex in production: building and installing
-the binaries, bootstrapping the Server, enrolling Runner machines, connecting
-MCP/GPT clients, and running smoke checks. For the shortest first ChatGPT/MCP
-connection, see [Quick Start](QUICK_START.md).
+This guide covers **production and advanced self-hosting**: building and installing the binaries, bootstrapping the Server, enrolling Runner machines, connecting MCP/GPT clients, and running smoke checks. For ordinary personal/daily use, start with the [Full Setup guide](PERSONAL_SETUP.md). If you only want a few-minute one-repository trial, use the [Quick Trial](QUICK_START.md).
 
 ## Components
 
@@ -59,13 +56,13 @@ webcodex pairing create --server-url http://127.0.0.1:8080 --env-file $envFile -
 Then, on the Windows machine that owns the repositories, redeem only that short-lived code and run the generated Runner config in the foreground:
 
 ```powershell
-webcodex login http://127.0.0.1:8080 --code <wc_pair_...> --allowed-root C:\src
+webcodex login http://127.0.0.1:8080 --code <wc_pair_...> --allowed-root C:\src --project C:\src\my-repo
 webcodex runner run --config <login-reported-agent-config>
 ```
 
 When Server and Runner are on different machines, replace the loopback URL with the Server's reachable HTTPS URL and configure the Server listener/public URL plus a trusted reverse proxy or tunnel as described below. Do not copy the Server bootstrap token or env file to the Runner machine. `webcodex server install/start/stop/restart/logs/uninstall` and `webcodex runner install` remain unsupported on Windows; Ctrl-C or Ctrl-Break ends the foreground runtime.
 
-To keep a Windows Server loopback-only while exposing MCP privately through an OpenAI Secure MCP Tunnel and operating an independent Runner like a normal long-lived Runner, see [Windows + OpenAI Secure MCP Tunnel](WINDOWS_OPENAI_TUNNEL.md). That guide records a real end-to-end dogfood run, including a Windows + Clash control-plane routing failure and its proxy fix.
+To keep a Windows Server loopback-only while exposing MCP privately through an OpenAI Secure MCP Tunnel and operating an independent Runner like a normal long-lived Runner, see the [Windows + OpenAI Secure MCP Tunnel deep dive](WINDOWS_OPENAI_TUNNEL.md). It is advanced setup/troubleshooting material and records a real end-to-end dogfood run, including a Windows + Clash control-plane routing failure and its proxy fix; ordinary users do not need it before understanding the full setup path.
 
 ## Connect a repository to an existing shared-key Server
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -2,9 +2,7 @@
 
 [English](DEPLOYMENT.md) | [简体中文](DEPLOYMENT.zh-CN.md)
 
-本文档覆盖 WebCodex 的生产自托管：构建与安装二进制、bootstrap Server、接入
-Runner 机器、连接 MCP/GPT 客户端以及 smoke 检查。第一次连接 ChatGPT/MCP 的最短路径见
-[快速开始](QUICK_START.zh-CN.md)。
+本文档覆盖 WebCodex 的**生产与高级自托管**：构建与安装二进制、bootstrap Server、接入 Runner 机器、连接 MCP/GPT 客户端以及 smoke 检查。普通个人/日常使用先看[完整使用指南](PERSONAL_SETUP.zh-CN.md)；如果只想几分钟临时体验一个仓库，再看[快速试用](QUICK_START.zh-CN.md)。
 
 ## 组件
 
@@ -56,13 +54,13 @@ webcodex pairing create --server-url http://127.0.0.1:8080 --env-file $envFile -
 然后在持有仓库的 Windows 机器上只兑换该短期 code，并以前台方式运行登录流程生成的 Runner 配置：
 
 ```powershell
-webcodex login http://127.0.0.1:8080 --code <wc_pair_...> --allowed-root C:\src
+webcodex login http://127.0.0.1:8080 --code <wc_pair_...> --allowed-root C:\src --project C:\src\my-repo
 webcodex runner run --config <login-reported-agent-config>
 ```
 
 如果 Server 与 Runner 位于不同机器，把 loopback URL 替换为 Server 可访问的 HTTPS URL，并按下文配置 Server listener/public URL 与受信任的反向代理或 tunnel。不要把 Server bootstrap token 或 env 文件复制到 Runner 机器。Windows 仍不支持 `webcodex server install/start/stop/restart/logs/uninstall` 与 `webcodex runner install`；Ctrl-C 或 Ctrl-Break 会结束前台 runtime。
 
-如果希望 Windows Server 保持 loopback-only，同时让 ChatGPT 通过 OpenAI Secure MCP Tunnel 访问，并把独立 Runner 当作普通长期 Runner 使用，见 [Windows + OpenAI Secure MCP Tunnel 实操指南](WINDOWS_OPENAI_TUNNEL.zh-CN.md)。该文档记录了一次真实端到端 dogfood，包括 Windows + Clash 环境下 control-plane 直连失败及代理修复。
+如果希望 Windows Server 保持 loopback-only，同时让 ChatGPT 通过 OpenAI Secure MCP Tunnel 访问，并把独立 Runner 当作普通长期 Runner 使用，见 [Windows + OpenAI Secure MCP Tunnel 深入实操](WINDOWS_OPENAI_TUNNEL.zh-CN.md)。该文档用于高级配置和排障，记录了一次真实端到端 dogfood，包括 Windows + Clash 环境下 control-plane 直连失败及代理修复；普通用户不需要先读它才能理解完整使用流程。
 
 ## 把仓库接入已有的 shared-key Server
 

--- a/docs/GPT_ACTIONS.md
+++ b/docs/GPT_ACTIONS.md
@@ -134,7 +134,8 @@ matching.
 
 ## Related
 
-- [Quick Start](QUICK_START.md)
+- [Full Setup](PERSONAL_SETUP.md)
+- [Quick Trial](QUICK_START.md)
 - [MCP](MCP.md)
 - [Authentication](AUTH_MODEL.md)
 - [Deployment](DEPLOYMENT.md)

--- a/docs/GPT_ACTIONS.zh-CN.md
+++ b/docs/GPT_ACTIONS.zh-CN.md
@@ -120,7 +120,8 @@ code，而不是匹配任意英文消息。
 
 ## 相关文档
 
-- [快速开始](QUICK_START.zh-CN.md)
+- [完整使用指南](PERSONAL_SETUP.zh-CN.md)
+- [快速试用](QUICK_START.zh-CN.md)
 - [MCP](MCP.zh-CN.md)
 - [认证模型](AUTH_MODEL.zh-CN.md)
 - [部署指南](DEPLOYMENT.zh-CN.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,19 +4,23 @@
 
 Start with the goal that matches what you are trying to do.
 
-## I want to try WebCodex
+## I want to use WebCodex normally
 
-- [README](../README.md) — what WebCodex does and the one-command first-run path
-- [Quick Start](QUICK_START.md) — zero to the first successful AI-assisted development request
-- [MCP](MCP.md) — ChatGPT, Claude, authentication choices, and other MCP clients
-- [AI-assisted setup](AI_ONBOARDING.md) — have an AI agent help configure WebCodex
+- [README](../README.md) — what WebCodex does and the difference between full use and a temporary trial
+- [Full Setup](PERSONAL_SETUP.md) — **recommended entry**: regular Server + Runner + projects + ChatGPT
+- [AI-assisted setup](AI_ONBOARDING.md) — have an AI agent configure WebCodex using ordinary user language
+- [MCP](MCP.md) — ChatGPT, Claude, and other MCP clients
 
-## I need Windows or a permanent deployment
+## I only want to try it for a few minutes
 
-- [Deployment](DEPLOYMENT.md) — self-hosting, Linux Server setup, Windows/Runner enrollment, and long-lived operation
-- [Windows + OpenAI Secure MCP Tunnel](WINDOWS_OPENAI_TUNNEL.md) — independent Windows Server/Runner, ChatGPT Tunnel Connector, and real troubleshooting notes
-- [Runner](RUNNER.md) — operate the component that works beside your repositories
-- [CLI](CLI.md) — commands, profiles, credentials, and operator reference
+- [Quick Trial](QUICK_START.md) — temporarily try one repository with one `webcodex share` command
+
+## I need production deployment or deep troubleshooting
+
+- [Deployment](DEPLOYMENT.md) — systemd/Docker, multi-user self-hosting, and long-lived operations
+- [Windows + OpenAI Secure MCP Tunnel deep dive](WINDOWS_OPENAI_TUNNEL.md) — independent Windows Server/Runner, Tunnel setup, and real troubleshooting notes
+- [Runner](RUNNER.md) — Runner operations reference
+- [CLI](CLI.md) — full command, configuration, and credential reference
 
 ## I need authentication or network options
 

--- a/docs/INDEX.zh-CN.md
+++ b/docs/INDEX.zh-CN.md
@@ -4,19 +4,23 @@
 
 按你现在想完成的事情选择文档即可。
 
-## 我想先试用 WebCodex
+## 我想正常使用 WebCodex
 
-- [README](../README.zh-CN.md) —— WebCodex 能做什么，以及一条命令的首次体验
-- [快速开始](QUICK_START.zh-CN.md) —— 从零到第一次成功完成 AI 开发请求
-- [MCP](MCP.zh-CN.md) —— ChatGPT、Claude、认证方式和其他 MCP 客户端
-- [AI 辅助接入](AI_ONBOARDING.zh-CN.md) —— 让 AI 帮你配置 WebCodex
+- [README](../README.zh-CN.md) —— WebCodex 能做什么，以及完整使用和临时试用的区别
+- [完整使用指南](PERSONAL_SETUP.zh-CN.md) —— **推荐入口**：普通 Server + Runner + 项目 + ChatGPT
+- [AI 辅助接入](AI_ONBOARDING.zh-CN.md) —— 让 AI 帮你按普通用户语言完成配置
+- [MCP](MCP.zh-CN.md) —— ChatGPT、Claude 与其他 MCP 客户端
 
-## 我需要 Windows 或长期部署
+## 我只想先试几分钟
 
-- [部署指南](DEPLOYMENT.zh-CN.md) —— 自托管 Linux Server、Windows/Runner 接入和长期运行
-- [Windows + OpenAI Secure MCP Tunnel 实操](WINDOWS_OPENAI_TUNNEL.zh-CN.md) —— 独立 Windows Server/Runner、ChatGPT Tunnel Connector 与真实故障排查
-- [Runner](RUNNER.zh-CN.md) —— 运维仓库所在机器上的执行组件
-- [CLI](CLI.zh-CN.md) —— 命令、配置、凭据和运维参考
+- [快速试用](QUICK_START.zh-CN.md) —— 一条 `webcodex share` 临时体验一个仓库
+
+## 我需要生产部署或深入排障
+
+- [部署指南](DEPLOYMENT.zh-CN.md) —— systemd/Docker、多用户、自托管和长期运维
+- [Windows + OpenAI Secure MCP Tunnel 深入实操](WINDOWS_OPENAI_TUNNEL.zh-CN.md) —— 独立 Windows Server/Runner、Tunnel 与真实故障排查
+- [Runner](RUNNER.zh-CN.md) —— Runner 运维参考
+- [CLI](CLI.zh-CN.md) —— 完整命令、配置和凭据参考
 
 ## 我需要认证或网络配置
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -2,17 +2,19 @@
 
 [English](MCP.md) | [简体中文](MCP.zh-CN.md)
 
-WebCodex exposes an MCP endpoint so ChatGPT, Claude, and other MCP clients can
-work with a repository through the Runner that owns it. For a first connection,
-start with the client setup below; protocol surfaces and scope ceilings are
-reference material, not onboarding prerequisites.
+WebCodex exposes an MCP endpoint so ChatGPT, Claude, and other MCP clients can work with repositories through the Runner that owns them. Ordinary users only need to choose between **full use** and a **temporary trial**; protocol surfaces, scopes, and credential taxonomy are reference material, not onboarding prerequisites.
 
-## ChatGPT Developer Mode: first connection
+## ChatGPT: recommended full setup
 
-The self-contained explicit `share` path below is supported on Linux, macOS, and Windows and owns a local foreground Server + Runner for the session. Windows x64 can use the managed default Cloudflare Quick Tunnel; Windows ARM64 needs a trusted explicit/PATH `cloudflared` because the pinned Cloudflare release publishes no official ARM64 artifact. Managed OpenAI `tunnel-client` supports both Windows x64 and arm64.
+For everyday use, run a regular Server + Runner. Follow the [Full Setup guide](PERSONAL_SETUP.md) for one-time login and project registration, and use `--print-mcp-config` during that same `webcodex login` to obtain regular HTTPS MCP connection values. Public HTTPS, Cloudflare Tunnel, and OpenAI Secure MCP Tunnel are reachability choices; they do not change the capabilities of this full development path.
 
-For the default temporary public path, WebCodex reuses an explicit/PATH
-`cloudflared` or downloads its pinned verified managed copy automatically, then run:
+If you only want to try one repository temporarily, use the `share` path below.
+
+## ChatGPT: temporary `share`
+
+Explicit `share` is supported on Linux, macOS, and Windows and owns a temporary single-project environment for that foreground run. Windows x64 can use the managed default Cloudflare Quick Tunnel; Windows ARM64 needs a trusted explicit/PATH `cloudflared` because the pinned Cloudflare release publishes no official ARM64 artifact. Managed OpenAI `tunnel-client` supports both Windows x64 and arm64.
+
+For the default temporary public path, WebCodex reuses an explicit/PATH `cloudflared` or downloads its pinned verified managed copy automatically, then run:
 
 ```bash
 npm install -g @yyjeqhc/webcodex
@@ -56,7 +58,7 @@ Read + Use, and run `webcodex share --tunnel openai`. ChatGPT uses Connection:
 Tunnel + No authentication; the temporary WebCodex Bearer stays local and is
 injected by the pinned verified OpenAI `tunnel-client`.
 
-For an explicit Windows Server + Runner + Tunnel topology, or to troubleshoot a case where local `/readyz` is healthy but ChatGPT Connector creation still fails, see [Windows + OpenAI Secure MCP Tunnel](WINDOWS_OPENAI_TUNNEL.md).
+For a regular independent Windows Server + Runner reached through OpenAI Tunnel, or to troubleshoot a case where local `/readyz` is healthy but ChatGPT Connector creation still fails, see the [Windows + OpenAI Secure MCP Tunnel deep dive](WINDOWS_OPENAI_TUNNEL.md). It is advanced setup/troubleshooting material, not required reading for a first-time user.
 
 ## Existing Server
 

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -2,16 +2,19 @@
 
 [English](MCP.md) | [简体中文](MCP.zh-CN.md)
 
-WebCodex 通过 MCP endpoint，让 ChatGPT、Claude 与其他 MCP client 使用持有仓库机器上的
-Runner。第一次接入先完成下面的客户端配置；protocol surface 与 scope ceiling 属于
-reference，不是 onboarding 前置知识。
+WebCodex 通过 MCP endpoint，让 ChatGPT、Claude 与其他 MCP client 使用持有仓库机器上的 Runner。普通用户先选择**完整使用**还是**临时试用**即可；protocol surface、scope、credential taxonomy 都属于 reference，不是 onboarding 前置知识。
 
-## ChatGPT Developer Mode：第一次接入
+## ChatGPT：推荐的完整使用方式
 
-下面的 self-contained 显式 `share` 路径支持 Linux、macOS 与 Windows，并由当前前台 session 持有本地 Server + Runner。Windows x64 可直接使用 managed 默认 Cloudflare Quick Tunnel；固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 ARM64 需要受信任的显式/`PATH` `cloudflared`。managed OpenAI `tunnel-client` 支持 Windows x64/arm64。
+日常使用推荐普通 Server + Runner。按照[完整使用指南](PERSONAL_SETUP.zh-CN.md)完成一次性登录和项目注册，并在同一次 `webcodex login` 中使用 `--print-mcp-config` 获取普通 HTTPS MCP 连接信息。公网 HTTPS、Cloudflare Tunnel 或 OpenAI Secure MCP Tunnel 只负责到达 Server，不改变这条完整开发路径本身的能力。
 
-默认临时公网路径会复用显式指定/`PATH` 中的 `cloudflared`，否则由 WebCodex 自动下载并校验
-固定的 managed 副本，然后执行：
+如果只是临时试用一个仓库，再使用下面的 `share` 路径。
+
+## ChatGPT：临时 `share`
+
+显式 `share` 支持 Linux、macOS 与 Windows，并由当前前台进程持有临时单项目环境。Windows x64 可直接使用 managed 默认 Cloudflare Quick Tunnel；固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 ARM64 需要受信任的显式/`PATH` `cloudflared`。managed OpenAI `tunnel-client` 支持 Windows x64/arm64。
+
+默认临时公网路径会复用显式指定/`PATH` 中的 `cloudflared`，否则由 WebCodex 自动下载并校验固定的 managed 副本，然后执行：
 
 ```bash
 npm install -g @yyjeqhc/webcodex
@@ -51,7 +54,7 @@ share 的 Project Credential，并不是 PAT/OAuth/shared-key 的通用 query au
 Connection: Tunnel + No authentication；临时 WebCodex Bearer 留在本机，由固定且经过校验的
 OpenAI `tunnel-client` 注入。
 
-如果需要在 Windows 上把 Server、Runner 和 Tunnel 显式拆开运行，或排查“本地 `/readyz` 正常但 ChatGPT Connector 创建失败”的情况，见 [Windows + OpenAI Secure MCP Tunnel 实操指南](WINDOWS_OPENAI_TUNNEL.zh-CN.md)。
+如果在 Windows 上使用普通独立 Server + Runner 并通过 OpenAI Tunnel 接入，或排查“本地 `/readyz` 正常但 ChatGPT Connector 创建失败”的情况，见 [Windows + OpenAI Secure MCP Tunnel 深入实操](WINDOWS_OPENAI_TUNNEL.zh-CN.md)。它是深入配置/排障文档，不是普通用户第一次必须阅读的教程。
 
 ## 已有 Server
 

--- a/docs/PERSONAL_SETUP.md
+++ b/docs/PERSONAL_SETUP.md
@@ -1,0 +1,199 @@
+# Full WebCodex Setup
+
+[English](PERSONAL_SETUP.md) | [简体中文](PERSONAL_SETUP.zh-CN.md)
+
+Use this path when WebCodex is part of your normal development setup rather than a temporary repository share. The goal is simple: connect ChatGPT to a regular WebCodex Server, then let a persistent Runner use the real projects, Git checkout, compiler, and test tools on your machine.
+
+If you only want to try WebCodex for a few minutes, use the [Quick Trial](QUICK_START.md) and `webcodex share` instead. `share` is a temporary, single-project, more restricted experience that ends when the command exits.
+
+## What you will have
+
+```text
+ChatGPT / another AI client
+          |
+          | MCP
+          v
+   WebCodex Server
+          |
+          v
+       Runner
+          |
+          +-- your projects
+          +-- Git
+          +-- compilers / tests / developer tools
+```
+
+The Server may run on the repository machine or elsewhere. The Runner should run on the machine that actually owns the code and development environment. Public HTTPS, Cloudflare Tunnel, and OpenAI Secure MCP Tunnel are only ways for the AI client to reach the Server; they do not turn a regular Server into a different restricted execution mode.
+
+## 1. Install WebCodex
+
+Install Node.js 18+ and Git, then:
+
+```bash
+npm install -g @yyjeqhc/webcodex
+webcodex --version
+```
+
+## 2. Start a regular Server
+
+For a first personal setup, foreground mode is the easiest path to understand and diagnose. You can switch to a Linux service or another long-lived process manager after the setup works.
+
+Linux example:
+
+```bash
+webcodex server init \
+  --listen 127.0.0.1:8080 \
+  --data-dir "$HOME/.local/share/webcodex" \
+  --env-file "$HOME/.config/webcodex/webcodex.env"
+
+webcodex server run \
+  --env-file "$HOME/.config/webcodex/webcodex.env"
+```
+
+Windows PowerShell example:
+
+```powershell
+$envFile = Join-Path $HOME ".config\webcodex\webcodex.env"
+$dataDir = Join-Path $HOME ".local\share\webcodex"
+
+webcodex server init --listen 127.0.0.1:8080 --data-dir $dataDir --env-file $envFile
+webcodex server run --env-file $envFile
+```
+
+Keep that terminal running. On Linux, once the setup is verified, the [Deployment guide](DEPLOYMENT.md) covers installing the Server as a service.
+
+## 3. Choose the connection paths
+
+There are really two connections. Ordinary users only need to make sure each can reach the Server:
+
+- **Runner / CLI → Server**: when Server and Runner are on the same machine, `http://127.0.0.1:8080` is enough; otherwise use a Server address reachable by the Runner machine.
+- **ChatGPT → Server**: hosted ChatGPT cannot reach your computer's `127.0.0.1`, so use a stable public HTTPS endpoint, Cloudflare Tunnel, OpenAI Secure MCP Tunnel, or another trusted reachable entry.
+
+A Tunnel solves reachability only. Do not switch to `webcodex share` merely because you use a Tunnel; the full setup continues to use the regular Server started above.
+
+With public HTTPS or Cloudflare, both connections can often use the same HTTPS Server URL. OpenAI Secure MCP Tunnel may differ: the Runner can keep using loopback/LAN while ChatGPT reaches `/mcp` through the Tunnel.
+
+For Windows + OpenAI Secure MCP Tunnel, see the [Windows + OpenAI Tunnel deep-dive and troubleshooting guide](WINDOWS_OPENAI_TUNNEL.md). It records a complete real-world setup and one real network failure; treat it as deeper troubleshooting material to read only when needed.
+
+Below, `<server-url>` means the address used by the **CLI / Runner** to reach the Server. A same-machine setup can use `http://127.0.0.1:8080`; an existing stable HTTPS URL can be used directly as well.
+
+## 4. Create a one-time login code
+
+On the Server machine, open another terminal and create a short-lived pairing code:
+
+```bash
+webcodex pairing create \
+  --server-url <server-url> \
+  --env-file <server-init-used-env-file> \
+  --username <your-name> \
+  --ttl-secs 600
+```
+
+Only carry the resulting `wc_pair_...` code to the Runner machine. Do not copy the Server administrator token or the whole Server env file.
+
+Even when Server and Runner are on the same computer, this login flow is useful because everyday development access stays separate from Server administration.
+
+## 5. Log in and choose a project
+
+On the machine that owns the code:
+
+The example below assumes **regular HTTPS MCP**, so it includes `--print-mcp-config` in the same one-time login. If ChatGPT will connect through **OpenAI Secure MCP Tunnel**, remove `--print-mcp-config` and follow the Tunnel guide for the ChatGPT-side connection; never redeem the same pairing code again just to print configuration.
+
+```bash
+webcodex login <server-url> \
+  --code <wc_pair_...> \
+  --allowed-root /path/to/your/projects \
+  --project /path/to/your/projects/my-repo \
+  --print-mcp-config
+```
+
+Windows PowerShell example:
+
+```powershell
+webcodex login <server-url> `
+  --code <wc_pair_...> `
+  --allowed-root E:\git `
+  --project E:\git\my-repo `
+  --print-mcp-config
+```
+
+For ordinary use, remember only two things:
+
+- `--project` is the project you want the AI to use now;
+- `--allowed-root` is a parent directory from which you may add more projects later.
+
+You do not need to edit the Runner's internal configuration files manually.
+
+To add another project later, use the Runner config printed by login:
+
+```bash
+webcodex project register --config <agent-config> /path/to/another-repo
+```
+
+## 6. Start the Runner
+
+`login` prints the Runner configuration path. On Windows, run it in the foreground:
+
+```bash
+webcodex runner run --config <login-reported-agent-config>
+```
+
+On Linux, foreground mode is also a good first check:
+
+```bash
+webcodex runner run --config <login-reported-agent-config>
+```
+
+Or install it as a user service:
+
+```bash
+webcodex runner install --scope user --config <login-reported-agent-config>
+```
+
+Once the Runner is online, WebCodex has an execution path to the machine's files, Git checkout, compiler, tests, and other development tools.
+
+## 7. Add WebCodex to ChatGPT
+
+If you chose regular HTTPS MCP, the `login --print-mcp-config` command above prints the connection values after that **same one-time login** succeeds. Do not redeem the pairing code first and then repeat `login` just to obtain MCP values; pairing codes are single-use.
+
+That output contains a user credential. Only you should enter it into ChatGPT; do not paste it into issues, logs, or chat messages. Create an App / MCP connection in ChatGPT using the MCP URL and authentication method printed by the CLI, then run **Scan Tools**.
+
+If you chose OpenAI Secure MCP Tunnel, login does not need `--print-mcp-config` for ChatGPT. ChatGPT normally uses Tunnel + No authentication while the local tunnel client injects the WebCodex credential. Follow the Tunnel guide instead of copying the local Bearer into ChatGPT.
+
+## 8. Verify the full experience
+
+Start with a read-only request:
+
+```text
+Inspect this project and summarize its structure. Do not change files yet.
+```
+
+Then try a small, reviewable change:
+
+```text
+Fix one small issue, run the relevant tests, and tell me what actually changed.
+```
+
+With the full setup, the AI should be able to explore and edit projects, use Git, run commands and tests, handle long-running work, and use code navigation. Exact availability still depends on the local directories/features you allow this Runner to use and the permissions actually granted by the AI client.
+
+## Quick share vs. full setup
+
+| Goal | Recommended entry | What it is |
+| --- | --- | --- |
+| Try one repository for a few minutes | `webcodex share` | One command, temporary, single-project, ends on exit, more restricted |
+| Use WebCodex for everyday development | regular Server + Runner (this guide) | Durable identity, multiple projects, full development tools, independent network choice |
+| Operate a team/production deployment | [Deployment](DEPLOYMENT.md) | systemd, Docker, OAuth, multi-user and operator reference |
+
+A Tunnel is a network path, not a permission mode. Choosing a public hostname, Cloudflare, or OpenAI Tunnel should not determine whether you use the temporary-share or full-setup product experience.
+
+## Troubleshooting
+
+Start with three simple checks:
+
+```bash
+webcodex server status --env-file <server-env-file>
+webcodex runner status --config <agent-config>
+webcodex ops status --server-url <server-url> --token-file <login-reported-webcodex-user-token>
+```
+
+See [Troubleshooting](TROUBLESHOOTING.md) for detailed failures. The [CLI reference](CLI.md) documents every command and internal configuration field, but you do not need to understand those internals before successfully using WebCodex.

--- a/docs/PERSONAL_SETUP.zh-CN.md
+++ b/docs/PERSONAL_SETUP.zh-CN.md
@@ -1,0 +1,199 @@
+# WebCodex 完整使用指南
+
+[English](PERSONAL_SETUP.md) | [简体中文](PERSONAL_SETUP.zh-CN.md)
+
+这条路径适合把 WebCodex 当作日常开发工具，而不是只临时分享一个仓库。目标很简单：让 ChatGPT 连接一个普通 WebCodex Server，再由长期运行的 Runner 使用你机器上的真实项目、Git、编译器和测试工具。
+
+如果你只想先试几分钟，不想配置长期服务，请直接看[快速试用](QUICK_START.zh-CN.md)并使用 `webcodex share`。`share` 是临时、单项目的受限体验；关闭命令后连接就会结束。
+
+## 你最终会得到什么
+
+```text
+ChatGPT / 其他 AI 客户端
+          |
+          | MCP
+          v
+   WebCodex Server
+          |
+          v
+       Runner
+          |
+          +-- 你的项目
+          +-- Git
+          +-- 编译器 / 测试 / 开发工具
+```
+
+Server 可以在仓库机器本身运行，也可以放在另一台机器。Runner 应运行在真正持有代码和开发环境的机器上。公网 HTTPS、Cloudflare Tunnel 或 OpenAI Secure MCP Tunnel 只负责让 AI 客户端到达 Server，不会把普通 Server 变成另一套受限执行模式。
+
+## 1. 安装 WebCodex
+
+需要 Node.js 18+ 和 Git：
+
+```bash
+npm install -g @yyjeqhc/webcodex
+webcodex --version
+```
+
+## 2. 启动普通 Server
+
+第一次个人使用可以先以前台方式运行。这样最容易理解和排查，之后再按需要改成 Linux service 或其他长期托管方式。
+
+Linux 示例：
+
+```bash
+webcodex server init \
+  --listen 127.0.0.1:8080 \
+  --data-dir "$HOME/.local/share/webcodex" \
+  --env-file "$HOME/.config/webcodex/webcodex.env"
+
+webcodex server run \
+  --env-file "$HOME/.config/webcodex/webcodex.env"
+```
+
+Windows PowerShell 示例：
+
+```powershell
+$envFile = Join-Path $HOME ".config\webcodex\webcodex.env"
+$dataDir = Join-Path $HOME ".local\share\webcodex"
+
+webcodex server init --listen 127.0.0.1:8080 --data-dir $dataDir --env-file $envFile
+webcodex server run --env-file $envFile
+```
+
+保持这个终端运行。Linux 如果希望开机长期运行，可在首次验证成功后再看[部署指南](DEPLOYMENT.zh-CN.md)中的 service 安装方式。
+
+## 3. 选择连接方式
+
+这里其实有两条连接，普通用户只需要保证它们各自能到达 Server：
+
+- **Runner / CLI → Server**：如果 Server 和 Runner 在同一台机器，可以直接使用 `http://127.0.0.1:8080`；如果不在同一台机器，就使用 Runner 能访问到的 Server 地址。
+- **ChatGPT → Server**：Hosted ChatGPT 不能直接访问你电脑上的 `127.0.0.1`，因此需要稳定公网 HTTPS、Cloudflare Tunnel 或 OpenAI Secure MCP Tunnel 等可达入口。
+
+Tunnel 只解决网络可达性。不要为了使用 Tunnel 改成 `webcodex share`；完整使用路径仍然是上一步启动的普通 Server。
+
+普通公网 HTTPS / Cloudflare 场景中，两条连接通常可以使用同一个 HTTPS Server URL。OpenAI Secure MCP Tunnel 可以不同：Runner 仍然通过 loopback/LAN 连接普通 Server，ChatGPT 单独通过 Tunnel 访问 `/mcp`。
+
+如果你使用 Windows + OpenAI Secure MCP Tunnel，可以参考[Windows + OpenAI Tunnel 深入配置与故障排查](WINDOWS_OPENAI_TUNNEL.zh-CN.md)。那篇文档记录了完整实操和一次真实网络故障，作为需要时再看的深入排障材料即可。
+
+下面用 `<server-url>` 表示 **CLI / Runner 用来访问 Server 的地址**。同机部署可以直接写 `http://127.0.0.1:8080`；已有稳定 HTTPS 时也可以直接使用该 HTTPS URL。
+
+## 4. 创建一次性登录码
+
+在 Server 机器上打开另一个终端，创建一个短期 pairing code：
+
+```bash
+webcodex pairing create \
+  --server-url <server-url> \
+  --env-file <server-init-used-env-file> \
+  --username <your-name> \
+  --ttl-secs 600
+```
+
+只需要把输出的 `wc_pair_...` 一次性登录码带到 Runner 机器。不要复制 Server 的管理员 token 或整个 env 文件。
+
+如果 Server 和 Runner 是同一台机器，也仍然建议走这条登录流程：日常开发权限与 Server 管理权限会保持分离。
+
+## 5. 登录并选择项目
+
+在持有代码的机器上运行：
+
+下面的示例按**普通 HTTPS MCP** 展示，因此在同一次一次性登录中带上 `--print-mcp-config`。如果 ChatGPT 将通过 **OpenAI Secure MCP Tunnel** 连接，请删掉 `--print-mcp-config`，并按 Tunnel 指南完成 ChatGPT 侧连接；不要为了打印配置再次兑换同一个 pairing code。
+
+```bash
+webcodex login <server-url> \
+  --code <wc_pair_...> \
+  --allowed-root /path/to/your/projects \
+  --project /path/to/your/projects/my-repo \
+  --print-mcp-config
+```
+
+Windows PowerShell 示例：
+
+```powershell
+webcodex login <server-url> `
+  --code <wc_pair_...> `
+  --allowed-root E:\git `
+  --project E:\git\my-repo `
+  --print-mcp-config
+```
+
+这里普通用户只需要记住两件事：
+
+- `--project` 是你现在希望 AI 使用的项目；
+- `--allowed-root` 是以后允许你继续添加项目的父目录。
+
+不需要手工编辑 Runner 的内部配置文件。
+
+如果以后再添加一个项目，使用 login 输出的 Runner 配置：
+
+```bash
+webcodex project register --config <agent-config> /path/to/another-repo
+```
+
+## 6. 启动 Runner
+
+`login` 会打印 Runner 配置路径。Windows 可以直接以前台方式运行：
+
+```bash
+webcodex runner run --config <login-reported-agent-config>
+```
+
+Linux 普通用户可以先以前台验证，也可以安装 user service：
+
+```bash
+webcodex runner run --config <login-reported-agent-config>
+```
+
+或：
+
+```bash
+webcodex runner install --scope user --config <login-reported-agent-config>
+```
+
+Runner 运行后，WebCodex 才真正拥有调用本机文件、Git、编译器和测试工具的执行入口。
+
+## 7. 把 WebCodex 加到 ChatGPT
+
+如果你选择普通 HTTPS MCP，上面的 `login --print-mcp-config` 会在**同一次一次性登录**成功后打印连接信息。不要先兑换 pairing code，再为了拿连接信息重复执行 `login`；pairing code 是一次性的。
+
+这段输出包含用户凭据，只应由你本人填入 ChatGPT，不要粘贴到 issue、日志或聊天消息中。在 ChatGPT 的 App / MCP 设置中创建连接，使用 CLI 打印的 MCP URL 与认证方式，然后 **Scan Tools**。
+
+如果你选择 OpenAI Secure MCP Tunnel，登录时不需要 `--print-mcp-config` 给 ChatGPT 使用；ChatGPT 侧通常选择 Tunnel + No authentication，由本机 tunnel client 注入 WebCodex 凭据。按对应 Tunnel 指南操作，不要把本地 Bearer 复制给 ChatGPT。
+
+## 8. 验证完整体验
+
+先让 AI 读取项目：
+
+```text
+检查这个项目并总结结构。先不要修改文件。
+```
+
+然后再做一个小而可审查的修改：
+
+```text
+修复一个小问题，运行相关测试，并告诉我实际修改了什么。
+```
+
+完整使用路径下，AI 应能够探索和编辑项目、使用 Git、运行命令和测试、处理长时间任务，并使用代码导航能力。最终可用范围仍由你给这台 Runner 开放的本机目录/功能，以及 ChatGPT 客户端实际授予的权限共同决定。
+
+## 临时试用和完整使用有什么区别？
+
+| 场景 | 推荐入口 | 特点 |
+| --- | --- | --- |
+| 我只想几分钟体验一下一个仓库 | `webcodex share` | 一条命令、临时、单项目、关闭即失效、能力更受限 |
+| 我准备日常使用 WebCodex | 普通 Server + Runner（本文） | 长期身份、多个项目、完整开发工具、网络入口可独立选择 |
+| 我在维护团队/生产部署 | [部署指南](DEPLOYMENT.zh-CN.md) | systemd、Docker、OAuth、多用户和运维参考 |
+
+Tunnel 是网络入口，不是权限模式。是否使用公网域名、Cloudflare 或 OpenAI Tunnel，不应该改变你选择“临时分享”还是“完整使用”。
+
+## 遇到问题
+
+优先检查三个简单状态：
+
+```bash
+webcodex server status --env-file <server-env-file>
+webcodex runner status --config <agent-config>
+webcodex ops status --server-url <server-url> --token-file <login-reported-webcodex-user-token>
+```
+
+更详细的错误处理见[故障排查](TROUBLESHOOTING.zh-CN.md)。命令和配置字段的完整参考见 [CLI](CLI.zh-CN.md)，但第一次成功使用 WebCodex 不需要先理解那些内部术语。

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,8 +1,10 @@
-# Quick Start
+# Quick Trial
 
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
-This page is only the shortest path from a local repository to a first successful AI-assisted development request. You do not need to understand WebCodex internals before starting.
+This page does one thing: use `webcodex share` to temporarily expose one local repository so you can decide within a few minutes whether WebCodex fits your workflow. This is a **temporary, single-project, restricted experience** that ends when the command exits.
+
+For everyday WebCodex use and the full regular Server + Runner coding experience, go directly to the [Full Setup guide](PERSONAL_SETUP.md) instead of treating `share` as the default long-lived deployment.
 
 ## Prerequisites
 
@@ -21,7 +23,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-You do not need to run `setup`, `doctor`, or `run` first. The default one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits.
+A temporary trial does not require `setup`, `doctor`, or `run` first. The one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits.
 
 ## 2. Wait for `WebCodex ready`
 
@@ -67,12 +69,12 @@ Use Git or the WebCodex review surfaces to inspect the result before accepting i
 
 ## Done
 
-You now have a working first connection. Keep the WebCodex terminal open while using this temporary share; Ctrl-C ends it.
+The temporary trial is working. Keep the WebCodex terminal open while using this share; Ctrl-C ends it.
 
-Next steps:
+If you want to keep using WebCodex for daily development, move next to the [Full Setup guide](PERSONAL_SETUP.md) for the regular Server + Runner coding experience. Other references:
 
 - [ChatGPT, Claude, and authentication options](MCP.md)
-- [Windows and permanent/self-hosted deployment](DEPLOYMENT.md)
+- [Production and advanced deployment](DEPLOYMENT.md)
 - [CLI reference](CLI.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
 - [Security](../SECURITY.md)

--- a/docs/QUICK_START.zh-CN.md
+++ b/docs/QUICK_START.zh-CN.md
@@ -1,8 +1,10 @@
-# 快速开始
+# 快速试用
 
 [English](QUICK_START.md) | [简体中文](QUICK_START.zh-CN.md)
 
-这个页面只做一件事：让一个本地代码仓库尽快完成第一次 AI 开发请求。开始之前不需要理解 WebCodex 的内部架构。
+这个页面只做一件事：用 `webcodex share` 临时分享一个本地仓库，让你几分钟内判断 WebCodex 是否适合自己。这个模式是一条命令的**临时、单项目、受限体验**；关闭命令后连接会结束。
+
+如果你准备日常使用 WebCodex，并希望获得普通 Server + Runner 的完整 coding 能力，请直接使用[完整使用指南](PERSONAL_SETUP.zh-CN.md)，不要把 `share` 当作长期默认部署。
 
 ## 前置条件
 
@@ -21,7 +23,7 @@ cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-第一次使用不需要提前运行 `setup`、`doctor` 或 `run`。默认的一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。
+临时试用不需要提前运行 `setup`、`doctor` 或 `run`。这一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。
 
 ## 2. 等待 `WebCodex ready`
 
@@ -67,12 +69,12 @@ npx --yes @yyjeqhc/webcodex share --auth query-token
 
 ## 完成
 
-第一次连接已经成功。使用这次临时分享时保持 WebCodex 终端运行；按 Ctrl-C 会结束本次连接。
+临时试用已经成功。使用这次分享时保持 WebCodex 终端运行；按 Ctrl-C 会结束本次连接。
 
-接下来按需要阅读：
+如果准备继续日常使用，下一步推荐切换到[完整使用指南](PERSONAL_SETUP.zh-CN.md)，获得普通 Server + Runner 的完整 coding 体验。其他参考：
 
 - [ChatGPT、Claude 与认证方式](MCP.zh-CN.md)
-- [Windows 与长期/自托管部署](DEPLOYMENT.zh-CN.md)
+- [生产与高级部署](DEPLOYMENT.zh-CN.md)
 - [CLI 参考](CLI.zh-CN.md)
 - [故障排查](TROUBLESHOOTING.zh-CN.md)
 - [安全说明](../SECURITY.md)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -36,8 +36,8 @@ During implementation/review, run focused lanes when touching runtime metadata, 
 
 Confirm the user-facing docs tell one story:
 
-- README states the product position in the first screen.
-- Quick Start has one recommended local-first path.
+- README states the product position in the first screen and clearly separates full daily use from temporary `share`.
+- Full Setup has one recommended regular Server + Runner path for ordinary daily use; Quick Trial stays focused on temporary single-project `share`.
 - Concepts explains server, agent, agent-registered projects, runtime project ids, ToolRuntime, MCP, GPT Actions, session, handoff, validation, review/hygiene, and `run_shell` as an escape hatch.
 - Architecture starts with client/server/agent/codebase, security-boundary, and runtime-module diagrams before Rust module notes.
 - MCP and GPT Actions both say they call the same WebCodex ToolRuntime.

--- a/docs/WINDOWS_OPENAI_TUNNEL.md
+++ b/docs/WINDOWS_OPENAI_TUNNEL.md
@@ -6,6 +6,8 @@
 
 ## When to use this topology
 
+If your goal is simply **normal long-lived WebCodex use**, start with the [Full Setup guide](PERSONAL_SETUP.md). This page is a Windows + OpenAI Tunnel deep dive and troubleshooting record; continue here when you deliberately choose this private network path, need to reproduce the explicit topology, or are diagnosing Tunnel behavior.
+
 Use this setup when the Windows machine should host the complete WebCodex runtime while keeping the Server private:
 
 - WebCodex Server runs in the foreground on Windows;

--- a/docs/WINDOWS_OPENAI_TUNNEL.zh-CN.md
+++ b/docs/WINDOWS_OPENAI_TUNNEL.zh-CN.md
@@ -6,6 +6,8 @@
 
 ## 适用场景
 
+如果你的目标只是**正常长期使用 WebCodex**，先看[完整使用指南](PERSONAL_SETUP.zh-CN.md)。本文是 Windows + OpenAI Tunnel 的深入配置与故障排查记录，只有在你明确选择这条私有网络入口、需要复现实操拓扑或排查 Tunnel 问题时才需要继续阅读。
+
 你希望 Windows 机器本身承担完整的 WebCodex runtime：
 
 - WebCodex Server 运行在 Windows 前台；

--- a/npm/webcodex/README.md
+++ b/npm/webcodex/README.md
@@ -8,37 +8,26 @@
 
 WebCodex lets an AI inspect and edit code, run tests and commands, use Git, and work with the development environment that already exists beside your repository.
 
-### Fastest first connection
+### Recommended: full everyday setup
 
-Requires Node.js 18+ and Git. On Linux, macOS, or Windows x64:
+For normal daily use, install WebCodex and run a regular Server + Runner. This gives ChatGPT the full coding runtime against your real projects; public HTTPS, Cloudflare, and OpenAI Tunnel are reachability choices rather than separate permission modes.
+
+```bash
+npm install -g @yyjeqhc/webcodex
+```
+
+Follow the [Full Setup guide](https://github.com/yyjeqhc/webcodex/blob/main/docs/PERSONAL_SETUP.md) for Server startup, one-time login, project selection, Runner startup, and ChatGPT connection.
+
+### Quick temporary trial
+
+If you only want to try one repository for a few minutes, use:
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-When WebCodex reports **WebCodex ready**, keep the terminal open. Linux and macOS normally copy the **MCP URL** to your clipboard and can use **Enter** in an interactive terminal to open ChatGPT App settings. On Windows, copy the printed **MCP URL** manually and open **Settings -> Apps -> Create**. Then:
-
-1. Enable **Developer Mode** if needed and choose **Create**.
-2. Paste the copied **MCP URL** (or use the URL printed by WebCodex).
-3. Choose **Access token / API key** (Bearer token) and paste the printed **Credential**.
-4. Run **Scan Tools**.
-
-The default one-command flow creates a temporary public HTTPS MCP endpoint protected by that run's temporary credential; both the endpoint and credential stop working when the command exits. Developer Mode, custom MCP Apps, and write/modify actions depend on your ChatGPT plan, workspace, and administrator policy; WebCodex cannot enable capabilities the client does not grant.
-
-Try:
-
-```text
-Inspect this repository and summarize its structure. Do not make changes.
-```
-
-If ChatGPT does not show a Bearer/access-token option, or reports **does not implement OAuth**, run:
-
-```bash
-npx --yes @yyjeqhc/webcodex share --auth query-token
-```
-
-Paste the complete `/mcp?token=...` URL and choose **No authentication**. This fallback requires WebCodex 0.3.9 or later. Treat the complete URL as a temporary secret. If the package is installed globally, `webcodex share --auth query-token` is equivalent.
+`share` is a temporary, single-project, more restricted experience. The endpoint and temporary credential stop working when the command exits. See the [Quick Trial](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.md) for the ChatGPT steps and authentication fallback.
 
 ### Platforms
 
@@ -46,7 +35,7 @@ Paste the complete `/mcp?token=...` URL and choose **No authentication**. This f
 - macOS x64/arm64: local one-command `share` and Runner workflows.
 - Windows x64/arm64: CLI + Runner, foreground Server, and explicit local `share` with `cloudflare`, `openai`, or `none`. Windows x64 auto-manages the pinned Cloudflare binary; managed OpenAI `tunnel-client` supports x64 and arm64. The pinned Cloudflare release has no official Windows ARM64 artifact, so ARM64 Cloudflare use requires a trusted explicit/PATH binary. Managed Windows Server services remain unsupported.
 
-For Windows, permanent/self-hosted setup, OAuth, private tunnels, proxy settings, and troubleshooting, use the [WebCodex documentation](https://github.com/yyjeqhc/webcodex/tree/main/docs). The [Quick Start](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.md) stays focused on the first successful connection.
+For normal Windows/Linux use, start with the [Full Setup guide](https://github.com/yyjeqhc/webcodex/blob/main/docs/PERSONAL_SETUP.md). Production hosting, OAuth, private-network details, proxy settings, and troubleshooting are available in the [WebCodex documentation](https://github.com/yyjeqhc/webcodex/tree/main/docs).
 
 ### Install globally
 
@@ -66,37 +55,26 @@ WebCodex can read and modify files and execute commands inside configured projec
 
 WebCodex 可以让 AI 理解和修改代码、运行测试与命令、检查 Git，并直接使用仓库旁边已经存在的真实开发环境。
 
-### 最快的第一次连接
+### 推荐：日常完整使用
 
-需要 Node.js 18+ 和 Git。Linux、macOS 或 Windows x64 上进入仓库：
+如果准备正常长期使用 WebCodex，推荐安装后运行普通 Server + Runner。这样 ChatGPT 可以使用真实项目上的完整 coding runtime；公网 HTTPS、Cloudflare、OpenAI Tunnel 都只是网络连接方式，不是不同的权限模式。
+
+```bash
+npm install -g @yyjeqhc/webcodex
+```
+
+按照[完整使用指南](https://github.com/yyjeqhc/webcodex/blob/main/docs/PERSONAL_SETUP.zh-CN.md)完成 Server 启动、一次性登录、项目选择、Runner 启动和 ChatGPT 连接。
+
+### 快速临时试用
+
+如果只想用几分钟体验一个仓库，可以运行：
 
 ```bash
 cd /path/to/your/repository
 npx --yes @yyjeqhc/webcodex share
 ```
 
-看到 **WebCodex ready** 后保持终端运行。Linux 与 macOS 通常会自动复制 **MCP URL**，并可在交互终端按 **Enter** 打开 ChatGPT App 设置；Windows 请手动复制终端中打印的 **MCP URL**，并进入 **Settings -> Apps -> Create**。然后：
-
-1. 如有需要，开启 **Developer Mode** 并选择 **Create**。
-2. 粘贴已经复制的 **MCP URL**；也可以使用 WebCodex 终端中打印的地址。
-3. 认证选择 **Access token / API key**（Bearer 令牌），并填入输出的临时 **Credential**。
-4. 点击 **Scan Tools**。
-
-默认的一键流程会创建一个由本次临时凭据保护的公网 HTTPS MCP 地址；关闭命令后，该地址和凭据都会失效。Developer Mode、自定义 MCP App 和写入/修改操作是否可用取决于 ChatGPT 套餐、workspace 与管理员策略；WebCodex 无法启用客户端未授予的权限。
-
-第一条可以先只读检查：
-
-```text
-检查这个仓库并总结它的结构。先不要做任何修改。
-```
-
-如果 ChatGPT 没有 Bearer/访问令牌选项，或者出现 **does not implement OAuth**，运行：
-
-```bash
-npx --yes @yyjeqhc/webcodex share --auth query-token
-```
-
-粘贴完整的 `/mcp?token=...` 地址并选择 **No authentication**。这个 fallback 需要 WebCodex 0.3.9 或更新版本。完整地址包含本次临时密钥，请按敏感信息处理。如果已经全局安装，也可以使用 `webcodex share --auth query-token`。
+`share` 是临时、单项目、能力更受限的体验；命令退出后地址和临时凭据都会失效。ChatGPT 配置和认证 fallback 见[快速试用](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.zh-CN.md)。
 
 ### 平台支持
 
@@ -104,7 +82,7 @@ npx --yes @yyjeqhc/webcodex share --auth query-token
 - macOS x64/arm64：支持本机一键 `share` 和 Runner 工作流。
 - Windows x64/arm64：支持 CLI、Runner、前台 Server，以及显式本机 `share --tunnel cloudflare|openai|none`。Windows x64 可自动管理固定版本 Cloudflare；OpenAI `tunnel-client` 的 managed 获取支持 x64/arm64。固定版本 Cloudflare 没有官方 Windows ARM64 artifact，因此 ARM64 使用 Cloudflare 时需要受信任的显式/`PATH` binary。WebCodex 托管的 Windows Server service 仍不支持。
 
-Windows、长期/自托管部署、OAuth、私有隧道、代理配置和故障排查见 [WebCodex 文档](https://github.com/yyjeqhc/webcodex/tree/main/docs)。[快速开始](https://github.com/yyjeqhc/webcodex/blob/main/docs/QUICK_START.zh-CN.md)只保留第一次成功连接所需的步骤。
+Windows/Linux 普通使用先看[完整使用指南](https://github.com/yyjeqhc/webcodex/blob/main/docs/PERSONAL_SETUP.zh-CN.md)。生产部署、OAuth、私有网络细节、代理配置和故障排查再查看 [WebCodex 文档](https://github.com/yyjeqhc/webcodex/tree/main/docs)。
 
 ### 全局安装
 


### PR DESCRIPTION
## Summary

Reframe the public onboarding path around the complete WebCodex daily setup rather than temporary `share` usage.

This makes the primary documentation path explain the real product topology and first-run sequence:

`Server -> one-time login -> Project -> Runner -> ChatGPT -> Ready`

while keeping `share` as an explicitly temporary quick-trial path.

## What changed

- add English and Chinese `PERSONAL_SETUP` guides for the normal self-hosted daily workflow
- make README / Quick Start / AI onboarding point to the full Server + Runner path first
- align CLI, MCP, GPT Actions, deployment, index, architecture, release, npm, and Windows tunnel docs with that framing
- keep advanced deployment/reference material available without requiring it for first-run understanding
- clarify that `share` is temporary and exits with its foreground process

## Scope

Documentation/product-entry change only. No auth, token scope, Runner authority, MCP model surface, runtime behavior, deployment, or release changes.

## Validation

- `git diff --check origin/main..HEAD`
- `python3 scripts/check_markdown_links.py`
  - `files=51 local_links=352 missing=0`

## Review notes

This is P0 of a two-PR onboarding stack. The follow-up P1 changes CLI human-facing readiness/output behavior and is intentionally based on this branch.
