### PR TITLE
Bind AgentTask attempts to durable CodingAgent runs

### DIFF
--- a/src/auth/scopes.rs
+++ b/src/auth/scopes.rs
@@ -768,6 +768,23 @@ mod tests {
                 OAuthToolScopePolicy::RequireAll(&[SCOPE_CODING_AGENT_RUN, SCOPE_PROJECT_WRITE]),
             ),
             (
+                "start_agent_task_coding_run",
+                OAuthToolScopePolicy::RequireAll(&[
+                    SCOPE_COMMUNICATION_READ,
+                    SCOPE_COMMUNICATION_MANAGE,
+                    SCOPE_CODING_AGENT_RUN,
+                    SCOPE_PROJECT_WRITE,
+                ]),
+            ),
+            (
+                "reconcile_agent_task_coding_run",
+                OAuthToolScopePolicy::RequireAll(&[
+                    SCOPE_COMMUNICATION_READ,
+                    SCOPE_COMMUNICATION_MANAGE,
+                    SCOPE_CODING_AGENT_RUN,
+                ]),
+            ),
+            (
                 "coding_agent_observe",
                 OAuthToolScopePolicy::Require(SCOPE_CODING_AGENT_RUN),
             ),
@@ -843,6 +860,19 @@ mod tests {
                     | "read_agent_task"
             ) {
                 OAuthToolScopePolicy::RequireAll(COMMUNICATION_READ_SCOPES)
+            } else if tool == "start_agent_task_coding_run" {
+                OAuthToolScopePolicy::RequireAll(&[
+                    SCOPE_COMMUNICATION_READ,
+                    SCOPE_COMMUNICATION_MANAGE,
+                    SCOPE_CODING_AGENT_RUN,
+                    SCOPE_PROJECT_WRITE,
+                ])
+            } else if tool == "reconcile_agent_task_coding_run" {
+                OAuthToolScopePolicy::RequireAll(&[
+                    SCOPE_COMMUNICATION_READ,
+                    SCOPE_COMMUNICATION_MANAGE,
+                    SCOPE_CODING_AGENT_RUN,
+                ])
             } else if matches!(
                 tool,
                 "create_agent_identity"

--- a/src/db.rs
+++ b/src/db.rs
@@ -25,7 +25,11 @@ mod task_kernel;
 
 pub use self::activity::WorkspaceActivityStore;
 pub(crate) use self::admin_project_lifecycle::AdminProjectAudit;
-pub(crate) use self::agent_task::{AgentTaskState, NewAgentTask, MAX_AGENT_TASK_LIST_LIMIT};
+pub(crate) use self::agent_task::{
+    AgentTaskCodingRunBindingIntent, AgentTaskCodingRunBindingRecord,
+    AgentTaskCodingRunDispatchState, AgentTaskCodingRunObservation, AgentTaskState, NewAgentTask,
+    MAX_AGENT_TASK_LIST_LIMIT, MAX_AGENT_TASK_TERMINAL_TEXT_BYTES,
+};
 #[allow(unused_imports)]
 pub(crate) use self::agent_wake::{
     AgentWakeClaim, AgentWakeConsumeResult, AgentWakeEnvelope, AgentWakePrepared, AgentWakeRecord,

--- a/src/db/agent_task.rs
+++ b/src/db/agent_task.rs
@@ -1610,7 +1610,7 @@ impl Database {
             attempt_fence,
             attempt_controller_generation,
             intent,
-            now_unix_ms(),
+            None,
         )
     }
 
@@ -1637,7 +1637,7 @@ impl Database {
             attempt_fence,
             attempt_controller_generation,
             intent,
-            now,
+            Some(now),
         )
     }
 
