### PR TITLE
Tighten pre-0.4 show_changes and MCP mutation hints

### DIFF
--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -711,7 +711,7 @@ async fn full_operator_explicit_surface_lists_full_runtime_and_dispatches() {
 }
 
 #[tokio::test]
-async fn full_operator_tools_list_projects_destructive_hints_for_project_mutations() {
+async fn full_operator_tools_list_projects_destructive_hints_for_non_additive_mutations() {
     let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
     let listed = handle_mcp_request(
         &runtime,
@@ -738,6 +738,25 @@ async fn full_operator_tools_list_projects_destructive_hints_for_project_mutatio
         "import_conversation_files_to_project",
         "artifact_upload_finish",
         "artifact_upload_abort",
+        "assign_agent_task",
+        "reconcile_agent_task_coding_run",
+        "heartbeat_agent_task_attempt",
+        "complete_agent_task_attempt",
+        "update_agent_identity",
+        "attach_agent_endpoint",
+        "detach_agent_endpoint",
+        "consume_agent_deliveries",
+        "consume_agent_wake",
+        "coding_agent_cancel",
+        "computer_write_clipboard",
+        "computer_pointer_click",
+        "computer_control",
+        "computer_key_input",
+        "update_session_context",
+        "close_session",
+        "resolve_session_message",
+        "complete_session_message",
+        "cargo_fmt",
     ] {
         let tool = tools
             .iter()
@@ -754,6 +773,12 @@ async fn full_operator_tools_list_projects_destructive_hints_for_project_mutatio
         "artifact_upload_begin",
         "artifact_upload_chunk",
         "computer_save_snapshot",
+        "start_agent_task_attempt",
+        "create_conversation",
+        "post_conversation_message",
+        "post_session_message",
+        "work_on_project",
+        "cargo_check",
     ] {
         let tool = tools
             .iter()

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -711,6 +711,62 @@ async fn full_operator_explicit_surface_lists_full_runtime_and_dispatches() {
 }
 
 #[tokio::test]
+async fn full_operator_tools_list_projects_destructive_hints_for_project_mutations() {
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
+    let listed = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/list",
+            Some(Value::from(721)),
+            mcp_2026_params(json!({})),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = listed else {
+        panic!("full operator tools/list must succeed");
+    };
+    let tools = value["result"]["tools"].as_array().unwrap();
+
+    for name in [
+        "apply_patch",
+        "apply_text_edits",
+        "apply_unified_diff",
+        "write_project_file",
+        "workspace_checkpoint_restore",
+        "save_project_artifact",
+        "import_conversation_files_to_project",
+        "artifact_upload_finish",
+        "artifact_upload_abort",
+    ] {
+        let tool = tools
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("missing {name} from full operator tools/list"));
+        assert_eq!(
+            tool["annotations"]["destructiveHint"], true,
+            "{name} may replace, restore, delete, or discard existing state"
+        );
+    }
+
+    for name in [
+        "workspace_checkpoint_create",
+        "artifact_upload_begin",
+        "artifact_upload_chunk",
+        "computer_save_snapshot",
+    ] {
+        let tool = tools
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("missing {name} from full operator tools/list"));
+        assert_eq!(
+            tool["annotations"]["destructiveHint"], false,
+            "{name} is intentionally additive-only"
+        );
+    }
+}
+
+#[tokio::test]
 async fn explicit_local_coding_v1_selects_local_coding() {
     let runtime = test_runtime_from_model_surface_env(Some(
         crate::model_surface::MCP_MODEL_SURFACE_LOCAL_CODING_V1,

--- a/src/mcp_tests/tools.rs
+++ b/src/mcp_tests/tools.rs
@@ -2137,7 +2137,7 @@ async fn mcp_show_changes_distinguishes_recording_session_id_from_query_session_
             "show_changes",
         )
         .await;
-        let stdout = "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0test head\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n";
+        let stdout = crate::tool_runtime::framed_clean_show_changes_test_stdout("test head", false);
         runtime
             .shell_clients
             .complete(ShellAgentResultRequest {
@@ -2145,7 +2145,7 @@ async fn mcp_show_changes_distinguishes_recording_session_id_from_query_session_
                 agent_instance_id: "inst".to_string(),
                 request_id: req.request_id,
                 exit_code: Some(0),
-                stdout: Some(stdout.to_string()),
+                stdout: Some(stdout),
                 stderr: Some(String::new()),
                 duration_ms: Some(1),
                 error: None,

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -1690,14 +1690,31 @@ async fn api_show_changes_with_session_id() {
             );
             tokio::task::yield_now().await;
         };
-        let stdout = "## main\n?? README.md\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nstatus_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=1\nfiles_returned=1\nfiles_truncated=0\nfiles_limit=200\nmodified=0\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=1\nconflicted=0\nstaged=0\nunstaged=0\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=20\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ncommit=abc123\nshort=abc123\nsummary=test head\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nhead_exit=0\nhead_truncated=0\nhead_bytes=44\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ndiff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=0\n";
+        let stdout = format!(
+            "{}{}{}",
+            crate::tool_runtime::framed_show_changes_test_block(
+                'S',
+                "## main\n?? README.md\n",
+                "status_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=1\nfiles_returned=1\nfiles_truncated=0\nfiles_limit=200\nmodified=0\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=1\nconflicted=0\nstaged=0\nunstaged=0\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=20\n"
+            ),
+            crate::tool_runtime::framed_show_changes_test_block(
+                'H',
+                "commit=abc123\nshort=abc123\nsummary=test head\n",
+                "head_exit=0\nhead_truncated=0\nhead_bytes=44\n"
+            ),
+            crate::tool_runtime::framed_show_changes_test_block(
+                'T',
+                "",
+                "diff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=0\n"
+            )
+        );
         registry
             .complete(ShellAgentResultRequest {
                 client_id: "importer".to_string(),
                 agent_instance_id: "inst-import".to_string(),
                 request_id: req.request_id,
                 exit_code: Some(0),
-                stdout: Some(stdout.to_string()),
+                stdout: Some(stdout),
                 stderr: Some(String::new()),
                 duration_ms: Some(1),
                 error: None,

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -24,6 +24,7 @@ use crate::tool_runtime::sessions::{SessionEvent, SessionSummary};
 /// combined `git_diff_summary` command output. Chosen to be extremely unlikely
 /// to appear in real git output.
 pub(crate) const DIFF_SUMMARY_SENTINEL: &str = "@@WEBCODEX_DIFF_SUMMARY_SEP@@";
+#[cfg(test)]
 pub(crate) const SHOW_CHANGES_SENTINEL: &str = "@@WEBCODEX_SHOW_CHANGES_SEP@@";
 const SHOW_CHANGES_BLOCK_TRAILER_BYTES: usize = 30;
 const SHOW_CHANGES_BLOCK_MAGIC: &[u8; 6] = b"WCSF1:";
@@ -633,8 +634,8 @@ pub(crate) struct ShowChangesStdout {
     pub(crate) head: String,
     pub(crate) stat: String,
     pub(crate) diff: String,
-    /// Authoritative status metadata parsed from the result frame. `None`
-    /// when a field is absent (e.g. a legacy/compat frame).
+    /// Authoritative status metadata parsed from the current bounded frame.
+    /// `None` means the frame was absent or invalid.
     pub(crate) files_total: Option<usize>,
     pub(crate) files_returned: Option<usize>,
     pub(crate) files_truncated: Option<bool>,
@@ -649,7 +650,7 @@ pub(crate) struct ShowChangesStdout {
     pub(crate) counts_staged: Option<usize>,
     pub(crate) counts_unstaged: Option<usize>,
     /// Per-segment byte-budget truncation flags parsed from the status result
-    /// frame. `None` when absent (legacy/compat frame).
+    /// frame. `None` when the current frame is absent or invalid.
     pub(crate) status_trunc_count: Option<bool>,
     pub(crate) status_trunc_bytes: Option<bool>,
     pub(crate) status_trunc_path: Option<bool>,
@@ -737,6 +738,47 @@ fn strip_wire_lf(value: &str) -> Option<String> {
     }
 }
 
+#[cfg(test)]
+pub(crate) fn framed_show_changes_test_block(kind: char, body: &str, metadata: &str) -> String {
+    format!(
+        "{body}{metadata}WCSF1:{kind}:{:010}:{:010}\n",
+        body.len(),
+        metadata.len()
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn framed_clean_show_changes_test_stdout(subject: &str, include_diff: bool) -> String {
+    let head = format!("commit=abc123\nshort=abc123\nsummary={subject}\n");
+    let head_bytes = head.strip_suffix('\n').unwrap_or(&head).len();
+    let mut stdout = format!(
+        "{}{}{}",
+        framed_show_changes_test_block(
+            'S',
+            "## main\n",
+            "status_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=0\nfiles_returned=0\nfiles_truncated=0\nfiles_limit=200\nmodified=0\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=0\nconflicted=0\nstaged=0\nunstaged=0\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=7\n"
+        ),
+        framed_show_changes_test_block(
+            'H',
+            &head,
+            &format!("head_exit=0\nhead_truncated=0\nhead_bytes={head_bytes}\n")
+        ),
+        framed_show_changes_test_block(
+            'T',
+            "",
+            "diff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=0\n"
+        )
+    );
+    if include_diff {
+        stdout.push_str(&framed_show_changes_test_block(
+            'D',
+            "",
+            "diff_exit=0\ndiff_hunks_returned=0\ndiff_hunks_truncated=0\ndiff_trunc_hunk_count=0\ndiff_trunc_hunk_lines=0\ndiff_trunc_bytes=0\ndiff_bytes=0\n",
+        ));
+    }
+    stdout
+}
+
 fn parse_framed_show_changes_stdout(stdout: &str, include_diff: bool) -> Option<ShowChangesStdout> {
     let mut cursor = stdout.len();
     let (diff, diff_meta) = if include_diff {
@@ -804,144 +846,7 @@ fn parse_framed_show_changes_stdout(stdout: &str, include_diff: bool) -> Option<
 }
 
 pub(crate) fn split_show_changes_stdout(stdout: &str, include_diff: bool) -> ShowChangesStdout {
-    if let Some(frames) = parse_framed_show_changes_stdout(stdout, include_diff) {
-        return frames;
-    }
-
-    // Legacy delimiter framing remains readable for graceful degradation only.
-    // It can never prove transport safety because Git data may contain the delimiter.
-    let frames: Vec<String> = stdout
-        .split(SHOW_CHANGES_SENTINEL)
-        .map(|part| part.trim_matches('\n').to_string())
-        .collect();
-    let status = frames.first().cloned().unwrap_or_default();
-    let second = frames.get(1).cloned().unwrap_or_default();
-    let mut head_exit = None;
-    let mut head_truncated = None;
-    let mut head_bytes = None;
-    let mut diff_stat_exit = None;
-    let mut diff_stat_truncated = None;
-    let mut diff_stat_bytes = None;
-    let mut diff_meta = String::new();
-    let head;
-    let stat;
-    let mut diff = String::new();
-
-    if second.starts_with("status_exit=") {
-        let status_result = second;
-        head = frames.get(2).cloned().unwrap_or_default();
-        if let Some(meta) = frames.get(3).filter(|meta| meta.starts_with("head_exit=")) {
-            head_exit = parse_status_result_field(meta, "head_exit").and_then(|v| v.parse().ok());
-            head_truncated = parse_optional_bool(meta, "head_truncated");
-            head_bytes = parse_optional_usize(meta, "head_bytes");
-        }
-        stat = frames.get(4).cloned().unwrap_or_default();
-        if let Some(meta) = frames
-            .get(5)
-            .filter(|meta| meta.starts_with("diff_stat_exit="))
-        {
-            diff_stat_exit =
-                parse_status_result_field(meta, "diff_stat_exit").and_then(|v| v.parse().ok());
-            diff_stat_truncated = parse_optional_bool(meta, "diff_stat_truncated");
-            diff_stat_bytes = parse_optional_usize(meta, "diff_stat_bytes");
-        }
-        if include_diff {
-            diff = frames.get(6).cloned().unwrap_or_default();
-            diff_meta = frames.get(7).cloned().unwrap_or_default();
-        }
-        return ShowChangesStdout {
-            framing_valid: false,
-            files_total: parse_optional_usize(&status_result, "files_total"),
-            files_returned: parse_optional_usize(&status_result, "files_returned"),
-            files_truncated: parse_optional_bool(&status_result, "files_truncated"),
-            files_limit: parse_optional_usize(&status_result, "files_limit"),
-            counts_modified: parse_optional_usize(&status_result, "modified"),
-            counts_added: parse_optional_usize(&status_result, "added"),
-            counts_deleted: parse_optional_usize(&status_result, "deleted"),
-            counts_renamed: parse_optional_usize(&status_result, "renamed"),
-            counts_copied: parse_optional_usize(&status_result, "copied"),
-            counts_untracked: parse_optional_usize(&status_result, "untracked"),
-            counts_conflicted: parse_optional_usize(&status_result, "conflicted"),
-            counts_staged: parse_optional_usize(&status_result, "staged"),
-            counts_unstaged: parse_optional_usize(&status_result, "unstaged"),
-            status_trunc_count: parse_optional_bool(&status_result, "status_trunc_count"),
-            status_trunc_bytes: parse_optional_bool(&status_result, "status_trunc_bytes"),
-            status_trunc_path: parse_optional_bool(&status_result, "status_trunc_path"),
-            status_bytes: parse_optional_usize(&status_result, "status_bytes"),
-            head_exit,
-            head_truncated,
-            head_bytes,
-            diff_stat_exit,
-            diff_stat_truncated,
-            diff_stat_bytes,
-            diff_hunks_returned: parse_optional_usize(&diff_meta, "diff_hunks_returned"),
-            diff_hunks_truncated: parse_optional_bool(&diff_meta, "diff_hunks_truncated"),
-            diff_trunc_hunk_count: parse_optional_bool(&diff_meta, "diff_trunc_hunk_count"),
-            diff_trunc_hunk_lines: parse_optional_bool(&diff_meta, "diff_trunc_hunk_lines"),
-            diff_trunc_bytes: parse_optional_bool(&diff_meta, "diff_trunc_bytes"),
-            diff_exit: parse_status_result_field(&diff_meta, "diff_exit")
-                .and_then(|v| v.parse().ok()),
-            diff_bytes: parse_optional_usize(&diff_meta, "diff_bytes"),
-            status,
-            status_result,
-            head,
-            stat,
-            diff,
-        };
-    }
-
-    let status_result = if status
-        .lines()
-        .any(|line| parse_status_header(line).is_some())
-    {
-        "status_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0".to_string()
-    } else {
-        String::new()
-    };
-    head = second;
-    stat = frames.get(2).cloned().unwrap_or_default();
-    if include_diff {
-        diff = frames.get(3).cloned().unwrap_or_default();
-        diff_meta = frames.get(4).cloned().unwrap_or_default();
-    }
-    ShowChangesStdout {
-        framing_valid: false,
-        files_total: parse_optional_usize(&status_result, "files_total"),
-        files_returned: parse_optional_usize(&status_result, "files_returned"),
-        files_truncated: parse_optional_bool(&status_result, "files_truncated"),
-        files_limit: parse_optional_usize(&status_result, "files_limit"),
-        counts_modified: parse_optional_usize(&status_result, "modified"),
-        counts_added: parse_optional_usize(&status_result, "added"),
-        counts_deleted: parse_optional_usize(&status_result, "deleted"),
-        counts_renamed: parse_optional_usize(&status_result, "renamed"),
-        counts_copied: parse_optional_usize(&status_result, "copied"),
-        counts_untracked: parse_optional_usize(&status_result, "untracked"),
-        counts_conflicted: parse_optional_usize(&status_result, "conflicted"),
-        counts_staged: parse_optional_usize(&status_result, "staged"),
-        counts_unstaged: parse_optional_usize(&status_result, "unstaged"),
-        status_trunc_count: None,
-        status_trunc_bytes: None,
-        status_trunc_path: None,
-        status_bytes: None,
-        head_exit,
-        head_truncated,
-        head_bytes,
-        diff_stat_exit,
-        diff_stat_truncated,
-        diff_stat_bytes,
-        diff_hunks_returned: parse_optional_usize(&diff_meta, "diff_hunks_returned"),
-        diff_hunks_truncated: parse_optional_bool(&diff_meta, "diff_hunks_truncated"),
-        diff_trunc_hunk_count: parse_optional_bool(&diff_meta, "diff_trunc_hunk_count"),
-        diff_trunc_hunk_lines: parse_optional_bool(&diff_meta, "diff_trunc_hunk_lines"),
-        diff_trunc_bytes: parse_optional_bool(&diff_meta, "diff_trunc_bytes"),
-        diff_exit: parse_status_result_field(&diff_meta, "diff_exit").and_then(|v| v.parse().ok()),
-        diff_bytes: parse_optional_usize(&diff_meta, "diff_bytes"),
-        status,
-        status_result,
-        head,
-        stat,
-        diff,
-    }
+    parse_framed_show_changes_stdout(stdout, include_diff).unwrap_or_default()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1067,26 +972,11 @@ fn parse_show_changes_head(head: &str) -> serde_json::Value {
             "summary": summary,
         });
     }
-
-    // Compatibility with legacy/in-flight output produced before the
-    // newline-labelled HEAD frame replaced the NUL-separated record.
-    let mut parts = head.splitn(3, '\0');
-    let commit = parts.next().unwrap_or_default().trim();
-    let short = parts.next().unwrap_or_default().trim();
-    let summary = parts.next().unwrap_or_default().trim();
-    if commit.is_empty() {
-        json!({
-            "commit": null,
-            "short": null,
-            "summary": null,
-        })
-    } else {
-        json!({
-            "commit": commit,
-            "short": if short.is_empty() { commit.chars().take(7).collect::<String>() } else { short.to_string() },
-            "summary": summary,
-        })
-    }
+    json!({
+        "commit": null,
+        "short": null,
+        "summary": null,
+    })
 }
 
 fn frame_bytes_match(value: &str, reported: Option<usize>, budget: usize) -> bool {

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -24,6 +24,8 @@ mod file_listing;
 mod file_tools;
 pub(crate) mod files;
 mod git;
+#[cfg(test)]
+pub(crate) use git::{framed_clean_show_changes_test_stdout, framed_show_changes_test_block};
 mod git_committed;
 mod git_review;
 mod git_tools;

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -1323,13 +1323,30 @@ async fn finish_coding_task_requires_explicit_session_and_returns_structured_fie
     });
     let req = wait_for_patch_agent_request(&runtime, "coding-finish").await;
     assert_internal_posix_script_contains(&req, "git status --porcelain=v1 -b");
-    let show_changes_stdout = "## main\n M README.md\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nstatus_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=1\nfiles_returned=1\nfiles_truncated=0\nfiles_limit=200\nmodified=1\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=0\nconflicted=0\nstaged=0\nunstaged=1\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=20\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ncommit=abc123\nshort=abc123\nsummary=add readme\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nhead_exit=0\nhead_truncated=0\nhead_bytes=45\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n README.md | 1 +\n 1 file changed, 1 insertion(+)\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ndiff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=52\n";
+    let show_changes_stdout = format!(
+        "{}{}{}",
+        crate::tool_runtime::framed_show_changes_test_block(
+            'S',
+            "## main\n M README.md\n",
+            "status_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=1\nfiles_returned=1\nfiles_truncated=0\nfiles_limit=200\nmodified=1\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=0\nconflicted=0\nstaged=0\nunstaged=1\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=20\n"
+        ),
+        crate::tool_runtime::framed_show_changes_test_block(
+            'H',
+            "commit=abc123\nshort=abc123\nsummary=add readme\n",
+            "head_exit=0\nhead_truncated=0\nhead_bytes=45\n"
+        ),
+        crate::tool_runtime::framed_show_changes_test_block(
+            'T',
+            " README.md | 1 +\n 1 file changed, 1 insertion(+)\n",
+            "diff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=52\n"
+        )
+    );
     complete_patch_agent_request(
         &runtime,
         "coding-finish",
         &req.request_id,
         0,
-        show_changes_stdout,
+        &show_changes_stdout,
         "",
     )
     .await;
@@ -3456,12 +3473,14 @@ async fn finish_coding_task_jobs_projection(fixture: &FinishSummaryFixture) -> T
     });
     let request = wait_for_patch_agent_request(&fixture.runtime, fixture.client_id).await;
     assert_internal_posix_script_contains(&request, "git status --porcelain=v1 -b");
+    let show_changes_stdout =
+        crate::tool_runtime::framed_clean_show_changes_test_stdout("add readme", false);
     complete_patch_agent_request(
         &fixture.runtime,
         fixture.client_id,
         &request.request_id,
         0,
-        "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0add readme\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n",
+        &show_changes_stdout,
         "",
     )
     .await;

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -147,12 +147,14 @@ async fn write_project_file_with_session_id_records_changed_path_without_content
     });
     let req = wait_for_patch_agent_request(&runtime, "telemetry-write").await;
     assert_internal_posix_script_contains(&req, "git status --porcelain=v1 -b");
+    let show_changes_stdout =
+        crate::tool_runtime::framed_clean_show_changes_test_stdout("write", false);
     complete_patch_agent_request(
         &runtime,
         "telemetry-write",
         &req.request_id,
         0,
-        "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0write\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n",
+        &show_changes_stdout,
         "",
     )
     .await;

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -3112,10 +3112,8 @@ async fn show_changes_include_diff_agent_command_does_not_enqueue_python_helper(
         payload.script
     );
     assert!(payload.script.contains("git diff --unified=80"));
-    // Modern frame layout: status, status-result, head, head-meta, stat,
-    // stat-meta, diff, diff-meta (with diff_exit=0 so success is provable).
-    let stdout = "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nstatus_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=0\nfiles_returned=0\nfiles_truncated=0\nfiles_limit=200\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0head\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nhead_exit=0\nhead_truncated=0\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ndiff_stat_exit=0\ndiff_stat_truncated=0\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ndiff_exit=0\ndiff_hunks_returned=0\ndiff_hunks_truncated=0\ndiff_trunc_hunk_count=0\ndiff_trunc_hunk_lines=0\ndiff_trunc_bytes=0\ndiff_bytes=0\n";
-    complete_patch_agent_request(&runtime, "show-native", &req.request_id, 0, stdout, "").await;
+    let stdout = framed_clean_show_changes_test_stdout("head", true);
+    complete_patch_agent_request(&runtime, "show-native", &req.request_id, 0, &stdout, "").await;
     let result = task.await.unwrap();
 
     assert!(result.success, "{:?}", result.error);
@@ -3127,7 +3125,7 @@ fn show_changes_clean_worktree() {
     let output = parse_show_changes_output(
             "agent:oe:webcodex",
             "## main...origin/main",
-            "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix: route anchor edit file ops through agent dispatch",
+            "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix: route anchor edit file ops through agent dispatch",
             "",
             None,
             20,
@@ -3153,7 +3151,7 @@ fn show_changes_without_session_id_treats_dirty_workspace_as_advisory() {
     let mut output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main\n M src/lib.rs",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         " src/lib.rs | 2 +-",
         None,
         20,
@@ -3207,7 +3205,7 @@ fn show_changes_with_session_id_includes_session_summary() {
     let mut output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main\n M src/foo.rs",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         " src/foo.rs | 2 +-",
         None,
         20,
@@ -3240,7 +3238,7 @@ fn show_changes_with_missing_session_id_returns_warning_not_panic() {
     let mut output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         "",
         None,
         20,
@@ -3278,7 +3276,7 @@ fn show_changes_session_changed_paths_are_deduped() {
     let mut output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main\n M src/foo.rs",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         " src/foo.rs | 2 +-",
         None,
         20,
@@ -3326,8 +3324,8 @@ async fn show_changes_session_event_limit_is_bounded() {
             .await
     });
     let req = wait_for_patch_agent_request(&runtime, "show").await;
-    let stdout = "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nstatus_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=0\nfiles_returned=0\nfiles_truncated=0\nfiles_limit=200\nmodified=0\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=0\nconflicted=0\nstaged=0\nunstaged=0\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=7\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ncommit=abc123\nshort=abc123\nsummary=head\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nhead_exit=0\nhead_truncated=0\nhead_bytes=39\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ndiff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=0\n";
-    complete_patch_agent_request(&runtime, "show", &req.request_id, 0, stdout, "").await;
+    let stdout = framed_clean_show_changes_test_stdout("head", false);
+    complete_patch_agent_request(&runtime, "show", &req.request_id, 0, &stdout, "").await;
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
     let len = result.output["session"]["recent_events"]
@@ -3342,7 +3340,7 @@ fn show_changes_reports_modified_file() {
     let output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main\n M src/users_http.rs",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         " src/users_http.rs | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)",
         None,
         20,
@@ -3369,7 +3367,7 @@ fn show_changes_reports_untracked_file() {
     let output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main\n?? webcodex-anchor-edit-smoke-c99f7de.txt",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         "",
         None,
         20,
@@ -3397,7 +3395,7 @@ fn show_changes_reports_conflicted_file() {
     let output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main\nUU conflicted.rs",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         "",
         None,
         20,
@@ -3451,7 +3449,7 @@ index 1111111..2222222 100644
     let output = parse_show_changes_output(
         "agent:oe:webcodex",
         "## main\n M src/lib.rs",
-        "b47e4fb000000000000000000000000000000000\0b47e4fb\0fix",
+        "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=fix",
         " src/lib.rs | 4 ++--",
         Some(diff),
         1,
@@ -3667,8 +3665,25 @@ async fn show_changes_with_session_id_returns_session_block_and_records_call() {
         }
     });
     let req = wait_for_patch_agent_request(&runtime, "telemetry-show").await;
-    let stdout = "## main\n M README.md\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nstatus_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=1\nfiles_returned=1\nfiles_truncated=0\nfiles_limit=200\nmodified=1\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=0\nconflicted=0\nstaged=0\nunstaged=1\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=20\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ncommit=abc123\nshort=abc123\nsummary=head\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nhead_exit=0\nhead_truncated=0\nhead_bytes=39\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nREADME.md | 1 +\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ndiff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=15\n";
-    complete_patch_agent_request(&runtime, "telemetry-show", &req.request_id, 0, stdout, "").await;
+    let stdout = format!(
+        "{}{}{}",
+        framed_block(
+            'S',
+            "## main\n M README.md\n",
+            "status_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=1\nfiles_returned=1\nfiles_truncated=0\nfiles_limit=200\nmodified=1\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=0\nconflicted=0\nstaged=0\nunstaged=1\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=20\n"
+        ),
+        framed_block(
+            'H',
+            "commit=abc123\nshort=abc123\nsummary=head\n",
+            "head_exit=0\nhead_truncated=0\nhead_bytes=39\n"
+        ),
+        framed_block(
+            'T',
+            "README.md | 1 +\n",
+            "diff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=15\n"
+        )
+    );
+    complete_patch_agent_request(&runtime, "telemetry-show", &req.request_id, 0, &stdout, "").await;
     let result = show_task.await.unwrap();
 
     assert!(result.success, "{:?}", result.error);
@@ -3717,7 +3732,7 @@ async fn show_changes_accepts_unique_short_id() {
     });
     let req = wait_for_agent_request_for_client(&runtime, "workstation").await;
     assert_eq!(req.cwd.as_deref(), Some("/root/git/workstation-other-repo"));
-    let stdout = "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nstatus_exit=0\nrepository_probe=inside_worktree\nrepository_probe_exit=0\nfiles_total=0\nfiles_returned=0\nfiles_truncated=0\nfiles_limit=200\nmodified=0\nadded=0\ndeleted=0\nrenamed=0\ncopied=0\nuntracked=0\nconflicted=0\nstaged=0\nunstaged=0\nstatus_trunc_count=0\nstatus_trunc_bytes=0\nstatus_trunc_path=0\nstatus_bytes=7\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ncommit=abc123\nshort=abc123\nsummary=head\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nhead_exit=0\nhead_truncated=0\nhead_bytes=39\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n\n@@WEBCODEX_SHOW_CHANGES_SEP@@\ndiff_stat_exit=0\ndiff_stat_truncated=0\ndiff_stat_bytes=0\n";
+    let stdout = framed_clean_show_changes_test_stdout("head", false);
     runtime
         .shell_clients
         .complete(ShellAgentResultRequest {
@@ -3725,7 +3740,7 @@ async fn show_changes_accepts_unique_short_id() {
             agent_instance_id: "inst-workstation".to_string(),
             request_id: req.request_id,
             exit_code: Some(0),
-            stdout: Some(stdout.to_string()),
+            stdout: Some(stdout),
             stderr: Some(String::new()),
             duration_ms: Some(1),
             error: None,
@@ -4884,11 +4899,7 @@ async fn run_show_changes_via_agent(
 }
 
 fn framed_block(kind: char, body: &str, metadata: &str) -> String {
-    format!(
-        "{body}{metadata}WCSF1:{kind}:{:010}:{:010}\n",
-        body.len(),
-        metadata.len()
-    )
+    crate::tool_runtime::git::framed_show_changes_test_block(kind, body, metadata)
 }
 
 #[test]
@@ -4954,6 +4965,26 @@ fn show_changes_modern_framing_requires_exact_blocks_and_tail() {
         framed_block('T', "", "diff_stat_exit=0\n")
     );
     assert!(split_show_changes_stdout(&synthetic, false).framing_valid);
+
+    let legacy = "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0head\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n";
+    let legacy_frames = split_show_changes_stdout(legacy, false);
+    assert!(!legacy_frames.framing_valid);
+    assert!(legacy_frames.status.is_empty());
+    assert!(legacy_frames.head.is_empty());
+    let legacy_head = parse_show_changes_output(
+        "demo",
+        "## main",
+        "abc123\0abc123\0head",
+        "",
+        None,
+        20,
+        80,
+        Some(0),
+        "",
+    );
+    assert!(legacy_head["head"]["commit"].is_null());
+    assert!(legacy_head["head"]["short"].is_null());
+    assert!(legacy_head["head"]["summary"].is_null());
 }
 
 #[tokio::test]
@@ -5445,7 +5476,7 @@ fn show_changes_parses_upstream_observation_states() {
         parse_show_changes_output(
             "agent:oe:webcodex",
             status,
-            "b47e4fb000000000000000000000000000000000\0b47e4fb\0head",
+            "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=head",
             "",
             None,
             20,
@@ -5505,7 +5536,7 @@ fn show_changes_parses_unborn_and_detached_branch_headers() {
         let output = parse_show_changes_output(
             "agent:oe:webcodex",
             status,
-            "b47e4fb000000000000000000000000000000000\0b47e4fb\0head",
+            "commit=b47e4fb000000000000000000000000000000000\nshort=b47e4fb\nsummary=head",
             "",
             None,
             20,
@@ -6182,12 +6213,7 @@ async fn show_changes_runtime_rejects_unavailable_diff_stat_observation() {
         .expect("show_changes must carry a typed internal script");
     let (command_exit, stdout, stderr) = run_command_full_capture(&payload.script, repo.path(), 30);
     assert_eq!(command_exit, 0, "show_changes command failed: {stderr}");
-    let mut missing_stat_exit = stdout
-        .lines()
-        .filter(|line| !line.starts_with("diff_stat_exit="))
-        .collect::<Vec<_>>()
-        .join("\n");
-    missing_stat_exit.push('\n');
+    let missing_stat_exit = stdout.replacen("diff_stat_exit=0", "xiff_stat_exit=0", 1);
     complete_patch_agent_request(
         &runtime,
         "stat-missing",

--- a/src/tool_runtime/tests/schema/annotations.rs
+++ b/src/tool_runtime/tests/schema/annotations.rs
@@ -101,6 +101,25 @@ fn tool_specs_annotations_are_canonical_semantic_projections() {
         "import_conversation_files_to_project",
         "artifact_upload_finish",
         "artifact_upload_abort",
+        "assign_agent_task",
+        "reconcile_agent_task_coding_run",
+        "heartbeat_agent_task_attempt",
+        "complete_agent_task_attempt",
+        "update_agent_identity",
+        "attach_agent_endpoint",
+        "detach_agent_endpoint",
+        "consume_agent_deliveries",
+        "consume_agent_wake",
+        "coding_agent_cancel",
+        "computer_write_clipboard",
+        "computer_pointer_click",
+        "computer_control",
+        "computer_key_input",
+        "update_session_context",
+        "close_session",
+        "resolve_session_message",
+        "complete_session_message",
+        "cargo_fmt",
     ] {
         let metadata = crate::tool_runtime::metadata::lookup_tool_metadata(name).unwrap();
         assert!(metadata.destructive, "{name}");
@@ -116,6 +135,12 @@ fn tool_specs_annotations_are_canonical_semantic_projections() {
         "artifact_upload_begin",
         "artifact_upload_chunk",
         "computer_save_snapshot",
+        "start_agent_task_attempt",
+        "create_conversation",
+        "post_conversation_message",
+        "post_session_message",
+        "work_on_project",
+        "cargo_check",
     ] {
         let metadata = crate::tool_runtime::metadata::lookup_tool_metadata(name).unwrap();
         assert!(!metadata.destructive, "{name}");

--- a/src/tool_runtime/tests/schema/annotations.rs
+++ b/src/tool_runtime/tests/schema/annotations.rs
@@ -91,6 +91,41 @@ fn tool_specs_annotations_are_canonical_semantic_projections() {
         );
     }
 
+    for name in [
+        "apply_patch",
+        "apply_text_edits",
+        "apply_unified_diff",
+        "write_project_file",
+        "workspace_checkpoint_restore",
+        "save_project_artifact",
+        "import_conversation_files_to_project",
+        "artifact_upload_finish",
+        "artifact_upload_abort",
+    ] {
+        let metadata = crate::tool_runtime::metadata::lookup_tool_metadata(name).unwrap();
+        assert!(metadata.destructive, "{name}");
+        assert_eq!(
+            spec_named(&specs, name).annotations["destructiveHint"],
+            true,
+            "{name} may replace, restore, delete, or discard existing state"
+        );
+    }
+
+    for name in [
+        "workspace_checkpoint_create",
+        "artifact_upload_begin",
+        "artifact_upload_chunk",
+        "computer_save_snapshot",
+    ] {
+        let metadata = crate::tool_runtime::metadata::lookup_tool_metadata(name).unwrap();
+        assert!(!metadata.destructive, "{name}");
+        assert_eq!(
+            spec_named(&specs, name).annotations["destructiveHint"],
+            false,
+            "{name} is intentionally additive-only"
+        );
+    }
+
     let close = crate::tool_runtime::metadata::lookup_tool_metadata("close_session").unwrap();
     assert_eq!(close.approval, ToolApprovalPolicy::None);
     assert_eq!(close.risk, ToolRisk::SessionCollaborate);

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -414,6 +414,7 @@ fn tool_definitions_drive_session_and_permission_policy() {
     );
 
     for (tool, risk) in [
+        ("cargo_fmt", PERMISSION_RISK_VALIDATION),
         ("cargo_check", PERMISSION_RISK_VALIDATION),
         ("run_process", PERMISSION_RISK_SHELL),
         ("run_script", PERMISSION_RISK_SHELL),
@@ -435,6 +436,24 @@ fn tool_definitions_drive_session_and_permission_policy() {
         ("workspace_checkpoint_restore", PERMISSION_RISK_PATCH),
         ("write_project_file", PERMISSION_RISK_WRITE),
         ("apply_text_edits", PERMISSION_RISK_WRITE),
+        ("assign_agent_task", PERMISSION_RISK_WRITE),
+        ("reconcile_agent_task_coding_run", PERMISSION_RISK_WRITE),
+        ("heartbeat_agent_task_attempt", PERMISSION_RISK_WRITE),
+        ("complete_agent_task_attempt", PERMISSION_RISK_WRITE),
+        ("update_agent_identity", PERMISSION_RISK_WRITE),
+        ("attach_agent_endpoint", PERMISSION_RISK_WRITE),
+        ("detach_agent_endpoint", PERMISSION_RISK_WRITE),
+        ("consume_agent_deliveries", PERMISSION_RISK_WRITE),
+        ("consume_agent_wake", PERMISSION_RISK_WRITE),
+        ("coding_agent_cancel", PERMISSION_RISK_WRITE),
+        ("computer_write_clipboard", PERMISSION_RISK_WRITE),
+        ("computer_pointer_click", PERMISSION_RISK_WRITE),
+        ("computer_control", PERMISSION_RISK_WRITE),
+        ("computer_key_input", PERMISSION_RISK_WRITE),
+        ("update_session_context", PERMISSION_RISK_WRITE),
+        ("close_session", PERMISSION_RISK_WRITE),
+        ("resolve_session_message", PERMISSION_RISK_WRITE),
+        ("complete_session_message", PERMISSION_RISK_WRITE),
     ] {
         assert_eq!(runtime_tool_permission_risk(tool), risk, "{tool}");
     }

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -423,10 +423,18 @@ fn tool_definitions_drive_session_and_permission_policy() {
         ("close_session_shell", PERMISSION_RISK_JOB),
         ("delete_project_files", PERMISSION_RISK_DESTRUCTIVE),
         ("save_project_artifact", PERMISSION_RISK_ARTIFACT_WRITE),
+        (
+            "import_conversation_files_to_project",
+            PERMISSION_RISK_ARTIFACT_WRITE,
+        ),
+        ("artifact_upload_finish", PERMISSION_RISK_ARTIFACT_WRITE),
+        ("artifact_upload_abort", PERMISSION_RISK_ARTIFACT_WRITE),
         ("computer_save_snapshot", PERMISSION_RISK_ARTIFACT_WRITE),
         ("apply_patch", PERMISSION_RISK_PATCH),
         ("apply_unified_diff", PERMISSION_RISK_PATCH),
+        ("workspace_checkpoint_restore", PERMISSION_RISK_PATCH),
         ("write_project_file", PERMISSION_RISK_WRITE),
+        ("apply_text_edits", PERMISSION_RISK_WRITE),
     ] {
         assert_eq!(runtime_tool_permission_risk(tool), risk, "{tool}");
     }

--- a/src/tool_runtime/tests/sessions.rs
+++ b/src/tool_runtime/tests/sessions.rs
@@ -792,12 +792,14 @@ async fn finish_coding_task_does_not_auto_close_session() {
         }
     });
     let req = wait_for_patch_agent_request(&runtime, "coding-finish-no-close").await;
+    let show_changes_stdout =
+        crate::tool_runtime::framed_clean_show_changes_test_stdout("add readme", false);
     complete_patch_agent_request(
         &runtime,
         "coding-finish-no-close",
         &req.request_id,
         0,
-        "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0add readme\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n",
+        &show_changes_stdout,
         "",
     )
     .await;

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -2458,12 +2458,14 @@ async fn finish_coding_task_validation_available_when_ledger_has_validation_even
     });
     let req = wait_for_patch_agent_request(&runtime, "validation-finish").await;
     assert_internal_posix_script_contains(&req, "git status --porcelain=v1 -b");
+    let show_changes_stdout =
+        crate::tool_runtime::framed_clean_show_changes_test_stdout("add lib", false);
     complete_patch_agent_request(
         &runtime,
         "validation-finish",
         &req.request_id,
         0,
-        "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0add lib\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n",
+        &show_changes_stdout,
         "",
     )
     .await;
@@ -2570,12 +2572,14 @@ async fn finish_coding_task_validation_available_when_ledger_has_validation_even
         }
     });
     let req = wait_for_patch_agent_request(&runtime, "validation-finish").await;
+    let show_changes_stdout =
+        crate::tool_runtime::framed_clean_show_changes_test_stdout("add lib", false);
     complete_patch_agent_request(
         &runtime,
         "validation-finish",
         &req.request_id,
         0,
-        "## main\n@@WEBCODEX_SHOW_CHANGES_SEP@@\nabc123\0abc123\0add lib\n@@WEBCODEX_SHOW_CHANGES_SEP@@\n",
+        &show_changes_stdout,
         "",
     )
     .await;

--- a/src/tool_runtime/tool_definition/agent_tasks.rs
+++ b/src/tool_runtime/tool_definition/agent_tasks.rs
@@ -2,7 +2,7 @@ use super::AgentCapability::CodingAgentRuns;
 use super::ToolVisibility::ModelVisible;
 use super::{
     def, model_spec, permission_risk, require_all_scopes, ToolDefinition, PERMISSION_RISK_JOB,
-    TOOL_CATEGORY_AGENT_TASK,
+    PERMISSION_RISK_WRITE, TOOL_CATEGORY_AGENT_TASK,
 };
 use crate::auth::scopes::{COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES};
 use crate::tool_runtime::metadata::{
@@ -96,7 +96,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         COMMUNICATION_READ_SCOPES,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "assign_agent_task",
                 ModelVisible,
@@ -112,11 +113,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Explicitly assign or reassign an owned AgentTask to an owned durable Agent. A live unexpired Attempt fences reassignment; lease expiry never transfers work automatically. Assignment grants no Project or executor authority.",
             assign_agent_task_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),
@@ -178,9 +181,10 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ),
         PERMISSION_RISK_JOB,
     ),
-    model_spec(
-        require_all_scopes(
-            def(
+    permission_risk(
+        model_spec(
+            require_all_scopes(
+                def(
                 "reconcile_agent_task_coding_run",
                 ModelVisible,
                 TOOL_CATEGORY_AGENT_TASK,
@@ -195,16 +199,19 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
+                true,
                 false,
-                false,
+                ),
+                &[COMMUNICATION_READ, COMMUNICATION_MANAGE, CODING_AGENT_RUN],
             ),
-            &[COMMUNICATION_READ, COMMUNICATION_MANAGE, CODING_AGENT_RUN],
+            "Reconcile only the exact CodingAgentRun already durably bound to one owned AgentTaskAttempt. It never starts execution, chooses a provider, changes intent, or requires the old browser's Attempt fence. Authoritative Completed/Failed/Cancelled truth can terminalize the exact latest bound Attempt even after its ordinary lease expires; Lost remains outcome_unknown.",
+            reconcile_agent_task_coding_run_input_schema,
         ),
-        "Reconcile only the exact CodingAgentRun already durably bound to one owned AgentTaskAttempt. It never starts execution, chooses a provider, changes intent, or requires the old browser's Attempt fence. Authoritative Completed/Failed/Cancelled truth can terminalize the exact latest bound Attempt even after its ordinary lease expires; Lost remains outcome_unknown.",
-        reconcile_agent_task_coding_run_input_schema,
+        PERMISSION_RISK_WRITE,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "heartbeat_agent_task_attempt",
                 ModelVisible,
@@ -220,16 +227,19 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Renew only the exact latest unexpired AgentTaskAttempt identified by task, attempt, assignee, opaque fence, and current Attempt-local controller generation. Expired, superseded, wrong-generation, or wrong-fence Attempts remain stale and cannot be revived.",
             heartbeat_agent_task_attempt_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "complete_agent_task_attempt",
                 ModelVisible,
@@ -245,11 +255,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Commit terminal success or failure only from the exact latest unexpired AgentTaskAttempt with matching assignee, fence, and controller generation. Completion is independently keyed: exact retry replays once, changed reuse conflicts, and stale Attempts cannot write Task truth.",
             complete_agent_task_attempt_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),

--- a/src/tool_runtime/tool_definition/artifacts.rs
+++ b/src/tool_runtime/tool_definition/artifacts.rs
@@ -1,7 +1,8 @@
 use super::AgentCapability::{FileRead, FileWrite};
 use super::ToolVisibility::ModelVisible;
 use super::{
-    def, model_spec, requires_artifact_upload_path_binding, ToolDefinition, TOOL_CATEGORY_ARTIFACT,
+    def, model_spec, permission_risk, requires_artifact_upload_path_binding, ToolDefinition,
+    PERMISSION_RISK_ARTIFACT_WRITE, TOOL_CATEGORY_ARTIFACT,
 };
 use crate::tool_runtime::metadata::{
     ToolPathHint::Artifact,
@@ -17,8 +18,9 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
-    model_spec(
-        def(
+    permission_risk(
+        model_spec(
+            def(
             "save_project_artifact",
             ModelVisible,
             TOOL_CATEGORY_ARTIFACT,
@@ -33,14 +35,17 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(PROJECT_WRITE),
             true,
             Artifact,
+            true,
             false,
-            false,
+            ),
+            "Write a bounded binary project artifact from base64. Use for imported session files, generated images, PDFs, ZIP archives, and DOCX/PPTX/XLSX Office artifacts; not for UTF-8 source edits.",
+            save_project_artifact_input_schema,
         ),
-        "Write a bounded binary project artifact from base64. Use for imported session files, generated images, PDFs, ZIP archives, and DOCX/PPTX/XLSX Office artifacts; not for UTF-8 source edits.",
-        save_project_artifact_input_schema,
+        PERMISSION_RISK_ARTIFACT_WRITE,
     ),
-    model_spec(
-        def(
+    permission_risk(
+        model_spec(
+            def(
             "import_conversation_files_to_project",
             ModelVisible,
             TOOL_CATEGORY_ARTIFACT,
@@ -55,11 +60,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(PROJECT_WRITE),
             true,
             Artifact,
+            true,
             false,
-            false,
+            ),
+            "Import 1..10 current ChatGPT attachments into an agent project using openaiFileIdRefs from the host file-reference mechanism. Do not base64-transfer files, construct download URLs, or use local /mnt/data paths; Control downloads and saves them as project artifacts.",
+            import_conversation_files_to_project_input_schema,
         ),
-        "Import 1..10 current ChatGPT attachments into an agent project using openaiFileIdRefs from the host file-reference mechanism. Do not base64-transfer files, construct download URLs, or use local /mnt/data paths; Control downloads and saves them as project artifacts.",
-        import_conversation_files_to_project_input_schema,
+        PERMISSION_RISK_ARTIFACT_WRITE,
     ),
     model_spec(
         def(
@@ -171,8 +178,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Append one base64 chunk up to 1 MiB decoded to an active artifact upload. path is required and must exactly match artifact_upload_begin; this binds upload_id to the target path.",
         artifact_upload_chunk_input_schema,
     )),
-    requires_artifact_upload_path_binding(model_spec(
-        def(
+    requires_artifact_upload_path_binding(permission_risk(
+        model_spec(
+            def(
             "artifact_upload_finish",
             ModelVisible,
             TOOL_CATEGORY_ARTIFACT,
@@ -187,14 +195,17 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(PROJECT_WRITE),
             true,
             Artifact,
+            true,
             false,
-            false,
+            ),
+            "Finish an active artifact upload. path is required and must exactly match artifact_upload_begin; this binds upload_id before atomic commit.",
+            artifact_upload_finish_input_schema,
         ),
-        "Finish an active artifact upload. path is required and must exactly match artifact_upload_begin; this binds upload_id before atomic commit.",
-        artifact_upload_finish_input_schema,
+        PERMISSION_RISK_ARTIFACT_WRITE,
     )),
-    requires_artifact_upload_path_binding(model_spec(
-        def(
+    requires_artifact_upload_path_binding(permission_risk(
+        model_spec(
+            def(
             "artifact_upload_abort",
             ModelVisible,
             TOOL_CATEGORY_ARTIFACT,
@@ -209,10 +220,12 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(PROJECT_WRITE),
             true,
             Artifact,
+            true,
             false,
-            false,
+            ),
+            "Abort an active artifact upload. path is required and must exactly match artifact_upload_begin; this binds upload_id before cleanup and reports final_file_exists without touching the final target.",
+            artifact_upload_abort_input_schema,
         ),
-        "Abort an active artifact upload. path is required and must exactly match artifact_upload_begin; this binds upload_id before cleanup and reports final_file_exists without touching the final target.",
-        artifact_upload_abort_input_schema,
+        PERMISSION_RISK_ARTIFACT_WRITE,
     )),
 ];

--- a/src/tool_runtime/tool_definition/checkpoints.rs
+++ b/src/tool_runtime/tool_definition/checkpoints.rs
@@ -1,6 +1,9 @@
 use super::AgentCapability::{FileRead, FileWrite, OwnerOnly};
 use super::ToolVisibility::ModelVisible;
-use super::{def, git_like, model_spec, ToolDefinition, TOOL_CATEGORY_CHECKPOINT};
+use super::{
+    def, git_like, model_spec, permission_risk, ToolDefinition, PERMISSION_RISK_PATCH,
+    TOOL_CATEGORY_CHECKPOINT,
+};
 use crate::tool_runtime::metadata::{
     ToolPathHint::{None as NoPath, Patch},
     ToolRisk::{ProjectWrite, Read},
@@ -78,8 +81,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Show bounded checkpoint metadata, file list, skipped files, and optional diff stat. Does not return full diff/content by default.",
         checkpoint_show_input_schema,
     ),
-    git_like(model_spec(
-        def(
+    git_like(permission_risk(
+        model_spec(
+            def(
             "workspace_checkpoint_restore",
             ModelVisible,
             TOOL_CATEGORY_CHECKPOINT,
@@ -94,11 +98,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(PROJECT_WRITE),
             true,
             Patch,
+            true,
             false,
-            false,
+            ),
+            "Restore a checkpoint after confirm=true. Requires matching HEAD and refuses unsafe current state rather than half-restoring.",
+            checkpoint_restore_input_schema,
         ),
-        "Restore a checkpoint after confirm=true. Requires matching HEAD and refuses unsafe current state rather than half-restoring.",
-        checkpoint_restore_input_schema,
+        PERMISSION_RISK_PATCH,
     )),
     model_spec(
         def(

--- a/src/tool_runtime/tool_definition/coding_agents.rs
+++ b/src/tool_runtime/tool_definition/coding_agents.rs
@@ -2,7 +2,7 @@ use super::AgentCapability::CodingAgentRuns;
 use super::ToolVisibility::ModelVisible;
 use super::{
     def, model_spec, permission_risk, require_all_scopes, ToolDefinition, PERMISSION_RISK_JOB,
-    TOOL_CATEGORY_CODING_AGENT,
+    PERMISSION_RISK_WRITE, TOOL_CATEGORY_CODING_AGENT,
 };
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath,
@@ -65,8 +65,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Observe bounded normalized events and lifecycle for one existing CodingAgentRun. Return the opaque token for only-new follow-ups; history loss/reset is explicit. Observation never starts, retries, or resumes ACP work.",
         coding_agent_observe_input_schema,
     ),
-    model_spec(
-        def(
+    permission_risk(
+        model_spec(
+            def(
             "coding_agent_cancel",
             ModelVisible,
             TOOL_CATEGORY_CODING_AGENT,
@@ -83,10 +84,12 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(CODING_AGENT_RUN),
             false,
             NoPath,
+            true,
             false,
-            false,
+            ),
+            "Request cancellation of one existing CodingAgentRun. This does not grant permission, retry a prompt, or create a replacement Run; observe the same run_id for authoritative terminal state.",
+            coding_agent_cancel_input_schema,
         ),
-        "Request cancellation of one existing CodingAgentRun. This does not grant permission, retry a prompt, or create a replacement Run; observe the same run_id for authoritative terminal state.",
-        coding_agent_cancel_input_schema,
+        PERMISSION_RISK_WRITE,
     ),
 ];

--- a/src/tool_runtime/tool_definition/communication.rs
+++ b/src/tool_runtime/tool_definition/communication.rs
@@ -1,5 +1,8 @@
 use super::ToolVisibility::ModelVisible;
-use super::{def, model_spec, require_all_scopes, ToolDefinition, TOOL_CATEGORY_COMMUNICATION};
+use super::{
+    def, model_spec, permission_risk, require_all_scopes, ToolDefinition, PERMISSION_RISK_WRITE,
+    TOOL_CATEGORY_COMMUNICATION,
+};
 use crate::auth::scopes::{COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES};
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath,
@@ -68,7 +71,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         COMMUNICATION_READ_SCOPES,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "update_agent_identity",
                 ModelVisible,
@@ -84,16 +88,19 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Update an owned Agent Card behind expected_profile_revision. Canonical agent_id never changes, and handle/display-name collisions remain allowed. On uncertain outcome, re-read the Agent instead of changing the revision fence blindly.",
             update_agent_identity_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "attach_agent_endpoint",
                 ModelVisible,
@@ -109,11 +116,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Attach a replacement Host/Client Endpoint to an owned durable Agent. The Server assigns a new monotonic controller generation and fences every older attachment. Public attachment is not wake-capable; only callable process-local Host adapter registration may enable continuation. Exact idempotency replay returns the original Endpoint.",
             attach_agent_endpoint_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),
@@ -143,7 +152,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         COMMUNICATION_MANAGE_SCOPES,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "detach_agent_endpoint",
                 ModelVisible,
@@ -159,11 +169,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Detach a principal-bound Agent Endpoint without deleting the durable Agent, Conversation transcript, or Inbox. Repeating the same detach is a safe desired-state retry; a new Endpoint may later attach the same agent_id.",
             detach_agent_endpoint_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),
@@ -293,7 +305,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         COMMUNICATION_READ_SCOPES,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "consume_agent_deliveries",
                 ModelVisible,
@@ -309,16 +322,19 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Mark exact deliveries consumed in an Agent Inbox proven by an active principal-bound Endpoint. This mutates recipient state only, never the append-only Message or Wake state. Repeating already-consumed ids is a safe desired-state retry.",
             consume_agent_deliveries_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "consume_agent_wake",
                 ModelVisible,
@@ -334,11 +350,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMMUNICATION_MANAGE),
                 false,
                 NoPath,
-                false,
+                true,
                 false,
             ),
             "Consume one exact durable Agent Wake continuation after accepting the resumed model turn. wake_id and consume_token identify the exact continuation, while endpoint_id and expected_controller_generation fence stale attachments. Repeating the same exact consume returns already_consumed without another state change. This operation never consumes Agent Inbox deliveries and grants no Project, filesystem, Runner, Task, or Workflow Session authority.",
             consume_agent_wake_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         COMMUNICATION_MANAGE_SCOPES,
     ),

--- a/src/tool_runtime/tool_definition/computer.rs
+++ b/src/tool_runtime/tool_definition/computer.rs
@@ -6,7 +6,8 @@ use super::AgentCapability::{
 };
 use super::ToolVisibility::ModelVisible;
 use super::{
-    def, model_spec, require_all_scopes, unit_arguments, ToolDefinition, TOOL_CATEGORY_COMPUTER,
+    def, model_spec, permission_risk, require_all_scopes, unit_arguments, ToolDefinition,
+    PERMISSION_RISK_WRITE, TOOL_CATEGORY_COMPUTER,
 };
 use crate::tool_runtime::metadata::{
     ToolPathHint::{Artifact, None},
@@ -55,7 +56,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         &[COMPUTER_READ, COMPUTER_CLIPBOARD_READ],
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "computer_write_clipboard",
                 ModelVisible,
@@ -71,11 +73,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMPUTER_CLIPBOARD_WRITE),
                 false,
                 None,
-                false,
+                true,
                 false,
             ),
             "Replace exact macOS or Windows clipboard with bounded Unicode text using NSPasteboardTypeString or CF_UNICODETEXT, clearing prior formats. Never pastes, focuses, activates, restores, retries, or reads back implicitly. Unknown outcomes require separate clipboard-read reconciliation.",
             computer_write_clipboard_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         &[COMPUTER_CONTROL, COMPUTER_CLIPBOARD_WRITE],
     ),
@@ -110,7 +114,8 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         ],
     ),
     require_all_scopes(
-        model_spec(
+        permission_risk(
+            model_spec(
             def(
                 "computer_pointer_click",
                 ModelVisible,
@@ -126,11 +131,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(COMPUTER_POINTER_CONTROL),
                 false,
                 None,
-                false,
+                true,
                 false,
             ),
             "Send a macOS or Windows left click at exact display-local source coordinates using the unspent snapshot generation. Held mouse/modifier state fails closed. No other buttons, double click, drag, implicit snapshot, fallback, or retry; reconcile unknown outcomes with fresh computer_snapshot_display.",
             computer_pointer_input_schema,
+            ),
+            PERMISSION_RISK_WRITE,
         ),
         &[
             COMPUTER_READ,
@@ -362,8 +369,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Activate and raise one exact previously observed macOS or Windows window surface. The tool accepts no app name, PID, path, bundle, command, or fallback target. Stale surfaces fail closed; if delivery may have occurred but the response is lost, observe current UI state before retrying.",
         computer_activate_window_input_schema,
     ),
-    model_spec(
-        def(
+    permission_risk(
+        model_spec(
+            def(
             "computer_control",
             ModelVisible,
             TOOL_CATEGORY_COMPUTER,
@@ -378,11 +386,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(COMPUTER_CONTROL),
             false,
             None,
+            true,
             false,
-            false,
+            ),
+            "Perform native macOS Accessibility or Windows UI Automation press/focus on an exact reusable element_id. Stale, protected, disabled, or unsupported targets fail closed. There is no script, shell, coordinate, or generic fallback; uncertain post-dispatch outcomes require re-observation.",
+            computer_control_input_schema,
         ),
-        "Perform native macOS Accessibility or Windows UI Automation press/focus on an exact reusable element_id. Stale, protected, disabled, or unsupported targets fail closed. There is no script, shell, coordinate, or generic fallback; uncertain post-dispatch outcomes require re-observation.",
-        computer_control_input_schema,
+        PERMISSION_RISK_WRITE,
     ),
     model_spec(
         def(
@@ -406,8 +416,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Scroll one exact macOS Accessibility or Windows UIA element into view with the native semantic scroll action. Stale, mismatched, unsupported, or protected targets fail closed; no wheel, coordinate, script, or shell fallback. Unknown post-dispatch outcomes require re-observation before retrying.",
         computer_scroll_to_element_input_schema,
     ),
-    model_spec(
-        def(
+    permission_risk(
+        model_spec(
+            def(
             "computer_key_input",
             ModelVisible,
             TOOL_CATEGORY_COMPUTER,
@@ -422,11 +433,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(COMPUTER_CONTROL),
             false,
             None,
+            true,
             false,
-            false,
+            ),
+            "Send one closed key to an exact revalidated frontmost/focused macOS or Windows window. Windows rejects command, unsafe system chords, and interfering held keys; input uses the shared input stream. No text, keycodes, repeat/held state, implicit focus, or fallback. Re-observe unknown outcomes.",
+            computer_key_input_input_schema,
         ),
-        "Send one closed key to an exact revalidated frontmost/focused macOS or Windows window. Windows rejects command, unsafe system chords, and interfering held keys; input uses the shared input stream. No text, keycodes, repeat/held state, implicit focus, or fallback. Re-observe unknown outcomes.",
-        computer_key_input_input_schema,
+        PERMISSION_RISK_WRITE,
     ),
     model_spec(
         def(

--- a/src/tool_runtime/tool_definition/edits.rs
+++ b/src/tool_runtime/tool_definition/edits.rs
@@ -1,6 +1,9 @@
 use super::AgentCapability::FileWrite;
 use super::ToolVisibility::ModelVisible;
-use super::{adaptive_runtime_direct, def, model_spec, ToolDefinition, TOOL_CATEGORY_EDIT};
+use super::{
+    adaptive_runtime_direct, def, model_spec, permission_risk, ToolDefinition,
+    PERMISSION_RISK_WRITE, TOOL_CATEGORY_EDIT,
+};
 use crate::tool_runtime::metadata::{
     ToolPathHint::{PathList, SinglePath},
     ToolRisk::ProjectWrite,
@@ -11,8 +14,9 @@ use crate::tool_runtime::registry::input_schemas::{
 };
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
-    model_spec(
-        def(
+    permission_risk(
+        model_spec(
+            def(
             "write_project_file",
             ModelVisible,
             TOOL_CATEGORY_EDIT,
@@ -27,15 +31,18 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(PROJECT_WRITE),
             true,
             SinglePath,
+            true,
             false,
-            false,
+            ),
+            "Create new files or intentional whole-file rewrites. Existing-file overwrite requires the exact current expected_sha256. Prefer apply_patch for model-generated changes and apply_text_edits for small exact guarded edits; inspect current content and worktree changes before replacing a file.",
+            write_project_file_input_schema,
         ),
-        "Create new files or intentional whole-file rewrites. Existing-file overwrite requires the exact current expected_sha256. Prefer apply_patch for model-generated changes and apply_text_edits for small exact guarded edits; inspect current content and worktree changes before replacing a file.",
-        write_project_file_input_schema,
+        PERMISSION_RISK_WRITE,
     ),
     adaptive_runtime_direct(
-        model_spec(
-            def(
+        permission_risk(
+            model_spec(
+                def(
                 "apply_text_edits",
                 ModelVisible,
                 TOOL_CATEGORY_EDIT,
@@ -50,11 +57,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(PROJECT_WRITE),
                 true,
                 PathList,
+                true,
                 false,
-                false,
+                ),
+                "Precision fallback for small exact guarded file changes on the current worktree. Transactional and SHA-guarded; exact matches are unique by default, occurrence remains global source order, and optional line_scope fences matches. Prefer apply_patch for contextual, multi-hunk, or multi-file model changes.",
+                apply_text_edits_input_schema,
             ),
-            "Precision fallback for small exact guarded file changes on the current worktree. Transactional and SHA-guarded; exact matches are unique by default, occurrence remains global source order, and optional line_scope fences matches. Prefer apply_patch for contextual, multi-hunk, or multi-file model changes.",
-            apply_text_edits_input_schema,
+            PERMISSION_RISK_WRITE,
         ),
         65,
     ),

--- a/src/tool_runtime/tool_definition/patches.rs
+++ b/src/tool_runtime/tool_definition/patches.rs
@@ -1,6 +1,9 @@
 use super::AgentCapability::{ApplyPatch, Shell};
 use super::ToolVisibility::ModelVisible;
-use super::{adaptive_runtime_direct, def, model_spec, ToolDefinition, TOOL_CATEGORY_PATCH};
+use super::{
+    adaptive_runtime_direct, def, model_spec, permission_risk, ToolDefinition,
+    PERMISSION_RISK_PATCH, TOOL_CATEGORY_PATCH,
+};
 use crate::tool_runtime::metadata::{
     ToolPathHint::Patch, ToolRisk::ProjectWrite, PROJECT_WRITE, TOOL_PROVIDER_AGENT,
 };
@@ -10,8 +13,9 @@ use crate::tool_runtime::registry::input_schemas::{
 
 pub(super) const DEFINITIONS: &[ToolDefinition] = &[
     adaptive_runtime_direct(
-        model_spec(
-            def(
+        permission_risk(
+            model_spec(
+                def(
                 "apply_patch",
                 ModelVisible,
                 TOOL_CATEGORY_PATCH,
@@ -26,34 +30,39 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 Some(PROJECT_WRITE),
                 true,
                 Patch,
+                true,
                 false,
-                false,
+                ),
+                "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. Inspect strict_match; set strict_matching=true to require exact-unique positioning. Use apply_text_edits for small exact edits; unified diff for external diffs.",
+                apply_patch_input_schema,
             ),
-            "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. Inspect strict_match; set strict_matching=true to require exact-unique positioning. Use apply_text_edits for small exact edits; unified diff for external diffs.",
-            apply_patch_input_schema,
+            PERMISSION_RISK_PATCH,
         ),
         60,
     ),
-    model_spec(
-    def(
-        "apply_unified_diff",
-        ModelVisible,
-        TOOL_CATEGORY_PATCH,
-        Some(Shell),
-        TOOL_PROVIDER_AGENT,
-        super::ToolSemanticContract {
-            effect: super::ToolEffect::Mutate,
-            risk: ProjectWrite,
-            approval: super::ToolApprovalPolicy::Standard,
-            idempotency: super::ToolIdempotency::NonIdempotent,
-        },
-        Some(PROJECT_WRITE),
-        true,
-        Patch,
-        false,
-        false,
+    permission_risk(
+        model_spec(
+            def(
+                "apply_unified_diff",
+                ModelVisible,
+                TOOL_CATEGORY_PATCH,
+                Some(Shell),
+                TOOL_PROVIDER_AGENT,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Mutate,
+                    risk: ProjectWrite,
+                    approval: super::ToolApprovalPolicy::Standard,
+                    idempotency: super::ToolIdempotency::NonIdempotent,
+                },
+                Some(PROJECT_WRITE),
+                true,
+                Patch,
+                true,
+                false,
+            ),
+            "External raw unified-diff mutation path. Prefer apply_patch for model-generated changes and apply_text_edits for small exact guarded edits. Performs bounded preflight before applying and never needs a separate validation call. Input must be a standard unified diff; shell heredocs and Codex *** Begin Patch wrappers are rejected with recovery metadata.",
+            apply_unified_diff_input_schema,
+        ),
+        PERMISSION_RISK_PATCH,
     ),
-    "External raw unified-diff mutation path. Prefer apply_patch for model-generated changes and apply_text_edits for small exact guarded edits. Performs bounded preflight before applying and never needs a separate validation call. Input must be a standard unified diff; shell heredocs and Codex *** Begin Patch wrappers are rejected with recovery metadata.",
-    apply_unified_diff_input_schema,
-),
 ];

--- a/src/tool_runtime/tool_definition/sessions.rs
+++ b/src/tool_runtime/tool_definition/sessions.rs
@@ -2,8 +2,8 @@ use super::AgentCapability::{GitOrShell, OwnerOnly};
 use super::ToolVisibility::{ModelHidden, ModelVisible};
 use super::{
     adaptive_runtime_direct, context_recovery_only, def, extra_accepted_flattened_args, model_spec,
-    requires_explicit_business_session, ToolDefinition, TOOL_CATEGORY_SESSION,
-    TOOL_CATEGORY_VALIDATION,
+    permission_risk, requires_explicit_business_session, ToolDefinition, PERMISSION_RISK_WRITE,
+    TOOL_CATEGORY_SESSION, TOOL_CATEGORY_VALIDATION,
 };
 use crate::tool_runtime::metadata::{
     ToolPathHint::None as NoPath, ToolRisk::Read, PROJECT_READ, PROJECT_WRITE, RUNTIME_READ,
@@ -131,8 +131,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Return a bounded structured summary from the session ledger for an explicit session_id: recorded events, message-board summary, task mode, guards, and lifecycle. Uses durable ledger data where session persistence is configured.",
         session_summary_input_schema,
     )),
-    requires_explicit_business_session(model_spec(
-        def(
+    requires_explicit_business_session(permission_risk(
+        model_spec(
+            def(
             "update_session_context",
             ModelVisible,
             TOOL_CATEGORY_SESSION,
@@ -147,14 +148,17 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(PROJECT_WRITE),
             true,
             NoPath,
+            true,
             false,
-            false,
+            ),
+            "Update Session defaults. Requires an authorized project matching the exact Session project; cross-project escape is not supported. Context and event commit under the store lock; the background writer persists, so success does not mean disk flush. Never falls back and never creates unknown Sessions.",
+            update_session_context_input_schema,
         ),
-        "Update Session defaults. Requires an authorized project matching the exact Session project; cross-project escape is not supported. Context and event commit under the store lock; the background writer persists, so success does not mean disk flush. Never falls back and never creates unknown Sessions.",
-        update_session_context_input_schema,
+        PERMISSION_RISK_WRITE,
     )),
-    requires_explicit_business_session(model_spec(
-        def(
+    requires_explicit_business_session(permission_risk(
+        model_spec(
+            def(
             "close_session",
             ModelVisible,
             TOOL_CATEGORY_SESSION,
@@ -169,11 +173,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(SESSION_COLLABORATE),
             false,
             NoPath,
+            true,
             false,
-            false,
+            ),
+            "Explicitly close a workflow session (Active to Closed) for a required session_id. Query remains available; write/shell/mutation tools are denied. Idempotent when already closed; unknown ids fail without create. finish_coding_task does not close.",
+            close_session_input_schema,
         ),
-        "Explicitly close a workflow session (Active to Closed) for a required session_id. Query remains available; write/shell/mutation tools are denied. Idempotent when already closed; unknown ids fail without create. finish_coding_task does not close.",
-        close_session_input_schema,
+        PERMISSION_RISK_WRITE,
     )),
     requires_explicit_business_session(model_spec(
         def(
@@ -285,8 +291,9 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         "Observe Session message-state delta after an opaque durable cursor. No token establishes the current baseline and returns no history; token calls may wait once for change. Reports retention loss; never a subscription, delivery receipt, or model-context proof.",
         observe_session_messages_input_schema,
     )),
-    requires_explicit_business_session(model_spec(
-        def(
+    requires_explicit_business_session(permission_risk(
+        model_spec(
+            def(
             "resolve_session_message",
             ModelVisible,
             TOOL_CATEGORY_SESSION,
@@ -301,14 +308,17 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(SESSION_COLLABORATE),
             false,
             NoPath,
+            true,
             false,
-            false,
+            ),
+            "Mark a session-local ledger message resolved. Idempotent when the message is already resolved; metadata-only and never modifies project files.",
+            resolve_session_message_input_schema,
         ),
-        "Mark a session-local ledger message resolved. Idempotent when the message is already resolved; metadata-only and never modifies project files.",
-        resolve_session_message_input_schema,
+        PERMISSION_RISK_WRITE,
     )),
-    requires_explicit_business_session(model_spec(
-        def(
+    requires_explicit_business_session(permission_risk(
+        model_spec(
+            def(
             "complete_session_message",
             ModelVisible,
             TOOL_CATEGORY_SESSION,
@@ -323,11 +333,13 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(SESSION_COLLABORATE),
             false,
             NoPath,
+            true,
             false,
-            false,
+            ),
+            "Atomically answer and resolve one exact open todo. expected_assignment_fence is required and must be the exact opaque fence from get_session_assignment; completion_key separately keeps uncertain-result retries idempotent.",
+            complete_session_message_input_schema,
         ),
-        "Atomically answer and resolve one exact open todo. expected_assignment_fence is required and must be the exact opaque fence from get_session_assignment; completion_key separately keeps uncertain-result retries idempotent.",
-        complete_session_message_input_schema,
+        PERMISSION_RISK_WRITE,
     )),
     requires_explicit_business_session(model_spec(
         def(

--- a/src/tool_runtime/tool_definition/testing.rs
+++ b/src/tool_runtime/tool_definition/testing.rs
@@ -28,7 +28,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             Some(JOB_RUN),
             true,
             NoPath,
-            false,
+            true,
             false,
         ),
         "Run cargo fmt. With check=true it is read-only validation; a long check continues as the same execution and returns job_id for observation. Mutating format stays synchronous.",


### PR DESCRIPTION
## Summary

- retire the pre-0.4 `show_changes` Python-helper framing path in favor of one bounded internal POSIX script with explicit status/HEAD/stat/diff frames
- keep `show_changes` transport-safe under large status output, pathological paths/lines, diff truncation, non-Git repositories, and command failures
- correct MCP destructive mutation metadata and make annotations canonical projections of ToolDefinition effect/idempotency/shell/destructive semantics
- add focused semantic audits so high-risk mutation tools cannot silently drift back to misleading MCP hints

## Why

This removes a redundant execution/helper layer before 0.4 and makes the model/host-facing MCP hints match the runtime's existing authority and effect contracts. The hint changes do not grant new authority or weaken permission gates.

## Validation

- `cargo test -p webcodex show_changes`: 77 passed
- `cargo test -p webcodex tool_specs_annotations_are_canonical_semantic_projections`: passed
- `cargo test -p webcodex tool_definitions_drive_session_and_permission_policy`: passed
- `cargo check --all-targets -p webcodex`: passed, 0 warnings

Independent review found no correctness blocker or additional code change required.