### PR TITLE
Improve adaptive runtime tool surface ergonomics

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -92,7 +92,10 @@ explicitly select `adaptive_runtime` with
 `WEBCODEX_MCP_MODEL_SURFACE=adaptive-runtime-v1`, or `full_operator_runtime` with
 `WEBCODEX_MCP_MODEL_SURFACE=full-operator-v1`. `adaptive_runtime` keeps a small
 high-frequency coding core directly typed in `tools/list` and exposes one
-`call_runtime_tool` gateway for discovered long-tail runtime tools. The gateway
+`call_runtime_tool` gateway for discovered long-tail runtime tools. Repeated-loop
+primitives such as `read_files`, `run_process`, and `observe_jobs` stay direct;
+less frequent convenience tools such as `list_projects`, `project_overview`,
+`run_script`, `validation_summary`, and `git_status` stay behind the gateway. The gateway
 only changes model-facing schema admission: the selected target still uses its
 normal OAuth scope, project authority, permission gate, argument validation,
 effect semantics, and explicit Session/ACK handling. These names describe

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -97,11 +97,13 @@ primitives such as `read_files`, `run_process`, and `observe_jobs` stay direct;
 less frequent convenience tools such as `list_projects`, `project_overview`,
 `run_script`, `validation_summary`, and `git_status` stay behind the gateway. After
 compact discovery, `tool_manifest(tool_name="<exact-name>")` returns exactly one
-tool's description, input schema, and annotations without expanding its output
-schema; the selected name can then be passed to `call_runtime_tool`. The gateway
-only changes model-facing schema admission: the selected target still uses its
-normal OAuth scope, project authority, permission gate, argument validation,
-effect semantics, and explicit Session/ACK handling. These names describe
+tool's description, input schema, annotations, and current MCP surface routing
+without expanding its output schema. `availability` is `direct`, `gateway`, or
+`unavailable`; `gateway_tool` is `call_runtime_tool` only for the gateway case.
+These fields describe invocation routing, not authorization or feature readiness.
+The selected target still uses its normal OAuth scope, project authority,
+permission gate, argument validation, effect semantics, and explicit Session/ACK
+handling. These names describe
 protocol/tool contracts; a first-time user does not need to choose among them.
 
 Model-facing failures may add a small recovery-control vocabulary without replacing existing subsystem fields. `error_kind` identifies what failed. `failure_kind`, when present, retains execution/effect/validation semantics such as `not_started`, `timeout`, or `outcome_unknown`. `recovery_kind` is the closed class of the next safe action: `fix_input`, `retry_same`, `reobserve`, `reconcile`, `wait`, `user_action`, or `none`. `recovery_tool`, when present, is a bounded public WebCodex tool for an explicit re-observation or reconciliation step; it never grants authority or triggers execution. `outcome_unknown` is not retry permission. `retry_same` is reserved for an exact idempotent replay contract and must not be interpreted as an ordinary repeat of an effect.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -95,7 +95,10 @@ high-frequency coding core directly typed in `tools/list` and exposes one
 `call_runtime_tool` gateway for discovered long-tail runtime tools. Repeated-loop
 primitives such as `read_files`, `run_process`, and `observe_jobs` stay direct;
 less frequent convenience tools such as `list_projects`, `project_overview`,
-`run_script`, `validation_summary`, and `git_status` stay behind the gateway. The gateway
+`run_script`, `validation_summary`, and `git_status` stay behind the gateway. After
+compact discovery, `tool_manifest(tool_name="<exact-name>")` returns exactly one
+tool's description, input schema, and annotations without expanding its output
+schema; the selected name can then be passed to `call_runtime_tool`. The gateway
 only changes model-facing schema admission: the selected target still uses its
 normal OAuth scope, project authority, permission gate, argument validation,
 effect semantics, and explicit Session/ACK handling. These names describe

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -84,7 +84,9 @@ surface；没有 Connector 配置时默认是更宽的 `local_coding`。operator
 `WEBCODEX_MCP_MODEL_SURFACE=adaptive-runtime-v1` 显式选择 `adaptive_runtime`，或通过
 `WEBCODEX_MCP_MODEL_SURFACE=full-operator-v1` 选择 `full_operator_runtime`。`adaptive_runtime`
 只把高频 coding core 直接放进 `tools/list`，低频 runtime tool 则通过
-`call_runtime_tool` gateway 调用；gateway 只改变 model-facing schema admission，不改变
+`call_runtime_tool` gateway 调用。`read_files`、`run_process`、`observe_jobs` 这类反复出现在
+coding loop 中的原语保持 direct；`list_projects`、`project_overview`、`run_script`、
+`validation_summary`、`git_status` 这类低频便利工具放在 gateway 后面。gateway 只改变 model-facing schema admission，不改变
 目标 tool 原有的 OAuth scope、project authority、permission gate、参数校验、effect 或
 Session/ACK 语义。这些名称描述 protocol/tool contract；第一次用户不需要先做选择。
 

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -86,8 +86,10 @@ surface；没有 Connector 配置时默认是更宽的 `local_coding`。operator
 只把高频 coding core 直接放进 `tools/list`，低频 runtime tool 则通过
 `call_runtime_tool` gateway 调用。`read_files`、`run_process`、`observe_jobs` 这类反复出现在
 coding loop 中的原语保持 direct；`list_projects`、`project_overview`、`run_script`、
