### PR TITLE
Layer model-facing tool results

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -111,6 +111,26 @@ protocol/tool contracts; a first-time user does not need to choose among them.
 
 Model-facing failures may add a small recovery-control vocabulary without replacing existing subsystem fields. `error_kind` identifies what failed. `failure_kind`, when present, retains execution/effect/validation semantics such as `not_started`, `timeout`, or `outcome_unknown`. `recovery_kind` is the closed class of the next safe action: `fix_input`, `retry_same`, `reobserve`, `reconcile`, `wait`, `user_action`, or `none`. `recovery_tool`, when present, is a bounded public WebCodex tool for an explicit re-observation or reconciliation step; it never grants authority or triggers execution. `outcome_unknown` is not retry permission. `retry_same` is reserved for an exact idempotent replay contract and must not be interpreted as an ordinary repeat of an effect.
 
+### Tool result framing (v0.4 contract)
+
+Starting with `v0.4.0`, `structuredContent` is the authoritative machine-readable
+result for WebCodex `tools/call` responses. Ordinary text content is a compact
+human-readable fallback and must not be treated as a second serialized copy of
+the tool result. A successful call may therefore return text such as
+`WebCodex tool completed successfully.` while the actual fields are present only
+in `structuredContent`. Clients that need tool data must consume
+`structuredContent` rather than parse `content.text`.
+
+This is an intentional `0.3.x -> 0.4.0` cleanup boundary and applies across the
+WebCodex-supported `2025-06-18`, `2025-11-25`, and `2026-07-28` MCP protocol
+eras. Supporting those protocol versions does not preserve the pre-0.4 duplicate
+JSON-in-text result representation. The `v0.4.0` framing above is the compatibility
+floor for `0.4.x`: machine-readable result fields remain in `structuredContent`,
+while `content` remains available for concise text or protocol-native content
+blocks such as images and resource links. When MCP-specific framing transforms a
+structured result, the MCP-facing output schema describes that post-framing
+`structuredContent` shape.
+
 Hosted clients need public HTTPS. `share` supplies a temporary Cloudflare Quick
 Tunnel by default; `connect` uses an existing hosted Server; self-hosted
 deployments provide their own stable HTTPS origin. Do not use bootstrap/admin

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -96,6 +96,23 @@ annotations 与当前 runtime ModelSurface routing，不展开庞大的 output s
 `call_runtime_tool`。这些字段只描述调用路由，不代表授权或 feature readiness；目标 tool 原有的
 OAuth scope、project authority、permission gate、参数校验、effect 与 Session/ACK 语义保持不变。这些名称描述 protocol/tool contract；第一次用户不需要先做选择。
 
+### Tool result framing（v0.4 contract）
+
+从 `v0.4.0` 起，WebCodex `tools/call` 返回中的 `structuredContent` 是
+authoritative machine-readable result。普通 text content 只保留简短的人类可读 fallback，
+不再作为同一 tool result 的第二份 JSON 序列化副本。因此一次成功调用可以只在
+`content.text` 中返回 `WebCodex tool completed successfully.`，真正的结果字段只存在于
+`structuredContent`。需要读取 tool data 的 client 必须消费 `structuredContent`，不能依赖
+解析 `content.text`。
+
+这是一次有意的 `0.3.x -> 0.4.0` cleanup boundary，并同时适用于 WebCodex 支持的
+`2025-06-18`、`2025-11-25` 与 `2026-07-28` MCP protocol era。继续支持这些 protocol
+version 不代表继续保留 0.4 之前“在 text 中重复整份 JSON”的 result representation。
+上述 `v0.4.0` framing 是 `0.4.x` 的 compatibility floor：machine-readable result field
+继续位于 `structuredContent`；`content` 用于简短文本或 image、resource link 等
+protocol-native content block。若 MCP-specific framing 会转换 structured result，则
+MCP-facing output schema 描述的是转换后的 `structuredContent` shape。
+
 Hosted client 需要公网 HTTPS：`share` 默认提供临时 Cloudflare Quick Tunnel，`connect` 使用
 已有 hosted Server，自托管部署则提供自己的稳定 HTTPS origin。不要把 bootstrap/admin token、
 Runner token 或持久 project-first Connector credential 当作公网 share secret。

