### PR TITLE
Close CI coverage gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,9 @@ jobs:
             packages: "-p webcodex-runner"
           - shard: workspace-crates
             packages: >-
-              -p webcodex-admin
-              -p webcodex-computer
-              -p webcodex-runner-config
-              -p webcodex-core
-              -p webcodex-cli
-              -p webcodex-persistent-shell
-              -p webcodex-workspace
-              -p webcodex-process
+              --workspace
+              --exclude webcodex
+              --exclude webcodex-runner
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -352,5 +347,39 @@ jobs:
              [ "$PACKAGE_RESULT" != success ] || \
              [ "$ARM64_RESULT" != success ]; then
             echo "required Windows CI lane did not succeed" >&2
+            exit 1
+          fi
+
+  test-native:
+    needs: [contract, test-linux-arm64, test-macos, test-windows]
+    # Always publish one stable native-coverage result. Owner-authored PRs may
+    # still start cheaply, but skipped native lanes remain visibly unsatisfied
+    # until the PR opts into the heavy matrix with `run-ci`.
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require successful native lanes
+        env:
+          CONTRACT_RESULT: ${{ needs.contract.result }}
+          LINUX_ARM64_RESULT: ${{ needs.test-linux-arm64.result }}
+          MACOS_RESULT: ${{ needs.test-macos.result }}
+          WINDOWS_RESULT: ${{ needs.test-windows.result }}
+        run: |
+          echo "contract=$CONTRACT_RESULT linux_arm64=$LINUX_ARM64_RESULT macos=$MACOS_RESULT windows=$WINDOWS_RESULT"
+          if [ "$CONTRACT_RESULT" != success ]; then
+            echo "contract CI did not succeed" >&2
+            exit 1
+          fi
+          if [ "$LINUX_ARM64_RESULT" = skipped ] || \
+             [ "$MACOS_RESULT" = skipped ] || \
+             [ "$WINDOWS_RESULT" = skipped ]; then
+            echo "native CI was skipped; owner-authored PRs must add the run-ci label before merge" >&2
+            exit 1
+          fi
+          if [ "$LINUX_ARM64_RESULT" != success ] || \
+             [ "$MACOS_RESULT" != success ] || \
+             [ "$WINDOWS_RESULT" != success ]; then
+            echo "required native CI lane did not succeed" >&2
             exit 1
           fi

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,15 +41,23 @@ The lanes above define test semantics; workflows decide when to run them.
   Release readiness must not be the first place complete Linux package suites or
   release-tooling tests execute. The historical `test` job id remains the aggregate
   Linux status check and always evaluates `contract` plus both Linux lanes, failing
-  unless every required result is `success`. Native macOS and Windows lanes still
-  retain the existing main/external-PR/owner-`run-ci` policy so routine owner PRs do
-  not automatically consume the full cross-platform matrix. This is CI orchestration,
-  not a claim that the repository now has perfectly pure fast/integration/platform suites.
+  unless every required result is `success`. Native macOS and Windows lanes plus
+  Linux arm64 retain the existing main/external-PR/owner-`run-ci` policy so routine
+  owner PRs do not automatically consume the full cross-platform matrix. The
+  always-evaluated `test-native` aggregate fails when those native lanes are skipped
+  instead of treating missing platform evidence as success; it provides one stable
+  check for branch protection once an owner PR opts into `run-ci`. This is CI
+  orchestration, not a claim that the repository now has perfectly pure
+  fast/integration/platform suites.
 - Linux Rust execution is package-sharded without test-name filters: the server
   package `webcodex`, the integration-rich Runner package `webcodex-runner`, and
   the remaining workspace crates run as three complete package groups in
-  parallel. Each workspace package appears in exactly one group, so sharding is
-  an execution optimization rather than a semantic coverage reduction. Package
+  parallel. The remainder shard uses the workspace selector
+  `--workspace --exclude webcodex --exclude webcodex-runner`, so newly added
+  workspace members enter CI automatically rather than depending on a
+  hand-maintained package list. Each
+  workspace package therefore executes in exactly one Linux Rust group; sharding
+  is an execution optimization rather than a semantic coverage reduction. Package
   boundaries do not imply that every test inside a shard has the same cost or
   integration characteristics.
 - Linux tooling runs in parallel with the Rust shards and retains


### PR DESCRIPTION
## Summary
- make the Linux remainder shard use `--workspace --exclude webcodex --exclude webcodex-runner`, so newly added workspace crates cannot silently lose unit-test coverage
- add an always-evaluated `test-native` aggregate that fails when native lanes are skipped instead of treating missing platform evidence as success
- document the automatic workspace coverage and stable native gate

## Validation
- `webcodex-tool-contracts` + `webcodex-workflow-session`: 77 passed, 0 failed on MSI
- local YAML parse/structure assertion confirms the workspace selector and `test-native` dependencies/`always()` gate
- `git diff --check`

The full native matrix will be enabled on this PR with the existing `run-ci` label. After merge, `test-native` can be added to the main branch ruleset as the stable required native check.