### PR TITLE
Harden CodingAgent observation monotonicity

### DIFF
--- a/crates/webcodex-core/src/coding_agent.rs
+++ b/crates/webcodex-core/src/coding_agent.rs
@@ -736,8 +736,30 @@ pub fn validate_coding_agent_run_transition(
     if incoming.observation_revision <= stored.observation_revision {
         return Err("CodingAgentRun transition does not advance observation revision".to_string());
     }
-    if stored.state.terminal() {
-        return Err("terminal CodingAgentRun observation cannot advance to new truth".to_string());
+    if matches!(
+        stored.state,
+        CodingAgentRunState::Completed
+            | CodingAgentRunState::Failed
+            | CodingAgentRunState::Cancelled
+    ) {
+        return Err(
+            "definitive terminal CodingAgentRun observation cannot advance to new truth"
+                .to_string(),
+        );
+    }
+    if stored.state == CodingAgentRunState::Lost
+        && !matches!(
+            incoming.state,
+            CodingAgentRunState::Lost
+                | CodingAgentRunState::Completed
+                | CodingAgentRunState::Failed
+                | CodingAgentRunState::Cancelled
+        )
+    {
+        return Err(
+            "lost CodingAgentRun may only reconcile to newer lost or definitive terminal truth"
+                .to_string(),
+        );
     }
     if stored.state != CodingAgentRunState::Starting
         && incoming.state == CodingAgentRunState::Starting
@@ -1210,6 +1232,35 @@ mod tests {
         terminal_regression.observation_revision = 3;
         terminal_regression.updated_at = 3;
         assert!(merge_coding_agent_run_snapshot(&completed, &terminal_regression).is_err());
+
+        let mut lost = snapshot(
+            CodingAgentRunState::Lost,
+            CodingAgentExecutionState::OutcomeUnknown,
+            None,
+            Some("coding_agent_transport_lost"),
+        );
+        lost.observation_revision = 2;
+        lost.updated_at = 2;
+        lost.terminal.as_mut().unwrap().completed_at = 2;
+        assert_eq!(
+            merge_coding_agent_run_snapshot(&running, &lost).unwrap(),
+            CodingAgentObservationMerge::Advance
+        );
+
+        let mut completed_after_lost = completed.clone();
+        completed_after_lost.observation_revision = 4;
+        completed_after_lost.updated_at = 4;
+        completed_after_lost.terminal.as_mut().unwrap().completed_at = 4;
+        assert_eq!(
+            merge_coding_agent_run_snapshot(&lost, &completed_after_lost).unwrap(),
+            CodingAgentObservationMerge::Advance,
+            "Lost is outcome-unknown recovery state, not definitive effect truth"
+        );
+
+        let mut active_after_lost = running.clone();
+        active_after_lost.observation_revision = 3;
+        active_after_lost.updated_at = 3;
+        assert!(merge_coding_agent_run_snapshot(&lost, &active_after_lost).is_err());
 
         let mut execution_regression = running.clone();
         execution_regression.observation_revision = 2;

--- a/crates/webcodex-core/src/coding_agent.rs
+++ b/crates/webcodex-core/src/coding_agent.rs
@@ -195,6 +195,13 @@ pub struct CodingAgentRunSnapshot {
     pub terminal: Option<CodingAgentTerminal>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodingAgentObservationMerge {
+    Stale,
+    ExactReplay,
+    Advance,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodingAgentRunInventory {
@@ -668,6 +675,105 @@ pub fn validate_coding_agent_run_snapshot(run: &CodingAgentRunSnapshot) -> Resul
     Ok(())
 }
 
+/// Classify one newer observation against the canonical snapshot already retained
+/// for the same CodingAgentRun. Revision ordering is authoritative: stale snapshots
+/// are ignored, exact same-revision replays are idempotent, conflicting same-revision
+/// truth fails closed, and only legal higher-revision state transitions may advance.
+pub fn merge_coding_agent_run_snapshot(
+    stored: &CodingAgentRunSnapshot,
+    incoming: &CodingAgentRunSnapshot,
+) -> Result<CodingAgentObservationMerge, String> {
+    validate_coding_agent_run_snapshot(stored)?;
+    validate_coding_agent_run_snapshot(incoming)?;
+    validate_coding_agent_run_identity_transition(stored, incoming)?;
+
+    match incoming
+        .observation_revision
+        .cmp(&stored.observation_revision)
+    {
+        std::cmp::Ordering::Less => Ok(CodingAgentObservationMerge::Stale),
+        std::cmp::Ordering::Equal => {
+            if incoming == stored {
+                Ok(CodingAgentObservationMerge::ExactReplay)
+            } else {
+                Err(
+                    "CodingAgentRun observation revision has conflicting authoritative snapshots"
+                        .to_string(),
+                )
+            }
+        }
+        std::cmp::Ordering::Greater => {
+            validate_coding_agent_run_transition(stored, incoming)?;
+            Ok(CodingAgentObservationMerge::Advance)
+        }
+    }
+}
+
+fn validate_coding_agent_run_identity_transition(
+    stored: &CodingAgentRunSnapshot,
+    incoming: &CodingAgentRunSnapshot,
+) -> Result<(), String> {
+    if stored.run_id != incoming.run_id
+        || stored.intent_fingerprint != incoming.intent_fingerprint
+        || stored.authority_fingerprint != incoming.authority_fingerprint
+        || stored.runtime_project_id != incoming.runtime_project_id
+        || stored.provider_id != incoming.provider_id
+        || stored.provider_instance_id != incoming.provider_instance_id
+        || stored.created_at != incoming.created_at
+    {
+        return Err("CodingAgentRun observation identity changed across revisions".to_string());
+    }
+    Ok(())
+}
+
+/// Validate an accepted higher-revision transition using the existing ACP v1 Run
+/// state machine. The validator intentionally permits skipped intermediate revisions:
+/// an observer may see Starting and then a terminal snapshot without seeing Running.
+pub fn validate_coding_agent_run_transition(
+    stored: &CodingAgentRunSnapshot,
+    incoming: &CodingAgentRunSnapshot,
+) -> Result<(), String> {
+    if incoming.observation_revision <= stored.observation_revision {
+        return Err("CodingAgentRun transition does not advance observation revision".to_string());
+    }
+    if stored.state.terminal() {
+        return Err("terminal CodingAgentRun observation cannot advance to new truth".to_string());
+    }
+    if stored.state != CodingAgentRunState::Starting
+        && incoming.state == CodingAgentRunState::Starting
+    {
+        return Err("CodingAgentRun state cannot regress to starting".to_string());
+    }
+
+    let execution_transition_valid = match stored.execution_state {
+        CodingAgentExecutionState::NotStarted => true,
+        CodingAgentExecutionState::OutcomeUnknown => {
+            matches!(
+                incoming.execution_state,
+                CodingAgentExecutionState::OutcomeUnknown
+                    | CodingAgentExecutionState::Started
+                    | CodingAgentExecutionState::Completed
+            ) || (incoming.execution_state == CodingAgentExecutionState::NotStarted
+                && matches!(
+                    incoming.state,
+                    CodingAgentRunState::Failed | CodingAgentRunState::Cancelled
+                ))
+        }
+        CodingAgentExecutionState::Started => {
+            matches!(
+                incoming.execution_state,
+                CodingAgentExecutionState::Started | CodingAgentExecutionState::Completed
+            ) || (incoming.execution_state == CodingAgentExecutionState::OutcomeUnknown
+                && incoming.state == CodingAgentRunState::Lost)
+        }
+        CodingAgentExecutionState::Completed => false,
+    };
+    if !execution_transition_valid {
+        return Err("CodingAgentRun execution state regressed across observations".to_string());
+    }
+    Ok(())
+}
+
 fn terminal_for_state(
     run: &CodingAgentRunSnapshot,
     execution_state: CodingAgentExecutionState,
@@ -1060,6 +1166,87 @@ mod tests {
         );
         terminal_without_metadata.terminal = None;
         assert!(validate_coding_agent_run_snapshot(&terminal_without_metadata).is_err());
+    }
+
+    #[test]
+    fn observation_merge_is_revision_monotonic_and_terminal_absorbing() {
+        let mut running = snapshot(
+            CodingAgentRunState::Running,
+            CodingAgentExecutionState::Started,
+            None,
+            None,
+        );
+        running.observation_revision = 1;
+
+        let mut completed = snapshot(
+            CodingAgentRunState::Completed,
+            CodingAgentExecutionState::Completed,
+            Some(CODING_AGENT_STOP_REASON_END_TURN),
+            None,
+        );
+        completed.observation_revision = 2;
+        completed.updated_at = 2;
+        completed.terminal.as_mut().unwrap().completed_at = 2;
+
+        assert_eq!(
+            merge_coding_agent_run_snapshot(&running, &completed).unwrap(),
+            CodingAgentObservationMerge::Advance
+        );
+        assert_eq!(
+            merge_coding_agent_run_snapshot(&completed, &running).unwrap(),
+            CodingAgentObservationMerge::Stale
+        );
+        assert_eq!(
+            merge_coding_agent_run_snapshot(&completed, &completed).unwrap(),
+            CodingAgentObservationMerge::ExactReplay
+        );
+
+        let mut same_revision_conflict = running.clone();
+        same_revision_conflict.observation_revision = 2;
+        same_revision_conflict.updated_at = 2;
+        assert!(merge_coding_agent_run_snapshot(&completed, &same_revision_conflict).is_err());
+
+        let mut terminal_regression = running.clone();
+        terminal_regression.observation_revision = 3;
+        terminal_regression.updated_at = 3;
+        assert!(merge_coding_agent_run_snapshot(&completed, &terminal_regression).is_err());
+
+        let mut execution_regression = running.clone();
+        execution_regression.observation_revision = 2;
+        execution_regression.updated_at = 2;
+        execution_regression.execution_state = CodingAgentExecutionState::OutcomeUnknown;
+        assert!(merge_coding_agent_run_snapshot(&running, &execution_regression).is_err());
+
+        let mut identity_change = completed.clone();
+        identity_change.observation_revision = 3;
+        identity_change.provider_instance_id = "provider_456".to_string();
+        assert!(merge_coding_agent_run_snapshot(&completed, &identity_change).is_err());
+
+        let mut uncertain = snapshot(
+            CodingAgentRunState::Running,
+            CodingAgentExecutionState::OutcomeUnknown,
+            None,
+            None,
+        );
+        uncertain.observation_revision = 1;
+        let mut proved_not_started = snapshot(
+            CodingAgentRunState::Cancelled,
+            CodingAgentExecutionState::NotStarted,
+            None,
+            None,
+        );
+        proved_not_started.observation_revision = 2;
+        proved_not_started.updated_at = 2;
+        proved_not_started.terminal = Some(CodingAgentTerminal {
+            stop_reason: None,
+            error_code: None,
+            message: Some("ACP prompt was not dispatched".to_string()),
+            completed_at: 2,
+        });
+        assert_eq!(
+            merge_coding_agent_run_snapshot(&uncertain, &proved_not_started).unwrap(),
+            CodingAgentObservationMerge::Advance
+        );
     }
 
     #[test]

--- a/src/db/agent_task.rs
+++ b/src/db/agent_task.rs
@@ -10,6 +10,10 @@ use rusqlite::{
 };
 use serde::Serialize;
 use serde_json::json;
+use webcodex_core::coding_agent::{
+    merge_coding_agent_run_snapshot, validate_coding_agent_run_snapshot, CodingAgentExecutionState,
+    CodingAgentObservationMerge, CodingAgentRunSnapshot, CodingAgentRunState, CodingAgentTerminal,
+};
 
 pub(crate) const AGENT_TASK_ID_PREFIX: &str = "wc_agent_task_";
 pub(crate) const AGENT_TASK_ATTEMPT_ID_PREFIX: &str = "wc_agent_task_attempt_";
@@ -1962,53 +1966,8 @@ impl Database {
                     "AgentTaskAttempt has no bound CodingAgentRun",
                 )
             })?;
-        require_coding_run_observation_identity(&binding, observation)?;
-        validate_coding_run_observation(observation)?;
-        let dispatch_state = if binding.dispatch_state == AgentTaskCodingRunDispatchState::Terminal
-        {
-            AgentTaskCodingRunDispatchState::Terminal
-        } else if observation.run_state == "lost"
-            || observation.execution_state == "outcome_unknown"
-        {
-            AgentTaskCodingRunDispatchState::OutcomeUnknown
-        } else {
-            AgentTaskCodingRunDispatchState::Bound
-        };
-        transaction
-            .execute(
-                "UPDATE wc_agent_task_coding_runs
-                 SET dispatch_state = ?3,
-                     last_observed_run_state = ?4,
-                     last_observed_execution_state = ?5,
-                     last_observation_revision = ?6,
-                     terminal_stop_reason = ?7,
-                     terminal_error_code = ?8,
-                     terminal_message = ?9,
-                     completed_at_unix = ?10,
-                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?11)
-                 WHERE task_id = ?1 AND attempt_id = ?2",
-                params![
-                    task_id,
-                    attempt_id,
-                    dispatch_state.as_str(),
-                    observation.run_state,
-                    observation.execution_state,
-                    observation.observation_revision,
-                    observation.terminal_stop_reason,
-                    observation.terminal_error_code,
-                    observation.terminal_message,
-                    observation.completed_at_unix,
-                    now,
-                ],
-            )
-            .map_err(store_error)?;
-        let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
-            .ok_or_else(|| {
-                CommunicationStoreError::new(
-                    "agent_task_storage_invariant",
-                    "AgentTask CodingAgent binding disappeared after observation",
-                )
-            })?;
+        let (binding, _) =
+            merge_agent_task_coding_run_observation(&transaction, &binding, observation, now)?;
         transaction.commit().map_err(store_error)?;
         Ok(binding)
     }
@@ -2065,17 +2024,6 @@ impl Database {
         validate_communication_principal(principal)?;
         let terminal_result = validate_optional_terminal_text(terminal_result, "terminal_result")?;
         let terminal_reason = validate_optional_terminal_text(terminal_reason, "terminal_reason")?;
-        let desired_task_state = match observation.run_state.as_str() {
-            "completed" => AgentTaskState::Succeeded,
-            "failed" | "cancelled" => AgentTaskState::Failed,
-            _ => {
-                return Err(CommunicationStoreError::new(
-                    "agent_task_coding_run_not_terminal",
-                    "CodingAgentRun is not an authoritative terminal result for AgentTask reconciliation",
-                ))
-            }
-        };
-        validate_coding_run_observation(observation)?;
         let now = now_unix_ms();
         let mut conn = self.conn.lock().unwrap();
         let transaction = conn
@@ -2100,7 +2048,30 @@ impl Database {
                     "AgentTaskAttempt has no bound CodingAgentRun",
                 )
             })?;
-        require_coding_run_observation_identity(&binding, observation)?;
+        let (binding, disposition) =
+            merge_agent_task_coding_run_observation(&transaction, &binding, observation, now)?;
+        if disposition == CodingAgentObservationMerge::Stale {
+            return Err(CommunicationStoreError::new(
+                "agent_task_coding_run_observation_stale",
+                "stale CodingAgentRun observation cannot terminalize AgentTask state",
+            ));
+        }
+        let desired_task_state = match binding.last_observed_run_state.as_deref() {
+            Some("completed") => AgentTaskState::Succeeded,
+            Some("failed" | "cancelled") => AgentTaskState::Failed,
+            _ => {
+                return Err(CommunicationStoreError::new(
+                    "agent_task_coding_run_not_terminal",
+                    "CodingAgentRun is not an authoritative terminal result for AgentTask reconciliation",
+                ))
+            }
+        };
+        let observation_revision = binding.last_observation_revision.ok_or_else(|| {
+            CommunicationStoreError::new(
+                "agent_task_storage_invariant",
+                "terminal CodingAgent reconciliation lacks an authoritative observation revision",
+            )
+        })?;
         let attempt =
             load_attempt_for_task(&transaction, task_id, attempt_id, now)?.ok_or_else(|| {
                 CommunicationStoreError::new(
@@ -2124,13 +2095,6 @@ impl Database {
                     "AgentTask is already terminal from a different authoritative result",
                 ));
             }
-            let binding = load_coding_run_binding_for_attempt(&transaction, task_id, attempt_id)?
-                .ok_or_else(|| {
-                CommunicationStoreError::new(
-                    "agent_task_storage_invariant",
-                    "Terminal AgentTask lost its CodingAgent binding",
-                )
-            })?;
             transaction.commit().map_err(store_error)?;
             return Ok(AgentTaskCodingRunReconcileMutation {
                 task: task.summary(now),
@@ -2168,34 +2132,22 @@ impl Database {
                 params![task_id, desired_task_state.as_str(), attempt_id, now],
             )
             .map_err(store_error)?;
-        transaction
+        let binding_updated = transaction
             .execute(
                 "UPDATE wc_agent_task_coding_runs
                  SET dispatch_state = 'terminal',
-                     last_observed_run_state = ?3,
-                     last_observed_execution_state = ?4,
-                     last_observation_revision = ?5,
-                     terminal_stop_reason = ?6,
-                     terminal_error_code = ?7,
-                     terminal_message = ?8,
-                     completed_at_unix = ?9,
-                     terminal_at_unix_ms = ?10,
-                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?10)
-                 WHERE task_id = ?1 AND attempt_id = ?2",
-                params![
-                    task_id,
-                    attempt_id,
-                    observation.run_state,
-                    observation.execution_state,
-                    observation.observation_revision,
-                    observation.terminal_stop_reason,
-                    observation.terminal_error_code,
-                    observation.terminal_message,
-                    observation.completed_at_unix,
-                    now,
-                ],
+                     terminal_at_unix_ms = ?4,
+                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?4)
+                 WHERE task_id = ?1 AND attempt_id = ?2 AND last_observation_revision = ?3",
+                params![task_id, attempt_id, observation_revision, now],
             )
             .map_err(store_error)?;
+        if binding_updated != 1 {
+            return Err(CommunicationStoreError::new(
+                "agent_task_storage_invariant",
+                "terminal CodingAgent binding revision CAS did not update the exact durable binding",
+            ));
+        }
         let task = load_owned_task(&transaction, principal, task_id, now)?;
         let attempt =
             load_attempt_for_task(&transaction, task_id, attempt_id, now)?.ok_or_else(|| {
@@ -2240,34 +2192,9 @@ fn require_coding_run_observation_identity(
     Ok(())
 }
 
-fn validate_coding_run_observation(
+fn canonical_coding_run_snapshot(
     observation: &AgentTaskCodingRunObservation,
-) -> Result<(), CommunicationStoreError> {
-    if !matches!(
-        observation.run_state.as_str(),
-        "starting"
-            | "running"
-            | "waiting_permission"
-            | "completed"
-            | "failed"
-            | "cancelled"
-            | "lost"
-    ) {
-        return Err(CommunicationStoreError::new(
-            "invalid_agent_task_coding_run_observation",
-            "CodingAgentRun snapshot contains an unsupported run state",
-        ));
-    }
-    if !matches!(
-        observation.execution_state.as_str(),
-        "not_started" | "started" | "outcome_unknown" | "completed"
-    ) || observation.observation_revision < 0
-    {
-        return Err(CommunicationStoreError::new(
-            "invalid_agent_task_coding_run_observation",
-            "CodingAgentRun snapshot contains an unsupported execution state or revision",
-        ));
-    }
+) -> Result<CodingAgentRunSnapshot, String> {
     for (label, value) in [
         (
             "terminal_stop_reason",
@@ -2281,14 +2208,241 @@ fn validate_coding_run_observation(
     ] {
         if let Some(value) = value {
             if value.len() > MAX_AGENT_TASK_TERMINAL_TEXT_BYTES {
-                return Err(CommunicationStoreError::new(
-                    "invalid_agent_task_coding_run_observation",
-                    format!("{label} exceeds the AgentTask bounded terminal text limit"),
+                return Err(format!(
+                    "{label} exceeds the AgentTask bounded terminal text limit"
                 ));
             }
         }
     }
-    Ok(())
+
+    let state = match observation.run_state.as_str() {
+        "starting" => CodingAgentRunState::Starting,
+        "running" => CodingAgentRunState::Running,
+        "waiting_permission" => CodingAgentRunState::WaitingPermission,
+        "completed" => CodingAgentRunState::Completed,
+        "failed" => CodingAgentRunState::Failed,
+        "cancelled" => CodingAgentRunState::Cancelled,
+        "lost" => CodingAgentRunState::Lost,
+        _ => return Err("CodingAgentRun snapshot contains an unsupported run state".to_string()),
+    };
+    let execution_state = match observation.execution_state.as_str() {
+        "not_started" => CodingAgentExecutionState::NotStarted,
+        "started" => CodingAgentExecutionState::Started,
+        "outcome_unknown" => CodingAgentExecutionState::OutcomeUnknown,
+        "completed" => CodingAgentExecutionState::Completed,
+        _ => {
+            return Err(
+                "CodingAgentRun snapshot contains an unsupported execution state".to_string(),
+            )
+        }
+    };
+    let observation_revision = u64::try_from(observation.observation_revision).map_err(|_| {
+        "CodingAgentRun snapshot contains a negative observation revision".to_string()
+    })?;
+    let has_terminal_metadata = observation.terminal_stop_reason.is_some()
+        || observation.terminal_error_code.is_some()
+        || observation.terminal_message.is_some()
+        || observation.completed_at_unix.is_some();
+    let terminal = if has_terminal_metadata {
+        Some(CodingAgentTerminal {
+            stop_reason: observation.terminal_stop_reason.clone(),
+            error_code: observation.terminal_error_code.clone(),
+            message: observation.terminal_message.clone(),
+            completed_at: observation.completed_at_unix.ok_or_else(|| {
+                "CodingAgentRun terminal observation lacks completed timestamp".to_string()
+            })?,
+        })
+    } else {
+        None
+    };
+    let snapshot = CodingAgentRunSnapshot {
+        run_id: observation.run_id.clone(),
+        intent_fingerprint: observation.coding_agent_intent_fingerprint.clone(),
+        authority_fingerprint: observation.authority_fingerprint.clone(),
+        runtime_project_id: observation.runtime_project_id.clone(),
+        provider_id: observation.provider_id.clone(),
+        provider_instance_id: observation.provider_instance_id.clone(),
+        state,
+        execution_state,
+        observation_revision,
+        // AgentTask persists the authoritative semantic observation fields but not
+        // Runner wall-clock snapshot metadata. Neutralize those non-persisted fields
+        // so durable replay/conflict classification compares exactly what is stored.
+        created_at: 0,
+        updated_at: 0,
+        terminal,
+    };
+    validate_coding_agent_run_snapshot(&snapshot)?;
+    Ok(snapshot)
+}
+
+fn validate_coding_run_observation(
+    observation: &AgentTaskCodingRunObservation,
+) -> Result<CodingAgentRunSnapshot, CommunicationStoreError> {
+    canonical_coding_run_snapshot(observation).map_err(|message| {
+        CommunicationStoreError::new("invalid_agent_task_coding_run_observation", message)
+    })
+}
+
+fn stored_coding_run_snapshot(
+    binding: &AgentTaskCodingRunBindingRecord,
+) -> Result<Option<CodingAgentRunSnapshot>, CommunicationStoreError> {
+    let Some(revision) = binding.last_observation_revision else {
+        if binding.last_observed_run_state.is_some()
+            || binding.last_observed_execution_state.is_some()
+            || binding.terminal_stop_reason.is_some()
+            || binding.terminal_error_code.is_some()
+            || binding.terminal_message.is_some()
+            || binding.completed_at_unix.is_some()
+        {
+            return Err(CommunicationStoreError::new(
+                "agent_task_storage_invariant",
+                "CodingAgent binding has observation fields without an observation revision",
+            ));
+        }
+        return Ok(None);
+    };
+    let observation = AgentTaskCodingRunObservation {
+        run_id: binding.run_id.clone(),
+        runtime_project_id: binding.runtime_project_id.clone(),
+        provider_id: binding.provider_id.clone(),
+        provider_instance_id: binding.provider_instance_id.clone(),
+        authority_fingerprint: binding.authority_fingerprint.clone(),
+        coding_agent_intent_fingerprint: binding.coding_agent_intent_fingerprint.clone(),
+        run_state: binding.last_observed_run_state.clone().ok_or_else(|| {
+            CommunicationStoreError::new(
+                "agent_task_storage_invariant",
+                "CodingAgent binding observation revision lacks run state",
+            )
+        })?,
+        execution_state: binding
+            .last_observed_execution_state
+            .clone()
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "CodingAgent binding observation revision lacks execution state",
+                )
+            })?,
+        observation_revision: revision,
+        terminal_stop_reason: binding.terminal_stop_reason.clone(),
+        terminal_error_code: binding.terminal_error_code.clone(),
+        terminal_message: binding.terminal_message.clone(),
+        completed_at_unix: binding.completed_at_unix,
+    };
+    canonical_coding_run_snapshot(&observation)
+        .map(Some)
+        .map_err(|message| {
+            CommunicationStoreError::new(
+                "agent_task_storage_invariant",
+                format!("stored CodingAgent observation is invalid: {message}"),
+            )
+        })
+}
+
+fn merge_agent_task_coding_run_observation(
+    transaction: &Transaction<'_>,
+    binding: &AgentTaskCodingRunBindingRecord,
+    observation: &AgentTaskCodingRunObservation,
+    now: i64,
+) -> Result<(AgentTaskCodingRunBindingRecord, CodingAgentObservationMerge), CommunicationStoreError>
+{
+    require_coding_run_observation_identity(binding, observation)?;
+    let incoming = validate_coding_run_observation(observation)?;
+    let disposition = match stored_coding_run_snapshot(binding)? {
+        Some(stored) => merge_coding_agent_run_snapshot(&stored, &incoming).map_err(|message| {
+            CommunicationStoreError::new("agent_task_coding_run_observation_conflict", message)
+        })?,
+        None => CodingAgentObservationMerge::Advance,
+    };
+    if matches!(
+        disposition,
+        CodingAgentObservationMerge::Stale | CodingAgentObservationMerge::ExactReplay
+    ) {
+        return Ok((binding.clone(), disposition));
+    }
+
+    let dispatch_state =
+        if observation.run_state == "lost" || observation.execution_state == "outcome_unknown" {
+            AgentTaskCodingRunDispatchState::OutcomeUnknown
+        } else {
+            AgentTaskCodingRunDispatchState::Bound
+        };
+    let updated = if let Some(expected_revision) = binding.last_observation_revision {
+        transaction
+            .execute(
+                "UPDATE wc_agent_task_coding_runs
+                 SET dispatch_state = ?3,
+                     last_observed_run_state = ?4,
+                     last_observed_execution_state = ?5,
+                     last_observation_revision = ?6,
+                     terminal_stop_reason = ?7,
+                     terminal_error_code = ?8,
+                     terminal_message = ?9,
+                     completed_at_unix = ?10,
+                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?11)
+                 WHERE task_id = ?1 AND attempt_id = ?2 AND last_observation_revision = ?12",
+                params![
+                    binding.task_id,
+                    binding.attempt_id,
+                    dispatch_state.as_str(),
+                    observation.run_state,
+                    observation.execution_state,
+                    observation.observation_revision,
+                    observation.terminal_stop_reason,
+                    observation.terminal_error_code,
+                    observation.terminal_message,
+                    observation.completed_at_unix,
+                    now,
+                    expected_revision,
+                ],
+            )
+            .map_err(store_error)?
+    } else {
+        transaction
+            .execute(
+                "UPDATE wc_agent_task_coding_runs
+                 SET dispatch_state = ?3,
+                     last_observed_run_state = ?4,
+                     last_observed_execution_state = ?5,
+                     last_observation_revision = ?6,
+                     terminal_stop_reason = ?7,
+                     terminal_error_code = ?8,
+                     terminal_message = ?9,
+                     completed_at_unix = ?10,
+                     updated_at_unix_ms = MAX(updated_at_unix_ms, ?11)
+                 WHERE task_id = ?1 AND attempt_id = ?2 AND last_observation_revision IS NULL",
+                params![
+                    binding.task_id,
+                    binding.attempt_id,
+                    dispatch_state.as_str(),
+                    observation.run_state,
+                    observation.execution_state,
+                    observation.observation_revision,
+                    observation.terminal_stop_reason,
+                    observation.terminal_error_code,
+                    observation.terminal_message,
+                    observation.completed_at_unix,
+                    now,
+                ],
+            )
+            .map_err(store_error)?
+    };
+    if updated != 1 {
+        return Err(CommunicationStoreError::new(
+            "agent_task_storage_invariant",
+            "CodingAgent observation revision CAS did not update the exact durable binding",
+        ));
+    }
+    let binding =
+        load_coding_run_binding_for_attempt(transaction, &binding.task_id, &binding.attempt_id)?
+            .ok_or_else(|| {
+                CommunicationStoreError::new(
+                    "agent_task_storage_invariant",
+                    "AgentTask CodingAgent binding disappeared after monotonic observation merge",
+                )
+            })?;
+    Ok((binding, disposition))
 }
 
 fn task_request_hash(value: &serde_json::Value) -> String {

--- a/src/db/agent_task_tests.rs
+++ b/src/db/agent_task_tests.rs
@@ -89,7 +89,7 @@ fn coding_binding_intent(label: &str) -> AgentTaskCodingRunBindingIntent {
         runtime_project_id: "agent:special:reference-only".to_string(),
         provider_id: "codex".to_string(),
         provider_instance_id: format!("provider-instance-{label}"),
-        authority_fingerprint: format!("authority-{label}"),
+        authority_fingerprint: format!("auth_{label}"),
         coding_agent_intent_fingerprint: format!("coding-intent-{label}"),
         binding_intent_fingerprint: format!("binding-intent-{label}"),
     }
@@ -111,12 +111,19 @@ fn coding_observation(
         run_state: run_state.to_string(),
         execution_state: execution_state.to_string(),
         observation_revision: revision,
-        terminal_stop_reason: matches!(run_state, "completed" | "failed" | "cancelled")
-            .then(|| format!("stop-{run_state}")),
-        terminal_error_code: (run_state == "failed").then(|| "provider_failed".to_string()),
-        terminal_message: matches!(run_state, "completed" | "failed" | "cancelled")
+        terminal_stop_reason: match (run_state, execution_state) {
+            ("completed", _) => Some("end_turn".to_string()),
+            ("cancelled", "completed") => Some("cancelled".to_string()),
+            _ => None,
+        },
+        terminal_error_code: match run_state {
+            "failed" => Some("provider_failed".to_string()),
+            "lost" => Some("coding_agent_transport_lost".to_string()),
+            _ => None,
+        },
+        terminal_message: matches!(run_state, "completed" | "failed" | "cancelled" | "lost")
             .then(|| format!("terminal-{run_state}")),
-        completed_at_unix: matches!(run_state, "completed" | "failed" | "cancelled")
+        completed_at_unix: matches!(run_state, "completed" | "failed" | "cancelled" | "lost")
             .then_some(1234),
     }
 }
@@ -564,6 +571,291 @@ fn backend_terminal_truth_reconciles_exact_attempt_after_ordinary_lease_expiry()
         )
         .unwrap();
     assert!(!replay.state_changed);
+}
+
+#[test]
+fn coding_run_observation_merge_preserves_newer_terminal_truth() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-monotonic.db")).unwrap();
+    let owner = principal('a');
+    let assignee = agent(&db, &owner, "coding-monotonic-agent");
+    let now = wall_now_ms();
+    let task_id = create_assigned_task(&db, &owner, &assignee, "coding-monotonic-task");
+    let started = start(
+        &db,
+        &owner,
+        &task_id,
+        &assignee,
+        "coding-monotonic-start",
+        now,
+    );
+    let intent = coding_binding_intent("monotonic-run");
+    prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 1);
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &assignee,
+        &started.attempt_fence,
+        1,
+        &intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+
+    let running_rev1 = coding_observation(&intent, "running", "started", 1);
+    db.record_agent_task_coding_run_observation(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &running_rev1,
+    )
+    .unwrap();
+
+    let mut completed_rev2 = coding_observation(&intent, "completed", "completed", 2);
+    completed_rev2.terminal_message = Some("authoritative rev2 completion".to_string());
+    completed_rev2.completed_at_unix = Some(2222);
+    db.record_agent_task_coding_run_observation(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &completed_rev2,
+    )
+    .unwrap();
+    let terminal = db
+        .terminalize_agent_task_coding_run(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed_rev2,
+            Some("authoritative result"),
+            Some("coding_agent_completed"),
+        )
+        .unwrap();
+    assert_eq!(terminal.task.state, AgentTaskState::Succeeded);
+    assert_eq!(terminal.attempt.state, AgentTaskAttemptState::Succeeded);
+
+    let stale = db
+        .record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &running_rev1,
+        )
+        .unwrap();
+    assert_eq!(
+        stale.dispatch_state,
+        AgentTaskCodingRunDispatchState::Terminal
+    );
+    assert_eq!(stale.last_observation_revision, Some(2));
+    assert_eq!(stale.last_observed_run_state.as_deref(), Some("completed"));
+    assert_eq!(
+        stale.last_observed_execution_state.as_deref(),
+        Some("completed")
+    );
+    assert_eq!(stale.terminal_stop_reason.as_deref(), Some("end_turn"));
+    assert_eq!(stale.terminal_error_code, None);
+    assert_eq!(
+        stale.terminal_message.as_deref(),
+        Some("authoritative rev2 completion")
+    );
+    assert_eq!(stale.completed_at_unix, Some(2222));
+
+    let exact_replay = db
+        .record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed_rev2,
+        )
+        .unwrap();
+    assert_eq!(exact_replay, stale);
+    let replay_terminal = db
+        .terminalize_agent_task_coding_run(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed_rev2,
+            Some("authoritative result"),
+            Some("coding_agent_completed"),
+        )
+        .unwrap();
+    assert!(!replay_terminal.state_changed);
+
+    let running_rev3 = coding_observation(&intent, "running", "started", 3);
+    let regression = db
+        .record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &running_rev3,
+        )
+        .unwrap_err();
+    assert_eq!(
+        regression.code(),
+        "agent_task_coding_run_observation_conflict"
+    );
+    let unchanged = db
+        .read_agent_task_coding_run_binding(&owner, &task_id, &started.attempt.attempt_id)
+        .unwrap();
+    assert_eq!(unchanged, stale);
+    let task = db.read_agent_task(&owner, &task_id).unwrap();
+    assert_eq!(task.summary.state, AgentTaskState::Succeeded);
+    assert_eq!(
+        task.summary.latest_attempt.unwrap().state,
+        AgentTaskAttemptState::Succeeded
+    );
+}
+
+#[test]
+fn coding_run_observation_equal_revision_conflict_keeps_stored_truth() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-revision-conflict.db")).unwrap();
+    let owner = principal('b');
+    let assignee = agent(&db, &owner, "coding-revision-conflict-agent");
+    let now = wall_now_ms();
+    let task_id = create_assigned_task(&db, &owner, &assignee, "coding-revision-conflict-task");
+    let started = start(
+        &db,
+        &owner,
+        &task_id,
+        &assignee,
+        "coding-revision-conflict-start",
+        now,
+    );
+    let intent = coding_binding_intent("revision-conflict-run");
+    prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 1);
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &assignee,
+        &started.attempt_fence,
+        1,
+        &intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+
+    let running_rev2 = coding_observation(&intent, "running", "started", 2);
+    let stored = db
+        .record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &running_rev2,
+        )
+        .unwrap();
+    let completed_rev2 = coding_observation(&intent, "completed", "completed", 2);
+    let conflict = db
+        .record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed_rev2,
+        )
+        .unwrap_err();
+    assert_eq!(
+        conflict.code(),
+        "agent_task_coding_run_observation_conflict"
+    );
+    let unchanged = db
+        .read_agent_task_coding_run_binding(&owner, &task_id, &started.attempt.attempt_id)
+        .unwrap();
+    assert_eq!(unchanged, stored);
+    assert_eq!(unchanged.last_observation_revision, Some(2));
+    assert_eq!(
+        unchanged.last_observed_run_state.as_deref(),
+        Some("running")
+    );
+    assert_eq!(unchanged.terminal_stop_reason, None);
+    assert_eq!(unchanged.terminal_message, None);
+}
+
+#[test]
+fn coding_run_terminal_observation_stays_monotonic_after_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("agent-task-coding-monotonic-restart.db");
+    let owner = principal('c');
+    let now = wall_now_ms();
+    let (task_id, attempt_id, running_rev1, completed_rev2) = {
+        let db = Database::open(&path).unwrap();
+        let assignee = agent(&db, &owner, "coding-monotonic-restart-agent");
+        let task_id = create_assigned_task(&db, &owner, &assignee, "coding-monotonic-restart-task");
+        let started = start(
+            &db,
+            &owner,
+            &task_id,
+            &assignee,
+            "coding-monotonic-restart-start",
+            now,
+        );
+        let intent = coding_binding_intent("monotonic-restart-run");
+        prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 1);
+        db.claim_agent_task_coding_run_dispatch(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &assignee,
+            &started.attempt_fence,
+            1,
+            &intent.binding_intent_fingerprint,
+        )
+        .unwrap();
+        let running_rev1 = coding_observation(&intent, "running", "started", 1);
+        db.record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &running_rev1,
+        )
+        .unwrap();
+        let mut completed_rev2 = coding_observation(&intent, "completed", "completed", 2);
+        completed_rev2.terminal_message = Some("restart rev2 completion".to_string());
+        completed_rev2.completed_at_unix = Some(3333);
+        db.record_agent_task_coding_run_observation(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed_rev2,
+        )
+        .unwrap();
+        db.terminalize_agent_task_coding_run(
+            &owner,
+            &task_id,
+            &started.attempt.attempt_id,
+            &completed_rev2,
+            Some("restart result"),
+            Some("coding_agent_completed"),
+        )
+        .unwrap();
+        (
+            task_id,
+            started.attempt.attempt_id,
+            running_rev1,
+            completed_rev2,
+        )
+    };
+
+    let reopened = Database::open(&path).unwrap();
+    let stale = reopened
+        .record_agent_task_coding_run_observation(&owner, &task_id, &attempt_id, &running_rev1)
+        .unwrap();
+    assert_eq!(
+        stale.dispatch_state,
+        AgentTaskCodingRunDispatchState::Terminal
+    );
+    assert_eq!(stale.last_observation_revision, Some(2));
+    assert_eq!(stale.last_observed_run_state.as_deref(), Some("completed"));
+    assert_eq!(
+        stale.terminal_message.as_deref(),
+        completed_rev2.terminal_message.as_deref()
+    );
+    assert_eq!(stale.completed_at_unix, Some(3333));
+    let task = reopened.read_agent_task(&owner, &task_id).unwrap();
+    assert_eq!(task.summary.state, AgentTaskState::Succeeded);
+    assert_eq!(
+        task.summary.latest_attempt.unwrap().state,
+        AgentTaskAttemptState::Succeeded
+    );
 }
 
 #[test]

