### PR TITLE
Reduce runtime tracing and console overhead

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -188,10 +188,13 @@ exact typed Server-to-Runner request when dispatch occurs, correlated Runner
 replies/Job updates, and final JSON tool response where a bounded JSON response
 exists. Full payloads are complete JSON compressed with
 zstd under `<trace-dir>/<server_trace_id>/`; they are not stored as BLOBs in the
-canonical runtime database. Large payloads are never silently truncated: if the
+canonical runtime database. Full-mode persistence runs on a bounded background
+writer so trace I/O and compression do not backpressure tool requests. Captures
+are best-effort diagnostics: if that writer queue is saturated, the affected
+record is omitted and the Server emits `tool_trace_capture_omitted` with
+`trace_writer_queue_full`. Large payloads are never silently truncated: if the
 configured total-byte budget cannot fit a capture after pruning expired/old
-traces, that capture is omitted and the Server emits
-`tool_trace_capture_omitted` with `trace_disk_budget_exceeded`.
+traces, that capture is omitted with `trace_disk_budget_exceeded`.
 
 Full tracing is an explicit self-hosted diagnostic mode and can contain source
 files, patches, script/stdin data, command output, user messages, or other tool

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -168,11 +168,13 @@ wrapper/session normalization 后 Server 实际使用的 effective arguments、�
 Server 真正发出的 typed Runner request、相关联的 Runner reply/Job update，以及存在
 有界 JSON body 时的最终 tool response。完整
 payload 以 JSON + zstd 存在 `<trace-dir>/<server_trace_id>/`，不会作为 BLOB 写入
-canonical runtime database。
+canonical runtime database。full-mode 持久化由有界后台 writer 执行，因此 trace I/O
+与压缩不会反压 tool request；这些 capture 是 best-effort 诊断数据。writer queue 饱和时，
+对应记录会被省略，Server 会记录 `tool_trace_capture_omitted` 和
+`trace_writer_queue_full`。
 
 大 payload 不会静默截断。如果清理过期/最旧 trace 后仍无法在总磁盘预算内完整保存，
-本次 capture 会被省略，Server 同时记录 `tool_trace_capture_omitted` 和
-`trace_disk_budget_exceeded`。`full` 是显式的自托管诊断模式，目录里可能包含源码、
+本次 capture 会被省略，并记录 `trace_disk_budget_exceeded`。`full` 是显式的自托管诊断模式，目录里可能包含源码、
 patch、script/stdin、命令输出、user message 或其他 tool payload，应按敏感诊断数据
 保护该目录。trace path 不会读取 WebCodex ingress HTTP `Authorization` header；但
 如果 token、key 或其他 secret 本身出现在 tool argument、script/stdin、Runner request

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -144,8 +144,10 @@ tool argument, script/stdin, Runner request, or Runner response will be captured
 as payload data.
 
 No payload file means neither "empty" nor "truncated". Check the Server journal
-for `tool_trace_capture_omitted` / `trace_disk_budget_exceeded` or
-`tool_trace_capture_failed`. Those trace failures are diagnostic only; they do
+for `tool_trace_capture_omitted` with `trace_writer_queue_full` or
+`trace_disk_budget_exceeded`, or for `tool_trace_capture_failed`. Full-mode writes
+use a bounded background queue, so saturation intentionally drops diagnostic
+records instead of slowing the tool request. Those trace failures are diagnostic only; they do
 not make the underlying tool fail. If WebCodex logged `tool_handler_returned`
 but the client saw no reply, correlate the same request time with the reverse
 proxy access log because handler return is not proof of client delivery.

--- a/docs/TROUBLESHOOTING.zh-CN.md
+++ b/docs/TROUBLESHOOTING.zh-CN.md
@@ -131,8 +131,10 @@ raw forensic 模式：如果 credential-like value 被放进 tool argument、scr
 Runner request 或 Runner response，它会作为 payload data 被完整记录。
 
 没有 payload 文件不代表 payload 是空的，也不代表内容被截断。检查 Server journal
-中的 `tool_trace_capture_omitted` / `trace_disk_budget_exceeded` 或
-`tool_trace_capture_failed`。这些 trace 失败只影响诊断，不会让底层 tool 失败。如果
+中的 `tool_trace_capture_omitted`，并区分 `trace_writer_queue_full` 与
+`trace_disk_budget_exceeded`，或检查 `tool_trace_capture_failed`。full-mode 写入使用有界
+后台 queue；queue 饱和时会主动丢弃诊断记录，而不是拖慢 tool request。这些 trace
+失败只影响诊断，不会让底层 tool 失败。如果
 WebCodex 已记录 `tool_handler_returned` 而 client 没收到 response，还要按同一请求时间
 关联 reverse proxy access log，因为 handler return 并不证明 client delivery。
 

--- a/frontend/dist/runtime.js
+++ b/frontend/dist/runtime.js
@@ -257,6 +257,26 @@ function runtimeCommunicationTranscriptAfterSeq(lastSeq, limit = 100) {
     const normalizedLimit = Number.isSafeInteger(limit) && limit > 0 ? limit : 100;
     return Math.max(0, normalizedLastSeq - normalizedLimit);
 }
