### PR TITLE
Speed up local Rust build iteration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,12 @@ For repository testing guidance, see [docs/TESTING.md](docs/TESTING.md). For the
 coding workflow and closeout conventions, see
 [docs/CODING_WORKFLOW.md](docs/CODING_WORKFLOW.md).
 
+On developer machines, ordinary `dev` and `test` Cargo profiles intentionally omit
+source-line debuginfo to keep large test binaries and links smaller. Linux developers
+may optionally run Cargo through `bash scripts/cargo_fast.sh <cargo-args>`; the wrapper
+runs Cargo under `mold -run` only when mold is available. Missing mold falls back to
+normal Cargo, and the wrapper never changes the macOS or Windows linker.
+
 ## Pull requests
 
 A pull request should explain what changed, why the change is needed, and what

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -38,6 +38,8 @@
 仓库测试说明见 [docs/TESTING.md](docs/TESTING.md)，coding workflow 与 closeout 约定见
 [docs/CODING_WORKFLOW.zh-CN.md](docs/CODING_WORKFLOW.zh-CN.md)。
 
+开发机上的普通 Cargo `dev` / `test` profile 会有意关闭源码行号 debuginfo，以减小大型测试二进制和链接开销。Linux 开发者可按需使用 `bash scripts/cargo_fast.sh <cargo-args>`；只有在 Linux 且检测到 mold 时才通过 `mold -run` 启动 Cargo。缺少 mold 时会透明回退到普通 Cargo，且不会修改 macOS 或 Windows 的链接器。
+
 ## Pull requests
 
 Pull request 应说明改了什么、为什么需要这项改动，以及执行了哪些验证。有相关 issue 时请进行关联。

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,15 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Threading",
 ] }
 
+# Developer builds favor iteration speed and compact artifacts. WebCodex does
+# not rely on source-line debug information in ordinary local/CI diagnostics;
+# debug assertions remain enabled independently of debuginfo.
+[profile.dev]
+debug = 0
+
+[profile.test]
+debug = 0
+
 # Release binaries ship via the npm wrapper; optimize for size without
 # changing runtime behavior (panic unwinding stays enabled).
 [profile.release]

--- a/crates/webcodex-core/build.rs
+++ b/crates/webcodex-core/build.rs
@@ -7,6 +7,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=WEBCODEX_GIT_COMMIT");
     println!("cargo:rerun-if-env-changed=WEBCODEX_GIT_DIRTY");
     println!("cargo:rerun-if-env-changed=WEBCODEX_BUILT_AT");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
 
     let head_path = git_metadata_path(&repo_root, "HEAD")
         .unwrap_or_else(|| repo_root.join(".git").join("HEAD"));
@@ -24,7 +25,15 @@ fn main() {
         env_value("WEBCODEX_GIT_COMMIT").unwrap_or_else(|| git_commit_from_git(&repo_root));
     let git_dirty =
         env_value("WEBCODEX_GIT_DIRTY").unwrap_or_else(|| git_dirty_from_git(&repo_root));
-    let built_at = env_value("WEBCODEX_BUILT_AT").unwrap_or_else(current_unix_timestamp);
+    // Release workflows pin WEBCODEX_BUILT_AT explicitly. For ordinary Git
+    // worktrees, prefer stable inputs so the same commit does not invalidate
+    // compiler caches merely because it was built at a different wall-clock
+    // time. SOURCE_DATE_EPOCH remains an explicit reproducible-build override;
+    // non-Git source trees retain the historical current-time fallback.
+    let built_at = env_value("WEBCODEX_BUILT_AT")
+        .or_else(|| env_value("SOURCE_DATE_EPOCH"))
+        .or_else(|| git_commit_timestamp_from_git(&repo_root))
+        .unwrap_or_else(current_unix_timestamp);
 
     println!("cargo:rustc-env=WEBCODEX_BUILD_GIT_COMMIT={git_commit}");
     println!("cargo:rustc-env=WEBCODEX_BUILD_GIT_DIRTY={git_dirty}");
@@ -48,6 +57,10 @@ fn repository_root() -> PathBuf {
 fn git_commit_from_git(repo_root: &Path) -> String {
     command_stdout(repo_root, ["rev-parse", "--short=12", "HEAD"])
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn git_commit_timestamp_from_git(repo_root: &Path) -> Option<String> {
+    command_stdout(repo_root, ["show", "-s", "--format=%ct", "HEAD"])
 }
 
 fn current_head_ref(repo_root: &Path) -> Option<String> {

--- a/scripts/cargo_fast.sh
+++ b/scripts/cargo_fast.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Opt-in accelerator for local Cargo work. Keep canonical Cargo commands valid
+# everywhere: missing accelerators always fall back to the normal toolchain.
+cargo_bin="${CARGO:-cargo}"
+
+# mold is Linux/ELF-only here. `mold -run` intercepts linker execution without
+# adding project-wide rustflags, so macOS and Windows linker selection is never
+# changed and Linux hosts without mold simply use Cargo's normal linker.
+if [[ "$(uname -s)" == "Linux" ]] && command -v mold >/dev/null 2>&1; then
+    exec mold -run "$cargo_bin" "$@"
+fi
+
+exec "$cargo_bin" "$@"


### PR DESCRIPTION
## Summary

- disable source-line debuginfo for ordinary Cargo dev/test profiles to reduce local test binary size and link cost
- stabilize non-release build `built_at` metadata using `WEBCODEX_BUILT_AT`, `SOURCE_DATE_EPOCH`, or the current Git commit timestamp
- add an opt-in Linux `scripts/cargo_fast.sh` wrapper that uses `mold -run` when available and otherwise falls back to normal Cargo
- document the local build-speed behavior for contributors

## Review

Independent review found no blocking correctness or provenance issues. Formal release builds continue to pin `WEBCODEX_BUILT_AT` explicitly, so release identity semantics remain unchanged.

## Validation

- `cargo fmt -- --check`
- `cargo test -p webcodex-core` — 103 passed
- `cargo check --all-targets -p webcodex-core`
- `bash scripts/cargo_fast.sh --version`
- `git diff --check origin/main...HEAD`
- workspace hygiene: clean