--- a/src/db/agent_task_tests.rs
+++ b/src/db/agent_task_tests.rs
@@ -987,6 +987,28 @@ fn failed_cancelled_and_lost_have_bounded_exact_terminal_semantics() {
             .state,
         AgentTaskState::Active
     );
+    let completed_after_lost = coding_observation(&lost_intent, "completed", "completed", 6);
+    let recovered = db
+        .terminalize_agent_task_coding_run(
+            &owner,
+            &lost_task,
+            &lost_started.attempt.attempt_id,
+            &completed_after_lost,
+            Some("recovered definitive result"),
+            Some("coding_agent_completed"),
+        )
+        .unwrap();
+    assert_eq!(recovered.task.state, AgentTaskState::Succeeded);
+    assert_eq!(recovered.attempt.state, AgentTaskAttemptState::Succeeded);
+    assert_eq!(
+        recovered.binding.dispatch_state,
+        AgentTaskCodingRunDispatchState::Terminal
+    );
+    assert_eq!(recovered.binding.last_observation_revision, Some(6));
+    assert_eq!(
+        recovered.binding.last_observed_run_state.as_deref(),
+        Some("completed")
+    );
 }
 
 #[test]

--- a/src/tool_runtime/agent_task.rs
+++ b/src/tool_runtime/agent_task.rs
@@ -46,13 +46,44 @@ fn agent_task_recovery_kind(
         "agent_task_attempt_stale"
         | "agent_task_execution_active"
         | "agent_task_execution_outcome_unknown"
-        | "agent_task_coding_run_identity_mismatch" => RecoveryKind::Reconcile,
+        | "agent_task_coding_run_identity_mismatch"
+        | "agent_task_coding_run_observation_conflict"
+        | "agent_task_coding_run_observation_stale" => RecoveryKind::Reconcile,
         "agent_task_attempt_active"
         | "agent_task_assignee_mismatch"
         | "agent_task_unassigned"
         | "agent_task_terminal"
         | "communication_idempotency_conflict" => RecoveryKind::Reobserve,
         _ => RecoveryKind::FixInput,
+    }
+}
+
+#[cfg(test)]
+mod observation_tests {
+    use super::*;
+
+    #[test]
+    fn coding_run_observation_revision_overflow_fails_closed() {
+        let run = CodingAgentRunSnapshot {
+            run_id: "wc_agent_run_revision_overflow".to_string(),
+            intent_fingerprint: "intent-overflow".to_string(),
+            authority_fingerprint: "auth_overflow".to_string(),
+            runtime_project_id: "agent:test:overflow".to_string(),
+            provider_id: "codex".to_string(),
+            provider_instance_id: "provider-overflow".to_string(),
+            state: CodingAgentRunState::Running,
+            execution_state: CodingAgentExecutionState::Started,
+            observation_revision: u64::MAX,
+            created_at: 1,
+            updated_at: 1,
+            terminal: None,
+        };
+        let error = coding_run_observation(&run).unwrap_err();
+        assert!(!error.success);
+        assert_eq!(
+            error.output["error_kind"],
+            "agent_task_coding_run_revision_out_of_range"
+        );
     }
 }
 