+function runtimeWorkflowSessionSummaryRevision(session) {
+    if (!session)
+        return "";
+    return JSON.stringify([
+        String(session.session_id || ""),
+        String(session.title || ""),
+        String(session.lifecycle || ""),
+        String(session.mode || ""),
+        typeof session.updated_at === "number" ? session.updated_at : null,
+        !!session.running_call,
+        typeof session.running_jobs === "number" ? session.running_jobs : null,
+        session.running_jobs_complete === true,
+        session.current_activity ?? null,
+        session.last_activity ?? null,
+        session.overview ?? null,
+    ]);
+}
+function runtimeWorkflowSessionSummaryChanged(previous, next) {
+    return runtimeWorkflowSessionSummaryRevision(previous) !== runtimeWorkflowSessionSummaryRevision(next);
+}
 function emptyCollaborationState() {
     return {
         generation: 0,
@@ -702,7 +722,7 @@ function adoptRuntimeWorkflowSessionDetail(state, request, detail) {
 }
 
 const API_BASE = "/api/runtime-console/";
-const REFRESH_MS = 8000;
+const REFRESH_MS = 30000;
 const COLLABORATION_WAIT_SECS = 25;
 const PROJECT_SEARCH_DEBOUNCE_MS = 200;
 const RUNTIME_CREDENTIAL_SESSION_KEY = "webcodex.runtime.credential.v1";
@@ -841,7 +861,7 @@ const RUNTIME_ZH_TEXT = {
     "No caller-visible Runners.": "没有调用方可见的运行器。",
     "Runtime-wide Runner facts require runtime:read.": "运行时全局运行器信息需要 runtime:read。",
     "Durable Agent Chat": "持久 Agent 对话",
-    "Durable Conversation transcript, recipient-specific Inbox, and coalesced Wake Intent state. The Console polls and renews its bounded Endpoint lease every 8 seconds; polling, renewal, refresh, or unload cleanup does not invoke or wake a model.": "展示持久对话记录、收件人专属收件箱与合并后的唤醒意图状态。控制台每 8 秒轮询并续期有界端点租约；轮询、续期、刷新或卸载清理都不会调用或唤醒模型。",
+    "Durable Conversation transcript, recipient-specific Inbox, and coalesced Wake Intent state. While Runtime & Agents is visible, the Console refreshes communication every 30 seconds; attached Endpoint leases are renewed every 30 seconds even outside that view. Polling, renewal, refresh, or unload cleanup does not invoke or wake a model.": "展示持久对话记录、收件人专属收件箱与合并后的唤醒意图状态。显示“运行时与 Agent”时，控制台每 30 秒刷新通信数据；即使离开该视图，已附加端点的租约仍每 30 秒续期。轮询、续期、刷新或卸载清理都不会调用或唤醒模型。",
     "Choose “Continue as this Agent” to bind this browser window to one durable Agent. The Console can poll and renew that bounded Endpoint lease, but it has no production model-resume adapter: pending Wake Intents remain durable until an explicit Host/model activation.": "选择“以此 Agent 继续”可将当前浏览器窗口绑定到一个持久 Agent。控制台可以轮询并续期该有界端点租约，但没有生产模型恢复适配器；待处理的唤醒意图会一直持久保留，直到主机或模型被明确激活。",
     "Durable Agent Chat requires communication:read. Project and Workflow Session access remain independent.": "持久 Agent 对话需要 communication:read；项目与工作流会话访问彼此独立。",
     "Agents": "Agent",
@@ -1105,6 +1125,12 @@ let knownProjectDevices = [];
 let selectedProjectSnapshot = null;
 let sessionRows = [];
 const state = initialRuntimeConsoleState();
+let renderedProjectSelectorsSignature = "";
+let renderedRunnerFleetSignature = "";
+let renderedRecentSessionsSignature = "";
+let renderedSessionListSignature = "";
+let renderedCollaborationSignature = "";
+let renderedCommunicationSurfaceSignature = "";
 let communicationAgents = [];
 let communicationConversations = [];
 let communicationDetail = null;
@@ -1312,6 +1338,8 @@ function applyWorkspaceView(view, persist = true) {
         if (inspector)
             inspector.open = false;
     }
+    if (operations && token)
+        void refreshCommunication(true);
     renderWorkspaceHeading();
     syncResponsiveNavigation();
     setMobileNavigationOpen(false, false);
@@ -1448,6 +1476,14 @@ function visibleFocusableElements(container) {
 function clearNode(node) {
     while (node && node.firstChild)
         node.removeChild(node.firstChild);
+}
+function renderFingerprint(value) {
+    try {
+        return JSON.stringify(value) || "";
+    }
+    catch {
+        return "";
+    }
 }
 const RUNTIME_ICON_PATHS = {
     folder: ["M3 6h7l2 2h9v10H3V6Z"],
@@ -1853,6 +1889,7 @@ function hideDetail() {
     setText("runtime-session-workspace", "");
     clearNode(el("runtime-collaboration-board"));
     renderedCollaborationMessageIds = new Set();
+    renderedCollaborationSignature = "";
     collaborationFollowLatest = true;
     collaborationPendingMessages = 0;
     syncNewMessageIndicator();
@@ -1861,6 +1898,8 @@ function hideDetail() {
 function clearSessionSurface() {
     saveCurrentDraft();
     sessionRows = [];
+    renderedSessionListSignature = "";
+    renderedCollaborationSignature = "";
     clearNode(el("runtime-session-list"));
     show("runtime-sessions-empty", false);
     clearRuntimeWorkflowSession(state);
@@ -1899,6 +1938,9 @@ function lock(message = "", clearRemembered = true) {
     resetCommunicationSurface();
     const projectList = el("runtime-project-list");
     const sessionsPanel = el("runtime-workflow-sessions-panel");
+    renderedProjectSelectorsSignature = "";
+    renderedRunnerFleetSignature = "";
+    renderedRecentSessionsSignature = "";
     sessionsPanel?.remove();
     clearNode(projectList);
     if (projectList && sessionsPanel) {
@@ -2203,6 +2245,22 @@ function renderProjectSelectors(projects, truncated) {
     const projectList = el("runtime-project-list");
     if (!deviceSelect || !projectList)
         return;
+    const effective = effectiveProjects(projects);
+    const signature = renderFingerprint({
+        language: runtimeLanguage,
+        selectedDevice: state.selectedDevice,
+        selectedProject: state.selectedProject,
+        projectDeviceFilter,
+        projectSearch,
+        truncated,
+        projectRowsTotal,
+        knownProjectDevices,
+        projects: effective,
+        runners: runnerRows.map((runner) => [runner?.client_id, runner?.connected, runner?.status]),
+    });
+    if (signature === renderedProjectSelectorsSignature)
+        return;
+    renderedProjectSelectorsSignature = signature;
     const sessionsPanel = el("runtime-workflow-sessions-panel");
     sessionsPanel?.remove();
     const devices = projectSelectorDevices(projects);
@@ -2218,7 +2276,6 @@ function renderProjectSelectors(projects, truncated) {
         deviceSelect.appendChild(option);
     }
     deviceSelect.value = projectDeviceFilter;
-    const effective = effectiveProjects(projects);
     const rows = filterAndSortRuntimeProjects(effective, projectDeviceFilter, "");
     clearNode(projectList);
     show("runtime-projects-empty", rows.length === 0);
@@ -2413,6 +2470,10 @@ function renderRunnerFleet(runners) {
     const node = el("runtime-runner-list");
     if (!node)
         return;
+    const signature = renderFingerprint([runtimeLanguage, state.selectedDevice, runners]);
+    if (signature === renderedRunnerFleetSignature)
+        return;
+    renderedRunnerFleetSignature = signature;
     clearNode(node);
     show("runtime-runners-empty", runners.length === 0 && !!el("runtime-runner-unavailable")?.hidden);
     for (const runner of runners) {
@@ -2498,6 +2559,16 @@ function renderRecentSessions(sessions, meta) {
     const node = el("runtime-recent-session-list");
     if (!node)
         return;
+    const signature = renderFingerprint([
+        runtimeLanguage,
+        state.selectedProject,
+        state.workflow.selectedSessionId,
+        sessions,
+        meta,
+    ]);
+    if (signature === renderedRecentSessionsSignature)
+        return;
+    renderedRecentSessionsSignature = signature;
     clearNode(node);
     show("runtime-recent-empty", sessions.length === 0 && !!el("runtime-recent-unavailable")?.hidden);
     for (const session of sessions) {
@@ -2605,14 +2676,22 @@ async function fetchSessions(request) {
         showError("Could not refresh Workflow Sessions.");
         return;
     }
+    const selected = String(state.workflow.selectedSessionId || "");
+    const previousSelected = selected
+        ? sessionRows.find((row) => String(row?.session_id || "") === selected)
+        : null;
     sessionRows = Array.isArray(response.data.sessions) ? response.data.sessions : [];
     renderSessionList(sessionRows, response.data);
     showError("");
-    const selected = String(state.workflow.selectedSessionId || "");
-    if (selected && sessionRows.some((row) => String(row.session_id || "") === selected)) {
-        const detailRequest = refreshRuntimeWorkflowSession(state);
-        if (detailRequest)
-            void fetchSessionDetail(detailRequest);
+    const nextSelected = selected
+        ? sessionRows.find((row) => String(row?.session_id || "") === selected)
+        : null;
+    if (selected && nextSelected) {
+        if (!state.workflow.snapshot || runtimeWorkflowSessionSummaryChanged(previousSelected, nextSelected)) {
+            const detailRequest = refreshRuntimeWorkflowSession(state);
+            if (detailRequest)
+                void fetchSessionDetail(detailRequest);
+        }
     }
     else if (selected) {
         abortCollaboration();
@@ -2750,11 +2829,15 @@ function renderSessionList(sessions, payload) {
     const node = el("runtime-session-list");
     if (!node)
         return;
+    const total = typeof payload.total === "number" ? payload.total : sessions.length;
+    const selected = String(state.workflow.selectedSessionId || "");
+    const signature = renderFingerprint([runtimeLanguage, selected, total, !!payload.truncated, sessions]);
+    if (signature === renderedSessionListSignature)
+        return;
+    renderedSessionListSignature = signature;
     clearNode(node);
     show("runtime-sessions-empty", sessions.length === 0);
-    const total = typeof payload.total === "number" ? payload.total : sessions.length;
     setText("runtime-sessions-count", total ? sessions.length + (payload.truncated ? " of " + total : "") : "0");
-    const selected = String(state.workflow.selectedSessionId || "");
     for (const session of sessions) {
         const id = String(session && session.session_id || "");
         if (!id)
@@ -3103,11 +3186,29 @@ function renderCollaboration(statusText, consumeMutationNotice = true) {
         : (runtimeLanguage === "zh-CN" ? "runtime:read 不可用" : "runtime:read unavailable");
     setText("runtime-collaboration-status", status);
     const node = el("runtime-collaboration-board");
-    clearNode(node);
     syncCollaborationComposer();
     if (!available)
         setHumanJoinSendEnabled(false);
-    if (!node || !available) {
+    const signature = renderFingerprint({
+        language: runtimeLanguage,
+        sessionId: state.collaboration.sessionId,
+        available,
+        phase: state.collaboration.phase,
+        uncertainMutation: state.collaboration.uncertainMutation,
+        locallyAuthored: Array.from(locallyAuthoredCollaborationMessageIds).sort(),
+        messages,
+    });
+    if (!node) {
+        renderedCollaborationMessageIds = nextRenderedMessageIds;
+        return;
+    }
+    if (signature === renderedCollaborationSignature) {
+        renderedCollaborationMessageIds = nextRenderedMessageIds;
+        return;
+    }
+    renderedCollaborationSignature = signature;
+    clearNode(node);
+    if (!available) {
         renderedCollaborationMessageIds = nextRenderedMessageIds;
         return;
     }
@@ -3761,6 +3862,7 @@ function idempotencyKeyFor(pending, fingerprint, prefix) {
 }
 function resetCommunicationSurface() {
     communicationGeneration += 1;
+    renderedCommunicationSurfaceSignature = "";
     communicationAgents = [];
     communicationConversations = [];
     communicationDetail = null;
@@ -3810,7 +3912,7 @@ function renderCommunicationAvailability() {
         : available
             ? "communication:read" + (communicationManageAvailable === false
                 ? (runtimeLanguage === "zh-CN" ? " · 只读" : " · read only")
-                : (runtimeLanguage === "zh-CN" ? " · 每 8 秒轮询并续租" : " · polling + lease renewal every 8s"))
+                : (runtimeLanguage === "zh-CN" ? " · 当前视图每 30 秒刷新 · 端点租约每 30 秒续期" : " · 30s refresh while visible · 30s endpoint lease renewal"))
             : (runtimeLanguage === "zh-CN" ? "communication:read 不可用" : "communication:read unavailable");
     setText("runtime-communication-status", access);
 }
@@ -4089,13 +4191,28 @@ function renderCommunicationInbox() {
 }
 function renderCommunicationSurface() {
     renderCommunicationAvailability();
+    const signature = renderFingerprint({
+        language: runtimeLanguage,
+        read: communicationReadAvailable,
+        manage: communicationManageAvailable,
+        selectedAgent: selectedCommunicationAgentId,
+        selectedConversation: selectedCommunicationConversationId,
+        endpoints: Array.from(communicationEndpoints.entries()).sort(([left], [right]) => left.localeCompare(right)),
+        agents: communicationAgents,
+        conversations: communicationConversations,
+        detail: communicationDetail,
+        inbox: communicationInbox,
+    });
+    if (signature === renderedCommunicationSurfaceSignature)
+        return;
+    renderedCommunicationSurfaceSignature = signature;
     renderCommunicationAgents();
     renderCommunicationAgentCard();
     renderCommunicationConversations();
     renderCommunicationConversation();
     renderCommunicationInbox();
 }
-async function fetchCommunicationAgents(generation) {
+async function fetchCommunicationAgents(generation, render = true) {
     const response = await api("communication/agents", { offset: 0, limit: 100 });
     if (generation !== communicationGeneration || !response)
         return false;
@@ -4109,7 +4226,8 @@ async function fetchCommunicationAgents(generation) {
         communicationConversations = [];
         communicationDetail = null;
         communicationInbox = [];
-        renderCommunicationSurface();
+        if (render)
+            renderCommunicationSurface();
         return true;
     }
     if (!response.ok || !response.data)
@@ -4120,11 +4238,13 @@ async function fetchCommunicationAgents(generation) {
         selectedCommunicationAgentId = String(communicationAgents[0]?.agent_id || "");
         communicationInbox = [];
     }
-    renderCommunicationAgents();
-    renderCommunicationAgentCard();
+    if (render) {
+        renderCommunicationAgents();
+        renderCommunicationAgentCard();
+    }
     return true;
 }
-async function fetchCommunicationConversations(generation) {
+async function fetchCommunicationConversations(generation, render = true) {
     const response = await api("communication/conversations", { offset: 0, limit: 100 });
     if (generation !== communicationGeneration || !response)
         return false;
@@ -4134,7 +4254,8 @@ async function fetchCommunicationConversations(generation) {
     }
     if (response.status === 403) {
         communicationReadAvailable = false;
-        renderCommunicationSurface();
+        if (render)
+            renderCommunicationSurface();
         return true;
     }
     if (!response.ok || !response.data)
@@ -4145,14 +4266,16 @@ async function fetchCommunicationConversations(generation) {
         selectedCommunicationConversationId = String(communicationConversations[0]?.conversation_id || "");
         communicationDetail = null;
     }
-    renderCommunicationConversations();
+    if (render)
+        renderCommunicationConversations();
     return true;
 }
-async function fetchCommunicationConversation(generation) {
+async function fetchCommunicationConversation(generation, render = true) {
     const conversationId = selectedCommunicationConversationId;
     if (!conversationId) {
         communicationDetail = null;
-        renderCommunicationConversation();
+        if (render)
+            renderCommunicationConversation();
         return true;
     }
     const afterSeq = runtimeCommunicationTranscriptAfterSeq(selectedCommunicationConversation()?.last_seq, 100);
@@ -4169,28 +4292,32 @@ async function fetchCommunicationConversation(generation) {
     }
     if (response.status === 403) {
         communicationReadAvailable = false;
-        renderCommunicationSurface();
+        if (render)
+            renderCommunicationSurface();
         return true;
     }
     if (response.status === 404) {
         communicationDetail = null;
         selectedCommunicationConversationId = "";
-        renderCommunicationConversation();
+        if (render)
+            renderCommunicationConversation();
         return false;
     }
     if (!response.ok || !response.data)
         return false;
     communicationDetail = response.data;
-    renderCommunicationConversation();
+    if (render)
+        renderCommunicationConversation();
     return true;
 }
-async function fetchCommunicationInbox(generation) {
+async function fetchCommunicationInbox(generation, render = true) {
     const agentId = selectedCommunicationAgentId;
     const endpoint = communicationEndpoint(agentId);
     const endpointId = endpoint?.endpoint_id || "";
     if (!agentId || !endpoint) {
         communicationInbox = [];
-        renderCommunicationInbox();
+        if (render)
+            renderCommunicationInbox();
         return true;
     }
     const response = await api("communication/inbox", {
@@ -4208,20 +4335,24 @@ async function fetchCommunicationInbox(generation) {
     }
     if (response.status === 403) {
         communicationReadAvailable = false;
-        renderCommunicationSurface();
+        if (render)
+            renderCommunicationSurface();
         return true;
     }
     if (response.status === 404 || response.status === 400) {
         communicationEndpoints.delete(agentId);
         communicationInbox = [];
-        renderCommunicationAgentCard();
-        renderCommunicationInbox();
+        if (render) {
+            renderCommunicationAgentCard();
+            renderCommunicationInbox();
+        }
         return false;
     }
     if (!response.ok || !response.data)
         return false;
     communicationInbox = Array.isArray(response.data.deliveries) ? response.data.deliveries : [];
-    renderCommunicationInbox();
+    if (render)
+        renderCommunicationInbox();
     return true;
 }
 async function renewCommunicationEndpoints(generation) {
@@ -4258,25 +4389,33 @@ async function renewCommunicationEndpoints(generation) {
     }
     return true;
 }
-async function refreshCommunication() {
+async function refreshCommunication(includeData = true) {
     if (!token || communicationRefreshInFlight)
         return true;
     communicationRefreshInFlight = true;
     const generation = ++communicationGeneration;
-    setText("runtime-communication-status", tr("Refreshing durable communication…"));
+    if (includeData && communicationReadAvailable !== false) {
+        setText("runtime-communication-status", tr("Refreshing durable communication…"));
+    }
     try {
         const endpointsOk = await renewCommunicationEndpoints(generation);
         if (generation !== communicationGeneration)
             return false;
-        const agentsOk = await fetchCommunicationAgents(generation);
-        if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true)
+        if (!includeData || communicationReadAvailable === false)
+            return endpointsOk;
+        const agentsOk = await fetchCommunicationAgents(generation, false);
+        if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true) {
+            renderCommunicationSurface();
             return endpointsOk && agentsOk;
-        const conversationsOk = await fetchCommunicationConversations(generation);
-        if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true)
+        }
+        const conversationsOk = await fetchCommunicationConversations(generation, false);
+        if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true) {
+            renderCommunicationSurface();
             return endpointsOk && agentsOk && conversationsOk;
+        }
         const [conversationOk, inboxOk] = await Promise.all([
-            fetchCommunicationConversation(generation),
-            fetchCommunicationInbox(generation),
+            fetchCommunicationConversation(generation, false),
+            fetchCommunicationInbox(generation, false),
         ]);
         renderCommunicationSurface();
         return endpointsOk && agentsOk && conversationsOk && conversationOk && inboxOk;
@@ -4663,17 +4802,22 @@ async function refreshAll() {
         setRefreshBusy(false);
     }
 }
+function refreshAutoSurfaces() {
+    if (!token)
+        return;
+    if (document.hidden) {
+        void refreshCommunication(false);
+        return;
+    }
+    void fetchOverview(refreshRuntimeOverview(state));
+    const request = refreshRuntimeSessionList(state);
+    if (request)
+        void fetchSessions(request);
+    void refreshCommunication(workspaceView === "operations");
+}
 function startAuto() {
     stopAuto();
-    timer = window.setInterval(() => {
-        if (!token)
-            return;
-        void fetchOverview(refreshRuntimeOverview(state));
-        const request = refreshRuntimeSessionList(state);
-        if (request)
-            void fetchSessions(request);
-        void refreshCommunication();
-    }, REFRESH_MS);
+    timer = window.setInterval(refreshAutoSurfaces, REFRESH_MS);
 }
 function stopAuto() { if (timer)
     window.clearInterval(timer); timer = 0; }
@@ -4687,7 +4831,7 @@ function connectRuntimeCredential(nextToken, rememberForTab) {
     const request = beginRuntimeCredential(state);
     void fetchOverview(refreshRuntimeOverview(state));
     void fetchProjects(request, true);
-    void refreshCommunication();
+    void refreshCommunication(workspaceView === "operations");
 }
 el("runtime-token-form")?.addEventListener("submit", (event) => {
     event.preventDefault();
@@ -4885,6 +5029,10 @@ document.addEventListener("keydown", (event) => {
     }
 });
 window.addEventListener("resize", syncResponsiveNavigation, { passive: true });
+document.addEventListener("visibilitychange", () => {
+    if (!document.hidden && token)
+        refreshAutoSurfaces();
+});
 const syncSystemAppearance = () => {
     if (appearancePreference(document.documentElement.dataset.theme) === "system")
         applyAppearance("system", false);

--- a/frontend/dist/runtime.js
+++ b/frontend/dist/runtime.js
@@ -250,6 +250,35 @@ function shouldFollowWorkflowSessionLatest(state) {
 function compareText(left, right) {
     return left < right ? -1 : left > right ? 1 : 0;
 }
+class RuntimeCommunicationRefreshCoordinator {
+    constructor(runRefresh) {
+        this.runRefresh = runRefresh;
+        this.generation = 0;
+        this.inFlight = null;
+    }
+    refresh(includeData = true) {
+        const generation = this.generation;
+        const current = this.inFlight;
+        if (current && current.generation === generation) {
+            if (!includeData || current.includeData)
+                return current.promise;
+            return current.promise.then(() => this.generation === generation ? this.refresh(true) : false, () => this.generation === generation ? this.refresh(true) : false);
+        }
+        const promise = Promise.resolve().then(() => this.runRefresh(includeData));
+        const started = { includeData, generation, promise };
+        this.inFlight = started;
+        const clear = () => {
+            if (this.inFlight === started)
+                this.inFlight = null;
+        };
+        void promise.then(clear, clear);
+        return promise;
+    }
+    reset() {
+        this.generation += 1;
+        this.inFlight = null;
+    }
+}
 function runtimeCommunicationTranscriptAfterSeq(lastSeq, limit = 100) {
     const normalizedLastSeq = typeof lastSeq === "number" && Number.isSafeInteger(lastSeq)
         ? Math.max(0, lastSeq)
@@ -1139,8 +1168,8 @@ let selectedCommunicationAgentId = "";
 let selectedCommunicationConversationId = "";
 let communicationReadAvailable = null;
 let communicationManageAvailable = null;
-let communicationRefreshInFlight = false;
 let communicationGeneration = 0;
+const communicationRefreshCoordinator = new RuntimeCommunicationRefreshCoordinator(performCommunicationRefresh);
 const communicationEndpoints = new Map();
 const pendingEndpointAttach = new Map();
 let pendingAgentCreate = null;
@@ -3871,7 +3900,7 @@ function resetCommunicationSurface() {
     selectedCommunicationConversationId = "";
     communicationReadAvailable = null;
     communicationManageAvailable = null;
-    communicationRefreshInFlight = false;
+    communicationRefreshCoordinator.reset();
     communicationEndpoints.clear();
     pendingEndpointAttach.clear();
     pendingAgentCreate = null;
@@ -4389,41 +4418,39 @@ async function renewCommunicationEndpoints(generation) {
     }
     return true;
 }
-async function refreshCommunication(includeData = true) {
-    if (!token || communicationRefreshInFlight)
+async function performCommunicationRefresh(includeData) {
+    if (!token)
         return true;
-    communicationRefreshInFlight = true;
     const generation = ++communicationGeneration;
     if (includeData && communicationReadAvailable !== false) {
         setText("runtime-communication-status", tr("Refreshing durable communication…"));
     }
-    try {
-        const endpointsOk = await renewCommunicationEndpoints(generation);
-        if (generation !== communicationGeneration)
-            return false;
-        if (!includeData || communicationReadAvailable === false)
-            return endpointsOk;
-        const agentsOk = await fetchCommunicationAgents(generation, false);
-        if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true) {
-            renderCommunicationSurface();
-            return endpointsOk && agentsOk;
-        }
-        const conversationsOk = await fetchCommunicationConversations(generation, false);
-        if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true) {
-            renderCommunicationSurface();
-            return endpointsOk && agentsOk && conversationsOk;
-        }
-        const [conversationOk, inboxOk] = await Promise.all([
-            fetchCommunicationConversation(generation, false),
-            fetchCommunicationInbox(generation, false),
-        ]);
+    const endpointsOk = await renewCommunicationEndpoints(generation);
+    if (generation !== communicationGeneration)
+        return false;
+    if (!includeData || communicationReadAvailable === false)
+        return endpointsOk;
+    const agentsOk = await fetchCommunicationAgents(generation, false);
+    if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true) {
         renderCommunicationSurface();
-        return endpointsOk && agentsOk && conversationsOk && conversationOk && inboxOk;
+        return endpointsOk && agentsOk;
     }
-    finally {
-        if (generation === communicationGeneration)
-            communicationRefreshInFlight = false;
+    const conversationsOk = await fetchCommunicationConversations(generation, false);
+    if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true) {
+        renderCommunicationSurface();
+        return endpointsOk && agentsOk && conversationsOk;
     }
+    const [conversationOk, inboxOk] = await Promise.all([
+        fetchCommunicationConversation(generation, false),
+        fetchCommunicationInbox(generation, false),
+    ]);
+    renderCommunicationSurface();
+    return endpointsOk && agentsOk && conversationsOk && conversationOk && inboxOk;
+}
+function refreshCommunication(includeData = true) {
+    if (!token)
+        return Promise.resolve(true);
+    return communicationRefreshCoordinator.refresh(includeData);
 }
 async function createCommunicationAgent(event) {
     event.preventDefault();

--- a/frontend/dist/runtime_console_state.js
+++ b/frontend/dist/runtime_console_state.js
@@ -9,6 +9,26 @@ export function runtimeCommunicationTranscriptAfterSeq(lastSeq, limit = 100) {
     const normalizedLimit = Number.isSafeInteger(limit) && limit > 0 ? limit : 100;
     return Math.max(0, normalizedLastSeq - normalizedLimit);
 }
+export function runtimeWorkflowSessionSummaryRevision(session) {
+    if (!session)
+        return "";
+    return JSON.stringify([
+        String(session.session_id || ""),
+        String(session.title || ""),
+        String(session.lifecycle || ""),
+        String(session.mode || ""),
+        typeof session.updated_at === "number" ? session.updated_at : null,
+        !!session.running_call,
+        typeof session.running_jobs === "number" ? session.running_jobs : null,
+        session.running_jobs_complete === true,
+        session.current_activity ?? null,
+        session.last_activity ?? null,
+        session.overview ?? null,
+    ]);
+}
+export function runtimeWorkflowSessionSummaryChanged(previous, next) {
+    return runtimeWorkflowSessionSummaryRevision(previous) !== runtimeWorkflowSessionSummaryRevision(next);
+}
 function emptyCollaborationState() {
     return {
         generation: 0,

--- a/frontend/dist/runtime_console_state.js
+++ b/frontend/dist/runtime_console_state.js
@@ -2,6 +2,35 @@ import { initialWorkflowSessionState, selectWorkflowSession, refreshWorkflowSess
 function compareText(left, right) {
     return left < right ? -1 : left > right ? 1 : 0;
 }
+export class RuntimeCommunicationRefreshCoordinator {
+    constructor(runRefresh) {
+        this.runRefresh = runRefresh;
+        this.generation = 0;
+        this.inFlight = null;
+    }
+    refresh(includeData = true) {
+        const generation = this.generation;
+        const current = this.inFlight;
+        if (current && current.generation === generation) {
+            if (!includeData || current.includeData)
+                return current.promise;
+            return current.promise.then(() => this.generation === generation ? this.refresh(true) : false, () => this.generation === generation ? this.refresh(true) : false);
+        }
+        const promise = Promise.resolve().then(() => this.runRefresh(includeData));
+        const started = { includeData, generation, promise };
+        this.inFlight = started;
+        const clear = () => {
+            if (this.inFlight === started)
+                this.inFlight = null;
+        };
+        void promise.then(clear, clear);
+        return promise;
+    }
+    reset() {
+        this.generation += 1;
+        this.inFlight = null;
+    }
+}
 export function runtimeCommunicationTranscriptAfterSeq(lastSeq, limit = 100) {
     const normalizedLastSeq = typeof lastSeq === "number" && Number.isSafeInteger(lastSeq)
         ? Math.max(0, lastSeq)

--- a/frontend/src/runtime.ts
+++ b/frontend/src/runtime.ts
@@ -14,6 +14,7 @@ import {
   runtimeProjectIdentityText,
   preferredRuntimeProjectSelection,
   runtimeCommunicationTranscriptAfterSeq,
+  runtimeWorkflowSessionSummaryChanged,
   invalidateRuntimeCredential,
   beginRuntimeCredential,
   refreshRuntimeOverview,
@@ -51,7 +52,7 @@ import {
 } from "./runtime_console_state.js";
 
 const API_BASE = "/api/runtime-console/";
-const REFRESH_MS = 8000;
+const REFRESH_MS = 30000;
 const COLLABORATION_WAIT_SECS = 25;
 const PROJECT_SEARCH_DEBOUNCE_MS = 200;
 const RUNTIME_CREDENTIAL_SESSION_KEY = "webcodex.runtime.credential.v1";
@@ -195,7 +196,7 @@ const RUNTIME_ZH_TEXT: Record<string, string> = {
   "No caller-visible Runners.": "没有调用方可见的运行器。",
   "Runtime-wide Runner facts require runtime:read.": "运行时全局运行器信息需要 runtime:read。",
   "Durable Agent Chat": "持久 Agent 对话",
-  "Durable Conversation transcript, recipient-specific Inbox, and coalesced Wake Intent state. The Console polls and renews its bounded Endpoint lease every 8 seconds; polling, renewal, refresh, or unload cleanup does not invoke or wake a model.": "展示持久对话记录、收件人专属收件箱与合并后的唤醒意图状态。控制台每 8 秒轮询并续期有界端点租约；轮询、续期、刷新或卸载清理都不会调用或唤醒模型。",
+  "Durable Conversation transcript, recipient-specific Inbox, and coalesced Wake Intent state. While Runtime & Agents is visible, the Console refreshes communication every 30 seconds; attached Endpoint leases are renewed every 30 seconds even outside that view. Polling, renewal, refresh, or unload cleanup does not invoke or wake a model.": "展示持久对话记录、收件人专属收件箱与合并后的唤醒意图状态。显示“运行时与 Agent”时，控制台每 30 秒刷新通信数据；即使离开该视图，已附加端点的租约仍每 30 秒续期。轮询、续期、刷新或卸载清理都不会调用或唤醒模型。",
   "Choose “Continue as this Agent” to bind this browser window to one durable Agent. The Console can poll and renew that bounded Endpoint lease, but it has no production model-resume adapter: pending Wake Intents remain durable until an explicit Host/model activation.": "选择“以此 Agent 继续”可将当前浏览器窗口绑定到一个持久 Agent。控制台可以轮询并续期该有界端点租约，但没有生产模型恢复适配器；待处理的唤醒意图会一直持久保留，直到主机或模型被明确激活。",
   "Durable Agent Chat requires communication:read. Project and Workflow Session access remain independent.": "持久 Agent 对话需要 communication:read；项目与工作流会话访问彼此独立。",
   "Agents": "Agent",
@@ -465,6 +466,12 @@ let knownProjectDevices: string[] = [];
 let selectedProjectSnapshot: any | null = null;
 let sessionRows: any[] = [];
 const state = initialRuntimeConsoleState();
+let renderedProjectSelectorsSignature = "";
+let renderedRunnerFleetSignature = "";
+let renderedRecentSessionsSignature = "";
+let renderedSessionListSignature = "";
+let renderedCollaborationSignature = "";
+let renderedCommunicationSurfaceSignature = "";
 
 type RuntimeCommunicationEndpoint = {
   endpoint_id: string;
@@ -672,6 +679,7 @@ function applyWorkspaceView(view: RuntimeWorkspaceView, persist = true): void {
     const inspector = document.querySelector(".runtime-inspector") as HTMLDetailsElement | null;
     if (inspector) inspector.open = false;
   }
+  if (operations && token) void refreshCommunication(true);
   renderWorkspaceHeading();
   syncResponsiveNavigation();
   setMobileNavigationOpen(false, false);
@@ -804,6 +812,11 @@ function visibleFocusableElements(container: HTMLElement): HTMLElement[] {
 
 function clearNode(node: any): void {
   while (node && node.firstChild) node.removeChild(node.firstChild);
+}
+
+function renderFingerprint(value: unknown): string {
+  try { return JSON.stringify(value) || ""; }
+  catch { return ""; }
 }
 
 type RuntimeIconName = "folder" | "monitor" | "message" | "reply" | "edit" | "trash" | "copy";
@@ -1192,6 +1205,7 @@ function hideDetail(): void {
   setText("runtime-session-workspace", "");
   clearNode(el("runtime-collaboration-board"));
   renderedCollaborationMessageIds = new Set<string>();
+  renderedCollaborationSignature = "";
   collaborationFollowLatest = true;
   collaborationPendingMessages = 0;
   syncNewMessageIndicator();
@@ -1201,6 +1215,8 @@ function hideDetail(): void {
 function clearSessionSurface(): void {
   saveCurrentDraft();
   sessionRows = [];
+  renderedSessionListSignature = "";
+  renderedCollaborationSignature = "";
   clearNode(el("runtime-session-list"));
   show("runtime-sessions-empty", false);
   clearRuntimeWorkflowSession(state);
@@ -1240,6 +1256,9 @@ function lock(message = "", clearRemembered = true): void {
   resetCommunicationSurface();
   const projectList = el("runtime-project-list");
   const sessionsPanel = el("runtime-workflow-sessions-panel");
+  renderedProjectSelectorsSignature = "";
+  renderedRunnerFleetSignature = "";
+  renderedRecentSessionsSignature = "";
   sessionsPanel?.remove();
   clearNode(projectList);
   if (projectList && sessionsPanel) {
@@ -1543,6 +1562,21 @@ function renderProjectSelectors(projects: any[], truncated: boolean): void {
   const deviceSelect = el("runtime-device-select") as HTMLSelectElement | null;
   const projectList = el("runtime-project-list");
   if (!deviceSelect || !projectList) return;
+  const effective = effectiveProjects(projects);
+  const signature = renderFingerprint({
+    language: runtimeLanguage,
+    selectedDevice: state.selectedDevice,
+    selectedProject: state.selectedProject,
+    projectDeviceFilter,
+    projectSearch,
+    truncated,
+    projectRowsTotal,
+    knownProjectDevices,
+    projects: effective,
+    runners: runnerRows.map((runner) => [runner?.client_id, runner?.connected, runner?.status]),
+  });
+  if (signature === renderedProjectSelectorsSignature) return;
+  renderedProjectSelectorsSignature = signature;
   const sessionsPanel = el("runtime-workflow-sessions-panel");
   sessionsPanel?.remove();
   const devices = projectSelectorDevices(projects);
@@ -1558,7 +1592,6 @@ function renderProjectSelectors(projects: any[], truncated: boolean): void {
     deviceSelect.appendChild(option);
   }
   deviceSelect.value = projectDeviceFilter;
-  const effective = effectiveProjects(projects);
   const rows = filterAndSortRuntimeProjects(
     effective,
     projectDeviceFilter,
@@ -1739,6 +1772,9 @@ function runnerAttentionCount(runner: any): number {
 function renderRunnerFleet(runners: any[]): void {
   const node = el("runtime-runner-list");
   if (!node) return;
+  const signature = renderFingerprint([runtimeLanguage, state.selectedDevice, runners]);
+  if (signature === renderedRunnerFleetSignature) return;
+  renderedRunnerFleetSignature = signature;
   clearNode(node);
   show("runtime-runners-empty", runners.length === 0 && !!el("runtime-runner-unavailable")?.hidden);
   for (const runner of runners) {
@@ -1805,6 +1841,15 @@ function renderRunnerFleet(runners: any[]): void {
 function renderRecentSessions(sessions: any[], meta: any): void {
   const node = el("runtime-recent-session-list");
   if (!node) return;
+  const signature = renderFingerprint([
+    runtimeLanguage,
+    state.selectedProject,
+    state.workflow.selectedSessionId,
+    sessions,
+    meta,
+  ]);
+  if (signature === renderedRecentSessionsSignature) return;
+  renderedRecentSessionsSignature = signature;
   clearNode(node);
   show("runtime-recent-empty", sessions.length === 0 && !!el("runtime-recent-unavailable")?.hidden);
   for (const session of sessions) {
@@ -1887,13 +1932,21 @@ async function fetchSessions(request: any): Promise<void> {
   if (response.status === 401) return lock("Credential rejected.");
   if (response.status === 403 || response.status === 404) { showError("Selected project is no longer available."); return; }
   if (!response.ok || !response.data) { showError("Could not refresh Workflow Sessions."); return; }
+  const selected = String(state.workflow.selectedSessionId || "");
+  const previousSelected = selected
+    ? sessionRows.find((row) => String(row?.session_id || "") === selected)
+    : null;
   sessionRows = Array.isArray(response.data.sessions) ? response.data.sessions : [];
   renderSessionList(sessionRows, response.data);
   showError("");
-  const selected = String(state.workflow.selectedSessionId || "");
-  if (selected && sessionRows.some((row) => String(row.session_id || "") === selected)) {
-    const detailRequest = refreshRuntimeWorkflowSession(state);
-    if (detailRequest) void fetchSessionDetail(detailRequest);
+  const nextSelected = selected
+    ? sessionRows.find((row) => String(row?.session_id || "") === selected)
+    : null;
+  if (selected && nextSelected) {
+    if (!state.workflow.snapshot || runtimeWorkflowSessionSummaryChanged(previousSelected, nextSelected)) {
+      const detailRequest = refreshRuntimeWorkflowSession(state);
+      if (detailRequest) void fetchSessionDetail(detailRequest);
+    }
   } else if (selected) {
     abortCollaboration();
     clearRuntimeWorkflowSession(state);
@@ -2011,10 +2064,13 @@ function appendPreview(parent: HTMLElement, label: string, activity: any): void 
 function renderSessionList(sessions: any[], payload: any): void {
   const node = el("runtime-session-list");
   if (!node) return;
-  clearNode(node); show("runtime-sessions-empty", sessions.length === 0);
   const total = typeof payload.total === "number" ? payload.total : sessions.length;
-  setText("runtime-sessions-count", total ? sessions.length + (payload.truncated ? " of " + total : "") : "0");
   const selected = String(state.workflow.selectedSessionId || "");
+  const signature = renderFingerprint([runtimeLanguage, selected, total, !!payload.truncated, sessions]);
+  if (signature === renderedSessionListSignature) return;
+  renderedSessionListSignature = signature;
+  clearNode(node); show("runtime-sessions-empty", sessions.length === 0);
+  setText("runtime-sessions-count", total ? sessions.length + (payload.truncated ? " of " + total : "") : "0");
   for (const session of sessions) {
     const id = String(session && session.session_id || "");
     if (!id) continue;
@@ -2304,10 +2360,29 @@ function renderCollaboration(statusText?: string, consumeMutationNotice = true):
     ? (runtimeLanguage === "zh-CN" ? "协作：" : "Collaboration: ") + collaborationPhaseLabel() + " · " + countLabel(messages.length, "retained message") + (localizedStatusText ? " · " + localizedStatusText : "")
     : (runtimeLanguage === "zh-CN" ? "runtime:read 不可用" : "runtime:read unavailable");
   setText("runtime-collaboration-status", status);
-  const node = el("runtime-collaboration-board"); clearNode(node);
+  const node = el("runtime-collaboration-board");
   syncCollaborationComposer();
   if (!available) setHumanJoinSendEnabled(false);
-  if (!node || !available) {
+  const signature = renderFingerprint({
+    language: runtimeLanguage,
+    sessionId: state.collaboration.sessionId,
+    available,
+    phase: state.collaboration.phase,
+    uncertainMutation: state.collaboration.uncertainMutation,
+    locallyAuthored: Array.from(locallyAuthoredCollaborationMessageIds).sort(),
+    messages,
+  });
+  if (!node) {
+    renderedCollaborationMessageIds = nextRenderedMessageIds;
+    return;
+  }
+  if (signature === renderedCollaborationSignature) {
+    renderedCollaborationMessageIds = nextRenderedMessageIds;
+    return;
+  }
+  renderedCollaborationSignature = signature;
+  clearNode(node);
+  if (!available) {
     renderedCollaborationMessageIds = nextRenderedMessageIds;
     return;
   }
@@ -2834,6 +2909,7 @@ function idempotencyKeyFor(
 
 function resetCommunicationSurface(): void {
   communicationGeneration += 1;
+  renderedCommunicationSurfaceSignature = "";
   communicationAgents = [];
   communicationConversations = [];
   communicationDetail = null;
@@ -2884,7 +2960,7 @@ function renderCommunicationAvailability(): void {
     : available
       ? "communication:read" + (communicationManageAvailable === false
         ? (runtimeLanguage === "zh-CN" ? " · 只读" : " · read only")
-        : (runtimeLanguage === "zh-CN" ? " · 每 8 秒轮询并续租" : " · polling + lease renewal every 8s"))
+        : (runtimeLanguage === "zh-CN" ? " · 当前视图每 30 秒刷新 · 端点租约每 30 秒续期" : " · 30s refresh while visible · 30s endpoint lease renewal"))
       : (runtimeLanguage === "zh-CN" ? "communication:read 不可用" : "communication:read unavailable");
   setText("runtime-communication-status", access);
 }
@@ -3170,6 +3246,20 @@ function renderCommunicationInbox(): void {
 
 function renderCommunicationSurface(): void {
   renderCommunicationAvailability();
+  const signature = renderFingerprint({
+    language: runtimeLanguage,
+    read: communicationReadAvailable,
+    manage: communicationManageAvailable,
+    selectedAgent: selectedCommunicationAgentId,
+    selectedConversation: selectedCommunicationConversationId,
+    endpoints: Array.from(communicationEndpoints.entries()).sort(([left], [right]) => left.localeCompare(right)),
+    agents: communicationAgents,
+    conversations: communicationConversations,
+    detail: communicationDetail,
+    inbox: communicationInbox,
+  });
+  if (signature === renderedCommunicationSurfaceSignature) return;
+  renderedCommunicationSurfaceSignature = signature;
   renderCommunicationAgents();
   renderCommunicationAgentCard();
   renderCommunicationConversations();
@@ -3177,7 +3267,7 @@ function renderCommunicationSurface(): void {
   renderCommunicationInbox();
 }
 
-async function fetchCommunicationAgents(generation: number): Promise<boolean> {
+async function fetchCommunicationAgents(generation: number, render = true): Promise<boolean> {
   const response = await api("communication/agents", { offset: 0, limit: 100 });
   if (generation !== communicationGeneration || !response) return false;
   if (response.status === 401) { lock("Credential rejected."); return false; }
@@ -3187,7 +3277,7 @@ async function fetchCommunicationAgents(generation: number): Promise<boolean> {
     communicationConversations = [];
     communicationDetail = null;
     communicationInbox = [];
-    renderCommunicationSurface();
+    if (render) renderCommunicationSurface();
     return true;
   }
   if (!response.ok || !response.data) return false;
@@ -3197,18 +3287,20 @@ async function fetchCommunicationAgents(generation: number): Promise<boolean> {
     selectedCommunicationAgentId = String(communicationAgents[0]?.agent_id || "");
     communicationInbox = [];
   }
-  renderCommunicationAgents();
-  renderCommunicationAgentCard();
+  if (render) {
+    renderCommunicationAgents();
+    renderCommunicationAgentCard();
+  }
   return true;
 }
 
-async function fetchCommunicationConversations(generation: number): Promise<boolean> {
+async function fetchCommunicationConversations(generation: number, render = true): Promise<boolean> {
   const response = await api("communication/conversations", { offset: 0, limit: 100 });
   if (generation !== communicationGeneration || !response) return false;
   if (response.status === 401) { lock("Credential rejected."); return false; }
   if (response.status === 403) {
     communicationReadAvailable = false;
-    renderCommunicationSurface();
+    if (render) renderCommunicationSurface();
     return true;
   }
   if (!response.ok || !response.data) return false;
@@ -3218,15 +3310,15 @@ async function fetchCommunicationConversations(generation: number): Promise<bool
     selectedCommunicationConversationId = String(communicationConversations[0]?.conversation_id || "");
     communicationDetail = null;
   }
-  renderCommunicationConversations();
+  if (render) renderCommunicationConversations();
   return true;
 }
 
-async function fetchCommunicationConversation(generation: number): Promise<boolean> {
+async function fetchCommunicationConversation(generation: number, render = true): Promise<boolean> {
   const conversationId = selectedCommunicationConversationId;
   if (!conversationId) {
     communicationDetail = null;
-    renderCommunicationConversation();
+    if (render) renderCommunicationConversation();
     return true;
   }
   const afterSeq = runtimeCommunicationTranscriptAfterSeq(selectedCommunicationConversation()?.last_seq, 100);
@@ -3239,28 +3331,28 @@ async function fetchCommunicationConversation(generation: number): Promise<boole
   if (response.status === 401) { lock("Credential rejected."); return false; }
   if (response.status === 403) {
     communicationReadAvailable = false;
-    renderCommunicationSurface();
+    if (render) renderCommunicationSurface();
     return true;
   }
   if (response.status === 404) {
     communicationDetail = null;
     selectedCommunicationConversationId = "";
-    renderCommunicationConversation();
+    if (render) renderCommunicationConversation();
     return false;
   }
   if (!response.ok || !response.data) return false;
   communicationDetail = response.data;
-  renderCommunicationConversation();
+  if (render) renderCommunicationConversation();
   return true;
 }
 
-async function fetchCommunicationInbox(generation: number): Promise<boolean> {
+async function fetchCommunicationInbox(generation: number, render = true): Promise<boolean> {
   const agentId = selectedCommunicationAgentId;
   const endpoint = communicationEndpoint(agentId);
   const endpointId = endpoint?.endpoint_id || "";
   if (!agentId || !endpoint) {
     communicationInbox = [];
-    renderCommunicationInbox();
+    if (render) renderCommunicationInbox();
     return true;
   }
   const response = await api("communication/inbox", {
@@ -3274,19 +3366,21 @@ async function fetchCommunicationInbox(generation: number): Promise<boolean> {
   if (response.status === 401) { lock("Credential rejected."); return false; }
   if (response.status === 403) {
     communicationReadAvailable = false;
-    renderCommunicationSurface();
+    if (render) renderCommunicationSurface();
     return true;
   }
   if (response.status === 404 || response.status === 400) {
     communicationEndpoints.delete(agentId);
     communicationInbox = [];
-    renderCommunicationAgentCard();
-    renderCommunicationInbox();
+    if (render) {
+      renderCommunicationAgentCard();
+      renderCommunicationInbox();
+    }
     return false;
   }
   if (!response.ok || !response.data) return false;
   communicationInbox = Array.isArray(response.data.deliveries) ? response.data.deliveries : [];
-  renderCommunicationInbox();
+  if (render) renderCommunicationInbox();
   return true;
 }
 
@@ -3317,21 +3411,30 @@ async function renewCommunicationEndpoints(generation: number): Promise<boolean>
   return true;
 }
 
-async function refreshCommunication(): Promise<boolean> {
+async function refreshCommunication(includeData = true): Promise<boolean> {
   if (!token || communicationRefreshInFlight) return true;
   communicationRefreshInFlight = true;
   const generation = ++communicationGeneration;
-  setText("runtime-communication-status", tr("Refreshing durable communication…"));
+  if (includeData && communicationReadAvailable !== false) {
+    setText("runtime-communication-status", tr("Refreshing durable communication…"));
+  }
   try {
     const endpointsOk = await renewCommunicationEndpoints(generation);
     if (generation !== communicationGeneration) return false;
-    const agentsOk = await fetchCommunicationAgents(generation);
-    if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true) return endpointsOk && agentsOk;
-    const conversationsOk = await fetchCommunicationConversations(generation);
-    if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true) return endpointsOk && agentsOk && conversationsOk;
+    if (!includeData || communicationReadAvailable === false) return endpointsOk;
+    const agentsOk = await fetchCommunicationAgents(generation, false);
+    if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true) {
+      renderCommunicationSurface();
+      return endpointsOk && agentsOk;
+    }
+    const conversationsOk = await fetchCommunicationConversations(generation, false);
+    if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true) {
+      renderCommunicationSurface();
+      return endpointsOk && agentsOk && conversationsOk;
+    }
     const [conversationOk, inboxOk] = await Promise.all([
-      fetchCommunicationConversation(generation),
-      fetchCommunicationInbox(generation),
+      fetchCommunicationConversation(generation, false),
+      fetchCommunicationInbox(generation, false),
     ]);
     renderCommunicationSurface();
     return endpointsOk && agentsOk && conversationsOk && conversationOk && inboxOk;
@@ -3679,14 +3782,21 @@ async function refreshAll(): Promise<void> {
   }
 }
 
+function refreshAutoSurfaces(): void {
+  if (!token) return;
+  if (document.hidden) {
+    void refreshCommunication(false);
+    return;
+  }
+  void fetchOverview(refreshRuntimeOverview(state));
+  const request = refreshRuntimeSessionList(state);
+  if (request) void fetchSessions(request);
+  void refreshCommunication(workspaceView === "operations");
+}
+
 function startAuto(): void {
   stopAuto();
-  timer = window.setInterval(() => {
-    if (!token) return;
-    void fetchOverview(refreshRuntimeOverview(state));
-    const request = refreshRuntimeSessionList(state); if (request) void fetchSessions(request);
-    void refreshCommunication();
-  }, REFRESH_MS);
+  timer = window.setInterval(refreshAutoSurfaces, REFRESH_MS);
 }
 function stopAuto(): void { if (timer) window.clearInterval(timer); timer = 0; }
 
@@ -3699,7 +3809,7 @@ function connectRuntimeCredential(nextToken: string, rememberForTab: boolean): v
   const request = beginRuntimeCredential(state);
   void fetchOverview(refreshRuntimeOverview(state));
   void fetchProjects(request, true);
-  void refreshCommunication();
+  void refreshCommunication(workspaceView === "operations");
 }
 
 el("runtime-token-form")?.addEventListener("submit", (event) => {
@@ -3875,6 +3985,9 @@ document.addEventListener("keydown", (event) => {
   }
 });
 window.addEventListener("resize", syncResponsiveNavigation, { passive: true });
+document.addEventListener("visibilitychange", () => {
+  if (!document.hidden && token) refreshAutoSurfaces();
+});
 const syncSystemAppearance = () => {
   if (appearancePreference(document.documentElement.dataset.theme) === "system") applyAppearance("system", false);
 };

--- a/frontend/src/runtime.ts
+++ b/frontend/src/runtime.ts
@@ -14,6 +14,7 @@ import {
   runtimeProjectIdentityText,
   preferredRuntimeProjectSelection,
   runtimeCommunicationTranscriptAfterSeq,
+  RuntimeCommunicationRefreshCoordinator,
   runtimeWorkflowSessionSummaryChanged,
   invalidateRuntimeCredential,
   beginRuntimeCredential,
@@ -494,8 +495,8 @@ let selectedCommunicationAgentId = "";
 let selectedCommunicationConversationId = "";
 let communicationReadAvailable: boolean | null = null;
 let communicationManageAvailable: boolean | null = null;
-let communicationRefreshInFlight = false;
 let communicationGeneration = 0;
+const communicationRefreshCoordinator = new RuntimeCommunicationRefreshCoordinator(performCommunicationRefresh);
 const communicationEndpoints = new Map<string, RuntimeCommunicationEndpoint>();
 const pendingEndpointAttach = new Map<string, { key: string; attachmentId: string }>();
 let pendingAgentCreate: { fingerprint: string; key: string } | null = null;
@@ -2918,7 +2919,7 @@ function resetCommunicationSurface(): void {
   selectedCommunicationConversationId = "";
   communicationReadAvailable = null;
   communicationManageAvailable = null;
-  communicationRefreshInFlight = false;
+  communicationRefreshCoordinator.reset();
   communicationEndpoints.clear();
   pendingEndpointAttach.clear();
   pendingAgentCreate = null;
@@ -3411,36 +3412,36 @@ async function renewCommunicationEndpoints(generation: number): Promise<boolean>
   return true;
 }
 
-async function refreshCommunication(includeData = true): Promise<boolean> {
-  if (!token || communicationRefreshInFlight) return true;
-  communicationRefreshInFlight = true;
+async function performCommunicationRefresh(includeData: boolean): Promise<boolean> {
+  if (!token) return true;
   const generation = ++communicationGeneration;
   if (includeData && communicationReadAvailable !== false) {
     setText("runtime-communication-status", tr("Refreshing durable communication…"));
   }
-  try {
-    const endpointsOk = await renewCommunicationEndpoints(generation);
-    if (generation !== communicationGeneration) return false;
-    if (!includeData || communicationReadAvailable === false) return endpointsOk;
-    const agentsOk = await fetchCommunicationAgents(generation, false);
-    if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true) {
-      renderCommunicationSurface();
-      return endpointsOk && agentsOk;
-    }
-    const conversationsOk = await fetchCommunicationConversations(generation, false);
-    if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true) {
-      renderCommunicationSurface();
-      return endpointsOk && agentsOk && conversationsOk;
-    }
-    const [conversationOk, inboxOk] = await Promise.all([
-      fetchCommunicationConversation(generation, false),
-      fetchCommunicationInbox(generation, false),
-    ]);
+  const endpointsOk = await renewCommunicationEndpoints(generation);
+  if (generation !== communicationGeneration) return false;
+  if (!includeData || communicationReadAvailable === false) return endpointsOk;
+  const agentsOk = await fetchCommunicationAgents(generation, false);
+  if (generation !== communicationGeneration || !agentsOk || communicationReadAvailable !== true) {
     renderCommunicationSurface();
-    return endpointsOk && agentsOk && conversationsOk && conversationOk && inboxOk;
-  } finally {
-    if (generation === communicationGeneration) communicationRefreshInFlight = false;
+    return endpointsOk && agentsOk;
   }
+  const conversationsOk = await fetchCommunicationConversations(generation, false);
+  if (generation !== communicationGeneration || !conversationsOk || communicationReadAvailable !== true) {
+    renderCommunicationSurface();
+    return endpointsOk && agentsOk && conversationsOk;
+  }
+  const [conversationOk, inboxOk] = await Promise.all([
+    fetchCommunicationConversation(generation, false),
+    fetchCommunicationInbox(generation, false),
+  ]);
+  renderCommunicationSurface();
+  return endpointsOk && agentsOk && conversationsOk && conversationOk && inboxOk;
+}
+
+function refreshCommunication(includeData = true): Promise<boolean> {
+  if (!token) return Promise.resolve(true);
+  return communicationRefreshCoordinator.refresh(includeData);
 }
 
 async function createCommunicationAgent(event: Event): Promise<void> {

--- a/frontend/src/runtime_console_state.ts
+++ b/frontend/src/runtime_console_state.ts
@@ -13,6 +13,39 @@ function compareText(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
+export class RuntimeCommunicationRefreshCoordinator {
+  private generation = 0;
+  private inFlight: { includeData: boolean; generation: number; promise: Promise<boolean> } | null = null;
+
+  constructor(private readonly runRefresh: (includeData: boolean) => Promise<boolean>) {}
+
+  refresh(includeData = true): Promise<boolean> {
+    const generation = this.generation;
+    const current = this.inFlight;
+    if (current && current.generation === generation) {
+      if (!includeData || current.includeData) return current.promise;
+      return current.promise.then(
+        () => this.generation === generation ? this.refresh(true) : false,
+        () => this.generation === generation ? this.refresh(true) : false,
+      );
+    }
+
+    const promise = Promise.resolve().then(() => this.runRefresh(includeData));
+    const started = { includeData, generation, promise };
+    this.inFlight = started;
+    const clear = () => {
+      if (this.inFlight === started) this.inFlight = null;
+    };
+    void promise.then(clear, clear);
+    return promise;
+  }
+
+  reset(): void {
+    this.generation += 1;
+    this.inFlight = null;
+  }
+}
+
 export function runtimeCommunicationTranscriptAfterSeq(lastSeq: unknown, limit = 100): number {
   const normalizedLastSeq = typeof lastSeq === "number" && Number.isSafeInteger(lastSeq)
     ? Math.max(0, lastSeq)

--- a/frontend/src/runtime_console_state.ts
+++ b/frontend/src/runtime_console_state.ts
@@ -21,6 +21,27 @@ export function runtimeCommunicationTranscriptAfterSeq(lastSeq: unknown, limit =
   return Math.max(0, normalizedLastSeq - normalizedLimit);
 }
 
+export function runtimeWorkflowSessionSummaryRevision(session: any): string {
+  if (!session) return "";
+  return JSON.stringify([
+    String(session.session_id || ""),
+    String(session.title || ""),
+    String(session.lifecycle || ""),
+    String(session.mode || ""),
+    typeof session.updated_at === "number" ? session.updated_at : null,
+    !!session.running_call,
+    typeof session.running_jobs === "number" ? session.running_jobs : null,
+    session.running_jobs_complete === true,
+    session.current_activity ?? null,
+    session.last_activity ?? null,
+    session.overview ?? null,
+  ]);
+}
+
+export function runtimeWorkflowSessionSummaryChanged(previous: any, next: any): boolean {
+  return runtimeWorkflowSessionSummaryRevision(previous) !== runtimeWorkflowSessionSummaryRevision(next);
+}
+
 function emptyCollaborationState(): any {
   return {
     generation: 0,

--- a/frontend/test/runtime_communication_refresh.test.mjs
+++ b/frontend/test/runtime_communication_refresh.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { RuntimeCommunicationRefreshCoordinator } from "../dist/runtime_console_state.js";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function settleMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function communicationRefreshHarness() {
+  const lease = deferred();
+  const full = deferred();
+  const refreshes = [];
+  const dataEndpoints = [];
+  const coordinator = new RuntimeCommunicationRefreshCoordinator(async (includeData) => {
+    refreshes.push(includeData ? "full" : "lease-only");
+    if (!includeData) {
+      await lease.promise;
+      return true;
+    }
+    dataEndpoints.push("agents", "conversations", "conversation", "inbox");
+    await full.promise;
+    return true;
+  });
+  return { coordinator, lease, full, refreshes, dataEndpoints };
+}
+
+test("lease-only in flight + manual full refresh waits for full communication data", async () => {
+  const { coordinator, lease, full, refreshes, dataEndpoints } = communicationRefreshHarness();
+  const autoRefresh = coordinator.refresh(false);
+  await settleMicrotasks();
+
+  const manualRefresh = coordinator.refresh(true);
+  let manualSettled = false;
+  void manualRefresh.then(() => { manualSettled = true; });
+  await settleMicrotasks();
+  assert.deepEqual(refreshes, ["lease-only"]);
+  assert.equal(manualSettled, false);
+
+  lease.resolve();
+  assert.equal(await autoRefresh, true);
+  await settleMicrotasks();
+  assert.deepEqual(refreshes, ["lease-only", "full"]);
+  assert.deepEqual(dataEndpoints, ["agents", "conversations", "conversation", "inbox"]);
+  assert.equal(manualSettled, false);
+
+  full.resolve();
+  assert.equal(await manualRefresh, true);
+  assert.equal(manualSettled, true);
+});
+
+test("lease-only in flight + switch to Operations queues exactly one full refresh", async () => {
+  const { coordinator, lease, full, refreshes, dataEndpoints } = communicationRefreshHarness();
+  const autoRefresh = coordinator.refresh(false);
+  await settleMicrotasks();
+
+  const operationsRefresh = coordinator.refresh(true);
+  const secondFullCaller = coordinator.refresh(true);
+  let operationsSettled = false;
+  void operationsRefresh.then(() => { operationsSettled = true; });
+  await settleMicrotasks();
+  assert.deepEqual(refreshes, ["lease-only"]);
+  assert.equal(operationsSettled, false);
+
+  lease.resolve();
+  assert.equal(await autoRefresh, true);
+  await settleMicrotasks();
+  assert.deepEqual(refreshes, ["lease-only", "full"]);
+  assert.deepEqual(dataEndpoints, ["agents", "conversations", "conversation", "inbox"]);
+  assert.equal(operationsSettled, false);
+
+  full.resolve();
+  assert.equal(await operationsRefresh, true);
+  assert.equal(await secondFullCaller, true);
+  assert.deepEqual(refreshes, ["lease-only", "full"]);
+});

--- a/frontend/test/runtime_console_state.test.mjs
+++ b/frontend/test/runtime_console_state.test.mjs
@@ -9,6 +9,8 @@ import {
   runtimeProjectIdentityText,
   preferredRuntimeProjectSelection,
   runtimeCommunicationTranscriptAfterSeq,
+  runtimeWorkflowSessionSummaryRevision,
+  runtimeWorkflowSessionSummaryChanged,
   beginRuntimeCredential,
   refreshRuntimeOverview,
   isCurrentRuntimeOverviewRequest,
@@ -53,6 +55,33 @@ test("communication transcript window follows the latest bounded page", () => {
   assert.equal(runtimeCommunicationTranscriptAfterSeq(250, 50), 200);
   assert.equal(runtimeCommunicationTranscriptAfterSeq(-1), 0);
   assert.equal(runtimeCommunicationTranscriptAfterSeq(Number.NaN), 0);
+});
+
+test("Workflow Session summary revision changes only for detail-relevant list state", () => {
+  const base = {
+    session_id: "wc_sess_a",
+    title: "Work",
+    lifecycle: "active",
+    mode: "normal",
+    updated_at: 100,
+    running_call: false,
+    running_jobs: 0,
+    running_jobs_complete: true,
+    current_activity: null,
+    last_activity: { kind: "Edited", summary: "file" },
+    overview: { attention: { open_todos: 0 } },
+  };
+  assert.equal(runtimeWorkflowSessionSummaryRevision(null), "");
+  assert.equal(runtimeWorkflowSessionSummaryChanged(base, { ...base }), false);
+  assert.equal(runtimeWorkflowSessionSummaryChanged(base, { ...base, updated_at: 101 }), true);
+  assert.equal(runtimeWorkflowSessionSummaryChanged(base, { ...base, running_jobs: 1 }), true);
+  assert.equal(
+    runtimeWorkflowSessionSummaryChanged(base, {
+      ...base,
+      overview: { attention: { open_todos: 1 } },
+    }),
+    true
+  );
 });
 
 test("runtime credential and project generations fence stale project responses", () => {
@@ -631,6 +660,14 @@ test("runtime collaboration rendering uses textContent and explicitly reloads on
   assert.doesNotMatch(recentRender, /\.sort\(/);
   assert.match(source, /applyRunnerFilter\(select\.value\)/);
   assert.match(source, /void fetchOverview\(refreshRuntimeOverview\(state\)\)/);
+  assert.match(source, /const REFRESH_MS = 30000;/);
+  assert.doesNotMatch(source, /every 8 seconds|每 8 秒|REFRESH_MS = 8000/);
+  const autoRefreshStart = source.indexOf("function refreshAutoSurfaces");
+  const autoRefreshEnd = source.indexOf("function connectRuntimeCredential", autoRefreshStart);
+  const autoRefresh = source.slice(autoRefreshStart, autoRefreshEnd);
+  assert.match(autoRefresh, /document\.hidden[\s\S]*refreshCommunication\(false\)/);
+  assert.match(autoRefresh, /refreshCommunication\(workspaceView === "operations"\)/);
+  assert.match(autoRefresh, /window\.setInterval\(refreshAutoSurfaces, REFRESH_MS\)/);
   assert.match(source, /appendRichMessage\(bubble, message\?\.message\)/);
   assert.match(source, /action === "reload"[\s\S]*loadRetainedCollaboration/);
   assert.match(source, /action === "drain"/);
@@ -667,10 +704,20 @@ test("runtime collaboration rendering uses textContent and explicitly reloads on
   assert.doesNotMatch(source, /Delivered|Read by model|Currently acknowledged/);
   assert.match(source, /Refresh failed · showing previous data/);
   assert.match(source, /runtimeCollaborationNeedsRefreshRecovery/);
+  assert.match(source, /signature === renderedCollaborationSignature/);
+  const communicationRefreshStart = source.indexOf("async function refreshCommunication");
+  const communicationRefreshEnd = source.indexOf("async function createCommunicationAgent", communicationRefreshStart);
+  const communicationRefresh = source.slice(communicationRefreshStart, communicationRefreshEnd);
+  assert.match(communicationRefresh, /!includeData \|\| communicationReadAvailable === false/);
+  assert.match(communicationRefresh, /fetchCommunicationAgents\(generation, false\)/);
+  assert.match(communicationRefresh, /fetchCommunicationConversation\(generation, false\)/);
+  assert.match(source, /operations && token\) void refreshCommunication\(true\)/);
+  assert.match(source, /visibilitychange/);
   const renderProjectsStart = source.indexOf("function renderProjectSelectors");
   const renderProjectsEnd = source.indexOf("function switchProject", renderProjectsStart);
   const renderProjects = source.slice(renderProjectsStart, renderProjectsEnd);
   assert.match(renderProjects, /document\.createElement\("button"\)/);
+  assert.match(renderProjects, /signature === renderedProjectSelectorsSignature/);
   assert.match(renderProjects, /row\.type = "button"/);
   assert.doesNotMatch(renderProjects, /addEventListener\("keydown"/);
   assert.match(renderProjects, /all\.textContent = tr\("All Runners"\)/);
@@ -702,6 +749,11 @@ test("runtime collaboration rendering uses textContent and explicitly reloads on
   assert.doesNotMatch(source.slice(fetchProjectsStart, fetchProjectsEnd), /fetchOverview\(/);
   const fetchProjects = source.slice(fetchProjectsStart, fetchProjectsEnd);
   assert.match(fetchProjects, /payload\.client_id = clientId/);
+  const fetchSessionsStart = source.indexOf("async function fetchSessions");
+  const fetchSessionsEnd = source.indexOf("function updatedLabel", fetchSessionsStart);
+  const fetchSessions = source.slice(fetchSessionsStart, fetchSessionsEnd);
+  assert.match(fetchSessions, /runtimeWorkflowSessionSummaryChanged\(previousSelected, nextSelected\)/);
+  assert.match(fetchSessions, /!state\.workflow\.snapshot \|\| runtimeWorkflowSessionSummaryChanged/);
   assert.match(fetchProjects, /payload\.query = query/);
   assert.match(fetchProjects, /if \(query\) \{[\s\S]*renderProjectSelectors\(projectRows, projectRowsTruncated\);[\s\S]*return true;/);
   assert.match(fetchProjects, /currentProject && projectRowsTruncated/);
@@ -730,7 +782,7 @@ test("runtime collaboration rendering uses textContent and explicitly reloads on
   assert.match(post, /Send outcome unknown\. Refresh and review retained messages before retrying\./);
   assert.match(post, /abortCollaboration\(\)[\s\S]*setRuntimeCollaborationPhase\(state, request, "paused"\)/);
   const refreshStart = source.indexOf("async function refreshAll");
-  const refreshEnd = source.indexOf("function startAuto", refreshStart);
+  const refreshEnd = source.indexOf("function refreshAutoSurfaces", refreshStart);
   assert.equal((source.slice(refreshStart, refreshEnd).match(/fetchOverview\(/g) || []).length, 1);
   const runnerFilterStart = source.indexOf('el("runtime-device-select")?.addEventListener("change"');
   const runnerFilterEnd = source.indexOf('el("runtime-project-search")', runnerFilterStart);

--- a/frontend/test/runtime_console_state.test.mjs
+++ b/frontend/test/runtime_console_state.test.mjs
@@ -705,12 +705,16 @@ test("runtime collaboration rendering uses textContent and explicitly reloads on
   assert.match(source, /Refresh failed · showing previous data/);
   assert.match(source, /runtimeCollaborationNeedsRefreshRecovery/);
   assert.match(source, /signature === renderedCollaborationSignature/);
-  const communicationRefreshStart = source.indexOf("async function refreshCommunication");
+  const communicationRefreshStart = source.indexOf("async function performCommunicationRefresh");
   const communicationRefreshEnd = source.indexOf("async function createCommunicationAgent", communicationRefreshStart);
   const communicationRefresh = source.slice(communicationRefreshStart, communicationRefreshEnd);
   assert.match(communicationRefresh, /!includeData \|\| communicationReadAvailable === false/);
   assert.match(communicationRefresh, /fetchCommunicationAgents\(generation, false\)/);
+  assert.match(communicationRefresh, /fetchCommunicationConversations\(generation, false\)/);
   assert.match(communicationRefresh, /fetchCommunicationConversation\(generation, false\)/);
+  assert.match(communicationRefresh, /fetchCommunicationInbox\(generation, false\)/);
+  assert.match(communicationRefresh, /communicationRefreshCoordinator\.refresh\(includeData\)/);
+  assert.doesNotMatch(source, /communicationRefreshInFlight/);
   assert.match(source, /operations && token\) void refreshCommunication\(true\)/);
   assert.match(source, /visibilitychange/);
   const renderProjectsStart = source.indexOf("function renderProjectSelectors");
@@ -784,6 +788,7 @@ test("runtime collaboration rendering uses textContent and explicitly reloads on
   const refreshStart = source.indexOf("async function refreshAll");
   const refreshEnd = source.indexOf("function refreshAutoSurfaces", refreshStart);
   assert.equal((source.slice(refreshStart, refreshEnd).match(/fetchOverview\(/g) || []).length, 1);
+  assert.match(source.slice(refreshStart, refreshEnd), /refreshCommunication\(\)/);
   const runnerFilterStart = source.indexOf('el("runtime-device-select")?.addEventListener("change"');
   const runnerFilterEnd = source.indexOf('el("runtime-project-search")', runnerFilterStart);
   const runnerFilter = source.slice(runnerFilterStart, runnerFilterEnd);

--- a/src/mcp_tests/http_transport.rs
+++ b/src/mcp_tests/http_transport.rs
@@ -298,6 +298,7 @@ async fn stateless_full_trace_preserves_raw_context_ack_and_records_effective_in
     .await;
     assert_eq!(status, StatusCode::OK, "{body}");
     assert_eq!(body["result"]["isError"], false, "{body}");
+    crate::tool_request_trace::flush_full_trace_writer();
 
     let trace_dir = full_trace_dir_with_payload(trace_root.path(), "raw_arguments", &arguments);
     let events = std::fs::read_to_string(trace_dir.join("events.jsonl")).unwrap();

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -655,6 +655,7 @@ async fn http_tools_call_full_trace_captures_raw_effective_and_final_payloads() 
     let (status, response) = http_tool_call(&service, request.clone()).await;
     assert_eq!(status, StatusCode::OK, "{response}");
     assert_eq!(response["success"], true);
+    crate::tool_request_trace::flush_full_trace_writer();
 
     let trace_dir = full_trace_dir_with_payload(trace_root.path(), "raw_request_body", &request);
     let events = std::fs::read_to_string(trace_dir.join("events.jsonl")).unwrap();
@@ -710,6 +711,7 @@ async fn http_tools_call_full_trace_captures_pre_dispatch_error_response() {
     assert!(response["error"]
         .as_str()
         .is_some_and(|error| error.contains("tool")));
+    crate::tool_request_trace::flush_full_trace_writer();
 
     let trace_dir = full_trace_dir_with_payload(trace_root.path(), "final_response", &response);
     let events = std::fs::read_to_string(trace_dir.join("events.jsonl")).unwrap();

--- a/src/tool_request_trace.rs
+++ b/src/tool_request_trace.rs
@@ -797,6 +797,7 @@ fn persist_metadata_event_with_config(
     append_event_locked(&mut accounting, config, trace_id, &event)
 }
 
+#[cfg(test)]
 fn persist_metadata_event(trace_id: &str, event: Value) -> io::Result<bool> {
     let config = trace_store_config();
     persist_metadata_event_with_config(trace_id, event, &config)
@@ -898,6 +899,7 @@ fn persist_payload_with_config(
     Ok(Some((raw.len(), compressed.len(), digest, relative_path)))
 }
 
+#[cfg(test)]
 fn persist_payload(
     trace_id: &str,
     phase: &str,

--- a/src/tool_request_trace.rs
+++ b/src/tool_request_trace.rs
@@ -4,15 +4,18 @@
 //! metadata-only behavior. `WEBCODEX_TOOL_REQUEST_TRACE=full` additionally
 //! persists semantic JSON request/argument/result payloads on the Server host.
 //! Full payloads are zstd-compressed files under a bounded trace directory; they
-//! are deliberately not stored in the canonical runtime database.
+//! are deliberately not stored in the canonical runtime database. Compression,
+//! filesystem persistence, reconciliation, and pruning run on a bounded dedicated
+//! writer thread so diagnostic trace maintenance never blocks tool request workers.
 //!
 //! Full tracing is an explicit self-hosted operator diagnostic mode. It may
 //! contain file contents, command input/output, user messages, or other tool
 //! payload data. The trace path never reads WebCodex ingress HTTP Authorization
 //! headers; credential-like values that are themselves part of a tool/Runner
 //! payload are captured like any other payload field. Trace persistence is
-//! fail-open: storage, compression, pruning, or correlation failures never change
-//! tool execution correctness.
+//! fail-open: storage, compression, pruning, correlation failures, or writer
+//! saturation never change tool execution correctness; saturated queues drop
+//! diagnostic records instead of backpressuring tool execution.
 //!
 //! `*_tool_handler_returned` means the handler constructed a response and handed
 //! it to the HTTP framework. It does **not** prove the client received the body;
@@ -29,7 +32,8 @@ use std::future::Future;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{mpsc, Mutex, OnceLock};
+use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 #[cfg(unix)]
 use std::{os::unix::fs::OpenOptionsExt, os::unix::fs::PermissionsExt};
@@ -41,10 +45,14 @@ tokio::task_local! {
 
 const TRACE_CORRELATION_TTL_SECS: i64 = 24 * 60 * 60;
 const MAX_TRACE_CORRELATIONS: usize = 8_192;
-const TRACE_STORE_RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
+// Ordinary writes update accounting incrementally. A full recursive scan exists
+// only to discover out-of-process drift, so keep it deliberately low-frequency.
+const TRACE_STORE_RECONCILE_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const TRACE_WRITER_QUEUE_CAPACITY: usize = 64;
 
 static TRACE_IO_STATE: OnceLock<Mutex<TraceStoreAccounting>> = OnceLock::new();
 static TRACE_CORRELATIONS: OnceLock<Mutex<TraceCorrelations>> = OnceLock::new();
+static TRACE_WRITER: OnceLock<Option<TraceWriter>> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 struct TraceCorrelation {
@@ -73,6 +81,30 @@ struct TraceStoreConfig {
     root: PathBuf,
     retention: Duration,
     budget: u64,
+}
+
+#[derive(Debug)]
+enum TraceWrite {
+    Metadata {
+        trace_id: String,
+        phase: String,
+        event: Value,
+        config: TraceStoreConfig,
+    },
+    Payload {
+        trace_id: String,
+        phase: String,
+        value: Value,
+        event: Value,
+        config: TraceStoreConfig,
+    },
+    #[cfg(test)]
+    Flush(mpsc::Sender<()>),
+}
+
+#[derive(Debug)]
+struct TraceWriter {
+    sender: mpsc::SyncSender<TraceWrite>,
 }
 
 #[derive(Debug)]
@@ -244,6 +276,155 @@ fn trace_store_config() -> TraceStoreConfig {
 
 fn trace_io_state() -> &'static Mutex<TraceStoreAccounting> {
     TRACE_IO_STATE.get_or_init(|| Mutex::new(TraceStoreAccounting::default()))
+}
+
+impl TraceWriter {
+    fn start() -> io::Result<Self> {
+        let (sender, receiver) = mpsc::sync_channel(TRACE_WRITER_QUEUE_CAPACITY);
+        thread::Builder::new()
+            .name("webcodex-tool-trace-writer".to_string())
+            .spawn(move || trace_writer_loop(receiver))?;
+        Ok(Self { sender })
+    }
+}
+
+fn trace_writer() -> Option<&'static TraceWriter> {
+    TRACE_WRITER
+        .get_or_init(|| match TraceWriter::start() {
+            Ok(writer) => Some(writer),
+            Err(error) => {
+                tracing::warn!(
+                    event = "tool_trace_writer_unavailable",
+                    error = %error,
+                    "tool_trace_writer_unavailable"
+                );
+                None
+            }
+        })
+        .as_ref()
+}
+
+fn trace_writer_loop(receiver: mpsc::Receiver<TraceWrite>) {
+    while let Ok(write) = receiver.recv() {
+        match write {
+            TraceWrite::Metadata {
+                trace_id,
+                phase,
+                event,
+                config,
+            } => match persist_metadata_event_with_config(&trace_id, event, &config) {
+                Ok(true) => {}
+                Ok(false) => tracing::warn!(
+                    event = "tool_trace_capture_omitted",
+                    server_trace_id = %trace_id,
+                    phase = %phase,
+                    reason = "trace_disk_budget_exceeded",
+                    "tool_trace_capture_omitted"
+                ),
+                Err(error) => tracing::warn!(
+                    event = "tool_trace_capture_failed",
+                    server_trace_id = %trace_id,
+                    phase = %phase,
+                    error = %error,
+                    "tool_trace_capture_failed"
+                ),
+            },
+            TraceWrite::Payload {
+                trace_id,
+                phase,
+                value,
+                event,
+                config,
+            } => match persist_payload_with_config(&trace_id, &phase, &value, event, &config) {
+                Ok(Some((payload_bytes, compressed_bytes, digest, path))) => tracing::info!(
+                    event = "tool_trace_payload_persisted",
+                    server_trace_id = %trace_id,
+                    phase = %phase,
+                    payload_bytes = payload_bytes as u64,
+                    compressed_bytes = compressed_bytes as u64,
+                    payload_sha256 = %digest,
+                    payload_path = %path,
+                    "tool_trace_payload_persisted"
+                ),
+                Ok(None) => tracing::warn!(
+                    event = "tool_trace_capture_omitted",
+                    server_trace_id = %trace_id,
+                    phase = %phase,
+                    reason = "trace_disk_budget_exceeded",
+                    "tool_trace_capture_omitted"
+                ),
+                Err(error) => tracing::warn!(
+                    event = "tool_trace_capture_failed",
+                    server_trace_id = %trace_id,
+                    phase = %phase,
+                    error = %error,
+                    "tool_trace_capture_failed"
+                ),
+            },
+            #[cfg(test)]
+            TraceWrite::Flush(done) => {
+                let _ = done.send(());
+            }
+        }
+    }
+}
+
+fn enqueue_trace_write(write: TraceWrite, trace_id: &str, phase: &str) {
+    let Some(writer) = trace_writer() else {
+        tracing::warn!(
+            event = "tool_trace_capture_failed",
+            server_trace_id = %trace_id,
+            phase = phase,
+            error = "trace writer unavailable",
+            "tool_trace_capture_failed"
+        );
+        return;
+    };
+    match writer.sender.try_send(write) {
+        Ok(()) => {}
+        Err(mpsc::TrySendError::Full(_)) => tracing::warn!(
+            event = "tool_trace_capture_omitted",
+            server_trace_id = %trace_id,
+            phase = phase,
+            reason = "trace_writer_queue_full",
+            "tool_trace_capture_omitted"
+        ),
+        Err(mpsc::TrySendError::Disconnected(_)) => tracing::warn!(
+            event = "tool_trace_capture_failed",
+            server_trace_id = %trace_id,
+            phase = phase,
+            error = "trace writer disconnected",
+            "tool_trace_capture_failed"
+        ),
+    }
+}
+
+fn enqueue_metadata_event(trace_id: &str, phase: &str, event: Value) {
+    enqueue_trace_write(
+        TraceWrite::Metadata {
+            trace_id: trace_id.to_string(),
+            phase: phase.to_string(),
+            event,
+            config: trace_store_config(),
+        },
+        trace_id,
+        phase,
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn flush_full_trace_writer() {
+    let Some(writer) = trace_writer() else {
+        panic!("full trace writer unavailable");
+    };
+    let (done_tx, done_rx) = mpsc::channel();
+    writer
+        .sender
+        .send(TraceWrite::Flush(done_tx))
+        .expect("full trace writer disconnected before flush");
+    done_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("full trace writer flush timed out");
 }
 
 fn directory_stats(path: &Path) -> io::Result<(u64, SystemTime)> {
@@ -605,25 +786,34 @@ fn append_event_locked(
     Ok(true)
 }
 
-fn persist_metadata_event(trace_id: &str, event: Value) -> io::Result<bool> {
+fn persist_metadata_event_with_config(
+    trace_id: &str,
+    event: Value,
+    config: &TraceStoreConfig,
+) -> io::Result<bool> {
     let mut accounting = trace_io_state()
         .lock()
         .map_err(|_| io::Error::other("tool trace I/O lock poisoned"))?;
-    let config = trace_store_config();
-    append_event_locked(&mut accounting, &config, trace_id, &event)
+    append_event_locked(&mut accounting, config, trace_id, &event)
 }
 
-fn persist_payload(
+fn persist_metadata_event(trace_id: &str, event: Value) -> io::Result<bool> {
+    let config = trace_store_config();
+    persist_metadata_event_with_config(trace_id, event, &config)
+}
+
+fn persist_payload_with_config(
     trace_id: &str,
     phase: &str,
     value: &Value,
+    mut event: Value,
+    config: &TraceStoreConfig,
 ) -> io::Result<Option<(usize, usize, String, String)>> {
     let raw = serde_json::to_vec(value).map_err(io::Error::other)?;
     let digest = sha256_hex(&raw);
     let compressed = zstd::stream::encode_all(&raw[..], 3)?;
     let file_name = format!("{}-{}.json.zst", Uuid::new_v4(), safe_phase(phase));
     let relative_path = format!("payloads/{file_name}");
-    let mut event = base_event(trace_id, "tool_trace_payload_captured");
     merge_event_fields(
         &mut event,
         json!({
@@ -642,8 +832,7 @@ fn persist_payload(
     let mut accounting = trace_io_state()
         .lock()
         .map_err(|_| io::Error::other("tool trace I/O lock poisoned"))?;
-    let config = trace_store_config();
-    if !reserve_trace_capacity(&mut accounting, &config, trace_id, incoming)? {
+    if !reserve_trace_capacity(&mut accounting, config, trace_id, incoming)? {
         return Ok(None);
     }
     let trace_dir = config.root.join(trace_id);
@@ -705,40 +894,40 @@ fn persist_payload(
         return Err(error);
     }
 
-    commit_trace_write(&mut accounting, &config, trace_id, incoming);
+    commit_trace_write(&mut accounting, config, trace_id, incoming);
     Ok(Some((raw.len(), compressed.len(), digest, relative_path)))
+}
+
+fn persist_payload(
+    trace_id: &str,
+    phase: &str,
+    value: &Value,
+) -> io::Result<Option<(usize, usize, String, String)>> {
+    let config = trace_store_config();
+    persist_payload_with_config(
+        trace_id,
+        phase,
+        value,
+        base_event(trace_id, "tool_trace_payload_captured"),
+        &config,
+    )
 }
 
 fn capture_payload_for_trace(trace_id: &str, phase: &str, value: &Value) {
     if !full_trace_enabled() {
         return;
     }
-    match persist_payload(trace_id, phase, value) {
-        Ok(Some((payload_bytes, compressed_bytes, digest, path))) => tracing::info!(
-            event = "tool_trace_payload_persisted",
-            server_trace_id = %trace_id,
-            phase = phase,
-            payload_bytes = payload_bytes as u64,
-            compressed_bytes = compressed_bytes as u64,
-            payload_sha256 = %digest,
-            payload_path = %path,
-            "tool_trace_payload_persisted"
-        ),
-        Ok(None) => tracing::warn!(
-            event = "tool_trace_capture_omitted",
-            server_trace_id = %trace_id,
-            phase = phase,
-            reason = "trace_disk_budget_exceeded",
-            "tool_trace_capture_omitted"
-        ),
-        Err(error) => tracing::warn!(
-            event = "tool_trace_capture_failed",
-            server_trace_id = %trace_id,
-            phase = phase,
-            error = %error,
-            "tool_trace_capture_failed"
-        ),
-    }
+    enqueue_trace_write(
+        TraceWrite::Payload {
+            trace_id: trace_id.to_string(),
+            phase: phase.to_string(),
+            value: value.clone(),
+            event: base_event(trace_id, "tool_trace_payload_captured"),
+            config: trace_store_config(),
+        },
+        trace_id,
+        phase,
+    );
 }
 
 fn correlations() -> &'static Mutex<TraceCorrelations> {
@@ -852,15 +1041,7 @@ pub(crate) fn record_runner_request_enqueued<T: Serialize>(
                 "runner_git_commit": runner_git_commit,
             }),
         );
-        if let Err(error) = persist_metadata_event(&trace_id, event) {
-            tracing::warn!(
-                event = "tool_trace_capture_failed",
-                server_trace_id = %trace_id,
-                phase = "runner_request_enqueued",
-                error = %error,
-                "tool_trace_capture_failed"
-            );
-        }
+        enqueue_metadata_event(&trace_id, "runner_request_enqueued", event);
     }
 }
 
@@ -1062,15 +1243,7 @@ impl ToolRequestLifecycle {
                     "category": category,
                 }),
             );
-            if let Err(error) = persist_metadata_event(&self.trace_id, stored) {
-                tracing::warn!(
-                    event = "tool_trace_capture_failed",
-                    server_trace_id = %self.trace_id,
-                    phase = %event,
-                    error = %error,
-                    "tool_trace_capture_failed"
-                );
-            }
+            enqueue_metadata_event(&self.trace_id, &event, stored);
         }
     }
 
@@ -1182,6 +1355,7 @@ mod tests {
     }
 
     fn reset_trace_store_accounting() {
+        flush_full_trace_writer();
         *trace_io_state().lock().unwrap() = TraceStoreAccounting::default();
     }
 
@@ -1261,6 +1435,8 @@ mod tests {
             "content": "large-body-".repeat(100_000),
         });
         guard.capture_payload("raw_arguments", &payload);
+        drop(guard);
+        flush_full_trace_writer();
         let files = payload_files(temp.path(), "trace-full");
         assert_eq!(files.len(), 1);
         let compressed = fs::read(&files[0]).unwrap();
@@ -1269,6 +1445,45 @@ mod tests {
         let events = fs::read_to_string(temp.path().join("trace-full/events.jsonl")).unwrap();
         assert!(events.contains("raw_arguments"));
         assert!(events.contains("payload_sha256"));
+    }
+
+    #[test]
+    fn full_mode_capture_does_not_wait_for_trace_io_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut env = crate::test_support::TestEnvGuard::new();
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+        env.set(
+            "WEBCODEX_TOOL_REQUEST_TRACE_DIR",
+            temp.path().to_string_lossy().as_ref(),
+        );
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE_MAX_TOTAL_BYTES", "8388608");
+        reset_trace_store_accounting();
+
+        let io_guard = trace_io_state().lock().unwrap();
+        let (done_tx, done_rx) = mpsc::channel();
+        let capture = thread::spawn(move || {
+            let guard = ToolRequestLifecycle::new(
+                "mcp",
+                "trace-background-writer".into(),
+                "none",
+                "tools/call",
+                Some("read_file".into()),
+            );
+            guard.capture_payload("raw_arguments", &json!({"path": "README.md"}));
+            let _ = done_tx.send(());
+        });
+        let returned_without_io = done_rx.recv_timeout(Duration::from_millis(250)).is_ok();
+        drop(io_guard);
+        capture.join().unwrap();
+        assert!(
+            returned_without_io,
+            "full trace capture must enqueue without waiting for trace-store I/O"
+        );
+        flush_full_trace_writer();
+        assert_eq!(
+            payload_files(temp.path(), "trace-background-writer").len(),
+            1
+        );
     }
 
     #[test]
@@ -1290,6 +1505,8 @@ mod tests {
             Some("read_file".into()),
         );
         guard.capture_payload("raw_arguments", &json!({"path": "README.md"}));
+        drop(guard);
+        flush_full_trace_writer();
         assert_eq!(fs::read(&not_a_directory).unwrap(), b"occupied");
     }
 
@@ -1311,6 +1528,8 @@ mod tests {
             Some("write_project_file".into()),
         );
         guard.capture_payload("raw_arguments", &json!({"content": "must-not-truncate"}));
+        drop(guard);
+        flush_full_trace_writer();
         assert!(payload_files(temp.path(), "trace-budget").is_empty());
     }
 
@@ -1624,6 +1843,8 @@ mod tests {
             Some("list_tools".into()),
         );
         guard.capture_payload("raw_arguments", &json!({"probe": true}));
+        drop(guard);
+        flush_full_trace_writer();
 
         assert!(unrelated.join("keep.bin").exists());
         assert_eq!(payload_files(temp.path(), &trace_id).len(), 1);
@@ -1649,6 +1870,8 @@ mod tests {
             Some("write_project_file".into()),
         );
         guard.capture_payload("raw_arguments", &json!({"content": "private"}));
+        drop(guard);
+        flush_full_trace_writer();
 
         let trace_dir = temp.path().join(&trace_id);
         let payload_dir = trace_dir.join("payloads");
@@ -1694,6 +1917,8 @@ mod tests {
         })
         .await;
         capture_runner_result("request-1", &json!({"exit_code": 0, "stdout": "ok"}));
+        drop(guard);
+        flush_full_trace_writer();
         let events = fs::read_to_string(temp.path().join("trace-runner/events.jsonl")).unwrap();
         assert!(events.contains("tool_runner_request_enqueued"));
         let events = events


### PR DESCRIPTION
## Summary
- move full tool-request trace persistence onto a bounded background writer and document best-effort queue saturation behavior
- reduce Runtime Console polling/render overhead while preserving explicit/manual refresh semantics
- make communication refresh single-flight strength-aware so a full refresh waits for and upgrades an in-flight lease-only refresh

## Validation
- frontend: `npm test` — 78 passed
- frontend: `npm run typecheck` — passed
- frontend: `npm run check:dist` — passed
- `cargo check -p webcodex --all-targets` — passed on the trace changes; only pre-existing agent_wake dead-code warnings remain
- focused tool-request trace tests — 24 passed
- `git diff --check origin/main...HEAD` — passed
- merge-tree against current `origin/main` — clean
