### PR TITLE
Retire internal StartCodingTask abstraction

### DIFF
--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -40,8 +40,9 @@ role selector.
 - `work_on_project` is the canonical external coding bootstrap and continuation
   entry. The retired `start_coding_task` wire/API tool name now fails closed with
   guidance to use `work_on_project`; its advanced startup fields are not a public
-  compatibility surface. An internal `StartCodingTask` primitive remains only as
-  shared implementation plumbing for the canonical workflow.
+  compatibility surface. Internally, `work_on_project` calls the shared coding
+  workflow engine directly; bounded minimal/full diagnostic projections remain
+  test-only implementation seams rather than a second tool identity.
 - Choose behavioral roles in the **task instruction**. For implementation work,
   explicitly say to use `implementation_owner` guidance. For a separate review,
   explicitly say to use `independent_review` guidance.

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -34,8 +34,9 @@ instructions；它不是 role selector。
   Job state 仍会显式返回。
 - `work_on_project` 是唯一 canonical 的外部 coding bootstrap / continuation 入口。
   `start_coding_task` 这一旧 wire/API tool name 已退休，调用会 fail closed 并提示改用
-  `work_on_project`；其 advanced startup fields 不再构成公共兼容面。内部仍保留
-  `StartCodingTask` primitive，仅作为 canonical workflow 的共享实现细节。
+  `work_on_project`；其 advanced startup fields 不再构成公共兼容面。内部由
+  `work_on_project` 直接调用共享 coding workflow engine；bounded minimal/full diagnostic
+  projection 只保留为 test-only implementation seam，不再形成第二个 tool identity。
 - behavioral role 由 **task instruction** 显式选择。实现任务明确写使用
   `implementation_owner` guidance；独立评审明确写使用 `independent_review` guidance。
 - 返回的 role guidance 永远只是 model guidance。它不会创建 authority、permission、

--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -303,7 +303,7 @@ it never infers readiness from configuration.
 | Layer envelope | Every layer carries `{status, observed_at, source, age_secs, stale_after_secs, reason_code}` plus layer facts |
 | No config-inferred readiness | `connector_endpoint` readiness comes only from readiness probes or successful connector requests; configuration presence never implies `ready`. `runner_process` never fakes "running"; a stale registration is never presented as callable |
 | Explicit Workflow targeting | Full-runtime Workflow Sessions have no process-local or durable window binding. `runtime_status` exposes no Workflow binding layer. Ordinary project tools without an explicit business Session or authorized wrapper recorder execute unlinked to Workflow Session state. This remains separate from Connector-owned window/project/task continuity |
-| Full-runtime start/continue | `work_on_project(session_id=<id>)` continues exactly that authorized Active same-project Session; omission creates a fresh Workflow Session. Stable window or credential identity never selects a Workflow Session. The internal `StartCodingTask` primitive is implementation plumbing, not a wire/API continuation entry |
+| Full-runtime start/continue | `work_on_project(session_id=<id>)` continues exactly that authorized Active same-project Session; omission creates a fresh Workflow Session. Stable window or credential identity never selects a Workflow Session. `work_on_project` calls the shared coding workflow engine directly; there is no second internal ToolCall identity |
 | Canonical model coding bootstrap | `work_on_project` is the external runtime coding bootstrap. `registered_tool_specs` defines the canonical model-visible runtime universe used by discovery and generic ToolCall admission. A startup-selected model surface may project that universe more narrowly: `local_coding` lists its focused typed set, `adaptive_runtime` lists a smaller typed core plus one long-tail gateway, and `full_operator_runtime` expands the runtime universe. Retired wire names such as `start_coding_task` fail closed before dispatch and never contribute selector names or flattened model fields |
 | Runtime exposure selection | The Server owns one top-level `RuntimeExposure`. Complete `WEBCODEX_CONNECTOR_SURFACE=task-v1` configuration selects `ProjectConnector`, exposed publicly as `project_connector`; ProjectConnector is a project-bound ConnectorTask capability contract, not a `ModelSurface`. Without Connector configuration, exposure is `Runtime(ModelSurface)`: an unset `WEBCODEX_MCP_MODEL_SURFACE` selects `local_coding`, while `local-coding-v1`, `adaptive-runtime-v1`, and `full-operator-v1` select `local_coding`, `adaptive_runtime`, and `full_operator_runtime` explicitly. `adaptive_runtime` direct admission/order is statically declared by canonical `ToolDefinition`s; ordinary model-visible runtime tools default to the bounded long-tail gateway unless explicitly promoted to direct. Gateway calls keep the target tool's existing scope, authority, permission, argument, effect, and Session/ACK semantics. A Connector + `WEBCODEX_MCP_MODEL_SURFACE` conflict, an unsupported value, or partial Connector configuration fails startup. MCP GET/initialize/discovery, `runtime_status.runtime_exposure`, and the startup log report the same flattened exposure name |
 | Meaningful-activity rule | `last_successful_tool_call` records only successful meaningful calls, scoped by principal/project/surface/session/tool. `runtime_status`, `list_tools`, `list_agents`, `list_projects`, and `tool_manifest` never refresh it. Bounded in-memory store; no arguments, outputs, or secrets |
@@ -315,9 +315,9 @@ it never infers readiness from configuration.
 
 `work_on_project` is the only external runtime coding bootstrap. The retired
 `start_coding_task` wire/API name and its advanced input schema are not accepted.
-The internal `StartCodingTask` primitive may still use
-`detail=minimal|standard|full` to build bounded startup projections for shared
-implementation paths; that control is not a public tool argument.
+The shared coding workflow engine owns startup behavior directly. Bounded
+`minimal|standard|full` diagnostic projections are retained only behind test
+seams; those controls are not a public tool argument or ToolCall identity.
 
 | Decision | Choice |
 |---|---|

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -346,10 +346,10 @@ the audit ledger.
 
 `work_on_project` is the canonical external full-runtime start-or-continue
 aggregate. The former `start_coding_task` tool name and advanced direct/API
-schema are retired and fail closed before dispatch. The Rust
-`ToolCall::StartCodingTask` variant remains internal implementation plumbing for
-shared startup behavior and tests; it is not an external Session-selection or
-compatibility surface.
+schema are retired and fail closed before dispatch. No internal `ToolCall`
+variant remains for that retired name; `work_on_project` calls the shared coding
+workflow engine directly, with diagnostic projection controls available only to
+tests rather than as a Session-selection or compatibility surface.
 
 `work_on_project` deliberately does not use Workflow Session identity, transport
 identity, a client-window key, credentials, project identity, or Server lifetime

--- a/src/connector_runtime/connector_runtime_tests.rs
+++ b/src/connector_runtime/connector_runtime_tests.rs
@@ -212,6 +212,8 @@ pub(crate) fn init_repo(project: &Path) {
         );
     };
     run(&["init", "-q"]);
