### PR TITLE
Canonicalize session ledger persistence compatibility

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -24,6 +24,7 @@ mod task_kernel;
 
 pub use self::activity::WorkspaceActivityStore;
 pub(crate) use self::admin_project_lifecycle::AdminProjectAudit;
+#[allow(unused_imports)]
 pub(crate) use self::agent_wake::{
     AgentWakeClaim, AgentWakeConsumeResult, AgentWakeEnvelope, AgentWakePrepared, AgentWakeRecord,
     AgentWakeState, AGENT_WAKE_CONSUME_TOKEN_PREFIX, AGENT_WAKE_ID_PREFIX,

--- a/src/db/agent_wake.rs
+++ b/src/db/agent_wake.rs
@@ -74,6 +74,7 @@ pub(crate) enum AgentWakeAttemptState {
 }
 
 impl AgentWakeAttemptState {
+    #[allow(dead_code)]
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Claimed => "claimed",

--- a/src/db/agent_wake_tests.rs
+++ b/src/db/agent_wake_tests.rs
@@ -15,6 +15,7 @@ use std::sync::Mutex;
 #[derive(Clone)]
 struct Fixture {
     owner: CommunicationPrincipal,
+    #[allow(dead_code)]
     sender_agent_id: String,
     receiver_agent_id: String,
     conversation_id: String,

--- a/src/tool_runtime/sessions/assignment_tests.rs
+++ b/src/tool_runtime/sessions/assignment_tests.rs
@@ -1,4 +1,7 @@
-use super::model::{DEFAULT_MAX_MESSAGES_PER_SESSION, MAX_SESSION_ASSIGNMENT_DIRECT_REPLIES};
+use super::model::{
+    DEFAULT_MAX_MESSAGES_PER_SESSION, MAX_SESSION_ASSIGNMENT_DIRECT_REPLIES,
+    SESSION_LEDGER_V1_VERSION,
+};
 use super::*;
 use serde_json::Value;
 use std::sync::Arc;
@@ -721,73 +724,66 @@ fn oversized_direct_reply_set_fails_closed_without_partial_fence() {
 }
 
 #[test]
-fn historical_no_fence_completion_restores_for_query_but_cannot_replay() {
-    for explicit_historical_null in [false, true] {
-        let dir = tempfile::tempdir().unwrap();
-        let ledger = dir.path().join("sessions.json");
-        let store = SessionStore::with_persistence(&ledger, 10, 50);
-        let session = store.start_session(None, None);
-        let todo = todo(&store, &session.session_id, "historical completion");
-        let snapshot = store
-            .get_assignment(&session.session_id, &todo.message_id)
-            .unwrap();
-        let input = fenced_completion(
-            &session.session_id,
-            &todo.message_id,
-            &"5".repeat(64),
-            snapshot.assignment_fence,
-        );
-        let first = store.complete_message(input.clone()).unwrap();
-        store.flush_persistence();
-        drop(store);
+fn v039_no_fence_completion_restores_for_query_but_cannot_replay() {
+    let dir = tempfile::tempdir().unwrap();
+    let ledger = dir.path().join("sessions.json");
+    let store = SessionStore::with_persistence(&ledger, 10, 50);
+    let session = store.start_session(None, None);
+    let todo = todo(&store, &session.session_id, "v0.3.9 completion");
+    let snapshot = store
+        .get_assignment(&session.session_id, &todo.message_id)
+        .unwrap();
+    let input = fenced_completion(
+        &session.session_id,
+        &todo.message_id,
+        &"5".repeat(64),
+        snapshot.assignment_fence,
+    );
+    let first = store.complete_message(input.clone()).unwrap();
+    store.flush_persistence();
+    drop(store);
 
-        let mut raw: Value =
-            serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
-        let record = raw["sessions"]
-            .as_array_mut()
-            .unwrap()
-            .iter_mut()
-            .find(|record| record["session_id"] == session.session_id)
-            .unwrap()
-            .as_object_mut()
-            .unwrap();
-        if explicit_historical_null {
-            record.insert(
-                "completion_assignment_fence_fingerprints".to_string(),
-                serde_json::json!({ todo.message_id.clone(): Value::Null }),
-            );
-            record.insert(
-                "completion_assignment_fence_tracking_complete".to_string(),
-                Value::Bool(true),
-            );
-        } else {
-            record.remove("completion_assignment_fence_fingerprints");
-            record.remove("completion_assignment_fence_tracking_complete");
-        }
-        std::fs::write(&ledger, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
-        let before_replay = std::fs::read(&ledger).unwrap();
-
-        let restored = SessionStore::with_persistence(&ledger, 10, 50);
-        let restored_todo = exact(&restored, &session.session_id, &todo.message_id);
-        assert_eq!(restored_todo.status, SessionMessageStatus::Resolved);
-        assert_eq!(
-            restored_todo.resolved_by_message_id.as_deref(),
-            Some(first.answer.message_id.as_str())
-        );
-        assert_eq!(
-            answer_count(&restored, &session.session_id, &todo.message_id),
-            1
-        );
-        assert!(matches!(
-            restored.complete_message(input.clone()),
-            Err(SessionMessageError::IdempotencyConflict)
-        ));
-        assert_eq!(std::fs::read(&ledger).unwrap(), before_replay);
-        assert_eq!(
-            answer_count(&restored, &session.session_id, &todo.message_id),
-            1
-        );
+    let mut raw: Value = serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
+    raw["version"] = Value::from(SESSION_LEDGER_V1_VERSION);
+    raw.as_object_mut().unwrap().insert(
+        "durable_current_bindings".to_string(),
+        serde_json::json!([]),
+    );
+    let record = raw["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|record| record["session_id"] == session.session_id)
+        .unwrap()
+        .as_object_mut()
+        .unwrap();
+    for field in [
+        "assignment_history_floors",
+        "assignment_history_tracking_complete",
+        "completion_assignment_fence_fingerprints",
+        "completion_assignment_fence_tracking_complete",
+    ] {
+        record.remove(field);
     }
+    std::fs::write(&ledger, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+    let before_replay = std::fs::read(&ledger).unwrap();
+
+    let restored = SessionStore::with_persistence(&ledger, 10, 50);
+    let restored_todo = exact(&restored, &session.session_id, &todo.message_id);
+    assert_eq!(restored_todo.status, SessionMessageStatus::Resolved);
+    assert_eq!(
+        restored_todo.resolved_by_message_id.as_deref(),
+        Some(first.answer.message_id.as_str())
+    );
+    assert_eq!(
+        answer_count(&restored, &session.session_id, &todo.message_id),
+        1
+    );
+    assert!(matches!(
+        restored.complete_message(input),
+        Err(SessionMessageError::IdempotencyConflict)
+    ));
+    assert_eq!(std::fs::read(&ledger).unwrap(), before_replay);
 }
 
 #[test]

--- a/src/tool_runtime/sessions/collaboration_tests.rs
+++ b/src/tool_runtime/sessions/collaboration_tests.rs
@@ -1,7 +1,7 @@
 use super::messages::encode_observation_token;
 use super::model::{
     SessionMessageObservationOutcome, DEFAULT_MAX_MESSAGES_PER_SESSION,
-    MESSAGE_COMPLETION_FINGERPRINT_HEX_CHARS,
+    MESSAGE_COMPLETION_FINGERPRINT_HEX_CHARS, SESSION_LEDGER_V1_VERSION,
 };
 use super::*;
 use serde_json::Value;
@@ -334,7 +334,7 @@ async fn observe_session_messages_retention_reports_history_loss_for_protected_t
 }
 
 #[tokio::test]
-async fn observe_session_messages_token_survives_restart_and_legacy_restore_baselines_safely() {
+async fn observe_session_messages_token_survives_restart_and_v039_upgrade() {
     let dir = tempfile::tempdir().unwrap();
     let ledger = dir.path().join("sessions.json");
     let store = SessionStore::with_persistence(&ledger, 10, 50);
@@ -384,6 +384,11 @@ async fn observe_session_messages_token_survives_restart_and_legacy_restore_base
     restored.flush_persistence();
     drop(restored);
     let mut raw: Value = serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
+    raw["version"] = Value::from(SESSION_LEDGER_V1_VERSION);
+    raw.as_object_mut().unwrap().insert(
+        "durable_current_bindings".to_string(),
+        serde_json::json!([]),
+    );
     let record = raw["sessions"]
         .as_array_mut()
         .unwrap()
@@ -392,32 +397,40 @@ async fn observe_session_messages_token_survives_restart_and_legacy_restore_base
         .unwrap()
         .as_object_mut()
         .unwrap();
-    record.remove("message_observation_revision");
-    record.remove("message_observation_floor");
-    record.remove("message_observation_revisions");
+    for field in [
+        "assignment_history_floors",
+        "assignment_history_tracking_complete",
+        "completion_assignment_fence_fingerprints",
+        "completion_assignment_fence_tracking_complete",
+    ] {
+        record.remove(field);
+    }
     std::fs::write(&ledger, serde_json::to_vec(&raw).unwrap()).unwrap();
-    let legacy = SessionStore::with_persistence(&ledger, 10, 50);
-    let legacy_baseline = baseline(&legacy, &session.session_id).await;
-    assert!(legacy_baseline.messages.is_empty());
-    assert!(!legacy_baseline.changed);
-    let post_legacy = post(
-        &legacy,
+    let v039 = SessionStore::with_persistence(&ledger, 10, 50);
+    let v039_baseline = baseline(&v039, &session.session_id).await;
+    assert!(v039_baseline.messages.is_empty());
+    assert!(!v039_baseline.changed);
+    let post_upgrade = post(
+        &v039,
         &session.session_id,
         SessionMessageKind::Note,
-        "after legacy restore",
+        "after v0.3.9 upgrade",
         SessionMessagePriority::Normal,
     );
-    let legacy_delta = legacy
+    let upgraded_delta = v039
         .observe_messages(
             &session.session_id,
-            Some(&legacy_baseline.observation_token),
+            Some(&v039_baseline.observation_token),
             None,
             None,
         )
         .await
         .unwrap();
-    assert_eq!(legacy_delta.messages.len(), 1);
-    assert_eq!(legacy_delta.messages[0].message_id, post_legacy.message_id);
+    assert_eq!(upgraded_delta.messages.len(), 1);
+    assert_eq!(
+        upgraded_delta.messages[0].message_id,
+        post_upgrade.message_id
+    );
 }
 
 #[tokio::test]
@@ -949,7 +962,7 @@ fn collaboration_session_message_exact_lookup_finds_old_retained_todo() {
 }
 
 #[test]
-fn collaboration_session_message_completion_replays_after_restart_and_legacy_defaults() {
+fn collaboration_session_message_completion_replays_after_restart_and_v039_upgrade() {
     let dir = tempfile::tempdir().unwrap();
     let ledger = dir.path().join("sessions.json");
     let store = SessionStore::with_persistence(&ledger, 10, 50);
@@ -1000,39 +1013,44 @@ fn collaboration_session_message_completion_replays_after_restart_and_legacy_def
     restored.flush_persistence();
     drop(restored);
     let mut raw: Value = serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
-    let messages = raw["sessions"]
-        .as_array_mut()
-        .unwrap()
-        .iter_mut()
-        .find(|session| session["session_id"] == coordinator.session_id)
-        .unwrap()["messages"]
-        .as_array_mut()
-        .unwrap();
-    let answer = messages
-        .iter_mut()
-        .find(|message| message["message_id"] == first.answer.message_id)
-        .unwrap()
-        .as_object_mut()
-        .unwrap();
-    answer.remove("author_session_id");
-    answer.remove("resolved_by_message_id");
-    answer.remove("completion_id");
+    raw["version"] = Value::from(SESSION_LEDGER_V1_VERSION);
+    raw.as_object_mut().unwrap().insert(
+        "durable_current_bindings".to_string(),
+        serde_json::json!([]),
+    );
+    for record in raw["sessions"].as_array_mut().unwrap() {
+        let record = record.as_object_mut().unwrap();
+        for field in [
+            "assignment_history_floors",
+            "assignment_history_tracking_complete",
+            "completion_assignment_fence_fingerprints",
+            "completion_assignment_fence_tracking_complete",
+        ] {
+            record.remove(field);
+        }
+    }
     std::fs::write(&ledger, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
-    let legacy = SessionStore::with_persistence(&ledger, 10, 50);
-    let legacy_answer = legacy
+    let v039 = SessionStore::with_persistence(&ledger, 10, 50);
+    let v039_answer = v039
         .list_messages(
             &coordinator.session_id,
             ListSessionMessagesFilter {
-                message_id: Some(first.answer.message_id),
+                message_id: Some(first.answer.message_id.clone()),
                 ..Default::default()
             },
         )
         .unwrap()
         .pop()
         .unwrap();
-    assert_eq!(legacy_answer.author_session_id, None);
-    assert_eq!(legacy_answer.resolved_by_message_id, None);
-    assert_eq!(legacy_answer.completion_id, None);
+    assert_eq!(
+        v039_answer.author_session_id,
+        first.answer.author_session_id
+    );
+    assert_eq!(
+        v039_answer.resolved_by_message_id,
+        first.answer.resolved_by_message_id
+    );
+    assert_eq!(v039_answer.completion_id, first.answer.completion_id);
 }
 
 #[test]

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -803,6 +803,7 @@ pub(crate) struct ToolEffectEventEvidence {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SessionEvent {
     pub(crate) event_id: String,
     /// Additive correlation only: it joins one tool-call start/finish pair and
@@ -975,6 +976,7 @@ pub(crate) enum SessionMessagePriority {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SessionMessage {
     pub(crate) message_id: String,
     pub(crate) session_id: String,

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -4,7 +4,7 @@ use super::super::project_instructions::{
     ProjectInstructionsSnapshot, ProjectInstructionsSummarySnapshot,
 };
 use super::super::tool_inputs::{ExecutionShell, SessionMode};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::{value::RawValue, Value};
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
@@ -40,7 +40,8 @@ pub(crate) const MAX_MODEL_VALIDATION_ASSERTION_NAME_CHARS: usize =
 pub(super) const MAX_INPUT_OBJECT_KEYS: usize = 16;
 pub(super) const MAX_INPUT_ARRAY_ITEMS: usize = 8;
 pub(crate) const MAX_VALIDATION_EXCERPT_CHARS: usize = 800;
-pub(super) const SESSION_LEDGER_VERSION: u32 = 1;
+pub(super) const SESSION_LEDGER_V1_VERSION: u32 = 1;
+pub(super) const SESSION_LEDGER_VERSION: u32 = 2;
 pub(crate) const MESSAGE_ID_PREFIX: &str = "wc_msg_";
 pub(crate) const DEFAULT_MAX_MESSAGES_PER_SESSION: usize = 200;
 pub(crate) const MAX_CODING_INSTRUCTION_CHARS: usize = 4000;
@@ -245,20 +246,6 @@ impl SessionLifecycle {
             Self::Closed => "closed",
         }
     }
-}
-
-fn deserialize_persisted_session_lifecycle<'de, D>(
-    deserializer: D,
-) -> Result<Option<SessionLifecycle>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = Value::deserialize(deserializer)?;
-    Ok(match value.as_str() {
-        Some("active") => Some(SessionLifecycle::Active),
-        Some("closed") => Some(SessionLifecycle::Closed),
-        _ => None,
-    })
 }
 
 /// Result of an explicit close attempt on a known session.
@@ -600,67 +587,37 @@ impl PersistedSessionSnapshot {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct PersistedSessionRecord {
     pub(super) session_id: String,
     pub(super) project: Option<String>,
-    /// Historical field name retained for JSON compatibility. Canonical writers
-    /// always store a domain-separated authority-group fingerprint; missing or
-    /// malformed values are rejected row-local during restore.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) owner_authority_fingerprint: Option<String>,
+    /// Historical field name retained on disk, but v2 requires the canonical
+    /// domain-separated authority-group fingerprint on every persisted row.
+    pub(super) owner_authority_fingerprint: String,
     pub(super) title: Option<String>,
     pub(super) mode: SessionMode,
     pub(super) guards: SessionGuards,
-    /// Additive ledger-v1 field. Older ledgers restore an empty context.
-    #[serde(default)]
     pub(super) execution_context: SessionExecutionContext,
-    /// Canonical writers always persist an explicit lifecycle. Missing, unknown,
-    /// or removed values deserialize as `None` so restore can discard only that
-    /// row instead of poisoning the whole ledger.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_persisted_session_lifecycle",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub(super) lifecycle: Option<SessionLifecycle>,
+    pub(super) lifecycle: SessionLifecycle,
     pub(super) created_at: i64,
     pub(super) updated_at: i64,
     pub(super) events: Vec<Arc<SessionEvent>>,
     pub(super) messages: Vec<Arc<SessionMessage>>,
-    #[serde(default)]
     pub(super) message_observation_revision: u64,
-    #[serde(default)]
     pub(super) message_observation_floor: u64,
-    #[serde(default)]
     pub(super) message_observation_revisions: BTreeMap<String, u64>,
-    /// Additive E3 field: relevant retention floor keyed by exact todo id.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    /// v2 requires exact per-todo retention metadata. Compatibility inference is
+    /// isolated to the explicit v0.3.9 ledger-v1 upgrade path.
     pub(super) assignment_history_floors: BTreeMap<String, u64>,
-    /// Additive E3 proof bit. Missing legacy field is fail-closed unless the
-    /// restore path can independently prove no message was ever evicted.
-    #[serde(default)]
     pub(super) assignment_history_tracking_complete: bool,
-    /// Additive completion replay metadata. Raw assignment fences are never
-    /// persisted here; canonical live rows store SHA-256 fingerprints, while
-    /// historical null values remain representable only for read-only compatibility.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub(super) completion_assignment_fence_fingerprints: BTreeMap<String, Option<String>>,
-    /// Missing historical metadata remains distinguishable so restore/query can
-    /// preserve old rows without fabricating a fence; live replay still fails closed.
-    #[serde(default)]
+    /// Raw assignment fences are never persisted. v2 stores only canonical
+    /// SHA-256 fingerprints; v1 no-fence history upgrades to an empty map with
+    /// incomplete tracking rather than encoding a synthetic/null fence.
+    pub(super) completion_assignment_fence_fingerprints: BTreeMap<String, String>,
     pub(super) completion_assignment_fence_tracking_complete: bool,
-    /// Additive v1 field. Cumulative number of events ever appended, including
-    /// those the per-session event cap has evicted. Older ledgers omit it and
-    /// deserialize to 0; the restore path treats 0 as "retain exactly the
-    /// persisted events" for legacy compatibility.
-    #[serde(default)]
     pub(super) events_observed: u64,
-    /// Additive ledger-v1 model-facing continuity watermark. Legacy rows
-    /// deserialize to zero and begin issuing revisions only after upgrade.
-    #[serde(default)]
     pub(super) context_revision: u64,
-    /// Additive ledger-v1 field. Exact identities are sanitized and bounded on
-    /// restore; old ledgers deserialize to an empty set.
+    /// v0.3.9 and v2 both omit this bounded list when empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(super) materialized_validation_job_ids: Vec<String>,
 }

--- a/src/tool_runtime/sessions/persistence.rs
+++ b/src/tool_runtime/sessions/persistence.rs
@@ -6,9 +6,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use serde::Deserialize;
+use serde_json::Value;
 
 use super::super::helpers::is_safe_job_id;
 use super::super::project_instructions::ProjectInstructionsSummarySnapshot;
+use super::super::tool_inputs::SessionMode;
 use super::assignment::is_valid_assignment_fence_fingerprint;
 use super::events::{
     context_result_summary_for_tool_result, exploration_tool_kind, is_valid_session_id,
@@ -17,11 +19,12 @@ use super::events::{
     sanitize_tool_execution_state, session_input_summary_for_tool,
 };
 use super::model::{
-    ColdSessionRecord, PersistedSessionLedger, PersistedSessionRecord, SessionEvent, SessionGuards,
-    SessionMessage, SessionRecord, StoredSession, DEFAULT_MAX_MESSAGES_PER_SESSION,
-    EVENT_ID_PREFIX, MAX_CODING_INSTRUCTION_CHARS, MAX_INPUT_ARRAY_ITEMS,
-    MAX_MATERIALIZED_VALIDATION_JOB_IDS, MAX_MESSAGE_CHARS, MAX_MESSAGE_RESOLUTION_CHARS,
-    MESSAGE_ID_PREFIX, SESSION_LEDGER_VERSION,
+    ColdSessionRecord, PersistedSessionLedger, PersistedSessionRecord, SessionEvent,
+    SessionExecutionContext, SessionGuards, SessionLifecycle, SessionMessage, SessionRecord,
+    StoredSession, DEFAULT_MAX_MESSAGES_PER_SESSION, EVENT_ID_PREFIX, MAX_CODING_INSTRUCTION_CHARS,
+    MAX_INPUT_ARRAY_ITEMS, MAX_MATERIALIZED_VALIDATION_JOB_IDS, MAX_MESSAGE_CHARS,
+    MAX_MESSAGE_RESOLUTION_CHARS, MESSAGE_ID_PREFIX, SESSION_LEDGER_V1_VERSION,
+    SESSION_LEDGER_VERSION,
 };
 use super::query::{is_valid_completion_id, validate_message_tags};
 use super::util::{
@@ -29,9 +32,87 @@ use super::util::{
 };
 
 #[derive(Deserialize)]
-struct LoadedSessionLedger {
+struct SessionLedgerVersionProbe {
     version: u32,
-    sessions: Vec<PersistedSessionRecord>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LoadedSessionLedgerV2 {
+    version: u32,
+    sessions: Vec<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LoadedSessionLedgerV1 {
+    version: u32,
+    sessions: Vec<Value>,
+    /// v0.3.9 always serialized this now-retired index. Its entries no longer
+    /// carry authority, so the v1 upgrade validates only the canonical array
+    /// envelope and intentionally discards the contents.
+    durable_current_bindings: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedSessionRecordV1 {
+    session_id: String,
+    project: Option<String>,
+    owner_authority_fingerprint: Option<String>,
+    title: Option<String>,
+    mode: SessionMode,
+    guards: SessionGuards,
+    execution_context: SessionExecutionContext,
+    lifecycle: SessionLifecycle,
+    created_at: i64,
+    updated_at: i64,
+    events: Vec<Arc<SessionEvent>>,
+    messages: Vec<Arc<SessionMessage>>,
+    message_observation_revision: u64,
+    message_observation_floor: u64,
+    message_observation_revisions: BTreeMap<String, u64>,
+    events_observed: u64,
+    context_revision: u64,
+    #[serde(default)]
+    materialized_validation_job_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PersistedLedgerSource {
+    V039V1,
+    CurrentV2,
+}
+
+impl PersistedSessionRecordV1 {
+    fn upgrade(self) -> Option<PersistedSessionRecord> {
+        Some(PersistedSessionRecord {
+            session_id: self.session_id,
+            project: self.project,
+            owner_authority_fingerprint: sanitize_owner_authority_fingerprint(
+                self.owner_authority_fingerprint?,
+            )?,
+            title: self.title,
+            mode: self.mode,
+            guards: self.guards,
+            execution_context: self.execution_context,
+            lifecycle: self.lifecycle,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            events: self.events,
+            messages: self.messages,
+            message_observation_revision: self.message_observation_revision,
+            message_observation_floor: self.message_observation_floor,
+            message_observation_revisions: self.message_observation_revisions,
+            assignment_history_floors: BTreeMap::new(),
+            assignment_history_tracking_complete: false,
+            completion_assignment_fence_fingerprints: BTreeMap::new(),
+            completion_assignment_fence_tracking_complete: false,
+            events_observed: self.events_observed,
+            context_revision: self.context_revision,
+            materialized_validation_job_ids: self.materialized_validation_job_ids,
+        })
+    }
 }
 
 impl PersistedSessionRecord {
@@ -58,12 +139,12 @@ impl PersistedSessionRecord {
         Self {
             session_id: record.session_id.clone(),
             project: record.project.clone(),
-            owner_authority_fingerprint: Some(record.owner_authority_fingerprint.clone()),
+            owner_authority_fingerprint: record.owner_authority_fingerprint.clone(),
             title: record.title.clone(),
             mode: record.mode,
             guards: record.guards,
             execution_context: record.execution_context.clone(),
-            lifecycle: Some(record.lifecycle),
+            lifecycle: record.lifecycle,
             created_at: record.created_at,
             updated_at: record.updated_at,
             events,
@@ -82,7 +163,13 @@ impl PersistedSessionRecord {
             assignment_history_tracking_complete: record.assignment_history_tracking_complete,
             completion_assignment_fence_fingerprints: record
                 .completion_assignment_fence_fingerprints
-                .clone(),
+                .iter()
+                .filter_map(|(todo_id, fingerprint)| {
+                    fingerprint
+                        .as_ref()
+                        .map(|fingerprint| (todo_id.clone(), fingerprint.clone()))
+                })
+                .collect(),
             completion_assignment_fence_tracking_complete: record
                 .completion_assignment_fence_tracking_complete,
         }
@@ -91,13 +178,12 @@ impl PersistedSessionRecord {
     pub(super) fn still_matches_record(&self, record: &SessionRecord) -> bool {
         self.session_id == record.session_id
             && self.project == record.project
-            && self.owner_authority_fingerprint.as_deref()
-                == Some(record.owner_authority_fingerprint.as_str())
+            && self.owner_authority_fingerprint == record.owner_authority_fingerprint
             && self.title == record.title
             && self.mode == record.mode
             && self.guards == record.guards
             && self.execution_context == record.execution_context
-            && self.lifecycle == Some(record.lifecycle)
+            && self.lifecycle == record.lifecycle
             && self.created_at == record.created_at
             && self.updated_at == record.updated_at
             && self.events_observed == record.events_observed
@@ -112,8 +198,18 @@ impl PersistedSessionRecord {
             && self.assignment_history_floors == record.assignment_history_floors
             && self.assignment_history_tracking_complete
                 == record.assignment_history_tracking_complete
-            && self.completion_assignment_fence_fingerprints
-                == record.completion_assignment_fence_fingerprints
+            && self.completion_assignment_fence_fingerprints.len()
+                == record.completion_assignment_fence_fingerprints.len()
+            && self
+                .completion_assignment_fence_fingerprints
+                .iter()
+                .all(|(todo_id, fingerprint)| {
+                    record
+                        .completion_assignment_fence_fingerprints
+                        .get(todo_id)
+                        .and_then(Option::as_ref)
+                        == Some(fingerprint)
+                })
             && self.completion_assignment_fence_tracking_complete
                 == record.completion_assignment_fence_tracking_complete
             && self.events.len() == record.events.len()
@@ -130,17 +226,21 @@ impl PersistedSessionRecord {
                 .all(|(snapshot, live)| Arc::ptr_eq(snapshot, live))
     }
 
-    pub(super) fn into_record(self, max_events_per_session: usize) -> Option<SessionRecord> {
+    fn into_record(
+        self,
+        max_events_per_session: usize,
+        source: PersistedLedgerSource,
+    ) -> Option<SessionRecord> {
         let session_id = self.session_id.trim().to_string();
         if !is_valid_session_id(&session_id) {
             return None;
         }
         // Canonical authority and lifecycle are required before any restored row
-        // can enter the in-memory Session store. Missing, malformed, unknown, or
-        // removed historical values fail closed by discarding only this row.
+        // can enter the in-memory Session store. v2 structural omissions never
+        // reach this point; v1 still fails closed on missing/malformed authority.
         let owner_authority_fingerprint =
             sanitize_owner_authority_fingerprint(self.owner_authority_fingerprint)?;
-        let lifecycle = self.lifecycle?;
+        let lifecycle = self.lifecycle;
         let events: VecDeque<Arc<SessionEvent>> = self
             .events
             .into_iter()
@@ -180,7 +280,8 @@ impl PersistedSessionRecord {
         let duplicate_retained_message_ids = !duplicate_message_ids.is_empty();
         let all_persisted_messages_restored =
             !duplicate_retained_message_ids && messages.len() == persisted_message_count;
-        let legacy_no_eviction_proven = all_persisted_messages_restored
+        let v1_no_eviction_proven = source == PersistedLedgerSource::V039V1
+            && all_persisted_messages_restored
             && persisted_message_count < DEFAULT_MAX_MESSAGES_PER_SESSION;
         if duplicate_retained_message_ids {
             messages.retain(|message| !duplicate_message_ids.contains(&message.message_id));
@@ -270,13 +371,18 @@ impl PersistedSessionRecord {
                 }
                 assignment_history_floors.insert(todo_id, revision);
             }
+            let source_tracking_complete = match source {
+                PersistedLedgerSource::V039V1 => observation_floor == 0 && v1_no_eviction_proven,
+                PersistedLedgerSource::CurrentV2 => self.assignment_history_tracking_complete,
+            };
             assignment_history_tracking_complete = all_persisted_messages_restored
                 && !assignment_metadata_inconsistent
-                && (self.assignment_history_tracking_complete
-                    || (observation_floor == 0 && legacy_no_eviction_proven));
+                && source_tracking_complete;
         } else {
-            // Pre-feature ledgers never issued observation tokens. Their retained
-            // messages therefore become safe baseline state at revision zero.
+            // v0.3.9 ledgers never persisted assignment-history metadata. Their
+            // retained messages form a safe revision-zero baseline only when the
+            // released v1 bounds prove that no message was evicted. v2 never
+            // infers completeness from a missing/zero revision.
             observation_revisions.extend(
                 retained_message_ids
                     .iter()
@@ -284,11 +390,15 @@ impl PersistedSessionRecord {
                     .map(|message_id| (message_id, 0)),
             );
             observation_floor = 0;
-            assignment_history_tracking_complete = legacy_no_eviction_proven;
+            assignment_history_tracking_complete = match source {
+                PersistedLedgerSource::V039V1 => v1_no_eviction_proven,
+                PersistedLedgerSource::CurrentV2 => {
+                    all_persisted_messages_restored && self.assignment_history_tracking_complete
+                }
+            };
         }
-        // Completion-fence optionality is historical representation only. Restore
-        // preserves missing/null metadata exactly enough for query compatibility;
-        // live completion never fabricates a fence or accepts a no-fence replay.
+        // v0.3.9 predates durable completion-fence metadata. Its explicit upgrade
+        // keeps tracking incomplete. v2 carries only canonical non-null fingerprints.
         let retained_completed_todo_ids = messages
             .iter()
             .filter(|message| {
@@ -303,16 +413,16 @@ impl PersistedSessionRecord {
         let mut completion_fence_metadata_inconsistent = false;
         for (todo_id, fingerprint) in self.completion_assignment_fence_fingerprints {
             if !retained_completed_todo_ids.contains(&todo_id)
-                || fingerprint
-                    .as_deref()
-                    .is_some_and(|value| !is_valid_assignment_fence_fingerprint(value))
+                || !is_valid_assignment_fence_fingerprint(&fingerprint)
             {
                 completion_fence_metadata_inconsistent = true;
                 continue;
             }
-            completion_assignment_fence_fingerprints.insert(todo_id, fingerprint);
+            completion_assignment_fence_fingerprints.insert(todo_id, Some(fingerprint));
         }
-        if self.completion_assignment_fence_tracking_complete
+        let persisted_completion_tracking_complete = source == PersistedLedgerSource::CurrentV2
+            && self.completion_assignment_fence_tracking_complete;
+        if persisted_completion_tracking_complete
             && retained_completed_todo_ids
                 .iter()
                 .any(|todo_id| !completion_assignment_fence_fingerprints.contains_key(todo_id))
@@ -320,7 +430,7 @@ impl PersistedSessionRecord {
             completion_fence_metadata_inconsistent = true;
         }
         let completion_assignment_fence_tracking_complete = all_persisted_messages_restored
-            && self.completion_assignment_fence_tracking_complete
+            && persisted_completion_tracking_complete
             && !completion_fence_metadata_inconsistent;
         let materialized_validation_job_ids =
             sanitize_materialized_validation_job_ids(self.materialized_validation_job_ids);
@@ -390,8 +500,7 @@ fn sanitize_materialized_validation_job_ids(values: Vec<String>) -> VecDeque<Str
     newest.into()
 }
 
-fn sanitize_owner_authority_fingerprint(value: Option<String>) -> Option<String> {
-    let value = value?;
+fn sanitize_owner_authority_fingerprint(value: String) -> Option<String> {
     is_lower_hex_sha256(&value).then_some(value)
 }
 
@@ -417,15 +526,10 @@ pub(super) fn cold_session_from_persisted(
             .ok_or_else(|| {
                 serde_json::Error::io(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    "persisted Session is missing canonical authority",
+                    "persisted Session has invalid canonical authority",
                 ))
             })?;
-    let lifecycle = persisted.lifecycle.ok_or_else(|| {
-        serde_json::Error::io(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "persisted Session is missing canonical lifecycle",
-        ))
-    })?;
+    let lifecycle = persisted.lifecycle;
     let raw = Arc::from(serde_json::value::to_raw_value(persisted)?);
     Ok(ColdSessionRecord {
         session_id: persisted.session_id.clone(),
@@ -447,7 +551,7 @@ pub(super) fn materialize_cold_session(
 ) -> Option<SessionRecord> {
     serde_json::from_str::<PersistedSessionRecord>(record.raw.get())
         .ok()?
-        .into_record(max_events_per_session)
+        .into_record(max_events_per_session, PersistedLedgerSource::CurrentV2)
 }
 
 pub(super) struct RestoredSessionLedger {
@@ -484,8 +588,8 @@ pub(super) fn load_persisted_ledger(
             return RestoredSessionLedger::empty(Some(error));
         }
     };
-    let ledger = match serde_json::from_str::<LoadedSessionLedger>(&content) {
-        Ok(ledger) => ledger,
+    let version = match serde_json::from_str::<SessionLedgerVersionProbe>(&content) {
+        Ok(probe) => probe.version,
         Err(err) => {
             let error = bound_summary_string(&format!(
                 "restore_failed: invalid session ledger JSON: {err}"
@@ -494,18 +598,63 @@ pub(super) fn load_persisted_ledger(
             return RestoredSessionLedger::empty(Some(error));
         }
     };
-    if ledger.version != SESSION_LEDGER_VERSION {
-        let error = format!(
-            "restore_failed: unsupported session ledger version {}",
-            ledger.version
-        );
-        tracing::warn!("session ledger restore failed: {}", error);
-        return RestoredSessionLedger::empty(Some(error));
-    }
-    let mut records: Vec<StoredSession> = ledger
-        .sessions
+    let restored_records: Result<Vec<SessionRecord>, String> = match version {
+        SESSION_LEDGER_VERSION => serde_json::from_str::<LoadedSessionLedgerV2>(&content)
+            .map_err(|err| format!("invalid v2 session ledger: {err}"))
+            .map(|ledger| {
+                debug_assert_eq!(ledger.version, SESSION_LEDGER_VERSION);
+                ledger
+                    .sessions
+                    .into_iter()
+                    .filter_map(|value| {
+                        let record = match serde_json::from_value::<PersistedSessionRecord>(value) {
+                            Ok(record) => record,
+                            Err(err) => {
+                                tracing::warn!("discarding malformed v2 Session row: {err}");
+                                return None;
+                            }
+                        };
+                        record.into_record(max_events_per_session, PersistedLedgerSource::CurrentV2)
+                    })
+                    .collect()
+            }),
+        SESSION_LEDGER_V1_VERSION => serde_json::from_str::<LoadedSessionLedgerV1>(&content)
+            .map_err(|err| format!("invalid v0.3.9 session ledger v1: {err}"))
+            .map(|ledger| {
+                debug_assert_eq!(ledger.version, SESSION_LEDGER_V1_VERSION);
+                let _retired_binding_count = ledger.durable_current_bindings.len();
+                ledger
+                    .sessions
+                    .into_iter()
+                    .filter_map(|value| {
+                        let record = match serde_json::from_value::<PersistedSessionRecordV1>(value)
+                        {
+                            Ok(record) => record,
+                            Err(err) => {
+                                tracing::warn!(
+                                    "discarding non-canonical v0.3.9 Session row: {err}"
+                                );
+                                return None;
+                            }
+                        };
+                        record
+                            .upgrade()?
+                            .into_record(max_events_per_session, PersistedLedgerSource::V039V1)
+                    })
+                    .collect()
+            }),
+        other => Err(format!("unsupported session ledger version {other}")),
+    };
+    let restored_records = match restored_records {
+        Ok(records) => records,
+        Err(err) => {
+            let error = bound_summary_string(&format!("restore_failed: {err}"));
+            tracing::warn!("session ledger restore failed: {}", error);
+            return RestoredSessionLedger::empty(Some(error));
+        }
+    };
+    let mut records: Vec<StoredSession> = restored_records
         .into_iter()
-        .filter_map(|record| record.into_record(max_events_per_session))
         .map(|record| {
             if record.lifecycle.allows_mutation() {
                 StoredSession::Hot(record)

--- a/src/tool_runtime/sessions/persistence.rs
+++ b/src/tool_runtime/sessions/persistence.rs
@@ -67,7 +67,7 @@ struct PersistedSessionRecordV1 {
     lifecycle: SessionLifecycle,
     created_at: i64,
     updated_at: i64,
-    events: Vec<Arc<SessionEvent>>,
+    events: Vec<Value>,
     messages: Vec<Arc<SessionMessage>>,
     message_observation_revision: u64,
     message_observation_floor: u64,
@@ -82,6 +82,43 @@ struct PersistedSessionRecordV1 {
 enum PersistedLedgerSource {
     V039V1,
     CurrentV2,
+}
+
+fn upgrade_v039_session_events(values: Vec<Value>) -> Option<Vec<Arc<SessionEvent>>> {
+    values
+        .into_iter()
+        .map(|mut value| {
+            let object = value.as_object_mut()?;
+            // These two audit-only fields existed in the canonical v0.3.9 event
+            // shape and were removed later. They never carried Session authority.
+            object.remove("allow_cross_project_session_required");
+            object.remove("allow_cross_project_session");
+            // v0.3.9 predates logical invocation correlation. Reject a v2 event
+            // mislabeled as v1 instead of treating the version as an alias.
+            if object.contains_key("logical_invocation_id")
+                || object.contains_key("logical_invocation_role")
+            {
+                return None;
+            }
+            serde_json::from_value::<SessionEvent>(value)
+                .ok()
+                .map(Arc::new)
+        })
+        .collect()
+}
+
+fn v2_record_has_canonical_logical_invocation_shape(value: &Value) -> bool {
+    value
+        .get("events")
+        .and_then(Value::as_array)
+        .is_some_and(|events| {
+            events.iter().all(|event| {
+                event.as_object().is_some_and(|object| {
+                    object.contains_key("logical_invocation_id")
+                        == object.contains_key("logical_invocation_role")
+                })
+            })
+        })
 }
 
 impl PersistedSessionRecordV1 {
@@ -99,7 +136,7 @@ impl PersistedSessionRecordV1 {
             lifecycle: self.lifecycle,
             created_at: self.created_at,
             updated_at: self.updated_at,
-            events: self.events,
+            events: upgrade_v039_session_events(self.events)?,
             messages: self.messages,
             message_observation_revision: self.message_observation_revision,
             message_observation_floor: self.message_observation_floor,
@@ -607,6 +644,12 @@ pub(super) fn load_persisted_ledger(
                     .sessions
                     .into_iter()
                     .filter_map(|value| {
+                        if !v2_record_has_canonical_logical_invocation_shape(&value) {
+                            tracing::warn!(
+                                "discarding malformed v2 Session row: event correlation shape is partial"
+                            );
+                            return None;
+                        }
                         let record = match serde_json::from_value::<PersistedSessionRecord>(value) {
                             Ok(record) => record,
                             Err(err) => {

--- a/src/tool_runtime/sessions/persistence.rs
+++ b/src/tool_runtime/sessions/persistence.rs
@@ -114,8 +114,17 @@ fn v2_record_has_canonical_logical_invocation_shape(value: &Value) -> bool {
         .is_some_and(|events| {
             events.iter().all(|event| {
                 event.as_object().is_some_and(|object| {
-                    object.contains_key("logical_invocation_id")
-                        == object.contains_key("logical_invocation_role")
+                    match (
+                        object.get("logical_invocation_id"),
+                        object.get("logical_invocation_role"),
+                    ) {
+                        (None, None) => true,
+                        (Some(Value::String(id)), Some(Value::String(role))) => {
+                            super::events::is_valid_logical_invocation_id(id)
+                                && super::events::is_valid_logical_invocation_role(role)
+                        }
+                        _ => false,
+                    }
                 })
             })
         })

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -4108,13 +4108,21 @@ fn v2_event_and_message_shape_corruption_discards_only_affected_rows() {
         Some("proj".to_string()),
         Some("retired event field".to_string()),
     );
+    let bad_noncanonical_correlation = store.start_session(
+        Some("proj".to_string()),
+        Some("noncanonical correlation values".to_string()),
+    );
     let bad_message = store.start_session(
         Some("proj".to_string()),
         Some("unknown message field".to_string()),
     );
     let good = store.start_session(Some("proj".to_string()), Some("good".to_string()));
 
-    for session_id in [&bad_missing.session_id, &bad_retired.session_id] {
+    for session_id in [
+        &bad_missing.session_id,
+        &bad_retired.session_id,
+        &bad_noncanonical_correlation.session_id,
+    ] {
         let mut metadata = ToolCallRecorderMetadata::default();
         metadata.assign_logical_invocation();
         let start = store.record_tool_call_started_with_metadata(
@@ -4161,6 +4169,14 @@ fn v2_event_and_message_shape_corruption_discards_only_affected_rows() {
         .unwrap()
         .insert("allow_cross_project_session".to_string(), Value::Bool(true));
 
+    let noncanonical_record = records
+        .iter_mut()
+        .find(|record| record["session_id"] == bad_noncanonical_correlation.session_id)
+        .unwrap();
+    let noncanonical_event = noncanonical_record["events"][0].as_object_mut().unwrap();
+    noncanonical_event.insert("logical_invocation_id".to_string(), Value::Null);
+    noncanonical_event.insert("logical_invocation_role".to_string(), Value::Null);
+
     let message_record = records
         .iter_mut()
         .find(|record| record["session_id"] == bad_message.session_id)
@@ -4175,6 +4191,9 @@ fn v2_event_and_message_shape_corruption_discards_only_affected_rows() {
     assert_eq!(restored.status().restored_sessions, 1);
     assert!(restored.summary(&bad_missing.session_id, None).is_none());
     assert!(restored.summary(&bad_retired.session_id, None).is_none());
+    assert!(restored
+        .summary(&bad_noncanonical_correlation.session_id, None)
+        .is_none());
     assert!(restored.summary(&bad_message.session_id, None).is_none());
     assert!(restored.summary(&good.session_id, None).is_some());
     assert_eq!(restored.status().last_persist_error, None);

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -5,8 +5,9 @@ use super::events::{
     session_input_summary_for_tool, SessionToolClassification,
 };
 use super::model::{
-    PersistedSessionLedger, PersistedSessionRecord, SessionLifecycle, MAX_OBSERVED_PATHS_PER_EVENT,
-    MAX_VALIDATION_EXCERPT_CHARS, MESSAGE_ID_PREFIX, SESSION_ID_PREFIX, SESSION_LEDGER_VERSION,
+    PersistedSessionLedger, SessionLifecycle, MAX_OBSERVED_PATHS_PER_EVENT,
+    MAX_VALIDATION_EXCERPT_CHARS, MESSAGE_ID_PREFIX, SESSION_LEDGER_V1_VERSION,
+    SESSION_LEDGER_VERSION,
 };
 use super::persistence::write_ledger_atomic;
 use super::*;
@@ -970,7 +971,7 @@ fn write_ledger_atomic_cleans_up_temp_file_when_rename_fails() {
 }
 
 #[test]
-fn session_execution_context_persistence_matrix_and_legacy_default() {
+fn session_execution_context_persistence_matrix() {
     let cases = [
         (
             "local-normalized",
@@ -985,7 +986,6 @@ fn session_execution_context_persistence_matrix_and_legacy_default() {
                 resource: None,
             },
             json!({"default_cwd": "frontend/src", "default_shell": "bash"}),
-            true,
         ),
         (
             "remote-resource",
@@ -1000,11 +1000,10 @@ fn session_execution_context_persistence_matrix_and_legacy_default() {
                 resource: Some("tmp".to_string()),
             },
             json!({"default_cwd": "/opt/webcodex-edge", "resource": "tmp"}),
-            false,
         ),
     ];
 
-    for (label, input, expected, persisted_context, check_legacy_default) in cases {
+    for (label, input, expected, persisted_context) in cases {
         let tmp = tempfile::tempdir().unwrap();
         let ledger = tmp.path().join("sessions.json");
         let store = persistent_store(ledger.clone());
@@ -1022,7 +1021,7 @@ fn session_execution_context_persistence_matrix_and_legacy_default() {
         assert_eq!(session.execution_context, expected, "{label}");
 
         store.flush_persistence();
-        let mut value: Value = serde_json::from_slice(&std::fs::read(&ledger).unwrap()).unwrap();
+        let value: Value = serde_json::from_slice(&std::fs::read(&ledger).unwrap()).unwrap();
         assert_eq!(
             value["sessions"][0]["execution_context"], persisted_context,
             "{label}"
@@ -1036,22 +1035,6 @@ fn session_execution_context_persistence_matrix_and_legacy_default() {
             expected,
             "{label}"
         );
-
-        if check_legacy_default {
-            value["sessions"][0]
-                .as_object_mut()
-                .unwrap()
-                .remove("execution_context");
-            std::fs::write(&ledger, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
-            let legacy = SessionStore::with_persistence(ledger, 10, 10);
-            assert_eq!(
-                legacy
-                    .summary(&session.session_id, None)
-                    .unwrap()
-                    .execution_context,
-                SessionExecutionContext::default()
-            );
-        }
     }
 }
 
@@ -1225,49 +1208,6 @@ fn update_session_execution_context_sets_clears_and_rejects_invalid_states() {
         SessionExecutionContextUpdateError::SessionNotActive {
             lifecycle: SessionLifecycle::Closed
         }
-    );
-}
-
-#[test]
-fn removed_lifecycle_value_is_discarded_instead_of_restored_active() {
-    let tmp = tempfile::tempdir().unwrap();
-    let ledger = tmp.path().join("sessions.json");
-    std::fs::write(
-        &ledger,
-        serde_json::to_vec_pretty(&json!({
-            "version": SESSION_LEDGER_VERSION,
-            "sessions": [{
-                "session_id": "wc_sess_removedlifecycle01",
-                "project": "agent:oe:private-drop",
-                "owner_authority_fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "title": "removed lifecycle",
-                "mode": "normal",
-                "guards": {
-                    "deny_write_tools": false,
-                    "deny_shell_tools": false
-                },
-                "execution_context": {"default_cwd": "frontend"},
-                "lifecycle": "archived",
-                "created_at": 1,
-                "updated_at": 1,
-                "events": [],
-                "messages": []
-            }]
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-    let store = SessionStore::with_persistence(ledger, 10, 10);
-    assert!(store.summary("wc_sess_removedlifecycle01", None).is_none());
-    assert_eq!(
-        store
-            .update_execution_context(
-                "wc_sess_removedlifecycle01",
-                SessionExecutionContext::default(),
-                SessionTransport::Api,
-            )
-            .unwrap_err(),
-        SessionExecutionContextUpdateError::UnknownSession
     );
 }
 
@@ -2175,34 +2115,32 @@ fn console_list_orders_recent_activity_first_with_deterministic_session_id_ties(
     let older = "wc_sess_order_old";
     let tie_a = "wc_sess_order_tie_a";
     let tie_z = "wc_sess_order_tie_z";
-    let record = |session_id: &str, created_at: i64, updated_at: i64| {
-        json!({
-            "session_id": session_id,
-            "project": project,
-            "owner_authority_fingerprint": TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT,
-            "title": session_id,
-            "mode": "normal",
-            "guards": {"deny_write_tools": false, "deny_shell_tools": false},
-            "lifecycle": "active",
-            "created_at": created_at,
-            "updated_at": updated_at,
-            "events": [],
-            "messages": []
-        })
-    };
-    std::fs::write(
-        &ledger,
-        serde_json::to_vec_pretty(&json!({
-            "version": SESSION_LEDGER_VERSION,
-            "sessions": [
-                record(older, 1, 10),
-                record(tie_a, 2, 20),
-                record(tie_z, 3, 20)
-            ]
-        }))
-        .unwrap(),
-    )
-    .unwrap();
+
+    let seed = persistent_store(ledger.clone());
+    let seed_older = seed.start_session(Some(project.to_string()), Some("older".to_string()));
+    let seed_tie_a = seed.start_session(Some(project.to_string()), Some("tie a".to_string()));
+    let seed_tie_z = seed.start_session(Some(project.to_string()), Some("tie z".to_string()));
+    seed.flush_persistence();
+    drop(seed);
+
+    let mut raw: Value = serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
+    for (seed_id, session_id, created_at, updated_at) in [
+        (seed_older.session_id.as_str(), older, 1, 10),
+        (seed_tie_a.session_id.as_str(), tie_a, 2, 20),
+        (seed_tie_z.session_id.as_str(), tie_z, 3, 20),
+    ] {
+        let record = raw["sessions"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|record| record["session_id"] == seed_id)
+            .unwrap();
+        record["session_id"] = Value::String(session_id.to_string());
+        record["title"] = Value::String(session_id.to_string());
+        record["created_at"] = Value::from(created_at);
+        record["updated_at"] = Value::from(updated_at);
+    }
+    std::fs::write(&ledger, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
     let store = persistent_store(ledger);
 
     let initial = store.console_list_for_project(project, Some(10));
@@ -4008,22 +3946,31 @@ fn persisted_ledger_writes_and_reads_lifecycle_active() {
 }
 
 #[test]
-fn obsolete_durable_current_bindings_member_is_ignored_and_not_repersisted() {
+fn v039_ledger_v1_upgrades_to_canonical_v2_on_next_write() {
     let tmp = tempfile::tempdir().unwrap();
     let ledger_path = tmp.path().join("sessions.json");
     let store = persistent_store(ledger_path.clone());
-    let session = store.start_session(Some("proj".to_string()), Some("canonical".to_string()));
+    let session = store.start_session(Some("proj".to_string()), Some("v0.3.9".to_string()));
     store.flush_persistence();
     drop(store);
 
     let mut ledger: Value =
         serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
-    ledger["durable_current_bindings"] = json!([{
-        "binding_key_sha256": "a".repeat(64),
-        "session_id": session.session_id,
-        "updated_at": 1_700_000_000
-    }]);
-    std::fs::write(&ledger_path, serde_json::to_vec(&ledger).unwrap()).unwrap();
+    ledger["version"] = json!(SESSION_LEDGER_V1_VERSION);
+    ledger
+        .as_object_mut()
+        .unwrap()
+        .insert("durable_current_bindings".to_string(), json!([]));
+    let record = ledger["sessions"][0].as_object_mut().unwrap();
+    for field in [
+        "assignment_history_floors",
+        "assignment_history_tracking_complete",
+        "completion_assignment_fence_fingerprints",
+        "completion_assignment_fence_tracking_complete",
+    ] {
+        record.remove(field);
+    }
+    std::fs::write(&ledger_path, serde_json::to_vec_pretty(&ledger).unwrap()).unwrap();
 
     let restored = persistent_store(ledger_path.clone());
     assert_eq!(restored.status().restored_sessions, 1);
@@ -4033,102 +3980,136 @@ fn obsolete_durable_current_bindings_member_is_ignored_and_not_repersisted() {
 
     let rewritten: Value =
         serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+    assert_eq!(rewritten["version"], SESSION_LEDGER_VERSION);
     assert!(rewritten.get("durable_current_bindings").is_none());
+    let record = &rewritten["sessions"][0];
+    assert_eq!(record["assignment_history_floors"], json!({}));
+    assert_eq!(record["assignment_history_tracking_complete"], true);
     assert_eq!(
-        rewritten["sessions"][0]["session_id"].as_str(),
-        Some(session.session_id.as_str())
+        record["completion_assignment_fence_fingerprints"],
+        json!({})
+    );
+    assert_eq!(
+        record["completion_assignment_fence_tracking_complete"],
+        false
     );
 }
 
 #[test]
-fn legacy_ledger_without_lifecycle_is_discarded() {
+fn v1_rejects_v2_only_record_metadata() {
     let tmp = tempfile::tempdir().unwrap();
     let ledger_path = tmp.path().join("sessions.json");
-    // Pre-lifecycle JSON shape: no `lifecycle` key on the session record.
-    let legacy = json!({
-        "version": SESSION_LEDGER_VERSION,
-        "sessions": [{
-            "session_id": "wc_sess_legacylifecycle01",
-            "project": "proj-legacy",
-            "title": "old row",
-            "mode": "normal",
-            "guards": {
-                "deny_write_tools": false,
-                "deny_shell_tools": false
-            },
-            "created_at": 1_700_000_000,
-            "updated_at": 1_700_000_100,
-            "events": [],
-            "messages": []
-        }]
-    });
-    std::fs::write(&ledger_path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+    let store = persistent_store(ledger_path.clone());
+    let session = store.start_session(Some("proj".to_string()), Some("v2-only".to_string()));
+    store.flush_persistence();
+    drop(store);
 
-    // Missing lifecycle/authority is tolerated at JSON decode but never inferred
-    // into an active in-memory Session.
+    let mut ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+    ledger["version"] = json!(SESSION_LEDGER_V1_VERSION);
+    ledger
+        .as_object_mut()
+        .unwrap()
+        .insert("durable_current_bindings".to_string(), json!([]));
+    std::fs::write(&ledger_path, serde_json::to_vec_pretty(&ledger).unwrap()).unwrap();
+
     let restored = persistent_store(ledger_path);
-    let status = restored.status();
-    assert_eq!(status.restored_sessions, 0);
-    assert_eq!(status.last_persist_error, None);
-    assert!(restored
-        .summary("wc_sess_legacylifecycle01", Some(10))
-        .is_none());
+    assert_eq!(restored.status().restored_sessions, 0);
+    assert!(restored.summary(&session.session_id, None).is_none());
+    assert_eq!(restored.status().last_persist_error, None);
 }
 
 #[test]
-fn persisted_session_record_missing_lifecycle_is_fail_closed() {
-    // Deserialize the row without poisoning the ledger, but never infer Active.
-    let json = r#"{
-        "session_id": "wc_sess_serde_default_ok",
-        "project": null,
-        "owner_authority_fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "title": null,
-        "mode": "normal",
-        "guards": {"deny_write_tools": false, "deny_shell_tools": false},
-        "created_at": 10,
-        "updated_at": 20,
-        "events": [],
-        "messages": []
-    }"#;
-    let record: PersistedSessionRecord = serde_json::from_str(json).unwrap();
-    assert_eq!(record.lifecycle, None);
-    let malformed = json.replace(
-        "\"created_at\": 10,",
-        "\"lifecycle\": {\"removed\": true}, \"created_at\": 10,",
-    );
-    let malformed_record: PersistedSessionRecord = serde_json::from_str(&malformed).unwrap();
-    assert_eq!(malformed_record.lifecycle, None);
-    let uppercase_authority = json.replace(
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-    );
-    let uppercase_record: PersistedSessionRecord =
-        serde_json::from_str(&uppercase_authority).unwrap();
-    assert!(uppercase_record.into_record(10).is_none());
-    let padded_authority = json.replace(
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        " bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ",
-    );
-    let padded_record: PersistedSessionRecord = serde_json::from_str(&padded_authority).unwrap();
-    assert!(padded_record.into_record(10).is_none());
-    assert!(record.session_id.starts_with(SESSION_ID_PREFIX));
-
-    let ledger_json = format!(
-        r#"{{"version":{version},"sessions":[{record}]}}"#,
-        version = SESSION_LEDGER_VERSION,
-        record = json
-    );
-    let ledger: PersistedSessionLedger = serde_json::from_str(&ledger_json).unwrap();
-    assert_eq!(ledger.version, SESSION_LEDGER_VERSION);
-    assert_eq!(ledger.sessions.len(), 1);
-    assert_eq!(ledger.sessions[0].hot().unwrap().lifecycle, None);
-
+fn v2_missing_assignment_metadata_discards_only_that_row() {
     let tmp = tempfile::tempdir().unwrap();
-    let ledger_path = tmp.path().join("missing-lifecycle.json");
-    std::fs::write(&ledger_path, ledger_json).unwrap();
-    let restored = SessionStore::with_persistence(ledger_path, 10, 10);
-    assert!(restored.summary("wc_sess_serde_default_ok", None).is_none());
+    let ledger_path = tmp.path().join("sessions.json");
+    let store = persistent_store(ledger_path.clone());
+    let bad = store.start_session(Some("proj".to_string()), Some("bad".to_string()));
+    let good = store.start_session(Some("proj".to_string()), Some("good".to_string()));
+    store.flush_persistence();
+    drop(store);
+
+    let mut ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+    let bad_record = ledger["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|record| record["session_id"] == bad.session_id)
+        .unwrap()
+        .as_object_mut()
+        .unwrap();
+    bad_record.remove("assignment_history_tracking_complete");
+    std::fs::write(&ledger_path, serde_json::to_vec_pretty(&ledger).unwrap()).unwrap();
+
+    let restored = persistent_store(ledger_path);
+    assert_eq!(restored.status().restored_sessions, 1);
+    assert!(restored.summary(&bad.session_id, None).is_none());
+    assert!(restored.summary(&good.session_id, None).is_some());
+    assert_eq!(restored.status().last_persist_error, None);
+}
+
+#[test]
+fn v2_rejects_v1_only_top_level_binding_member() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger_path = tmp.path().join("sessions.json");
+    let store = persistent_store(ledger_path.clone());
+    let session = store.start_session(Some("proj".to_string()), Some("canonical".to_string()));
+    store.flush_persistence();
+    drop(store);
+
+    let mut ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+    ledger["durable_current_bindings"] = json!([]);
+    std::fs::write(&ledger_path, serde_json::to_vec_pretty(&ledger).unwrap()).unwrap();
+
+    let restored = persistent_store(ledger_path);
     assert_eq!(restored.status().restored_sessions, 0);
+    assert!(restored.summary(&session.session_id, None).is_none());
+    assert!(restored
+        .status()
+        .last_persist_error
+        .as_deref()
+        .is_some_and(|error| error.contains("invalid v2 session ledger")));
+}
+
+#[test]
+fn v2_missing_or_removed_lifecycle_discards_only_that_row() {
+    for lifecycle in [None, Some(json!("archived"))] {
+        let tmp = tempfile::tempdir().unwrap();
+        let ledger_path = tmp.path().join("sessions.json");
+        let store = persistent_store(ledger_path.clone());
+        let bad = store.start_session(Some("proj".to_string()), Some("bad lifecycle".to_string()));
+        let good =
+            store.start_session(Some("proj".to_string()), Some("good lifecycle".to_string()));
+        store.flush_persistence();
+        drop(store);
+
+        let mut ledger: Value =
+            serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+        let bad_record = ledger["sessions"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|record| record["session_id"] == bad.session_id)
+            .unwrap()
+            .as_object_mut()
+            .unwrap();
+        match lifecycle.clone() {
+            Some(value) => {
+                bad_record.insert("lifecycle".to_string(), value);
+            }
+            None => {
+                bad_record.remove("lifecycle");
+            }
+        }
+        std::fs::write(&ledger_path, serde_json::to_vec_pretty(&ledger).unwrap()).unwrap();
+
+        let restored = persistent_store(ledger_path);
+        assert_eq!(restored.status().restored_sessions, 1);
+        assert!(restored.summary(&bad.session_id, None).is_none());
+        assert!(restored.summary(&good.session_id, None).is_some());
+    }
 }
 
 #[test]

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -1503,15 +1503,15 @@ fn legacy_session_events_without_call_id_restore() {
 }
 
 #[test]
-fn legacy_session_events_without_logical_invocation_correlation_restore_without_invention() {
+fn v039_session_events_upgrade_without_inventing_logical_correlation() {
     let tmp = tempfile::tempdir().unwrap();
     let ledger = tmp.path().join("sessions.json");
     let store = persistent_store(ledger.clone());
     let session = store.start_session(
         Some("agent:eval:demo".to_string()),
-        Some("legacy logical invocation".to_string()),
+        Some("v0.3.9 logical invocation boundary".to_string()),
     );
-    let arguments = json!({"project": "agent:eval:demo", "path": "src/legacy-logical.rs"});
+    let arguments = json!({"project": "agent:eval:demo", "path": "src/v039.rs"});
     let mut metadata = ToolCallRecorderMetadata::default();
     metadata.assign_logical_invocation();
     let start = store.record_tool_call_started_with_metadata(
@@ -1524,24 +1524,47 @@ fn legacy_session_events_without_logical_invocation_correlation_restore_without_
     );
     store.record_tool_call_finished(start, true, &json!({"content": "omitted"}), None, None);
     store.flush_persistence();
+    drop(store);
 
     let mut ledger_value: Value =
         serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
-    let events = ledger_value["sessions"][0]["events"]
-        .as_array_mut()
-        .unwrap();
-    assert!(events
-        .iter()
-        .any(|event| event.get("logical_invocation_id").is_some()));
-    for event in events.iter_mut() {
+    ledger_value["version"] = json!(SESSION_LEDGER_V1_VERSION);
+    ledger_value
+        .as_object_mut()
+        .unwrap()
+        .insert("durable_current_bindings".to_string(), json!([]));
+    let record = ledger_value["sessions"][0].as_object_mut().unwrap();
+    for field in [
+        "assignment_history_floors",
+        "assignment_history_tracking_complete",
+        "completion_assignment_fence_fingerprints",
+        "completion_assignment_fence_tracking_complete",
+    ] {
+        record.remove(field);
+    }
+    let events = record.get_mut("events").unwrap().as_array_mut().unwrap();
+    assert!(events.iter().all(|event| {
+        event.get("logical_invocation_id").is_some()
+            && event.get("logical_invocation_role").is_some()
+    }));
+    for (index, event) in events.iter_mut().enumerate() {
         let object = event.as_object_mut().unwrap();
         object.remove("logical_invocation_id");
         object.remove("logical_invocation_role");
+        if index == 0 {
+            object.insert(
+                "allow_cross_project_session_required".to_string(),
+                Value::Bool(true),
+            );
+            object.insert(
+                "allow_cross_project_session".to_string(),
+                Value::Bool(false),
+            );
+        }
     }
     std::fs::write(&ledger, serde_json::to_vec_pretty(&ledger_value).unwrap()).unwrap();
-    drop(store);
 
-    let restored = SessionStore::with_persistence(ledger, 10, 20);
+    let restored = SessionStore::with_persistence(ledger.clone(), 10, 20);
     let summary = restored.summary(&session.session_id, Some(20)).unwrap();
     assert_eq!(summary.counts.tool_calls, 1);
     assert!(summary
@@ -1556,8 +1579,31 @@ fn legacy_session_events_without_logical_invocation_correlation_restore_without_
     assert_eq!(
         canonical.len(),
         1,
-        "legacy uncorrelated facts remain conservative per-event evidence"
+        "v0.3.9 uncorrelated facts remain conservative per-event evidence"
     );
+
+    restored
+        .post_message(PostSessionMessageInput {
+            session_id: session.session_id.clone(),
+            kind: SessionMessageKind::Note,
+            message: "force canonical v2 rewrite".to_string(),
+            tags: Vec::new(),
+            reply_to: None,
+            priority: SessionMessagePriority::Normal,
+        })
+        .unwrap();
+    restored.flush_persistence();
+    let rewritten: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger).unwrap()).unwrap();
+    assert_eq!(rewritten["version"], SESSION_LEDGER_VERSION);
+    assert!(rewritten.get("durable_current_bindings").is_none());
+    let rewritten_events = rewritten["sessions"][0]["events"].as_array().unwrap();
+    assert!(rewritten_events.iter().all(|event| {
+        event.get("logical_invocation_id").is_none()
+            && event.get("logical_invocation_role").is_none()
+            && event.get("allow_cross_project_session_required").is_none()
+            && event.get("allow_cross_project_session").is_none()
+    }));
 }
 
 #[test]
@@ -4046,6 +4092,137 @@ fn v2_missing_assignment_metadata_discards_only_that_row() {
     assert_eq!(restored.status().restored_sessions, 1);
     assert!(restored.summary(&bad.session_id, None).is_none());
     assert!(restored.summary(&good.session_id, None).is_some());
+    assert_eq!(restored.status().last_persist_error, None);
+}
+
+#[test]
+fn v2_event_and_message_shape_corruption_discards_only_affected_rows() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger_path = tmp.path().join("sessions.json");
+    let store = persistent_store(ledger_path.clone());
+    let bad_missing = store.start_session(
+        Some("proj".to_string()),
+        Some("missing correlation key".to_string()),
+    );
+    let bad_retired = store.start_session(
+        Some("proj".to_string()),
+        Some("retired event field".to_string()),
+    );
+    let bad_message = store.start_session(
+        Some("proj".to_string()),
+        Some("unknown message field".to_string()),
+    );
+    let good = store.start_session(Some("proj".to_string()), Some("good".to_string()));
+
+    for session_id in [&bad_missing.session_id, &bad_retired.session_id] {
+        let mut metadata = ToolCallRecorderMetadata::default();
+        metadata.assign_logical_invocation();
+        let start = store.record_tool_call_started_with_metadata(
+            Some(session_id),
+            SessionTransport::Api,
+            "read_file",
+            &json!({"project": "proj", "path": "src/lib.rs"}),
+            Some("proj".to_string()),
+            metadata,
+        );
+        store.record_tool_call_finished(start, true, &json!({"content": "omitted"}), None, None);
+    }
+    store
+        .post_message(PostSessionMessageInput {
+            session_id: bad_message.session_id.clone(),
+            kind: SessionMessageKind::Note,
+            message: "message row".to_string(),
+            tags: Vec::new(),
+            reply_to: None,
+            priority: SessionMessagePriority::Normal,
+        })
+        .unwrap();
+    store.flush_persistence();
+    drop(store);
+
+    let mut ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+    let records = ledger["sessions"].as_array_mut().unwrap();
+    let missing_record = records
+        .iter_mut()
+        .find(|record| record["session_id"] == bad_missing.session_id)
+        .unwrap();
+    let missing_event = missing_record["events"][0].as_object_mut().unwrap();
+    assert!(missing_event.contains_key("logical_invocation_id"));
+    assert!(missing_event.contains_key("logical_invocation_role"));
+    missing_event.remove("logical_invocation_role");
+
+    let retired_record = records
+        .iter_mut()
+        .find(|record| record["session_id"] == bad_retired.session_id)
+        .unwrap();
+    retired_record["events"][0]
+        .as_object_mut()
+        .unwrap()
+        .insert("allow_cross_project_session".to_string(), Value::Bool(true));
+
+    let message_record = records
+        .iter_mut()
+        .find(|record| record["session_id"] == bad_message.session_id)
+        .unwrap();
+    message_record["messages"][0]
+        .as_object_mut()
+        .unwrap()
+        .insert("post_v039_development_field".to_string(), Value::Bool(true));
+
+    std::fs::write(&ledger_path, serde_json::to_vec_pretty(&ledger).unwrap()).unwrap();
+    let restored = persistent_store(ledger_path);
+    assert_eq!(restored.status().restored_sessions, 1);
+    assert!(restored.summary(&bad_missing.session_id, None).is_none());
+    assert!(restored.summary(&bad_retired.session_id, None).is_none());
+    assert!(restored.summary(&bad_message.session_id, None).is_none());
+    assert!(restored.summary(&good.session_id, None).is_some());
+    assert_eq!(restored.status().last_persist_error, None);
+}
+
+#[test]
+fn v1_rejects_v2_only_event_correlation_metadata() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger_path = tmp.path().join("sessions.json");
+    let store = persistent_store(ledger_path.clone());
+    let session = store.start_session(Some("proj".to_string()), Some("v2 event".to_string()));
+    let mut metadata = ToolCallRecorderMetadata::default();
+    metadata.assign_logical_invocation();
+    let start = store.record_tool_call_started_with_metadata(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "read_file",
+        &json!({"project": "proj", "path": "src/lib.rs"}),
+        Some("proj".to_string()),
+        metadata,
+    );
+    store.record_tool_call_finished(start, true, &json!({"content": "omitted"}), None, None);
+    store.flush_persistence();
+    drop(store);
+
+    let mut ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+    ledger["version"] = json!(SESSION_LEDGER_V1_VERSION);
+    ledger
+        .as_object_mut()
+        .unwrap()
+        .insert("durable_current_bindings".to_string(), json!([]));
+    let record = ledger["sessions"][0].as_object_mut().unwrap();
+    for field in [
+        "assignment_history_floors",
+        "assignment_history_tracking_complete",
+        "completion_assignment_fence_fingerprints",
+        "completion_assignment_fence_tracking_complete",
+    ] {
+        record.remove(field);
+    }
+    assert!(record["events"][0].get("logical_invocation_id").is_some());
+    assert!(record["events"][0].get("logical_invocation_role").is_some());
+    std::fs::write(&ledger_path, serde_json::to_vec_pretty(&ledger).unwrap()).unwrap();
+
+    let restored = persistent_store(ledger_path);
+    assert_eq!(restored.status().restored_sessions, 0);
+    assert!(restored.summary(&session.session_id, None).is_none());
     assert_eq!(restored.status().last_persist_error, None);
 }
 


### PR DESCRIPTION
## Summary

- make the current Session ledger v2 schema canonical instead of carrying broad additive compatibility defaults
- isolate released v0.3.9 ledger-v1 compatibility in an explicit, fail-closed upgrade path and retire durable current bindings as authority
- tighten persisted Session event/message compatibility, including logical invocation correlation shape and conservative assignment/completion replay semantics
- suppress three intentional Agent Wake unused/dead-code warnings with narrowly scoped `allow` attributes

## Validation

- `cargo test -p webcodex --lib tool_runtime::sessions::` — 157 passed
- focused v2 event/message corruption regression — passed
- warning-suppression rebuild — passed with the three prior warnings absent
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
