### PR TITLE
Harden managed-user discovery and logout safety

### DIFF
--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -868,6 +868,7 @@ fn parse_logout(args: &[String]) -> CliAction {
     }
     let mut server_url: Option<String> = None;
     let mut username: Option<String> = None;
+    let mut all = false;
     let mut base_dir: Option<PathBuf> = None;
     let mut yes = false;
     let mut json = false;
@@ -890,6 +891,7 @@ fn parse_logout(args: &[String]) -> CliAction {
                 }
             }
             "--yes" | "-y" => yes = true,
+            "--all" => all = true,
             "--json" => json = true,
             other if other.starts_with('-') => {
                 return cli_parse_error(format!("unknown flag {other}"))
@@ -903,6 +905,9 @@ fn parse_logout(args: &[String]) -> CliAction {
         }
         index += 1;
     }
+    if username.is_some() && all {
+        return cli_parse_error("--user and --all are mutually exclusive".to_string());
+    }
     let Some(server_url) = server_url else {
         return cli_parse_error("logout needs a server URL".to_string());
     };
@@ -914,6 +919,7 @@ fn parse_logout(args: &[String]) -> CliAction {
         server_url,
         username,
         base_dir,
+        all,
         yes,
         json,
     })

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -308,6 +308,7 @@ pub(crate) struct LoginOptions {
 pub(crate) struct LogoutOptions {
     pub(crate) server_url: String,
     pub(crate) username: Option<String>,
+    pub(crate) all: bool,
     pub(crate) base_dir: PathBuf,
     pub(crate) yes: bool,
     pub(crate) json: bool,
@@ -832,14 +833,17 @@ pub(crate) fn render_status(connections: &[Connection], json: bool) -> Result<St
 
 /// Connections a logout would remove.
 pub(crate) fn logout_targets(opts: &LogoutOptions) -> Vec<Connection> {
-    connections_for_server(&opts.base_dir, &opts.server_url)
-        .into_iter()
-        .filter(|connection| {
-            opts.username
-                .as_deref()
-                .is_none_or(|username| connection.username.eq_ignore_ascii_case(username))
-        })
-        .collect()
+    let candidates = connections_for_server(&opts.base_dir, &opts.server_url);
+    if let Some(username) = opts.username.as_deref() {
+        return candidates
+            .into_iter()
+            .filter(|connection| connection.username.eq_ignore_ascii_case(username))
+            .collect();
+    }
+    if opts.all || candidates.len() <= 1 {
+        return candidates;
+    }
+    Vec::new()
 }
 
 /// Remove one connection directory.
@@ -1082,6 +1086,33 @@ pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
 
 pub(crate) fn run_logout(opts: LogoutOptions) -> Result<String, String> {
     canonical_server_url(&opts.server_url)?;
+    let candidates = connections_for_server(&opts.base_dir, &opts.server_url);
+    if opts.username.is_none() && !opts.all && candidates.len() > 1 {
+        let mut users = candidates
+            .iter()
+            .map(|connection| connection.username.clone())
+            .collect::<Vec<_>>();
+        users.sort_by_key(|username| username.to_ascii_lowercase());
+        users.dedup_by(|left, right| left.eq_ignore_ascii_case(right));
+        let server_url = candidates
+            .first()
+            .map(|connection| connection.server_url.as_str())
+            .unwrap_or(opts.server_url.as_str());
+        if opts.json {
+            let output = serde_json::to_string_pretty(&serde_json::json!({
+                "error": "multiple_users",
+                "server_url": server_url,
+                "users": users,
+                "hint": "Choose one user with --user USER, or explicitly choose every saved user with --all."
+            }))
+            .map_err(|error| error.to_string())?;
+            return Err(output);
+        }
+        return Err(format!(
+            "multiple local users are logged in to {server_url}:\n  {}\n\nChoose one user:\n  webcodex logout {server_url} --user <USER>\n\nOr explicitly choose every saved user:\n  webcodex logout {server_url} --all",
+            users.join("\n  ")
+        ));
+    }
     let targets = logout_targets(&opts);
     if targets.is_empty() {
         return Err(format!("not logged in to {}", opts.server_url));
@@ -1528,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn logout_without_username_targets_every_user_on_that_server() {
+    fn logout_with_multiple_users_requires_explicit_user_or_all() {
         let temp = tempfile::TempDir::new().unwrap();
         let base = temp.path();
         seed_connection(base, "https://api.example.com", "alice");
@@ -1538,11 +1569,19 @@ mod tests {
         let opts = LogoutOptions {
             server_url: "https://api.example.com".to_string(),
             username: None,
+            all: false,
             base_dir: base.to_path_buf(),
             yes: true,
             json: false,
         };
-        assert_eq!(logout_targets(&opts).len(), 2);
+        assert!(logout_targets(&opts).is_empty());
+        let error = run_logout(opts.clone()).unwrap_err();
+        assert!(error.contains("multiple local users"));
+        assert!(error.contains("alice"));
+        assert!(error.contains("bob"));
+        assert!(error.contains("--user <USER>"));
+        assert!(error.contains("--all"));
+        assert_eq!(all_connections(base).len(), 3);
 
         let scoped = LogoutOptions {
             username: Some("bob".to_string()),
@@ -1551,11 +1590,43 @@ mod tests {
         let targets = logout_targets(&scoped);
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].username, "bob");
+        run_logout(scoped).unwrap();
 
-        run_logout(opts).unwrap();
+        let all = LogoutOptions { all: true, ..opts };
+        let targets = logout_targets(&all);
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].username, "alice");
+        run_logout(all).unwrap();
+
         let left = all_connections(base);
         assert_eq!(left.len(), 1);
         assert_eq!(left[0].server_url, "https://other.example.com");
+    }
+
+    #[test]
+    fn logout_json_multiple_user_ambiguity_is_structured_and_secret_free() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let base = temp.path();
+        seed_connection(base, "https://api.example.com", "alice");
+        seed_connection(base, "https://api.example.com", "bob");
+
+        let error = run_logout(LogoutOptions {
+            server_url: "https://api.example.com".to_string(),
+            username: None,
+            all: false,
+            base_dir: base.to_path_buf(),
+            yes: true,
+            json: true,
+        })
+        .unwrap_err();
+        let value: serde_json::Value = serde_json::from_str(&error).unwrap();
+        assert_eq!(value["error"], "multiple_users");
+        assert_eq!(value["users"], serde_json::json!(["alice", "bob"]));
+        assert!(value.get("token").is_none());
+        assert!(value.get("path").is_none());
+        assert!(!error.contains(USER_TOKEN));
+        assert!(!error.contains(AGENT_TOKEN));
+        assert_eq!(all_connections(base).len(), 2);
     }
 
     #[test]
@@ -1569,6 +1640,7 @@ mod tests {
         run_logout(LogoutOptions {
             server_url: "https://api.example.com".to_string(),
             username: None,
+            all: false,
             base_dir: base.to_path_buf(),
             yes: true,
             json: false,
@@ -1590,6 +1662,7 @@ mod tests {
         run_logout(LogoutOptions {
             server_url: "https://api.example.com:8443".to_string(),
             username: None,
+            all: false,
             base_dir: base.to_path_buf(),
             yes: true,
             json: false,

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -454,12 +454,14 @@ pub(crate) fn logout_usage() -> &'static str {
     "Usage: webcodex logout <SERVER-URL> [OPTIONS]\n\n\
      Remove this device's stored credentials for a server.\n\n\
      Options:\n\
-     \x20\x20--user NAME    Only log out this user [default: every user on that server]\n\
+     \x20\x20--user NAME    Log out one saved user\n\
+     \x20\x20--all          Log out every saved user on this server (mutually exclusive with --user)\n\
      \x20\x20--dir PATH     Where connections are stored [default: ~/.config/webcodex]\n\
      \x20\x20-y, --yes      Confirm removal\n\
      \x20\x20--json         Print machine-readable output\n\
      \x20\x20-h, --help     Print help and exit\n\n\
-     Without --yes this only reports what would be removed.\n"
+     With one saved user, no selector is needed. With several saved users, choose\n\
+     --user NAME or --all. Without --yes this only reports what would be removed.\n"
 }
 
 pub(crate) fn status_usage() -> &'static str {

--- a/docs/AUTH_MODEL.md
+++ b/docs/AUTH_MODEL.md
@@ -138,6 +138,13 @@ workflow. For example, a GPT Action that inspects and edits projects may need
 or close Workflow Session collaboration state. `runtime:read` alone remains
 observation-only for that collaboration state.
 
+Managed user discovery is owner-scoped. A normal PAT or managed OAuth token for
+`alice` can discover only Runners, projects, Jobs, and derived runtime metadata
+owned by `alice`, including several devices registered to that same username.
+Bootstrap/admin callers retain their existing global visibility. Shared-key and
+Project Credential callers remain isolated by their existing authorization
+groups rather than by managed usernames.
+
 ## `wc_agent_xxx` (Runner token)
 
 `wc_agent_xxx` is a Runner token generated locally by the user; the server

--- a/docs/AUTH_MODEL.md
+++ b/docs/AUTH_MODEL.md
@@ -145,6 +145,11 @@ Bootstrap/admin callers retain their existing global visibility. Shared-key and
 Project Credential callers remain isolated by their existing authorization
 groups rather than by managed usernames.
 
+Local saved identities are also selected explicitly at logout time. If one
+Server has several saved usernames on the same machine, `webcodex logout
+<server-url>` is ambiguous and removes nothing; use `--user USER` for one
+identity or `--all` for every saved identity on that exact Server URL.
+
 ## `wc_agent_xxx` (Runner token)
 
 `wc_agent_xxx` is a Runner token generated locally by the user; the server

--- a/docs/AUTH_MODEL.zh-CN.md
+++ b/docs/AUTH_MODEL.zh-CN.md
@@ -111,6 +111,12 @@ agent 连接 token。
 complete、replace、withdraw 或 close Workflow Session 协作状态时才额外授予
 `session:collaborate`。仅有 `runtime:read` 对这类协作状态保持只读观察能力。
 
+Managed user 的 discovery 按 owner 隔离。普通 PAT 或 managed OAuth token 若属于
+`alice`，只能发现 owner 为 `alice` 的 Runner、项目、Jobs 与派生 runtime 元数据；
+同一 username 在多台设备上的 Runner 仍可互相发现。Bootstrap/admin 保留现有全局
+可见能力。Shared-key 与 Project Credential 仍按原有 authorization group 隔离，不会
+与 managed username 混成同一身份模型。
+
 ## `wc_agent_xxx`（Runner 令牌）
 
 `wc_agent_xxx` 是用户本地生成的 Runner 令牌；server 只存其 hash，并绑定

--- a/docs/AUTH_MODEL.zh-CN.md
+++ b/docs/AUTH_MODEL.zh-CN.md
@@ -117,6 +117,11 @@ Managed user 的 discovery 按 owner 隔离。普通 PAT 或 managed OAuth token
 可见能力。Shared-key 与 Project Credential 仍按原有 authorization group 隔离，不会
 与 managed username 混成同一身份模型。
 
+本地 logout 也显式选择 saved identity。同一台机器若为同一 Server 保存了多个
+username，`webcodex logout <server-url>` 视为歧义并且不删除任何连接；用
+`--user USER` 选择单个身份，或用 `--all` 显式选择该 Server URL 下的全部 saved
+identity。
+
 ## `wc_agent_xxx`（Runner 令牌）
 
 `wc_agent_xxx` 是用户本地生成的 Runner 令牌；server 只存其 hash，并绑定

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,7 +72,7 @@ not advertised by ordinary MCP/GPT Actions model discovery.
 | `webcodex project register --config PATH <PROJECT>` | Add another project to an existing Runner | Persists that Runner's project configuration without requiring the Server to be online; follow the command output if an already-running Runner needs a reload. |
 | `webcodex pairing create` | Server/admin side: create a short-lived pairing code | Needs server bootstrap/admin auth. |
 | `webcodex client enroll` | Advanced client enrollment with explicit `--client-id` | Advanced; ordinary users should use `login`, which derives the client id and publishes the canonical per-server/user connection layout in one step. |
-| `webcodex logout <server-url>` | Remove this device's credentials for a Server | |
+| `webcodex logout <server-url> [--user USER|--all]` | Remove this device's credentials for a Server | With one saved user, the user is selected automatically. With multiple saved users, choose one with `--user USER` or explicitly choose all with `--all`; deletion still uses the existing confirmation/`--yes` flow. |
 
 ### Runner lifecycle
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -67,7 +67,7 @@ Cloudflare Quick Tunnel 的公网 origin 仍然是临时的。如需稳定 HTTPS
 | `webcodex project register --config PATH <PROJECT>` | 给现有 Runner 再添加一个项目 | 写入该 Runner 的项目配置；不要求 Server 在线即可持久化，运行中的 Runner 是否需 reload 以命令输出为准。 |
 | `webcodex pairing create` | Server/admin 侧：创建短期 pairing code | 需要 server bootstrap/admin 认证。 |
 | `webcodex client enroll` | 高级客户端接入，可显式指定 `--client-id` | 高级入口；普通用户应使用 `login`，它会自动派生 client id 并一步写入规范的 server/user 本地连接布局。 |
-| `webcodex logout <server-url>` | 移除本机对某 Server 的凭据 | |
+| `webcodex logout <server-url> [--user USER|--all]` | 移除本机对某 Server 的凭据 | 只有一个 saved user 时自动选择；多个 saved user 时必须用 `--user USER` 选择一个，或显式用 `--all` 选择全部；真正删除仍遵守现有 confirmation/`--yes` 流程。 |
 
 ### Runner 生命周期
 

--- a/src/shell_client/auth.rs
+++ b/src/shell_client/auth.rs
@@ -74,7 +74,19 @@ pub(super) fn shell_client_visible_to_auth(
     match auth {
         None => true,
         Some(auth) if auth.is_admin() => true,
-        Some(_) => lightweight_group_matches(auth, client.auth_group.as_ref()),
+        Some(auth) if !lightweight_group_matches(Some(auth), client.auth_group.as_ref()) => false,
+        Some(_) if client.auth_group.is_some() => true,
+        Some(auth) => {
+            let username = auth
+                .username
+                .as_deref()
+                .filter(|username| !username.trim().is_empty());
+            let owner = client
+                .owner
+                .as_deref()
+                .filter(|owner| !owner.trim().is_empty());
+            username.is_some() && username == owner
+        }
     }
 }
 

--- a/src/shell_client/mod_tests/shared_key_isolation.rs
+++ b/src/shell_client/mod_tests/shared_key_isolation.rs
@@ -27,6 +27,7 @@ async fn registry_filters_lightweight_clients_by_auth_group() {
     let shared_hash = crate::auth::shared_key::shared_key_hash_of("token-a");
     let bridge_a = oauth_bridge_auth_context(&shared_hash, vec![]);
     let managed_oauth = managed_oauth_auth_context("alice", Some("hash-a"));
+    let managed_pat = auth_context(Some("alice"), false);
     let open = open_auth_context();
     let bootstrap = auth_context(None, true);
 
@@ -60,27 +61,33 @@ async fn registry_filters_lightweight_clients_by_auth_group() {
             .await
             .unwrap();
     }
-    registry
-        .register(ShellClientRegisterRequest {
-            process_started_at: None,
-            build: None,
-            job_concurrency_limit: None,
-            job_inventory: None,
-            coding_agent_providers: None,
-            coding_agent_inventory: None,
-            client_id: "managed".to_string(),
-            agent_instance_id: "inst-managed".to_string(),
-            display_name: None,
-            owner: Some("alice".to_string()),
-            hostname: None,
-            host_context: None,
-            capabilities: Some(async_job_capabilities()),
-            projects: Some(vec![project_summary("managed", "/tmp/managed")]),
-            agent_protocol_version: Some("polling-v1".to_string()),
-            policy: None,
-        })
-        .await
-        .unwrap();
+    for (client_id, owner, project_path) in [
+        ("alice-laptop", "alice", "/tmp/alice-laptop"),
+        ("alice-server", "alice", "/tmp/alice-server"),
+        ("bob-runner", "bob", "/home/bob/private"),
+    ] {
+        registry
+            .register(ShellClientRegisterRequest {
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: None,
+                job_inventory: None,
+                coding_agent_providers: None,
+                coding_agent_inventory: None,
+                client_id: client_id.to_string(),
+                agent_instance_id: format!("inst-{client_id}"),
+                display_name: None,
+                owner: Some(owner.to_string()),
+                hostname: None,
+                host_context: None,
+                capabilities: Some(async_job_capabilities()),
+                projects: Some(vec![project_summary(client_id, project_path)]),
+                agent_protocol_version: Some("polling-v1".to_string()),
+                policy: None,
+            })
+            .await
+            .unwrap();
+    }
 
     let visible_to_a: Vec<String> = registry
         .list_clients_for_auth(Some(&shared_a))
@@ -143,22 +150,29 @@ async fn registry_filters_lightweight_clients_by_auth_group() {
     assert!(bridge_a.is_oauth_shared_key_subject());
     assert_eq!(ShellClientAuthGroup::from_auth(&managed_oauth), None);
     assert!(!managed_oauth.is_oauth_shared_key_subject());
-    let visible_to_managed_oauth: Vec<String> = registry
-        .list_clients_for_auth(Some(&managed_oauth))
-        .await
-        .into_iter()
-        .map(|c| c.client_id)
-        .collect();
-    assert_eq!(visible_to_managed_oauth, vec!["managed"]);
-    assert!(registry
-        .assert_client_access(Some(&managed_oauth), "managed")
-        .await
-        .is_ok());
-    assert!(registry
-        .assert_client_access(Some(&managed_oauth), "shared-a")
-        .await
-        .unwrap_err()
-        .contains("unknown shell client"));
+    for managed_auth in [&managed_oauth, &managed_pat] {
+        let visible: Vec<String> = registry
+            .list_clients_for_auth(Some(managed_auth))
+            .await
+            .into_iter()
+            .map(|c| c.client_id)
+            .collect();
+        assert_eq!(visible, vec!["alice-laptop", "alice-server"]);
+        assert!(registry
+            .assert_client_access(Some(managed_auth), "alice-laptop")
+            .await
+            .is_ok());
+        assert!(registry
+            .assert_client_access(Some(managed_auth), "bob-runner")
+            .await
+            .unwrap_err()
+            .contains("unknown shell client"));
+        assert!(registry
+            .assert_client_access(Some(managed_auth), "shared-a")
+            .await
+            .unwrap_err()
+            .contains("unknown shell client"));
+    }
 
     let visible_to_bootstrap: Vec<String> = registry
         .list_clients_for_auth(Some(&bootstrap))
@@ -168,8 +182,101 @@ async fn registry_filters_lightweight_clients_by_auth_group() {
         .collect();
     assert_eq!(
         visible_to_bootstrap,
-        vec!["managed", "open", "shared-a", "shared-b"]
+        vec![
+            "alice-laptop",
+            "alice-server",
+            "bob-runner",
+            "open",
+            "shared-a",
+            "shared-b"
+        ]
     );
+}
+
+#[tokio::test]
+async fn managed_user_coding_agent_inventory_does_not_cross_owner() {
+    let registry = ShellClientRegistry::default();
+    let alice = auth_context(Some("alice"), false);
+    let bob = auth_context(Some("bob"), false);
+    let bootstrap = auth_context(None, true);
+
+    for (client_id, owner, run_id) in [
+        ("alice-runner", "alice", "wc_agent_run_alice"),
+        ("bob-runner", "bob", "wc_agent_run_bob"),
+    ] {
+        registry
+            .register(ShellClientRegisterRequest {
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: None,
+                job_inventory: None,
+                coding_agent_providers: Some(vec![
+                    webcodex_core::coding_agent::CodingAgentProvider {
+                        provider_id: "codex".to_string(),
+                        provider_instance_id: format!("provider-{owner}"),
+                        name: "Codex".to_string(),
+                    },
+                ]),
+                coding_agent_inventory: Some(
+                    webcodex_core::coding_agent::CodingAgentRunInventory {
+                        runs: vec![webcodex_core::coding_agent::CodingAgentRunSnapshot {
+                            run_id: run_id.to_string(),
+                            intent_fingerprint: format!("intent-{owner}"),
+                            authority_fingerprint: format!("auth_{owner}"),
+                            runtime_project_id: format!("agent:{client_id}:private"),
+                            provider_id: "codex".to_string(),
+                            provider_instance_id: format!("provider-{owner}"),
+                            state: webcodex_core::coding_agent::CodingAgentRunState::Running,
+                            execution_state:
+                                webcodex_core::coding_agent::CodingAgentExecutionState::Started,
+                            observation_revision: 1,
+                            created_at: 1,
+                            updated_at: 1,
+                            terminal: None,
+                        }],
+                    },
+                ),
+                client_id: client_id.to_string(),
+                agent_instance_id: format!("inst-{client_id}"),
+                display_name: None,
+                owner: Some(owner.to_string()),
+                hostname: None,
+                host_context: None,
+                capabilities: Some(ShellClientCapabilities {
+                    coding_agent_runs: true,
+                    ..Default::default()
+                }),
+                projects: Some(vec![project_summary(
+                    "private",
+                    &format!("/home/{owner}/private"),
+                )]),
+                agent_protocol_version: Some("polling-v1".to_string()),
+                policy: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    assert!(registry
+        .coding_agent_run_for_client_for_auth(Some(&alice), "alice-runner", "wc_agent_run_alice",)
+        .await
+        .is_some());
+    assert!(registry
+        .coding_agent_run_for_client_for_auth(Some(&alice), "bob-runner", "wc_agent_run_bob")
+        .await
+        .is_none());
+    assert!(registry
+        .coding_agent_run_for_auth(Some(&alice), "wc_agent_run_bob")
+        .await
+        .is_none());
+    assert!(registry
+        .coding_agent_run_for_auth(Some(&bob), "wc_agent_run_alice")
+        .await
+        .is_none());
+    assert!(registry
+        .coding_agent_run_for_auth(Some(&bootstrap), "wc_agent_run_bob")
+        .await
+        .is_some());
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -2473,6 +2473,52 @@ async fn register_job_agent_for_auth(
         .unwrap();
 }
 
+fn managed_job_auth(username: &str) -> crate::auth::AuthContext {
+    let mut auth = auth_context(Some(username), false);
+    auth.scopes = vec![
+        crate::auth::SCOPE_RUNTIME_READ.to_string(),
+        crate::auth::SCOPE_PROJECT_READ.to_string(),
+        crate::auth::SCOPE_JOB_RUN.to_string(),
+    ];
+    auth
+}
+
+async fn register_managed_job_agent(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project_id: &str,
+    owner: &str,
+) {
+    runtime
+        .shell_clients
+        .register(ShellClientRegisterRequest {
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: Some(4),
+            job_inventory: None,
+            coding_agent_providers: None,
+            coding_agent_inventory: None,
+            client_id: client_id.to_string(),
+            agent_instance_id: "inst".to_string(),
+            display_name: None,
+            owner: Some(owner.to_string()),
+            hostname: None,
+            host_context: None,
+            capabilities: Some(ShellClientCapabilities {
+                async_shell_jobs: true,
+                ..Default::default()
+            }),
+            projects: Some(vec![registered_project(
+                project_id,
+                &format!("/tmp/{owner}/{project_id}"),
+            )]),
+            agent_protocol_version: Some("polling-v1".to_string()),
+            policy: None,
+        })
+        .await
+        .unwrap();
+}
+
 async fn start_agent_runtime_job(
     runtime: &ToolRuntime,
     client_id: &str,
@@ -2586,6 +2632,79 @@ async fn agent_job_log_invalid_token_is_fix_input_not_unknown_job() {
     assert_eq!(result.output["recovery_kind"], "fix_input");
     assert!(result.output.get("recovery_tool").is_none());
     assert!(result.error.unwrap_or_default().contains("malformed"));
+}
+
+#[tokio::test]
+async fn managed_user_job_inventory_and_counts_do_not_cross_owner() {
+    let runtime = test_runtime();
+    let alice = managed_job_auth("alice");
+    let bob = managed_job_auth("bob");
+    let bootstrap = bootstrap_auth_context();
+
+    register_managed_job_agent(&runtime, "alice-runner", "alice-project", "alice").await;
+    register_managed_job_agent(&runtime, "bob-runner", "bob-project", "bob").await;
+
+    let alice_job =
+        start_agent_runtime_job(&runtime, "alice-runner", "alice-project", &alice).await;
+    let bob_job = start_agent_runtime_job(&runtime, "bob-runner", "bob-project", &bob).await;
+
+    let alice_list = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: None,
+                project: None,
+                session_id: None,
+            },
+            Some(&alice),
+        )
+        .await;
+    assert_eq!(listed_job_ids(&alice_list), vec![alice_job.clone()]);
+    assert!(!alice_list.output.to_string().contains(&bob_job));
+
+    let hidden_bob_job = runtime
+        .dispatch_with_auth(
+            ToolCall::JobStatus {
+                job_id: bob_job.clone(),
+                include_command_preview: false,
+            },
+            Some(&alice),
+        )
+        .await;
+    assert_unknown_job(hidden_bob_job);
+
+    let alice_status = runtime
+        .dispatch_with_auth(
+            ToolCall::RuntimeStatus {
+                compact: false,
+                summary_only: false,
+                client_id: None,
+            },
+            Some(&alice),
+        )
+        .await;
+    assert!(alice_status.success, "{:?}", alice_status.error);
+    assert_eq!(alice_status.output["agents"]["count"], 1);
+    assert_eq!(alice_status.output["jobs"]["active_count"], 1);
+    assert!(!alice_status.output.to_string().contains("bob-runner"));
+    assert!(!alice_status.output.to_string().contains(&bob_job));
+
+    let bootstrap_list = runtime
+        .dispatch_with_auth(
+            ToolCall::ListJobs {
+                limit: None,
+                status: None,
+                project: None,
+                session_id: None,
+            },
+            Some(&bootstrap),
+        )
+        .await;
+    let mut bootstrap_ids = listed_job_ids(&bootstrap_list);
+    bootstrap_ids.sort();
+    let mut expected = vec![alice_job, bob_job];
+    expected.sort();
+    assert_eq!(bootstrap_ids, expected);
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/targeted_inventory.rs
+++ b/src/tool_runtime/tests/targeted_inventory.rs
@@ -111,6 +111,46 @@ async fn register_target_agent_for_auth(
         .unwrap();
 }
 
+fn managed_discovery_auth(username: &str) -> crate::auth::AuthContext {
+    let mut auth = auth_context(Some(username), false);
+    auth.scopes = vec![
+        crate::auth::SCOPE_RUNTIME_READ.to_string(),
+        crate::auth::SCOPE_PROJECT_READ.to_string(),
+    ];
+    auth
+}
+
+async fn register_managed_target_agent(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    owner: &str,
+    project_id: &str,
+    project_path: &str,
+) {
+    runtime
+        .shell_clients
+        .register(ShellClientRegisterRequest {
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: Some(4),
+            job_inventory: None,
+            coding_agent_providers: None,
+            coding_agent_inventory: None,
+            client_id: client_id.to_string(),
+            agent_instance_id: format!("inst-{client_id}"),
+            display_name: Some(format!("{owner} private runner")),
+            owner: Some(owner.to_string()),
+            hostname: Some(format!("{owner}-private-host")),
+            host_context: None,
+            capabilities: Some(ShellClientCapabilities::default()),
+            projects: Some(vec![registered_project(project_id, project_path)]),
+            agent_protocol_version: Some("polling-v1".to_string()),
+            policy: None,
+        })
+        .await
+        .unwrap();
+}
+
 fn large_fixture_projects(count: usize) -> Vec<crate::shell_protocol::ShellAgentProjectSummary> {
     (0..count)
         .map(|index| {
@@ -390,6 +430,132 @@ async fn list_projects_filters_only_after_authorization_visibility() {
         .await;
     assert!(!hidden_status.success);
     assert_eq!(hidden_status.output["error_kind"], "unknown_client_id");
+}
+
+#[tokio::test]
+async fn managed_users_discover_only_their_own_runner_project_metadata() {
+    let runtime = test_runtime();
+    let alice = managed_discovery_auth("alice");
+    let bob = managed_discovery_auth("bob");
+    let bootstrap = bootstrap_auth_context();
+
+    register_managed_target_agent(
+        &runtime,
+        "alice-laptop",
+        "alice",
+        "common",
+        "/home/alice/laptop/common",
+    )
+    .await;
+    register_managed_target_agent(
+        &runtime,
+        "alice-server",
+        "alice",
+        "common",
+        "/srv/alice/common",
+    )
+    .await;
+    register_managed_target_agent(
+        &runtime,
+        "bob-runner",
+        "bob",
+        "bob-private",
+        "/home/bob/private",
+    )
+    .await;
+
+    let alice_agents = runtime
+        .dispatch_with_auth(
+            list_agents_call(None, None, Some(true), false),
+            Some(&alice),
+        )
+        .await;
+    assert!(alice_agents.success, "{:?}", alice_agents.error);
+    assert_eq!(alice_agents.output["count"], 2);
+    let alice_agents_text = alice_agents.output.to_string();
+    assert!(!alice_agents_text.contains("bob-runner"));
+    assert!(!alice_agents_text.contains("bob-private"));
+    assert!(!alice_agents_text.contains("/home/bob/private"));
+    assert!(!alice_agents_text.contains("bob-private-host"));
+
+    let alice_projects = runtime
+        .dispatch_with_auth(
+            list_projects_call(None, None, None, None, false),
+            Some(&alice),
+        )
+        .await;
+    assert!(alice_projects.success, "{:?}", alice_projects.error);
+    assert_eq!(alice_projects.output["count"], 2);
+    assert!(!alice_projects.output.to_string().contains("bob-private"));
+
+    for call in [
+        list_projects_call(
+            None,
+            Some("agent:bob-runner:bob-private"),
+            None,
+            None,
+            false,
+        ),
+        list_projects_call(None, None, Some("bob-private"), None, false),
+        list_projects_call(Some("bob-runner"), None, None, None, false),
+    ] {
+        let hidden = runtime.dispatch_with_auth(call, Some(&alice)).await;
+        assert!(hidden.success, "{:?}", hidden.error);
+        assert_eq!(hidden.output["count"], 0);
+        assert_eq!(hidden.output["matched_count"], 0);
+    }
+
+    let hidden_agent = runtime
+        .dispatch_with_auth(
+            list_agents_call(Some("bob-runner"), None, Some(false), true),
+            Some(&alice),
+        )
+        .await;
+    assert!(hidden_agent.success);
+    assert_eq!(hidden_agent.output["count"], 0);
+
+    let alice_status = runtime
+        .dispatch_with_auth(runtime_status_call(None, true), Some(&alice))
+        .await;
+    assert!(alice_status.success, "{:?}", alice_status.error);
+    assert_eq!(alice_status.output["agents"]["count"], 2);
+    assert!(!alice_status.output.to_string().contains("bob-runner"));
+    let hidden_status = runtime
+        .dispatch_with_auth(runtime_status_call(Some("bob-runner"), true), Some(&alice))
+        .await;
+    assert!(!hidden_status.success);
+    assert_eq!(hidden_status.output["error_kind"], "unknown_client_id");
+
+    let ambiguous = runtime
+        .resolve_project_input_for_auth("common", Some(&alice))
+        .await
+        .unwrap_err();
+    assert_eq!(
+        ambiguous.kind,
+        super::super::project_resolution::ProjectResolverErrorKind::AmbiguousProject
+    );
+    assert_eq!(ambiguous.candidates.len(), 2);
+    assert!(ambiguous
+        .candidates
+        .iter()
+        .all(|candidate| candidate.client_id.starts_with("alice-")));
+    assert!(!ambiguous.to_message().contains("bob"));
+
+    let bob_agents = runtime
+        .dispatch_with_auth(list_agents_call(None, None, Some(true), false), Some(&bob))
+        .await;
+    assert!(bob_agents.success, "{:?}", bob_agents.error);
+    assert_eq!(bob_agents.output["count"], 1);
+    assert_eq!(bob_agents.output["agents"][0]["client_id"], "bob-runner");
+
+    let admin_agents = runtime
+        .dispatch_with_auth(
+            list_agents_call(None, None, Some(false), true),
+            Some(&bootstrap),
+        )
+        .await;
+    assert!(admin_agents.success, "{:?}", admin_agents.error);
+    assert_eq!(admin_agents.output["count"], 3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Close two multi-user privacy / identity safety gaps without changing auth scopes, Runner transport, or project authority semantics.

- scope managed-user Runner / Project / Job / CodingAgentRun discovery to the authenticated owner while preserving same-owner multi-device visibility
- preserve existing bootstrap/admin global visibility and shared-key / OAuth bridge / Project Credential auth-group isolation
- hide unauthorized exact Runner / Project / Job lookups behind caller-safe unknown/empty results
- make `webcodex logout SERVER` fail closed when several local users are saved for that Server
- add explicit `--user USER` and `--all` selectors, with existing `--yes` confirmation retained
- document the managed-owner discovery boundary and new logout semantics

## Commits

- `e17f2d5a` Harden managed-user discovery isolation
- `2477d7e4` Make multi-user logout explicit

## Validation

Fresh independent review re-ran the focused contracts on exact HEAD `2477d7e4df088e0055ff653a740ef9af41ddc71a`:

- `cargo test -p webcodex managed_user -- --nocapture` — 5 passed
- `cargo test -p webcodex shell_client::tests::shared_key_isolation -- --nocapture` — 4 passed
- `cargo test -p webcodex tool_runtime::tests::targeted_inventory -- --nocapture` — 11 passed
- `cargo test -p webcodex-cli logout -- --nocapture` — 6 passed
- `cargo fmt --all -- --check`
- `cargo check -p webcodex`
- `cargo check -p webcodex-cli`
- `git diff --check origin/main..HEAD`

Independent review found no blocking or bounded follow-up issue. Worktree is clean and the branch is exactly two commits ahead of current `origin/main`.