### PR TITLE
Advance model context at durable checkpoints

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -118,7 +118,9 @@ fn adaptive_runtime_gateway_tool_spec() -> ToolSpec {
 }
 
 fn adaptive_runtime_gateway_target_allowed(target: &str, stateless_2026: bool) -> bool {
-    if target == ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME {
+    if target == ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME
+        || ADAPTIVE_RUNTIME_CORE_TOOL_NAMES.contains(&target)
+    {
         return false;
     }
     if target == crate::mcp_gateway::MCP_TOOL_NAME {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -17,7 +17,9 @@ use crate::tool_runtime::kernel::{
 use crate::tool_runtime::model_ergonomics_telemetry::{
     ModelErgonomicsRecord, ModelErgonomicsTimer,
 };
-use crate::tool_runtime::tool_definition::LOCAL_CODING_TOOL_NAMES;
+use crate::tool_runtime::tool_definition::{
+    runtime_tool_accepts_context_ack, LOCAL_CODING_TOOL_NAMES,
+};
 #[cfg(test)]
 use crate::tool_runtime::ToolResult;
 use crate::tool_runtime::{registered_tool_specs, ToolRuntime, ToolSpec};
@@ -116,9 +118,7 @@ fn adaptive_runtime_gateway_tool_spec() -> ToolSpec {
 }
 
 fn adaptive_runtime_gateway_target_allowed(target: &str, stateless_2026: bool) -> bool {
-    if target == ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME
-        || ADAPTIVE_RUNTIME_CORE_TOOL_NAMES.contains(&target)
-    {
+    if target == ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME {
         return false;
     }
     if target == crate::mcp_gateway::MCP_TOOL_NAME {
@@ -370,6 +370,10 @@ pub(super) fn add_stateless_workflow_recorder_metadata(
         return;
     };
     for tool in tools {
+        let accepts_context_ack = tool
+            .get("name")
+            .and_then(Value::as_str)
+            .is_none_or(runtime_tool_accepts_context_ack);
         let Some(properties) = tool
             .pointer_mut("/inputSchema/properties")
             .and_then(Value::as_object_mut)
@@ -432,15 +436,17 @@ pub(super) fn add_stateless_workflow_recorder_metadata(
                     "description": format!("Request bounded context material after this tool's main effect/observation; keys are open-ended and currently include {}. This sidecar grants no authority and cannot make requested guidance a retroactive precondition of the current effect. Recover missing project or Memory guidance on a read/observation call before any later dependent mutation.", crate::tool_runtime::context_projection::context_material_keys_csv())
                 }),
             );
-            properties.insert(
-                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD
-                    .to_string(),
-                json!({
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "Echo the latest Session context revision retained by the model; omit it when unknown. A known behind revision may receive bounded delta recovery; missing, invalid, future, lost-history, or truncated recovery gets a compact current Session handoff. Recovery is nonblocking."
-                }),
-            );
+            if accepts_context_ack {
+                properties.insert(
+                    crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD
+                        .to_string(),
+                    json!({
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Echo the latest Session context revision retained by the model; omit it when unknown. A known behind revision may receive bounded delta recovery; missing, invalid, future, lost-history, or truncated recovery gets a compact current Session handoff. Recovery is nonblocking."
+                    }),
+                );
+            }
             add_stateless_context_projection_output_schema(tool);
         }
     }
@@ -1320,11 +1326,11 @@ pub(super) async fn handle_call(
             );
         }
     }
-    let context_continuity_capable =
+    let context_continuity_surface_capable =
         stateless_2026 && runtime.model_surface().supports_operator_extensions();
-    // The sidecar is surface-scoped like the ACK today, but it is a
-    // separate caller-explicit protocol and must not participate in
-    // revision continuity bookkeeping.
+    let context_continuity_capable =
+        context_continuity_surface_capable && runtime_tool_accepts_context_ack(&params.name);
+    // context_request remains surface-scoped and independent from ACK policy.
     let context_sidecar_capable =
         stateless_2026 && runtime.model_surface().supports_operator_extensions();
     let skill_runtime_capable =
@@ -1366,21 +1372,25 @@ pub(super) async fn handle_call(
             );
         }
     }
