### PR TITLE
Improve large diff review handoff

### DIFF
--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -2922,7 +2922,15 @@ fn finish_suggested_next_actions(output: &Value) -> Vec<String> {
         .and_then(Value::as_bool)
         == Some(false)
     {
-        push(&mut actions, "review workspace changes with show_changes");
+        if output
+            .pointer("/changes/show_changes/diff_review_handoff/tool")
+            .and_then(Value::as_str)
+            == Some("git_diff_hunks")
+        {
+            push(&mut actions, "continue the diff review with git_diff_hunks");
+        } else {
+            push(&mut actions, "review workspace changes with show_changes");
+        }
     }
     if output
         .get("jobs")
@@ -3013,6 +3021,28 @@ fn append_hygiene_warnings(hygiene: &Value, warnings: &mut Vec<Value>) {
 mod startup_runner_tests {
     use super::*;
     use crate::projects::ProjectConfig;
+
+    #[test]
+    fn finish_actions_use_git_diff_hunks_when_nested_show_changes_hands_off() {
+        let output = json!({
+            "workspace": {"clean": false},
+            "changes": {
+                "show_changes": {
+                    "diff_review_handoff": {"tool": "git_diff_hunks"}
+                }
+            },
+            "jobs": {"blocking_active_count": 0},
+            "validation": {},
+            "tool_failures": {},
+        });
+        let actions = finish_suggested_next_actions(&output);
+        assert!(actions
+            .iter()
+            .any(|action| action == "continue the diff review with git_diff_hunks"));
+        assert!(!actions
+            .iter()
+            .any(|action| action == "review workspace changes with show_changes"));
+    }
 
     fn resolved_agent(client_id: &str) -> ResolvedProject {
         ResolvedProject {

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -2162,24 +2162,75 @@ fn set_show_changes_verdict(output: &mut Value) {
         push_unique_reason(&mut warning_reasons, "review_warnings_present");
     }
 
-    if output
+    let hunks_truncated = output
         .get("hunks_truncated")
         .and_then(Value::as_bool)
-        .unwrap_or(false)
-        || output
-            .get("untracked_previews_truncated")
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
-    {
+        .unwrap_or(false);
+    if hunks_truncated {
+        actions.retain(|action| action != "review workspace changes with show_changes");
+        let diff_truncation_reasons = output
+            .get("truncation_reasons")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|reason| match reason.as_str() {
+                Some("diff_hunk_count_limit") => Some("diff_hunk_count_limit"),
+                Some("diff_hunk_line_limit") => Some("diff_hunk_line_limit"),
+                Some("diff_byte_budget") => Some("diff_byte_budget"),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let page_truncated = diff_truncation_reasons
+            .iter()
+            .any(|reason| matches!(*reason, "diff_hunk_count_limit" | "diff_byte_budget"));
+        let hunk_line_truncated = diff_truncation_reasons
+            .iter()
+            .any(|reason| *reason == "diff_hunk_line_limit");
+        output["diff_review_handoff"] = json!({
+            "tool": "git_diff_hunks",
+            "scope": "worktree",
+            "reason": "show_changes_diff_truncated",
+            "truncation_reasons": diff_truncation_reasons,
+        });
         push_unique_reason(&mut warning_reasons, "truncated_by_limit");
         push_unique_action(
             &mut actions,
-            "review bounded diff output or rerun with a narrower path set",
+            "continue the diff review with git_diff_hunks; use paths to narrow scope when useful",
+        );
+        if page_truncated {
+            push_unique_action(
+                &mut actions,
+                "follow git_diff_hunks.next_continuation while has_more=true",
+            );
+        }
+        if hunk_line_truncated {
+            push_unique_action(
+                &mut actions,
+                "increase git_diff_hunks.max_hunk_lines and/or narrow paths; continuation alone does not recover omitted lines from the same hunk",
+            );
+        }
+    } else if let Some(object) = output.as_object_mut() {
+        object.remove("diff_review_handoff");
+    }
+
+    let untracked_previews_truncated = output
+        .get("untracked_previews_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if untracked_previews_truncated {
+        actions.retain(|action| action != "review workspace changes with show_changes");
+        push_unique_reason(&mut warning_reasons, "truncated_by_limit");
+        push_unique_action(
+            &mut actions,
+            "inspect the relevant untracked files separately",
         );
     }
 
     if actions.is_empty() {
         actions.push("no action needed".to_string());
+    }
+    if hunks_truncated || untracked_previews_truncated {
+        output["suggested_next_actions"] = json!(actions.clone());
     }
     let status = if blocking_reasons.is_empty() {
         if warning_reasons.is_empty() {

--- a/src/tool_runtime/registry/output_schemas/git.rs
+++ b/src/tool_runtime/registry/output_schemas/git.rs
@@ -422,6 +422,41 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 schema_type("boolean", "Whether diff hunks were truncated by limits."),
             ),
             (
+                "diff_review_handoff",
+                json!({
+                    "type": "object",
+                    "description": "Present only when bounded show_changes diff hunks are incomplete; identifies the canonical focused/paged review tool without starting it or inventing a continuation.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tool": {
+                            "type": "string",
+                            "const": "git_diff_hunks"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "const": "worktree"
+                        },
+                        "reason": {
+                            "type": "string",
+                            "const": "show_changes_diff_truncated"
+                        },
+                        "truncation_reasons": {
+                            "type": "array",
+                            "description": "Actual show_changes diff bounds that caused this handoff.",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "diff_hunk_count_limit",
+                                    "diff_hunk_line_limit",
+                                    "diff_byte_budget"
+                                ]
+                            }
+                        }
+                    },
+                    "required": ["tool", "scope", "reason", "truncation_reasons"]
+                }),
+            ),
+            (
                 "untracked_previews",
                 array_schema(
                     open_object_schema("Bounded untracked file preview or skip reason."),

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -2802,6 +2802,27 @@ fn show_changes_include_diff_false_omits_diff_and_metadata() {
     );
     assert!(output.get("hunk_count").is_none());
     assert!(output.get("hunks_truncated").is_none());
+    assert!(output.get("diff_review_handoff").is_none());
+}
+
+#[test]
+fn show_changes_complete_diff_does_not_handoff_to_git_diff_hunks() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "README.md", "hello\n", "initial");
+    std::fs::write(tmp.path().join("README.md"), "hello\nchanged\n").unwrap();
+
+    let output = bounded_show_changes_output(tmp.path(), true, 20, 80);
+    assert_eq!(output["hunks_truncated"], false);
+    assert!(output.get("diff_review_handoff").is_none());
+    assert!(!output["suggested_next_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|action| action
+            .as_str()
+            .is_some_and(|action| action.contains("git_diff_hunks"))));
+    assert_show_changes_envelope_value_matches_schema(&output, "complete diff handoff");
 }
 
 #[test]
@@ -2828,6 +2849,29 @@ fn show_changes_diff_respects_max_hunks() {
     assert!(reasons.iter().any(|r| r == "diff_hunk_count_limit"));
     assert!(!reasons.iter().any(|r| r == "diff_hunk_line_limit"));
     assert!(!reasons.iter().any(|r| r == "diff_byte_budget"));
+    assert_eq!(output["diff_review_handoff"]["tool"], "git_diff_hunks");
+    assert_eq!(output["diff_review_handoff"]["scope"], "worktree");
+    assert_eq!(
+        output["diff_review_handoff"]["reason"],
+        "show_changes_diff_truncated"
+    );
+    assert_eq!(
+        output["diff_review_handoff"]["truncation_reasons"],
+        json!(["diff_hunk_count_limit"])
+    );
+    let actions = output["suggested_next_actions"].as_array().unwrap();
+    assert!(!actions
+        .iter()
+        .any(|action| action == "review workspace changes with show_changes"));
+    assert!(actions.iter().any(|action| action
+        == "continue the diff review with git_diff_hunks; use paths to narrow scope when useful"));
+    assert!(actions
+        .iter()
+        .any(|action| action == "follow git_diff_hunks.next_continuation while has_more=true"));
+    assert!(!actions.iter().any(|action| action
+        .as_str()
+        .is_some_and(|action| action.contains("continuation alone does not recover"))));
+    assert_show_changes_envelope_value_matches_schema(&output, "hunk count handoff");
 }
 
 #[test]
@@ -2855,6 +2899,94 @@ fn show_changes_diff_respects_max_hunk_lines() {
     assert!(reasons.iter().any(|r| r == "diff_hunk_line_limit"));
     assert!(!reasons.iter().any(|r| r == "diff_hunk_count_limit"));
     assert!(!reasons.iter().any(|r| r == "diff_byte_budget"));
+    assert_eq!(output["diff_review_handoff"]["tool"], "git_diff_hunks");
+    assert_eq!(
+        output["diff_review_handoff"]["truncation_reasons"],
+        json!(["diff_hunk_line_limit"])
+    );
+    let actions = output["suggested_next_actions"].as_array().unwrap();
+    assert!(actions.iter().any(|action| action
+        == "increase git_diff_hunks.max_hunk_lines and/or narrow paths; continuation alone does not recover omitted lines from the same hunk"));
+    assert!(!actions
+        .iter()
+        .any(|action| action == "follow git_diff_hunks.next_continuation while has_more=true"));
+    assert_show_changes_envelope_value_matches_schema(&output, "hunk line handoff");
+}
+
+#[test]
+fn show_changes_combined_hunk_count_and_line_truncation_keeps_both_guidance_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    let original = (0..20).map(|i| format!("line-{i}\n")).collect::<String>();
+    for name in ["a.txt", "b.txt"] {
+        commit_file(tmp.path(), name, &original, "initial");
+        let changed = (0..20)
+            .map(|i| format!("changed-{name}-{i}\n"))
+            .collect::<String>();
+        std::fs::write(tmp.path().join(name), changed).unwrap();
+    }
+
+    let output = bounded_show_changes_output(tmp.path(), true, 1, 3);
+    assert_eq!(output["hunks_truncated"], true);
+    let reasons = output["truncation_reasons"].as_array().unwrap();
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "diff_hunk_count_limit"));
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "diff_hunk_line_limit"));
+    let handoff_reasons = output["diff_review_handoff"]["truncation_reasons"]
+        .as_array()
+        .unwrap();
+    assert!(handoff_reasons
+        .iter()
+        .any(|reason| reason == "diff_hunk_count_limit"));
+    assert!(handoff_reasons
+        .iter()
+        .any(|reason| reason == "diff_hunk_line_limit"));
+    let actions = output["suggested_next_actions"].as_array().unwrap();
+    assert!(actions
+        .iter()
+        .any(|action| action == "follow git_diff_hunks.next_continuation while has_more=true"));
+    assert!(actions.iter().any(|action| action
+        .as_str()
+        .is_some_and(|action| action.contains("continuation alone does not recover"))));
+    assert_show_changes_envelope_value_matches_schema(&output, "combined diff handoff");
+}
+
+#[tokio::test]
+async fn show_changes_untracked_preview_truncation_does_not_create_diff_handoff() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "README.md", "hello\n", "initial");
+    for i in 0..6 {
+        std::fs::write(
+            tmp.path().join(format!("untracked-{i}.txt")),
+            format!("u{i}\n"),
+        )
+        .unwrap();
+    }
+
+    let runtime = test_runtime();
+    let client_id = "show-untracked-handoff";
+    let project = register_agent_project_at_path(&runtime, client_id, "repo", tmp.path()).await;
+    let result = run_show_changes_via_agent(&runtime, client_id, project, None, true).await;
+    assert!(result.success, "{:?}", result.error);
+    assert_show_changes_envelope_matches_schema("untracked-only truncation", &result);
+    let output = &result.output;
+    assert_eq!(output["hunks_truncated"], false);
+    assert_eq!(output["untracked_previews_truncated"], true);
+    assert!(output.get("diff_review_handoff").is_none());
+    let actions = output["suggested_next_actions"].as_array().unwrap();
+    assert!(!actions
+        .iter()
+        .any(|action| action == "review workspace changes with show_changes"));
+    assert!(actions
+        .iter()
+        .any(|action| action == "inspect the relevant untracked files separately"));
+    assert!(!actions.iter().any(|action| action
+        .as_str()
+        .is_some_and(|action| action.contains("git_diff_hunks"))));
 }
 
 #[test]