+    run(&["config", "core.autocrlf", "false"]);
+    run(&["config", "core.longpaths", "true"]);
     std::fs::write(project.join("README.md"), "fixture\n").unwrap();
     std::fs::write(
         project.join("Cargo.toml"),

--- a/src/connector_runtime/execution_tests.rs
+++ b/src/connector_runtime/execution_tests.rs
@@ -229,6 +229,12 @@ async fn fixture_built(
         tests::credential(),
     )
     .unwrap();
+    #[cfg(windows)]
+    let yield_ms = if yield_ms >= 1_000 {
+        yield_ms.max(8_000)
+    } else {
+        yield_ms
+    };
     connector.executions = configure(connector.executions.clone().with_yield_ms(yield_ms));
     let registration_registry = registry.clone();
     let registration = tokio::spawn(async move {

--- a/src/connector_runtime/host_tests.rs
+++ b/src/connector_runtime/host_tests.rs
@@ -33,6 +33,8 @@ fn fixture(finish: bool) -> Fixture {
     let root = temp.path().join("project");
     fs::create_dir(&root).unwrap();
     git(&root, &["init", "-q"]);
+    git(&root, &["config", "core.autocrlf", "false"]);
+    git(&root, &["config", "core.longpaths", "true"]);
     fs::write(root.join("README.md"), "before\n").unwrap();
     git(&root, &["add", "README.md"]);
     git(

--- a/src/connector_runtime/workspace.rs
+++ b/src/connector_runtime/workspace.rs
@@ -345,13 +345,14 @@ impl WorkspaceManager {
                 })
         } else {
             let _ = git_output(target_root, [OsStr::new("worktree"), OsStr::new("prune")]);
+            let git_execution_root = git_cli_path(&execution_root);
             git_output(
                 target_root,
                 [
                     OsStr::new("worktree"),
                     OsStr::new("add"),
                     OsStr::new("--detach"),
-                    execution_root.as_os_str(),
+                    git_execution_root.as_os_str(),
                     OsStr::new(&baseline_commit),
                 ],
             )
@@ -1770,6 +1771,35 @@ fn git_text<const N: usize>(root: &Path, args: [&str; N]) -> Result<String, Stri
         .map_err(|_| "Git returned non-UTF-8 metadata".to_string())
 }
 
+#[cfg(not(windows))]
+fn git_cli_path(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+#[cfg(windows)]
+fn git_cli_path(path: &Path) -> PathBuf {
+    use std::path::Prefix;
+
+    let mut components = path.components();
+    let Some(Component::Prefix(prefix)) = components.next() else {
+        return path.to_path_buf();
+    };
+    let mut normalized = match prefix.kind() {
+        Prefix::VerbatimDisk(letter) => PathBuf::from(format!("{}:", char::from(letter))),
+        Prefix::VerbatimUNC(server, share) => {
+            let mut root = PathBuf::from(r"\\");
+            root.push(server);
+            root.push(share);
+            root
+        }
+        _ => return path.to_path_buf(),
+    };
+    for component in components {
+        normalized.push(component.as_os_str());
+    }
+    normalized
+}
+
 fn git_output<I, S>(root: &Path, args: I) -> Result<Output, String>
 where
     I: IntoIterator<Item = S>,
@@ -1791,7 +1821,7 @@ where
     Command::new("git")
         .arg("-C")
         .arg(root)
-        .env("GIT_INDEX_FILE", index)
+        .env("GIT_INDEX_FILE", git_cli_path(index))
         .args(args)
         .output()
         .map_err(|error| format!("cannot start Git precondition operation: {error}"))
@@ -1951,6 +1981,8 @@ mod tests {
         let root = temp.path().join("project");
         fs::create_dir(&root).unwrap();
         git(&root, &["init", "-q"]);
+        git(&root, &["config", "core.autocrlf", "false"]);
+        git(&root, &["config", "core.longpaths", "true"]);
         fs::write(root.join("README.md"), "before\n").unwrap();
         git(&root, &["add", "README.md"]);
         git(

--- a/src/project_entry_cloudflared_tests.rs
+++ b/src/project_entry_cloudflared_tests.rs
@@ -134,34 +134,34 @@ fn explicit_override_is_authoritative_then_path_is_used() {
 
 #[test]
 fn managed_root_prefers_xdg_then_home_and_requires_private_user_base() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = temp.path().join("state");
+    let home = temp.path().join("home");
+    let local = temp.path().join("local");
     assert_eq!(
         managed_cloudflared_root_from(
-            Some(OsStr::new("/state")),
-            Some(OsStr::new("/home/user")),
-            Some(OsStr::new("/local")),
+            Some(state.as_os_str()),
+            Some(home.as_os_str()),
+            Some(local.as_os_str()),
         )
         .unwrap(),
-        PathBuf::from("/state/webcodex/tools/cloudflared")
+        state.join("webcodex/tools/cloudflared")
     );
     assert_eq!(
-        managed_cloudflared_root_from(
-            None,
-            Some(OsStr::new("/home/user")),
-            Some(OsStr::new("/local")),
-        )
-        .unwrap(),
-        PathBuf::from("/home/user/.local/state/webcodex/tools/cloudflared")
+        managed_cloudflared_root_from(None, Some(home.as_os_str()), Some(local.as_os_str()),)
+            .unwrap(),
+        home.join(".local/state/webcodex/tools/cloudflared")
     );
     assert_eq!(
-        managed_cloudflared_root_from(None, None, Some(OsStr::new("/local"))).unwrap(),
-        PathBuf::from("/local/WebCodex/tools/cloudflared")
+        managed_cloudflared_root_from(None, None, Some(local.as_os_str())).unwrap(),
+        local.join("WebCodex/tools/cloudflared")
     );
     let error = managed_cloudflared_root_from(None, None, None).unwrap_err();
     assert_eq!(error.code, "tunnel_unavailable");
     assert!(error.message.contains("private user directory"));
     let relative_xdg = managed_cloudflared_root_from(
         Some(OsStr::new("relative-state")),
-        Some(OsStr::new("/home/user")),
+        Some(home.as_os_str()),
         None,
     )
     .unwrap_err();

--- a/src/project_entry_openai_tunnel_tests.rs
+++ b/src/project_entry_openai_tunnel_tests.rs
@@ -76,32 +76,32 @@ fn official_release_assets_and_extracted_binaries_are_pinned_per_supported_platf
 
 #[test]
 fn managed_root_prefers_private_xdg_then_home() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = temp.path().join("state");
+    let home = temp.path().join("home");
+    let local = temp.path().join("local");
     assert_eq!(
         managed_tunnel_client_root_from(
-            Some(OsStr::new("/state")),
-            Some(OsStr::new("/home/user")),
-            Some(OsStr::new("/local")),
+            Some(state.as_os_str()),
+            Some(home.as_os_str()),
+            Some(local.as_os_str()),
         )
         .unwrap(),
-        PathBuf::from("/state/webcodex/tools/tunnel-client")
+        state.join("webcodex/tools/tunnel-client")
     );
     assert_eq!(
-        managed_tunnel_client_root_from(
-            None,
-            Some(OsStr::new("/home/user")),
-            Some(OsStr::new("/local")),
-        )
-        .unwrap(),
-        PathBuf::from("/home/user/.local/state/webcodex/tools/tunnel-client")
+        managed_tunnel_client_root_from(None, Some(home.as_os_str()), Some(local.as_os_str()),)
+            .unwrap(),
+        home.join(".local/state/webcodex/tools/tunnel-client")
     );
     assert_eq!(
-        managed_tunnel_client_root_from(None, None, Some(OsStr::new("/local"))).unwrap(),
-        PathBuf::from("/local/WebCodex/tools/tunnel-client")
+        managed_tunnel_client_root_from(None, None, Some(local.as_os_str())).unwrap(),
+        local.join("WebCodex/tools/tunnel-client")
     );
     assert!(managed_tunnel_client_root_from(None, None, None).is_err());
     assert!(managed_tunnel_client_root_from(
         Some(OsStr::new("relative")),
-        Some(OsStr::new("/home/user")),
+        Some(home.as_os_str()),
         None,
     )
     .is_err());

--- a/src/project_entry_tests.rs
+++ b/src/project_entry_tests.rs
@@ -34,6 +34,8 @@ fn repo(name: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
     let state = temp.path().join("state");
     fs::create_dir(&root).unwrap();
     git(&["init", "-q"], &root);
+    git(&["config", "core.autocrlf", "false"], &root);
+    git(&["config", "core.longpaths", "true"], &root);
     fs::write(root.join("README.md"), "fixture\n").unwrap();
     git(&["add", "README.md"], &root);
     git(
@@ -562,7 +564,7 @@ fn record_agent_request(recorder: &Arc<Mutex<Vec<String>>>, request: &ShellAgent
 }
 
 fn run_agent_shell_request(request: &ShellAgentShellRequest) -> (i32, String, String) {
-    let mut command = Command::new("sh");
+    let mut command = Command::new(crate::tool_runtime::test_shell());
     command.args(["-lc", &request.command]);
     if let Some(cwd) = request.cwd.as_deref() {
         command.current_dir(cwd);
@@ -667,9 +669,9 @@ async fn run_authenticated_golden_path(recipe: &str) -> GoldenPathEvidence {
         }),
     )
     .await;
-    registration.await.unwrap();
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(status, StatusCode::OK, "{started}");
     assert_eq!(started["ok"], true, "{started}");
+    registration.await.unwrap();
     let task_id = started["task_id"].as_str().unwrap().to_string();
 
     let registry = fixture.registry.clone();
@@ -799,9 +801,9 @@ async fn run_authenticated_golden_path(recipe: &str) -> GoldenPathEvidence {
         command,
     )
     .await;
-    commander.await.unwrap();
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(status, StatusCode::OK, "{commanded}");
     assert_eq!(commanded["ok"], true, "{commanded}");
+    commander.await.unwrap();
 
     let registry = fixture.registry.clone();
     let client_id = fixture.client_id.clone();
@@ -1729,7 +1731,7 @@ fn doctor_reports_malformed_registration() {
 
 #[test]
 fn doctor_reports_conflicting_registration() {
-    let (_temp, root, state) = repo("conflicting-registration");
+    let (temp, root, state) = repo("conflicting-registration");
     let options = options(root, state.clone());
     setup(&options).unwrap();
     let project_path = fs::read_dir(state.join("agent/project-registry"))
@@ -1739,11 +1741,12 @@ fn doctor_reports_conflicting_registration() {
         .unwrap()
         .path();
     let before = fs::read_to_string(&project_path).unwrap();
-    let canonical_root = options.root.canonicalize().unwrap();
-    let conflicting = before.replace(
-        &format!("path = \"{}\"", canonical_root.display()),
-        "path = \"/different/project\"",
-    );
+    let different_root = temp.path().join("different-project");
+    fs::create_dir(&different_root).unwrap();
+    let different_root = different_root.canonicalize().unwrap();
+    let mut registration: toml::Value = toml::from_str(&before).unwrap();
+    registration["path"] = toml::Value::String(different_root.to_string_lossy().into_owned());
+    let conflicting = toml::to_string(&registration).unwrap();
     assert_ne!(conflicting, before);
     fs::write(&project_path, &conflicting).unwrap();
 

--- a/src/server_instance.rs
+++ b/src/server_instance.rs
@@ -81,8 +81,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let db = Database::open(&temp.path().join("metadata.db")).unwrap();
         let guard = ServerInstanceGuard::acquire(&db).unwrap();
-        let lock_path = lock_path_for_database(db.state_path());
-        assert_eq!(std::fs::read(lock_path).unwrap(), Vec::<u8>::new());
+        assert_eq!(guard.file.metadata().unwrap().len(), 0);
         drop(guard);
     }
 }

--- a/src/task_cli.rs
+++ b/src/task_cli.rs
@@ -657,6 +657,8 @@ mod tests {
             );
         };
         git(&["init", "-q"]);
+        git(&["config", "core.autocrlf", "false"]);
+        git(&["config", "core.longpaths", "true"]);
         std::fs::write(root.join("README.md"), "before\n").unwrap();
         git(&["add", "README.md"]);
         git(&[

--- a/src/tool_runtime/coding_task.rs
+++ b/src/tool_runtime/coding_task.rs
@@ -82,10 +82,11 @@ struct CodingStartupOptions {
 }
 
 impl CodingStartupOptions {
-    fn start_coding_task(detail: StartupDetail) -> Self {
+    #[cfg(test)]
+    fn diagnostic(detail: StartupDetail) -> Self {
         Self {
             detail,
-            tool_name: "start_coding_task",
+            tool_name: "work_on_project",
             include_repository_overview: true,
             include_project_instructions: true,
             include_reused_instruction_content: false,
@@ -276,43 +277,6 @@ impl ToolRuntime {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn start_coding_task(
-        &self,
-        project: String,
-        client_id: Option<String>,
-        path: Option<String>,
-        title: Option<String>,
-        mode: SessionMode,
-        deny_write_tools: bool,
-        deny_shell_tools: bool,
-        detail: StartupDetail,
-        resume_session_id: Option<String>,
-        execution_context: Option<sessions::SessionExecutionContext>,
-        auth: Option<&AuthContext>,
-        trusted_recording_session_id: Option<&str>,
-        trusted_recording_session_project: Option<&str>,
-        transport: SessionTransport,
-    ) -> ToolResult {
-        self.start_coding_task_with_options(
-            project,
-            client_id,
-            path,
-            title,
-            mode,
-            deny_write_tools,
-            deny_shell_tools,
-            CodingStartupOptions::start_coding_task(detail),
-            resume_session_id,
-            execution_context,
-            auth,
-            trusted_recording_session_id,
-            trusted_recording_session_project,
-            transport,
-        )
-        .await
-    }
-
     async fn explicit_coding_session_project(
         &self,
         session_id: &str,
@@ -370,7 +334,7 @@ impl ToolRuntime {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn start_coding_task_with_options(
+    async fn start_coding_workflow(
         &self,
         project: String,
         client_id: Option<String>,
@@ -665,8 +629,8 @@ impl ToolRuntime {
             }
         }
         // Semantic-navigation and fixed project-instruction observation remain
-        // mandatory startup probes. The advanced start_coding_task entry also
-        // runs the independent repository overview concurrently. The ordinary
+        // mandatory startup probes. Diagnostic test projections also run the
+        // independent repository overview concurrently. The ordinary
         // work_on_project entry deliberately omits that optional scan/request.
         let (semantic_navigation, project_instructions, repository_overview) =
             if startup.include_repository_overview {
@@ -735,7 +699,7 @@ impl ToolRuntime {
             runtime_status_call_failed,
         );
         let git = self
-            .start_coding_task_git_summary(
+            .coding_startup_git_summary(
                 &resolved.resolved_id,
                 include_recent_commits,
                 &mut warnings,
@@ -817,7 +781,7 @@ impl ToolRuntime {
                 return attach_project_resolution(
                     ToolResult::err_with_output(
                         format!(
-                            "{error_kind}: start_coding_task cannot resume a {} session",
+                            "{error_kind}: work_on_project cannot resume a {} session",
                             lifecycle.as_str()
                         ),
                         json!({
@@ -946,7 +910,7 @@ impl ToolRuntime {
             .active_jobs_summary(Some(&resolved.resolved_id), auth, 10)
             .await;
         let continuation_feedback = self
-            .start_continuation_feedback(
+            .startup_continuation_feedback(
                 &session_outcome.summary,
                 session_outcome.pre_instruction_summary.as_ref(),
                 continuation_kind,
@@ -1024,8 +988,8 @@ impl ToolRuntime {
         // against (fresh session, or a session whose rules were never
         // persisted, e.g. restored after a restart). Otherwise the shared
         // brief compares fingerprints and reports reused/changed. Whether a
-        // reused body is projected is intentionally separate: advanced
-        // start_coding_task stays incremental, while work_on_project follows
+        // reused body is projected is intentionally separate: diagnostic test
+        // projections stay incremental, while work_on_project follows
         // its caller-explicit include_project_instructions preference.
         let force_instruction_load = previous_instructions.is_none();
         let canonical_repository_root_matches = if resume_requested {
@@ -1068,11 +1032,51 @@ impl ToolRuntime {
         attach_permission(result, project_resolution.permission.as_ref())
     }
 
-    /// Thin `start_coding_task` wrapper for the daily model coding loop.
+    /// Test-only diagnostic projection over the same canonical coding workflow
+    /// engine used by `work_on_project`. This is deliberately not a ToolCall or
+    /// a model/API identity.
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn start_coding_workflow_for_test(
+        &self,
+        project: String,
+        client_id: Option<String>,
+        path: Option<String>,
+        title: Option<String>,
+        mode: SessionMode,
+        deny_write_tools: bool,
+        deny_shell_tools: bool,
+        detail: StartupDetail,
+        resume_session_id: Option<String>,
+        execution_context: Option<sessions::SessionExecutionContext>,
+        auth: Option<&AuthContext>,
+        trusted_recording_session_id: Option<&str>,
+        trusted_recording_session_project: Option<&str>,
+        transport: SessionTransport,
+    ) -> ToolResult {
+        self.start_coding_workflow(
+            project,
+            client_id,
+            path,
+            title,
+            mode,
+            deny_write_tools,
+            deny_shell_tools,
+            CodingStartupOptions::diagnostic(detail),
+            resume_session_id,
+            execution_context,
+            auth,
+            trusted_recording_session_id,
+            trusted_recording_session_project,
+            transport,
+        )
+        .await
+    }
+
+    /// Canonical entry for the daily model coding loop.
     ///
-    /// The wrapper validates its simple inputs, maps them onto normal coding-task
-    /// defaults, delegates the business implementation to `start_coding_task`,
-    /// and projects a compact startup result. With `session_id` present, it
+    /// This validates the public inputs, maps them onto the shared coding
+    /// workflow engine, and projects a compact startup result. With `session_id` present, it
     /// exactly resumes that one Workflow Session after project/lifecycle/access/
     /// capability checks; without it, it always creates a fresh Session.
     pub(crate) async fn work_on_project(
@@ -1135,13 +1139,13 @@ impl ToolRuntime {
             Some(session_id) => Some(session_id),
             None => None,
         };
-        // Map onto the existing coding-task business implementation. The
-        // internal work-on-project profile keeps the standard shared brief,
+        // Map onto the canonical coding workflow engine. The work-on-project
+        // profile keeps the standard shared brief,
         // including rules, semantic navigation, workspace, and job metadata,
         // while deliberately skipping the optional repository overview. Without
         // an explicit session_id this always creates a fresh Workflow Session.
         let result = self
-            .start_coding_task_with_options(
+            .start_coding_workflow(
                 project.clone(),
                 client_id,
                 path,
@@ -1468,14 +1472,14 @@ impl ToolRuntime {
         ToolResult::ok(output)
     }
 
-    /// Build the bounded continuation feedback projection for `start_coding_task`.
+    /// Build the bounded continuation feedback projection for coding startup.
     ///
     /// Pure read-only: validation is derived from the session ledger only
     /// (`validation_summary_from_events`, no job-status enrichment), jobs come
     /// from the bounded `active_jobs_summary` metadata, and guidance is read
     /// from the message board without marking anything read or resolved. No
     /// shell, no file reads, no Agent requests, no ledger mutation.
-    async fn start_continuation_feedback(
+    async fn startup_continuation_feedback(
         &self,
         summary: &sessions::SessionSummary,
         pre_instruction_summary: Option<&sessions::SessionSummary>,
@@ -1550,7 +1554,7 @@ impl ToolRuntime {
         }
     }
 
-    async fn start_coding_task_git_summary(
+    async fn coding_startup_git_summary(
         &self,
         project: &str,
         include_recent_commits: bool,
@@ -1988,8 +1992,8 @@ fn is_default_work_on_project_repository(repository: &Value) -> bool {
     })
 }
 
-/// Convert a successful `start_coding_task` result into the compact
-/// `work_on_project` contract. The delegated call may already have changed
+/// Convert a successful canonical coding-startup result into the compact
+/// `work_on_project` contract. The delegated engine may already have changed
 /// Session state, so protocol drift fails closed with `state_changed=true`.
 #[cfg(test)]
 pub(crate) fn project_work_on_project_output(project: String, output: Value) -> ToolResult {
@@ -2189,7 +2193,7 @@ fn work_on_project_projection_failed(
         json!({
             "error_kind": "work_on_project_projection_failed",
             "failure_kind": "work_on_project_projection_failed",
-            "underlying_tool": "start_coding_task",
+            "underlying_tool": "work_on_project",
             "field": field,
             "expected": expected,
             "actual": actual,

--- a/src/tool_runtime/coding_task_tools.rs
+++ b/src/tool_runtime/coding_task_tools.rs
@@ -13,36 +13,6 @@ impl ToolRuntime {
         trusted_recording_session_project: Option<&str>,
     ) -> ToolResult {
         match call {
-            ToolCall::StartCodingTask {
-                project,
-                client_id,
-                path,
-                title,
-                mode,
-                deny_write_tools,
-                deny_shell_tools,
-                detail,
-                resume_session_id,
-                execution_context,
-            } => {
-                self.start_coding_task(
-                    project,
-                    client_id,
-                    path,
-                    title,
-                    mode,
-                    deny_write_tools,
-                    deny_shell_tools,
-                    detail,
-                    resume_session_id,
-                    execution_context,
-                    auth,
-                    trusted_recording_session_id,
-                    trusted_recording_session_project,
-                    transport,
-                )
-                .await
-            }
             ToolCall::WorkOnProject {
                 project,
                 client_id,

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -898,7 +898,8 @@ impl ToolRuntime {
         };
         // work_on_project.session_id is explicit coding-resume business input,
         // never a generic tool recorder. Its implementation delegates exact
-        // Session/project/lifecycle/authority handling to start_coding_task.
+        // Session/project/lifecycle/authority handling to the coding workflow
+        // engine.
         let defer_work_session = matches!(&call, ToolCall::WorkOnProject { .. });
         // session_handoff_summary.session_id remains business input for direct
         // internal dispatch. When the kernel already has an explicit outer
@@ -1362,9 +1363,7 @@ impl ToolRuntime {
                 self.dispatch_session_tool(call, auth, transport).await
             }
 
-            call @ (ToolCall::StartCodingTask { .. }
-            | ToolCall::WorkOnProject { .. }
-            | ToolCall::FinishCodingTask { .. }) => {
+            call @ (ToolCall::WorkOnProject { .. } | ToolCall::FinishCodingTask { .. }) => {
                 self.dispatch_coding_task_tool(
                     call,
                     auth,

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -261,7 +261,10 @@ pub(crate) fn validate_edit_file_path(path: &str) -> Result<(), String> {
         return Err("path cannot contain NUL bytes".to_string());
     }
     let p = Path::new(path);
-    if p.is_absolute() {
+    if p.has_root()
+        || p.components()
+            .any(|component| matches!(component, std::path::Component::Prefix(_)))
+    {
         return Err("path must be project-relative".to_string());
     }
     if p.components()

--- a/src/tool_runtime/files/search.rs
+++ b/src/tool_runtime/files/search.rs
@@ -1011,7 +1011,9 @@ fn is_trusted_search_record_path(path: &str) -> bool {
         return false;
     }
     let p = Path::new(path);
-    if p.is_absolute()
+    if p.has_root()
+        || p.components()
+            .any(|component| matches!(component, std::path::Component::Prefix(_)))
         || p.components()
             .any(|component| matches!(component, std::path::Component::ParentDir))
     {
@@ -1021,6 +1023,10 @@ fn is_trusted_search_record_path(path: &str) -> bool {
 }
 
 fn normalize_search_record_path(path: &str) -> Option<String> {
+    #[cfg(windows)]
+    let normalized = path.replace('\\', "/");
+    #[cfg(windows)]
+    let path = normalized.as_str();
     let path = path.strip_prefix("./").unwrap_or(path);
     if !is_trusted_search_record_path(path) {
         return None;

--- a/src/tool_runtime/helpers.rs
+++ b/src/tool_runtime/helpers.rs
@@ -10,7 +10,8 @@ pub(crate) fn run_command_sync(
     cwd: &Path,
     timeout_secs: u64,
 ) -> (i32, String, String, u64) {
-    run_command_sync_with_shell(cmd, cwd, timeout_secs, "sh")
+    let shell = test_shell();
+    run_command_sync_with_shell(cmd, cwd, timeout_secs, &shell)
 }
 
 #[cfg(test)]
@@ -18,13 +19,15 @@ fn run_command_sync_with_shell(
     cmd: &str,
     cwd: &Path,
     timeout_secs: u64,
-    shell: &str,
+    shell: &Path,
 ) -> (i32, String, String, u64) {
     let start = Instant::now();
     let mut command = std::process::Command::new(shell);
+    #[cfg(windows)]
+    command.arg("-s").stdin(std::process::Stdio::piped());
+    #[cfg(not(windows))]
+    command.arg("-c").arg(cmd);
     command
-        .arg("-c")
-        .arg(cmd)
         .current_dir(cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
@@ -50,6 +53,25 @@ fn run_command_sync_with_shell(
             );
         }
     };
+    #[cfg(windows)]
+    {
+        use std::io::Write;
+        let write_result = child
+            .stdin
+            .take()
+            .expect("test shell stdin")
+            .write_all(cmd.as_bytes());
+        if let Err(error) = write_result {
+            let _ = child.kill();
+            let _ = child.wait();
+            return (
+                -1,
+                String::new(),
+                format!("Failed to write command to test shell: {error}"),
+                start.elapsed().as_millis() as u64,
+            );
+        }
+    }
     // Under `process_group(0)` the child's pid is also its process-group id.
     let pgid = child.id();
     let timeout = Duration::from_secs(timeout_secs);
@@ -115,6 +137,33 @@ fn run_command_sync_with_shell(
             elapsed,
         ),
     }
+}
+
+#[cfg(all(test, not(windows)))]
+pub(crate) fn test_shell() -> PathBuf {
+    PathBuf::from("sh")
+}
+
+#[cfg(all(test, windows))]
+pub(crate) fn test_shell() -> PathBuf {
+    git_for_windows_shell().unwrap_or_else(|| PathBuf::from("sh"))
+}
+
+#[cfg(all(test, windows))]
+fn git_for_windows_shell() -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("--exec-path")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let exec_path = String::from_utf8_lossy(&output.stdout);
+    let exec_path = PathBuf::from(exec_path.trim());
+    exec_path.ancestors().find_map(|ancestor| {
+        let candidate = ancestor.join("bin").join("sh.exe");
+        candidate.is_file().then_some(candidate)
+    })
 }
 
 /// Best-effort SIGKILL of an entire process group (`kill(-pgid, SIGKILL)`; a

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -98,7 +98,17 @@ pub(crate) fn check_runtime_tool_scope(
     auth: Option<&AuthContext>,
     tool_name: &str,
 ) -> Result<(), ToolCallErrorStatus> {
-    let policy = crate::auth::scopes::oauth_scope_policy_for_runtime_tool(tool_name);
+    // `start_coding_task` is a retired wire/API name that is rejected by
+    // `ToolCall::from_tool_name` after this scope gate. Preserve its former
+    // runtime:read admission for one compatibility window so authorized legacy
+    // callers still reach the actionable retirement error without reviving a
+    // ToolDefinition or dispatch identity. All other unknown names remain
+    // fail-closed through the canonical metadata lookup below.
+    let policy = if tool_name == "start_coding_task" {
+        OAuthToolScopePolicy::Require(crate::auth::SCOPE_RUNTIME_READ)
+    } else {
+        crate::auth::scopes::oauth_scope_policy_for_runtime_tool(tool_name)
+    };
     let Some(auth) = auth else {
         // Preserve historical unauthenticated compatibility for unrelated
         // internal tools, but explicit Memory and administrator authority is
@@ -986,6 +996,61 @@ mod tests {
         let finished = &summary.events[1];
         assert_eq!(finished.transport, "mcp");
         assert_eq!(finished.error_kind.as_deref(), Some("invalid_arguments"));
+    }
+
+    #[tokio::test]
+    async fn retired_start_coding_task_keeps_preparse_runtime_read_admission() {
+        let runtime = test_runtime();
+        let runtime_read = oauth(&[crate::auth::SCOPE_RUNTIME_READ]);
+        let outcome = runtime
+            .call_tool_with_context(
+                ToolCallRequest {
+                    tool_name: "start_coding_task".to_string(),
+                    arguments: json!({"project": "demo"}),
+                },
+                ToolCallContext {
+                    transport: ToolTransport::Mcp,
+                    session_id: None,
+                    auth: Some(&runtime_read),
+                    window: None,
+                    record_oauth_scope_denials: false,
+                    host_file_import_trust: HostFileImportTrust::Untrusted,
+                },
+            )
+            .await;
+        assert!(matches!(
+            outcome.error_status,
+            Some(ToolCallErrorStatus::InvalidArguments { ref message })
+                if message.contains("no longer supported") && message.contains("work_on_project")
+        ));
+
+        let no_runtime_read = oauth(&[]);
+        let denied = runtime
+            .call_tool_with_context(
+                ToolCallRequest {
+                    tool_name: "start_coding_task".to_string(),
+                    arguments: json!({"project": "demo"}),
+                },
+                ToolCallContext {
+                    transport: ToolTransport::Mcp,
+                    session_id: None,
+                    auth: Some(&no_runtime_read),
+                    window: None,
+                    record_oauth_scope_denials: false,
+                    host_file_import_trust: HostFileImportTrust::Untrusted,
+                },
+            )
+            .await;
+        assert_eq!(
+            denied.error_status,
+            Some(ToolCallErrorStatus::InsufficientScope {
+                required_scope: Some(crate::auth::SCOPE_RUNTIME_READ),
+                description: format!(
+                    "missing required scope: {}",
+                    crate::auth::SCOPE_RUNTIME_READ
+                ),
+            })
+        );
     }
 
     #[tokio::test]

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -33,6 +33,8 @@ mod handoff;
 mod handoff_brief;
 mod handoff_tools;
 mod helpers;
+#[cfg(test)]
+pub(crate) use helpers::test_shell;
 mod hygiene;
 mod hygiene_tools;
 mod job_tools;

--- a/src/tool_runtime/model_ergonomics_telemetry.rs
+++ b/src/tool_runtime/model_ergonomics_telemetry.rs
@@ -821,7 +821,7 @@ mod tests {
     }
 
     #[test]
-    fn hidden_tools_do_not_start_generic_model_usage_telemetry() {
+    fn retired_and_internal_tools_do_not_start_generic_model_usage_telemetry() {
         assert!(ModelErgonomicsTimer::start("start_coding_task").is_none());
         assert!(ModelErgonomicsTimer::start("definitely_internal_helper").is_none());
     }

--- a/src/tool_runtime/registry/mod.rs
+++ b/src/tool_runtime/registry/mod.rs
@@ -9,6 +9,8 @@ pub(crate) use input_schemas::ACCEPTED_FLATTENED_ARG_PREFERRED_ORDER;
 pub(crate) use input_schemas::{
     accepted_flattened_args_for_spec, generic_tool_call_flattened_args_for_spec,
 };
+#[cfg(test)]
+pub(crate) use output_schemas::coding_workflow_diagnostic_output_schema_for_test;
 pub(crate) use output_schemas::output_schema_for_tool;
 pub(crate) use tool_specs::{
     memory_management_tool_specs, memory_runtime_tool_specs, operator_diagnostic_tool_specs,

--- a/src/tool_runtime/registry/output_schemas.rs
+++ b/src/tool_runtime/registry/output_schemas.rs
@@ -84,3 +84,8 @@ pub(crate) fn output_schema_for_tool(name: &str) -> Value {
 
     default_output_schema()
 }
+
+#[cfg(test)]
+pub(crate) fn coding_workflow_diagnostic_output_schema_for_test() -> Value {
+    coding_tasks::coding_workflow_diagnostic_output_schema()
+}

--- a/src/tool_runtime/registry/output_schemas/coding_tasks.rs
+++ b/src/tool_runtime/registry/output_schemas/coding_tasks.rs
@@ -2,11 +2,14 @@ use serde_json::{json, Value};
 
 use super::super::input_schemas::session_execution_context_schema;
 use super::common::{
-    array_schema, authority_profile_schema, continuation_feedback_schema, evidence_history_schema,
-    evidence_integrity_schema, exploration_tool_name_schema, handoff_brief_schema,
-    job_lifecycle_summary_schema, nullable_schema, open_object_schema, permission_decision_schema,
-    permission_summary_schema, schema_type, session_hint_schema, task_outcome_schema,
-    wrapped_output_schema,
+    array_schema, continuation_feedback_schema, evidence_history_schema, evidence_integrity_schema,
+    handoff_brief_schema, job_lifecycle_summary_schema, nullable_schema, open_object_schema,
+    permission_summary_schema, schema_type, task_outcome_schema, wrapped_output_schema,
+};
+#[cfg(test)]
+use super::common::{
+    authority_profile_schema, exploration_tool_name_schema, permission_decision_schema,
+    session_hint_schema,
 };
 use super::files::{
     key_file_schema, path_kind_schema, project_type_schema, scan_schema, suggested_read_schema,
@@ -19,7 +22,6 @@ use crate::tool_runtime::startup_brief::{
 
 pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
     match name {
-        "start_coding_task" => Some(start_coding_task_output_schema()),
         "work_on_project" => Some(work_on_project_output_schema()),
         "finish_coding_task" => Some(wrapped_output_schema(vec![
             (
@@ -136,7 +138,8 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
     }
 }
 
-fn start_coding_task_output_schema() -> Value {
+#[cfg(test)]
+pub(super) fn coding_workflow_diagnostic_output_schema() -> Value {
     json!({
         "type": "object",
         "properties": {
@@ -160,12 +163,14 @@ fn start_coding_task_output_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_brief_output_schema(detail: &str) -> Value {
     let mut schema = startup_brief_schema(detail);
     add_startup_model_metadata(&mut schema);
     schema
 }
 
+#[cfg(test)]
 fn add_startup_model_metadata(schema: &mut Value) {
     let properties = schema
         .get_mut("properties")
@@ -175,6 +180,7 @@ fn add_startup_model_metadata(schema: &mut Value) {
     properties.insert("permission".to_string(), permission_decision_schema());
 }
 
+#[cfg(test)]
 fn startup_brief_schema(detail: &str) -> Value {
     json!({
         "type": "object",
@@ -217,6 +223,7 @@ fn startup_brief_schema(detail: &str) -> Value {
     })
 }
 
+#[cfg(test)]
 fn full_startup_output_schema() -> Value {
     let mut schema = json!({
         "type": "object",
@@ -300,6 +307,7 @@ fn project_resolution_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_session_schema() -> Value {
     json!({
         "type": "object",
@@ -327,6 +335,7 @@ fn startup_session_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_project_schema() -> Value {
     json!({
         "type": "object",
@@ -356,6 +365,7 @@ fn startup_project_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_workspace_schema() -> Value {
     json!({
         "type": "object",
@@ -451,6 +461,7 @@ fn startup_workflow_role_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_instructions_schema() -> Value {
     json!({
         "type": "object",
@@ -549,6 +560,7 @@ fn startup_instruction_source_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_continuation_schema(detail: &str) -> Value {
     let exploration_limit = if detail == "minimal" { 3 } else { 12 };
     json!({
@@ -665,6 +677,7 @@ fn startup_continuation_schema(detail: &str) -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_validation_schema() -> Value {
     json!({
         "type": "object",
@@ -698,6 +711,7 @@ fn startup_validation_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_failure_schema() -> Value {
     json!({
         "type": "object",
@@ -717,6 +731,7 @@ fn startup_failure_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn bounded_list_schema(items: Value, max_items: usize) -> Value {
     json!({
         "type": "object",
@@ -731,6 +746,7 @@ fn bounded_list_schema(items: Value, max_items: usize) -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_semantic_navigation_schema() -> Value {
     json!({
         "type": "object",
@@ -867,6 +883,7 @@ fn startup_issue_list_schema(blockers: bool) -> Value {
     })
 }
 
+#[cfg(test)]
 fn startup_verdict_schema() -> Value {
     json!({
         "type": "object",
@@ -884,6 +901,7 @@ fn startup_verdict_schema() -> Value {
     })
 }
 
+#[cfg(test)]
 fn semantic_navigation_schema() -> Value {
     json!({
         "type": "object",

--- a/src/tool_runtime/sessions/model.rs
+++ b/src/tool_runtime/sessions/model.rs
@@ -480,7 +480,7 @@ impl SessionCreateOptions {
     }
 }
 
-/// Atomic create-or-explicit-resume request used by `start_coding_task`.
+/// Atomic create-or-explicit-resume request used by coding workflow startup.
 ///
 /// The Workflow Session, instruction event, and capability transition are
 /// committed under one store lock. This is deliberately an internal Workflow

--- a/src/tool_runtime/sessions/store.rs
+++ b/src/tool_runtime/sessions/store.rs
@@ -2283,7 +2283,7 @@ fn coding_instruction_event(
         logical_invocation_id: None,
         logical_invocation_role: None,
         transport: transport.as_str().to_string(),
-        tool_name: "start_coding_task".to_string(),
+        tool_name: "work_on_project".to_string(),
         project: Some(project.to_string()),
         resolved_project: Some(project.to_string()),
         risk_class: "read_only".to_string(),

--- a/src/tool_runtime/startup_brief.rs
+++ b/src/tool_runtime/startup_brief.rs
@@ -1,4 +1,4 @@
-//! Shared model-facing projection for `start_coding_task`.
+//! Shared model-facing projection for canonical coding workflow startup.
 //!
 //! The runtime builds this once and every transport carries the same core
 //! value. The projection is deterministic, bounded, path-safe, and contains

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -6,7 +6,8 @@ use crate::tool_runtime::metadata::lookup_tool_metadata;
 use crate::tool_runtime::sessions::SessionTransport;
 use crate::tool_runtime::validation_parser::VALIDATION_OUTPUT_METADATA_ABSENT_REASON;
 use crate::tool_runtime::{
-    is_known_tool_name, registered_tool_specs, SessionMode, ToolCall, ToolResult, ToolRuntime,
+    is_known_tool_name, registered_tool_specs, SessionMode, StartupDetail, ToolCall, ToolResult,
+    ToolRuntime,
 };
 use serde_json::{json, Value};
 use std::fs;
@@ -43,7 +44,16 @@ fn coding_task_tools_are_registered_in_metadata_and_openapi() {
     );
     assert!(!is_known_tool_name("resolve_or_register_project"));
 
-    for name in ["start_coding_task", "finish_coding_task"] {
+    assert!(
+        !is_known_tool_name("start_coding_task"),
+        "retired start_coding_task must not remain a current tool identity"
+    );
+    assert!(lookup_tool_metadata("start_coding_task").is_none());
+    assert!(
+        crate::tool_runtime::tool_definition::lookup_tool_definition("start_coding_task").is_none()
+    );
+
+    for name in ["work_on_project", "finish_coding_task"] {
         assert!(is_known_tool_name(name), "{name} missing from known names");
         let metadata = lookup_tool_metadata(name).expect("metadata");
         assert!(!metadata.destructive);
@@ -53,7 +63,7 @@ fn coding_task_tools_are_registered_in_metadata_and_openapi() {
             crate::tool_runtime::metadata::ToolAuthorityPolicy::Require("runtime:read")
         );
     }
-    let start_metadata = lookup_tool_metadata("start_coding_task").expect("start metadata");
+    let start_metadata = lookup_tool_metadata("work_on_project").expect("work metadata");
     assert_eq!(
         start_metadata.effect,
         crate::tool_runtime::metadata::ToolEffect::Mutate
@@ -80,10 +90,8 @@ fn coding_task_tools_are_registered_in_metadata_and_openapi() {
         crate::tool_runtime::metadata::ToolIdempotency::PureRead
     );
     assert!(!names.contains(&"start_coding_task"));
+    assert!(names.contains(&"work_on_project"));
     assert!(names.contains(&"finish_coding_task"));
-    let start_definition =
-        crate::tool_runtime::tool_definition::lookup_tool_definition("start_coding_task").unwrap();
-    assert!(start_definition.visibility.is_model_hidden());
 
     let retired = ToolCall::from_tool_name("start_coding_task", json!({"project": "demo"}))
         .expect_err("retired start_coding_task wire entry must fail closed");
@@ -117,7 +125,8 @@ fn coding_task_tools_are_registered_in_metadata_and_openapi() {
             "work_on_project must not grow advanced start knob {advanced}"
         );
     }
-    let start_output = crate::tool_runtime::registry::output_schema_for_tool("start_coding_task");
+    let start_output =
+        crate::tool_runtime::registry::coding_workflow_diagnostic_output_schema_for_test();
     let startup_variants = start_output["properties"]["output"]["oneOf"]
         .as_array()
         .expect("start output should expose detail-specific variants");
@@ -145,14 +154,14 @@ fn coding_task_tools_are_registered_in_metadata_and_openapi() {
             .as_object()
             .unwrap()
             .contains_key("startup_verdict"),
-        "start_coding_task output schema should include startup_verdict"
+        "coding workflow diagnostic schema should include startup_verdict"
     );
     assert!(
         standard["properties"]
             .as_object()
             .unwrap()
             .contains_key("project_resolution"),
-        "start_coding_task output schema should include project_resolution"
+        "coding workflow diagnostic schema should include project_resolution"
     );
     assert!(
         !standard["properties"]
@@ -256,18 +265,10 @@ fn coding_task_tools_are_registered_in_metadata_and_openapi() {
         .map(|methods| methods.as_object().unwrap().len())
         .sum();
     assert_eq!(operation_count, 22, "no dedicated OpenAPI operations added");
-
-    let call =
-        internal_start_coding_task_call(json!({"project": "agent:test:demo", "detail": "full"}));
-    assert_eq!(
-        call.session_log_arguments()["detail"],
-        "full",
-        "ToolCall audit serialization must preserve detail"
-    );
 }
 
 #[tokio::test]
-async fn hidden_start_coding_task_keeps_internal_advanced_dispatch() {
+async fn coding_workflow_test_seam_keeps_internal_diagnostic_modes_without_tool_identity() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     let runtime = test_runtime();
@@ -284,16 +285,7 @@ async fn hidden_start_coding_task_keeps_internal_advanced_dispatch() {
     let wire_error = ToolCall::from_tool_name("start_coding_task", params.clone())
         .expect_err("retired wire entry must reject the internal advanced primitive");
     assert!(wire_error.contains("work_on_project"));
-    let parsed = internal_start_coding_task_call(params.clone());
-    match parsed {
-        ToolCall::StartCodingTask { mode, detail, .. } => {
-            assert_eq!(mode, SessionMode::ReadOnly);
-            assert_eq!(detail, crate::tool_runtime::StartupDetail::Minimal);
-        }
-        other => panic!("expected StartCodingTask, got {}", other.tool_name()),
-    }
-
-    let result = start_coding_task_serviced(&runtime, client_id, params, &auth).await;
+    let result = coding_workflow_serviced(&runtime, client_id, params, &auth).await;
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["detail"], "minimal");
     let session_id = result.output["session"]["session_id"].as_str().unwrap();
@@ -304,7 +296,7 @@ async fn hidden_start_coding_task_keeps_internal_advanced_dispatch() {
 }
 
 #[tokio::test]
-async fn start_coding_task_full_brief_has_no_binding_projection() {
+async fn coding_workflow_full_diagnostic_has_no_binding_projection() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     commit_file(
@@ -319,34 +311,17 @@ async fn start_coding_task_full_brief_has_no_binding_projection() {
         register_agent_project_at_path(&runtime, "coding-start", "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let task = tokio::spawn({
-        let runtime = runtime.clone();
-        let project = project.clone();
-        let auth = auth.clone();
-        async move {
-            runtime
-                .dispatch_with_auth(
-                    ToolCall::StartCodingTask {
-                        project,
-                        client_id: None,
-                        path: None,
-                        title: Some("implement deterministic aggregate".to_string()),
-                        mode: SessionMode::Normal,
-                        detail: crate::tool_runtime::StartupDetail::Full,
-                        deny_write_tools: false,
-                        deny_shell_tools: false,
-                        resume_session_id: None,
-                        execution_context: None,
-                    },
-                    Some(&auth),
-                )
-                .await
-        }
-    });
-
-    service_agent_task_until_finished(&runtime, "coding-start", &task, "start_coding_task").await;
-
-    let result = task.await.unwrap();
+    let result = coding_workflow_serviced(
+        &runtime,
+        "coding-start",
+        json!({
+            "project": project,
+            "title": "implement deterministic aggregate",
+            "detail": "full"
+        }),
+        &auth,
+    )
+    .await;
 
     assert!(result.success, "{:?}", result.error);
     let session_id = result.output["session"]["session_id"].as_str().unwrap();
@@ -372,7 +347,7 @@ async fn start_coding_task_full_brief_has_no_binding_projection() {
     ] {
         assert!(
             result.output.get(field).is_some(),
-            "start_coding_task output should include {field}"
+            "coding workflow diagnostic should include {field}"
         );
     }
     assert_eq!(result.output["authority"]["mode"], "trusted_agent");
@@ -444,7 +419,7 @@ async fn start_coding_task_full_brief_has_no_binding_projection() {
 }
 
 #[tokio::test]
-async fn start_coding_task_can_omit_compact_tool_manifest() {
+async fn coding_workflow_standard_omits_compact_tool_manifest() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     let runtime = test_runtime();
@@ -452,23 +427,16 @@ async fn start_coding_task_can_omit_compact_tool_manifest() {
         register_agent_project_at_path(&runtime, "coding-no-manifest", "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = runtime
-        .dispatch_with_auth(
-            ToolCall::StartCodingTask {
-                project,
-                client_id: None,
-                path: None,
-                title: Some("small startup payload".to_string()),
-                mode: SessionMode::Normal,
-                detail: Default::default(),
-                deny_write_tools: false,
-                deny_shell_tools: false,
-                resume_session_id: None,
-                execution_context: None,
-            },
-            Some(&auth),
-        )
-        .await;
+    let result = coding_workflow_serviced(
+        &runtime,
+        "coding-no-manifest",
+        json!({
+            "project": project,
+            "title": "small startup payload"
+        }),
+        &auth,
+    )
+    .await;
 
     assert!(result.success, "{:?}", result.error);
     assert!(
@@ -478,7 +446,7 @@ async fn start_coding_task_can_omit_compact_tool_manifest() {
 }
 
 #[tokio::test]
-async fn start_coding_task_minimal_brief_is_bounded_and_path_safe() {
+async fn coding_workflow_minimal_brief_is_bounded_and_path_safe() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     let runtime = test_runtime();
@@ -496,7 +464,7 @@ async fn start_coding_task_minimal_brief_is_bounded_and_path_safe() {
     let auth = auth_context(None, true);
     let project = "agent:coding-full-status:demo".to_string();
 
-    let result = start_coding_task_serviced(
+    let result = coding_workflow_serviced(
         &runtime,
         "coding-full-status",
         json!({
@@ -543,7 +511,7 @@ async fn start_coding_task_minimal_brief_is_bounded_and_path_safe() {
 }
 
 #[tokio::test]
-async fn start_coding_task_standard_returns_model_facing_brief_without_diagnostics() {
+async fn coding_workflow_standard_returns_model_facing_brief_without_diagnostics() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     let runtime = test_runtime();
@@ -561,7 +529,7 @@ async fn start_coding_task_standard_returns_model_facing_brief_without_diagnosti
     let auth = auth_context(None, true);
     let project = "agent:coding-compact-status:demo".to_string();
 
-    let result = start_coding_task_serviced(
+    let result = coding_workflow_serviced(
         &runtime,
         "coding-compact-status",
         json!({ "project": project }),
@@ -627,7 +595,7 @@ async fn start_coding_task_standard_returns_model_facing_brief_without_diagnosti
 }
 
 #[tokio::test]
-async fn start_coding_task_compact_startup_verdict_accepts_clean_workspace() {
+async fn coding_workflow_full_startup_verdict_accepts_clean_workspace() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     commit_file(tmp.path(), "README.md", "hello\n", "add readme");
@@ -636,7 +604,7 @@ async fn start_coding_task_compact_startup_verdict_accepts_clean_workspace() {
         register_agent_project_at_path(&runtime, "coding-start-verdict", "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = start_coding_task_serviced(
+    let result = coding_workflow_serviced(
         &runtime,
         "coding-start-verdict",
         json!({ "project": project, "detail": "full" }),
@@ -657,55 +625,109 @@ async fn start_coding_task_compact_startup_verdict_accepts_clean_workspace() {
     assert_compact_verdict_safe(verdict, "startup clean verdict");
 }
 
-/// Shared helper: start_coding_task with git inspection against a real temp repo.
-async fn start_coding_task_with_git_inspection(
+/// Shared helper: canonical coding-workflow diagnostics with Git inspection
+/// against a real temp repo.
+async fn coding_workflow_with_git_inspection(
     runtime: &ToolRuntime,
     client_id: &str,
     project: &str,
     auth: &AuthContext,
 ) -> ToolResult {
-    let task = tokio::spawn({
-        let runtime = runtime.clone();
-        let project = project.to_string();
-        let auth = auth.clone();
-        async move {
-            runtime
-                .dispatch_with_auth(
-                    internal_start_coding_task_call(json!({
-                        "project": project,
-                    })),
-                    Some(&auth),
-                )
-                .await
-        }
-    });
-    service_agent_task_until_finished(runtime, client_id, &task, "start_coding_task").await;
-    task.await.unwrap()
+    coding_workflow_serviced(runtime, client_id, json!({"project": project}), auth).await
 }
 
-fn internal_start_coding_task_call(params: Value) -> ToolCall {
-    serde_json::from_value(json!({"tool": "start_coding_task", "params": params}))
-        .expect("internal StartCodingTask primitive")
+#[derive(serde::Deserialize)]
+struct CodingWorkflowTestParams {
+    #[serde(default)]
+    project: String,
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    mode: SessionMode,
+    #[serde(default)]
+    deny_write_tools: bool,
+    #[serde(default)]
+    deny_shell_tools: bool,
+    #[serde(default)]
+    detail: StartupDetail,
+    #[serde(default)]
+    resume_session_id: Option<String>,
+    #[serde(default)]
+    execution_context: Option<crate::tool_runtime::sessions::SessionExecutionContext>,
 }
 
-/// Shared helper: dispatch start_coding_task and service every startup agent
-/// request (rules read, git status, git log) locally until the call finishes.
-async fn start_coding_task_serviced(
+/// Shared test-only driver for the canonical coding workflow engine. It
+/// preserves the old diagnostic coverage without creating another ToolCall or
+/// model/API identity.
+async fn coding_workflow_serviced(
     runtime: &ToolRuntime,
     client_id: &str,
     params: Value,
     auth: &AuthContext,
 ) -> ToolResult {
+    let params: CodingWorkflowTestParams = serde_json::from_value(params).unwrap();
     let task = tokio::spawn({
         let runtime = runtime.clone();
         let auth = auth.clone();
         async move {
             runtime
-                .dispatch_with_auth(internal_start_coding_task_call(params), Some(&auth))
+                .start_coding_workflow_for_test(
+                    params.project,
+                    params.client_id,
+                    params.path,
+                    params.title,
+                    params.mode,
+                    params.deny_write_tools,
+                    params.deny_shell_tools,
+                    params.detail,
+                    params.resume_session_id,
+                    params.execution_context,
+                    Some(&auth),
+                    None,
+                    None,
+                    SessionTransport::Api,
+                )
                 .await
         }
     });
-    service_agent_task_until_finished(runtime, client_id, &task, "start_coding_task").await;
+    service_agent_task_until_finished(runtime, client_id, &task, "coding workflow").await;
+    task.await.unwrap()
+}
+
+async fn work_on_project_serviced(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: &str,
+    instruction: &str,
+    auth: &AuthContext,
+) -> ToolResult {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.to_string();
+        let instruction = instruction.to_string();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::WorkOnProject {
+                        project,
+                        client_id: None,
+                        path: None,
+                        instruction,
+                        session_id: None,
+                        include_project_instructions: true,
+                        include_workflow_guidance: true,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    service_agent_task_until_finished(runtime, client_id, &task, "work_on_project").await;
     task.await.unwrap()
 }
 
@@ -740,7 +762,7 @@ fn assert_startup_nonblocking_dirty(result: &ToolResult, workspace_reason: &str)
 }
 
 #[tokio::test]
-async fn start_coding_task_untracked_only_is_nonblocking_warning() {
+async fn coding_workflow_untracked_only_is_nonblocking_warning() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     commit_file(tmp.path(), "README.md", "hello\n", "add readme");
@@ -752,7 +774,7 @@ async fn start_coding_task_untracked_only_is_nonblocking_warning() {
     let project = register_agent_project_at_path(&runtime, client_id, "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = start_coding_task_with_git_inspection(&runtime, client_id, &project, &auth).await;
+    let result = coding_workflow_with_git_inspection(&runtime, client_id, &project, &auth).await;
 
     assert_startup_nonblocking_dirty(&result, "workspace_dirty");
     assert_eq!(result.output["workspace"]["untracked"], 1);
@@ -760,12 +782,12 @@ async fn start_coding_task_untracked_only_is_nonblocking_warning() {
     assert_eq!(
         fs::read_to_string(tmp.path().join("report.md")).unwrap(),
         report_before,
-        "start_coding_task must not modify untracked report.md"
+        "coding workflow must not modify untracked report.md"
     );
 }
 
 #[tokio::test]
-async fn start_coding_task_tracked_modified_is_nonblocking_and_allows_continued_edit() {
+async fn coding_workflow_tracked_modified_is_nonblocking_and_allows_continued_edit() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     fs::create_dir_all(tmp.path().join("src")).unwrap();
@@ -784,7 +806,7 @@ async fn start_coding_task_tracked_modified_is_nonblocking_and_allows_continued_
     let project = register_agent_project_at_path(&runtime, client_id, "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = start_coding_task_with_git_inspection(&runtime, client_id, &project, &auth).await;
+    let result = coding_workflow_with_git_inspection(&runtime, client_id, &project, &auth).await;
 
     assert_startup_nonblocking_dirty(&result, "workspace_dirty");
     assert_eq!(result.output["workspace"]["modified"], 1);
@@ -853,7 +875,7 @@ async fn start_coding_task_tracked_modified_is_nonblocking_and_allows_continued_
 }
 
 #[tokio::test]
-async fn start_coding_task_staged_changes_are_nonblocking() {
+async fn coding_workflow_staged_changes_are_nonblocking() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     fs::create_dir_all(tmp.path().join("src")).unwrap();
@@ -872,7 +894,7 @@ async fn start_coding_task_staged_changes_are_nonblocking() {
     let project = register_agent_project_at_path(&runtime, client_id, "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = start_coding_task_with_git_inspection(&runtime, client_id, &project, &auth).await;
+    let result = coding_workflow_with_git_inspection(&runtime, client_id, &project, &auth).await;
 
     assert_startup_nonblocking_dirty(&result, "workspace_dirty");
     assert_eq!(result.output["workspace"]["staged"], 1);
@@ -887,7 +909,7 @@ async fn start_coding_task_staged_changes_are_nonblocking() {
 }
 
 #[tokio::test]
-async fn start_coding_task_mixed_dirty_workspace_summarizes_counts_without_blocking() {
+async fn coding_workflow_mixed_dirty_workspace_summarizes_counts_without_blocking() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     commit_file(tmp.path(), "tracked.rs", "tracked\n", "add tracked");
@@ -904,7 +926,7 @@ async fn start_coding_task_mixed_dirty_workspace_summarizes_counts_without_block
     let project = register_agent_project_at_path(&runtime, client_id, "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = start_coding_task_with_git_inspection(&runtime, client_id, &project, &auth).await;
+    let result = coding_workflow_with_git_inspection(&runtime, client_id, &project, &auth).await;
 
     assert_startup_nonblocking_dirty(&result, "workspace_dirty");
     assert_eq!(result.output["workspace"]["modified"], 2);
@@ -913,7 +935,7 @@ async fn start_coding_task_mixed_dirty_workspace_summarizes_counts_without_block
 }
 
 #[tokio::test]
-async fn start_coding_task_conflict_state_is_a_hard_blocker_but_remains_inspectable() {
+async fn coding_workflow_conflict_state_is_a_hard_blocker_but_remains_inspectable() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     commit_file(tmp.path(), "conflicted.rs", "base\n", "base");
@@ -940,7 +962,7 @@ async fn start_coding_task_conflict_state_is_a_hard_blocker_but_remains_inspecta
     let project = register_agent_project_at_path(&runtime, client_id, "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = start_coding_task_serviced(
+    let result = coding_workflow_serviced(
         &runtime,
         client_id,
         json!({"project": project, "detail": "minimal"}),
@@ -975,15 +997,25 @@ async fn start_coding_task_conflict_state_is_a_hard_blocker_but_remains_inspecta
 }
 
 #[tokio::test]
-async fn start_coding_task_unknown_project_still_fails() {
+async fn coding_workflow_unknown_project_still_fails() {
     let runtime = test_runtime();
     let auth = auth_context(None, true);
     let result = runtime
-        .dispatch_with_auth(
-            internal_start_coding_task_call(json!({
-                "project": "agent:missing:does-not-exist"
-            })),
+        .start_coding_workflow_for_test(
+            "agent:missing:does-not-exist".to_string(),
+            None,
+            None,
+            None,
+            SessionMode::Normal,
+            false,
+            false,
+            StartupDetail::Standard,
+            None,
+            None,
             Some(&auth),
+            None,
+            None,
+            SessionTransport::Api,
         )
         .await;
     assert!(
@@ -1024,7 +1056,7 @@ async fn start_coding_task_unknown_project_still_fails() {
 }
 
 #[tokio::test]
-async fn start_coding_task_agent_offline_is_still_blocking() {
+async fn coding_workflow_runner_offline_is_still_blocking() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     commit_file(tmp.path(), "README.md", "hello\n", "add readme");
@@ -1039,11 +1071,21 @@ async fn start_coding_task_agent_offline_is_still_blocking() {
 
     let auth = auth_context(None, true);
     let result = runtime
-        .dispatch_with_auth(
-            internal_start_coding_task_call(json!({
-                "project": project
-            })),
+        .start_coding_workflow_for_test(
+            project,
+            None,
+            None,
+            None,
+            SessionMode::Normal,
+            false,
+            false,
+            StartupDetail::Standard,
+            None,
+            None,
             Some(&auth),
+            None,
+            None,
+            SessionTransport::Api,
         )
         .await;
 
@@ -1069,7 +1111,7 @@ async fn start_coding_task_agent_offline_is_still_blocking() {
 }
 
 #[test]
-fn start_coding_task_rejection_precedes_legacy_argument_validation() {
+fn retired_start_coding_task_rejection_precedes_legacy_argument_validation() {
     let error = ToolCall::from_tool_name(
         "start_coding_task",
         json!({"project": "agent:demo:demo", "include_runtime_status": false}),
@@ -1092,28 +1134,16 @@ async fn finish_coding_task_requires_explicit_session_and_returns_structured_fie
     let project =
         register_agent_project_at_path(&runtime, "coding-finish", "demo", tmp.path()).await;
     let auth = auth_context(None, true);
-    let start = runtime
-        .dispatch_with_auth(
-            ToolCall::StartCodingTask {
-                project: project.clone(),
-                client_id: None,
-                path: None,
-                title: Some("finish contract".to_string()),
-                mode: SessionMode::Normal,
-                detail: Default::default(),
-                deny_write_tools: false,
-                deny_shell_tools: false,
-                resume_session_id: None,
-                execution_context: None,
-            },
-            Some(&auth),
-        )
-        .await;
+    let start = work_on_project_serviced(
+        &runtime,
+        "coding-finish",
+        &project,
+        "finish contract",
+        &auth,
+    )
+    .await;
     assert!(start.success, "{:?}", start.error);
-    let session_id = start.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
+    let session_id = start.output["session_id"].as_str().unwrap().to_string();
 
     fs::write(tmp.path().join("README.md"), "hello\nchanged\n").unwrap();
     let task = tokio::spawn({
@@ -3402,7 +3432,7 @@ async fn session_handoff_summary_only_with_agent_limit(
 }
 
 #[tokio::test]
-async fn start_coding_task_top_level_recommended_flow_projects_to_visible_manifest_tools() {
+async fn coding_workflow_full_diagnostic_recommended_flow_projects_to_visible_manifest_tools() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     let runtime = test_runtime();
@@ -3410,7 +3440,7 @@ async fn start_coding_task_top_level_recommended_flow_projects_to_visible_manife
         register_agent_project_at_path(&runtime, "coding-flow-proj", "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let result = start_coding_task_serviced(
+    let result = coding_workflow_serviced(
         &runtime,
         "coding-flow-proj",
         json!({ "project": project, "detail": "full" }),
@@ -3456,7 +3486,7 @@ async fn start_coding_task_top_level_recommended_flow_projects_to_visible_manife
 }
 
 #[tokio::test]
-async fn start_coding_task_standard_omits_repeated_manifest_and_recommended_flow() {
+async fn coding_workflow_standard_omits_repeated_manifest_and_recommended_flow() {
     let tmp = tempfile::tempdir().unwrap();
     init_git_repo(tmp.path());
     let runtime = test_runtime();
@@ -3464,25 +3494,16 @@ async fn start_coding_task_standard_omits_repeated_manifest_and_recommended_flow
         register_agent_project_at_path(&runtime, "coding-flow-full", "demo", tmp.path()).await;
     let auth = auth_context(None, true);
 
-    let task = tokio::spawn({
-        let runtime = runtime.clone();
-        let project = project.clone();
-        let auth = auth.clone();
-        async move {
-            runtime
-                .dispatch_with_auth(
-                    internal_start_coding_task_call(json!({
-                        "project": project,
-                        "detail": "standard"
-                    })),
-                    Some(&auth),
-                )
-                .await
-        }
-    });
-    let request = wait_for_patch_agent_request(&runtime, "coding-flow-full").await;
-    complete_agent_request_by_running_locally(&runtime, "coding-flow-full", request).await;
-    let result = task.await.unwrap();
+    let result = coding_workflow_serviced(
+        &runtime,
+        "coding-flow-full",
+        json!({
+            "project": project,
+            "detail": "standard"
+        }),
+        &auth,
+    )
+    .await;
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["detail"], "standard");
     assert!(result.output.get("tool_manifest").is_none());

--- a/src/tool_runtime/tests/coding_task_semantic_navigation.rs
+++ b/src/tool_runtime/tests/coding_task_semantic_navigation.rs
@@ -8,8 +8,8 @@ use crate::shell_protocol::{
     SHELL_CLIENT_CAPABILITY_LSP_READ_ONLY_NAVIGATION,
 };
 use crate::tool_runtime::{
-    known_tool_names, model_hidden_tool_names, registered_tool_specs, SessionMode, ToolCall,
-    ToolResult, ToolRuntime,
+    known_tool_names, model_hidden_tool_names, registered_tool_specs, SessionMode, ToolResult,
+    ToolRuntime,
 };
 use serde_json::{json, Value};
 use std::time::{Duration, Instant};
@@ -43,21 +43,6 @@ async fn register_semantic_agent(
     crate::tool_runtime::agent_project_runtime_id(client_id, project_id)
 }
 
-fn start_call(project: String, mode: SessionMode) -> ToolCall {
-    ToolCall::StartCodingTask {
-        project,
-        client_id: None,
-        path: None,
-        title: Some("semantic navigation startup".to_string()),
-        mode,
-        detail: Default::default(),
-        deny_write_tools: false,
-        deny_shell_tools: false,
-        resume_session_id: None,
-        execution_context: None,
-    }
-}
-
 fn spawn_start(
     runtime: &ToolRuntime,
     project: String,
@@ -66,7 +51,22 @@ fn spawn_start(
     let runtime = runtime.clone();
     tokio::spawn(async move {
         runtime
-            .dispatch_with_auth(start_call(project, mode), Some(&auth_context(None, true)))
+            .start_coding_workflow_for_test(
+                project,
+                None,
+                None,
+                Some("semantic navigation startup".to_string()),
+                mode,
+                false,
+                false,
+                Default::default(),
+                None,
+                None,
+                Some(&auth_context(None, true)),
+                None,
+                None,
+                crate::tool_runtime::sessions::SessionTransport::Api,
+            )
             .await
     })
 }
@@ -153,8 +153,8 @@ fn seed_clean_repo(root: &std::path::Path) {
     commit_file(root, "README.md", "# demo\n", "chore: seed fixture");
 }
 
-/// Standard-detail startup inspects git through the agent; service those
-/// remaining requests locally until start_coding_task finishes.
+/// Standard-detail startup inspects Git through the Runner; service those
+/// remaining requests locally until the coding workflow finishes.
 async fn finish_start_servicing_locally(
     runtime: &ToolRuntime,
     client_id: &str,
@@ -164,7 +164,7 @@ async fn finish_start_servicing_locally(
     while !task.is_finished() {
         assert!(
             Instant::now() < deadline,
-            "start_coding_task did not finish within the 10-second test deadline"
+            "coding workflow did not finish within the 10-second test deadline"
         );
         if let Some(request) = probe_patch_agent_request(runtime, client_id).await {
             complete_agent_request_by_running_locally(runtime, client_id, request).await;
@@ -298,9 +298,21 @@ async fn coding_task_semantic_navigation_disconnected_agent_is_nonblocking() {
         .reconcile_disconnect("offline-agent", "inst")
         .await;
     let result = runtime
-        .dispatch_with_auth(
-            start_call(project, SessionMode::Normal),
+        .start_coding_workflow_for_test(
+            project,
+            None,
+            None,
+            Some("semantic navigation startup".to_string()),
+            SessionMode::Normal,
+            false,
+            false,
+            Default::default(),
+            None,
+            None,
             Some(&auth_context(None, true)),
+            None,
+            None,
+            crate::tool_runtime::sessions::SessionTransport::Api,
         )
         .await;
     assert!(result.success, "{result:?}");
@@ -476,7 +488,7 @@ async fn coding_task_semantic_navigation_read_only_keeps_compact_shape() {
 }
 
 #[test]
-fn coding_task_semantic_navigation_output_schema_is_explicit_and_surface_counts_are_stable() {
+fn coding_workflow_semantic_navigation_output_schema_is_explicit_and_surface_counts_are_stable() {
     let specs = registered_tool_specs();
     let runtime_tool_count = specs.len();
     assert_eq!(
@@ -484,7 +496,7 @@ fn coding_task_semantic_navigation_output_schema_is_explicit_and_surface_counts_
         known_tool_names().count(),
         "visible runtime tool count + hidden tools must cover every known tool"
     );
-    let schema = crate::tool_runtime::registry::output_schema_for_tool("start_coding_task");
+    let schema = crate::tool_runtime::registry::coding_workflow_diagnostic_output_schema_for_test();
     let standard = schema["properties"]["output"]["oneOf"]
         .as_array()
         .unwrap()

--- a/src/tool_runtime/tests/context_projection.rs
+++ b/src/tool_runtime/tests/context_projection.rs
@@ -451,9 +451,10 @@ async fn mutation_context_projection_is_post_tool_and_does_not_change_authority_
             "mutation sidecar fixture timed out"
         );
         if let Some(request) = probe_patch_agent_request(&runtime, "context-write").await {
-            assert_eq!(
-                request.kind, "file_read",
-                "only post-tool instruction reads may follow the write"
+            assert!(
+                matches!(request.kind.as_str(), "file_read" | "file_list"),
+                "only post-tool instruction observation may follow the write: {}",
+                request.kind
             );
             let (exit_code, stdout, stderr) = run_agent_shell_request_locally(&request);
             complete_patch_agent_request(

--- a/src/tool_runtime/tests/continuation_feedback.rs
+++ b/src/tool_runtime/tests/continuation_feedback.rs
@@ -1707,46 +1707,89 @@ fn jobs_block_recovering_hidden_beyond_truncated_recent_still_reported() {
 }
 
 // =========================================================================
-// Real entry integration: start_coding_task pre-instruction attempt
+// Canonical coding workflow integration: pre-instruction attempt
 // =========================================================================
 
-use crate::tool_runtime::tests::reconnect::dispatch_start_coding_task_in_window;
-use crate::tool_runtime::{StartupDetail, ToolCall};
+use crate::tool_runtime::{StartupDetail, ToolCall, ToolResult};
 
-fn coding_call(project: &str, instruction: &str, resume: Option<&str>) -> ToolCall {
-    ToolCall::StartCodingTask {
-        project: project.to_string(),
-        client_id: None,
-        path: None,
-        title: Some(instruction.to_string()),
-        mode: SessionMode::Normal,
-        deny_write_tools: false,
-        deny_shell_tools: false,
-        // These integration assertions exercise the complete underlying
-        // continuation_feedback block retained by full diagnostics. Standard
-        // uses the separately tested bounded model-facing projection.
-        detail: StartupDetail::Full,
-        resume_session_id: resume.map(str::to_string),
-        execution_context: None,
+async fn diagnostic_coding_workflow(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: &str,
+    instruction: &str,
+    resume: Option<&str>,
+) -> ToolResult {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.to_string();
+        let instruction = instruction.to_string();
+        let resume = resume.map(str::to_string);
+        let auth = auth_context(None, true);
+        async move {
+            runtime
+                .start_coding_workflow_for_test(
+                    project,
+                    None,
+                    None,
+                    Some(instruction),
+                    SessionMode::Normal,
+                    false,
+                    false,
+                    // These integration assertions exercise the complete
+                    // continuation_feedback block retained by full diagnostics.
+                    StartupDetail::Full,
+                    resume,
+                    None,
+                    Some(&auth),
+                    None,
+                    None,
+                    crate::tool_runtime::sessions::SessionTransport::Mcp,
+                )
+                .await
+        }
+    });
+    while !task.is_finished() {
+        if let Some(req) = runtime
+            .shell_clients
+            .poll(crate::shell_protocol::ShellAgentPollRequest {
+                client_id: client_id.to_string(),
+                agent_instance_id: "inst".to_string(),
+            })
+            .await
+            .unwrap()
+        {
+            let (exit_code, stdout, stderr) = run_agent_shell_request_locally(&req);
+            complete_patch_agent_request(
+                runtime,
+                client_id,
+                &req.request_id,
+                exit_code,
+                &stdout,
+                &stderr,
+            )
+            .await;
+        } else {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
     }
+    task.await.unwrap()
 }
 
 #[tokio::test]
-async fn start_coding_task_continuation_describes_previous_attempt_not_empty_new_one() {
+async fn coding_workflow_continuation_describes_previous_attempt_not_empty_new_one() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
     let runtime = ToolRuntime::new_for_tests();
     let project =
         register_agent_project_at_path(&runtime, "continuation-agent", "demo", dir.path()).await;
-    let auth = auth_context(None, true);
 
-    // First start_coding_task creates the session with instruction A.
-    let first = dispatch_start_coding_task_in_window(
+    // First coding workflow creates the session with instruction A.
+    let first = diagnostic_coding_workflow(
         &runtime,
         "continuation-agent",
-        coding_call(&project, "instruction A", None),
-        Some(&auth),
-        "continuation-window",
+        &project,
+        "instruction A",
+        None,
     )
     .await;
     assert!(first.success, "{:?}", first.error);
@@ -1773,13 +1816,13 @@ async fn start_coding_task_continuation_describes_previous_attempt_not_empty_new
         .events
         .len();
 
-    // Second start_coding_task continues with instruction B on the same session.
-    let second = dispatch_start_coding_task_in_window(
+    // Second coding workflow continues with instruction B on the same session.
+    let second = diagnostic_coding_workflow(
         &runtime,
         "continuation-agent",
-        coding_call(&project, "instruction B", Some(&session_id)),
-        Some(&auth),
-        "continuation-window",
+        &project,
+        "instruction B",
+        Some(&session_id),
     )
     .await;
     assert!(second.success, "{:?}", second.error);
@@ -1837,21 +1880,14 @@ async fn start_coding_task_continuation_describes_previous_attempt_not_empty_new
 }
 
 #[tokio::test]
-async fn start_coding_task_fresh_session_continuation_is_not_applicable() {
+async fn coding_workflow_fresh_session_continuation_is_not_applicable() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
     let runtime = ToolRuntime::new_for_tests();
     let project = register_agent_project_at_path(&runtime, "fresh-agent", "demo", dir.path()).await;
-    let auth = auth_context(None, true);
 
-    let first = dispatch_start_coding_task_in_window(
-        &runtime,
-        "fresh-agent",
-        coding_call(&project, "fresh start", None),
-        Some(&auth),
-        "fresh-window",
-    )
-    .await;
+    let first =
+        diagnostic_coding_workflow(&runtime, "fresh-agent", &project, "fresh start", None).await;
     assert!(first.success, "{:?}", first.error);
     assert_eq!(first.output["session"]["continuation"], "created");
     let feedback = &first.output["continuation_feedback"];

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -5207,21 +5207,40 @@ fn simulate_transport_tail(stdout: &str, max_bytes: usize) -> String {
 /// the child status. Used by large-output regression tests where the command
 /// legitimately exceeds the pipe buffer.
 fn run_command_full_capture(cmd: &str, cwd: &Path, timeout_secs: u64) -> (i32, String, String) {
-    use std::io::Read;
+    use std::io::{Read, Write};
     use std::process::Command;
     use std::sync::mpsc;
     use std::time::{Duration, Instant};
-    let mut command = Command::new("sh");
+    let mut command = Command::new(crate::tool_runtime::helpers::test_shell());
+    #[cfg(windows)]
+    command.arg("-s").stdin(std::process::Stdio::piped());
+    #[cfg(not(windows))]
+    command.arg("-c").arg(cmd);
     command
-        .arg("-c")
-        .arg(cmd)
         .current_dir(cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     let mut child = match command.spawn() {
         Ok(c) => c,
-        Err(_) => return (-1, String::new(), "failed to spawn".to_string()),
+        Err(error) => return (-1, String::new(), format!("failed to spawn: {error}")),
     };
+    #[cfg(windows)]
+    {
+        let write_result = child
+            .stdin
+            .take()
+            .expect("test shell stdin")
+            .write_all(cmd.as_bytes());
+        if let Err(error) = write_result {
+            let _ = child.kill();
+            let _ = child.wait();
+            return (
+                -1,
+                String::new(),
+                format!("failed to write shell command: {error}"),
+            );
+        }
+    }
     let mut stdout = child.stdout.take().expect("stdout piped");
     let mut stderr = child.stderr.take().expect("stderr piped");
     // Drain each pipe on its own thread so the child never blocks on a full
@@ -5727,7 +5746,7 @@ fn show_changes_long_path_diff_budgets_complete_preambles_and_bytes() {
 
     let mut rejected_seen = false;
     for (i, path) in paths.iter().enumerate() {
-        let display = path.to_string_lossy();
+        let display = path.to_string_lossy().replace('\\', "/");
         let preamble = format!("diff --git a/{display} b/{display}");
         let body = format!("+changed-{i}");
         let accepted = frames.diff.contains(&preamble);

--- a/src/tool_runtime/tests/reconnect.rs
+++ b/src/tool_runtime/tests/reconnect.rs
@@ -398,19 +398,16 @@ async fn canonical_project_session_explicit_resume_survives_restart() {
         &alice,
     )
     .await;
-    let started = dispatch_start_coding_task_in_window(
+    let started = dispatch_coding_call_in_window(
         &runtime1,
         "canonical-restart-agent",
-        coding_start_call(&project, "canonical root", SessionMode::Normal),
+        coding_start_call(&project, "canonical root"),
         Some(&alice),
         "canonical-restart-window",
     )
     .await;
     assert!(started.success, "{:?}", started.error);
-    let session_id = started.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
+    let session_id = started.output["session_id"].as_str().unwrap().to_string();
     runtime1.sessions.flush_persistence();
     assert_eq!(
         persisted_session_authority_fingerprint(&ledger, &session_id).as_deref(),
@@ -428,7 +425,7 @@ async fn canonical_project_session_explicit_resume_survives_restart() {
     )
     .await;
     assert_eq!(runtime2.sessions.status().restored_sessions, 1);
-    let resumed = dispatch_start_coding_task_in_window(
+    let resumed = dispatch_coding_call_in_window(
         &runtime2,
         "canonical-restart-agent",
         coding_resume_call(&project, "explicit canonical resume", &session_id),
@@ -437,7 +434,7 @@ async fn canonical_project_session_explicit_resume_survives_restart() {
     )
     .await;
     assert!(resumed.success, "{:?}", resumed.error);
-    assert_eq!(resumed.output["session"]["session_id"], session_id);
+    assert_eq!(resumed.output["session_id"], session_id);
     assert_eq!(
         runtime2
             .sessions
@@ -465,19 +462,16 @@ async fn malformed_persisted_authority_is_discarded_fail_closed() {
         &alice,
     )
     .await;
-    let started = dispatch_start_coding_task_in_window(
+    let started = dispatch_coding_call_in_window(
         &runtime1,
         "malformed-authority-agent",
-        coding_start_call(&project, "canonical root", SessionMode::Normal),
+        coding_start_call(&project, "canonical root"),
         Some(&alice),
         "malformed-authority-window",
     )
     .await;
     assert!(started.success, "{:?}", started.error);
-    let session_id = started.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
+    let session_id = started.output["session_id"].as_str().unwrap().to_string();
     runtime1.sessions.flush_persistence();
     drop(runtime1);
     rewrite_persisted_session_with_malformed_authority(&ledger, &session_id);
@@ -799,14 +793,14 @@ async fn runner_host_context_is_revalidated_at_server_registration() {
         .is_none());
 }
 
-pub(in crate::tool_runtime::tests) async fn dispatch_start_coding_task_in_window(
+pub(in crate::tool_runtime::tests) async fn dispatch_coding_call_in_window(
     runtime: &ToolRuntime,
     client_id: &str,
     call: ToolCall,
     auth: Option<&AuthContext>,
     window_id: &str,
 ) -> crate::tool_runtime::ToolResult {
-    dispatch_start_coding_task_in_window_with_transport(
+    dispatch_coding_call_in_window_with_transport(
         runtime,
         client_id,
         call,
@@ -817,7 +811,7 @@ pub(in crate::tool_runtime::tests) async fn dispatch_start_coding_task_in_window
     .await
 }
 
-async fn dispatch_start_coding_task_in_window_with_transport(
+async fn dispatch_coding_call_in_window_with_transport(
     runtime: &ToolRuntime,
     client_id: &str,
     call: ToolCall,
@@ -846,7 +840,7 @@ async fn dispatch_start_coding_task_in_window_with_transport(
     while !task.is_finished() {
         assert!(
             std::time::Instant::now() < deadline,
-            "start_coding_task did not finish within the 10-second test deadline"
+            "coding workflow did not finish within the 10-second test deadline"
         );
         if let Some(req) = runtime
             .shell_clients
@@ -874,38 +868,32 @@ async fn dispatch_start_coding_task_in_window_with_transport(
     task.await.unwrap()
 }
 
-fn coding_start_call(project: &str, instruction: &str, mode: SessionMode) -> ToolCall {
-    ToolCall::StartCodingTask {
+fn coding_start_call(project: &str, instruction: &str) -> ToolCall {
+    ToolCall::WorkOnProject {
         project: project.to_string(),
         client_id: None,
         path: None,
-        title: Some(instruction.to_string()),
-        mode,
-        deny_write_tools: false,
-        deny_shell_tools: false,
-        detail: StartupDetail::Standard,
-        resume_session_id: None,
-        execution_context: None,
+        instruction: instruction.to_string(),
+        session_id: None,
+        include_project_instructions: true,
+        include_workflow_guidance: true,
     }
 }
 
 fn coding_resume_call(project: &str, instruction: &str, session_id: &str) -> ToolCall {
-    ToolCall::StartCodingTask {
+    ToolCall::WorkOnProject {
         project: project.to_string(),
         client_id: None,
         path: None,
-        title: Some(instruction.to_string()),
-        mode: SessionMode::Normal,
-        deny_write_tools: false,
-        deny_shell_tools: false,
-        detail: StartupDetail::Standard,
-        resume_session_id: Some(session_id.to_string()),
-        execution_context: None,
+        instruction: instruction.to_string(),
+        session_id: Some(session_id.to_string()),
+        include_project_instructions: true,
+        include_workflow_guidance: true,
     }
 }
 
 #[tokio::test]
-async fn start_coding_task_without_resume_always_creates_fresh_session() {
+async fn work_on_project_without_resume_always_creates_fresh_session() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
     let runtime = ToolRuntime::new_for_tests();
@@ -913,18 +901,18 @@ async fn start_coding_task_without_resume_always_creates_fresh_session() {
         register_agent_project_at_path(&runtime, "continuity-agent", "demo", dir.path()).await;
     let auth = auth_context(None, true);
 
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "continuity-agent",
-        coding_start_call(&project, "root objective", SessionMode::Normal),
+        coding_start_call(&project, "root objective"),
         Some(&auth),
         "continuity-window",
     )
     .await;
-    let second = dispatch_start_coding_task_in_window(
+    let second = dispatch_coding_call_in_window(
         &runtime,
         "continuity-agent",
-        coding_start_call(&project, "follow-up objective", SessionMode::Normal),
+        coding_start_call(&project, "follow-up objective"),
         Some(&auth),
         "continuity-window",
     )
@@ -932,11 +920,11 @@ async fn start_coding_task_without_resume_always_creates_fresh_session() {
 
     assert!(first.success, "{:?}", first.error);
     assert!(second.success, "{:?}", second.error);
-    let first_id = first.output["session"]["session_id"].as_str().unwrap();
-    let second_id = second.output["session"]["session_id"].as_str().unwrap();
+    let first_id = first.output["session_id"].as_str().unwrap();
+    let second_id = second.output["session_id"].as_str().unwrap();
     assert_ne!(second_id, first_id);
-    assert_eq!(first.output["session"]["continuation"], "created");
-    assert_eq!(second.output["session"]["continuation"], "created");
+    assert_eq!(first.output["continuation"], "created");
+    assert_eq!(second.output["continuation"], "created");
     assert_eq!(
         runtime
             .sessions
@@ -966,32 +954,32 @@ async fn start_coding_task_without_resume_always_creates_fresh_session() {
 }
 
 #[tokio::test]
-async fn start_coding_task_second_fresh_start_preserves_previous_session() {
+async fn work_on_project_second_fresh_start_preserves_previous_session() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
     let runtime = ToolRuntime::new_for_tests();
     let project =
         register_agent_project_at_path(&runtime, "isolation-agent", "demo", dir.path()).await;
     let auth = auth_context(None, true);
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "isolation-agent",
-        coding_start_call(&project, "first root", SessionMode::Normal),
+        coding_start_call(&project, "first root"),
         Some(&auth),
         "isolation-window",
     )
     .await;
-    let isolated = dispatch_start_coding_task_in_window(
+    let isolated = dispatch_coding_call_in_window(
         &runtime,
         "isolation-agent",
-        coding_start_call(&project, "second root", SessionMode::Normal),
+        coding_start_call(&project, "second root"),
         Some(&auth),
         "isolation-window",
     )
     .await;
     assert!(first.success && isolated.success);
-    let first_id = first.output["session"]["session_id"].as_str().unwrap();
-    let isolated_id = isolated.output["session"]["session_id"].as_str().unwrap();
+    let first_id = first.output["session_id"].as_str().unwrap();
+    let isolated_id = isolated.output["session_id"].as_str().unwrap();
     assert_ne!(first_id, isolated_id);
     assert_eq!(
         runtime
@@ -1013,20 +1001,20 @@ async fn failed_project_start_does_not_create_or_mutate_workflow_session() {
     let runtime = ToolRuntime::new_for_tests();
     let project = register_agent_project_at_path(&runtime, "stable-agent", "a", dir.path()).await;
     let auth = auth_context(None, true);
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "stable-agent",
-        coding_start_call(&project, "stable A", SessionMode::Normal),
+        coding_start_call(&project, "stable A"),
         Some(&auth),
         "failed-switch-window",
     )
     .await;
     assert!(first.success);
 
-    let failed = dispatch_start_coding_task_in_window(
+    let failed = dispatch_coding_call_in_window(
         &runtime,
         "stable-agent",
-        coding_start_call("agent:missing-agent:b", "failed B", SessionMode::Normal),
+        coding_start_call("agent:missing-agent:b", "failed B"),
         Some(&auth),
         "failed-switch-window",
     )
@@ -1040,19 +1028,16 @@ async fn failed_project_start_does_not_create_or_mutate_workflow_session() {
         1
     );
 
-    let again = dispatch_start_coding_task_in_window(
+    let again = dispatch_coding_call_in_window(
         &runtime,
         "stable-agent",
-        coding_start_call(&project, "fresh A", SessionMode::Normal),
+        coding_start_call(&project, "fresh A"),
         Some(&auth),
         "failed-switch-window",
     )
     .await;
     assert!(again.success);
-    assert_ne!(
-        first.output["session"]["session_id"],
-        again.output["session"]["session_id"]
-    );
+    assert_ne!(first.output["session_id"], again.output["session_id"]);
     assert_eq!(
         runtime
             .sessions
@@ -1062,7 +1047,7 @@ async fn failed_project_start_does_not_create_or_mutate_workflow_session() {
 }
 
 #[tokio::test]
-async fn start_coding_task_read_only_upgrade_is_atomic_and_permission_checked() {
+async fn coding_workflow_read_only_upgrade_is_atomic_and_permission_checked() {
     let dir = tempfile::tempdir().unwrap();
     init_git_repo(dir.path());
     commit_file(
@@ -1102,20 +1087,62 @@ async fn start_coding_task_read_only_upgrade_is_atomic_and_permission_checked() 
         &read_auth,
     )
     .await;
-    let read_only_started = dispatch_start_coding_task_in_window(
-        &runtime,
-        "oauth-client",
-        coding_start_call(&project, "read only first", SessionMode::ReadOnly),
-        Some(&read_auth),
-        "upgrade-window",
-    )
-    .await;
+    let read_only_task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let read_auth = read_auth.clone();
+        async move {
+            runtime
+                .start_coding_workflow_for_test(
+                    project,
+                    None,
+                    None,
+                    Some("read only first".to_string()),
+                    SessionMode::ReadOnly,
+                    false,
+                    false,
+                    StartupDetail::Standard,
+                    None,
+                    None,
+                    Some(&read_auth),
+                    None,
+                    None,
+                    crate::tool_runtime::sessions::SessionTransport::Mcp,
+                )
+                .await
+        }
+    });
+    while !read_only_task.is_finished() {
+        if let Some(req) = runtime
+            .shell_clients
+            .poll(crate::shell_protocol::ShellAgentPollRequest {
+                client_id: "oauth-client".to_string(),
+                agent_instance_id: "inst".to_string(),
+            })
+            .await
+            .unwrap()
+        {
+            let (exit_code, stdout, stderr) = run_agent_shell_request_locally(&req);
+            complete_patch_agent_request(
+                &runtime,
+                "oauth-client",
+                &req.request_id,
+                exit_code,
+                &stdout,
+                &stderr,
+            )
+            .await;
+        } else {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    }
+    let read_only_started = read_only_task.await.unwrap();
     assert!(read_only_started.success, "{:?}", read_only_started.error);
     let session_id = read_only_started.output["session"]["session_id"]
         .as_str()
         .unwrap()
         .to_string();
-    let read = dispatch_start_coding_task_in_window(
+    let read = dispatch_coding_call_in_window(
         &runtime,
         "oauth-client",
         ToolCall::ReadFile {
@@ -1132,7 +1159,7 @@ async fn start_coding_task_read_only_upgrade_is_atomic_and_permission_checked() 
     .await;
     assert!(read.success, "{:?}", read.error);
 
-    let denied = dispatch_start_coding_task_in_window(
+    let denied = dispatch_coding_call_in_window(
         &runtime,
         "oauth-client",
         coding_resume_call(&project, "request writes", &session_id),
@@ -1158,7 +1185,7 @@ async fn start_coding_task_read_only_upgrade_is_atomic_and_permission_checked() 
         1
     );
 
-    let upgraded = dispatch_start_coding_task_in_window(
+    let upgraded = dispatch_coding_call_in_window(
         &runtime,
         "oauth-client",
         coding_resume_call(&project, "enable writes", &session_id),
@@ -1167,22 +1194,11 @@ async fn start_coding_task_read_only_upgrade_is_atomic_and_permission_checked() 
     )
     .await;
     assert!(upgraded.success, "{:?}", upgraded.error);
-    assert_eq!(upgraded.output["session"]["session_id"], session_id);
-    assert_eq!(upgraded.output["session"]["mode"], "normal");
+    assert_eq!(upgraded.output["session_id"], session_id);
+    assert_eq!(upgraded.output["continuation"], "resumed_explicitly");
     assert_eq!(upgraded.output["instructions"]["status"], "reused");
-    assert_eq!(upgraded.output["instructions"]["content_included"], false);
-    assert_eq!(
-        upgraded.output["continuation"]["exploration"]["paths"]["items"],
-        serde_json::json!(["src/inspect.rs"])
-    );
-    assert_eq!(
-        upgraded.output["continuation"]["exploration"]["read_count"],
-        1
-    );
-    assert_eq!(
-        upgraded.output["continuation"]["exploration"]["complete"],
-        true
-    );
+    assert_eq!(upgraded.output["instructions"]["content_included"], true);
+    assert!(upgraded.output.get("continuation_feedback").is_none());
     let summary = runtime.sessions.summary(&session_id, Some(20)).unwrap();
     assert!(!summary.guards.deny_write_tools);
     assert!(!summary.guards.deny_shell_tools);
@@ -1206,6 +1222,6 @@ async fn start_coding_task_read_only_upgrade_is_atomic_and_permission_checked() 
             })
             .count(),
         1,
-        "start_coding_task must not reread ordinary explored source files"
+        "coding workflow must not reread ordinary explored source files"
     );
 }

--- a/src/tool_runtime/tests/schema/definitions.rs
+++ b/src/tool_runtime/tests/schema/definitions.rs
@@ -245,7 +245,6 @@ fn tool_call_parser_name_gate_matches_tool_definitions() {
     // they are absent here.
     let expected_hidden: BTreeSet<&str> = [
         "start_session",
-        "start_coding_task",
         "job_tail",
         "read_tool_trace",
         "skill_list",

--- a/src/tool_runtime/tests/schema/policy.rs
+++ b/src/tool_runtime/tests/schema/policy.rs
@@ -391,7 +391,7 @@ fn tool_definitions_drive_session_and_permission_policy() {
         .collect::<Vec<_>>();
     assert_eq!(
         extra_accepted_flattened_arg_tools,
-        vec![("start_coding_task", vec!["session_id"])]
+        Vec::<(&str, Vec<&str>)>::new()
     );
 
     let unit_argument_tools = tool_definitions()

--- a/src/tool_runtime/tests/sessions_guards.rs
+++ b/src/tool_runtime/tests/sessions_guards.rs
@@ -1000,7 +1000,7 @@ async fn deny_shell_only_allows_write_tools() {
 fn project_tool_schemas_include_optional_session_id() {
     let specs = registered_tool_specs();
     // `start_session` is ModelHidden (the model coding line is covered by
-    // `start_coding_task`): it has no public ToolSpec, so its guard schema is
+    // `work_on_project`): it has no public ToolSpec, so its guard schema is
     // verified directly from the output schema builder rather than via
     // `spec_named`, keeping the session guard-field contract asserted at the
     // implementation level.

--- a/src/tool_runtime/tests/startup_brief.rs
+++ b/src/tool_runtime/tests/startup_brief.rs
@@ -1,4 +1,4 @@
-use super::reconnect::dispatch_start_coding_task_in_window;
+use super::reconnect::dispatch_coding_call_in_window;
 use super::support::*;
 use crate::shell_client::ShellJobStartMetadata;
 use crate::shell_protocol::{
@@ -14,43 +14,72 @@ use serde_json::{json, Value};
 use std::fs;
 use std::path::Path;
 
-fn start_call(
-    project: &str,
-    detail: StartupDetail,
-    title: &str,
-    resume_session_id: Option<&str>,
-) -> ToolCall {
-    ToolCall::StartCodingTask {
-        project: project.to_string(),
-        client_id: None,
-        path: None,
-        title: Some(title.to_string()),
-        mode: SessionMode::Normal,
-        detail,
-        deny_write_tools: false,
-        deny_shell_tools: false,
-        resume_session_id: resume_session_id.map(str::to_string),
-        execution_context: None,
-    }
-}
-
 async fn start(
     runtime: &ToolRuntime,
     client_id: &str,
     project: &str,
-    window: &str,
+    _window: &str,
     detail: StartupDetail,
     title: &str,
     resume_session_id: Option<&str>,
 ) -> ToolResult {
-    dispatch_start_coding_task_in_window(
-        runtime,
-        client_id,
-        start_call(project, detail, title, resume_session_id),
-        Some(&auth_context(None, true)),
-        window,
-    )
-    .await
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.to_string();
+        let title = title.to_string();
+        let resume_session_id = resume_session_id.map(str::to_string);
+        let auth = auth_context(None, true);
+        async move {
+            runtime
+                .start_coding_workflow_for_test(
+                    project,
+                    None,
+                    None,
+                    Some(title),
+                    SessionMode::Normal,
+                    false,
+                    false,
+                    detail,
+                    resume_session_id,
+                    None,
+                    Some(&auth),
+                    None,
+                    None,
+                    crate::tool_runtime::sessions::SessionTransport::Mcp,
+                )
+                .await
+        }
+    });
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !task.is_finished() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "coding workflow did not finish within the 10-second test deadline"
+        );
+        if let Some(req) = runtime
+            .shell_clients
+            .poll(crate::shell_protocol::ShellAgentPollRequest {
+                client_id: client_id.to_string(),
+                agent_instance_id: "inst".to_string(),
+            })
+            .await
+            .unwrap()
+        {
+            let (exit_code, stdout, stderr) = run_agent_shell_request_locally(&req);
+            complete_patch_agent_request(
+                runtime,
+                client_id,
+                &req.request_id,
+                exit_code,
+                &stdout,
+                &stderr,
+            )
+            .await;
+        } else {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    }
+    task.await.unwrap()
 }
 
 fn seed_rules(root: &Path) {
@@ -739,12 +768,14 @@ async fn restart_restored_coding_task_session_reloads_rules_without_persisting_b
     let runtime1 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
     let project =
         register_agent_project_at_path(&runtime1, "rules-restart", "demo", root.path()).await;
-    let first = dispatch_start_coding_task_in_window(
+    let first = start(
         &runtime1,
         "rules-restart",
-        start_call(&project, StartupDetail::Standard, "before restart", None),
-        Some(&auth),
+        &project,
         "rules-restart-window",
+        StartupDetail::Standard,
+        "before restart",
+        None,
     )
     .await;
     assert!(first.success, "{:?}", first.error);
@@ -752,7 +783,7 @@ async fn restart_restored_coding_task_session_reloads_rules_without_persisting_b
         .as_str()
         .unwrap()
         .to_string();
-    let read = dispatch_start_coding_task_in_window(
+    let read = dispatch_coding_call_in_window(
         &runtime1,
         "rules-restart",
         ToolCall::ReadFile {
@@ -777,17 +808,14 @@ async fn restart_restored_coding_task_session_reloads_rules_without_persisting_b
 
     let runtime2 = ToolRuntime::new_for_tests().with_session_ledger(&ledger);
     register_agent_project_at_path(&runtime2, "rules-restart", "demo", root.path()).await;
-    let restored = dispatch_start_coding_task_in_window(
+    let restored = start(
         &runtime2,
         "rules-restart",
-        start_call(
-            &project,
-            StartupDetail::Standard,
-            "after restart",
-            Some(&session_id),
-        ),
-        Some(&auth),
+        &project,
         "rules-restart-window",
+        StartupDetail::Standard,
+        "after restart",
+        Some(&session_id),
     )
     .await;
 
@@ -1151,14 +1179,21 @@ async fn startup_runner_health_uses_the_exact_project_client() {
 
     let auth = auth_context(None, true);
     let unavailable = runtime
-        .dispatch_with_auth(
-            start_call(
-                &target_project,
-                StartupDetail::Full,
-                "inspect unavailable target runner",
-                None,
-            ),
+        .start_coding_workflow_for_test(
+            target_project.clone(),
+            None,
+            None,
+            Some("inspect unavailable target runner".to_string()),
+            SessionMode::Normal,
+            false,
+            false,
+            StartupDetail::Full,
+            None,
+            None,
             Some(&auth),
+            None,
+            None,
+            crate::tool_runtime::sessions::SessionTransport::Api,
         )
         .await;
     assert!(unavailable.success, "{:?}", unavailable.error);
@@ -1226,13 +1261,13 @@ async fn startup_runner_health_uses_the_exact_project_client() {
 }
 
 #[tokio::test]
-async fn minimal_standard_and_full_coding_task_outputs_validate_against_strict_schema() {
+async fn minimal_standard_and_full_coding_workflow_diagnostics_validate_against_strict_schema() {
     let root = tempfile::tempdir().unwrap();
     seed_rules(root.path());
     let runtime = ToolRuntime::new_for_tests();
     let project =
         register_agent_project_at_path(&runtime, "rules-schema", "demo", root.path()).await;
-    let schema = registry::output_schema_for_tool("start_coding_task");
+    let schema = registry::coding_workflow_diagnostic_output_schema_for_test();
     let recorder = runtime.sessions.start_session_with_guards(
         Some(project.clone()),
         Some("startup schema recorder".to_string()),
@@ -1388,7 +1423,7 @@ async fn worst_case_startup_with_huge_repository_stays_below_hard_limit() {
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["repository"]["status"], "available");
 
-    let schema = registry::output_schema_for_tool("start_coding_task");
+    let schema = registry::coding_workflow_diagnostic_output_schema_for_test();
     let value = json!({
         "success": result.success,
         "output": result.output,

--- a/src/tool_runtime/tests/support/agent.rs
+++ b/src/tool_runtime/tests/support/agent.rs
@@ -178,17 +178,11 @@ pub(in crate::tool_runtime::tests) fn run_agent_shell_request_locally(
         command.args(&process.args);
         (command, req.stdin.clone())
     } else if let Some(script) = internal_posix {
-        #[cfg(windows)]
-        let mut command = std::process::Command::new("bash.exe");
-        #[cfg(not(windows))]
-        let mut command = std::process::Command::new("sh");
+        let mut command = std::process::Command::new(crate::tool_runtime::helpers::test_shell());
         command.arg("-s");
         (command, Some(script.to_string()))
     } else if let Some(script) = internal_search {
-        #[cfg(windows)]
-        let mut command = std::process::Command::new("bash.exe");
-        #[cfg(not(windows))]
-        let mut command = std::process::Command::new("sh");
+        let mut command = std::process::Command::new(crate::tool_runtime::helpers::test_shell());
         command.arg("-s");
         let script = if cfg!(windows) {
             format!(
@@ -199,7 +193,7 @@ pub(in crate::tool_runtime::tests) fn run_agent_shell_request_locally(
         };
         (command, Some(script))
     } else {
-        let mut command = std::process::Command::new("sh");
+        let mut command = std::process::Command::new(crate::tool_runtime::helpers::test_shell());
         command.arg("-c").arg(&req.command);
         (command, req.stdin.clone())
     };

--- a/src/tool_runtime/tests/support/files.rs
+++ b/src/tool_runtime/tests/support/files.rs
@@ -2,7 +2,7 @@ use crate::tool_runtime::git::{
     collect_show_changes_untracked_previews_for_root, git_log_command, parse_porcelain_summary,
     parse_show_changes_output, show_changes_command, split_show_changes_stdout,
 };
-use crate::tool_runtime::helpers::{run_command_sync, shell_escape_simple};
+use crate::tool_runtime::helpers::run_command_sync;
 use crate::tool_runtime::{
     ApplyFileChangeInput, ApplyFileChangeKind, ApplyTextEditInput, ApplyTextEditKind,
 };
@@ -15,6 +15,8 @@ pub(in crate::tool_runtime::tests) fn init_git_repo(root: &Path) {
         "git init",
         "git config user.email webcodex-test@example.com",
         "git config user.name 'WebCodex Test'",
+        "git config core.autocrlf false",
+        "git config core.longpaths true",
     ] {
         let (exit_code, stdout, stderr, _) = run_command_sync(cmd, root, 30);
         assert_eq!(
@@ -31,16 +33,34 @@ pub(in crate::tool_runtime::tests) fn commit_file(
     subject: &str,
 ) {
     fs::write(root.join(path), content).unwrap();
-    for cmd in [
-        format!("git add -- {}", shell_escape_simple(path)),
-        format!("git commit -m {}", shell_escape_simple(subject)),
-    ] {
-        let (exit_code, stdout, stderr, _) = run_command_sync(&cmd, root, 30);
-        assert_eq!(
-            exit_code, 0,
-            "git commit helper command failed: {cmd}\nstdout:\n{stdout}\nstderr:\n{stderr}"
-        );
-    }
+    let add = std::process::Command::new("git")
+        .args(["add", "--"])
+        .arg(path)
+        .current_dir(root)
+        .output()
+        .expect("run git add fixture command");
+    assert!(
+        add.status.success(),
+        "git add fixture command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let message_path = root.join(".git").join("webcodex-test-commit-message");
+    fs::write(&message_path, subject).unwrap();
+    let commit = std::process::Command::new("git")
+        .args(["commit", "-F"])
+        .arg(&message_path)
+        .current_dir(root)
+        .output()
+        .expect("run git commit fixture command");
+    let _ = fs::remove_file(&message_path);
+    assert!(
+        commit.status.success(),
+        "git commit fixture command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&commit.stdout),
+        String::from_utf8_lossy(&commit.stderr)
+    );
 }
 
 pub(in crate::tool_runtime::tests) fn git_log_stdout(

--- a/src/tool_runtime/tests/support/runtime.rs
+++ b/src/tool_runtime/tests/support/runtime.rs
@@ -51,12 +51,8 @@ pub(in crate::tool_runtime::tests) fn sample_tool_args_for_spec(spec: &ToolSpec)
         .collect();
     // Conditional project-source schemas cannot express one representative
     // source through the top-level `required` array. Keep fixtures aligned with
-    // each tool's metadata contract: start_coding_task may create/resolve its
-    // project, while work_on_project is always project-scoped.
+    // each tool's metadata contract.
     match spec.name.as_str() {
-        "start_coding_task" => {
-            args.insert("client_id".to_string(), json!("oe"));
-        }
         "work_on_project" => {
             args.insert("project".to_string(), json!(SAMPLE_PROJECT));
         }

--- a/src/tool_runtime/tests/tool_call.rs
+++ b/src/tool_runtime/tests/tool_call.rs
@@ -805,29 +805,6 @@ fn work_on_project_parses_path_source_and_rejects_ambiguous_sources() {
 
 #[test]
 fn session_execution_context_parses_as_strongly_typed_replacement() {
-    let call: ToolCall = serde_json::from_value(json!({
-        "tool": "start_coding_task",
-        "params": {
-            "project": "agent:oe:demo",
-            "execution_context": {
-                "default_cwd": "frontend",
-                "default_shell": "bash"
-            }
-        }
-    }))
-    .unwrap();
-    assert!(matches!(
-        call,
-        ToolCall::StartCodingTask {
-            execution_context: Some(sessions::SessionExecutionContext {
-                default_cwd: Some(ref cwd),
-                default_shell: Some(ExecutionShell::Bash),
-                ..
-            }),
-            ..
-        } if cwd == "frontend"
-    ));
-
     let ssh = ToolCall::from_tool_name(
         "update_session_context",
         json!({
@@ -1372,6 +1349,21 @@ fn retired_start_coding_task_wire_name_is_rejected() {
         .expect_err("retired start_coding_task entry must fail closed");
     assert!(error.contains("no longer supported"), "{error}");
     assert!(error.contains("work_on_project"), "{error}");
+
+    // Kernel audit recording happens before ToolCall parsing, so rejected
+    // legacy requests keep a bounded compatibility sanitizer without reviving
+    // a current ToolCall identity or retaining the raw path.
+    let audit = super::super::tool_audit::session_log_arguments_for_tool_request(
+        "start_coding_task",
+        &json!({
+            "project": "agent:legacy:demo",
+            "path": "/private/legacy/path",
+            "title": "legacy request"
+        }),
+    );
+    assert_eq!(audit["path_source_requested"], true);
+    assert!(audit.get("path").is_none());
+    assert!(!audit.to_string().contains("/private/legacy/path"));
 }
 
 #[test]

--- a/src/tool_runtime/tests/trusted_smoke.rs
+++ b/src/tool_runtime/tests/trusted_smoke.rs
@@ -6,7 +6,7 @@
 //! output; this is test/baseline data, not product telemetry.
 
 use super::support::*;
-use crate::tool_runtime::tool_inputs::{ExecutionPurpose, SessionMode, StartupDetail};
+use crate::tool_runtime::tool_inputs::ExecutionPurpose;
 use crate::tool_runtime::{ToolCall, ToolResult, ToolRuntime};
 use serde_json::Value;
 use sha2::Digest;
@@ -150,31 +150,26 @@ async fn trusted_agent_smoke_full_chain_has_zero_approval_interruptions() {
     // 1. Startup: one call, no manifest/runtime probing required afterwards.
     let start = dispatch_with_local_agent(
         &runtime,
-        ToolCall::StartCodingTask {
+        ToolCall::WorkOnProject {
             project: project.clone(),
             client_id: None,
             path: None,
-            title: Some("trusted agent smoke".to_string()),
-            mode: SessionMode::Normal,
-            deny_write_tools: false,
-            deny_shell_tools: false,
-            detail: StartupDetail::Standard,
-            resume_session_id: None,
-            execution_context: None,
+            instruction: "trusted agent smoke".to_string(),
+            session_id: None,
+            include_project_instructions: true,
+            include_workflow_guidance: true,
         },
         &poll_calls,
     )
     .await;
     track(&start);
     assert!(start.success, "{:?}", start.error);
-    assert_no_approval_interruption(&start, "start_coding_task");
-    let session_id = start.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    // Dirty worktree is advisory context, not a blocker.
-    assert_ne!(start.output["startup_verdict"]["status"], "fail");
-    assert_eq!(start.output["startup_verdict"]["blocking"], false);
+    assert_no_approval_interruption(&start, "work_on_project");
+    let session_id = start.output["session_id"].as_str().unwrap().to_string();
+    // Dirty worktree is advisory context, not a blocker. The canonical compact
+    // entry intentionally omits the old full diagnostic startup_verdict.
+    assert!(start.output.get("startup_verdict").is_none());
+    assert_ne!(start.output["readiness"]["status"], "fail");
 
     // 2. Edit: add a script whose assertion initially fails.
     let write = dispatch_with_local_agent(

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -2336,26 +2336,20 @@ async fn finish_coding_task_validation_available_when_ledger_has_validation_even
 
     let start = runtime
         .dispatch_with_auth(
-            ToolCall::StartCodingTask {
+            ToolCall::WorkOnProject {
                 project: project.clone(),
                 client_id: None,
                 path: None,
-                title: Some("validation finish".to_string()),
-                mode: SessionMode::Normal,
-                detail: Default::default(),
-                deny_write_tools: false,
-                deny_shell_tools: false,
-                resume_session_id: None,
-                execution_context: None,
+                instruction: "validation finish".to_string(),
+                session_id: None,
+                include_project_instructions: true,
+                include_workflow_guidance: true,
             },
             Some(&auth),
         )
         .await;
     assert!(start.success, "{:?}", start.error);
-    let session_id = start.output["session"]["session_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
+    let session_id = start.output["session_id"].as_str().unwrap().to_string();
 
     let check_task = tokio::spawn({
         let runtime = runtime.clone();

--- a/src/tool_runtime/tests/work_on_project.rs
+++ b/src/tool_runtime/tests/work_on_project.rs
@@ -1,12 +1,11 @@
-//! Focused tests for the `work_on_project` thin coding-task entry point.
+//! Focused tests for the canonical `work_on_project` coding entry point.
 //!
-//! `work_on_project` is a model-facing wrapper over `start_coding_task`: it
-//! validates one of two project sources plus the task inputs, maps them onto
-//! normal coding-task defaults, delegates the business implementation, and
-//! projects a compact startup result. It never binds a current window, never
-//! guesses a recent Session, and never falls back to a credential-wide Session.
+//! `work_on_project` validates one of two project sources plus the task inputs,
+//! invokes the shared coding workflow engine, and projects a compact startup
+//! result. It never binds a current window, never guesses a recent Session, and
+//! never falls back to a credential-wide Session.
 
-use super::reconnect::dispatch_start_coding_task_in_window;
+use super::reconnect::dispatch_coding_call_in_window;
 use super::support::*;
 use crate::lsp_bridge::{AgentLspRequest, AgentLspResultEnvelope, AGENT_LSP_REQUEST_KIND};
 use crate::shell_protocol::ShellClientCapabilities;
@@ -74,21 +73,6 @@ fn path_work_on_project_call(
     }
 }
 
-fn start_coding_task_call(project: &str, instruction: &str, detail: StartupDetail) -> ToolCall {
-    ToolCall::StartCodingTask {
-        project: project.to_string(),
-        client_id: None,
-        path: None,
-        title: Some(instruction.to_string()),
-        mode: SessionMode::Normal,
-        detail,
-        deny_write_tools: false,
-        deny_shell_tools: false,
-        resume_session_id: None,
-        execution_context: None,
-    }
-}
-
 /// Drive any coding startup to completion while recording every Runner request.
 /// The typed LSP status probe gets a valid bounded error envelope; file/Git and
 /// overview requests use the existing local fixture implementation.
@@ -116,6 +100,51 @@ async fn dispatch_recording_startup_requests(
                 .await
         }
     });
+    record_startup_requests(runtime, client_id, task).await
+}
+
+async fn dispatch_recording_coding_workflow_diagnostic(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: &str,
+    instruction: &str,
+    detail: StartupDetail,
+    auth: Option<&crate::auth::AuthContext>,
+) -> (ToolResult, Vec<String>) {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.to_string();
+        let instruction = instruction.to_string();
+        let auth = auth.cloned();
+        async move {
+            runtime
+                .start_coding_workflow_for_test(
+                    project,
+                    None,
+                    None,
+                    Some(instruction),
+                    SessionMode::Normal,
+                    false,
+                    false,
+                    detail,
+                    None,
+                    None,
+                    auth.as_ref(),
+                    None,
+                    None,
+                    crate::tool_runtime::sessions::SessionTransport::Mcp,
+                )
+                .await
+        }
+    });
+    record_startup_requests(runtime, client_id, task).await
+}
+
+async fn record_startup_requests(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    task: tokio::task::JoinHandle<ToolResult>,
+) -> (ToolResult, Vec<String>) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     let mut request_kinds = Vec::new();
     loop {
@@ -478,7 +507,7 @@ fn work_on_project_schema_and_registration() {
         );
     }
 
-    // The wrapper must not expose advanced start_coding_task controls.
+    // The canonical entry must not expose internal diagnostic controls.
     for hidden in [
         "resume_session_id",
         "mode",
@@ -644,7 +673,7 @@ fn work_on_project_tool_call_enforces_authoritative_source_contract() {
         );
     }
     // The schema declares additionalProperties: false so advanced
-    // start_coding_task controls are not part of the wrapper surface.
+    // internal diagnostic controls are not part of the canonical entry surface.
     let spec = registered_tool_specs()
         .into_iter()
         .find(|spec| spec.name == "work_on_project")
@@ -861,7 +890,7 @@ async fn work_on_project_without_session_id_always_creates_fresh_session() {
     let project = register_agent_project_at_path(&runtime, "wop-create", "demo", root.path()).await;
     let auth = auth_context(None, true);
 
-    let result = dispatch_start_coding_task_in_window(
+    let result = dispatch_coding_call_in_window(
         &runtime,
         "wop-create",
         work_on_project_call("demo", "first root instruction", None),
@@ -951,7 +980,7 @@ async fn work_on_project_without_session_id_always_creates_fresh_session() {
 
     // A second call in the same window/project without session_id must create a
     // distinct Workflow Session instead of continuing the first implicitly.
-    let second = dispatch_start_coding_task_in_window(
+    let second = dispatch_coding_call_in_window(
         &runtime,
         "wop-create",
         work_on_project_call("demo", "second root instruction", None),
@@ -1036,7 +1065,7 @@ async fn work_on_project_without_session_id_always_creates_fresh_session() {
 }
 
 #[tokio::test]
-async fn path_source_auto_registers_reuses_and_supports_both_coding_entries() {
+async fn path_source_auto_registers_reuses_and_supports_canonical_coding_entry() {
     let root = tempfile::tempdir().unwrap();
     init_git_repo(root.path());
     std::fs::write(root.path().join("hello.txt"), "hello\n").unwrap();
@@ -1114,38 +1143,6 @@ async fn path_source_auto_registers_reuses_and_supports_both_coding_entries() {
         "reused_existing_registration"
     );
     assert_eq!(instruction_events(&runtime, &session_id).len(), 2);
-
-    let advanced: ToolCall = serde_json::from_value(json!({
-        "tool": "start_coding_task",
-        "params": {
-            "client_id": client_id,
-            "path": project_path,
-            "title": "internal path entry",
-            "detail": "standard"
-        }
-    }))
-    .unwrap();
-    let advanced = dispatch_with_path_runner(
-        &runtime,
-        client_id,
-        advanced,
-        "repo-a1b2c3d4",
-        &project_path,
-        "reused_existing_registration",
-        false,
-    )
-    .await;
-    assert!(advanced.success, "{:?}", advanced.error);
-    assert_eq!(advanced.output["permission"]["status"], "auto_approved");
-    assert_eq!(
-        advanced.output["permission"]["tool_name"],
-        "register_project"
-    );
-    assert_eq!(advanced.output["project_resolution"]["source"], "path");
-    assert_eq!(
-        advanced.output["project_resolution"]["resolved_project"],
-        "agent:wop-path:repo-a1b2c3d4"
-    );
 
     let listed = runtime.list_projects(Some(&auth_context(None, true))).await;
     assert!(listed.success);
@@ -1245,36 +1242,6 @@ async fn path_source_explicit_session_mismatch_fails_before_registration() {
         mismatch.output["request_project"],
         format!("path:{client_id}:{second_path}")
     );
-    assert_eq!(instruction_events(&runtime, session_id).len(), 1);
-
-    let advanced_mismatch: ToolCall = serde_json::from_value(json!({
-        "tool": "start_coding_task",
-        "params": {
-            "client_id": client_id,
-            "path": second_path,
-            "resume_session_id": session_id,
-            "detail": "standard"
-        }
-    }))
-    .unwrap();
-    let advanced_mismatch = dispatch_with_path_runner(
-        &runtime,
-        client_id,
-        advanced_mismatch,
-        "second-a1b2c3d4",
-        &second_path,
-        "reused_existing_registration",
-        false,
-    )
-    .await;
-    assert!(!advanced_mismatch.success);
-    assert_eq!(
-        advanced_mismatch.output["error_kind"],
-        "session_project_mismatch"
-    );
-    assert_eq!(advanced_mismatch.output["state_changed"], false);
-    assert!(advanced_mismatch.output.get("permission").is_none());
-    assert!(advanced_mismatch.output.get("project_resolution").is_none());
     assert_eq!(instruction_events(&runtime, session_id).len(), 1);
 
     let listed = runtime.list_projects(Some(&auth_context(None, true))).await;
@@ -1570,7 +1537,7 @@ async fn work_on_project_continues_exact_session_and_appends_instruction() {
         register_agent_project_at_path(&runtime, "wop-continue", "demo", root.path()).await;
     let auth = auth_context(None, true);
 
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "wop-continue",
         work_on_project_call(&project, "root objective", None),
@@ -1583,7 +1550,7 @@ async fn work_on_project_continues_exact_session_and_appends_instruction() {
     let before = instruction_events(&runtime, &session_id);
     assert_eq!(before.len(), 1);
 
-    let continued = dispatch_start_coding_task_in_window(
+    let continued = dispatch_coding_call_in_window(
         &runtime,
         "wop-continue",
         work_on_project_call(&project, "follow-up instruction", Some(&session_id)),
@@ -1661,7 +1628,7 @@ async fn work_on_project_failures_never_create_or_fall_back() {
     let auth = auth_context(None, true);
 
     // Create a stable active session on project A, plus a closed one.
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "wop-fail",
         work_on_project_call(&project_a, "stable session", None),
@@ -1683,7 +1650,7 @@ async fn work_on_project_failures_never_create_or_fall_back() {
     runtime.sessions.close_session(&closed_id).unwrap();
 
     // Unknown Session: no creation, structured unknown_session_id failure.
-    let unknown = dispatch_start_coding_task_in_window(
+    let unknown = dispatch_coding_call_in_window(
         &runtime,
         "wop-fail",
         work_on_project_call(&project_a, "must not create", Some("wc_sess_missing")),
@@ -1695,7 +1662,7 @@ async fn work_on_project_failures_never_create_or_fall_back() {
     assert_eq!(unknown.output["error_kind"], "unknown_session_id");
 
     // Closed Session: no creation, structured session_closed failure.
-    let closed = dispatch_start_coding_task_in_window(
+    let closed = dispatch_coding_call_in_window(
         &runtime,
         "wop-fail",
         work_on_project_call(&project_a, "must not reopen", Some(&closed_id)),
@@ -1708,7 +1675,7 @@ async fn work_on_project_failures_never_create_or_fall_back() {
     assert_eq!(closed.output["lifecycle"], "closed");
 
     // Project mismatch: no fallback to any other session.
-    let mismatch = dispatch_start_coding_task_in_window(
+    let mismatch = dispatch_coding_call_in_window(
         &runtime,
         "wop-fail",
         work_on_project_call(&project_b, "must not cross", Some(&active_id)),
@@ -1722,7 +1689,7 @@ async fn work_on_project_failures_never_create_or_fall_back() {
     assert_eq!(mismatch.output["request_project"], project_b);
 
     // Invalid Session id fails before execution (no session created).
-    let invalid = dispatch_start_coding_task_in_window(
+    let invalid = dispatch_coding_call_in_window(
         &runtime,
         "wop-fail",
         work_on_project_call(&project_a, "must not run", Some("not-a-session")),
@@ -1987,7 +1954,7 @@ async fn work_on_project_can_omit_instruction_bodies_for_a_fresh_session() {
             .await;
     let auth = auth_context(None, true);
 
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "wop-instruction-projection",
         work_on_project_call(&project, "first task", None),
@@ -2072,7 +2039,7 @@ async fn work_on_project_can_omit_static_workflow_guidance() {
             .await;
     let auth = auth_context(None, true);
 
-    let result = dispatch_start_coding_task_in_window(
+    let result = dispatch_coding_call_in_window(
         &runtime,
         "wop-workflow-projection",
         work_on_project_call_with_projections(
@@ -2116,7 +2083,7 @@ async fn work_on_project_static_projection_is_caller_explicit_not_window_state()
         register_agent_project_at_path(&runtime, "wop-explicit", "demo", root.path()).await;
     let auth = auth_context(None, true);
 
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "wop-explicit",
         work_on_project_call(&project, "first", None),
@@ -2128,7 +2095,7 @@ async fn work_on_project_static_projection_is_caller_explicit_not_window_state()
     let session_id = first.output["session_id"].as_str().unwrap().to_string();
     assert!(first.output["workflow"].is_object());
 
-    let repeated = dispatch_start_coding_task_in_window(
+    let repeated = dispatch_coding_call_in_window(
         &runtime,
         "wop-explicit",
         work_on_project_call(&project, "repeat true", Some(&session_id)),
@@ -2141,7 +2108,7 @@ async fn work_on_project_static_projection_is_caller_explicit_not_window_state()
     assert_eq!(repeated.output["instructions"]["status"], "reused");
     assert_eq!(repeated.output["instructions"]["content_included"], true);
 
-    let suppressed = dispatch_start_coding_task_in_window(
+    let suppressed = dispatch_coding_call_in_window(
         &runtime,
         "wop-explicit",
         work_on_project_call_with_projections(
@@ -2172,7 +2139,7 @@ async fn work_on_project_static_projection_is_caller_explicit_not_window_state()
     assert!(suppressed_agents.get("headings").is_none());
     assert!(suppressed_agents.get("read_more").is_none());
 
-    let restored_other_window = dispatch_start_coding_task_in_window(
+    let restored_other_window = dispatch_coding_call_in_window(
         &runtime,
         "wop-explicit",
         work_on_project_call(&project, "true in another window", Some(&session_id)),
@@ -2213,7 +2180,7 @@ async fn work_on_project_suppressed_instruction_bodies_still_track_changed_rules
             .await;
     let auth = auth_context(None, true);
 
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "wop-suppressed-change",
         work_on_project_call(&project, "first", None),
@@ -2238,7 +2205,7 @@ async fn work_on_project_suppressed_instruction_bodies_still_track_changed_rules
         .collect::<Vec<_>>()
         .join("\n");
     overwrite_agents_rule(root.path(), &long_changed_body);
-    let changed = dispatch_start_coding_task_in_window(
+    let changed = dispatch_coding_call_in_window(
         &runtime,
         "wop-suppressed-change",
         work_on_project_call_with_instruction_projection(
@@ -2268,7 +2235,7 @@ async fn work_on_project_suppressed_instruction_bodies_still_track_changed_rules
     assert!(changed_agents.get("headings").is_none());
     assert!(changed_agents.get("read_more").is_none());
 
-    let projected = dispatch_start_coding_task_in_window(
+    let projected = dispatch_coding_call_in_window(
         &runtime,
         "wop-suppressed-change",
         work_on_project_call(&project, "project current body", Some(&session_id)),
@@ -2297,7 +2264,7 @@ async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
     let project = register_agent_project_at_path(&runtime, "wop-reuse", "demo", root.path()).await;
     let auth = auth_context(None, true);
 
-    let first = dispatch_start_coding_task_in_window(
+    let first = dispatch_coding_call_in_window(
         &runtime,
         "wop-reuse",
         work_on_project_call(&project, "root objective", None),
@@ -2310,7 +2277,7 @@ async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
 
     // Exact resume with unchanged rules: repository delta status remains reused,
     // while the caller-explicit default still projects the current bounded body.
-    let reused = dispatch_start_coding_task_in_window(
+    let reused = dispatch_coding_call_in_window(
         &runtime,
         "wop-reuse",
         work_on_project_call(&project, "follow-up", Some(&session_id)),
@@ -2339,7 +2306,7 @@ async fn work_on_project_exact_resume_reuses_rules_and_detects_changes() {
 
     // Change the rule then resume: status=changed, changed_sources includes it.
     overwrite_agents_rule(root.path(), "changed rule body");
-    let changed = dispatch_start_coding_task_in_window(
+    let changed = dispatch_coding_call_in_window(
         &runtime,
         "wop-reuse",
         work_on_project_call(&project, "after rule change", Some(&session_id)),
@@ -2431,16 +2398,13 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
     assert!(workflow_omitted.success, "{:?}", workflow_omitted.error);
     assert!(workflow_omitted.output.get("workflow").is_none());
 
-    let (standard, standard_requests) = dispatch_recording_startup_requests(
+    let (standard, standard_requests) = dispatch_recording_coding_workflow_diagnostic(
         &runtime,
         "wop-size",
-        start_coding_task_call(
-            &project,
-            "same fixture standard startup",
-            StartupDetail::Standard,
-        ),
+        &project,
+        "same fixture standard startup",
+        StartupDetail::Standard,
         Some(&auth),
-        "wop-size-standard",
     )
     .await;
     assert!(standard.success, "{:?}", standard.error);
@@ -2539,7 +2503,7 @@ async fn work_on_project_sizes_and_runner_request_reduction_are_stable() {
 }
 
 #[tokio::test]
-async fn start_coding_task_standard_repository_overview_timeout_is_nonblocking() {
+async fn coding_workflow_standard_repository_overview_timeout_is_nonblocking() {
     let root = tempfile::tempdir().unwrap();
     seed_coding_repository(root.path(), "rules load despite overview timeout");
     // Tight overview timeout so the probe expires quickly.
@@ -2554,18 +2518,22 @@ async fn start_coding_task_standard_repository_overview_timeout_is_nonblocking()
         let auth = auth.clone();
         let project = project.clone();
         async move {
-            let window = crate::client_window::ClientWindow::for_test("wop-timeout-window");
             runtime
-                .dispatch_with_auth_transport_options_and_metadata_with_window(
-                    start_coding_task_call(
-                        &project,
-                        "start despite overview timeout",
-                        StartupDetail::Standard,
-                    ),
+                .start_coding_workflow_for_test(
+                    project,
+                    None,
+                    None,
+                    Some("start despite overview timeout".to_string()),
+                    SessionMode::Normal,
+                    false,
+                    false,
+                    StartupDetail::Standard,
+                    None,
+                    None,
                     Some(&auth),
+                    None,
+                    None,
                     crate::tool_runtime::sessions::SessionTransport::Mcp,
-                    Default::default(),
-                    Some(&window),
                 )
                 .await
         }
@@ -2641,11 +2609,11 @@ async fn start_coding_task_standard_repository_overview_timeout_is_nonblocking()
     }
 }
 
-/// Drive an advanced `start_coding_task` dispatch to completion, completing the
+/// Drive a coding-workflow diagnostic to completion, completing the
 /// `file_project_overview` probe with `overview_stdout` (exit code 0, no error)
 /// while servicing every other agent request locally. Returns the startup
 /// result and the overview request id that was answered.
-async fn dispatch_start_coding_task_with_overview_stdout(
+async fn dispatch_coding_workflow_diagnostic_with_overview_stdout(
     runtime: &ToolRuntime,
     client_id: &str,
     project: &str,
@@ -2654,22 +2622,30 @@ async fn dispatch_start_coding_task_with_overview_stdout(
     overview_stdout: String,
     auth: Option<&crate::auth::AuthContext>,
 ) -> (crate::tool_runtime::ToolResult, Option<String>) {
-    use crate::client_window::ClientWindow;
     use crate::tool_runtime::sessions::SessionTransport;
 
     let task = tokio::spawn({
         let runtime = runtime.clone();
         let auth = auth.cloned();
-        let call = start_coding_task_call(project, instruction, detail);
+        let project = project.to_string();
+        let instruction = instruction.to_string();
         async move {
-            let window = ClientWindow::for_test("overview-window");
             runtime
-                .dispatch_with_auth_transport_options_and_metadata_with_window(
-                    call,
+                .start_coding_workflow_for_test(
+                    project,
+                    None,
+                    None,
+                    Some(instruction),
+                    SessionMode::Normal,
+                    false,
+                    false,
+                    detail,
+                    None,
+                    None,
                     auth.as_ref(),
+                    None,
+                    None,
                     SessionTransport::Mcp,
-                    Default::default(),
-                    Some(&window),
                 )
                 .await
         }
@@ -2729,7 +2705,7 @@ fn valid_agent_overview_stdout(
 }
 
 #[tokio::test]
-async fn start_coding_task_standard_repository_overview_rejects_malformed_runner_responses() {
+async fn coding_workflow_standard_repository_overview_rejects_malformed_runner_responses() {
     let root = tempfile::tempdir().unwrap();
     seed_coding_repository(root.path(), "rules load despite malformed overview");
     let runtime = ToolRuntime::new_for_tests();
@@ -2808,7 +2784,7 @@ async fn start_coding_task_standard_repository_overview_rejects_malformed_runner
 
     for (label, payload) in cases {
         let stdout = payload.to_string();
-        let (result, overview_id) = dispatch_start_coding_task_with_overview_stdout(
+        let (result, overview_id) = dispatch_coding_workflow_diagnostic_with_overview_stdout(
             &runtime,
             "wop-malformed",
             &project,
@@ -2878,7 +2854,7 @@ async fn start_coding_task_standard_repository_overview_rejects_malformed_runner
 }
 
 #[tokio::test]
-async fn start_coding_task_standard_overview_strips_unknown_runner_fields_and_stays_bounded() {
+async fn coding_workflow_standard_overview_strips_unknown_runner_fields_and_stays_bounded() {
     let root = tempfile::tempdir().unwrap();
     seed_coding_repository(root.path(), "rules load despite extra runner fields");
     let runtime = ToolRuntime::new_for_tests();
@@ -2895,7 +2871,7 @@ async fn start_coding_task_standard_overview_strips_unknown_runner_fields_and_st
     payload["scan"]["nested"] = json!({"deep": json!(["Y".repeat(10_000), 1, 2])});
     payload["runner_secret"] = json!("/absolute/leak");
 
-    let (result, overview_id) = dispatch_start_coding_task_with_overview_stdout(
+    let (result, overview_id) = dispatch_coding_workflow_diagnostic_with_overview_stdout(
         &runtime,
         "wop-strip",
         &project,
@@ -2954,7 +2930,7 @@ async fn start_coding_task_standard_overview_strips_unknown_runner_fields_and_st
 }
 
 #[tokio::test]
-async fn start_coding_task_standard_and_full_accept_valid_repository_overview() {
+async fn coding_workflow_standard_and_full_accept_valid_repository_overview() {
     let root = tempfile::tempdir().unwrap();
     seed_coding_repository(root.path(), "rules load with valid overview");
     let runtime = ToolRuntime::new_for_tests();
@@ -2964,7 +2940,7 @@ async fn start_coding_task_standard_and_full_accept_valid_repository_overview() 
     let auth = auth_context(None, true);
     for detail in [StartupDetail::Standard, StartupDetail::Full] {
         let stdout = valid_agent_overview_stdout(&runtime, "wop-valid-overview", root.path());
-        let (result, overview_id) = dispatch_start_coding_task_with_overview_stdout(
+        let (result, overview_id) = dispatch_coding_workflow_diagnostic_with_overview_stdout(
             &runtime,
             "wop-valid-overview",
             &project,
@@ -3007,11 +2983,12 @@ async fn start_coding_task_standard_and_full_accept_valid_repository_overview() 
         let serialized = repository.to_string();
         assert!(!serialized.contains(&root.path().to_string_lossy().to_string()));
 
-        let schema = crate::tool_runtime::registry::output_schema_for_tool("start_coding_task");
+        let schema =
+            crate::tool_runtime::registry::coding_workflow_diagnostic_output_schema_for_test();
         let instance = json!({"success": true, "output": result.output});
         crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&instance, &schema)
             .unwrap_or_else(|error| {
-                panic!("{detail:?} advanced startup must match strict schema: {error}")
+                panic!("{detail:?} coding workflow diagnostic must match strict schema: {error}")
             });
     }
 }

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -442,7 +442,7 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
             );
             copy_keys(obj, &mut out, &["limit", "status"]);
         }
-        "start_session" | "start_coding_task" | "update_session_context" => {
+        "start_session" | "update_session_context" => {
             copy_keys(
                 obj,
                 &mut out,
@@ -458,12 +458,40 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
                     "session_id",
                 ],
             );
-            if tool_name == "start_coding_task" {
-                out.insert(
-                    "path_source_requested".to_string(),
-                    Value::Bool(obj.contains_key("path")),
-                );
-            }
+            let context = obj
+                .get("execution_context")
+                .cloned()
+                .and_then(|value| {
+                    serde_json::from_value::<super::sessions::SessionExecutionContext>(value).ok()
+                })
+                .map(|context| context.audit_summary())
+                .unwrap_or(Value::Null);
+            out.insert("execution_context".to_string(), context);
+        }
+        // Compatibility-only audit sanitizer for the retired wire name. The
+        // kernel records a bounded request summary before ToolCall parsing, so
+        // a rejected legacy request still passes through this branch. This is
+        // not a current ToolCall identity or dispatch path.
+        "start_coding_task" => {
+            copy_keys(
+                obj,
+                &mut out,
+                &[
+                    "project",
+                    "client_id",
+                    "title",
+                    "mode",
+                    "deny_write_tools",
+                    "deny_shell_tools",
+                    "detail",
+                    "resume_session_id",
+                    "session_id",
+                ],
+            );
+            out.insert(
+                "path_source_requested".to_string(),
+                Value::Bool(obj.contains_key("path")),
+            );
             let context = obj
                 .get("execution_context")
                 .cloned()
@@ -5484,31 +5512,6 @@ impl ToolCall {
                 "mode": mode,
                 "deny_write_tools": deny_write_tools,
                 "deny_shell_tools": deny_shell_tools,
-                "execution_context": execution_context
-                    .as_ref()
-                    .map(super::sessions::SessionExecutionContext::audit_summary),
-            }),
-            Self::StartCodingTask {
-                project,
-                client_id,
-                path,
-                title,
-                mode,
-                deny_write_tools,
-                deny_shell_tools,
-                detail,
-                resume_session_id,
-                execution_context,
-            } => serde_json::json!({
-                "project": project,
-                "client_id": client_id,
-                "path_source_requested": path.is_some(),
-                "title": title,
-                "mode": mode,
-                "deny_write_tools": deny_write_tools,
-                "deny_shell_tools": deny_shell_tools,
-                "detail": detail,
-                "resume_session_id": resume_session_id,
                 "execution_context": execution_context
                     .as_ref()
                     .map(super::sessions::SessionExecutionContext::audit_summary),

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -12,7 +12,7 @@ use super::sessions::{
 use super::tool_definition::{lookup_tool_definition, model_visible_tool_names_csv};
 use super::tool_inputs::{
     default_true, ApplyFileChangeInput, CheckpointValidationInput, ExecutionPurpose,
-    ExecutionShell, SessionMode, StartupDetail,
+    ExecutionShell, SessionMode,
 };
 use crate::lsp_bridge::{
     CallHierarchyDirection, DEFAULT_CALL_HIERARCHY_DEPTH, DEFAULT_CALL_HIERARCHY_LIMIT,
@@ -296,50 +296,9 @@ pub enum ToolCall {
         execution_context: Option<SessionExecutionContext>,
     },
 
-    /// Create a task session and return deterministic startup context: project
-    /// resolution, runtime/git summaries scaled by `detail`, and recommended
-    /// flow. Never calls an LLM.
-    ///
-    /// `detail` is the only projection control. The removed legacy startup
-    /// flags (`compact_startup`, `include_*`, `tool_manifest_*`) are rejected
-    /// as unknown fields by strict argument validation.
-    StartCodingTask {
-        /// Existing runtime project id. Omit this with `client_id` plus
-        /// `path` for Runner-side path resolution/registration.
-        #[serde(default)]
-        project: String,
-        /// Runner client that owns `path`.
-        #[serde(default)]
-        client_id: Option<String>,
-        /// Existing absolute directory on the selected Runner. The Runner
-        /// canonicalizes, policy-checks, reuses, or permanently registers it.
-        #[serde(default)]
-        path: Option<String>,
-        #[serde(default)]
-        title: Option<String>,
-        #[serde(default)]
-        mode: SessionMode,
-        #[serde(default)]
-        deny_write_tools: bool,
-        #[serde(default)]
-        deny_shell_tools: bool,
-        #[serde(default)]
-        detail: StartupDetail,
-        /// Explicitly continue one existing Workflow Session. This business
-        /// input is distinct from project-tool `session_id` and wrapper-level
-        /// `recording_session_id` metadata. Omission always creates a fresh
-        /// Workflow Session.
-        #[serde(default)]
-        resume_session_id: Option<String>,
-        /// Optional complete replacement. Omission preserves the current value
-        /// on continuation; `{}` explicitly clears it.
-        #[serde(default)]
-        execution_context: Option<SessionExecutionContext>,
-    },
-
-    /// Start a normal coding task with practical defaults, or continue one by
-    /// `session_id`. Thin wrapper over `start_coding_task` that never creates a
-    /// temporary project and returns only a compact startup projection.
+    /// Start a normal coding workflow with practical defaults, or continue one
+    /// by `session_id`. This is the canonical coding entry and returns only a
+    /// compact startup projection.
     /// `session_id` is explicit business input for the exact Workflow Session
     /// to continue; omission always creates a fresh Session.
     WorkOnProject {
@@ -2492,7 +2451,6 @@ impl ToolCall {
         match self {
             Self::ListTools { .. } => "list_tools",
             Self::StartSession { .. } => "start_session",
-            Self::StartCodingTask { .. } => "start_coding_task",
             Self::WorkOnProject { .. } => "work_on_project",
             Self::FinishCodingTask { .. } => "finish_coding_task",
             Self::SessionSummary { .. } => "session_summary",
@@ -2839,9 +2797,6 @@ impl ToolCall {
             | Self::GotoDefinition { project, .. }
             | Self::FindReferences { project, .. } => Some(project.as_str()),
             Self::CallHierarchy { project, .. } => Some(project.as_str()),
-            Self::StartCodingTask { project, .. } if !project.trim().is_empty() => {
-                Some(project.as_str())
-            }
             Self::WorkOnProject { project, .. } if !project.trim().is_empty() => {
                 Some(project.as_str())
             }

--- a/src/tool_runtime/tool_definition.rs
+++ b/src/tool_runtime/tool_definition.rs
@@ -525,19 +525,6 @@ const fn context_recovery_only(definition: ToolDefinition) -> ToolDefinition {
     context_continuity(definition, ToolContextContinuityPolicy::RECOVERY_ONLY)
 }
 
-const fn extra_accepted_flattened_args(
-    definition: ToolDefinition,
-    fields: &'static [&'static str],
-) -> ToolDefinition {
-    ToolDefinition {
-        policy: ToolDefinitionPolicy {
-            extra_accepted_flattened_args: fields,
-            ..definition.policy
-        },
-        ..definition
-    }
-}
-
 const fn permission_risk(
     definition: ToolDefinition,
     permission_risk: &'static str,

--- a/src/tool_runtime/tool_definition/sessions.rs
+++ b/src/tool_runtime/tool_definition/sessions.rs
@@ -1,8 +1,8 @@
 use super::AgentCapability::{GitOrShell, OwnerOnly};
 use super::ToolVisibility::{ModelHidden, ModelVisible};
 use super::{
-    adaptive_runtime_direct, context_recovery_only, def, extra_accepted_flattened_args, model_spec,
-    permission_risk, requires_explicit_business_session, ToolDefinition, PERMISSION_RISK_WRITE,
+    adaptive_runtime_direct, context_recovery_only, def, model_spec, permission_risk,
+    requires_explicit_business_session, ToolDefinition, PERMISSION_RISK_WRITE,
     TOOL_CATEGORY_SESSION, TOOL_CATEGORY_VALIDATION,
 };
 use crate::tool_runtime::metadata::{
@@ -37,27 +37,6 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
         NoPath,
         false,
         false,
-    ),
-    extra_accepted_flattened_args(
-        def(
-            "start_coding_task",
-            ModelHidden,
-            "workflow",
-            Some(GitOrShell),
-            TOOL_PROVIDER_CONTROL,
-            super::ToolSemanticContract {
-                effect: super::ToolEffect::Mutate,
-                risk: super::ToolRisk::WorkflowManage,
-                approval: super::ToolApprovalPolicy::None,
-                idempotency: super::ToolIdempotency::NonIdempotent,
-            },
-            Some(RUNTIME_READ),
-            false,
-            NoPath,
-            false,
-            false,
-        ),
-        &["session_id"],
     ),
     adaptive_runtime_direct(
         context_recovery_only(model_spec(


### PR DESCRIPTION
## Summary
- make `work_on_project` the sole canonical coding bootstrap and remove the internal `ToolCall::StartCodingTask` / hidden ToolDefinition / dispatch identity
- rename the shared implementation to `start_coding_workflow`, retaining advanced startup projections only behind test-only diagnostic seams
- keep the retired `start_coding_task` wire name fail-closed with an actionable migration error and bounded audit sanitization
- preserve its historical `runtime:read` pre-parser admission so authorized legacy callers still reach the retirement error without reviving a current ToolDefinition

## Compatibility
- no Runner/Server protocol generation, route, token, database, or serialized transport changes
- old persisted Session events remain readable; new task-instruction events use the current `work_on_project` identity
- `start_session` behavior is unchanged

## Validation
- focused D1 coding/workflow/reconnect/startup/continuation/schema suites passed in the implementation handoff
- reviewer: retired `start_coding_task` boundary 6 passed / 0 failed
- reviewer: `cargo check --all-targets` passed with 0 warnings
- reviewer: `cargo fmt --all -- --check` and `git diff --check` passed
