### PR TITLE
Harden bounded diagnostic trace tooling

### DIFF
--- a/crates/webcodex-runner/src/webcodex_runner/validation/execute.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/validation/execute.rs
@@ -551,7 +551,28 @@ mod tests {
         ok == 1 && exit_code == 259 // 259 == STILL_ACTIVE
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
+    fn process_alive(pid: u32) -> bool {
+        // `kill(pid, 0)` also succeeds for zombies, while ManagedChild's Linux
+        // tree-liveness contract deliberately treats zombies as unable to run.
+        // Use /proc to align this test probe with that contract, but fall back
+        // conservatively if procfs cannot be read or parsed.
+        // SAFETY: signal 0 is an existence probe; the pid comes from our own
+        // test helper.
+        if (unsafe { libc::kill(pid as i32, 0) }) != 0 {
+            return false;
+        }
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            return true;
+        };
+        let Some((_, rest)) = stat.rsplit_once(')') else {
+            return true;
+        };
+        let state = rest.split_whitespace().next().unwrap_or("");
+        state != "Z" && state != "X"
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
     fn process_alive(pid: u32) -> bool {
         // SAFETY: signal 0 is an existence probe; the pid comes from our own
         // test helper.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -206,6 +206,20 @@ mode. Trace I/O, compression, pruning, or correlation failures are fail-open for
 the tool itself and are reported as `tool_trace_capture_failed` rather than
 changing execution correctness.
 
+With `full` mode enabled, eligible failed model calls may expose an opaque
+`trace_ref` only to an `admin` caller on a Stateless MCP 2026 operator-capable
+surface. The ModelHidden `read_tool_trace` tool reads that Server-hosted store;
+Full Operator Runtime projects it directly, while Adaptive Runtime invokes it
+through `call_runtime_tool`. The tool is unavailable to ordinary runtime scopes,
+Local Coding, legacy MCP protocol eras, and HTTP runtime calls. It lists bounded
+payload metadata before raw content is requested, never accepts or returns native
+trace paths, verifies the owned trace directory/index plus payload size and
+SHA-256, and reads at most 256 KiB of uncompressed JSON for one selected payload
+(with a 512 KiB compressed-file safety ceiling). Larger retained payloads remain
+operator-visible as metadata but are not returned to the model. `read_tool_trace`
+does not recursively persist its own raw payload, and its Workflow Session audit
+record contains only trace metadata rather than the selected body.
+
 When a tool dispatches to a Runner, the Server records the mapping from
 `server_trace_id` to the existing `runner_request_id`, Runner client/instance,
 transport, and advertised build version/commit; the full store also captures the

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -182,6 +182,16 @@ patch、script/stdin、命令输出、user message 或其他 tool payload，应�
 trace 写盘、压缩、清理或 correlation 失败只产生 `tool_trace_capture_failed`，不会改变
 tool execution correctness。
 
+开启 `full` 后，只有 Stateless MCP 2026 operator-capable surface 上的 `admin` caller，
+才可能在符合条件的失败结果中收到 opaque `trace_ref`。ModelHidden `read_tool_trace`
+读取对应的 Server-hosted store：Full Operator Runtime 直接投影该工具，Adaptive Runtime
+则通过 `call_runtime_tool` 调用；普通 runtime scope、Local Coding、旧 MCP protocol era 与
+HTTP runtime call 都不能使用。reader 会先返回有界 payload metadata，再按 index 读取单个
+raw payload；它不接受或返回 native trace path，会重新检查 owned trace directory/index、
+payload size 与 SHA-256。一次最多向模型返回 256 KiB 的未压缩 JSON，并额外限制压缩文件
+不超过 512 KiB；更大的已保留 payload 只返回 metadata，不返回 body。`read_tool_trace`
+不会递归持久化自己读取出的 raw payload，其 Workflow Session audit 也只记录 trace metadata。
+
 当 tool 派发到 Runner 时，Server 会记录 `server_trace_id` 到现有
 `runner_request_id` 的映射，以及 Runner client/instance、transport 和注册时报告的
 build version/commit；full store 还会把 exact typed Runner request 记录为

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -121,6 +121,27 @@ the tool result. A successful call may therefore return text such as
 in `structuredContent`. Clients that need tool data must consume
 `structuredContent` rather than parse `content.text`.
 
+The default failure projection follows the same layering rule. It keeps facts
+that can change the caller's next safe action, including failure/recovery kind,
+`not_started` / `outcome_unknown`, exit state and bounded process output, Job
+handoff identifiers, permission denials, and reconciliation hints. Recorder and
+diagnostic telemetry that has already served its audit purpose is omitted from
+ordinary failures: for example auto-approved permission envelopes, Session
+recorder ids, and `run_process` / `run_script` executor, cwd, duration, declared
+purpose, and command/script summary.
+
+When the Server explicitly runs with full tool-request tracing, an eligible
+failed call from an `admin` caller on a Stateless MCP 2026 operator-capable
+surface may additionally contain one opaque `trace_ref`. `read_tool_trace` is a
+ModelHidden, admin-only, bounded forensic reader for that Server-hosted trace;
+it is directly projected by `full_operator_runtime` and is a long-tail target
+behind `call_runtime_tool` in `adaptive_runtime`. It is unavailable on Local
+Coding, legacy MCP protocol eras, and ordinary HTTP runtime calls. Callers should
+list the trace payload index first and select one payload only when needed. The
+reader never returns native trace paths, does not recursively capture its own
+raw result, and raw payload bodies are not copied into the durable Workflow
+Session ledger.
+
 This is an intentional `0.3.x -> 0.4.0` cleanup boundary and applies across the
 WebCodex-supported `2025-06-18`, `2025-11-25`, and `2026-07-28` MCP protocol
 eras. Supporting those protocol versions does not preserve the pre-0.4 duplicate

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -105,6 +105,22 @@ authoritative machine-readable result。普通 text content 只保留简短的�
 `structuredContent`。需要读取 tool data 的 client 必须消费 `structuredContent`，不能依赖
 解析 `content.text`。
 
+默认 failure projection 也遵循同一分层原则：会保留真正影响下一步安全动作的事实，例如
+failure/recovery kind、`not_started` / `outcome_unknown`、exit state 与有界 process output、
+Job handoff identifier、permission denial 和 reconciliation hint。已经完成审计用途的 recorder /
+diagnostic telemetry 不再默认回给模型，例如 auto-approved permission envelope、Session recorder
+id，以及 `run_process` / `run_script` 的 executor、cwd、duration、declared purpose 与
+command/script summary。
+
+当 Server 显式开启 full tool-request trace 时，Stateless MCP 2026 operator-capable surface
+上的 `admin` caller 在符合条件的失败结果中还可能收到一个 opaque `trace_ref`。
+`read_tool_trace` 是 ModelHidden、admin-only、强制有界的 Server-hosted forensic reader；
+`full_operator_runtime` 会直接投影它，`adaptive_runtime` 则把它作为
+`call_runtime_tool` 后面的 long-tail target。Local Coding、旧 MCP protocol era 与普通 HTTP
+runtime call 都不能使用它。调用方应先读取 payload index，再按需选择单个 payload；reader
+不会返回 native trace path，不会递归 capture 自己的 raw result，raw payload body 也不会被
+复制到 durable Workflow Session ledger。
+
 这是一次有意的 `0.3.x -> 0.4.0` cleanup boundary，并同时适用于 WebCodex 支持的
 `2025-06-18`、`2025-11-25` 与 `2026-07-28` MCP protocol era。继续支持这些 protocol
 version 不代表继续保留 0.4 之前“在 text 中重复整份 JSON”的 result representation。

--- a/src/config.rs
+++ b/src/config.rs
@@ -349,6 +349,10 @@ impl ToolRequestTraceMode {
 }
 
 pub(crate) fn tool_request_trace_mode() -> ToolRequestTraceMode {
+    #[cfg(test)]
+    if !crate::test_support::tool_request_trace_env_visible_for_current_thread() {
+        return ToolRequestTraceMode::Off;
+    }
     let Ok(value) = std::env::var("WEBCODEX_TOOL_REQUEST_TRACE") else {
         return ToolRequestTraceMode::Off;
     };
@@ -966,5 +970,23 @@ mod tests {
         env.set("WEBCODEX_TOOL_REQUEST_TRACE", "maybe");
         assert_eq!(tool_request_trace_mode(), ToolRequestTraceMode::Off);
         env.remove("WEBCODEX_TOOL_REQUEST_TRACE");
+    }
+
+    #[test]
+    fn tool_request_trace_test_env_is_visible_only_to_opted_in_threads() {
+        let mut env = crate::test_support::TestEnvGuard::new();
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+        assert_eq!(tool_request_trace_mode(), ToolRequestTraceMode::Full);
+
+        let unrelated = std::thread::spawn(tool_request_trace_mode).join().unwrap();
+        assert_eq!(unrelated, ToolRequestTraceMode::Off);
+
+        let explicit_reader = std::thread::spawn(|| {
+            let _reader = crate::test_support::TestToolRequestTraceEnvReaderGuard::new();
+            tool_request_trace_mode()
+        })
+        .join()
+        .unwrap();
+        assert_eq!(explicit_reader, ToolRequestTraceMode::Full);
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -59,6 +59,11 @@ fn full_operator_runtime_specs_for_auth(
                 .chain(crate::tool_runtime::memory_management_tool_specs())
                 .filter(|spec| check_runtime_tool_scope(auth, &spec.name).is_ok()),
         );
+        specs.extend(
+            crate::tool_runtime::operator_diagnostic_tool_specs()
+                .into_iter()
+                .filter(|spec| check_runtime_tool_scope(auth, &spec.name).is_ok()),
+        );
     }
     specs
 }
@@ -77,6 +82,7 @@ fn adaptive_runtime_gateway_target_specs(stateless_2026: bool) -> Vec<ToolSpec> 
         specs.extend(crate::tool_runtime::skill_management_tool_specs());
         specs.extend(crate::tool_runtime::memory_runtime_tool_specs());
         specs.extend(crate::tool_runtime::memory_management_tool_specs());
+        specs.extend(crate::tool_runtime::operator_diagnostic_tool_specs());
     }
     specs
 }
@@ -1351,6 +1357,7 @@ pub(super) async fn handle_call(
     let skill_runtime_capable = stateless_2026 && model_surface.supports_operator_extensions();
     let skill_management_capable = stateless_2026 && model_surface.supports_operator_extensions();
     let memory_surface_capable = stateless_2026 && model_surface.supports_operator_extensions();
+    let trace_diagnostics_capable = stateless_2026 && model_surface.supports_operator_extensions();
     let context_request = if context_sidecar_capable {
         match strip_stateless_context_request(&mut params.arguments) {
             Ok(keys) => keys,
@@ -1430,6 +1437,7 @@ pub(super) async fn handle_call(
                 skill_runtime: skill_runtime_capable,
                 skill_management: skill_management_capable,
                 memory_surface: memory_surface_capable,
+                trace_diagnostics: trace_diagnostics_capable,
             },
         )
         .await;

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -423,6 +423,37 @@ async fn adaptive_runtime_requires_gateway_for_long_tail_and_preserves_dispatch(
         value["result"]["structuredContent"]["output"]["returned_count"],
         1
     );
+
+    let admin = crate::auth::AuthContext {
+        role: Some("admin".to_string()),
+        scopes: vec![crate::auth::SCOPE_ADMIN.to_string()],
+        is_bootstrap: true,
+        ..crate::auth::AuthContext::new(crate::auth::AuthKind::Bootstrap)
+    };
+    let trace_gateway = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(723)),
+            mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {
+                    "tool": "read_tool_trace",
+                    "arguments": {"trace_ref": "not-a-trace-ref"}
+                }
+            })),
+        ),
+        Some(&admin),
+    )
+    .await;
+    let McpOutcome::Ok(value) = trace_gateway else {
+        panic!("adaptive gateway must admit the admin-only trace reader target");
+    };
+    assert_eq!(value["result"]["structuredContent"]["success"], false);
+    assert!(matches!(
+        value["result"]["structuredContent"]["output"]["error_kind"].as_str(),
+        Some("trace_mode_not_full" | "invalid_trace_ref")
+    ));
 }
 
 #[tokio::test]

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -372,6 +372,76 @@ fn memory_tools_are_stateless_full_operator_only_scope_filtered_and_schema_stati
 }
 
 #[test]