@@ -2901,12 +3033,34 @@ fn show_changes_schema_covers_truncation_and_transport_fields() {
         "output_budget_bytes",
         "output_truncated",
         "truncation_reasons",
+        "diff_review_handoff",
     ] {
         assert!(
             properties.contains_key(field),
             "missing truncation/transport field {field}"
         );
     }
+    let handoff = &properties["diff_review_handoff"];
+    assert_eq!(handoff["type"], "object");
+    assert_eq!(handoff["additionalProperties"], false);
+    assert_eq!(handoff["properties"]["tool"]["const"], "git_diff_hunks");
+    assert_eq!(handoff["properties"]["scope"]["const"], "worktree");
+    assert_eq!(
+        handoff["properties"]["reason"]["const"],
+        "show_changes_diff_truncated"
+    );
+    assert_eq!(
+        handoff["properties"]["truncation_reasons"]["items"]["enum"],
+        json!([
+            "diff_hunk_count_limit",
+            "diff_hunk_line_limit",
+            "diff_byte_budget"
+        ])
+    );
+    assert_eq!(
+        handoff["required"],
+        json!(["tool", "scope", "reason", "truncation_reasons"])
+    );
 }
 
 #[tokio::test]
@@ -5518,6 +5672,18 @@ fn show_changes_long_path_diff_budgets_complete_preambles_and_bytes() {
     );
     assert!(!reasons.iter().any(|r| r == "diff_hunk_count_limit"));
     assert!(!reasons.iter().any(|r| r == "diff_hunk_line_limit"));
