### PR TITLE
Remove retired public compatibility aliases

### DIFF
--- a/docs/agent/openapi-guidelines.md
+++ b/docs/agent/openapi-guidelines.md
@@ -97,8 +97,8 @@ failures. `policy_rejected` means policy blocked the request before a write.
 
 ## 6. Flattened Action fields
 
-- GPT Actions should prefer **flattened top-level fields** over `params` /
-  `arguments`.
+- GPT Actions should prefer **flattened top-level fields** over the direct
+  `params` envelope.
 - Use `recording_session_id` for generic wrapper recorder metadata.
 - Use `session_id` as tool business input.
 - When a **model-visible** runtime tool is expected to work through GPT Action
@@ -108,7 +108,7 @@ failures. `policy_rejected` means policy blocked the request before a write.
   `checkpoint_id`, `confirm`, `dry_run`, `include_untracked`, and
   `include_diff_stat`). Hidden direct/API compatibility tools remain out-of-band
   parser/dispatch contracts and must not contribute flattened model fields;
-  explicit direct callers should prefer `params` or `arguments`, while any
+  explicit direct callers should use the canonical `params` envelope, while any
   retained historical flattened form stays a runtime compatibility detail only.
 - Add/update tests that fail when flattened Action fields are missing.
 - Do **not** loosen `additionalProperties` to `true` as a workaround — list the

--- a/scripts/e2e_zero_config_ws.sh
+++ b/scripts/e2e_zero_config_ws.sh
@@ -1294,12 +1294,12 @@ else
     fail "callRuntimeTool(list_tools) params null failed (body: ${body:0:300})"
 fi
 
-# callRuntimeTool: arguments alias -> list_tools succeeds.
+# callRuntimeTool: retired arguments envelope is rejected; use params or flattened fields.
 body="$(api_post /api/tools/call '{"tool":"list_tools","arguments":null}')"
-if printf '%s' "$body" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("success") is True else 1)'; then
-    pass "callRuntimeTool(list_tools) arguments alias succeeds"
+if printf '%s' "$body" | python3 -c 'import json,sys; body=json.load(sys.stdin); err=str(body.get("error", "")); sys.exit(0 if body.get("success") is False and "arguments" in err and "no longer supported" in err else 1)'; then
+    pass "callRuntimeTool(list_tools) rejects retired arguments envelope"
 else
-    fail "callRuntimeTool(list_tools) arguments alias failed (body: ${body:0:300})"
+    fail "callRuntimeTool(list_tools) accepted retired arguments envelope (body: ${body:0:300})"
 fi
 
 # callRuntimeTool: git_diff_summary against the agent project succeeds.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -70,7 +70,6 @@ use tools::{
     strip_stateless_ack_session_context_revision, strip_stateless_ack_session_message_ids,
     strip_stateless_context_request, strip_stateless_session_message_resolution,
     take_last_mcp_host_file_import_trust_decision, HostFileImportTrustReason, McpToolCallParams,
-    MCP_RESERVED_SESSION_ID_FIELD,
 };
 
 /// Hard upper bound on a single MCP JSON-RPC dispatch, applied in `mcp_post`.

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -899,7 +899,6 @@ pub(super) async fn mcp_artifact_export_read_legacy_chunk(
                     "encoding": "base64",
                     "offset": offset,
                     "length": length,
-                    "max_bytes": length,
                 }),
             },
             ToolCallContext {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -23,7 +23,6 @@ use crate::tool_runtime::{registered_tool_specs, ToolRuntime, ToolSpec};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-pub(super) const MCP_RESERVED_SESSION_ID_FIELD: &str = "_session_id";
 pub(super) const ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME: &str = "call_runtime_tool";
 
 fn filter_specs_for_oauth(mut specs: Vec<ToolSpec>, auth: Option<&AuthContext>) -> Vec<ToolSpec> {
@@ -159,7 +158,7 @@ fn unwrap_adaptive_runtime_gateway_arguments(
         "adaptive runtime gateway field 'arguments' must be an object".to_string()
     })?;
 
-    let mut allowed_wrapper_fields = vec![MCP_RESERVED_SESSION_ID_FIELD];
+    let mut allowed_wrapper_fields = Vec::new();
     if stateless_2026 {
         allowed_wrapper_fields.extend([
             crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,
@@ -462,7 +461,7 @@ fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, _app_enabled: bool) -> 
                 "as_image".to_string(),
                 json!({
                     "type": "boolean",
-                    "description": "MCP-only. When true, read one complete PNG, JPEG, or WebP up to 1 MiB and return it as native image content. Cannot be combined with offset, length, or max_bytes."
+                    "description": "MCP-only. When true, read one complete PNG, JPEG, or WebP up to 1 MiB and return it as native image content. Cannot be combined with offset or length."
                 }),
             );
         }
@@ -807,16 +806,17 @@ fn log_mcp_host_file_import_trust_decision(
     );
 }
 
-pub(super) fn strip_reserved_session_id(arguments: &mut Value) -> Result<Option<String>, String> {
+pub(super) fn strip_recording_session_id(arguments: &mut Value) -> Result<Option<String>, String> {
     let Some(object) = arguments.as_object_mut() else {
         return Ok(None);
     };
-    let canonical =
-        object.remove(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD);
-    let legacy = object.remove(MCP_RESERVED_SESSION_ID_FIELD);
-
-    let canonical = match canonical {
-        None => None,
+    if object.contains_key("_session_id") {
+        return Err(
+            "field '_session_id' is no longer supported; use 'recording_session_id'".to_string(),
+        );
+    }
+    match object.remove(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD) {
+        None => Ok(None),
         Some(Value::String(value)) => {
             let value = value.trim();
             if value.is_empty() {
@@ -825,30 +825,13 @@ pub(super) fn strip_reserved_session_id(arguments: &mut Value) -> Result<Option<
                     crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
                 ));
             }
-            Some(value.to_string())
+            Ok(Some(value.to_string()))
         }
-        Some(_) => {
-            return Err(format!(
-                "field '{}' must be a non-empty string",
-                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
-            ));
-        }
-    };
-    let legacy = legacy
-        .and_then(|value| value.as_str().map(str::to_string))
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
-
-    if let (Some(canonical), Some(legacy)) = (&canonical, &legacy) {
-        if canonical != legacy {
-            return Err(format!(
-                "fields '{}' and '{}' must identify the same Workflow Session when both are provided",
-                crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,
-                MCP_RESERVED_SESSION_ID_FIELD
-            ));
-        }
+        Some(_) => Err(format!(
+            "field '{}' must be a non-empty string",
+            crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD
+        )),
     }
-    Ok(canonical.or(legacy))
 }
 
 pub(super) fn strip_stateless_ack_session_message_ids(
@@ -1235,7 +1218,7 @@ pub(super) async fn handle_call(
             },
         ));
     }