@@ -1652,7 +1652,7 @@ impl Database {
         attempt_fence: &str,
         attempt_controller_generation: i64,
         intent: &AgentTaskCodingRunBindingIntent,
-        now: i64,
+        now: Option<i64>,
     ) -> Result<AgentTaskCodingRunPrepared, CommunicationStoreError> {
         validate_attempt_mutation_inputs(
             principal,
@@ -1666,6 +1666,7 @@ impl Database {
         let transaction = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(store_error)?;
+        let now = now.unwrap_or_else(now_unix_ms);
         let task = load_owned_task(&transaction, principal, task_id, now)?;
         let referenced_project = task.referenced_project_id.as_deref().ok_or_else(|| {
             CommunicationStoreError::new(
@@ -1829,7 +1830,6 @@ impl Database {
         attempt_controller_generation: i64,
         binding_intent_fingerprint: &str,
     ) -> Result<AgentTaskCodingRunDispatchClaim, CommunicationStoreError> {
-        let now = now_unix_ms();
         validate_attempt_mutation_inputs(
             principal,
             task_id,
@@ -1842,6 +1842,7 @@ impl Database {
         let transaction = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(store_error)?;
+        let now = now_unix_ms();
         let task = load_owned_task(&transaction, principal, task_id, now)?;
         let _attempt = require_current_attempt(
             &transaction,

--- a/src/db/agent_task.rs
+++ b/src/db/agent_task.rs
@@ -109,6 +109,183 @@ impl AgentTaskAttemptState {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentTaskCodingRunDispatchState {
+    Prepared,
+    NotStarted,
+    OutcomeUnknown,
+    Bound,
+    Terminal,
+}
+
+impl AgentTaskCodingRunDispatchState {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepared => "prepared",
+            Self::NotStarted => "not_started",
+            Self::OutcomeUnknown => "outcome_unknown",
+            Self::Bound => "bound",
+            Self::Terminal => "terminal",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "prepared" => Ok(Self::Prepared),
+            "not_started" => Ok(Self::NotStarted),
+            "outcome_unknown" => Ok(Self::OutcomeUnknown),
+            "bound" => Ok(Self::Bound),
+            "terminal" => Ok(Self::Terminal),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported AgentTask CodingAgent dispatch state: {other}").into(),
+            )),
+        }
+    }
+
+    const fn blocks_replacement(self) -> bool {
+        matches!(self, Self::OutcomeUnknown | Self::Bound)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentTaskExecutionStatus {
+    NotStarted,
+    Active,
+    WaitingPermission,
+    OutcomeUnknown,
+    Terminal,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentTaskExecutionRecoveryKind {
+    None,
+    Observe,
+    Reconcile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTaskCodingRunBindingIntent {
+    pub(crate) run_id: String,
+    pub(crate) runtime_project_id: String,
+    pub(crate) provider_id: String,
+    pub(crate) provider_instance_id: String,
+    pub(crate) authority_fingerprint: String,
+    pub(crate) coding_agent_intent_fingerprint: String,
+    pub(crate) binding_intent_fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTaskCodingRunObservation {
+    pub(crate) run_id: String,
+    pub(crate) runtime_project_id: String,
+    pub(crate) provider_id: String,
+    pub(crate) provider_instance_id: String,
+    pub(crate) authority_fingerprint: String,
+    pub(crate) coding_agent_intent_fingerprint: String,
+    pub(crate) run_state: String,
+    pub(crate) execution_state: String,
+    pub(crate) observation_revision: i64,
+    pub(crate) terminal_stop_reason: Option<String>,
+    pub(crate) terminal_error_code: Option<String>,
+    pub(crate) terminal_message: Option<String>,
+    pub(crate) completed_at_unix: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTaskCodingRunBindingRecord {
+    pub(crate) task_id: String,
+    pub(crate) attempt_id: String,
+    pub(crate) run_id: String,
+    pub(crate) runtime_project_id: String,
+    pub(crate) provider_id: String,
+    pub(crate) provider_instance_id: String,
+    pub(crate) authority_fingerprint: String,
+    pub(crate) coding_agent_intent_fingerprint: String,
+    pub(crate) binding_intent_fingerprint: String,
+    pub(crate) dispatch_state: AgentTaskCodingRunDispatchState,
+    pub(crate) last_observed_run_state: Option<String>,
+    pub(crate) last_observed_execution_state: Option<String>,
+    pub(crate) last_observation_revision: Option<i64>,
+    pub(crate) terminal_stop_reason: Option<String>,
+    pub(crate) terminal_error_code: Option<String>,
+    pub(crate) terminal_message: Option<String>,
+    pub(crate) completed_at_unix: Option<i64>,
+    pub(crate) created_at_unix_ms: i64,
+    pub(crate) updated_at_unix_ms: i64,
+    pub(crate) terminal_at_unix_ms: Option<i64>,
+}
+
+impl AgentTaskCodingRunBindingRecord {
+    fn execution_status(&self) -> AgentTaskExecutionStatus {
+        match self.dispatch_state {
+            AgentTaskCodingRunDispatchState::Prepared
+            | AgentTaskCodingRunDispatchState::NotStarted => AgentTaskExecutionStatus::NotStarted,
+            AgentTaskCodingRunDispatchState::OutcomeUnknown => {
+                AgentTaskExecutionStatus::OutcomeUnknown
+            }
+            AgentTaskCodingRunDispatchState::Terminal => AgentTaskExecutionStatus::Terminal,
+            AgentTaskCodingRunDispatchState::Bound => match self.last_observed_run_state.as_deref()
+            {
+                Some("waiting_permission") => AgentTaskExecutionStatus::WaitingPermission,
+                Some("lost") => AgentTaskExecutionStatus::OutcomeUnknown,
+                Some("completed" | "failed" | "cancelled") => AgentTaskExecutionStatus::Terminal,
+                _ => AgentTaskExecutionStatus::Active,
+            },
+        }
+    }
+
+    fn recovery_kind(&self) -> AgentTaskExecutionRecoveryKind {
+        match self.dispatch_state {
+            AgentTaskCodingRunDispatchState::Prepared
+            | AgentTaskCodingRunDispatchState::NotStarted
+            | AgentTaskCodingRunDispatchState::Terminal => AgentTaskExecutionRecoveryKind::None,
+            AgentTaskCodingRunDispatchState::OutcomeUnknown => {
+                AgentTaskExecutionRecoveryKind::Reconcile
+            }
+            AgentTaskCodingRunDispatchState::Bound => match self.execution_status() {
+                AgentTaskExecutionStatus::Active | AgentTaskExecutionStatus::WaitingPermission => {
+                    AgentTaskExecutionRecoveryKind::Observe
+                }
+                AgentTaskExecutionStatus::OutcomeUnknown | AgentTaskExecutionStatus::Terminal => {
+                    AgentTaskExecutionRecoveryKind::Reconcile
+                }
+                AgentTaskExecutionStatus::NotStarted => AgentTaskExecutionRecoveryKind::None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTaskCodingRunStartContext {
+    pub(crate) task: AgentTaskDetail,
+    pub(crate) attempt: AgentTaskAttemptRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTaskCodingRunPrepared {
+    pub(crate) binding: AgentTaskCodingRunBindingRecord,
+    pub(crate) replayed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTaskCodingRunDispatchClaim {
+    pub(crate) binding: AgentTaskCodingRunBindingRecord,
+    pub(crate) may_dispatch: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTaskCodingRunReconcileMutation {
+    pub(crate) task: AgentTaskSummary,
+    pub(crate) attempt: AgentTaskAttemptRecord,
+    pub(crate) binding: AgentTaskCodingRunBindingRecord,
+    pub(crate) state_changed: bool,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct AgentTaskAttemptRecord {
     pub(crate) attempt_id: String,
@@ -139,6 +316,9 @@ pub(crate) struct AgentTaskSummary {
     pub(crate) updated_at_unix_ms: i64,
     pub(crate) terminal_at_unix_ms: Option<i64>,
     pub(crate) latest_attempt: Option<AgentTaskAttemptRecord>,
+    pub(crate) execution_bound: bool,
+    pub(crate) execution_status: Option<AgentTaskExecutionStatus>,
+    pub(crate) recovery_kind: AgentTaskExecutionRecoveryKind,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -250,6 +430,7 @@ struct StoredTask {
     updated_at_unix_ms: i64,
     terminal_at_unix_ms: Option<i64>,
     latest_attempt: Option<StoredAttempt>,
+    latest_coding_run: Option<AgentTaskCodingRunBindingRecord>,
 }
 
 impl StoredTask {
@@ -258,6 +439,10 @@ impl StoredTask {
             && self.latest_attempt.as_ref().is_some_and(|attempt| {
                 attempt.effective_state(now) == AgentTaskAttemptState::Expired
             })
+            && !self
+                .latest_coding_run
+                .as_ref()
+                .is_some_and(|binding| binding.dispatch_state.blocks_replacement())
         {
             AgentTaskState::Ready
         } else {
@@ -281,6 +466,16 @@ impl StoredTask {
                 .latest_attempt
                 .as_ref()
                 .map(|attempt| attempt.record(now)),
+            execution_bound: self.latest_coding_run.is_some(),
+            execution_status: self
+                .latest_coding_run
+                .as_ref()
+                .map(AgentTaskCodingRunBindingRecord::execution_status),
+            recovery_kind: self
+                .latest_coding_run
+                .as_ref()
+                .map(AgentTaskCodingRunBindingRecord::recovery_kind)
+                .unwrap_or(AgentTaskExecutionRecoveryKind::None),
         }
     }
 
@@ -347,6 +542,33 @@ impl Database {
                 FOREIGN KEY(task_id) REFERENCES wc_agent_tasks(task_id),
                 FOREIGN KEY(assignee_agent_id) REFERENCES wc_agent_identities(agent_id)
             );
+            CREATE TABLE IF NOT EXISTS wc_agent_task_coding_runs (
+                task_id TEXT NOT NULL,
+                attempt_id TEXT NOT NULL UNIQUE,
+                run_id TEXT NOT NULL UNIQUE,
+                runtime_project_id TEXT NOT NULL,
+                provider_id TEXT NOT NULL,
+                provider_instance_id TEXT NOT NULL,
+                authority_fingerprint TEXT NOT NULL,
+                coding_agent_intent_fingerprint TEXT NOT NULL,
+                binding_intent_fingerprint TEXT NOT NULL,
+                dispatch_state TEXT NOT NULL CHECK(dispatch_state IN ('prepared', 'not_started', 'outcome_unknown', 'bound', 'terminal')),
+                last_observed_run_state TEXT,
+                last_observed_execution_state TEXT,
+                last_observation_revision INTEGER,
+                terminal_stop_reason TEXT,
+                terminal_error_code TEXT,
+                terminal_message TEXT,
+                completed_at_unix INTEGER,
+                created_at_unix_ms INTEGER NOT NULL,
+                updated_at_unix_ms INTEGER NOT NULL,
+                terminal_at_unix_ms INTEGER,
+                FOREIGN KEY(task_id) REFERENCES wc_agent_tasks(task_id),
+                FOREIGN KEY(attempt_id) REFERENCES wc_agent_task_attempts(attempt_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_wc_agent_task_coding_runs_task
+                ON wc_agent_task_coding_runs(task_id, updated_at_unix_ms DESC);
+
             CREATE UNIQUE INDEX IF NOT EXISTS idx_wc_agent_task_attempts_one_active
                 ON wc_agent_task_attempts(task_id) WHERE state = 'active';
             CREATE INDEX IF NOT EXISTS idx_wc_agent_task_attempts_task_number
@@ -655,6 +877,11 @@ impl Database {
         }
         require_owned_agent(&transaction, principal, assignee_agent_id)?;
         materialize_expired_latest_attempt(&transaction, &mut task, now)?;
+        if task.assignee_agent_id.as_deref() != Some(assignee_agent_id) {
+            if let Some(error) = blocking_execution_error(task.latest_coding_run.as_ref()) {
+                return Err(error);
+            }
+        }
         if task
             .latest_attempt
             .as_ref()
@@ -805,6 +1032,9 @@ impl Database {
         }
         require_owned_agent(&transaction, principal, assignee_agent_id)?;
         materialize_expired_latest_attempt(&transaction, &mut task, now)?;
+        if let Some(error) = blocking_execution_error(task.latest_coding_run.as_ref()) {
+            return Err(error);
+        }
         if task
             .latest_attempt
             .as_ref()
@@ -1261,6 +1491,803 @@ impl Database {
             state_changed: true,
         })
     }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn agent_task_coding_run_start_context(
+        &self,
+        principal: &CommunicationPrincipal,
+        project: &str,
+        task_id: &str,
+        attempt_id: &str,
+        assignee_agent_id: &str,
+        attempt_fence: &str,
+        attempt_controller_generation: i64,
+    ) -> Result<AgentTaskCodingRunStartContext, CommunicationStoreError> {
+        self.agent_task_coding_run_start_context_with_now(
+            principal,
+            project,
+            task_id,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+            now_unix_ms(),
+        )
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn agent_task_coding_run_start_context_at(
+        &self,
+        principal: &CommunicationPrincipal,
+        project: &str,
+        task_id: &str,
+        attempt_id: &str,
+        assignee_agent_id: &str,
+        attempt_fence: &str,
+        attempt_controller_generation: i64,
+        now: i64,
+    ) -> Result<AgentTaskCodingRunStartContext, CommunicationStoreError> {
+        self.agent_task_coding_run_start_context_with_now(
+            principal,
+            project,
+            task_id,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+            now,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn agent_task_coding_run_start_context_with_now(
+        &self,
+        principal: &CommunicationPrincipal,
+        project: &str,
+        task_id: &str,
+        attempt_id: &str,
+        assignee_agent_id: &str,
+        attempt_fence: &str,
+        attempt_controller_generation: i64,
+        now: i64,
+    ) -> Result<AgentTaskCodingRunStartContext, CommunicationStoreError> {
+        validate_attempt_mutation_inputs(
+            principal,
+            task_id,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+        )?;
+        let conn = self.conn.lock().unwrap();
+        let task = load_owned_task(&conn, principal, task_id, now)?;
+        let referenced_project = task.referenced_project_id.as_deref().ok_or_else(|| {
+            CommunicationStoreError::new(
+                "agent_task_project_required",
+                "AgentTask has no referenced_project_id and cannot dispatch a CodingAgentRun",
+            )
+        })?;
+        if project != referenced_project {
+            return Err(CommunicationStoreError::new(
+                "agent_task_project_mismatch",
+                "Requested Project does not match AgentTask referenced_project_id",
+            ));
+        }
+        let attempt = require_current_attempt(
+            &conn,
+            &task,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+            now,
+        )?;
+        Ok(AgentTaskCodingRunStartContext {
+            task: task.detail(now),
+            attempt: attempt.record(now),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare_agent_task_coding_run(
+        &self,
+        principal: &CommunicationPrincipal,
+        project: &str,
+        task_id: &str,
+        attempt_id: &str,
+        assignee_agent_id: &str,
+        attempt_fence: &str,
+        attempt_controller_generation: i64,
+        intent: &AgentTaskCodingRunBindingIntent,
+    ) -> Result<AgentTaskCodingRunPrepared, CommunicationStoreError> {
+        self.prepare_agent_task_coding_run_with_now(
+            principal,
+            project,
+            task_id,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+            intent,
+            now_unix_ms(),
+        )
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare_agent_task_coding_run_at(
+        &self,
+        principal: &CommunicationPrincipal,
+        project: &str,
+        task_id: &str,
+        attempt_id: &str,
+        assignee_agent_id: &str,
+        attempt_fence: &str,
+        attempt_controller_generation: i64,
+        intent: &AgentTaskCodingRunBindingIntent,
+        now: i64,
+    ) -> Result<AgentTaskCodingRunPrepared, CommunicationStoreError> {
+        self.prepare_agent_task_coding_run_with_now(
+            principal,
+            project,
+            task_id,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+            intent,
+            now,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_agent_task_coding_run_with_now(
+        &self,
+        principal: &CommunicationPrincipal,
+        project: &str,
+        task_id: &str,
+        attempt_id: &str,
+        assignee_agent_id: &str,
+        attempt_fence: &str,
+        attempt_controller_generation: i64,
+        intent: &AgentTaskCodingRunBindingIntent,
+        now: i64,
+    ) -> Result<AgentTaskCodingRunPrepared, CommunicationStoreError> {
+        validate_attempt_mutation_inputs(
+            principal,
+            task_id,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+        )?;
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(store_error)?;
+        let task = load_owned_task(&transaction, principal, task_id, now)?;
+        let referenced_project = task.referenced_project_id.as_deref().ok_or_else(|| {
+            CommunicationStoreError::new(
+                "agent_task_project_required",
+                "AgentTask has no referenced_project_id and cannot dispatch a CodingAgentRun",
+            )
+        })?;
+        if project != referenced_project || intent.runtime_project_id != referenced_project {
+            return Err(CommunicationStoreError::new(
+                "agent_task_project_mismatch",
+                "CodingAgentRun Project does not match AgentTask referenced_project_id",
+            ));
+        }
+        let _attempt = require_current_attempt(
+            &transaction,
+            &task,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+            now,
+        )?;
+        if let Some(mut existing) =
+            load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+        {
+            let same_intent = existing.run_id == intent.run_id
+                && existing.runtime_project_id == intent.runtime_project_id
+                && existing.provider_id == intent.provider_id
+                && existing.authority_fingerprint == intent.authority_fingerprint
+                && existing.coding_agent_intent_fingerprint
+                    == intent.coding_agent_intent_fingerprint
+                && existing.binding_intent_fingerprint == intent.binding_intent_fingerprint;
+            if !same_intent {
+                return Err(CommunicationStoreError::new(
+                    "agent_task_coding_run_binding_conflict",
+                    "AgentTaskAttempt is already bound to a different CodingAgentRun intent",
+                ));
+            }
+            if existing.provider_instance_id != intent.provider_instance_id {
+                if matches!(
+                    existing.dispatch_state,
+                    AgentTaskCodingRunDispatchState::Prepared
+                        | AgentTaskCodingRunDispatchState::NotStarted
+                ) {
+                    transaction
+                        .execute(
+                            "UPDATE wc_agent_task_coding_runs
+                             SET provider_instance_id = ?3, updated_at_unix_ms = MAX(updated_at_unix_ms, ?4)
+                             WHERE task_id = ?1 AND attempt_id = ?2",
+                            params![task_id, attempt_id, intent.provider_instance_id, now],
+                        )
+                        .map_err(store_error)?;
+                    existing =
+                        load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+                            .ok_or_else(|| {
+                                CommunicationStoreError::new(
+                                    "agent_task_storage_invariant",
+                                    "AgentTask CodingAgent binding disappeared during replay",
+                                )
+                            })?;
+                } else {
+                    return Err(CommunicationStoreError::new(
+                        "agent_task_coding_run_binding_conflict",
+                        "AgentTaskAttempt CodingAgent provider instance cannot change after dispatch may have started",
+                    ));
+                }
+            }
+            transaction.commit().map_err(store_error)?;
+            return Ok(AgentTaskCodingRunPrepared {
+                binding: existing,
+                replayed: true,
+            });
+        }
+        let conflicting_attempt = transaction
+            .query_row(
+                "SELECT attempt_id FROM wc_agent_task_coding_runs WHERE run_id = ?1",
+                [intent.run_id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(store_error)?;
+        if conflicting_attempt.is_some() {
+            return Err(CommunicationStoreError::new(
+                "agent_task_coding_run_binding_conflict",
+                "CodingAgentRun is already bound to another AgentTaskAttempt",
+            ));
+        }
+        transaction
+            .execute(
+                "INSERT INTO wc_agent_task_coding_runs (
+                    task_id, attempt_id, run_id, runtime_project_id, provider_id,
+                    provider_instance_id, authority_fingerprint, coding_agent_intent_fingerprint,
+                    binding_intent_fingerprint, dispatch_state, created_at_unix_ms,
+                    updated_at_unix_ms
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'prepared', ?10, ?10)",
+                params![
+                    task_id,
+                    attempt_id,
+                    intent.run_id,
+                    intent.runtime_project_id,
+                    intent.provider_id,
+                    intent.provider_instance_id,
+                    intent.authority_fingerprint,
+                    intent.coding_agent_intent_fingerprint,
+                    intent.binding_intent_fingerprint,
+                    now,
+                ],
+            )
+            .map_err(store_error)?;
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "AgentTask CodingAgent binding disappeared after prepare",
+                )
+            })?;
+        transaction.commit().map_err(store_error)?;
+        Ok(AgentTaskCodingRunPrepared {
+            binding,
+            replayed: false,
+        })
+    }
+
+    pub(crate) fn read_agent_task_coding_run_binding(
+        &self,
+        principal: &CommunicationPrincipal,
+        task_id: &str,
+        attempt_id: &str,
+    ) -> Result<AgentTaskCodingRunBindingRecord, CommunicationStoreError> {
+        validate_communication_principal(principal)?;
+        validate_id(task_id, AGENT_TASK_ID_PREFIX, "invalid_agent_task_id")?;
+        validate_id(
+            attempt_id,
+            AGENT_TASK_ATTEMPT_ID_PREFIX,
+            "invalid_agent_task_attempt_id",
+        )?;
+        let conn = self.conn.lock().unwrap();
+        let task = load_owned_task(&conn, principal, task_id, now_unix_ms())?;
+        load_attempt_for_task(&conn, task_id, attempt_id, now_unix_ms())?.ok_or_else(|| {
+            CommunicationStoreError::new(
+                "agent_task_attempt_not_found",
+                "AgentTaskAttempt does not exist",
+            )
+        })?;
+        load_coding_run_binding_for_attempt(&conn, &task.task_id, attempt_id)?.ok_or_else(|| {
+            CommunicationStoreError::new(
+                "agent_task_coding_run_not_found",
+                "AgentTaskAttempt has no bound CodingAgentRun",
+            )
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn claim_agent_task_coding_run_dispatch(
+        &self,
+        principal: &CommunicationPrincipal,
+        task_id: &str,
+        attempt_id: &str,
+        assignee_agent_id: &str,
+        attempt_fence: &str,
+        attempt_controller_generation: i64,
+        binding_intent_fingerprint: &str,
+    ) -> Result<AgentTaskCodingRunDispatchClaim, CommunicationStoreError> {
+        let now = now_unix_ms();
+        validate_attempt_mutation_inputs(
+            principal,
+            task_id,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+        )?;
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(store_error)?;
+        let task = load_owned_task(&transaction, principal, task_id, now)?;
+        let _attempt = require_current_attempt(
+            &transaction,
+            &task,
+            attempt_id,
+            assignee_agent_id,
+            attempt_fence,
+            attempt_controller_generation,
+            now,
+        )?;
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_coding_run_not_found",
+                    "AgentTaskAttempt has no prepared CodingAgentRun binding",
+                )
+            })?;
+        if binding.binding_intent_fingerprint != binding_intent_fingerprint {
+            return Err(CommunicationStoreError::new(
+                "agent_task_coding_run_binding_conflict",
+                "CodingAgentRun binding intent does not match the durable Attempt binding",
+            ));
+        }
+        let may_dispatch = matches!(
+            binding.dispatch_state,
+            AgentTaskCodingRunDispatchState::Prepared | AgentTaskCodingRunDispatchState::NotStarted
+        );
+        if may_dispatch {
+            transaction
+                .execute(
+                    "UPDATE wc_agent_task_coding_runs
+                     SET dispatch_state = 'outcome_unknown', updated_at_unix_ms = MAX(updated_at_unix_ms, ?3)
+                     WHERE task_id = ?1 AND attempt_id = ?2
+                       AND dispatch_state IN ('prepared', 'not_started')",
+                    params![task_id, attempt_id, now],
+                )
+                .map_err(store_error)?;
+        }
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "AgentTask CodingAgent binding disappeared during dispatch fencing",
+                )
+            })?;
+        transaction.commit().map_err(store_error)?;
+        Ok(AgentTaskCodingRunDispatchClaim {
+            binding,
+            may_dispatch,
+        })
+    }
+
+    pub(crate) fn record_agent_task_coding_run_not_started(
+        &self,
+        principal: &CommunicationPrincipal,
+        task_id: &str,
+        attempt_id: &str,
+        run_id: &str,
+    ) -> Result<AgentTaskCodingRunBindingRecord, CommunicationStoreError> {
+        let now = now_unix_ms();
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(store_error)?;
+        let _task = load_owned_task(&transaction, principal, task_id, now)?;
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_coding_run_not_found",
+                    "AgentTaskAttempt has no bound CodingAgentRun",
+                )
+            })?;
+        if binding.run_id != run_id {
+            return Err(CommunicationStoreError::new(
+                "agent_task_coding_run_identity_mismatch",
+                "CodingAgentRun does not match the durable AgentTaskAttempt binding",
+            ));
+        }
+        if binding.dispatch_state == AgentTaskCodingRunDispatchState::OutcomeUnknown {
+            transaction
+                .execute(
+                    "UPDATE wc_agent_task_coding_runs
+                     SET dispatch_state = 'not_started', updated_at_unix_ms = MAX(updated_at_unix_ms, ?3)
+                     WHERE task_id = ?1 AND attempt_id = ?2 AND dispatch_state = 'outcome_unknown'",
+                    params![task_id, attempt_id, now],
+                )
+                .map_err(store_error)?;
+        }
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "AgentTask CodingAgent binding disappeared after NotStarted observation",
+                )
+            })?;
+        transaction.commit().map_err(store_error)?;
+        Ok(binding)
+    }
+
+    pub(crate) fn record_agent_task_coding_run_observation(
+        &self,
+        principal: &CommunicationPrincipal,
+        task_id: &str,
+        attempt_id: &str,
+        observation: &AgentTaskCodingRunObservation,
+    ) -> Result<AgentTaskCodingRunBindingRecord, CommunicationStoreError> {
+        let now = now_unix_ms();
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(store_error)?;
+        let _task = load_owned_task(&transaction, principal, task_id, now)?;
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_coding_run_not_found",
+                    "AgentTaskAttempt has no bound CodingAgentRun",
+                )
+            })?;
+        require_coding_run_observation_identity(&binding, observation)?;
+        validate_coding_run_observation(observation)?;
+        let dispatch_state = if binding.dispatch_state == AgentTaskCodingRunDispatchState::Terminal
+        {
+            AgentTaskCodingRunDispatchState::Terminal
+        } else if observation.run_state == "lost"
+            || observation.execution_state == "outcome_unknown"
+        {
+            AgentTaskCodingRunDispatchState::OutcomeUnknown
+        } else {
+            AgentTaskCodingRunDispatchState::Bound
+        };
+        transaction
+            .execute(
+                "UPDATE wc_agent_task_coding_runs
+                 SET dispatch_state = ?3,
+                     last_observed_run_state = ?4,
+                     last_observed_execution_state = ?5,
+                     last_observation_revision = ?6,
+                     terminal_stop_reason = ?7,
+                     terminal_error_code = ?8,
+                     terminal_message = ?9,
+                     completed_at_unix = ?10,
+                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?11)
+                 WHERE task_id = ?1 AND attempt_id = ?2",
+                params![
+                    task_id,
+                    attempt_id,
+                    dispatch_state.as_str(),
+                    observation.run_state,
+                    observation.execution_state,
+                    observation.observation_revision,
+                    observation.terminal_stop_reason,
+                    observation.terminal_error_code,
+                    observation.terminal_message,
+                    observation.completed_at_unix,
+                    now,
+                ],
+            )
+            .map_err(store_error)?;
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "AgentTask CodingAgent binding disappeared after observation",
+                )
+            })?;
+        transaction.commit().map_err(store_error)?;
+        Ok(binding)
+    }
+
+    pub(crate) fn mark_agent_task_coding_run_reconcile_unavailable(
+        &self,
+        principal: &CommunicationPrincipal,
+        task_id: &str,
+        attempt_id: &str,
+    ) -> Result<AgentTaskCodingRunBindingRecord, CommunicationStoreError> {
+        let now = now_unix_ms();
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(store_error)?;
+        let _task = load_owned_task(&transaction, principal, task_id, now)?;
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_coding_run_not_found",
+                    "AgentTaskAttempt has no bound CodingAgentRun",
+                )
+            })?;
+        if binding.dispatch_state == AgentTaskCodingRunDispatchState::Bound {
+            transaction
+                .execute(
+                    "UPDATE wc_agent_task_coding_runs
+                     SET dispatch_state = 'outcome_unknown', updated_at_unix_ms = MAX(updated_at_unix_ms, ?3)
+                     WHERE task_id = ?1 AND attempt_id = ?2 AND dispatch_state = 'bound'",
+                    params![task_id, attempt_id, now],
+                )
+                .map_err(store_error)?;
+        }
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "AgentTask CodingAgent binding disappeared during reconciliation",
+                )
+            })?;
+        transaction.commit().map_err(store_error)?;
+        Ok(binding)
+    }
+
+    pub(crate) fn terminalize_agent_task_coding_run(
+        &self,
+        principal: &CommunicationPrincipal,
+        task_id: &str,
+        attempt_id: &str,
+        observation: &AgentTaskCodingRunObservation,
+        terminal_result: Option<&str>,
+        terminal_reason: Option<&str>,
+    ) -> Result<AgentTaskCodingRunReconcileMutation, CommunicationStoreError> {
+        validate_communication_principal(principal)?;
+        let terminal_result = validate_optional_terminal_text(terminal_result, "terminal_result")?;
+        let terminal_reason = validate_optional_terminal_text(terminal_reason, "terminal_reason")?;
+        let desired_task_state = match observation.run_state.as_str() {
+            "completed" => AgentTaskState::Succeeded,
+            "failed" | "cancelled" => AgentTaskState::Failed,
+            _ => {
+                return Err(CommunicationStoreError::new(
+                    "agent_task_coding_run_not_terminal",
+                    "CodingAgentRun is not an authoritative terminal result for AgentTask reconciliation",
+                ))
+            }
+        };
+        validate_coding_run_observation(observation)?;
+        let now = now_unix_ms();
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(store_error)?;
+        let task = load_owned_task(&transaction, principal, task_id, now)?;
+        if task
+            .latest_attempt
+            .as_ref()
+            .map(|attempt| attempt.attempt_id.as_str())
+            != Some(attempt_id)
+        {
+            return Err(CommunicationStoreError::new(
+                "agent_task_attempt_stale",
+                "Bound CodingAgentRun no longer belongs to the latest authoritative AgentTaskAttempt",
+            ));
+        }
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_coding_run_not_found",
+                    "AgentTaskAttempt has no bound CodingAgentRun",
+                )
+            })?;
+        require_coding_run_observation_identity(&binding, observation)?;
+        let attempt =
+            load_attempt_for_task(&transaction, task_id, attempt_id, now)?.ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_attempt_not_found",
+                    "AgentTaskAttempt does not exist",
+                )
+            })?;
+        if task.stored_state.terminal() {
+            let terminal_attempt_id = transaction
+                .query_row(
+                    "SELECT terminal_attempt_id FROM wc_agent_tasks WHERE task_id = ?1",
+                    [task_id],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .map_err(store_error)?;
+            if terminal_attempt_id.as_deref() != Some(attempt_id)
+                || task.stored_state != desired_task_state
+            {
+                return Err(CommunicationStoreError::new(
+                    "agent_task_attempt_stale",
+                    "AgentTask is already terminal from a different authoritative result",
+                ));
+            }
+            let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+                .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "Terminal AgentTask lost its CodingAgent binding",
+                )
+            })?;
+            transaction.commit().map_err(store_error)?;
+            return Ok(AgentTaskCodingRunReconcileMutation {
+                task: task.summary(now),
+                attempt: attempt.record(now),
+                binding,
+                state_changed: false,
+            });
+        }
+        let attempt_state = match desired_task_state {
+            AgentTaskState::Succeeded => AgentTaskAttemptState::Succeeded,
+            AgentTaskState::Failed => AgentTaskAttemptState::Failed,
+            AgentTaskState::Ready | AgentTaskState::Active => unreachable!(),
+        };
+        transaction
+            .execute(
+                "UPDATE wc_agent_task_attempts
+                 SET state = ?2, terminal_at_unix_ms = ?3,
+                     terminal_result = ?4, terminal_reason = ?5
+                 WHERE attempt_id = ?1",
+                params![
+                    attempt_id,
+                    attempt_state.as_str(),
+                    now,
+                    terminal_result,
+                    terminal_reason,
+                ],
+            )
+            .map_err(store_error)?;
+        transaction
+            .execute(
+                "UPDATE wc_agent_tasks
+                 SET state = ?2, terminal_attempt_id = ?3, terminal_at_unix_ms = ?4,
+                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?4)
+                 WHERE task_id = ?1",
+                params![task_id, desired_task_state.as_str(), attempt_id, now],
+            )
+            .map_err(store_error)?;
+        transaction
+            .execute(
+                "UPDATE wc_agent_task_coding_runs
+                 SET dispatch_state = 'terminal',
+                     last_observed_run_state = ?3,
+                     last_observed_execution_state = ?4,
+                     last_observation_revision = ?5,
+                     terminal_stop_reason = ?6,
+                     terminal_error_code = ?7,
+                     terminal_message = ?8,
+                     completed_at_unix = ?9,
+                     terminal_at_unix_ms = ?10,
+                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?10)
+                 WHERE task_id = ?1 AND attempt_id = ?2",
+                params![
+                    task_id,
+                    attempt_id,
+                    observation.run_state,
+                    observation.execution_state,
+                    observation.observation_revision,
+                    observation.terminal_stop_reason,
+                    observation.terminal_error_code,
+                    observation.terminal_message,
+                    observation.completed_at_unix,
+                    now,
+                ],
+            )
+            .map_err(store_error)?;
+        let task = load_owned_task(&transaction, principal, task_id, now)?;
+        let attempt =
+            load_attempt_for_task(&transaction, task_id, attempt_id, now)?.ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_attempt_not_found",
+                    "AgentTaskAttempt disappeared after backend reconciliation",
+                )
+            })?;
+        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "AgentTask CodingAgent binding disappeared after terminal reconciliation",
+                )
+            })?;
+        transaction.commit().map_err(store_error)?;
+        Ok(AgentTaskCodingRunReconcileMutation {
+            task: task.summary(now),
+            attempt: attempt.record(now),
+            binding,
+            state_changed: true,
+        })
+    }
+}
+
+fn require_coding_run_observation_identity(
+    binding: &AgentTaskCodingRunBindingRecord,
+    observation: &AgentTaskCodingRunObservation,
+) -> Result<(), CommunicationStoreError> {
+    if binding.run_id != observation.run_id
+        || binding.runtime_project_id != observation.runtime_project_id
+        || binding.provider_id != observation.provider_id
+        || binding.provider_instance_id != observation.provider_instance_id
+        || binding.authority_fingerprint != observation.authority_fingerprint
+        || binding.coding_agent_intent_fingerprint != observation.coding_agent_intent_fingerprint
+    {
+        return Err(CommunicationStoreError::new(
+            "agent_task_coding_run_identity_mismatch",
+            "CodingAgentRun snapshot does not match the exact durable AgentTaskAttempt binding",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_coding_run_observation(
+    observation: &AgentTaskCodingRunObservation,
+) -> Result<(), CommunicationStoreError> {
+    if !matches!(
+        observation.run_state.as_str(),
+        "starting"
+            | "running"
+            | "waiting_permission"
+            | "completed"
+            | "failed"
+            | "cancelled"
+            | "lost"
+    ) {
+        return Err(CommunicationStoreError::new(
+            "invalid_agent_task_coding_run_observation",
+            "CodingAgentRun snapshot contains an unsupported run state",
+        ));
+    }
+    if !matches!(
+        observation.execution_state.as_str(),
+        "not_started" | "started" | "outcome_unknown" | "completed"
+    ) || observation.observation_revision < 0
+    {
+        return Err(CommunicationStoreError::new(
+            "invalid_agent_task_coding_run_observation",
+            "CodingAgentRun snapshot contains an unsupported execution state or revision",
+        ));
+    }
+    for (label, value) in [
+        (
+            "terminal_stop_reason",
+            observation.terminal_stop_reason.as_deref(),
+        ),
+        (
+            "terminal_error_code",
+            observation.terminal_error_code.as_deref(),
+        ),
+        ("terminal_message", observation.terminal_message.as_deref()),
+    ] {
+        if let Some(value) = value {
+            if value.len() > MAX_AGENT_TASK_TERMINAL_TEXT_BYTES {
+                return Err(CommunicationStoreError::new(
+                    "invalid_agent_task_coding_run_observation",
+                    format!("{label} exceeds the AgentTask bounded terminal text limit"),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn task_request_hash(value: &serde_json::Value) -> String {
@@ -1461,9 +2488,12 @@ fn load_owned_task(
                 updated_at_unix_ms: row.10,
                 terminal_at_unix_ms: row.11,
                 latest_attempt: None,
+                latest_coding_run: None,
             })
         }
     };
+    let latest_coding_run =
+        load_coding_run_binding_for_attempt(conn, task_id, &latest_attempt.attempt_id)?;
     Ok(StoredTask {
         task_id: row.0,
         assignee_agent_id: row.1,
@@ -1477,6 +2507,7 @@ fn load_owned_task(
         updated_at_unix_ms: row.10,
         terminal_at_unix_ms: row.11,
         latest_attempt: Some(latest_attempt),
+        latest_coding_run,
     })
 }
 
@@ -1521,6 +2552,72 @@ fn load_attempt_for_task(
     .map_err(store_error)
 }
 
+fn load_coding_run_binding_for_attempt(
+    conn: &Connection,
+    task_id: &str,
+    attempt_id: &str,
+) -> Result<Option<AgentTaskCodingRunBindingRecord>, CommunicationStoreError> {
+    conn.query_row(
+        "SELECT task_id, attempt_id, run_id, runtime_project_id, provider_id,
+                provider_instance_id, authority_fingerprint, coding_agent_intent_fingerprint,
+                binding_intent_fingerprint, dispatch_state, last_observed_run_state,
+                last_observed_execution_state, last_observation_revision,
+                terminal_stop_reason, terminal_error_code, terminal_message,
+                completed_at_unix, created_at_unix_ms, updated_at_unix_ms, terminal_at_unix_ms
+         FROM wc_agent_task_coding_runs
+         WHERE task_id = ?1 AND attempt_id = ?2",
+        params![task_id, attempt_id],
+        |row| {
+            Ok(AgentTaskCodingRunBindingRecord {
+                task_id: row.get(0)?,
+                attempt_id: row.get(1)?,
+                run_id: row.get(2)?,
+                runtime_project_id: row.get(3)?,
+                provider_id: row.get(4)?,
+                provider_instance_id: row.get(5)?,
+                authority_fingerprint: row.get(6)?,
+                coding_agent_intent_fingerprint: row.get(7)?,
+                binding_intent_fingerprint: row.get(8)?,
+                dispatch_state: AgentTaskCodingRunDispatchState::from_db(
+                    &row.get::<_, String>(9)?,
+                    9,
+                )?,
+                last_observed_run_state: row.get(10)?,
+                last_observed_execution_state: row.get(11)?,
+                last_observation_revision: row.get(12)?,
+                terminal_stop_reason: row.get(13)?,
+                terminal_error_code: row.get(14)?,
+                terminal_message: row.get(15)?,
+                completed_at_unix: row.get(16)?,
+                created_at_unix_ms: row.get(17)?,
+                updated_at_unix_ms: row.get(18)?,
+                terminal_at_unix_ms: row.get(19)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(store_error)
+}
+
+fn blocking_execution_error(
+    binding: Option<&AgentTaskCodingRunBindingRecord>,
+) -> Option<CommunicationStoreError> {
+    let binding = binding.filter(|binding| binding.dispatch_state.blocks_replacement())?;
+    if binding.dispatch_state == AgentTaskCodingRunDispatchState::OutcomeUnknown
+        || binding.last_observed_run_state.as_deref() == Some("lost")
+    {
+        Some(CommunicationStoreError::new(
+            "agent_task_execution_outcome_unknown",
+            "AgentTask has a CodingAgent execution whose outcome is unresolved; reconcile the exact bound Run before replacement",
+        ))
+    } else {
+        Some(CommunicationStoreError::new(
+            "agent_task_execution_active",
+            "AgentTask has a bound CodingAgent execution that must be reconciled before replacement",
+        ))
+    }
+}
+
 fn materialize_expired_latest_attempt(
     transaction: &Transaction<'_>,
     task: &mut StoredTask,
@@ -1542,17 +2639,23 @@ fn materialize_expired_latest_attempt(
             params![attempt.attempt_id, now],
         )
         .map_err(store_error)?;
-    transaction
-        .execute(
-            "UPDATE wc_agent_tasks
-             SET state = 'ready', updated_at_unix_ms = MAX(updated_at_unix_ms, ?2)
-             WHERE task_id = ?1 AND state = 'active'",
-            params![task.task_id, now],
-        )
-        .map_err(store_error)?;
+    let execution_blocks_replacement = task
+        .latest_coding_run
+        .as_ref()
+        .is_some_and(|binding| binding.dispatch_state.blocks_replacement());
+    if !execution_blocks_replacement {
+        transaction
+            .execute(
+                "UPDATE wc_agent_tasks
+                 SET state = 'ready', updated_at_unix_ms = MAX(updated_at_unix_ms, ?2)
+                 WHERE task_id = ?1 AND state = 'active'",
+                params![task.task_id, now],
+            )
+            .map_err(store_error)?;
+        task.stored_state = AgentTaskState::Ready;
+    }
     attempt.stored_state = AgentTaskAttemptState::Expired;
     attempt.terminal_at_unix_ms = Some(now);
-    task.stored_state = AgentTaskState::Ready;
     task.updated_at_unix_ms = task.updated_at_unix_ms.max(now);
     Ok(())
 }

--- a/src/db/agent_task_tests.rs
+++ b/src/db/agent_task_tests.rs
@@ -83,6 +83,757 @@ fn start(
         .unwrap()
 }
 
+fn coding_binding_intent(label: &str) -> AgentTaskCodingRunBindingIntent {
+    AgentTaskCodingRunBindingIntent {
+        run_id: format!("wc_agent_run_{label}"),
+        runtime_project_id: "agent:special:reference-only".to_string(),
+        provider_id: "codex".to_string(),
+        provider_instance_id: format!("provider-instance-{label}"),
+        authority_fingerprint: format!("authority-{label}"),
+        coding_agent_intent_fingerprint: format!("coding-intent-{label}"),
+        binding_intent_fingerprint: format!("binding-intent-{label}"),
+    }
+}
+
+fn coding_observation(
+    intent: &AgentTaskCodingRunBindingIntent,
+    run_state: &str,
+    execution_state: &str,
+    revision: i64,
+) -> AgentTaskCodingRunObservation {
+    AgentTaskCodingRunObservation {
+        run_id: intent.run_id.clone(),
+        runtime_project_id: intent.runtime_project_id.clone(),
+        provider_id: intent.provider_id.clone(),
+        provider_instance_id: intent.provider_instance_id.clone(),
+        authority_fingerprint: intent.authority_fingerprint.clone(),
+        coding_agent_intent_fingerprint: intent.coding_agent_intent_fingerprint.clone(),
+        run_state: run_state.to_string(),
+        execution_state: execution_state.to_string(),
+        observation_revision: revision,
+        terminal_stop_reason: matches!(run_state, "completed" | "failed" | "cancelled")
+            .then(|| format!("stop-{run_state}")),
+        terminal_error_code: (run_state == "failed").then(|| "provider_failed".to_string()),
+        terminal_message: matches!(run_state, "completed" | "failed" | "cancelled")
+            .then(|| format!("terminal-{run_state}")),
+        completed_at_unix: matches!(run_state, "completed" | "failed" | "cancelled")
+            .then_some(1234),
+    }
+}
+
+fn prepare_coding_binding(
+    db: &Database,
+    owner: &CommunicationPrincipal,
+    task_id: &str,
+    assignee: &str,
+    started: &AgentTaskAttemptStartMutation,
+    intent: &AgentTaskCodingRunBindingIntent,
+    now: i64,
+) -> AgentTaskCodingRunPrepared {
+    db.prepare_agent_task_coding_run_at(
+        owner,
+        "agent:special:reference-only",
+        task_id,
+        &started.attempt.attempt_id,
+        assignee,
+        &started.attempt_fence,
+        started.attempt.attempt_controller_generation,
+        intent,
+        now,
+    )
+    .unwrap()
+}
+
+#[test]
+fn coding_run_binding_is_unique_replayable_and_fenced_before_dispatch() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-binding.db")).unwrap();
+    let owner = principal('1');
+    let assignee = agent(&db, &owner, "coding-binding-agent");
+    let task_id = create_assigned_task(&db, &owner, &assignee, "coding-binding-task");
+    let now = wall_now_ms();
+    let started = start(
+        &db,
+        &owner,
+        &task_id,
+        &assignee,
+        "coding-binding-start",
+        now,
+    );
+
+    let context = db
+        .agent_task_coding_run_start_context_at(
+            &owner,
+            "agent:special:reference-only",
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            now + 1,
+        )
+        .unwrap();
+    assert_eq!(
+        context.task.instruction,
+        task_input(None, "ignored").instruction
+    );
+    assert_eq!(context.attempt.attempt_id, started.attempt.attempt_id);
+    let project_error = db
+        .agent_task_coding_run_start_context_at(
+            &owner,
+            "agent:special:wrong-project",
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            now + 1,
+        )
+        .unwrap_err();
+    assert_eq!(project_error.code(), "agent_task_project_mismatch");
+
+    let intent = coding_binding_intent("binding-one");
+    let prepared =
+        prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 2);
+    assert_eq!(
+        prepared.binding.dispatch_state,
+        AgentTaskCodingRunDispatchState::Prepared
+    );
+    assert!(!prepared.replayed);
+
+    let replay =
+        prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 3);
+    assert!(replay.replayed);
+    assert_eq!(replay.binding.run_id, intent.run_id);
+
+    let mut changed = intent.clone();
+    changed.provider_id = "other-provider".to_string();
+    changed.binding_intent_fingerprint = "binding-intent-changed".to_string();
+    let conflict = db
+        .prepare_agent_task_coding_run_at(
+            &owner,
+            "agent:special:reference-only",
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            &changed,
+            now + 4,
+        )
+        .unwrap_err();
+    assert_eq!(conflict.code(), "agent_task_coding_run_binding_conflict");
+
+    let first_claim = db
+        .claim_agent_task_coding_run_dispatch(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            &intent.binding_intent_fingerprint,
+        )
+        .unwrap();
+    assert!(first_claim.may_dispatch);
+    assert_eq!(
+        first_claim.binding.dispatch_state,
+        AgentTaskCodingRunDispatchState::OutcomeUnknown
+    );
+    let retry_claim = db
+        .claim_agent_task_coding_run_dispatch(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            &intent.binding_intent_fingerprint,
+        )
+        .unwrap();
+    assert!(!retry_claim.may_dispatch);
+    assert_eq!(retry_claim.binding.run_id, intent.run_id);
+    assert_eq!(
+        db.conn_for_tests()
+            .query_row(
+                "SELECT COUNT(*) FROM wc_agent_task_coding_runs",
+                [],
+                |row| { row.get::<_, i64>(0) }
+            )
+            .unwrap(),
+        1
+    );
+}
+
+#[test]
+fn definitive_not_started_releases_backend_fence_after_lease_expiry() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-not-started.db")).unwrap();
+    let owner = principal('2');
+    let agent_a = agent(&db, &owner, "coding-not-started-a");
+    let agent_b = agent(&db, &owner, "coding-not-started-b");
+    let now = wall_now_ms();
+
+    let task_id = create_assigned_task(&db, &owner, &agent_a, "coding-not-started-task");
+    let started = start(
+        &db,
+        &owner,
+        &task_id,
+        &agent_a,
+        "coding-not-started-start",
+        now,
+    );
+    let intent = coding_binding_intent("not-started-one");
+    prepare_coding_binding(&db, &owner, &task_id, &agent_a, &started, &intent, now + 1);
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &agent_a,
+        &started.attempt_fence,
+        1,
+        &intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+    let not_started = db
+        .record_agent_task_coding_run_not_started(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &intent.run_id,
+        )
+        .unwrap();
+    assert_eq!(
+        not_started.dispatch_state,
+        AgentTaskCodingRunDispatchState::NotStarted
+    );
+    let second = db
+        .start_agent_task_attempt_at(
+            &owner,
+            &task_id,
+            &agent_a,
+            "coding-not-started-second",
+            started.attempt.lease_expires_at_unix_ms,
+        )
+        .unwrap();
+    assert_eq!(second.attempt.attempt_number, 2);
+
+    let reassign_task =
+        create_assigned_task(&db, &owner, &agent_a, "coding-not-started-reassign-task");
+    let reassign_started = start(
+        &db,
+        &owner,
+        &reassign_task,
+        &agent_a,
+        "coding-not-started-reassign-start",
+        now + 10,
+    );
+    let reassign_intent = coding_binding_intent("not-started-reassign");
+    prepare_coding_binding(
+        &db,
+        &owner,
+        &reassign_task,
+        &agent_a,
+        &reassign_started,
+        &reassign_intent,
+        now + 11,
+    );
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &reassign_task,
+        &reassign_started.attempt.attempt_id,
+        &agent_a,
+        &reassign_started.attempt_fence,
+        1,
+        &reassign_intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+    db.record_agent_task_coding_run_not_started(
+        &owner,
+        &reassign_task,
+        &reassign_started.attempt.attempt_id,
+        &reassign_intent.run_id,
+    )
+    .unwrap();
+    let reassigned = db
+        .assign_agent_task_at(
+            &owner,
+            &reassign_task,
+            &agent_b,
+            reassign_started.attempt.lease_expires_at_unix_ms,
+        )
+        .unwrap();
+    assert_eq!(
+        reassigned.task.summary.assignee_agent_id.as_deref(),
+        Some(agent_b.as_str())
+    );
+}
+
+#[test]
+fn unresolved_coding_execution_blocks_replacement_and_reassignment_after_lease_expiry() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-blocking.db")).unwrap();
+    let owner = principal('3');
+    let agent_a = agent(&db, &owner, "coding-block-a");
+    let agent_b = agent(&db, &owner, "coding-block-b");
+    let now = wall_now_ms();
+
+    for (index, run_state, execution_state, expected_error) in [
+        (0_i64, None, None, "agent_task_execution_outcome_unknown"),
+        (
+            1,
+            Some("running"),
+            Some("started"),
+            "agent_task_execution_active",
+        ),
+        (
+            2,
+            Some("waiting_permission"),
+            Some("started"),
+            "agent_task_execution_active",
+        ),
+        (
+            3,
+            Some("lost"),
+            Some("outcome_unknown"),
+            "agent_task_execution_outcome_unknown",
+        ),
+    ] {
+        let task_id =
+            create_assigned_task(&db, &owner, &agent_a, &format!("coding-block-task-{index}"));
+        let started = start(
+            &db,
+            &owner,
+            &task_id,
+            &agent_a,
+            &format!("coding-block-start-{index}"),
+            now + index * 20,
+        );
+        let intent = coding_binding_intent(&format!("blocking-{index}"));
+        prepare_coding_binding(
+            &db,
+            &owner,
+            &task_id,
+            &agent_a,
+            &started,
+            &intent,
+            now + index * 20 + 1,
+        );
+        db.claim_agent_task_coding_run_dispatch(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &agent_a,
+            &started.attempt_fence,
+            1,
+            &intent.binding_intent_fingerprint,
+        )
+        .unwrap();
+        if let (Some(run_state), Some(execution_state)) = (run_state, execution_state) {
+            db.record_agent_task_coding_run_observation(
+                &owner,
+                &task_id,
+                &started.attempt.attempt_id,
+                &coding_observation(&intent, run_state, execution_state, 1),
+            )
+            .unwrap();
+        }
+        let replacement = db
+            .start_agent_task_attempt_at(
+                &owner,
+                &task_id,
+                &agent_a,
+                &format!("coding-block-replacement-{index}"),
+                started.attempt.lease_expires_at_unix_ms,
+            )
+            .unwrap_err();
+        assert_eq!(replacement.code(), expected_error, "case {index}");
+        let reassignment = db
+            .assign_agent_task_at(
+                &owner,
+                &task_id,
+                &agent_b,
+                started.attempt.lease_expires_at_unix_ms + 1,
+            )
+            .unwrap_err();
+        assert_eq!(reassignment.code(), expected_error, "case {index}");
+        let task = db
+            .read_agent_task_at(
+                &owner,
+                &task_id,
+                started.attempt.lease_expires_at_unix_ms + 2,
+            )
+            .unwrap();
+        assert_eq!(task.summary.state, AgentTaskState::Active);
+        assert!(task.summary.execution_bound);
+    }
+}
+
+#[test]
+fn backend_terminal_truth_reconciles_exact_attempt_after_ordinary_lease_expiry() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-terminal.db")).unwrap();
+    let owner = principal('4');
+    let assignee = agent(&db, &owner, "coding-terminal-agent");
+    let now = wall_now_ms();
+    let task_id = create_assigned_task(&db, &owner, &assignee, "coding-terminal-task");
+    let started = start(
+        &db,
+        &owner,
+        &task_id,
+        &assignee,
+        "coding-terminal-start",
+        now,
+    );
+    let intent = coding_binding_intent("terminal-completed");
+    prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 1);
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &assignee,
+        &started.attempt_fence,
+        1,
+        &intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+    let completed = coding_observation(&intent, "completed", "completed", 7);
+    db.record_agent_task_coding_run_observation(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &completed,
+    )
+    .unwrap();
+
+    let stale_generic = db
+        .complete_agent_task_attempt_at(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            AgentTaskState::Succeeded,
+            Some("stale browser completion"),
+            None,
+            "stale-generic-completion",
+            started.attempt.lease_expires_at_unix_ms,
+        )
+        .unwrap_err();
+    assert_eq!(stale_generic.code(), "agent_task_attempt_stale");
+
+    let reconciled = db
+        .terminalize_agent_task_coding_run(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed,
+            Some("bounded coding result"),
+            Some("coding_agent_completed"),
+        )
+        .unwrap();
+    assert!(reconciled.state_changed);
+    assert_eq!(reconciled.task.state, AgentTaskState::Succeeded);
+    assert_eq!(reconciled.attempt.state, AgentTaskAttemptState::Succeeded);
+    assert_eq!(
+        reconciled.binding.dispatch_state,
+        AgentTaskCodingRunDispatchState::Terminal
+    );
+
+    let replay_observation = db
+        .record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed,
+        )
+        .unwrap();
+    assert_eq!(
+        replay_observation.dispatch_state,
+        AgentTaskCodingRunDispatchState::Terminal
+    );
+    let replay = db
+        .terminalize_agent_task_coding_run(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed,
+            Some("bounded coding result"),
+            Some("coding_agent_completed"),
+        )
+        .unwrap();
+    assert!(!replay.state_changed);
+}
+
+#[test]
+fn failed_cancelled_and_lost_have_bounded_exact_terminal_semantics() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-terminal-states.db")).unwrap();
+    let owner = principal('5');
+    let assignee = agent(&db, &owner, "coding-terminal-states-agent");
+    let now = wall_now_ms();
+
+    for (index, run_state, reason) in [
+        (0_i64, "failed", "provider_failed"),
+        (1_i64, "cancelled", "coding_agent_cancelled"),
+    ] {
+        let task_id = create_assigned_task(
+            &db,
+            &owner,
+            &assignee,
+            &format!("coding-terminal-state-task-{index}"),
+        );
+        let started = start(
+            &db,
+            &owner,
+            &task_id,
+            &assignee,
+            &format!("coding-terminal-state-start-{index}"),
+            now + index * 20,
+        );
+        let intent = coding_binding_intent(&format!("terminal-state-{index}"));
+        prepare_coding_binding(
+            &db,
+            &owner,
+            &task_id,
+            &assignee,
+            &started,
+            &intent,
+            now + index * 20 + 1,
+        );
+        db.claim_agent_task_coding_run_dispatch(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            &intent.binding_intent_fingerprint,
+        )
+        .unwrap();
+        let observation = coding_observation(&intent, run_state, "completed", 3);
+        db.record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &observation,
+        )
+        .unwrap();
+        let mutation = db
+            .terminalize_agent_task_coding_run(
+                &owner,
+                &task_id,
+                &started.attempt.attempt_id,
+                &observation,
+                Some("bounded terminal result"),
+                Some(reason),
+            )
+            .unwrap();
+        assert_eq!(mutation.task.state, AgentTaskState::Failed);
+        assert_eq!(mutation.attempt.state, AgentTaskAttemptState::Failed);
+        assert_eq!(mutation.attempt.terminal_reason.as_deref(), Some(reason));
+    }
+
+    let lost_task = create_assigned_task(&db, &owner, &assignee, "coding-lost-task");
+    let lost_started = start(
+        &db,
+        &owner,
+        &lost_task,
+        &assignee,
+        "coding-lost-start",
+        now + 50,
+    );
+    let lost_intent = coding_binding_intent("lost-terminal-state");
+    prepare_coding_binding(
+        &db,
+        &owner,
+        &lost_task,
+        &assignee,
+        &lost_started,
+        &lost_intent,
+        now + 51,
+    );
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &lost_task,
+        &lost_started.attempt.attempt_id,
+        &assignee,
+        &lost_started.attempt_fence,
+        1,
+        &lost_intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+    let lost = coding_observation(&lost_intent, "lost", "outcome_unknown", 4);
+    let binding = db
+        .record_agent_task_coding_run_observation(
+            &owner,
+            &lost_task,
+            &lost_started.attempt.attempt_id,
+            &lost,
+        )
+        .unwrap();
+    assert_eq!(
+        binding.dispatch_state,
+        AgentTaskCodingRunDispatchState::OutcomeUnknown
+    );
+    let terminal_error = db
+        .terminalize_agent_task_coding_run(
+            &owner,
+            &lost_task,
+            &lost_started.attempt.attempt_id,
+            &lost,
+            Some("must not commit"),
+            Some("must not commit"),
+        )
+        .unwrap_err();
+    assert_eq!(terminal_error.code(), "agent_task_coding_run_not_terminal");
+    assert_eq!(
+        db.read_agent_task(&owner, &lost_task)
+            .unwrap()
+            .summary
+            .state,
+        AgentTaskState::Active
+    );
+}
+
+#[test]
+fn old_coding_run_cannot_terminalize_task_after_later_attempt_exists() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-later-attempt.db")).unwrap();
+    let owner = principal('6');
+    let assignee = agent(&db, &owner, "coding-later-agent");
+    let now = wall_now_ms();
+    let task_id = create_assigned_task(&db, &owner, &assignee, "coding-later-task");
+    let first = start(&db, &owner, &task_id, &assignee, "coding-later-first", now);
+    let intent = coding_binding_intent("later-attempt-old-run");
+    prepare_coding_binding(&db, &owner, &task_id, &assignee, &first, &intent, now + 1);
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &task_id,
+        &first.attempt.attempt_id,
+        &assignee,
+        &first.attempt_fence,
+        1,
+        &intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+    db.record_agent_task_coding_run_not_started(
+        &owner,
+        &task_id,
+        &first.attempt.attempt_id,
+        &intent.run_id,
+    )
+    .unwrap();
+    let second = db
+        .start_agent_task_attempt_at(
+            &owner,
+            &task_id,
+            &assignee,
+            "coding-later-second",
+            first.attempt.lease_expires_at_unix_ms,
+        )
+        .unwrap();
+    assert_eq!(second.attempt.attempt_number, 2);
+
+    let old_terminal = coding_observation(&intent, "completed", "completed", 9);
+    db.record_agent_task_coding_run_observation(
+        &owner,
+        &task_id,
+        &first.attempt.attempt_id,
+        &old_terminal,
+    )
+    .unwrap();
+    let stale = db
+        .terminalize_agent_task_coding_run(
+            &owner,
+            &task_id,
+            &first.attempt.attempt_id,
+            &old_terminal,
+            Some("old result"),
+            Some("coding_agent_completed"),
+        )
+        .unwrap_err();
+    assert_eq!(stale.code(), "agent_task_attempt_stale");
+    let task = db.read_agent_task(&owner, &task_id).unwrap();
+    assert_eq!(task.summary.state, AgentTaskState::Active);
+    assert_eq!(
+        task.summary.latest_attempt.unwrap().attempt_id,
+        second.attempt.attempt_id
+    );
+}
+
+#[test]
+fn coding_run_binding_survives_restart_without_endpoint_or_window_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("agent-task-coding-restart.db");
+    let owner = principal('7');
+    let foreign = principal('8');
+    let now = wall_now_ms();
+    let (task_id, attempt_id, run_id) = {
+        let db = Database::open(&path).unwrap();
+        let assignee = agent(&db, &owner, "coding-restart-agent");
+        let task_id = create_assigned_task(&db, &owner, &assignee, "coding-restart-task");
+        let started = start(
+            &db,
+            &owner,
+            &task_id,
+            &assignee,
+            "coding-restart-start",
+            now,
+        );
+        let intent = coding_binding_intent("restart-run");
+        prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 1);
+        db.claim_agent_task_coding_run_dispatch(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            &intent.binding_intent_fingerprint,
+        )
+        .unwrap();
+        db.record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &coding_observation(&intent, "running", "started", 11),
+        )
+        .unwrap();
+        (task_id, started.attempt.attempt_id, intent.run_id)
+    };
+
+    let reopened = Database::open(&path).unwrap();
+    let binding = reopened
+        .read_agent_task_coding_run_binding(&owner, &task_id, &attempt_id)
+        .unwrap();
+    assert_eq!(binding.run_id, run_id);
+    assert_eq!(binding.runtime_project_id, "agent:special:reference-only");
+    assert_eq!(binding.provider_id, "codex");
+    assert_eq!(
+        binding.dispatch_state,
+        AgentTaskCodingRunDispatchState::Bound
+    );
+    assert_eq!(binding.last_observed_run_state.as_deref(), Some("running"));
+    assert_eq!(binding.last_observation_revision, Some(11));
+    let task = reopened.read_agent_task(&owner, &task_id).unwrap();
+    assert!(task.summary.execution_bound);
+    assert_eq!(
+        task.summary.execution_status,
+        Some(AgentTaskExecutionStatus::Active)
+    );
+    assert_eq!(
+        task.summary.recovery_kind,
+        AgentTaskExecutionRecoveryKind::Observe
+    );
+
+    let foreign_error = reopened
+        .read_agent_task_coding_run_binding(&foreign, &task_id, &attempt_id)
+        .unwrap_err();
+    assert_eq!(foreign_error.code(), "agent_task_not_found");
+}
+
 #[test]
 fn agent_task_create_is_keyed_bounded_and_restart_durable() {
     let temp = tempfile::tempdir().unwrap();

--- a/src/db/agent_task_tests.rs
+++ b/src/db/agent_task_tests.rs
@@ -1008,6 +1008,145 @@ fn concurrent_attempt_start_creates_exactly_one_authoritative_attempt() {
 }
 
 #[test]
+fn live_coding_dispatch_mutations_sample_server_time_after_serialization_wait() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("agent-task-coding-serialized-clock.db");
+    let db = Arc::new(Database::open(&path).unwrap());
+    let owner = principal('d');
+    let assignee = agent(&db, &owner, "coding-serialized-clock-agent");
+    let now = wall_now_ms();
+
+    let prepare_task =
+        create_assigned_task(&db, &owner, &assignee, "coding-serialized-prepare-task");
+    let prepare_attempt = start(
+        &db,
+        &owner,
+        &prepare_task,
+        &assignee,
+        "coding-serialized-prepare-start",
+        now,
+    );
+    let prepare_intent = coding_binding_intent("serialized-prepare");
+
+    let claim_task = create_assigned_task(&db, &owner, &assignee, "coding-serialized-claim-task");
+    let claim_attempt = start(
+        &db,
+        &owner,
+        &claim_task,
+        &assignee,
+        "coding-serialized-claim-start",
+        now + 1,
+    );
+    let claim_intent = coding_binding_intent("serialized-claim");
+    prepare_coding_binding(
+        &db,
+        &owner,
+        &claim_task,
+        &assignee,
+        &claim_attempt,
+        &claim_intent,
+        now + 2,
+    );
+
+    // Hold the same Database mutex/transaction boundary used by live A4a mutations.
+    // Both workers enter their production wrappers before the lease is shortened, then
+    // wait until after expiry. A pre-serialization clock sample would incorrectly let
+    // prepare create a binding or claim cross the external-dispatch fence.
+    let guard = db.conn_for_tests();
+    let (ready_tx, ready_rx) = mpsc::channel();
+
+    let prepare_db = Arc::clone(&db);
+    let prepare_owner = owner.clone();
+    let prepare_assignee = assignee.clone();
+    let prepare_task_id = prepare_task.clone();
+    let prepare_attempt_id = prepare_attempt.attempt.attempt_id.clone();
+    let prepare_fence = prepare_attempt.attempt_fence.clone();
+    let prepare_intent_for_thread = prepare_intent.clone();
+    let prepare_ready = ready_tx.clone();
+    let prepare_handle = std::thread::spawn(move || {
+        prepare_ready.send(()).unwrap();
+        prepare_db.prepare_agent_task_coding_run(
+            &prepare_owner,
+            "agent:special:reference-only",
+            &prepare_task_id,
+            &prepare_attempt_id,
+            &prepare_assignee,
+            &prepare_fence,
+            1,
+            &prepare_intent_for_thread,
+        )
+    });
+
+    let claim_db = Arc::clone(&db);
+    let claim_owner = owner.clone();
+    let claim_assignee = assignee.clone();
+    let claim_task_id = claim_task.clone();
+    let claim_attempt_id = claim_attempt.attempt.attempt_id.clone();
+    let claim_fence = claim_attempt.attempt_fence.clone();
+    let claim_fingerprint = claim_intent.binding_intent_fingerprint.clone();
+    let claim_ready = ready_tx.clone();
+    let claim_handle = std::thread::spawn(move || {
+        claim_ready.send(()).unwrap();
+        claim_db.claim_agent_task_coding_run_dispatch(
+            &claim_owner,
+            &claim_task_id,
+            &claim_attempt_id,
+            &claim_assignee,
+            &claim_fence,
+            1,
+            &claim_fingerprint,
+        )
+    });
+
+    ready_rx.recv().unwrap();
+    ready_rx.recv().unwrap();
+    std::thread::sleep(Duration::from_millis(500));
+    let expires_at = wall_now_ms().saturating_add(200);
+    guard
+        .execute(
+            "UPDATE wc_agent_task_attempts
+             SET lease_expires_at_unix_ms = ?1
+             WHERE attempt_id IN (?2, ?3)",
+            params![
+                expires_at,
+                prepare_attempt.attempt.attempt_id,
+                claim_attempt.attempt.attempt_id,
+            ],
+        )
+        .unwrap();
+    std::thread::sleep(Duration::from_millis(300));
+    drop(guard);
+
+    let prepare_error = prepare_handle.join().unwrap().unwrap_err();
+    assert_eq!(prepare_error.code(), "agent_task_attempt_stale");
+    let claim_error = claim_handle.join().unwrap().unwrap_err();
+    assert_eq!(claim_error.code(), "agent_task_attempt_stale");
+
+    assert_eq!(
+        db.conn_for_tests()
+            .query_row(
+                "SELECT COUNT(*) FROM wc_agent_task_coding_runs WHERE attempt_id = ?1",
+                [prepare_attempt.attempt.attempt_id.as_str()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0,
+        "expired prepare must not create a durable backend binding",
+    );
+    assert_eq!(
+        db.read_agent_task_coding_run_binding(
+            &owner,
+            &claim_task,
+            &claim_attempt.attempt.attempt_id,
+        )
+        .unwrap()
+        .dispatch_state,
+        AgentTaskCodingRunDispatchState::Prepared,
+        "expired claim must not cross the durable outcome-unknown dispatch fence",
+    );
+}
+
+#[test]
 fn live_lease_mutations_sample_server_time_after_serialization_wait() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("agent-task-serialized-clock.db");

--- a/src/tool_runtime/agent_task.rs
+++ b/src/tool_runtime/agent_task.rs
@@ -1,8 +1,22 @@
+use super::coding_agent::{
+    CodingAgentPreparedStart, CodingAgentStartCertainty, CodingAgentStartFailure,
+    CodingAgentTypedStartOutcome,
+};
 use super::{RecoveryKind, ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
-use crate::db::{AgentTaskState, CommunicationStoreError, NewAgentTask, MAX_AGENT_TASK_LIST_LIMIT};
+use crate::db::{
+    AgentTaskCodingRunBindingIntent, AgentTaskCodingRunBindingRecord,
+    AgentTaskCodingRunDispatchState, AgentTaskCodingRunObservation, AgentTaskState,
+    CommunicationStoreError, NewAgentTask, MAX_AGENT_TASK_LIST_LIMIT,
+    MAX_AGENT_TASK_TERMINAL_TEXT_BYTES,
+};
 use serde::Serialize;
-use serde_json::{json, to_value};
+use serde_json::{json, to_value, Value};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use webcodex_core::coding_agent::{
+    CodingAgentConfigValue, CodingAgentExecutionState, CodingAgentRunSnapshot, CodingAgentRunState,
+};
 
 const DEFAULT_AGENT_TASK_LIST_LIMIT: usize = 50;
 
@@ -29,7 +43,10 @@ fn agent_task_recovery_kind(
 ) -> RecoveryKind {
     match error_kind {
         "communication_store_unavailable" => store_failure_recovery,
-        "agent_task_attempt_stale" => RecoveryKind::Reconcile,
+        "agent_task_attempt_stale"
+        | "agent_task_execution_active"
+        | "agent_task_execution_outcome_unknown"
+        | "agent_task_coding_run_identity_mismatch" => RecoveryKind::Reconcile,
         "agent_task_attempt_active"
         | "agent_task_assignee_mismatch"
         | "agent_task_unassigned"
@@ -67,6 +84,223 @@ fn serialized_task_success<T: Serialize>(value: T) -> ToolResult {
         )
         .with_recovery(RecoveryKind::NoAction, None),
     }
+}
+
+fn coding_run_state_name(state: &CodingAgentRunState) -> &'static str {
+    match state {
+        CodingAgentRunState::Starting => "starting",
+        CodingAgentRunState::Running => "running",
+        CodingAgentRunState::WaitingPermission => "waiting_permission",
+        CodingAgentRunState::Completed => "completed",
+        CodingAgentRunState::Failed => "failed",
+        CodingAgentRunState::Cancelled => "cancelled",
+        CodingAgentRunState::Lost => "lost",
+    }
+}
+
+fn coding_execution_state_name(state: CodingAgentExecutionState) -> &'static str {
+    match state {
+        CodingAgentExecutionState::NotStarted => "not_started",
+        CodingAgentExecutionState::Started => "started",
+        CodingAgentExecutionState::OutcomeUnknown => "outcome_unknown",
+        CodingAgentExecutionState::Completed => "completed",
+    }
+}
+
+fn coding_run_replay_key(attempt_id: &str) -> String {
+    format!("agent-task-coding-run:v1:{attempt_id}")
+}
+
+fn hash_binding_field(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn coding_run_binding_fingerprint(
+    task_id: &str,
+    attempt_id: &str,
+    prepared: &CodingAgentPreparedStart,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex.agent-task-coding-run-binding.v1\0");
+    for value in [
+        task_id,
+        attempt_id,
+        prepared.run_id.as_str(),
+        prepared.runtime_project_id.as_str(),
+        prepared.provider_id.as_str(),
+        prepared.intent_fingerprint.as_str(),
+    ] {
+        hash_binding_field(&mut hasher, value);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn truncate_utf8_bytes(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+    let mut end = max_bytes.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_string()
+}
+
+fn bounded_optional_terminal(value: Option<&str>) -> Option<String> {
+    value.map(|value| truncate_utf8_bytes(value, MAX_AGENT_TASK_TERMINAL_TEXT_BYTES))
+}
+
+fn coding_run_observation(run: &CodingAgentRunSnapshot) -> AgentTaskCodingRunObservation {
+    AgentTaskCodingRunObservation {
+        run_id: run.run_id.clone(),
+        runtime_project_id: run.runtime_project_id.clone(),
+        provider_id: run.provider_id.clone(),
+        provider_instance_id: run.provider_instance_id.clone(),
+        authority_fingerprint: run.authority_fingerprint.clone(),
+        coding_agent_intent_fingerprint: run.intent_fingerprint.clone(),
+        run_state: coding_run_state_name(&run.state).to_string(),
+        execution_state: coding_execution_state_name(run.execution_state).to_string(),
+        observation_revision: i64::try_from(run.observation_revision).unwrap_or(i64::MAX),
+        terminal_stop_reason: bounded_optional_terminal(
+            run.terminal
+                .as_ref()
+                .and_then(|terminal| terminal.stop_reason.as_deref()),
+        ),
+        terminal_error_code: bounded_optional_terminal(
+            run.terminal
+                .as_ref()
+                .and_then(|terminal| terminal.error_code.as_deref()),
+        ),
+        terminal_message: bounded_optional_terminal(
+            run.terminal
+                .as_ref()
+                .and_then(|terminal| terminal.message.as_deref()),
+        ),
+        completed_at_unix: run.terminal.as_ref().map(|terminal| terminal.completed_at),
+    }
+}
+
+fn binding_execution_status(binding: &AgentTaskCodingRunBindingRecord) -> &'static str {
+    match binding.dispatch_state {
+        AgentTaskCodingRunDispatchState::Prepared | AgentTaskCodingRunDispatchState::NotStarted => {
+            "not_started"
+        }
+        AgentTaskCodingRunDispatchState::OutcomeUnknown => "outcome_unknown",
+        AgentTaskCodingRunDispatchState::Terminal => "terminal",
+        AgentTaskCodingRunDispatchState::Bound => {
+            match binding.last_observed_run_state.as_deref() {
+                Some("waiting_permission") => "waiting_permission",
+                Some("lost") => "outcome_unknown",
+                Some("completed" | "failed" | "cancelled") => "terminal",
+                _ => "active",
+            }
+        }
+    }
+}
+
+fn binding_recovery_kind(binding: &AgentTaskCodingRunBindingRecord) -> &'static str {
+    match binding.dispatch_state {
+        AgentTaskCodingRunDispatchState::Prepared
+        | AgentTaskCodingRunDispatchState::NotStarted
+        | AgentTaskCodingRunDispatchState::Terminal => "none",
+        AgentTaskCodingRunDispatchState::OutcomeUnknown => "reconcile",
+        AgentTaskCodingRunDispatchState::Bound => {
+            match binding.last_observed_run_state.as_deref() {
+                Some("lost" | "completed" | "failed" | "cancelled") => "reconcile",
+                _ => "observe",
+            }
+        }
+    }
+}
+
+fn coding_run_binding_projection(
+    binding: &AgentTaskCodingRunBindingRecord,
+    state_changed: bool,
+    replayed: bool,
+) -> Value {
+    json!({
+        "task_id": binding.task_id,
+        "attempt_id": binding.attempt_id,
+        "run_id": binding.run_id,
+        "project": binding.runtime_project_id,
+        "provider_id": binding.provider_id,
+        "dispatch_state": binding.dispatch_state.as_str(),
+        "run_state": binding.last_observed_run_state,
+        "execution_state": binding.last_observed_execution_state,
+        "execution_status": binding_execution_status(binding),
+        "execution_recovery": binding_recovery_kind(binding),
+        "terminal": {
+            "stop_reason": binding.terminal_stop_reason,
+            "error_code": binding.terminal_error_code,
+            "message": binding.terminal_message,
+            "completed_at": binding.completed_at_unix,
+        },
+        "state_changed": state_changed,
+        "replayed": replayed,
+    })
+}
+
+fn coding_run_failure_result(
+    task_id: &str,
+    attempt_id: &str,
+    failure: CodingAgentStartFailure,
+) -> ToolResult {
+    let execution_status = match failure.certainty {
+        CodingAgentStartCertainty::NotStarted => "not_started",
+        CodingAgentStartCertainty::OutcomeUnknown => "outcome_unknown",
+    };
+    ToolResult::err_with_output(
+        failure.message.clone(),
+        json!({
+            "error_kind": failure.kind,
+            "task_id": task_id,
+            "attempt_id": attempt_id,
+            "run_id": failure.run_id,
+            "execution_status": execution_status,
+            "recovery_kind": failure.recovery.as_str(),
+            "state_changed": false,
+        }),
+    )
+    .with_recovery(failure.recovery, None)
+}
+
+fn coding_run_terminal_result(run: &CodingAgentRunSnapshot) -> String {
+    let mut result = format!(
+        "CodingAgentRun {} {}",
+        run.run_id,
+        coding_run_state_name(&run.state)
+    );
+    if let Some(terminal) = run.terminal.as_ref() {
+        if let Some(message) = terminal.message.as_deref() {
+            result.push_str(": ");
+            result.push_str(message);
+        } else if let Some(error_code) = terminal.error_code.as_deref() {
+            result.push_str(": ");
+            result.push_str(error_code);
+        } else if let Some(stop_reason) = terminal.stop_reason.as_deref() {
+            result.push_str(": ");
+            result.push_str(stop_reason);
+        }
+    }
+    truncate_utf8_bytes(&result, MAX_AGENT_TASK_TERMINAL_TEXT_BYTES)
+}
+
+fn coding_run_terminal_reason(run: &CodingAgentRunSnapshot) -> String {
+    let reason = match run.state {
+        CodingAgentRunState::Completed => "coding_agent_completed".to_string(),
+        CodingAgentRunState::Failed => run
+            .terminal
+            .as_ref()
+            .and_then(|terminal| terminal.error_code.clone())
+            .unwrap_or_else(|| "coding_agent_failed".to_string()),
+        CodingAgentRunState::Cancelled => "coding_agent_cancelled".to_string(),
+        CodingAgentRunState::Starting
+        | CodingAgentRunState::Running
+        | CodingAgentRunState::WaitingPermission
+        | CodingAgentRunState::Lost => "coding_agent_not_terminal".to_string(),
+    };
+    truncate_utf8_bytes(&reason, MAX_AGENT_TASK_TERMINAL_TEXT_BYTES)
 }
 
 impl ToolRuntime {
@@ -197,6 +431,242 @@ impl ToolRuntime {
         ) {
             Ok(result) => serialized_task_success(result),
             Err(error) => agent_task_error(error, RecoveryKind::RetrySame),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn start_agent_task_coding_run(
+        &self,
+        auth: Option<&AuthContext>,
+        project: String,
+        task_id: String,
+        attempt_id: String,
+        assignee_agent_id: String,
+        attempt_fence: String,
+        attempt_controller_generation: i64,
+        provider_id: String,
+        config: Option<BTreeMap<String, CodingAgentConfigValue>>,
+        timeout_secs: Option<u64>,
+    ) -> ToolResult {
+        let principal = match task_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return agent_task_store_unavailable();
+        };
+        let context = match db.agent_task_coding_run_start_context(
+            &principal,
+            &project,
+            &task_id,
+            &attempt_id,
+            &assignee_agent_id,
+            &attempt_fence,
+            attempt_controller_generation,
+        ) {
+            Ok(context) => context,
+            Err(error) => return agent_task_error(error, RecoveryKind::Reconcile),
+        };
+        let replay_key = coding_run_replay_key(&attempt_id);
+        let prepared = match self
+            .prepare_coding_agent_start(
+                project.clone(),
+                provider_id,
+                replay_key,
+                context.task.instruction.clone(),
+                config,
+                timeout_secs,
+                auth,
+            )
+            .await
+        {
+            Ok(prepared) => prepared,
+            Err(result) => return result,
+        };
+        if prepared.runtime_project_id != project {
+            return ToolResult::err_with_output(
+                "Resolved CodingAgent Project does not match AgentTask execution intent",
+                json!({
+                    "error_kind": "agent_task_project_mismatch",
+                    "task_id": task_id,
+                    "attempt_id": attempt_id,
+                    "state_changed": false,
+                }),
+            )
+            .with_recovery(RecoveryKind::FixInput, None);
+        }
+        let binding_intent_fingerprint =
+            coding_run_binding_fingerprint(&task_id, &attempt_id, &prepared);
+        let binding_intent = AgentTaskCodingRunBindingIntent {
+            run_id: prepared.run_id.clone(),
+            runtime_project_id: prepared.runtime_project_id.clone(),
+            provider_id: prepared.provider_id.clone(),
+            provider_instance_id: prepared.provider_instance_id.clone(),
+            authority_fingerprint: prepared.authority_fingerprint.clone(),
+            coding_agent_intent_fingerprint: prepared.intent_fingerprint.clone(),
+            binding_intent_fingerprint: binding_intent_fingerprint.clone(),
+        };
+        let prepared_binding = match db.prepare_agent_task_coding_run(
+            &principal,
+            &project,
+            &task_id,
+            &attempt_id,
+            &assignee_agent_id,
+            &attempt_fence,
+            attempt_controller_generation,
+            &binding_intent,
+        ) {
+            Ok(prepared) => prepared,
+            Err(error) => return agent_task_error(error, RecoveryKind::Reconcile),
+        };
+        let claim = match db.claim_agent_task_coding_run_dispatch(
+            &principal,
+            &task_id,
+            &attempt_id,
+            &assignee_agent_id,
+            &attempt_fence,
+            attempt_controller_generation,
+            &binding_intent_fingerprint,
+        ) {
+            Ok(claim) => claim,
+            Err(error) => return agent_task_error(error, RecoveryKind::Reconcile),
+        };
+        if !claim.may_dispatch {
+            return self
+                .reconcile_agent_task_coding_run(auth, task_id, attempt_id)
+                .await;
+        }
+
+        match self
+            .dispatch_prepared_coding_agent_start(prepared, None, auth)
+            .await
+        {
+            CodingAgentTypedStartOutcome::Run(run) => {
+                let observation = coding_run_observation(&run);
+                match db.record_agent_task_coding_run_observation(
+                    &principal,
+                    &task_id,
+                    &attempt_id,
+                    &observation,
+                ) {
+                    Ok(binding) => ToolResult::ok(coding_run_binding_projection(
+                        &binding,
+                        false,
+                        prepared_binding.replayed,
+                    )),
+                    Err(error) => agent_task_error(error, RecoveryKind::Reconcile),
+                }
+            }
+            CodingAgentTypedStartOutcome::Failure(failure) => {
+                if failure.certainty == CodingAgentStartCertainty::NotStarted {
+                    if let Err(error) = db.record_agent_task_coding_run_not_started(
+                        &principal,
+                        &task_id,
+                        &attempt_id,
+                        &failure.run_id,
+                    ) {
+                        return agent_task_error(error, RecoveryKind::Reconcile);
+                    }
+                }
+                coding_run_failure_result(&task_id, &attempt_id, failure)
+            }
+        }
+    }
+
+    pub(crate) async fn reconcile_agent_task_coding_run(
+        &self,
+        auth: Option<&AuthContext>,
+        task_id: String,
+        attempt_id: String,
+    ) -> ToolResult {
+        let principal = match task_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return agent_task_store_unavailable();
+        };
+        let binding = match db.read_agent_task_coding_run_binding(&principal, &task_id, &attempt_id)
+        {
+            Ok(binding) => binding,
+            Err(error) => return agent_task_error(error, RecoveryKind::Reconcile),
+        };
+        let snapshot = match self
+            .reconcile_coding_agent_run_snapshot(&binding.run_id, auth)
+            .await
+        {
+            Ok(snapshot) => snapshot,
+            Err(result) => return result,
+        };
+        let Some(run) = snapshot else {
+            let binding = if matches!(
+                binding.dispatch_state,
+                AgentTaskCodingRunDispatchState::Bound
+                    | AgentTaskCodingRunDispatchState::OutcomeUnknown
+            ) {
+                match db.mark_agent_task_coding_run_reconcile_unavailable(
+                    &principal,
+                    &task_id,
+                    &attempt_id,
+                ) {
+                    Ok(binding) => binding,
+                    Err(error) => return agent_task_error(error, RecoveryKind::Reconcile),
+                }
+            } else {
+                binding
+            };
+            return ToolResult::ok(coding_run_binding_projection(&binding, false, false));
+        };
+
+        let observation = coding_run_observation(&run);
+        let observed_binding = match db.record_agent_task_coding_run_observation(
+            &principal,
+            &task_id,
+            &attempt_id,
+            &observation,
+        ) {
+            Ok(binding) => binding,
+            Err(error) => return agent_task_error(error, RecoveryKind::Reconcile),
+        };
+        if !matches!(
+            run.state,
+            CodingAgentRunState::Completed
+                | CodingAgentRunState::Failed
+                | CodingAgentRunState::Cancelled
+        ) {
+            return ToolResult::ok(coding_run_binding_projection(
+                &observed_binding,
+                false,
+                false,
+            ));
+        }
+
+        let terminal_result = coding_run_terminal_result(&run);
+        let terminal_reason = coding_run_terminal_reason(&run);
+        match db.terminalize_agent_task_coding_run(
+            &principal,
+            &task_id,
+            &attempt_id,
+            &observation,
+            Some(&terminal_result),
+            Some(&terminal_reason),
+        ) {
+            Ok(mutation) => {
+                let mut output =
+                    coding_run_binding_projection(&mutation.binding, mutation.state_changed, false);
+                if let Some(object) = output.as_object_mut() {
+                    object.insert(
+                        "task_state".to_string(),
+                        json!(mutation.task.state.as_str()),
+                    );
+                    object.insert(
+                        "attempt_state".to_string(),
+                        json!(mutation.attempt.state.as_str()),
+                    );
+                }
+                ToolResult::ok(output)
+            }
+            Err(error) => agent_task_error(error, RecoveryKind::Reconcile),
         }
     }
 

--- a/src/tool_runtime/coding_agent.rs
+++ b/src/tool_runtime/coding_agent.rs
@@ -59,6 +59,57 @@ pub(crate) struct CodingAgentServerState {
     runs: Mutex<HashMap<String, ServerRunBinding>>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct CodingAgentPreparedStart {
+    pub(crate) run_id: String,
+    pub(crate) authority_fingerprint: String,
+    pub(crate) runtime_project_id: String,
+    pub(crate) provider_id: String,
+    pub(crate) provider_instance_id: String,
+    pub(crate) intent_fingerprint: String,
+    client: crate::shell_protocol::ShellClientView,
+    project_root: String,
+    instruction: String,
+    config: BTreeMap<String, CodingAgentConfigValue>,
+    timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CodingAgentStartCertainty {
+    NotStarted,
+    OutcomeUnknown,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CodingAgentStartFailure {
+    pub(crate) kind: String,
+    pub(crate) message: String,
+    pub(crate) certainty: CodingAgentStartCertainty,
+    pub(crate) recovery: RecoveryKind,
+    pub(crate) run_id: String,
+}
+
+impl CodingAgentStartFailure {
+    fn into_tool_result(self) -> ToolResult {
+        coding_agent_error(
+            &self.kind,
+            self.message,
+            match self.certainty {
+                CodingAgentStartCertainty::NotStarted => "not_started",
+                CodingAgentStartCertainty::OutcomeUnknown => "outcome_unknown",
+            },
+            self.recovery,
+            Some(&self.run_id),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum CodingAgentTypedStartOutcome {
+    Run(CodingAgentRunSnapshot),
+    Failure(CodingAgentStartFailure),
+}
+
 fn prune_server_runs_locked(runs: &mut HashMap<String, ServerRunBinding>, now: i64) {
     let cutoff = now.saturating_sub(SERVER_TERMINAL_RETENTION_SECS);
     runs.retain(|_, binding| {
@@ -214,6 +265,44 @@ impl ToolRuntime {
         recording_session_id: Option<String>,
         auth: Option<&AuthContext>,
     ) -> ToolResult {
+        let prepared = match self
+            .prepare_coding_agent_start(
+                project,
+                provider_id,
+                idempotency_key,
+                instruction,
+                config,
+                timeout_secs,
+                auth,
+            )
+            .await
+        {
+            Ok(prepared) => prepared,
+            Err(error) => return error,
+        };
+        let run_id = prepared.run_id.clone();
+        match self
+            .dispatch_prepared_coding_agent_start(prepared, recording_session_id, auth)
+            .await
+        {
+            CodingAgentTypedStartOutcome::Run(run) => ToolResult::ok(start_projection(
+                &run,
+                self.coding_agent_runs.observation_token(&run_id, 0),
+            )),
+            CodingAgentTypedStartOutcome::Failure(error) => error.into_tool_result(),
+        }
+    }
+
+    pub(crate) async fn prepare_coding_agent_start(
+        &self,
+        project: String,
+        provider_id: String,
+        idempotency_key: String,
+        instruction: String,
+        config: Option<BTreeMap<String, CodingAgentConfigValue>>,
+        timeout_secs: Option<u64>,
+        auth: Option<&AuthContext>,
+    ) -> Result<CodingAgentPreparedStart, ToolResult> {
         if let Err(error) = validate_start_input(
             &provider_id,
             &idempotency_key,
@@ -221,87 +310,83 @@ impl ToolRuntime {
             config.as_ref(),
             timeout_secs,
         ) {
-            return coding_agent_error(
+            return Err(coding_agent_error(
                 "invalid_coding_agent_start",
                 error,
                 "not_started",
                 RecoveryKind::FixInput,
                 None,
-            );
+            ));
         }
-        let principal = match stable_principal(auth) {
-            Ok(principal) => principal,
-            Err(error) => {
-                return coding_agent_error(
-                    "coding_agent_identity_unavailable",
-                    error,
-                    "not_started",
-                    RecoveryKind::FixInput,
-                    None,
-                )
-            }
-        };
+        let principal = stable_principal(auth).map_err(|error| {
+            coding_agent_error(
+                "coding_agent_identity_unavailable",
+                error,
+                "not_started",
+                RecoveryKind::FixInput,
+                None,
+            )
+        })?;
         let authority_fingerprint = authority_fingerprint(&principal);
         let run_id = deterministic_run_id(&principal, &idempotency_key);
-        let resolved = match self.resolve_project_input_for_auth(&project, auth).await {
-            Ok(resolved) => resolved,
-            Err(error) => return error.into_tool_result(),
-        };
+        let resolved = self
+            .resolve_project_input_for_auth(&project, auth)
+            .await
+            .map_err(|error| error.into_tool_result())?;
         if !resolved.config.allow_patch {
-            return coding_agent_project_not_writable_result(&run_id);
+            return Err(coding_agent_project_not_writable_result(&run_id));
         }
-        let client_id = match resolved.config.agent_client_id() {
-            Ok(value) => value.to_string(),
-            Err(error) => {
-                return coding_agent_error(
-                    "invalid_project",
-                    error,
-                    "not_started",
-                    RecoveryKind::FixInput,
-                    Some(&run_id),
-                )
-            }
-        };
+        let client_id = resolved.config.agent_client_id().map_err(|error| {
+            coding_agent_error(
+                "invalid_project",
+                error,
+                "not_started",
+                RecoveryKind::FixInput,
+                Some(&run_id),
+            )
+        })?;
         let client = match self
             .shell_clients
-            .get_client_semantic_view_for_auth(&client_id, auth)
+            .get_client_semantic_view_for_auth(client_id, auth)
             .await
         {
             Some(client) if client.view.connected => client,
             _ => {
-                return coding_agent_error(
+                return Err(coding_agent_error(
                     "coding_agent_runner_unavailable",
                     "exact Project Runner is offline or unauthorized",
                     "not_started",
                     RecoveryKind::Wait,
                     Some(&run_id),
-                )
+                ))
             }
         };
         if !client.supports(RunnerFeature::CodingAgentRuns) {
-            return coding_agent_error(
+            return Err(coding_agent_error(
                 "coding_agent_unsupported",
                 "exact Project Runner does not advertise CodingAgentRun",
                 "not_started",
                 RecoveryKind::Reobserve,
                 Some(&run_id),
-            );
+            ));
         }
         let client = client.view;
-        let providers = client.coding_agent_providers.as_deref().unwrap_or(&[]);
-        let provider = match providers
+        let provider_instance_id = match client
+            .coding_agent_providers
+            .as_deref()
+            .unwrap_or(&[])
             .iter()
             .find(|provider| provider.provider_id == provider_id)
         {
-            Some(provider) => provider,
+            Some(provider) => provider.provider_instance_id.clone(),
             None => {
-                return coding_agent_error(
+                return Err(coding_agent_error(
                     "coding_agent_provider_unavailable",
                     "logical ACP provider is not advertised by the exact Project Runner",
                     "not_started",
                     RecoveryKind::Reobserve,
                     Some(&run_id),
-                )
+                ))
             }
         };
         let timeout_secs = timeout_secs.unwrap_or(DEFAULT_RUN_TIMEOUT_SECS);
@@ -313,73 +398,86 @@ impl ToolRuntime {
             &config,
             timeout_secs,
         );
-
-        if let Some(existing) = self
-            .reconcile_run(&run_id, &authority_fingerprint, auth)
-            .await
-        {
-            if existing.snapshot.intent_fingerprint != intent_fingerprint {
-                return coding_agent_error(
-                    "idempotency_conflict",
-                    "idempotency_key is already bound to a different CodingAgentRun intent",
-                    "not_started",
-                    RecoveryKind::FixInput,
-                    Some(&run_id),
-                );
-            }
-            if existing.runtime_project_id != resolved.resolved_id {
-                return coding_agent_error(
-                    "idempotency_conflict",
-                    "idempotency_key is already bound to another Project",
-                    "not_started",
-                    RecoveryKind::FixInput,
-                    Some(&run_id),
-                );
-            }
-            self.coding_agent_runs
-                .attach_recorder(&run_id, recording_session_id.clone())
-                .await;
-            self.record_coding_agent_lifecycle_if_needed(&run_id).await;
-            return ToolResult::ok(start_projection(
-                &existing.snapshot,
-                self.coding_agent_runs.observation_token(&run_id, 0),
-            ));
-        }
-
-        let operation = CodingAgentRequest::Start(CodingAgentStartRequest {
-            run_id: run_id.clone(),
-            intent_fingerprint: intent_fingerprint.clone(),
-            authority_fingerprint: authority_fingerprint.clone(),
-            runtime_project_id: resolved.resolved_id.clone(),
-            project_root: resolved.config.path.clone(),
-            provider_id: provider_id.clone(),
-            provider_instance_id: provider.provider_instance_id.clone(),
+        Ok(CodingAgentPreparedStart {
+            run_id,
+            authority_fingerprint,
+            runtime_project_id: resolved.resolved_id,
+            provider_id,
+            provider_instance_id,
+            intent_fingerprint,
+            client,
+            project_root: resolved.config.path,
             instruction,
             config,
             timeout_secs,
+        })
+    }
+
+    pub(crate) async fn dispatch_prepared_coding_agent_start(
+        &self,
+        prepared: CodingAgentPreparedStart,
+        recording_session_id: Option<String>,
+        auth: Option<&AuthContext>,
+    ) -> CodingAgentTypedStartOutcome {
+        if let Some(existing) = self
+            .reconcile_run(&prepared.run_id, &prepared.authority_fingerprint, auth)
+            .await
+        {
+            if existing.snapshot.intent_fingerprint != prepared.intent_fingerprint
+                || existing.runtime_project_id != prepared.runtime_project_id
+            {
+                return CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                    kind: "idempotency_conflict".to_string(),
+                    message:
+                        "idempotency_key is already bound to a different CodingAgentRun intent"
+                            .to_string(),
+                    certainty: CodingAgentStartCertainty::NotStarted,
+                    recovery: RecoveryKind::FixInput,
+                    run_id: prepared.run_id,
+                });
+            }
+            self.coding_agent_runs
+                .attach_recorder(&prepared.run_id, recording_session_id)
+                .await;
+            self.record_coding_agent_lifecycle_if_needed(&prepared.run_id)
+                .await;
+            return CodingAgentTypedStartOutcome::Run(existing.snapshot);
+        }
+
+        let operation = CodingAgentRequest::Start(CodingAgentStartRequest {
+            run_id: prepared.run_id.clone(),
+            intent_fingerprint: prepared.intent_fingerprint.clone(),
+            authority_fingerprint: prepared.authority_fingerprint.clone(),
+            runtime_project_id: prepared.runtime_project_id.clone(),
+            project_root: prepared.project_root.clone(),
+            provider_id: prepared.provider_id.clone(),
+            provider_instance_id: prepared.provider_instance_id.clone(),
+            instruction: prepared.instruction.clone(),
+            config: prepared.config.clone(),
+            timeout_secs: prepared.timeout_secs,
         });
         let (request_id, receiver) = match self
             .shell_clients
             .enqueue_coding_agent(
-                &client.client_id,
-                &client.agent_instance_id,
-                &provider_id,
-                &provider.provider_instance_id,
+                &prepared.client.client_id,
+                &prepared.client.agent_instance_id,
+                &prepared.provider_id,
+                &prepared.provider_instance_id,
                 operation,
                 auth,
-                authority_fingerprint.clone(),
+                prepared.authority_fingerprint.clone(),
             )
             .await
         {
             Ok(value) => value,
             Err(error) => {
-                return coding_agent_error(
-                    "coding_agent_dispatch_rejected",
-                    error,
-                    "not_started",
-                    RecoveryKind::Reobserve,
-                    Some(&run_id),
-                )
+                return CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                    kind: "coding_agent_dispatch_rejected".to_string(),
+                    message: error,
+                    certainty: CodingAgentStartCertainty::NotStarted,
+                    recovery: RecoveryKind::Reobserve,
+                    run_id: prepared.run_id,
+                })
             }
         };
         let response =
@@ -389,11 +487,11 @@ impl ToolRuntime {
                 Ok(Ok(response)) => response,
                 Ok(Err(_)) | Err(_) => {
                     return self
-                        .start_waiter_lost(
+                        .start_waiter_lost_typed(
                             &request_id,
-                            &run_id,
-                            &authority_fingerprint,
-                            recording_session_id.clone(),
+                            &prepared.run_id,
+                            &prepared.authority_fingerprint,
+                            recording_session_id,
                             auth,
                         )
                         .await;
@@ -401,31 +499,54 @@ impl ToolRuntime {
             };
         match response.payload {
             Some(CodingAgentResponsePayload::Start { run }) => {
-                if run.authority_fingerprint != authority_fingerprint
-                    || run.intent_fingerprint != intent_fingerprint
-                    || run.runtime_project_id != resolved.resolved_id
-                    || run.provider_id != provider_id
-                    || run.provider_instance_id != provider.provider_instance_id
+                if run.authority_fingerprint != prepared.authority_fingerprint
+                    || run.intent_fingerprint != prepared.intent_fingerprint
+                    || run.runtime_project_id != prepared.runtime_project_id
+                    || run.provider_id != prepared.provider_id
+                    || run.provider_instance_id != prepared.provider_instance_id
                 {
-                    return coding_agent_error(
-                        "invalid_runner_response",
-                        "Runner returned mismatched CodingAgentRun identity",
-                        "outcome_unknown",
-                        RecoveryKind::Reconcile,
-                        Some(&run_id),
-                    );
+                    return CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                        kind: "invalid_runner_response".to_string(),
+                        message: "Runner returned mismatched CodingAgentRun identity".to_string(),
+                        certainty: CodingAgentStartCertainty::OutcomeUnknown,
+                        recovery: RecoveryKind::Reconcile,
+                        run_id: prepared.run_id,
+                    });
                 }
                 self.coding_agent_runs
-                    .bind(&client, run.clone(), recording_session_id)
+                    .bind(&prepared.client, run.clone(), recording_session_id)
                     .await;
-                self.record_coding_agent_lifecycle_if_needed(&run_id).await;
-                ToolResult::ok(start_projection(
-                    &run,
-                    self.coding_agent_runs.observation_token(&run_id, 0),
-                ))
+                self.record_coding_agent_lifecycle_if_needed(&prepared.run_id)
+                    .await;
+                CodingAgentTypedStartOutcome::Run(run)
             }
-            _ => response_to_tool_error(response, Some(&run_id)),
+            _ => CodingAgentTypedStartOutcome::Failure(coding_agent_start_failure_from_response(
+                response,
+                &prepared.run_id,
+            )),
         }
+    }
+
+    pub(crate) async fn reconcile_coding_agent_run_snapshot(
+        &self,
+        run_id: &str,
+        auth: Option<&AuthContext>,
+    ) -> Result<Option<CodingAgentRunSnapshot>, ToolResult> {
+        let principal = stable_principal(auth).map_err(|error| {
+            coding_agent_error(
+                "coding_agent_identity_unavailable",
+                error,
+                "not_started",
+                RecoveryKind::FixInput,
+                Some(run_id),
+            )
+        })?;
+        let authority = authority_fingerprint(&principal);
+        Ok(self
+            .reconcile_run(run_id, &authority, auth)
+            .await
+            .filter(|binding| binding.authority_fingerprint == authority)
+            .map(|binding| binding.snapshot))
     }
 
     pub(crate) async fn coding_agent_observe(
@@ -745,14 +866,14 @@ impl ToolRuntime {
         }
     }
 
-    async fn start_waiter_lost(
+    async fn start_waiter_lost_typed(
         &self,
         request_id: &str,
         run_id: &str,
         authority: &str,
         recording_session_id: Option<String>,
         auth: Option<&AuthContext>,
-    ) -> ToolResult {
+    ) -> CodingAgentTypedStartOutcome {
         let dispatched = self
             .shell_clients
             .cancel_request_dispatch_state(request_id)
@@ -762,14 +883,23 @@ impl ToolRuntime {
                 .attach_recorder(run_id, recording_session_id)
                 .await;
             self.record_coding_agent_lifecycle_if_needed(run_id).await;
-            return ToolResult::ok(start_projection(
-                &binding.snapshot,
-                self.coding_agent_runs.observation_token(run_id, 0),
-            ));
+            return CodingAgentTypedStartOutcome::Run(binding.snapshot);
         }
         match dispatched {
-            Some(false) => coding_agent_error("coding_agent_start_timeout", "Run admission timed out before Runner dispatch", "not_started", RecoveryKind::RetrySame, Some(run_id)),
-            Some(true) | None => coding_agent_error("coding_agent_start_outcome_unknown", "Run dispatch may have reached the Runner; do not use a new idempotency key, reobserve/retry the same initiation", "outcome_unknown", RecoveryKind::Reconcile, Some(run_id)),
+            Some(false) => CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                kind: "coding_agent_start_timeout".to_string(),
+                message: "Run admission timed out before Runner dispatch".to_string(),
+                certainty: CodingAgentStartCertainty::NotStarted,
+                recovery: RecoveryKind::RetrySame,
+                run_id: run_id.to_string(),
+            }),
+            Some(true) | None => CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                kind: "coding_agent_start_outcome_unknown".to_string(),
+                message: "Run dispatch may have reached the Runner; do not use a new idempotency key, reobserve/retry the same initiation".to_string(),
+                certainty: CodingAgentStartCertainty::OutcomeUnknown,
+                recovery: RecoveryKind::Reconcile,
+                run_id: run_id.to_string(),
+            }),
         }
     }
 
@@ -1398,6 +1528,43 @@ fn coding_agent_error(
         }),
     )
     .with_recovery(recovery, None)
+}
+
+fn coding_agent_start_failure_from_response(
+    response: CodingAgentResponse,
+    run_id: &str,
+) -> CodingAgentStartFailure {
+    let dispatch = response.dispatch_state;
+    let certainty = if dispatch == CodingAgentDispatchState::NotStarted {
+        CodingAgentStartCertainty::NotStarted
+    } else {
+        CodingAgentStartCertainty::OutcomeUnknown
+    };
+    let Some(error) = response.error else {
+        return CodingAgentStartFailure {
+            kind: "invalid_runner_response".to_string(),
+            message: "Runner CodingAgentRun response contained no result".to_string(),
+            certainty,
+            recovery: RecoveryKind::Reobserve,
+            run_id: run_id.to_string(),
+        };
+    };
+    let recovery = match error.recovery_kind.as_deref() {
+        Some("fix_input") => RecoveryKind::FixInput,
+        Some("retry_same") => RecoveryKind::RetrySame,
+        Some("reconcile") => RecoveryKind::Reconcile,
+        Some("wait") => RecoveryKind::Wait,
+        Some("user_action") => RecoveryKind::UserAction,
+        Some("none") => RecoveryKind::NoAction,
+        _ => RecoveryKind::Reobserve,
+    };
+    CodingAgentStartFailure {
+        kind: error.code,
+        message: error.message,
+        certainty,
+        recovery,
+        run_id: run_id.to_string(),
+    }
 }
 
 fn response_to_tool_error(response: CodingAgentResponse, run_id: Option<&str>) -> ToolResult {

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -1605,6 +1605,40 @@ impl ToolRuntime {
                 idempotency_key,
             } => self.start_agent_task_attempt(auth, task_id, assignee_agent_id, idempotency_key),
 
+            ToolCall::StartAgentTaskCodingRun {
+                project,
+                task_id,
+                attempt_id,
+                assignee_agent_id,
+                attempt_fence,
+                attempt_controller_generation,
+                provider_id,
+                config,
+                timeout_secs,
+            } => {
+                self.start_agent_task_coding_run(
+                    auth,
+                    project,
+                    task_id,
+                    attempt_id,
+                    assignee_agent_id,
+                    attempt_fence,
+                    attempt_controller_generation,
+                    provider_id,
+                    config,
+                    timeout_secs,
+                )
+                .await
+            }
+
+            ToolCall::ReconcileAgentTaskCodingRun {
+                task_id,
+                attempt_id,
+            } => {
+                self.reconcile_agent_task_coding_run(auth, task_id, attempt_id)
+                    .await
+            }
+
             ToolCall::HeartbeatAgentTaskAttempt {
                 task_id,
                 attempt_id,

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -1382,7 +1382,7 @@ impl ToolRuntime {
                 timeout_secs,
                 recording_session_id,
             } => {
-                self.coding_agent_start(
+                Box::pin(self.coding_agent_start(
                     project,
                     provider_id,
                     idempotency_key,
@@ -1391,7 +1391,7 @@ impl ToolRuntime {
                     timeout_secs,
                     recording_session_id,
                     auth,
-                )
+                ))
                 .await
             }
             ToolCall::CodingAgentObserve {
@@ -1616,7 +1616,9 @@ impl ToolRuntime {
                 config,
                 timeout_secs,
             } => {
-                self.start_agent_task_coding_run(
+                // Keep this relatively large orchestration future off the shared dispatch
+                // future's inline state so unrelated tool calls do not inherit its stack cost.
+                Box::pin(self.start_agent_task_coding_run(
                     auth,
                     project,
                     task_id,
@@ -1627,17 +1629,14 @@ impl ToolRuntime {
                     provider_id,
                     config,
                     timeout_secs,
-                )
+                ))
                 .await
             }
 
             ToolCall::ReconcileAgentTaskCodingRun {
                 task_id,
                 attempt_id,
-            } => {
-                self.reconcile_agent_task_coding_run(auth, task_id, attempt_id)
-                    .await
-            }
+            } => Box::pin(self.reconcile_agent_task_coding_run(auth, task_id, attempt_id)).await,
 
             ToolCall::HeartbeatAgentTaskAttempt {
                 task_id,

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -1170,6 +1170,57 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_coding_run_tools_require_task_and_execution_authority() {
+        let communication_only = oauth(&["communication:read", "communication:manage"]);
+        for tool in [
+            "start_agent_task_coding_run",
+            "reconcile_agent_task_coding_run",
+        ] {
+            assert_eq!(
+                check_runtime_tool_scope(Some(&communication_only), tool),
+                Err(ToolCallErrorStatus::InsufficientScope {
+                    required_scope: Some(crate::auth::SCOPE_CODING_AGENT_RUN),
+                    description: "missing required scope: coding_agent:run".to_string(),
+                }),
+                "communication authority must not grant CodingAgent execution/observation authority for {tool}"
+            );
+        }
+
+        let task_and_run = oauth(&[
+            "communication:read",
+            "communication:manage",
+            "coding_agent:run",
+        ]);
+        assert_eq!(
+            check_runtime_tool_scope(Some(&task_and_run), "start_agent_task_coding_run"),
+            Err(ToolCallErrorStatus::InsufficientScope {
+                required_scope: Some(crate::auth::SCOPE_PROJECT_WRITE),
+                description: "missing required scope: project:write".to_string(),
+            }),
+            "Task ownership and CodingAgent authority must not imply Project write authority"
+        );
+        assert_eq!(
+            check_runtime_tool_scope(
+                Some(&task_and_run),
+                "reconcile_agent_task_coding_run"
+            ),
+            Ok(()),
+            "reconciliation observes exact bound execution and must not require a new Project write grant"
+        );
+
+        let start_allowed = oauth(&[
+            "communication:read",
+            "communication:manage",
+            "coding_agent:run",
+            "project:write",
+        ]);
+        assert_eq!(
+            check_runtime_tool_scope(Some(&start_allowed), "start_agent_task_coding_run"),
+            Ok(())
+        );
+    }
+
+    #[test]
     fn computer_tools_require_independent_scope() {
         let denied = oauth(&["runtime:read", "project:read"]);
         assert_eq!(

--- a/src/tool_runtime/registry/input_schemas.rs
+++ b/src/tool_runtime/registry/input_schemas.rs
@@ -26,7 +26,8 @@ pub(crate) use agent_tasks::{
     assign_agent_task_input_schema, complete_agent_task_attempt_input_schema,
     create_agent_task_input_schema, heartbeat_agent_task_attempt_input_schema,
     list_agent_tasks_input_schema, read_agent_task_input_schema,
-    start_agent_task_attempt_input_schema,
+    reconcile_agent_task_coding_run_input_schema, start_agent_task_attempt_input_schema,
+    start_agent_task_coding_run_input_schema,
 };
 pub(crate) use artifacts::{
     artifact_upload_abort_input_schema, artifact_upload_begin_input_schema,

--- a/src/tool_runtime/registry/input_schemas/agent_tasks.rs
+++ b/src/tool_runtime/registry/input_schemas/agent_tasks.rs
@@ -1,4 +1,7 @@
 use serde_json::{json, Value};
+use webcodex_core::coding_agent::{
+    CODING_AGENT_MAX_CONFIG_OPTIONS, CODING_AGENT_TIMEOUT_MAX_SECS, CODING_AGENT_TIMEOUT_MIN_SECS,
+};
 
 const AGENT_ID_PATTERN: &str = "^wc_dagent_[0-9a-f]{32}$";
 const TASK_ID_PATTERN: &str = "^wc_agent_task_[0-9a-f]{32}$";
@@ -133,6 +136,73 @@ pub(crate) fn start_agent_task_attempt_input_schema() -> Value {
             "idempotency_key": idempotency_key("Caller-generated Attempt-start key. Exact retry returns the same attempt_id and attempt_fence, even if that Attempt later becomes stale.")
         },
         "required": ["task_id", "assignee_agent_id", "idempotency_key"],
+        "additionalProperties": false
+    })
+}
+
+pub(crate) fn start_agent_task_coding_run_input_schema() -> Value {
+    let mut properties = attempt_identity_properties();
+    properties.insert(
+        "project".to_string(),
+        json!({
+            "type": "string",
+            "minLength": 1,
+            "description": "Exact registered Project id. It must equal AgentTask.referenced_project_id, which remains correlation only; this execution call independently re-authorizes Project write and CodingAgentRun authority."
+        }),
+    );
+    properties.insert(
+        "provider_id".to_string(),
+        json!({
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "Logical Runner-advertised CodingAgent provider. The Server binds its exact provider instance; callers cannot supply provider_instance_id."
+        }),
+    );
+    properties.insert(
+        "config".to_string(),
+        json!({
+            "type": "object",
+            "maxProperties": CODING_AGENT_MAX_CONFIG_OPTIONS,
+            "additionalProperties": {
+                "anyOf": [
+                    {"type": "string", "maxLength": 4096},
+                    {"type": "boolean"},
+                    {"type": "integer"}
+                ]
+            },
+            "description": "Optional run-level CodingAgent config. It participates in the immutable Attempt binding intent; changing it after binding conflicts rather than creating a second Run."
+        }),
+    );
+    properties.insert(
+        "timeout_secs".to_string(),
+        json!({
+            "type": "integer",
+            "minimum": CODING_AGENT_TIMEOUT_MIN_SECS,
+            "maximum": CODING_AGENT_TIMEOUT_MAX_SECS,
+            "default": 300,
+            "description": "Total CodingAgentRun budget. It participates in immutable binding intent."
+        }),
+    );
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": [
+            "project", "task_id", "attempt_id", "assignee_agent_id", "attempt_fence",
+            "attempt_controller_generation", "provider_id"
+        ],
+        "additionalProperties": false
+    })
+}
+
+pub(crate) fn reconcile_agent_task_coding_run_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "task_id": task_id(),
+            "attempt_id": canonical_id(ATTEMPT_ID_PATTERN, "Exact durable AgentTaskAttempt whose already-bound CodingAgentRun must be reconciled. No old attempt fence is required because this operation can only consume authoritative backend truth.")
+        },
+        "required": ["task_id", "attempt_id"],
         "additionalProperties": false
     })
 }

--- a/src/tool_runtime/registry/input_schemas/discovery.rs
+++ b/src/tool_runtime/registry/input_schemas/discovery.rs
@@ -25,7 +25,7 @@ pub(crate) fn list_tools_input_schema() -> Value {
             },
             "limit": {
                 "type": "integer",
-                "description": "Maximum returned tools for focused discovery; capped at 128."
+                "description": "Maximum returned tools for focused discovery; capped at 256."
             }
         },
         "required": [],

--- a/src/tool_runtime/registry/output_schemas/agent_tasks.rs
+++ b/src/tool_runtime/registry/output_schemas/agent_tasks.rs
@@ -64,6 +64,19 @@ fn task_summary_properties() -> serde_json::Map<String, Value> {
             "updated_at_unix_ms": schema_type("integer", "Latest durable Task/Attempt ownership update time."),
             "terminal_at_unix_ms": nullable_integer("Task terminal time, or null while nonterminal."),
             "latest_attempt": nullable_attempt_schema()
+            ,"execution_bound": schema_type("boolean", "True when the latest AgentTaskAttempt has a durable CodingAgentRun binding. This high-level projection grants no execution authority."),
+            "execution_status": {
+                "anyOf": [
+                    {"type": "string", "enum": ["not_started", "active", "waiting_permission", "outcome_unknown", "terminal"]},
+                    {"type": "null"}
+                ],
+                "description": "High-level bound execution status only; no run id, provider instance, authority fingerprint, backend key, or private Runner identity is exposed by generic Task reads."
+            },
+            "recovery_kind": {
+                "type": "string",
+                "enum": ["none", "observe", "reconcile"],
+                "description": "High-level recovery action for the latest bound execution."
+            }
         }
     })["properties"]
         .as_object()
