### PR TITLE
Tighten pre-0.4 runner registration contract

### DIFF
--- a/crates/webcodex-core/src/shell_protocol.rs
+++ b/crates/webcodex-core/src/shell_protocol.rs
@@ -622,12 +622,6 @@ pub struct ShellClientCapabilities {
     /// Optional and never inferred from shell/MCP.
     #[serde(default, skip_serializing_if = "is_false")]
     pub coding_agent_runs: bool,
-    /// Registration-only explicit protocol generation marker.
-    ///
-    /// Current Server ingress requires generation 2 and removes this marker before
-    /// retaining the ordinary capability projection. It is not a RunnerFeature.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_protocol_generation: Option<AgentProtocolGenerationNumber>,
 }
 
 /// Bounded, non-secret status for the agent's active configuration generation.
@@ -706,7 +700,6 @@ impl Default for ShellClientCapabilities {
             computer_text_input: false,
             job_state_reconciliation: false,
             coding_agent_runs: false,
-            agent_protocol_generation: None,
         }
     }
 }
@@ -940,6 +933,24 @@ fn default_policy_max_output_bytes() -> usize {
     256 * 1024
 }
 
+fn deserialize_registration_capabilities<'de, D>(
+    deserializer: D,
+) -> Result<ShellClientCapabilities, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let Some(object) = value.as_object() else {
+        return Err(serde::de::Error::custom(
+            "registration capabilities must be an object",
+        ));
+    };
+    if !object.contains_key("shell") {
+        return Err(serde::de::Error::missing_field("shell"));
+    }
+    serde_json::from_value(value).map_err(serde::de::Error::custom)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShellClientRegisterRequest {
     pub client_id: String,
@@ -951,14 +962,20 @@ pub struct ShellClientRegisterRequest {
     /// first is online, and a stale/replaced instance can no longer poll or
     /// submit results. It is not a secret.
     pub agent_instance_id: String,
+    /// Canonical Runner protocol generation. This is registration identity, not a
+    /// capability bit, and is required at every 0.4 registration ingress.
+    pub agent_protocol_generation: AgentProtocolGenerationNumber,
     #[serde(default)]
     pub display_name: Option<String>,
     #[serde(default)]
     pub owner: Option<String>,
     #[serde(default)]
     pub hostname: Option<String>,
-    #[serde(default)]
-    pub capabilities: Option<ShellClientCapabilities>,
+    /// Complete Runner capability snapshot for this registration. The field is
+    /// required, and `shell` must be explicitly present so 0.4 registration never
+    /// inherits the pre-0.4 missing-field=true behavior.
+    #[serde(deserialize_with = "deserialize_registration_capabilities")]
+    pub capabilities: ShellClientCapabilities,
     /// Optional bounded planning context declared by the Runner configuration.
     /// This is descriptive metadata only: it never grants authority or proves
     /// current host/service/network state.
@@ -2788,9 +2805,8 @@ impl AgentEnvelope {
 }
 
 /// QUIC-v1 transport registration wire. Authentication remains transport-owned
-/// while retaining the byte-compatible first-frame JSON shape expected by
-/// rolling-old Servers and Runners: `type=register`, flattened registration
-/// payload fields, and an optional `auth_token`.
+/// while the first frame carries `type=register`, the complete canonical 0.4
+/// registration payload, and an optional `auth_token`.
 ///
 /// Deliberately does not implement `Debug`: the credential must not become
 /// printable through routine transport diagnostics.
@@ -3171,11 +3187,12 @@ mod envelope_tests {
             build: None,
             client_id: "ws-1".to_string(),
             agent_instance_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            agent_protocol_generation: AGENT_PROTOCOL_GENERATION_V2,
             display_name: Some("WS Agent".to_string()),
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 shell: true,
                 file_read: true,
                 file_write: false,
@@ -3225,8 +3242,7 @@ mod envelope_tests {
                 computer_text_input: false,
                 job_state_reconciliation: false,
                 coding_agent_runs: false,
-                agent_protocol_generation: Some(AGENT_PROTOCOL_GENERATION_V2),
-            }),
+            },
             policy: None,
             job_concurrency_limit: Some(4),
             job_inventory: None,
@@ -3269,11 +3285,11 @@ mod envelope_tests {
             AgentEnvelope::Register { payload, .. } => {
                 assert_eq!(payload.client_id, "ws-1");
                 assert_eq!(payload.job_concurrency_limit, Some(4));
-                let caps = payload.capabilities.expect("capabilities");
                 assert_eq!(
-                    caps.agent_protocol_generation,
-                    Some(AGENT_PROTOCOL_GENERATION_V2)
+                    payload.agent_protocol_generation,
+                    AGENT_PROTOCOL_GENERATION_V2
                 );
+                let caps = payload.capabilities;
                 assert!(caps.shell);
                 assert!(!caps.file_write);
                 assert!(caps.persistent_shell);
@@ -3285,22 +3301,10 @@ mod envelope_tests {
     #[test]
     fn raw_protocol_generation_number_preserves_future_wire_values_for_ingress_rejection() {
         let mut payload = sample_register();
-        payload
-            .capabilities
-            .as_mut()
-            .unwrap()
-            .agent_protocol_generation = Some(AgentProtocolGenerationNumber::new(u16::MAX));
+        payload.agent_protocol_generation = AgentProtocolGenerationNumber::new(u16::MAX);
         let json = serde_json::to_string(&payload).unwrap();
         let decoded: ShellClientRegisterRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(
-            decoded
-                .capabilities
-                .unwrap()
-                .agent_protocol_generation
-                .unwrap()
-                .get(),
-            u16::MAX
-        );
+        assert_eq!(decoded.agent_protocol_generation.get(), u16::MAX);
     }
 
     #[test]
@@ -3601,11 +3605,7 @@ mod envelope_tests {
     async fn job_reconciliation_inventory_round_trips_across_all_register_transports() {
         let inventory = reconciliation_inventory();
         let mut polling = sample_register();
-        polling
-            .capabilities
-            .as_mut()
-            .unwrap()
-            .job_state_reconciliation = true;
+        polling.capabilities.job_state_reconciliation = true;
         polling.job_inventory = Some(inventory.clone());
         let polling_json = serde_json::to_vec(&polling).unwrap();
         let polling_back: ShellClientRegisterRequest =
@@ -4328,10 +4328,11 @@ mod envelope_tests {
     }
 
     #[test]
-    fn older_register_request_without_job_concurrency_limit_deserializes_as_unknown() {
+    fn register_request_without_job_concurrency_limit_deserializes_as_unknown() {
         let json = r#"{
-            "client_id": "legacy-runner",
-            "agent_instance_id": "legacy-instance",
+            "client_id": "current-runner",
+            "agent_instance_id": "current-instance",
+            "agent_protocol_generation": 2,
             "capabilities": {"shell": true}
         }"#;
         let request: ShellClientRegisterRequest = serde_json::from_str(json).unwrap();
@@ -4496,16 +4497,17 @@ mod envelope_tests {
     }
 
     #[tokio::test]
-    async fn quic_register_codec_preserves_legacy_wire_shape_and_round_trips() {
+    async fn quic_register_codec_round_trips_current_wire_shape() {
         let payload = ShellClientRegisterRequest {
             process_started_at: None,
             build: None,
             client_id: "q-1".to_string(),
             agent_instance_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            agent_protocol_generation: AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
-            capabilities: None,
+            capabilities: ShellClientCapabilities::default(),
             host_context: None,
             policy: None,
             job_concurrency_limit: None,
@@ -4519,42 +4521,30 @@ mod envelope_tests {
         assert!(json.contains(r#""type":"register""#), "json was: {json}");
         assert!(json.contains(r#""client_id":"q-1""#), "json was: {json}");
         assert!(
+            json.contains(r#""agent_protocol_generation":2"#),
+            "json was: {json}"
+        );
+        assert!(
+            json.contains(r#""capabilities":{"shell":true"#),
+            "json was: {json}"
+        );
+        assert!(
             json.contains(r#""auth_token":"wc_agent_secret""#),
             "json was: {json}"
         );
 
-        #[derive(Deserialize)]
-        #[serde(tag = "type", rename_all = "snake_case")]
-        enum LegacyQuicRegisterEnvelope {
-            Register {
-                #[serde(flatten)]
-                payload: ShellClientRegisterRequest,
-                #[serde(default)]
-                auth_token: Option<String>,
-            },
-        }
-        match serde_json::from_str::<LegacyQuicRegisterEnvelope>(json).unwrap() {
-            LegacyQuicRegisterEnvelope::Register {
-                payload,
-                auth_token,
-            } => {
-                assert_eq!(payload.client_id, "q-1");
-                assert_eq!(auth_token.as_deref(), Some("wc_agent_secret"));
-            }
-        }
-
-        let legacy_json = format!(
-            r#"{{"type":"register","client_id":"q-legacy","agent_instance_id":"11111111-1111-1111-1111-111111111112","agent_protocol_version":"quic-v1","auth_token":"legacy-secret"}}"#
-        );
-        let mut legacy_wire = Vec::new();
-        legacy_wire.extend_from_slice(&(legacy_json.len() as u32).to_be_bytes());
-        legacy_wire.extend_from_slice(legacy_json.as_bytes());
-        let (legacy_payload, legacy_token) = read_quic_register_frame(&mut legacy_wire.as_slice())
+        let mut reader = encoded.as_slice();
+        let (decoded, token) = read_quic_register_frame(&mut reader)
             .await
             .unwrap()
             .into_parts();
-        assert_eq!(legacy_payload.client_id, "q-legacy");
-        assert_eq!(legacy_token.as_deref(), Some("legacy-secret"));
+        assert_eq!(decoded.client_id, "q-1");
+        assert_eq!(
+            decoded.agent_protocol_generation,
+            AGENT_PROTOCOL_GENERATION_V2
+        );
+        assert!(decoded.capabilities.shell);
+        assert_eq!(token.as_deref(), Some("wc_agent_secret"));
     }
 }
 

--- a/crates/webcodex-runner-config/src/lib.rs
+++ b/crates/webcodex-runner-config/src/lib.rs
@@ -296,9 +296,6 @@ pub fn generated_runner_config_toml(opts: &RunnerInitOptions) -> Result<String, 
             // ACP autonomous coding is a runtime-only capability and must not be
             // silently enabled by generated legacy agent config.
             coding_agent_runs: false,
-            // Protocol generation is a live Runner registration fact, never a
-            // static generated-config capability.
-            agent_protocol_generation: None,
         },
         policy: GeneratedRunnerPolicy {
             allow_raw_shell: true,

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2015,7 +2015,6 @@ fn build_register_request_with_provider_status(
 ) {
     let hot = runtime.snapshot();
     let mut capabilities = runner_register_capabilities(cfg);
-    capabilities.agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
     let coding_agent_providers = runtime
         .coding_agents()
         .map(|manager| manager.providers())
@@ -2028,11 +2027,12 @@ fn build_register_request_with_provider_status(
         ShellClientRegisterRequest {
             client_id: cfg.client_id.clone(),
             agent_instance_id: agent_instance_id.to_string(),
+            agent_protocol_generation: AGENT_PROTOCOL_GENERATION_V2,
             display_name: cfg.display_name.clone(),
             owner: cfg.owner.clone(),
             hostname: cfg.hostname.clone().or_else(hostname),
             host_context: cfg.host_context.clone(),
-            capabilities: Some(capabilities),
+            capabilities,
             policy: Some(register_policy_summary(
                 &hot,
                 prepared_cache_count,

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -1112,10 +1112,7 @@ fn generated_agent_instance_id_is_non_empty_uuid_like() {
     assert_eq!(body.agent_instance_id, id);
     assert!(!body.agent_instance_id.is_empty());
     assert_eq!(
-        body.capabilities
-            .as_ref()
-            .and_then(|capabilities| capabilities.agent_protocol_generation),
-        Some(AGENT_PROTOCOL_GENERATION_V2),
+        body.agent_protocol_generation, AGENT_PROTOCOL_GENERATION_V2,
         "current Runner registration must explicitly declare protocol generation 2"
     );
 }

--- a/crates/webcodex-runner/src/main_tests/registration.rs
+++ b/crates/webcodex-runner/src/main_tests/registration.rs
@@ -41,14 +41,9 @@ fn current_runner_registration_advertises_v2_and_complete_generation_baseline() 
     let tmp = tempfile::tempdir().unwrap();
     let cfg = test_config(tmp.path().join("config/projects.d"));
     let body = build_register_request(&cfg, "baseline-instance", 0);
-    assert_eq!(
-        body.capabilities
-            .as_ref()
-            .and_then(|capabilities| capabilities.agent_protocol_generation),
-        Some(AGENT_PROTOCOL_GENERATION_V2)
-    );
+    assert_eq!(body.agent_protocol_generation, AGENT_PROTOCOL_GENERATION_V2);
 
-    let capabilities = serde_json::to_value(body.capabilities.as_ref().unwrap()).unwrap();
+    let capabilities = serde_json::to_value(&body.capabilities).unwrap();
     assert_eq!(
         AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES.len(),
         22
@@ -98,14 +93,9 @@ fn computer_register_request_announces_platform_capabilities_and_generation() {
     });
     let body = build_register_request(&cfg, "inst-1", 0);
     assert_eq!(body.agent_instance_id, "inst-1");
-    assert_eq!(
-        body.capabilities
-            .as_ref()
-            .and_then(|capabilities| capabilities.agent_protocol_generation),
-        Some(AGENT_PROTOCOL_GENERATION_V2)
-    );
+    assert_eq!(body.agent_protocol_generation, AGENT_PROTOCOL_GENERATION_V2);
     // Verify all effective capabilities are advertised from the real host probe.
-    let caps = body.capabilities.expect("agent registers capabilities");
+    let caps = body.capabilities;
     assert!(caps.shell);
     assert!(caps.file_read);
     assert!(caps.file_write);

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -2621,10 +2621,16 @@ fn structured_process_job_handoff_observation_does_not_reset_the_original_total_
     // still prove the original timeout is not reset at handoff.
     assert!(wait_until(Duration::from_secs(30), || marker.exists()));
 
-    // Once the marker proves the child started, the JobManager has no further
-    // sync-grace state transition to wait for: ToolRuntime handoff only exposes
-    // this same execution. Inventory observation is deliberately read-only and
-    // cannot replace the process or reset its original deadline.
+    // The child can write its marker before the parent task is rescheduled to
+    // publish the post-spawn `running` state. That race is visible under a
+    // heavily parallel test load, so wait only for that state publication;
+    // inventory observation remains read-only and cannot replace the process
+    // or reset its original deadline.
+    assert!(wait_until(Duration::from_secs(2), || {
+        manager.inventory().jobs.into_iter().any(|snapshot| {
+            snapshot.job_id == "structured-original-timeout" && snapshot.status == "running"
+        })
+    }));
     let handoff = manager
         .inventory()
         .jobs

--- a/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
@@ -4318,9 +4318,10 @@ fn polling_once_startup_with_100_projects_registers_liveness_then_completes_page
                 assert!(payload.get("projects").is_none());
                 assert!(payload.get("agent_protocol_version").is_none());
                 assert_eq!(
-                    payload["capabilities"]["agent_protocol_generation"],
+                    payload["agent_protocol_generation"],
                     AGENT_PROTOCOL_GENERATION_V2.get()
                 );
+                assert!(payload["capabilities"]["shell"].is_boolean());
                 register_inventory_support_response()
             }
             "/api/shell/agent/poll" => {
@@ -5275,11 +5276,11 @@ async fn websocket_disconnect_loop_reregisters_identity_generation_and_capabilit
     for register in [first, second] {
         assert_eq!(register.client_id, "oe");
         assert_eq!(register.agent_instance_id, "inst-reconnect");
-        let caps = register.capabilities.expect("capabilities");
         assert_eq!(
-            caps.agent_protocol_generation,
-            Some(AGENT_PROTOCOL_GENERATION_V2)
+            register.agent_protocol_generation,
+            AGENT_PROTOCOL_GENERATION_V2
         );
+        let caps = register.capabilities;
         assert!(caps.shell);
         assert!(caps.file_read);
         assert!(caps.file_write);

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -78,13 +78,16 @@ enlarge the generation-2 baseline-required capability set; new requirements use
 additive `RegistrationRequired` capabilities. This promise does not extend rolling
 compatibility back to pre-0.4 binaries.
 
-Current first-party Runner registration is generation-2-only:
-`capabilities.agent_protocol_generation` must be exactly `2`. A missing value,
-generation `1`, or an unknown generation fails closed before the Runner record is
-accepted. The 22 generation-2 baseline capability booleans are protocol facts;
-omitting or contradicting one rejects registration rather than degrading it to
-unavailable. RegistrationRequired additive capabilities remain explicit and
-fail closed as unavailable when omitted.
+Current first-party Runner registration is generation-2-only. The top-level
+`agent_protocol_generation` field is required and must be exactly `2`; it is
+protocol identity, not a capability bit. `capabilities` is also required, and its
+`shell` field must be explicit rather than inheriting the pre-0.4 missing-field
+`true` default. Missing generation/capabilities/shell, generation `1`, or an
+unknown generation fails closed before the Runner record is accepted. The 22
+generation-2 baseline capability booleans are protocol facts; omitting or
+contradicting one rejects registration rather than degrading it to unavailable.
+RegistrationRequired additive capabilities remain explicit and fail closed as
+unavailable when omitted.
 
 In `v0.4`, protocol generation is the only Runner protocol-version identity.
 Transport is an independent ingress fact (`polling`, `websocket`, or `quic`), and

--- a/docs/RUNNER.zh-CN.md
+++ b/docs/RUNNER.zh-CN.md
@@ -65,11 +65,14 @@ Server 与 Runner。只有当前合同明确保留的兼容面才属于受支持
 不兼容。patch release 不扩大 generation-2 baseline-required capability set；新增要求使用
 additive `RegistrationRequired` capability。这一承诺不向 pre-0.4 二进制提供滚动兼容保证。
 
-当前 first-party Runner 注册只接受 protocol generation 2：
-`capabilities.agent_protocol_generation` 必须精确为 `2`。缺失、generation `1` 或未知
-值都会在创建 Runner record 前 fail closed。generation 2 的 22 个 baseline capability
-bool 是协议事实；缺失或与 baseline 矛盾时直接拒绝注册，而不是降级成 unavailable。
-RegistrationRequired 的增量 capability 仍保持显式声明，省略时按不可用处理。
+当前 first-party Runner 注册只接受 protocol generation 2。顶层
+`agent_protocol_generation` 字段是必填项且必须精确为 `2`；它属于协议 identity，
+不是 capability bit。`capabilities` 也必须显式存在，其中 `shell` 必须明确提供，不能再
+继承 pre-0.4“字段缺失即 `true`”的注册语义。缺失 generation/capabilities/shell、
+generation `1` 或未知值都会在创建 Runner record 前 fail closed。generation 2 的 22 个
+baseline capability bool 是协议事实；缺失或与 baseline 矛盾时直接拒绝注册，而不是
+降级成 unavailable。RegistrationRequired 的增量 capability 仍保持显式声明，省略时按
+不可用处理。
 
 在 `v0.4` 中，protocol generation 是 Runner 唯一的协议版本 identity。transport
 作为独立 ingress 事实（`polling`、`websocket` 或 `quic`）存在；项目清单在注册后统一

--- a/src/admin_project_lifecycle.rs
+++ b/src/admin_project_lifecycle.rs
@@ -881,17 +881,18 @@ mod tests {
                 ShellClientRegisterRequest {
                     client_id: "owned-runner".to_string(),
                     agent_instance_id: "instance-owned".to_string(),
+                    agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                     display_name: None,
                     owner: Some("alice".to_string()),
                     hostname: None,
                     host_context: None,
-                    capabilities: Some(ShellClientCapabilities {
+                    capabilities: ShellClientCapabilities {
                         jobs: true,
                         async_jobs: true,
                         async_shell_jobs: true,
                         project_lifecycle: true,
                         ..Default::default()
-                    }),
+                    },
                     policy: None,
                     process_started_at: None,
                     build: None,

--- a/src/agent_quic.rs
+++ b/src/agent_quic.rs
@@ -556,21 +556,16 @@ mod tests {
     }
 
     fn register_envelope(client_id: &str, instance: &str) -> QuicRegisterFrame {
-        register_envelope_with_generation(
-            client_id,
-            instance,
-            Some(AGENT_PROTOCOL_GENERATION_V2),
-            None,
-        )
+        register_envelope_with_generation(client_id, instance, AGENT_PROTOCOL_GENERATION_V2, None)
     }
 
     fn register_envelope_with_generation(
         client_id: &str,
         instance: &str,
-        generation: Option<AgentProtocolGenerationNumber>,
+        generation: AgentProtocolGenerationNumber,
         auth_token: Option<String>,
     ) -> QuicRegisterFrame {
-        let mut capabilities =
+        let capabilities =
             crate::test_support::current_runner_capabilities(ShellClientCapabilities {
                 shell: true,
                 file_read: true,
@@ -621,9 +616,7 @@ mod tests {
                 computer_text_input: false,
                 job_state_reconciliation: false,
                 coding_agent_runs: false,
-                agent_protocol_generation: None,
             });
-        capabilities.agent_protocol_generation = generation;
         QuicRegisterFrame::new(
             ShellClientRegisterRequest {
                 process_started_at: None,
@@ -634,11 +627,12 @@ mod tests {
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: instance.to_string(),
+                agent_protocol_generation: generation,
                 display_name: Some("quic-test".to_string()),
                 owner: Some("tester".to_string()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(capabilities),
+                capabilities: capabilities,
                 policy: None,
             },
             auth_token,
@@ -752,15 +746,17 @@ mod tests {
         .await;
         let (client_endpoint, conn, mut send, mut recv) =
             connect_quic_client(&cert_der, addr).await;
-        let register = register_envelope_with_generation(
-            "quic-missing-generation",
-            "inst-missing-generation",
-            None,
-            None,
-        );
-        write_quic_register_frame(&mut send, &register)
+        let register = register_envelope("quic-missing-generation", "inst-missing-generation");
+        let mut register = serde_json::to_value(&register).unwrap();
+        register
+            .as_object_mut()
+            .unwrap()
+            .remove("agent_protocol_generation");
+        let json = serde_json::to_vec(&register).unwrap();
+        send.write_all(&(json.len() as u32).to_be_bytes())
             .await
-            .expect("write register");
+            .expect("write register length");
+        send.write_all(&json).await.expect("write register body");
 
         let error = tokio::time::timeout(Duration::from_secs(5), read_quic_frame(&mut recv))
             .await
@@ -768,8 +764,8 @@ mod tests {
             .expect("read register error");
         match error {
             AgentEnvelope::Error { code, message } => {
-                assert_eq!(code, "register_failed");
-                assert_eq!(message, "agent_protocol_generation is required");
+                assert_eq!(code, "expected_register");
+                assert!(message.contains("agent_protocol_generation"), "{message}");
             }
             other => panic!("expected register_failed, got {:?}", other.kind()),
         }
@@ -797,7 +793,7 @@ mod tests {
         let register = register_envelope_with_generation(
             "quic-unsupported-generation",
             "inst-unsupported",
-            Some(AgentProtocolGenerationNumber::new(3)),
+            AgentProtocolGenerationNumber::new(3),
             None,
         );
         write_quic_register_frame(&mut send, &register)
@@ -957,7 +953,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-gen2-rt",
                 "inst-v2",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 None,
             ),
         )
@@ -1077,7 +1073,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-job",
                 "inst-job",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 None,
             ),
         )
@@ -1180,7 +1176,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-disc",
                 "inst-disc",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 None,
             ),
         )
@@ -1289,7 +1285,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-goodbye",
                 "inst-a",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 None,
             ),
         )
@@ -1331,7 +1327,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-goodbye",
                 "inst-b",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 None,
             ),
         )
@@ -1380,7 +1376,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-auth-ok",
                 "inst-auth-ok",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 Some("bootstrap-secret".to_string()),
             ),
         )
@@ -1405,7 +1401,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-auth-missing",
                 "inst-auth-missing",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 None,
             ),
         )
@@ -1434,7 +1430,7 @@ mod tests {
             &register_envelope_with_generation(
                 "quic-auth-bad",
                 "inst-auth-bad",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
                 Some("wrong-secret".to_string()),
             ),
         )

--- a/src/agent_session_tests.rs
+++ b/src/agent_session_tests.rs
@@ -30,11 +30,12 @@ fn streaming_registration(client_id: &str, agent_instance_id: &str) -> ShellClie
         coding_agent_inventory: None,
         client_id: client_id.to_string(),
         agent_instance_id: agent_instance_id.to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: None,
         hostname: None,
         host_context: None,
-        capabilities: Some(capabilities),
+        capabilities: capabilities,
         policy: None,
     })
 }

--- a/src/agent_tokens_http/tests.rs
+++ b/src/agent_tokens_http/tests.rs
@@ -538,6 +538,7 @@ async fn http_agent_tokens_register_hash_enforces_transport_and_client_id_bindin
         .json(&json!({
             "client_id": "alice-laptop",
             "agent_instance_id": "inst-1",
+            "agent_protocol_generation": 2,
             "capabilities": crate::test_support::current_runner_capabilities(crate::shell_protocol::ShellClientCapabilities::default()),
             "owner": "alice",
         }))
@@ -554,6 +555,7 @@ async fn http_agent_tokens_register_hash_enforces_transport_and_client_id_bindin
         .json(&json!({
             "client_id": "other-laptop",
             "agent_instance_id": "inst-2",
+            "agent_protocol_generation": 2,
             "capabilities": crate::test_support::current_runner_capabilities(crate::shell_protocol::ShellClientCapabilities::default()),
             "owner": "alice",
         }))

--- a/src/agent_ws.rs
+++ b/src/agent_ws.rs
@@ -360,11 +360,12 @@ mod tests {
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: instance_id.to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: Some("ws-test".to_string()),
                 owner: Some("tester".to_string()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         file_read: true,
@@ -415,9 +416,8 @@ mod tests {
                         computer_text_input: false,
                         job_state_reconciliation: false,
                         coding_agent_runs: false,
-                        agent_protocol_generation: None,
                     },
-                )),
+                ),
                 policy: Some(AgentPolicySummary::default()),
             },
         }
@@ -694,23 +694,19 @@ mod tests {
         let addr = start_server(registry.clone()).await;
         let url = format!("ws://{}/api/agents/ws", addr);
         let (mut ws, _resp) = connect_async(url).await.expect("ws connect");
-        let mut register = register_envelope("ws-missing-protocol");
-        let AgentEnvelope::Register { payload, .. } = &mut register else {
-            unreachable!("register helper must return Register")
-        };
-        payload
-            .capabilities
-            .as_mut()
+        let mut register = serde_json::to_value(register_envelope("ws-missing-protocol")).unwrap();
+        register
+            .as_object_mut()
             .unwrap()
-            .agent_protocol_generation = None;
-        ws.send(TungsteniteMessage::Text(register.to_json().unwrap().into()))
+            .remove("agent_protocol_generation");
+        ws.send(TungsteniteMessage::Text(register.to_string().into()))
             .await
             .unwrap();
 
         match recv_envelope(&mut ws).await {
             AgentEnvelope::Error { code, message } => {
-                assert_eq!(code, "register_failed");
-                assert_eq!(message, "agent_protocol_generation is required");
+                assert_eq!(code, "expected_register");
+                assert!(message.contains("agent_protocol_generation"), "{message}");
             }
             other => panic!("expected register_failed, got {:?}", other.kind()),
         }
@@ -730,11 +726,7 @@ mod tests {
         let AgentEnvelope::Register { payload, .. } = &mut register else {
             unreachable!("register helper must return Register")
         };
-        payload
-            .capabilities
-            .as_mut()
-            .unwrap()
-            .agent_protocol_generation = Some(AgentProtocolGenerationNumber::new(3));
+        payload.agent_protocol_generation = AgentProtocolGenerationNumber::new(3);
         ws.send(TungsteniteMessage::Text(register.to_json().unwrap().into()))
             .await
             .unwrap();

--- a/src/connector_runtime/connector_runtime_tests.rs
+++ b/src/connector_runtime/connector_runtime_tests.rs
@@ -61,11 +61,12 @@ async fn register_agent_with_lsp_capabilities(
                 coding_agent_inventory: None,
                 client_id: "hosted".to_string(),
                 agent_instance_id: "instance".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some("owner".to_string()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         file_read: true,
@@ -116,9 +117,8 @@ async fn register_agent_with_lsp_capabilities(
                         computer_text_input: false,
                         job_state_reconciliation: false,
                         coding_agent_runs: false,
-                        agent_protocol_generation: None,
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(&auth("u1")),

--- a/src/connector_runtime/execution_tests.rs
+++ b/src/connector_runtime/execution_tests.rs
@@ -112,13 +112,14 @@ pub(crate) async fn console_fixture() -> ConsoleFixture {
                 coding_agent_inventory: None,
                 client_id: "laptop".into(),
                 agent_instance_id: "instance-b".into(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some("owner".into()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities::default(),
-                )),
+                ),
                 policy: None,
             },
             Some(&grant_b),
@@ -172,17 +173,18 @@ async fn fixture_built(
                 coding_agent_inventory: None,
                 client_id: "hosted".into(),
                 agent_instance_id: "instance".into(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some("owner".into()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         internal_posix_script: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(&owner),
@@ -3915,11 +3917,12 @@ async fn read_only_commands_run_is_denied_even_when_agent_supports_shell() {
                 coding_agent_inventory: None,
                 client_id: "hosted".into(),
                 agent_instance_id: "instance".into(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some("owner".into()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         project_lifecycle: false,
@@ -3927,7 +3930,7 @@ async fn read_only_commands_run_is_denied_even_when_agent_supports_shell() {
                         internal_posix_script: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(&fixture.owner),
@@ -4292,11 +4295,12 @@ async fn manifestless_python_unittest_checks_finish_with_clean_result() {
                 coding_agent_inventory: None,
                 client_id: "hosted".into(),
                 agent_instance_id: "instance".into(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some("owner".into()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         file_read: true,
@@ -4307,7 +4311,7 @@ async fn manifestless_python_unittest_checks_finish_with_clean_result() {
                         structured_validation_argv: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(&owner),

--- a/src/mcp_tests/artifact_export.rs
+++ b/src/mcp_tests/artifact_export.rs
@@ -22,11 +22,12 @@ async fn mcp_export_runtime(
                 coding_agent_inventory: None,
                 client_id: "exporter".to_string(),
                 agent_instance_id: "inst-export".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: owner.map(str::to_string),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(ShellClientCapabilities::default()),
+                capabilities: ShellClientCapabilities::default(),
                 policy: None,
             },
         ))

--- a/src/mcp_tests/file_import.rs
+++ b/src/mcp_tests/file_import.rs
@@ -268,14 +268,15 @@ async fn mcp_import_runtime(
                 coding_agent_inventory: None,
                 client_id: "importer".to_string(),
                 agent_instance_id: "inst-import".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: owner.map(str::to_string),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(ShellClientCapabilities {
+                capabilities: ShellClientCapabilities {
                     file_write: true,
                     ..Default::default()
-                }),
+                },
                 policy: None,
             },
         ))

--- a/src/mcp_tests/http_transport.rs
+++ b/src/mcp_tests/http_transport.rs
@@ -99,11 +99,12 @@ async fn stateless_observation_shell_clients() -> Arc<crate::shell_client::Shell
                 coding_agent_inventory: None,
                 client_id: "mcp-observation-agent".to_string(),
                 agent_instance_id: "inst-mcp-observation".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(ShellClientCapabilities::default()),
+                capabilities: ShellClientCapabilities::default(),
                 policy: None,
             },
         ))

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -1196,14 +1196,15 @@ async fn mcp_image_call_returns_native_image_for_remote_agent_project() {
             ShellClientRegisterRequest {
                 client_id: client_id.to_string(),
                 agent_instance_id: agent_instance_id.to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(ShellClientCapabilities {
+                capabilities: ShellClientCapabilities {
                     file_read: true,
                     ..Default::default()
-                }),
+                },
                 policy: None,
                 process_started_at: None,
                 build: None,
@@ -1979,16 +1980,17 @@ async fn mcp_show_changes_distinguishes_recording_session_id_from_query_session_
                 coding_agent_inventory: None,
                 client_id: "mcp-client".to_string(),
                 agent_instance_id: "inst".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(ShellClientCapabilities {
+                capabilities: ShellClientCapabilities {
                     shell: true,
                     git: true,
                     internal_posix_script: true,
                     ..Default::default()
-                }),
+                },
                 policy: None,
             },
         ))

--- a/src/oauth_http/tests/shared_key_bridge.rs
+++ b/src/oauth_http/tests/shared_key_bridge.rs
@@ -265,12 +265,11 @@ async fn register_shared_key_runner_with_capabilities(
             crate::shell_protocol::ShellClientRegisterRequest {
                 client_id: client_id.to_string(),
                 agent_instance_id: instance_id.to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
-                    capabilities,
-                )),
+                capabilities: crate::test_support::current_runner_capabilities(capabilities),
                 host_context: None,
                 policy: None,
                 process_started_at: None,

--- a/src/project_entry_tests.rs
+++ b/src/project_entry_tests.rs
@@ -240,16 +240,17 @@ async fn authenticated_project_fixture_for(recipe: &str) -> AuthenticatedProject
                 coding_agent_inventory: None,
                 client_id: config.executor_client_id.clone(),
                 agent_instance_id: "project-agent-instance".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: Some("configured project Agent".to_string()),
                 owner: Some("local-owner".to_string()),
                 hostname: Some("private-host".to_string()),
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(&agent_auth),
@@ -395,6 +396,7 @@ fn agent_transport_cases(client_id: &str) -> [(&'static str, serde_json::Value);
             serde_json::json!({
                 "client_id": client_id,
                 "agent_instance_id": PROJECT_AGENT_INSTANCE,
+                "agent_protocol_generation": 2,
                 "capabilities": crate::test_support::current_runner_capabilities(ShellClientCapabilities::default()),
                 "owner": "local-owner"
             }),
@@ -470,6 +472,7 @@ async fn project_agent_token_enforces_client_id_and_bootstrap_still_registers() 
         serde_json::json!({
             "client_id": "bootstrap-client",
             "agent_instance_id": "bootstrap-instance",
+            "agent_protocol_generation": 2,
             "capabilities": crate::test_support::current_runner_capabilities(ShellClientCapabilities::default()),
             "owner": "local-owner"
         }),

--- a/src/runtime_console_http.rs
+++ b/src/runtime_console_http.rs
@@ -2365,13 +2365,14 @@ mod tests {
                     coding_agent_inventory: None,
                     client_id: client_id.to_string(),
                     agent_instance_id: agent_instance_id.clone(),
+                    agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                     display_name: Some(format!("Device {client_id}")),
                     owner: auth.and_then(|auth| auth.username.clone()),
                     hostname: Some(format!("private-host-{client_id}")),
                     host_context: None,
-                    capabilities: Some(crate::test_support::current_runner_capabilities(
+                    capabilities: crate::test_support::current_runner_capabilities(
                         ShellClientCapabilities::default(),
-                    )),
+                    ),
                     policy: None,
                 },
                 auth,

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -275,11 +275,12 @@ async fn register_import_agent_with_capabilities(
                 coding_agent_inventory: None,
                 client_id: "importer".to_string(),
                 agent_instance_id: "inst-import".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities,
+                capabilities: capabilities.unwrap_or_default(),
                 policy: None,
             },
         ))

--- a/src/shell_client/agents.rs
+++ b/src/shell_client/agents.rs
@@ -246,11 +246,9 @@ impl ShellClientRegistry {
 
         let client_id = body.client_id.trim().to_string();
         let agent_instance_id = body.agent_instance_id.trim().to_string();
-        let mut capabilities = body.capabilities.clone().unwrap_or_default();
-        let announced_generation = capabilities.agent_protocol_generation.take();
         let accepted_protocol =
-            AcceptedRunnerProtocol::try_from_registration(announced_generation)?;
-        let runner_features = RunnerFeatureSet::try_from_registration(&capabilities)?;
+            AcceptedRunnerProtocol::try_from_registration(body.agent_protocol_generation)?;
+        let runner_features = RunnerFeatureSet::try_from_registration(&body.capabilities)?;
         let job_inventory = body.job_inventory.clone();
         let coding_agent_providers = body.coding_agent_providers.clone();
         let coding_agent_inventory = body.coding_agent_inventory.clone();
@@ -290,7 +288,6 @@ impl ShellClientRegistry {
             owner: trim_string(body.owner),
             hostname: trim_string(body.hostname),
             host_context,
-            capabilities: capabilities.clone(),
             runner_features: runner_features.clone(),
             projects,
             project_inventory,
@@ -1413,7 +1410,7 @@ impl ShellClientRegistry {
             status: if connected { "online" } else { "stale" }.to_string(),
             connected,
             last_seen: client.last_seen,
-            capabilities: client.capabilities.clone(),
+            capabilities: client.runner_features.wire_capabilities().clone(),
             coding_agent_providers: (!client.coding_agent_providers.is_empty())
                 .then(|| client.coding_agent_providers.clone()),
             pending_requests,

--- a/src/shell_client/capabilities.rs
+++ b/src/shell_client/capabilities.rs
@@ -1,12 +1,11 @@
 use crate::shell_protocol::{self as wire, ShellClientCapabilities};
-use std::collections::BTreeSet;
 
 /// Canonical Server-side identity for one Runner-advertised wire capability.
 ///
 /// These identities never infer support from protocol generation, transport,
 /// host OS, or any other Server-side observation. A feature enters
-/// [`RunnerFeatureSet`] only through the accepted registration's effective wire
-/// semantics, including the historical `shell` missing-field default.
+/// [`RunnerFeatureSet`] only through the accepted registration's explicit wire
+/// capability snapshot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum RunnerFeature {
     Shell,
@@ -415,7 +414,7 @@ impl RunnerFeature {
 /// semantics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RunnerFeatureSet {
-    effective_features: BTreeSet<RunnerFeature>,
+    capabilities: ShellClientCapabilities,
 }
 
 impl RunnerFeatureSet {
@@ -428,44 +427,37 @@ impl RunnerFeatureSet {
     pub(crate) fn try_from_registration(
         capabilities: &ShellClientCapabilities,
     ) -> Result<Self, String> {
-        let mut effective_features = BTreeSet::new();
         for feature in RunnerFeature::all().iter().copied() {
-            let advertised = feature.advertised_by(capabilities);
-            match feature.inference() {
-                RunnerFeatureInference::GenerationEligible => {
-                    if !advertised {
-                        return Err(format!(
-                            "runner generation baseline capability mismatch: {}",
-                            feature.as_wire_name()
-                        ));
-                    }
-                    effective_features.insert(feature);
-                }
-                RunnerFeatureInference::RegistrationRequired => {
-                    if advertised {
-                        effective_features.insert(feature);
-                    }
-                }
+            if feature.inference() == RunnerFeatureInference::GenerationEligible
+                && !feature.advertised_by(capabilities)
+            {
+                return Err(format!(
+                    "runner generation baseline capability mismatch: {}",
+                    feature.as_wire_name()
+                ));
             }
         }
-        Ok(Self { effective_features })
+        Ok(Self {
+            capabilities: capabilities.clone(),
+        })
     }
 
     #[cfg(test)]
     pub(crate) fn from_wire_for_test(capabilities: &ShellClientCapabilities) -> Self {
-        let effective_features = RunnerFeature::all()
-            .iter()
-            .copied()
-            .filter(|feature| feature.advertised_by(capabilities))
-            .collect();
-        Self { effective_features }
+        Self {
+            capabilities: capabilities.clone(),
+        }
     }
 
     pub(crate) fn supports(&self, feature: RunnerFeature) -> bool {
-        self.effective_features.contains(&feature)
+        feature.advertised_by(&self.capabilities)
     }
 
     pub(crate) fn supports_wire_name(&self, capability: &str) -> bool {
         RunnerFeature::from_wire_name(capability).is_some_and(|feature| self.supports(feature))
+    }
+
+    pub(crate) fn wire_capabilities(&self) -> &ShellClientCapabilities {
+        &self.capabilities
     }
 }

--- a/src/shell_client/mod_tests.rs
+++ b/src/shell_client/mod_tests.rs
@@ -110,11 +110,12 @@ fn runner_registration(
         coding_agent_inventory: None,
         client_id: client_id.to_string(),
         agent_instance_id: agent_instance_id.to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: None,
         hostname: None,
         host_context: None,
-        capabilities: Some(async_job_capabilities()),
+        capabilities: async_job_capabilities(),
         policy: None,
     }
 }
@@ -127,19 +128,13 @@ fn v2_baseline_capabilities() -> ShellClientCapabilities {
     for capability in AGENT_PROTOCOL_GENERATION_V2_BASELINE_CAPABILITY_NAMES {
         value.insert((*capability).to_string(), serde_json::Value::Bool(true));
     }
-    let mut capabilities: ShellClientCapabilities =
-        serde_json::from_value(serde_json::Value::Object(value)).unwrap();
-    capabilities.agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
-    capabilities
+    serde_json::from_value(serde_json::Value::Object(value)).unwrap()
 }
 
 fn current_runner_registration(
-    mut registration: ShellClientRegisterRequest,
+    registration: ShellClientRegisterRequest,
 ) -> ShellClientRegisterRequest {
-    registration.capabilities = Some(crate::test_support::current_runner_capabilities(
-        registration.capabilities.take().unwrap_or_default(),
-    ));
-    registration
+    crate::test_support::current_runner_registration(registration)
 }
 
 fn async_job_capabilities() -> ShellClientCapabilities {
@@ -262,11 +257,12 @@ async fn register_computer_test_client(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "computer-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some(owner.to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 shell: true,
                 file_read: true,
                 computer_observe: observe_capable,
@@ -275,7 +271,7 @@ async fn register_computer_test_client(
                 computer_window_activate: false,
                 computer_text_input: text_input_capable,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -296,11 +292,12 @@ async fn register_quic_v1_client(registry: &ShellClientRegistry, client_id: &str
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         })
         .await
@@ -336,11 +333,12 @@ async fn register_instance_with_capabilities(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: instance.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(capabilities),
+            capabilities: capabilities,
             policy: None,
         }))
         .await
@@ -405,11 +403,12 @@ async fn register_with_instance(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: instance.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         })
         .await

--- a/src/shell_client/mod_tests/capabilities.rs
+++ b/src/shell_client/mod_tests/capabilities.rs
@@ -233,9 +233,8 @@ fn missing_additive_wire_fields_remain_false_in_canonical_semantics() {
 async fn current_protocol_generation_never_infers_registration_required_host_features() {
     let registry = ShellClientRegistry::default();
     let mut registration = runner_registration("no-inference", "inst-a", Vec::new());
-    let mut capabilities = v2_baseline_capabilities();
-    capabilities.agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
-    registration.capabilities = Some(capabilities);
+    let capabilities = v2_baseline_capabilities();
+    registration.capabilities = capabilities;
     registry.register(registration).await.unwrap();
 
     for feature in [
@@ -267,10 +266,9 @@ async fn shell_client_view_preserves_capability_wire_projection() {
     advertised.computer_control = true;
 
     let mut registration = runner_registration("projection", "inst-a", Vec::new());
-    registration.capabilities = Some(advertised.clone());
+    registration.capabilities = advertised.clone();
     let view = registry.register(registration).await.unwrap();
 
-    advertised.agent_protocol_generation = None;
     assert_eq!(view.capabilities, advertised);
     let serialized = serde_json::to_value(&view.capabilities).unwrap();
     assert_eq!(serialized["shell"], false);
@@ -282,17 +280,16 @@ async fn shell_client_view_preserves_capability_wire_projection() {
 }
 
 #[tokio::test]
-async fn v2_generation_advertisement_never_enters_public_capability_projection() {
+async fn top_level_generation_stays_separate_from_public_capability_projection() {
     let registry = ShellClientRegistry::default();
     let mut capabilities = v2_baseline_capabilities();
-    capabilities.agent_protocol_generation = Some(AGENT_PROTOCOL_GENERATION_V2);
     capabilities.computer_control = true;
 
     let mut registration = runner_registration("v2-projection", "inst-v2", Vec::new());
-    registration.capabilities = Some(capabilities);
+    registration.capabilities = capabilities;
     let view = registry.register(registration).await.unwrap();
 
-    assert!(view.capabilities.agent_protocol_generation.is_none());
+    assert_eq!(view.agent_protocol_generation, AGENT_PROTOCOL_GENERATION_V2);
     assert!(view.capabilities.computer_control);
     let serialized = serde_json::to_value(&view.capabilities).unwrap();
     assert!(serialized.get("agent_protocol_generation").is_none());
@@ -306,7 +303,7 @@ async fn semantic_snapshot_keeps_identity_state_and_features_atomic_across_repla
     let mut first_capabilities = v2_baseline_capabilities();
     first_capabilities.computer_observe = true;
     let mut first = runner_registration("semantic-snapshot", "inst-a", Vec::new());
-    first.capabilities = Some(first_capabilities);
+    first.capabilities = first_capabilities;
     registry.register(first).await.unwrap();
 
     let first_snapshot = registry
@@ -331,7 +328,7 @@ async fn semantic_snapshot_keeps_identity_state_and_features_atomic_across_repla
     let mut replacement_capabilities = v2_baseline_capabilities();
     replacement_capabilities.computer_text_input = true;
     let mut replacement = runner_registration("semantic-snapshot", "inst-b", Vec::new());
-    replacement.capabilities = Some(replacement_capabilities);
+    replacement.capabilities = replacement_capabilities;
     registry.register(replacement).await.unwrap();
 
     let replacement_snapshot = registry
@@ -377,7 +374,7 @@ async fn generation_baseline_project_features_cannot_downgrade_on_reregistration
     let mut downgraded = runner_registration("project-feature-fence", "inst-a", Vec::new());
     let mut capabilities = v2_baseline_capabilities();
     capabilities.project_path_registration = false;
-    downgraded.capabilities = Some(capabilities);
+    downgraded.capabilities = capabilities;
     let error = registry.register(downgraded).await.unwrap_err();
     assert_eq!(
         error,
@@ -397,7 +394,7 @@ async fn coding_agent_registration_consistency_uses_canonical_feature_semantics(
     let registry = ShellClientRegistry::default();
 
     let mut metadata_without_feature = runner_registration("coding-metadata", "inst-a", Vec::new());
-    metadata_without_feature.capabilities = Some(v2_baseline_capabilities());
+    metadata_without_feature.capabilities = v2_baseline_capabilities();
     metadata_without_feature.coding_agent_providers =
         Some(vec![webcodex_core::coding_agent::CodingAgentProvider {
             provider_id: "codex".to_string(),
@@ -416,11 +413,11 @@ async fn coding_agent_registration_consistency_uses_canonical_feature_semantics(
     );
 
     let mut feature_without_metadata = runner_registration("coding-feature", "inst-a", Vec::new());
-    feature_without_metadata.capabilities = Some(with_wire_feature(
+    feature_without_metadata.capabilities = with_wire_feature(
         &v2_baseline_capabilities(),
         RunnerFeature::CodingAgentRuns,
         true,
-    ));
+    );
     let error = registry
         .register(feature_without_metadata)
         .await
@@ -440,7 +437,7 @@ async fn register_sticky_feature_state(
 ) -> Result<(), String> {
     let capabilities = with_wire_feature(&v2_baseline_capabilities(), feature, enabled);
     let mut registration = runner_registration(client_id, instance_id, Vec::new());
-    registration.capabilities = Some(capabilities);
+    registration.capabilities = capabilities;
 
     if feature == RunnerFeature::JobStateReconciliation && enabled {
         registration.job_inventory = Some(crate::shell_protocol::ShellJobInventory {
@@ -478,11 +475,7 @@ async fn generation_baseline_features_reject_reregistration_downgrade() {
             .await
             .unwrap();
         let mut downgraded = runner_registration(&client_id, "inst-a", Vec::new());
-        downgraded.capabilities = Some(with_wire_feature(
-            &v2_baseline_capabilities(),
-            feature,
-            false,
-        ));
+        downgraded.capabilities = with_wire_feature(&v2_baseline_capabilities(), feature, false);
         let error = registry.register(downgraded).await.unwrap_err();
         assert_eq!(
             error,

--- a/src/shell_client/mod_tests/client_liveness.rs
+++ b/src/shell_client/mod_tests/client_liveness.rs
@@ -13,11 +13,12 @@ async fn touch_client_refreshes_stale_client_back_to_online() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/computer_accessibility.rs
+++ b/src/shell_client/mod_tests/computer_accessibility.rs
@@ -82,18 +82,19 @@ async fn computer_element_state_requires_its_own_additive_capability() {
             coding_agent_inventory: None,
             client_id: "computer-state-capable".to_string(),
             agent_instance_id: "computer-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 shell: true,
                 file_read: true,
                 computer_observe: true,
                 computer_accessibility_observe: true,
                 computer_element_state: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/computer_control.rs
+++ b/src/shell_client/mod_tests/computer_control.rs
@@ -103,15 +103,16 @@ async fn computer_scroll_to_element_requires_independent_capability() {
             coding_agent_inventory: None,
             client_id: "computer-scroll-capable".to_string(),
             agent_instance_id: "computer-scroll-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_control: true,
                 computer_scroll_to_element: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -180,15 +181,16 @@ async fn computer_key_input_requires_independent_capability() {
             coding_agent_inventory: None,
             client_id: "computer-key-capable".to_string(),
             agent_instance_id: "computer-key-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_control: true,
                 computer_key_input: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -235,15 +237,16 @@ async fn computer_pointer_enqueue_requires_independent_capability_and_typed_enve
             coding_agent_inventory: None,
             client_id: "computer-pointer-old".to_string(),
             agent_instance_id: "pointer-old-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_control: true,
                 computer_display_observe: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -276,14 +279,15 @@ async fn computer_pointer_enqueue_requires_independent_capability_and_typed_enve
             coding_agent_inventory: None,
             client_id: "computer-pointer-capable".to_string(),
             agent_instance_id: "pointer-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_pointer_control: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -330,16 +334,17 @@ async fn computer_clipboard_enqueue_requires_independent_capabilities_and_typed_
             coding_agent_inventory: None,
             client_id: "computer-clipboard-old".to_string(),
             agent_instance_id: "clipboard-old-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_observe: true,
                 computer_control: true,
                 computer_text_input: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -379,14 +384,15 @@ async fn computer_clipboard_enqueue_requires_independent_capabilities_and_typed_
             coding_agent_inventory: None,
             client_id: "computer-clipboard-read".to_string(),
             agent_instance_id: "clipboard-read-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_clipboard_read: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -440,14 +446,15 @@ async fn computer_clipboard_enqueue_requires_independent_capabilities_and_typed_
             coding_agent_inventory: None,
             client_id: "computer-clipboard-write".to_string(),
             agent_instance_id: "clipboard-write-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_clipboard_write: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -530,11 +537,12 @@ async fn computer_window_activation_requires_its_own_additive_capability() {
             coding_agent_inventory: None,
             client_id: "computer-activate".to_string(),
             agent_instance_id: "computer-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 shell: true,
                 file_read: true,
                 computer_observe: true,
@@ -542,7 +550,7 @@ async fn computer_window_activation_requires_its_own_additive_capability() {
                 computer_control: true,
                 computer_window_activate: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/computer_observe.rs
+++ b/src/shell_client/mod_tests/computer_observe.rs
@@ -115,17 +115,18 @@ async fn computer_snapshot_region_requires_additive_capability() {
             coding_agent_inventory: None,
             client_id: "computer-region-only".to_string(),
             agent_instance_id: "computer-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 shell: true,
                 file_read: true,
                 computer_observe: false,
                 computer_snapshot_region: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -153,17 +154,18 @@ async fn computer_snapshot_region_requires_additive_capability() {
             coding_agent_inventory: None,
             client_id: "computer-region-new".to_string(),
             agent_instance_id: "computer-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 shell: true,
                 file_read: true,
                 computer_observe: true,
                 computer_snapshot_region: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -206,14 +208,15 @@ async fn computer_snapshot_display_preserves_large_native_image_response_stdout(
             coding_agent_inventory: None,
             client_id: "computer-display-large".to_string(),
             agent_instance_id: "display-large-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 computer_display_observe: true,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/computer_snapshot_artifact.rs
+++ b/src/shell_client/mod_tests/computer_snapshot_artifact.rs
@@ -36,16 +36,15 @@ async fn computer_snapshot_artifact_rechecks_current_target_project_and_authorit
         coding_agent_inventory: None,
         client_id: client_id.to_string(),
         agent_instance_id: instance_id.to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: Some("alice".to_string()),
         hostname: None,
         host_context: None,
-        capabilities: Some(crate::test_support::current_runner_capabilities(
-            ShellClientCapabilities {
-                shell: true,
-                ..Default::default()
-            },
-        )),
+        capabilities: crate::test_support::current_runner_capabilities(ShellClientCapabilities {
+            shell: true,
+            ..Default::default()
+        }),
         policy: None,
     };
 

--- a/src/shell_client/mod_tests/connection_lease.rs
+++ b/src/shell_client/mod_tests/connection_lease.rs
@@ -21,11 +21,12 @@ async fn register_with_connection(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: instance.to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some("alice".to_string()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(async_job_capabilities()),
+                capabilities: async_job_capabilities(),
                 policy: None,
             },
             None,
@@ -118,11 +119,7 @@ async fn failed_streaming_registration_preserves_current_session_exactly() {
 
     let notify_b = Arc::new(Notify::new());
     let mut rejected = runner_registration("atomic-preserve", "atomic-instance", Vec::new());
-    rejected
-        .capabilities
-        .as_mut()
-        .unwrap()
-        .agent_protocol_generation = Some(AgentProtocolGenerationNumber::new(3));
+    rejected.agent_protocol_generation = AgentProtocolGenerationNumber::new(3);
     let error = registry
         .register_streaming_session_with_cancel(
             rejected,
@@ -355,11 +352,12 @@ async fn stale_connection_runtime_metadata_does_not_overwrite_current() {
                     coding_agent_inventory: None,
                     client_id: "oe".to_string(),
                     agent_instance_id: "inst-x".to_string(),
+                    agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                     display_name: None,
                     owner: Some("alice".to_string()),
                     hostname: None,
                     host_context: None,
-                    capabilities: Some(async_job_capabilities()),
+                    capabilities: async_job_capabilities(),
                     policy: Some(AgentPolicySummary::default()),
                 },
                 None,

--- a/src/shell_client/mod_tests/disconnect_reconciliation.rs
+++ b/src/shell_client/mod_tests/disconnect_reconciliation.rs
@@ -13,11 +13,12 @@ async fn reconcile_disconnect_marks_running_jobs_lost() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         }))
         .await
@@ -70,11 +71,14 @@ async fn reconcile_disconnect_fails_pending_sync_requests_fast() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/instance_lease.rs
+++ b/src/shell_client/mod_tests/instance_lease.rs
@@ -38,11 +38,12 @@ async fn lease_different_online_instance_rejected() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst-b".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         }))
         .await
@@ -516,11 +517,14 @@ async fn lease_register_rejects_empty_instance_id() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await
@@ -555,11 +559,12 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst-a".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(capabilities()),
+            capabilities: capabilities(),
             policy: None,
         }))
         .await
@@ -680,11 +685,12 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst-b".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(capabilities()),
+            capabilities: capabilities(),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/job_lifecycle.rs
+++ b/src/shell_client/mod_tests/job_lifecycle.rs
@@ -13,11 +13,12 @@ async fn terminal_observed_poll_complete_and_log() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         })
         .await
@@ -129,11 +130,12 @@ async fn terminal_observed_queued_stop_records_server_time() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         })
         .await
@@ -191,11 +193,12 @@ async fn registry_shell_job_stop_running_delivers_stop_to_client() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         })
         .await
@@ -259,11 +262,12 @@ async fn registry_marks_running_job_lost_when_client_stale() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         })
         .await

--- a/src/shell_client/mod_tests/job_log_wait.rs
+++ b/src/shell_client/mod_tests/job_log_wait.rs
@@ -64,11 +64,12 @@ async fn register_sequenced(registry: &ShellClientRegistry, instance: &str) {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: instance.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(sequenced_job_capabilities()),
+            capabilities: sequenced_job_capabilities(),
             policy: None,
         }))
         .await
@@ -455,11 +456,12 @@ async fn job_log_wait_legacy_update_between_calls_and_noop_replacement() {
             coding_agent_inventory: None,
             client_id: "legacy".to_string(),
             agent_instance_id: "legacy-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(capabilities),
+            capabilities: capabilities,
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/lsp.rs
+++ b/src/shell_client/mod_tests/lsp.rs
@@ -32,15 +32,16 @@ async fn register_lsp_test_client_capabilities(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 lsp_read_only_navigation: lsp_capable,
                 lsp_call_hierarchy: call_hierarchy_capable,
                 ..Default::default()
-            }),
+            },
             policy: None,
         }))
         .await
@@ -74,12 +75,11 @@ async fn enqueue_lsp_prunes_expired_shared_key_registration_before_admission() {
     let registry = ShellClientRegistry::with_shared_key_limits_for_test(1, 4, ttl_secs);
     let auth = crate::auth::shared_key::shared_key_context("ttl-lsp");
     let mut registration = runner_registration("ttl-lsp", "inst", Vec::new());
-    registration.capabilities = Some(crate::test_support::current_runner_capabilities(
-        ShellClientCapabilities {
+    registration.capabilities =
+        crate::test_support::current_runner_capabilities(ShellClientCapabilities {
             lsp_call_hierarchy: true,
             ..Default::default()
-        },
-    ));
+        });
     registry
         .register_with_auth(registration, Some(&auth))
         .await

--- a/src/shell_client/mod_tests/mcp_gateway.rs
+++ b/src/shell_client/mod_tests/mcp_gateway.rs
@@ -22,12 +22,13 @@ async fn register_bridge_runner(registry: &ShellClientRegistry) {
         .register(ShellClientRegisterRequest {
             client_id: "bridge-runner".to_string(),
             agent_instance_id: "bridge-instance".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities::default(),
-            )),
+            ),
             host_context: None,
             policy: Some(AgentPolicySummary {
                 mcp_gateway_providers: Some(vec![bridge_provider("provider-instance")]),
@@ -59,10 +60,11 @@ fn bridge_registration(
     current_runner_registration(ShellClientRegisterRequest {
         client_id: client_id.to_string(),
         agent_instance_id: agent_instance_id.to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: Some("alice".to_string()),
         hostname: None,
-        capabilities: Some(ShellClientCapabilities::default()),
+        capabilities: ShellClientCapabilities::default(),
         host_context: None,
         policy: providers.map(|providers| AgentPolicySummary {
             mcp_gateway_providers: Some(providers),

--- a/src/shell_client/mod_tests/polling.rs
+++ b/src/shell_client/mod_tests/polling.rs
@@ -13,11 +13,14 @@ async fn registry_enqueues_polls_and_completes_shell_request() {
             coding_agent_inventory: None,
             client_id: "xrh".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await
@@ -78,11 +81,14 @@ async fn polling_out_of_order_results_resolve_only_their_original_waiters() {
             coding_agent_inventory: None,
             client_id: "ordered".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/project_inventory.rs
+++ b/src/shell_client/mod_tests/project_inventory.rs
@@ -201,11 +201,7 @@ async fn unsupported_protocol_registration_does_not_publish_project_inventory() 
         instance_id,
         vec![project_summary("untrusted", "/tmp/untrusted")],
     );
-    registration
-        .capabilities
-        .as_mut()
-        .unwrap()
-        .agent_protocol_generation = Some(AgentProtocolGenerationNumber::new(3));
+    registration.agent_protocol_generation = AgentProtocolGenerationNumber::new(3);
 
     let error = registry.register(registration).await.unwrap_err();
     assert_eq!(error, "agent_protocol_generation is unsupported");

--- a/src/shell_client/mod_tests/project_projection.rs
+++ b/src/shell_client/mod_tests/project_projection.rs
@@ -144,11 +144,14 @@ async fn registry_inventory_snapshot_saves_projects() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await
@@ -182,11 +185,14 @@ async fn registry_inventory_snapshot_updates_projects() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await
@@ -228,11 +234,14 @@ async fn registry_poll_without_projects_preserves_existing_projection() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await
@@ -273,11 +282,14 @@ async fn registry_project_owner_check_enforces_boundary() {
             coding_agent_inventory: None,
             client_id: "alice-client".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await
@@ -292,11 +304,14 @@ async fn registry_project_owner_check_enforces_boundary() {
             coding_agent_inventory: None,
             client_id: "bob-client".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("bob".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/protocol.rs
+++ b/src/shell_client/mod_tests/protocol.rs
@@ -2,20 +2,13 @@ use super::*;
 
 #[test]
 fn accepted_runner_protocol_requires_exact_generation_two() {
-    let accepted =
-        AcceptedRunnerProtocol::try_from_registration(Some(AGENT_PROTOCOL_GENERATION_V2))
-            .expect("generation 2");
+    let accepted = AcceptedRunnerProtocol::try_from_registration(AGENT_PROTOCOL_GENERATION_V2)
+        .expect("generation 2");
     assert_eq!(accepted.generation(), AGENT_PROTOCOL_GENERATION_V2);
-    assert_eq!(
-        AcceptedRunnerProtocol::try_from_registration(None).unwrap_err(),
-        "agent_protocol_generation is required"
-    );
     for raw in [0, 1, 3, u16::MAX] {
         assert_eq!(
-            AcceptedRunnerProtocol::try_from_registration(Some(
-                AgentProtocolGenerationNumber::new(raw)
-            ))
-            .unwrap_err(),
+            AcceptedRunnerProtocol::try_from_registration(AgentProtocolGenerationNumber::new(raw))
+                .unwrap_err(),
             "agent_protocol_generation is unsupported"
         );
     }
@@ -24,29 +17,19 @@ fn accepted_runner_protocol_requires_exact_generation_two() {
 fn generation_registration(
     client_id: &str,
     instance_id: &str,
-    generation: Option<AgentProtocolGenerationNumber>,
+    generation: AgentProtocolGenerationNumber,
 ) -> ShellClientRegisterRequest {
     let mut registration = runner_registration(client_id, instance_id, Vec::new());
-    let mut capabilities = v2_baseline_capabilities();
-    capabilities.agent_protocol_generation = generation;
-    registration.capabilities = Some(capabilities);
+    registration.agent_protocol_generation = generation;
+    registration.capabilities = v2_baseline_capabilities();
     registration
 }
 
 #[tokio::test]
 async fn registration_rejects_non_v2_generation_before_creating_a_record() {
-    for (suffix, generation, expected) in [
-        ("missing", None, "agent_protocol_generation is required"),
-        (
-            "generation-one",
-            Some(AgentProtocolGenerationNumber::new(1)),
-            "agent_protocol_generation is unsupported",
-        ),
-        (
-            "future",
-            Some(AgentProtocolGenerationNumber::new(3)),
-            "agent_protocol_generation is unsupported",
-        ),
+    for (suffix, generation) in [
+        ("generation-one", AgentProtocolGenerationNumber::new(1)),
+        ("future", AgentProtocolGenerationNumber::new(3)),
     ] {
         let registry = ShellClientRegistry::default();
         let client_id = format!("non-v2-{suffix}");
@@ -54,7 +37,7 @@ async fn registration_rejects_non_v2_generation_before_creating_a_record() {
             .register(generation_registration(&client_id, "inst-a", generation))
             .await
             .unwrap_err();
-        assert_eq!(error, expected);
+        assert_eq!(error, "agent_protocol_generation is unsupported");
         assert!(registry.get_client_view(&client_id).await.is_none());
     }
 }
@@ -62,16 +45,9 @@ async fn registration_rejects_non_v2_generation_before_creating_a_record() {
 #[tokio::test]
 async fn registration_rejects_v2_baseline_contradiction_before_creating_a_record() {
     let registry = ShellClientRegistry::default();
-    let mut registration = generation_registration(
-        "v2-contradiction",
-        "inst-a",
-        Some(AGENT_PROTOCOL_GENERATION_V2),
-    );
-    registration
-        .capabilities
-        .as_mut()
-        .unwrap()
-        .structured_process_argv = false;
+    let mut registration =
+        generation_registration("v2-contradiction", "inst-a", AGENT_PROTOCOL_GENERATION_V2);
+    registration.capabilities.structured_process_argv = false;
     let error = registry.register(registration).await.unwrap_err();
     assert_eq!(
         error,
@@ -88,7 +64,7 @@ async fn same_instance_generation_two_reconnects_remain_valid() {
             .register(generation_registration(
                 "v2-stable",
                 "inst-a",
-                Some(AGENT_PROTOCOL_GENERATION_V2),
+                AGENT_PROTOCOL_GENERATION_V2,
             ))
             .await
             .unwrap();
@@ -112,7 +88,7 @@ async fn replacement_cannot_bypass_generation_two_admission() {
         .register(generation_registration(
             "replacement-v2",
             "inst-a",
-            Some(AGENT_PROTOCOL_GENERATION_V2),
+            AGENT_PROTOCOL_GENERATION_V2,
         ))
         .await
         .unwrap();
@@ -121,10 +97,14 @@ async fn replacement_cannot_bypass_generation_two_admission() {
         .await;
 
     let error = registry
-        .register(generation_registration("replacement-v2", "inst-b", None))
+        .register(generation_registration(
+            "replacement-v2",
+            "inst-b",
+            AgentProtocolGenerationNumber::new(3),
+        ))
         .await
         .unwrap_err();
-    assert_eq!(error, "agent_protocol_generation is required");
+    assert_eq!(error, "agent_protocol_generation is unsupported");
     assert_eq!(
         registry
             .get_client_view("replacement-v2")
@@ -138,7 +118,7 @@ async fn replacement_cannot_bypass_generation_two_admission() {
         .register(generation_registration(
             "replacement-v2",
             "inst-b",
-            Some(AGENT_PROTOCOL_GENERATION_V2),
+            AGENT_PROTOCOL_GENERATION_V2,
         ))
         .await
         .unwrap();
@@ -153,7 +133,7 @@ async fn replacement_cannot_bypass_generation_two_admission() {
 }
 
 #[test]
-fn protocol_capability_defaults_remain_fail_closed() {
+fn registration_wire_requires_generation_capabilities_and_explicit_shell() {
     let capabilities = ShellClientCapabilities::default();
     assert!(!capabilities.async_jobs);
     assert!(!capabilities.async_shell_jobs);
@@ -162,45 +142,36 @@ fn protocol_capability_defaults_remain_fail_closed() {
     assert!(!capabilities.structured_go_test_tool);
     assert!(!capabilities.structured_go_test_packages);
 
+    let missing_generation = serde_json::from_str::<ShellClientRegisterRequest>(
+        r#"{"client_id":"oe","agent_instance_id":"inst-1","capabilities":{"shell":true}}"#,
+    )
+    .unwrap_err();
+    assert!(missing_generation
+        .to_string()
+        .contains("agent_protocol_generation"));
+
+    let missing_capabilities = serde_json::from_str::<ShellClientRegisterRequest>(
+        r#"{"client_id":"oe","agent_instance_id":"inst-1","agent_protocol_generation":2}"#,
+    )
+    .unwrap_err();
+    assert!(missing_capabilities.to_string().contains("capabilities"));
+
+    let missing_shell = serde_json::from_str::<ShellClientRegisterRequest>(
+        r#"{"client_id":"oe","agent_instance_id":"inst-1","agent_protocol_generation":2,"capabilities":{}}"#,
+    )
+    .unwrap_err();
+    assert!(missing_shell.to_string().contains("shell"));
+
     let request: ShellClientRegisterRequest = serde_json::from_str(
-        r#"{
-            "client_id": "oe",
-            "agent_instance_id": "inst-1",
-            "capabilities": {"shell": true}
-        }"#,
+        r#"{"client_id":"oe","agent_instance_id":"inst-1","agent_protocol_generation":2,"capabilities":{"shell":true}}"#,
     )
     .unwrap();
-    let capabilities = request.capabilities.unwrap();
-    assert!(!capabilities.async_jobs);
-    assert!(capabilities.agent_protocol_generation.is_none());
-}
-
-#[tokio::test]
-async fn missing_generation_is_rejected_across_all_runner_transports() {
-    for (transport, transport_label) in [
-        (AgentTransport::Polling, TRANSPORT_POLLING),
-        (AgentTransport::WebSocket, TRANSPORT_WEBSOCKET),
-        (AgentTransport::Quic, TRANSPORT_QUIC),
-    ] {
-        let registry = ShellClientRegistry::default();
-        let client_id = format!("missing-generation-{transport_label}");
-        let registration = generation_registration(&client_id, "inst-a", None);
-        let error = match transport {
-            AgentTransport::Polling => registry.register(registration).await.unwrap_err(),
-            AgentTransport::WebSocket | AgentTransport::Quic => registry
-                .register_streaming_session(
-                    registration,
-                    None,
-                    &format!("connection-{transport_label}"),
-                    transport,
-                    Arc::new(Notify::new()),
-                )
-                .await
-                .unwrap_err(),
-        };
-        assert_eq!(error, "agent_protocol_generation is required");
-        assert!(registry.get_client_view(&client_id).await.is_none());
-    }
+    assert_eq!(
+        request.agent_protocol_generation,
+        AGENT_PROTOCOL_GENERATION_V2
+    );
+    assert!(request.capabilities.shell);
+    assert!(!request.capabilities.async_jobs);
 }
 
 #[tokio::test]
@@ -219,7 +190,7 @@ async fn polling_http_register_requires_generation() {
         .json(&json!({
             "client_id": "polling-missing-generation",
             "agent_instance_id": "inst",
-            "capabilities": {}
+            "capabilities": {"shell": true}
         }))
         .send(&service)
         .await;
@@ -229,7 +200,12 @@ async fn polling_http_register_requires_generation() {
     );
     let body: serde_json::Value = response.take_json().await.unwrap();
     assert_eq!(body["success"], false);
-    assert_eq!(body["error"], "agent_protocol_generation is required");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("agent_protocol_generation")),
+        "{body:?}"
+    );
     assert!(registry.list_clients().await.is_empty());
 }
 
@@ -249,6 +225,7 @@ async fn polling_http_register_accepts_generation_two() {
         .json(&json!({
             "client_id": "polling-generation-two",
             "agent_instance_id": "inst",
+            "agent_protocol_generation": AGENT_PROTOCOL_GENERATION_V2.get(),
             "capabilities": crate::test_support::current_runner_capabilities(ShellClientCapabilities::default())
         }))
         .send(&service)
@@ -297,11 +274,12 @@ async fn client_supports_reflects_registered_capabilities() {
             coding_agent_inventory: None,
             client_id: "oe".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(caps),
+            capabilities: caps,
             policy: None,
         })
         .await
@@ -404,15 +382,16 @@ async fn coding_agent_run_lookup_is_exact_when_bound_and_ambiguous_when_unbound(
                 ),
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst_{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some({
+                capabilities: {
                     let mut capabilities = v2_baseline_capabilities();
                     capabilities.coding_agent_runs = true;
                     capabilities
-                }),
+                },
                 policy: None,
             })
             .await
@@ -450,15 +429,16 @@ async fn coding_agent_registration_rejects_semantically_contradictory_snapshot()
             }),
             client_id: "test".to_string(),
             agent_instance_id: "inst_test".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some({
+            capabilities: {
                 let mut capabilities = v2_baseline_capabilities();
                 capabilities.coding_agent_runs = true;
                 capabilities
-            }),
+            },
             policy: None,
         };
     let base = webcodex_core::coding_agent::CodingAgentRunSnapshot {
@@ -537,11 +517,12 @@ async fn client_supports_recognizes_all_protocol_capability_names() {
             ),
             client_id: "all".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities {
+            capabilities: ShellClientCapabilities {
                 shell: true,
                 file_read: true,
                 file_write: true,
@@ -591,8 +572,7 @@ async fn client_supports_recognizes_all_protocol_capability_names() {
                 computer_text_input: true,
                 job_state_reconciliation: true,
                 coding_agent_runs: true,
-                agent_protocol_generation: Some(AGENT_PROTOCOL_GENERATION_V2),
-            }),
+            },
             policy: None,
         })
         .await

--- a/src/shell_client/mod_tests/queue_admission.rs
+++ b/src/shell_client/mod_tests/queue_admission.rs
@@ -13,11 +13,14 @@ async fn registry_rejects_enqueue_when_queue_full() {
             coding_agent_inventory: None,
             client_id: "full".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await
@@ -77,11 +80,14 @@ async fn registry_rejects_enqueue_when_client_offline() {
             coding_agent_inventory: None,
             client_id: "stale".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/quic_queueing.rs
+++ b/src/shell_client/mod_tests/quic_queueing.rs
@@ -171,11 +171,12 @@ async fn registry_allows_quic_v1_stop_job_delivery_queueing() {
             coding_agent_inventory: None,
             client_id: "quic-stop".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/raw_shell.rs
+++ b/src/shell_client/mod_tests/raw_shell.rs
@@ -12,12 +12,11 @@ async fn raw_shell_run_wait_timeout_preserves_known_dispatch_evidence() {
         "inst",
         vec![project_summary("webcodex", "/tmp/webcodex")],
     );
-    registration.capabilities = Some(crate::test_support::current_runner_capabilities(
-        ShellClientCapabilities {
+    registration.capabilities =
+        crate::test_support::current_runner_capabilities(ShellClientCapabilities {
             shell: true,
             ..Default::default()
-        },
-    ));
+        });
     registry.register(registration).await.unwrap();
 
     let service = Service::new(

--- a/src/shell_client/mod_tests/registration_projection.rs
+++ b/src/shell_client/mod_tests/registration_projection.rs
@@ -53,11 +53,14 @@ async fn registry_registers_and_lists_client() {
             coding_agent_inventory: None,
             client_id: "xrh".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: Some("XRH".to_string()),
             owner: Some("yyjeqhc".to_string()),
             hostname: Some("fineserver".to_string()),
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/run_enqueue.rs
+++ b/src/shell_client/mod_tests/run_enqueue.rs
@@ -13,11 +13,14 @@ async fn registry_allows_session_scoped_run_without_ssh_resource() {
             coding_agent_inventory: None,
             client_id: "xrh".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: None,
+            capabilities: crate::test_support::current_runner_capabilities(
+                ShellClientCapabilities::default(),
+            ),
             policy: None,
         }))
         .await

--- a/src/shell_client/mod_tests/shared_key_isolation.rs
+++ b/src/shell_client/mod_tests/shared_key_isolation.rs
@@ -47,11 +47,12 @@ async fn registry_filters_lightweight_clients_by_auth_group() {
                     coding_agent_inventory: None,
                     client_id: client_id.to_string(),
                     agent_instance_id: format!("inst-{}", client_id),
+                    agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                     display_name: None,
                     owner: None,
                     hostname: None,
                     host_context: None,
-                    capabilities: Some(async_job_capabilities()),
+                    capabilities: async_job_capabilities(),
                     policy: None,
                 },
                 Some(auth),
@@ -74,11 +75,12 @@ async fn registry_filters_lightweight_clients_by_auth_group() {
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some(owner.to_string()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(async_job_capabilities()),
+                capabilities: async_job_capabilities(),
                 policy: None,
             })
             .await
@@ -241,16 +243,17 @@ async fn managed_user_coding_agent_inventory_does_not_cross_owner() {
                 ),
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: Some(owner.to_string()),
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         coding_agent_runs: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             })
             .await
@@ -295,11 +298,12 @@ async fn same_client_id_in_different_project_grants_is_isolated() {
         coding_agent_inventory: None,
         client_id: "same-project-agent".to_string(),
         agent_instance_id: "same-instance-id".to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: None,
         hostname: Some(hostname.to_string()),
         host_context: None,
-        capabilities: Some(async_job_capabilities()),
+        capabilities: async_job_capabilities(),
         policy: None,
     };
     registry
@@ -357,11 +361,12 @@ async fn shared_key_client_id_collision_cannot_cross_group_or_revive_old_connect
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: instance.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: owner.map(str::to_string),
             hostname: Some(hostname.to_string()),
             host_context: None,
-            capabilities: Some(async_job_capabilities()),
+            capabilities: async_job_capabilities(),
             policy: None,
         }
     };

--- a/src/shell_client/mod_tests/skill_store.rs
+++ b/src/shell_client/mod_tests/skill_store.rs
@@ -13,14 +13,15 @@ fn skill_store_registration(
     current_runner_registration(ShellClientRegisterRequest {
         client_id: "skill-store-runner".to_string(),
         agent_instance_id: instance.to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: Some("alice".to_string()),
         hostname: None,
-        capabilities: Some(ShellClientCapabilities {
+        capabilities: ShellClientCapabilities {
             skill_store_read: read,
             skill_store_manage: manage,
             ..Default::default()
-        }),
+        },
         host_context: None,
         policy: None,
         process_started_at: None,

--- a/src/shell_client/mod_tests/structured_file_delete.rs
+++ b/src/shell_client/mod_tests/structured_file_delete.rs
@@ -11,11 +11,12 @@ async fn register_structured_delete_client(registry: &ShellClientRegistry, clien
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(ShellClientCapabilities::default()),
+            capabilities: ShellClientCapabilities::default(),
             policy: None,
         }))
         .await

--- a/src/shell_client/protocol.rs
+++ b/src/shell_client/protocol.rs
@@ -9,12 +9,14 @@ pub(crate) struct AcceptedRunnerProtocol {
 
 impl AcceptedRunnerProtocol {
     pub(crate) fn try_from_registration(
-        generation_number: Option<AgentProtocolGenerationNumber>,
+        generation_number: AgentProtocolGenerationNumber,
     ) -> Result<Self, String> {
-        match generation_number {
-            Some(value) if value == AGENT_PROTOCOL_GENERATION_V2 => Ok(Self { generation: value }),
-            None => Err("agent_protocol_generation is required".to_string()),
-            Some(_) => Err("agent_protocol_generation is unsupported".to_string()),
+        if generation_number == AGENT_PROTOCOL_GENERATION_V2 {
+            Ok(Self {
+                generation: generation_number,
+            })
+        } else {
+            Err("agent_protocol_generation is unsupported".to_string())
         }
     }
 

--- a/src/shell_client/reconciliation_tests.rs
+++ b/src/shell_client/reconciliation_tests.rs
@@ -71,11 +71,12 @@ fn register_request(instance: &str, inventory: ShellJobInventory) -> ShellClient
     crate::test_support::current_runner_registration(ShellClientRegisterRequest {
         client_id: CLIENT_ID.to_string(),
         agent_instance_id: instance.to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: Some("reconciliation test runner".to_string()),
         owner: Some("tester".to_string()),
         hostname: None,
         host_context: None,
-        capabilities: Some(reconciliation_capabilities()),
+        capabilities: reconciliation_capabilities(),
         policy: None,
         process_started_at: Some(1_700_000_000),
         build: None,
@@ -2454,9 +2455,8 @@ async fn job_reconciliation_absent_capability_keeps_immediate_lost_semantics() {
         .unwrap_err()
         .contains("requires job_inventory"));
     let mut unexpected_inventory = register_request(INSTANCE_A, empty_inventory());
-    unexpected_inventory.capabilities = Some(crate::test_support::current_runner_capabilities(
-        ShellClientCapabilities::default(),
-    ));
+    unexpected_inventory.capabilities =
+        crate::test_support::current_runner_capabilities(ShellClientCapabilities::default());
     assert!(mismatch_registry
         .register(unexpected_inventory)
         .await
@@ -2465,9 +2465,8 @@ async fn job_reconciliation_absent_capability_keeps_immediate_lost_semantics() {
     let downgrade_registry = ShellClientRegistry::default();
     register(&downgrade_registry, INSTANCE_A, empty_inventory()).await;
     let mut downgraded = register_request(INSTANCE_A, empty_inventory());
-    downgraded.capabilities = Some(crate::test_support::current_runner_capabilities(
-        ShellClientCapabilities::default(),
-    ));
+    downgraded.capabilities =
+        crate::test_support::current_runner_capabilities(ShellClientCapabilities::default());
     downgraded.job_inventory = None;
     assert!(downgrade_registry
         .register(downgraded)
@@ -2477,14 +2476,13 @@ async fn job_reconciliation_absent_capability_keeps_immediate_lost_semantics() {
 
     let registry = ShellClientRegistry::default();
     let mut request = register_request(INSTANCE_A, empty_inventory());
-    request.capabilities = Some(crate::test_support::current_runner_capabilities(
-        ShellClientCapabilities {
+    request.capabilities =
+        crate::test_support::current_runner_capabilities(ShellClientCapabilities {
             jobs: true,
             async_jobs: true,
             async_shell_jobs: true,
             ..Default::default()
-        },
-    ));
+        });
     request.job_inventory = None;
     registry.register(request).await.unwrap();
     let job = registry

--- a/src/shell_client/state.rs
+++ b/src/shell_client/state.rs
@@ -3,9 +3,9 @@ use super::{AcceptedRunnerProtocol, AgentTransport, RunnerFeature, RunnerFeature
 use crate::mcp_gateway::McpGatewayResponse;
 use crate::shell_protocol::{
     AgentBuildInfo, AgentHostContext, AgentPolicySummary, PersistentShellResult,
-    ShellAgentProjectSummary, ShellAgentShellRequest, ShellClientCapabilities, ShellClientView,
-    ShellCommandExecutionState, ShellJobCodexMetadata, ShellJobStructuredExecutionMetadata,
-    ShellJobValidationProgress, ShellProcessArgv, ShellProjectInventoryStatus, ShellRunResponse,
+    ShellAgentProjectSummary, ShellAgentShellRequest, ShellClientView, ShellCommandExecutionState,
+    ShellJobCodexMetadata, ShellJobStructuredExecutionMetadata, ShellJobValidationProgress,
+    ShellProcessArgv, ShellProjectInventoryStatus, ShellRunResponse,
     JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_TERMINAL_RETENTION_SECS,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -54,12 +54,9 @@ pub(super) struct ShellClientRecord {
     /// Bounded Runner-configured planning metadata. This is not policy or live
     /// state and is replaced by each successful registration.
     pub(super) host_context: Option<AgentHostContext>,
-    /// Accepted legacy wire snapshot retained only for wire-compatible public
-    /// projection and diagnostics. Server capability authority lives in
-    /// `runner_features` below.
-    pub(super) capabilities: ShellClientCapabilities,
-    /// Canonical Server capability truth normalized once from `capabilities`
-    /// during registration. This set has no independent mutation path.
+    /// Canonical Server capability truth normalized once from the required
+    /// registration snapshot. It also owns the public wire projection, so the
+    /// record has no second independently stored capability copy.
     pub(super) runner_features: RunnerFeatureSet,
     pub(super) projects: Vec<ShellAgentProjectSummary>,
     /// Authoritative project snapshot plus bounded in-progress staging. A

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -113,11 +113,6 @@ pub(crate) fn current_runner_capabilities(
     {
         object.insert((*capability).to_string(), serde_json::Value::Bool(true));
     }
-    object.insert(
-        "agent_protocol_generation".to_string(),
-        serde_json::to_value(crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2)
-            .expect("serialize Runner protocol generation"),
-    );
     serde_json::from_value(value).expect("deserialize canonical Runner test capabilities")
 }
 
@@ -127,9 +122,8 @@ pub(crate) fn current_runner_capabilities(
 pub(crate) fn current_runner_registration(
     mut registration: crate::shell_protocol::ShellClientRegisterRequest,
 ) -> crate::shell_protocol::ShellClientRegisterRequest {
-    registration.capabilities = Some(current_runner_capabilities(
-        registration.capabilities.take().unwrap_or_default(),
-    ));
+    registration.agent_protocol_generation = crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2;
+    registration.capabilities = current_runner_capabilities(registration.capabilities);
     registration
 }
 

--- a/src/tool_runtime/tests/agent_tasks.rs
+++ b/src/tool_runtime/tests/agent_tasks.rs
@@ -68,16 +68,17 @@ async fn register_coding_agent_task_runner(
             coding_agent_inventory: Some(inventory),
             client_id: client_id.to_string(),
             agent_instance_id: instance_id.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: Some("A4a test runner".to_string()),
             owner: Some(owner.to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities {
                     coding_agent_runs: true,
                     ..Default::default()
                 },
-            )),
+            ),
             policy: None,
         })
         .await

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -845,17 +845,18 @@ async fn long_run_shell_async_job_capability_does_not_bypass_shell_authority() {
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: "inst".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: false,
                         async_shell_jobs: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(&auth),
@@ -2260,11 +2261,12 @@ async fn register_job_agent_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: "inst".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(caps),
+                capabilities: caps,
                 policy: None,
             },
             Some(auth),
@@ -2310,16 +2312,17 @@ async fn register_managed_job_agent(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some(owner.to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities {
                     async_shell_jobs: true,
                     ..Default::default()
                 },
-            )),
+            ),
             policy: None,
         })
         .await

--- a/src/tool_runtime/tests/lsp.rs
+++ b/src/tool_runtime/tests/lsp.rs
@@ -354,18 +354,19 @@ async fn register_lsp_agent_capabilities(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: "inst".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(ShellClientCapabilities {
+                capabilities: ShellClientCapabilities {
                     shell: true,
                     file_read: true,
                     file_write: true,
                     lsp_read_only_navigation: lsp_capable,
                     lsp_call_hierarchy: call_hierarchy_capable,
                     ..Default::default()
-                }),
+                },
                 policy: None,
             },
         ))

--- a/src/tool_runtime/tests/memory.rs
+++ b/src/tool_runtime/tests/memory.rs
@@ -1550,11 +1550,12 @@ async fn memory_scope_missing_or_incomplete_inventory_is_unknown_until_complete(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(ShellClientCapabilities::default()),
+                capabilities: ShellClientCapabilities::default(),
                 policy: None,
             },
         ))

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -114,11 +114,12 @@ fn metadata_agent_registration(client_id: &str) -> ShellClientRegisterRequest {
         coding_agent_inventory: None,
         client_id: client_id.to_string(),
         agent_instance_id: format!("inst-{client_id}"),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: None,
         hostname: None,
         host_context: None,
-        capabilities: None,
+        capabilities: ShellClientCapabilities::default(),
         policy: None,
     })
 }
@@ -144,18 +145,19 @@ async fn register_computer_target_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: Some(display_name.to_string()),
                 owner: None,
                 hostname: Some(format!("host-{client_id}")),
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         computer_observe,
                         computer_snapshot_region,
                         computer_accessibility_observe,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -184,17 +186,18 @@ async fn register_application_target_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: Some(display_name.to_string()),
                 owner: None,
                 hostname: Some(format!("host-{client_id}")),
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         computer_application_discovery,
                         computer_application_launch,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -221,16 +224,17 @@ async fn register_display_target_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: Some(display_name.to_string()),
                 owner: None,
                 hostname: Some(format!("host-{client_id}")),
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         computer_display_observe: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -257,16 +261,17 @@ async fn register_pointer_target_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: Some(display_name.to_string()),
                 owner: None,
                 hostname: Some(format!("host-{client_id}")),
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         computer_pointer_control: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -294,17 +299,18 @@ async fn register_clipboard_target_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: Some(display_name.to_string()),
                 owner: None,
                 hostname: Some(format!("host-{client_id}")),
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         computer_clipboard_read: read,
                         computer_clipboard_write: write,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -331,11 +337,12 @@ async fn register_agent_projects_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{}", client_id),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         file_read: true,
@@ -386,9 +393,8 @@ async fn register_agent_projects_for_auth(
                         computer_text_input: false,
                         job_state_reconciliation: false,
                         coding_agent_runs: false,
-                        agent_protocol_generation: None,
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -839,13 +845,12 @@ async fn replacement_runner_pending_inventory_has_zero_project_routing_authority
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: new_instance.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
-                capabilities,
-            )),
+            capabilities: crate::test_support::current_runner_capabilities(capabilities),
             policy: None,
         })
         .await
@@ -1010,13 +1015,12 @@ async fn replacement_runner_removed_project_never_inherits_old_authority() {
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: new_instance.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
-                capabilities,
-            )),
+            capabilities: crate::test_support::current_runner_capabilities(capabilities),
             policy: None,
         })
         .await
@@ -1223,13 +1227,14 @@ async fn runtime_status_shell_profiles_summary_is_sanitized() {
             coding_agent_inventory: None,
             client_id: "profile-agent".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities::default(),
-            )),
+            ),
             policy: Some(AgentPolicySummary {
                 allow_raw_shell: true,
                 allow_cwd_anywhere: false,

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -816,11 +816,12 @@ async fn observe_jobs_recovering_lost_and_stop_requested_match_job_log_semantics
                 coding_agent_inventory: None,
                 client_id: "observe-recovering".to_string(),
                 agent_instance_id: "inst".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(recovering_caps),
+                capabilities: recovering_caps,
                 policy: None,
             },
         ))

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -717,13 +717,12 @@ async fn detached_process_lost_initiation_after_server_restart_recovers_same_job
             coding_agent_inventory: None,
             client_id: "detached-restart-recovery".to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
-                capabilities,
-            )),
+            capabilities: crate::test_support::current_runner_capabilities(capabilities),
             policy: None,
         })
         .await

--- a/src/tool_runtime/tests/reconnect.rs
+++ b/src/tool_runtime/tests/reconnect.rs
@@ -51,11 +51,12 @@ fn register_request(
     crate::test_support::current_runner_registration(ShellClientRegisterRequest {
         client_id: client_id.to_string(),
         agent_instance_id: instance.to_string(),
+        agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
         display_name: None,
         owner: None,
         hostname: None,
         host_context: None,
-        capabilities: Some(ShellClientCapabilities {
+        capabilities: ShellClientCapabilities {
             shell: true,
             git: true,
             file_read: true,
@@ -64,7 +65,7 @@ fn register_request(
             async_jobs: true,
             async_shell_jobs: true,
             ..Default::default()
-        }),
+        },
         policy: None,
         process_started_at,
         build,
@@ -621,11 +622,7 @@ async fn version_compatibility_reports_stable_mismatch_facts() {
     // Unsupported protocol generations fail registration and therefore never
     // become a diagnostic-but-operational runtime client.
     let mut unsupported = register_request("future-generation", "inst-3", None, None);
-    unsupported
-        .capabilities
-        .as_mut()
-        .unwrap()
-        .agent_protocol_generation = Some(AgentProtocolGenerationNumber::new(3));
+    unsupported.agent_protocol_generation = AgentProtocolGenerationNumber::new(3);
     let unsupported = runtime
         .shell_clients
         .register(unsupported)

--- a/src/tool_runtime/tests/support/agent.rs
+++ b/src/tool_runtime/tests/support/agent.rs
@@ -31,11 +31,12 @@ pub(in crate::tool_runtime::tests) async fn register_agent_project_at_path(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities {
                     shell: true,
                     git: true,
@@ -44,7 +45,7 @@ pub(in crate::tool_runtime::tests) async fn register_agent_project_at_path(
                     internal_posix_script: true,
                     ..Default::default()
                 },
-            )),
+            ),
             policy: None,
         })
         .await
@@ -85,11 +86,12 @@ pub(in crate::tool_runtime::tests) async fn register_agent_project_at_path_with_
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: "inst".to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities {
                         shell: true,
                         git: true,
@@ -98,7 +100,7 @@ pub(in crate::tool_runtime::tests) async fn register_agent_project_at_path_with_
                         internal_posix_script: true,
                         ..Default::default()
                     },
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -620,11 +622,12 @@ pub(in crate::tool_runtime::tests) async fn register_agent(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: owner.map(str::to_string),
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(caps)),
+            capabilities: crate::test_support::current_runner_capabilities(caps),
             policy: None,
         })
         .await
@@ -663,11 +666,12 @@ pub(in crate::tool_runtime::tests) async fn register_agent_with_instance(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: agent_instance_id.to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: owner.map(str::to_string),
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(caps)),
+            capabilities: crate::test_support::current_runner_capabilities(caps),
             policy: None,
         })
         .await
@@ -762,11 +766,12 @@ pub(in crate::tool_runtime::tests) async fn register_agent_projects(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: agent_instance_id.clone(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: owner.map(str::to_string),
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(caps)),
+            capabilities: crate::test_support::current_runner_capabilities(caps),
             policy: None,
         })
         .await
@@ -800,11 +805,12 @@ pub(in crate::tool_runtime::tests) async fn register_agent_projects_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: agent_instance_id.clone(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(caps)),
+                capabilities: crate::test_support::current_runner_capabilities(caps),
                 policy: None,
             },
             Some(auth),
@@ -1076,11 +1082,12 @@ pub(in crate::tool_runtime::tests) async fn register_agent_with_projects(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: owner.map(str::to_string),
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(caps)),
+            capabilities: crate::test_support::current_runner_capabilities(caps),
             policy: None,
         })
         .await
@@ -1114,13 +1121,14 @@ pub(in crate::tool_runtime::tests) async fn register_agent_with_shell_profiles(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: None,
             hostname: None,
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities::default(),
-            )),
+            ),
             policy,
         })
         .await

--- a/src/tool_runtime/tests/targeted_inventory.rs
+++ b/src/tool_runtime/tests/targeted_inventory.rs
@@ -58,17 +58,18 @@ async fn register_target_agent(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: format!("inst-{client_id}"),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: Some(format!("Runner {client_id}")),
             owner: None,
             hostname: Some(format!("host-{client_id}")),
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities {
                     git: true,
                     async_shell_jobs: true,
                     ..Default::default()
                 },
-            )),
+            ),
             policy: None,
         })
         .await
@@ -100,13 +101,14 @@ async fn register_target_agent_for_auth(
                 coding_agent_inventory: None,
                 client_id: client_id.to_string(),
                 agent_instance_id: format!("inst-{client_id}"),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
                 display_name: None,
                 owner: None,
                 hostname: None,
                 host_context: None,
-                capabilities: Some(crate::test_support::current_runner_capabilities(
+                capabilities: crate::test_support::current_runner_capabilities(
                     ShellClientCapabilities::default(),
-                )),
+                ),
                 policy: None,
             },
             Some(auth),
@@ -152,13 +154,14 @@ async fn register_managed_target_agent(
             coding_agent_inventory: None,
             client_id: client_id.to_string(),
             agent_instance_id: format!("inst-{client_id}"),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
             display_name: Some(format!("{owner} private runner")),
             owner: Some(owner.to_string()),
             hostname: Some(format!("{owner}-private-host")),
             host_context: None,
-            capabilities: Some(crate::test_support::current_runner_capabilities(
+            capabilities: crate::test_support::current_runner_capabilities(
                 ShellClientCapabilities::default(),
-            )),
+            ),
             policy: None,
         })
         .await


### PR DESCRIPTION
## Summary
- move Runner protocol generation to a required top-level registration identity
- require an explicit capability snapshot and explicit `shell` presence at registration ingress
- remove the duplicate stored capability snapshot and project public capabilities from canonical Runner feature state
- preserve additive `RegistrationRequired` capability semantics, including `apply_patch`
- align polling, WebSocket, QUIC, tests, generated config, and Runner documentation with the 0.4 contract

## Validation
- `cargo test -p webcodex --lib` — 3234 passed
- `cargo test -p webcodex-runner` — 801 passed, 4 ignored
- focused polling/WebSocket/QUIC registration and generation-baseline tests — passed
- `cargo fmt --all -- --check` — passed
- `cargo check --all-targets -p webcodex-core -p webcodex -p webcodex-runner` — passed
- `git diff --check origin/main..HEAD` — passed