-    if context_continuity_capable {
+    if context_continuity_surface_capable {
         if let Some(arguments) = params.arguments.as_object_mut() {
             arguments.remove(
                 crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
             );
         }
+        // Tolerate cached old schemas: strip the public wrapper from every
+        // operator request, but preserve it as proof only for ACK-capable tools.
         let context_revision = strip_stateless_ack_session_context_revision(&mut params.arguments);
-        if let (Some(arguments), Some(context_revision)) =
-            (params.arguments.as_object_mut(), context_revision)
-        {
-            arguments.insert(
-                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD
-                    .to_string(),
-                context_revision,
-            );
+        if context_continuity_capable {
+            if let (Some(arguments), Some(context_revision)) =
+                (params.arguments.as_object_mut(), context_revision)
+            {
+                arguments.insert(
+                    crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD
+                        .to_string(),
+                    context_revision,
+                );
+            }
         }
     }
     if let Some(lc) = lifecycle.as_deref() {

--- a/src/mcp_tests/http_transport.rs
+++ b/src/mcp_tests/http_transport.rs
@@ -1122,192 +1122,134 @@ async fn http_mcp_2026_session_context_revision_recovers_missing_stale_and_inval
         .unwrap()
         .to_string();
 
-    let first_args = with_mcp_recording_session(json!({}), &session_id);
-    let (status, first_body) =
-        stateless_2026_tool_call(&service, "secret", 228, "list_tools", first_args, None).await;
-    assert_eq!(status, StatusCode::OK, "{first_body}");
-    let first = stateless_tool_output(&first_body);
-    assert_eq!(first["session_context_revision"], 1);
-    assert!(first.get("session_continuity").is_none());
-    assert!(first.get("session_recovery").is_none());
+    let mut cached_read_args = with_mcp_recording_session(json!({}), &session_id);
+    cached_read_args.as_object_mut().unwrap().insert(
+        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
+        json!(999),
+    );
+    let (status, cached_read_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        228,
+        "list_tools",
+        cached_read_args,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{cached_read_body}");
+    let cached_read = stateless_tool_output(&cached_read_body);
+    assert!(cached_read.get("session_context_revision").is_none());
+    assert!(cached_read.get("session_continuity").is_none());
+    assert!(cached_read.get("session_recovery").is_none());
+    assert_eq!(runtime.sessions.context_revision(&session_id), Some(0));
 
-    let mut exact_args = with_mcp_recording_session(json!({}), &session_id);
+    let mut exact_args =
+        with_mcp_recording_session(json!({"title": "context checkpoint exact"}), &session_id);
     exact_args.as_object_mut().unwrap().insert(
         crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
-        json!(1),
+        json!(0),
     );
     let (status, exact_body) =
-        stateless_2026_tool_call(&service, "secret", 229, "list_tools", exact_args, None).await;
+        stateless_2026_tool_call(&service, "secret", 229, "start_session", exact_args, None).await;
     assert_eq!(status, StatusCode::OK, "{exact_body}");
     let exact = stateless_tool_output(&exact_body);
-    assert_eq!(exact["session_context_revision"], 2);
+    assert_eq!(exact["session_context_revision"], 1);
     assert!(exact.get("session_continuity").is_none());
     assert!(exact.get("session_recovery").is_none());
+    assert_eq!(runtime.sessions.context_revision(&session_id), Some(1));
 
-    let mut stale_args = with_mcp_recording_session(json!({}), &session_id);
-    stale_args.as_object_mut().unwrap().insert(
+    let mut second_cached_read_args = with_mcp_recording_session(json!({}), &session_id);
+    second_cached_read_args.as_object_mut().unwrap().insert(
         crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
         json!(1),
     );
+    let (status, second_cached_read_body) = stateless_2026_tool_call(
+        &service,
+        "secret",
+        230,
+        "list_tools",
+        second_cached_read_args,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{second_cached_read_body}");
+    assert!(stateless_tool_output(&second_cached_read_body)
+        .get("session_context_revision")
+        .is_none());
+    assert_eq!(runtime.sessions.context_revision(&session_id), Some(1));
+
+    let mut stale_args =
+        with_mcp_recording_session(json!({"title": "context checkpoint stale"}), &session_id);
+    stale_args.as_object_mut().unwrap().insert(
+        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
+        json!(0),
+    );
     let (status, stale_body) =
-        stateless_2026_tool_call(&service, "secret", 230, "list_tools", stale_args, None).await;
+        stateless_2026_tool_call(&service, "secret", 231, "start_session", stale_args, None).await;
     assert_eq!(status, StatusCode::OK, "{stale_body}");
     let stale = stateless_tool_output(&stale_body);
-    assert_eq!(stale["session_context_revision"], 3);
+    assert_eq!(stale["session_context_revision"], 2);
     assert_eq!(stale["session_continuity"]["status"], "behind");
-    assert_eq!(stale["session_continuity"]["ack_revision"], 1);
-    assert_eq!(stale["session_continuity"]["pre_call_revision"], 2);
+    assert_eq!(stale["session_continuity"]["ack_revision"], 0);
+    assert_eq!(stale["session_continuity"]["pre_call_revision"], 1);
     assert_eq!(
         stale["session_recovery"]["model_facing_events"][0]["context_revision"],
-        2
+        1
     );
+    assert_eq!(runtime.sessions.context_revision(&session_id), Some(2));
 
-    let mut recovered_args = with_mcp_recording_session(json!({}), &session_id);
-    recovered_args.as_object_mut().unwrap().insert(
-        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
-        json!(3),
-    );
-    let (status, recovered_body) =
-        stateless_2026_tool_call(&service, "secret", 231, "list_tools", recovered_args, None).await;
-    assert_eq!(status, StatusCode::OK, "{recovered_body}");
-    let recovered = stateless_tool_output(&recovered_body);
-    assert_eq!(recovered["session_context_revision"], 4);
-    assert!(recovered.get("session_recovery").is_none());
-
-    let mut invalid_args = with_mcp_recording_session(json!({}), &session_id);
-    invalid_args.as_object_mut().unwrap().insert(
-        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
-        json!("not-a-revision"),
-    );
-    let (status, invalid_body) =
-        stateless_2026_tool_call(&service, "secret", 232, "list_tools", invalid_args, None).await;
-    assert_eq!(
-        status,
-        StatusCode::OK,
-        "invalid ACK must not block tool: {invalid_body}"
-    );
-    let invalid = stateless_tool_output(&invalid_body);
-    assert_eq!(invalid["session_context_revision"], 5);
-    assert_eq!(invalid["session_continuity"]["status"], "invalid");
-    assert!(invalid["session_continuity"]
-        .get("events_after_ack")
-        .is_none());
-    assert!(invalid["session_recovery"]["model_facing_events"]
-        .as_array()
-        .unwrap()
-        .is_empty());
-    assert!(invalid["session_recovery"]["current_handoff"].is_object());
-    assert_eq!(invalid["session_recovery"]["history_lost"], false);
-
-    let mut future_args = with_mcp_recording_session(json!({}), &session_id);
+    let mut future_args =
+        with_mcp_recording_session(json!({"title": "context checkpoint future"}), &session_id);
     future_args.as_object_mut().unwrap().insert(
         crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
         json!(999),
     );
     let (status, future_body) =
-        stateless_2026_tool_call(&service, "secret", 233, "list_tools", future_args, None).await;
+        stateless_2026_tool_call(&service, "secret", 232, "start_session", future_args, None).await;
     assert_eq!(status, StatusCode::OK, "{future_body}");
     let future = stateless_tool_output(&future_body);
-    assert_eq!(future["session_context_revision"], 6);
+    assert_eq!(future["session_context_revision"], 3);
     assert_eq!(future["session_continuity"]["status"], "invalid");
     assert_eq!(future["session_continuity"]["ack_revision"], 999);
-    assert!(future["session_continuity"]
-        .get("events_after_ack")
-        .is_none());
     assert!(future["session_recovery"]["model_facing_events"]
         .as_array()
         .unwrap()
         .is_empty());
     assert!(future["session_recovery"]["current_handoff"].is_object());
 
-    let omitted_args = with_mcp_recording_session(json!({}), &session_id);
-    let (status, omitted_body) =
-        stateless_2026_tool_call(&service, "secret", 234, "list_tools", omitted_args, None).await;
-    assert_eq!(status, StatusCode::OK, "{omitted_body}");
-    let omitted = stateless_tool_output(&omitted_body);
-    assert_eq!(omitted["session_context_revision"], 7);
-    assert_eq!(omitted["session_continuity"]["status"], "unacknowledged");
-    assert!(omitted["session_continuity"]
-        .get("events_after_ack")
-        .is_none());
-    assert!(omitted["session_recovery"]["model_facing_events"]
-        .as_array()
-        .unwrap()
-        .is_empty());
-    assert!(omitted["session_recovery"]["current_handoff"].is_object());
+    let missing_args =
+        with_mcp_recording_session(json!({"title": "context checkpoint missing"}), &session_id);
+    let (status, missing_body) =
+        stateless_2026_tool_call(&service, "secret", 233, "start_session", missing_args, None)
+            .await;
+    assert_eq!(status, StatusCode::OK, "{missing_body}");
+    let missing = stateless_tool_output(&missing_body);
+    assert_eq!(missing["session_context_revision"], 4);
+    assert_eq!(missing["session_continuity"]["status"], "unacknowledged");
+    assert!(missing["session_recovery"]["current_handoff"].is_object());
 
-    let mut after_missing_args = with_mcp_recording_session(json!({}), &session_id);
+    let mut after_missing_args = with_mcp_recording_session(
+        json!({"title": "context checkpoint after missing"}),
+        &session_id,
+    );
     after_missing_args.as_object_mut().unwrap().insert(
         crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD.to_string(),
-        json!(7),
+        json!(4),
     );
     let (status, after_missing_body) = stateless_2026_tool_call(
         &service,
         "secret",
-        235,
-        "list_tools",
+        234,
+        "start_session",
         after_missing_args,
         None,
     )
     .await;
     assert_eq!(status, StatusCode::OK, "{after_missing_body}");
     let after_missing = stateless_tool_output(&after_missing_body);
-    assert_eq!(after_missing["session_context_revision"], 8);
+    assert_eq!(after_missing["session_context_revision"], 5);
     assert!(after_missing.get("session_continuity").is_none());
     assert!(after_missing.get("session_recovery").is_none());
-
-    let telemetry_rows = {
-        let conn = db.conn_for_tests();
-        let mut statement = conn
-            .prepare(
-                "SELECT summary_json FROM action_events WHERE endpoint = '/mcp' AND operation = 'list_tools' ORDER BY rowid",
-            )
-            .unwrap();
-        statement
-            .query_map([], |row| row.get::<_, String>(0))
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap()
-    };
-    let telemetry = telemetry_rows
-        .iter()
-        .map(|row| serde_json::from_str::<Value>(row).unwrap())
-        .map(|summary| summary["model_ergonomics"].clone())
-        .collect::<Vec<_>>();
-    assert!(telemetry.iter().all(|row| row["schema_version"] == 3));
-    assert!(telemetry
-        .iter()
-        .all(|row| row["context_continuity_eligible"] == true));
-    assert_eq!(telemetry[0]["context_ack_present"], false);
-    assert_eq!(telemetry[0]["context_continuity_status"], "unacknowledged");
-    assert_eq!(telemetry[0]["session_recovery_event_count"], 0);
-    assert_eq!(telemetry[1]["context_ack_present"], true);
-    assert_eq!(telemetry[1]["context_continuity_status"], "exact");
-    assert_eq!(telemetry[2]["context_continuity_status"], "behind");
-    assert!(
-        telemetry[2]["session_recovery_event_count"]
-            .as_u64()
-            .unwrap()
-            > 0
-    );
-    assert_eq!(telemetry[4]["context_ack_present"], true);
-    assert_eq!(telemetry[4]["context_continuity_status"], "invalid");
-    assert_eq!(telemetry[4]["session_recovery_event_count"], 0);
-    assert_eq!(telemetry[4]["session_history_lost"], false);
-    assert_eq!(telemetry[5]["context_ack_present"], true);
-    assert_eq!(telemetry[5]["context_continuity_status"], "invalid");
-    assert_eq!(telemetry[5]["session_recovery_event_count"], 0);
-    assert_eq!(telemetry[6]["context_ack_present"], false);
-    assert_eq!(telemetry[6]["context_continuity_status"], "unacknowledged");
-    assert_eq!(telemetry[6]["session_recovery_event_count"], 0);
-    assert_eq!(telemetry[7]["context_continuity_status"], "exact");
-    assert!(telemetry
-        .iter()
-        .all(|row| row["serialized_result_bytes"].is_u64()));
-    let serialized_telemetry = serde_json::to_string(&telemetry).unwrap();
-    assert!(!serialized_telemetry.contains(&session_id));
-    assert!(!serialized_telemetry.contains("ack_revision"));
-    assert!(!serialized_telemetry.contains("model_facing_events"));
 
     let audit = serde_json::to_string(
         &runtime

--- a/src/mcp_tests/http_transport.rs
+++ b/src/mcp_tests/http_transport.rs
@@ -1138,9 +1138,14 @@ async fn http_mcp_2026_session_context_revision_recovers_missing_stale_and_inval
     .await;
     assert_eq!(status, StatusCode::OK, "{cached_read_body}");
     let cached_read = stateless_tool_output(&cached_read_body);
-    assert!(cached_read.get("session_context_revision").is_none());
-    assert!(cached_read.get("session_continuity").is_none());
-    assert!(cached_read.get("session_recovery").is_none());
+    assert_eq!(cached_read["session_context_revision"], 0);
+    assert_eq!(cached_read["session_continuity"]["status"], "invalid");
+    assert_eq!(cached_read["session_continuity"]["ack_revision"], 999);
+    assert!(cached_read["session_recovery"]["model_facing_events"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    assert!(cached_read["session_recovery"]["current_handoff"].is_object());
     assert_eq!(runtime.sessions.context_revision(&session_id), Some(0));
 
     let mut exact_args =
@@ -1173,9 +1178,10 @@ async fn http_mcp_2026_session_context_revision_recovers_missing_stale_and_inval
     )
     .await;
     assert_eq!(status, StatusCode::OK, "{second_cached_read_body}");
-    assert!(stateless_tool_output(&second_cached_read_body)
-        .get("session_context_revision")
-        .is_none());
+    let second_cached_read = stateless_tool_output(&second_cached_read_body);
+    assert_eq!(second_cached_read["session_context_revision"], 1);
+    assert!(second_cached_read.get("session_continuity").is_none());
+    assert!(second_cached_read.get("session_recovery").is_none());
     assert_eq!(runtime.sessions.context_revision(&session_id), Some(1));
 
     let mut stale_args =

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -359,6 +359,133 @@ async fn adaptive_runtime_requires_gateway_for_long_tail_and_preserves_dispatch(
 }
 
 #[tokio::test]
+async fn adaptive_runtime_gateway_uses_target_checkpoint_policy_once() {
+    let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let direct_session = runtime.sessions.start_session(
+        Some("missing-project".to_string()),
+        Some("direct checkpoint parity".to_string()),
+    );
+    let gateway_session = runtime.sessions.start_session(
+        Some("missing-project".to_string()),
+        Some("gateway checkpoint parity".to_string()),
+    );
+
+    let direct_read = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7221)),
+            mcp_2026_params(json!({
+                "name": "read_files",
+                "arguments": {
+                    "project": "missing-project",
+                    "items": [{"path": "src/lib.rs"}],
+                    "recording_session_id": direct_session.session_id,
+                    "ack_session_context_revision": 999
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    assert!(matches!(direct_read, McpOutcome::Ok(_)));
+    assert_eq!(
+        runtime
+            .sessions
+            .context_revision(&direct_session.session_id),
+        Some(0),
+        "direct no-checkpoint read must not consume a revision"
+    );
+
+    let gateway_read = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7222)),
+            mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {
+                    "tool": "read_files",
+                    "arguments": {
+                        "project": "missing-project",
+                        "items": [{"path": "src/lib.rs"}]
+                    },
+                    "recording_session_id": gateway_session.session_id,
+                    "ack_session_context_revision": 999
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    assert!(matches!(gateway_read, McpOutcome::Ok(_)));
+    assert_eq!(
+        runtime
+            .sessions
+            .context_revision(&gateway_session.session_id),
+        Some(0),
+        "gateway read must inherit the target no-checkpoint policy"
+    );
+
+    let direct_edit = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7223)),
+            mcp_2026_params(json!({
+                "name": "apply_text_edits",
+                "arguments": {
+                    "project": "missing-project",
+                    "changes": [{"kind": "create", "path": "x.txt", "content": "x"}],
+                    "recording_session_id": direct_session.session_id,
+                    "ack_session_context_revision": 0
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    assert!(matches!(direct_edit, McpOutcome::Ok(_)));
+    assert_eq!(
+        runtime
+            .sessions
+            .context_revision(&direct_session.session_id),
+        Some(1),
+        "direct edit result is one checkpoint even when business validation fails"
+    );
+
+    let gateway_edit = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7224)),
+            mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {
+                    "tool": "apply_text_edits",
+                    "arguments": {
+                        "project": "missing-project",
+                        "changes": [{"kind": "create", "path": "x.txt", "content": "x"}]
+                    },
+                    "recording_session_id": gateway_session.session_id,
+                    "ack_session_context_revision": 0
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    assert!(matches!(gateway_edit, McpOutcome::Ok(_)));
+    assert_eq!(
+        runtime
+            .sessions
+            .context_revision(&gateway_session.session_id),
+        Some(1),
+        "one gateway logical invocation must not allocate outer and inner checkpoints"
+    );
+}
+
+#[tokio::test]
 async fn adaptive_runtime_gateway_rejects_recursive_and_unknown_targets() {
     let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
     for target in [

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -359,56 +359,25 @@ async fn adaptive_runtime_requires_gateway_for_long_tail_and_preserves_dispatch(
 }
 
 #[tokio::test]
-async fn adaptive_runtime_gateway_uses_target_checkpoint_policy_once() {
+async fn adaptive_runtime_gateway_uses_long_tail_target_checkpoint_policy_once() {
     let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
-    let direct_session = runtime.sessions.start_session(
-        Some("missing-project".to_string()),
-        Some("direct checkpoint parity".to_string()),
-    );
     let gateway_session = runtime.sessions.start_session(
         Some("missing-project".to_string()),
         Some("gateway checkpoint parity".to_string()),
-    );
-
-    let direct_read = handle_mcp_request(
-        &runtime,
-        rpc(
-            "tools/call",
-            Some(json!(7221)),
-            mcp_2026_params(json!({
-                "name": "read_files",
-                "arguments": {
-                    "project": "missing-project",
-                    "items": [{"path": "src/lib.rs"}],
-                    "recording_session_id": direct_session.session_id,
-                    "ack_session_context_revision": 999
-                }
-            })),
-        ),
-        None,
-    )
-    .await;
-    assert!(matches!(direct_read, McpOutcome::Ok(_)));
-    assert_eq!(
-        runtime
-            .sessions
-            .context_revision(&direct_session.session_id),
-        Some(0),
-        "direct no-checkpoint read must not consume a revision"
     );
 
     let gateway_read = handle_mcp_request(
         &runtime,
         rpc(
             "tools/call",
-            Some(json!(7222)),
+            Some(json!(7221)),
             mcp_2026_params(json!({
                 "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
                 "arguments": {
-                    "tool": "read_files",
+                    "tool": "read_file",
                     "arguments": {
                         "project": "missing-project",
-                        "items": [{"path": "src/lib.rs"}]
+                        "path": "src/lib.rs"
                     },
                     "recording_session_id": gateway_session.session_id,
                     "ack_session_context_revision": 999
@@ -424,48 +393,22 @@ async fn adaptive_runtime_gateway_uses_target_checkpoint_policy_once() {
             .sessions
             .context_revision(&gateway_session.session_id),
         Some(0),
-        "gateway read must inherit the target no-checkpoint policy"
+        "gateway read must inherit the long-tail target no-checkpoint policy"
     );
 
-    let direct_edit = handle_mcp_request(
+    let gateway_script = handle_mcp_request(
         &runtime,
         rpc(
             "tools/call",
-            Some(json!(7223)),
-            mcp_2026_params(json!({
-                "name": "apply_text_edits",
-                "arguments": {
-                    "project": "missing-project",
-                    "changes": [{"kind": "create", "path": "x.txt", "content": "x"}],
-                    "recording_session_id": direct_session.session_id,
-                    "ack_session_context_revision": 0
-                }
-            })),
-        ),
-        None,
-    )
-    .await;
-    assert!(matches!(direct_edit, McpOutcome::Ok(_)));
-    assert_eq!(
-        runtime
-            .sessions
-            .context_revision(&direct_session.session_id),
-        Some(1),
-        "direct edit result is one checkpoint even when business validation fails"
-    );
-
-    let gateway_edit = handle_mcp_request(
-        &runtime,
-        rpc(
-            "tools/call",
-            Some(json!(7224)),
+            Some(json!(7222)),
             mcp_2026_params(json!({
                 "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
                 "arguments": {
-                    "tool": "apply_text_edits",
+                    "tool": "run_script",
                     "arguments": {
                         "project": "missing-project",
-                        "changes": [{"kind": "create", "path": "x.txt", "content": "x"}]
+                        "language": "bash",
+                        "script": "exit 0"
                     },
                     "recording_session_id": gateway_session.session_id,
                     "ack_session_context_revision": 0
@@ -475,13 +418,13 @@ async fn adaptive_runtime_gateway_uses_target_checkpoint_policy_once() {
         None,
     )
     .await;
-    assert!(matches!(gateway_edit, McpOutcome::Ok(_)));
+    assert!(matches!(gateway_script, McpOutcome::Ok(_)));
     assert_eq!(
         runtime
             .sessions
             .context_revision(&gateway_session.session_id),
         Some(1),
-        "one gateway logical invocation must not allocate outer and inner checkpoints"
+        "one checkpoint-capable gateway invocation must allocate exactly one revision"
     );
 }
 
@@ -490,6 +433,7 @@ async fn adaptive_runtime_gateway_rejects_recursive_and_unknown_targets() {
     let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
     for target in [
         crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+        "read_files",
         "work_on_project",
         "start_coding_task",
         "not_a_real_webcodex_tool",
@@ -510,7 +454,12 @@ async fn adaptive_runtime_gateway_rejects_recursive_and_unknown_targets() {
         match outcome {
             McpOutcome::BadRequest(value) => {
                 assert_eq!(value["error"]["code"], -32602);
-                assert!(value["error"]["message"].as_str().unwrap().contains(target));
+                assert_eq!(
+                    value["error"]["message"],
+                    format!(
+                        "tool '{target}' is not available through the adaptive runtime gateway"
+                    )
+                );
             }
             other => panic!("target {target} must fail closed, got {other:?}"),
         }

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -586,6 +586,51 @@ fn stateless_workflow_recorder_metadata_does_not_expand_connector_or_generic_too
 
     let mut full = mcp_tools_list_payload_with_compact(ModelSurface::FullOperatorRuntime, false);
     add_stateless_workflow_recorder_metadata(&mut full, ModelSurface::FullOperatorRuntime);
+    for name in [
+        "read_files",
+        "search_project_texts",
+        "tool_manifest",
+        "show_changes",
+    ] {
+        let tool = full["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("missing {name} schema"));
+        let properties = tool["inputSchema"]["properties"].as_object().unwrap();
+        assert!(
+            !properties.contains_key(
+                crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD
+            ),
+            "{name} must not advertise checkpoint ACK"
+        );
+        assert!(properties.contains_key(
+            crate::tool_runtime::context_projection::TOOL_CALL_CONTEXT_REQUEST_FIELD
+        ));
+        assert!(properties
+            .contains_key(crate::tool_runtime::sessions::TOOL_CALL_RECORDING_SESSION_ID_FIELD));
+        assert!(properties
+            .contains_key(crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_MESSAGE_IDS_FIELD));
+        assert!(properties.contains_key(
+            crate::tool_runtime::sessions::TOOL_CALL_SESSION_MESSAGE_RESOLUTION_FIELD
+        ));
+    }
+    for name in ["work_on_project", "apply_text_edits", "run_process"] {
+        let tool = full["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("missing {name} schema"));
+        let properties = tool["inputSchema"]["properties"].as_object().unwrap();
+        assert!(properties.contains_key(
+            crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD
+        ));
+        assert!(properties.contains_key(
+            crate::tool_runtime::context_projection::TOOL_CALL_CONTEXT_REQUEST_FIELD
+        ));
+    }
     for tool in full["tools"].as_array().unwrap() {
         if tool["name"] != "work_on_project" {
             let serialized = serde_json::to_string(tool).unwrap();
@@ -850,6 +895,34 @@ fn stateless_context_revision_ack_is_request_scoped_and_removed_before_parsing()
         recorder.ack_session_context_revision,
         crate::tool_runtime::sessions::SessionContextRevisionAck::Invalid
     );
+}
+
+#[test]
+fn stale_cached_context_revision_ack_is_ignored_for_no_ack_tool() {
+    let mut arguments = json!({
+        "project": "proj",
+        "items": [{"path": "src/lib.rs"}],
+        crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD: 41,
+    });
+    let discarded = strip_stateless_ack_session_context_revision(&mut arguments).unwrap();
+    assert_eq!(discarded, json!(41));
+    assert!(arguments
+        .get(crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD)
+        .is_none());
+
+    let accepts_ack =
+        crate::tool_runtime::tool_definition::runtime_tool_accepts_context_ack("read_files");
+    assert!(!accepts_ack);
+    let recorder = crate::tool_runtime::sessions::ToolCallRecorderMetadata::
+        from_arguments_with_context_continuity(&arguments, accepts_ack);
+    assert_eq!(
+        recorder.ack_session_context_revision,
+        crate::tool_runtime::sessions::SessionContextRevisionAck::Unsupported
+    );
+
+    let concrete = crate::tool_runtime::sessions::strip_tool_call_expectation_metadata(arguments);
+    crate::tool_runtime::ToolCall::from_tool_name("read_files", concrete)
+        .expect("cached ACK must be stripped before concrete read_files parsing");
 }
 
 #[test]
@@ -1778,7 +1851,11 @@ async fn mcp_tools_call_records_event_with_recording_session_id() {
         .unwrap();
     assert_eq!(finished.transport, "mcp");
     assert_eq!(finished.status.as_deref(), Some("succeeded"));
-    assert_eq!(finished.context_revision, Some(1));
+    assert_eq!(finished.context_revision, None);
+    assert_eq!(
+        runtime.sessions.context_revision(&session.session_id),
+        Some(0)
+    );
     assert_eq!(finished.risk_class, "read_only");
 }
 

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -600,10 +600,10 @@ fn stateless_workflow_recorder_metadata_does_not_expand_connector_or_generic_too
             .unwrap_or_else(|| panic!("missing {name} schema"));
         let properties = tool["inputSchema"]["properties"].as_object().unwrap();
         assert!(
-            !properties.contains_key(
+            properties.contains_key(
                 crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD
             ),
-            "{name} must not advertise checkpoint ACK"
+            "{name} must advertise recovery ACK even when it does not advance checkpoints"
         );
         assert!(properties.contains_key(
             crate::tool_runtime::context_projection::TOOL_CALL_CONTEXT_REQUEST_FIELD
@@ -898,26 +898,29 @@ fn stateless_context_revision_ack_is_request_scoped_and_removed_before_parsing()
 }
 
 #[test]
-fn stale_cached_context_revision_ack_is_ignored_for_no_ack_tool() {
+fn no_checkpoint_tool_still_accepts_context_revision_ack() {
     let mut arguments = json!({
         "project": "proj",
         "items": [{"path": "src/lib.rs"}],
         crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD: 41,
     });
-    let discarded = strip_stateless_ack_session_context_revision(&mut arguments).unwrap();
-    assert_eq!(discarded, json!(41));
+    let ack = strip_stateless_ack_session_context_revision(&mut arguments).unwrap();
+    assert_eq!(ack, json!(41));
     assert!(arguments
         .get(crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD)
         .is_none());
 
     let accepts_ack =
         crate::tool_runtime::tool_definition::runtime_tool_accepts_context_ack("read_files");
-    assert!(!accepts_ack);
+    assert!(accepts_ack);
+    arguments
+        [crate::tool_runtime::sessions::TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD] =
+        ack;
     let recorder = crate::tool_runtime::sessions::ToolCallRecorderMetadata::
         from_arguments_with_context_continuity(&arguments, accepts_ack);
     assert_eq!(
         recorder.ack_session_context_revision,
-        crate::tool_runtime::sessions::SessionContextRevisionAck::Unsupported
+        crate::tool_runtime::sessions::SessionContextRevisionAck::Revision(41)
     );
 
     let concrete = crate::tool_runtime::sessions::strip_tool_call_expectation_metadata(arguments);

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -240,10 +240,12 @@ impl ToolRuntime {
         context: ToolCallContext<'_>,
         capabilities: ToolProtocolCapabilities,
     ) -> ToolCallOutcome {
+        let context_continuity_capable = capabilities.context_continuity
+            && super::tool_definition::runtime_tool_accepts_context_ack(&request.tool_name);
         let telemetry = ModelErgonomicsTimer::start_with_protocol(
             &request.tool_name,
             &request.arguments,
-            capabilities.context_continuity,
+            context_continuity_capable,
         );
         let mut outcome = self
             .call_tool_with_context_inner(request, context, capabilities)
@@ -258,10 +260,12 @@ impl ToolRuntime {
         context: ToolCallContext<'_>,
         capabilities: ToolProtocolCapabilities,
     ) -> ToolCallOutcome {
+        let context_continuity_capable = capabilities.context_continuity
+            && super::tool_definition::runtime_tool_accepts_context_ack(&request.tool_name);
         let mut recorder_metadata =
             ToolCallRecorderMetadata::from_arguments_with_context_continuity(
                 &request.arguments,
-                capabilities.context_continuity,
+                context_continuity_capable,
             );
         // One trusted identity per real kernel request. The outer recorder and
         // inner business ledger pairs inherit it, but it never affects execution.

--- a/src/tool_runtime/session_context.rs
+++ b/src/tool_runtime/session_context.rs
@@ -462,13 +462,7 @@ pub(crate) fn add_session_context_continuity(
         sessions::SessionContextRevisionAck::Unacknowledged => ("unacknowledged", None, true, None),
         sessions::SessionContextRevisionAck::Invalid => ("invalid", None, true, None),
     };
-    let suppress_fresh_empty_recovery = matches!(
-        recorded.ack_session_context_revision,
-        sessions::SessionContextRevisionAck::Unacknowledged
-    ) && pre_response_context_revision == 0
-        && recorded.recovery_events.is_empty()
-        && !recorded.history_lost;
-    if needs_recovery && !suppress_fresh_empty_recovery {
+    if needs_recovery {
         let total_retained = recorded.recovery_events.len();
         let events = bounded_model_facing_recovery_events(recorded);
         let omitted_count = total_retained.saturating_sub(events.len());

--- a/src/tool_runtime/session_context.rs
+++ b/src/tool_runtime/session_context.rs
@@ -410,6 +410,11 @@ pub(crate) fn add_session_context_continuity(
     result: &mut ToolResult,
     recorded: &sessions::RecordedModelFacingToolCall,
 ) -> bool {
+    debug_assert_eq!(
+        recorded.checkpoint_advanced,
+        recorded.context_revision > recorded.pre_response_context_revision,
+        "checkpoint allocation must match the recorded pre-response watermark"
+    );
     if matches!(
         recorded.ack_session_context_revision,
         sessions::SessionContextRevisionAck::Unsupported
@@ -428,7 +433,7 @@ pub(crate) fn add_session_context_continuity(
         "session_context_revision".to_string(),
         Value::from(recorded.context_revision),
     );
-    let pre_response_context_revision = recorded.context_revision.saturating_sub(1);
+    let pre_response_context_revision = recorded.pre_response_context_revision;
     let (status, ack_revision, needs_recovery, events_after_ack) = match recorded
         .ack_session_context_revision
     {

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -679,6 +679,7 @@ pub(crate) struct ToolCallStart {
     pub(crate) permission: Option<PermissionDecision>,
     pub(crate) expectation: ToolCallExpectation,
     pub(crate) pre_call_context_revision: u64,
+    pub(crate) advances_context_checkpoint: bool,
     pub(crate) ack_session_context_revision: SessionContextRevisionAck,
 }
 
@@ -719,9 +720,9 @@ pub(crate) struct ToolCallRecorderMetadata {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum SessionContextRevisionAck {
-    /// The current request surface does not expose the context-continuity ACK
-    /// protocol. Model-facing history still advances its durable watermark,
-    /// but the response must preserve the legacy surface contract.
+    /// The current tool/surface does not accept the context-continuity ACK
+    /// protocol. Checkpoint advancement is a separate ToolDefinition policy and
+    /// may still advance the cross-surface watermark.
     #[default]
     Unsupported,
     Unacknowledged,
@@ -734,6 +735,11 @@ pub(crate) struct RecordedModelFacingToolCall {
     pub(crate) event_id: String,
     pub(crate) session_id: String,
     pub(crate) context_revision: u64,
+    /// Session checkpoint watermark immediately before the current model-facing
+    /// result was recorded. This must not be inferred from `context_revision - 1`
+    /// because continuity-aware recovery calls may not advance a checkpoint.
+    pub(crate) pre_response_context_revision: u64,
+    pub(crate) checkpoint_advanced: bool,
     pub(crate) pre_call_context_revision: u64,
     pub(crate) ack_session_context_revision: SessionContextRevisionAck,
     /// Retained model-facing results strictly after a caller's explicitly proven
@@ -818,8 +824,9 @@ pub(crate) struct SessionEvent {
     pub(crate) logical_invocation_role: Option<String>,
     pub(crate) session_id: String,
     pub(crate) kind: String,
-    /// Model-facing context revision assigned atomically with a finished
-    /// ToolResult. Started/background/system events leave this unset.
+    /// Model-facing context checkpoint revision assigned atomically only when the
+    /// finished ToolResult advances model knowledge. Non-checkpoint results and
+    /// started/background/system events leave this unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) context_revision: Option<u64>,
     /// Closed, bounded consequence projection used only for model-context

--- a/src/tool_runtime/sessions/store.rs
+++ b/src/tool_runtime/sessions/store.rs
@@ -3,6 +3,9 @@
 //! All durable session-map mutations flow through `SessionStoreInner` helpers.
 //! Callers outside this module use `SessionStore` methods only.
 use super::super::permissions::PermissionDecision;
+use super::super::tool_definition::{
+    runtime_tool_accepts_context_ack, runtime_tool_advances_context_checkpoint,
+};
 use super::super::tool_inputs::SessionMode;
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
@@ -1194,7 +1197,11 @@ impl SessionStore {
         let diff_review_like = diff_review_like_for_tool(tool_name, arguments);
         let input_summary = Some(session_input_summary_for_tool(tool_name, arguments));
         let expectation = metadata.expectation;
-        let ack_session_context_revision = metadata.ack_session_context_revision;
+        let ack_session_context_revision = if runtime_tool_accepts_context_ack(tool_name) {
+            metadata.ack_session_context_revision
+        } else {
+            SessionContextRevisionAck::Unsupported
+        };
         let start = ToolCallStart {
             event_id: event_id.clone(),
             call_id: call_id.clone(),
@@ -1219,6 +1226,7 @@ impl SessionStore {
             permission: None,
             expectation: expectation.clone(),
             pre_call_context_revision,
+            advances_context_checkpoint: runtime_tool_advances_context_checkpoint(tool_name),
             ack_session_context_revision,
         };
         self.push_event(SessionEvent {
@@ -1353,6 +1361,7 @@ impl SessionStore {
         mut event: SessionEvent,
         pre_call_context_revision: u64,
         ack_session_context_revision: SessionContextRevisionAck,
+        advances_context_checkpoint: bool,
     ) -> Option<RecordedModelFacingToolCall> {
         let session_id = event.session_id.clone();
         let outcome = {
@@ -1374,13 +1383,15 @@ impl SessionStore {
             if record.context_revision < pre_call_context_revision {
                 return None;
             }
-            let next_revision = record.context_revision.checked_add(1)?;
-            // A call may have started at revision N while another model-facing
-            // call completes before this result is recorded. The response for
-            // this result must recover those intervening completions before it
-            // exposes its own newer revision, otherwise a caller could ACK the
-            // newer revision without ever seeing a complete context prefix.
-            let pre_response_context_revision = next_revision.saturating_sub(1);
+            // Recover only the checkpoint prefix that existed immediately before
+            // this result. Non-checkpoint model-facing events stay in the ledger
+            // without consuming a context revision.
+            let pre_response_context_revision = record.context_revision;
+            let context_revision = if advances_context_checkpoint {
+                pre_response_context_revision.checked_add(1)?
+            } else {
+                pre_response_context_revision
+            };
             let recovery_start = match ack_session_context_revision {
                 SessionContextRevisionAck::Revision(revision)
                     if revision <= pre_call_context_revision =>
@@ -1412,9 +1423,11 @@ impl SessionStore {
                 _ => 0,
             };
             let history_lost = expected_recovery_count > recovery_events.len() as u64;
-            event.context_revision = Some(next_revision);
+            event.context_revision = advances_context_checkpoint.then_some(context_revision);
             let event_id = event.event_id.clone();
-            record.context_revision = next_revision;
+            if advances_context_checkpoint {
+                record.context_revision = context_revision;
+            }
             record.updated_at = record.updated_at.max(event.timestamp);
             record.events.push_back(Arc::new(event));
             record.events_observed = record.events_observed.saturating_add(1);
@@ -1424,7 +1437,9 @@ impl SessionStore {
             let outcome = RecordedModelFacingToolCall {
                 event_id,
                 session_id: session_id.clone(),
-                context_revision: next_revision,
+                context_revision,
+                pre_response_context_revision,
+                checkpoint_advanced: advances_context_checkpoint,
                 pre_call_context_revision,
                 ack_session_context_revision,
                 recovery_events,
@@ -1453,15 +1468,15 @@ impl SessionStore {
         error: Option<&str>,
         error_kind: Option<&str>,
     ) -> Option<String> {
-        let (event, _, _) =
+        let (event, _, _, _) =
             Self::tool_call_finished_event(start, success, output, error, error_kind)?;
         let event_id = event.event_id.clone();
         self.push_event(event);
         Some(event_id)
     }
 
-    /// Append a finished model-facing ToolResult and atomically allocate its next
-    /// Session-local context revision with the corresponding event annotation.
+    /// Append a finished model-facing ToolResult and atomically advance the
+    /// Session-local context revision only for a ToolDefinition checkpoint.
     pub(crate) fn record_model_facing_tool_call_finished(
         &self,
         start: Option<ToolCallStart>,
@@ -1470,12 +1485,17 @@ impl SessionStore {
         error: Option<&str>,
         error_kind: Option<&str>,
     ) -> Option<RecordedModelFacingToolCall> {
-        let (event, pre_call_context_revision, ack_session_context_revision) =
-            Self::tool_call_finished_event(start, success, output, error, error_kind)?;
+        let (
+            event,
+            pre_call_context_revision,
+            ack_session_context_revision,
+            advances_context_checkpoint,
+        ) = Self::tool_call_finished_event(start, success, output, error, error_kind)?;
         self.push_model_facing_event(
             event,
             pre_call_context_revision,
             ack_session_context_revision,
+            advances_context_checkpoint,
         )
     }
 
@@ -1485,10 +1505,11 @@ impl SessionStore {
         output: &Value,
         error: Option<&str>,
         error_kind: Option<&str>,
-    ) -> Option<(SessionEvent, u64, SessionContextRevisionAck)> {
+    ) -> Option<(SessionEvent, u64, SessionContextRevisionAck, bool)> {
         let start = start?;
         let pre_call_context_revision = start.pre_call_context_revision;
         let ack_session_context_revision = start.ack_session_context_revision;
+        let advances_context_checkpoint = start.advances_context_checkpoint;
         let finished_at = now_ts();
         let duration_ms = start
             .started_instant
@@ -1600,6 +1621,7 @@ impl SessionStore {
             event,
             pre_call_context_revision,
             ack_session_context_revision,
+            advances_context_checkpoint,
         ))
     }
 

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -4793,7 +4793,7 @@ fn raw_model_facing_events_do_not_consume_context_revisions() {
         assert!(!observed.checkpoint_advanced, "{tool}");
         assert_eq!(
             observed.ack_session_context_revision,
-            SessionContextRevisionAck::Unsupported,
+            SessionContextRevisionAck::Revision(0),
             "{tool}"
         );
     }
@@ -5286,7 +5286,7 @@ fn simultaneous_no_checkpoint_results_leave_revision_unchanged() {
         assert!(!recorded.checkpoint_advanced);
         assert_eq!(
             recorded.ack_session_context_revision,
-            SessionContextRevisionAck::Unsupported
+            SessionContextRevisionAck::Revision(1)
         );
     }
     assert_eq!(store.context_revision(&session.session_id), Some(1));
@@ -5433,7 +5433,7 @@ fn batch_budget_preserves_recorder_overlay_for_no_ack_read_batch() {
         assert!(!recorded.checkpoint_advanced);
         assert_eq!(
             recorded.ack_session_context_revision,
-            SessionContextRevisionAck::Unsupported
+            SessionContextRevisionAck::Revision(1)
         );
         assert!(recorded.recovery_events.is_empty());
 
@@ -5445,16 +5445,13 @@ fn batch_budget_preserves_recorder_overlay_for_no_ack_read_batch() {
             Some(recorded.event_id.clone()),
         );
         assert!(
-            !super::super::session_context::add_session_context_continuity(
-                &mut response,
-                &recorded,
-            )
+            super::super::session_context::add_session_context_continuity(&mut response, &recorded,)
         );
         super::super::read_files::apply_model_facing_output_budget(&mut response, None);
         super::super::dispatch::sparsify_complete_read_success("read_files", &mut response);
         assert_eq!(response.output["session_recorded"], true);
         assert_eq!(response.output["session_id"], session.session_id);
-        assert!(response.output.get("session_context_revision").is_none());
+        assert_eq!(response.output["session_context_revision"], 1);
         assert!(response.output.get("session_continuity").is_none());
         assert!(response.output.get("session_recovery").is_none());
         assert!(

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -4574,24 +4574,28 @@ fn session_context_revision_exact_missing_stale_invalid_future_and_failure_seman
     let first = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "one"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.pre_call_context_revision, 0);
+    assert_eq!(first.pre_response_context_revision, 0);
     assert_eq!(first.context_revision, 1);
+    assert!(first.checkpoint_advanced);
 
     let second = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "work_on_project",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"content": "two"}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(second.pre_call_context_revision, 1);
-    assert_eq!(second.context_revision, 2);
+    assert_eq!(second.pre_response_context_revision, 1);
+    assert_eq!(second.context_revision, 1);
+    assert!(!second.checkpoint_advanced);
     assert!(second.recovery_events.is_empty());
     assert!(!second.history_lost);
 
@@ -4603,7 +4607,7 @@ fn session_context_revision_exact_missing_stale_invalid_future_and_failure_seman
         true,
         json!({"state_changed": true}),
     );
-    assert_eq!(missing.context_revision, 3);
+    assert_eq!(missing.context_revision, 2);
     assert!(
         missing.recovery_events.is_empty(),
         "unknown caller state must not be treated as an acknowledged revision-zero delta"
@@ -4613,45 +4617,47 @@ fn session_context_revision_exact_missing_stale_invalid_future_and_failure_seman
     let stale = record_model_facing_result(
         &store,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
-    assert_eq!(stale.pre_call_context_revision, 3);
-    assert_eq!(stale.context_revision, 4);
+    assert_eq!(stale.pre_call_context_revision, 2);
+    assert_eq!(stale.pre_response_context_revision, 2);
+    assert_eq!(stale.context_revision, 2);
+    assert!(!stale.checkpoint_advanced);
     assert_eq!(
         stale
             .recovery_events
             .iter()
             .filter_map(|event| event.context_revision)
             .collect::<Vec<_>>(),
-        vec![2, 3]
+        vec![2]
     );
 
     let future = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "work_on_project",
         SessionContextRevisionAck::Revision(999),
         true,
-        json!({"content": "future ack still executes"}),
+        json!({"session_id": session.session_id}),
     );
-    assert_eq!(future.context_revision, 5);
-    assert_eq!(future.pre_call_context_revision, 4);
+    assert_eq!(future.context_revision, 2);
+    assert_eq!(future.pre_call_context_revision, 2);
     assert!(future.recovery_events.is_empty());
     assert!(!future.history_lost);
 
     let invalid = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "work_on_project",
         SessionContextRevisionAck::Invalid,
         true,
-        json!({"content": "malformed ack still executes"}),
+        json!({"session_id": session.session_id}),
     );
-    assert_eq!(invalid.context_revision, 6);
-    assert_eq!(invalid.pre_call_context_revision, 5);
+    assert_eq!(invalid.context_revision, 2);
+    assert_eq!(invalid.pre_call_context_revision, 2);
     assert!(invalid.recovery_events.is_empty());
     assert!(!invalid.history_lost);
 
@@ -4659,13 +4665,15 @@ fn session_context_revision_exact_missing_stale_invalid_future_and_failure_seman
         &store,
         &session.session_id,
         "run_process",
-        SessionContextRevisionAck::Revision(6),
+        SessionContextRevisionAck::Revision(2),
         false,
         json!({"failure_kind": "process_failed", "command_started": true, "command_completed": true}),
     );
-    assert_eq!(failed.pre_call_context_revision, 6);
-    assert_eq!(failed.context_revision, 7);
-    assert_eq!(store.context_revision(&session.session_id), Some(7));
+    assert_eq!(failed.pre_call_context_revision, 2);
+    assert_eq!(failed.pre_response_context_revision, 2);
+    assert_eq!(failed.context_revision, 3);
+    assert!(failed.checkpoint_advanced);
+    assert_eq!(store.context_revision(&session.session_id), Some(3));
 }
 
 #[test]
@@ -4675,10 +4683,10 @@ fn non_capable_model_facing_result_advances_cross_surface_recovery_watermark() {
     let seed = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "seed"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(seed.context_revision, 1);
 
@@ -4704,13 +4712,15 @@ fn non_capable_model_facing_result_advances_cross_surface_recovery_watermark() {
     let resumed = record_model_facing_result(
         &store,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"clean": false}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(resumed.pre_call_context_revision, 2);
-    assert_eq!(resumed.context_revision, 3);
+    assert_eq!(resumed.pre_response_context_revision, 2);
+    assert_eq!(resumed.context_revision, 2);
+    assert!(!resumed.checkpoint_advanced);
     assert_eq!(
         resumed
             .recovery_events
@@ -4735,10 +4745,10 @@ fn session_context_revision_retention_reports_history_loss_without_counter_regre
         let recorded = record_model_facing_result(
             &store,
             &session.session_id,
-            "read_file",
+            "apply_text_edits",
             SessionContextRevisionAck::Revision(latest),
             true,
-            json!({"content": "bounded"}),
+            json!({"state_changed": true}),
         );
         latest = recorded.context_revision;
     }
@@ -4748,15 +4758,243 @@ fn session_context_revision_retention_reports_history_loss_without_counter_regre
     let stale = record_model_facing_result(
         &store,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(stale.pre_call_context_revision, 6);
-    assert_eq!(stale.context_revision, 7);
+    assert_eq!(stale.pre_response_context_revision, 6);
+    assert_eq!(stale.context_revision, 6);
+    assert!(!stale.checkpoint_advanced);
     assert!(stale.history_lost);
     assert!(stale.recovery_events.len() < 5);
+}
+
+#[test]
+fn raw_model_facing_events_do_not_consume_context_revisions() {
+    let store = SessionStore::new(10, 100);
+    let session = store.start_session(
+        Some("proj".to_string()),
+        Some("checkpoint loop".to_string()),
+    );
+
+    for tool in ["read_file", "search_project_texts", "show_changes"] {
+        let observed = record_model_facing_result(
+            &store,
+            &session.session_id,
+            tool,
+            SessionContextRevisionAck::Revision(0),
+            true,
+            json!({"observed": true}),
+        );
+        assert_eq!(observed.context_revision, 0, "{tool}");
+        assert_eq!(observed.pre_response_context_revision, 0, "{tool}");
+        assert!(!observed.checkpoint_advanced, "{tool}");
+        assert_eq!(
+            observed.ack_session_context_revision,
+            SessionContextRevisionAck::Unsupported,
+            "{tool}"
+        );
+    }
+
+    let edit = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "apply_text_edits",
+        SessionContextRevisionAck::Revision(0),
+        true,
+        json!({"state_changed": true}),
+    );
+    assert_eq!(edit.context_revision, 1);
+
+    let read_batch = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "read_files",
+        SessionContextRevisionAck::Revision(1),
+        true,
+        json!({"observed": true}),
+    );
+    assert_eq!(read_batch.context_revision, 1);
+    assert!(!read_batch.checkpoint_advanced);
+
+    let process = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "run_process",
+        SessionContextRevisionAck::Revision(1),
+        true,
+        json!({"command_started": true, "command_completed": true, "exit_code": 0}),
+    );
+    assert_eq!(process.context_revision, 2);
+    assert_eq!(store.context_revision(&session.session_id), Some(2));
+
+    let summary = store.summary(&session.session_id, Some(100)).unwrap();
+    let finished = summary
+        .events
+        .iter()
+        .filter(|event| event.kind == "tool_call_finished")
+        .collect::<Vec<_>>();
+    for event in &finished {
+        let expected = match event.tool_name.as_str() {
+            "apply_text_edits" => Some(1),
+            "run_process" => Some(2),
+            "read_file" | "search_project_texts" | "show_changes" | "read_files" => None,
+            other => panic!("unexpected finished tool {other}"),
+        };
+        assert_eq!(event.context_revision, expected, "{}", event.tool_name);
+    }
+}
+
+#[test]
+fn history_lost_counts_checkpoint_revisions_not_raw_events() {
+    let store = SessionStore::new(10, 40);
+    let session = store.start_session(
+        Some("proj".to_string()),
+        Some("mixed retention".to_string()),
+    );
+
+    let first = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "apply_text_edits",
+        SessionContextRevisionAck::Revision(0),
+        true,
+        json!({"state_changed": true}),
+    );
+    assert_eq!(first.context_revision, 1);
+    for _ in 0..8 {
+        let read = record_model_facing_result(
+            &store,
+            &session.session_id,
+            "read_file",
+            SessionContextRevisionAck::Revision(1),
+            true,
+            json!({"content": "re-observable"}),
+        );
+        assert_eq!(read.context_revision, 1);
+    }
+    let second = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "run_process",
+        SessionContextRevisionAck::Revision(1),
+        true,
+        json!({"command_started": true, "command_completed": true, "exit_code": 0}),
+    );
+    assert_eq!(second.context_revision, 2);
+    for _ in 0..4 {
+        let status = record_model_facing_result(
+            &store,
+            &session.session_id,
+            "git_status",
+            SessionContextRevisionAck::Revision(2),
+            true,
+            json!({"clean": true}),
+        );
+        assert_eq!(status.context_revision, 2);
+    }
+
+    let recovered = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "work_on_project",
+        SessionContextRevisionAck::Revision(0),
+        true,
+        json!({"session_id": session.session_id}),
+    );
+    assert_eq!(recovered.context_revision, 2);
+    assert!(!recovered.history_lost);
+    assert_eq!(
+        recovered
+            .recovery_events
+            .iter()
+            .filter_map(|event| event.context_revision)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    let mut response = super::super::ToolResult::ok(json!({"session_id": session.session_id}));
+    assert!(
+        super::super::session_context::add_session_context_continuity(&mut response, &recovered,)
+    );
+    assert_eq!(response.output["session_continuity"]["events_after_ack"], 2);
+}
+
+#[test]
+fn history_lost_detects_evicted_checkpoint_after_raw_event_churn() {
+    let store = SessionStore::new(10, 8);
+    let session = store.start_session(
+        Some("proj".to_string()),
+        Some("raw event retention".to_string()),
+    );
+
+    let first = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "apply_text_edits",
+        SessionContextRevisionAck::Revision(0),
+        true,
+        json!({"state_changed": true}),
+    );
+    assert_eq!(first.context_revision, 1);
+
+    for _ in 0..3 {
+        let read = record_model_facing_result(
+            &store,
+            &session.session_id,
+            "read_file",
+            SessionContextRevisionAck::Revision(1),
+            true,
+            json!({"content": "raw churn"}),
+        );
+        assert_eq!(read.context_revision, 1);
+        assert!(!read.checkpoint_advanced);
+    }
+
+    let second = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "run_process",
+        SessionContextRevisionAck::Revision(1),
+        true,
+        json!({"command_started": true, "command_completed": true, "exit_code": 0}),
+    );
+    assert_eq!(second.context_revision, 2);
+
+    let recovered = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "work_on_project",
+        SessionContextRevisionAck::Revision(0),
+        true,
+        json!({"session_id": session.session_id}),
+    );
+    assert_eq!(recovered.context_revision, 2);
+    assert!(recovered.history_lost);
+    assert_eq!(
+        recovered
+            .recovery_events
+            .iter()
+            .filter_map(|event| event.context_revision)
+            .collect::<Vec<_>>(),
+        vec![2],
+        "raw event churn may evict checkpoint 1, but must never be counted as extra revisions"
+    );
+
+    let mut response = super::super::ToolResult::ok(json!({"session_id": session.session_id}));
+    assert!(
+        super::super::session_context::add_session_context_continuity(&mut response, &recovered,)
+    );
+    assert_eq!(response.output["session_continuity"]["events_after_ack"], 2);
+    assert_eq!(response.output["session_continuity"]["history_lost"], true);
+    assert_eq!(
+        response.output["session_recovery"]["model_facing_events"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -4766,10 +5004,10 @@ fn generic_session_events_do_not_advance_model_context_revision() {
     let first = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "one"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.context_revision, 1);
 
@@ -4793,13 +5031,15 @@ fn generic_session_events_do_not_advance_model_context_revision() {
     let exact = record_model_facing_result(
         &store,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(exact.pre_call_context_revision, 1);
-    assert_eq!(exact.context_revision, 2);
+    assert_eq!(exact.pre_response_context_revision, 1);
+    assert_eq!(exact.context_revision, 1);
+    assert!(!exact.checkpoint_advanced);
     assert!(exact.recovery_events.is_empty());
 }
 
@@ -4810,10 +5050,10 @@ fn simultaneous_model_facing_results_allocate_unique_ordered_revisions() {
     let first = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "seed"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.context_revision, 1);
 
@@ -4822,7 +5062,7 @@ fn simultaneous_model_facing_results_allocate_unique_ordered_revisions() {
             .record_tool_call_started_with_metadata(
                 Some(&session.session_id),
                 SessionTransport::Mcp,
-                "read_file",
+                "apply_text_edits",
                 &json!({"project": "proj"}),
                 Some("proj".to_string()),
                 ToolCallRecorderMetadata {
@@ -4906,18 +5146,230 @@ fn simultaneous_model_facing_results_allocate_unique_ordered_revisions() {
     let next = record_model_facing_result(
         &store,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Revision(3),
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(next.pre_call_context_revision, 3);
-    assert_eq!(next.context_revision, 4);
+    assert_eq!(next.context_revision, 3);
+    assert!(!next.checkpoint_advanced);
     assert!(next.recovery_events.is_empty());
+
+    let future_start = store
+        .record_tool_call_started_with_metadata(
+            Some(&session.session_id),
+            SessionTransport::Mcp,
+            "run_process",
+            &json!({"project": "proj"}),
+            Some("proj".to_string()),
+            ToolCallRecorderMetadata {
+                ack_session_context_revision: SessionContextRevisionAck::Revision(4),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let intervening_start = store
+        .record_tool_call_started_with_metadata(
+            Some(&session.session_id),
+            SessionTransport::Mcp,
+            "run_process",
+            &json!({"project": "proj"}),
+            Some("proj".to_string()),
+            ToolCallRecorderMetadata {
+                ack_session_context_revision: SessionContextRevisionAck::Revision(3),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(future_start.pre_call_context_revision, 3);
+    assert_eq!(intervening_start.pre_call_context_revision, 3);
+    let intervening = store
+        .record_model_facing_tool_call_finished(
+            Some(intervening_start),
+            true,
+            &json!({"command_started": true, "command_completed": true, "exit_code": 0}),
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(intervening.context_revision, 4);
+    let future = store
+        .record_model_facing_tool_call_finished(
+            Some(future_start),
+            true,
+            &json!({"command_started": true, "command_completed": true, "exit_code": 0}),
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(future.pre_call_context_revision, 3);
+    assert_eq!(future.pre_response_context_revision, 4);
+    assert_eq!(future.context_revision, 5);
+    let mut future_response = super::super::ToolResult::ok(json!({"exit_code": 0}));
+    assert!(
+        super::super::session_context::add_session_context_continuity(
+            &mut future_response,
+            &future,
+        )
+    );
+    assert_eq!(
+        future_response.output["session_continuity"]["status"],
+        "invalid"
+    );
 }
 
 #[test]
-fn batch_budget_preserves_compact_and_recovery_session_protocol_overlays() {
+fn simultaneous_no_checkpoint_results_leave_revision_unchanged() {
+    let store = SessionStore::new(10, 100);
+    let session = store.start_session(
+        Some("proj".to_string()),
+        Some("read concurrency".to_string()),
+    );
+    let seed = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "apply_text_edits",
+        SessionContextRevisionAck::Unacknowledged,
+        true,
+        json!({"state_changed": true}),
+    );
+    assert_eq!(seed.context_revision, 1);
+
+    let make_start = |tool_name: &str| {
+        store
+            .record_tool_call_started_with_metadata(
+                Some(&session.session_id),
+                SessionTransport::Mcp,
+                tool_name,
+                &json!({"project": "proj"}),
+                Some("proj".to_string()),
+                ToolCallRecorderMetadata {
+                    ack_session_context_revision: SessionContextRevisionAck::Revision(1),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+    };
+    let read_start = make_start("read_file");
+    let search_start = make_start("search_project_texts");
+    assert_eq!(read_start.pre_call_context_revision, 1);
+    assert_eq!(search_start.pre_call_context_revision, 1);
+
+    let a_store = store.clone();
+    let b_store = store.clone();
+    let read = std::thread::spawn(move || {
+        a_store
+            .record_model_facing_tool_call_finished(
+                Some(read_start),
+                true,
+                &json!({"content": "read"}),
+                None,
+                None,
+            )
+            .unwrap()
+    });
+    let search = std::thread::spawn(move || {
+        b_store
+            .record_model_facing_tool_call_finished(
+                Some(search_start),
+                true,
+                &json!({"matches": []}),
+                None,
+                None,
+            )
+            .unwrap()
+    });
+    for recorded in [read.join().unwrap(), search.join().unwrap()] {
+        assert_eq!(recorded.context_revision, 1);
+        assert_eq!(recorded.pre_response_context_revision, 1);
+        assert!(!recorded.checkpoint_advanced);
+        assert_eq!(
+            recorded.ack_session_context_revision,
+            SessionContextRevisionAck::Unsupported
+        );
+    }
+    assert_eq!(store.context_revision(&session.session_id), Some(1));
+}
+
+#[test]
+fn concurrent_checkpoint_and_raw_result_advance_once() {
+    let store = SessionStore::new(10, 100);
+    let session = store.start_session(
+        Some("proj".to_string()),
+        Some("mixed concurrency".to_string()),
+    );
+    let seed = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "apply_text_edits",
+        SessionContextRevisionAck::Unacknowledged,
+        true,
+        json!({"state_changed": true}),
+    );
+    assert_eq!(seed.context_revision, 1);
+
+    let read_start = store
+        .record_tool_call_started_with_metadata(
+            Some(&session.session_id),
+            SessionTransport::Mcp,
+            "read_file",
+            &json!({"project": "proj"}),
+            Some("proj".to_string()),
+            ToolCallRecorderMetadata::default(),
+        )
+        .unwrap();
+    let checkpoint_start = store
+        .record_tool_call_started_with_metadata(
+            Some(&session.session_id),
+            SessionTransport::Mcp,
+            "run_process",
+            &json!({"project": "proj"}),
+            Some("proj".to_string()),
+            ToolCallRecorderMetadata {
+                ack_session_context_revision: SessionContextRevisionAck::Revision(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(read_start.pre_call_context_revision, 1);
+    assert_eq!(checkpoint_start.pre_call_context_revision, 1);
+
+    let a_store = store.clone();
+    let b_store = store.clone();
+    let read = std::thread::spawn(move || {
+        a_store
+            .record_model_facing_tool_call_finished(
+                Some(read_start),
+                true,
+                &json!({"content": "read"}),
+                None,
+                None,
+            )
+            .unwrap()
+    });
+    let checkpoint = std::thread::spawn(move || {
+        b_store
+            .record_model_facing_tool_call_finished(
+                Some(checkpoint_start),
+                true,
+                &json!({"command_started": true, "command_completed": true, "exit_code": 0}),
+                None,
+                None,
+            )
+            .unwrap()
+    });
+    let read = read.join().unwrap();
+    let checkpoint = checkpoint.join().unwrap();
+    assert!(!read.checkpoint_advanced);
+    assert!(matches!(read.context_revision, 1 | 2));
+    assert!(checkpoint.checkpoint_advanced);
+    assert_eq!(checkpoint.context_revision, 2);
+    assert_eq!(store.context_revision(&session.session_id), Some(2));
+}
+
+#[test]
+fn batch_budget_preserves_recorder_overlay_for_no_ack_read_batch() {
     fn canonical_read_batch(text: String) -> Value {
         let default_limit =
             webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
@@ -4959,85 +5411,58 @@ fn batch_budget_preserves_compact_and_recovery_session_protocol_overlays() {
     let first = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "seed"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.context_revision, 1);
 
-    let compact_batch = canonical_read_batch("x".repeat(56 * 1024));
-    let exact = record_model_facing_result(
-        &store,
-        &session.session_id,
-        "read_files",
-        SessionContextRevisionAck::Revision(1),
-        true,
-        compact_batch.clone(),
-    );
-    assert_eq!(exact.context_revision, 2);
-    let mut exact_response = super::super::ToolResult::ok(compact_batch);
-    super::super::session_context::add_session_telemetry_hint(
-        &mut exact_response,
-        &store,
-        &session.session_id,
-        Some(exact.event_id.clone()),
-    );
-    assert!(
-        super::super::session_context::add_session_context_continuity(&mut exact_response, &exact,)
-    );
-    assert_eq!(exact_response.output["session_context_revision"], 2);
-    assert!(exact_response.output.get("session_continuity").is_none());
-    assert!(exact_response.output.get("session_recovery").is_none());
+    for text in ["x".repeat(56 * 1024), "y".repeat(8 * 1024)] {
+        let batch = canonical_read_batch(text);
+        let recorded = record_model_facing_result(
+            &store,
+            &session.session_id,
+            "read_files",
+            SessionContextRevisionAck::Revision(1),
+            true,
+            batch.clone(),
+        );
+        assert_eq!(recorded.context_revision, 1);
+        assert_eq!(recorded.pre_response_context_revision, 1);
+        assert!(!recorded.checkpoint_advanced);
+        assert_eq!(
+            recorded.ack_session_context_revision,
+            SessionContextRevisionAck::Unsupported
+        );
+        assert!(recorded.recovery_events.is_empty());
 
-    super::super::read_files::apply_model_facing_output_budget(&mut exact_response, None);
-    super::super::dispatch::sparsify_complete_read_success("read_files", &mut exact_response);
-    assert_eq!(exact_response.output["session_recorded"], true);
-    assert_eq!(exact_response.output["session_id"], session.session_id);
-    assert_eq!(exact_response.output["session_context_revision"], 2);
-    assert!(exact_response.output.get("session_continuity").is_none());
-    assert!(exact_response.output.get("session_recovery").is_none());
-    assert!(
-        serde_json::to_vec(&exact_response).unwrap().len()
-            <= super::super::read_files::DEFAULT_READ_FILES_RESULT_BYTES,
-        "compact exact Session overlays must fit inside the reserved default result budget"
-    );
-    assert_eq!(store.context_revision(&session.session_id), Some(2));
-
-    let stale_batch = canonical_read_batch("y".repeat(8 * 1024));
-    let stale = record_model_facing_result(
-        &store,
-        &session.session_id,
-        "read_files",
-        SessionContextRevisionAck::Revision(1),
-        true,
-        stale_batch.clone(),
-    );
-    assert_eq!(stale.context_revision, 3);
-    assert_eq!(stale.recovery_events.len(), 1);
-    let mut stale_response = super::super::ToolResult::ok(stale_batch);
-    super::super::session_context::add_session_telemetry_hint(
-        &mut stale_response,
-        &store,
-        &session.session_id,
-        Some(stale.event_id.clone()),
-    );
-    assert!(
-        super::super::session_context::add_session_context_continuity(&mut stale_response, &stale,)
-    );
-    assert_eq!(
-        stale_response.output["session_continuity"]["status"],
-        "behind"
-    );
-    let continuity = stale_response.output["session_continuity"].clone();
-    let recovery = stale_response.output["session_recovery"].clone();
-
-    super::super::read_files::apply_model_facing_output_budget(&mut stale_response, None);
-    super::super::dispatch::sparsify_complete_read_success("read_files", &mut stale_response);
-    assert_eq!(stale_response.output["session_context_revision"], 3);
-    assert_eq!(stale_response.output["session_continuity"], continuity);
-    assert_eq!(stale_response.output["session_recovery"], recovery);
-    assert_eq!(store.context_revision(&session.session_id), Some(3));
+        let mut response = super::super::ToolResult::ok(batch);
+        super::super::session_context::add_session_telemetry_hint(
+            &mut response,
+            &store,
+            &session.session_id,
+            Some(recorded.event_id.clone()),
+        );
+        assert!(
+            !super::super::session_context::add_session_context_continuity(
+                &mut response,
+                &recorded,
+            )
+        );
+        super::super::read_files::apply_model_facing_output_budget(&mut response, None);
+        super::super::dispatch::sparsify_complete_read_success("read_files", &mut response);
+        assert_eq!(response.output["session_recorded"], true);
+        assert_eq!(response.output["session_id"], session.session_id);
+        assert!(response.output.get("session_context_revision").is_none());
+        assert!(response.output.get("session_continuity").is_none());
+        assert!(response.output.get("session_recovery").is_none());
+        assert!(
+            serde_json::to_vec(&response).unwrap().len()
+                <= super::super::read_files::DEFAULT_READ_FILES_RESULT_BYTES
+        );
+    }
+    assert_eq!(store.context_revision(&session.session_id), Some(1));
 }
 
 #[tokio::test]
@@ -5049,36 +5474,38 @@ async fn unknown_session_context_recovery_uses_current_handoff_not_history_repla
     let first = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "one"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.context_revision, 1);
     let second = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "read_file",
+        "run_process",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"content": "two"}),
+        json!({"command_started": true, "command_completed": true, "exit_code": 0}),
     );
     assert_eq!(second.context_revision, 2);
 
     let unknown = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"clean": false}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(unknown.pre_call_context_revision, 2);
-    assert_eq!(unknown.context_revision, 3);
+    assert_eq!(unknown.pre_response_context_revision, 2);
+    assert_eq!(unknown.context_revision, 2);
+    assert!(!unknown.checkpoint_advanced);
     assert!(unknown.recovery_events.is_empty());
     assert!(!unknown.history_lost);
 
-    let mut response = super::super::ToolResult::ok(json!({"clean": false}));
+    let mut response = super::super::ToolResult::ok(json!({"session_id": session.session_id}));
     assert!(
         super::super::session_context::add_session_context_continuity(&mut response, &unknown,)
     );
@@ -5106,7 +5533,7 @@ async fn unknown_session_context_recovery_uses_current_handoff_not_history_repla
         .as_array()
         .unwrap()
         .iter()
-        .any(|work| work["tool_name"] == "git_status"));
+        .any(|work| work["tool_name"] == "work_on_project"));
     assert!(response.output["session_recovery"]["model_facing_events"]
         .as_array()
         .unwrap()
@@ -5123,32 +5550,32 @@ async fn required_session_context_recovery_handoff_failure_does_not_expose_new_r
     let first = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "seed"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.context_revision, 1);
     let mut unknown = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
-    assert_eq!(unknown.context_revision, 2);
+    assert_eq!(unknown.context_revision, 1);
     assert!(unknown.recovery_events.is_empty());
 
     // The production path re-authorizes the exact recorded Session before
     // reading current handoff state. Corrupt only this local projection id to
     // force that read to fail and verify the revision fail-safe.
     unknown.session_id = "wc_sess_missing_for_handoff_test".to_string();
-    let mut response = super::super::ToolResult::ok(json!({"clean": true}));
+    let mut response = super::super::ToolResult::ok(json!({"session_id": session.session_id}));
     assert!(
         super::super::session_context::add_session_context_continuity(&mut response, &unknown,)
     );
-    assert_eq!(response.output["session_context_revision"], 2);
+    assert_eq!(response.output["session_context_revision"], 1);
     assert_eq!(
         response.output["session_continuity"]["status"],
         "unacknowledged"
@@ -5174,10 +5601,10 @@ async fn bounded_session_context_recovery_adds_current_handoff_before_latest_ack
         let recorded = record_model_facing_result(
             &runtime.sessions,
             &session.session_id,
-            "read_file",
+            "apply_text_edits",
             SessionContextRevisionAck::Revision(latest),
             true,
-            json!({"content": "bounded"}),
+            json!({"state_changed": true}),
         );
         latest = recorded.context_revision;
     }
@@ -5186,17 +5613,19 @@ async fn bounded_session_context_recovery_adds_current_handoff_before_latest_ack
     let stale = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Revision(0),
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(stale.pre_call_context_revision, 25);
-    assert_eq!(stale.context_revision, 26);
+    assert_eq!(stale.pre_response_context_revision, 25);
+    assert_eq!(stale.context_revision, 25);
+    assert!(!stale.checkpoint_advanced);
     assert_eq!(stale.recovery_events.len(), 25);
     assert!(!stale.history_lost);
 
-    let mut response = super::super::ToolResult::ok(json!({"clean": true}));
+    let mut response = super::super::ToolResult::ok(json!({"session_id": session.session_id}));
     assert!(super::super::session_context::add_session_context_continuity(&mut response, &stale,));
     assert_eq!(response.output["session_recovery"]["truncated"], true);
     assert_eq!(response.output["session_recovery"]["omitted_count"], 5);
@@ -5209,7 +5638,7 @@ async fn bounded_session_context_recovery_adds_current_handoff_before_latest_ack
         .await;
     assert!(
         response.output["session_recovery"]["current_handoff"].is_object(),
-        "bounded event omission must add a compact current-state recovery before revision 26 is ACK-able"
+        "bounded event omission must add a compact current-state recovery before revision 25 is ACK-able"
     );
 }
 
@@ -5222,19 +5651,19 @@ async fn history_lost_session_context_recovery_adds_current_handoff() {
     let first = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "seed"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.context_revision, 1);
     let mut behind = record_model_facing_result(
         &runtime.sessions,
         &session.session_id,
-        "git_status",
+        "work_on_project",
         SessionContextRevisionAck::Revision(0),
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
     assert_eq!(
         behind
@@ -5248,7 +5677,7 @@ async fn history_lost_session_context_recovery_adds_current_handoff() {
     // recorded projection flag here so this test isolates the response fallback.
     behind.history_lost = true;
 
-    let mut response = super::super::ToolResult::ok(json!({"clean": true}));
+    let mut response = super::super::ToolResult::ok(json!({"session_id": session.session_id}));
     assert!(super::super::session_context::add_session_context_continuity(&mut response, &behind,));
     assert_eq!(response.output["session_continuity"]["status"], "behind");
     assert_eq!(response.output["session_continuity"]["history_lost"], true);
@@ -5271,12 +5700,23 @@ fn session_context_revision_survives_persistence_restart() {
     let first = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "persisted"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(first.context_revision, 1);
+    let raw = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "read_file",
+        SessionContextRevisionAck::Revision(1),
+        true,
+        json!({"content": "persisted raw observation"}),
+    );
+    assert_eq!(raw.context_revision, 1);
+    assert!(!raw.checkpoint_advanced);
+    assert_eq!(store.context_revision(&session.session_id), Some(1));
     store.flush_persistence();
     drop(store);
 
@@ -5285,14 +5725,61 @@ fn session_context_revision_survives_persistence_restart() {
     let second = record_model_facing_result(
         &restored,
         &session.session_id,
-        "git_status",
+        "run_process",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"clean": true}),
+        json!({"command_started": true, "command_completed": true, "exit_code": 0}),
     );
     assert_eq!(second.pre_call_context_revision, 1);
+    assert_eq!(second.pre_response_context_revision, 1);
     assert_eq!(second.context_revision, 2);
+    assert!(second.checkpoint_advanced);
     assert!(second.recovery_events.is_empty());
+}
+
+#[test]
+fn existing_persisted_context_watermark_is_not_renumbered() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ledger = tmp.path().join("sessions.json");
+    let store = SessionStore::with_persistence(&ledger, 10, 100);
+    let session = store.start_session(Some("proj".to_string()), Some("high watermark".to_string()));
+    let first = record_model_facing_result(
+        &store,
+        &session.session_id,
+        "apply_text_edits",
+        SessionContextRevisionAck::Unacknowledged,
+        true,
+        json!({"state_changed": true}),
+    );
+    assert_eq!(first.context_revision, 1);
+    store.flush_persistence();
+    drop(store);
+
+    let mut persisted: Value = serde_json::from_slice(&std::fs::read(&ledger).unwrap()).unwrap();
+    persisted["sessions"][0]["context_revision"] = json!(847);
+    std::fs::write(&ledger, serde_json::to_vec(&persisted).unwrap()).unwrap();
+
+    let restored = SessionStore::with_persistence(&ledger, 10, 100);
+    assert_eq!(restored.context_revision(&session.session_id), Some(847));
+    let read = record_model_facing_result(
+        &restored,
+        &session.session_id,
+        "read_file",
+        SessionContextRevisionAck::Revision(847),
+        true,
+        json!({"content": "still 847"}),
+    );
+    assert_eq!(read.context_revision, 847);
+    assert!(!read.checkpoint_advanced);
+    let next = record_model_facing_result(
+        &restored,
+        &session.session_id,
+        "run_process",
+        SessionContextRevisionAck::Revision(847),
+        true,
+        json!({"command_started": true, "command_completed": true, "exit_code": 0}),
+    );
+    assert_eq!(next.context_revision, 848);
 }
 
 #[test]
@@ -5379,10 +5866,10 @@ fn stale_session_recovery_preserves_consequential_git_workspace_evidence() {
     let seed = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "apply_text_edits",
         SessionContextRevisionAck::Unacknowledged,
         true,
-        json!({"content": "seed"}),
+        json!({"state_changed": true}),
     );
     assert_eq!(seed.context_revision, 1);
 
@@ -5440,25 +5927,29 @@ fn stale_session_recovery_preserves_consequential_git_workspace_evidence() {
         true,
         json!({"clean": true, "head": "64ac72ae", "remote_head": "64ac72ae"}),
     );
-    assert_eq!(status.context_revision, 5);
+    assert_eq!(status.context_revision, 4);
+    assert_eq!(status.pre_response_context_revision, 4);
+    assert!(!status.checkpoint_advanced);
 
     let resumed = record_model_facing_result(
         &store,
         &session.session_id,
-        "read_file",
+        "work_on_project",
         SessionContextRevisionAck::Revision(1),
         true,
-        json!({"content": "resume normally"}),
+        json!({"session_id": session.session_id}),
     );
-    assert_eq!(resumed.pre_call_context_revision, 5);
-    assert_eq!(resumed.context_revision, 6);
+    assert_eq!(resumed.pre_call_context_revision, 4);
+    assert_eq!(resumed.pre_response_context_revision, 4);
+    assert_eq!(resumed.context_revision, 4);
+    assert!(!resumed.checkpoint_advanced);
     assert_eq!(
         resumed
             .recovery_events
             .iter()
             .filter_map(|event| event.context_revision)
             .collect::<Vec<_>>(),
-        vec![2, 3, 4, 5]
+        vec![2, 3, 4]
     );
     assert!(resumed.recovery_events.iter().any(|event| {
         event.tool_name == "workspace_checkpoint_create"
@@ -5478,15 +5969,23 @@ fn stale_session_recovery_preserves_consequential_git_workspace_evidence() {
                 .validation_output_summary
                 .as_ref()
                 .is_some_and(|summary| summary.to_string().contains("64ac72ae"))));
+    assert!(
+        resumed
+            .recovery_events
+            .iter()
+            .all(|event| event.tool_name != "git_status"),
+        "recovery replays checkpoint knowledge, not re-observable git_status results"
+    );
 
     let exact = record_model_facing_result(
         &store,
         &session.session_id,
-        "git_status",
-        SessionContextRevisionAck::Revision(6),
+        "work_on_project",
+        SessionContextRevisionAck::Revision(4),
         true,
-        json!({"clean": true}),
+        json!({"session_id": session.session_id}),
     );
-    assert_eq!(exact.context_revision, 7);
+    assert_eq!(exact.context_revision, 4);
+    assert!(!exact.checkpoint_advanced);
     assert!(exact.recovery_events.is_empty());
 }

--- a/src/tool_runtime/tests/memory.rs
+++ b/src/tool_runtime/tests/memory.rs
@@ -869,7 +869,7 @@ async fn memory_bootstrap_is_explicit_and_never_inferred_from_session_ack_recove
     assert!(missing_ack.output.get("context_projection").is_none());
     assert!(!missing_ack.output.to_string().contains(private_summary));
 
-    let behind = list_files_with_session_context(
+    let exact = list_files_with_session_context(
         &runtime,
         "memory-ack",
         &project_id,
@@ -878,10 +878,11 @@ async fn memory_bootstrap_is_explicit_and_never_inferred_from_session_ack_recove
         Vec::new(),
     )
     .await;
-    assert!(behind.success);
-    assert!(behind.output.get("session_recovery").is_some());
-    assert!(behind.output.get("context_projection").is_none());
-    assert!(!behind.output.to_string().contains(private_summary));
+    assert!(exact.success);
+    assert_eq!(exact.output["session_context_revision"], 0);
+    assert!(exact.output.get("session_recovery").is_none());
+    assert!(exact.output.get("context_projection").is_none());
+    assert!(!exact.output.to_string().contains(private_summary));
 
     let explicit = list_files_with_session_context(
         &runtime,

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -993,7 +993,7 @@ async fn read_files_outer_recording_session_preserves_complete_sparse_shape() {
     let result = task.await.unwrap().result.expect("model-facing result");
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["session_recorded"], true);
-    assert_eq!(result.output["session_context_revision"], 1);
+    assert_eq!(result.output["session_context_revision"], 0);
     assert!(result.output.get("session_continuity").is_none());
     assert!(result.output.get("session_recovery").is_none());
     for omitted in [

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -1,6 +1,81 @@
 use super::*;
 
 #[test]
+fn tool_definitions_are_context_continuity_ssot() {
+    use crate::tool_runtime::metadata::ToolEffect;
+    use crate::tool_runtime::tool_definition::{
+        runtime_tool_accepts_context_ack, runtime_tool_advances_context_checkpoint,
+        runtime_tool_context_continuity_policy,
+    };
+    use crate::tool_runtime::tool_policy::lookup_tool_definition;
+
+    for (name, accepts_ack, advances_checkpoint) in [
+        ("read_files", false, false),
+        ("search_project_texts", false, false),
+        ("tool_manifest", false, false),
+        ("show_changes", false, false),
+        ("work_on_project", true, false),
+        ("apply_text_edits", true, true),
+        ("run_process", true, true),
+        ("observe_jobs", true, true),
+    ] {
+        let definition =
+            lookup_tool_definition(name).unwrap_or_else(|| panic!("missing definition for {name}"));
+        let direct = definition.context_continuity_policy();
+        assert_eq!(
+            runtime_tool_context_continuity_policy(name),
+            direct,
+            "{name}"
+        );
+        assert_eq!(direct.accepts_context_ack, accepts_ack, "{name}");
+        assert_eq!(
+            direct.advances_context_checkpoint(),
+            advances_checkpoint,
+            "{name}"
+        );
+        assert_eq!(
+            runtime_tool_accepts_context_ack(name),
+            accepts_ack,
+            "{name}"
+        );
+        assert_eq!(
+            runtime_tool_advances_context_checkpoint(name),
+            advances_checkpoint,
+            "{name}"
+        );
+    }
+
+    assert_eq!(
+        lookup_tool_definition("work_on_project")
+            .unwrap()
+            .metadata()
+            .effect,
+        ToolEffect::Mutate
+    );
+    assert_eq!(
+        lookup_tool_definition("show_changes")
+            .unwrap()
+            .metadata()
+            .effect,
+        ToolEffect::Observe
+    );
+    assert_eq!(
+        lookup_tool_definition("observe_jobs")
+            .unwrap()
+            .metadata()
+            .effect,
+        ToolEffect::Observe
+    );
+    assert!(!runtime_tool_advances_context_checkpoint("show_changes"));
+    assert!(runtime_tool_advances_context_checkpoint("observe_jobs"));
+
+    assert!(runtime_tool_accepts_context_ack("unknown_open_world_tool"));
+    assert!(runtime_tool_advances_context_checkpoint(
+        "unknown_open_world_tool"
+    ));
+}
+
+#[test]
 fn tool_definitions_drive_session_and_permission_policy() {
     use crate::tool_runtime::metadata::{
         ToolApprovalPolicy, ToolAuthorityPolicy, ToolEffect, ToolIdempotency, ToolRisk,

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -10,10 +10,10 @@ fn tool_definitions_are_context_continuity_ssot() {
     use crate::tool_runtime::tool_policy::lookup_tool_definition;
 
     for (name, accepts_ack, advances_checkpoint) in [
-        ("read_files", false, false),
-        ("search_project_texts", false, false),
-        ("tool_manifest", false, false),
-        ("show_changes", false, false),
+        ("read_files", true, false),
+        ("search_project_texts", true, false),
+        ("tool_manifest", true, false),
+        ("show_changes", true, false),
         ("work_on_project", true, false),
         ("apply_text_edits", true, true),
         ("run_process", true, true),

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -1804,7 +1804,7 @@ async fn search_project_texts_outer_recording_session_preserves_complete_sparse_
     let result = task.await.unwrap().result.expect("model-facing result");
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["session_recorded"], true);
-    assert_eq!(result.output["session_context_revision"], 1);
+    assert_eq!(result.output["session_context_revision"], 0);
     assert!(result.output.get("session_continuity").is_none());
     assert!(result.output.get("session_recovery").is_none());
     for omitted in [

--- a/src/tool_runtime/tool_definition.rs
+++ b/src/tool_runtime/tool_definition.rs
@@ -331,11 +331,6 @@ impl ToolContextContinuityPolicy {
         checkpoint: ContextCheckpointPolicy::OnModelFacingResult,
     };
 
-    pub(crate) const NONE: Self = Self {
-        accepts_context_ack: false,
-        checkpoint: ContextCheckpointPolicy::Never,
-    };
-
     pub(crate) const RECOVERY_ONLY: Self = Self {
         accepts_context_ack: true,
         checkpoint: ContextCheckpointPolicy::Never,
@@ -494,10 +489,6 @@ const fn context_continuity(
     }
 }
 
-const fn no_context_continuity(definition: ToolDefinition) -> ToolDefinition {
-    context_continuity(definition, ToolContextContinuityPolicy::NONE)
-}
-
 const fn context_recovery_only(definition: ToolDefinition) -> ToolDefinition {
     context_continuity(definition, ToolContextContinuityPolicy::RECOVERY_ONLY)
 }
@@ -576,7 +567,7 @@ const TOOL_DEFINITION_GROUPS: &[&[ToolDefinition]] = &[
     edits::DEFINITIONS,
 ];
 
-const TOOL_DEFINITION_HEAD: &[ToolDefinition] = &[no_context_continuity(model_spec(
+const TOOL_DEFINITION_HEAD: &[ToolDefinition] = &[context_recovery_only(model_spec(
     def(
         "list_tools",
         ModelVisible,

--- a/src/tool_runtime/tool_definition.rs
+++ b/src/tool_runtime/tool_definition.rs
@@ -48,17 +48,18 @@ pub use super::tool_policy::is_known_tool_name;
 #[cfg(test)]
 pub(crate) use super::tool_policy::{
     is_model_hidden_tool_name, known_tool_names, model_hidden_tool_names,
-    runtime_tool_requires_explicit_business_session,
+    runtime_tool_context_continuity_policy, runtime_tool_requires_explicit_business_session,
 };
 pub(crate) use super::tool_policy::{
     is_model_visible_tool_name, lookup_tool_definition, model_visible_tool_definitions,
-    model_visible_tool_names_csv, runtime_tool_agent_capability, runtime_tool_approval_policy,
-    runtime_tool_captures_validation_output, runtime_tool_category, runtime_tool_disabled_message,
-    runtime_tool_effect_annotations, runtime_tool_extra_accepted_flattened_args,
-    runtime_tool_is_change_summary_like, runtime_tool_is_git_like, runtime_tool_is_read_like,
-    runtime_tool_is_shell_like, runtime_tool_is_write_like, runtime_tool_metadata,
-    runtime_tool_permission_risk, runtime_tool_requires_permission,
-    runtime_tool_session_risk_class,
+    model_visible_tool_names_csv, runtime_tool_accepts_context_ack,
+    runtime_tool_advances_context_checkpoint, runtime_tool_agent_capability,
+    runtime_tool_approval_policy, runtime_tool_captures_validation_output, runtime_tool_category,
+    runtime_tool_disabled_message, runtime_tool_effect_annotations,
+    runtime_tool_extra_accepted_flattened_args, runtime_tool_is_change_summary_like,
+    runtime_tool_is_git_like, runtime_tool_is_read_like, runtime_tool_is_shell_like,
+    runtime_tool_is_write_like, runtime_tool_metadata, runtime_tool_permission_risk,
+    runtime_tool_requires_permission, runtime_tool_session_risk_class,
 };
 use crate::shell_protocol::{
     SHELL_CLIENT_CAPABILITY_ASYNC_JOBS, SHELL_CLIENT_CAPABILITY_ASYNC_SHELL_JOBS,
@@ -313,7 +314,44 @@ pub(crate) struct ToolEffectAnnotations {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContextCheckpointPolicy {
+    Never,
+    OnModelFacingResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ToolContextContinuityPolicy {
+    pub(crate) accepts_context_ack: bool,
+    pub(crate) checkpoint: ContextCheckpointPolicy,
+}
+
+impl ToolContextContinuityPolicy {
+    pub(crate) const CONSERVATIVE: Self = Self {
+        accepts_context_ack: true,
+        checkpoint: ContextCheckpointPolicy::OnModelFacingResult,
+    };
+
+    pub(crate) const NONE: Self = Self {
+        accepts_context_ack: false,
+        checkpoint: ContextCheckpointPolicy::Never,
+    };
+
+    pub(crate) const RECOVERY_ONLY: Self = Self {
+        accepts_context_ack: true,
+        checkpoint: ContextCheckpointPolicy::Never,
+    };
+
+    pub(crate) const fn advances_context_checkpoint(self) -> bool {
+        matches!(
+            self.checkpoint,
+            ContextCheckpointPolicy::OnModelFacingResult
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ToolDefinitionPolicy {
+    pub(crate) context_continuity: ToolContextContinuityPolicy,
     pub(crate) change_summary_like: bool,
     pub(crate) captures_validation_output: bool,
     pub(crate) disabled_message: Option<&'static str>,
@@ -327,6 +365,7 @@ pub(crate) struct ToolDefinitionPolicy {
 
 impl ToolDefinitionPolicy {
     const DEFAULT: Self = Self {
+        context_continuity: ToolContextContinuityPolicy::CONSERVATIVE,
         change_summary_like: false,
         captures_validation_output: false,
         disabled_message: None,
@@ -442,6 +481,27 @@ bool_policy_modifier!(change_summary_like, change_summary_like);
 
 bool_policy_modifier!(git_like, git_like);
 
+const fn context_continuity(
+    definition: ToolDefinition,
+    context_continuity: ToolContextContinuityPolicy,
+) -> ToolDefinition {
+    ToolDefinition {
+        policy: ToolDefinitionPolicy {
+            context_continuity,
+            ..definition.policy
+        },
+        ..definition
+    }
+}
+
+const fn no_context_continuity(definition: ToolDefinition) -> ToolDefinition {
+    context_continuity(definition, ToolContextContinuityPolicy::NONE)
+}
+
+const fn context_recovery_only(definition: ToolDefinition) -> ToolDefinition {
+    context_continuity(definition, ToolContextContinuityPolicy::RECOVERY_ONLY)
+}
+
 const fn extra_accepted_flattened_args(
     definition: ToolDefinition,
     fields: &'static [&'static str],
@@ -516,7 +576,7 @@ const TOOL_DEFINITION_GROUPS: &[&[ToolDefinition]] = &[
     edits::DEFINITIONS,
 ];
 
-const TOOL_DEFINITION_HEAD: &[ToolDefinition] = &[model_spec(
+const TOOL_DEFINITION_HEAD: &[ToolDefinition] = &[no_context_continuity(model_spec(
     def(
         "list_tools",
         ModelVisible,
@@ -537,4 +597,4 @@ const TOOL_DEFINITION_HEAD: &[ToolDefinition] = &[model_spec(
     ),
     "List runtime tools. Full output includes schemas and may be large; use summary_only with category, features, or limit for bounded GPT Action discovery.",
     list_tools_input_schema,
-)];
+))];

--- a/src/tool_runtime/tool_definition/discovery.rs
+++ b/src/tool_runtime/tool_definition/discovery.rs
@@ -1,6 +1,6 @@
 use super::ToolVisibility::ModelVisible;
 use super::{
-    def, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_PROJECT,
+    context_recovery_only, def, model_spec, ToolDefinition, TOOL_CATEGORY_PROJECT,
     TOOL_CATEGORY_RUNTIME,
 };
 use crate::tool_runtime::metadata::{
@@ -15,7 +15,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "list_projects",
             ModelVisible,
@@ -103,7 +103,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Create a directory on one Runner and register it as a Project. Use this for a new workspace; existing directories belong on the registration path.",
         create_project_input_schema,
     ),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "list_agents",
             ModelVisible,
@@ -125,7 +125,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "List caller-visible Runners; use exact client_id/client_ids if known, summary_only + include_projects=false for health. Full mode includes shared Job concurrency and host_context advisory metadata; never authority.",
         list_agents_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "runtime_status",
             ModelVisible,
@@ -147,7 +147,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read runtime status; pass exact client_id for one Runner deployment/source alignment, omit for fleet-wide. Reports shared Job concurrency; global mode includes bounded host_context advisory metadata, never authority.",
         runtime_status_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "tool_manifest",
             ModelVisible,

--- a/src/tool_runtime/tool_definition/discovery.rs
+++ b/src/tool_runtime/tool_definition/discovery.rs
@@ -1,5 +1,8 @@
 use super::ToolVisibility::ModelVisible;
-use super::{def, model_spec, ToolDefinition, TOOL_CATEGORY_PROJECT, TOOL_CATEGORY_RUNTIME};
+use super::{
+    def, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_PROJECT,
+    TOOL_CATEGORY_RUNTIME,
+};
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath,
     ToolRisk::{ProjectWrite, Read},
@@ -12,7 +15,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
-    model_spec(
+    no_context_continuity(model_spec(
         def(
             "list_projects",
             ModelVisible,
@@ -33,7 +36,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "List caller-visible Projects. When Runner/Project identity is known, pass exact client_id/project; use bounded query and summary_only instead of reading the full registry.",
         list_projects_input_schema,
-    ),
+    )),
     model_spec(
         def(
             "register_project",
@@ -100,7 +103,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Create a directory on one Runner and register it as a Project. Use this for a new workspace; existing directories belong on the registration path.",
         create_project_input_schema,
     ),
-    model_spec(
+    no_context_continuity(model_spec(
         def(
             "list_agents",
             ModelVisible,
@@ -121,8 +124,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "List caller-visible Runners; use exact client_id/client_ids if known, summary_only + include_projects=false for health. Full mode includes shared Job concurrency and host_context advisory metadata; never authority.",
         list_agents_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "runtime_status",
             ModelVisible,
@@ -143,8 +146,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read runtime status; pass exact client_id for one Runner deployment/source alignment, omit for fleet-wide. Reports shared Job concurrency; global mode includes bounded host_context advisory metadata, never authority.",
         runtime_status_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "tool_manifest",
             ModelVisible,
@@ -165,5 +168,5 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Return compact runtime discovery. Filter by category/intent, or pass exact tool_name for one contract with description + input schema and no output schema. Discovery never changes behavior, authority, permissions, execution, or verdicts.",
         tool_manifest_input_schema,
-    ),
+    )),
 ];

--- a/src/tool_runtime/tool_definition/files.rs
+++ b/src/tool_runtime/tool_definition/files.rs
@@ -1,6 +1,9 @@
 use super::AgentCapability::{FileRead, Shell};
 use super::ToolVisibility::ModelVisible;
-use super::{def, model_spec, ToolDefinition, TOOL_CATEGORY_FILE, TOOL_CATEGORY_PROJECT};
+use super::{
+    def, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_FILE,
+    TOOL_CATEGORY_PROJECT,
+};
 use crate::tool_runtime::metadata::{
     ToolPathHint::{None as NoPath, SinglePath},
     ToolRisk::Read,
@@ -13,7 +16,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
-    model_spec(
+    no_context_continuity(model_spec(
         def(
             "project_overview",
             ModelVisible,
@@ -34,8 +37,8 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Deterministic, bounded, metadata-only overview of an unfamiliar project: conventional project types, manifests, key files, roots, and direct children. Reads no file contents, uses no LLM, and is not semantic/LSP analysis; use read_file for contents.",
         project_overview_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "list_project_files",
             ModelVisible,
@@ -56,8 +59,8 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "List files in an agent-registered project directory (bounded, read-only). Returns project-relative paths plus a file/dir kind. Routed to the owning registered agent; the server never reads the agent project path directly.",
         list_project_files_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "list_project_tracked_files",
             ModelVisible,
@@ -80,8 +83,8 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Default discovery tool: what files does this project contain? Lists Git-tracked paths in one bounded call, so ignored directories like .venv and target never appear. Supports globs, a scope, and paging; a project too large to list file by file rolls up to the deepest directory depth that fits.",
         list_project_tracked_files_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "search_project_text",
             ModelVisible,
@@ -102,8 +105,8 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Default inspect/search tool for project text. Uses rg-first with grep fallback. Regex is default; prefer pattern_mode=literal for exact identifiers, snippets, and paths. Supports matches/files_with_matches/count and context. Structured output reports backend, truncated, and failure metadata.",
         search_project_text_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "search_project_texts",
             ModelVisible,
@@ -124,11 +127,11 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Run 1 to 8 independent project-text searches with isolated failures and at most two Runner requests in flight. Each query defaults to regex; prefer pattern_mode=literal for identifiers, snippets, paths, and exact text. Budget continuation is whole-query via next_index.",
         search_project_texts_input_schema,
-    ),
+    )),
 ];
 
 pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
-    model_spec(
+    no_context_continuity(model_spec(
         def(
             "read_file",
             ModelVisible,
@@ -149,8 +152,8 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Default inspect tool for targeted source reading. Bounded UTF-8 range read with full-file sha256 and a continuation cursor (next_start_line); line numbers only change text. Oversized ranges fail range_too_large: shrink limit or narrow the range.",
         read_file_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "read_files",
             ModelVisible,
@@ -171,5 +174,5 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read 1 to 8 UTF-8 file ranges in request order with isolated failures and four Runner reads in flight. The primary batch projection defaults to ~64 KiB; max_result_bytes raises it to 256 KiB. Session/continuity overlays stay separately bounded. Partial reads return deterministic cursors.",
         read_files_input_schema,
-    ),
+    )),
 ];

--- a/src/tool_runtime/tool_definition/files.rs
+++ b/src/tool_runtime/tool_definition/files.rs
@@ -1,7 +1,7 @@
 use super::AgentCapability::{FileRead, Shell};
 use super::ToolVisibility::ModelVisible;
 use super::{
-    def, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_FILE,
+    context_recovery_only, def, model_spec, ToolDefinition, TOOL_CATEGORY_FILE,
     TOOL_CATEGORY_PROJECT,
 };
 use crate::tool_runtime::metadata::{
@@ -16,7 +16,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "project_overview",
             ModelVisible,
@@ -38,7 +38,7 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         "Deterministic, bounded, metadata-only overview of an unfamiliar project: conventional project types, manifests, key files, roots, and direct children. Reads no file contents, uses no LLM, and is not semantic/LSP analysis; use read_file for contents.",
         project_overview_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "list_project_files",
             ModelVisible,
@@ -60,7 +60,7 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         "List files in an agent-registered project directory (bounded, read-only). Returns project-relative paths plus a file/dir kind. Routed to the owning registered agent; the server never reads the agent project path directly.",
         list_project_files_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "list_project_tracked_files",
             ModelVisible,
@@ -84,7 +84,7 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         "Default discovery tool: what files does this project contain? Lists Git-tracked paths in one bounded call, so ignored directories like .venv and target never appear. Supports globs, a scope, and paging; a project too large to list file by file rolls up to the deepest directory depth that fits.",
         list_project_tracked_files_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "search_project_text",
             ModelVisible,
@@ -106,7 +106,7 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
         "Default inspect/search tool for project text. Uses rg-first with grep fallback. Regex is default; prefer pattern_mode=literal for exact identifiers, snippets, and paths. Supports matches/files_with_matches/count and context. Structured output reports backend, truncated, and failure metadata.",
         search_project_text_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "search_project_texts",
             ModelVisible,
@@ -131,7 +131,7 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
 ];
 
 pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "read_file",
             ModelVisible,
@@ -153,7 +153,7 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
         "Default inspect tool for targeted source reading. Bounded UTF-8 range read with full-file sha256 and a continuation cursor (next_start_line); line numbers only change text. Oversized ranges fail range_too_large: shrink limit or narrow the range.",
         read_file_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "read_files",
             ModelVisible,

--- a/src/tool_runtime/tool_definition/git.rs
+++ b/src/tool_runtime/tool_definition/git.rs
@@ -1,7 +1,7 @@
 use super::AgentCapability::GitOrShell;
 use super::ToolVisibility::ModelVisible;
 use super::{
-    change_summary_like, def, git_like, model_spec, no_context_continuity, ToolDefinition,
+    change_summary_like, context_recovery_only, def, git_like, model_spec, ToolDefinition,
     TOOL_CATEGORY_GIT,
 };
 use crate::tool_runtime::metadata::{
@@ -14,7 +14,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
-    no_context_continuity(change_summary_like(git_like(model_spec(
+    context_recovery_only(change_summary_like(git_like(model_spec(
         def(
             "git_diff_summary",
             ModelVisible,
@@ -36,7 +36,7 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
         "Read-only git diff summary for a project: `git status --porcelain`, `git diff --stat`, and a parsed changed-file list. Does not modify the worktree.",
         git_diff_summary_input_schema,
     )))),
-    no_context_continuity(change_summary_like(git_like(model_spec(
+    context_recovery_only(change_summary_like(git_like(model_spec(
         def(
             "git_review_summary",
             ModelVisible,
@@ -58,7 +58,7 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
         "Deterministic bounded committed-range review map. Use before targeted git_diff_hunks/read_file during branch or PR review. Does not judge correctness and never mutates the repository.",
         git_review_summary_input_schema,
     )))),
-    no_context_continuity(change_summary_like(git_like(model_spec(
+    context_recovery_only(change_summary_like(git_like(model_spec(
         def(
             "show_changes",
             ModelVisible,
@@ -83,7 +83,7 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
 ];
 
 pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
-    no_context_continuity(git_like(model_spec(
+    context_recovery_only(git_like(model_spec(
         def(
             "git_status",
             ModelVisible,
@@ -105,7 +105,7 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
         "Run git status --porcelain for a project.",
         git_status_input_schema,
     ))),
-    no_context_continuity(git_like(model_spec(
+    context_recovery_only(git_like(model_spec(
         def(
             "git_diff",
             ModelVisible,
@@ -127,7 +127,7 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
         "Run git diff for a project, optionally scoped to paths.",
         git_diff_input_schema,
     ))),
-    no_context_continuity(change_summary_like(git_like(model_spec(
+    context_recovery_only(change_summary_like(git_like(model_spec(
         def(
             "git_diff_hunks",
             ModelVisible,
@@ -149,7 +149,7 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
         "Targeted/paged diff review for worktree/cached or exact base/head ranges, with paths and scope-bound opaque continuation. Replay scope and paging inputs unchanged. Continuation pages later records; hunk_line_limit needs a fresh call with larger max_hunk_lines and/or narrower paths. Read-only.",
         git_diff_hunks_input_schema,
     )))),
-    no_context_continuity(git_like(model_spec(
+    context_recovery_only(git_like(model_spec(
         def(
             "git_log",
             ModelVisible,

--- a/src/tool_runtime/tool_definition/git.rs
+++ b/src/tool_runtime/tool_definition/git.rs
@@ -1,6 +1,9 @@
 use super::AgentCapability::GitOrShell;
 use super::ToolVisibility::ModelVisible;
-use super::{change_summary_like, def, git_like, model_spec, ToolDefinition, TOOL_CATEGORY_GIT};
+use super::{
+    change_summary_like, def, git_like, model_spec, no_context_continuity, ToolDefinition,
+    TOOL_CATEGORY_GIT,
+};
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath, ToolRisk::Read, PROJECT_READ, TOOL_PROVIDER_AGENT,
 };
@@ -11,7 +14,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
-    change_summary_like(git_like(model_spec(
+    no_context_continuity(change_summary_like(git_like(model_spec(
         def(
             "git_diff_summary",
             ModelVisible,
@@ -32,8 +35,8 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only git diff summary for a project: `git status --porcelain`, `git diff --stat`, and a parsed changed-file list. Does not modify the worktree.",
         git_diff_summary_input_schema,
-    ))),
-    change_summary_like(git_like(model_spec(
+    )))),
+    no_context_continuity(change_summary_like(git_like(model_spec(
         def(
             "git_review_summary",
             ModelVisible,
@@ -54,8 +57,8 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Deterministic bounded committed-range review map. Use before targeted git_diff_hunks/read_file during branch or PR review. Does not judge correctness and never mutates the repository.",
         git_review_summary_input_schema,
-    ))),
-    change_summary_like(git_like(model_spec(
+    )))),
+    no_context_continuity(change_summary_like(git_like(model_spec(
         def(
             "show_changes",
             ModelVisible,
@@ -76,11 +79,11 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Default inspect/review tool before final response. Read-only worktree overview with status, warnings, next actions, and bounded hunks. If hunks truncate, diff_review_handoff points to git_diff_hunks for focused/paged review.",
         show_changes_input_schema,
-    ))),
+    )))),
 ];
 
 pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
-    git_like(model_spec(
+    no_context_continuity(git_like(model_spec(
         def(
             "git_status",
             ModelVisible,
@@ -101,8 +104,8 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Run git status --porcelain for a project.",
         git_status_input_schema,
-    )),
-    git_like(model_spec(
+    ))),
+    no_context_continuity(git_like(model_spec(
         def(
             "git_diff",
             ModelVisible,
@@ -123,8 +126,8 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Run git diff for a project, optionally scoped to paths.",
         git_diff_input_schema,
-    )),
-    change_summary_like(git_like(model_spec(
+    ))),
+    no_context_continuity(change_summary_like(git_like(model_spec(
         def(
             "git_diff_hunks",
             ModelVisible,
@@ -145,8 +148,8 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Targeted/paged diff review for worktree/cached or exact base/head ranges, with paths and scope-bound opaque continuation. Replay scope and paging inputs unchanged. Continuation pages later records; hunk_line_limit needs a fresh call with larger max_hunk_lines and/or narrower paths. Read-only.",
         git_diff_hunks_input_schema,
-    ))),
-    git_like(model_spec(
+    )))),
+    no_context_continuity(git_like(model_spec(
         def(
             "git_log",
             ModelVisible,
@@ -167,5 +170,5 @@ pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Return bounded structured recent git commit history for a project. Does not return commit bodies or modify the worktree.",
         git_log_input_schema,
-    )),
+    ))),
 ];

--- a/src/tool_runtime/tool_definition/hygiene.rs
+++ b/src/tool_runtime/tool_definition/hygiene.rs
@@ -1,7 +1,7 @@
 use super::AgentCapability::{GitOrShell, Shell, StructuredProcess};
 use super::ToolVisibility::ModelVisible;
 use super::{
-    def, git_like, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_CLEANUP,
+    context_recovery_only, def, git_like, model_spec, ToolDefinition, TOOL_CATEGORY_CLEANUP,
 };
 use crate::tool_runtime::metadata::{
     ToolPathHint::{None as NoPath, PathList},
@@ -13,7 +13,7 @@ use crate::tool_runtime::registry::input_schemas::{
     git_restore_paths_input_schema, workspace_hygiene_check_input_schema,
 };
 
-pub(super) const DEFINITIONS: &[ToolDefinition] = &[no_context_continuity(model_spec(
+pub(super) const DEFINITIONS: &[ToolDefinition] = &[context_recovery_only(model_spec(
     def(
         "workspace_hygiene_check",
         ModelVisible,

--- a/src/tool_runtime/tool_definition/hygiene.rs
+++ b/src/tool_runtime/tool_definition/hygiene.rs
@@ -1,6 +1,8 @@
 use super::AgentCapability::{GitOrShell, Shell, StructuredProcess};
 use super::ToolVisibility::ModelVisible;
-use super::{def, git_like, model_spec, ToolDefinition, TOOL_CATEGORY_CLEANUP};
+use super::{
+    def, git_like, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_CLEANUP,
+};
 use crate::tool_runtime::metadata::{
     ToolPathHint::{None as NoPath, PathList},
     ToolRisk::{ProjectWrite, Read},
@@ -11,7 +13,7 @@ use crate::tool_runtime::registry::input_schemas::{
     git_restore_paths_input_schema, workspace_hygiene_check_input_schema,
 };
 
-pub(super) const DEFINITIONS: &[ToolDefinition] = &[model_spec(
+pub(super) const DEFINITIONS: &[ToolDefinition] = &[no_context_continuity(model_spec(
     def(
         "workspace_hygiene_check",
         ModelVisible,
@@ -32,7 +34,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[model_spec(
     ),
     "Default pre-final workspace hygiene review; read-only. Detects dirty worktree, untracked temp/smoke files, cache dirs, secret-like names, and large untracked files before validation or handoff. Never reads file contents.",
     workspace_hygiene_check_input_schema,
-)];
+))];
 
 pub(super) const CLEANUP_DEFINITIONS: &[ToolDefinition] = &[
     model_spec(

--- a/src/tool_runtime/tool_definition/lsp.rs
+++ b/src/tool_runtime/tool_definition/lsp.rs
@@ -1,6 +1,6 @@
 use super::AgentCapability::{LspCallHierarchy, LspReadOnlyNavigation};
 use super::ToolVisibility::ModelVisible;
-use super::{def, model_spec, ToolDefinition, TOOL_CATEGORY_LSP};
+use super::{def, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_LSP};
 use crate::tool_runtime::metadata::{
     ToolPathHint::{None as NoPath, SinglePath},
     ToolRisk::Read,
@@ -13,7 +13,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
-    model_spec(
+    no_context_continuity(model_spec(
         def(
             "lsp_status",
             ModelVisible,
@@ -34,8 +34,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only probe of configured agent-side language-server availability for a project. Does not start a language server, run checks, or execute project code. Returns detected languages and availability/running status without absolute executable paths.",
         lsp_status_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "document_symbols",
             ModelVisible,
@@ -56,8 +56,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only hierarchical document symbols for a project-relative supported source file via its configured agent-side language server. Returns project-relative paths, 1-based Unicode scalar columns, and bounded pre-order results. External or invalid ranges are omitted.",
         document_symbols_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "document_diagnostics",
             ModelVisible,
@@ -78,8 +78,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only bounded diagnostics for a project-relative supported source file via agent-side publishDiagnostics. Returns normalized 1-based Unicode scalar ranges and explicit freshness/timeout state; it does not run a project check.",
         document_diagnostics_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "hover",
             ModelVisible,
@@ -100,8 +100,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only hover for a project-relative supported source file at a 1-based Unicode scalar position via its configured agent-side language server. MarkupContent and MarkedString forms are normalized to bounded markdown/plaintext; invalid optional ranges are omitted.",
         hover_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "workspace_symbols",
             ModelVisible,
@@ -122,8 +122,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only bounded workspace/symbol query via configured agent-side language servers. Requires a non-empty 1..200 character query; results are workspace-filtered, sorted, deduplicated, and use project-relative paths only.",
         workspace_symbols_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "goto_definition",
             ModelVisible,
@@ -144,8 +144,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only goto-definition for a project-relative supported source file at a 1-based Unicode scalar position via its configured agent-side language server. Supports Location, Location[], and LocationLink[]; external dependency results are omitted.",
         goto_definition_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "find_references",
             ModelVisible,
@@ -166,8 +166,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only find-references for a project-relative supported source file at a 1-based Unicode scalar position via its configured agent-side language server. Results are deduplicated and truncated on the agent; external/invalid locations are counted separately.",
         find_references_input_schema,
-    ),
-    model_spec(
+    )),
+    no_context_continuity(model_spec(
         def(
             "call_hierarchy",
             ModelVisible,
@@ -188,5 +188,5 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Read-only bounded call hierarchy for a project-relative supported source position. The Runner performs prepare plus incoming/outgoing breadth-first traversal to depth 1 or 2, returning only normalized project-local symbols and globally bounded edges.",
         call_hierarchy_input_schema,
-    ),
+    )),
 ];

--- a/src/tool_runtime/tool_definition/lsp.rs
+++ b/src/tool_runtime/tool_definition/lsp.rs
@@ -1,6 +1,6 @@
 use super::AgentCapability::{LspCallHierarchy, LspReadOnlyNavigation};
 use super::ToolVisibility::ModelVisible;
-use super::{def, model_spec, no_context_continuity, ToolDefinition, TOOL_CATEGORY_LSP};
+use super::{context_recovery_only, def, model_spec, ToolDefinition, TOOL_CATEGORY_LSP};
 use crate::tool_runtime::metadata::{
     ToolPathHint::{None as NoPath, SinglePath},
     ToolRisk::Read,
@@ -13,7 +13,7 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "lsp_status",
             ModelVisible,
@@ -35,7 +35,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read-only probe of configured agent-side language-server availability for a project. Does not start a language server, run checks, or execute project code. Returns detected languages and availability/running status without absolute executable paths.",
         lsp_status_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "document_symbols",
             ModelVisible,
@@ -57,7 +57,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read-only hierarchical document symbols for a project-relative supported source file via its configured agent-side language server. Returns project-relative paths, 1-based Unicode scalar columns, and bounded pre-order results. External or invalid ranges are omitted.",
         document_symbols_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "document_diagnostics",
             ModelVisible,
@@ -79,7 +79,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read-only bounded diagnostics for a project-relative supported source file via agent-side publishDiagnostics. Returns normalized 1-based Unicode scalar ranges and explicit freshness/timeout state; it does not run a project check.",
         document_diagnostics_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "hover",
             ModelVisible,
@@ -101,7 +101,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read-only hover for a project-relative supported source file at a 1-based Unicode scalar position via its configured agent-side language server. MarkupContent and MarkedString forms are normalized to bounded markdown/plaintext; invalid optional ranges are omitted.",
         hover_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "workspace_symbols",
             ModelVisible,
@@ -123,7 +123,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read-only bounded workspace/symbol query via configured agent-side language servers. Requires a non-empty 1..200 character query; results are workspace-filtered, sorted, deduplicated, and use project-relative paths only.",
         workspace_symbols_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "goto_definition",
             ModelVisible,
@@ -145,7 +145,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read-only goto-definition for a project-relative supported source file at a 1-based Unicode scalar position via its configured agent-side language server. Supports Location, Location[], and LocationLink[]; external dependency results are omitted.",
         goto_definition_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "find_references",
             ModelVisible,
@@ -167,7 +167,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Read-only find-references for a project-relative supported source file at a 1-based Unicode scalar position via its configured agent-side language server. Results are deduplicated and truncated on the agent; external/invalid locations are counted separately.",
         find_references_input_schema,
     )),
-    no_context_continuity(model_spec(
+    context_recovery_only(model_spec(
         def(
             "call_hierarchy",
             ModelVisible,

--- a/src/tool_runtime/tool_definition/sessions.rs
+++ b/src/tool_runtime/tool_definition/sessions.rs
@@ -1,8 +1,9 @@
 use super::AgentCapability::{GitOrShell, OwnerOnly};
 use super::ToolVisibility::{ModelHidden, ModelVisible};
 use super::{
-    def, extra_accepted_flattened_args, model_spec, requires_explicit_business_session,
-    ToolDefinition, TOOL_CATEGORY_SESSION, TOOL_CATEGORY_VALIDATION,
+    context_recovery_only, def, extra_accepted_flattened_args, model_spec,
+    requires_explicit_business_session, ToolDefinition, TOOL_CATEGORY_SESSION,
+    TOOL_CATEGORY_VALIDATION,
 };
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath, ToolRisk::Read, PROJECT_READ, PROJECT_WRITE, RUNTIME_READ,
@@ -58,7 +59,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         &["session_id"],
     ),
-    model_spec(
+    context_recovery_only(model_spec(
         def(
             "work_on_project",
             ModelVisible,
@@ -79,7 +80,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         "Canonical model entry for ordinary coding/review via an existing project or Runner path; Git not required. Supports exact Session continuation and returns compact workflow plus project instructions.",
         work_on_project_input_schema,
-    ),
+    )),
     requires_explicit_business_session(model_spec(
         def(
             "finish_coding_task",

--- a/src/tool_runtime/tool_policy.rs
+++ b/src/tool_runtime/tool_policy.rs
@@ -4,9 +4,10 @@ use super::metadata::{
     tool_metadata, ToolApprovalPolicy, ToolEffect, ToolMetadata, ToolPathHint, ToolRisk,
 };
 use super::tool_definition::{
-    tool_definitions, AgentCapability, ToolDefinition, ToolEffectAnnotations,
-    PERMISSION_RISK_ARTIFACT_WRITE, PERMISSION_RISK_DESTRUCTIVE, PERMISSION_RISK_PATCH,
-    PERMISSION_RISK_SHELL, PERMISSION_RISK_VALIDATION, PERMISSION_RISK_WRITE,
+    tool_definitions, AgentCapability, ToolContextContinuityPolicy, ToolDefinition,
+    ToolEffectAnnotations, PERMISSION_RISK_ARTIFACT_WRITE, PERMISSION_RISK_DESTRUCTIVE,
+    PERMISSION_RISK_PATCH, PERMISSION_RISK_SHELL, PERMISSION_RISK_VALIDATION,
+    PERMISSION_RISK_WRITE,
 };
 
 impl ToolDefinition {
@@ -56,6 +57,10 @@ impl ToolDefinition {
 
     pub(crate) fn captures_validation_output(self) -> bool {
         self.policy.captures_validation_output
+    }
+
+    pub(crate) fn context_continuity_policy(self) -> ToolContextContinuityPolicy {
+        self.policy.context_continuity
     }
 
     #[cfg(test)]
@@ -163,6 +168,25 @@ pub(crate) fn runtime_tool_metadata(name: &str) -> ToolMetadata {
         Ok(definition) => definition.metadata(),
         Err(metadata) => metadata,
     }
+}
+
+fn tool_context_continuity_policy(name: &str) -> ToolContextContinuityPolicy {
+    lookup_tool_definition(name)
+        .map(|definition| definition.context_continuity_policy())
+        .unwrap_or(ToolContextContinuityPolicy::CONSERVATIVE)
+}
+
+#[cfg(test)]
+pub(crate) fn runtime_tool_context_continuity_policy(name: &str) -> ToolContextContinuityPolicy {
+    tool_context_continuity_policy(name)
+}
+
+pub(crate) fn runtime_tool_accepts_context_ack(name: &str) -> bool {
+    tool_context_continuity_policy(name).accepts_context_ack
+}
+
+pub(crate) fn runtime_tool_advances_context_checkpoint(name: &str) -> bool {
+    tool_context_continuity_policy(name).advances_context_checkpoint()
 }
 
 pub(crate) fn runtime_tool_effect_annotations(name: &str) -> ToolEffectAnnotations {


### PR DESCRIPTION
## Summary

- add typed per-tool model-context continuity policy, separating ACK acceptance from checkpoint advancement
- make `context_revision` a durable model-knowledge checkpoint watermark instead of a raw model-facing event counter
- stop ordinary read/search/discovery/review hot paths from advancing checkpoints while preserving conservative fallback for unclassified tools
- keep `work_on_project` recovery-capable without creating a new checkpoint
- preserve nonblocking stale/missing/future ACK recovery, concurrency fencing, sparse-revision history-loss accounting, persistence compatibility, and cross-surface checkpoint semantics
- make Stateless MCP ACK schema per-tool while keeping cached old ACK calls rolling-compatible
- make adaptive gateway checkpoint behavior follow the resolved long-tail target exactly once
- restore the existing Adaptive Runtime routing fence so direct core tools remain direct-only and the gateway remains long-tail-only

## Validation

- Session context revision / HTTP MCP targeted suite: passed
- Session module: 96 passed
- MCP tools module: 32 passed
- MCP model-surface suite: 16 passed
- adaptive long-tail gateway checkpoint parity: passed
- stale cached ACK compatibility: passed
- history-loss retention regression: passed
- `cargo fmt --all -- --check`: passed
- `cargo check -p webcodex --all-targets`: passed
- `git diff --check`: passed
- workspace hygiene: clean

Existing AgentWake dead-code warnings are unchanged from the prepared base.