@@ -80,7 +93,8 @@ fn task_summary_schema() -> Value {
         "required": [
             "task_id", "assignee_agent_id", "title", "source_conversation_id",
             "source_message_id", "referenced_project_id", "state", "created_at_unix_ms",
-            "updated_at_unix_ms", "terminal_at_unix_ms", "latest_attempt"
+            "updated_at_unix_ms", "terminal_at_unix_ms", "latest_attempt",
+            "execution_bound", "execution_status", "recovery_kind"
         ]
     })
 }
@@ -115,6 +129,41 @@ fn task_mutation_schema() -> Value {
     ])
 }
 
+fn coding_run_terminal_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "stop_reason": nullable_string("Bounded authoritative CodingAgent terminal stop reason when available."),
+            "error_code": nullable_string("Bounded authoritative CodingAgent terminal error code when available."),
+            "message": nullable_string("Bounded CodingAgent terminal diagnostic; never a transcript or full event history."),
+            "completed_at": nullable_integer("Unix terminal timestamp when authoritative terminal evidence exists.")
+        },
+        "required": ["stop_reason", "error_code", "message", "completed_at"]
+    })
+}
+
+fn coding_run_binding_output_schema() -> Value {
+    wrapped_output_schema(vec![
+        ("task_id", schema_type("string", "Owning durable AgentTask id.")),
+        ("attempt_id", schema_type("string", "Exact durable AgentTaskAttempt id.")),
+        ("run_id", schema_type("string", "Exact durable CodingAgentRun id for execution-authorized follow-up observation/cancellation.")),
+        ("project", schema_type("string", "Exact execution-authorized runtime Project id bound to this Attempt.")),
+        ("provider_id", schema_type("string", "Logical CodingAgent provider id. Provider instance identity remains private.")),
+        ("dispatch_state", {json!({"type":"string","enum":["prepared","not_started","outcome_unknown","bound","terminal"]})}),
+        ("run_state", json!({"anyOf":[{"type":"string","enum":["starting","running","waiting_permission","completed","failed","cancelled","lost"]},{"type":"null"}]})),
+        ("execution_state", json!({"anyOf":[{"type":"string","enum":["not_started","started","outcome_unknown","completed"]},{"type":"null"}]})),
+        ("execution_status", {json!({"type":"string","enum":["not_started","active","waiting_permission","outcome_unknown","terminal"]})}),
+        ("execution_recovery", {json!({"type":"string","enum":["none","observe","reconcile"]})}),
+        ("terminal", coding_run_terminal_schema()),
+        ("task_state", {json!({"type":"string","enum":["ready","active","succeeded","failed"]})}),
+        ("attempt_state", {json!({"type":"string","enum":["active","expired","succeeded","failed"]})}),
+        ("replayed", schema_type("boolean", "True when the durable Attempt binding was an exact intent replay.")),
+        ("state_changed", schema_type("boolean", "Whether this call changed durable Task terminal truth.")),
+        ("error_kind", schema_type("string", "Bounded failure classification when the operation is unsuccessful.")),
+    ])
+}
+
 pub(crate) fn output_schema_for_tool(name: &str) -> Option<Value> {
     let schema = match name {
         "create_agent_task" | "assign_agent_task" => task_mutation_schema(),
@@ -133,6 +182,9 @@ pub(crate) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("replayed", schema_type("boolean", "True for exact keyed Attempt-start replay.")),
             ("state_changed", schema_type("boolean", "Whether this call first created the Attempt.")),
         ]),