-`validation_summary`、`git_status` 这类低频便利工具放在 gateway 后面。gateway 只改变 model-facing schema admission，不改变
-目标 tool 原有的 OAuth scope、project authority、permission gate、参数校验、effect 或
+`validation_summary`、`git_status` 这类低频便利工具放在 gateway 后面。compact discovery 后可用
+`tool_manifest(tool_name="<exact-name>")` 只读取一个工具的 description、input schema 和
+annotations，不展开庞大的 output schema；随后把该名称交给 `call_runtime_tool`。gateway 只改变
+model-facing schema admission，不改变目标 tool 原有的 OAuth scope、project authority、permission gate、参数校验、effect 或
 Session/ACK 语义。这些名称描述 protocol/tool contract；第一次用户不需要先做选择。
 
 Hosted client 需要公网 HTTPS：`share` 默认提供临时 Cloudflare Quick Tunnel，`connect` 使用

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -87,10 +87,11 @@ surface；没有 Connector 配置时默认是更宽的 `local_coding`。operator
 `call_runtime_tool` gateway 调用。`read_files`、`run_process`、`observe_jobs` 这类反复出现在
 coding loop 中的原语保持 direct；`list_projects`、`project_overview`、`run_script`、
 `validation_summary`、`git_status` 这类低频便利工具放在 gateway 后面。compact discovery 后可用
-`tool_manifest(tool_name="<exact-name>")` 只读取一个工具的 description、input schema 和
-annotations，不展开庞大的 output schema；随后把该名称交给 `call_runtime_tool`。gateway 只改变
-model-facing schema admission，不改变目标 tool 原有的 OAuth scope、project authority、permission gate、参数校验、effect 或
-Session/ACK 语义。这些名称描述 protocol/tool contract；第一次用户不需要先做选择。
+`tool_manifest(tool_name="<exact-name>")` 只读取一个工具的 description、input schema、
+annotations 与当前 MCP surface routing，不展开庞大的 output schema。`availability` 明确为
+`direct`、`gateway` 或 `unavailable`；只有 `gateway` 时 `gateway_tool` 才是
+`call_runtime_tool`。这些字段只描述调用路由，不代表授权或 feature readiness；目标 tool 原有的
+OAuth scope、project authority、permission gate、参数校验、effect 与 Session/ACK 语义保持不变。这些名称描述 protocol/tool contract；第一次用户不需要先做选择。
 
 Hosted client 需要公网 HTTPS：`share` 默认提供临时 Cloudflare Quick Tunnel，`connect` 使用
 已有 hosted Server，自托管部署则提供自己的稳定 HTTPS origin。不要把 bootstrap/admin token、

--- a/docs/agent/openapi-guidelines.md
+++ b/docs/agent/openapi-guidelines.md
@@ -58,9 +58,12 @@ or implementation-only fields into the model-facing Action schema.
   Action.
 - `listRuntimeTools` full detail discovery includes expanded schemas and may be
   too large for GPT Actions. Daily discovery should prefer
-  `callRuntimeTool(tool="tool_manifest")`; focused `listRuntimeTools` calls
-  should pass `summary_only=true` with `category`, `features`, or `limit`.
-  Prefer `runtime_status` or the tool manifest for the current tool count; the
+  `callRuntimeTool(tool="tool_manifest")`; once the exact target is known, pass
+  `tool_name=<exact-name>` to that manifest call to retrieve only its description,
+  input schema, and annotations. Full output schemas stay out of this exact view.
+  Focused `listRuntimeTools` calls should be reserved for schema/debug work and
+  pass `summary_only=true` with `category`, `features`, or `limit`. Prefer
+  `runtime_status` or the tool manifest for the current tool count; the
   response-size issue is expanded schema/metadata, not a fixed tool count.
 
 ---

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -7,6 +7,7 @@ use super::tasks;
 use super::{require_mcp_scope, scope_forbidden, McpOutcome};
 use crate::auth::AuthContext;
 use crate::connector_runtime::{ConnectorRuntime, ConnectorTransport};