+
+    assert_eq!(output["hunks_truncated"], true);
+    assert_eq!(output["diff_review_handoff"]["tool"], "git_diff_hunks");
+    assert_eq!(
+        output["diff_review_handoff"]["truncation_reasons"],
+        json!(["diff_byte_budget"])
+    );
+    let actions = output["suggested_next_actions"].as_array().unwrap();
+    assert!(actions
+        .iter()
+        .any(|action| action == "follow git_diff_hunks.next_continuation while has_more=true"));
+    assert_show_changes_envelope_value_matches_schema(&output, "diff byte handoff");
 
     let mut rejected_seen = false;
     for (i, path) in paths.iter().enumerate() {

--- a/src/tool_runtime/tests/schema/descriptions.rs
+++ b/src/tool_runtime/tests/schema/descriptions.rs
@@ -40,6 +40,8 @@ fn tool_specs_describe_default_coding_loop_preferences() {
         "default inspect/review tool",
         "before final response",
         "bounded hunks",
+        "diff_review_handoff",
+        "git_diff_hunks",
     ] {
         assert!(
             show_changes_desc.contains(phrase),
@@ -49,7 +51,17 @@ fn tool_specs_describe_default_coding_loop_preferences() {
 
     let git_diff_hunks = spec_named(&specs, "git_diff_hunks");
     let git_diff_hunks_desc = git_diff_hunks.description.to_lowercase();
-    for phrase in ["scope-bound", "replay", "scope", "paging inputs"] {
+    for phrase in [
+        "targeted/paged",
+        "scope-bound",
+        "replay",
+        "scope",
+        "paging inputs",
+        "later records",
+        "hunk_line_limit",
+        "larger max_hunk_lines",
+        "narrower paths",
+    ] {
         assert!(
             git_diff_hunks_desc.contains(phrase),
             "git_diff_hunks description should mention {phrase}: {git_diff_hunks_desc}"

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -993,7 +993,8 @@ fn tool_categories_and_recommended_flows_are_well_formed() {
         "validate: use cargo_check / cargo_test / go_test",
         "raw run_shell is a bounded escape hatch",
         "not the primary validation path",
-        "review: use show_changes / git_diff_hunks / workspace_hygiene_check",
+        "review: start with show_changes for the bounded worktree overview",
+        "if hunks truncate, continue/focus with git_diff_hunks",
         "handoff: use session_summary / session_handoff_summary",
     ] {
         assert!(

--- a/src/tool_runtime/tests/schema/spot_checks.rs
+++ b/src/tool_runtime/tests/schema/spot_checks.rs
@@ -91,6 +91,7 @@ fn tool_specs_show_changes_schema() {
             "counts",
             "files",
             "diff_stat",
+            "diff_review_handoff",
             "untracked_previews",
             "untracked_previews_truncated",
             "warnings",

--- a/src/tool_runtime/tool_catalog.rs
+++ b/src/tool_runtime/tool_catalog.rs
@@ -362,7 +362,7 @@ pub(crate) const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
     },
     ToolRecommendedFlow {
         name: "review",
-        summary: "Review: use show_changes / git_diff_hunks / workspace_hygiene_check before final response; for committed ranges, map with git_review_summary, inspect targeted exact-range git_diff_hunks, then read_file as needed.",
+        summary: "Review: start with show_changes for the bounded worktree overview; if hunks truncate, continue/focus with git_diff_hunks. For committed ranges, map with git_review_summary then inspect exact-range git_diff_hunks; use workspace_hygiene_check before final response.",
         manifest_purpose: "Map committed review ranges, inspect targeted diffs, and check workspace hygiene before the final response.",
         tools: &[
             "git_review_summary",

--- a/src/tool_runtime/tool_definition/git.rs
+++ b/src/tool_runtime/tool_definition/git.rs
@@ -74,7 +74,7 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
             false,
             false,
         ),
-        "Default inspect/review tool before final response. Read-only worktree plus optional session summary; reports status, warnings, next actions, and bounded hunks without modifying files.",
+        "Default inspect/review tool before final response. Read-only worktree overview with status, warnings, next actions, and bounded hunks. If hunks truncate, diff_review_handoff points to git_diff_hunks for focused/paged review.",
         show_changes_input_schema,
     ))),
 ];
@@ -143,7 +143,7 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
             false,
             false,
         ),
-        "Return producer-bounded structured git diff hunks for worktree/cached state or an exact committed base/head range, with scope-bound opaque continuation. Continuation calls must replay the original scope and paging inputs unchanged. Read-only.",
+        "Targeted/paged diff review for worktree/cached or exact base/head ranges, with paths and scope-bound opaque continuation. Replay scope and paging inputs unchanged. Continuation pages later records; hunk_line_limit needs a fresh call with larger max_hunk_lines and/or narrower paths. Read-only.",
         git_diff_hunks_input_schema,
     ))),
     git_like(model_spec(


### PR DESCRIPTION
## Summary
- add an explicit `diff_review_handoff` when `show_changes` returns incomplete bounded hunks
- distinguish paged truncation from per-hunk line truncation so continuation is only recommended where it can recover later records
- propagate the handoff into `finish_coding_task` next-action guidance and update model-facing review flow descriptions

## Validation
- `cargo test -p webcodex show_changes_ -- --nocapture` — 77 passed
- `cargo test -p webcodex tool_specs_describe_default_coding_loop_preferences -- --nocapture` — passed
- `cargo test -p webcodex tool_categories_and_recommended_flows_are_well_formed -- --nocapture` — passed
- `cargo fmt --all -- --check` — passed
- `cargo check -p webcodex` — passed
- `git diff --check origin/main...HEAD` — passed