### PR TITLE
Document durable Agent runtime and asynchronous work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ V2 development is paused; V1 is the active product line and is not feature-froze
 - For model-facing execution, prefer structured process/argv and durable Job/observation primitives over shell-text orchestration. Keep shell as an escape hatch; structured lifecycle state is the source of truth for retry safety.
 - Keep model-facing ToolSpec/OpenAPI operation descriptions concise and prefer 300 characters or fewer when semantics remain complete. Never delete necessary authority, retry, continuation, uncertainty, safety, or recovery semantics merely for brevity; the canonical tested hard ceiling is `MODEL_TOOL_DESCRIPTION_MAX_CHARS`.
 - Treat demonstrated host features such as MCP App orchestration as optional adapters. Core execution and Job semantics must remain protocol-, UI-, transport-, and OS-neutral.
-- Never assume a model-facing HTTP/MCP request has stable model-window or Workflow Session identity. Treat requests as stateless unless that exact adapter/protocol contract explicitly supplies a stable `ClientWindow`. Stateless MCP 2026 must not derive hidden continuity from `Mcp-Session-Id`, connection state, credentials, project identity, or prior requests. Transport/audit/session correlation ids are not Workflow Session, model-context-retention, or authority proofs by themselves; use explicit durable task/session ids and recorder metadata only under their own contracts.
+- Never assume a model-facing HTTP/MCP request has stable model-window or Workflow Session identity. Treat requests as stateless unless that exact adapter/protocol contract explicitly supplies a stable `ClientWindow`. Stateless MCP 2026 must not derive hidden continuity from `Mcp-Session-Id`, connection state, credentials, project identity, or prior requests. Transport/audit/session correlation ids are not Workflow Session, model-context-retention, or authority proofs by themselves; use explicit durable identifiers from their owning domain. Connector Tasks, Workflow Sessions, durable Agents/Conversations, and future Agent Tasks are distinct identities and must not be inferred from one another.
 
 Product direction: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