@@ -151,8 +182,21 @@ fn bounded_optional_terminal(value: Option<&str>) -> Option<String> {
     value.map(|value| truncate_utf8_bytes(value, MAX_AGENT_TASK_TERMINAL_TEXT_BYTES))
 }
 
-fn coding_run_observation(run: &CodingAgentRunSnapshot) -> AgentTaskCodingRunObservation {
-    AgentTaskCodingRunObservation {
+fn coding_run_observation(
+    run: &CodingAgentRunSnapshot,
+) -> Result<AgentTaskCodingRunObservation, ToolResult> {
+    let observation_revision = i64::try_from(run.observation_revision).map_err(|_| {
+        ToolResult::err_with_output(
+            "CodingAgentRun observation revision exceeds the durable AgentTask range",
+            json!({
+                "error_kind": "agent_task_coding_run_revision_out_of_range",
+                "run_id": run.run_id,
+                "state_changed": false,
+            }),
+        )
+        .with_recovery(RecoveryKind::Reconcile, None)
+    })?;
+    Ok(AgentTaskCodingRunObservation {
         run_id: run.run_id.clone(),
         runtime_project_id: run.runtime_project_id.clone(),
         provider_id: run.provider_id.clone(),
@@ -161,7 +205,7 @@ fn coding_run_observation(run: &CodingAgentRunSnapshot) -> AgentTaskCodingRunObs
         coding_agent_intent_fingerprint: run.intent_fingerprint.clone(),
         run_state: coding_run_state_name(&run.state).to_string(),
         execution_state: coding_execution_state_name(run.execution_state).to_string(),
-        observation_revision: i64::try_from(run.observation_revision).unwrap_or(i64::MAX),
+        observation_revision,
         terminal_stop_reason: bounded_optional_terminal(
             run.terminal
                 .as_ref()
@@ -178,7 +222,7 @@ fn coding_run_observation(run: &CodingAgentRunSnapshot) -> AgentTaskCodingRunObs
                 .and_then(|terminal| terminal.message.as_deref()),
         ),
         completed_at_unix: run.terminal.as_ref().map(|terminal| terminal.completed_at),
-    }
+    })
 }
 
 fn binding_execution_status(binding: &AgentTaskCodingRunBindingRecord) -> &'static str {
@@ -542,7 +586,10 @@ impl ToolRuntime {
             .await
         {
             CodingAgentTypedStartOutcome::Run(run) => {
-                let observation = coding_run_observation(&run);
+                let observation = match coding_run_observation(&run) {
+                    Ok(observation) => observation,
+                    Err(result) => return result,
+                };
                 match db.record_agent_task_coding_run_observation(
                     &principal,
                     &task_id,
@@ -618,7 +665,10 @@ impl ToolRuntime {
             return ToolResult::ok(coding_run_binding_projection(&binding, false, false));
         };
 
-        let observation = coding_run_observation(&run);
+        let observation = match coding_run_observation(&run) {
+            Ok(observation) => observation,
+            Err(result) => return result,
+        };
         let observed_binding = match db.record_agent_task_coding_run_observation(
             &principal,
             &task_id,
@@ -628,12 +678,12 @@ impl ToolRuntime {
             Ok(binding) => binding,
             Err(error) => return agent_task_error(error, RecoveryKind::Reconcile),
         };
-        if !matches!(
-            run.state,
-            CodingAgentRunState::Completed
-                | CodingAgentRunState::Failed
-                | CodingAgentRunState::Cancelled
-        ) {
+        if observed_binding.last_observation_revision != Some(observation.observation_revision)
+            || !matches!(
+                observed_binding.last_observed_run_state.as_deref(),
+                Some("completed" | "failed" | "cancelled")
+            )
+        {
             return ToolResult::ok(coding_run_binding_projection(
                 &observed_binding,
                 false,

--- a/src/tool_runtime/coding_agent.rs
+++ b/src/tool_runtime/coding_agent.rs
@@ -1871,6 +1871,32 @@ mod tests {
             .bind(&client, terminal_regression, None)
             .await
             .is_err());
+        let lost_run_id = "wc_agent_run_lost_recovery";
+        let mut lost =
+            test_server_binding(lost_run_id.to_string(), CodingAgentRunState::Running, now)
+                .snapshot;
+        lost.state = CodingAgentRunState::Lost;
+        lost.execution_state = CodingAgentExecutionState::OutcomeUnknown;
+        lost.observation_revision = 2;
+        lost.terminal = Some(CodingAgentTerminal {
+            stop_reason: None,
+            error_code: Some("coding_agent_transport_lost".to_string()),
+            message: Some("outcome is uncertain".to_string()),
+            completed_at: now,
+        });
+        state.bind(&client, lost, None).await.unwrap();
+
+        let mut recovered =
+            test_server_binding(lost_run_id.to_string(), CodingAgentRunState::Completed, now)
+                .snapshot;
+        recovered.observation_revision = 4;
+        let accepted = state.bind(&client, recovered.clone(), None).await.unwrap();
+        assert_eq!(accepted.snapshot, recovered);
+        assert_eq!(
+            state.get(lost_run_id).await.unwrap().snapshot.state,
+            CodingAgentRunState::Completed
+        );
+
         assert_eq!(state.get(run_id).await.unwrap().snapshot, completed);
     }
 

--- a/src/tool_runtime/coding_agent.rs
+++ b/src/tool_runtime/coding_agent.rs
@@ -14,8 +14,9 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use webcodex_core::coding_agent::{
-    CodingAgentCancelRequest, CodingAgentConfigValue, CodingAgentDispatchState, CodingAgentEvent,
-    CodingAgentExecutionState, CodingAgentObserveRequest, CodingAgentObserveResult,
+    merge_coding_agent_run_snapshot, validate_coding_agent_run_snapshot, CodingAgentCancelRequest,
+    CodingAgentConfigValue, CodingAgentDispatchState, CodingAgentEvent, CodingAgentExecutionState,
+    CodingAgentObservationMerge, CodingAgentObserveRequest, CodingAgentObserveResult,
     CodingAgentRequest, CodingAgentResponse, CodingAgentResponsePayload, CodingAgentRunSnapshot,
     CodingAgentRunState, CodingAgentStartRequest, CodingAgentTerminal,
     CODING_AGENT_MAX_CONFIG_OPTIONS, CODING_AGENT_MAX_EVENTS_PER_RESPONSE,
@@ -139,6 +140,37 @@ fn run_matches_binding_identity(binding: &ServerRunBinding, run: &CodingAgentRun
         && run.provider_instance_id == binding.provider_instance_id
 }
 
+fn merge_server_run_binding_locked(
+    runs: &mut HashMap<String, ServerRunBinding>,
+    mut incoming: ServerRunBinding,
+) -> Result<ServerRunBinding, String> {
+    let run_id = incoming.snapshot.run_id.clone();
+    let Some(existing) = runs.get_mut(&run_id) else {
+        validate_coding_agent_run_snapshot(&incoming.snapshot)?;
+        runs.insert(run_id, incoming.clone());
+        return Ok(incoming);
+    };
+
+    let disposition = merge_coding_agent_run_snapshot(&existing.snapshot, &incoming.snapshot)?;
+    match disposition {
+        CodingAgentObservationMerge::Stale | CodingAgentObservationMerge::ExactReplay => {
+            if existing.recording_session_id.is_none() {
+                existing.recording_session_id = incoming.recording_session_id.take();
+            }
+            Ok(existing.clone())
+        }
+        CodingAgentObservationMerge::Advance => {
+            incoming.recording_session_id = existing
+                .recording_session_id
+                .clone()
+                .or(incoming.recording_session_id);
+            incoming.recorded_lifecycle_mask = existing.recorded_lifecycle_mask;
+            *existing = incoming;
+            Ok(existing.clone())
+        }
+    }
+}
+
 impl Default for CodingAgentServerState {
     fn default() -> Self {
         Self::with_observation_mac_key(new_observation_mac_key())
@@ -172,30 +204,51 @@ impl CodingAgentServerState {
         client: &crate::shell_protocol::ShellClientView,
         run: CodingAgentRunSnapshot,
         recording_session_id: Option<String>,
-    ) {
+    ) -> Result<ServerRunBinding, String> {
+        let incoming = ServerRunBinding {
+            authority_fingerprint: run.authority_fingerprint.clone(),
+            client_id: client.client_id.clone(),
+            agent_instance_id: client.agent_instance_id.clone(),
+            runtime_project_id: run.runtime_project_id.clone(),
+            provider_id: run.provider_id.clone(),
+            provider_instance_id: run.provider_instance_id.clone(),
+            recording_session_id,
+            recorded_lifecycle_mask: 0,
+            snapshot: run,
+        };
         let mut runs = self.runs.lock().await;
         prune_server_runs_locked(&mut runs, Utc::now().timestamp());
-        let existing = runs.get(&run.run_id);
-        let recording_session_id = existing
-            .and_then(|binding| binding.recording_session_id.clone())
-            .or(recording_session_id);
-        let recorded_lifecycle_mask = existing
-            .map(|binding| binding.recorded_lifecycle_mask)
-            .unwrap_or_default();
-        runs.insert(
-            run.run_id.clone(),
-            ServerRunBinding {
-                authority_fingerprint: run.authority_fingerprint.clone(),
-                client_id: client.client_id.clone(),
-                agent_instance_id: client.agent_instance_id.clone(),
-                runtime_project_id: run.runtime_project_id.clone(),
-                provider_id: run.provider_id.clone(),
-                provider_instance_id: run.provider_instance_id.clone(),
-                recording_session_id,
-                recorded_lifecycle_mask,
-                snapshot: run,
-            },
-        );
+        merge_server_run_binding_locked(&mut runs, incoming)
+    }
+
+    async fn mark_lost(
+        &self,
+        run_id: &str,
+        code: &str,
+    ) -> Result<Option<ServerRunBinding>, String> {
+        let mut runs = self.runs.lock().await;
+        prune_server_runs_locked(&mut runs, Utc::now().timestamp());
+        let Some(current) = runs.get(run_id).cloned() else {
+            return Ok(None);
+        };
+        if current.snapshot.state.terminal() {
+            return Ok(Some(current));
+        }
+        let mut lost = current.clone();
+        mark_server_binding_lost(&mut lost, code)?;
+        merge_server_run_binding_locked(&mut runs, lost).map(Some)
+    }
+
+    async fn merge_bound_snapshot(
+        &self,
+        binding: &ServerRunBinding,
+        run: CodingAgentRunSnapshot,
+    ) -> Result<ServerRunBinding, String> {
+        let mut incoming = binding.clone();
+        incoming.snapshot = run;
+        let mut runs = self.runs.lock().await;
+        prune_server_runs_locked(&mut runs, Utc::now().timestamp());
+        merge_server_run_binding_locked(&mut runs, incoming)
     }
 
     async fn attach_recorder(&self, run_id: &str, recording_session_id: Option<String>) {
@@ -419,10 +472,22 @@ impl ToolRuntime {
         recording_session_id: Option<String>,
         auth: Option<&AuthContext>,
     ) -> CodingAgentTypedStartOutcome {
-        if let Some(existing) = self
+        let existing = match self
             .reconcile_run(&prepared.run_id, &prepared.authority_fingerprint, auth)
             .await
         {
+            Ok(existing) => existing,
+            Err(message) => {
+                return CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                    kind: "coding_agent_observation_conflict".to_string(),
+                    message,
+                    certainty: CodingAgentStartCertainty::OutcomeUnknown,
+                    recovery: RecoveryKind::Reconcile,
+                    run_id: prepared.run_id,
+                })
+            }
+        };
+        if let Some(existing) = existing {
             if existing.snapshot.intent_fingerprint != prepared.intent_fingerprint
                 || existing.runtime_project_id != prepared.runtime_project_id
             {
@@ -513,12 +578,25 @@ impl ToolRuntime {
                         run_id: prepared.run_id,
                     });
                 }
-                self.coding_agent_runs
-                    .bind(&prepared.client, run.clone(), recording_session_id)
-                    .await;
+                let binding = match self
+                    .coding_agent_runs
+                    .bind(&prepared.client, run, recording_session_id)
+                    .await
+                {
+                    Ok(binding) => binding,
+                    Err(message) => {
+                        return CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                            kind: "coding_agent_observation_conflict".to_string(),
+                            message,
+                            certainty: CodingAgentStartCertainty::OutcomeUnknown,
+                            recovery: RecoveryKind::Reconcile,
+                            run_id: prepared.run_id,
+                        })
+                    }
+                };
                 self.record_coding_agent_lifecycle_if_needed(&prepared.run_id)
                     .await;
-                CodingAgentTypedStartOutcome::Run(run)
+                CodingAgentTypedStartOutcome::Run(binding.snapshot)
             }
             _ => CodingAgentTypedStartOutcome::Failure(coding_agent_start_failure_from_response(
                 response,
@@ -542,9 +620,19 @@ impl ToolRuntime {
             )
         })?;
         let authority = authority_fingerprint(&principal);
-        Ok(self
+        let binding = self
             .reconcile_run(run_id, &authority, auth)
             .await
+            .map_err(|error| {
+                coding_agent_error(
+                    "coding_agent_observation_conflict",
+                    error,
+                    "outcome_unknown",
+                    RecoveryKind::Reconcile,
+                    Some(run_id),
+                )
+            })?;
+        Ok(binding
             .filter(|binding| binding.authority_fingerprint == authority)
             .map(|binding| binding.snapshot))
     }
@@ -578,14 +666,26 @@ impl ToolRuntime {
                 )
             }
         };
-        let Some(binding) = self.reconcile_run(&run_id, &authority, auth).await else {
-            return coding_agent_error(
-                "unknown_coding_agent_run",
-                "CodingAgentRun is not visible to this caller",
-                "not_started",
-                RecoveryKind::Reobserve,
-                Some(&run_id),
-            );
+        let binding = match self.reconcile_run(&run_id, &authority, auth).await {
+            Ok(Some(binding)) => binding,
+            Ok(None) => {
+                return coding_agent_error(
+                    "unknown_coding_agent_run",
+                    "CodingAgentRun is not visible to this caller",
+                    "not_started",
+                    RecoveryKind::Reobserve,
+                    Some(&run_id),
+                )
+            }
+            Err(error) => {
+                return coding_agent_error(
+                    "coding_agent_observation_conflict",
+                    error,
+                    "outcome_unknown",
+                    RecoveryKind::Reconcile,
+                    Some(&run_id),
+                )
+            }
         };
         if binding.authority_fingerprint != authority {
             return coding_agent_error(
@@ -740,9 +840,23 @@ impl ToolRuntime {
                         )
                     }
                 };
-                self.coding_agent_runs
+                let merged = match self
+                    .coding_agent_runs
                     .bind(&client, observation.run.clone(), None)
-                    .await;
+                    .await
+                {
+                    Ok(binding) => binding,
+                    Err(error) => {
+                        return coding_agent_error(
+                            "coding_agent_observation_conflict",
+                            error,
+                            "outcome_unknown",
+                            RecoveryKind::Reconcile,
+                            Some(&run_id),
+                        )
+                    }
+                };
+                observation.run = merged.snapshot;
                 self.record_coding_agent_lifecycle_if_needed(&run_id).await;
                 ToolResult::ok(observe_projection(
                     observation,
@@ -771,14 +885,26 @@ impl ToolRuntime {
                 )
             }
         };
-        let Some(binding) = self.reconcile_run(&run_id, &authority, auth).await else {
-            return coding_agent_error(
-                "unknown_coding_agent_run",
-                "CodingAgentRun is not visible to this caller",
-                "not_started",
-                RecoveryKind::Reobserve,
-                Some(&run_id),
-            );
+        let binding = match self.reconcile_run(&run_id, &authority, auth).await {
+            Ok(Some(binding)) => binding,
+            Ok(None) => {
+                return coding_agent_error(
+                    "unknown_coding_agent_run",
+                    "CodingAgentRun is not visible to this caller",
+                    "not_started",
+                    RecoveryKind::Reobserve,
+                    Some(&run_id),
+                )
+            }
+            Err(error) => {
+                return coding_agent_error(
+                    "coding_agent_observation_conflict",
+                    error,
+                    "outcome_unknown",
+                    RecoveryKind::Reconcile,
+                    Some(&run_id),
+                )
+            }
         };
         self.record_coding_agent_lifecycle_if_needed(&run_id).await;
         if binding.snapshot.state.terminal() {
@@ -855,12 +981,25 @@ impl ToolRuntime {
                             Some(&run_id),
                         );
                     }
-                    self.coding_agent_runs
-                        .bind(&client, run.clone(), None)
-                        .await;
                 }
+                let merged = match self
+                    .coding_agent_runs
+                    .merge_bound_snapshot(&binding, run)
+                    .await
+                {
+                    Ok(binding) => binding,
+                    Err(error) => {
+                        return coding_agent_error(
+                            "coding_agent_observation_conflict",
+                            error,
+                            "outcome_unknown",
+                            RecoveryKind::Reconcile,
+                            Some(&run_id),
+                        )
+                    }
+                };
                 self.record_coding_agent_lifecycle_if_needed(&run_id).await;
-                ToolResult::ok(cancel_projection(&run))
+                ToolResult::ok(cancel_projection(&merged.snapshot))
             }
             _ => response_to_tool_error(response, Some(&run_id)),
         }
@@ -878,12 +1017,24 @@ impl ToolRuntime {
             .shell_clients
             .cancel_request_dispatch_state(request_id)
             .await;
-        if let Some(binding) = self.reconcile_run(run_id, authority, auth).await {
-            self.coding_agent_runs
-                .attach_recorder(run_id, recording_session_id)
-                .await;
-            self.record_coding_agent_lifecycle_if_needed(run_id).await;
-            return CodingAgentTypedStartOutcome::Run(binding.snapshot);
+        match self.reconcile_run(run_id, authority, auth).await {
+            Ok(Some(binding)) => {
+                self.coding_agent_runs
+                    .attach_recorder(run_id, recording_session_id)
+                    .await;
+                self.record_coding_agent_lifecycle_if_needed(run_id).await;
+                return CodingAgentTypedStartOutcome::Run(binding.snapshot);
+            }
+            Ok(None) => {}
+            Err(message) => {
+                return CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
+                    kind: "coding_agent_observation_conflict".to_string(),
+                    message,
+                    certainty: CodingAgentStartCertainty::OutcomeUnknown,
+                    recovery: RecoveryKind::Reconcile,
+                    run_id: run_id.to_string(),
+                })
+            }
         }
         match dispatched {
             Some(false) => CodingAgentTypedStartOutcome::Failure(CodingAgentStartFailure {
@@ -933,11 +1084,11 @@ impl ToolRuntime {
         run_id: &str,
         authority: &str,
         auth: Option<&AuthContext>,
-    ) -> Option<ServerRunBinding> {
+    ) -> Result<Option<ServerRunBinding>, String> {
         let existing = self.coding_agent_runs.get(run_id).await;
-        if let Some(mut binding) = existing {
+        if let Some(binding) = existing {
             if binding.authority_fingerprint != authority {
-                return None;
+                return Ok(None);
             }
             // Once the Server has a binding, only the exact bound client may
             // refresh it. Another visible Runner advertising the same run_id is
@@ -948,33 +1099,28 @@ impl ToolRuntime {
                 .await
             {
                 if run.authority_fingerprint != authority {
-                    return None;
+                    return Ok(None);
                 }
                 let identity_changed = !run_matches_binding_identity(&binding, &run);
                 let runner_replaced_while_active =
                     client.agent_instance_id != binding.agent_instance_id && !run.state.terminal();
                 if identity_changed || runner_replaced_while_active {
-                    mark_server_binding_lost(
-                        &mut binding,
-                        if identity_changed {
-                            "coding_agent_identity_changed_uncertain"
-                        } else {
-                            "runner_replaced_uncertain"
-                        },
-                    );
-                    self.coding_agent_runs
-                        .runs
-                        .lock()
-                        .await
-                        .insert(run_id.to_string(), binding.clone());
-                    return Some(binding);
+                    let code = if identity_changed {
+                        "coding_agent_identity_changed_uncertain"
+                    } else {
+                        "runner_replaced_uncertain"
+                    };
+                    return self.coding_agent_runs.mark_lost(run_id, code).await;
                 }
-                self.coding_agent_runs.bind(&client, run, None).await;
-                return self.coding_agent_runs.get(run_id).await;
+                return self
+                    .coding_agent_runs
+                    .bind(&client, run, None)
+                    .await
+                    .map(Some);
             }
 
             if binding.snapshot.state.terminal() {
-                return Some(binding);
+                return Ok(Some(binding));
             }
 
             // A temporary disconnect of the same Runner is not proof of loss: keep
@@ -1003,29 +1149,29 @@ impl ToolRuntime {
                     } else {
                         "provider_replaced_uncertain"
                     };
-                    mark_server_binding_lost(&mut binding, code);
-                    self.coding_agent_runs
-                        .runs
-                        .lock()
-                        .await
-                        .insert(run_id.to_string(), binding.clone());
+                    return self.coding_agent_runs.mark_lost(run_id, code).await;
                 }
             }
-            return Some(binding);
+            return Ok(self.coding_agent_runs.get(run_id).await);
         }
 
         // After a Server restart there is no process-local binding. Recover only
         // from a unique visible Runner inventory match; the registry fails closed
         // on duplicate run ids instead of choosing by iteration order.
-        let (client, run) = self
+        let Some((client, run)) = self
             .shell_clients
             .coding_agent_run_for_auth(auth, run_id)
-            .await?;
+            .await
+        else {
+            return Ok(None);
+        };
         if run.authority_fingerprint != authority {
-            return None;
+            return Ok(None);
         }
-        self.coding_agent_runs.bind(&client, run, None).await;
-        self.coding_agent_runs.get(run_id).await
+        self.coding_agent_runs
+            .bind(&client, run, None)
+            .await
+            .map(Some)
     }
 
     async fn current_agent_instance(
@@ -1040,15 +1186,20 @@ impl ToolRuntime {
     }
 }
 
-fn mark_server_binding_lost(binding: &mut ServerRunBinding, code: &str) {
+fn mark_server_binding_lost(binding: &mut ServerRunBinding, code: &str) -> Result<(), String> {
     if binding.snapshot.state.terminal() {
-        return;
+        return Ok(());
     }
+    let next_revision = binding
+        .snapshot
+        .observation_revision
+        .checked_add(1)
+        .ok_or_else(|| "CodingAgentRun observation revision is exhausted".to_string())?;
     let completed_at = chrono::Utc::now().timestamp();
     binding.snapshot.state = CodingAgentRunState::Lost;
     binding.snapshot.execution_state = CodingAgentExecutionState::OutcomeUnknown;
     binding.snapshot.updated_at = completed_at;
-    binding.snapshot.observation_revision = binding.snapshot.observation_revision.saturating_add(1);
+    binding.snapshot.observation_revision = next_revision;
     binding.snapshot.terminal = Some(CodingAgentTerminal {
         stop_reason: None,
         error_code: Some(code.to_string()),
@@ -1058,6 +1209,7 @@ fn mark_server_binding_lost(binding: &mut ServerRunBinding, code: &str) {
         ),
         completed_at,
     });
+    Ok(())
 }
 
 fn validate_start_input(
@@ -1647,6 +1799,79 @@ mod tests {
                 terminal,
             },
         }
+    }
+
+    fn test_shell_client() -> crate::shell_protocol::ShellClientView {
+        crate::shell_protocol::ShellClientView {
+            client_id: "client".to_string(),
+            agent_instance_id: "instance".to_string(),
+            display_name: None,
+            owner: None,
+            hostname: None,
+            host_context: None,
+            status: "online".to_string(),
+            connected: true,
+            last_seen: 0,
+            capabilities: Default::default(),
+            coding_agent_providers: None,
+            pending_requests: 0,
+            projects: Vec::new(),
+            project_inventory: None,
+            agent_protocol_version: "websocket-v1".to_string(),
+            transport: "websocket".to_string(),
+            agent_protocol_semantics: crate::shell_protocol::normalize_agent_protocol_semantics(
+                "websocket-v1",
+            ),
+            policy: None,
+            registered_at: 0,
+            connected_at: 0,
+            disconnected_at: None,
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn server_run_binding_rejects_out_of_order_and_conflicting_observations() {
+        let state = CodingAgentServerState::default();
+        let client = test_shell_client();
+        let run_id = "wc_agent_run_monotonic";
+        let now = chrono::Utc::now().timestamp();
+
+        let mut running =
+            test_server_binding(run_id.to_string(), CodingAgentRunState::Running, now).snapshot;
+        running.observation_revision = 1;
+        state.bind(&client, running.clone(), None).await.unwrap();
+
+        let mut completed =
+            test_server_binding(run_id.to_string(), CodingAgentRunState::Completed, now).snapshot;
+        completed.observation_revision = 2;
+        let accepted = state.bind(&client, completed.clone(), None).await.unwrap();
+        assert_eq!(accepted.snapshot, completed);
+
+        let stale = state.bind(&client, running.clone(), None).await.unwrap();
+        assert_eq!(stale.snapshot, completed);
+        let replay = state.bind(&client, completed.clone(), None).await.unwrap();
+        assert_eq!(replay.snapshot, completed);
+
+        let mut same_revision_conflict = running.clone();
+        same_revision_conflict.observation_revision = 2;
+        same_revision_conflict.updated_at = now;
+        assert!(state
+            .bind(&client, same_revision_conflict, None)
+            .await
+            .is_err());
+        assert_eq!(state.get(run_id).await.unwrap().snapshot, completed);
+
+        let mut terminal_regression = running;
+        terminal_regression.observation_revision = 3;
+        terminal_regression.updated_at = now;
+        assert!(state
+            .bind(&client, terminal_regression, None)
+            .await
+            .is_err());
+        assert_eq!(state.get(run_id).await.unwrap().snapshot, completed);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a canonical revision-monotonic merge contract for CodingAgentRun snapshots
- treat lower revisions as stale no-ops, exact same-revision snapshots as replay, and same-revision semantic divergence as fail-closed conflict
- validate higher-revision state/execution transitions before accepting them
- apply the same contract to process-local CodingAgent bindings and durable AgentTask -> CodingAgentRun observations
- guard durable observation updates with revision CAS and reject observation revisions that cannot be represented safely in SQLite INTEGER
- terminalize AgentTask/Attempt only from the accepted authoritative durable observation, never directly from a stale incoming snapshot

## Reviewer fix
Fresh independent review found one semantic regression in the initial hardening: `CodingAgentRunState::terminal()` also includes `Lost`, but Lost is outcome-unknown recovery state rather than definitive effect truth. Making all terminal states absorbing would prevent a later authoritative Runner `Completed`/`Failed`/`Cancelled` snapshot from resolving a prior synthetic Lost.

The reviewer fix keeps `Completed`/`Failed`/`Cancelled` absorbing, allows higher-revision `Lost -> Lost` or `Lost -> definitive terminal`, and still rejects `Lost -> active` regression. Focused process-local and durable AgentTask regressions cover this recovery path.

## Validation
- `cargo test -p webcodex-core coding_agent --lib` — 6/6 pass
- `cargo test db::agent_task_tests --lib` — 26/26 pass
- `cargo test coding_agent --lib` — 23/23 pass
- `cargo test tool_runtime::tests::agent_tasks --lib` — 7/7 pass
- direct process-local out-of-order/Lost recovery regression — pass
- direct durable Lost -> definitive terminal regression — pass
- `cargo fmt --all -- --check` — pass
- `cargo check --all-targets` — pass; only the existing four AgentWake dead-code warnings
- `git diff --check` — pass
- final WebCodex closeout: clean workspace, no unresolved validation failures

## Scope
No model-visible tool/schema changes, OAuth changes, DB schema migration, scheduler, Host continuation, cards, artifact handoff, or provider abstraction work.