+pub(super) use crate::model_surface::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME;
 use crate::model_surface::{ModelSurface, ADAPTIVE_RUNTIME_CORE_TOOL_NAMES};
 use crate::tool_request_trace::ToolRequestLifecycle;
 use crate::tool_runtime::kernel::{
@@ -22,8 +23,6 @@ use crate::tool_runtime::ToolResult;
 use crate::tool_runtime::{registered_tool_specs, ToolRuntime, ToolSpec};
 use serde::Deserialize;
 use serde_json::{json, Value};
-
-pub(super) const ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME: &str = "call_runtime_tool";
 
 fn filter_specs_for_oauth(mut specs: Vec<ToolSpec>, auth: Option<&AuthContext>) -> Vec<ToolSpec> {
     if auth.is_some_and(AuthContext::is_oauth_token) {

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -265,8 +265,13 @@ async fn adaptive_runtime_tools_list_is_small_core_plus_gateway() {
     );
     for long_tail in [
         "list_tools",
+        "list_projects",
+        "project_overview",
         "read_file",
+        "run_script",
         "run_shell",
+        "validation_summary",
+        "git_status",
         "goto_definition",
         "computer_list_windows",
         "post_session_message",

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -417,6 +417,16 @@ async fn adaptive_runtime_tool_manifest_describes_one_long_tail_contract_without
     let output = &value["result"]["structuredContent"]["output"];
     assert_eq!(output["tool_name"], "run_script");
     assert_eq!(output["contract"]["name"], "run_script");
+    assert_eq!(output["contract"]["availability"], "gateway");
+    assert_eq!(
+        output["contract"]["gateway_tool"],
+        crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME
+    );
+    assert_eq!(output["tools"][0]["availability"], "gateway");
+    assert_eq!(
+        output["tools"][0]["gateway_tool"],
+        crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME
+    );
     assert_eq!(output["contract"]["input_schema"]["type"], "object");
     assert!(output["contract"]["input_schema"]["properties"]["script"].is_object());
     assert!(output["contract"].get("output_schema").is_none());

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -391,6 +391,53 @@ async fn adaptive_runtime_gateway_rejects_recursive_and_unknown_targets() {
 }
 
 #[tokio::test]
+async fn adaptive_runtime_tool_manifest_describes_one_long_tail_contract_without_expanding_surface()
+{
+    let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let described = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(724)),
+            mcp_2026_params(json!({
+                "name": "tool_manifest",
+                "arguments": {
+                    "tool_name": "run_script",
+                    "include_recommended_flows": false,
+                    "include_risk_summary": false
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = described else {
+        panic!("adaptive tool_manifest exact contract must succeed");
+    };
+    let output = &value["result"]["structuredContent"]["output"];
+    assert_eq!(output["tool_name"], "run_script");
+    assert_eq!(output["contract"]["name"], "run_script");
+    assert_eq!(output["contract"]["input_schema"]["type"], "object");
+    assert!(output["contract"]["input_schema"]["properties"]["script"].is_object());
+    assert!(output["contract"].get("output_schema").is_none());
+
+    let listed = handle_mcp_request(
+        &runtime,
+        rpc("tools/list", Some(json!(725)), mcp_2026_params(json!({}))),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(listed) = listed else {
+        panic!("adaptive tools/list must remain available");
+    };
+    assert!(!listed["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|tool| tool["name"] == "run_script"));
+}
+
+#[tokio::test]
 async fn full_operator_explicit_surface_lists_full_runtime_and_dispatches() {
     let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let listed = handle_mcp_request(
@@ -621,6 +668,7 @@ async fn local_coding_list_manifest_and_catalog_are_identical() {
         .collect();
     let manifest = runtime
         .dispatch(crate::tool_runtime::ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: Some("coding".to_string()),
             include_recommended_flows: false,

--- a/src/model_surface.rs
+++ b/src/model_surface.rs
@@ -14,7 +14,7 @@
 //!   falls through to another surface.
 
 use crate::connector_runtime::ConnectorContext;
-use crate::tool_runtime::tool_definition::LOCAL_CODING_TOOL_NAMES;
+use crate::tool_runtime::tool_definition::{is_model_visible_tool_name, LOCAL_CODING_TOOL_NAMES};
 use crate::tool_runtime::{registered_tool_specs, ToolSpec};
 
 pub(crate) const MODEL_SURFACE_LOCAL_CODING: &str = "local_coding";
@@ -26,6 +26,11 @@ pub(crate) const MCP_MODEL_SURFACE_ENV: &str = "WEBCODEX_MCP_MODEL_SURFACE";
 pub(crate) const MCP_MODEL_SURFACE_LOCAL_CODING_V1: &str = "local-coding-v1";
 pub(crate) const MCP_MODEL_SURFACE_ADAPTIVE_RUNTIME_V1: &str = "adaptive-runtime-v1";
 pub(crate) const MCP_MODEL_SURFACE_FULL_OPERATOR_V1: &str = "full-operator-v1";
+
+pub(crate) const ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME: &str = "call_runtime_tool";
+pub(crate) const TOOL_SURFACE_AVAILABILITY_DIRECT: &str = "direct";
+pub(crate) const TOOL_SURFACE_AVAILABILITY_GATEWAY: &str = "gateway";
+pub(crate) const TOOL_SURFACE_AVAILABILITY_UNAVAILABLE: &str = "unavailable";
 
 /// Small typed surface for hosts that can discover a long-tail runtime gateway lazily.
 /// Keep high-frequency coding operations direct; advanced domains remain reachable
@@ -70,6 +75,41 @@ impl ModelSurface {
     /// surface even though their individual schemas are hidden behind one gateway.
     pub(crate) fn supports_operator_extensions(self) -> bool {
         matches!(self, Self::AdaptiveRuntime | Self::FullOperatorRuntime)
+    }
+
+    /// Model-surface routing for one registered model-visible runtime tool.
+    /// This does not grant OAuth scope, project authority, feature availability,
+    /// or permission; those remain enforced by the selected tool at invocation.
+    pub(crate) fn runtime_tool_invocation_route(
+        self,
+        tool_name: &str,
+    ) -> (&'static str, Option<&'static str>) {
+        if !is_model_visible_tool_name(tool_name) {
+            return (TOOL_SURFACE_AVAILABILITY_UNAVAILABLE, None);
+        }
+        match self {
+            Self::LocalCoding => {
+                if LOCAL_CODING_TOOL_NAMES.contains(&tool_name) {
+                    (TOOL_SURFACE_AVAILABILITY_DIRECT, None)
+                } else {
+                    (TOOL_SURFACE_AVAILABILITY_UNAVAILABLE, None)
+                }
+            }
+            Self::AdaptiveRuntime => {
+                if ADAPTIVE_RUNTIME_CORE_TOOL_NAMES.contains(&tool_name) {
+                    (TOOL_SURFACE_AVAILABILITY_DIRECT, None)
+                } else {
+                    (
+                        TOOL_SURFACE_AVAILABILITY_GATEWAY,
+                        Some(ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME),
+                    )
+                }
+            }
+            Self::FullOperatorRuntime => (TOOL_SURFACE_AVAILABILITY_DIRECT, None),
+            // canonical_connector uses its own capability names rather than raw
+            // runtime-tool names, so runtime contracts are not directly invokable.
+            Self::CanonicalConnector => (TOOL_SURFACE_AVAILABILITY_UNAVAILABLE, None),
+        }
     }
 }
 

--- a/src/model_surface.rs
+++ b/src/model_surface.rs
@@ -32,21 +32,16 @@ pub(crate) const MCP_MODEL_SURFACE_FULL_OPERATOR_V1: &str = "full-operator-v1";
 /// through the adaptive MCP gateway without expanding their schemas into tools/list.
 pub(crate) const ADAPTIVE_RUNTIME_CORE_TOOL_NAMES: &[&str] = &[
     "work_on_project",
-    "list_projects",
     "runtime_status",
     "tool_manifest",
-    "project_overview",
     "search_project_texts",
     "read_files",
     "apply_text_edits",
     "run_process",
-    "run_script",
     "observe_jobs",
     "cargo_check",
     "cargo_test",
     "go_test",
-    "validation_summary",
-    "git_status",
     "git_review_summary",
     "show_changes",
     "workspace_hygiene_check",
@@ -181,7 +176,7 @@ mod tests {
     fn adaptive_runtime_core_is_small_unique_and_fully_registered() {
         assert_eq!(
             ADAPTIVE_RUNTIME_CORE_TOOL_NAMES.len(),
-            20,
+            15,
             "adaptive core size is an intentional model-admission budget"
         );
         let mut seen = std::collections::HashSet::new();

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -1032,6 +1032,7 @@ fn openapi_call_runtime_tool_exposes_only_canonical_params_envelope() {
 
 #[test]
 fn openapi_call_runtime_tool_declares_flattened_action_fields() {
+    // `tool_name` is a tool_manifest argument, distinct from the outer `tool` selector.
     let spec = build_openapi_spec();
     let tool_call = &spec["components"]["schemas"]["ToolCallRequest"];
     let properties = tool_call["properties"].as_object().unwrap();
@@ -1055,6 +1056,7 @@ fn openapi_call_runtime_tool_declares_flattened_action_fields() {
 
     assert!(properties.contains_key(TOOL_CALL_PARAMS_FIELD));
     assert!(!properties.contains_key("arguments"));
+    assert_eq!(properties["tool_name"]["type"], "string");
     assert!(
         !properties.contains_key("allow_cross_project_session"),
         "ToolCallRequest must not publish the cross-project debug escape as a flattened Action field"

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -752,6 +752,29 @@ async fn flattened_tool_manifest_audit_intent_survives_null_params_wrapper() {
 }
 
 #[tokio::test]
+async fn flattened_tool_manifest_exact_name_survives_null_params_wrapper() {
+    let (tool, params) = extract_tool_call(&json!({
+        "tool": "tool_manifest",
+        "params": null,
+        "tool_name": "cargo_test",
+        "include_recommended_flows": false,
+        "include_risk_summary": false,
+    }))
+    .unwrap();
+    let call = ToolCall::from_tool_name(&tool, params).unwrap();
+    let tmp_proj = tempfile::tempdir().unwrap();
+    let runtime = runtime_with_local_project(tmp_proj.path(), "demo");
+
+    let result = runtime.dispatch(call).await;
+
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["tool_name"], "cargo_test");
+    assert_eq!(result.output["contract"]["name"], "cargo_test");
+    assert_eq!(result.output["contract"]["input_schema"]["type"], "object");
+    assert!(result.output["contract"].get("output_schema").is_none());
+}
+
+#[tokio::test]
 async fn http_start_coding_task_retirement_precedes_flattened_legacy_params() {
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();

--- a/src/tool_runtime/discovery_tools.rs
+++ b/src/tool_runtime/discovery_tools.rs
@@ -49,12 +49,14 @@ impl ToolRuntime {
                     .await
             }
             ToolCall::ToolManifest {
+                tool_name,
                 category,
                 intent,
                 include_recommended_flows,
                 include_risk_summary,
             } => {
                 self.tool_manifest(
+                    tool_name,
                     category,
                     intent,
                     include_recommended_flows,

--- a/src/tool_runtime/registry/input_schemas/discovery.rs
+++ b/src/tool_runtime/registry/input_schemas/discovery.rs
@@ -37,6 +37,12 @@ pub(crate) fn tool_manifest_input_schema() -> Value {
     json!({
         "type": "object",
         "properties": {
+            "tool_name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "description": "Optional exact model-visible runtime tool name. Returns one precise contract with description, input_schema, and annotations, without the output schema. Cannot be combined with category or intent."
+            },
             "category": {
                 "type": "string",
                 "description": "Optional category filter (e.g. session, edit, git, checkpoint, runtime, job, validation). Distinct from intent."

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -231,6 +231,30 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
             ),
             (
+                "tool_name",
+                nullable_schema("string", "Exact requested tool name in one-tool contract mode, or null."),
+            ),
+            (
+                "contract",
+                json!({
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "description": "Exact one-tool contract containing name, description, input_schema, and annotations. output_schema is intentionally omitted.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "name": {"type": "string"},
+                                "description": {"type": "string"},
+                                "input_schema": {"type": "object", "additionalProperties": true},
+                                "annotations": {"type": "object", "additionalProperties": true}
+                            },
+                            "required": ["name", "description", "input_schema", "annotations"]
+                        },
+                        {"type": "null"}
+                    ]
+                }),
+            ),
+            (
                 "category",
                 nullable_schema(
                     "string",

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -240,15 +240,27 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "anyOf": [
                         {
                             "type": "object",
-                            "description": "Exact one-tool contract containing name, description, input_schema, and annotations. output_schema is intentionally omitted.",
+                            "description": "Exact one-tool contract containing name, description, input_schema, annotations, and current MCP model-surface invocation routing. output_schema is intentionally omitted.",
                             "additionalProperties": false,
                             "properties": {
                                 "name": {"type": "string"},
                                 "description": {"type": "string"},
                                 "input_schema": {"type": "object", "additionalProperties": true},
-                                "annotations": {"type": "object", "additionalProperties": true}
+                                "annotations": {"type": "object", "additionalProperties": true},
+                                "availability": {
+                                    "type": "string",
+                                    "enum": ["direct", "gateway", "unavailable"],
+                                    "description": "Invocation route on the current MCP ModelSurface only; authorization, feature gates, and project authority are checked separately."
+                                },
+                                "gateway_tool": {
+                                    "anyOf": [
+                                        {"type": "string", "const": "call_runtime_tool"},
+                                        {"type": "null"}
+                                    ],
+                                    "description": "call_runtime_tool only when availability=gateway; otherwise null."
+                                }
                             },
-                            "required": ["name", "description", "input_schema", "annotations"]
+                            "required": ["name", "description", "input_schema", "annotations", "availability", "gateway_tool"]
                         },
                         {"type": "null"}
                     ]
@@ -318,7 +330,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 "tools",
                 array_schema(
                     open_object_schema(
-                        "Compact tool entry: name, category, accepted_flattened_args, deprecated_or_unsupported_args, provider, risk, read_only, requires_project, path_hint, destructive, shell_like, oauth_scope.",
+                        "Compact tool entry: name, category, accepted_flattened_args, deprecated_or_unsupported_args, provider, risk, read_only, requires_project, path_hint, destructive, shell_like, oauth_scope, availability, gateway_tool. availability is MCP ModelSurface routing only, not authorization."
                     ),
                     "Compact tool entries without input/output schemas.",
                 ),

--- a/src/tool_runtime/surface.rs
+++ b/src/tool_runtime/surface.rs
@@ -178,6 +178,9 @@ impl ToolRuntime {
             return Err(unknown_tool_manifest_tool_result(tool_name));
         };
         let category = runtime_tool_category(spec.name.as_str());
+        let (availability, gateway_tool) = self
+            .model_surface()
+            .runtime_tool_invocation_route(spec.name.as_str());
         let mut exact_categories = serde_json::Map::new();
         exact_categories.insert(category.to_string(), json!([spec.name]));
         let mut output = json!({
@@ -193,6 +196,8 @@ impl ToolRuntime {
                 "description": spec.description,
                 "input_schema": spec.input_schema,
                 "annotations": spec.annotations,
+                "availability": availability,
+                "gateway_tool": gateway_tool,
             },
             "category": category,
             "intent": Value::Null,
@@ -205,7 +210,7 @@ impl ToolRuntime {
             "limit_applied": false,
             "requested_limit": Value::Null,
             "categories": Value::Object(exact_categories),
-            "tools": [compact_manifest_tool_entry(spec)],
+            "tools": [compact_manifest_tool_entry(spec, self.model_surface())],
         });
         if include_risk_summary {
             output["risk_summary"] = build_risk_summary(&[spec]);
@@ -298,9 +303,10 @@ impl ToolRuntime {
             None => filtered_specs,
         };
         let risk_summary = include_risk_summary.then(|| build_risk_summary(&returned_specs));
+        let model_surface = self.model_surface();
         let tools: Vec<Value> = returned_specs
             .iter()
-            .map(|spec| compact_manifest_tool_entry(spec))
+            .map(|spec| compact_manifest_tool_entry(spec, model_surface))
             .collect();
 
         let mut output = json!({
@@ -474,9 +480,13 @@ pub(super) fn build_list_tools_summary_entries(specs: &[ToolSpec]) -> Vec<Value>
         .collect()
 }
 
-pub(super) fn compact_manifest_tool_entry(spec: &ToolSpec) -> Value {
+pub(super) fn compact_manifest_tool_entry(
+    spec: &ToolSpec,
+    model_surface: crate::model_surface::ModelSurface,
+) -> Value {
     let name = spec.name.as_str();
     let m = runtime_tool_metadata(name);
+    let (availability, gateway_tool) = model_surface.runtime_tool_invocation_route(name);
     json!({
         "name": name,
         "category": runtime_tool_category(name),
@@ -490,6 +500,8 @@ pub(super) fn compact_manifest_tool_entry(spec: &ToolSpec) -> Value {
         "destructive": m.destructive,
         "shell_like": m.shell_like,
         "oauth_scope": m.legacy_oauth_scope_hint,
+        "availability": availability,
+        "gateway_tool": gateway_tool,
     })
 }
 

--- a/src/tool_runtime/surface.rs
+++ b/src/tool_runtime/surface.rs
@@ -122,14 +122,14 @@ impl ToolRuntime {
         output
     }
 
-    /// Return a compact, bounded tool manifest with categories, risk summary,
-    /// recommended flows, and optional intent-shaped tool views. Read-only
-    /// runtime introspection; never exposes full input/output schemas, tokens,
-    /// secrets, or internal paths. Intent views only filter and rank discovery
-    /// output; they do not change tool behavior, policy, permissions,
-    /// execution, or finish verdict semantics. Intended as a lightweight
-    /// alternative to `list_tools` for long-running tasks where the full
-    /// schemas cause ResponseTooLargeError.
+    /// Return compact, bounded runtime discovery. List/filter mode stays
+    /// schema-free; exact tool_name mode exposes one tool's input schema while
+    /// intentionally omitting its output schema. Never exposes tokens, secrets,
+    /// or internal paths. Intent views only filter and rank discovery output;
+    /// they do not change tool behavior, policy, permissions, execution, or
+    /// finish verdict semantics. Intended as a lightweight alternative to
+    /// `list_tools` for long-running tasks where full catalog schemas cause
+    /// ResponseTooLargeError.
     pub(super) async fn tool_manifest(
         &self,
         tool_name: Option<String>,

--- a/src/tool_runtime/surface.rs
+++ b/src/tool_runtime/surface.rs
@@ -132,11 +132,25 @@ impl ToolRuntime {
     /// schemas cause ResponseTooLargeError.
     pub(super) async fn tool_manifest(
         &self,
+        tool_name: Option<String>,
         category: Option<String>,
         intent: Option<String>,
         include_recommended_flows: bool,
         include_risk_summary: bool,
     ) -> ToolResult {
+        if let Some(tool_name) = tool_name {
+            if category.is_some() || intent.is_some() {
+                return tool_manifest_exact_filter_conflict_result();
+            }
+            return match self.tool_manifest_exact_payload(
+                &tool_name,
+                include_recommended_flows,
+                include_risk_summary,
+            ) {
+                Ok(payload) => ToolResult::ok(payload),
+                Err(result) => result,
+            };
+        }
         match self.tool_manifest_payload(
             category,
             intent,
@@ -146,6 +160,63 @@ impl ToolRuntime {
             Ok(payload) => ToolResult::ok(payload),
             Err(result) => result,
         }
+    }
+
+    fn tool_manifest_exact_payload(
+        &self,
+        raw_tool_name: &str,
+        include_recommended_flows: bool,
+        include_risk_summary: bool,
+    ) -> Result<Value, ToolResult> {
+        let tool_name = raw_tool_name.trim();
+        if tool_name.is_empty() {
+            return Err(unknown_tool_manifest_tool_result(tool_name));
+        }
+        let specs = registered_tool_specs();
+        let tool_count = specs.len();
+        let Some(spec) = specs.iter().find(|spec| spec.name == tool_name) else {
+            return Err(unknown_tool_manifest_tool_result(tool_name));
+        };
+        let category = runtime_tool_category(spec.name.as_str());
+        let mut exact_categories = serde_json::Map::new();
+        exact_categories.insert(category.to_string(), json!([spec.name]));
+        let mut output = json!({
+            "schema_version": 1,
+            "tool_count": tool_count,
+            "count": 1,
+            "returned_count": 1,
+            "total_count": tool_count,
+            "filtered_count": 1,
+            "tool_name": spec.name,
+            "contract": {
+                "name": spec.name,
+                "description": spec.description,
+                "input_schema": spec.input_schema,
+                "annotations": spec.annotations,
+            },
+            "category": category,
+            "intent": Value::Null,
+            "available_intents": available_tool_manifest_intent_names(),
+            "filtered": true,
+            "categories_requested": Value::Null,
+            "limit": Value::Null,
+            "truncated": false,
+            "truncation_reason": Value::Null,
+            "limit_applied": false,
+            "requested_limit": Value::Null,
+            "categories": Value::Object(exact_categories),
+            "tools": [compact_manifest_tool_entry(spec)],
+        });
+        if include_risk_summary {
+            output["risk_summary"] = build_risk_summary(&[spec]);
+        }
+        if include_recommended_flows {
+            output["recommended_flows"] =
+                Value::Array(tool_manifest_recommended_flows_for_visible_tools([spec
+                    .name
+                    .as_str()]));
+        }
+        Ok(output)
     }
 
     pub(crate) fn compact_tool_manifest_payload(&self) -> Value {
@@ -239,6 +310,8 @@ impl ToolRuntime {
             "returned_count": tools.len(),
             "total_count": tool_count,
             "filtered_count": filtered_count,
+            "tool_name": Value::Null,
+            "contract": Value::Null,
             "category": category,
             "intent": intent_name,
             "available_intents": available_intents,
@@ -319,6 +392,27 @@ fn unknown_tool_manifest_intent_result(unknown: &str) -> ToolResult {
                 unknown,
                 available_intents.join(", ")
             ),
+        }),
+    )
+}
+
+fn unknown_tool_manifest_tool_result(tool_name: &str) -> ToolResult {
+    ToolResult::err_with_output(
+        format!("unknown tool_manifest tool_name '{tool_name}'"),
+        json!({
+            "code": "unknown_tool_manifest_tool",
+            "tool_name": tool_name,
+            "message": format!("unknown model-visible runtime tool '{tool_name}'; use category or intent discovery to find a valid name"),
+        }),
+    )
+}
+
+fn tool_manifest_exact_filter_conflict_result() -> ToolResult {
+    ToolResult::err_with_output(
+        "tool_manifest tool_name cannot be combined with category or intent",
+        json!({
+            "code": "tool_manifest_exact_filter_conflict",
+            "message": "tool_name selects one exact contract; omit category and intent",
         }),
     )
 }

--- a/src/tool_runtime/tests/handoff.rs
+++ b/src/tool_runtime/tests/handoff.rs
@@ -77,6 +77,7 @@ async fn session_handoff_summary_is_known_and_in_specs() {
     let runtime = test_runtime();
     let manifest = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: Some("session".to_string()),
             intent: None,
             include_recommended_flows: false,

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1644,6 +1644,7 @@ async fn tool_manifest_reports_accepted_flattened_args_without_schemas() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: None,
             include_recommended_flows: true,
@@ -1803,6 +1804,7 @@ async fn tool_manifest_model_fields_and_hidden_start_compatibility_stay_separate
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: None,
             include_recommended_flows: false,
@@ -1953,6 +1955,7 @@ async fn tool_manifest_recommends_default_remote_coding_loop() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: None,
             include_recommended_flows: true,

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -1640,7 +1640,7 @@ fn project_overview_metadata_schema_and_flattened_args_are_read_only() {
 }
 
 #[tokio::test]
-async fn tool_manifest_reports_accepted_flattened_args_without_schemas() {
+async fn tool_manifest_keeps_list_compact_and_exact_contract_bounded() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
@@ -1688,6 +1688,20 @@ async fn tool_manifest_reports_accepted_flattened_args_without_schemas() {
             }
         }
     }
+
+    let exact = runtime
+        .dispatch(ToolCall::ToolManifest {
+            tool_name: Some("run_script".to_string()),
+            category: None,
+            intent: None,
+            include_recommended_flows: false,
+            include_risk_summary: false,
+        })
+        .await;
+    assert!(exact.success, "{:?}", exact.error);
+    assert_eq!(exact.output["contract"]["name"], "run_script");
+    assert_eq!(exact.output["contract"]["input_schema"]["type"], "object");
+    assert!(exact.output["contract"].get("output_schema").is_none());
 
     let accepted = |name: &str| -> Vec<String> {
         tools

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -1661,9 +1661,72 @@ async fn tool_manifest_exact_tool_returns_input_contract_without_output_schema()
     assert_eq!(contract["input_schema"]["type"], "object");
     assert!(contract["input_schema"]["properties"]["package"].is_object());
     assert!(contract["annotations"].is_object());
+    assert_eq!(contract["availability"], "direct");
+    assert!(contract["gateway_tool"].is_null());
     assert!(contract.get("output_schema").is_none());
     assert_eq!(result.output["tools"][0]["name"], "cargo_test");
+    assert_eq!(result.output["tools"][0]["availability"], "direct");
+    assert!(result.output["tools"][0]["gateway_tool"].is_null());
     assert!(result.output["tools"][0].get("input_schema").is_none());
+}
+
+#[tokio::test]
+async fn tool_manifest_surface_routing_metadata_tracks_current_model_surface() {
+    use crate::model_surface::ModelSurface;
+
+    for (surface, tool_name, availability, gateway_tool) in [
+        (
+            ModelSurface::LocalCoding,
+            "computer_snapshot",
+            "unavailable",
+            None,
+        ),
+        (ModelSurface::AdaptiveRuntime, "run_process", "direct", None),
+        (
+            ModelSurface::AdaptiveRuntime,
+            "run_script",
+            "gateway",
+            Some("call_runtime_tool"),
+        ),
+        (
+            ModelSurface::FullOperatorRuntime,
+            "run_script",
+            "direct",
+            None,
+        ),
+        (
+            ModelSurface::CanonicalConnector,
+            "run_process",
+            "unavailable",
+            None,
+        ),
+    ] {
+        let runtime = test_runtime().with_model_surface(surface);
+        let result = runtime
+            .dispatch(ToolCall::ToolManifest {
+                tool_name: Some(tool_name.to_string()),
+                category: None,
+                intent: None,
+                include_recommended_flows: false,
+                include_risk_summary: false,
+            })
+            .await;
+        assert!(
+            result.success,
+            "{surface:?} {tool_name}: {:?}",
+            result.error
+        );
+        assert_eq!(result.output["contract"]["availability"], availability);
+        assert_eq!(
+            result.output["contract"]["gateway_tool"],
+            gateway_tool.map_or(Value::Null, |name| json!(name))
+        );
+        assert_eq!(result.output["tools"][0]["availability"], availability);
+        assert_eq!(
+            result.output["tools"][0]["gateway_tool"],
+            gateway_tool.map_or(Value::Null, |name| json!(name))
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -876,6 +876,7 @@ async fn tool_manifest_omits_recommended_flows_when_disabled() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: None,
             include_recommended_flows: false,
@@ -1175,6 +1176,7 @@ async fn tool_manifest_intent_coding_returns_ranked_compact_tools() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: Some("coding".to_string()),
             include_recommended_flows: false,
@@ -1222,6 +1224,7 @@ async fn tool_manifest_accepts_hyphenated_intent_alias() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: Some("Discovery".to_string()),
             include_recommended_flows: false,
@@ -1285,6 +1288,7 @@ async fn tool_manifest_intent_can_combine_with_category_filter() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: Some("validation".to_string()),
             intent: Some("coding".to_string()),
             include_recommended_flows: false,
@@ -1319,6 +1323,7 @@ async fn audit_and_exploration_intents_exclude_shell_and_jobs() {
         let runtime = test_runtime();
         let result = runtime
             .dispatch(ToolCall::ToolManifest {
+                tool_name: None,
                 category: None,
                 intent: Some(intent.to_string()),
                 include_recommended_flows: false,
@@ -1389,6 +1394,7 @@ async fn release_intent_includes_list_jobs_but_not_run_shell_or_run_job() {
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: Some("release".to_string()),
             include_recommended_flows: false,
@@ -1508,6 +1514,7 @@ async fn filtered_tool_manifest_recommended_flows_only_reference_returned_tools(
     // intent=coding
     let coding = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: Some("coding".to_string()),
             include_recommended_flows: true,
@@ -1539,6 +1546,7 @@ async fn filtered_tool_manifest_recommended_flows_only_reference_returned_tools(
     // single category filter
     let file_only = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: Some("file".to_string()),
             intent: None,
             include_recommended_flows: true,
@@ -1629,12 +1637,71 @@ async fn filtered_tool_manifest_recommended_flows_only_reference_returned_tools(
 }
 
 #[tokio::test]
+async fn tool_manifest_exact_tool_returns_input_contract_without_output_schema() {
+    let runtime = test_runtime();
+    let result = runtime
+        .dispatch(ToolCall::ToolManifest {
+            tool_name: Some("cargo_test".to_string()),
+            category: None,
+            intent: None,
+            include_recommended_flows: false,
+            include_risk_summary: false,
+        })
+        .await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["tool_name"], "cargo_test");
+    assert_eq!(result.output["count"], 1);
+    assert_eq!(result.output["returned_count"], 1);
+    let categories = result.output["categories"].as_object().unwrap();
+    assert_eq!(categories.len(), 1);
+    assert_eq!(categories["validation"], json!(["cargo_test"]));
+    let contract = &result.output["contract"];
+    assert_eq!(contract["name"], "cargo_test");
+    assert!(contract["description"].as_str().is_some());
+    assert_eq!(contract["input_schema"]["type"], "object");
+    assert!(contract["input_schema"]["properties"]["package"].is_object());
+    assert!(contract["annotations"].is_object());
+    assert!(contract.get("output_schema").is_none());
+    assert_eq!(result.output["tools"][0]["name"], "cargo_test");
+    assert!(result.output["tools"][0].get("input_schema").is_none());
+}
+
+#[tokio::test]
+async fn tool_manifest_exact_tool_fails_closed_for_unknown_or_mixed_filters() {
+    let runtime = test_runtime();
+    let unknown = runtime
+        .dispatch(ToolCall::ToolManifest {
+            tool_name: Some("not_a_real_webcodex_tool".to_string()),
+            category: None,
+            intent: None,
+            include_recommended_flows: false,
+            include_risk_summary: false,
+        })
+        .await;
+    assert!(!unknown.success);
+    assert_eq!(unknown.output["code"], "unknown_tool_manifest_tool");
+
+    let mixed = runtime
+        .dispatch(ToolCall::ToolManifest {
+            tool_name: Some("cargo_test".to_string()),
+            category: Some("validation".to_string()),
+            intent: None,
+            include_recommended_flows: false,
+            include_risk_summary: false,
+        })
+        .await;
+    assert!(!mixed.success);
+    assert_eq!(mixed.output["code"], "tool_manifest_exact_filter_conflict");
+}
+
+#[tokio::test]
 async fn unfiltered_tool_manifest_keeps_full_recommended_flows() {
     use crate::tool_runtime::tool_definition::TOOL_RECOMMENDED_FLOWS;
 
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: None,
             intent: None,
             include_recommended_flows: true,

--- a/src/tool_runtime/tests/validation_summary.rs
+++ b/src/tool_runtime/tests/validation_summary.rs
@@ -682,6 +682,7 @@ async fn validation_summary_is_present_in_validation_tool_manifest_without_new_a
     let runtime = test_runtime();
     let manifest = runtime
         .dispatch(ToolCall::ToolManifest {
+            tool_name: None,
             category: Some("validation".to_string()),
             intent: None,
             include_recommended_flows: true,

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -5211,11 +5211,13 @@ impl ToolCall {
                 "session_id_present": session_id.is_some(),
             }),
             Self::ToolManifest {
+                tool_name,
                 category,
                 intent,
                 include_recommended_flows,
                 include_risk_summary,
             } => serde_json::json!({
+                "tool_name": tool_name,
                 "category": category,
                 "intent": intent,
                 "include_recommended_flows": include_recommended_flows,

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -1983,6 +1983,9 @@ pub enum ToolCall {
     /// runtime introspection; never exposes schemas, tokens, secrets, or
     /// internal paths.
     ToolManifest {
+        /// Optional exact model-visible runtime tool name for one-tool contract discovery.
+        #[serde(default)]
+        tool_name: Option<String>,
         #[serde(default)]
         category: Option<String>,
         /// Optional task intent view such as coding, audit, exploration,

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -1979,9 +1979,10 @@ pub enum ToolCall {
     /// only filter and rank discovery output; they do not change tool behavior,
     /// policy, permissions, execution, or finish verdict semantics. Intended as
     /// a lightweight alternative to `list_tools` for long-running tasks where
-    /// the full input/output schemas cause ResponseTooLargeError. Read-only
-    /// runtime introspection; never exposes schemas, tokens, secrets, or
-    /// internal paths.
+    /// full catalog schemas cause ResponseTooLargeError. Read-only runtime
+    /// introspection; list/filter mode stays schema-free, while exact tool_name
+    /// mode exposes only that tool's input schema. Never exposes tokens, secrets,
+    /// internal paths, or output schemas.
     ToolManifest {
         /// Optional exact model-visible runtime tool name for one-tool contract discovery.
         #[serde(default)]

--- a/src/tool_runtime/tool_definition/discovery.rs
+++ b/src/tool_runtime/tool_definition/discovery.rs
@@ -128,7 +128,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             false,
             false,
         ),
-        "Return a compact, bounded tool manifest with categories, flattened args, risk, flows, and optional coding/audit/exploration/release/discovery intent views. Intents only filter and rank discovery; they do not change behavior, policy, permissions, execution, or verdicts. Read-only.",
+        "Return compact runtime discovery. Filter by category/intent, or pass exact tool_name for one contract with description + input schema and no output schema. Discovery never changes behavior, authority, permissions, execution, or verdicts.",
         tool_manifest_input_schema,
     ),
 ];


### PR DESCRIPTION
## Summary

- rebalance `adaptive_runtime` to keep a 15-tool high-frequency typed core while routing long-tail runtime tools through `call_runtime_tool`
- add exact `tool_manifest(tool_name=...)` contract discovery with one input schema and no output-schema expansion
- expose `direct` / `gateway` / `unavailable` invocation routing in compact manifests without changing authorization semantics
- preserve canonical target OAuth scope, Project authority, permission gates, argument validation, effects, and Session/ACK handling through the adaptive gateway
- clarify exact manifest schema exposure and add reviewer regression coverage

## Independent review

Reviewed the full branch against exact `origin/main` (`6a1f2a80`). No blocking model-surface, routing, authorization, or compatibility issue found. The gateway rejects recursion, direct-core retargeting, retired names, and unknown names; target-specific authorization remains authoritative after routing. The existing Stateless 2026 Skill/Memory operator-extension behavior is unchanged by this branch.

Reviewer follow-up commit:

- `e4330f72` Clarify exact tool manifest schema exposure

## Validation

- `cargo fmt --all -- --check`
- adaptive runtime focused tests: 7 passed
- exact tool-manifest focused tests: 3 passed
- invocation-routing manifest test: 1 passed
- adaptive OAuth canonical-scope test: 1 passed
- full MCP model-surface suite: 15 passed
- tool-manifest schema/discovery suite: 17 passed
- reviewer manifest metadata regression: 1 passed
- OpenAPI flattened action-field regression: 1 passed
- `git diff --check origin/main...HEAD`

Existing unrelated dead-code warnings in Agent Wake code remain unchanged.