+        "start_agent_task_coding_run" | "reconcile_agent_task_coding_run" => {
+            coding_run_binding_output_schema()
+        }
         "heartbeat_agent_task_attempt" => wrapped_output_schema(vec![
             ("task", task_summary_schema()),
             ("attempt", attempt_schema()),

--- a/src/tool_runtime/surface.rs
+++ b/src/tool_runtime/surface.rs
@@ -42,7 +42,7 @@ pub(crate) fn recommended_flows() -> Vec<&'static str> {
 }
 
 impl ToolRuntime {
-    pub(crate) const LIST_TOOLS_MAX_LIMIT: usize = 128;
+    pub(crate) const LIST_TOOLS_MAX_LIMIT: usize = 256;
 
     pub(crate) fn list_tools_payload(&self, options: ListToolsOptions) -> Value {
         let specs = registered_tool_specs();

--- a/src/tool_runtime/tests/agent_tasks.rs
+++ b/src/tool_runtime/tests/agent_tasks.rs
@@ -1,12 +1,25 @@
 use super::support::*;
-use crate::auth::scopes::{COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES};
+use crate::auth::scopes::{
+    COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES, SCOPE_CODING_AGENT_RUN,
+    SCOPE_COMMUNICATION_MANAGE, SCOPE_COMMUNICATION_READ, SCOPE_PROJECT_WRITE,
+};
+use crate::shell_client::ShellClientRegistry;
+use crate::shell_protocol::{
+    ShellAgentResultPayload, ShellAgentResultRequest, ShellClientCapabilities,
+    ShellClientRegisterRequest,
+};
 use crate::tool_runtime::metadata::{
     ToolApprovalPolicy, ToolAuthorityPolicy, ToolEffect, ToolIdempotency, ToolRisk,
 };
 use crate::tool_runtime::tool_definition::{lookup_tool_definition, AgentCapability};
-use crate::tool_runtime::{ToolCall, ToolRuntime};
+use crate::tool_runtime::{RuntimeInfo, ToolCall, ToolRuntime};
 use serde_json::json;
 use std::sync::Arc;
+use webcodex_core::coding_agent::{
+    CodingAgentExecutionState, CodingAgentProvider, CodingAgentRequest, CodingAgentResponse,
+    CodingAgentResponsePayload, CodingAgentRunInventory, CodingAgentRunSnapshot,
+    CodingAgentRunState, CodingAgentTerminal,
+};
 
 fn runtime_with_db() -> (tempfile::TempDir, Arc<crate::db::Database>, ToolRuntime) {
     let temp = tempfile::tempdir().unwrap();
@@ -31,8 +44,62 @@ fn create_agent(runtime: &ToolRuntime, handle: &str) -> String {
         .to_string()
 }
 
+async fn register_coding_agent_task_runner(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    instance_id: &str,
+    owner: &str,
+    project_id: &str,
+    root: &std::path::Path,
+    inventory: CodingAgentRunInventory,
+) -> String {
+    runtime
+        .shell_clients
+        .register(ShellClientRegisterRequest {
+            process_started_at: Some(1_700_000_000),
+            build: None,
+            job_concurrency_limit: None,
+            job_inventory: None,
+            coding_agent_providers: Some(vec![CodingAgentProvider {
+                provider_id: "codex".to_string(),
+                provider_instance_id: "codex-instance-a4a".to_string(),
+                name: "Codex A4a test provider".to_string(),
+            }]),
+            coding_agent_inventory: Some(inventory),
+            client_id: client_id.to_string(),
+            agent_instance_id: instance_id.to_string(),
+            display_name: Some("A4a test runner".to_string()),
+            owner: Some(owner.to_string()),
+            hostname: None,
+            host_context: None,
+            capabilities: Some(crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities {
+                    coding_agent_runs: true,
+                    ..Default::default()
+                },
+            )),
+            projects: Some(vec![registered_project(
+                project_id,
+                &root.to_string_lossy(),
+            )]),
+            agent_protocol_version: Some("polling-v1".to_string()),
+            policy: None,
+        })
+        .await
+        .unwrap();
+    crate::tool_runtime::agent_project_runtime_id(client_id, project_id)
+}
+
+fn runtime_with_agent_task_db(db: Arc<crate::db::Database>) -> ToolRuntime {
+    ToolRuntime::new(
+        Arc::new(ShellClientRegistry::default()),
+        Arc::new(RuntimeInfo::default()),
+    )
+    .with_communication_database(db)
+}
+
 #[test]
-fn agent_task_tools_are_definition_owned_and_do_not_require_runner_or_project_authority() {
+fn agent_task_tools_are_definition_owned_and_a4a_adds_execution_authority_explicitly() {
     for name in [
         "create_agent_task",
         "list_agent_tasks",
@@ -52,6 +119,54 @@ fn agent_task_tools_are_definition_owned_and_do_not_require_runner_or_project_au
         assert_eq!(definition.agent_capability, None::<AgentCapability>);
         assert_eq!(definition.metadata.provider_id, "control");
     }
+
+    let start_coding = lookup_tool_definition("start_agent_task_coding_run").unwrap();
+    assert!(start_coding.model_spec.is_some());
+    assert_eq!(start_coding.category, "agent_task");
+    assert!(start_coding.metadata.requires_project);
+    assert_eq!(
+        start_coding.agent_capability,
+        Some(AgentCapability::CodingAgentRuns)
+    );
+    assert_eq!(start_coding.metadata.provider_id, "agent");
+    assert_eq!(start_coding.metadata.effect, ToolEffect::Execute);
+    assert_eq!(start_coding.metadata.risk, ToolRisk::JobRun);
+    assert_eq!(start_coding.metadata.approval, ToolApprovalPolicy::Standard);
+    assert_eq!(
+        start_coding.metadata.idempotency,
+        ToolIdempotency::FencedReplay
+    );
+    assert_eq!(
+        start_coding.metadata.authority,
+        ToolAuthorityPolicy::RequireAll(&[
+            SCOPE_COMMUNICATION_READ,
+            SCOPE_COMMUNICATION_MANAGE,
+            SCOPE_CODING_AGENT_RUN,
+            SCOPE_PROJECT_WRITE,
+        ])
+    );
+
+    let reconcile = lookup_tool_definition("reconcile_agent_task_coding_run").unwrap();
+    assert!(reconcile.model_spec.is_some());
+    assert_eq!(reconcile.category, "agent_task");
+    assert!(!reconcile.metadata.requires_project);
+    assert_eq!(reconcile.agent_capability, None::<AgentCapability>);
+    assert_eq!(reconcile.metadata.provider_id, "agent");
+    assert_eq!(reconcile.metadata.effect, ToolEffect::Mutate);
+    assert_eq!(reconcile.metadata.risk, ToolRisk::WorkflowManage);
+    assert_eq!(reconcile.metadata.approval, ToolApprovalPolicy::None);
+    assert_eq!(
+        reconcile.metadata.idempotency,
+        ToolIdempotency::DesiredState
+    );
+    assert_eq!(
+        reconcile.metadata.authority,
+        ToolAuthorityPolicy::RequireAll(&[
+            SCOPE_COMMUNICATION_READ,
+            SCOPE_COMMUNICATION_MANAGE,
+            SCOPE_CODING_AGENT_RUN,
+        ])
+    );
 
     for name in ["list_agent_tasks", "read_agent_task"] {
         let definition = lookup_tool_definition(name).unwrap();
@@ -139,6 +254,9 @@ fn agent_task_output_schemas_publish_bounded_task_and_attempt_contracts() {
         "referenced_project_id",
         "state",
         "latest_attempt",
+        "execution_bound",
+        "execution_status",
+        "recovery_kind",
     ] {
         assert!(
             task_summary["properties"].get(field).is_some(),
@@ -146,6 +264,19 @@ fn agent_task_output_schemas_publish_bounded_task_and_attempt_contracts() {
         );
     }
     assert!(task_summary["properties"].get("instruction").is_none());
+    for forbidden in [
+        "run_id",
+        "provider_id",
+        "provider_instance_id",
+        "authority_fingerprint",
+        "binding_intent_fingerprint",
+        "attempt_fence",
+    ] {
+        assert!(
+            task_summary["properties"].get(forbidden).is_none(),
+            "generic communication read must not publish private CodingAgent binding field {forbidden}"
+        );
+    }
     assert!(
         task_summary["properties"]["latest_attempt"]["anyOf"][0]["properties"]
             .get("attempt_fence")
@@ -179,6 +310,46 @@ fn agent_task_output_schemas_publish_bounded_task_and_attempt_contracts() {
         assert!(output["attempt"]["properties"].get("attempt_id").is_some());
         assert!(output.get("attempt_fence").is_none());
     }
+
+    let coding_start = spec("start_agent_task_coding_run");
+    let coding_start_input = coding_start.input_schema["properties"].as_object().unwrap();
+    for required in [
+        "project",
+        "task_id",
+        "attempt_id",
+        "assignee_agent_id",
+        "attempt_fence",
+        "attempt_controller_generation",
+        "provider_id",
+    ] {
+        assert!(coding_start_input.contains_key(required));
+    }
+    for forbidden in [
+        "instruction",
+        "idempotency_key",
+        "run_id",
+        "client_id",
+        "provider_instance_id",
+        "execution_kind",
+    ] {
+        assert!(!coding_start_input.contains_key(forbidden));
+    }
+    let coding_start_output = &coding_start.output_schema["properties"]["output"]["properties"];
+    assert!(coding_start_output.get("run_id").is_some());
+    assert!(coding_start_output.get("provider_instance_id").is_none());
+    assert!(coding_start_output.get("authority_fingerprint").is_none());
+    assert!(coding_start_output
+        .get("binding_intent_fingerprint")
+        .is_none());
+    assert!(coding_start_output.get("attempt_fence").is_none());
+
+    let reconcile = spec("reconcile_agent_task_coding_run");
+    let reconcile_input = reconcile.input_schema["properties"].as_object().unwrap();
+    assert_eq!(reconcile_input.len(), 2);
+    assert!(reconcile_input.contains_key("task_id"));
+    assert!(reconcile_input.contains_key("attempt_id"));
+    assert!(!reconcile_input.contains_key("attempt_fence"));
+    assert!(!reconcile_input.contains_key("project"));
 
     for name in ["start_agent_task_attempt", "heartbeat_agent_task_attempt"] {
         let properties = spec(name).input_schema["properties"]
@@ -228,6 +399,27 @@ fn tool_call_parser_keeps_agent_task_and_connector_task_identities_distinct() {
     )
     .unwrap();
     assert_eq!(heartbeat.tool_name(), "heartbeat_agent_task_attempt");
+
+    let coding_start = ToolCall::from_tool_name(
+        "start_agent_task_coding_run",
+        json!({
+            "project": "agent:special:task-project",
+            "task_id": task_id,
+            "attempt_id": attempt_id,
+            "assignee_agent_id": assignee,
+            "attempt_fence": fence,
+            "attempt_controller_generation": 1,
+            "provider_id": "codex"
+        }),
+    )
+    .unwrap();
+    assert_eq!(coding_start.tool_name(), "start_agent_task_coding_run");
+    let reconcile = ToolCall::from_tool_name(
+        "reconcile_agent_task_coding_run",
+        json!({"task_id": task_id, "attempt_id": attempt_id}),
+    )
+    .unwrap();
+    assert_eq!(reconcile.tool_name(), "reconcile_agent_task_coding_run");
 
     assert!(ToolCall::from_tool_name(
         "start_agent_task_attempt",
@@ -298,6 +490,17 @@ fn runtime_surface_exposes_fence_only_for_exact_start_and_never_requires_endpoin
         1
     );
     assert!(started.output["attempt"].get("attempt_fence").is_none());
+    assert_eq!(
+        _db.conn_for_tests()
+            .query_row(
+                "SELECT COUNT(*) FROM wc_agent_task_coding_runs",
+                [],
+                |row| { row.get::<_, i64>(0) }
+            )
+            .unwrap(),
+        0,
+        "A3 start_agent_task_attempt must remain ownership-only and dispatch no backend"
+    );
 
     let heartbeat = runtime.heartbeat_agent_task_attempt(
         None,
@@ -330,6 +533,243 @@ fn runtime_surface_exposes_fence_only_for_exact_start_and_never_requires_endpoin
     assert!(terminal.success);
     assert_eq!(terminal.output["task"]["summary"]["state"], "succeeded");
     assert!(terminal.output["task"].get("attempt_fence").is_none());
+}
+
+#[tokio::test]
+async fn coding_run_executes_then_reconciles_from_reopened_db_and_fresh_runtime() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("agent-task-a4a-runtime.db");
+    let db = Arc::new(crate::db::Database::open(&db_path).unwrap());
+    let runtime = runtime_with_agent_task_db(db.clone());
+    let client_id = "a4a-task-runner";
+    let instance_id = "a4a-task-runner-instance";
+    let project_id = "a4a-task-project";
+    let auth = auth_context(Some("a4a-owner"), false);
+    let project = register_coding_agent_task_runner(
+        &runtime,
+        client_id,
+        instance_id,
+        "a4a-owner",
+        project_id,
+        temp.path(),
+        CodingAgentRunInventory::default(),
+    )
+    .await;
+    let agent_result = runtime.create_agent_identity(
+        Some(&auth),
+        "a4a-runtime-agent".to_string(),
+        "A4a Runtime Agent".to_string(),
+        None,
+        Vec::new(),
+        "a4a-runtime-agent-create".to_string(),
+    );
+    assert!(agent_result.success, "{:?}", agent_result.output);
+    let assignee = agent_result.output["agent"]["agent_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let instruction = "Implement the exact durable A4a runtime test instruction.";
+    let created = runtime.create_agent_task(
+        Some(&auth),
+        "A4a runtime task".to_string(),
+        instruction.to_string(),
+        Some(assignee.clone()),
+        None,
+        None,
+        Some(project.clone()),
+        "a4a-runtime-task-create".to_string(),
+    );
+    assert!(created.success, "{:?}", created.output);
+    let task_id = created.output["task"]["summary"]["task_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let started = runtime.start_agent_task_attempt(
+        Some(&auth),
+        task_id.clone(),
+        assignee.clone(),
+        "a4a-runtime-attempt".to_string(),
+    );
+    assert!(started.success, "{:?}", started.output);
+    let attempt_id = started.output["attempt"]["attempt_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let fence = started.output["attempt_fence"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        probe_agent_request_for_instance(&runtime, client_id, instance_id)
+            .await
+            .is_none(),
+        "start_agent_task_attempt must not enqueue CodingAgent work"
+    );
+
+    let mut start_task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let task_id = task_id.clone();
+        let attempt_id = attempt_id.clone();
+        let assignee = assignee.clone();
+        let fence = fence.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .start_agent_task_coding_run(
+                    Some(&auth),
+                    project,
+                    task_id,
+                    attempt_id,
+                    assignee,
+                    fence,
+                    1,
+                    "codex".to_string(),
+                    None,
+                    Some(300),
+                )
+                .await
+        }
+    });
+    let request = tokio::select! {
+        result = &mut start_task => {
+            let result = result.unwrap();
+            panic!("A4a start returned before Runner dispatch: success={} output={:?} error={:?}", result.success, result.output, result.error);
+        }
+        request = wait_for_agent_request_for_instance(&runtime, client_id, instance_id) => request,
+    };
+    let start = match request
+        .coding_agent
+        .as_ref()
+        .expect("typed CodingAgent request")
+    {
+        CodingAgentRequest::Start(start) => start.clone(),
+        other => panic!("expected CodingAgent Start, got {other:?}"),
+    };
+    assert_eq!(start.runtime_project_id, project);
+    assert_eq!(start.provider_id, "codex");
+    assert_eq!(start.provider_instance_id, "codex-instance-a4a");
+    assert_eq!(start.instruction, instruction);
+    assert!(start.run_id.starts_with("wc_agent_run_"));
+    let run_now = chrono::Utc::now().timestamp();
+    let running = CodingAgentRunSnapshot {
+        run_id: start.run_id.clone(),
+        intent_fingerprint: start.intent_fingerprint.clone(),
+        authority_fingerprint: start.authority_fingerprint.clone(),
+        runtime_project_id: start.runtime_project_id.clone(),
+        provider_id: start.provider_id.clone(),
+        provider_instance_id: start.provider_instance_id.clone(),
+        state: CodingAgentRunState::Running,
+        execution_state: CodingAgentExecutionState::Started,
+        observation_revision: 1,
+        created_at: run_now,
+        updated_at: run_now,
+        terminal: None,
+    };
+    runtime
+        .shell_clients
+        .complete(ShellAgentResultPayload {
+            result: ShellAgentResultRequest {
+                client_id: client_id.to_string(),
+                agent_instance_id: instance_id.to_string(),
+                request_id: request.request_id,
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: None,
+                error: None,
+            },
+            command_execution_state: None,
+            mcp_gateway: None,
+            coding_agent: Some(CodingAgentResponse::success(
+                CodingAgentResponsePayload::Start {
+                    run: running.clone(),
+                },
+            )),
+        })
+        .await
+        .unwrap();
+    let started_run = start_task.await.unwrap();
+    assert!(started_run.success, "{:?}", started_run.output);
+    assert_eq!(started_run.output["run_id"], running.run_id);
+    assert_eq!(started_run.output["execution_status"], "active");
+    assert_eq!(
+        db.conn_for_tests()
+            .query_row(
+                "SELECT COUNT(*) FROM wc_agent_task_coding_runs",
+                [],
+                |row| { row.get::<_, i64>(0) }
+            )
+            .unwrap(),
+        1
+    );
+
+    let completed = CodingAgentRunSnapshot {
+        state: CodingAgentRunState::Completed,
+        execution_state: CodingAgentExecutionState::Completed,
+        observation_revision: 2,
+        updated_at: run_now + 1,
+        terminal: Some(CodingAgentTerminal {
+            stop_reason: Some("end_turn".to_string()),
+            error_code: None,
+            message: Some("A4a durable run completed".to_string()),
+            completed_at: run_now + 1,
+        }),
+        ..running
+    };
+
+    drop(runtime);
+    drop(db);
+    let reopened_db = Arc::new(crate::db::Database::open(&db_path).unwrap());
+    let fresh_runtime = runtime_with_agent_task_db(reopened_db.clone());
+    let fresh_project = register_coding_agent_task_runner(
+        &fresh_runtime,
+        client_id,
+        instance_id,
+        "a4a-owner",
+        project_id,
+        temp.path(),
+        CodingAgentRunInventory {
+            runs: vec![completed.clone()],
+        },
+    )
+    .await;
+    assert_eq!(fresh_project, project);
+    let (_, inventory_run) = fresh_runtime
+        .shell_clients
+        .coding_agent_run_for_auth(Some(&auth), &completed.run_id)
+        .await
+        .expect("fresh runtime must see the exact durable CodingAgentRun inventory entry");
+    assert_eq!(inventory_run, completed);
+
+    let reconciled = fresh_runtime
+        .reconcile_agent_task_coding_run(Some(&auth), task_id.clone(), attempt_id.clone())
+        .await;
+    assert!(reconciled.success, "{:?}", reconciled.output);
+    assert_eq!(reconciled.output["run_id"], completed.run_id);
+    assert_eq!(
+        reconciled.output["task_state"], "succeeded",
+        "reconcile output: {:?}",
+        reconciled.output
+    );
+    assert_eq!(reconciled.output["attempt_state"], "succeeded");
+    assert_eq!(reconciled.output["state_changed"], true);
+
+    let task = fresh_runtime.read_agent_task(Some(&auth), task_id);
+    assert!(task.success, "{:?}", task.output);
+    assert_eq!(task.output["task"]["summary"]["state"], "succeeded");
+    assert_eq!(task.output["task"]["summary"]["execution_bound"], true);
+    assert_eq!(
+        task.output["task"]["summary"]["execution_status"],
+        "terminal"
+    );
+    assert_eq!(task.output["task"]["summary"]["recovery_kind"], "none");
+    assert!(
+        probe_agent_request_for_instance(&fresh_runtime, client_id, instance_id)
+            .await
+            .is_none(),
+        "restart reconciliation from authoritative inventory must not mint another Start"
+    );
 }
 
 #[test]

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -493,6 +493,11 @@ fn required_agent_capability_matches_metadata_risk_table() {
             ToolRisk::JobRun,
             AgentCapability::CodingAgentRuns,
         ),
+        (
+            "start_agent_task_coding_run",
+            ToolRisk::JobRun,
+            AgentCapability::CodingAgentRuns,
+        ),
         ("run_shell", ToolRisk::JobRun, AgentCapability::Shell),
         (
             "open_session_shell",

--- a/src/tool_runtime/tests/schema/specs.rs
+++ b/src/tool_runtime/tests/schema/specs.rs
@@ -612,6 +612,8 @@ fn tool_specs_covers_expected_tool_set() {
         "read_agent_task",
         "assign_agent_task",
         "start_agent_task_attempt",
+        "start_agent_task_coding_run",
+        "reconcile_agent_task_coding_run",
         "heartbeat_agent_task_attempt",
         "complete_agent_task_attempt",
         "run_process",

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -549,6 +549,37 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
                 Value::Bool(obj.get("idempotency_key").and_then(Value::as_str).is_some()),
             );
         }
+        "start_agent_task_coding_run" => {
+            copy_keys(
+                obj,
+                &mut out,
+                &[
+                    "project",
+                    "task_id",
+                    "attempt_id",
+                    "assignee_agent_id",
+                    "attempt_controller_generation",
+                    "provider_id",
+                    "timeout_secs",
+                ],
+            );
+            out.insert(
+                "attempt_fence_present".to_string(),
+                Value::Bool(obj.get("attempt_fence").and_then(Value::as_str).is_some()),
+            );
+            out.insert(
+                "config_count".to_string(),
+                Value::from(
+                    obj.get("config")
+                        .and_then(Value::as_object)
+                        .map(serde_json::Map::len)
+                        .unwrap_or_default(),
+                ),
+            );
+        }
+        "reconcile_agent_task_coding_run" => {
+            copy_keys(obj, &mut out, &["task_id", "attempt_id"]);
+        }
         "heartbeat_agent_task_attempt" => {
             copy_keys(
                 obj,
@@ -1605,6 +1636,23 @@ pub(crate) fn session_log_result_for_tool(tool_name: &str, output: &Value) -> Va
             "attempt_number": output.pointer("/attempt/attempt_number").cloned().unwrap_or(Value::Null),
             "attempt_state": output.pointer("/attempt/state").cloned().unwrap_or(Value::Null),
             "controller_generation": output.pointer("/attempt/attempt_controller_generation").cloned().unwrap_or(Value::Null),
+            "replayed": output.get("replayed").cloned().unwrap_or(Value::Null),
+            "state_changed": output.get("state_changed").cloned().unwrap_or(Value::Null),
+            "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
+        }),
+        "start_agent_task_coding_run" | "reconcile_agent_task_coding_run" => serde_json::json!({
+            "task_id": output.get("task_id").cloned().unwrap_or(Value::Null),
+            "attempt_id": output.get("attempt_id").cloned().unwrap_or(Value::Null),
+            "run_id": output.get("run_id").cloned().unwrap_or(Value::Null),
+            "project": output.get("project").cloned().unwrap_or(Value::Null),
+            "provider_id": output.get("provider_id").cloned().unwrap_or(Value::Null),
+            "dispatch_state": output.get("dispatch_state").cloned().unwrap_or(Value::Null),
+            "run_state": output.get("run_state").cloned().unwrap_or(Value::Null),
+            "execution_state": output.get("execution_state").cloned().unwrap_or(Value::Null),
+            "execution_status": output.get("execution_status").cloned().unwrap_or(Value::Null),
+            "execution_recovery": output.get("execution_recovery").cloned().unwrap_or(Value::Null),
+            "task_state": output.get("task_state").cloned().unwrap_or(Value::Null),
+            "attempt_state": output.get("attempt_state").cloned().unwrap_or(Value::Null),
             "replayed": output.get("replayed").cloned().unwrap_or(Value::Null),
             "state_changed": output.get("state_changed").cloned().unwrap_or(Value::Null),
             "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
@@ -4455,6 +4503,40 @@ impl ToolCall {
                     "task_id": task_id,
                     "assignee_agent_id": assignee_agent_id,
                     "idempotency_key": idempotency_key,
+                }),
+            ),
+            Self::StartAgentTaskCodingRun {
+                project,
+                task_id,
+                attempt_id,
+                assignee_agent_id,
+                attempt_fence,
+                attempt_controller_generation,
+                provider_id,
+                config,
+                timeout_secs,
+            } => session_log_arguments_for_tool_request(
+                "start_agent_task_coding_run",
+                &serde_json::json!({
+                    "project": project,
+                    "task_id": task_id,
+                    "attempt_id": attempt_id,
+                    "assignee_agent_id": assignee_agent_id,
+                    "attempt_fence": attempt_fence,
+                    "attempt_controller_generation": attempt_controller_generation,
+                    "provider_id": provider_id,
+                    "config": config,
+                    "timeout_secs": timeout_secs,
+                }),
+            ),
+            Self::ReconcileAgentTaskCodingRun {
+                task_id,
+                attempt_id,
+            } => session_log_arguments_for_tool_request(
+                "reconcile_agent_task_coding_run",
+                &serde_json::json!({
+                    "task_id": task_id,
+                    "attempt_id": attempt_id,
                 }),
             ),
             Self::HeartbeatAgentTaskAttempt {

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -1045,6 +1045,27 @@ pub enum ToolCall {
         idempotency_key: String,
     },
 
+    /// Explicitly dispatch the exact latest fenced AgentTaskAttempt to one durable CodingAgentRun.
+    StartAgentTaskCodingRun {
+        project: String,
+        task_id: String,
+        attempt_id: String,
+        assignee_agent_id: String,
+        attempt_fence: String,
+        attempt_controller_generation: i64,
+        provider_id: String,
+        #[serde(default)]
+        config: Option<BTreeMap<String, webcodex_core::coding_agent::CodingAgentConfigValue>>,
+        #[serde(default)]
+        timeout_secs: Option<u64>,
+    },
+
+    /// Reconcile the exact durable CodingAgentRun already bound to one AgentTaskAttempt.
+    ReconcileAgentTaskCodingRun {
+        task_id: String,
+        attempt_id: String,
+    },
+
     /// Renew only the exact latest unexpired fenced AgentTaskAttempt.
     HeartbeatAgentTaskAttempt {
         task_id: String,
@@ -2517,6 +2538,8 @@ impl ToolCall {
             Self::ReadAgentTask { .. } => "read_agent_task",
             Self::AssignAgentTask { .. } => "assign_agent_task",
             Self::StartAgentTaskAttempt { .. } => "start_agent_task_attempt",
+            Self::StartAgentTaskCodingRun { .. } => "start_agent_task_coding_run",
+            Self::ReconcileAgentTaskCodingRun { .. } => "reconcile_agent_task_coding_run",
             Self::HeartbeatAgentTaskAttempt { .. } => "heartbeat_agent_task_attempt",
             Self::CompleteAgentTaskAttempt { .. } => "complete_agent_task_attempt",
             Self::CreateAgentIdentity { .. } => "create_agent_identity",
@@ -2734,6 +2757,7 @@ impl ToolCall {
             Self::RunProcess { project, .. }
             | Self::RunDetachedProcess { project, .. }
             | Self::CodingAgentStart { project, .. }
+            | Self::StartAgentTaskCodingRun { project, .. }
             | Self::RunScript { project, .. }
             | Self::RunShell { project, .. }
             | Self::OpenSessionShell { project, .. }

--- a/src/tool_runtime/tool_catalog.rs
+++ b/src/tool_runtime/tool_catalog.rs
@@ -85,6 +85,8 @@ pub(crate) const TOOL_DISCOVERY_GROUPS: &[ToolDiscoveryGroup] = &[
             "read_agent_task",
             "assign_agent_task",
             "start_agent_task_attempt",
+            "start_agent_task_coding_run",
+            "reconcile_agent_task_coding_run",
             "heartbeat_agent_task_attempt",
             "complete_agent_task_attempt",
         ],

--- a/src/tool_runtime/tool_definition/agent_tasks.rs
+++ b/src/tool_runtime/tool_definition/agent_tasks.rs
@@ -1,16 +1,22 @@
+use super::AgentCapability::CodingAgentRuns;
 use super::ToolVisibility::ModelVisible;
-use super::{def, model_spec, require_all_scopes, ToolDefinition, TOOL_CATEGORY_AGENT_TASK};
+use super::{
+    def, model_spec, permission_risk, require_all_scopes, ToolDefinition, PERMISSION_RISK_JOB,
+    TOOL_CATEGORY_AGENT_TASK,
+};
 use crate::auth::scopes::{COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES};
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath,
-    ToolRisk::{Read, WorkflowManage},
-    COMMUNICATION_MANAGE, COMMUNICATION_READ, TOOL_PROVIDER_CONTROL,
+    ToolRisk::{JobRun, Read, WorkflowManage},
+    CODING_AGENT_RUN, COMMUNICATION_MANAGE, COMMUNICATION_READ, TOOL_PROVIDER_AGENT,
+    TOOL_PROVIDER_CONTROL,
 };
 use crate::tool_runtime::registry::input_schemas::{
     assign_agent_task_input_schema, complete_agent_task_attempt_input_schema,
     create_agent_task_input_schema, heartbeat_agent_task_attempt_input_schema,
     list_agent_tasks_input_schema, read_agent_task_input_schema,
-    start_agent_task_attempt_input_schema,
+    reconcile_agent_task_coding_run_input_schema, start_agent_task_attempt_input_schema,
+    start_agent_task_coding_run_input_schema,
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
@@ -138,6 +144,64 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             start_agent_task_attempt_input_schema,
         ),
         COMMUNICATION_MANAGE_SCOPES,
+    ),
+    permission_risk(
+        model_spec(
+            require_all_scopes(
+                def(
+                    "start_agent_task_coding_run",
+                    ModelVisible,
+                    TOOL_CATEGORY_AGENT_TASK,
+                    Some(CodingAgentRuns),
+                    TOOL_PROVIDER_AGENT,
+                    super::ToolSemanticContract {
+                        effect: super::ToolEffect::Execute,
+                        risk: JobRun,
+                        approval: super::ToolApprovalPolicy::Standard,
+                        idempotency: super::ToolIdempotency::FencedReplay,
+                    },
+                    Some(CODING_AGENT_RUN),
+                    true,
+                    NoPath,
+                    true,
+                    false,
+                ),
+                &[
+                    COMMUNICATION_READ,
+                    COMMUNICATION_MANAGE,
+                    CODING_AGENT_RUN,
+                    crate::auth::SCOPE_PROJECT_WRITE,
+                ],
+            ),
+            "Explicitly dispatch the exact latest unexpired fenced AgentTaskAttempt to its one durable CodingAgentRun backend. The Server derives the backend replay identity from the Attempt and uses AgentTask.instruction; the supplied Project must match referenced_project_id and is independently re-authorized through normal CodingAgent admission. Durable binding and outcome-unknown fencing precede external dispatch, so uncertain retries never mint replacement work.",
+            start_agent_task_coding_run_input_schema,
+        ),
+        PERMISSION_RISK_JOB,
+    ),
+    model_spec(
+        require_all_scopes(
+            def(
+                "reconcile_agent_task_coding_run",
+                ModelVisible,
+                TOOL_CATEGORY_AGENT_TASK,
+                None,
+                TOOL_PROVIDER_AGENT,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Mutate,
+                    risk: WorkflowManage,
+                    approval: super::ToolApprovalPolicy::None,
+                    idempotency: super::ToolIdempotency::DesiredState,
+                },
+                Some(COMMUNICATION_MANAGE),
+                false,
+                NoPath,
+                false,
+                false,
+            ),
+            &[COMMUNICATION_READ, COMMUNICATION_MANAGE, CODING_AGENT_RUN],
+        ),
+        "Reconcile only the exact CodingAgentRun already durably bound to one owned AgentTaskAttempt. It never starts execution, chooses a provider, changes intent, or requires the old browser's Attempt fence. Authoritative Completed/Failed/Cancelled truth can terminalize the exact latest bound Attempt even after its ordinary lease expires; Lost remains outcome_unknown.",
+        reconcile_agent_task_coding_run_input_schema,
     ),
     require_all_scopes(
         model_spec(


### PR DESCRIPTION
## Summary
- durably bind each exact AgentTaskAttempt to at most one existing CodingAgentRun
- derive backend replay identity from the Attempt and fence uncertain dispatch before crossing the Runner boundary
- reconcile authoritative CodingAgent terminal truth back into the exact latest Attempt/Task across Server or browser-window loss
- keep normal AgentTask lease/controller completion semantics unchanged while blocking replacement during active or outcome-unknown execution
- reuse existing CodingAgent authorization, provider-instance fencing, reconciliation, and bounded terminal semantics

## Reviewer fixes
- sample Server time only after authoritative DB serialization for A4a prepare/dispatch lease checks, preventing a request queued before expiry from dispatching after the Attempt lease has expired
- heap-box the larger CodingAgent dispatch futures so the shared tool-dispatch future does not inherit enough inline state to overflow test-thread stacks

## Boundaries
- no scheduler, worker pool, generic execution/provider framework, Host continuation, automatic Conversation reply, Agent Endpoint continuation, or A4b behavior
- `AgentTask.referenced_project_id` remains correlation/intent only; dispatch independently re-authorizes Project write + CodingAgent execution authority

## Validation
- `cargo test db::agent_task_tests:: --lib` — 23/23 pass
- `cargo test tool_runtime::tests::agent_tasks:: --lib` — 7/7 pass
- exact former stack-overflow regression `mcp_tools_call_tasks_extension_switches_only_active_command_results_to_tasks` — 1/1 pass
- prior independent review: Tool schema 112/112, CodingAgent regression 22/22, permission gate 9/9, OAuth policy coverage 1/1, `cargo check --all-targets`, `cargo fmt --all -- --check`
- post-rebase `git diff --check origin/main..HEAD` — pass

Independent reviewer verdict before PR creation: approve after reviewer fix, 0 remaining blocker.