### PR TITLE
Fix cross-platform CI portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           - shard: workspace-crates
             packages: >-
               -p webcodex-admin
+              -p webcodex-computer
               -p webcodex-runner-config
               -p webcodex-core
               -p webcodex-cli
@@ -181,8 +182,8 @@ jobs:
       github.event_name == 'push' ||
       github.event.pull_request.user.login != github.repository_owner ||
       contains(github.event.pull_request.labels.*.name, 'run-ci')
-    # Native macOS gates for both published architectures plus the Runner's
-    # detached ownership/restart suites. Keep these ahead of immutable tagging.
+    # Native macOS gates for both published architectures plus the Runner and
+    # Computer platform suites. Keep these ahead of immutable tagging.
     strategy:
       fail-fast: false
       matrix:
@@ -212,13 +213,15 @@ jobs:
           rust_host="$(rustc -vV | sed -n 's/^host: //p')"
           test "$rust_host" = "$EXPECTED_RUST_HOST"
       - name: Check macOS release production surfaces
-        run: cargo check --locked -p webcodex -p webcodex-cli -p webcodex-runner
-      - name: Run native macOS Runner tests
-        run: cargo test --locked -p webcodex-runner
+        run: cargo check --locked -p webcodex -p webcodex-cli -p webcodex-runner -p webcodex-computer
+      - name: Run native macOS Runner and Computer tests
+        run: cargo test --locked -p webcodex-runner -p webcodex-computer
 
   # Keep Windows process-heavy suites isolated on separate hosted VMs. The
   # webcodex-runner lane remains test-function-serial because its real
   # PowerShell/process-tree fixtures can starve each other on hosted Windows.
+  # Keep webcodex-computer in the same native lane so platform tests continue
+  # running after the Computer runtime was split out of the Runner crate.
   # Core/library and packaging coverage can run independently in parallel.
   test-windows-core:
     needs: contract
@@ -258,12 +261,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: windows-runner-ci
-      - name: Run Windows Runner tests
+      - name: Run Windows Runner and Computer tests
         # The Runner suite starts many real PowerShell/process-tree fixtures. On
         # hosted Windows, parallel test functions can starve process startup long
         # enough to trip intentionally tight command timeouts. Serialize only
         # the test functions; concurrency exercised inside each test is unchanged.
-        run: cargo test --locked -p webcodex-runner -- --test-threads=1
+        run: cargo test --locked -p webcodex-runner -p webcodex-computer -- --test-threads=1
 
   test-windows-package:
     needs: contract

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -594,10 +594,16 @@ fn spawn_ops_route_server(
     (format!("http://{}", addr), stop_tx, handle)
 }
 
