### PR TITLE
Keep diagnostic execution failures actionable

### DIFF
--- a/src/tool_runtime/handoff.rs
+++ b/src/tool_runtime/handoff.rs
@@ -1250,6 +1250,10 @@ fn unexpected_failure_is_proven_non_actionable(event: &SessionEvent) -> bool {
     {
         return false;
     }
+    // ExecutionPurpose is caller-declared evidence metadata, not effect-safety
+    // proof. Once a generic shell/process command has started, a failed result
+    // remains actionable regardless of whether its declared purpose was
+    // diagnostic, validation, or anything else.
     if effect.and_then(|effect| effect.command_started) == Some(true)
         || matches!(
             execution_state,

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -450,12 +450,14 @@ fn exploration_input_audit_omits_queries_and_shell_commands() {
             "process_summary": "RAW_EXECUTABLE RAW_ARG",
             "executable_present": true,
             "arg_count": 2,
-            "stdin_present": true
+            "stdin_present": true,
+            "purpose": "diagnostic"
         }),
     );
     assert_eq!(process["executable_present"], true);
     assert_eq!(process["arg_count"], 2);
     assert_eq!(process["stdin_present"], true);
+    assert_eq!(process["purpose"], "diagnostic");
     assert!(process.get("executable").is_none());
     assert!(process.get("args").is_none());
     assert!(process.get("stdin").is_none());

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -2429,6 +2429,84 @@ async fn failure_history_fail_closed_attempts_do_not_block_clean_finish() {
 }
 
 #[tokio::test]
+async fn failure_history_started_diagnostic_process_failure_remains_actionable() {
+    let fixture = finish_summary_fixture("coding-finish-diagnostic-history").await;
+    record_coding_task_tool_event(
+        &fixture.runtime,
+        &fixture.session_id,
+        "cargo_check",
+        json!({"project": fixture.project.clone()}),
+        true,
+        json!({"exit_code": 0}),
+    );
+    record_coding_task_tool_event(
+        &fixture.runtime,
+        &fixture.session_id,
+        "run_process",
+        json!({
+            "project": fixture.project.clone(),
+            "executable": "diagnostic-probe",
+            "purpose": "diagnostic"
+        }),
+        false,
+        json!({
+            "failure_kind": "command_exit_nonzero",
+            "exit_code": 1,
+            "state_changed": false,
+            "command_started": true,
+            "command_completed": true,
+            "execution_state": "completed"
+        }),
+    );
+
+    let result = finish_coding_task_summary_only_with_agent(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project.clone(),
+        fixture.session_id.clone(),
+        fixture.auth.clone(),
+    )
+    .await;
+    let full = finish_coding_task_with_agent(
+        &fixture.runtime,
+        fixture.client_id,
+        fixture.project,
+        fixture.session_id,
+        fixture.auth,
+        false,
+    )
+    .await;
+
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["tool_failures"]["unexpected_count"], 1);
+    assert_eq!(
+        result.output["tool_failures"]["historical_non_actionable_count"],
+        0
+    );
+    assert_eq!(
+        result.output["tool_failures"]["actionable_unexpected_count"],
+        1
+    );
+    assert_eq!(result.output["task_outcome"]["status"], "fail");
+    assert_eq!(result.output["task_outcome"]["blocking"], true);
+    assert_reason_list_contains(
+        &result.output["task_outcome"],
+        "blocking_reasons",
+        "unexpected_tool_failures",
+    );
+    assert_action_list_contains(
+        &result.output["suggested_next_actions"],
+        "review unexpected failed tool calls before proceeding",
+    );
+    assert!(!full.output["informational_notes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|note| note.as_str()
+            == Some("completed diagnostic tool failures are retained as non-actionable evidence")));
+}
+
+#[tokio::test]
 async fn failure_history_started_shell_failure_remains_actionable() {
     let fixture = finish_summary_fixture("coding-finish-started-shell-failure").await;
     record_coding_task_tool_event(

--- a/src/tool_runtime/tests/handoff.rs
+++ b/src/tool_runtime/tests/handoff.rs
@@ -425,6 +425,48 @@ async fn failure_history_read_only_failure_is_non_actionable_in_handoff() {
 }
 
 #[tokio::test]
+async fn failure_history_started_diagnostic_process_failure_remains_actionable_in_handoff() {
+    let runtime = test_runtime();
+    let session = runtime
+        .sessions
+        .start_session(None, Some("diagnostic failure".to_string()));
+    let sid = session.session_id.clone();
+
+    record_handoff_tool_event(
+        &runtime,
+        &sid,
+        "run_process",
+        json!({"purpose": "diagnostic"}),
+        false,
+        json!({
+            "failure_kind": "command_exit_nonzero",
+            "exit_code": 1,
+            "state_changed": false,
+            "command_started": true,
+            "command_completed": true,
+            "execution_state": "completed"
+        }),
+    );
+
+    let handoff = handoff_summary(&runtime, &sid).await;
+    assert!(handoff.success, "{:?}", handoff.error);
+    assert_eq!(handoff.output["tool_failures"]["unexpected_count"], 1);
+    assert_eq!(
+        handoff.output["tool_failures"]["historical_non_actionable_count"],
+        0
+    );
+    assert_eq!(
+        handoff.output["tool_failures"]["actionable_unexpected_count"],
+        1
+    );
+    assert_reason_list_contains(
+        &handoff.output["verdict"],
+        "blocking_reasons",
+        "unexpected_tool_failures",
+    );
+}
+
+#[tokio::test]
 async fn expectation_mismatch_and_unexpected_success_are_visible() {
     let runtime = test_runtime();
     let auth = open_auth_context();


### PR DESCRIPTION
## Summary
- preserve raw failure history while keeping only structurally proven non-actionable failures out of the current blocker count
- explicitly keep started generic process/shell failures actionable even when the caller declares purpose=diagnostic
- add closeout/handoff regressions and Session input-summary privacy coverage

## Safety
`ExecutionPurpose` remains evidence metadata only. A generic command that started cannot become non-actionable solely from a diagnostic label; outcome_unknown and missing effect proof remain blocking.

## Validation
- `cargo test -p webcodex failure_history_` — 8 passed
- `cargo test -p webcodex exploration_input_audit_omits_queries_and_shell_commands` — 1 passed
- `cargo check --all-targets -p webcodex` — passed, 0 warnings
- `git diff --check` — passed
- workspace hygiene — clean