@@ -84,6 +84,8 @@ Release guidance: [`docs/agent/release-process.md`](docs/agent/release-process.m
 - Public runtime and API surfaces: [`docs/agent/openapi-guidelines.md`](docs/agent/openapi-guidelines.md).
 - Workflow Sessions: [`docs/agent/session-model.md`](docs/agent/session-model.md).
 - Manual multi-window collaboration: [`docs/agent/manual-window-collaboration.md`](docs/agent/manual-window-collaboration.md).
+- Durable Agent identity, Conversation/Wake, and asynchronous Agent work: [`docs/architecture/durable-agent-runtime.md`](docs/architecture/durable-agent-runtime.md).
+- Current durable Agent/Conversation/Wake implementation contract: [`docs/architecture/durable-agent-conversation.md`](docs/architecture/durable-agent-conversation.md).
 - Authority boundaries: [`docs/agent/permission-model.md`](docs/agent/permission-model.md).
 - Architecture decisions: [`docs/agent/architecture-decisions.md`](docs/agent/architecture-decisions.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # Architecture
 
 WebCodex is a self-hosted tool runtime that lets online AI clients operate
-private code through a Server and a local Runner. This page is a conceptual
-overview; the [CLI](CLI.md), [Runner](RUNNER.md), [Deployment](DEPLOYMENT.md),
+private code through a Server and a local Runner, while the Server can also retain
+durable Agent/Conversation state independently of a browser window. This page is a
+conceptual overview; the [CLI](CLI.md), [Runner](RUNNER.md), [Deployment](DEPLOYMENT.md),
 and [Authentication](AUTH_MODEL.md) guides cover the operational details.
 
 For a short definition of the terms, see the terminology sections in
@@ -41,7 +42,7 @@ WebCodex exposes the same runtime through several thin adapters:
   returns the standard runtime OpenAPI schema.
 - **REST** — the Server's HTTP runtime API.
 - **CLI** — the operator/developer command-line interface.
-- **Console** — a read-only browser view of project readiness and review.
+- **Console** — the Server-hosted operator browser surface for runtime readiness, Workflow Session collaboration, and bounded durable Agent/Conversation interaction. Its mutations use the same Server authority paths rather than a second state store.
 
 All adapters share the same Server, project registration, authentication, and
 policy boundaries. A regular Server is the normal long-lived coding runtime and
@@ -64,14 +65,39 @@ is the id registered by that Runner in its `projects.d` registry.
 `allowed_roots` controls where projects may be registered or created (default
 `$HOME`; an explicit list narrows it).
 
-## Task / Job / session continuity
+## Durable Agent identity and asynchronous work
 
-- **Task** — a bounded unit of project work created by the model and reviewed
-  by a human. Tasks are durable and can be resumed. A project-bound Connector
-  may bind an active task only when its exact adapter/protocol supplies a stable
-  `ClientWindow`. Stateless MCP 2026 has no hidden window continuity: each
-  `task_start` is independent and existing work continues explicitly with its
-  durable `task_id` through `task_resume`.
+The Server also owns a durable Agent communication domain. A durable Agent uses a
+Server-minted `wc_dagent_*` identity and is deliberately independent from a browser
+window, MCP connection, credential, Runtime Project, or Workflow Session. The
+`agent:` prefix in `agent:<client_id>:<project_id>` is Runner-address syntax and is
+not a durable Agent identity.
+
+Today this domain includes Agent profiles, replaceable Endpoint attachments,
+Conversations, append-only Messages, recipient Deliveries/Inbox state, and durable
+Wake Intents with Endpoint/generation-fenced delivery attempts. Conversation
+membership and Agent identity grant communication authority only; they do not grant
+Project, Runner, filesystem, Job, or Workflow Session authority.
+
+The next asynchronous-work boundary is an **Agent Task** plus an exact fenced
+**Agent TaskAttempt**. An Agent Task represents accepted work that can outlive a
+model turn or Endpoint. It is intentionally separate from both the existing
+Connector Task continuity model and Workflow Session todos. WebCodex is not defined
+as a swarm scheduler: worker pools, runnable-frontier scheduling, graph execution,
+and autonomous delegation remain optional later capabilities.
+
+See [Durable Agent runtime and asynchronous work](architecture/durable-agent-runtime.md)
+and the current [Agent/Conversation/Wake implementation contract](architecture/durable-agent-conversation.md).
+
+## Connector Task / Job / Workflow Session continuity
+
+- **Connector Task** — the existing bounded project-first continuity unit used by
+  `task_start` / `task_resume`. Connector Tasks are durable and can be resumed. A
+  project-bound Connector may bind an active Connector Task only when its exact
+  adapter/protocol supplies a stable `ClientWindow`. Stateless MCP 2026 has no
+  hidden window continuity: each `task_start` is independent and existing work
+  continues explicitly with its durable `task_id` through `task_resume`. A
+  Connector Task is not an Agent Task.
 - **Job** — a long-running command or validation that continues after the
   initiating call returns. A single execution is promoted to a Job with the
   same `job_id` when it outlives the synchronous grace period; it is never
@@ -120,13 +146,14 @@ See [SECURITY.md](../SECURITY.md) and [AUTH_MODEL.md](AUTH_MODEL.md).
 
 ## Persistence and recovery
 
-The Server persists users, tokens, projects, audit entries, and OAuth rows in a
-SQLite database. Task history is durable. Per-repository window mappings exist
-only for adapters that explicitly provide a stable `ClientWindow`; they are not
-inferred from credentials, connections, or project identity. Process-local
+The Server persists users, tokens, projects, audit entries, OAuth rows, Connector
+Task history, and the durable Agent/Conversation/Delivery/Wake domain in SQLite.
+Per-repository Connector window mappings exist only for adapters that explicitly
+provide a stable `ClientWindow`; they are not inferred from credentials,
+connections, or project identity. Process-local
 "currently viewed project" state is deliberately discarded on restart.
-Stateless MCP 2026 restores no hidden window mapping: callers continue exact work
-with an explicit durable task id. A stateful adapter may restore only its exact
+Stateless MCP 2026 restores no hidden Connector window mapping: callers continue
+exact Connector work with an explicit durable Connector task id. A stateful adapter may restore only its exact
 window/repository mapping under that adapter's own contract.
 
 Runner Job state is reconciled from the Runner's inventory on reconnect.
@@ -147,9 +174,11 @@ results.
 ## Module map
 
 ```text
-HTTP / MCP / OpenAPI --> ToolRuntime --> Project resolution --> Agent bridge
-                                                  |--> File/Edit/Git/Validation/Job tools
-                                                  |--> Session / Handoff / Hygiene
+MCP / OpenAPI / Runtime HTTP --> ToolRuntime --+--> Project resolution --> Runner bridge
+                                               |      |--> File/Edit/Git/Validation/Job tools
+                                               |      +--> Workflow Session / Handoff / Hygiene
+                                               +--> Durable Agent / Conversation / Delivery / Wake
+Runtime Console -----------------------> canonical Server HTTP/kernel paths above
 ```
 
 - `runtime_http` — REST runtime routes.
@@ -167,6 +196,8 @@ HTTP / MCP / OpenAPI --> ToolRuntime --> Project resolution --> Agent bridge
 
 ## Further reading
 
+- [Durable Agent runtime and asynchronous work](architecture/durable-agent-runtime.md) — persistent Agent identity and planned asynchronous Agent work
+- [Durable Agent/Conversation/Wake contract](architecture/durable-agent-conversation.md) — current communication implementation
 - [CLI](CLI.md) — commands and terminology
 - [Runner](RUNNER.md) — the execution boundary and operations
 - [Deployment](DEPLOYMENT.md) — self-hosting

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -116,7 +116,7 @@ cross-Session/cross-owner delegation.
 
 For a coordinator or worker window that needs to notice later message-board changes without re-listing history, call `observe_session_messages(session_id=...)` once without a token to establish the current baseline, then reuse its opaque `observation_token`. A token call may optionally wait once for up to 60 seconds. The result reports retained current-state delta, `has_more`, and explicit `history_lost` when retention prevents a complete delta. Use `list_session_messages` for historical or exact filtered reads; observation does not replace it.
 
-Message observation is not a delivery receipt, model-context-retention proof, subscription, or orchestrator wake-up. It does not automatically resume a model, route a conversation, or spawn a worker. Room/Discussion remains a future additive collaboration container, not part of this Workflow Session observation primitive.
+Message observation is not a delivery receipt, model-context-retention proof, subscription, or Agent Wake. It does not automatically resume a model, route a Conversation, or spawn a worker. Durable Agent/Conversation/Delivery/Wake state is a separate Server-owned domain and is not part of this Workflow Session observation primitive.
 
 See [Manual Multi-Window Collaboration](agent/manual-window-collaboration.md) for
 coordinator/implementation, implementation/reviewer, parallel-worktree, and

--- a/docs/agent/acp-coding-agent-run.md
+++ b/docs/agent/acp-coding-agent-run.md
@@ -985,7 +985,7 @@ P0/P1 do not imply:
 - hot ACP provider reload/generic provider framework;
 - ACP v2 or experimental extensions;
 - scheduler, worker pool, automatic worker spawning, or orchestration;
-- Room/Discussion/Participant/presence/typing;
+- integration with durable Agent/Conversation/Participant state, presence, or typing;
 - durable Operation DAG;
 - unification of Workflow Session, Job, ACP Session, and CodingAgentRun;
 - a claim that Project cwd is a filesystem sandbox;

--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -352,8 +352,12 @@ The standing direction for model-facing execution is defined in
 5. **Optional host UI is an adapter, not an owner.** MCP Apps or another host may
    observe Jobs and later resume a model, but core execution cannot depend on
    Apps, MCP Tasks, MRTR, elicitation, progress extensions, or iframe state. If
-   automatic model resume is provided, one conversation-level Orchestrator owns
-   that authority; independent Job Views do not race to resume the model.
+   automatic model resume is provided, exactly one durable continuation domain
+   owns each logical resume event; independent Job Views, cards, or Host views do
+   not race to resume the model. For Agent-bound continuation, the Agent Wake /
+   Wake Delivery Attempt domain owns that logical continuation; Host/controller
+   state is adapter-local delivery state rather than a second WebCodex
+   continuation truth.
 6. **Transport fallback must preserve execution semantics.** Polling, WebSocket,
    and QUIC may differ in delivery behavior, but none may silently duplicate a
    command or turn a transport stall into a false pre-start rejection.

--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -5,6 +5,7 @@ live in [`AGENTS.md`](../../AGENTS.md).** This file explains durable product
 structure so agents do not re-litigate settled shape during ordinary tasks.
 
 Related product docs: [`ARCHITECTURE.md`](../ARCHITECTURE.md),
+[`../architecture/durable-agent-runtime.md`](../architecture/durable-agent-runtime.md),
 [`TESTING.md`](../TESTING.md).
 
 ---
@@ -28,56 +29,48 @@ Full naming, lifecycle, compatibility, and non-goals:
 
 Do **not** change `wc_sess_*` ID format, ledger event shape, or lifecycle
 semantics casually. Session / guard / explicit-targeting work must preserve the
-invariants listed in `AGENTS.md` §6 (Architecture) and the session section.
+invariants linked from `AGENTS.md` §6 (domain rules) and the Session model.
 
-### Collaboration boundary (standing)
+### Durable Agent and collaboration boundary (standing)
 
-A Workflow Session remains a bounded **execution and evidence unit** even when
-its session-local message board is used for coordinator/worker handoff. Do not
-turn `wc_sess_*` lifecycle, ownership, or evidence history into a generic chat
-room, participant registry, worker pool, or scheduler.
+A Workflow Session remains a bounded **execution and evidence unit** even when its
+session-local message board is used for coordinator/worker handoff. Do not turn
+`wc_sess_*` lifecycle, ownership, or evidence history into a generic chat room,
+Agent identity, task queue, worker pool, or scheduler.
 
-If repeated dogfood later demonstrates a real need for durable multi-party
-conversation, add an independent Room/Discussion-style collaboration container
-rather than reinterpreting existing Workflow Sessions. The standing extension
-rules are:
+The independent durable collaboration domain now exists: Server-minted Agents,
+replaceable Agent Endpoints, Conversations, Messages, recipient Deliveries, and
+Wake Intents/Attempts. The earlier `Room/Discussion` placeholder is superseded by
+this concrete Agent/Conversation model. Standing rules are:
 
-- each executing model/worker continues to own an independent Workflow Session
-  for its tool calls, validation, Jobs, checkpoints, and review evidence; pure
-  collaboration observers need no execution Session merely to participate;
-- Room/Discussion state never proves model-context retention or message delivery.
-  Membership, presence, transport/window identity, or a referenced Workflow
-  Session cannot be used as a receipt that a model has seen prior messages, nor
-  as hidden Workflow Session/context inference. Models explicitly observe the
-  bounded collaboration state they need;
-- Room/Discussion membership or roles may govern only that collaboration
-  container's own visibility/posting contract; they never confer Project,
-  Workflow Session, Job, Artifact, shell, Computer, or other execution
-  authority. Message authorship and object references remain provenance or
-  correlation, and dereferencing an object always re-runs that object's normal
-  authorization;
-- Room/Discussion identifiers and participant claims are not bearer capabilities;
-  Room reads/posts still require authenticated caller authorization against that
-  collaboration container's own visibility/posting contract;
-- the collaboration substrate may own bounded messages, reply/thread
-  correlation, provenance, and observation, while automatic wake-up, worker
-  spawning, routing, scheduling, or continuation belongs to a separate optional
-  orchestrator layer;
-- an orchestrator may choose when and where to dispatch work, but it never
-  inherits execution authority from collaboration state. Consequential actions
-  still name explicit targets and pass the same caller authorization, Project and
-  Workflow Session scope, guards, capabilities, and dispatch-time revalidation as
-  direct tool calls;
-- a Room/Discussion is never itself a filesystem/worktree lock, task lease, or
-  execution authority;
-- extract shared message/participant machinery only after a second concrete
-  consumer exists; do not pre-build a generic collaboration framework for a
-  hypothetical future UI;
-- future collaboration storage is additive: existing `wc_sess_*` and
-  Session-message meanings remain unchanged rather than being migrated into a
-  new interpretation.
+- a durable Agent is not a browser window, MCP connection, credential, Runner,
+  Runtime Project, or Workflow Session;
+- Conversation participation governs communication only. It never confers Project,
+  Workflow Session, Job, Artifact, shell, Computer, CodingAgent, or filesystem
+  authority;
+- Message, Delivery, Wake, and execution are separate durable facts. Message/read
+  state never proves model-context retention, and Wake never proves Agent Task completion;
+- each concrete execution may still use an independent Workflow Session for tool
+  calls, validation, Jobs, checkpoints, and review evidence; pure communication
+  does not require an execution Session;
+- the Session message board remains the explicit manual coordinator/worker handoff
+  substrate. It is not migrated into Conversation and its todo semantics are not an
+  Agent Task lease;
+- the planned asynchronous work object is an independent **Agent Task** with an
+  exact fenced **Agent TaskAttempt**. It is not the existing Connector Task and is
+  not inferred merely because a Conversation Message exists;
+- references among Conversation, Agent Task, Workflow Session, Job, CodingAgentRun,
+  commit, PR, or Artifact provide correlation only. Dereferencing always re-runs
+  the referenced object's normal authorization;
+- automatic worker spawning, runnable-frontier scheduling, capacity management,
+  dependency graphs, or orchestration are optional later control layers, not the
+  definition of a durable Agent and not authority sources.
 
-Current bounded handoff behavior and non-goals are documented in
+The standing Agent/asynchronous-work design is documented in
+[`../architecture/durable-agent-runtime.md`](../architecture/durable-agent-runtime.md).
+Current communication/wake implementation details live in
+[`../architecture/durable-agent-conversation.md`](../architecture/durable-agent-conversation.md).
+Current bounded Session handoff behavior remains documented in
 [`manual-window-collaboration.md`](manual-window-collaboration.md).
 
 ### Action audit session (HTTP / operator audit)

--- a/docs/agent/manual-window-collaboration.md
+++ b/docs/agent/manual-window-collaboration.md
@@ -1,6 +1,6 @@
 # Manual Multi-Window Collaboration
 
-This guide defines bounded collaboration between independent WebCodex Workflow Sessions. It reuses the Session handoff and message board; it is not a scheduler, worker pool, task queue, claim service, shared transcript, or filesystem lock.
+This guide defines bounded collaboration between independent WebCodex Workflow Sessions. It reuses the Session handoff and message board; it is not a scheduler, worker pool, task queue, claim service, shared transcript, or filesystem lock. This manual engineering workflow remains valid alongside the separate durable Agent/Conversation domain.
 
 ## Core model
 
@@ -82,7 +82,7 @@ Observation tracks real message-state mutation, not deque length. Posts advance 
 
 Retention is explicit. Each retained message carries internal latest-revision bookkeeping and the Session maintains a durable low-watermark for evicted observation history. When the caller cursor predates an unrecoverable retention hole, `history_lost=true`; retained current-state delta may still be returned, but it is not represented as complete history. Pagination advances the returned token only through the last change actually returned while `has_more=true`.
 
-Message observation is **not** a delivery receipt, **not** proof of model-context retention, **not** a subscription/stream, and **not** an orchestrator wake-up. It never automatically wakes a model or spawns/routes work. Room/Discussion remains only a future additive direction; this Workflow Session primitive does not create Room, participant, presence, typing, scheduler, worker-pool, or routing state.
+Message observation is **not** a delivery receipt, **not** proof of model-context retention, **not** a subscription/stream, and **not** an Agent Wake. It never automatically wakes a model or spawns/routes work. Durable Agent/Conversation/Delivery/Wake state exists in a separate Server-owned domain; this Workflow Session primitive neither creates nor observes that state and does not create presence, typing, scheduler, worker-pool, or routing state.
 
 ## Runtime Collaboration Console
 
@@ -153,62 +153,50 @@ This workflow does not add automatic worker spawning, scheduler/worker pool beha
 
 The human or coordinator still chooses workers and isolated worktrees/Projects. WebCodex supplies bounded durable collaboration state and deterministic completion correlation, not a multi-agent execution scheduler.
 
-## Future extensibility boundary
+## Relationship to durable Agent/Conversation and asynchronous work
 
-The current message board is intentionally scoped to a Workflow Session because
-that is sufficient for short coordinator/worker handoffs. That storage choice
-does not make the Workflow Session the future long-lived conversation object.
+The Session message board remains intentionally scoped to a Workflow Session. It is
+still the right primitive for explicit engineering handoffs such as coordinator ->
+implementation worker and implementation -> independent reviewer. The existence of
+the durable Agent/Conversation domain does not migrate, reinterpret, or obsolete
+that workflow.
 
-If real usage later needs a durable multi-participant chat or discussion space,
-introduce an additive Room/Discussion container with its own collaboration
-lifecycle. Independent Workflow Sessions may participate in that container, but
-they continue to own their own execution/evidence histories and may be created,
-closed, or replaced independently of the room.
-
-Room/Discussion state is durable application collaboration state, not model-context
-continuity or delivery proof. Membership, presence, a transport/window identity,
-or a referenced Workflow Session never proves that a model still retains or has
-ever read any room message. Models must explicitly observe the bounded messages
-or deltas they need; Room identity must not become hidden Workflow Session selection
-or a context-retention fallback.
-
-Room/Discussion identifiers and participant claims are not bearer capabilities:
-every Room read or post still requires the authenticated caller to satisfy that
-container's own visibility/posting authorization.
-
-Keep the future layers separate:
+Long-lived Agent communication now belongs to the separate durable Agent domain:
 
 ```text
-collaboration substrate
-  bounded messages / replies / provenance / observation
+Durable Agent / Conversation
+  Message -> recipient Delivery -> Wake opportunity
+            |
+            | explicit accept/create work (planned)
+            v
+Agent Task -> exact fenced TaskAttempt
+            |
+            +--> CodingAgentRun
+            +--> Agent Endpoint continuation
+            +--> later concrete execution backend
             |
             v
-optional orchestrator
-  wake-up / routing / worker spawning / scheduling
-            |
-            v
-Workflow Sessions / Jobs / Projects
-  authoritative execution and evidence
+Workflow Session / Job / execution evidence
 ```
 
-A message or room may reference a Workflow Session, Job, Artifact, checkpoint,
-commit, PR, or another collaboration object. Such references only locate the
-authoritative object; they never delegate authority, and consumers revalidate
-the referenced source before consequential use. Participant roles and presence
-are likewise collaboration metadata, not execution permissions.
+These arrows are correlations, not authority inheritance. Conversation membership,
+Message authorship, Delivery state, Wake state, Session todo state, and object
+references never grant Project or execution authority.
 
-An optional orchestrator may decide when to wake, route, or spawn work, but it
-must not mint, inherit, or cache execution authority from Room membership,
-participant role, message authorship, or object references. Every consequential
-execution still goes through the normal explicit Project/Workflow Session target,
-caller authorization, guards, capability checks, and dispatch-time revalidation.
-Collaboration state may be scheduling input; it is not execution-effect truth or
-a lease over a Project, Session, Job, or worktree.
+A Workflow Session todo and future Agent Task are deliberately different. The todo
+is a bounded explicit assignment inside one Session collaboration ledger. An Agent
+Task will represent asynchronous work that survives model/window turns and owns
+independent TaskAttempt/lease/fencing state. Do not silently convert historical or
+current Session todos into Agent Tasks, and do not use `assignment_fence` as an
+Agent Task execution lease.
 
-Do not introduce Room membership, participant registries, presence, typing
-state, generic task leases, or automatic agent routing until a concrete product
-need exists. When a second real collaboration container does exist, shared
-message semantics may be extracted from the existing model rather than creating
-parallel `ChatMessage`, `WorkItem`, and `Todo` systems. Preserve historical
-`wc_sess_*` and Session-message semantics through additive fields/objects rather
-than reinterpretation migrations.
+Likewise, the existing Connector Task used by `task_start` / `task_resume` remains a
+separate project-bound continuity domain. The standing naming and boundary rules for
+future Agent Tasks are in
+[`../architecture/durable-agent-runtime.md`](../architecture/durable-agent-runtime.md).
+
+If later product use justifies runnable-frontier scheduling, worker spawning,
+capacity management, dependency graphs, or autonomous routing, those mechanisms may
+consume durable Agent Task state as input. They remain optional control layers and
+must revalidate claim/execution authority at the consequential boundary; they are
+not hidden behavior of the Session message board or Conversation substrate.

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -54,12 +54,20 @@ MCP and never proof of Workflow Session identity, model-context retention, or
 authority. Raw window values are not stored; only their domain-separated hash is
 used where that adapter contract permits window binding.
 
-Restart recovery follows the same boundary: durable task history always
+Restart recovery follows the same boundary: durable Connector Task history always
 survives; only adapters with an explicit stable window may restore an exact
 window/repository mapping automatically. Stateless callers recover explicitly by
 `task_id`. `task_resume` may rebind only when the current adapter actually
-supplies a new stable `ClientWindow`; otherwise the durable task resumes without
+supplies a new stable `ClientWindow`; otherwise the durable Connector Task resumes without
 manufacturing one.
+
+The durable Agent/Conversation/Wake domain is also not a session type. A
+Server-minted Agent may participate in Conversations and later own asynchronous
+Agent Tasks while concrete execution uses zero or more independent Workflow
+Sessions. Future **Agent Task** / **Agent TaskAttempt** semantics are distinct from
+the Connector Task described above; similar names do not imply shared lifecycle,
+window binding, storage, or authority. See
+[`../architecture/durable-agent-runtime.md`](../architecture/durable-agent-runtime.md).
 
 ---
 
@@ -135,7 +143,7 @@ Retention correctness does not infer continuity from deque length or position. R
 
 Waiting uses process-local notification only as a wake signal; durable revision state remains the truth. No Session-store or persistence-writer mutex is held across the bounded await, unrelated Session mutation can only cause a spurious recheck, and timeout is a successful unchanged result rather than a tool failure.
 
-Message observation is not a delivery receipt, not model-context retention, not a subscription/stream, and not an orchestrator wake-up. Room/Discussion, Participant, presence, typing, scheduler/worker-pool, automatic worker spawning, and routing remain future additive capabilities rather than reinterpretations of this cursor.
+Message observation is not a delivery receipt, not model-context retention, not a subscription/stream, and not an Agent Wake. Durable Agent/Conversation/Participant/Delivery/Wake state already exists as a separate Server-owned domain; this Workflow Session cursor neither observes nor mutates it. Presence, typing, Agent Task scheduling/worker-pool behavior, automatic worker spawning, and routing remain separate additive capabilities rather than reinterpretations of this cursor.
 
 Every Workflow Session admitted to the in-memory store carries one canonical creation-time authority-group fingerprint. The ledger keeps only that domain-separated SHA-256 fingerprint under the historical `owner_authority_fingerprint` field; raw user, shared-key, project-grant, credential, or window identity material is never persisted as Session authority. Project authorization and creation-time Session authority are separate checks: access to a project does not authorize another authority group's Session, and a matching Session fingerprint does not bypass project authorization or project equality.
 

--- a/docs/architecture/durable-agent-conversation.md
+++ b/docs/architecture/durable-agent-conversation.md
@@ -1,6 +1,6 @@
 # Durable Agent identity, Conversation, and wake foundation
 
-A1 adds a concrete communication domain without changing the meaning of Workflow Sessions or project Memory. A2 extends that domain with durable wake intent, Endpoint lifecycle/generation fencing, dispatch uncertainty, and exact continuation consume semantics without making model execution part of Conversation or Inbox state.
+A1 adds a concrete communication domain without changing the meaning of Workflow Sessions or project Memory. A2 extends that domain with durable wake intent, Endpoint lifecycle/generation fencing, dispatch uncertainty, and exact continuation consume semantics without making model execution part of Conversation or Inbox state. The standing direction beyond this implemented substrate is defined in [`durable-agent-runtime.md`](durable-agent-runtime.md).
 
 ## Domain boundaries
 
@@ -13,10 +13,10 @@ A1 adds a concrete communication domain without changing the meaning of Workflow
 | Agent Delivery | Recipient-specific queued/consumed Inbox state pointing to one Message | a duplicate Message or model invocation |
 | Wake Intent | Durable logical continuation saying an Agent should receive another processing opportunity | a Message, Inbox Delivery, or Host delivery attempt |
 | Wake Delivery Attempt | One Endpoint/generation-bound attempt to deliver a Wake Intent through a continuation adapter | the durable communication fact or a grant of execution authority |
-| Task | Reserved future bridge from communication to requested work | implemented by A1 or A2 |
+| Agent Task | Planned durable asynchronous work accepted/created for an Agent | Connector Task, Conversation Message, Session todo, or execution authority |
 | Workflow Session | Existing execution, provenance, validation, Job, workspace, todo, and guidance context | a chat room |
 
-An Agent Card contains a mutable non-unique handle, display name, description, bounded specialty labels, profile revision, and timestamps. These fields are self-description metadata. Canonical identity is only the Server-generated `agent_id`, and neither identity nor metadata grants Project, filesystem, Runner, Task, or Workflow Session authority.
+An Agent Card contains a mutable non-unique handle, display name, description, bounded specialty labels, profile revision, and timestamps. These fields are self-description metadata. Canonical identity is only the Server-generated `agent_id`, and neither identity nor metadata grants Project, filesystem, Runner, Agent Task, or Workflow Session authority.
 
 ## Authoritative persistence
 
@@ -76,8 +76,10 @@ The page performs bounded polling on the existing eight-second Runtime Console c
 
 A2 also defines a narrow Host-neutral `ContinuationAdapter`: preflight occurs before the dispatch fence and must not resume a model, while dispatch happens only after the Attempt is durably prepared. The checked-in deterministic adapter is test-only; A2 does not claim a production ChatGPT/MCP-App auto-resume path.
 
-## Future boundaries
+## Next boundaries
 
-A later slice may add a production Host continuation adapter and dogfood, an explicit operator/Host reconciliation policy for long-lived `delivery_unknown` ambiguity, a concrete bridge such as `Message -> accepted Task -> Workflow Session -> Job -> Conversation reply`, richer participant administration, and cluster storage. ChatGPT MCP Apps remain one possible Endpoint/continuation adapter rather than a core dependency.
+The next standing work-domain boundary is an independent Agent Task plus fenced Agent TaskAttempt, described in [`durable-agent-runtime.md`](durable-agent-runtime.md). A Conversation Message may later become the stable origin of explicitly accepted work, but Message/Delivery/Wake state is not silently reinterpreted as an Agent Task, claim, lease, or execution result. Existing Connector Tasks and Workflow Session todos remain separate domains.
 
-Current project-scoped Memory behavior is unchanged. Agent identity is stable enough for a future Memory principal or namespace keyed by `agent_id`; A1/A2 do not migrate Memory, add Agent Skills, schedule work, spawn autonomous workers, implement Task/DAG orchestration, federation, A2A compatibility, PostgreSQL, or distributed multi-Server leases.
+A separate later slice may add a production Host continuation adapter and dogfood plus an explicit operator/Host reconciliation policy for long-lived `delivery_unknown` ambiguity. ChatGPT MCP Apps remain one possible Endpoint/continuation adapter rather than a core dependency.
+
+Current project-scoped Memory behavior is unchanged. Agent identity is stable enough for a future Memory principal or namespace keyed by `agent_id`; A1/A2 do not migrate Memory, add Agent Skills, schedule work, spawn autonomous workers, implement Agent Task/DAG orchestration, federation, A2A compatibility, PostgreSQL, or distributed multi-Server leases.

--- a/docs/architecture/durable-agent-runtime.md
+++ b/docs/architecture/durable-agent-runtime.md
@@ -1,0 +1,496 @@
+# Durable Agent runtime and asynchronous work
+
+This document defines the standing product direction for durable Agent identity and
+asynchronous work in WebCodex. It builds on the implemented Agent/Conversation/Wake
+foundation without turning WebCodex into a generic swarm framework or workflow
+scheduler.
+
+Implementation details for the current communication and wake substrate live in
+[`durable-agent-conversation.md`](durable-agent-conversation.md). Workflow Session
+semantics remain defined by [`../agent/session-model.md`](../agent/session-model.md).
+
+## Product direction
+
+The product goal is a durable Agent entity that can outlive any one model turn,
+browser window, host connection, Project, or execution carrier.
+
+A user should eventually be able to:
+
+1. create or select a durable Agent;
+2. attach a current window/host to that Agent;
+3. communicate through durable Conversations and Inbox Deliveries;
+4. leave work for the Agent that remains durable while no model is running;
+5. later attach another Endpoint and continue as the same Agent;
+6. execute accepted work through whatever authorized carrier is appropriate;
+7. inspect durable status instead of inferring progress from browser/UI state.
+
+The model process is not the Agent. A model turn executes **on behalf of** a durable
+Agent. Closing a window therefore means that an Endpoint disappeared; it does not
+mean that the Agent, its Conversations, or its accepted work disappeared.
+
+This direction may eventually make multi-Agent scheduling possible, but scheduling
+is not the product definition. WebCodex should first make Agent identity and work
+independent from windows and synchronous model turns. Runnable-frontier scheduling,
+capacity management, graph execution, and autonomous delegation remain optional
+capabilities that require separate product evidence.
+
+## Names that must not collapse
+
+WebCodex already contains several concepts that use similar words. They are separate
+domains and must remain explicit in code, schemas, documentation, and reviews.
+
+| Concept | Meaning | Not interchangeable with |
+| --- | --- | --- |
+| Runtime Project | Runner-registered execution target addressed as `agent:<client_id>:<project_id>` | durable Agent identity |
+| Durable Agent | Server-minted `wc_dagent_*` identity representing who acts/communicates | Runner, browser window, credential, Workflow Session |
+| Agent Endpoint | Current Host/Client attachment for one Agent, with lifecycle/generation | Agent identity or work ownership |
+| Conversation | Durable communication space | Workflow Session, task queue, execution context |
+| Agent Delivery | Recipient-specific Inbox state for one Message | model invocation or accepted work |
+| Wake Intent | Durable logical processing opportunity for an Agent | Message, Delivery, Agent Task, execution lease |
+| Connector Task | Existing project-bound `task_start` / `task_resume` continuity domain | Agent Task |
+| Agent Task | Planned durable unit of accepted asynchronous Agent work | Connector Task, Session todo, Conversation Message |
+| Agent TaskAttempt | Planned exact execution/ownership attempt for one Agent Task | Endpoint, Workflow Session, CodingAgentRun |
+| Workflow Session | Existing execution/provenance/validation/handoff evidence context | Agent, Conversation, Agent Task |
+| Job | Concrete long-running process/validation execution | Agent Task or TaskAttempt |
+| CodingAgentRun | Existing ACP delegated coding execution | Agent Task itself |
+
+The `agent:` prefix in a runtime Project id is historical Runner-address syntax. It
+is unrelated to the durable `wc_dagent_*` Agent identity domain.
+
+In implementation names, prefer `ConnectorTask` for the existing Connector
+continuity domain and `AgentTask` / `AgentTaskAttempt` for the asynchronous Agent
+work domain. Do not introduce an unqualified new `Task` type where ownership would
+be ambiguous.
+
+## Implemented durable Agent foundation
+
+The current implementation already establishes these boundaries:
+
+```text
+Durable Agent
+    |
+    +-- Agent Card / profile
+    +-- Endpoint attachments + controller generations
+    +-- Conversations
+    |     +-- append-only Messages
+    |     +-- recipient Deliveries / Inbox
+    |
+    +-- Wake Intents
+          +-- Endpoint/generation-bound Wake Delivery Attempts
+```
+
+Important current invariants:
+
+- `agent_id` is Server-minted stable identity; Agent Card metadata grants no
+  execution authority.
+- Endpoint identity is replaceable and principal-bound; lease validity and
+  controller generation fence stale attachments.
+- Conversation participation grants communication authority only.
+- Message, Delivery, Wake Intent, and Wake Delivery Attempt are independent durable
+  facts.
+- Message/Delivery creation and required Wake coalescing are transactional.
+- communication-resource authorization hides existence from unauthorized exact-id
+  probes.
+- generic database open is storage-only; standalone Server takeover recovery runs
+  only after explicit Server instance ownership is acquired.
+- dispatch uncertainty after the Wake dispatch fence is preserved rather than
+  blindly retried.
+- project-scoped Memory is unchanged; Agent-scoped Memory is only a future boundary.
+
+These invariants are prerequisites for asynchronous Agent work, not a scheduler.
+
+## Asynchronous Agent work
+
+An **Agent Task** represents durable work that has been explicitly accepted or
+created for later completion. It answers:
+
+> What work remains to be completed?
+
+It must survive model-turn completion, Endpoint detach, browser closure, Server
+restart, and temporary absence of an execution carrier.
+
+An Agent Task is not created merely because a Conversation Message exists. A Message
+is communication; converting or accepting a request into work must be an explicit
+durable transition. An Agent Task may retain stable origin references such as `conversation_id` and
+`source_message_id`, but the Message body remains owned by the Conversation domain.
+
+Likewise, an Agent Task that references a Project does not receive Project authority.
+The Project reference identifies where work may need to occur; every actual execution
+still passes the normal Project/Runner/filesystem/permission checks.
+
+A first Agent Task model should stay deliberately small. Candidate durable fields
+are:
+
+```text
+AgentTask
+  task_id
+  creator / owner principal attribution
+  assignee_agent_id?
+  bounded title / instruction
+  source_conversation_id?
+  source_message_id?
+  referenced_project_id?
+  state
+  created_at
+  updated_at
+  terminal result / reason references?
+```
+
+The exact state enum should be chosen by the implementing slice, not expanded in
+advance for hypothetical graph execution. The first slice needs only enough states
+to distinguish available/active work from terminal success/failure and any explicit
+cancellation that is actually required.
+
+## TaskAttempt is the execution ownership unit
+
+An Agent Task does not record a mutable `claimed_by` field that is repeatedly reused
+across retries. Each concrete attempt is a separate durable **Agent TaskAttempt**.
+
+```text
+AgentTask
+   |
+   +-- TaskAttempt 1 -> expired / failed
+   +-- TaskAttempt 2 -> failed
+   +-- TaskAttempt 3 -> completed
+```
+
+A TaskAttempt answers:
+
+> Who owns this exact execution attempt, and which generation of that attempt is
+> still allowed to make progress?
+
+Candidate durable fields are:
+
+```text
+AgentTaskAttempt
+  attempt_id
+  task_id
+  attempt_number
+  assignee_agent_id
+  state
+  lease_expires_at
+  attempt_fence
+  attempt_controller_generation
+  workflow_session_id?
+  execution_kind?
+  execution_ref?
+  created_at
+  started_at?
+  terminal_at?
+```
+
+The Attempt belongs to the durable Agent, not to a browser window. An Endpoint or
+other execution carrier is only a current way of executing that Attempt.
+
+### Two different stale-execution fences
+
+Attempt retry and carrier replacement are different events and need different
+fences.
+
+**Attempt fence** separates one TaskAttempt from a later TaskAttempt:
+
+```text
+Attempt 1 (fence A) -> lease expires
+Attempt 2 (fence B) -> becomes current
+
+late heartbeat(A) -> stale
+late complete(A)  -> stale
+late fail(A)      -> stale
+```
+
+The same Agent reclaiming work after Attempt 1 expires creates Attempt 2. Matching
+`agent_id` must never revive an expired Attempt.
+
+**Attempt controller generation** separates execution carriers inside the same Attempt:
+
+```text
+Attempt 2
+  Agent A
+  attempt_fence = B
+  attempt_controller_generation = 4
+       |
+       +-- old carrier binding / attempt generation 3 -> stale
+       +-- replacement carrier binding / attempt generation 4 -> current
+```
+
+Carrier replacement therefore does not necessarily create a new Attempt, but the
+old carrier must lose the ability to heartbeat, dispatch, or submit a terminal
+result. `attempt_controller_generation` is Attempt-local freshness metadata, not a
+credential or a grant of Project authority. It is distinct from the existing Agent
+Endpoint controller generation. When the carrier is an Agent Endpoint, the binding
+must also preserve and validate the exact `endpoint_id` plus that Endpoint's own
+controller generation.
+
+If an execution backend already has a stronger exact identity (for example a
+CodingAgentRun `run_id` plus provider-instance fencing), bind and revalidate that
+identity rather than weakening it into a generic controller token.
+
+## Attempt authority and lease semantics
+
+Possession of an Attempt id, fence, lease timestamp, Agent id, or controller
+generation is never sufficient authority by itself.
+
+The intended admission rule is conceptually:
+
+```text
+normal caller authorization
++ authorized Agent Task visibility / operation
++ exact active task_id + attempt_id
++ exact assignee_agent_id
++ unexpired Attempt lease
++ exact opaque attempt_fence
++ current attempt_controller_generation when a replaceable carrier is bound
++ normal Project / executor authority for consequential execution
+```
+
+`attempt_fence` is conflict-detection/freshness metadata, not a bearer credential.
+A lease that is already expired cannot be renewed by the stale owner and cannot
+submit completion. A new claim after expiry creates a new Attempt.
+
+Planner or scheduler output, if one is added later, is advisory. The authoritative
+claim/dispatch mutation must re-check current Agent Task state, Attempt state, lease,
+assignee, Project/executor authority, and any dependency rules that eventually
+exist.
+
+## Idempotency, replay, and uncertainty
+
+Agent Task mutations should follow the existing WebCodex durable patterns:
+
+- create-like operations use caller-generated idempotency keys plus canonical
+  request fingerprints;
+- exact uncertain retry returns the original Agent Task/TaskAttempt/result;
+- reusing one key for changed intent fails closed;
+- duplicate terminal completion is exact replay, not a second side effect;
+- expired Attempt heartbeat/completion is rejected even when the Agent is the same;
+- once a later Attempt exists, an older Attempt remains permanently stale;
+- restart restores durable Task/Attempt truth rather than inferring ownership from
+  process-local state.
+
+Execution dispatch has a separate uncertainty boundary. If a backend dispatch may
+have happened, the TaskAttempt must preserve that ambiguity and reconcile the exact
+execution rather than minting a replacement execution blindly. Existing
+CodingAgentRun `outcome_unknown` / provider-instance semantics are the preferred
+first backend precedent.
+
+## Communication, Wake, Task, and execution are separate
+
+The expected relationship is:
+
+```text
+Human / Agent
+    |
+    v
+Conversation Message
+    |
+    | explicit accept/create work
+    v
+Agent Task
+    |
+    | exact claim
+    v
+Agent TaskAttempt
+    |
+    +--> CodingAgentRun
+    |       or
+    +--> Agent Endpoint continuation
+    |       or future concrete backend
+    v
+Workflow Session / Job / backend execution evidence
+    |
+    v
+exact Attempt terminal transition
+    |
+    v
+Agent Task result
+    |
+    v
+Conversation reply / durable notification
+```
+
+The arrows are correlations, not authority inheritance.
+
+A Wake Intent says that an Agent should receive another processing opportunity. It
+is not an Agent Task claim and does not mean work completed. Consuming a Wake does
+not consume Agent Task work. Consuming Inbox Deliveries does not complete an Agent
+Task. An Agent Task may remain durable while the Agent has no wake-capable Endpoint.
+
+A Workflow Session remains the execution/provenance/validation context for concrete
+work. It does not become the Agent Task identity. A Session todo remains a useful
+manual coordinator/worker assignment primitive, but it is not silently upgraded
+into an Agent Task.
+
+## Authority and privacy boundaries
+
+Agent entity work crosses communication and execution domains, so the boundary must
+remain explicit from the first Agent Task slice.
+
+Standing rules:
+
+- Agent identity or Agent Card metadata grants no execution authority.
+- Conversation membership, authorship, mention, Delivery, or Wake possession grants
+  no Agent Task execution authority.
+- Agent Task assignment grants no Project, Runner, filesystem, Job, Workflow
+  Session, Computer, or CodingAgent authority.
+- An Agent Task's Project reference grants no access to that Project.
+- Claim/dispatch/completion re-authorize their owning Agent Task domain and any
+  actual Project/executor target at the consequential boundary.
+- Agent Task visibility, Agent Task management, assignment/claim, and underlying execution
+  authority are conceptually distinct even if the first implementation can safely
+  reuse a smaller closed scope set.
+- exact Task/Attempt lookups should follow the existing authorization-result privacy
+  discipline: an unauthorized caller must not use guessed opaque ids as an
+  existence oracle.
+- generic audit/telemetry should keep ids, state, counts, generations, and bounded
+  metadata, not duplicate full Agent Task instructions, Conversation bodies, secrets, or
+  opaque fences/tokens.
+
+Do not name new scopes merely to make the model look symmetric. Introduce a scope
+only when the actual first Agent Task surface creates a distinct authority audience.
+
+## Agent continuity across windows
+
+The durable identity model is intentionally stronger than window continuity:
+
+```text
+Window / Host Endpoint E1 disappears
+        |
+        v
+Durable Agent still exists
+        |
+        +-- Agent Card
+        +-- Conversation / Inbox / Wake
+        +-- future Agent Memory
+        +-- Agent Tasks / TaskAttempts
+        |
+        v
+Endpoint E2 attaches later
+```
+
+A replacement Endpoint may continue the same Agent, subject to current principal
+ownership, Endpoint generation, TaskAttempt controller fencing, and the execution
+backend's own rules. No model is assumed to remain resident between turns.
+
+This also leaves a clean future boundary for Agent-scoped Memory and Skills. Current
+Project Memory remains unchanged until a deliberate migration/namespace design is
+implemented. Agent Skills are later additive capability/configuration, not part of
+TaskAttempt authority.
+
+## Execution backend sequence
+
+Do not build a universal execution-provider framework in the Agent Task foundation.
+Use concrete backends first.
+
+### A3 — Agent Task + fenced TaskAttempt
+
+Establish durable Agent Task and TaskAttempt semantics only:
+
+- explicit work creation/acceptance;
+- atomic claim;
+- lease + exact Attempt fencing;
+- carrier/controller-generation fencing where needed;
+- exact heartbeat/completion/replay;
+- restart recovery;
+- authority/privacy boundaries;
+- minimal observation/listing needed to dogfood the domain.
+
+A3 does **not** automatically spawn workers or choose execution capacity.
+
+### A4a — TaskAttempt -> existing CodingAgentRun
+
+Use the existing ACP CodingAgentRun as the first real execution backend. It already
+has durable run identity, caller/project/provider intent binding, provider-instance
+fencing, uncertain-dispatch handling, and restart reconciliation.
+
+This is deliberately the first backend because it proves that Agent Task execution
+is independent from ChatGPT browser windows.
+
+### A4b — TaskAttempt -> Agent Endpoint continuation
+
+After a production Host continuation adapter exists, allow a TaskAttempt to execute
+through a wake-capable Agent Endpoint. The TaskAttempt remains Agent-owned; the
+Endpoint remains a replaceable carrier.
+
+Only after both backends reveal repeated common machinery should WebCodex extract a
+minimal shared execution binding/adapter abstraction.
+
+## Scheduling is optional derived capability
+
+Later dogfood may show that many durable Agent Tasks benefit from a runnable-frontier
+scheduler. If so, scheduling should derive from durable work, not from browser tabs
+or UI idle state.
+
+Useful future invariants include:
+
+- planning is advisory; claim remains authoritative;
+- runnable work and live execution reservations drive capacity decisions;
+- active execution reservations form a floor only for the carrier class they
+  actually consume;
+- semantic durable state transitions create wake pressure; visual UI state does not;
+- stale workers/carriers cannot renew expired leases or submit late results.
+
+Capacity is therefore potentially per execution class rather than simply
+"number of active Agent Tasks = number of ChatGPT windows".
+
+This is a possible A5 product slice, not an A3 requirement and not WebCodex's north
+star.
+
+## Dependencies and workflow graphs come later
+
+Do not add dependency DAGs, fan-out/reducers, graph node kinds, conditional routing,
+supersteps/barriers, or parent/child Agent orchestration merely because another
+system demonstrates them.
+
+First prove:
+
+```text
+Agent Task -> exact TaskAttempt -> concrete execution -> exact terminal result
+```
+
+Add dependency semantics only after real workflows require `A -> B` or fan-out/join.
+Add an explicit workflow graph only after dependency plus conditional-routing use
+cases justify a third abstraction layer. Superstep/BSP-style coordination has no
+current roadmap commitment.
+
+## A3 acceptance matrix
+
+The first Agent Task foundation should close at least these cases:
+
+| Case | Required result |
+| --- | --- |
+| two Agents concurrently claim one Agent Task | exactly one authoritative Attempt is created/accepted |
+| exact claim retry | returns the same Attempt without redispatch |
+| heartbeat before lease expiry | succeeds only for exact current Attempt/controller |
+| heartbeat after lease expiry | rejected as stale |
+| completion after lease expiry | rejected as stale |
+| same Agent claims after expiry | creates a new Attempt |
+| different Agent claims after expiry | creates a new Attempt only if current assignment/authority makes that Agent eligible |
+| Attempt 1 responds after Attempt 2 exists | Attempt 1 remains permanently stale |
+| Endpoint replacement inside one Attempt | old controller generation is fenced |
+| Server restart | Task/Attempt truth and accepted replay identities survive |
+| Endpoint detach | Task/Attempt durable state does not disappear |
+| duplicate completion | exact replay, no repeated terminal side effect |
+| changed replay | idempotency conflict |
+| Conversation participant references Agent Task | receives no implicit Agent Task execution authority |
+| Agent Task references Project | receives no implicit Project authority |
+| unauthorized exact Agent Task/Attempt id | does not disclose foreign-resource existence |
+
+## Explicit non-goals for the next slice
+
+The Agent Task foundation must not expand into:
+
+- a generic swarm scheduler or worker pool;
+- automatic Agent spawning or autonomous delegation;
+- runnable-frontier/capacity autoscaling;
+- dependency DAG, fan-out/reducer, graph DSL, or superstep;
+- a universal execution-provider framework;
+- Agent parent/child hierarchy;
+- production ChatGPT continuation unless that is the dedicated A4b slice;
+- Agent-scoped Memory migration or Agent Skills;
+- federation/A2A compatibility;
+- PostgreSQL/distributed multi-Server scheduling;
+- a generic Actor/Event/Entity ORM.
+
+The design goal is narrower: make a durable Agent able to own and resume
+asynchronous work correctly, with explicit identity, authority, replay, and stale
+execution fencing. More automated coordination can grow from that foundation only
+when real product use demonstrates the need.

--- a/docs/architecture/durable-agent-runtime.md
+++ b/docs/architecture/durable-agent-runtime.md
@@ -114,6 +114,13 @@ is communication; converting or accepting a request into work must be an explici
 durable transition. An Agent Task may retain stable origin references such as `conversation_id` and
 `source_message_id`, but the Message body remains owned by the Conversation domain.
 
+A3 does not define a global work-stealing queue. Before an Agent Task can create an
+Attempt, it has an explicit current assignee Agent established by Task creation,
+acceptance, or a separate authorized reassignment transition. An unassigned Task may
+exist if a real UI/workflow needs it, but it is not claimable by arbitrary Agents.
+Changing the assignee is an explicit durable mutation; lease expiry alone never
+silently transfers work to a different Agent.
+
 Likewise, an Agent Task that references a Project does not receive Project authority.
 The Project reference identifies where work may need to occur; every actual execution
 still passes the normal Project/Runner/filesystem/permission checks.
@@ -125,7 +132,7 @@ are:
 AgentTask
   task_id
   creator / owner principal attribution
-  assignee_agent_id?
+  assignee_agent_id?  # must be explicit before creating an Attempt
   bounded title / instruction
   source_conversation_id?
   source_message_id?
@@ -179,8 +186,9 @@ AgentTaskAttempt
   terminal_at?
 ```
 
-The Attempt belongs to the durable Agent, not to a browser window. An Endpoint or
-other execution carrier is only a current way of executing that Attempt.
+The Attempt belongs to the durable Agent named by the Agent Task's current explicit
+assignment, not to a browser window. An Endpoint or other execution carrier is only
+a current way of executing that Attempt.
 
 ### Two different stale-execution fences
 
@@ -227,7 +235,7 @@ identity rather than weakening it into a generic controller token.
 
 ## Attempt authority and lease semantics
 
-Possession of an Attempt id, fence, lease timestamp, Agent id, or controller
+Possession of an Attempt id, fence, lease timestamp, Agent id, or Attempt controller
 generation is never sufficient authority by itself.
 
 The intended admission rule is conceptually:
@@ -245,12 +253,14 @@ normal caller authorization
 
 `attempt_fence` is conflict-detection/freshness metadata, not a bearer credential.
 A lease that is already expired cannot be renewed by the stale owner and cannot
-submit completion. A new claim after expiry creates a new Attempt.
+submit completion. A new authorized start/claim by the current assignee after expiry
+creates a new Attempt.
 
-Planner or scheduler output, if one is added later, is advisory. The authoritative
-claim/dispatch mutation must re-check current Agent Task state, Attempt state, lease,
-assignee, Project/executor authority, and any dependency rules that eventually
-exist.
+Planner or scheduler output, if one is added later, is advisory. In A3, assignment
+is explicit rather than selected by a scheduler. The authoritative Attempt
+start/claim and dispatch mutations must re-check current Agent Task state, current
+assignee, Attempt state, lease, Project/executor authority, and any dependency rules
+that eventually exist.
 
 ## Idempotency, replay, and uncertainty
 
@@ -384,8 +394,8 @@ Use concrete backends first.
 
 Establish durable Agent Task and TaskAttempt semantics only:
 
-- explicit work creation/acceptance;
-- atomic claim;
+- explicit work creation;
+- explicit assignment/acceptance and atomic Attempt start/claim by that assignee;
 - lease + exact Attempt fencing;
 - carrier/controller-generation fencing where needed;
 - exact heartbeat/completion/replay;
@@ -393,7 +403,8 @@ Establish durable Agent Task and TaskAttempt semantics only:
 - authority/privacy boundaries;
 - minimal observation/listing needed to dogfood the domain.
 
-A3 does **not** automatically spawn workers or choose execution capacity.
+A3 does **not** automatically choose an assignee, spawn workers, operate a global
+claimable queue, or choose execution capacity.
 
 ### A4a — TaskAttempt -> existing CodingAgentRun
 
@@ -421,7 +432,7 @@ or UI idle state.
 
 Useful future invariants include:
 
-- planning is advisory; claim remains authoritative;
+- planning is advisory; explicit assignment plus claim/dispatch remains authoritative;
 - runnable work and live execution reservations drive capacity decisions;
 - active execution reservations form a floor only for the carrier class they
   actually consume;
@@ -457,16 +468,17 @@ The first Agent Task foundation should close at least these cases:
 
 | Case | Required result |
 | --- | --- |
-| two Agents concurrently claim one Agent Task | exactly one authoritative Attempt is created/accepted |
-| exact claim retry | returns the same Attempt without redispatch |
+| two concurrent start/claim requests for one explicitly assigned Agent Task | exactly one authoritative Attempt is created/accepted |
+| exact start/claim retry | returns the same Attempt without redispatch |
 | heartbeat before lease expiry | succeeds only for exact current Attempt/controller |
 | heartbeat after lease expiry | rejected as stale |
 | completion after lease expiry | rejected as stale |
-| same Agent claims after expiry | creates a new Attempt |
-| different Agent claims after expiry | creates a new Attempt only if current assignment/authority makes that Agent eligible |
+| same assigned Agent starts again after expiry | creates a new Attempt |
+| different Agent tries after expiry without reassignment | rejected; lease expiry does not transfer assignment |
+| authorized explicit reassignment, then new assignee starts | creates a new Attempt for the new current assignee |
 | Attempt 1 responds after Attempt 2 exists | Attempt 1 remains permanently stale |
-| Endpoint replacement inside one Attempt | old controller generation is fenced |
-| Server restart | Task/Attempt truth and accepted replay identities survive |
+| Endpoint/carrier replacement inside one Attempt | old Attempt controller/binding is fenced |
+| Server restart | Agent Task/TaskAttempt truth and accepted replay identities survive |
 | Endpoint detach | Task/Attempt durable state does not disappear |
 | duplicate completion | exact replay, no repeated terminal side effect |
 | changed replay | idempotency conflict |

--- a/docs/architecture/durable-agent-runtime.md
+++ b/docs/architecture/durable-agent-runtime.md
@@ -357,6 +357,22 @@ Standing rules:
 Do not name new scopes merely to make the model look symmetric. Introduce a scope
 only when the actual first Agent Task surface creates a distinct authority audience.
 
+For the first A3 slice, Agent assignment must not manufacture a new bearer
+principal. Task creation/assignment/start/heartbeat/completion run under the current
+authenticated caller and must prove that caller may operate the exact Task and its
+current assignee Agent in the Task domain. A simple first implementation may reuse
+the Agent's existing owner communication principal when that is the actual product
+audience, but doing so does not confer Project or executor authority and does not
+make `agent_id`, `task_id`, `attempt_id`, or an opaque fence a credential.
+
+Execution-carrier admission is then additive rather than implicit. A
+CodingAgentRun-backed Attempt does not require any browser/Host Endpoint; it
+re-authorizes the exact Project and CodingAgent backend under their normal rules. An
+Endpoint-backed Attempt additionally requires the exact currently authorized
+Endpoint plus its generation/binding fences. This keeps Task ownership independent
+from window presence while preventing either Agent ownership or Endpoint possession
+from silently broadening execution authority.
+
 ## Agent continuity across windows
 
 The durable identity model is intentionally stronger than window continuity:


### PR DESCRIPTION
## Summary

Consolidate the current durable Agent architecture after the A1/A2 communication and wake work, and remove documentation that still described Conversation/Participant as a future Room/Discussion concept.

This PR:

- adds a standing `docs/architecture/durable-agent-runtime.md` design for durable Agent identity and asynchronous Agent work;
- distinguishes Runtime Project `agent:` addressing, durable `wc_dagent_*` Agents, Connector Tasks, future Agent Tasks/TaskAttempts, Workflow Sessions, Jobs, and CodingAgentRuns;
- defines the next work boundary as explicit Agent Task assignment plus fenced TaskAttempts, without making a global work-stealing queue or swarm scheduler part of A3;
- keeps scheduling, DAGs, autonomous delegation, Agent Memory migration, and Agent Skills as later optional capabilities;
- clarifies that Agent/Task ownership does not imply Host Endpoint presence or Project/executor authority;
- makes Agent-bound automatic continuation owned by the durable Agent Wake / Wake Delivery Attempt domain rather than by UI cards or Host views;
- updates `AGENTS.md`, top-level architecture, Session/collaboration guidance, ACP notes, and the A1/A2 implementation contract to match the implemented Agent/Conversation/Wake domain.

## Direction

The intended product model is:

`Durable Agent -> Conversations / Inbox / Wake -> Agent Task -> exact TaskAttempt -> concrete authorized execution carrier`

A model turn or browser window acts on behalf of the durable Agent; it is not the Agent itself. WebCodex may later grow scheduling capabilities from durable work state, but a generic multi-Agent scheduler is not the product definition or an A3 prerequisite.

## Review notes

The final follow-up commit tightens continuation authority:

- Task operations remain authenticated caller operations and do not mint bearer Agent identities;
- CodingAgentRun-backed attempts do not require a browser/Host Endpoint;
- Endpoint-backed attempts additionally require the exact authorized Endpoint and freshness fences;
- exactly one durable continuation domain owns a logical model-resume event.

## Validation

- `git diff --check origin/main...HEAD`
- repository Markdown local-link scan: 52 files, 367 local links, 0 missing
- documentation-only change; no Cargo build/tests run per repository guidance
- final worktree clean
