### PR TITLE
Judge closeout from current validation evidence

### DIFF
--- a/src/tool_runtime/checkpoint.rs
+++ b/src/tool_runtime/checkpoint.rs
@@ -401,12 +401,20 @@ impl ToolRuntime {
                 output: helper_output,
             };
         }
+        let changed_paths = helper_output
+            .get("changed_paths")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        let state_changed = changed_paths
+            .as_array()
+            .is_some_and(|paths| !paths.is_empty());
         ToolResult::ok(json!({
             "restored": true,
             "checkpoint_id": checkpoint_id,
             "project": project,
             "resolved_project": resolved.resolved_id,
-            "changed_paths": helper_output.get("changed_paths").cloned().unwrap_or_else(|| json!([])),
+            "state_changed": state_changed,
+            "changed_paths": changed_paths,
             "warnings": helper_output.get("warnings").cloned().unwrap_or_else(|| json!([])),
         }))
     }

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -1568,7 +1568,7 @@ impl ToolRuntime {
         });
         let reconciliation = reconcile_closeout_evidence(
             output.get("tool_failures").unwrap_or(&Value::Null),
-            &closeout_session_summary.events,
+            &closeout_session_summary,
             output.get("validation").unwrap_or(&Value::Null),
         );
         output["tool_failures"] = reconciliation.tool_failures;