-    let session_id = match strip_reserved_session_id(&mut params.arguments) {
+    let session_id = match strip_recording_session_id(&mut params.arguments) {
         Ok(session_id) => session_id,
         Err(message) => {
             if let Some(lc) = lifecycle.as_deref() {

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -143,7 +143,7 @@ async fn mcp_tools_list_returns_same_names_as_runtime() {
             assert!(ack_description.contains("Repeat while retained"));
             assert!(ack_description.contains("If later omitted"));
             assert!(ack_description.contains("neither resolves messages nor grants authority"));
-            assert!(!properties.contains_key(MCP_RESERVED_SESSION_ID_FIELD));
+            assert!(!properties.contains_key("_session_id"));
         }
         // Exercise the real env adapter, not just the pure renderer: compact
         // must change outputSchema shape while preserving the common fields.
@@ -156,7 +156,7 @@ async fn mcp_tools_list_returns_same_names_as_runtime() {
             let properties = tool["inputSchema"]["properties"].as_object().unwrap();
             assert!(!properties
                 .contains_key(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD));
-            assert!(!properties.contains_key(MCP_RESERVED_SESSION_ID_FIELD));
+            assert!(!properties.contains_key("_session_id"));
             if compact {
                 assert!(
                     tool.get("outputSchema").is_none(),
@@ -1591,47 +1591,42 @@ async fn mcp_tools_call_list_projects_returns_content_blocks() {
 }
 
 #[tokio::test]
-async fn mcp_tools_call_strips_reserved_session_id_before_dispatch() {
+async fn mcp_tools_call_rejects_legacy_reserved_session_id_before_dispatch() {
     let runtime = test_runtime();
-    let session = runtime
-        .sessions
-        .start_session(Some("demo".to_string()), Some("mcp strip".to_string()));
+    let session = runtime.sessions.start_session(
+        Some("demo".to_string()),
+        Some("legacy recorder".to_string()),
+    );
     let outcome = handle_mcp_request(
         &runtime,
         rpc(
             "tools/call",
             Some(Value::from(32)),
-            json!({
+            mcp_2026_params(json!({
                 "name": "list_projects",
-                "arguments": {
-                    MCP_RESERVED_SESSION_ID_FIELD: &session.session_id
-                }
-            }),
+                "arguments": {"_session_id": &session.session_id}
+            })),
         ),
         None,
     )
     .await;
-    match outcome {
-        McpOutcome::Ok(_) => {}
-        other => panic!("expected Ok, got {:?}", other),
-    }
-    let summary = runtime
-        .sessions
-        .summary(&session.session_id, Some(10))
-        .unwrap();
-    assert_eq!(summary.counts.tool_calls, 1);
-    let started = summary
-        .events
-        .iter()
-        .find(|event| event.kind == "tool_call_started")
-        .unwrap();
-    assert_eq!(started.transport, "mcp");
-    assert_eq!(started.tool_name, "list_projects");
-    assert!(
-        !serde_json::to_string(&started.input_summary)
+    let value = match outcome {
+        McpOutcome::BadRequest(value) => value,
+        other => panic!("expected invalid-params BadRequest, got {other:?}"),
+    };
+    assert_eq!(value["error"]["code"], -32602);
+    let message = value["error"]["message"].as_str().unwrap();
+    assert!(message.contains("_session_id"));
+    assert!(message.contains("no longer supported"));
+    assert!(message.contains("recording_session_id"));
+    assert_eq!(
+        runtime
+            .sessions
+            .summary(&session.session_id, Some(10))
             .unwrap()
-            .contains(MCP_RESERVED_SESSION_ID_FIELD),
-        "_session_id must be stripped before recording/dispatch"
+            .counts
+            .tool_calls,
+        0
     );
 }
 
@@ -1716,14 +1711,11 @@ async fn stateless_mcp_ack_wrapper_is_removed_before_concrete_dispatch_and_is_re
 }
 
 #[tokio::test]
-async fn mcp_tools_call_rejects_conflicting_recorder_metadata_before_dispatch() {
+async fn mcp_tools_call_rejects_legacy_session_alias_even_with_canonical_recorder() {
     let runtime = test_runtime();
     let canonical = runtime
         .sessions
         .start_session(None, Some("canonical recorder".to_string()));
-    let legacy = runtime
-        .sessions
-        .start_session(None, Some("legacy recorder".to_string()));
 
     let outcome = handle_mcp_request(
         &runtime,
@@ -1734,7 +1726,7 @@ async fn mcp_tools_call_rejects_conflicting_recorder_metadata_before_dispatch() 
                 "name": "list_projects",
                 "arguments": {
                     crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD: &canonical.session_id,
-                    MCP_RESERVED_SESSION_ID_FIELD: &legacy.session_id
+                    "_session_id": &canonical.session_id
                 }
             })),
         ),
@@ -1748,15 +1740,22 @@ async fn mcp_tools_call_rejects_conflicting_recorder_metadata_before_dispatch() 
     assert_eq!(value["error"]["code"], -32602);
     assert!(value["error"]["message"]
         .as_str()
-        .is_some_and(|message| message.contains("must identify the same Workflow Session")));
-    for session_id in [&canonical.session_id, &legacy.session_id] {
-        let summary = runtime.sessions.summary(session_id, Some(10)).unwrap();
-        assert_eq!(summary.counts.tool_calls, 0);
-    }
+        .is_some_and(
+            |message| message.contains("_session_id") && message.contains("no longer supported")
+        ));
+    assert_eq!(
+        runtime
+            .sessions
+            .summary(&canonical.session_id, Some(10))
+            .unwrap()
+            .counts
+            .tool_calls,
+        0
+    );
 }
 
 #[tokio::test]
-async fn mcp_tools_call_records_event_with_session_id() {
+async fn mcp_tools_call_records_event_with_recording_session_id() {
     let runtime = test_runtime();
     let session = runtime.sessions.start_session(None, None);
     let outcome = handle_mcp_request(
@@ -1764,12 +1763,12 @@ async fn mcp_tools_call_records_event_with_session_id() {
         rpc(
             "tools/call",
             Some(Value::from(33)),
-            json!({
+            mcp_2026_params(json!({
                 "name": "list_projects",
                 "arguments": {
-                    MCP_RESERVED_SESSION_ID_FIELD: &session.session_id
+                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD: &session.session_id
                 }
-            }),
+            })),
         ),
         None,
     )
@@ -1777,10 +1776,6 @@ async fn mcp_tools_call_records_event_with_session_id() {
     match outcome {
         McpOutcome::Ok(value) => {
             assert_eq!(value["result"]["structuredContent"]["success"], true);
-            let output = &value["result"]["structuredContent"]["output"];
-            assert!(output.get("session_context_revision").is_none());
-            assert!(output.get("session_continuity").is_none());
-            assert!(output.get("session_recovery").is_none());
         }
         other => panic!("expected Ok, got {:?}", other),
     }
@@ -1840,16 +1835,16 @@ async fn mcp_tools_list_hides_testing_metadata_while_raw_call_records_it() {
         rpc(
             "tools/call",
             Some(Value::from(331)),
-            json!({
+            mcp_2026_params(json!({
                 "name": "job_status",
                 "arguments": {
-                    MCP_RESERVED_SESSION_ID_FIELD: &session.session_id,
+                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD: &session.session_id,
                     "job_id": "missing-job",
                     "expected_failure": true,
                     "expected_failure_kind": "job_not_found",
                     "assertion_name": "mcp hidden metadata compatibility"
                 }
-            }),
+            })),
         ),
         None,
     )
@@ -1890,7 +1885,7 @@ async fn mcp_tools_list_hides_testing_metadata_while_raw_call_records_it() {
 }
 
 #[tokio::test]
-async fn mcp_show_changes_distinguishes_reserved_session_id_from_query_session_id() {
+async fn mcp_show_changes_distinguishes_recording_session_id_from_query_session_id() {
     use crate::shell_protocol::{
         ShellAgentProjectSummary, ShellAgentResultRequest, ShellClientCapabilities,
         ShellClientRegisterRequest,
@@ -1968,15 +1963,15 @@ async fn mcp_show_changes_distinguishes_reserved_session_id_from_query_session_i
         rpc(
             "tools/call",
             Some(Value::from(34)),
-            json!({
+            mcp_2026_params(json!({
                 "name": "show_changes",
                 "arguments": {
-                    MCP_RESERVED_SESSION_ID_FIELD: &tracking_session.session_id,
+                    crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD: &tracking_session.session_id,
                     "project": project,
                     "session_id": &query_session.session_id,
                     "include_diff": false
                 }
-            }),
+            })),
         ),
         Some(&auth),
     );

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -5,13 +5,13 @@ use std::collections::BTreeMap;
 use crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD;
 use crate::tool_runtime::{
     generic_tool_call_flattened_args_for_spec, registered_tool_specs, MAX_UNIFIED_DIFF_BYTES,
-    TOOL_CALL_ARGUMENTS_FIELD, TOOL_CALL_PARAMS_FIELD, TOOL_CALL_TOOL_FIELD,
+    TOOL_CALL_PARAMS_FIELD, TOOL_CALL_TOOL_FIELD,
 };
 
 const UNIFIED_DIFF_FIELD_DESCRIPTION: &str = "Raw standard unified diff only. Do not include shell heredocs or Codex apply_patch wrapper syntax such as *** Begin Patch / *** Update File / *** End Patch. The first non-empty line should be diff --git ..., --- ..., or another git-apply-compatible unified diff header.";
 const SESSION_ID_FIELD_DESCRIPTION: &str = "Optional explicit existing wc_sess_* id. When provided, records this dedicated action in that exact Workflow Session; omission does not infer a Session.";
 const FLATTENED_TOOL_ARG_DESCRIPTION: &str =
-    "Flattened tool-specific argument. Used only when `params` and `arguments` are absent.";
+    "Flattened tool-specific argument. Used only when `params` is absent or null.";
 
 fn flattened_tool_arg_schema(schema_type: &str) -> Value {
     json!({
@@ -652,7 +652,7 @@ pub(crate) fn build_openapi_spec() -> Value {
                 "post": operation_with_examples(
                     "callRuntimeTool",
                     "Call runtime tool (advanced)",
-                    "Advanced generic escape hatch for model-visible runtime tools. Prefer dedicated actions or tool_manifest. GPT Actions use flattened fields; params/arguments remain direct/non-Action compatibility envelopes. recording_session_id records wrapper calls.",
+                    "Advanced generic escape hatch for model-visible runtime tools. Prefer dedicated actions or tool_manifest. GPT Actions use flattened fields; params is the canonical direct/non-Action envelope. recording_session_id records wrapper calls.",
                     "ToolCallRequest",
                     "ToolResult",
                     json!({
@@ -773,13 +773,11 @@ pub(crate) fn build_openapi_spec() -> Value {
                                 }]
                             }
                         },
-                        "argumentsAlias": {
-                            "summary": "MCP-style arguments alias (non-null params wins when both are present)",
+                        "paramsEnvelope": {
+                            "summary": "Canonical direct/non-Action params envelope",
                             "value": {
                                 "tool": "git_diff_summary",
-                                "arguments": {
-                                    "project": "webcodex"
-                                }
+                                "params": {"project": "webcodex"}
                             }
                         },
                         "noParams": {
@@ -1028,7 +1026,7 @@ fn schemas() -> Value {
             "type": "object",
             "additionalProperties": false,
             "required": [TOOL_CALL_TOOL_FIELD],
-            "description": "Generic GPT Actions runtime tool call. The model-facing `tool` selector and flattened top-level fields cover only model-visible runtime tools and match registered_tool_specs, MCP discovery, and tool_manifest. GPT Actions should pass tool-specific arguments as flattened top-level fields because some Action runtimes reject free-form params/arguments objects. `params` and `arguments` remain accepted direct/non-Action compatibility envelopes; non-null `params` takes precedence, and null wrappers do not suppress flattened arguments. Top-level `session_id` is ordinary explicit tool business input when declared by the selected visible tool; use `recording_session_id` only to record this wrapper call in an explicitly selected existing Workflow Session. Omitted Session identifiers never infer a Workflow Session from window, credential, project, or prior calls. For daily discovery prefer tool_manifest; it exposes accepted_flattened_args for model-facing top-level calls. Use list_tools with summary_only/category/features/limit only for focused discovery.",
+            "description": "Generic GPT Actions runtime tool call. The model-facing `tool` selector and flattened top-level fields cover only model-visible runtime tools and match registered_tool_specs, MCP discovery, and tool_manifest. GPT Actions should pass tool-specific arguments as flattened top-level fields because some Action runtimes reject free-form params objects. `params` is the canonical direct/non-Action argument envelope; a non-null value takes precedence and a null wrapper does not suppress flattened arguments. The retired `arguments` wrapper is rejected. Top-level `session_id` is ordinary explicit tool business input when declared by the selected visible tool; use `recording_session_id` only to record this wrapper call in an explicitly selected existing Workflow Session. Omitted Session identifiers never infer a Workflow Session from window, credential, project, or prior calls. For daily discovery prefer tool_manifest; it exposes accepted_flattened_args for model-facing top-level calls. Use list_tools with summary_only/category/features/limit only for focused discovery.",
             "properties": {
                 "session_id": {
                     "type": "string",
@@ -1036,13 +1034,13 @@ fn schemas() -> Value {
                 },
                 "kind": {
                     "type": "string",
-                    "description": "Flattened tool-specific argument. For message-board tools, one of note, proposal, question, answer, decision, risk, progress, guidance, todo. For workspace_checkpoint_create, one of snapshot, baseline, before_refactor, after_refactor, last_known_good, rollback_candidate. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened tool-specific argument. For message-board tools, one of note, proposal, question, answer, decision, risk, progress, guidance, todo. For workspace_checkpoint_create, one of snapshot, baseline, before_refactor, after_refactor, last_known_good, rollback_candidate. Used only when `params` is absent or null."
                 },
                 "labels": {
                     "type": "array",
                     "items": {"type": "string", "maxLength": 64, "pattern": "^[A-Za-z0-9._-]+$"},
                     "maxItems": 20,
-                    "description": "Flattened workspace_checkpoint_create labels. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened workspace_checkpoint_create labels. Used only when `params` is absent or null."
                 },
                 "validation": {
                     "type": "object",
@@ -1069,27 +1067,27 @@ fn schemas() -> Value {
                 },
                 "note": {
                     "type": "string",
-                    "description": "Flattened workspace_checkpoint_create optional note (not used by restore). Used only when `params` and `arguments` are absent."
+                    "description": "Flattened workspace_checkpoint_create optional note (not used by restore). Used only when `params` is absent or null."
                 },
                 "include_untracked": {
                     "type": "boolean",
-                    "description": "Flattened workspace_checkpoint_create flag to capture small non-secret UTF-8 untracked files (default false). Used only when `params` and `arguments` are absent."
+                    "description": "Flattened workspace_checkpoint_create flag to capture small non-secret UTF-8 untracked files (default false). Used only when `params` is absent or null."
                 },
                 "checkpoint_id": {
                     "type": "string",
-                    "description": "Flattened workspace_checkpoint_show/restore/delete wc_ckpt_* id. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened workspace_checkpoint_show/restore/delete wc_ckpt_* id. Used only when `params` is absent or null."
                 },
                 "confirm": {
                     "type": "boolean",
-                    "description": "Flattened confirmation flag for workspace_checkpoint_restore/delete and stop_job; must be true to proceed. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened confirmation flag for workspace_checkpoint_restore/delete and stop_job; must be true to proceed. Used only when `params` is absent or null."
                 },
                 "include_command_preview": {
                     "type": "boolean",
-                    "description": "Flattened job_status debug flag. Defaults to false; when true, job_status includes bounded command_preview metadata. stdout/stderr bodies are never included. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened job_status debug flag. Defaults to false; when true, job_status includes bounded command_preview metadata. stdout/stderr bodies are never included. Used only when `params` is absent or null."
                 },
                 "include_diff_stat": {
                     "type": "boolean",
-                    "description": "Flattened workspace_checkpoint_show flag to include tracked/staged diff stat strings (default false). Used only when `params` and `arguments` are absent."
+                    "description": "Flattened workspace_checkpoint_show flag to include tracked/staged diff stat strings (default false). Used only when `params` is absent or null."
                 },
                 // Keep the flattened GPT Action shape composition-free. The canonical MCP/local-coding
                 // ToolSpec carries the strict per-kind oneOf contract; this import-facing projection uses
@@ -1099,7 +1097,7 @@ fn schemas() -> Value {
                     "type": "array",
                     "minItems": 1,
                     "maxItems": 16,
-                    "description": "Flattened apply_text_edits transactional file changes. kind=edit requires path, expected_sha256, and edits and forbids to_path/content; create requires path/content and forbids to_path/expected_sha256/edits; delete requires path/expected_sha256 and forbids to_path/content/edits; rename requires path/to_path/expected_sha256 and forbids content/edits. Used only when `params` and `arguments` are absent.",
+                    "description": "Flattened apply_text_edits transactional file changes. kind=edit requires path, expected_sha256, and edits and forbids to_path/content; create requires path/content and forbids to_path/expected_sha256/edits; delete requires path/expected_sha256 and forbids to_path/content/edits; rename requires path/to_path/expected_sha256 and forbids content/edits. Used only when `params` is absent or null.",
                     "items": {
                         "type": "object",
                         "additionalProperties": false,
@@ -1152,99 +1150,99 @@ fn schemas() -> Value {
                 },
                 "dry_run": {
                     "type": "boolean",
-                    "description": "Flattened apply_text_edits flag to compute the plan without writing. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened apply_text_edits flag to compute the plan without writing. Used only when `params` is absent or null."
                 },
                 "message": {
                     "type": "string",
-                    "description": "Flattened post_session_message body. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened post_session_message body. Used only when `params` is absent or null."
                 },
                 "tags": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Flattened post_session_message tags. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened post_session_message tags. Used only when `params` is absent or null."
                 },
                 "reply_to": {
                     "type": "string",
-                    "description": "Flattened post_session_message reply target wc_msg_* id. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened post_session_message reply target wc_msg_* id. Used only when `params` is absent or null."
                 },
                 "priority": {
                     "type": "string",
-                    "description": "Flattened post_session_message priority: low, normal, or high. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened post_session_message priority: low, normal, or high. Used only when `params` is absent or null."
                 },
                 "status": {
                     "type": "string",
-                    "description": "Flattened list_session_messages status filter: open or resolved. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened list_session_messages status filter: open or resolved. Used only when `params` is absent or null."
                 },
                 "after_observation_token": {
                     "type": "string",
                     "maxLength": 192,
-                    "description": "Flattened opaque observation token for observe_session_messages and compatible bounded observation tools. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened opaque observation token for observe_session_messages and compatible bounded observation tools. Used only when `params` is absent or null."
                 },
                 "wait_secs": {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 60,
-                    "description": "Flattened one-shot bounded wait for observe_session_messages and compatible observation tools. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened one-shot bounded wait for observe_session_messages and compatible observation tools. Used only when `params` is absent or null."
                 },
                 "message_id": {
                     "type": "string",
-                    "description": "Flattened resolve_session_message wc_msg_* id. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened resolve_session_message wc_msg_* id. Used only when `params` is absent or null."
                 },
                 "resolution": {
                     "type": "string",
-                    "description": "Flattened resolve_session_message resolution note. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened resolve_session_message resolution note. Used only when `params` is absent or null."
                 },
                 "compact": {
                     "type": "boolean",
-                    "description": "Flattened runtime_status flag. Defaults to false. When true, returns compact runtime observability for sanity checks instead of the full status payload. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened runtime_status flag. Defaults to false. When true, returns compact runtime observability for sanity checks instead of the full status payload. Used only when `params` is absent or null."
                 },
                 "path": {
                     "type": "string",
-                    "description": "Flattened tool-specific argument. For artifact_upload_chunk/finish/abort this is required and must exactly match the path used by artifact_upload_begin to bind upload_id to the target path. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened tool-specific argument. For artifact_upload_chunk/finish/abort this is required and must exactly match the path used by artifact_upload_begin to bind upload_id to the target path. Used only when `params` is absent or null."
                 },
                 "skip": {
                     "type": "integer",
-                    "description": "Flattened git_log commit offset. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened git_log commit offset. Used only when `params` is absent or null."
                 },
                 "category": {
                     "type": "string",
-                    "description": "Flattened list_tools/tool_manifest category filter. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened list_tools/tool_manifest category filter. Used only when `params` is absent or null."
                 },
                 "intent": {
                     "type": "string",
-                    "description": "Flattened tool_manifest task-intent view such as coding, audit, exploration, release, or discovery. Distinct from category. Intent views only filter and rank discovery output; they do not change tool behavior, policy, permissions, execution, or finish verdict semantics. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened tool_manifest task-intent view such as coding, audit, exploration, release, or discovery. Distinct from category. Intent views only filter and rank discovery output; they do not change tool behavior, policy, permissions, execution, or finish verdict semantics. Used only when `params` is absent or null."
                 },
                 "include_recommended_flows": {
                     "type": "boolean",
-                    "description": "Flattened tool_manifest flag. Defaults to true and controls recommended_flows in compact discovery output. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened tool_manifest flag. Defaults to true and controls recommended_flows in compact discovery output. Used only when `params` is absent or null."
                 },
                 "include_risk_summary": {
                     "type": "boolean",
-                    "description": "Flattened tool_manifest flag. Defaults to true and controls risk_summary in compact discovery output. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened tool_manifest flag. Defaults to true and controls risk_summary in compact discovery output. Used only when `params` is absent or null."
                 },
                 "include_hygiene": {
                     "type": "boolean",
-                    "description": "Flattened finish_coding_task flag. Defaults to true. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened finish_coding_task flag. Defaults to true. Used only when `params` is absent or null."
                 },
                 "max_findings": {
                     "type": "integer",
-                    "description": "Flattened workspace_hygiene_check maximum findings to return; clamped by the runtime to 1..200. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened workspace_hygiene_check maximum findings to return; clamped by the runtime to 1..200. Used only when `params` is absent or null."
                 },
                 "include_tracked": {
                     "type": "boolean",
-                    "description": "Flattened workspace_hygiene_check flag. When true, also report tracked suspicious path names by path/name only; file contents are never read. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened workspace_hygiene_check flag. When true, also report tracked suspicious path names by path/name only; file contents are never read. Used only when `params` is absent or null."
                 },
                 "include_handoff": {
                     "type": "boolean",
-                    "description": "Flattened finish_coding_task flag. Defaults to true. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened finish_coding_task flag. Defaults to true. Used only when `params` is absent or null."
                 },
                 "include_validation_summary": {
                     "type": "boolean",
-                    "description": "Flattened finish_coding_task flag. Defaults to true; minimal diagnostics may be derived from safe bounded validation metadata, but raw stdout/stderr is never exposed. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened finish_coding_task flag. Defaults to true; minimal diagnostics may be derived from safe bounded validation metadata, but raw stdout/stderr is never exposed. Used only when `params` is absent or null."
                 },
                 "include_validation": {
                     "type": "boolean",
-                    "description": "Flattened session_handoff_summary flag. Defaults to true; validation is ledger-derived and parser.available is true only when safe bounded metadata is present. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened session_handoff_summary flag. Defaults to true; validation is ledger-derived and parser.available is true only when safe bounded metadata is present. Used only when `params` is absent or null."
                 },
                 "include_workspace": {
                     "type": "boolean",
@@ -1256,23 +1254,23 @@ fn schemas() -> Value {
                 },
                 "features": {
                     "type": "string",
-                    "description": "Flattened list_tools feature filter, or cargo feature selection for cargo tools. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened list_tools feature filter, or cargo feature selection for cargo tools. Used only when `params` is absent or null."
                 },
                 "summary_only": {
                     "type": "boolean",
-                    "description": "Flattened list_tools/runtime_status/session_handoff_summary/finish_coding_task flag. For list_tools, returns compact tool summaries without full schemas. For runtime_status, aliases compact=true. For handoff/finish, returns compact closeout outcome fields and omits recent_events, long ledger details, command text, stdout/stderr, tails, and excerpts. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened list_tools/runtime_status/session_handoff_summary/finish_coding_task flag. For list_tools, returns compact tool summaries without full schemas. For runtime_status, aliases compact=true. For handoff/finish, returns compact closeout outcome fields and omits recent_events, long ledger details, command text, stdout/stderr, tails, and excerpts. Used only when `params` is absent or null."
                 },
                 "upload_id": {
                     "type": "string",
-                    "description": "Flattened artifact_upload_chunk/finish/abort wc_upload_* id. The same path from artifact_upload_begin is also required so the runtime can bind upload_id to the requested target path. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened artifact_upload_chunk/finish/abort wc_upload_* id. The same path from artifact_upload_begin is also required so the runtime can bind upload_id to the requested target path. Used only when `params` is absent or null."
                 },
                 "expected_bytes": {
                     "type": "integer",
-                    "description": "Flattened artifact_upload_begin final byte count guard. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened artifact_upload_begin final byte count guard. Used only when `params` is absent or null."
                 },
                 "allow_missing": {
                     "type": "boolean",
-                    "description": "Flattened read_project_artifact_metadata flag. When true, a missing artifact returns exists=false instead of a failed tool call. Used only when `params` and `arguments` are absent."
+                    "description": "Flattened read_project_artifact_metadata flag. When true, a missing artifact returns exists=false instead of a failed tool call. Used only when `params` is absent or null."
                 },
             }
         },
@@ -1989,16 +1987,7 @@ fn insert_tool_call_request_reserved_properties(schemas: &mut Value) {
         TOOL_CALL_PARAMS_FIELD.to_string(),
         json!({
             "type": "object",
-            "description": "Tool-specific arguments object for non-Action clients. Takes precedence over `arguments` when both are non-null. A null wrapper does not suppress flattened top-level fields. GPT Actions should prefer flattened top-level fields.",
-            "nullable": true,
-            "additionalProperties": true
-        }),
-    );
-    properties.insert(
-        TOOL_CALL_ARGUMENTS_FIELD.to_string(),
-        json!({
-            "type": "object",
-            "description": "Compatibility alias for `params`. Used only when `params` is absent; ignored otherwise.",
+            "description": "Canonical tool-specific arguments object for non-Action clients. A non-null value takes precedence; a null wrapper does not suppress flattened top-level fields. GPT Actions should prefer flattened top-level fields.",
             "nullable": true,
             "additionalProperties": true
         }),

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -1014,30 +1014,20 @@ fn openapi_call_runtime_tool_params_is_explicit_object() {
 }
 
 #[test]
-fn openapi_call_runtime_tool_documents_arguments_alias() {
-    // Phase 2: ToolCallRequest must document the `arguments` compatibility
-    // alias and state that `params` wins. Both must be object-typed.
+fn openapi_call_runtime_tool_exposes_only_canonical_params_envelope() {
     let spec = build_openapi_spec();
     let properties = spec["components"]["schemas"]["ToolCallRequest"]["properties"]
         .as_object()
         .unwrap();
+    assert!(properties.contains_key(TOOL_CALL_PARAMS_FIELD));
     assert!(
-        properties.contains_key(TOOL_CALL_ARGUMENTS_FIELD),
-        "ToolCallRequest must declare an `arguments` alias property"
+        !properties.contains_key("arguments"),
+        "retired arguments alias must not remain in ToolCallRequest"
     );
-    let arguments = &properties[TOOL_CALL_ARGUMENTS_FIELD];
-    assert_eq!(arguments["type"], "object", "arguments must be type object");
-    assert_eq!(arguments["nullable"], true, "arguments must allow null");
-    assert_eq!(
-        arguments["additionalProperties"], true,
-        "arguments must allow arbitrary object properties"
-    );
-    let desc_blob =
-        serde_json::to_string(&spec["components"]["schemas"]["ToolCallRequest"]).unwrap();
-    assert!(
-        desc_blob.contains("params") && desc_blob.contains("precedence"),
-        "ToolCallRequest description must document params precedence over arguments"
-    );
+    let params = &properties[TOOL_CALL_PARAMS_FIELD];
+    assert_eq!(params["type"], "object");
+    assert_eq!(params["nullable"], true);
+    assert_eq!(params["additionalProperties"], true);
 }
 
 #[test]
@@ -1064,7 +1054,7 @@ fn openapi_call_runtime_tool_declares_flattened_action_fields() {
     }
 
     assert!(properties.contains_key(TOOL_CALL_PARAMS_FIELD));
-    assert!(properties.contains_key(TOOL_CALL_ARGUMENTS_FIELD));
+    assert!(!properties.contains_key("arguments"));
     assert!(
         !properties.contains_key("allow_cross_project_session"),
         "ToolCallRequest must not publish the cross-project debug escape as a flattened Action field"
@@ -1087,8 +1077,10 @@ fn openapi_call_runtime_tool_declares_flattened_action_fields() {
 
     let desc_blob = serde_json::to_string(tool_call).unwrap();
     assert!(
-        desc_blob.contains("top-level fields") && desc_blob.contains("params/arguments"),
-        "ToolCallRequest must document flattened GPT Action compatibility"
+        desc_blob.contains("top-level fields")
+            && desc_blob.contains("canonical direct/non-Action argument envelope")
+            && desc_blob.contains("retired `arguments` wrapper is rejected"),
+        "ToolCallRequest must document flattened GPT Action compatibility and the canonical params envelope"
     );
 }
 
@@ -1549,30 +1541,31 @@ fn openapi_work_on_project_example_keeps_first_use_projection_defaults() {
 }
 
 #[test]
-fn openapi_call_runtime_tool_examples_cover_alias_and_no_params() {
-    // Phase 2: callRuntimeTool examples should demonstrate the arguments
-    // alias and the argument-less (params omitted) shapes so a custom GPT
-    // has concrete templates for both.
+fn openapi_call_runtime_tool_examples_cover_params_and_no_params_without_retired_alias() {
     let spec = build_openapi_spec();
     let examples = &spec["paths"]["/api/tools/call"]["post"]["requestBody"]["content"]
         ["application/json"]["examples"];
-    let keys: Vec<&str> = examples
+    let values = examples
         .as_object()
         .unwrap()
-        .keys()
-        .map(|k| k.as_str())
-        .collect();
+        .values()
+        .map(|example| &example["value"])
+        .collect::<Vec<_>>();
     assert!(
-        keys.iter()
-            .any(|k| examples[*k]["value"]["arguments"].is_object()),
-        "callRuntimeTool examples should include an arguments-alias variant"
+        values.iter().all(|value| value.get("arguments").is_none()),
+        "callRuntimeTool examples must not advertise the retired arguments alias"
     );
     assert!(
-        keys.iter().any(|k| {
-            let v = &examples[*k]["value"];
-            v["tool"].as_str() == Some("list_tools") && v.get("params").is_none()
+        values
+            .iter()
+            .any(|value| value.get("params").is_some_and(|params| params.is_object())),
+        "callRuntimeTool examples should include the canonical params envelope"
+    );
+    assert!(
+        values.iter().any(|value| {
+            value["tool"].as_str() == Some("list_tools") && value.get("params").is_none()
         }),
-        "callRuntimeTool examples should include an argument-less variant"
+        "callRuntimeTool examples should include an argument-less flattened variant"
     );
 }
 

--- a/src/runtime_http.rs
+++ b/src/runtime_http.rs
@@ -9,8 +9,8 @@ use crate::tool_runtime::kernel::{
 use crate::tool_runtime::model_ergonomics_telemetry::ModelErgonomicsCompletion;
 use crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD;
 use crate::tool_runtime::{
-    ListToolsOptions, ToolCall, ToolRuntime, TOOL_CALL_ARGUMENTS_FIELD, TOOL_CALL_PARAMS_FIELD,
-    TOOL_CALL_TOOL_FIELD, TOOL_CALL_WRAPPER_FIELDS,
+    ListToolsOptions, ToolCall, ToolRuntime, TOOL_CALL_PARAMS_FIELD, TOOL_CALL_TOOL_FIELD,
+    TOOL_CALL_WRAPPER_FIELDS,
 };
 use salvo::prelude::*;
 use serde_json::{json, Value};
@@ -455,19 +455,18 @@ pub async fn tools_call(req: &mut Request, depot: &mut Depot, res: &mut Response
 /// - `{"tool":"list_tools"}`
 /// - `{"tool":"list_tools","params":null}`
 /// - `{"tool":"git_diff_summary","params":{"project":"agent:c:p"}}`
-/// - `{"tool":"git_diff_summary","arguments":{"project":"agent:c:p"}}`
 /// - `{"tool":"git_diff_summary","project":"agent:c:p"}`
 /// - `{"tool":"git_status","project":"agent:c:p","recording_session_id":"wc_sess_..."}`
 ///
-/// When both non-null `params` and `arguments` are present, `params` wins;
-/// `arguments` is only a compatibility alias. Null wrappers are treated as
-/// absent. When neither non-null wrapper is present, every top-level field
-/// except `tool` and reserved metadata like `recording_session_id` is collected
-/// into the params object for GPT Action compatibility. Top-level `session_id`
-/// is not reserved here; it remains a normal flattened tool argument for tools
-/// such as `session_summary`. Returns a human-readable error string (never
-/// including the raw body) when the body is not a JSON object or `tool` is
-/// missing/not a non-empty string.
+/// Non-null `params` take precedence over flattened GPT Action fields. A null
+/// `params` wrapper is treated as absent. When `params` is absent/null, every
+/// top-level field except `tool` and reserved metadata like
+/// `recording_session_id` is collected into the params object for GPT Action
+/// compatibility. The retired `arguments` wrapper is rejected explicitly.
+/// Top-level `session_id` is not reserved here; it remains a normal flattened
+/// tool argument for tools such as `session_summary`. Returns a human-readable
+/// error string (never including the raw body) when the body is not a JSON
+/// object or `tool` is missing/not a non-empty string.
 fn extract_tool_call(body: &Value) -> Result<(String, Value), String> {
     let obj = body
         .as_object()
@@ -485,8 +484,10 @@ fn extract_tool_call(body: &Value) -> Result<(String, Value), String> {
             return Err(format!("missing required field '{TOOL_CALL_TOOL_FIELD}'"));
         }
     };
-    // Non-null params take precedence over the `arguments` alias; flattened
-    // GPT Action fields are collected when neither wrapper has a value. Some
+    if obj.contains_key("arguments") {
+        return Err("field 'arguments' is no longer supported; use 'params' or flattened top-level tool arguments".to_string());
+    }
+    // Non-null params take precedence over flattened GPT Action fields. Some
     // Action runtimes emit optional object properties as explicit nulls, which
     // must not erase valid flattened tool arguments.
     let params = if let Some(params) = obj
@@ -494,11 +495,6 @@ fn extract_tool_call(body: &Value) -> Result<(String, Value), String> {
         .filter(|params| !params.is_null())
     {
         params.clone()
-    } else if let Some(arguments) = obj
-        .get(TOOL_CALL_ARGUMENTS_FIELD)
-        .filter(|arguments| !arguments.is_null())
-    {
-        arguments.clone()
     } else {
         let mut flattened = serde_json::Map::new();
         for (key, value) in obj {

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -648,8 +648,7 @@ async fn http_tools_call_full_trace_captures_raw_effective_and_final_payloads() 
     let (_tmp, service) = phase2_service();
     let request = json!({
         "tool": "list_tools",
-        "params": {},
-        "arguments": {"raw_only_marker": "client-wrapper-evidence"}
+        "params": {}
     });
     let (status, response) = http_tool_call(&service, request.clone()).await;
     assert_eq!(status, StatusCode::OK, "{response}");
@@ -902,51 +901,56 @@ async fn http_start_coding_task_default_response_is_standard() {
 }
 
 #[tokio::test]
-async fn http_hidden_start_coding_task_keeps_params_and_arguments_advanced_compatibility() {
+async fn http_hidden_start_coding_task_uses_only_canonical_params_envelope() {
     let _compact = ActionCompactEnvGuard::disabled();
-    for wrapper in ["params", "arguments"] {
-        let config = test_config(Some("secret"));
-        let (_tmp, db) = test_db();
-        let tmp_proj = tempfile::tempdir().unwrap();
-        let (runtime, registry) = register_import_agent_with_capabilities(
-            tmp_proj.path(),
-            Some(crate::shell_protocol::ShellClientCapabilities {
-                shell: true,
-                file_read: true,
-                file_write: true,
-                git: true,
-                ..Default::default()
-            }),
-        )
-        .await;
-        let executor = spawn_startup_agent_executor(registry);
-        let service = Service::new(build_projects_router(config, db, runtime));
-        let advanced = json!({
-            "project": "agent:importer:demo",
-            "mode": "read_only",
-            "detail": "minimal"
-        });
-        let body = if wrapper == "params" {
-            json!({"tool": "start_coding_task", "params": advanced})
-        } else {
-            json!({"tool": "start_coding_task", "arguments": advanced})
-        };
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let tmp_proj = tempfile::tempdir().unwrap();
+    let (runtime, registry) = register_import_agent_with_capabilities(
+        tmp_proj.path(),
+        Some(crate::shell_protocol::ShellClientCapabilities {
+            shell: true,
+            file_read: true,
+            file_write: true,
+            git: true,
+            ..Default::default()
+        }),
+    )
+    .await;
+    let executor = spawn_startup_agent_executor(registry);
+    let service = Service::new(build_projects_router(config, db, runtime));
+    let advanced = json!({
+        "project": "agent:importer:demo",
+        "mode": "read_only",
+        "detail": "minimal"
+    });
 
-        let mut resp = TestClient::post("http://localhost/api/tools/call")
-            .bearer_auth("secret")
-            .json(&body)
-            .send(&service)
-            .await;
-        assert_eq!(effective_status(&resp), StatusCode::OK, "{wrapper}: {body}");
-        let output: Value = resp.take_json().await.unwrap();
-        assert_eq!(output["success"], true, "{wrapper}: {output}");
-        assert_eq!(output["output"]["detail"], "minimal");
-        assert_eq!(output["output"]["session"]["mode"], "read_only");
-        assert!(output["output"]["session"]["session_id"]
-            .as_str()
-            .is_some_and(|id| id.starts_with("wc_sess_")));
-        executor.abort();
-    }
+    let mut resp = TestClient::post("http://localhost/api/tools/call")
+        .bearer_auth("secret")
+        .json(&json!({"tool": "start_coding_task", "params": advanced.clone()}))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&resp), StatusCode::OK);
+    let output: Value = resp.take_json().await.unwrap();
+    assert_eq!(output["success"], true, "{output}");
+    assert_eq!(output["output"]["detail"], "minimal");
+    assert_eq!(output["output"]["session"]["mode"], "read_only");
+    assert!(output["output"]["session"]["session_id"]
+        .as_str()
+        .is_some_and(|id| id.starts_with("wc_sess_")));
+
+    let mut rejected = TestClient::post("http://localhost/api/tools/call")
+        .bearer_auth("secret")
+        .json(&json!({"tool": "start_coding_task", "arguments": advanced}))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&rejected), StatusCode::BAD_REQUEST);
+    let rejected: Value = rejected.take_json().await.unwrap();
+    let error = rejected["error"].as_str().unwrap();
+    assert!(error.contains("arguments"));
+    assert!(error.contains("no longer supported"));
+    assert!(error.contains("params"));
+    executor.abort();
 }
 
 #[tokio::test]
@@ -1116,16 +1120,18 @@ fn extract_tool_call_params_precede_flattened_fields() {
 }
 
 #[test]
-fn extract_tool_call_arguments_precede_flattened_fields_without_params() {
-    let (tool, params) = extract_tool_call(&json!({
-        "tool": "git_status",
-        "project": "wrong",
-        "arguments": {"project": "right"},
-    }))
-    .unwrap();
-
-    assert_eq!(tool, "git_status");
-    assert_eq!(params, json!({"project": "right"}));
+fn extract_tool_call_rejects_retired_arguments_envelope() {
+    for arguments in [json!(null), json!({"project": "right"})] {
+        let error = extract_tool_call(&json!({
+            "tool": "git_status",
+            "project": "flattened",
+            "arguments": arguments,
+        }))
+        .unwrap_err();
+        assert!(error.contains("arguments"));
+        assert!(error.contains("no longer supported"));
+        assert!(error.contains("params"));
+    }
 }
 
 #[test]
@@ -1419,19 +1425,24 @@ async fn http_tools_call_rejects_malformed_and_unknown_request_matrix() {
 }
 
 #[tokio::test]
-async fn http_tools_call_accepts_omitted_null_and_alias_params() {
-    // Wrapper compatibility is HTTP-owned; ToolRuntime owns list_tools parsing.
+async fn http_tools_call_accepts_omitted_and_null_params_but_rejects_arguments_alias() {
     let (_tmp, service) = phase2_service();
     for request in [
         json!({"tool": "list_tools"}),
         json!({"tool": "list_tools", "params": null}),
-        json!({"tool": "list_tools", "arguments": null}),
     ] {
         let (status, body) = http_tool_call(&service, request.clone()).await;
         assert_eq!(status, StatusCode::OK, "request: {request}");
         assert_eq!(body["success"], true, "request: {request}");
         assert!(body["output"]["tools"].is_array(), "request: {request}");
     }
+
+    let request = json!({"tool": "list_tools", "arguments": null});
+    let (status, body) = http_tool_call(&service, request).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    let error = body["error"].as_str().unwrap();
+    assert!(error.contains("arguments"));
+    assert!(error.contains("no longer supported"));
 }
 
 #[tokio::test]
@@ -1843,23 +1854,23 @@ async fn session_summary_bounds_event_limit() {
 }
 
 #[tokio::test]
-async fn http_tools_call_params_wins_over_arguments() {
-    // `params` precedence is an HTTP wrapper contract; ToolRuntime owns the tool semantics.
+async fn http_tools_call_rejects_arguments_even_when_params_are_present() {
     let (_tmp, service) = phase2_service();
     let (status, body) = http_tool_call(
         &service,
         json!({
             "tool": "git_diff_summary",
-            "params": {"project": "agent:params-wins:p"},
-            "arguments": {"project": "agent:arguments-loses:p"},
+            "params": {"project": "agent:canonical:p"},
+            "arguments": {"project": "agent:retired:p"},
         }),
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert_eq!(body["success"], false);
     let error = body["error"].as_str().unwrap();
-    assert!(error.contains("params-wins"), "{error}");
-    assert!(!error.contains("arguments-loses"), "{error}");
+    assert!(error.contains("arguments"), "{error}");
+    assert!(error.contains("no longer supported"), "{error}");
+    assert!(!error.contains("agent:canonical:p"), "{error}");
+    assert!(!error.contains("agent:retired:p"), "{error}");
 }
 
 #[tokio::test]

--- a/src/tool_runtime/file_tools.rs
+++ b/src/tool_runtime/file_tools.rs
@@ -198,7 +198,6 @@ impl ToolRuntime {
                 encoding,
                 offset,
                 length,
-                max_bytes,
                 as_image,
             } => {
                 if as_image == Some(true) && !matches!(transport, SessionTransport::Mcp) {
@@ -206,10 +205,8 @@ impl ToolRuntime {
                         "as_image is only supported over MCP; omit it to use the existing chunked artifact response",
                     )
                 } else {
-                    self.read_project_artifact(
-                        project, path, encoding, offset, length, max_bytes, as_image,
-                    )
-                    .await
+                    self.read_project_artifact(project, path, encoding, offset, length, as_image)
+                        .await
                 }
             }
             ToolCall::ArtifactUploadBegin {

--- a/src/tool_runtime/files/artifacts.rs
+++ b/src/tool_runtime/files/artifacts.rs
@@ -717,7 +717,6 @@ impl ToolRuntime {
         encoding: Option<String>,
         offset: Option<usize>,
         length: Option<usize>,
-        max_bytes: Option<usize>,
         as_image: Option<bool>,
     ) -> ToolResult {
         if let Err(e) = validate_artifact_file_path(&path) {
@@ -728,23 +727,17 @@ impl ToolRuntime {
             return ToolResult::err("unsupported encoding; only 'base64' is currently supported");
         }
         let as_image = as_image.unwrap_or(false);
-        if as_image && (offset.is_some() || length.is_some() || max_bytes.is_some()) {
+        if as_image && (offset.is_some() || length.is_some()) {
             return ToolResult::err(
-                "as_image cannot be combined with offset, length, or max_bytes; the MCP image path always reads one complete bounded image",
+                "as_image cannot be combined with offset or length; the MCP image path always reads one complete bounded image",
             );
         }
         let offset = offset.unwrap_or(0);
-        let mut length = if as_image {
+        let length = if as_image {
             MAX_MCP_IMAGE_BYTES
         } else {
-            length.unwrap_or_else(|| max_bytes.unwrap_or(DEFAULT_READ_PROJECT_ARTIFACT_LENGTH))
+            length.unwrap_or(DEFAULT_READ_PROJECT_ARTIFACT_LENGTH)
         };
-        if let Some(max_bytes) = max_bytes {
-            if max_bytes == 0 {
-                return ToolResult::err("max_bytes must be at least 1");
-            }
-            length = length.min(max_bytes);
-        }
         if length == 0 {
             return ToolResult::err("length must be at least 1");
         }

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -108,8 +108,7 @@ pub use tool_call::{
     ToolCall,
 };
 pub(crate) use tool_call::{
-    TOOL_CALL_ARGUMENTS_FIELD, TOOL_CALL_PARAMS_FIELD, TOOL_CALL_TOOL_FIELD,
-    TOOL_CALL_WRAPPER_FIELDS,
+    TOOL_CALL_PARAMS_FIELD, TOOL_CALL_TOOL_FIELD, TOOL_CALL_WRAPPER_FIELDS,
 };
 #[cfg(test)]
 pub use tool_definition::is_known_tool_name;

--- a/src/tool_runtime/permissions/mod.rs
+++ b/src/tool_runtime/permissions/mod.rs
@@ -140,7 +140,7 @@ pub(crate) fn permission_summary_from_events(events: &[SessionEvent], limit: usi
     let mut events_total = 0usize;
     let mut required_count = 0usize;
     let mut auto_approved_count = 0usize;
-    let mut approved_count = 0usize;
+    let mut manual_approved_count = 0usize;
     let mut denied_count = 0usize;
     let mut pending_count = 0usize;
     let mut hard_denied_count = 0usize;
@@ -159,7 +159,7 @@ pub(crate) fn permission_summary_from_events(events: &[SessionEvent], limit: usi
         }
         match permission.status.as_str() {
             "auto_approved" => auto_approved_count += 1,
-            "approved" => approved_count += 1,
+            "approved" => manual_approved_count += 1,
             "denied" | "expired" => denied_count += 1,
             "requested" => pending_count += 1,
             "hard_denied" => hard_denied_count += 1,
@@ -175,7 +175,6 @@ pub(crate) fn permission_summary_from_events(events: &[SessionEvent], limit: usi
         }
     }
 
-    let manual_approved_count = approved_count;
     let total_approved_count = manual_approved_count + auto_approved_count;
     let config = EffectiveAuthorityConfig::from_env();
 
@@ -186,7 +185,6 @@ pub(crate) fn permission_summary_from_events(events: &[SessionEvent], limit: usi
         "auto_approved_count": auto_approved_count,
         "manual_approved_count": manual_approved_count,
         "total_approved_count": total_approved_count,
-        "approved_count": approved_count,
         "denied_count": denied_count,
         "pending_count": pending_count,
         "hard_denied_count": hard_denied_count,

--- a/src/tool_runtime/registry/input_schemas/artifacts.rs
+++ b/src/tool_runtime/registry/input_schemas/artifacts.rs
@@ -132,12 +132,6 @@ pub(crate) fn read_project_artifact_input_schema() -> Value {
             "Optional chunk length in bytes; defaults to 32768 and cannot exceed 65536.",
             false,
         ),
-        (
-            "max_bytes",
-            "integer",
-            "Compatibility alias/upper bound for length; cannot exceed 65536.",
-            false,
-        ),
     ]))
 }
 

--- a/src/tool_runtime/registry/output_schemas/common.rs
+++ b/src/tool_runtime/registry/output_schemas/common.rs
@@ -174,7 +174,6 @@ pub(crate) fn permission_summary_schema(description: &str) -> Value {
             "policy": schema_type("string", "Effective permission policy."),
             "events_total": schema_type("integer", "Permission-bearing ledger events counted."),
             "required_count": schema_type("integer", "Permission decisions that required approval handling."),
-            "approved_count": schema_type("integer", "Compatibility alias for manual_approved_count."),
             "manual_approved_count": schema_type("integer", "Manually approved decisions."),
             "auto_approved_count": schema_type("integer", "Automatically approved decisions."),
             "total_approved_count": schema_type("integer", "manual_approved_count plus auto_approved_count."),

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -1400,7 +1400,6 @@ async fn finish_coding_task_requires_explicit_session_and_returns_structured_fie
     assert_eq!(result.output["permissions"]["required_count"], 0);
     assert_eq!(result.output["permissions"]["auto_approved_count"], 0);
     assert_eq!(result.output["permissions"]["manual_approved_count"], 0);
-    assert_eq!(result.output["permissions"]["approved_count"], 0);
     assert_eq!(result.output["permissions"]["total_approved_count"], 0);
     assert!(result.output["permissions"]["recent"]
         .as_array()

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -109,7 +109,6 @@ async fn write_project_file_with_session_id_records_changed_path_without_content
     assert_eq!(handoff.output["permissions"]["required_count"], 1);
     assert_eq!(handoff.output["permissions"]["auto_approved_count"], 1);
     assert_eq!(handoff.output["permissions"]["manual_approved_count"], 0);
-    assert_eq!(handoff.output["permissions"]["approved_count"], 0);
     assert_eq!(handoff.output["permissions"]["total_approved_count"], 1);
     assert_eq!(
         handoff.output["permissions"]["recent"][0]["tool_name"],
@@ -155,7 +154,6 @@ async fn write_project_file_with_session_id_records_changed_path_without_content
     assert_eq!(finish.output["permissions"]["required_count"], 1);
     assert_eq!(finish.output["permissions"]["auto_approved_count"], 1);
     assert_eq!(finish.output["permissions"]["manual_approved_count"], 0);
-    assert_eq!(finish.output["permissions"]["approved_count"], 0);
     assert_eq!(finish.output["permissions"]["total_approved_count"], 1);
 }
 
@@ -4290,7 +4288,6 @@ async fn read_project_artifact_rejects_sensitive_path_before_resolving_project()
             None,
             None,
             None,
-            None,
         )
         .await;
     assert!(!out.success);
@@ -4306,7 +4303,6 @@ async fn read_project_artifact_rejects_invalid_length_before_resolving_project()
             None,
             None,
             Some(crate::tool_runtime::files::MAX_READ_PROJECT_ARTIFACT_LENGTH + 1),
-            None,
             None,
         )
         .await;

--- a/src/tool_runtime/tests/files_helpers.rs
+++ b/src/tool_runtime/tests/files_helpers.rs
@@ -197,7 +197,6 @@ async fn read_project_artifact_routes_to_agent_file_op() {
                     Some(5),
                     Some(7),
                     None,
-                    None,
                 )
                 .await
         }
@@ -257,7 +256,6 @@ async fn read_project_artifact_mcp_image_routes_complete_bounded_remote_read() {
                 .read_project_artifact(
                     project,
                     "docs/images/remote.png".to_string(),
-                    None,
                     None,
                     None,
                     None,
@@ -329,7 +327,6 @@ async fn read_project_artifact_mcp_image_rejects_untrusted_remote_mime() {
                     None,
                     None,
                     None,
-                    None,
                     Some(true),
                 )
                 .await
@@ -384,7 +381,6 @@ async fn read_project_artifact_image_mode_is_rejected_outside_mcp() {
                 encoding: None,
                 offset: None,
                 length: None,
-                max_bytes: None,
                 as_image: Some(true),
             },
             SessionTransport::Api,
@@ -619,7 +615,6 @@ async fn project_artifact_tools_require_file_capabilities() {
                 encoding: None,
                 offset: None,
                 length: None,
-                max_bytes: None,
                 as_image: None,
             },
             Some(&bootstrap),

--- a/src/tool_runtime/tests/handoff.rs
+++ b/src/tool_runtime/tests/handoff.rs
@@ -1737,7 +1737,6 @@ async fn session_handoff_summary_read_only_session_allowed() {
     assert_eq!(result.output["permissions"]["required_count"], 0);
     assert_eq!(result.output["permissions"]["auto_approved_count"], 0);
     assert_eq!(result.output["permissions"]["manual_approved_count"], 0);
-    assert_eq!(result.output["permissions"]["approved_count"], 0);
     assert_eq!(result.output["permissions"]["total_approved_count"], 0);
     assert!(result.output["permissions"]["recent"]
         .as_array()

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -133,7 +133,7 @@ async fn run_shell_session_events_record_exit_without_stdio_bodies() {
     assert_eq!(permission_summary["required_count"], 2);
     assert_eq!(permission_summary["auto_approved_count"], 2);
     assert_eq!(permission_summary["manual_approved_count"], 0);
-    assert_eq!(permission_summary["approved_count"], 0);
+    assert!(permission_summary.get("approved_count").is_none());
     assert_eq!(permission_summary["total_approved_count"], 2);
     let failed = summary
         .events

--- a/src/tool_runtime/tests/schema/artifacts.rs
+++ b/src/tool_runtime/tests/schema/artifacts.rs
@@ -1,6 +1,27 @@
 use super::*;
 
 #[test]
+fn read_project_artifact_uses_only_canonical_length_bound() {
+    let specs = registered_tool_specs();
+    let spec = spec_named(&specs, "read_project_artifact");
+    let props = spec.input_schema["properties"].as_object().unwrap();
+    assert!(props.contains_key("length"));
+    assert!(
+        !props.contains_key("max_bytes"),
+        "read_project_artifact must not advertise the retired max_bytes alias"
+    );
+
+    let error = ToolCall::from_tool_name(
+        "read_project_artifact",
+        json!({"project": "agent:test:demo", "path": "artifact.bin", "max_bytes": 32}),
+    )
+    .unwrap_err();
+    assert!(error.contains("max_bytes"));
+    assert!(error.contains("no longer supported"));
+    assert!(error.contains("length"));
+}
+
+#[test]
 fn read_project_artifact_metadata_schema_exposes_allow_missing() {
     let specs = registered_tool_specs();
     let spec = spec_named(&specs, "read_project_artifact_metadata");

--- a/src/tool_runtime/tests/schema/flattened_args.rs
+++ b/src/tool_runtime/tests/schema/flattened_args.rs
@@ -227,8 +227,8 @@ fn openapi_generic_call_runtime_tool_schema_remains_strict_model_visible_surface
         "ToolCallRequest.properties must keep params for non-Action clients"
     );
     assert!(
-        properties.contains_key(TOOL_CALL_ARGUMENTS_FIELD),
-        "ToolCallRequest.properties must keep arguments alias"
+        !properties.contains_key("arguments"),
+        "ToolCallRequest.properties must not retain the retired arguments alias"
     );
 
     let tool_property = &properties[TOOL_CALL_TOOL_FIELD];
@@ -309,10 +309,6 @@ fn explicit_tool_call_request_extra_fields() -> BTreeMap<&'static str, &'static 
         (
             TOOL_CALL_PARAMS_FIELD,
             "non-Action object argument envelope with arbitrary tool-specific keys",
-        ),
-        (
-            TOOL_CALL_ARGUMENTS_FIELD,
-            "params compatibility alias for non-Action clients",
         ),
         (
             crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD,

--- a/src/tool_runtime/tests/schema/outputs.rs
+++ b/src/tool_runtime/tests/schema/outputs.rs
@@ -1965,13 +1965,16 @@ fn session_handoff_summary_schema_exposes_ledger_validation_summary() {
 fn assert_permission_summary_schema_fields(schema: &Value) {
     let props = schema["properties"].as_object().unwrap();
     for field in [
-        "approved_count",
         "manual_approved_count",
         "auto_approved_count",
         "total_approved_count",
     ] {
         assert!(props.contains_key(field), "permissions missing {field}");
     }
+    assert!(
+        !props.contains_key("approved_count"),
+        "permission schema must not retain the approved_count compatibility alias"
+    );
 }
 
 fn assert_job_lifecycle_summary_schema_fields(schema: &Value) {

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -4843,7 +4843,6 @@ impl ToolCall {
                 encoding,
                 offset,
                 length,
-                max_bytes,
                 as_image,
                 ..
             } => serde_json::json!({
@@ -4852,7 +4851,6 @@ impl ToolCall {
                 "encoding": encoding,
                 "offset": offset,
                 "length": length,
-                "max_bytes": max_bytes,
                 "as_image": as_image,
             }),
             Self::ArtifactUploadBegin {

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -24,12 +24,8 @@ use std::collections::{BTreeMap, HashSet};
 
 pub(crate) const TOOL_CALL_TOOL_FIELD: &str = "tool";
 pub(crate) const TOOL_CALL_PARAMS_FIELD: &str = "params";
-pub(crate) const TOOL_CALL_ARGUMENTS_FIELD: &str = "arguments";
-pub(crate) const TOOL_CALL_WRAPPER_FIELDS: &[&str] = &[
-    TOOL_CALL_TOOL_FIELD,
-    TOOL_CALL_PARAMS_FIELD,
-    TOOL_CALL_ARGUMENTS_FIELD,
-];
+pub(crate) const TOOL_CALL_WRAPPER_FIELDS: &[&str] =
+    &[TOOL_CALL_TOOL_FIELD, TOOL_CALL_PARAMS_FIELD];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -1533,8 +1529,6 @@ pub enum ToolCall {
         #[serde(default)]
         length: Option<usize>,
         #[serde(default)]
-        max_bytes: Option<usize>,
-        #[serde(default)]
         as_image: Option<bool>,
     },
 
@@ -2021,7 +2015,6 @@ fn reject_unknown_start_coding_task_fields(arguments: &Value) -> Result<(), Stri
         // Wrapper/session metadata that transports may leave in params.
         "session_id",
         "recording_session_id",
-        "_session_id",
     ];
     let Some(object) = arguments.as_object() else {
         return Ok(());
@@ -2136,7 +2129,6 @@ fn reject_unknown_read_files_fields(arguments: &Value) -> Result<(), String> {
         "max_result_bytes",
         // Wrapper/session metadata that transports may leave in params.
         "recording_session_id",
-        "_session_id",
     ];
     let Some(object) = arguments.as_object() else {
         return Ok(());
@@ -2163,7 +2155,6 @@ fn reject_unknown_observe_jobs_fields(arguments: &Value) -> Result<(), String> {
         // Wrapper/session metadata that transports may leave in params.
         "session_id",
         "recording_session_id",
-        "_session_id",
     ];
     let Some(object) = arguments.as_object() else {
         return Ok(());
@@ -2190,7 +2181,6 @@ fn reject_unknown_search_project_texts_fields(arguments: &Value) -> Result<(), S
         "max_result_bytes",
         // Wrapper/session metadata that transports may leave in params.
         "recording_session_id",
-        "_session_id",
     ];
     let Some(object) = arguments.as_object() else {
         return Ok(());
@@ -2222,7 +2212,6 @@ fn reject_unknown_git_diff_hunks_fields(arguments: &Value) -> Result<(), String>
         "session_id",
         // Wrapper/session metadata that transports may leave in params.
         "recording_session_id",
-        "_session_id",
     ];
     let Some(object) = arguments.as_object() else {
         return Ok(());
@@ -2334,6 +2323,16 @@ impl ToolCall {
         validate_model_facing_assertion_name(name, &arguments)?;
         let recorder_metadata = ToolCallRecorderMetadata::from_arguments(&arguments);
         let arguments = strip_tool_call_expectation_metadata(arguments);
+        if name == "read_project_artifact"
+            && arguments
+                .as_object()
+                .is_some_and(|object| object.contains_key("max_bytes"))
+        {
+            return Err(
+                "invalid arguments for tool 'read_project_artifact': field 'max_bytes' is no longer supported; use 'length'"
+                    .to_string(),
+            );
+        }
         if name == "start_coding_task" {
             reject_unknown_start_coding_task_fields(&arguments)?;
             validate_coding_project_source_shape(name, &arguments, true)?;


### PR DESCRIPTION
## Summary

- remove the retired MCP `_session_id` wrapper alias; `recording_session_id` is the canonical recorder field
- remove the HTTP `/api/tools/call` `arguments` wrapper alias; direct callers use `params`, while GPT Actions keep flattened top-level arguments
- remove the duplicate `approved_count` permission-summary field in favor of `manual_approved_count`, `auto_approved_count`, and `total_approved_count`
- remove the model/API `read_project_artifact.max_bytes` alias in favor of `length`
- reject all four retired inputs explicitly instead of silently ignoring them

The cleanup is intentionally limited to these public compatibility aliases. MCP JSON-RPC/adaptive-gateway `arguments`, MCP transport session handling, and internal Runner/file-protocol `max_bytes` fields remain unchanged.

## Validation

- MCP tests: 148 passed
- runtime HTTP tests: 83 passed
- OpenAPI tests: 47 passed
- artifact schema tests: 3 passed
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p webcodex --lib`: 3210 passed, 0 failed