--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -425,7 +425,14 @@ standing rule for `0.4.x` is compatibility-first:
 5. **Model, HTTP, and MCP contracts.** Canonical model-visible tool names,
    documented REST routes, MCP capability names, and documented serialized
    field names released in `v0.4.0` evolve additively or migration-first during
-   `0.4.x`. A true removal or rename should normally wait for `v0.5.0`.
+   `0.4.x`. A true removal or rename should normally wait for `v0.5.0`. The
+   `v0.4.0` MCP result-framing floor makes `structuredContent` the canonical
+   machine-readable `tools/call` result. `content.text` is a concise human
+   fallback, not a duplicate serialization of that result. This applies to all
+   MCP protocol eras WebCodex advertises; protocol-version support does not
+   preserve the pre-0.4 JSON-in-text duplication. `0.4.x` must keep this
+   structured-result ownership stable, including any transport-specific
+   post-framing output schema.
 
 The product concept and public lifecycle namespace are **Runner**, but several
 older `agent_*` names are already compatibility vocabulary and are deliberately

--- a/src/mcp/response.rs
+++ b/src/mcp/response.rs
@@ -34,7 +34,18 @@ pub(super) fn mcp_stateless_result(mut result: Value, cacheable: bool) -> Value 
 }
 
 pub(super) fn connector_call_tool_result(outcome: ConnectorCallOutcome) -> Value {
-    let text = serde_json::to_string(&outcome.body).unwrap_or_else(|_| "{}".to_string());
+    // Connector output follows the same MCP layering as Runtime tools: the body
+    // is canonical in structuredContent and content.text is only a tiny fallback.
+    let text = if outcome.ok {
+        "WebCodex connector tool completed successfully.".to_string()
+    } else {
+        outcome
+            .body
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("WebCodex connector tool failed.")
+            .to_string()
+    };
     json!({
         "content": [{ "type": "text", "text": text }],
         "structuredContent": outcome.body,
@@ -43,12 +54,17 @@ pub(super) fn connector_call_tool_result(outcome: ConnectorCallOutcome) -> Value
 }
 
 pub(super) fn mcp_runtime_tool_result_fallback(result: ToolResult) -> Value {
-    let text = serde_json::to_string(&json!({
-        "success": result.success,
-        "output": result.output.clone(),
-        "error": result.error.clone(),
-    }))
-    .unwrap_or_else(|_| "{}".to_string());
+    // `structuredContent` is the canonical machine-readable result. Repeating
+    // that full JSON object in `content.text` doubles model context and echoes
+    // metadata the caller already has. Keep text as a tiny fallback instead.
+    let text = if result.success {
+        "WebCodex tool completed successfully.".to_string()
+    } else {
+        result
+            .error
+            .clone()
+            .unwrap_or_else(|| "WebCodex tool failed.".to_string())
+    };
     json!({
         "content": [{ "type": "text", "text": text }],
         "structuredContent": {

--- a/src/mcp_tests/project_connector.rs
+++ b/src/mcp_tests/project_connector.rs
@@ -416,6 +416,14 @@ async fn http_project_connector_lists_and_dispatches_only_project_capabilities()
         .await;
     assert_eq!(effective_status(&started), StatusCode::OK);
     let started_body: Value = started.take_json().await.unwrap();
+    assert_eq!(
+        started_body["result"]["content"][0]["text"],
+        "WebCodex connector tool completed successfully."
+    );
+    assert!(!started_body["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("task_id"));
     assert_eq!(started_body["result"]["structuredContent"]["ok"], true);
     assert!(started_body["result"]["structuredContent"]["task_id"]
         .as_str()

--- a/src/mcp_tests/runtime_tools.rs
+++ b/src/mcp_tests/runtime_tools.rs
@@ -175,13 +175,21 @@ async fn mcp_tools_call_runtime_status_returns_content() {
     // content blocks
     assert!(value["result"]["content"].is_array());
     assert_eq!(value["result"]["content"][0]["type"], "text");
-    assert!(value["result"]["content"][0]["text"].is_string());
-    // structuredContent carries the ToolResult shape
+    assert_eq!(
+        value["result"]["content"][0]["text"],
+        "WebCodex tool completed successfully."
+    );
+    // structuredContent carries the ToolResult shape exactly once; content.text
+    // must not serialize the structured payload again.
     assert!(value["result"]["structuredContent"].is_object());
     assert_eq!(value["result"]["structuredContent"]["success"], true);
     let out = &value["result"]["structuredContent"]["output"];
     assert_eq!(out["service"], "webcodex");
     assert_eq!(out["version"], env!("CARGO_PKG_VERSION"));
+    assert!(!value["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains(env!("CARGO_PKG_VERSION")));
     // runtime_status never errors on a failed-projects runtime — it
     // reports configured=false instead.
     assert_eq!(value["result"]["isError"], false);

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -1384,7 +1384,8 @@ async fn api_tools_call_uses_recording_session_id_for_recorder_metadata() {
     let body: Value = resp.take_json().await.unwrap();
     assert_eq!(body["output"]["session_id"], business_session_id);
     assert_eq!(body["output"]["title"], "business");
-    assert_eq!(body["output"]["session_recorded"], true);
+    assert!(body["output"].get("session_recorded").is_none());
+    assert!(body["output"].get("session_event_id").is_none());
     assert!(body["output"].get("session_context_revision").is_none());
     assert!(body["output"].get("session_continuity").is_none());
     assert!(body["output"].get("session_recovery").is_none());
@@ -1454,7 +1455,8 @@ async fn api_tools_call_message_tool_keeps_business_session_id_with_recording_se
     assert!(body["output"]["message_id"]
         .as_str()
         .is_some_and(|id| id.starts_with("wc_msg_")));
-    assert_eq!(body["output"]["session_recorded"], true);
+    assert!(body["output"].get("session_recorded").is_none());
+    assert!(body["output"].get("session_event_id").is_none());
 
     let mut resp = TestClient::post("http://localhost/api/tools/call")
         .bearer_auth("secret")

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -91,6 +91,15 @@ fn sparsify_terminal_structured_execution_success(tool_name: &str, result: &mut 
         "observation_token",
         "effective_timeout_secs",
         "sync_wait_secs",
+        "execution_state",
+        "command_started",
+        "command_completed",
+        "command_ok",
+        "exit_code",
+        "duration_ms",
+        "purpose",
+        "cwd",
+        "executor",
     ] {
         output.remove(key);
     }
@@ -137,6 +146,24 @@ fn sparsify_terminal_structured_execution_success(tool_name: &str, result: &mut 
     if canonical_source && canonical_summary {
         output.remove(summary_key);
         output.remove("execution_source");
+    }
+}
+
+/// Strip successful wrapper/telemetry facts only after every authority and
+/// Session recorder that needs them has consumed the canonical ToolResult.
+/// Failures keep the full decision/recovery envelope because those fields are
+/// actionable for retry, escalation, and reconciliation.
+pub(super) fn sparsify_success_model_result_metadata(result: &mut ToolResult) {
+    if !result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object_mut() else {
+        return;
+    };
+    output.remove("permission");
+    if output.get("session_recorded").and_then(Value::as_bool) == Some(true) {
+        output.remove("session_recorded");
+        output.remove("session_event_id");
     }
 }
 
@@ -2028,10 +2055,21 @@ mod structured_execution_sparse_projection_tests {
     fn terminal_execution_only_omits_summary_and_source_for_exact_canonical_source() {
         let mut canonical = terminal_process_result("run_process");
         sparsify_terminal_structured_execution_success("run_process", &mut canonical);
-        assert!(canonical.output.get("process_summary").is_none());
-        assert!(canonical.output.get("execution_source").is_none());
-        assert_eq!(canonical.output["cwd"], ".");
-        assert_eq!(canonical.output["executor"], "agent");
+        for omitted in [
+            "process_summary",
+            "execution_source",
+            "execution_state",
+            "command_started",
+            "command_completed",
+            "command_ok",
+            "exit_code",
+            "duration_ms",
+            "purpose",
+            "cwd",
+            "executor",
+        ] {
+            assert!(canonical.output.get(omitted).is_none(), "{omitted}");
+        }
 
         let mut alternate = terminal_process_result("alternate_process_source");
         sparsify_terminal_structured_execution_success("run_process", &mut alternate);
@@ -2040,6 +2078,9 @@ mod structured_execution_sparse_projection_tests {
             alternate.output["execution_source"],
             "alternate_process_source"
         );
+        assert!(alternate.output.get("cwd").is_none());
+        assert!(alternate.output.get("executor").is_none());
+        assert!(alternate.output.get("execution_state").is_none());
     }
 }
 

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -818,6 +818,9 @@ impl ToolRuntime {
             );
             super::dispatch::sparsify_complete_read_success(&request.tool_name, &mut result);
         }
+        // Final model-facing projection: the authoritative permission decision
+        // and recorder event have already been consumed by the Session ledger.
+        super::dispatch::sparsify_success_model_result_metadata(&mut result);
         ToolCallOutcome {
             success: result.success,
             result: Some(result),

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -30,7 +30,7 @@ fn process_execution_state_schema() -> Value {
     json!({
         "type": "string",
         "enum": ["not_started", "outcome_unknown", "completed", "timed_out", "queued", "running"],
-        "description": "Canonical lifecycle: not_started means no command dispatch; outcome_unknown means effects may have occurred and must be reconciled before retry; completed and timed_out are terminal. queued/running appear only when the same execution has been exposed as a durable Job. Only not_started is structurally safe to retry without first inspecting target state."
+        "description": "Canonical lifecycle when explicit: not_started means no command dispatch; outcome_unknown means effects may have occurred and must be reconciled before retry; timed_out is terminal; queued/running appear only for durable Job handoff. Ordinary synchronous success omits this field because outer success already implies completed. Only explicit not_started is structurally safe to retry without first inspecting target state."
     })
 }
 
@@ -573,11 +573,11 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             let mut properties = vec![
                 (
                     "duration_ms",
-                    schema_type("integer", "Process duration in milliseconds."),
+                    schema_type("integer", "Process duration in milliseconds; omitted on ordinary synchronous terminal success."),
                 ),
                 (
                     "exit_code",
-                    nullable_schema("integer", "Process exit code, when available."),
+                    nullable_schema("integer", "Process exit code when it must be explicit; omitted when outer success already implies 0."),
                 ),
                 (
                     "stdout_tail",
@@ -607,19 +607,19 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "command_started",
                     schema_type(
                         "boolean",
-                        "Whether callers must conservatively treat the process as started; true includes outcome_unknown because side effects may have occurred.",
+                        "Whether callers must conservatively treat the process as started; true includes outcome_unknown because side effects may have occurred. Omitted on ordinary synchronous terminal success.",
                     ),
                 ),
                 (
                     "command_completed",
                     schema_type(
                         "boolean",
-                        "Whether the process reached a terminal result before tool timeout.",
+                        "Whether the process reached a terminal result before tool timeout. Omitted on ordinary synchronous terminal success.",
                     ),
                 ),
                 (
                     "command_ok",
-                    schema_type("boolean", "Whether the process completed with exit code 0."),
+                    schema_type("boolean", "Whether the process completed with exit code 0; omitted on ordinary synchronous terminal success."),
                 ),
                 (
                     "failure_kind",
@@ -635,7 +635,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                         "True for WebCodex tool/runtime failures; false for child exit status failures. Omitted when false on ordinary synchronous terminal success.",
                     ),
                 ),
-                ("purpose", schema_type("string", "Declared execution purpose.")),
+                ("purpose", schema_type("string", "Declared execution purpose; omitted on ordinary synchronous terminal success because it echoes the request.")),
                 (
                     "process_summary",
                     schema_type(
@@ -645,9 +645,9 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
                 (
                     "cwd",
-                    schema_type("string", "Resolved project-relative cwd."),
+                    schema_type("string", "Resolved project-relative cwd; omitted on ordinary synchronous terminal success."),
                 ),
-                ("executor", schema_type("string", "Executor type: local or agent.")),
+                ("executor", schema_type("string", "Executor type: local or agent; omitted on ordinary synchronous terminal success.")),
                 (
                     "execution_source",
                     schema_type("string", "Canonical source is run_process. Omitted on ordinary synchronous terminal success only when the actual source is exactly canonical; any future schema-supported alternate source must remain explicit."),
@@ -669,11 +669,11 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             let mut properties = vec![
                 (
                     "duration_ms",
-                    schema_type("integer", "Script duration in milliseconds."),
+                    schema_type("integer", "Script duration in milliseconds; omitted on ordinary synchronous terminal success."),
                 ),
                 (
                     "exit_code",
-                    nullable_schema("integer", "Interpreter exit code, when available."),
+                    nullable_schema("integer", "Interpreter exit code when it must be explicit; omitted when outer success already implies 0."),
                 ),
                 (
                     "stdout_tail",
@@ -703,21 +703,21 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "command_started",
                     schema_type(
                         "boolean",
-                        "Whether callers must conservatively treat the script as started; true includes outcome_unknown because side effects may have occurred.",
+                        "Whether callers must conservatively treat the script as started; true includes outcome_unknown because side effects may have occurred. Omitted on ordinary synchronous terminal success.",
                     ),
                 ),
                 (
                     "command_completed",
                     schema_type(
                         "boolean",
-                        "Whether the interpreter reached a known terminal result before tool timeout.",
+                        "Whether the interpreter reached a known terminal result before tool timeout. Omitted on ordinary synchronous terminal success.",
                     ),
                 ),
                 (
                     "command_ok",
                     schema_type(
                         "boolean",
-                        "Whether the interpreter completed with exit code 0.",
+                        "Whether the interpreter completed with exit code 0. Omitted on ordinary synchronous terminal success.",
                     ),
                 ),
                 (
@@ -734,7 +734,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                         "True for WebCodex tool/runtime failures; false for interpreter exit status failures. Omitted when false on ordinary synchronous terminal success.",
                     ),
                 ),
-                ("purpose", schema_type("string", "Declared execution purpose.")),
+                ("purpose", schema_type("string", "Declared execution purpose; omitted on ordinary synchronous terminal success because it echoes the request.")),
                 (
                     "script_summary",
                     schema_type(
@@ -748,9 +748,9 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
                 (
                     "cwd",
-                    schema_type("string", "Resolved project-relative cwd."),
+                    schema_type("string", "Resolved project-relative cwd; omitted on ordinary synchronous terminal success."),
                 ),
-                ("executor", schema_type("string", "Executor type: local or agent.")),
+                ("executor", schema_type("string", "Executor type: local or agent; omitted on ordinary synchronous terminal success.")),
                 (
                     "execution_source",
                     schema_type("string", "Canonical source is run_script. Omitted on ordinary synchronous terminal success only when the actual source is exactly canonical; any future schema-supported alternate source must remain explicit."),

--- a/src/tool_runtime/tests/memory.rs
+++ b/src/tool_runtime/tests/memory.rs
@@ -1095,9 +1095,10 @@ async fn memory_surface_scopes_and_permission_are_independent_authority() {
         .await;
     let allowed_result = allowed.result.expect("memory_set result");
     assert!(allowed_result.success, "{}", allowed_result.output);
-    assert_eq!(
-        allowed_result.output["permission"]["status"],
-        "auto_approved"
+    assert!(
+        allowed_result.output.get("permission").is_none(),
+        "successful model-facing memory result should not repeat permission telemetry: {}",
+        allowed_result.output
     );
 
     let read_allowed = runtime

--- a/src/tool_runtime/tests/permission_gate.rs
+++ b/src/tool_runtime/tests/permission_gate.rs
@@ -385,6 +385,51 @@ async fn coding_agent_cancel_inherits_start_approval_without_second_evaluator_de
 }
 
 #[tokio::test]
+async fn kernel_path_preserves_permission_denial_for_model_recovery() {
+    let client_id = "perm-kernel-denied";
+    let runtime = runtime_with_mode(client_id, AuthorityMode::Restricted);
+    register_write_agent(&runtime, client_id).await;
+    let project = agent_test_project_id(client_id);
+    let recording = runtime.sessions.start_session(Some(project.clone()), None);
+    let bootstrap = auth_context(None, true);
+    let recording_id = recording.session_id.clone();
+
+    let outcome = runtime
+        .call_tool_with_context(
+            ToolCallRequest {
+                tool_name: "write_project_file".to_string(),
+                arguments: json!({
+                    "project": project,
+                    "path": "src/kernel-denied.txt",
+                    "content": "nope\n",
+                    "session_id": recording_id,
+                }),
+            },
+            ToolCallContext {
+                transport: ToolTransport::Api,
+                session_id: Some(&recording_id),
+                auth: Some(&bootstrap),
+                window: None,
+                record_oauth_scope_denials: true,
+                host_file_import_trust: crate::tool_runtime::kernel::HostFileImportTrust::Untrusted,
+            },
+        )
+        .await;
+
+    assert!(!outcome.success);
+    let result = outcome.result.expect("permission denial tool result");
+    assert_eq!(result.output["error_kind"], "permission_denied");
+    assert_eq!(result.output["permission"]["status"], "denied");
+    assert_eq!(
+        result.output["permission"]["reason"],
+        "restricted_requires_human_authorization"
+    );
+    assert!(probe_patch_agent_request(&runtime, client_id)
+        .await
+        .is_none());
+}
+
+#[tokio::test]
 async fn kernel_path_does_not_double_evaluate_or_duplicate_request_id() {
     let counter = Arc::new(AtomicUsize::new(0));
     let client_id = "perm-kernel-once";
@@ -441,12 +486,13 @@ async fn kernel_path_does_not_double_evaluate_or_duplicate_request_id() {
     );
 
     let result = outcome.result.expect("tool result");
-    let request_id = result.output["permission"]["request_id"]
-        .as_str()
-        .expect("permission.request_id")
-        .to_string();
-    assert!(request_id.starts_with("wc_perm_"));
-    assert_eq!(result.output["permission"]["status"], "auto_approved");
+    assert!(
+        result.output.get("permission").is_none(),
+        "successful kernel result should not repeat permission metadata: {}",
+        result.output
+    );
+    assert!(result.output.get("session_recorded").is_none());
+    assert!(result.output.get("session_event_id").is_none());
 
     let summary = runtime
         .sessions
@@ -462,12 +508,7 @@ async fn kernel_path_does_not_double_evaluate_or_duplicate_request_id() {
         !seen_ids.is_empty(),
         "outer recording session should reuse attached decision"
     );
-    for id in &seen_ids {
-        assert_eq!(
-            id, &request_id,
-            "all ledger permission request ids must match the single decision"
-        );
-    }
+    assert!(seen_ids.iter().all(|id| id.starts_with("wc_perm_")));
     let unique: std::collections::BTreeSet<_> = seen_ids.iter().collect();
     assert_eq!(
         unique.len(),

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -361,18 +361,35 @@ async fn run_process_enqueues_only_typed_argv_and_reports_completed_exit_codes()
         .await;
         let result = task.await.unwrap();
         assert_eq!(result.success, expected_success);
-        assert_eq!(result.output["execution_state"], "completed");
-        assert_eq!(result.output["command_started"], true);
-        assert_eq!(result.output["command_completed"], true);
-        assert_eq!(result.output["exit_code"], exit_code);
         if expected_success {
-            assert!(result.output.get("execution_source").is_none());
-            assert!(result.output.get("process_summary").is_none());
+            for omitted in [
+                "execution_state",
+                "command_started",
+                "command_completed",
+                "command_ok",
+                "exit_code",
+                "duration_ms",
+                "purpose",
+                "cwd",
+                "executor",
+                "execution_source",
+                "process_summary",
+            ] {
+                assert!(
+                    result.output.get(omitted).is_none(),
+                    "{omitted}: {}",
+                    result.output
+                );
+            }
         } else {
+            assert_eq!(result.output["execution_state"], "completed");
+            assert_eq!(result.output["command_started"], true);
+            assert_eq!(result.output["command_completed"], true);
+            assert_eq!(result.output["exit_code"], exit_code);
             assert_eq!(result.output["execution_source"], "run_process");
             assert!(result.output["process_summary"].as_str().is_some());
+            assert_eq!(result.output["purpose"], "diagnostic");
         }
-        assert_eq!(result.output["purpose"], "diagnostic");
     }
 }
 
@@ -865,13 +882,17 @@ async fn run_process_fast_terminal_jobs_project_back_without_visible_duplicates(
 
         let result = task.await.unwrap();
         assert_eq!(result.success, expected_success);
-        assert_eq!(result.output["execution_state"], "completed");
-        assert_eq!(result.output["command_started"], true);
-        assert_eq!(result.output["command_completed"], true);
-        assert_eq!(result.output["exit_code"], exit_code);
         if expected_success {
-            assert_eq!(result.output["command_ok"], true);
             for omitted in [
+                "execution_state",
+                "command_started",
+                "command_completed",
+                "command_ok",
+                "exit_code",
+                "duration_ms",
+                "purpose",
+                "cwd",
+                "executor",
                 "promoted_to_job",
                 "terminal",
                 "job_id",
@@ -892,6 +913,10 @@ async fn run_process_fast_terminal_jobs_project_back_without_visible_duplicates(
                 );
             }
         } else {
+            assert_eq!(result.output["execution_state"], "completed");
+            assert_eq!(result.output["command_started"], true);
+            assert_eq!(result.output["command_completed"], true);
+            assert_eq!(result.output["exit_code"], exit_code);
             assert_eq!(result.output["promoted_to_job"], false);
             assert_eq!(result.output["terminal"], true);
             assert!(result.output["job_id"].is_null());
@@ -958,12 +983,16 @@ async fn run_process_terminal_success_is_sparse_after_full_session_effect_record
 
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["execution_state"], "completed");
-    assert_eq!(result.output["command_started"], true);
-    assert_eq!(result.output["command_completed"], true);
-    assert_eq!(result.output["command_ok"], true);
-    assert_eq!(result.output["exit_code"], 0);
     for omitted in [
+        "execution_state",
+        "command_started",
+        "command_completed",
+        "command_ok",
+        "exit_code",
+        "duration_ms",
+        "purpose",
+        "cwd",
+        "executor",
         "promoted_to_job",
         "terminal",
         "job_id",
@@ -989,11 +1018,9 @@ async fn run_process_terminal_success_is_sparse_after_full_session_effect_record
         );
     }
 
-    assert!(result.output["cwd"].as_str().is_some());
-    assert!(result.output["executor"].as_str().is_some());
     let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
     assert!(
-        sparse_bytes <= 620,
+        sparse_bytes <= 420,
         "boring run_process success regressed above the model-facing context budget: {sparse_bytes} bytes"
     );
     eprintln!("run_process_sparse_terminal_success_bytes={sparse_bytes}");
@@ -1347,7 +1374,7 @@ async fn run_process_short_timeout_stays_direct_without_job_headroom() {
     .await;
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["execution_state"], "completed");
+    assert!(result.output.get("execution_state").is_none());
     assert!(result.output.get("promoted_to_job").is_none());
     assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
 }
@@ -1732,7 +1759,7 @@ async fn run_process_session_default_cwd_applies_without_default_shell() {
     .await;
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["cwd"], "frontend");
+    assert!(result.output.get("cwd").is_none());
     let summary = runtime
         .sessions
         .summary(&session.session_id, Some(20))

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -991,7 +991,8 @@ async fn read_files_outer_recording_session_preserves_complete_sparse_shape() {
 
     let result = task.await.unwrap().result.expect("model-facing result");
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["session_recorded"], true);
+    assert!(result.output.get("session_recorded").is_none());
+    assert!(result.output.get("session_event_id").is_none());
     assert_eq!(result.output["session_context_revision"], 0);
     assert!(result.output.get("session_continuity").is_none());
     assert!(result.output.get("session_recovery").is_none());

--- a/src/tool_runtime/tests/script.rs
+++ b/src/tool_runtime/tests/script.rs
@@ -251,15 +251,27 @@ async fn run_script_wire_is_typed_body_free_command_and_supports_more_than_32_ki
     .await;
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
-    assert!(result.output.get("execution_source").is_none());
-    assert!(result.output.get("script_summary").is_none());
-    assert_eq!(result.output["execution_state"], "completed");
-    assert_eq!(result.output["command_started"], true);
-    assert_eq!(result.output["command_completed"], true);
     assert_eq!(result.output["language"], "bash");
-    assert_eq!(result.output["purpose"], "operation");
-    assert!(result.output["cwd"].as_str().is_some());
-    assert!(result.output["executor"].as_str().is_some());
+    assert_eq!(result.output["stdout_tail"], "done\n");
+    for omitted in [
+        "execution_source",
+        "script_summary",
+        "execution_state",
+        "command_started",
+        "command_completed",
+        "command_ok",
+        "exit_code",
+        "duration_ms",
+        "purpose",
+        "cwd",
+        "executor",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "{omitted}: {}",
+            result.output
+        );
+    }
 }
 
 #[tokio::test]
@@ -317,11 +329,16 @@ async fn run_script_fast_success_projects_back_and_removes_the_hidden_job() {
     .await;
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["execution_state"], "completed");
-    assert_eq!(result.output["command_started"], true);
-    assert_eq!(result.output["command_completed"], true);
-    assert_eq!(result.output["command_ok"], true);
     for omitted in [
+        "execution_state",
+        "command_started",
+        "command_completed",
+        "command_ok",
+        "exit_code",
+        "duration_ms",
+        "purpose",
+        "cwd",
+        "executor",
         "promoted_to_job",
         "terminal",
         "job_id",
@@ -345,11 +362,9 @@ async fn run_script_fast_success_projects_back_and_removes_the_hidden_job() {
             result.output
         );
     }
-    assert!(result.output["cwd"].as_str().is_some());
-    assert!(result.output["executor"].as_str().is_some());
     let sparse_bytes = serde_json::to_vec(&result.output).unwrap().len();
     assert!(
-        sparse_bytes <= 620,
+        sparse_bytes <= 460,
         "boring run_script success regressed above the model-facing context budget: {sparse_bytes} bytes"
     );
     eprintln!("run_script_sparse_terminal_success_bytes={sparse_bytes}");
@@ -432,8 +447,8 @@ async fn run_script_explicit_sync_wait_captures_terminal_after_old_ten_second_th
     .await;
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["execution_state"], "completed");
-    assert_eq!(result.output["command_completed"], true);
+    assert!(result.output.get("execution_state").is_none());
+    assert!(result.output.get("command_completed").is_none());
     assert!(result.output.get("job_id").is_none());
     assert!(result.output.get("promoted_to_job").is_none());
     assert!(runtime.shell_clients.list_jobs(Some(10)).await.is_empty());
@@ -910,7 +925,7 @@ async fn run_script_session_defaults_and_evidence_are_body_and_stdin_free() {
     .await;
     let result = task.await.unwrap();
     assert!(result.success);
-    assert_eq!(result.output["cwd"], "frontend");
+    assert!(result.output.get("cwd").is_none());
 
     let summary = runtime
         .sessions

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -1801,7 +1801,8 @@ async fn search_project_texts_outer_recording_session_preserves_complete_sparse_
 
     let result = task.await.unwrap().result.expect("model-facing result");
     assert!(result.success, "{:?}", result.error);
-    assert_eq!(result.output["session_recorded"], true);
+    assert!(result.output.get("session_recorded").is_none());
+    assert!(result.output.get("session_event_id").is_none());
     assert_eq!(result.output["session_context_revision"], 0);
     assert!(result.output.get("session_continuity").is_none());
     assert!(result.output.get("session_recovery").is_none());


### PR DESCRIPTION
## Summary
- separate canonical Session/audit evidence from sparse model-facing success projections
- remove redundant successful process/script lifecycle, permission, and recorder metadata only after authoritative consumers have recorded it
- make MCP `structuredContent` the canonical machine-readable tool result and keep `content.text` as a compact human fallback
- document the intentional 0.3.x -> 0.4.0 MCP result-framing break and freeze it as the 0.4.x compatibility floor

## Safety / contract
- failures, `not_started`, `outcome_unknown`, timeouts, non-zero exits, and durable Job handoffs keep explicit recovery/effect lifecycle fields
- permission denials remain model-visible; successful permission decisions remain in the Session ledger without repeated model-facing telemetry
- supported MCP protocol eras remain 2025-06-18, 2025-11-25, and 2026-07-28; protocol-version support no longer implies the pre-0.4 duplicate JSON-in-`content.text` representation

## Validation
- `cargo test -p webcodex`: 3235 passed, 0 failed on the code commit
- `cargo check --all-targets -p webcodex`: pass, 0 warnings on the code commit
- `python3 scripts/check_markdown_links.py`: 367 local links, 0 missing after the documentation commit
- `git diff --check`: pass