+fn trace_reader_is_stateless_operator_only_admin_scoped_and_schema_static() {
+    let render =
+        |surface: ModelSurface, stateless_2026: bool, auth: Option<&crate::auth::AuthContext>| {
+            mcp_tools_list_payload_with_features_for_auth(
+                surface,
+                false,
+                false,
+                true,
+                stateless_2026,
+                auth,
+            )
+        };
+    let names = |payload: &Value| {
+        payload["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool["name"].as_str().map(str::to_string))
+            .collect::<Vec<_>>()
+    };
+    let admin = crate::auth::AuthContext {
+        role: Some("admin".to_string()),
+        scopes: vec![crate::auth::SCOPE_ADMIN.to_string()],
+        is_bootstrap: true,
+        ..crate::auth::AuthContext::new(crate::auth::AuthKind::Bootstrap)
+    };
+    let ordinary = crate::auth::AuthContext {
+        scopes: vec![crate::auth::SCOPE_PROJECT_READ.to_string()],
+        ..crate::auth::AuthContext::new(crate::auth::AuthKind::OAuth2Token)
+    };
+
+    assert!(
+        !names(&render(ModelSurface::FullOperatorRuntime, true, None))
+            .contains(&"read_tool_trace".to_string())
+    );
+    assert!(!names(&render(
+        ModelSurface::FullOperatorRuntime,
+        true,
+        Some(&ordinary)
+    ))
+    .contains(&"read_tool_trace".to_string()));
+    assert!(!names(&render(
+        ModelSurface::FullOperatorRuntime,
+        false,
+        Some(&admin)
+    ))
+    .contains(&"read_tool_trace".to_string()));
+    assert!(
+        !names(&render(ModelSurface::LocalCoding, true, Some(&admin)))
+            .contains(&"read_tool_trace".to_string())
+    );
+
+    let full = render(ModelSurface::FullOperatorRuntime, true, Some(&admin));
+    let tool = full["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tool| tool["name"] == "read_tool_trace")
+        .expect("admin Stateless Full Operator trace reader");
+    assert_eq!(tool["inputSchema"]["required"], json!(["trace_ref"]));
+    assert_eq!(tool["inputSchema"]["additionalProperties"], false);
+    assert!(tool["inputSchema"]["properties"]["payload_index"].is_object());
+    assert!(tool["outputSchema"]["properties"]["output"]["properties"]["payload"].is_object());
+
+    let adaptive = render(ModelSurface::AdaptiveRuntime, true, Some(&admin));
+    let adaptive_names = names(&adaptive);
+    assert!(!adaptive_names.contains(&"read_tool_trace".to_string()));
+}
+
+#[test]
 fn skill_runtime_tools_are_stateless_full_operator_only_and_schema_static() {
     let generic_names = registered_tool_specs()
         .into_iter()

--- a/src/shell_client/job_updates.rs
+++ b/src/shell_client/job_updates.rs
@@ -1824,12 +1824,6 @@ impl ShellClientRegistry {
         &self,
         body: ShellAgentJobUpdateRequest,
     ) -> Result<ShellJobInfo, String> {
-        crate::tool_request_trace::capture_runner_job_update(
-            body.request_id.as_deref(),
-            &body.job_id,
-            body.finished,
-            &body,
-        );
         self.update_job_checked(body, None).await
     }
 
@@ -1844,12 +1838,6 @@ impl ShellClientRegistry {
         body: ShellAgentJobUpdateRequest,
         connection_id: &str,
     ) -> Result<ShellJobInfo, String> {
-        crate::tool_request_trace::capture_runner_job_update(
-            body.request_id.as_deref(),
-            &body.job_id,
-            body.finished,
-            &body,
-        );
         self.update_job_checked(body, Some(connection_id)).await
     }
 
@@ -2003,6 +1991,11 @@ impl ShellClientRegistry {
                         .to_string(),
                 );
             }
+            crate::tool_request_trace::capture_runner_job_update(
+                body.request_id.as_deref(),
+                &body.job_id,
+                &body,
+            );
             if let Err(error) = validate_validation_progress(job, &body)
                 .and_then(|_| validate_command_execution_state(job, &body))
             {
@@ -2103,6 +2096,12 @@ impl ShellClientRegistry {
         }
         if remove_cleanup_terminal {
             inner.jobs_by_id.remove(&body.job_id);
+        }
+        if is_final_job_status(&view.status) {
+            crate::tool_request_trace::finalize_runner_job_correlation(
+                body.request_id.as_deref(),
+                &body.job_id,
+            );
         }
         Ok(view)
     }

--- a/src/shell_client/mod_tests/job_lifecycle.rs
+++ b/src/shell_client/mod_tests/job_lifecycle.rs
@@ -118,6 +118,85 @@ async fn terminal_observed_poll_complete_and_log() {
 }
 
 #[tokio::test]
+async fn job_update_rejects_mismatched_request_id_without_mutating_target_job() {
+    let registry = ShellClientRegistry::default();
+    registry
+        .register(ShellClientRegisterRequest {
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: None,
+            job_inventory: None,
+            coding_agent_providers: None,
+            coding_agent_inventory: None,
+            client_id: "oe".to_string(),
+            agent_instance_id: "inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
+            display_name: None,
+            owner: None,
+            hostname: None,
+            host_context: None,
+            capabilities: async_job_capabilities(),
+            policy: None,
+        })
+        .await
+        .unwrap();
+
+    let start = |command: &str| ShellJobOpRequest {
+        op: "start".to_string(),
+        client_id: Some("oe".to_string()),
+        cwd: None,
+        command: Some(command.to_string()),
+        timeout_secs: Some(10),
+        job_id: None,
+        since_stdout_line: None,
+        since_stderr_line: None,
+        tail_lines: None,
+        limit: None,
+        codex: None,
+    };
+    let job_a = registry
+        .start_job(start("job-a"), "test".to_string())
+        .await
+        .unwrap();
+    let job_b = registry
+        .start_job(start("job-b"), "test".to_string())
+        .await
+        .unwrap();
+    let request_a = job_a.request_id.clone().expect("job A request id");
+    let request_b = job_b.request_id.clone().expect("job B request id");
+
+    let update = |request_id: String| ShellAgentJobUpdateRequest {
+        client_id: "oe".to_string(),
+        agent_instance_id: "inst".to_string(),
+        job_id: job_b.job_id.clone(),
+        request_id: Some(request_id),
+        update_seq: None,
+        status: "running".to_string(),
+        stdout_chunk: None,
+        stderr_chunk: None,
+        stdout_tail: None,
+        stderr_tail: None,
+        log_snapshot: None,
+        exit_code: None,
+        duration_ms: None,
+        error: None,
+        command_execution_state: None,
+        validation_progress: None,
+        finished: false,
+    };
+
+    let error = registry.update_job(update(request_a)).await.unwrap_err();
+    assert_eq!(error, "job update request_id does not match job_id");
+    assert_eq!(
+        registry.get_job(&job_b.job_id).await.unwrap().status,
+        "queued"
+    );
+
+    let accepted = registry.update_job(update(request_b)).await.unwrap();
+    assert_eq!(accepted.status, "running");
+}
+
+#[tokio::test]
 async fn terminal_observed_queued_stop_records_server_time() {
     let registry = ShellClientRegistry::default();
     registry

--- a/src/shell_client/mod_tests/polling.rs
+++ b/src/shell_client/mod_tests/polling.rs
@@ -69,6 +69,88 @@ async fn registry_enqueues_polls_and_completes_shell_request() {
 }
 
 #[tokio::test]
+async fn rejected_cross_client_result_does_not_consume_pending_request() {
+    let registry = ShellClientRegistry::default();
+    for (client_id, instance) in [("owner", "inst-owner"), ("other", "inst-other")] {
+        registry
+            .register(current_runner_registration(ShellClientRegisterRequest {
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: None,
+                job_inventory: None,
+                coding_agent_providers: None,
+                coding_agent_inventory: None,
+                client_id: client_id.to_string(),
+                agent_instance_id: instance.to_string(),
+                agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
+                display_name: None,
+                owner: None,
+                hostname: None,
+                host_context: None,
+                capabilities: crate::test_support::current_runner_capabilities(
+                    ShellClientCapabilities::default(),
+                ),
+                policy: None,
+            }))
+            .await
+            .unwrap();
+    }
+    let (request_id, waiter) = registry
+        .enqueue_run(
+            ShellRunRequest {
+                client_id: "owner".to_string(),
+                cwd: None,
+                command: "echo owner".to_string(),
+                stdin: None,
+                timeout_secs: 10,
+                wait_timeout_secs: 10,
+            },
+            "tester".to_string(),
+        )
+        .await
+        .unwrap();
+
+    let error = registry
+        .complete(ShellAgentResultRequest {
+            client_id: "other".to_string(),
+            agent_instance_id: "inst-other".to_string(),
+            request_id: request_id.clone(),
+            exit_code: Some(0),
+            stdout: Some("spoofed\n".to_string()),
+            stderr: None,
+            duration_ms: Some(1),
+            error: None,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error, "request_id does not belong to client_id");
+
+    let polled = registry
+        .poll(ShellAgentPollRequest {
+            client_id: "owner".to_string(),
+            agent_instance_id: "inst-owner".to_string(),
+        })
+        .await
+        .unwrap()
+        .expect("rejected cross-client result must leave the request pending");
+    assert_eq!(polled.request_id, request_id);
+    registry
+        .complete(ShellAgentResultRequest {
+            client_id: "owner".to_string(),
+            agent_instance_id: "inst-owner".to_string(),
+            request_id,
+            exit_code: Some(0),
+            stdout: Some("owner\n".to_string()),
+            stderr: None,
+            duration_ms: Some(1),
+            error: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(waiter.await.unwrap().stdout.as_deref(), Some("owner\n"));
+}
+
+#[tokio::test]
 async fn polling_out_of_order_results_resolve_only_their_original_waiters() {
     let registry = ShellClientRegistry::default();
     registry

--- a/src/shell_client/polling.rs
+++ b/src/shell_client/polling.rs
@@ -10,7 +10,7 @@ use crate::mcp_gateway::{
 };
 use crate::shell_protocol::{
     ShellAgentPersistentShellResultRequest, ShellAgentPollRequest, ShellAgentResultPayload,
-    ShellAgentResultRequest, ShellAgentShellRequest, ShellCommandExecutionState, ShellRunResponse,
+    ShellAgentShellRequest, ShellCommandExecutionState, ShellRunResponse,
 };
 use webcodex_core::coding_agent::{
     validate_response_for_request as validate_coding_agent_response, CodingAgentDispatchState,
@@ -392,16 +392,7 @@ impl ShellClientRegistry {
         &self,
         payload: impl Into<ShellAgentResultPayload>,
     ) -> Result<(), String> {
-        let payload = payload.into();
-        crate::tool_request_trace::capture_runner_result(&payload.result.request_id, &payload);
-        self.complete_checked(
-            payload.result,
-            payload.command_execution_state,
-            payload.mcp_gateway,
-            payload.coding_agent,
-            None,
-        )
-        .await
+        self.complete_checked(payload.into(), None).await
     }
 
     /// Connection-scoped result entry point for long-lived transports. A
@@ -416,25 +407,15 @@ impl ShellClientRegistry {
         payload: ShellAgentResultPayload,
         connection_id: &str,
     ) -> Result<(), String> {
-        crate::tool_request_trace::capture_runner_result(&payload.result.request_id, &payload);
-        self.complete_checked(
-            payload.result,
-            payload.command_execution_state,
-            payload.mcp_gateway,
-            payload.coding_agent,
-            Some(connection_id),
-        )
-        .await
+        self.complete_checked(payload, Some(connection_id)).await
     }
 
     async fn complete_checked(
         &self,
-        body: ShellAgentResultRequest,
-        command_execution_state: Option<ShellCommandExecutionState>,
-        mcp_gateway: Option<crate::mcp_gateway::McpGatewayResponse>,
-        coding_agent: Option<CodingAgentResponse>,
+        payload: ShellAgentResultPayload,
         expected_connection_id: Option<&str>,
     ) -> Result<(), String> {
+        let body = &payload.result;
         validate_id(&body.client_id, "client_id")?;
         validate_id(&body.request_id, "request_id")?;
         validate_agent_instance_id(&body.agent_instance_id)?;
@@ -457,7 +438,7 @@ impl ShellClientRegistry {
                 client.last_seen = now_ts();
             }
         }
-        let Some(mut pending) = take_pending_request_locked(&mut inner, &body.request_id) else {
+        let Some(pending) = inner.pending_by_id.get(&body.request_id) else {
             return Err(format!(
                 "unknown or expired shell request: {}",
                 body.request_id
@@ -466,6 +447,26 @@ impl ShellClientRegistry {
         if pending.request.client_id != body.client_id {
             return Err("request_id does not belong to client_id".to_string());
         }
+        if pending.request.coding_agent.is_none() && payload.coding_agent.is_some() {
+            return Err("unexpected CodingAgentRun result for non-coding request".to_string());
+        }
+        if pending.request.mcp_gateway.is_none() && payload.mcp_gateway.is_some() {
+            return Err("unexpected MCP gateway result for non-bridge request".to_string());
+        }
+        crate::tool_request_trace::capture_runner_result(&body.request_id, &payload);
+        let trace_request_id = body.request_id.clone();
+        let ShellAgentResultPayload {
+            result: body,
+            command_execution_state,
+            mcp_gateway,
+            coding_agent,
+        } = payload;
+        let Some(mut pending) = take_pending_request_locked(&mut inner, &body.request_id) else {
+            return Err(format!(
+                "unknown or expired shell request: {}",
+                body.request_id
+            ));
+        };
         if pending.request.mcp_gateway.is_some() {
             let response = match mcp_gateway {
                 Some(response)
@@ -497,6 +498,7 @@ impl ShellClientRegistry {
             if let Some(waiter) = waiter {
                 let _ = waiter.send(response);
             }
+            crate::tool_request_trace::finalize_runner_result_correlation(&trace_request_id);
             return Ok(());
         }
         if pending.request.coding_agent.is_some() {
@@ -542,13 +544,8 @@ impl ShellClientRegistry {
             if let Some(waiter) = waiter {
                 let _ = waiter.send(response);
             }
+            crate::tool_request_trace::finalize_runner_result_correlation(&trace_request_id);
             return Ok(());
-        }
-        if coding_agent.is_some() {
-            return Err("unexpected CodingAgentRun result for non-coding request".to_string());
-        }
-        if mcp_gateway.is_some() {
-            return Err("unexpected MCP gateway result for non-bridge request".to_string());
         }
         let request_id = body.request_id.clone();
         let client_id = body.client_id.clone();
@@ -567,9 +564,10 @@ impl ShellClientRegistry {
             None | Some(ShellCommandExecutionState::Completed)
         ) && error.is_none()
             && body.exit_code == Some(0);
-        if let Some(job_id) = pending.job_id.clone() {
+        let terminal_job_id = pending.job_id.clone();
+        if let Some(job_id) = terminal_job_id.as_deref() {
             inner.request_to_job.remove(&request_id);
-            if let Some(job) = inner.jobs_by_id.get_mut(&job_id) {
+            if let Some(job) = inner.jobs_by_id.get_mut(job_id) {
                 let terminal_now = now_ts();
                 job.status = if success {
                     "completed".to_string()
@@ -603,6 +601,14 @@ impl ShellClientRegistry {
         };
         if let Some(waiter) = pending.waiter.take() {
             let _ = waiter.send(response);
+        }
+        if let Some(job_id) = terminal_job_id.as_deref() {
+            crate::tool_request_trace::finalize_runner_job_correlation(
+                Some(&trace_request_id),
+                job_id,
+            );
+        } else {
+            crate::tool_request_trace::finalize_runner_result_correlation(&trace_request_id);
         }
         Ok(())
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -8,6 +8,41 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+thread_local! {
+    static TOOL_REQUEST_TRACE_ENV_READ_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Test-only opt-in for reading the process-global tool-request trace env.
+///
+/// libtest executes tests in parallel within one process. Trace tests still use
+/// [`TestEnvGuard`] to serialize env mutation, but unrelated test threads must
+/// not observe a temporary `WEBCODEX_TOOL_REQUEST_TRACE=full` and start feeding
+/// the same bounded global trace writer. Child threads intentionally exercising
+/// trace behavior can opt in explicitly with this guard while the parent keeps
+/// the canonical env lock held.
+pub(crate) struct TestToolRequestTraceEnvReaderGuard;
+
+impl TestToolRequestTraceEnvReaderGuard {
+    pub(crate) fn new() -> Self {
+        TOOL_REQUEST_TRACE_ENV_READ_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+impl Drop for TestToolRequestTraceEnvReaderGuard {
+    fn drop(&mut self) {
+        TOOL_REQUEST_TRACE_ENV_READ_DEPTH.with(|depth| {
+            let current = depth.get();
+            debug_assert!(current > 0, "tool-request trace env reader depth underflow");
+            depth.set(current.saturating_sub(1));
+        });
+    }
+}
+
+pub(crate) fn tool_request_trace_env_visible_for_current_thread() -> bool {
+    TOOL_REQUEST_TRACE_ENV_READ_DEPTH.with(|depth| depth.get() > 0)
+}
+
 /// Panic-safe process-global environment mutation guard for server tests.
 ///
 /// The guard holds the canonical server test env lock for its full lifetime,
@@ -16,6 +51,7 @@ use std::sync::Arc;
 pub(crate) struct TestEnvGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     previous: std::collections::BTreeMap<String, Option<std::ffi::OsString>>,
+    tool_request_trace_env_reader: Option<TestToolRequestTraceEnvReaderGuard>,
 }
 
 impl TestEnvGuard {
@@ -25,10 +61,14 @@ impl TestEnvGuard {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner()),
             previous: std::collections::BTreeMap::new(),
+            tool_request_trace_env_reader: None,
         }
     }
 
     fn remember(&mut self, name: &str) {
+        if name == "WEBCODEX_TOOL_REQUEST_TRACE" && self.tool_request_trace_env_reader.is_none() {
+            self.tool_request_trace_env_reader = Some(TestToolRequestTraceEnvReaderGuard::new());
+        }
         if !self.previous.contains_key(name) {
             self.previous
                 .insert(name.to_string(), std::env::var_os(name));

--- a/src/tool_request_trace.rs
+++ b/src/tool_request_trace.rs
@@ -1997,6 +1997,7 @@ mod tests {
         let io_guard = trace_io_state().lock().unwrap();
         let (done_tx, done_rx) = mpsc::channel();
         let capture = thread::spawn(move || {
+            let _trace_env = crate::test_support::TestToolRequestTraceEnvReaderGuard::new();
             let guard = ToolRequestLifecycle::new(
                 "mcp",
                 "trace-background-writer".into(),

--- a/src/tool_request_trace.rs
+++ b/src/tool_request_trace.rs
@@ -27,9 +27,9 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::future::Future;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Mutex, OnceLock};
@@ -98,8 +98,29 @@ enum TraceWrite {
         event: Value,
         config: TraceStoreConfig,
     },
-    #[cfg(test)]
     Flush(mpsc::Sender<()>),
+}
+
+const MAX_MODEL_TRACE_PAYLOAD_BYTES: usize = 256 * 1024;
+const MAX_MODEL_TRACE_COMPRESSED_BYTES: usize = 512 * 1024;
+const MAX_TRACE_EVENTS_FILE_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_TRACE_PAYLOAD_ENTRIES: usize = 4096;
+const DEFAULT_TRACE_INDEX_LIMIT: usize = 20;
+const MAX_TRACE_INDEX_LIMIT: usize = 64;
+
+#[derive(Debug, Clone)]
+pub(crate) struct TraceReadError {
+    pub(crate) kind: &'static str,
+    pub(crate) message: String,
+}
+
+impl TraceReadError {
+    fn new(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -167,6 +188,13 @@ where
 
 fn current_active_trace_id() -> Option<String> {
     ACTIVE_TOOL_TRACE_ID.try_with(Clone::clone).ok()
+}
+
+/// Opaque reference for the currently executing inbound request, but only when
+/// the Server is actually retaining full payload traces. This never exposes the
+/// native trace root or a filesystem path.
+pub(crate) fn current_full_trace_ref() -> Option<String> {
+    full_trace_enabled().then(current_active_trace_id).flatten()
 }
 
 /// Safe JSON-RPC id summary: type + length + short digest. Never the raw string.
@@ -361,12 +389,342 @@ fn trace_writer_loop(receiver: mpsc::Receiver<TraceWrite>) {
                     "tool_trace_capture_failed"
                 ),
             },
-            #[cfg(test)]
             TraceWrite::Flush(done) => {
                 let _ = done.send(());
             }
         }
     }
+}
+
+fn flush_trace_writer_for_read() -> Result<(), TraceReadError> {
+    let Some(writer) = trace_writer() else {
+        return Err(TraceReadError::new(
+            "trace_store_unavailable",
+            "full trace writer is unavailable",
+        ));
+    };
+    let (done_tx, done_rx) = mpsc::channel();
+    match writer.sender.try_send(TraceWrite::Flush(done_tx)) {
+        Ok(()) => done_rx.recv_timeout(Duration::from_secs(2)).map_err(|_| {
+            TraceReadError::new("trace_store_busy", "full trace writer flush timed out")
+        }),
+        Err(mpsc::TrySendError::Full(_)) => Err(TraceReadError::new(
+            "trace_store_busy",
+            "full trace writer queue is busy; retry the diagnostic read",
+        )),
+        Err(mpsc::TrySendError::Disconnected(_)) => Err(TraceReadError::new(
+            "trace_store_unavailable",
+            "full trace writer is disconnected",
+        )),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IndexedTracePayload {
+    phase: String,
+    payload_bytes: usize,
+    compressed_bytes: usize,
+    payload_sha256: String,
+    file_name: String,
+}
+
+fn invalid_trace_ref() -> TraceReadError {
+    TraceReadError::new(
+        "invalid_trace_ref",
+        "trace_ref must be the canonical UUID returned by an eligible failed tool call",
+    )
+}
+
+fn validate_trace_ref(trace_ref: &str) -> Result<(), TraceReadError> {
+    let parsed = Uuid::parse_str(trace_ref).map_err(|_| invalid_trace_ref())?;
+    if parsed.to_string() != trace_ref {
+        return Err(invalid_trace_ref());
+    }
+    Ok(())
+}
+
+fn require_private_regular_file(
+    path: &Path,
+    kind: &'static str,
+) -> Result<fs::Metadata, TraceReadError> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            TraceReadError::new(
+                "trace_not_found",
+                "trace data is unavailable or has expired",
+            )
+        } else {
+            TraceReadError::new(kind, "trace storage could not be inspected safely")
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(TraceReadError::new(
+            kind,
+            "trace storage failed the regular-file safety check",
+        ));
+    }
+    Ok(metadata)
+}
+
+fn require_private_directory(
+    path: &Path,
+    not_found_kind: &'static str,
+) -> Result<(), TraceReadError> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            TraceReadError::new(not_found_kind, "trace data is unavailable or has expired")
+        } else {
+            TraceReadError::new(
+                "trace_store_unavailable",
+                "trace storage could not be inspected safely",
+            )
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(TraceReadError::new(
+            "trace_corrupt",
+            "trace storage failed the directory safety check",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_trace_payload_index(
+    trace_ref: &str,
+    trace_dir: &Path,
+) -> Result<Vec<IndexedTracePayload>, TraceReadError> {
+    require_private_regular_file(&trace_dir.join(TRACE_OWNER_MARKER), "trace_corrupt")?;
+    let events_path = trace_dir.join("events.jsonl");
+    let metadata = require_private_regular_file(&events_path, "trace_corrupt")?;
+    if metadata.len() > MAX_TRACE_EVENTS_FILE_BYTES {
+        return Err(TraceReadError::new(
+            "trace_too_large",
+            "trace event index exceeds the diagnostic read ceiling",
+        ));
+    }
+    let text = fs::read_to_string(events_path)
+        .map_err(|_| TraceReadError::new("trace_corrupt", "trace event index is unreadable"))?;
+    let mut payloads = Vec::new();
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        let event: Value = serde_json::from_str(line).map_err(|_| {
+            TraceReadError::new("trace_corrupt", "trace event index contains invalid JSON")
+        })?;
+        if event.get("event").and_then(Value::as_str) != Some("tool_trace_payload_captured") {
+            continue;
+        }
+        if event.get("server_trace_id").and_then(Value::as_str) != Some(trace_ref)
+            || event.get("encoding").and_then(Value::as_str) != Some("json+zstd")
+        {
+            return Err(TraceReadError::new(
+                "trace_corrupt",
+                "trace payload index correlation is invalid",
+            ));
+        }
+        let phase = event
+            .get("phase")
+            .and_then(Value::as_str)
+            .filter(|phase| !phase.is_empty() && phase.len() <= 80 && safe_phase(phase) == *phase)
+            .ok_or_else(|| TraceReadError::new("trace_corrupt", "trace payload phase is invalid"))?
+            .to_string();
+        let payload_bytes = event
+            .get("payload_bytes")
+            .and_then(Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or_else(|| TraceReadError::new("trace_corrupt", "trace payload size is invalid"))?;
+        let compressed_bytes = event
+            .get("compressed_bytes")
+            .and_then(Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or_else(|| {
+                TraceReadError::new("trace_corrupt", "trace compressed size is invalid")
+            })?;
+        let payload_sha256 = event
+            .get("payload_sha256")
+            .and_then(Value::as_str)
+            .filter(|digest| {
+                digest.len() == 64
+                    && digest
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            })
+            .ok_or_else(|| TraceReadError::new("trace_corrupt", "trace payload digest is invalid"))?
+            .to_string();
+        let payload_path = event
+            .get("payload_path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                TraceReadError::new("trace_corrupt", "trace payload location is invalid")
+            })?;
+        let Some(file_name) = payload_path.strip_prefix("payloads/") else {
+            return Err(TraceReadError::new(
+                "trace_corrupt",
+                "trace payload location is outside the owned payload directory",
+            ));
+        };
+        if file_name.is_empty()
+            || file_name.contains('/')
+            || file_name.contains('\\')
+            || file_name.contains("..")
+            || !file_name.ends_with(".json.zst")
+        {
+            return Err(TraceReadError::new(
+                "trace_corrupt",
+                "trace payload filename failed the safety check",
+            ));
+        }
+        payloads.push(IndexedTracePayload {
+            phase,
+            payload_bytes,
+            compressed_bytes,
+            payload_sha256,
+            file_name: file_name.to_string(),
+        });
+        if payloads.len() > MAX_TRACE_PAYLOAD_ENTRIES {
+            return Err(TraceReadError::new(
+                "trace_too_large",
+                "trace payload index exceeds the diagnostic entry ceiling",
+            ));
+        }
+    }
+    Ok(payloads)
+}
+
+fn trace_payload_metadata(index: usize, payload: &IndexedTracePayload) -> Value {
+    json!({
+        "payload_index": index,
+        "phase": payload.phase,
+        "payload_bytes": payload.payload_bytes,
+        "compressed_bytes": payload.compressed_bytes,
+        "payload_sha256": payload.payload_sha256,
+        "payload_available": payload.payload_bytes <= MAX_MODEL_TRACE_PAYLOAD_BYTES,
+    })
+}
+
+pub(crate) fn read_full_trace(
+    trace_ref: &str,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    payload_index: Option<usize>,
+) -> Result<Value, TraceReadError> {
+    if !full_trace_enabled() {
+        return Err(TraceReadError::new(
+            "trace_mode_not_full",
+            "full tool-request tracing is not enabled on this Server",
+        ));
+    }
+    validate_trace_ref(trace_ref)?;
+    if payload_index.is_some() && (offset.is_some() || limit.is_some()) {
+        return Err(TraceReadError::new(
+            "invalid_trace_request",
+            "offset and limit cannot be combined with payload_index",
+        ));
+    }
+    let offset = offset.unwrap_or(0);
+    let limit = limit.unwrap_or(DEFAULT_TRACE_INDEX_LIMIT);
+    if offset > 4095 || !(1..=MAX_TRACE_INDEX_LIMIT).contains(&limit) {
+        return Err(TraceReadError::new(
+            "invalid_trace_request",
+            "trace listing bounds are outside the supported range",
+        ));
+    }
+    if payload_index.is_some_and(|index| index > 4095) {
+        return Err(TraceReadError::new(
+            "invalid_trace_request",
+            "payload_index is outside the supported range",
+        ));
+    }
+
+    flush_trace_writer_for_read()?;
+    let trace_dir = trace_root().join(trace_ref);
+    require_private_directory(&trace_dir, "trace_not_found")?;
+    let payloads = parse_trace_payload_index(trace_ref, &trace_dir)?;
+
+    let Some(payload_index) = payload_index else {
+        let returned = payloads
+            .iter()
+            .enumerate()
+            .skip(offset)
+            .take(limit)
+            .map(|(index, payload)| trace_payload_metadata(index, payload))
+            .collect::<Vec<_>>();
+        let next_offset =
+            (offset + returned.len() < payloads.len()).then_some(offset + returned.len());
+        return Ok(json!({
+            "trace_ref": trace_ref,
+            "trace_mode": "full",
+            "payload_count": payloads.len(),
+            "returned_count": returned.len(),
+            "offset": offset,
+            "next_offset": next_offset,
+            "payloads": returned,
+            "max_payload_bytes": MAX_MODEL_TRACE_PAYLOAD_BYTES,
+        }));
+    };
+
+    let Some(indexed) = payloads.get(payload_index) else {
+        return Err(TraceReadError::new(
+            "invalid_payload_index",
+            "payload_index does not identify a retained payload in this trace",
+        ));
+    };
+    if indexed.payload_bytes > MAX_MODEL_TRACE_PAYLOAD_BYTES {
+        return Ok(json!({
+            "trace_ref": trace_ref,
+            "trace_mode": "full",
+            "payload_index": payload_index,
+            "phase": indexed.phase,
+            "payload_bytes": indexed.payload_bytes,
+            "payload_sha256": indexed.payload_sha256,
+            "payload_available": false,
+            "max_payload_bytes": MAX_MODEL_TRACE_PAYLOAD_BYTES,
+            "reason": "payload_exceeds_model_read_limit",
+        }));
+    }
+    if indexed.compressed_bytes > MAX_MODEL_TRACE_COMPRESSED_BYTES {
+        return Err(TraceReadError::new(
+            "trace_corrupt",
+            "trace payload compressed size exceeds the diagnostic read ceiling",
+        ));
+    }
+
+    let payload_dir = trace_dir.join("payloads");
+    require_private_directory(&payload_dir, "trace_corrupt")?;
+    let payload_path = payload_dir.join(&indexed.file_name);
+    let metadata = require_private_regular_file(&payload_path, "trace_corrupt")?;
+    if metadata.len() != indexed.compressed_bytes as u64 {
+        return Err(TraceReadError::new(
+            "trace_corrupt",
+            "trace payload compressed size does not match its index",
+        ));
+    }
+    let file = File::open(payload_path)
+        .map_err(|_| TraceReadError::new("trace_corrupt", "trace payload is unreadable"))?;
+    let decoder = zstd::stream::read::Decoder::new(file)
+        .map_err(|_| TraceReadError::new("trace_corrupt", "trace payload decompression failed"))?;
+    let mut raw = Vec::with_capacity(indexed.payload_bytes);
+    decoder
+        .take((MAX_MODEL_TRACE_PAYLOAD_BYTES + 1) as u64)
+        .read_to_end(&mut raw)
+        .map_err(|_| TraceReadError::new("trace_corrupt", "trace payload decompression failed"))?;
+    if raw.len() != indexed.payload_bytes || sha256_hex(&raw) != indexed.payload_sha256 {
+        return Err(TraceReadError::new(
+            "trace_corrupt",
+            "trace payload failed its size or digest check",
+        ));
+    }
+    let payload: Value = serde_json::from_slice(&raw)
+        .map_err(|_| TraceReadError::new("trace_corrupt", "trace payload is not valid JSON"))?;
+    Ok(json!({
+        "trace_ref": trace_ref,
+        "trace_mode": "full",
+        "payload_index": payload_index,
+        "phase": indexed.phase,
+        "payload_bytes": indexed.payload_bytes,
+        "payload_sha256": indexed.payload_sha256,
+        "payload_available": true,
+        "max_payload_bytes": MAX_MODEL_TRACE_PAYLOAD_BYTES,
+        "payload": payload,
+    }))
 }
 
 fn enqueue_trace_write(write: TraceWrite, trace_id: &str, phase: &str) {
@@ -1125,6 +1483,7 @@ pub struct ToolRequestLifecycle {
     jsonrpc_id: String,
     method: String,
     tool_name: Option<String>,
+    suppress_payload_capture: bool,
     started: Instant,
     completed: AtomicBool,
 }
@@ -1137,6 +1496,7 @@ impl ToolRequestLifecycle {
         method: impl Into<String>,
         tool_name: Option<String>,
     ) -> Self {
+        let suppress_payload_capture = tool_name.as_deref() == Some("read_tool_trace");
         Self {
             prefix,
             mode: crate::config::tool_request_trace_mode(),
@@ -1144,6 +1504,7 @@ impl ToolRequestLifecycle {
             jsonrpc_id: jsonrpc_id.into(),
             method: method.into(),
             tool_name,
+            suppress_payload_capture,
             started: Instant::now(),
             completed: AtomicBool::new(false),
         }
@@ -1162,7 +1523,7 @@ impl ToolRequestLifecycle {
     }
 
     pub fn capture_payload(&self, phase: &str, value: &Value) {
-        if self.full_enabled() {
+        if self.full_enabled() && !self.suppress_payload_capture {
             capture_payload_for_trace(&self.trace_id, phase, value);
         }
     }
@@ -1172,6 +1533,7 @@ impl ToolRequestLifecycle {
     }
 
     pub fn set_tool_name(&mut self, tool_name: Option<String>) {
+        self.suppress_payload_capture = tool_name.as_deref() == Some("read_tool_trace");
         self.tool_name = tool_name;
     }
 
@@ -1447,6 +1809,110 @@ mod tests {
         let events = fs::read_to_string(temp.path().join("trace-full/events.jsonl")).unwrap();
         assert!(events.contains("raw_arguments"));
         assert!(events.contains("payload_sha256"));
+    }
+
+    #[test]
+    fn full_mode_trace_reader_lists_then_reads_verified_payload_without_native_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut env = crate::test_support::TestEnvGuard::new();
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+        env.set(
+            "WEBCODEX_TOOL_REQUEST_TRACE_DIR",
+            temp.path().to_string_lossy().as_ref(),
+        );
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE_MAX_TOTAL_BYTES", "8388608");
+        reset_trace_store_accounting();
+
+        let trace_id = Uuid::new_v4().to_string();
+        let payload = json!({
+            "private_diagnostic": "visible only through the side channel",
+            "nested": [1, 2, 3]
+        });
+        assert!(persist_payload(&trace_id, "runner_result", &payload)
+            .unwrap()
+            .is_some());
+
+        let listing = read_full_trace(&trace_id, None, None, None).unwrap();
+        assert_eq!(listing["payload_count"], 1);
+        assert_eq!(listing["returned_count"], 1);
+        assert_eq!(listing["payloads"][0]["payload_index"], 0);
+        assert_eq!(listing["payloads"][0]["phase"], "runner_result");
+        assert_eq!(listing["payloads"][0]["payload_available"], true);
+        let serialized_listing = serde_json::to_string(&listing).unwrap();
+        assert!(!serialized_listing.contains("payload_path"));
+        assert!(!serialized_listing.contains(temp.path().to_string_lossy().as_ref()));
+        assert!(!serialized_listing.contains("private_diagnostic"));
+
+        let selected = read_full_trace(&trace_id, None, None, Some(0)).unwrap();
+        assert_eq!(selected["payload_index"], 0);
+        assert_eq!(selected["phase"], "runner_result");
+        assert_eq!(selected["payload_available"], true);
+        assert_eq!(selected["payload"], payload);
+    }
+
+    #[test]
+    fn full_mode_trace_reader_rejects_unsafe_refs_and_never_returns_oversize_payload() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut env = crate::test_support::TestEnvGuard::new();
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+        env.set(
+            "WEBCODEX_TOOL_REQUEST_TRACE_DIR",
+            temp.path().to_string_lossy().as_ref(),
+        );
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE_MAX_TOTAL_BYTES", "8388608");
+        reset_trace_store_accounting();
+
+        let unsafe_ref = read_full_trace("../etc/passwd", None, None, None).unwrap_err();
+        assert_eq!(unsafe_ref.kind, "invalid_trace_ref");
+        let canonical = Uuid::new_v4().to_string();
+        let uppercase = canonical.to_ascii_uppercase();
+        let uppercase_error = read_full_trace(&uppercase, None, None, None).unwrap_err();
+        assert_eq!(uppercase_error.kind, "invalid_trace_ref");
+
+        let large_payload = json!({"body": "x".repeat(MAX_MODEL_TRACE_PAYLOAD_BYTES + 1024)});
+        assert!(
+            persist_payload(&canonical, "final_response", &large_payload)
+                .unwrap()
+                .is_some()
+        );
+        let selected = read_full_trace(&canonical, None, None, Some(0)).unwrap();
+        assert_eq!(selected["payload_available"], false);
+        assert_eq!(selected["reason"], "payload_exceeds_model_read_limit");
+        assert_eq!(selected["max_payload_bytes"], MAX_MODEL_TRACE_PAYLOAD_BYTES);
+        assert!(selected.get("payload").is_none());
+    }
+
+    #[test]
+    fn read_tool_trace_lifecycle_never_recursively_captures_payloads() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut env = crate::test_support::TestEnvGuard::new();
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+        env.set(
+            "WEBCODEX_TOOL_REQUEST_TRACE_DIR",
+            temp.path().to_string_lossy().as_ref(),
+        );
+        env.set("WEBCODEX_TOOL_REQUEST_TRACE_MAX_TOTAL_BYTES", "8388608");
+        reset_trace_store_accounting();
+
+        let trace_id = Uuid::new_v4().to_string();
+        let mut guard = ToolRequestLifecycle::new(
+            "mcp",
+            trace_id.clone(),
+            "none",
+            "tools/call",
+            Some("call_runtime_tool".into()),
+        );
+        // Adaptive routing begins at the gateway and later identifies the real
+        // target. The setter must suppress every subsequent forensic payload.
+        guard.set_tool_name(Some("read_tool_trace".into()));
+        guard.capture_payload(
+            "effective_arguments",
+            &json!({"trace_ref": Uuid::new_v4().to_string()}),
+        );
+        guard.capture_payload("final_response", &json!({"payload": "PRIVATE_RAW_TRACE"}));
+        drop(guard);
+        flush_full_trace_writer();
+        assert!(payload_files(temp.path(), &trace_id).is_empty());
     }
 
     #[test]

--- a/src/tool_request_trace.rs
+++ b/src/tool_request_trace.rs
@@ -54,7 +54,7 @@ static TRACE_IO_STATE: OnceLock<Mutex<TraceStoreAccounting>> = OnceLock::new();
 static TRACE_CORRELATIONS: OnceLock<Mutex<TraceCorrelations>> = OnceLock::new();
 static TRACE_WRITER: OnceLock<Option<TraceWriter>> = OnceLock::new();
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct TraceCorrelation {
     trace_id: String,
     request_id: String,
@@ -1411,12 +1411,23 @@ fn lookup_request_correlation(request_id: &str) -> Option<TraceCorrelation> {
     correlations.requests.get(request_id).cloned()
 }
 
+fn resolve_job_correlation(
+    correlations: &TraceCorrelations,
+    request_id: Option<&str>,
+    job_id: &str,
+) -> Option<TraceCorrelation> {
+    let job_correlation = correlations.jobs.get(job_id).cloned()?;
+    let Some(request_id) = request_id else {
+        return Some(job_correlation);
+    };
+    let request_correlation = correlations.requests.get(request_id).cloned()?;
+    (request_correlation == job_correlation).then_some(request_correlation)
+}
+
 fn lookup_job_correlation(request_id: Option<&str>, job_id: &str) -> Option<TraceCorrelation> {
     let mut correlations = correlations().lock().ok()?;
     prune_correlations(&mut correlations);
-    request_id
-        .and_then(|request_id| correlations.requests.get(request_id).cloned())
-        .or_else(|| correlations.jobs.get(job_id).cloned())
+    resolve_job_correlation(&correlations, request_id, job_id)
 }
 
 fn remove_correlation(correlation: &TraceCorrelation) {
@@ -1428,7 +1439,9 @@ fn remove_correlation(correlation: &TraceCorrelation) {
     }
 }
 
-/// Capture the raw typed Runner result at the Server-side correlation boundary.
+/// Capture one authoritative Runner result after the shell-client layer has
+/// accepted its client / instance / request ownership. Capture never consumes
+/// correlation; finalization is a separate post-acceptance step.
 pub(crate) fn capture_runner_result<T: Serialize>(request_id: &str, payload: &T) {
     let Some(correlation) = lookup_request_correlation(request_id) else {
         return;
@@ -1443,18 +1456,27 @@ pub(crate) fn capture_runner_result<T: Serialize>(request_id: &str, payload: &T)
             "tool_trace_capture_failed"
         ),
     }
+}
+
+/// Finalize a non-Job Runner result correlation only after authoritative result
+/// acceptance. Job-backed requests stay correlated until authoritative Job
+/// terminal state is accepted.
+pub(crate) fn finalize_runner_result_correlation(request_id: &str) {
+    let Some(correlation) = lookup_request_correlation(request_id) else {
+        return;
+    };
     if correlation.job_id.is_none() {
         remove_correlation(&correlation);
     }
 }
 
-/// Capture Runner Job updates, including terminal materialization, into the trace
-/// that originally admitted the Job. Updates lacking request_id can still use
-/// the bounded job_id correlation created at enqueue.
+/// Capture one authoritative Runner Job update into the trace that originally
+/// admitted the Job. Updates without request_id may use job_id correlation; when
+/// both identities are present they must resolve to the same TraceCorrelation.
+/// Capture never consumes correlation.
 pub(crate) fn capture_runner_job_update<T: Serialize>(
     request_id: Option<&str>,
     job_id: &str,
-    finished: bool,
     payload: &T,
 ) {
     let Some(correlation) = lookup_job_correlation(request_id, job_id) else {
@@ -1470,9 +1492,16 @@ pub(crate) fn capture_runner_job_update<T: Serialize>(
             "tool_trace_capture_failed"
         ),
     }
-    if finished {
-        remove_correlation(&correlation);
-    }
+}
+
+/// Consume Job correlation only after the shell-client layer has accepted a
+/// terminal Server-authoritative Job state. A mismatched request_id + job_id
+/// pair never resolves and therefore cannot consume either trace.
+pub(crate) fn finalize_runner_job_correlation(request_id: Option<&str>, job_id: &str) {
+    let Some(correlation) = lookup_job_correlation(request_id, job_id) else {
+        return;
+    };
+    remove_correlation(&correlation);
 }
 
 /// Lifecycle guard shared by MCP `/mcp` and API `/api/tools/call` handlers.
@@ -1725,6 +1754,44 @@ mod tests {
 
     fn event_line_len(event: &Value) -> u64 {
         serde_json::to_vec(event).unwrap().len() as u64 + 1
+    }
+
+    #[test]
+    fn job_trace_correlation_requires_request_and_job_to_agree() {
+        let request_correlation = TraceCorrelation {
+            trace_id: "trace-a".to_string(),
+            request_id: "request-a".to_string(),
+            job_id: Some("job-a".to_string()),
+            created_at: 1,
+        };
+        let other_correlation = TraceCorrelation {
+            trace_id: "trace-b".to_string(),
+            request_id: "request-b".to_string(),
+            job_id: Some("job-b".to_string()),
+            created_at: 1,
+        };
+        let mut correlations = TraceCorrelations::default();
+        correlations
+            .requests
+            .insert("request-a".to_string(), request_correlation.clone());
+        correlations
+            .jobs
+            .insert("job-b".to_string(), other_correlation.clone());
+
+        assert!(resolve_job_correlation(&correlations, Some("request-a"), "job-b").is_none());
+        assert!(resolve_job_correlation(&correlations, Some("missing"), "job-b").is_none());
+        assert_eq!(
+            resolve_job_correlation(&correlations, None, "job-b"),
+            Some(other_correlation)
+        );
+
+        correlations
+            .jobs
+            .insert("job-a".to_string(), request_correlation.clone());
+        assert_eq!(
+            resolve_job_correlation(&correlations, Some("request-a"), "job-a"),
+            Some(request_correlation)
+        );
     }
 
     fn accounting_snapshot() -> (PathBuf, u64, usize, u64) {

--- a/src/tool_runtime/discovery_tools.rs
+++ b/src/tool_runtime/discovery_tools.rs
@@ -48,6 +48,40 @@ impl ToolRuntime {
                 self.runtime_status_with_options(auth, compact, summary_only, client_id)
                     .await
             }
+            ToolCall::ReadToolTrace {
+                trace_ref,
+                offset,
+                limit,
+                payload_index,
+            } => match tokio::task::spawn_blocking({
+                let trace_ref = trace_ref.clone();
+                move || {
+                    crate::tool_request_trace::read_full_trace(
+                        &trace_ref,
+                        offset,
+                        limit,
+                        payload_index,
+                    )
+                }
+            })
+            .await
+            .map_err(|_| crate::tool_request_trace::TraceReadError {
+                kind: "trace_store_unavailable",
+                message: "trace diagnostic worker failed".to_string(),
+            })
+            .and_then(|result| result)
+            {
+                Ok(output) => ToolResult::ok(output),
+                Err(error) => ToolResult::err_with_output(
+                    error.message.clone(),
+                    serde_json::json!({
+                        "error_kind": error.kind,
+                        "message": error.message,
+                        "trace_ref": trace_ref,
+                        "state_changed": false,
+                    }),
+                ),
+            },
             ToolCall::ToolManifest {
                 tool_name,
                 category,

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -151,8 +151,8 @@ fn sparsify_terminal_structured_execution_success(tool_name: &str, result: &mut 
 
 /// Strip successful wrapper/telemetry facts only after every authority and
 /// Session recorder that needs them has consumed the canonical ToolResult.
-/// Failures keep the full decision/recovery envelope because those fields are
-/// actionable for retry, escalation, and reconciliation.
+/// Failure projection is handled separately and preserves every fact required
+/// for retry, escalation, uncertainty, Job handoff, and reconciliation.
 pub(super) fn sparsify_success_model_result_metadata(result: &mut ToolResult) {
     if !result.success {
         return;
@@ -164,6 +164,47 @@ pub(super) fn sparsify_success_model_result_metadata(result: &mut ToolResult) {
     if output.get("session_recorded").and_then(Value::as_bool) == Some(true) {
         output.remove("session_recorded");
         output.remove("session_event_id");
+    }
+}
+
+/// Strip model-irrelevant audit/wrapper facts from failures only after the
+/// canonical ToolResult has been consumed by permission and Session recorders.
+/// Retry/recovery, uncertainty, process output, exit state, Job handoff, and
+/// authorization-denial evidence remain explicit.
+pub(super) fn sparsify_failure_model_result_metadata(tool_name: &str, result: &mut ToolResult) {
+    if result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object_mut() else {
+        return;
+    };
+    if output
+        .get("permission")
+        .and_then(|permission| permission.get("status"))
+        .and_then(Value::as_str)
+        == Some("auto_approved")
+    {
+        output.remove("permission");
+    }
+    if output.get("session_recorded").and_then(Value::as_bool) == Some(true) {
+        output.remove("session_recorded");
+        output.remove("session_event_id");
+    }
+    if matches!(tool_name, "run_process" | "run_script") {
+        for key in [
+            "executor",
+            "duration_ms",
+            "purpose",
+            "cwd",
+            "execution_source",
+        ] {
+            output.remove(key);
+        }
+        output.remove(match tool_name {
+            "run_process" => "process_summary",
+            "run_script" => "script_summary",
+            _ => unreachable!("structured failure sparsifier is tool-gated"),
+        });
     }
 }
 
@@ -1312,6 +1353,7 @@ impl ToolRuntime {
             call @ (ToolCall::ListTools { .. }
             | ToolCall::ListAgents { .. }
             | ToolCall::RuntimeStatus { .. }
+            | ToolCall::ReadToolTrace { .. }
             | ToolCall::ToolManifest { .. }) => self.dispatch_discovery_tool(call, auth).await,
 
             call @ (ToolCall::StartSession { .. }
@@ -2081,6 +2123,96 @@ mod structured_execution_sparse_projection_tests {
         assert!(alternate.output.get("cwd").is_none());
         assert!(alternate.output.get("executor").is_none());
         assert!(alternate.output.get("execution_state").is_none());
+    }
+
+    #[test]
+    fn failure_projection_removes_audit_noise_but_preserves_decision_relevant_facts() {
+        let mut result = ToolResult::err_with_output(
+            "process exited 17",
+            json!({
+                "permission": {"status": "auto_approved", "request_id": "wc_perm_private"},
+                "session_recorded": true,
+                "session_event_id": "evt_private",
+                "executor": "agent",
+                "duration_ms": 123,
+                "purpose": "diagnostic",
+                "cwd": "src/private",
+                "execution_source": "run_process",
+                "process_summary": "private-command --secret value",
+                "failure_kind": "command_exit_nonzero",
+                "execution_state": "completed",
+                "command_started": true,
+                "command_completed": true,
+                "command_ok": false,
+                "exit_code": 17,
+                "stderr_tail": "compiler error",
+                "stderr_truncated": false,
+                "job_id": "job_keep",
+                "observation_token": "token_keep",
+                "recovery": {"kind": "inspect_output"}
+            }),
+        );
+        sparsify_failure_model_result_metadata("run_process", &mut result);
+
+        for omitted in [
+            "permission",
+            "session_recorded",
+            "session_event_id",
+            "executor",
+            "duration_ms",
+            "purpose",
+            "cwd",
+            "execution_source",
+            "process_summary",
+        ] {
+            assert!(
+                result.output.get(omitted).is_none(),
+                "{omitted}: {}",
+                result.output
+            );
+        }
+        for retained in [
+            "failure_kind",
+            "execution_state",
+            "command_started",
+            "command_completed",
+            "command_ok",
+            "exit_code",
+            "stderr_tail",
+            "stderr_truncated",
+            "job_id",
+            "observation_token",
+            "recovery",
+        ] {
+            assert!(
+                result.output.get(retained).is_some(),
+                "{retained}: {}",
+                result.output
+            );
+        }
+    }
+
+    #[test]
+    fn failure_projection_keeps_permission_denials_and_unknown_outcomes() {
+        let mut result = ToolResult::err_with_output(
+            "permission denied",
+            json!({
+                "permission": {
+                    "status": "denied",
+                    "reason": "restricted_requires_human_authorization"
+                },
+                "failure_kind": "outcome_unknown",
+                "execution_state": "outcome_unknown",
+                "command_started": true,
+                "command_completed": false
+            }),
+        );
+        sparsify_failure_model_result_metadata("run_process", &mut result);
+        assert_eq!(result.output["permission"]["status"], "denied");
+        assert_eq!(result.output["failure_kind"], "outcome_unknown");
+        assert_eq!(result.output["execution_state"], "outcome_unknown");
+        assert_eq!(result.output["command_started"], true);
+        assert_eq!(result.output["command_completed"], false);
     }
 }
 

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -69,6 +69,9 @@ pub(crate) struct ToolProtocolCapabilities {
     /// read, manage, and administrator authority comes only from canonical
     /// ToolDefinition metadata.
     pub(crate) memory_surface: bool,
+    /// Protocol-surface support for privileged forensic trace retrieval. Caller
+    /// authority is still derived only from the canonical ToolDefinition.
+    pub(crate) trace_diagnostics: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -215,6 +218,7 @@ impl ToolRuntime {
                 skill_runtime: context_sidecar_capable,
                 skill_management: false,
                 memory_surface: false,
+                trace_diagnostics: false,
             },
         )
         .await
@@ -256,6 +260,18 @@ impl ToolRuntime {
         // One trusted identity per real kernel request. The outer recorder and
         // inner business ledger pairs inherit it, but it never affects execution.
         recorder_metadata.assign_logical_invocation();
+        if request.tool_name == "read_tool_trace" && !capabilities.trace_diagnostics {
+            return ToolCallOutcome {
+                success: false,
+                result: None,
+                error_status: Some(ToolCallErrorStatus::InvalidArguments {
+                    message: "Tool trace diagnostics are available only on Stateless MCP 2026 operator surfaces"
+                        .to_string(),
+                }),
+                project: None,
+                model_ergonomics: None,
+            };
+        }
         // Project Memory tools are kernel-known but globally model-hidden. One
         // explicit protocol-surface capability gates all six fixed tools; their
         // canonical ToolDefinition authority decides caller access below.
@@ -818,8 +834,23 @@ impl ToolRuntime {
             );
             super::dispatch::sparsify_complete_read_success(&request.tool_name, &mut result);
         }
-        // Final model-facing projection: the authoritative permission decision
-        // and recorder event have already been consumed by the Session ledger.
+        // Final model-facing projection: authoritative permission decisions and
+        // recorder events have already been consumed by the Session ledger.
+        super::dispatch::sparsify_failure_model_result_metadata(&request.tool_name, &mut result);
+        if !result.success
+            && request.tool_name != "read_tool_trace"
+            && capabilities.trace_diagnostics
+            && context
+                .auth
+                .is_some_and(|auth| auth.has_scope(crate::auth::SCOPE_ADMIN))
+        {
+            if let (Some(trace_ref), Some(output)) = (
+                crate::tool_request_trace::current_full_trace_ref(),
+                result.output.as_object_mut(),
+            ) {
+                output.insert("trace_ref".to_string(), Value::String(trace_ref));
+            }
+        }
         super::dispatch::sparsify_success_model_result_metadata(&mut result);
         ToolCallOutcome {
             success: result.success,

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -145,8 +145,8 @@ pub(crate) use project_resolution::{agent_project_runtime_id, ProjectResolverErr
 pub(crate) use registry::accepted_flattened_args_for_spec;
 pub(crate) use registry::{
     generic_tool_call_flattened_args_for_spec, memory_management_tool_specs,
-    memory_runtime_tool_specs, registered_tool_specs, skill_management_tool_specs,
-    skill_runtime_tool_specs,
+    memory_runtime_tool_specs, operator_diagnostic_tool_specs, registered_tool_specs,
+    skill_management_tool_specs, skill_runtime_tool_specs,
 };
 pub(crate) use session_context::{add_session_telemetry_hint, unknown_session_result};
 pub(crate) use session_shell::SessionShellRegistry;

--- a/src/tool_runtime/observations.rs
+++ b/src/tool_runtime/observations.rs
@@ -25,6 +25,7 @@ pub(crate) const NON_MEANINGFUL_ACTIVITY_TOOLS: &[&str] = &[
     "list_agents",
     "list_projects",
     "tool_manifest",
+    "read_tool_trace",
 ];
 
 pub(crate) fn is_meaningful_activity_tool(tool_name: &str) -> bool {

--- a/src/tool_runtime/registry/input_schemas.rs
+++ b/src/tool_runtime/registry/input_schemas.rs
@@ -78,7 +78,8 @@ pub(crate) use discovery::{
 };
 pub(crate) use discovery::{
     empty_input_schema, list_agents_input_schema, list_projects_input_schema,
-    list_tools_input_schema, runtime_status_input_schema, tool_manifest_input_schema,
+    list_tools_input_schema, read_tool_trace_input_schema, runtime_status_input_schema,
+    tool_manifest_input_schema,
 };
 pub(crate) use files::{
     list_project_files_input_schema, list_project_tracked_files_input_schema,

--- a/src/tool_runtime/registry/input_schemas/discovery.rs
+++ b/src/tool_runtime/registry/input_schemas/discovery.rs
@@ -159,6 +159,40 @@ pub(crate) fn runtime_status_input_schema() -> Value {
     })
 }
 
+pub(crate) fn read_tool_trace_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "trace_ref": {
+                "type": "string",
+                "minLength": 36,
+                "maxLength": 36,
+                "description": "Opaque trace reference returned on an eligible failed tool result. Must be the canonical UUID; native trace paths are never accepted."
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 4095,
+                "description": "Payload-index offset for metadata listing mode. Omit when payload_index is provided."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 64,
+                "description": "Maximum payload metadata entries returned in listing mode. Defaults to 20. Omit when payload_index is provided."
+            },
+            "payload_index": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 4095,
+                "description": "Read one indexed full-trace JSON payload. Omit to list bounded payload metadata first."
+            }
+        },
+        "required": ["trace_ref"],
+        "additionalProperties": false
+    })
+}
+
 pub(crate) fn empty_input_schema() -> Value {
     object_schema(vec![])
 }

--- a/src/tool_runtime/registry/mod.rs
+++ b/src/tool_runtime/registry/mod.rs
@@ -11,6 +11,6 @@ pub(crate) use input_schemas::{
 };
 pub(crate) use output_schemas::output_schema_for_tool;
 pub(crate) use tool_specs::{
-    memory_management_tool_specs, memory_runtime_tool_specs, registered_tool_specs,
-    skill_management_tool_specs, skill_runtime_tool_specs,
+    memory_management_tool_specs, memory_runtime_tool_specs, operator_diagnostic_tool_specs,
+    registered_tool_specs, skill_management_tool_specs, skill_runtime_tool_specs,
 };

--- a/src/tool_runtime/registry/output_schemas/common.rs
+++ b/src/tool_runtime/registry/output_schemas/common.rs
@@ -332,6 +332,13 @@ pub(crate) fn wrapped_output_schema(output_properties: Vec<(&str, Value)>) -> Va
     let mut output_properties = output_properties;
     output_properties.extend([
         (
+            "trace_ref",
+            schema_type(
+                "string",
+                "Opaque operator diagnostic reference emitted only on eligible failed calls while full tracing is enabled. Read with read_tool_trace; on Adaptive Runtime invoke that target through call_runtime_tool. Never a native path.",
+            ),
+        ),
+        (
             "session_recorded",
             schema_type(
                 "boolean",

--- a/src/tool_runtime/registry/output_schemas/discovery.rs
+++ b/src/tool_runtime/registry/output_schemas/discovery.rs
@@ -99,6 +99,22 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 open_object_schema("QUIC transport status, when enabled."),
             ),
         ])),
+        "read_tool_trace" => Some(wrapped_output_schema(vec![
+            ("trace_mode", schema_type("string", "Trace mode; read_tool_trace requires full.")),
+            ("payload_count", schema_type("integer", "Total indexed payloads in this trace.")),
+            ("returned_count", schema_type("integer", "Payload metadata entries returned in listing mode.")),
+            ("offset", schema_type("integer", "Listing offset.")),
+            ("next_offset", nullable_schema("integer", "Next listing offset or null.")),
+            ("payloads", array_schema(open_object_schema("Safe payload metadata: payload_index, phase, payload_bytes, compressed_bytes, payload_sha256, and payload_available. Native paths are never returned."), "Bounded payload metadata.")),
+            ("payload_index", schema_type("integer", "Selected payload index in payload-read mode.")),
+            ("phase", schema_type("string", "Selected payload lifecycle phase.")),
+            ("payload_bytes", schema_type("integer", "Uncompressed payload size.")),
+            ("payload_sha256", schema_type("string", "SHA-256 of the selected uncompressed payload.")),
+            ("payload_available", schema_type("boolean", "Whether the selected payload is within the model read ceiling.")),
+            ("max_payload_bytes", schema_type("integer", "Maximum uncompressed payload bytes readable through this tool.")),
+            ("reason", schema_type("string", "Bounded reason when a payload is not model-readable.")),
+            ("payload", json!({"description": "Selected raw JSON trace payload of any JSON type. May contain sensitive tool data; operator-only."})),
+        ])),
         "list_projects" => Some(wrapped_output_schema(vec![
             (
                 "projects",

--- a/src/tool_runtime/registry/output_schemas/jobs.rs
+++ b/src/tool_runtime/registry/output_schemas/jobs.rs
@@ -573,7 +573,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             let mut properties = vec![
                 (
                     "duration_ms",
-                    schema_type("integer", "Process duration in milliseconds; omitted on ordinary synchronous terminal success."),
+                    schema_type("integer", "Process duration in milliseconds. Diagnostic telemetry: omitted on ordinary synchronous terminal success and from the default model-facing failure projection."),
                 ),
                 (
                     "exit_code",
@@ -635,22 +635,22 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                         "True for WebCodex tool/runtime failures; false for child exit status failures. Omitted when false on ordinary synchronous terminal success.",
                     ),
                 ),
-                ("purpose", schema_type("string", "Declared execution purpose; omitted on ordinary synchronous terminal success because it echoes the request.")),
+                ("purpose", schema_type("string", "Declared execution purpose. Audit metadata: omitted on ordinary synchronous terminal success and from the default model-facing failure projection.")),
                 (
                     "process_summary",
                     schema_type(
                         "string",
-                        "Bounded human-readable executable/argv summary; never execution input. Omitted on ordinary synchronous terminal success when the canonical run_process source is implied by tool identity.",
+                        "Bounded human-readable executable/argv summary; never execution input. Omitted on ordinary synchronous terminal success and from the default model-facing failure projection; full operator trace diagnostics can retain the canonical execution payload when enabled.",
                     ),
                 ),
                 (
                     "cwd",
-                    schema_type("string", "Resolved project-relative cwd; omitted on ordinary synchronous terminal success."),
+                    schema_type("string", "Resolved project-relative cwd. Diagnostic telemetry: omitted on ordinary synchronous terminal success and from the default model-facing failure projection."),
                 ),
-                ("executor", schema_type("string", "Executor type: local or agent; omitted on ordinary synchronous terminal success.")),
+                ("executor", schema_type("string", "Executor type: local or agent. Diagnostic telemetry: omitted on ordinary synchronous terminal success and from the default model-facing failure projection.")),
                 (
                     "execution_source",
-                    schema_type("string", "Canonical source is run_process. Omitted on ordinary synchronous terminal success only when the actual source is exactly canonical; any future schema-supported alternate source must remain explicit."),
+                    schema_type("string", "Canonical source is run_process. Diagnostic telemetry: omitted on ordinary synchronous terminal success when canonical and from the default model-facing failure projection."),
                 ),
                 (
                     "execution_state",
@@ -669,7 +669,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             let mut properties = vec![
                 (
                     "duration_ms",
-                    schema_type("integer", "Script duration in milliseconds; omitted on ordinary synchronous terminal success."),
+                    schema_type("integer", "Script duration in milliseconds. Diagnostic telemetry: omitted on ordinary synchronous terminal success and from the default model-facing failure projection."),
                 ),
                 (
                     "exit_code",
@@ -734,12 +734,12 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                         "True for WebCodex tool/runtime failures; false for interpreter exit status failures. Omitted when false on ordinary synchronous terminal success.",
                     ),
                 ),
-                ("purpose", schema_type("string", "Declared execution purpose; omitted on ordinary synchronous terminal success because it echoes the request.")),
+                ("purpose", schema_type("string", "Declared execution purpose. Audit metadata: omitted on ordinary synchronous terminal success and from the default model-facing failure projection.")),
                 (
                     "script_summary",
                     schema_type(
                         "string",
-                        "Bounded body-free language/byte/argument summary; never execution input. Omitted on ordinary synchronous terminal success when the canonical run_script source is implied by tool identity.",
+                        "Bounded body-free language/byte/argument summary; never execution input. Omitted on ordinary synchronous terminal success and from the default model-facing failure projection; full operator trace diagnostics can retain the canonical execution payload when enabled.",
                     ),
                 ),
                 (
@@ -748,12 +748,12 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
                 (
                     "cwd",
-                    schema_type("string", "Resolved project-relative cwd; omitted on ordinary synchronous terminal success."),
+                    schema_type("string", "Resolved project-relative cwd. Diagnostic telemetry: omitted on ordinary synchronous terminal success and from the default model-facing failure projection."),
                 ),
-                ("executor", schema_type("string", "Executor type: local or agent; omitted on ordinary synchronous terminal success.")),
+                ("executor", schema_type("string", "Executor type: local or agent. Diagnostic telemetry: omitted on ordinary synchronous terminal success and from the default model-facing failure projection.")),
                 (
                     "execution_source",
-                    schema_type("string", "Canonical source is run_script. Omitted on ordinary synchronous terminal success only when the actual source is exactly canonical; any future schema-supported alternate source must remain explicit."),
+                    schema_type("string", "Canonical source is run_script. Diagnostic telemetry: omitted on ordinary synchronous terminal success when canonical and from the default model-facing failure projection."),
                 ),
                 (
                     "execution_state",

--- a/src/tool_runtime/registry/tool_specs.rs
+++ b/src/tool_runtime/registry/tool_specs.rs
@@ -14,6 +14,16 @@ pub(crate) fn registered_tool_specs() -> Vec<ToolSpec> {
     resolve_tool_specs(model_visible_tool_definitions())
 }
 
+/// Fixed admin-only forensic trace reader. It remains globally ModelHidden and
+/// is projected only by capable Stateless MCP 2026 operator adapters.
+pub(crate) fn operator_diagnostic_tool_specs() -> Vec<ToolSpec> {
+    vec![tool_spec(
+        "read_tool_trace",
+        "Admin-only bounded reader for Server-hosted full tool-request traces. Omit payload_index to list safe payload metadata first; then read one bounded JSON payload by index. Available only when full trace mode is enabled. Trace payloads may contain sensitive tool data and never grant execution authority.",
+        super::input_schemas::read_tool_trace_input_schema(),
+    )]
+}
+
 /// Fixed read-only project Memory runtime contract. Definitions remain hidden
 /// from generic/GPT Action registries and are projected only by capable
 /// Stateless MCP Full Operator adapters.

--- a/src/tool_runtime/tests/diagnostics.rs
+++ b/src/tool_runtime/tests/diagnostics.rs
@@ -1,0 +1,153 @@
+use super::super::kernel::{
+    check_runtime_tool_scope, HostFileImportTrust, ToolCallContext, ToolCallErrorStatus,
+    ToolCallRequest, ToolProtocolCapabilities, ToolTransport,
+};
+use super::super::ToolRuntime;
+use serde_json::json;
+
+fn admin_auth() -> crate::auth::AuthContext {
+    crate::auth::AuthContext {
+        role: Some("admin".to_string()),
+        scopes: vec![crate::auth::SCOPE_ADMIN.to_string()],
+        is_bootstrap: true,
+        ..crate::auth::AuthContext::new(crate::auth::AuthKind::Bootstrap)
+    }
+}
+
+fn runtime_reader_auth() -> crate::auth::AuthContext {
+    crate::auth::AuthContext {
+        scopes: vec![crate::auth::SCOPE_RUNTIME_READ.to_string()],
+        ..crate::auth::AuthContext::new(crate::auth::AuthKind::OAuth2Token)
+    }
+}
+
+fn context(auth: Option<&crate::auth::AuthContext>) -> ToolCallContext<'_> {
+    ToolCallContext {
+        transport: ToolTransport::Mcp,
+        session_id: None,
+        auth,
+        window: None,
+        record_oauth_scope_denials: false,
+        host_file_import_trust: HostFileImportTrust::Untrusted,
+    }
+}
+
+fn missing_job_request() -> ToolCallRequest {
+    ToolCallRequest {
+        tool_name: "job_status".to_string(),
+        arguments: json!({"job_id": "missing-trace-ref-job"}),
+    }
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn failed_tool_trace_ref_requires_full_mode_admin_and_operator_capability() {
+    let mut env = crate::test_support::TestEnvGuard::new();
+    env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+    let runtime = ToolRuntime::new_for_tests();
+    let admin = admin_auth();
+    let ordinary = runtime_reader_auth();
+    let capable = ToolProtocolCapabilities {
+        trace_diagnostics: true,
+        ..Default::default()
+    };
+
+    assert!(matches!(
+        check_runtime_tool_scope(None, "read_tool_trace"),
+        Err(ToolCallErrorStatus::InsufficientScope {
+            required_scope: Some(crate::auth::SCOPE_ADMIN),
+            ..
+        })
+    ));
+    assert!(matches!(
+        check_runtime_tool_scope(Some(&ordinary), "read_tool_trace"),
+        Err(ToolCallErrorStatus::InsufficientScope {
+            required_scope: Some(crate::auth::SCOPE_ADMIN),
+            ..
+        })
+    ));
+    assert!(check_runtime_tool_scope(Some(&admin), "read_tool_trace").is_ok());
+
+    let admin_trace = crate::tool_request_trace::new_trace_id();
+    let admin_result = crate::tool_request_trace::scope_active_trace(
+        Some(admin_trace.clone()),
+        runtime.call_tool_with_protocol_capabilities(
+            missing_job_request(),
+            context(Some(&admin)),
+            capable,
+        ),
+    )
+    .await
+    .result
+    .expect("missing Job should return a structured failed tool result");
+    assert!(!admin_result.success);
+    assert_eq!(admin_result.output["trace_ref"], admin_trace);
+
+    let ordinary_trace = crate::tool_request_trace::new_trace_id();
+    let ordinary_result = crate::tool_request_trace::scope_active_trace(
+        Some(ordinary_trace),
+        runtime.call_tool_with_protocol_capabilities(
+            missing_job_request(),
+            context(Some(&ordinary)),
+            capable,
+        ),
+    )
+    .await
+    .result
+    .expect("ordinary missing Job should remain a structured failed tool result");
+    assert!(!ordinary_result.success);
+    assert!(ordinary_result.output.get("trace_ref").is_none());
+
+    let hidden_trace = crate::tool_request_trace::new_trace_id();
+    let hidden_result = crate::tool_request_trace::scope_active_trace(
+        Some(hidden_trace),
+        runtime.call_tool_with_protocol_capabilities(
+            missing_job_request(),
+            context(Some(&admin)),
+            ToolProtocolCapabilities::default(),
+        ),
+    )
+    .await
+    .result
+    .expect("capability-hidden trace diagnostics must not change tool failure delivery");
+    assert!(!hidden_result.success);
+    assert!(hidden_result.output.get("trace_ref").is_none());
+
+    env.remove("WEBCODEX_TOOL_REQUEST_TRACE");
+    let disabled_trace = crate::tool_request_trace::new_trace_id();
+    let disabled_result = crate::tool_request_trace::scope_active_trace(
+        Some(disabled_trace),
+        runtime.call_tool_with_protocol_capabilities(
+            missing_job_request(),
+            context(Some(&admin)),
+            capable,
+        ),
+    )
+    .await
+    .result
+    .expect("trace-disabled failure must remain structured");
+    assert!(!disabled_result.success);
+    assert!(disabled_result.output.get("trace_ref").is_none());
+}
+
+#[tokio::test]
+async fn trace_reader_tool_name_is_fail_closed_outside_operator_protocol_capability() {
+    let runtime = ToolRuntime::new_for_tests();
+    let admin = admin_auth();
+    let outcome = runtime
+        .call_tool_with_protocol_capabilities(
+            ToolCallRequest {
+                tool_name: "read_tool_trace".to_string(),
+                arguments: json!({"trace_ref": crate::tool_request_trace::new_trace_id()}),
+            },
+            context(Some(&admin)),
+            ToolProtocolCapabilities::default(),
+        )
+        .await;
+    assert!(matches!(
+        outcome.error_status,
+        Some(ToolCallErrorStatus::InvalidArguments { ref message })
+            if message.contains("Stateless MCP 2026 operator surfaces")
+    ));
+    assert!(outcome.result.is_none());
+}

--- a/src/tool_runtime/tests/mod.rs
+++ b/src/tool_runtime/tests/mod.rs
@@ -11,6 +11,7 @@ mod coding_task_semantic_navigation;
 mod collaboration;
 mod context_projection;
 mod continuation_feedback;
+mod diagnostics;
 mod dispatch;
 mod edit_tool_telemetry;
 mod execution_context;

--- a/src/tool_runtime/tests/reconnect.rs
+++ b/src/tool_runtime/tests/reconnect.rs
@@ -10,6 +10,7 @@ use crate::shell_protocol::{
     AgentBuildInfo, AgentHostContext, AgentProtocolGenerationNumber, ShellClientCapabilities,
     ShellClientRegisterRequest, ShellJobOpRequest, AGENT_PROTOCOL_GENERATION_V2,
 };
+use crate::tool_runtime::observations::ToolCallObservation;
 use crate::tool_runtime::tool_inputs::{SessionMode, StartupDetail};
 use crate::tool_runtime::{ToolCall, ToolRuntime};
 use serde_json::Value;
@@ -327,6 +328,31 @@ async fn meaningful_activity_is_scoped_and_not_refreshed_by_status_calls() {
     assert_eq!(last["surface"], "api");
     assert!(last["principal_kind"].is_string());
     let observed_at = last["observed_at"].as_i64().unwrap();
+
+    // Reading forensic trace data is itself observability and must not become
+    // meaningful activity even if the operator call succeeds.
+    runtime
+        .observations
+        .record_successful_tool_call(ToolCallObservation {
+            principal_kind: "bootstrap".to_string(),
+            principal_id: "trace-reader".to_string(),
+            project: None,
+            surface: "mcp".to_string(),
+            session_id: None,
+            tool: "read_tool_trace".to_string(),
+            observed_at: observed_at + 100,
+        });
+    let after_trace_read = layers(&runtime).await;
+    assert_eq!(
+        after_trace_read["last_successful_tool_call"]["tool"],
+        "start_session"
+    );
+    assert_eq!(
+        after_trace_read["last_successful_tool_call"]["observed_at"]
+            .as_i64()
+            .unwrap(),
+        observed_at
+    );
 
     // Additional status polling must not refresh the observation.
     for _ in 0..3 {

--- a/src/tool_runtime/tests/schema/definitions.rs
+++ b/src/tool_runtime/tests/schema/definitions.rs
@@ -234,6 +234,7 @@ fn tool_call_parser_name_gate_matches_tool_definitions() {
         "start_session",
         "start_coding_task",
         "job_tail",
+        "read_tool_trace",
         "skill_list",
         "skill_read_file",
         "skill_versions",

--- a/src/tool_runtime/tests/unified_diff.rs
+++ b/src/tool_runtime/tests/unified_diff.rs
@@ -345,6 +345,7 @@ fn apply_unified_diff_schema_matches_flat_runtime_contract_and_old_tools_are_abs
         "session_hint",
         "session_id",
         "session_recorded",
+        "trace_ref",
     ]
     .into_iter()
     .collect();

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -1456,6 +1456,21 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
 
 pub(crate) fn session_log_result_for_tool(tool_name: &str, output: &Value) -> Value {
     match tool_name {
+        "read_tool_trace" => serde_json::json!({
+            "trace_ref": output.get("trace_ref").cloned().unwrap_or(Value::Null),
+            "trace_mode": output.get("trace_mode").cloned().unwrap_or(Value::Null),
+            "payload_count": output.get("payload_count").cloned().unwrap_or(Value::Null),
+            "returned_count": output.get("returned_count").cloned().unwrap_or(Value::Null),
+            "offset": output.get("offset").cloned().unwrap_or(Value::Null),
+            "next_offset": output.get("next_offset").cloned().unwrap_or(Value::Null),
+            "payload_index": output.get("payload_index").cloned().unwrap_or(Value::Null),
+            "phase": output.get("phase").cloned().unwrap_or(Value::Null),
+            "payload_bytes": output.get("payload_bytes").cloned().unwrap_or(Value::Null),
+            "payload_sha256": output.get("payload_sha256").cloned().unwrap_or(Value::Null),
+            "payload_available": output.get("payload_available").cloned().unwrap_or(Value::Null),
+            "reason": output.get("reason").cloned().unwrap_or(Value::Null),
+            "error_kind": output.get("error_kind").cloned().unwrap_or(Value::Null),
+        }),
         "coding_agent_start" | "coding_agent_cancel" => serde_json::json!({
             "run_id": output.get("run_id").cloned().unwrap_or(Value::Null),
             "project": output.get("project").cloned().unwrap_or(Value::Null),
@@ -2546,6 +2561,34 @@ mod computer_privacy_tests {
         assert!(!serialized.contains("Private App"));
         assert!(!serialized.contains("application_"));
         assert!(!serialized.contains("native_identity"));
+    }
+
+    #[test]
+    fn trace_reader_audit_result_never_persists_raw_payload() {
+        let summary = session_log_result_for_tool(
+            "read_tool_trace",
+            &json!({
+                "trace_ref": "01234567-89ab-cdef-0123-456789abcdef",
+                "trace_mode": "full",
+                "payload_index": 2,
+                "phase": "final_response",
+                "payload_bytes": 123,
+                "payload_sha256": "a".repeat(64),
+                "payload_available": true,
+                "payload": {
+                    "private_token": "PRIVATE_RAW_TRACE_BODY",
+                    "stdout": "PRIVATE_OUTPUT"
+                }
+            }),
+        );
+        let serialized = serde_json::to_string(&summary).unwrap();
+        assert_eq!(summary["payload_index"], 2);
+        assert_eq!(summary["phase"], "final_response");
+        assert_eq!(summary["payload_bytes"], 123);
+        assert!(summary.get("payload").is_none());
+        assert!(!serialized.contains("PRIVATE_RAW_TRACE_BODY"));
+        assert!(!serialized.contains("PRIVATE_OUTPUT"));
+        assert!(!serialized.contains("private_token"));
     }
 
     #[test]

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -2070,6 +2070,17 @@ pub enum ToolCall {
         client_id: Option<String>,
     },
 
+    /// Admin-only bounded read of one Server-hosted full tool-request trace.
+    ReadToolTrace {
+        trace_ref: String,
+        #[serde(default)]
+        offset: Option<usize>,
+        #[serde(default)]
+        limit: Option<usize>,
+        #[serde(default)]
+        payload_index: Option<usize>,
+    },
+
     /// Return a compact, bounded tool manifest with categories, risk summary,
     /// recommended flows, and optional intent-shaped tool views. Intent views
     /// only filter and rank discovery output; they do not change tool behavior,
@@ -2641,6 +2652,7 @@ impl ToolCall {
             Self::CreateProject { .. } => "create_project",
             Self::ListAgents { .. } => "list_agents",
             Self::RuntimeStatus { .. } => "runtime_status",
+            Self::ReadToolTrace { .. } => "read_tool_trace",
             Self::ToolManifest { .. } => "tool_manifest",
         }
     }

--- a/src/tool_runtime/tool_definition.rs
+++ b/src/tool_runtime/tool_definition.rs
@@ -11,6 +11,7 @@ mod checkpoints;
 mod coding_agents;
 mod communication;
 mod computer;
+mod diagnostics;
 mod discovery;
 mod edits;
 mod files;
@@ -583,6 +584,7 @@ const TOOL_DEFINITION_GROUPS: &[&[ToolDefinition]] = &[
     checkpoints::DEFINITIONS,
     coding_agents::DEFINITIONS,
     computer::DEFINITIONS,
+    diagnostics::DEFINITIONS,
     discovery::DEFINITIONS,
     jobs::EXECUTION_DEFINITIONS,
     files::SEARCH_DEFINITIONS,

--- a/src/tool_runtime/tool_definition/diagnostics.rs
+++ b/src/tool_runtime/tool_definition/diagnostics.rs
@@ -1,0 +1,27 @@
+use super::ToolVisibility::ModelHidden;
+use super::{context_recovery_only, def, ToolDefinition, TOOL_CATEGORY_RUNTIME};
+use crate::tool_runtime::metadata::{
+    ToolPathHint::None as NoPath, ToolRisk::Read, ADMIN, TOOL_PROVIDER_CONTROL,
+};
+
+/// Operator-only forensic diagnostics. The tool is kernel-known so the shared
+/// typed dispatcher can enforce its contract, but it is projected only by a
+/// capable Stateless MCP 2026 operator surface.
+pub(super) const DEFINITIONS: &[ToolDefinition] = &[context_recovery_only(def(
+    "read_tool_trace",
+    ModelHidden,
+    TOOL_CATEGORY_RUNTIME,
+    None,
+    TOOL_PROVIDER_CONTROL,
+    super::ToolSemanticContract {
+        effect: super::ToolEffect::Observe,
+        risk: Read,
+        approval: super::ToolApprovalPolicy::None,
+        idempotency: super::ToolIdempotency::PureRead,
+    },
+    Some(ADMIN),
+    false,
+    NoPath,
+    false,
+    false,
+))];


### PR DESCRIPTION
## Summary
- add bounded operator-facing diagnostic trace discovery and projections
- harden Server↔Runner trace correlation across polling/job lifecycle boundaries
- isolate full-trace env visibility in tests so parallel libtest threads cannot contaminate the global bounded trace writer

## Validation
- `cargo test --locked -p webcodex full_trace` — 3 passed
- `cargo test --locked -p webcodex` — 3250 passed, 0 failed
- `cargo fmt --all -- --check` — passed
- `git diff --check origin/main..HEAD` — passed

The test-isolation change is `cfg(test)` only; production trace writer queueing and fail-open/drop semantics are unchanged.