@@ -2610,6 +2610,7 @@ fn compact_finish_output(decision: &Value) -> Value {
 }
 
 fn compact_finish_validation(validation: &Value) -> Value {
+    let current = validation.get("current_evidence").unwrap_or(&Value::Null);
     json!({
         "status": validation.get("status").cloned().unwrap_or_else(|| json!("not_run")),
         "reason": validation.get("reason").cloned().unwrap_or(Value::Null),
@@ -2618,6 +2619,14 @@ fn compact_finish_validation(validation: &Value) -> Value {
         "failures": validation.get("failures").and_then(Value::as_u64).unwrap_or(0),
         "resolved_failure_count": validation.pointer("/resolved_failures/count").and_then(Value::as_u64).unwrap_or(0),
         "unresolved_failure_count": validation.pointer("/unresolved_failures/count").and_then(Value::as_u64).unwrap_or(0),
+        "current_status": current.get("status").cloned().unwrap_or_else(|| json!("unknown")),
+        "current_reason": current.get("reason").cloned().unwrap_or(Value::Null),
+        "current_validation_events": current.get("events_total").and_then(Value::as_u64).unwrap_or(0),
+        "current_successes": current.get("successes").and_then(Value::as_u64).unwrap_or(0),
+        "current_failures": current.get("failures").and_then(Value::as_u64).unwrap_or(0),
+        "current_resolved_failure_count": current.get("resolved_failure_count").and_then(Value::as_u64).unwrap_or(0),
+        "current_unresolved_failure_count": current.get("unresolved_failure_count").and_then(Value::as_u64).unwrap_or(0),
+        "stale_failure_count": current.get("stale_failure_count").and_then(Value::as_u64).unwrap_or(0),
         "cargo_test_zero_tests_run": validation_has_cargo_test_zero_tests(validation),
     })
 }

--- a/src/tool_runtime/continuation_feedback.rs
+++ b/src/tool_runtime/continuation_feedback.rs
@@ -32,8 +32,8 @@ use std::collections::BTreeSet;
 
 use super::handoff::closeout_work_projection;
 use super::sessions::{
-    canonical_tool_call_finished_events, SessionDiscussionSummary, SessionEvent, SessionMessage,
-    SessionSummary,
+    canonical_tool_call_finished_events, current_attempt_event_view, SessionDiscussionSummary,
+    SessionEvent, SessionMessage, SessionSummary,
 };
 use super::sessions::{
     exploration_tool_kind, normalize_observed_project_path, ExplorationToolKind,
@@ -170,13 +170,17 @@ pub(crate) struct AttemptExploration {
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct AttemptValidation {
-    /// `available`, `not_run`, or `unknown`.
+    /// Current workspace evidence status: `passed`, `failed`, `stale`, `not_run`, or `unknown`.
+    pub(crate) status: String,
+    /// Latest validation event status inside the current evidence window.
     pub(crate) latest_status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) latest_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) latest_at: Option<i64>,
     pub(crate) unresolved_failure_count: usize,
+    pub(crate) validation_events: usize,
+    pub(crate) stale_failure_count: usize,
     pub(crate) open_failures: Vec<FailureIdentity>,
     pub(crate) total_open_failures: usize,
     pub(crate) failures_truncated: bool,
@@ -329,36 +333,24 @@ impl ContinuationFeedback {
             return not_applicable_continuation_feedback_value(reason_code);
         }
 
-        let boundary = resolve_attempt_boundary(events, input.session_summary);
-        // Attempt events start *after* the boundary task_instruction event.
-        let attempt_start = boundary.event_index.map(|index| index + 1).unwrap_or(0);
+        let attempt_view = current_attempt_event_view(input.session_summary);
+        // Attempt events start *after* the boundary task_instruction event. The
+        // shared view canonicalizes finished recorder/business evidence against
+        // the whole retained Session before slicing.
+        let attempt_start = attempt_view.attempt_start;
         let attempt_events = &events[attempt_start..];
-        // Canonicalize finished evidence against the whole retained Session,
-        // not only the post-boundary slice. A concurrent request may publish its
-        // business finish just before a new task_instruction and its outer
-        // recorder finish just after it; treating the slice in isolation would
-        // recount that prior logical invocation in the new attempt.
-        let canonical_finished_ids = canonical_tool_call_finished_events(events)
-            .into_iter()
-            .map(|event| event.event_id.as_str())
-            .collect::<BTreeSet<_>>();
-        let semantic_attempt_events = attempt_events
-            .iter()
-            .filter(|event| {
-                event.kind != "tool_call_finished"
-                    || canonical_finished_ids.contains(event.event_id.as_str())
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        let boundary_event = boundary.event_index.map(|index| &events[index]);
+        let semantic_attempt_events = attempt_view.semantic_events;
+        let boundary_event = attempt_view
+            .boundary_event_index
+            .map(|index| &events[index]);
 
         let attempt = build_attempt_summary(
             attempt_events,
             &semantic_attempt_events,
             boundary_event,
-            boundary.event_index,
-            boundary.source,
-            boundary.reason_code,
+            attempt_view.boundary_event_index,
+            attempt_view.boundary_source,
+            attempt_view.boundary_reason_code,
             attempt_start,
             input.session_summary,
             input.validation,
@@ -433,10 +425,13 @@ fn empty_attempt() -> AttemptSummary {
             complete: true,
         },
         validation: AttemptValidation {
+            status: "not_run".to_string(),
             latest_status: "not_run".to_string(),
             latest_kind: None,
             latest_at: None,
             unresolved_failure_count: 0,
+            validation_events: 0,
+            stale_failure_count: 0,
             open_failures: Vec::new(),
             total_open_failures: 0,
             failures_truncated: false,
@@ -465,61 +460,6 @@ fn empty_attempt() -> AttemptSummary {
             reason_codes: Vec::new(),
         },
         suggested_next_actions: Vec::new(),
-    }
-}
-
-/// Return the index and event id of the last `task_instruction` event.
-fn last_task_instruction(events: &[SessionEvent]) -> (Option<usize>, Option<String>) {
-    events
-        .iter()
-        .rposition(|event| event.kind == "task_instruction")
-        .map(|index| (Some(index), Some(events[index].event_id.clone())))
-        .unwrap_or((None, None))
-}
-
-/// Resolved attempt boundary: where the current attempt begins, and whether the
-/// boundary is genuinely observed, a real session-start fallback, or unknown
-/// because the durable ledger truncated the most recent `task_instruction`.
-struct AttemptBoundaryResolution {
-    source: &'static str,
-    reason_code: Option<&'static str>,
-    event_index: Option<usize>,
-}
-
-/// Determine the attempt boundary from the retained summary window.
-///
-/// - When a `task_instruction` is present in the retained window, it is the
-///   boundary (`source = task_instruction`).
-/// - When none is present and the window was *not* truncated, the session
-///   genuinely has no instruction and we fall back to `session_start`.
-/// - When none is present and the window *was* truncated, the most recent
-///   `task_instruction` was evicted by the per-session event cap: report
-///   `unavailable` with `attempt_boundary_evicted` rather than masquerading the
-///   retained tail as a complete `session_start` attempt. We never guess the
-///   true session start.
-fn resolve_attempt_boundary(
-    events: &[SessionEvent],
-    summary: &SessionSummary,
-) -> AttemptBoundaryResolution {
-    if let (Some(index), Some(_event_id)) = last_task_instruction(events) {
-        return AttemptBoundaryResolution {
-            source: "task_instruction",
-            reason_code: None,
-            event_index: Some(index),
-        };
-    }
-    if summary.events_truncated {
-        AttemptBoundaryResolution {
-            source: "unavailable",
-            reason_code: Some("attempt_boundary_evicted"),
-            event_index: None,
-        }
-    } else {
-        AttemptBoundaryResolution {
-            source: "session_start",
-            reason_code: None,
-            event_index: None,
-        }
     }
 }
 
@@ -594,16 +534,24 @@ fn build_attempt_summary(
                 == "matched_expected_failure"
         })
         .count();
-    // The session-wide resolved/unresolved counts span every prior attempt,
-    // so failures from an earlier attempt (before the boundary task_instruction)
-    // would pollute the current attempt's activity. Re-derive the counts from
-    // the attempt-scoped events only: a failure counts as resolved only when a
-    // later success within *this* attempt resolves it, and unresolved
-    // otherwise. The session-wide `validation` is still used for the validation
-    // block's latest verdict and for the cross-attempt delta.
-    let attempt_validation =
-        super::validation_events::validation_summary_from_events(semantic_attempt_events, 20);
-    let (resolved_failures, unresolved_failures) = validation_failure_counts(&attempt_validation);
+    // Current attempt validation is additionally reset by the latest trusted
+    // material workspace-content change. Historical validation remains intact
+    // in the session-wide summary, while activity/open-failure counts use only
+    // evidence that still describes the current workspace state.
+    let current_validation =
+        super::validation_events::current_validation_evidence_for_session(session_summary, 20);
+    let current_evidence = validation
+        .get("current_evidence")
+        .filter(|value| value.is_object())
+        .unwrap_or(&current_validation.evidence);
+    let resolved_failures = current_evidence
+        .get("resolved_failure_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let unresolved_failures = current_evidence
+        .get("unresolved_failure_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
 
     // --- changes (deduped, deterministic order via closeout_work_projection) ---
     let (_, changed_paths_value) = closeout_work_projection(semantic_attempt_events);
@@ -624,7 +572,7 @@ fn build_attempt_summary(
 
     // --- validation (current attempt verdict, history must not pollute) ---
     let delta = validation_delta(validation);
-    let validation_block = build_attempt_validation(validation, &attempt_validation, &delta);
+    let validation_block = build_attempt_validation(validation, &current_validation, &delta);
 
     // --- jobs (reuse existing lifecycle fields) ---
     let jobs_block = build_attempt_jobs(jobs);
@@ -800,25 +748,9 @@ fn is_meaningful_tool(tool_name: &str) -> bool {
         || runtime_tool_captures_validation_output(tool_name)
 }
 
-/// Reuse the existing `validation_summary` resolved/unresolved failure sets
-/// to count failures for the current attempt. Historical failures that were
-/// resolved by a later success within the attempt are *resolved*; failures
-/// with no later success are *unresolved*. This never re-parses stdout/stderr.
-fn validation_failure_counts(validation: &Value) -> (usize, usize) {
-    let resolved = validation
-        .pointer("/resolved_failures/count")
-        .and_then(Value::as_u64)
-        .unwrap_or(0) as usize;
-    let unresolved = validation
-        .pointer("/unresolved_failures/count")
-        .and_then(Value::as_u64)
-        .unwrap_or(0) as usize;
-    (resolved, unresolved)
-}
-
 fn build_attempt_validation(
     validation: &Value,
-    attempt_validation: &Value,
+    current_validation: &super::validation_events::CurrentValidationEvidenceProjection,
     delta: &ValidationDelta,
 ) -> AttemptValidation {
     // When the caller explicitly did not request validation (handoff with
@@ -828,22 +760,40 @@ fn build_attempt_validation(
         .get("not_requested")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let available = validation
-        .get("available")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let (open_failures, total_open_failures, failures_truncated) = if not_requested {
+    let evidence = validation
+        .get("current_evidence")
+        .filter(|value| value.is_object())
+        .unwrap_or(&current_validation.evidence);
+    let current_status = if not_requested {
+        "unknown"
+    } else {
+        evidence
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+    };
+    let current_unresolved = if not_requested {
+        0
+    } else {
+        evidence
+            .get("unresolved_failure_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize
+    };
+    let (open_failures, observed_open_failures, observed_truncated) = if not_requested {
         (Vec::new(), 0, false)
     } else {
-        attempt_open_failures(attempt_validation)
+        attempt_open_failures(&current_validation.current_validation)
     };
+    let total_open_failures = observed_open_failures.max(current_unresolved);
+    let failures_truncated = observed_truncated || total_open_failures > open_failures.len();
     let latest_status = if not_requested {
         "unavailable".to_string()
     } else {
-        validation
+        evidence
             .get("latest_status")
             .and_then(Value::as_str)
-            .unwrap_or("not_run")
+            .unwrap_or("unknown")
             .to_string()
     };
     let delta_available = !not_requested && delta.comparison.status == "available";
@@ -858,20 +808,7 @@ fn build_attempt_validation(
             .map(|code| code.to_string())
             .or_else(|| Some("no_previous_validation".to_string()))
     };
-    if !available {
-        return AttemptValidation {
-            latest_status,
-            latest_kind: None,
-            latest_at: None,
-            unresolved_failure_count: 0,
-            open_failures,
-            total_open_failures,
-            failures_truncated,
-            delta_available,
-            delta_reason_code,
-        };
-    }
-    let latest = validation.get("latest");
+    let latest = current_validation.current_validation.get("latest");
     let latest_kind = latest
         .and_then(|event| event.get("validation_kind"))
         .and_then(Value::as_str)
@@ -883,17 +820,30 @@ fn build_attempt_validation(
                 .or_else(|| event.get("started_at"))
         })
         .and_then(Value::as_i64);
-    // Unresolved count is attempt-scoped so an earlier attempt's resolved
-    // failure does not surface as an open failure for the current attempt.
-    let unresolved_failure_count = attempt_validation
-        .pointer("/unresolved_failures/count")
-        .and_then(Value::as_u64)
-        .unwrap_or(0) as usize;
+    let validation_events = if not_requested {
+        0
+    } else {
+        evidence
+            .get("events_total")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize
+    };
+    let stale_failure_count = if not_requested {
+        0
+    } else {
+        evidence
+            .get("stale_failure_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize
+    };
     AttemptValidation {
+        status: current_status.to_string(),
         latest_status,
         latest_kind,
         latest_at,
-        unresolved_failure_count,
+        unresolved_failure_count: current_unresolved,
+        validation_events,
+        stale_failure_count,
         open_failures,
         total_open_failures,
         failures_truncated,
@@ -1015,8 +965,11 @@ fn build_attempt_outcome(
     if guidance.open_count > 0 {
         push_unique(&mut reasons, "open_guidance");
     }
-    if validation.latest_status == "not_run" && !meaningful.is_empty() {
+    if validation.status == "not_run" && !meaningful.is_empty() {
         push_unique(&mut reasons, "validation_not_run");
+    }
+    if validation.status == "stale" {
+        push_unique(&mut reasons, "validation_stale_after_changes");
     }
     let status = if reasons.is_empty() {
         "in_progress".to_string()
@@ -1074,7 +1027,7 @@ fn build_suggested_next_actions(
             "address open guidance on the session message board",
         );
     }
-    if validation.latest_status == "not_run" {
+    if matches!(validation.status.as_str(), "not_run" | "stale") {
         push_unique(
             &mut actions,
             "run validation before proceeding when the task warrants it",

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -834,6 +834,7 @@ impl ToolRuntime {
         }
         ToolResult::ok(json!({
             "ok": true,
+            "state_changed": !paths.is_empty(),
             "deleted_paths": paths,
             "missing_paths": [],
             "refused_paths": [],
@@ -847,6 +848,7 @@ impl ToolRuntime {
             Ok(root) => root,
             Err(_) => return ToolResult::err("project root is unavailable"),
         };
+        let mut state_changed = false;
         for path in &paths {
             let target = canonical_root.join(path);
             match std::fs::symlink_metadata(&target) {
@@ -869,7 +871,7 @@ impl ToolRuntime {
                         );
                     }
                     match std::fs::remove_file(&target) {
-                        Ok(()) => {}
+                        Ok(()) => state_changed = true,
                         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                         Err(_) => return ToolResult::err("delete_project_files failed"),
                     }
@@ -907,6 +909,7 @@ impl ToolRuntime {
         }
         ToolResult::ok(json!({
             "ok": true,
+            "state_changed": state_changed,
             "deleted_paths": paths,
             "missing_paths": [],
             "refused_paths": [],
@@ -969,7 +972,7 @@ impl ToolRuntime {
             "expected_sha256": expected_sha256,
             "expected_content_prefix": expected_content_prefix,
         });
-        let obj = match self
+        let mut obj = match self
             .run_agent_json_file_op(
                 client_id,
                 proj.path.clone(),
@@ -993,6 +996,9 @@ impl ToolRuntime {
                 output: obj,
                 error: Some(err),
             };
+        }
+        if let Some(changed) = obj.get("changed").and_then(Value::as_bool) {
+            obj["state_changed"] = json!(changed);
         }
         ToolResult::ok(obj)
     }

--- a/src/tool_runtime/handoff.rs
+++ b/src/tool_runtime/handoff.rs
@@ -36,14 +36,12 @@ const MAX_OPEN_ITEMS: usize = 20;
 const MAX_RECENT_CHECKPOINTS: usize = 10;
 const HANDOFF_MESSAGE_CHARS: usize = 240;
 
-/// Actionable guidance for an unresolved validation identity, accurate for
-/// both identity forms: `assertion:<name>` identities resolve by reusing the
-/// original assertion_name, while command-derived identities (which never had
-/// an assertion_name) resolve by rerunning the same logical validation
-/// consistently. The conditional phrasing never claims an original
-/// assertion_name exists for command-derived validations.
+/// Actionable guidance only for a validation failure that still belongs to the
+/// current evidence window. Identity reuse is conditional: it strengthens
+/// correlation when the same logical validation is intentionally rerun, but is
+/// never a requirement to clean stale audit history.
 pub(crate) const VALIDATION_IDENTITY_REUSE_ACTION: &str =
-    "rerun the same logical validation using the same validation identity; if assertion_name was supplied, reuse the original assertion_name";
+    "address the current validation failure; when intentionally rerunning the same logical validation, reuse its validation identity and original assertion_name when supplied";
 
 impl ToolRuntime {
     pub(crate) async fn session_handoff_summary(
@@ -317,7 +315,7 @@ impl ToolRuntime {
         });
         let reconciliation = reconcile_closeout_evidence(
             output.get("tool_failures").unwrap_or(&Value::Null),
-            &closeout_session.events,
+            &closeout_session,
             &feedback_validation,
         );
         output["tool_failures"] = reconciliation.tool_failures;
@@ -971,6 +969,10 @@ fn compact_workflow_outcomes(
     }
 
     let validation_status = validation.get("status").and_then(Value::as_str);
+    let current_validation_status = validation
+        .pointer("/current_evidence/status")
+        .and_then(Value::as_str)
+        .or(validation_status);
     let resolved_failure_count = validation
         .pointer("/resolved_failures/count")
         .and_then(Value::as_u64)
@@ -979,6 +981,10 @@ fn compact_workflow_outcomes(
         .pointer("/unresolved_failures/count")
         .and_then(Value::as_u64)
         .unwrap_or(0);
+    let current_unresolved_failure_count = validation
+        .pointer("/current_evidence/unresolved_failure_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(unresolved_failure_count);
     let evidence_history_status = if validation_historical_failures_resolved(validation) {
         "mixed_resolved"
     } else {
@@ -990,7 +996,7 @@ fn compact_workflow_outcomes(
         }
     };
 
-    match validation_status {
+    match current_validation_status {
         Some("not_run") => {
             let review_evidence_total = output
                 .get("review_evidence")
@@ -1014,32 +1020,20 @@ fn compact_workflow_outcomes(
                 );
             }
         }
-        Some("failed") if unresolved_failure_count > 0 => {
-            push_unique(&mut blocking_reasons, "validation_failed");
-            push_unique_action(&mut actions, "review validation failures before closeout");
+        Some("stale") => {
+            push_unique(&mut warning_reasons, "validation_stale_after_changes");
+            push_unique_action(
+                &mut actions,
+                "run task-appropriate validation when warranted",
+            );
         }
-        Some("mixed") => {
-            if unresolved_failure_count == 0 {
-                push_unique(
-                    &mut informational_notes,
-                    "historical validation failures were resolved by later successful validation",
-                );
-            } else {
-                push_unique(&mut blocking_reasons, "validation_mixed");
-                if validation_historical_failures_unresolved(validation) {
-                    push_unique_action(&mut actions, VALIDATION_IDENTITY_REUSE_ACTION);
-                } else {
-                    push_unique_action(
-                        &mut actions,
-                        "review mixed validation results before closeout",
-                    );
-                }
-            }
+        Some("failed") if current_unresolved_failure_count > 0 => {
+            push_unique(&mut blocking_reasons, "validation_failed");
+            push_unique_action(&mut actions, VALIDATION_IDENTITY_REUSE_ACTION);
         }
         Some("unknown") | None => {
             push_unique(&mut warning_reasons, "validation_unknown");
         }
-        Some("failed") => {}
         Some(_) => {}
     }
     if validation_historical_failures_resolved(validation) {
@@ -1047,13 +1041,13 @@ fn compact_workflow_outcomes(
             &mut informational_notes,
             "historical validation failures were resolved by later successful validation",
         );
-    }
-    if unresolved_failure_count > 0 && !matches!(validation_status, Some("failed" | "mixed")) {
+    } else if validation_historical_failures_unresolved(validation)
+        && current_unresolved_failure_count == 0
+    {
         push_unique(
-            &mut blocking_reasons,
-            "validation_historical_failures_unresolved",
+            &mut informational_notes,
+            "historical validation failures remain without exact identity resolution but are not current workspace blockers",
         );
-        push_unique_action(&mut actions, VALIDATION_IDENTITY_REUSE_ACTION);
     }
     if validation_has_cargo_test_zero_tests(validation) {
         push_unique(&mut integrity_warnings, "cargo_test_zero_tests");
@@ -1104,7 +1098,7 @@ fn compact_workflow_outcomes(
         .get("events")
         .cloned()
         .unwrap_or_else(|| json!([]));
-    let validation_skipped = matches!(validation_status, Some("not_run"))
+    let validation_skipped = matches!(current_validation_status, Some("not_run" | "stale"))
         || validation
             .get("skipped")
             .and_then(Value::as_bool)
@@ -1177,17 +1171,21 @@ pub(crate) struct CloseoutEvidenceReconciliation {
 /// events remain intact; only their current actionability/status is projected.
 pub(crate) fn reconcile_closeout_evidence(
     tool_failures: &Value,
-    events: &[SessionEvent],
+    summary: &SessionSummary,
     validation: &Value,
 ) -> CloseoutEvidenceReconciliation {
-    let validation = reconcile_closeout_validation(validation);
+    let validation = validation.clone();
+    let current = super::validation_events::current_validation_evidence_for_session(summary, 100);
     let mut projected = tool_failures.clone();
     let raw_unexpected = count_field(tool_failures, "unexpected_count");
-    let historical_non_actionable = canonical_tool_call_finished_events(events)
+    let historical_non_actionable = canonical_tool_call_finished_events(&summary.events)
         .into_iter()
         .filter(|event| unexpected_failure_event(event))
         .filter(|event| {
             is_resolved_unexpected_validation_failure(event, &validation)
+                || current
+                    .non_current_failure_event_ids
+                    .contains(&event.event_id)
                 || unexpected_failure_is_proven_non_actionable(event)
         })
         .count() as u64;
@@ -1199,25 +1197,6 @@ pub(crate) fn reconcile_closeout_evidence(
         validation,
         tool_failures: projected,
     }
-}
-
-fn reconcile_closeout_validation(validation: &Value) -> Value {
-    let mut projected = validation.clone();
-    let current_validation_passed = validation.get("latest_status").and_then(Value::as_str)
-        == Some("passed")
-        && validation
-            .get("successes")
-            .and_then(Value::as_u64)
-            .unwrap_or(0)
-            > 0
-        && validation
-            .pointer("/unresolved_failures/count")
-            .and_then(Value::as_u64)
-            == Some(0);
-    if projected.is_object() && current_validation_passed {
-        projected["status"] = json!("passed");
-    }
-    projected
 }
 
 fn unexpected_failure_event(event: &SessionEvent) -> bool {
@@ -1462,7 +1441,17 @@ fn handoff_suggested_next_actions(output: &Value) -> Vec<String> {
         }
     }
     let validation = output.get("validation").unwrap_or(&Value::Null);
-    if validation_historical_failures_unresolved(validation) {
+    if validation
+        .pointer("/current_evidence/unresolved_failure_count")
+        .and_then(Value::as_u64)
+        .unwrap_or_else(|| {
+            validation
+                .pointer("/unresolved_failures/count")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        })
+        > 0
+    {
         push(&mut actions, VALIDATION_IDENTITY_REUSE_ACTION);
     }
     if validation_has_cargo_test_zero_tests(validation) {

--- a/src/tool_runtime/handoff.rs
+++ b/src/tool_runtime/handoff.rs
@@ -41,7 +41,7 @@ const HANDOFF_MESSAGE_CHARS: usize = 240;
 /// correlation when the same logical validation is intentionally rerun, but is
 /// never a requirement to clean stale audit history.
 pub(crate) const VALIDATION_IDENTITY_REUSE_ACTION: &str =
-    "address the current validation failure; when intentionally rerunning the same logical validation, reuse its validation identity and original assertion_name when supplied";
+    "address the current validation failure; when intentionally rerunning it, reuse the original assertion_name when supplied and the same validation identity";
 
 impl ToolRuntime {
     pub(crate) async fn session_handoff_summary(

--- a/src/tool_runtime/handoff_brief.rs
+++ b/src/tool_runtime/handoff_brief.rs
@@ -397,27 +397,50 @@ fn project_validation(requested: bool, validation: Option<&Value>) -> Validation
         };
     };
 
-    let available = validation.get("available").and_then(Value::as_bool);
-    let status = validation.get("status").and_then(Value::as_str);
-    let latest_status = validation.get("latest_status").and_then(Value::as_str);
-    let unresolved = validation
-        .pointer("/unresolved_failures/count")
-        .and_then(Value::as_u64);
-    let projected = if available == Some(false)
-        && (status == Some("not_run") || latest_status == Some("not_run"))
+    let current = validation
+        .get("current_evidence")
+        .filter(|value| value.is_object());
+    let projected = if let Some(status) = current
+        .and_then(|value| value.get("status"))
+        .and_then(Value::as_str)
     {
-        "not_run"
-    } else if unresolved.is_some_and(|count| count > 0)
-        || latest_status == Some("failed")
-        || status == Some("failed")
-    {
-        "failed"
-    } else if available == Some(true) && latest_status == Some("passed") && unresolved == Some(0) {
-        "passed"
-    } else if status == Some("not_run") || latest_status == Some("not_run") {
-        "not_run"
+        match status {
+            "passed" => "passed",
+            "failed" => "failed",
+            "stale" => "stale",
+            "not_run" => "not_run",
+            _ => "unavailable",
+        }
     } else {
-        "unavailable"
+        // Additive compatibility for callers/tests that still provide the
+        // pre-current-evidence validation shape. Production closeout summaries
+        // carry current_evidence and therefore never derive a current verdict
+        // from these historical fields.
+        let available = validation.get("available").and_then(Value::as_bool);
+        let status = validation.get("status").and_then(Value::as_str);
+        let latest_status = validation.get("latest_status").and_then(Value::as_str);
+        let unresolved = validation
+            .pointer("/unresolved_failures/count")
+            .and_then(Value::as_u64);
+        if available == Some(false)
+            && (status == Some("not_run") || latest_status == Some("not_run"))
+        {
+            "not_run"
+        } else if unresolved.is_some_and(|count| count > 0)
+            || latest_status == Some("failed")
+            || status == Some("failed")
+        {
+            "failed"
+        } else if available == Some(true)
+            && latest_status == Some("passed")
+            && unresolved == Some(0)
+        {
+            "passed"
+        } else if status == Some("not_run") || latest_status == Some("not_run") {
+            "not_run"
+        } else {
+            "unavailable"
+        }
     };
     let reason_code = (projected == "unavailable").then_some("validation_unavailable");
     ValidationProjection {
@@ -572,7 +595,9 @@ fn progress_state(
     {
         return "blocked";
     }
-    if workspace.dirty == Some(true) && validation.status != "passed" {
+    if validation.status == "stale"
+        || (workspace.dirty == Some(true) && validation.status != "passed")
+    {
         return "needs_validation";
     }
     if !continuation_available
@@ -624,7 +649,7 @@ fn next_actions(
     if open_risks.is_some_and(|count| count > 0) {
         push_unique(&mut actions, "review open risk guidance before continuing");
     }
-    if validation.status == "not_run" {
+    if matches!(validation.status, "not_run" | "stale") {
         push_known_or(
             &mut actions,
             &known,

--- a/src/tool_runtime/registry/output_schemas/checkpoints.rs
+++ b/src/tool_runtime/registry/output_schemas/checkpoints.rs
@@ -159,6 +159,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 schema_type("string", "Resolved runtime project id."),
             ),
             (
+                "state_changed",
+                schema_type("boolean", "True when the authoritative restore result reports one or more changed project paths."),
+            ),
+            (
                 "changed_paths",
                 array_schema(
                     schema_type("string", "Project-relative path."),

--- a/src/tool_runtime/registry/output_schemas/coding_tasks.rs
+++ b/src/tool_runtime/registry/output_schemas/coding_tasks.rs
@@ -54,7 +54,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "validation",
-                open_object_schema("Validation closeout evidence. Full closeout preserves bounded historical/resolved/unresolved evidence by stable identity; summary_only keeps only final status/reason, success/failure counts, resolved/unresolved failure counts, and the zero-test integrity flag."),
+                open_object_schema("Validation closeout evidence. Full closeout preserves bounded historical/resolved/unresolved evidence by stable identity and adds current_evidence for the current attempt after the latest trusted material content change. summary_only keeps final status/reason, historical and current success/failure counts, resolved/unresolved counts, current_status/stale_failure_count, and the zero-test integrity flag."),
             ),
             (
                 "continuation_feedback",

--- a/src/tool_runtime/registry/output_schemas/common.rs
+++ b/src/tool_runtime/registry/output_schemas/common.rs
@@ -678,6 +678,7 @@ pub(crate) fn handoff_brief_schema(description: &str) -> Value {
                         "enum": [
                             "passed",
                             "failed",
+                            "stale",
                             "not_run",
                             "not_requested",
                             "unavailable"
@@ -915,9 +916,13 @@ fn attempt_exploration_schema() -> Value {
 fn attempt_validation_schema() -> Value {
     json!({
         "type": "object",
-        "description": "Current-attempt validation verdict (projection only; never a new verdict).",
+        "description": "Current-attempt validation evidence after the latest trusted material workspace-content change. Historical validation remains separate.",
         "additionalProperties": false,
         "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["passed", "failed", "stale", "not_run", "unknown"]
+            },
             "latest_status": {
                 "type": "string",
                 "enum": ["passed", "failed", "not_run", "unknown", "unavailable"]
@@ -925,13 +930,15 @@ fn attempt_validation_schema() -> Value {
             "latest_kind": nullable_schema("string", "Validation kind of the latest run, when present."),
             "latest_at": nullable_schema("integer", "Unix timestamp of the latest run, when present."),
             "unresolved_failure_count": schema_type("integer", "Unresolved failure event count from this attempt."),
+            "validation_events": schema_type("integer", "Validation event count in the current evidence window."),
+            "stale_failure_count": schema_type("integer", "Failure events from this attempt that predate the latest trusted material workspace-content change."),
             "open_failures": array_schema(failure_identity_schema(), "Bounded stable identities for currently unresolved failures in this attempt."),
             "total_open_failures": schema_type("integer", "Total unresolved failure identities before bounding."),
             "failures_truncated": schema_type("boolean", "True when open_failures was capped at the bound."),
             "delta_available": schema_type("boolean", "Whether the validation delta is comparable."),
             "delta_reason_code": nullable_schema("string", "Reason code when the delta is not available; null otherwise.")
         },
-        "required": ["latest_status", "unresolved_failure_count", "open_failures", "total_open_failures", "failures_truncated", "delta_available"]
+        "required": ["status", "latest_status", "unresolved_failure_count", "validation_events", "stale_failure_count", "open_failures", "total_open_failures", "failures_truncated", "delta_available"]
     })
 }
 

--- a/src/tool_runtime/registry/output_schemas/edits.rs
+++ b/src/tool_runtime/registry/output_schemas/edits.rs
@@ -112,6 +112,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 nullable_schema("string", "sha256 of the written file, current file on sha guard mismatch, or null when unavailable."),
             ),
             (
+                "state_changed",
+                schema_type("boolean", "Authoritative whole-file write effect derived from the agent's changed result; false means the successful write left file content unchanged."),
+            ),
+            (
                 "warning",
                 nullable_schema("string", "Whole-file write safety warning, such as an unguarded overwrite warning; null otherwise."),
             ),

--- a/src/tool_runtime/registry/output_schemas/hygiene.rs
+++ b/src/tool_runtime/registry/output_schemas/hygiene.rs
@@ -85,6 +85,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
             ),
             (
+                "state_changed",
+                schema_type("boolean", "True only when successful cleanup evidence proves at least one requested project file was deleted."),
+            ),
+            (
                 "deleted_paths",
                 array_schema(
                     schema_type("string", "Deleted project-relative path."),

--- a/src/tool_runtime/registry/output_schemas/sessions.rs
+++ b/src/tool_runtime/registry/output_schemas/sessions.rs
@@ -619,6 +619,31 @@ fn validation_summary_tool_output_schema() -> Value {
 }
 
 fn validation_evidence_schema() -> Value {
+    fn current_validation_evidence_schema() -> Value {
+        json!({
+            "type": "object",
+            "description": "Current workspace validation evidence for the current attempt after the latest trusted material workspace-content change. Historical ledger failures remain separately visible and are not erased by this projection.",
+            "additionalProperties": false,
+            "properties": {
+                "status": {"type": "string", "enum": ["passed", "failed", "stale", "not_run", "unknown"]},
+                "reason": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                "latest_status": {"type": "string", "enum": ["passed", "failed", "not_run", "unknown"]},
+                "events_total": {"type": "integer", "minimum": 0},
+                "successes": {"type": "integer", "minimum": 0},
+                "failures": {"type": "integer", "minimum": 0},
+                "resolved_failure_count": {"type": "integer", "minimum": 0},
+                "unresolved_failure_count": {"type": "integer", "minimum": 0},
+                "stale_failure_count": {"type": "integer", "minimum": 0},
+                "evidence_after_latest_content_change": {"type": "boolean"},
+                "boundary_reason": {"type": "string", "enum": ["attempt_start", "workspace_content_changed", "attempt_boundary_unavailable"]}
+            },
+            "required": [
+                "status", "reason", "latest_status", "events_total", "successes", "failures",
+                "resolved_failure_count", "unresolved_failure_count", "stale_failure_count",
+                "evidence_after_latest_content_change", "boundary_reason"
+            ]
+        })
+    }
     let event = validation_event_schema();
     json!({
         "type": "object",
@@ -630,6 +655,7 @@ fn validation_evidence_schema() -> Value {
             "reason": { "anyOf": [{"type": "string"}, {"type": "null"}] },
             "latest": { "anyOf": [event.clone(), {"type": "null"}] },
             "latest_status": { "type": "string", "enum": ["not_run", "passed", "failed", "unknown"] },
+            "current_evidence": current_validation_evidence_schema(),
             "historical_failures": validation_historical_failures_schema(),
             "resolved_failures": validation_failure_set_schema(),
             "unresolved_failures": validation_failure_set_schema(),
@@ -650,7 +676,7 @@ fn validation_evidence_schema() -> Value {
             "skipped": schema_type("boolean", "True only when validation summary generation was explicitly skipped by a closeout caller.")
         },
         "required": [
-            "available", "status", "reason", "latest", "latest_status",
+            "available", "status", "reason", "latest", "latest_status", "current_evidence",
             "historical_failures", "resolved_failures", "unresolved_failures",
             "source", "events_total", "events", "parser",
             "cargo_test_zero_tests_run"

--- a/src/tool_runtime/sessions/events.rs
+++ b/src/tool_runtime/sessions/events.rs
@@ -14,12 +14,12 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 
 use super::model::{
-    PersistentShellEventEvidence, SessionContextRevisionAck, SessionEvent, ToolCallExpectation,
-    ToolCallRecorderMetadata, ToolCallSessionMessageResolution, LOGICAL_INVOCATION_ID_PREFIX,
-    LOGICAL_INVOCATION_ROLE_BUSINESS, LOGICAL_INVOCATION_ROLE_RECORDER,
-    MAX_MODEL_VALIDATION_ASSERTION_NAME_CHARS, MAX_OBSERVED_PATHS_PER_EVENT,
-    MAX_VALIDATION_EXCERPT_CHARS, SESSION_ID_PREFIX, TOOL_ASSERTION_NAME_FIELD,
-    TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
+    PersistentShellEventEvidence, SessionContextRevisionAck, SessionEvent, SessionSummary,
+    ToolCallExpectation, ToolCallRecorderMetadata, ToolCallSessionMessageResolution,
+    LOGICAL_INVOCATION_ID_PREFIX, LOGICAL_INVOCATION_ROLE_BUSINESS,
+    LOGICAL_INVOCATION_ROLE_RECORDER, MAX_MODEL_VALIDATION_ASSERTION_NAME_CHARS,
+    MAX_OBSERVED_PATHS_PER_EVENT, MAX_VALIDATION_EXCERPT_CHARS, SESSION_ID_PREFIX,
+    TOOL_ASSERTION_NAME_FIELD, TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
     TOOL_CALL_ACK_SESSION_MESSAGE_IDS_INTERNAL_FIELD, TOOL_CALL_EXPECTATION_METADATA_FIELDS,
     TOOL_CALL_RECORDING_SESSION_ID_FIELD, TOOL_CALL_SESSION_MESSAGE_RESOLUTION_INTERNAL_FIELD,
     TOOL_EXPECTATION_RESULT_MATCHED, TOOL_EXPECTATION_RESULT_MISMATCH,
@@ -196,6 +196,55 @@ pub(crate) fn canonical_tool_call_finished_events(events: &[SessionEvent]) -> Ve
 
     selected.sort_by_key(|(event_index, _)| *event_index);
     selected.into_iter().map(|(_, event)| event).collect()
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CurrentAttemptEventView {
+    pub(crate) semantic_events: Vec<SessionEvent>,
+    pub(crate) attempt_start: usize,
+    pub(crate) boundary_source: &'static str,
+    pub(crate) boundary_reason_code: Option<&'static str>,
+    pub(crate) boundary_event_index: Option<usize>,
+    pub(crate) complete: bool,
+}
+
+/// Resolve the current semantic attempt once for all read-only projections.
+/// Finished recorder/business duplicates are canonicalized against the whole
+/// retained Session before the post-instruction slice is taken, so a recorder
+/// finish that lands just after a new instruction cannot contaminate it.
+pub(crate) fn current_attempt_event_view(summary: &SessionSummary) -> CurrentAttemptEventView {
+    let events = &summary.events;
+    let boundary_event_index = events
+        .iter()
+        .rposition(|event| event.kind == "task_instruction");
+    let (boundary_source, boundary_reason_code) = if boundary_event_index.is_some() {
+        ("task_instruction", None)
+    } else if summary.events_truncated {
+        ("unavailable", Some("attempt_boundary_evicted"))
+    } else {
+        ("session_start", None)
+    };
+    let attempt_start = boundary_event_index.map(|index| index + 1).unwrap_or(0);
+    let canonical_finished_ids = canonical_tool_call_finished_events(events)
+        .into_iter()
+        .map(|event| event.event_id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    let semantic_events = events[attempt_start..]
+        .iter()
+        .filter(|event| {
+            event.kind != "tool_call_finished"
+                || canonical_finished_ids.contains(event.event_id.as_str())
+        })
+        .cloned()
+        .collect();
+    CurrentAttemptEventView {
+        semantic_events,
+        attempt_start,
+        boundary_source,
+        boundary_reason_code,
+        boundary_event_index,
+        complete: boundary_reason_code.is_none(),
+    }
 }
 
 pub(crate) fn extract_project(value: &Value) -> Option<String> {
@@ -553,6 +602,22 @@ pub(crate) fn changed_paths_for_tool(tool_name: &str, arguments: &Value) -> Vec<
         ToolPathHint::Patch | ToolPathHint::None => {}
     }
     paths
+}
+
+/// Add trusted result-side changed paths for canonical mutations whose input
+/// intentionally does not expose a structured path list. Never parses raw diff
+/// text; only authoritative bounded runtime result metadata is accepted.
+pub(crate) fn changed_paths_for_tool_result(tool_name: &str, output: &Value) -> Vec<String> {
+    let key = match tool_name {
+        "apply_unified_diff" => "affected_files",
+        "workspace_checkpoint_restore" => "changed_paths",
+        _ => return Vec::new(),
+    };
+    output
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|values| sanitize_observed_paths(values.iter().filter_map(Value::as_str)))
+        .unwrap_or_default()
 }
 
 /// Internal exploration classification derived from the canonical

--- a/src/tool_runtime/sessions/mod.rs
+++ b/src/tool_runtime/sessions/mod.rs
@@ -35,7 +35,7 @@ pub(crate) use console::{
     WorkflowSessionConsoleList, WorkflowSessionConsoleListItem,
 };
 pub(crate) use events::{
-    canonical_tool_call_finished_events, exploration_tool_kind,
+    canonical_tool_call_finished_events, current_attempt_event_view, exploration_tool_kind,
     is_tool_call_expectation_metadata_field, is_valid_session_id, normalize_observed_project_path,
     safe_model_facing_assertion_name, strip_tool_call_expectation_metadata,
     tool_failure_summary_from_events, tool_supports_model_facing_assertion_name,

--- a/src/tool_runtime/sessions/store.rs
+++ b/src/tool_runtime/sessions/store.rs
@@ -24,12 +24,13 @@ use super::console::{
     WorkflowSessionConsoleDetail, WorkflowSessionConsoleList,
 };
 use super::events::{
-    actual_failure_kind_for_tool_result, changed_paths_for_tool, classify_failure_expectation,
-    context_result_summary_for_tool_result, diff_review_like_for_tool, extract_job_id,
-    extract_project, is_valid_session_id, observed_input_paths_for_tool,
-    observed_paths_for_successful_result, persistent_shell_event_evidence_for_tool_result,
-    sanitize_tool_execution_state, session_input_summary_for_tool,
-    validation_output_summary_for_tool_result, SessionToolClassification,
+    actual_failure_kind_for_tool_result, changed_paths_for_tool, changed_paths_for_tool_result,
+    classify_failure_expectation, context_result_summary_for_tool_result,
+    diff_review_like_for_tool, extract_job_id, extract_project, is_valid_session_id,
+    observed_input_paths_for_tool, observed_paths_for_successful_result,
+    persistent_shell_event_evidence_for_tool_result, sanitize_tool_execution_state,
+    session_input_summary_for_tool, validation_output_summary_for_tool_result,
+    SessionToolClassification,
 };
 use super::model::{
     CodingSessionError, CodingSessionOutcome, CodingSessionRequest, ColdSessionRecord,
@@ -1558,6 +1559,12 @@ impl SessionStore {
         let persistent_shell =
             persistent_shell_event_evidence_for_tool_result(&start.tool_name, output);
         let effect_evidence = Self::tool_effect_event_evidence_for_result(output);
+        let mut changed_paths = start.changed_paths.clone();
+        for path in changed_paths_for_tool_result(&start.tool_name, output) {
+            if !changed_paths.iter().any(|existing| existing == &path) {
+                changed_paths.push(path);
+            }
+        }
         let event = SessionEvent {
             event_id,
             session_id: start.session_id,
@@ -1598,7 +1605,7 @@ impl SessionStore {
             session_project,
             request_project,
             error_message_summary,
-            changed_paths: start.changed_paths,
+            changed_paths,
             observed_paths,
             job_id: extract_job_id(output),
             persistent_shell,

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -124,6 +124,85 @@ fn changed_paths_single_path_and_path_list_from_metadata() {
 }
 
 #[test]
+fn apply_unified_diff_finished_event_records_trusted_result_changed_paths() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("demo".to_string()), Some("patch evidence".to_string()));
+    let start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "apply_unified_diff",
+        &json!({"project": "demo", "diff": "@@ -1 +1 @@\n-old\n+new\n"}),
+    );
+    store.record_tool_call_finished(
+        start,
+        true,
+        &json!({
+            "state_changed": true,
+            "affected_files": ["src/lib.rs", "src/lib.rs", "../escape.rs"]
+        }),
+        None,
+        None,
+    );
+
+    let summary = store.summary(&session.session_id, Some(20)).unwrap();
+    let finished = summary
+        .events
+        .iter()
+        .find(|event| event.kind == "tool_call_finished" && event.tool_name == "apply_unified_diff")
+        .unwrap();
+    assert_eq!(finished.changed_paths, vec!["src/lib.rs".to_string()]);
+    assert_eq!(
+        finished
+            .effect_evidence
+            .as_ref()
+            .and_then(|evidence| evidence.state_changed),
+        Some(true)
+    );
+}
+
+#[test]
+fn checkpoint_restore_finished_event_records_trusted_result_changed_paths() {
+    let store = SessionStore::default();
+    let session = store.start_session(
+        Some("demo".to_string()),
+        Some("restore evidence".to_string()),
+    );
+    let start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "workspace_checkpoint_restore",
+        &json!({"project": "demo", "checkpoint_id": "wc_ckpt_demo", "confirm": true}),
+    );
+    store.record_tool_call_finished(
+        start,
+        true,
+        &json!({
+            "state_changed": true,
+            "changed_paths": ["src/lib.rs", "src/lib.rs", "../escape.rs"]
+        }),
+        None,
+        None,
+    );
+
+    let summary = store.summary(&session.session_id, Some(20)).unwrap();
+    let finished = summary
+        .events
+        .iter()
+        .find(|event| {
+            event.kind == "tool_call_finished" && event.tool_name == "workspace_checkpoint_restore"
+        })
+        .unwrap();
+    assert_eq!(finished.changed_paths, vec!["src/lib.rs".to_string()]);
+    assert_eq!(
+        finished
+            .effect_evidence
+            .as_ref()
+            .and_then(|evidence| evidence.state_changed),
+        Some(true)
+    );
+}
+
+#[test]
 fn exploration_paths_are_normalized_and_reject_escape_absolute_and_uri_forms() {
     for (raw, expected) in [
         (
@@ -2786,7 +2865,7 @@ fn failure_history_legacy_event_without_effect_evidence_restores_conservatively(
     assert!(finished.effect_evidence.is_none());
     let projected = crate::tool_runtime::handoff::reconcile_closeout_evidence(
         &json!({"unexpected_count": 1}),
-        &summary.events,
+        &summary,
         &json!({}),
     )
     .tool_failures;

--- a/src/tool_runtime/startup_brief.rs
+++ b/src/tool_runtime/startup_brief.rs
@@ -70,7 +70,7 @@ pub(crate) fn builtin_coding_workflow_projection() -> Value {
                     "Close it end to end before local hardening.",
                     "Minimize new concepts, not touched-file count.",
                     "Use compiler/schema/exhaustiveness failures to find missing adapters and projections.",
-                    "When used, reuse the same assertion_name after a fix to resolve that validation identity.",
+                    "When intentionally rerunning the same logical validation, reuse assertion_name for strong correlation; do not rerun solely to clear stale historical validation evidence after material workspace changes.",
                     "After validation, review completeness, trust, bounds, privacy, and replay.",
                     "Fix discovered correctness issues; do not fragment the change around speculative concerns."
                 ]

--- a/src/tool_runtime/startup_brief.rs
+++ b/src/tool_runtime/startup_brief.rs
@@ -70,7 +70,7 @@ pub(crate) fn builtin_coding_workflow_projection() -> Value {
                     "Close it end to end before local hardening.",
                     "Minimize new concepts, not touched-file count.",
                     "Use compiler/schema/exhaustiveness failures to find missing adapters and projections.",
-                    "When intentionally rerunning the same logical validation, reuse assertion_name for strong correlation; do not rerun solely to clear stale historical validation evidence after material workspace changes.",
+                    "When intentionally rerunning the same logical validation, reuse the same assertion_name; do not rerun solely to clear stale historical validation evidence.",
                     "After validation, review completeness, trust, bounds, privacy, and replay.",
                     "Fix discovered correctness issues; do not fragment the change around speculative concerns."
                 ]

--- a/src/tool_runtime/tests/checkpoint.rs
+++ b/src/tool_runtime/tests/checkpoint.rs
@@ -642,6 +642,8 @@ async fn checkpoint_restore_tracked_changes() {
     .await;
     assert!(restored.success, "{:?}", restored.error);
     assert_eq!(restored.output["restored"], true);
+    assert_eq!(restored.output["state_changed"], true);
+    assert_eq!(restored.output["changed_paths"], json!(["a.txt"]));
     assert_eq!(restored.output["checkpoint_id"], checkpoint_id);
     assert_eq!(restored.output["session_recorded"], true);
     assert_eq!(
@@ -656,6 +658,14 @@ async fn checkpoint_restore_tracked_changes() {
     assert_eq!(event.status.as_deref(), Some("succeeded"));
     assert!(event.write_like);
     assert!(!event.read_like);
+    assert_eq!(event.changed_paths, vec!["a.txt".to_string()]);
+    assert_eq!(
+        event
+            .effect_evidence
+            .as_ref()
+            .and_then(|evidence| evidence.state_changed),
+        Some(true)
+    );
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -1,6 +1,7 @@
 use super::support::*;
 use crate::auth::AuthContext;
 use crate::shell_protocol::{AgentPolicySummary, ShellClientCapabilities};
+use crate::tool_runtime::handoff::VALIDATION_IDENTITY_REUSE_ACTION;
 use crate::tool_runtime::metadata::lookup_tool_metadata;
 use crate::tool_runtime::sessions::SessionTransport;
 use crate::tool_runtime::validation_parser::VALIDATION_OUTPUT_METADATA_ABSENT_REASON;
@@ -1765,9 +1766,76 @@ async fn finish_coding_task_does_not_resolve_a_different_validation_identity() {
     assert_reason_list_contains(
         &result.output["task_outcome"],
         "blocking_reasons",
-        "validation_mixed",
+        "validation_failed",
     );
     assert_finish_uses_canonical_outcomes(&result.output);
+}
+
+#[tokio::test]
+async fn finish_coding_task_historical_unresolved_current_pass_does_not_request_ledger_cleanup() {
+    let fixture = finish_summary_fixture("coding-finish-current-evidence-pass").await;
+
+    record_coding_task_tool_event(
+        &fixture.runtime,
+        &fixture.session_id,
+        "cargo_test",
+        json!({"project": fixture.project.clone()}),
+        false,
+        json!({"exit_code": 101, "failure_kind": "validation_failed"}),
+    );
+    record_coding_task_tool_event(
+        &fixture.runtime,
+        &fixture.session_id,
+        "apply_text_edits",
+        json!({
+            "project": fixture.project.clone(),
+            "changes": [{"kind": "edit", "path": "src/lib.rs"}]
+        }),
+        true,
+        json!({"state_changed": true}),
+    );
+    record_coding_task_tool_event(
+        &fixture.runtime,
+        &fixture.session_id,
+        "cargo_check",
+        json!({"project": fixture.project.clone()}),
+        true,
+        json!({"exit_code": 0}),
+    );
+
+    let result = finish_coding_task_summary_only_with_agent(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project,
+        fixture.session_id,
+        fixture.auth,
+    )
+    .await;
+
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["validation"]["status"], "mixed");
+    assert_eq!(result.output["validation"]["unresolved_failure_count"], 1);
+    assert_eq!(result.output["validation"]["current_status"], "passed");
+    assert_eq!(
+        result.output["validation"]["current_unresolved_failure_count"],
+        0
+    );
+    assert_eq!(result.output["validation"]["stale_failure_count"], 1);
+    assert_eq!(result.output["tool_failures"]["unexpected_count"], 1);
+    assert_eq!(
+        result.output["tool_failures"]["historical_non_actionable_count"],
+        1
+    );
+    assert_eq!(
+        result.output["tool_failures"]["actionable_unexpected_count"],
+        0
+    );
+    assert_eq!(result.output["task_outcome"]["status"], "pass");
+    assert_eq!(result.output["task_outcome"]["blocking"], false);
+    assert_action_list_not_contains(
+        &result.output["suggested_next_actions"],
+        VALIDATION_IDENTITY_REUSE_ACTION,
+    );
 }
 
 #[tokio::test]
@@ -1848,11 +1916,24 @@ async fn finish_coding_task_summary_only_passes_with_resolved_unexpected_cargo_f
         result.output["tool_failures"]["actionable_unexpected_count"],
         0
     );
-    assert_eq!(result.output["validation"]["status"], "passed");
+    assert_eq!(result.output["validation"]["status"], "mixed");
     assert_eq!(result.output["validation"]["latest_status"], "passed");
-    assert_eq!(full.output["validation"]["status"], "passed");
+    assert_eq!(result.output["validation"]["current_status"], "passed");
+    assert_eq!(
+        result.output["validation"]["current_unresolved_failure_count"],
+        0
+    );
+    assert_eq!(full.output["validation"]["status"], "mixed");
+    assert_eq!(
+        full.output["validation"]["current_evidence"]["status"],
+        "passed"
+    );
     assert!(handoff.success, "{:?}", handoff.error);
-    assert_eq!(handoff.output["validation"]["status"], "passed");
+    assert_eq!(handoff.output["validation"]["status"], "mixed");
+    assert_eq!(
+        handoff.output["validation"]["current_evidence"]["status"],
+        "passed"
+    );
     assert_eq!(
         handoff.output["validation"]["resolved_failures"]["count"],
         result.output["validation"]["resolved_failure_count"]
@@ -2142,10 +2223,15 @@ async fn finish_coding_task_resolved_history_keeps_real_workspace_advisory() {
     .await;
 
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["validation"]["status"], "passed");
+    assert_eq!(result.output["validation"]["status"], "mixed");
     assert_eq!(result.output["validation"]["latest_status"], "passed");
     assert_eq!(result.output["validation"]["resolved_failure_count"], 1);
     assert_eq!(result.output["validation"]["unresolved_failure_count"], 0);
+    assert_eq!(result.output["validation"]["current_status"], "passed");
+    assert_eq!(
+        result.output["validation"]["current_unresolved_failure_count"],
+        0
+    );
     assert!(result.output.get("evidence_history").is_none());
     assert_eq!(result.output["task_outcome"]["status"], "warn");
     assert_eq!(result.output["task_outcome"]["blocking"], false);
@@ -2204,10 +2290,15 @@ async fn finish_coding_task_resolved_history_keeps_real_tool_failure_blocking() 
     .await;
 
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["validation"]["status"], "passed");
+    assert_eq!(result.output["validation"]["status"], "mixed");
     assert_eq!(result.output["validation"]["latest_status"], "passed");
     assert_eq!(result.output["validation"]["resolved_failure_count"], 1);
     assert_eq!(result.output["validation"]["unresolved_failure_count"], 0);
+    assert_eq!(result.output["validation"]["current_status"], "passed");
+    assert_eq!(
+        result.output["validation"]["current_unresolved_failure_count"],
+        0
+    );
     assert!(result.output.get("evidence_history").is_none());
     assert_eq!(result.output["task_outcome"]["status"], "fail");
     assert_eq!(result.output["task_outcome"]["blocking"], true);

--- a/src/tool_runtime/tests/continuation_feedback.rs
+++ b/src/tool_runtime/tests/continuation_feedback.rs
@@ -2285,6 +2285,42 @@ fn is_meaningful(name: &str) -> bool {
         || runtime_tool_captures_validation_output(name)
 }
 
+#[test]
+fn current_validation_window_excludes_pre_mutation_failure_from_attempt_activity() {
+    let runtime = test_runtime();
+    let session = create_session(&runtime, "current validation window");
+    add_instruction(
+        &runtime,
+        &session,
+        "fix validation and continue",
+        SessionMode::Normal,
+    );
+    record_validation_event(
+        &runtime,
+        &session,
+        "cargo_test",
+        false,
+        test_output(0, 1, 0, &["tests::parser"]),
+    );
+    record_write(&runtime, &session, &["src/parser.rs"]);
+    record_validation_event(&runtime, &session, "cargo_check", true, check_output(0, 1));
+
+    let summary = runtime.sessions.summary(&session, Some(200)).unwrap();
+    let historical = validation_summary_from_events(&summary.events, 20);
+    assert_eq!(historical["status"], "mixed");
+    assert_eq!(historical["unresolved_failures"]["count"], 1);
+
+    let feedback = feedback_for(&runtime, &summary, "continued");
+    assert_eq!(feedback["attempt"]["activity"]["unresolved_failures"], 0);
+    assert_eq!(feedback["attempt"]["validation"]["status"], "passed");
+    assert_eq!(
+        feedback["attempt"]["validation"]["unresolved_failure_count"],
+        0
+    );
+    assert_eq!(feedback["attempt"]["validation"]["validation_events"], 1);
+    assert_eq!(feedback["attempt"]["validation"]["stale_failure_count"], 1);
+}
+
 // =========================================================================
 // Helpers
 // =========================================================================
@@ -2360,9 +2396,13 @@ fn record_write_for(runtime: &ToolRuntime, session_id: &str, project: &str, path
             "changes": changes,
         }),
     );
-    runtime
-        .sessions
-        .record_tool_call_finished(start, true, &json!({"applied": true}), None, None);
+    runtime.sessions.record_tool_call_finished(
+        start,
+        true,
+        &json!({"applied": true, "state_changed": true}),
+        None,
+        None,
+    );
 }
 
 fn record_exploration_event(

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -67,6 +67,7 @@ async fn write_project_file_with_session_id_records_changed_path_without_content
 
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["permission"]["required"], true);
+    assert_eq!(result.output["state_changed"], true);
     assert_eq!(result.output["permission"]["policy"], "trusted_agent");
     assert_eq!(result.output["permission"]["status"], "auto_approved");
     assert_eq!(
@@ -82,6 +83,13 @@ async fn write_project_file_with_session_id_records_changed_path_without_content
     let event = finished_event(&summary, "write_project_file");
     assert!(event.write_like);
     assert_eq!(event.changed_paths, vec!["src/new.txt".to_string()]);
+    assert_eq!(
+        event
+            .effect_evidence
+            .as_ref()
+            .and_then(|evidence| evidence.state_changed),
+        Some(true)
+    );
     let permission = event.permission.as_ref().expect("permission metadata");
     assert!(permission.required);
     assert_eq!(permission.policy, "trusted_agent");
@@ -200,6 +208,7 @@ async fn delete_project_files_capable_agent_uses_structured_delete_without_outpu
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["ok"], true);
+    assert_eq!(result.output["state_changed"], true);
     assert_eq!(result.output["deleted_paths"], json!(["tmp.txt"]));
     assert_eq!(result.output["missing_paths"], json!([]));
     assert_eq!(result.output["refused_paths"], json!([]));

--- a/src/tool_runtime/tests/handoff.rs
+++ b/src/tool_runtime/tests/handoff.rs
@@ -2119,8 +2119,194 @@ async fn session_handoff_does_not_resolve_a_different_validation_identity() {
     assert_eq!(result.output["evidence_integrity"]["status"], "clean");
     assert_eq!(verdict["status"], "fail");
     assert_eq!(verdict["blocking"], true);
-    assert_reason_list_contains(verdict, "blocking_reasons", "validation_mixed");
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["status"],
+        "failed"
+    );
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["unresolved_failure_count"],
+        1
+    );
+    assert_reason_list_contains(verdict, "blocking_reasons", "validation_failed");
     assert_action_list_contains(
+        &result.output["suggested_next_actions"],
+        VALIDATION_IDENTITY_REUSE_ACTION,
+    );
+}
+
+#[tokio::test]
+async fn session_handoff_historical_mixed_current_pass_does_not_block_closeout() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "README.md", "hello\n", "initial");
+    let runtime = test_runtime();
+    let project = register_agent_project_at_path(
+        &runtime,
+        "handoff-current-evidence-pass",
+        "demo",
+        tmp.path(),
+    )
+    .await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("current validation evidence pass".to_string()),
+    );
+    let sid = session.session_id.clone();
+
+    record_handoff_tool_event(
+        &runtime,
+        &sid,
+        "cargo_test",
+        json!({"project": project.clone()}),
+        false,
+        json!({"exit_code": 101, "failure_kind": "validation_failed"}),
+    );
+    record_handoff_tool_event(
+        &runtime,
+        &sid,
+        "apply_text_edits",
+        json!({
+            "project": project.clone(),
+            "changes": [{"kind": "edit", "path": "src/lib.rs"}]
+        }),
+        true,
+        json!({"state_changed": true}),
+    );
+    record_handoff_tool_event(
+        &runtime,
+        &sid,
+        "cargo_check",
+        json!({"project": project.clone()}),
+        true,
+        json!({"exit_code": 0}),
+    );
+
+    let result = dispatch_handoff_summary_only_with_agent(
+        &runtime,
+        "handoff-current-evidence-pass",
+        sid,
+        Some(project),
+        true,
+        false,
+    )
+    .await;
+
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["validation"]["status"], "mixed");
+    assert_eq!(
+        result.output["validation"]["historical_failures"]["unresolved"],
+        true
+    );
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["status"],
+        "passed"
+    );
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+    assert_eq!(result.output["tool_failures"]["unexpected_count"], 1);
+    assert_eq!(
+        result.output["tool_failures"]["historical_non_actionable_count"],
+        1
+    );
+    assert_eq!(
+        result.output["tool_failures"]["actionable_unexpected_count"],
+        0
+    );
+    assert_eq!(result.output["task_outcome"]["status"], "pass");
+    assert_eq!(result.output["task_outcome"]["blocking"], false);
+    assert_eq!(
+        result.output["evidence_history"]["status"],
+        "mixed_unresolved"
+    );
+    assert_reason_list_not_contains(
+        &result.output["task_outcome"],
+        "blocking_reasons",
+        "validation_failed",
+    );
+    assert_action_list_not_contains(
+        &result.output["suggested_next_actions"],
+        VALIDATION_IDENTITY_REUSE_ACTION,
+    );
+}
+
+#[tokio::test]
+async fn session_handoff_stale_validation_after_content_change_warns_without_blocking() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "README.md", "hello\n", "initial");
+    let runtime = test_runtime();
+    let project = register_agent_project_at_path(
+        &runtime,
+        "handoff-current-evidence-stale",
+        "demo",
+        tmp.path(),
+    )
+    .await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("stale validation handoff".to_string()),
+    );
+    let sid = session.session_id.clone();
+
+    record_handoff_tool_event(
+        &runtime,
+        &sid,
+        "cargo_test",
+        json!({"project": project.clone()}),
+        false,
+        json!({"exit_code": 101, "failure_kind": "validation_failed"}),
+    );
+    record_handoff_tool_event(
+        &runtime,
+        &sid,
+        "apply_text_edits",
+        json!({
+            "project": project.clone(),
+            "changes": [{"kind": "edit", "path": "src/lib.rs"}]
+        }),
+        true,
+        json!({"state_changed": true}),
+    );
+
+    let result = dispatch_handoff_summary_only_with_agent(
+        &runtime,
+        "handoff-current-evidence-stale",
+        sid,
+        Some(project),
+        true,
+        false,
+    )
+    .await;
+
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["validation"]["status"], "failed");
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["status"],
+        "stale"
+    );
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+    assert_eq!(
+        result.output["tool_failures"]["actionable_unexpected_count"],
+        0
+    );
+    assert_eq!(result.output["task_outcome"]["status"], "warn");
+    assert_eq!(result.output["task_outcome"]["blocking"], false);
+    assert_reason_list_contains(
+        &result.output["task_outcome"],
+        "warning_reasons",
+        "validation_stale_after_changes",
+    );
+    assert_reason_list_not_contains(
+        &result.output["task_outcome"],
+        "blocking_reasons",
+        "validation_failed",
+    );
+    assert_action_list_not_contains(
         &result.output["suggested_next_actions"],
         VALIDATION_IDENTITY_REUSE_ACTION,
     );
@@ -2284,8 +2470,16 @@ async fn session_handoff_summary_only_passes_with_resolved_unexpected_cargo_test
         result.output["tool_failures"]["actionable_unexpected_count"],
         0
     );
-    assert_eq!(result.output["validation"]["status"], "passed");
+    assert_eq!(result.output["validation"]["status"], "mixed");
     assert_eq!(result.output["validation"]["latest_status"], "passed");
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["status"],
+        "passed"
+    );
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["unresolved_failure_count"],
+        0
+    );
     assert_eq!(
         result.output["validation"]["historical_failures"]["resolved"],
         true
@@ -2580,7 +2774,11 @@ async fn session_handoff_summary_only_verdict_fails_for_unresolved_mixed_validat
     );
     assert_eq!(verdict["status"], "fail");
     assert_eq!(verdict["blocking"], true);
-    assert_reason_list_contains(verdict, "blocking_reasons", "validation_mixed");
+    assert_eq!(
+        result.output["validation"]["current_evidence"]["status"],
+        "failed"
+    );
+    assert_reason_list_contains(verdict, "blocking_reasons", "validation_failed");
     assert_reason_list_not_contains(
         verdict,
         "warning_reasons",

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -1066,6 +1066,27 @@ async fn read_files_recovery_handoff_and_attention_overlays_stay_bounded() {
                 .unwrap();
         }
     }
+    // Seed an explicit retained attempt boundary after the deliberately large
+    // historical overlay. Current validation evidence must not infer a complete
+    // attempt from a truncated Session tail.
+    runtime
+        .sessions
+        .ensure_coding_session(crate::tool_runtime::sessions::CodingSessionRequest {
+            project: project.clone(),
+            authority_fingerprint:
+                crate::tool_runtime::sessions::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT
+                    .to_string(),
+            resume_session_id: Some(session.session_id.clone()),
+            instruction: Some("validate bounded recovery overlays".to_string()),
+            mode: crate::tool_runtime::SessionMode::Normal,
+            guards: crate::tool_runtime::sessions::SessionGuards::default(),
+            execution_context: None,
+            project_instructions: None,
+            transport: crate::tool_runtime::sessions::SessionTransport::Api,
+            context_refreshed: true,
+            write_scope_verified: true,
+        })
+        .unwrap();
     let assertion_name = "recovery websocket validation";
     let validation_request = json!({
         "project": project,

--- a/src/tool_runtime/tests/startup_brief.rs
+++ b/src/tool_runtime/tests/startup_brief.rs
@@ -152,14 +152,21 @@ fn assert_builtin_workflow(output: &Value) {
                 <= crate::tool_runtime::startup_brief::BUILTIN_CODING_WORKFLOW_MAX_GUIDANCE_ITEMS
         );
     }
-    assert!(workflow["roles"]["implementation_owner"]["guidance"]
+    let implementation_guidance = workflow["roles"]["implementation_owner"]["guidance"]
         .as_array()
-        .unwrap()
-        .iter()
-        .any(|item| item.as_str().is_some_and(|value| {
-            value.contains("reuse the same assertion_name")
-                && value.contains("resolve that validation identity")
-        })));
+        .unwrap();
+    assert!(implementation_guidance.iter().any(|item| {
+        item.as_str().is_some_and(|value| {
+            value.contains("intentionally rerunning the same logical validation")
+                && value.contains("reuse assertion_name for strong correlation")
+                && value
+                    .contains("do not rerun solely to clear stale historical validation evidence")
+        })
+    }));
+    assert!(!implementation_guidance.iter().any(|item| {
+        item.as_str()
+            .is_some_and(|value| value.contains("resolve that validation identity"))
+    }));
     let serialized = workflow.to_string();
     for forbidden in ["ChatGPT", "browser", "another window", "online", "offline"] {
         assert!(

--- a/src/tool_runtime/tests/startup_brief.rs
+++ b/src/tool_runtime/tests/startup_brief.rs
@@ -158,7 +158,7 @@ fn assert_builtin_workflow(output: &Value) {
     assert!(implementation_guidance.iter().any(|item| {
         item.as_str().is_some_and(|value| {
             value.contains("intentionally rerunning the same logical validation")
-                && value.contains("reuse assertion_name for strong correlation")
+                && value.contains("reuse the same assertion_name")
                 && value
                     .contains("do not rerun solely to clear stale historical validation evidence")
         })

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -2618,6 +2618,159 @@ fn current_evidence_failure_then_content_change_then_different_success_passes() 
 }
 
 #[test]
+fn current_evidence_validation_started_before_content_change_then_pass_is_stale() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    let validation_start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "cargo_check",
+        &json!({"project": "agent:eval:demo"}),
+    );
+    record_content_mutation(&store, &session.session_id, true);
+    store.record_tool_call_finished(validation_start, true, &json!({"exit_code": 0}), None, None);
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "passed");
+    assert_eq!(validation["current_evidence"]["status"], "stale");
+    assert_eq!(validation["current_evidence"]["events_total"], 0);
+    assert_eq!(
+        validation["current_evidence"]["evidence_after_latest_content_change"],
+        false
+    );
+}
+
+#[test]
+fn current_evidence_validation_started_before_content_change_then_fail_is_stale() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    let validation_start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "cargo_test",
+        &json!({"project": "agent:eval:demo"}),
+    );
+    record_content_mutation(&store, &session.session_id, true);
+    store.record_tool_call_finished(
+        validation_start,
+        false,
+        &json!({"exit_code": 101, "failure_kind": "validation_failed"}),
+        Some("validation failed"),
+        None,
+    );
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "failed");
+    assert_eq!(validation["unresolved_failures"]["count"], 1);
+    assert_eq!(validation["current_evidence"]["status"], "stale");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+    assert_eq!(validation["current_evidence"]["stale_failure_count"], 1);
+}
+
+#[test]
+fn current_evidence_validation_started_after_content_change_can_pass() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_content_mutation(&store, &session.session_id, true);
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["current_evidence"]["status"], "passed");
+    assert_eq!(validation["current_evidence"]["events_total"], 1);
+    assert_eq!(
+        validation["current_evidence"]["evidence_after_latest_content_change"],
+        true
+    );
+}
+
+#[test]
+fn current_evidence_validation_started_before_new_attempt_does_not_enter_new_attempt() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    let validation_start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "cargo_check",
+        &json!({"project": "agent:eval:demo"}),
+    );
+    record_task_instruction(&store, &session.session_id, "review current workspace");
+    store.record_tool_call_finished(validation_start, true, &json!({"exit_code": 0}), None, None);
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "passed");
+    assert_eq!(validation["current_evidence"]["status"], "not_run");
+    assert_eq!(validation["current_evidence"]["events_total"], 0);
+}
+
+#[test]
+fn current_evidence_validation_job_started_before_content_change_is_stale() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    let job_id = "job_current_evidence_overlap";
+    let validation_start = store.record_tool_call_started(
+        Some(&session.session_id),
+        SessionTransport::Api,
+        "cargo_check",
+        &json!({"project": "agent:eval:demo"}),
+    );
+    store.record_tool_call_finished(
+        validation_start,
+        true,
+        &json!({"job_id": job_id, "execution_state": "started"}),
+        None,
+        None,
+    );
+    record_content_mutation(&store, &session.session_id, true);
+    assert!(store.record_validation_job_terminal(
+        &session.session_id,
+        job_id,
+        &[job_id],
+        "cargo_check",
+        Some("agent:eval:demo".to_string()),
+        "target:aaaaaaaaaaaaaaaaaaaaaaaa",
+        None,
+        "completed",
+        Some(0),
+        Some(true),
+        Some(100),
+        Some(110),
+        Some(10_000),
+        None,
+    ));
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "passed");
+    assert_eq!(validation["current_evidence"]["status"], "stale");
+    assert_eq!(validation["current_evidence"]["events_total"], 0);
+}
+
+#[test]
+fn current_evidence_legacy_validation_without_exact_start_correlation_is_not_current() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let mut summary = store.summary(&session.session_id, Some(50)).unwrap();
+    for event in &mut summary.events {
+        if event.tool_name == "cargo_check" {
+            event.call_id = None;
+        }
+    }
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "passed");
+    assert_eq!(validation["current_evidence"]["status"], "not_run");
+    assert_eq!(validation["current_evidence"]["events_total"], 0);
+}
+
+#[test]
 fn current_evidence_different_success_without_mutation_keeps_failure_open() {
     let store = SessionStore::default();
     let session = store.start_session(Some("agent:eval:demo".to_string()), None);

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -1,6 +1,8 @@
 use super::support::*;
 use crate::tool_runtime::cargo::parse_cargo_test_run_metadata;
-use crate::tool_runtime::sessions::{SessionStore, SessionTransport, MAX_VALIDATION_EXCERPT_CHARS};
+use crate::tool_runtime::sessions::{
+    self, SessionGuards, SessionStore, SessionTransport, MAX_VALIDATION_EXCERPT_CHARS,
+};
 use crate::tool_runtime::validation_events::{
     validation_kind_for_tool, validation_summary_for_session,
 };
@@ -2588,6 +2590,283 @@ async fn finish_coding_task_validation_available_when_ledger_has_validation_even
     );
     assert!(finish_compact.output["validation"].get("events").is_none());
     assert!(finish_compact.output["validation"].get("latest").is_none());
+}
+
+#[test]
+fn current_evidence_failure_then_content_change_then_different_success_passes() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_content_mutation(&store, &session.session_id, true);
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "mixed");
+    assert_eq!(validation["historical_failures"]["count"], 1);
+    assert_eq!(validation["unresolved_failures"]["count"], 1);
+    assert_eq!(validation["current_evidence"]["status"], "passed");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+    assert_eq!(validation["current_evidence"]["stale_failure_count"], 1);
+    assert_eq!(
+        validation["current_evidence"]["boundary_reason"],
+        "workspace_content_changed"
+    );
+}
+
+#[test]
+fn current_evidence_different_success_without_mutation_keeps_failure_open() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["current_evidence"]["status"], "failed");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        1
+    );
+    assert_eq!(validation["current_evidence"]["stale_failure_count"], 0);
+    assert_eq!(
+        validation["current_evidence"]["boundary_reason"],
+        "attempt_start"
+    );
+}
+
+#[test]
+fn current_evidence_same_identity_failure_success_resolves_inside_window() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_check");
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "mixed");
+    assert_eq!(validation["resolved_failures"]["count"], 1);
+    assert_eq!(validation["unresolved_failures"]["count"], 0);
+    assert_eq!(validation["current_evidence"]["status"], "passed");
+    assert_eq!(validation["current_evidence"]["resolved_failure_count"], 1);
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+}
+
+#[test]
+fn current_evidence_pass_then_content_change_is_stale() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_success(&store, &session.session_id, "cargo_check");
+    record_content_mutation(&store, &session.session_id, true);
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "passed");
+    assert_eq!(validation["current_evidence"]["status"], "stale");
+    assert_eq!(validation["current_evidence"]["events_total"], 0);
+    assert_eq!(
+        validation["current_evidence"]["evidence_after_latest_content_change"],
+        false
+    );
+}
+
+#[test]
+fn current_evidence_failure_then_content_change_without_validation_is_stale_not_failed() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_content_mutation(&store, &session.session_id, true);
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "failed");
+    assert_eq!(validation["unresolved_failures"]["count"], 1);
+    assert_eq!(validation["current_evidence"]["status"], "stale");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+    assert_eq!(validation["current_evidence"]["stale_failure_count"], 1);
+}
+
+#[test]
+fn current_evidence_failed_noop_mutation_does_not_reset() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_finished_tool(
+        &store,
+        &session.session_id,
+        "apply_text_edits",
+        json!({"project": "agent:eval:demo", "changes": [{"kind": "edit", "path": "src/lib.rs"}]}),
+        false,
+        json!({"state_changed": false, "failure_kind": "stale_precondition"}),
+    );
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["current_evidence"]["status"], "failed");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        1
+    );
+}
+
+#[test]
+fn current_evidence_metadata_only_state_change_does_not_reset() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_finished_tool(
+        &store,
+        &session.session_id,
+        "git_push",
+        json!({"project": "agent:eval:demo"}),
+        true,
+        json!({"state_changed": true}),
+    );
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["current_evidence"]["status"], "failed");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        1
+    );
+    assert_eq!(
+        validation["current_evidence"]["boundary_reason"],
+        "attempt_start"
+    );
+}
+
+#[test]
+fn current_evidence_second_content_change_resets_post_first_change_validation() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_content_mutation(&store, &session.session_id, true);
+    record_validation_success(&store, &session.session_id, "cargo_check");
+    record_content_mutation(&store, &session.session_id, true);
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["current_evidence"]["status"], "stale");
+    assert_eq!(validation["current_evidence"]["events_total"], 0);
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+}
+
+#[test]
+fn current_evidence_old_attempt_failure_is_excluded() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_task_instruction(&store, &session.session_id, "review current workspace");
+    record_finished_tool(
+        &store,
+        &session.session_id,
+        "read_file",
+        json!({"project": "agent:eval:demo", "path": "src/lib.rs"}),
+        true,
+        json!({}),
+    );
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["status"], "failed");
+    assert_eq!(validation["unresolved_failures"]["count"], 1);
+    assert_eq!(validation["current_evidence"]["status"], "not_run");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        0
+    );
+}
+
+#[test]
+fn current_evidence_legacy_mutation_without_effect_proof_is_conservative() {
+    let store = SessionStore::default();
+    let session = store.start_session(Some("agent:eval:demo".to_string()), None);
+    record_validation_failure(&store, &session.session_id, "cargo_test");
+    record_content_mutation(&store, &session.session_id, false);
+    record_validation_success(&store, &session.session_id, "cargo_check");
+
+    let summary = store.summary(&session.session_id, Some(50)).unwrap();
+    let validation = validation_summary_for_session(&summary);
+    assert_eq!(validation["current_evidence"]["status"], "failed");
+    assert_eq!(
+        validation["current_evidence"]["unresolved_failure_count"],
+        1
+    );
+    assert_eq!(
+        validation["current_evidence"]["boundary_reason"],
+        "attempt_start"
+    );
+}
+
+fn record_validation_failure(store: &SessionStore, session_id: &str, tool_name: &str) {
+    record_finished_tool(
+        store,
+        session_id,
+        tool_name,
+        json!({"project": "agent:eval:demo"}),
+        false,
+        json!({"exit_code": 101, "failure_kind": "validation_failed"}),
+    );
+}
+
+fn record_validation_success(store: &SessionStore, session_id: &str, tool_name: &str) {
+    record_finished_tool(
+        store,
+        session_id,
+        tool_name,
+        json!({"project": "agent:eval:demo"}),
+        true,
+        json!({"exit_code": 0}),
+    );
+}
+
+fn record_content_mutation(store: &SessionStore, session_id: &str, proven: bool) {
+    record_finished_tool(
+        store,
+        session_id,
+        "apply_text_edits",
+        json!({"project": "agent:eval:demo", "changes": [{"kind": "edit", "path": "src/lib.rs"}]}),
+        true,
+        if proven {
+            json!({"state_changed": true})
+        } else {
+            json!({})
+        },
+    );
+}
+
+fn record_task_instruction(store: &SessionStore, session_id: &str, instruction: &str) {
+    store
+        .ensure_coding_session(sessions::CodingSessionRequest {
+            project: "agent:eval:demo".to_string(),
+            authority_fingerprint: sessions::TEST_ONLY_PROJECT_SESSION_AUTHORITY_FINGERPRINT
+                .to_string(),
+            resume_session_id: Some(session_id.to_string()),
+            instruction: Some(instruction.to_string()),
+            mode: SessionMode::Normal,
+            guards: SessionGuards::default(),
+            execution_context: None,
+            project_instructions: None,
+            transport: SessionTransport::Api,
+            context_refreshed: true,
+            write_scope_verified: true,
+        })
+        .unwrap();
 }
 
 fn record_finished_tool(

--- a/src/tool_runtime/validation_events.rs
+++ b/src/tool_runtime/validation_events.rs
@@ -686,15 +686,21 @@ fn validation_summary_for_session_events(
     limit: usize,
 ) -> Value {
     let mut historical = validation_summary_from_events(events, limit);
-    let mut projected_summary = summary.clone();
-    projected_summary.events = events.to_vec();
-    let current = current_validation_evidence_for_session(&projected_summary, limit);
+    let current = current_validation_evidence_for_events(summary, events, limit);
     historical["current_evidence"] = current.evidence;
     historical
 }
 
 pub(crate) fn current_validation_evidence_for_session(
     summary: &SessionSummary,
+    limit: usize,
+) -> CurrentValidationEvidenceProjection {
+    current_validation_evidence_for_events(summary, &summary.events, limit)
+}
+
+fn current_validation_evidence_for_events(
+    summary: &SessionSummary,
+    events: &[SessionEvent],
     limit: usize,
 ) -> CurrentValidationEvidenceProjection {
     let attempt = current_attempt_event_view(summary);
@@ -718,13 +724,67 @@ pub(crate) fn current_validation_evidence_for_session(
         };
     }
 
-    let reset_index = attempt
-        .semantic_events
+    // Attempt and mutation boundaries are durable ledger-order fences. A
+    // validation can prove the current workspace only when its exact execution
+    // start is after the effective fence; completing after the fence is not
+    // sufficient because the execution may have overlapped a content change.
+    let canonical_finished_ids = canonical_tool_call_finished_events(&summary.events)
+        .into_iter()
+        .map(|event| event.event_id.as_str())
+        .collect::<HashSet<_>>();
+    let reset_index = summary
+        .events
         .iter()
-        .rposition(material_workspace_content_change);
-    let current_start = reset_index.map(|index| index + 1).unwrap_or(0);
-    let current_events = &attempt.semantic_events[current_start..];
-    let current_validation = validation_summary_from_events(current_events, limit);
+        .enumerate()
+        .skip(attempt.attempt_start)
+        .filter(|(_, event)| {
+            event.kind != "tool_call_finished"
+                || canonical_finished_ids.contains(event.event_id.as_str())
+        })
+        .filter(|(_, event)| material_workspace_content_change(event))
+        .map(|(index, _)| index)
+        .last();
+    let effective_boundary_index = reset_index.or(attempt.boundary_event_index);
+
+    let validation_records = extract_validation_event_records(events);
+    let mut current_source_event_ids = HashSet::new();
+    let mut current_failure_ids = HashSet::new();
+    let mut stale_failure_count = 0usize;
+    let mut stale_validation_count = 0usize;
+
+    for record in &validation_records {
+        let start_index = authoritative_validation_start_event_index(&summary.events, record);
+        let started_in_attempt = start_index.is_some_and(|index| index >= attempt.attempt_start);
+        let started_after_boundary = start_index.is_some_and(|index| {
+            started_in_attempt && effective_boundary_index.is_none_or(|boundary| index > boundary)
+        });
+        if started_after_boundary {
+            current_source_event_ids.insert(record.source_event_id.clone());
+            if !record.event.success {
+                current_failure_ids.insert(record.source_event_id.clone());
+            }
+        } else if reset_index.is_some_and(|boundary| {
+            start_index.is_some_and(|index| index >= attempt.attempt_start && index <= boundary)
+        }) {
+            stale_validation_count += 1;
+            if !record.event.success {
+                stale_failure_count += 1;
+            }
+        }
+    }
+
+    // Keep all starts so exact call_id correlation and validation identity
+    // extraction remain unchanged, but admit only validation outcomes whose
+    // source execution was proven to start after the effective boundary.
+    let current_events = events
+        .iter()
+        .filter(|event| {
+            event.kind == "tool_call_started"
+                || current_source_event_ids.contains(event.event_id.as_str())
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let current_validation = validation_summary_from_events(&current_events, limit);
     let current_events_total = current_validation
         .get("events_total")
         .and_then(Value::as_u64)
@@ -745,21 +805,11 @@ pub(crate) fn current_validation_evidence_for_session(
         .pointer("/unresolved_failures/count")
         .and_then(Value::as_u64)
         .unwrap_or(0) as usize;
-    let stale_failure_count = reset_index
-        .map(|index| {
-            extract_validation_event_records(&attempt.semantic_events[..=index])
-                .into_iter()
-                .filter(|record| !record.event.success)
-                .count()
-        })
-        .unwrap_or(0);
-    let attempt_had_validation =
-        !extract_validation_event_records(&attempt.semantic_events).is_empty();
     let (status, reason) = if current_events_total > 0 && unresolved_failure_count > 0 {
         ("failed", Some("current_validation_failures"))
     } else if current_events_total > 0 && successes > 0 {
         ("passed", None)
-    } else if reset_index.is_some() && attempt_had_validation {
+    } else if reset_index.is_some() && stale_validation_count > 0 {
         ("stale", Some("validation_stale_after_changes"))
     } else if current_events_total == 0 {
         ("not_run", Some("no_validation_in_current_attempt"))
@@ -776,12 +826,7 @@ pub(crate) fn current_validation_evidence_for_session(
         "attempt_start"
     };
 
-    let current_failure_ids = extract_validation_event_records(current_events)
-        .into_iter()
-        .filter(|record| !record.event.success)
-        .map(|record| record.source_event_id)
-        .collect::<HashSet<_>>();
-    let non_current_failure_event_ids = extract_validation_event_records(&summary.events)
+    let non_current_failure_event_ids = validation_records
         .into_iter()
         .filter(|record| !record.event.success)
         .map(|record| record.source_event_id)
@@ -805,6 +850,52 @@ pub(crate) fn current_validation_evidence_for_session(
         current_validation,
         non_current_failure_event_ids,
     }
+}
+
+fn authoritative_validation_start_event_index(
+    ledger_events: &[SessionEvent],
+    record: &ExtractedValidationEvent,
+) -> Option<usize> {
+    let (source_index, source) = ledger_events
+        .iter()
+        .enumerate()
+        .find(|(_, event)| event.event_id == record.source_event_id)?;
+    match source.kind.as_str() {
+        "tool_call_finished" => exact_tool_start_event_index(ledger_events, source_index, source),
+        "validation_job_terminal" => {
+            let job_id = source.job_id.as_deref()?;
+            let (acceptance_index, acceptance) = ledger_events[..source_index]
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, event)| {
+                    event.kind == "tool_call_finished"
+                        && event.job_id.as_deref() == Some(job_id)
+                        && job_acceptance_only(event)
+                })?;
+            exact_tool_start_event_index(ledger_events, acceptance_index, acceptance)
+        }
+        _ => None,
+    }
+}
+
+fn exact_tool_start_event_index(
+    ledger_events: &[SessionEvent],
+    finish_index: usize,
+    finished: &SessionEvent,
+) -> Option<usize> {
+    let call_id = finished.call_id.as_deref()?;
+    ledger_events[..finish_index]
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, event)| {
+            event.kind == "tool_call_started"
+                && event.call_id.as_deref() == Some(call_id)
+                && event.session_id == finished.session_id
+                && event.tool_name == finished.tool_name
+        })
+        .map(|(index, _)| index)
 }
 
 fn material_workspace_content_change(event: &SessionEvent) -> bool {

--- a/src/tool_runtime/validation_events.rs
+++ b/src/tool_runtime/validation_events.rs
@@ -8,14 +8,15 @@
 use serde::Serialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::session_context::{
     session_project_mismatch_result, unknown_session_result, SessionProjectMismatch,
 };
 use super::sessions::{
-    canonical_tool_call_finished_events, safe_model_facing_assertion_name,
-    tool_supports_model_facing_assertion_name, SessionEvent, SessionSummary,
+    canonical_tool_call_finished_events, current_attempt_event_view,
+    safe_model_facing_assertion_name, tool_supports_model_facing_assertion_name, SessionEvent,
+    SessionSummary,
 };
 use super::tool_audit::{
     assertion_validation_identity, is_structured_validation_target_identity,
@@ -151,9 +152,22 @@ struct ValidationFailureSet {
     events: Vec<ValidationEvent>,
 }
 
+#[derive(Debug, Clone)]
+struct ExtractedValidationEvent {
+    source_event_id: String,
+    event: ValidationEvent,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CurrentValidationEvidenceProjection {
+    pub(crate) evidence: Value,
+    pub(crate) current_validation: Value,
+    pub(crate) non_current_failure_event_ids: HashSet<String>,
+}
+
 #[cfg(test)]
 pub(crate) fn validation_summary_for_session(summary: &SessionSummary) -> Value {
-    validation_summary_from_events(&summary.events, DEFAULT_VALIDATION_EVENT_LIMIT)
+    validation_summary_for_session_events(summary, &summary.events, DEFAULT_VALIDATION_EVENT_LIMIT)
 }
 
 impl ToolRuntime {
@@ -231,7 +245,7 @@ impl ToolRuntime {
                 event.finished_at.unwrap_or(event.timestamp),
             )
         });
-        validation_summary_from_events(&events, limit)
+        validation_summary_for_session_events(&refreshed, &events, limit)
     }
 
     /// Preserve generic `run_job` and promoted `run_shell` validation evidence without mixing
@@ -630,7 +644,7 @@ fn remove_public_validation_input_summaries(validation: &mut Value) {
 }
 
 pub(crate) fn skipped_validation_summary() -> Value {
-    to_value(ValidationSummary {
+    let mut validation = to_value(ValidationSummary {
         available: false,
         status: "unknown",
         reason: Some("validation_summary_not_requested"),
@@ -649,7 +663,158 @@ pub(crate) fn skipped_validation_summary() -> Value {
         parser: parser_unavailable(),
         cargo_test_zero_tests_run: false,
         skipped: true,
-    })
+    });
+    validation["current_evidence"] = json!({
+        "status": "unknown",
+        "reason": "validation_summary_not_requested",
+        "latest_status": "unknown",
+        "events_total": 0,
+        "successes": 0,
+        "failures": 0,
+        "resolved_failure_count": 0,
+        "unresolved_failure_count": 0,
+        "stale_failure_count": 0,
+        "evidence_after_latest_content_change": false,
+        "boundary_reason": "attempt_boundary_unavailable",
+    });
+    validation
+}
+
+fn validation_summary_for_session_events(
+    summary: &SessionSummary,
+    events: &[SessionEvent],
+    limit: usize,
+) -> Value {
+    let mut historical = validation_summary_from_events(events, limit);
+    let mut projected_summary = summary.clone();
+    projected_summary.events = events.to_vec();
+    let current = current_validation_evidence_for_session(&projected_summary, limit);
+    historical["current_evidence"] = current.evidence;
+    historical
+}
+
+pub(crate) fn current_validation_evidence_for_session(
+    summary: &SessionSummary,
+    limit: usize,
+) -> CurrentValidationEvidenceProjection {
+    let attempt = current_attempt_event_view(summary);
+    if !attempt.complete {
+        return CurrentValidationEvidenceProjection {
+            evidence: json!({
+                "status": "unknown",
+                "reason": "attempt_boundary_unavailable",
+                "latest_status": "unknown",
+                "events_total": 0,
+                "successes": 0,
+                "failures": 0,
+                "resolved_failure_count": 0,
+                "unresolved_failure_count": 0,
+                "stale_failure_count": 0,
+                "evidence_after_latest_content_change": false,
+                "boundary_reason": "attempt_boundary_unavailable",
+            }),
+            current_validation: validation_summary_from_events(&[], limit),
+            non_current_failure_event_ids: HashSet::new(),
+        };
+    }
+
+    let reset_index = attempt
+        .semantic_events
+        .iter()
+        .rposition(material_workspace_content_change);
+    let current_start = reset_index.map(|index| index + 1).unwrap_or(0);
+    let current_events = &attempt.semantic_events[current_start..];
+    let current_validation = validation_summary_from_events(current_events, limit);
+    let current_events_total = current_validation
+        .get("events_total")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let successes = current_validation
+        .get("successes")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let failures = current_validation
+        .get("failures")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let resolved_failure_count = current_validation
+        .pointer("/resolved_failures/count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let unresolved_failure_count = current_validation
+        .pointer("/unresolved_failures/count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let stale_failure_count = reset_index
+        .map(|index| {
+            extract_validation_event_records(&attempt.semantic_events[..=index])
+                .into_iter()
+                .filter(|record| !record.event.success)
+                .count()
+        })
+        .unwrap_or(0);
+    let attempt_had_validation =
+        !extract_validation_event_records(&attempt.semantic_events).is_empty();
+    let (status, reason) = if current_events_total > 0 && unresolved_failure_count > 0 {
+        ("failed", Some("current_validation_failures"))
+    } else if current_events_total > 0 && successes > 0 {
+        ("passed", None)
+    } else if reset_index.is_some() && attempt_had_validation {
+        ("stale", Some("validation_stale_after_changes"))
+    } else if current_events_total == 0 {
+        ("not_run", Some("no_validation_in_current_attempt"))
+    } else {
+        ("unknown", Some("current_validation_evidence_unknown"))
+    };
+    let latest_status = current_validation
+        .get("latest_status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let boundary_reason = if reset_index.is_some() {
+        "workspace_content_changed"
+    } else {
+        "attempt_start"
+    };
+
+    let current_failure_ids = extract_validation_event_records(current_events)
+        .into_iter()
+        .filter(|record| !record.event.success)
+        .map(|record| record.source_event_id)
+        .collect::<HashSet<_>>();
+    let non_current_failure_event_ids = extract_validation_event_records(&summary.events)
+        .into_iter()
+        .filter(|record| !record.event.success)
+        .map(|record| record.source_event_id)
+        .filter(|event_id| !current_failure_ids.contains(event_id))
+        .collect();
+
+    CurrentValidationEvidenceProjection {
+        evidence: json!({
+            "status": status,
+            "reason": reason,
+            "latest_status": latest_status,
+            "events_total": current_events_total,
+            "successes": successes,
+            "failures": failures,
+            "resolved_failure_count": resolved_failure_count,
+            "unresolved_failure_count": unresolved_failure_count,
+            "stale_failure_count": stale_failure_count,
+            "evidence_after_latest_content_change": reset_index.is_some() && current_events_total > 0,
+            "boundary_reason": boundary_reason,
+        }),
+        current_validation,
+        non_current_failure_event_ids,
+    }
+}
+
+fn material_workspace_content_change(event: &SessionEvent) -> bool {
+    event.kind == "tool_call_finished"
+        && event
+            .effect_evidence
+            .as_ref()
+            .and_then(|evidence| evidence.state_changed)
+            == Some(true)
+        && !event.changed_paths.is_empty()
 }
 
 pub(crate) fn validation_summary_from_events(events: &[SessionEvent], limit: usize) -> Value {
@@ -854,13 +1019,20 @@ fn no_failures() -> ValidationFailureSet {
 }
 
 pub(crate) fn extract_validation_events(events: &[SessionEvent]) -> Vec<ValidationEvent> {
+    extract_validation_event_records(events)
+        .into_iter()
+        .map(|record| record.event)
+        .collect()
+}
+
+fn extract_validation_event_records(events: &[SessionEvent]) -> Vec<ExtractedValidationEvent> {
     let mut started = Vec::new();
     let mut validation_events = Vec::new();
-    let mut terminal_jobs = std::collections::HashSet::new();
+    let mut terminal_jobs = HashSet::new();
     let canonical_finished_ids = canonical_tool_call_finished_events(events)
         .into_iter()
         .map(|event| event.event_id.as_str())
-        .collect::<std::collections::HashSet<_>>();
+        .collect::<HashSet<_>>();
 
     for event in events {
         match event.kind.as_str() {
@@ -882,7 +1054,10 @@ pub(crate) fn extract_validation_events(events: &[SessionEvent]) -> Vec<Validati
                 if let Some(validation_event) =
                     validation_event_from_finished(event, start.as_ref())
                 {
-                    validation_events.push(validation_event);
+                    validation_events.push(ExtractedValidationEvent {
+                        source_event_id: event.event_id.clone(),
+                        event: validation_event,
+                    });
                 }
             }
             "validation_job_terminal" => {
@@ -893,7 +1068,10 @@ pub(crate) fn extract_validation_events(events: &[SessionEvent]) -> Vec<Validati
                     continue;
                 }
                 if let Some(validation_event) = validation_event_from_finished(event, Some(event)) {
-                    validation_events.push(validation_event);
+                    validation_events.push(ExtractedValidationEvent {
+                        source_event_id: event.event_id.clone(),
+                        event: validation_event,
+                    });
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary

- separate immutable validation audit history from current workspace delivery evidence
- reset current validation evidence only on trusted material workspace-content mutations
- drive closeout, handoff, and continuation from current evidence while retaining historical failures
- fence current validation on exact execution start so validations overlapping a mutation or attempt boundary cannot prove the newer workspace
- propagate authoritative changed-path/effect evidence for supported mutation tools

## Validation

- `cargo test -p webcodex current_evidence_ --lib -- --nocapture` — 16 passed
- `completed_run_job_validation_enters_handoff_from_job_authority` — passed
- `promoted_run_process_cargo_test_materializes_canonical_validation_evidence` — passed
- `current_evidence_validation_job_started_before_content_change_is_stale` — passed
- `current_evidence_validation_started_before_new_attempt_does_not_enter_new_attempt` — passed
- `cargo check -p webcodex --all-targets` — passed (4 pre-existing `agent_wake` dead-code warnings)
- `cargo fmt --all -- --check` — passed
- `git diff --check origin/main..HEAD` — passed
- workspace hygiene — clean