+// Route fixtures may intentionally exercise the unauthenticated 401 contract.
+// Serialize them with the process-env credential test and remove any ambient
+// token for the duration, while still preserving explicit per-command tokens.
+#[allow(clippy::await_holding_lock)]
 async fn run_ops_with_routes(
     command: OpsCommand,
     routes: Vec<(&'static str, OpsHttpResponse)>,
 ) -> String {
+    let _env_guard = env_test_guard();
+    let _env = EnvGuard::new().remove("WEBCODEX_TOKEN");
     let (server_url, stop_tx, handle) = spawn_ops_route_server(routes);
     let command = match command {
         OpsCommand::Status(mut opts) => {

--- a/crates/webcodex-runner/src/main_tests/project_registration.rs
+++ b/crates/webcodex-runner/src/main_tests/project_registration.rs
@@ -25,12 +25,11 @@ fn register_project_writes_valid_toml_into_project_registry_dir() {
         value["project_record_path"], value["projects_config_path"],
         "legacy projects_config_path must remain an additive alias"
     );
+    let expected_record_path =
+        std::fs::canonicalize(project_registry_dir.join("demo.toml")).unwrap();
     assert_eq!(
         value["project_record_path"],
-        project_registry_dir
-            .join("demo.toml")
-            .to_string_lossy()
-            .as_ref()
+        expected_record_path.to_string_lossy().as_ref()
     );
 
     let content = std::fs::read_to_string(project_registry_dir.join("demo.toml")).unwrap();

--- a/crates/webcodex-runner/src/webcodex_runner/artifacts.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/artifacts.rs
@@ -14,7 +14,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use xml::reader::{EventReader, XmlEvent};
@@ -62,12 +62,13 @@ pub(crate) fn validate_artifact_runner_path(path: &str) -> Result<(), String> {
         return Err("path cannot contain NUL bytes".to_string());
     }
     let p = Path::new(path);
-    if p.is_absolute() {
+    let bytes = path.as_bytes();
+    let windows_drive_prefix =
+        bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+    if p.has_root() || path.starts_with('\\') || windows_drive_prefix {
         return Err("path must be project-relative".to_string());
     }
-    if p.components()
-        .any(|component| matches!(component, Component::ParentDir))
-    {
+    if path.split(['/', '\\']).any(|component| component == "..") {
         return Err("path cannot contain parent traversal".to_string());
     }
     if is_sensitive_artifact_path(path) {
@@ -77,18 +78,7 @@ pub(crate) fn validate_artifact_runner_path(path: &str) -> Result<(), String> {
 }
 
 fn is_sensitive_artifact_path(path: &str) -> bool {
-    for comp in path.to_lowercase().split('/') {
-        if matches!(
-            comp,
-            ".git" | "target" | "node_modules" | "secrets" | "tokens"
-        ) {
-            return true;
-        }
-        if comp == ".env" || comp.starts_with(".env") || comp.ends_with(".pem") {
-            return true;
-        }
-    }
-    false
+    webcodex_core::sensitive_paths::is_bulk_skipped_path(path)
 }
 
 fn parse_json_payload(request: &ShellAgentShellRequest) -> Result<Value, String> {
@@ -2603,6 +2593,29 @@ fn handle_read_project_artifact(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn artifact_runner_path_validation_is_cross_platform_and_uses_shared_sensitive_policy() {
+        assert!(validate_artifact_runner_path("artifacts/report.bin").is_ok());
+        for path in [
+            "/absolute/report.bin",
+            "\\rooted\\report.bin",
+            "C:\\absolute\\report.bin",
+            "C:drive-relative\\report.bin",
+            "../report.bin",
+            "nested\\..\\report.bin",
+            ".git\\config",
+            "secrets\\token.bin",
+            "certs\\server.key",
+            "config\\runner.toml",
+            "project-registry\\demo.toml",
+        ] {
+            assert!(
+                validate_artifact_runner_path(path).is_err(),
+                "{path} should be rejected"
+            );
+        }
+    }
 
     #[test]
     fn atomic_artifact_write_create_only_never_replaces_existing_target() {

--- a/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
@@ -2981,6 +2981,7 @@ for line in sys.stdin:
   else:
    v=m['params']['value']; opts=[{'id':'mode','name':'Mode','type':'select','currentValue':v,'options':[{'value':'agent','name':'Agent'},{'value':'read-only','name':'Read Only'}]}]
   send({'jsonrpc':'2.0','id':rid,'result':{'configOptions':opts}})
+  if scenario=='slow_configs': log({'config_applied':k})
  elif method=='session/prompt':
   if scenario=='crash_after_prompt': sys.exit(7)
   if scenario=='spawn_descendant':
@@ -4299,14 +4300,15 @@ for line in sys.stdin:
                 .and_then(|t| t.error_code.as_deref()),
             Some("coding_agent_setup_timeout")
         );
-        let methods = received_methods(&wire_log(&temp));
-        let config_attempts = methods
+        let log = wire_log(&temp);
+        let methods = received_methods(&log);
+        let completed_configs = log
             .iter()
-            .filter(|m| m.as_str() == "session/set_config_option")
+            .filter(|entry| entry.get("config_applied").is_some())
             .count();
         assert!(
-            config_attempts < 4,
-            "the total run deadline must expire before all slow config writes complete: {methods:?}"
+            completed_configs < 4,
+            "the total run deadline must expire before all slow config responses complete: {log:?}"
         );
         assert_eq!(
             methods

--- a/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/coding_agent.rs
@@ -4300,13 +4300,13 @@ for line in sys.stdin:
             Some("coding_agent_setup_timeout")
         );
         let methods = received_methods(&wire_log(&temp));
+        let config_attempts = methods
+            .iter()
+            .filter(|m| m.as_str() == "session/set_config_option")
+            .count();
         assert!(
-            methods
-                .iter()
-                .filter(|m| m.as_str() == "session/set_config_option")
-                .count()
-                >= 3,
-            "expected cumulative config setup before total deadline: {methods:?}"
+            config_attempts < 4,
+            "the total run deadline must expire before all slow config writes complete: {methods:?}"
         );
         assert_eq!(
             methods

--- a/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
@@ -306,12 +306,8 @@ impl DetachedJobStore {
     }
 
     pub(crate) fn read(&self, job_id: &str) -> Result<DetachedJobRecord, String> {
-        let record: DetachedJobRecord = read_json_bounded(
-            &self.state_path_for_job(job_id),
-            DETACHED_STATE_MAX_BYTES,
-            "detached Job state",
-        )?;
-        validate_record(&record)?;
+        let job_dir = self.job_dir(job_id);
+        let record = read_state_record_locked(&job_dir)?;
         if record.job_id != job_id {
             return Err("detached Job state job_id does not match its lookup identity".to_string());
         }
@@ -362,12 +358,7 @@ impl DetachedJobStore {
                     "detached Job state root exceeds {DETACHED_STATE_MAX_RECORDS} records"
                 ));
             }
-            let record: DetachedJobRecord = read_json_bounded(
-                &entry.path().join(STATE_FILE),
-                DETACHED_STATE_MAX_BYTES,
-                "detached Job state",
-            )?;
-            validate_record(&record)?;
+            let record = read_state_record_locked(&entry.path())?;
             if self.job_dir(&record.job_id) != entry.path() {
                 return Err(
                     "detached Job state directory does not match its job identity".to_string(),
@@ -519,12 +510,7 @@ impl DetachedJobStore {
                 );
             }
             let job_dir = entry.path();
-            let initial: DetachedJobRecord = read_json_bounded(
-                &job_dir.join(STATE_FILE),
-                DETACHED_STATE_MAX_BYTES,
-                "detached Job state",
-            )?;
-            validate_record(&initial)?;
+            let initial = read_state_record_locked(&job_dir)?;
             if self.job_dir(&initial.job_id) != job_dir {
                 return Err(
                     "detached Job reclamation state directory does not match durable job identity"
@@ -1461,6 +1447,22 @@ fn reject_symlink_or_non_dir(path: &Path, label: &str) -> Result<(), String> {
         return Err(format!("{label} must be a real directory, not a symlink"));
     }
     Ok(())
+}
+
+fn read_state_record_locked(job_dir: &Path) -> Result<DetachedJobRecord, String> {
+    reject_symlink_or_non_dir(job_dir, "detached Job directory")?;
+    // Durable updates replace STATE_FILE atomically, which intentionally changes
+    // its inode. Serialize pathname revalidation with those writers so a trusted
+    // atomic replacement cannot be mistaken for same-user path tampering. The
+    // O_NOFOLLOW + dev/inode checks in read_json_bounded remain authoritative.
+    let _guard = exclusive_lock(&job_dir.join(STATE_LOCK_FILE), true)?;
+    let record: DetachedJobRecord = read_json_bounded(
+        &job_dir.join(STATE_FILE),
+        DETACHED_STATE_MAX_BYTES,
+        "detached Job state",
+    )?;
+    validate_record(&record)?;
+    Ok(record)
 }
 
 fn read_json_bounded<T: for<'de> Deserialize<'de>>(

--- a/src/tool_runtime/files/artifacts.rs
+++ b/src/tool_runtime/files/artifacts.rs
@@ -120,12 +120,13 @@ pub(crate) fn validate_artifact_file_path(path: &str) -> Result<(), String> {
         return Err("path cannot contain NUL bytes".to_string());
     }
     let p = Path::new(path);
-    if p.is_absolute() {
+    let bytes = path.as_bytes();
+    let windows_drive_prefix =
+        bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+    if p.has_root() || path.starts_with('\\') || windows_drive_prefix {
         return Err("path must be project-relative".to_string());
     }
-    if p.components()
-        .any(|component| matches!(component, std::path::Component::ParentDir))
-    {
+    if path.split(['/', '\\']).any(|component| component == "..") {
         return Err("path cannot contain parent traversal".to_string());
     }
     if is_sensitive_artifact_path(path) {

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -4054,14 +4054,23 @@ fn removed_legacy_edit_tools_are_rejected_as_unknown() {
 }
 
 #[test]
-fn validate_artifact_file_path_rejects_sensitive_paths() {
+fn validate_artifact_file_path_rejects_unsafe_and_sensitive_paths() {
     assert!(validate_artifact_file_path("docs/assets/generated.png").is_ok());
     for path in [
+        "/absolute/evil.png",
+        "\\rooted\\evil.png",
+        "C:\\absolute\\evil.png",
+        "C:drive-relative\\evil.png",
         "../evil.png",
+        "nested\\..\\evil.png",
         ".git/config",
+        ".git\\config",
         ".env",
         "secrets/key.pem",
+        "secrets\\key.pem",
         "tokens/api.txt",
+        "certs\\server.key",
+        "config\\agent.toml",
         "target/out.bin",
         "node_modules/pkg/file",
     ] {


### PR DESCRIPTION
## Summary
- make project registration path assertions compare canonical paths on Windows and macOS
- restore `webcodex-computer` native tests to Linux, macOS, and Windows CI after the crate split
- harden artifact paths against Windows rooted, drive-relative, and backslash traversal forms
- make the Coding Agent total-deadline test assert deadline semantics instead of host-specific IPC speed

## Context
This fixes the native Runner failures from CI run 33708626335 after #269. The Windows and both macOS lanes were failing the same project registration path assertion (`\\?\\C:\\...` / short path on Windows and `/private/var` / `/var` on macOS).

## Validation
- Windows `cargo test --locked -p webcodex`: 3154 passed, 0 failed
- Windows `cargo test --locked -p webcodex-runner -p webcodex-computer -- --test-threads=1`: passed; Runner 744 passed / 0 failed / 2 ignored
- Windows `webcodex-computer`: 59 passed / 0 failed / 6 ignored
- macOS focused project-registration and Coding Agent deadline tests: passed
- `cargo check --locked --workspace --all-targets`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed