### PR TITLE
Improve adaptive tool routing discoverability

### DIFF
--- a/crates/webcodex-core/src/runtime_contract.rs
+++ b/crates/webcodex-core/src/runtime_contract.rs
@@ -47,5 +47,5 @@ pub const RECOVERY_TOOL_VALUES: [&str; 7] = [
 ];
 
 pub const BUILTIN_CODING_WORKFLOW_CONTRACT: &str = "webcodex.coding_workflow";
-pub const BUILTIN_CODING_WORKFLOW_VERSION: u64 = 5;
+pub const BUILTIN_CODING_WORKFLOW_VERSION: u64 = 6;
 pub const BUILTIN_CODING_WORKFLOW_MAX_GUIDANCE_ITEMS: usize = 8;

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas.rs
@@ -85,9 +85,9 @@ pub use files::{
     search_project_text_input_schema, search_project_texts_input_schema,
 };
 pub use git::{
-    git_diff_hunks_input_schema, git_diff_input_schema, git_diff_summary_input_schema,
-    git_log_input_schema, git_review_summary_input_schema, git_status_input_schema,
-    show_changes_input_schema,
+    git_commit_paths_input_schema, git_diff_hunks_input_schema, git_diff_input_schema,
+    git_diff_summary_input_schema, git_log_input_schema, git_review_summary_input_schema,
+    git_status_input_schema, show_changes_input_schema,
 };
 pub use hygiene::workspace_hygiene_check_input_schema;
 pub use jobs::{

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/git.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/git.rs
@@ -82,11 +82,11 @@ pub fn git_status_input_schema() -> Value {
 
 pub fn git_commit_paths_input_schema() -> Value {
     let mut schema = object_schema(with_optional_session_id(vec![
-        ("project", "string", "Agent-registered project id.", true),
+        ("project", "string", "Runner-registered project id.", true),
         (
             "expected_head",
             "string",
-            "Exact current 40-hex HEAD required before staging or committing.",
+            "Exact current 40-hex HEAD fence; normally copy show_changes.head.commit immediately before committing.",
             true,
         ),
         (

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/git.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/git.rs
@@ -80,6 +80,43 @@ pub fn git_status_input_schema() -> Value {
     )]))
 }
 
+pub fn git_commit_paths_input_schema() -> Value {
+    let mut schema = object_schema(with_optional_session_id(vec![
+        ("project", "string", "Agent-registered project id.", true),
+        (
+            "expected_head",
+            "string",
+            "Exact current 40-hex HEAD required before staging or committing.",
+            true,
+        ),
+        (
+            "paths",
+            "array",
+            "Exact project-relative file paths to commit. Directories, project root, sensitive paths, and unchanged paths are rejected.",
+            true,
+        ),
+        (
+            "message",
+            "string",
+            "Commit message. Bounded and never persisted in model-facing audit previews.",
+            true,
+        ),
+    ]));
+    schema["properties"]["expected_head"]["minLength"] = Value::from(40);
+    schema["properties"]["expected_head"]["maxLength"] = Value::from(40);
+    schema["properties"]["expected_head"]["pattern"] = Value::from("^[0-9A-Fa-f]{40}$");
+    schema["properties"]["paths"]["minItems"] = Value::from(1);
+    schema["properties"]["paths"]["maxItems"] = Value::from(32);
+    schema["properties"]["paths"]["items"] = json!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512
+    });
+    schema["properties"]["message"]["minLength"] = Value::from(1);
+    schema["properties"]["message"]["maxLength"] = Value::from(1000);
+    schema
+}
+
 pub fn git_diff_input_schema() -> Value {
     object_schema(with_optional_session_id(vec![
         ("project", "string", "Configured project id.", true),

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/coding_tasks.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/coding_tasks.rs
@@ -417,6 +417,8 @@ fn startup_workflow_schema() -> Value {
                     "session_message_ack": {"type": "string", "maxLength": 720},
                     "session_message_resolution": {"type": "string", "maxLength": 480},
                     "context_sidecar": {"type": "string", "maxLength": 320},
+                    "runner_targeting": {"type": "string", "maxLength": 320},
+                    "persistent_shell": {"type": "string", "maxLength": 320},
                     "normal_closeout": {"type": "string", "maxLength": 480}
                 },
                 "required": [
@@ -425,6 +427,8 @@ fn startup_workflow_schema() -> Value {
                     "session_message_ack",
                     "session_message_resolution",
                     "context_sidecar",
+                    "runner_targeting",
+                    "persistent_shell",
                     "normal_closeout"
                 ],
                 "additionalProperties": false

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
@@ -439,9 +439,14 @@ pub fn cargo_test_count_assertion_schema() -> Value {
             "reason_code": {
                 "type": "string",
                 "enum": ["minimum_satisfied", "minimum_not_met", "test_count_unproven"]
+            },
+            "evidence_reason_code": {
+                "type": "string",
+                "enum": ["complete_summary", "output_truncated", "partial_harness_summary", "no_complete_summary"],
+                "description": "Why executed-test count evidence was proven or remained unavailable; this refines evidence diagnostics without changing the assertion verdict."
             }
         },
-        "required": ["minimum_tests", "actual_tests_run", "status", "reason_code"]
+        "required": ["minimum_tests", "actual_tests_run", "status", "reason_code", "evidence_reason_code"]
     })
 }
 

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
@@ -231,9 +231,31 @@ pub fn search_context_line_schema() -> Value {
 
 pub fn search_match_schema() -> Value {
     let context_lines = array_schema(search_context_line_schema(), "Context lines.");
+    let read_hint = json!({
+        "type": "object",
+        "description": "Ready-to-use read_file/read_files item for bounded expansion around this match. Reuse the same project; this hint performs no read and contains no additional file content.",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Same trusted project-relative file path as the match."
+            },
+            "start_line": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Deterministic 1-based expansion start, up to 20 lines before the match."
+            },
+            "limit": {
+                "type": "integer",
+                "const": 80,
+                "description": "Deterministic bounded line count for read_file/read_files expansion."
+            }
+        },
+        "required": ["path", "start_line", "limit"],
+        "additionalProperties": false
+    });
     json!({
         "type": "object",
-        "description": "Search match with path, 1-based line, preview, and bounded context lines.",
+        "description": "Search match with path, 1-based line, preview, bounded context lines, and deterministic search-to-read continuation metadata.",
         "properties": {
             "path": {
                 "type": "string",
@@ -249,8 +271,9 @@ pub fn search_match_schema() -> Value {
             },
             "context_before": context_lines.clone(),
             "context_after": context_lines,
+            "read_hint": read_hint,
         },
-        "required": ["path", "line", "preview", "context_before", "context_after"],
+        "required": ["path", "line", "preview", "context_before", "context_after", "read_hint"],
         "additionalProperties": true
     })
 }

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/git.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/git.rs
@@ -6,6 +6,24 @@ use super::common::{
 
 pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
     match name {
+        "git_commit_paths" => Some(wrapped_output_schema(vec![
+            ("committed", nullable_schema("boolean", "True only when the exact-path commit is known to have completed; null when dispatch outcome is unknown.")),
+            ("expected_head", schema_type("string", "Exact caller-supplied HEAD fence.")),
+            ("previous_head", nullable_schema("string", "Known parent HEAD used by the successful commit, or null before it is proven.")),
+            ("actual_head", nullable_schema("string", "Observed HEAD when a deterministic precondition failure can report it.")),
+            ("new_head", nullable_schema("string", "New exact commit SHA when known.")),
+            (
+                "committed_paths",
+                array_schema(
+                    schema_type("string", "Exact project-relative path committed."),
+                    "Exact requested paths committed on known success; empty otherwise.",
+                ),
+            ),
+            ("state_changed", nullable_schema("boolean", "Whether repository HEAD is known to have changed.")),
+            ("outcome_unknown", schema_type("boolean", "True only when Runner dispatch may have executed but no trustworthy terminal result was received.")),
+            ("failure_kind", nullable_schema("string", "Stable bounded commit rejection/failure kind.")),
+            ("hook_policy", schema_type("string", "Always bypassed_exact_tree: commit-tree is used so hooks cannot add unrelated paths.")),
+        ])),
         "git_status" | "git_diff" => Some(wrapped_output_schema(vec![
             (
                 "exit_code",

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/git.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/git.rs
@@ -469,9 +469,25 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                                     "diff_byte_budget"
                                 ]
                             }
+                        },
+                        "suggested_call": {
+                            "type": "object",
+                            "description": "Ready-to-call worktree git_diff_hunks arguments. paths is currently empty to preserve whole-worktree coverage because show_changes does not publish authoritative per-hunk line-truncation provenance.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "project": {"type": "string"},
+                                "cached": {"type": "boolean", "const": false},
+                                "paths": {
+                                    "type": "array",
+                                    "items": {"type": "string"}
+                                },
+                                "max_hunks": {"type": "integer"},
+                                "max_hunk_lines": {"type": "integer"}
+                            },
+                            "required": ["project", "cached", "paths", "max_hunks", "max_hunk_lines"]
                         }
                     },
-                    "required": ["tool", "scope", "reason", "truncation_reasons"]
+                    "required": ["tool", "scope", "reason", "truncation_reasons", "suggested_call"]
                 }),
             ),
             (

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
@@ -330,6 +330,12 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
                 "Whether this Runner can continue the same original execution as a durable Job. Omitted after ordinary synchronous terminal success; exposed only when this tool's durable handoff path is relevant.",
             ),
         ),
+        (
+            "detected_summary",
+            super::common::open_object_schema(
+                "Current bounded operation/build/check/test summary at the initial durable Job handoff; advisory only and never retry authority.",
+            ),
+        ),
     ]
 }
 

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/testing.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/testing.rs
@@ -1,8 +1,8 @@
 use serde_json::{json, Value};
 
 use super::common::{
-    cargo_test_count_assertion_schema, nullable_schema, permission_decision_schema, schema_type,
-    session_hint_schema,
+    cargo_test_count_assertion_schema, nullable_schema, open_object_schema,
+    permission_decision_schema, schema_type, session_hint_schema,
 };
 
 pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
@@ -128,6 +128,7 @@ fn cargo_output_schema(tool_name: &str) -> Value {
             ("command_ok", schema_type("boolean", "Whether execution completed successfully.")),
             ("tool_failure", schema_type("boolean", "Whether rejection happened before execution.")),
             ("async_handoff_available", schema_type("boolean", "Whether this Runner supports validation Job handoff.")),
+            ("detected_summary", open_object_schema("Current bounded validation/progress summary at the initial durable Job handoff; advisory only and never retry authority.")),
             ("session_hint", session_hint_schema()),
             ("permission", permission_decision_schema()),
     ];

--- a/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
+++ b/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
@@ -253,6 +253,16 @@ fn discovery_and_persistent_shell_flows_route_high_value_adaptive_tools() {
     }
     assert!(discovery.summary.contains("exact Runner client_id"));
     assert!(discovery.summary.contains("before treating it as absent"));
+    for phrase in [
+        "runtime_status(client_id=...)",
+        "list_projects(client_id=...)",
+        "list_agents",
+    ] {
+        assert!(
+            discovery.manifest_purpose.contains(phrase),
+            "discovery: {phrase}"
+        );
+    }
 
     let persistent = TOOL_RECOMMENDED_FLOWS
         .iter()
@@ -270,6 +280,18 @@ fn discovery_and_persistent_shell_flows_route_high_value_adaptive_tools() {
     assert!(persistent
         .summary
         .contains("isolated one-shot native commands"));
+    for tool in [
+        "open_session_shell",
+        "session_shell_exec",
+        "session_shell_status",
+        "close_session_shell",
+        "run_process",
+    ] {
+        assert!(
+            persistent.manifest_purpose.contains(tool),
+            "persistent_shell: {tool}"
+        );
+    }
 }
 
 #[test]

--- a/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
+++ b/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
@@ -231,6 +231,7 @@ fn tool_categories_and_recommended_flows_are_well_formed() {
         "validate: use cargo_check / cargo_test / go_test",
         "raw run_shell is a bounded escape hatch",
         "not the primary validation path",
+        "copy show_changes.head.commit",
         "review: start with show_changes for the bounded worktree overview",
         "if hunks truncate, continue/focus with git_diff_hunks",
         "handoff: use session_summary / session_handoff_summary",
@@ -248,7 +249,7 @@ fn discovery_and_persistent_shell_flows_route_high_value_adaptive_tools() {
         .iter()
         .find(|flow| flow.name == "discovery")
         .expect("discovery recommended flow");
-    for tool in ["runtime_status", "list_agents", "list_projects"] {
+    for tool in ["runtime_status", "list_runners", "list_projects"] {
         assert!(discovery.tools.contains(&tool), "discovery: {tool}");
     }
     assert!(discovery.summary.contains("exact Runner client_id"));
@@ -256,13 +257,15 @@ fn discovery_and_persistent_shell_flows_route_high_value_adaptive_tools() {
     for phrase in [
         "runtime_status(client_id=...)",
         "list_projects(client_id=...)",
-        "list_agents",
+        "list_runners",
     ] {
         assert!(
             discovery.manifest_purpose.contains(phrase),
             "discovery: {phrase}"
         );
     }
+    assert!(!discovery.tools.contains(&"list_agents"));
+    assert!(!discovery.manifest_purpose.contains("list_agents"));
 
     let persistent = TOOL_RECOMMENDED_FLOWS
         .iter()

--- a/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
+++ b/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
@@ -217,8 +217,11 @@ fn tool_categories_and_recommended_flows_are_well_formed() {
     }
     let joined_flows = flows.join("\n").to_lowercase();
     for phrase in [
-        "use search_project_text for bounded code search",
-        "run_shell with rg or git grep remains the diagnostic escape hatch",
+        "if the user gives an exact runner client_id",
+        "runtime_status/list_projects for that runner",
+        "persistent shell: for repeated commands in one workflow session",
+        "especially on a named ssh resource",
+        "keep run_process for isolated one-shot native commands",
         "inspect: use search_project_text and read_file before editing",
         "run_shell with rg or git grep is the diagnostic escape hatch",
         "edit: prefer apply_patch for model-generated contextual",
@@ -237,6 +240,36 @@ fn tool_categories_and_recommended_flows_are_well_formed() {
             "recommended flows should mention {phrase}"
         );
     }
+}
+
+#[test]
+fn discovery_and_persistent_shell_flows_route_high_value_adaptive_tools() {
+    let discovery = TOOL_RECOMMENDED_FLOWS
+        .iter()
+        .find(|flow| flow.name == "discovery")
+        .expect("discovery recommended flow");
+    for tool in ["runtime_status", "list_agents", "list_projects"] {
+        assert!(discovery.tools.contains(&tool), "discovery: {tool}");
+    }
+    assert!(discovery.summary.contains("exact Runner client_id"));
+    assert!(discovery.summary.contains("before treating it as absent"));
+
+    let persistent = TOOL_RECOMMENDED_FLOWS
+        .iter()
+        .find(|flow| flow.name == "persistent_shell")
+        .expect("persistent shell recommended flow");
+    assert_eq!(
+        persistent.tools.first().copied(),
+        Some("open_session_shell")
+    );
+    assert_eq!(persistent.tools.get(1).copied(), Some("session_shell_exec"));
+    assert!(persistent.tools.contains(&"session_shell_status"));
+    assert!(persistent.tools.contains(&"close_session_shell"));
+    assert!(persistent.tools.contains(&"run_process"));
+    assert!(persistent.summary.contains("named SSH resource"));
+    assert!(persistent
+        .summary
+        .contains("isolated one-shot native commands"));
 }
 
 #[test]

--- a/crates/webcodex-tool-contracts/src/tests/metadata_policy.rs
+++ b/crates/webcodex-tool-contracts/src/tests/metadata_policy.rs
@@ -130,6 +130,7 @@ fn tool_specs_annotations_are_canonical_semantic_projections() {
 
     for name in [
         "workspace_checkpoint_create",
+        "git_commit_paths",
         "artifact_upload_begin",
         "artifact_upload_chunk",
         "computer_save_snapshot",
@@ -162,6 +163,16 @@ fn tool_specs_annotations_are_canonical_semantic_projections() {
     assert_eq!(
         spec_named(&specs, "coding_agent_cancel").annotations["readOnlyHint"],
         false
+    );
+
+    let commit = lookup_tool_metadata("git_commit_paths").unwrap();
+    assert_eq!(commit.effect, ToolEffect::Mutate);
+    assert_eq!(commit.risk, ToolRisk::ProjectWrite);
+    assert_eq!(commit.approval, ToolApprovalPolicy::Standard);
+    assert_eq!(commit.idempotency, ToolIdempotency::NonIdempotent);
+    assert_eq!(
+        commit.authority,
+        ToolAuthorityPolicy::RequireAll(&[PROJECT_WRITE, JOB_RUN])
     );
     assert_eq!(
         spec_named(&specs, "coding_agent_cancel").annotations["idempotentHint"],

--- a/crates/webcodex-tool-contracts/src/tests/policy_contracts.rs
+++ b/crates/webcodex-tool-contracts/src/tests/policy_contracts.rs
@@ -574,7 +574,7 @@ fn required_runner_capability_matches_metadata_risk_table() {
         (
             "git_commit_paths",
             ToolRisk::ProjectWrite,
-            AgentCapability::GitOrShell,
+            RunnerCapabilityRequirement::GitOrShell,
         ),
         (
             "discard_untracked",

--- a/crates/webcodex-tool-contracts/src/tests/policy_contracts.rs
+++ b/crates/webcodex-tool-contracts/src/tests/policy_contracts.rs
@@ -572,6 +572,11 @@ fn required_runner_capability_matches_metadata_risk_table() {
             RunnerCapabilityRequirement::StructuredProcess,
         ),
         (
+            "git_commit_paths",
+            ToolRisk::ProjectWrite,
+            AgentCapability::GitOrShell,
+        ),
+        (
             "discard_untracked",
             ToolRisk::ProjectWrite,
             RunnerCapabilityRequirement::StructuredProcess,

--- a/crates/webcodex-tool-contracts/src/tool_catalog.rs
+++ b/crates/webcodex-tool-contracts/src/tool_catalog.rs
@@ -277,7 +277,7 @@ pub const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
         name: "discovery",
         summary: "Discovery: if the user gives an exact Runner client_id, query runtime_status/list_projects for that Runner before treating it as absent from a fleet snapshot. Otherwise use bounded runtime/project discovery, then structured search; run_shell remains the diagnostic escape hatch.",
         manifest_purpose:
-            "Prefer exact Runner lookup when client_id is known; otherwise resolve bounded runtime/project context, inspect structure, then search code.",
+            "Exact Runner targeting: with client_id use runtime_status(client_id=...) or list_projects(client_id=...); use list_agents only for broad fleet discovery, then inspect/search the resolved project.",
         tools: &[
             "runtime_status",
             "list_agents",
@@ -296,7 +296,7 @@ pub const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
         name: "persistent_shell",
         summary: "Persistent shell: for repeated commands in one Workflow Session, especially on a named SSH resource, open_session_shell once and reuse session_shell_exec. Keep run_process for isolated one-shot native commands; inspect status or close the shell when needed.",
         manifest_purpose:
-            "Reuse one bounded Session shell for repeated local or named-SSH commands while keeping run_process for isolated one-shot native execution.",
+            "Persistent shell route: open_session_shell once, reuse session_shell_exec for repeated local or named-SSH commands, inspect with session_shell_status, close with close_session_shell; keep run_process for isolated one-shot native execution.",
         tools: &[
             "open_session_shell",
             "session_shell_exec",

--- a/crates/webcodex-tool-contracts/src/tool_catalog.rs
+++ b/crates/webcodex-tool-contracts/src/tool_catalog.rs
@@ -275,10 +275,12 @@ pub const TOOL_DISCOVERY_GROUPS: &[ToolDiscoveryGroup] = &[
 pub const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
     ToolRecommendedFlow {
         name: "discovery",
-        summary: "Discovery: use search_project_text for bounded code search after list_projects/project_overview. Prefer run_process for native argv and run_script for typed scripts; run_shell with rg or git grep remains the diagnostic escape hatch.",
+        summary: "Discovery: if the user gives an exact Runner client_id, query runtime_status/list_projects for that Runner before treating it as absent from a fleet snapshot. Otherwise use bounded runtime/project discovery, then structured search; run_shell remains the diagnostic escape hatch.",
         manifest_purpose:
-            "Resolve the project, inspect bounded structure, then search code with search_project_text or search_project_texts.",
+            "Prefer exact Runner lookup when client_id is known; otherwise resolve bounded runtime/project context, inspect structure, then search code.",
         tools: &[
+            "runtime_status",
+            "list_agents",
             "list_projects",
             "project_overview",
             "read_file",
@@ -288,6 +290,19 @@ pub const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
             "run_process",
             "run_script",
             "run_shell",
+        ],
+    },
+    ToolRecommendedFlow {
+        name: "persistent_shell",
+        summary: "Persistent shell: for repeated commands in one Workflow Session, especially on a named SSH resource, open_session_shell once and reuse session_shell_exec. Keep run_process for isolated one-shot native commands; inspect status or close the shell when needed.",
+        manifest_purpose:
+            "Reuse one bounded Session shell for repeated local or named-SSH commands while keeping run_process for isolated one-shot native execution.",
+        tools: &[
+            "open_session_shell",
+            "session_shell_exec",
+            "session_shell_status",
+            "close_session_shell",
+            "run_process",
         ],
     },
     ToolRecommendedFlow {

--- a/crates/webcodex-tool-contracts/src/tool_catalog.rs
+++ b/crates/webcodex-tool-contracts/src/tool_catalog.rs
@@ -121,6 +121,7 @@ pub const TOOL_DISCOVERY_GROUPS: &[ToolDiscoveryGroup] = &[
     ToolDiscoveryGroup {
         name: TOOL_DISCOVERY_GROUP_GIT,
         tools: &[
+            "git_commit_paths",
             "git_status",
             "git_diff",
             "git_diff_summary",
@@ -378,6 +379,13 @@ pub const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
             "computer_list_windows",
             "computer_activate_window",
         ],
+    },
+    ToolRecommendedFlow {
+        name: "commit",
+        summary: "Commit: inspect git_status/show_changes, then use git_commit_paths with the exact current HEAD and explicit changed file paths. It rejects pre-existing staged state and never pushes; keep run_process for unusual Git operations outside this narrow contract.",
+        manifest_purpose:
+            "Safe exact-path commit route: inspect with git_status/show_changes, then call git_commit_paths with expected_head and explicit file paths; it requires project:write plus job:run because clean filters may execute, uses an isolated exact-tree commit, bypasses commit hooks, refuses unrelated staged state, and never pushes.",
+        tools: &["git_status", "show_changes", "git_commit_paths"],
     },
     ToolRecommendedFlow {
         name: "review",

--- a/crates/webcodex-tool-contracts/src/tool_catalog.rs
+++ b/crates/webcodex-tool-contracts/src/tool_catalog.rs
@@ -278,10 +278,10 @@ pub const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
         name: "discovery",
         summary: "Discovery: if the user gives an exact Runner client_id, query runtime_status/list_projects for that Runner before treating it as absent from a fleet snapshot. Otherwise use bounded runtime/project discovery, then structured search; run_shell remains the diagnostic escape hatch.",
         manifest_purpose:
-            "Exact Runner targeting: with client_id use runtime_status(client_id=...) or list_projects(client_id=...); use list_agents only for broad fleet discovery, then inspect/search the resolved project.",
+            "Exact Runner targeting: with client_id use runtime_status(client_id=...) or list_projects(client_id=...); use list_runners only for broad fleet discovery, then inspect/search the resolved project.",
         tools: &[
             "runtime_status",
-            "list_agents",
+            "list_runners",
             "list_projects",
             "project_overview",
             "read_file",
@@ -382,9 +382,9 @@ pub const TOOL_RECOMMENDED_FLOWS: &[ToolRecommendedFlow] = &[
     },
     ToolRecommendedFlow {
         name: "commit",
-        summary: "Commit: inspect git_status/show_changes, then use git_commit_paths with the exact current HEAD and explicit changed file paths. It rejects pre-existing staged state and never pushes; keep run_process for unusual Git operations outside this narrow contract.",
+        summary: "Commit: inspect git_status/show_changes, copy show_changes.head.commit into git_commit_paths.expected_head, and pass explicit changed file paths. It rejects pre-existing staged state and never pushes; keep run_process for unusual Git operations outside this narrow contract.",
         manifest_purpose:
-            "Safe exact-path commit route: inspect with git_status/show_changes, then call git_commit_paths with expected_head and explicit file paths; it requires project:write plus job:run because clean filters may execute, uses an isolated exact-tree commit, bypasses commit hooks, refuses unrelated staged state, and never pushes.",
+            "Commit route: inspect with show_changes, copy head.commit to expected_head, then call git_commit_paths with explicit paths. Requires project:write + job:run because clean filters may run; isolated exact-tree commit bypasses hooks, rejects staged state, never pushes.",
         tools: &["git_status", "show_changes", "git_commit_paths"],
     },
     ToolRecommendedFlow {

--- a/crates/webcodex-tool-contracts/src/tool_definition/discovery.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/discovery.rs
@@ -170,7 +170,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Return compact runtime discovery. Filter by category/intent, or pass exact tool_name for one contract with description + input schema and no output schema. Discovery never changes behavior, authority, permissions, execution, or verdicts.",
+            "Global runtime discovery; do not pass project. Filter by category/intent, or pass exact tool_name for one contract with description + input schema and no output schema. The returned tool may itself require project. Discovery never changes behavior, authority, permissions, execution, or verdicts.",
             tool_manifest_input_schema,
         )),
         30,

--- a/crates/webcodex-tool-contracts/src/tool_definition/git.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/git.rs
@@ -2,15 +2,17 @@ use super::RunnerCapabilityRequirement::GitOrShell;
 use super::ToolVisibility::ModelVisible;
 use super::{
     adaptive_runtime_direct, change_summary_like, context_recovery_only, def, git_like, model_spec,
-    ToolDefinition, TOOL_CATEGORY_GIT,
+    require_all_scopes, ToolDefinition, TOOL_CATEGORY_GIT,
 };
 use crate::metadata::{
-    ToolPathHint::None as NoPath, ToolRisk::Read, PROJECT_READ, TOOL_PROVIDER_RUNNER,
+    ToolPathHint::{None as NoPath, PathList},
+    ToolRisk::{ProjectWrite, Read},
+    JOB_RUN, PROJECT_READ, PROJECT_WRITE, TOOL_PROVIDER_RUNNER,
 };
 use crate::registry::input_schemas::{
-    git_diff_hunks_input_schema, git_diff_input_schema, git_diff_summary_input_schema,
-    git_log_input_schema, git_review_summary_input_schema, git_status_input_schema,
-    show_changes_input_schema,
+    git_commit_paths_input_schema, git_diff_hunks_input_schema, git_diff_input_schema,
+    git_diff_summary_input_schema, git_log_input_schema, git_review_summary_input_schema,
+    git_status_input_schema, show_changes_input_schema,
 };
 
 pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
@@ -89,6 +91,28 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
 ];
 
 pub(super) const DETAIL_DEFINITIONS: &[ToolDefinition] = &[
+    require_all_scopes(git_like(model_spec(
+        def(
+            "git_commit_paths",
+            ModelVisible,
+            TOOL_CATEGORY_GIT,
+            Some(GitOrShell),
+            TOOL_PROVIDER_RUNNER,
+            super::ToolSemanticContract {
+                effect: super::ToolEffect::Mutate,
+                risk: ProjectWrite,
+                approval: super::ToolApprovalPolicy::Standard,
+                idempotency: super::ToolIdempotency::NonIdempotent,
+            },
+            Some(PROJECT_WRITE),
+            true,
+            PathList,
+            false,
+            false,
+        ),
+        "Commit exactly requested changed file paths with an atomic expected_head fence and isolated temporary index; normal Git clean filters may run under job:run authority, ordinary commit hooks are bypassed so they cannot add unrelated paths, and the tool never pushes.",
+        git_commit_paths_input_schema,
+    )), &[PROJECT_WRITE, JOB_RUN]),
     context_recovery_only(git_like(model_spec(
         def(
             "git_status",

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -171,6 +171,9 @@ explicit count assertion passes only when complete parser evidence proves the
 minimum; incomplete or truncated evidence fails the validation contract without
 rewriting the process exit code. Count assertions cannot be combined with
 `no_run: true`.
+When a count assertion is unproven, `test_count_assertion.evidence_reason_code`
+distinguishes truncated output, a partial harness summary, and the absence of a
+complete summary without weakening the fail-closed count proof.
 
 **Declare non-default execution outcomes before running them.** Supported execution and
 structured-validation tools accept `result_expectation` with three meanings: omitted

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -176,8 +176,8 @@ distinguishes truncated output, a partial harness summary, and the absence of a
 complete summary without weakening the fail-closed count proof.
 
 For routine exact-path commits, `git_commit_paths` is the guarded structured path:
-pass the exact current 40-hex `expected_head`, the explicit changed file paths, and
-the commit message. It refuses pre-existing staged state, conflicts, stale HEAD,
+copy the exact current 40-hex `show_changes.head.commit` into `expected_head`, then
+pass the explicit changed file paths and commit message. It refuses pre-existing staged state, conflicts, stale HEAD,
 directories, sensitive paths, and unchanged requested paths; it never pushes.
 Staging uses an isolated temporary index, so normal Git clean filters may run and
 the tool therefore requires both `project:write` and `job:run`. The final commit

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -175,6 +175,17 @@ When a count assertion is unproven, `test_count_assertion.evidence_reason_code`
 distinguishes truncated output, a partial harness summary, and the absence of a
 complete summary without weakening the fail-closed count proof.
 
+For routine exact-path commits, `git_commit_paths` is the guarded structured path:
+pass the exact current 40-hex `expected_head`, the explicit changed file paths, and
+the commit message. It refuses pre-existing staged state, conflicts, stale HEAD,
+directories, sensitive paths, and unchanged requested paths; it never pushes.
+Staging uses an isolated temporary index, so normal Git clean filters may run and
+the tool therefore requires both `project:write` and `job:run`. The final commit
+uses an exact-tree `commit-tree` plus atomic `update-ref` fence; ordinary commit
+hooks are intentionally bypassed so they cannot add unrelated paths. If the
+dispatch result is uncertain, observe HEAD/status before deciding what to do and
+never blindly retry the commit.
+
 **Declare non-default execution outcomes before running them.** Supported execution and
 structured-validation tools accept `result_expectation` with three meanings: omitted
 (or `success`) keeps the normal fail-closed success requirement; `failure` is for a

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -137,6 +137,9 @@ test，或使用 `min_tests: N` 声明更大的 bounded minimum；两者同时�
 返回 `tests_run_count: 0` 与 `zero_tests_run: true`。显式 count assertion 只有在完整 parser
 evidence 能证明达到 minimum 时才通过；evidence 缺失或被截断时 validation contract 会失败，
 但不会改写真实 process exit code。count assertion 不能与 `no_run: true` 同时使用。
+当 count assertion 无法证明时，`test_count_assertion.evidence_reason_code` 会进一步区分
+输出被截断、harness summary 不完整、或完全没有完整 summary；这些诊断不会放松 fail-closed
+的 test-count 证明要求。
 
 **在执行前声明非默认结果。** 支持该契约的执行与 structured-validation 工具接受
 `result_expectation`：省略（或 `success`）保持默认的 fail-closed 成功要求；`failure` 用于

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -142,7 +142,7 @@ evidence 能证明达到 minimum 时才通过；evidence 缺失或被截断时 v
 的 test-count 证明要求。
 
 对于日常的精确路径提交，优先使用受控的 `git_commit_paths`：传入当前精确 40 位
-`expected_head`、明确的变更文件路径和 commit message。它会拒绝已有 staged state、冲突、
+`show_changes.head.commit` 作为 `expected_head`，再传入明确的变更文件路径和 commit message。它会拒绝已有 staged state、冲突、
 过期 HEAD、目录、敏感路径以及没有变化的目标文件，并且永远不会 push。staging 使用隔离的
 临时 index，因此正常 Git clean filter 仍可能执行，所以该工具同时要求 `project:write` 与
 `job:run`。最终提交通过 exact-tree `commit-tree` 与原子的 `update-ref` HEAD fence 完成；为了

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -141,6 +141,14 @@ evidence 能证明达到 minimum 时才通过；evidence 缺失或被截断时 v
 输出被截断、harness summary 不完整、或完全没有完整 summary；这些诊断不会放松 fail-closed
 的 test-count 证明要求。
 
+对于日常的精确路径提交，优先使用受控的 `git_commit_paths`：传入当前精确 40 位
+`expected_head`、明确的变更文件路径和 commit message。它会拒绝已有 staged state、冲突、
+过期 HEAD、目录、敏感路径以及没有变化的目标文件，并且永远不会 push。staging 使用隔离的
+临时 index，因此正常 Git clean filter 仍可能执行，所以该工具同时要求 `project:write` 与
+`job:run`。最终提交通过 exact-tree `commit-tree` 与原子的 `update-ref` HEAD fence 完成；为了
+保证 hook 不能偷偷加入无关文件，普通 commit hook 会被有意绕过。如果 dispatch 结果不确定，
+必须先重新观察 HEAD/status，不能盲目重试提交。
+
 **在执行前声明非默认结果。** 支持该契约的执行与 structured-validation 工具接受
 `result_expectation`：省略（或 `success`）保持默认的 fail-closed 成功要求；`failure` 用于
 负向测试，只有已完成且结果已知的业务失败才算命中预期；`observe` 用于只观察结果的探测，

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -1100,11 +1100,10 @@ impl ToolRuntime {
                 );
             }
         };
-        let queued = matches!(
+        let (execution_state, command_started) = validation_handoff_execution_state(
             latest_status.as_str(),
-            "queued" | "agent_queued" | "started"
+            observation.job.started_at.is_some(),
         );
-        let execution_state = if queued { "queued" } else { "running" };
         let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
             Some(&handoff.command_summary),
             Some(&handoff.purpose),
@@ -1121,7 +1120,7 @@ impl ToolRuntime {
             "job_status": latest_status,
             "observation_token": observation_token,
             "promoted_to_job": true,
-            "command_started": !queued,
+            "command_started": command_started,
             "command_completed": false,
             "effective_timeout_secs": handoff.effective_timeout_secs,
             "sync_wait_secs": handoff.sync_wait_secs,
@@ -1676,6 +1675,40 @@ impl Drop for ValidationCleanupGuard {
                 clients.process_hidden_cleanup_intents().await;
             });
         }
+    }
+}
+
+fn validation_handoff_execution_state(status: &str, started: bool) -> (&'static str, bool) {
+    let pending_status = matches!(status, "queued" | "agent_queued" | "started");
+    let command_started = !pending_status || started;
+    (
+        if command_started { "running" } else { "queued" },
+        command_started,
+    )
+}
+
+#[cfg(test)]
+mod validation_handoff_projection_tests {
+    use super::validation_handoff_execution_state;
+
+    #[test]
+    fn fresh_started_evidence_prevents_false_queued_validation_handoff() {
+        assert_eq!(
+            validation_handoff_execution_state("agent_queued", false),
+            ("queued", false)
+        );
+        assert_eq!(
+            validation_handoff_execution_state("agent_queued", true),
+            ("running", true)
+        );
+        assert_eq!(
+            validation_handoff_execution_state("started", true),
+            ("running", true)
+        );
+        assert_eq!(
+            validation_handoff_execution_state("running", true),
+            ("running", true)
+        );
     }
 }
 

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -9,6 +9,7 @@ use super::helpers::{
     SYNC_VALIDATION_WAIT_SECS,
 };
 use super::shell::{command_execution_state_name, ProjectCommandOutput};
+use super::structured_execution::structured_job_observation;
 use super::tool_result::ToolResult;
 use super::validation_parser::parse_complete_cargo_test_summary_counts;
 use super::validation_profile::{
@@ -1068,7 +1069,30 @@ impl ToolRuntime {
             guard.disarm();
             return result;
         }
-        let observation_token = match promoted.observation_token {
+        let observation = match structured_job_observation(
+            &self.shell_clients,
+            handoff.auth.as_ref(),
+            &job_id,
+        )
+        .await
+        {
+            Ok(observation) => observation,
+            Err(error) => {
+                return ToolResult::err(command_rejected_message(
+                    error,
+                    "observe the returned Job from list_jobs before deciding whether any retry is safe.",
+                ));
+            }
+        };
+        let latest_status = observation.job.status.clone();
+        if crate::tool_runtime::jobs::is_terminal_job_status(&latest_status) {
+            let result = self
+                .validation_terminal_result(job_id, adapter, &latest_status, handoff)
+                .await;
+            guard.disarm();
+            return result;
+        }
+        let observation_token = match observation.job.observation_token.clone() {
             Some(token) => token,
             None => {
                 return ToolResult::err(
@@ -1081,6 +1105,14 @@ impl ToolRuntime {
             "queued" | "agent_queued" | "started"
         );
         let execution_state = if queued { "queued" } else { "running" };
+        let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
+            Some(&handoff.command_summary),
+            Some(&handoff.purpose),
+            &latest_status,
+            observation.job.exit_code.map(i64::from),
+            &observation.stdout_tail,
+            &observation.stderr_tail,
+        );
         let payload = json!({
             "execution_source": handoff.execution_source,
             "purpose": handoff.purpose,
@@ -1098,12 +1130,13 @@ impl ToolRuntime {
             "shell": handoff.shell,
             "executor": handoff.executor,
             "command_summary": handoff.command_summary,
-            "stdout_tail": "",
-            "stderr_tail": "",
-            "stdout_lines": 0,
-            "stderr_lines": 0,
-            "stdout_truncated": false,
-            "stderr_truncated": false,
+            "stdout_tail": observation.stdout_tail,
+            "stderr_tail": observation.stderr_tail,
+            "stdout_lines": observation.stdout_lines,
+            "stderr_lines": observation.stderr_lines,
+            "stdout_truncated": observation.stdout_truncated,
+            "stderr_truncated": observation.stderr_truncated,
+            "detected_summary": detected_summary,
             "terminal": false,
         });
         guard.disarm();

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -97,6 +97,7 @@ pub(crate) struct CargoTestRunMetadata {
     pub(crate) tests_passed: Option<u64>,
     pub(crate) tests_failed: Option<u64>,
     pub(crate) zero_tests_run: Option<bool>,
+    pub(crate) count_evidence_reason: &'static str,
 }
 
 pub(crate) fn parse_cargo_test_run_metadata(text: &str) -> CargoTestRunMetadata {
@@ -152,6 +153,7 @@ pub(crate) fn parse_cargo_test_run_metadata(text: &str) -> CargoTestRunMetadata 
             tests_passed: Some(tests_passed),
             tests_failed: Some(tests_failed),
             zero_tests_run: Some(tests_run_count == 0),
+            count_evidence_reason: "complete_summary",
         }
     } else {
         CargoTestRunMetadata {
@@ -160,6 +162,11 @@ pub(crate) fn parse_cargo_test_run_metadata(text: &str) -> CargoTestRunMetadata 
             tests_passed: None,
             tests_failed: None,
             zero_tests_run: None,
+            count_evidence_reason: if incomplete_summary_found {
+                "partial_harness_summary"
+            } else {
+                "no_complete_summary"
+            },
         }
     }
 }

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -2020,6 +2020,7 @@ impl ToolRuntime {
 
             call @ (ToolCall::GitRestorePaths { .. }
             | ToolCall::DiscardUntracked { .. }
+            | ToolCall::GitCommitPaths { .. }
             | ToolCall::GitStatus { .. }
             | ToolCall::GitDiff { .. }
             | ToolCall::GitDiffHunks { .. }

--- a/src/tool_runtime/files/search.rs
+++ b/src/tool_runtime/files/search.rs
@@ -799,6 +799,24 @@ struct SearchContextLine {
     text: String,
 }
 
+const SEARCH_READ_HINT_CONTEXT_BEFORE: u64 = 20;
+const SEARCH_READ_HINT_LIMIT: u64 = 80;
+
+#[derive(Debug, Serialize)]
+struct SearchReadHint {
+    path: String,
+    start_line: u64,
+    limit: u64,
+}
+
+fn search_read_hint(path: &str, line: u64) -> SearchReadHint {
+    SearchReadHint {
+        path: path.to_string(),
+        start_line: line.saturating_sub(SEARCH_READ_HINT_CONTEXT_BEFORE).max(1),
+        limit: SEARCH_READ_HINT_LIMIT,
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct SearchMatch {
     path: String,
@@ -806,6 +824,7 @@ struct SearchMatch {
     preview: String,
     context_before: Vec<SearchContextLine>,
     context_after: Vec<SearchContextLine>,
+    read_hint: SearchReadHint,
 }
 
 #[derive(Debug, Serialize)]
@@ -1190,6 +1209,7 @@ fn search_matches_from_records(
             preview: record.text.clone(),
             context_before,
             context_after,
+            read_hint: search_read_hint(&record.path, record.line),
         });
     }
     (matches, truncated)

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -2086,11 +2086,31 @@ fn set_show_changes_verdict(output: &mut Value) {
         let hunk_line_truncated = diff_truncation_reasons
             .iter()
             .any(|reason| *reason == "diff_hunk_line_limit");
+        // show_changes currently reports line truncation at the aggregate diff
+        // level, not as authoritative per-hunk provenance. Keep whole-worktree
+        // scope rather than guessing which returned path owns the omitted lines.
+        let suggested_paths: Vec<String> = Vec::new();
+        let suggested_max_hunk_lines = if hunk_line_truncated {
+            MAX_MAX_HUNK_LINES
+        } else {
+            DEFAULT_MAX_HUNK_LINES
+        };
+        let project = output
+            .get("project")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
         output["diff_review_handoff"] = json!({
             "tool": "git_diff_hunks",
             "scope": "worktree",
             "reason": "show_changes_diff_truncated",
             "truncation_reasons": diff_truncation_reasons,
+            "suggested_call": {
+                "project": project,
+                "cached": false,
+                "paths": suggested_paths,
+                "max_hunks": DEFAULT_MAX_HUNKS,
+                "max_hunk_lines": suggested_max_hunk_lines,
+            },
         });
         push_unique_reason(&mut warning_reasons, "truncated_by_limit");
         push_unique_action(

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -16,9 +16,10 @@ use super::helpers::{
     decode_git_quoted_path, shell_escape_simple, validate_limited_cleanup_paths,
     validate_project_relative_path,
 };
-use super::tool_result::ToolResult;
+use super::shell::{agent_command_lifecycle, dispatch_uncertainty_lifecycle};
+use super::tool_result::{RecoveryKind, ToolResult};
 use super::ToolRuntime;
-use crate::shell_protocol::ShellRunRequest;
+use crate::shell_protocol::{ShellCommandExecutionState, ShellRunRequest};
 use crate::tool_runtime::sessions::{SessionEvent, SessionSummary};
 
 /// Sentinel separating `git status --porcelain` from `git diff --stat` in the
@@ -43,6 +44,10 @@ const GIT_DIFF_HUNKS_BLOCK_TRAILER_BYTES: usize = 30;
 const GIT_DIFF_HUNKS_BLOCK_MAGIC: &[u8; 6] = b"WCDH1:";
 const SHOW_CHANGES_DEFAULT_MAX_HUNKS: usize = 20;
 const SHOW_CHANGES_MAX_HUNKS: usize = 100;
+const GIT_COMMIT_PATHS_MAX_PATHS: usize = 32;
+const GIT_COMMIT_PATH_MAX_CHARS: usize = 512;
+const GIT_COMMIT_MESSAGE_MAX_CHARS: usize = 1000;
+pub(crate) const GIT_COMMIT_RESULT_PREFIX: &str = "@@WEBCODEX_GIT_COMMIT@@";
 const SHOW_CHANGES_DEFAULT_MAX_HUNK_LINES: usize = 80;
 const SHOW_CHANGES_MAX_HUNK_LINES: usize = 240;
 const SHOW_CHANGES_DEFAULT_SESSION_EVENT_LIMIT: usize = 30;
@@ -3200,6 +3205,177 @@ pub(crate) fn parse_porcelain_summary(porcelain: &str) -> PorcelainSummary {
     summary
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitCommitMarker {
+    pub(crate) status: String,
+    pub(crate) previous_head: Option<String>,
+    pub(crate) actual_head: Option<String>,
+    pub(crate) new_head: Option<String>,
+}
+
+fn validate_git_commit_paths_input(
+    expected_head: &str,
+    paths: &[String],
+    message: &str,
+) -> Result<(String, Vec<String>, String), String> {
+    let expected_head = normalize_exact_commit_id(expected_head)
+        .map_err(|_| "expected_head must be one exact 40-hex commit id".to_string())?;
+    if paths.len() > GIT_COMMIT_PATHS_MAX_PATHS {
+        return Err(format!(
+            "paths may contain at most {GIT_COMMIT_PATHS_MAX_PATHS} entries"
+        ));
+    }
+    let paths = validate_limited_cleanup_paths(paths, true)?;
+    for path in &paths {
+        if path.chars().count() > GIT_COMMIT_PATH_MAX_CHARS {
+            return Err(format!(
+                "commit path exceeds {GIT_COMMIT_PATH_MAX_CHARS} characters"
+            ));
+        }
+        if path.chars().any(char::is_control) {
+            return Err("commit paths must not contain control characters".to_string());
+        }
+    }
+    if message.trim().is_empty() {
+        return Err("message must not be empty or whitespace-only".to_string());
+    }
+    if message.chars().count() > GIT_COMMIT_MESSAGE_MAX_CHARS {
+        return Err(format!(
+            "message may contain at most {GIT_COMMIT_MESSAGE_MAX_CHARS} characters"
+        ));
+    }
+    if message.contains('\0') {
+        return Err("message must not contain NUL".to_string());
+    }
+    Ok((expected_head, paths, message.to_string()))
+}
+
+fn git_commit_paths_script(expected_head: &str, paths: &[String], message: &str) -> String {
+    let expected = shell_escape_simple(expected_head);
+    let message = shell_escape_simple(message);
+    let mut path_checks = String::new();
+    let mut index_adds = String::new();
+    let mut requested_lines = String::new();
+    let mut reset_args = String::new();
+    for path in paths {
+        let quoted = shell_escape_simple(path);
+        path_checks.push_str(&format!(
+            "if [ -d {quoted} ]; then printf '{GIT_COMMIT_RESULT_PREFIX} status=directory_path\\n'; exit 23; fi\n\
+             if [ ! -e {quoted} ] && [ ! -L {quoted} ] && ! git ls-files --error-unmatch -- {quoted} >/dev/null 2>&1; then printf '{GIT_COMMIT_RESULT_PREFIX} status=missing_path\\n'; exit 24; fi\n\
+             if [ -z \"$(git status --porcelain=v1 --untracked-files=all -- {quoted})\" ]; then printf '{GIT_COMMIT_RESULT_PREFIX} status=unchanged_path\\n'; exit 25; fi\n"
+        ));
+        index_adds.push_str(&format!(
+            "if ! GIT_INDEX_FILE=\"$index_file\" git add -A -- {quoted}; then printf '{GIT_COMMIT_RESULT_PREFIX} status=stage_failed\\n'; exit 26; fi\n"
+        ));
+        requested_lines.push_str(&format!("printf '%s\\n' {quoted} >> \"$req_file\"\n"));
+        reset_args.push(' ');
+        reset_args.push_str(&quoted);
+    }
+
+    format!(
+        "set -eu\n\
+         export LC_ALL=C GIT_PAGER=cat GIT_TERMINAL_PROMPT=0\n\
+         unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE\n\
+         expected={expected}\n\
+         index_file=$(mktemp \"${{TMPDIR:-/tmp}}/webcodex-index.XXXXXX\")\n\
+         req_file=$(mktemp \"${{TMPDIR:-/tmp}}/webcodex-req.XXXXXX\")\n\
+         req_sorted=$(mktemp \"${{TMPDIR:-/tmp}}/webcodex-req-sorted.XXXXXX\")\n\
+         staged_file=$(mktemp \"${{TMPDIR:-/tmp}}/webcodex-staged.XXXXXX\")\n\
+         msg_file=$(mktemp \"${{TMPDIR:-/tmp}}/webcodex-msg.XXXXXX\")\n\
+         rm -f \"$index_file\"\n\
+         cleanup() {{ rm -f \"$index_file\" \"$req_file\" \"$req_sorted\" \"$staged_file\" \"$msg_file\"; }}\n\
+         trap cleanup EXIT HUP INT TERM\n\
+         actual=$(git rev-parse --verify HEAD 2>/dev/null || true)\n\
+         if [ \"$actual\" != \"$expected\" ]; then printf '{GIT_COMMIT_RESULT_PREFIX} status=head_mismatch actual=%s\\n' \"$actual\"; exit 20; fi\n\
+         if [ -n \"$(git diff --name-only --diff-filter=U)\" ]; then printf '{GIT_COMMIT_RESULT_PREFIX} status=conflicts\\n'; exit 21; fi\n\
+         if ! git diff --cached --quiet --exit-code; then printf '{GIT_COMMIT_RESULT_PREFIX} status=existing_staged\\n'; exit 22; fi\n\
+         {path_checks}\
+         {requested_lines}\
+         if ! GIT_INDEX_FILE=\"$index_file\" git read-tree \"$expected\"; then printf '{GIT_COMMIT_RESULT_PREFIX} status=index_init_failed\\n'; exit 26; fi\n\
+         {index_adds}\
+         LC_ALL=C sort -u \"$req_file\" > \"$req_sorted\"\n\
+         GIT_INDEX_FILE=\"$index_file\" git -c core.quotepath=false diff --cached --name-only --no-renames \"$expected\" | LC_ALL=C sort -u > \"$staged_file\"\n\
+         if ! cmp -s \"$req_sorted\" \"$staged_file\"; then printf '{GIT_COMMIT_RESULT_PREFIX} status=staged_set_mismatch\\n'; exit 27; fi\n\
+         if GIT_INDEX_FILE=\"$index_file\" git diff --cached --quiet --exit-code \"$expected\"; then printf '{GIT_COMMIT_RESULT_PREFIX} status=no_changes\\n'; exit 25; fi\n\
+         if [ -n \"$(git diff --name-only --diff-filter=U)\" ] || ! git diff --cached --quiet --exit-code; then printf '{GIT_COMMIT_RESULT_PREFIX} status=staged_state_changed\\n'; exit 28; fi\n\
+         actual=$(git rev-parse --verify HEAD 2>/dev/null || true)\n\
+         if [ \"$actual\" != \"$expected\" ]; then printf '{GIT_COMMIT_RESULT_PREFIX} status=head_changed actual=%s\\n' \"$actual\"; exit 29; fi\n\
+         tree=$(GIT_INDEX_FILE=\"$index_file\" git write-tree) || {{ printf '{GIT_COMMIT_RESULT_PREFIX} status=tree_failed\\n'; exit 30; }}\n\
+         printf '%s' {message} > \"$msg_file\"\n\
+         new=$(git commit-tree \"$tree\" -p \"$expected\" < \"$msg_file\") || {{ printf '{GIT_COMMIT_RESULT_PREFIX} status=commit_create_failed\\n'; exit 31; }}\n\
+         if ! git update-ref -m 'webcodex git_commit_paths' HEAD \"$new\" \"$expected\"; then actual=$(git rev-parse --verify HEAD 2>/dev/null || true); printf '{GIT_COMMIT_RESULT_PREFIX} status=head_update_failed actual=%s\\n' \"$actual\"; exit 32; fi\n\
+         if ! git reset -q \"$new\" --{reset_args}; then printf '{GIT_COMMIT_RESULT_PREFIX} status=index_cleanup_failed previous=%s new=%s\\n' \"$expected\" \"$new\"; exit 33; fi\n\
+         printf '{GIT_COMMIT_RESULT_PREFIX} status=success previous=%s new=%s\\n' \"$expected\" \"$new\"\n"
+    )
+}
+
+pub(crate) fn parse_git_commit_marker(stdout: &str) -> Option<GitCommitMarker> {
+    let line = stdout
+        .lines()
+        .rev()
+        .find(|line| line.starts_with(GIT_COMMIT_RESULT_PREFIX))?;
+    let mut status = None;
+    let mut previous_head = None;
+    let mut actual_head = None;
+    let mut new_head = None;
+    for field in line[GIT_COMMIT_RESULT_PREFIX.len()..].split_whitespace() {
+        let (key, value) = field.split_once('=')?;
+        match key {
+            "status" => status = Some(value.to_string()),
+            "previous" => previous_head = normalize_exact_commit_id(value).ok(),
+            "actual" => actual_head = normalize_exact_commit_id(value).ok(),
+            "new" => new_head = normalize_exact_commit_id(value).ok(),
+            _ => {}
+        }
+    }
+    Some(GitCommitMarker {
+        status: status?,
+        previous_head,
+        actual_head,
+        new_head,
+    })
+}
+
+fn git_commit_paths_failure_output(
+    expected_head: &str,
+    failure_kind: &str,
+    actual_head: Option<String>,
+) -> Value {
+    json!({
+        "committed": false,
+        "expected_head": expected_head,
+        "previous_head": null,
+        "actual_head": actual_head,
+        "new_head": null,
+        "committed_paths": [],
+        "state_changed": false,
+        "outcome_unknown": false,
+        "failure_kind": failure_kind,
+        "hook_policy": "bypassed_exact_tree",
+    })
+}
+
+fn git_commit_paths_outcome_unknown(expected_head: &str, reason: &str) -> ToolResult {
+    ToolResult::err_with_output(
+        format!(
+            "git_commit_paths outcome is unknown: {reason}. Do not retry the commit blindly; observe HEAD/status first."
+        ),
+        json!({
+            "committed": null,
+            "expected_head": expected_head,
+            "previous_head": null,
+            "actual_head": null,
+            "new_head": null,
+            "committed_paths": [],
+            "state_changed": null,
+            "outcome_unknown": true,
+            "failure_kind": "outcome_unknown",
+            "hook_policy": "bypassed_exact_tree",
+        }),
+    )
+    .with_recovery(RecoveryKind::Reobserve, None)
+}
+
 impl ToolRuntime {
     async fn collect_show_changes_untracked_previews(
         &self,
@@ -3839,6 +4015,169 @@ impl ToolRuntime {
                     "stderr": output.stderr,
                 }),
                 error: Some("git log failed".to_string()),
+            }
+        }
+    }
+
+    pub(crate) async fn git_commit_paths(
+        &self,
+        project: String,
+        expected_head: String,
+        paths: Vec<String>,
+        message: String,
+    ) -> ToolResult {
+        let (expected_head, paths, message) =
+            match validate_git_commit_paths_input(&expected_head, &paths, &message) {
+                Ok(values) => values,
+                Err(error) => return ToolResult::err(error),
+            };
+        let proj = match self.resolve_project(&project).await {
+            Ok(project) => project,
+            Err(error) => return ToolResult::err(error),
+        };
+        let script = git_commit_paths_script(&expected_head, &paths, &message);
+        let client_id = proj.client_id.clone();
+        let (request_id, rx) = match self
+            .shell_clients
+            .enqueue_internal_posix_script(
+                client_id,
+                Some(proj.path.clone()),
+                script,
+                60,
+                60,
+                "tool_runtime".to_string(),
+            )
+            .await
+        {
+            Ok(request) => request,
+            Err(error) => {
+                return ToolResult::err_with_output(
+                    error,
+                    git_commit_paths_failure_output(&expected_head, "runner_rejected", None),
+                )
+            }
+        };
+
+        match tokio::time::timeout(Duration::from_secs(64), rx).await {
+            Ok(Ok(response)) => {
+                let lifecycle = agent_command_lifecycle(&response, 60);
+                if lifecycle == ShellCommandExecutionState::NotStarted {
+                    return ToolResult::err_with_output(
+                        response
+                            .error
+                            .unwrap_or_else(|| "git commit request was not started".to_string()),
+                        git_commit_paths_failure_output(&expected_head, "not_started", None),
+                    );
+                }
+                if matches!(
+                    lifecycle,
+                    ShellCommandExecutionState::OutcomeUnknown
+                        | ShellCommandExecutionState::TimedOut
+                ) {
+                    return git_commit_paths_outcome_unknown(
+                        &expected_head,
+                        response.error.as_deref().unwrap_or(
+                            "Runner did not provide a trustworthy terminal commit result",
+                        ),
+                    );
+                }
+
+                let stdout = response.stdout.unwrap_or_default();
+                let Some(marker) = parse_git_commit_marker(&stdout) else {
+                    return git_commit_paths_outcome_unknown(
+                        &expected_head,
+                        "completed Runner response omitted the structured commit marker",
+                    );
+                };
+                match marker.status.as_str() {
+                    "success"
+                        if response.exit_code == Some(0)
+                            && marker.previous_head.as_deref() == Some(expected_head.as_str())
+                            && marker.new_head.is_some() =>
+                    {
+                        let new_head = marker.new_head.expect("checked above");
+                        ToolResult::ok(json!({
+                            "committed": true,
+                            "expected_head": expected_head,
+                            "previous_head": expected_head,
+                            "actual_head": new_head,
+                            "new_head": new_head,
+                            "committed_paths": paths,
+                            "state_changed": true,
+                            "outcome_unknown": false,
+                            "failure_kind": null,
+                            "hook_policy": "bypassed_exact_tree",
+                        }))
+                    }
+                    "index_cleanup_failed"
+                        if marker.previous_head.as_deref() == Some(expected_head.as_str())
+                            && marker.new_head.is_some() =>
+                    {
+                        let new_head = marker.new_head.expect("checked above");
+                        ToolResult::err_with_output(
+                            "commit was created and HEAD advanced, but the real index could not be aligned to the new commit; do not retry the commit",
+                            json!({
+                                "committed": true,
+                                "expected_head": expected_head,
+                                "previous_head": expected_head,
+                                "actual_head": new_head,
+                                "new_head": new_head,
+                                "committed_paths": paths,
+                                "state_changed": true,
+                                "outcome_unknown": false,
+                                "failure_kind": "index_cleanup_failed",
+                                "hook_policy": "bypassed_exact_tree",
+                            }),
+                        )
+                        .with_recovery(RecoveryKind::Reobserve, None)
+                    }
+                    "success" | "index_cleanup_failed" => git_commit_paths_outcome_unknown(
+                        &expected_head,
+                        "Runner returned a mutation-like commit marker with inconsistent SHA or exit-code evidence",
+                    ),
+                    status => ToolResult::err_with_output(
+                        format!("git_commit_paths rejected or failed: {status}"),
+                        git_commit_paths_failure_output(&expected_head, status, marker.actual_head),
+                    ),
+                }
+            }
+            Ok(Err(_)) => {
+                let dispatch = self
+                    .shell_clients
+                    .cancel_request_dispatch_state(&request_id)
+                    .await;
+                if dispatch_uncertainty_lifecycle(dispatch)
+                    == ShellCommandExecutionState::NotStarted
+                {
+                    ToolResult::err_with_output(
+                        "git commit request waiter was dropped before Runner dispatch",
+                        git_commit_paths_failure_output(&expected_head, "not_started", None),
+                    )
+                } else {
+                    git_commit_paths_outcome_unknown(
+                        &expected_head,
+                        "git commit request waiter was dropped after dispatch may have occurred",
+                    )
+                }
+            }
+            Err(_) => {
+                let dispatch = self
+                    .shell_clients
+                    .cancel_request_dispatch_state(&request_id)
+                    .await;
+                if dispatch_uncertainty_lifecycle(dispatch)
+                    == ShellCommandExecutionState::NotStarted
+                {
+                    ToolResult::err_with_output(
+                        "timed out before git commit request reached the Runner",
+                        git_commit_paths_failure_output(&expected_head, "not_started", None),
+                    )
+                } else {
+                    git_commit_paths_outcome_unknown(
+                        &expected_head,
+                        "timed out after Runner dispatch may have occurred",
+                    )
+                }
             }
         }
     }

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -16,7 +16,7 @@ use super::helpers::{
     decode_git_quoted_path, shell_escape_simple, validate_limited_cleanup_paths,
     validate_project_relative_path,
 };
-use super::shell::{agent_command_lifecycle, dispatch_uncertainty_lifecycle};
+use super::shell::{dispatch_uncertainty_lifecycle, runner_command_lifecycle};
 use super::tool_result::{RecoveryKind, ToolResult};
 use super::ToolRuntime;
 use crate::shell_protocol::{ShellCommandExecutionState, ShellRunRequest};
@@ -4080,7 +4080,7 @@ impl ToolRuntime {
 
         match tokio::time::timeout(Duration::from_secs(64), rx).await {
             Ok(Ok(response)) => {
-                let lifecycle = agent_command_lifecycle(&response, 60);
+                let lifecycle = runner_command_lifecycle(&response, 60);
                 if lifecycle == ShellCommandExecutionState::NotStarted {
                     return ToolResult::err_with_output(
                         response

--- a/src/tool_runtime/git_tools.rs
+++ b/src/tool_runtime/git_tools.rs
@@ -15,6 +15,16 @@ impl ToolRuntime {
                 paths,
                 session_id: _,
             } => self.discard_untracked(project, paths).await,
+            ToolCall::GitCommitPaths {
+                project,
+                expected_head,
+                paths,
+                message,
+                session_id: _,
+            } => {
+                self.git_commit_paths(project, expected_head, paths, message)
+                    .await
+            }
             ToolCall::GitStatus {
                 project,
                 session_id: _,

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -72,6 +72,44 @@ pub(crate) fn detected_job_summary(
         "kind": kind,
         "outcome": outcome,
     });
+    if outcome == "in_progress" {
+        let lower = format!("{stdout}\n{stderr}").to_ascii_lowercase();
+        let cargo_command = normalized == "cargo" || normalized.starts_with("cargo ");
+        let progress = if cargo_command && lower.contains("blocking waiting for file lock") {
+            Some(json!({
+                "state": "waiting",
+                "reason_code": "cargo_build_lock",
+                "summary": "Waiting for Cargo build lock",
+            }))
+        } else if cargo_command
+            && matches!(kind, "test" | "check" | "build" | "format")
+            && lower
+                .lines()
+                .any(|line| line.trim_start().starts_with("compiling "))
+        {
+            Some(json!({
+                "state": "working",
+                "reason_code": "cargo_compiling",
+                "summary": "Cargo compilation in progress",
+            }))
+        } else if cargo_command
+            && matches!(kind, "test" | "check" | "build" | "format")
+            && lower
+                .lines()
+                .any(|line| line.trim_start().starts_with("checking "))
+        {
+            Some(json!({
+                "state": "working",
+                "reason_code": "cargo_checking",
+                "summary": "Cargo checking in progress",
+            }))
+        } else {
+            None
+        };
+        if let Some(progress) = progress {
+            detected["progress"] = progress;
+        }
+    }
     if kind == "test" {
         let combined = format!("{stdout}\n{stderr}");
         let metadata = super::cargo::parse_cargo_test_run_metadata(&combined);
@@ -82,6 +120,45 @@ pub(crate) fn detected_job_summary(
         detected["tests_failed"] = json!(metadata.tests_failed);
     }
     detected
+}
+
+#[cfg(test)]
+mod detected_summary_tests {
+    use super::detected_job_summary;
+
+    #[test]
+    fn cargo_progress_is_advisory_and_command_scoped() {
+        let locked = detected_job_summary(
+            Some("cargo check -p webcodex"),
+            Some("validation"),
+            "running",
+            None,
+            "",
+            "Blocking waiting for file lock on build directory\n",
+        );
+        assert_eq!(locked["progress"]["state"], "waiting");
+        assert_eq!(locked["progress"]["reason_code"], "cargo_build_lock");
+
+        let compiling = detected_job_summary(
+            Some("cargo test -p webcodex"),
+            Some("test"),
+            "running",
+            None,
+            "",
+            "   Compiling webcodex v0.3.9\n",
+        );
+        assert_eq!(compiling["progress"]["reason_code"], "cargo_compiling");
+
+        let unrelated = detected_job_summary(
+            Some("custom-tool"),
+            Some("operation"),
+            "running",
+            None,
+            "Blocking waiting for file lock on build directory\n",
+            "",
+        );
+        assert!(unrelated.get("progress").is_none());
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -92,6 +92,7 @@ pub(crate) struct StructuredValidationEvidence {
     pub(crate) tests_passed: Option<u64>,
     pub(crate) tests_failed: Option<u64>,
     pub(crate) zero_tests_run: Option<bool>,
+    pub(crate) test_count_evidence_reason: Option<&'static str>,
     pub(crate) warnings_count: Option<u64>,
     pub(crate) errors_count: Option<u64>,
 }
@@ -115,6 +116,7 @@ pub(crate) fn structured_validation_evidence(
         tests_passed: None,
         tests_failed: None,
         zero_tests_run: None,
+        test_count_evidence_reason: None,
         warnings_count: None,
         errors_count: None,
     };
@@ -141,6 +143,11 @@ pub(crate) fn structured_validation_evidence(
         "test" => {
             let metadata = super::cargo::parse_cargo_test_run_metadata(&combined);
             evidence.tests_detected = Some(metadata.tests_detected);
+            evidence.test_count_evidence_reason = Some(if truncated {
+                "output_truncated"
+            } else {
+                metadata.count_evidence_reason
+            });
             if !truncated {
                 evidence.tests_run_count = metadata.tests_run_count;
                 evidence.tests_passed = metadata.tests_passed;
@@ -256,6 +263,9 @@ pub(crate) fn validation_job_projection(
                         "actual_tests_run": evidence.tests_run_count,
                         "status": status,
                         "reason_code": reason_code,
+                        "evidence_reason_code": evidence
+                            .test_count_evidence_reason
+                            .unwrap_or("no_complete_summary"),
                     });
                 }
             }
@@ -1814,6 +1824,10 @@ mod recovery_projection_tests {
             ignored_only_required["test_count_assertion"]["reason_code"],
             "minimum_not_met"
         );
+        assert_eq!(
+            ignored_only_required["test_count_assertion"]["evidence_reason_code"],
+            "complete_summary"
+        );
 
         let one_passed_with_ignored = project(
             "running 6 tests\n\ntest result: ok. 1 passed; 0 failed; 5 ignored\n",
@@ -1866,6 +1880,10 @@ mod recovery_projection_tests {
             assert_eq!(value["test_count_assertion"]["actual_tests_run"], actual);
             assert_eq!(value["test_count_assertion"]["status"], status);
             assert_eq!(
+                value["test_count_assertion"]["evidence_reason_code"],
+                "complete_summary"
+            );
+            assert_eq!(
                 value["test_count_assertion"]["reason_code"],
                 if passed {
                     "minimum_satisfied"
@@ -1890,6 +1908,24 @@ mod recovery_projection_tests {
             );
             assert!(unproven["test_count_assertion"]["actual_tests_run"].is_null());
         }
+
+        assert_eq!(
+            project("", false, Some(1))["test_count_assertion"]["evidence_reason_code"],
+            "no_complete_summary"
+        );
+        assert_eq!(
+            project("test result: ok. 10 passed;\n", false, Some(6))["test_count_assertion"]
+                ["evidence_reason_code"],
+            "partial_harness_summary"
+        );
+        assert_eq!(
+            project(
+                "test result: ok. 10 passed; 0 failed; 0 ignored\n",
+                true,
+                Some(6)
+            )["test_count_assertion"]["evidence_reason_code"],
+            "output_truncated"
+        );
 
         let command_failure = validation_job_projection(
             Some("cargo_test"),

--- a/src/tool_runtime/process.rs
+++ b/src/tool_runtime/process.rs
@@ -785,32 +785,43 @@ impl ToolRuntime {
                     result
                 }
                 Ok(HiddenStructuredJobWait::Continued {
-                    job,
+                    observation,
                     execution_state,
                     command_started,
-                }) => ToolResult::ok(json!({
-                    "execution_state": execution_state,
-                    "command_started": command_started,
-                    "command_completed": false,
-                    "command_ok": false,
-                    "exit_code": null,
-                    "failure_kind": null,
-                    "tool_failure": false,
-                    "promoted_to_job": true,
-                    "terminal": false,
-                    "job_id": job.job_id,
-                    "job_status": job.status,
-                    "observation_token": job.observation_token,
-                    "effective_timeout_secs": timeout,
-                    "sync_wait_secs": budget.sync_wait_secs,
-                    "async_handoff_available": true,
-                    "stdout_tail": "",
-                    "stderr_tail": "",
-                    "stdout_lines": 0,
-                    "stderr_lines": 0,
-                    "stdout_truncated": false,
-                    "stderr_truncated": false,
-                })),
+                }) => {
+                    let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
+                        Some(&summary),
+                        Some(declared_purpose.as_str()),
+                        &observation.job.status,
+                        observation.job.exit_code.map(i64::from),
+                        &observation.stdout_tail,
+                        &observation.stderr_tail,
+                    );
+                    ToolResult::ok(json!({
+                        "execution_state": execution_state,
+                        "command_started": command_started,
+                        "command_completed": false,
+                        "command_ok": false,
+                        "exit_code": null,
+                        "failure_kind": null,
+                        "tool_failure": false,
+                        "promoted_to_job": true,
+                        "terminal": false,
+                        "job_id": observation.job.job_id,
+                        "job_status": observation.job.status,
+                        "observation_token": observation.job.observation_token,
+                        "effective_timeout_secs": timeout,
+                        "sync_wait_secs": budget.sync_wait_secs,
+                        "async_handoff_available": true,
+                        "stdout_tail": observation.stdout_tail,
+                        "stderr_tail": observation.stderr_tail,
+                        "stdout_lines": observation.stdout_lines,
+                        "stderr_lines": observation.stderr_lines,
+                        "stdout_truncated": observation.stdout_truncated,
+                        "stderr_truncated": observation.stderr_truncated,
+                        "detected_summary": detected_summary,
+                    }))
+                }
                 Err(error) => outcome_unknown_result(format!(
                     "the durable process Job could not be observed during handoff: {error}"
                 )),

--- a/src/tool_runtime/script.rs
+++ b/src/tool_runtime/script.rs
@@ -240,32 +240,43 @@ impl ToolRuntime {
                     result
                 }
                 Ok(HiddenStructuredJobWait::Continued {
-                    job,
+                    observation,
                     execution_state,
                     command_started,
-                }) => ToolResult::ok(json!({
-                    "execution_state": execution_state,
-                    "command_started": command_started,
-                    "command_completed": false,
-                    "command_ok": false,
-                    "exit_code": null,
-                    "failure_kind": null,
-                    "tool_failure": false,
-                    "promoted_to_job": true,
-                    "terminal": false,
-                    "job_id": job.job_id,
-                    "job_status": job.status,
-                    "observation_token": job.observation_token,
-                    "effective_timeout_secs": timeout,
-                    "sync_wait_secs": budget.sync_wait_secs,
-                    "async_handoff_available": true,
-                    "stdout_tail": "",
-                    "stderr_tail": "",
-                    "stdout_lines": 0,
-                    "stderr_lines": 0,
-                    "stdout_truncated": false,
-                    "stderr_truncated": false,
-                })),
+                }) => {
+                    let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
+                        Some(&summary),
+                        Some(declared_purpose.as_str()),
+                        &observation.job.status,
+                        observation.job.exit_code.map(i64::from),
+                        &observation.stdout_tail,
+                        &observation.stderr_tail,
+                    );
+                    ToolResult::ok(json!({
+                        "execution_state": execution_state,
+                        "command_started": command_started,
+                        "command_completed": false,
+                        "command_ok": false,
+                        "exit_code": null,
+                        "failure_kind": null,
+                        "tool_failure": false,
+                        "promoted_to_job": true,
+                        "terminal": false,
+                        "job_id": observation.job.job_id,
+                        "job_status": observation.job.status,
+                        "observation_token": observation.job.observation_token,
+                        "effective_timeout_secs": timeout,
+                        "sync_wait_secs": budget.sync_wait_secs,
+                        "async_handoff_available": true,
+                        "stdout_tail": observation.stdout_tail,
+                        "stderr_tail": observation.stderr_tail,
+                        "stdout_lines": observation.stdout_lines,
+                        "stderr_lines": observation.stderr_lines,
+                        "stdout_truncated": observation.stdout_truncated,
+                        "stderr_truncated": observation.stderr_truncated,
+                        "detected_summary": detected_summary,
+                    }))
+                }
                 Err(error) => outcome_unknown_result(format!(
                     "the durable script Job could not be observed during handoff: {error}"
                 )),

--- a/src/tool_runtime/search_project_texts.rs
+++ b/src/tool_runtime/search_project_texts.rs
@@ -615,7 +615,12 @@ mod tests {
                     "line": match_index + 1,
                     "preview": format!("m{match_index:03}-{}", "界".repeat(preview_bytes / 3)),
                     "context_before": [],
-                    "context_after": []
+                    "context_after": [],
+                    "read_hint": {
+                        "path": format!("src/{index}-{match_index:03}.rs"),
+                        "start_line": 1,
+                        "limit": 80
+                    }
                 })
             })
             .collect::<Vec<_>>();
@@ -712,7 +717,12 @@ mod tests {
                         "line": 1,
                         "preview": text,
                         "context_before": [],
-                        "context_after": []
+                        "context_after": [],
+                        "read_hint": {
+                            "path": format!("src/{index}.rs"),
+                            "start_line": 1,
+                            "limit": 80
+                        }
                     }],
                     "truncated": false,
                     "truncation_reason": null

--- a/src/tool_runtime/shell.rs
+++ b/src/tool_runtime/shell.rs
@@ -643,10 +643,19 @@ impl ToolRuntime {
                         result
                     }
                     Ok(HiddenStructuredJobWait::Continued {
-                        job,
+                        observation,
                         execution_state,
                         command_started,
-                    }) => ToolResult::ok(json!({
+                    }) => {
+                        let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
+                            Some(&command_summary),
+                            Some(declared_purpose.as_str()),
+                            &observation.job.status,
+                            observation.job.exit_code.map(i64::from),
+                            &observation.stdout_tail,
+                            &observation.stderr_tail,
+                        );
+                        ToolResult::ok(json!({
                         "execution_state": execution_state,
                         "command_started": command_started,
                         "command_completed": false,
@@ -656,19 +665,21 @@ impl ToolRuntime {
                         "tool_failure": false,
                         "promoted_to_job": true,
                         "terminal": false,
-                        "job_id": job.job_id,
-                        "job_status": job.status,
-                        "observation_token": job.observation_token,
+                        "job_id": observation.job.job_id,
+                        "job_status": observation.job.status,
+                        "observation_token": observation.job.observation_token,
                         "effective_timeout_secs": timeout,
                         "sync_wait_secs": STRUCTURED_EXECUTION_SYNC_WAIT_SECS,
                         "async_handoff_available": true,
-                        "stdout_tail": "",
-                        "stderr_tail": "",
-                        "stdout_lines": 0,
-                        "stderr_lines": 0,
-                        "stdout_truncated": false,
-                        "stderr_truncated": false,
-                    })),
+                        "stdout_tail": observation.stdout_tail,
+                        "stderr_tail": observation.stderr_tail,
+                        "stdout_lines": observation.stdout_lines,
+                        "stderr_lines": observation.stderr_lines,
+                        "stdout_truncated": observation.stdout_truncated,
+                        "stderr_truncated": observation.stderr_truncated,
+                        "detected_summary": detected_summary,
+                    }))
+                    },
                     Err(error) => Self::run_shell_outcome_unknown_result(format!(
                         "the hidden durable shell Job {} could not be safely promoted or observed during handoff: {error}. Do not redispatch this command; inspect Job inventory and target state before deciding whether any retry is safe.",
                         job.job_id

--- a/src/tool_runtime/startup_brief.rs
+++ b/src/tool_runtime/startup_brief.rs
@@ -62,6 +62,8 @@ pub(crate) fn builtin_coding_workflow_projection() -> Value {
             "session_message_ack": "When session_attention has open requires_ack guidance still in context, echo its id in ack_session_message_ids. This request-scoped model-context proof neither resolves messages nor grants authority or gates execution.",
             "session_message_resolution": "Resolve a handled non-todo by attaching session_message_resolution to the next ordinary call with recording_session_id; ACK-required guidance also needs ack_session_message_ids. It cannot predict the main call. Todos use complete_session_message.",
             "context_sidecar": "context_request adds bounded context after the main tool and never authorizes its effect. Recover lost project.instructions on an observation call before dependent mutation.",
+            "runner_targeting": "When the user supplies an exact Runner client_id, query that Runner with runtime_status(client_id=...) or list_projects(client_id=...) before treating it as absent from a broad fleet snapshot.",
+            "persistent_shell": "For repeated commands in one Workflow Session, especially on a named SSH resource, prefer open_session_shell plus session_shell_exec. Keep run_process for isolated one-shot native commands.",
             "normal_closeout": "Normal success: finish_coding_task(summary_only=true); full closeout only for unresolved validation/evidence or handoff/debug detail."
         },
         "roles": {

--- a/src/tool_runtime/structured_execution.rs
+++ b/src/tool_runtime/structured_execution.rs
@@ -1,3 +1,4 @@
+use super::helpers::{bounded_tail, COMMAND_STDIO_TAIL_CHARS};
 use crate::auth::AuthContext;
 use crate::shell_client::ShellClientRegistry;
 use crate::shell_protocol::{
@@ -9,6 +10,7 @@ use std::time::Duration;
 use webcodex_runner_registry::RunnerAccess;
 
 pub(crate) const STRUCTURED_EXECUTION_SYNC_WAIT_SECS: u64 = 10;
+pub(crate) const INITIAL_JOB_HANDOFF_TAIL_LINES: usize = 40;
 pub(crate) use webcodex_core::runtime_contract::STRUCTURED_EXECUTION_SYNC_WAIT_MAX_SECS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,10 +67,54 @@ pub(crate) enum HiddenStructuredJobWait {
         stderr: String,
     },
     Continued {
-        job: ShellJobInfo,
+        observation: StructuredJobObservation,
         execution_state: &'static str,
         command_started: bool,
     },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StructuredJobObservation {
+    pub(crate) job: ShellJobInfo,
+    pub(crate) stdout_tail: String,
+    pub(crate) stderr_tail: String,
+    pub(crate) stdout_lines: usize,
+    pub(crate) stderr_lines: usize,
+    pub(crate) stdout_truncated: bool,
+    pub(crate) stderr_truncated: bool,
+}
+
+pub(crate) async fn structured_job_observation(
+    clients: &ShellClientRegistry,
+    access: Option<&RunnerAccess>,
+    job_id: &str,
+) -> Result<StructuredJobObservation, String> {
+    let (job, stdout, stderr, next_stdout_line, next_stderr_line) = clients
+        .hidden_job_log_for_auth(access, job_id, Some(INITIAL_JOB_HANDOFF_TAIL_LINES))
+        .await?;
+    let stdout = stdout.unwrap_or_default();
+    let stderr = stderr.unwrap_or_default();
+    let stdout_lines = next_stdout_line.saturating_sub(1);
+    let stderr_lines = next_stderr_line.saturating_sub(1);
+    let (stdout_tail, stdout_char_truncated) = bounded_tail(&stdout, COMMAND_STDIO_TAIL_CHARS);
+    let (stderr_tail, stderr_char_truncated) = bounded_tail(&stderr, COMMAND_STDIO_TAIL_CHARS);
+    let stdout_truncated = job.stdout_log_truncated
+        || job.stdout_retained_from_line.is_some_and(|line| line > 1)
+        || stdout.lines().count() < stdout_lines
+        || stdout_char_truncated;
+    let stderr_truncated = job.stderr_log_truncated
+        || job.stderr_retained_from_line.is_some_and(|line| line > 1)
+        || stderr.lines().count() < stderr_lines
+        || stderr_char_truncated;
+    Ok(StructuredJobObservation {
+        job,
+        stdout_tail,
+        stderr_tail,
+        stdout_lines,
+        stderr_lines,
+        stdout_truncated,
+        stderr_truncated,
+    })
 }
 
 pub(crate) async fn await_hidden_structured_job(
@@ -103,7 +149,13 @@ pub(crate) async fn await_hidden_structured_job(
         guard.disarm();
         return Ok(terminal);
     }
-    let (execution_state, command_started) = match promoted.status.as_str() {
+    let observation = structured_job_observation(&clients, access.as_ref(), &job_id).await?;
+    if crate::tool_runtime::jobs::is_terminal_job_status(&observation.job.status) {
+        let terminal = hidden_terminal_snapshot(&clients, access.as_ref(), &job_id).await?;
+        guard.disarm();
+        return Ok(terminal);
+    }
+    let (execution_state, command_started) = match observation.job.status.as_str() {
         "queued" | "agent_queued" | "started" => ("queued", false),
         "running" => ("running", true),
         "stop_requested" if promoted.started_at.is_some() => ("running", true),
@@ -115,7 +167,7 @@ pub(crate) async fn await_hidden_structured_job(
     };
     guard.disarm();
     Ok(HiddenStructuredJobWait::Continued {
-        job: promoted,
+        observation,
         execution_state,
         command_started,
     })

--- a/src/tool_runtime/structured_execution.rs
+++ b/src/tool_runtime/structured_execution.rs
@@ -155,22 +155,30 @@ pub(crate) async fn await_hidden_structured_job(
         guard.disarm();
         return Ok(terminal);
     }
-    let (execution_state, command_started) = match observation.job.status.as_str() {
-        "queued" | "agent_queued" | "started" => ("queued", false),
-        "running" => ("running", true),
-        "stop_requested" if promoted.started_at.is_some() => ("running", true),
-        "stop_requested" => ("queued", false),
-        // Recovery is a real retained Job contract, but it is not proof that
-        // the execution is presently running. Preserve uncertainty explicitly.
-        "recovering" => ("outcome_unknown", true),
-        _ => ("outcome_unknown", true),
-    };
+    let (execution_state, command_started) = continued_execution_state(
+        observation.job.status.as_str(),
+        observation.job.started_at.is_some(),
+    );
     guard.disarm();
     Ok(HiddenStructuredJobWait::Continued {
         observation,
         execution_state,
         command_started,
     })
+}
+
+fn continued_execution_state(status: &str, started: bool) -> (&'static str, bool) {
+    match status {
+        "queued" | "agent_queued" | "started" if started => ("running", true),
+        "queued" | "agent_queued" | "started" => ("queued", false),
+        "running" => ("running", true),
+        "stop_requested" if started => ("running", true),
+        "stop_requested" => ("queued", false),
+        // Recovery is a real retained Job contract, but it is not proof that
+        // the execution is presently running. Preserve uncertainty explicitly.
+        "recovering" => ("outcome_unknown", true),
+        _ => ("outcome_unknown", true),
+    }
 }
 
 async fn hidden_terminal_snapshot(
@@ -234,6 +242,38 @@ impl Drop for HiddenJobCleanupGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn continued_execution_state_uses_the_fresh_observed_started_state() {
+        assert_eq!(
+            continued_execution_state("stop_requested", false),
+            ("queued", false)
+        );
+        assert_eq!(
+            continued_execution_state("stop_requested", true),
+            ("running", true)
+        );
+        assert_eq!(
+            continued_execution_state("agent_queued", false),
+            ("queued", false)
+        );
+        assert_eq!(
+            continued_execution_state("agent_queued", true),
+            ("running", true)
+        );
+        assert_eq!(
+            continued_execution_state("started", true),
+            ("running", true)
+        );
+        assert_eq!(
+            continued_execution_state("running", true),
+            ("running", true)
+        );
+        assert_eq!(
+            continued_execution_state("recovering", true),
+            ("outcome_unknown", true)
+        );
+    }
 
     #[test]
     fn structured_execution_budget_preserves_default_and_validates_explicit_sync_wait() {

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -1027,7 +1027,36 @@ fn parse_search_matches_is_bounded_and_strips_dot_slash() {
     assert_eq!(matches[0]["preview"], "fn main() {}");
     assert_eq!(matches[0]["context_before"], json!([]));
     assert_eq!(matches[0]["context_after"], json!([]));
+    assert_eq!(
+        matches[0]["read_hint"],
+        json!({"path": "src/main.rs", "start_line": 1, "limit": 80})
+    );
     assert_eq!(matches[1]["path"], "src/lib.rs");
+    assert_eq!(
+        matches[1]["read_hint"],
+        json!({"path": "src/lib.rs", "start_line": 1, "limit": 80})
+    );
+}
+
+#[test]
+fn search_match_read_hint_is_deterministic_and_centers_later_matches() {
+    let stdout =
+        "{\"webcodex_search\":{\"backend\":\"rg\"}}\nsrc/lib.rs:42:needle\nsrc/lib.rs:120:later\n";
+    let options = SearchOptions::normalize(SearchRequest {
+        limit: Some(10),
+        ..raw_search_request()
+    })
+    .unwrap();
+    let result = search_project_text_output("demo", &options, stdout, Some(0), "");
+    let matches = result.output["matches"].as_array().unwrap();
+    assert_eq!(
+        matches[0]["read_hint"],
+        json!({"path": "src/lib.rs", "start_line": 22, "limit": 80})
+    );
+    assert_eq!(
+        matches[1]["read_hint"],
+        json!({"path": "src/lib.rs", "start_line": 100, "limit": 80})
+    );
 }
 
 #[test]

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -3064,6 +3064,22 @@ fn show_changes_diff_respects_max_hunks() {
         output["diff_review_handoff"]["truncation_reasons"],
         json!(["diff_hunk_count_limit"])
     );
+    assert_eq!(
+        output["diff_review_handoff"]["suggested_call"]["project"],
+        "demo"
+    );
+    assert_eq!(
+        output["diff_review_handoff"]["suggested_call"]["cached"],
+        false
+    );
+    assert_eq!(
+        output["diff_review_handoff"]["suggested_call"]["paths"],
+        json!([])
+    );
+    assert_eq!(
+        output["diff_review_handoff"]["suggested_call"]["max_hunks"],
+        30
+    );
     let actions = output["suggested_next_actions"].as_array().unwrap();
     assert!(!actions
         .iter()
@@ -3109,6 +3125,15 @@ fn show_changes_diff_respects_max_hunk_lines() {
         output["diff_review_handoff"]["truncation_reasons"],
         json!(["diff_hunk_line_limit"])
     );
+    assert_eq!(
+        output["diff_review_handoff"]["suggested_call"]["paths"],
+        json!([]),
+        "line truncation must not guess a narrower path without per-hunk provenance"
+    );
+    assert_eq!(
+        output["diff_review_handoff"]["suggested_call"]["max_hunk_lines"],
+        400
+    );
     let actions = output["suggested_next_actions"].as_array().unwrap();
     assert!(actions.iter().any(|action| action
         == "increase git_diff_hunks.max_hunk_lines and/or narrow paths; continuation alone does not recover omitted lines from the same hunk"));
@@ -3149,6 +3174,11 @@ fn show_changes_combined_hunk_count_and_line_truncation_keeps_both_guidance_path
     assert!(handoff_reasons
         .iter()
         .any(|reason| reason == "diff_hunk_line_limit"));
+    assert_eq!(
+        output["diff_review_handoff"]["suggested_call"]["paths"],
+        json!([]),
+        "combined page truncation must not narrow away later files"
+    );
     let actions = output["suggested_next_actions"].as_array().unwrap();
     assert!(actions
         .iter()
@@ -3264,7 +3294,20 @@ fn show_changes_schema_covers_truncation_and_transport_fields() {
     );
     assert_eq!(
         handoff["required"],
-        json!(["tool", "scope", "reason", "truncation_reasons"])
+        json!([
+            "tool",
+            "scope",
+            "reason",
+            "truncation_reasons",
+            "suggested_call"
+        ])
+    );
+    let suggested = &handoff["properties"]["suggested_call"];
+    assert_eq!(suggested["additionalProperties"], false);
+    assert_eq!(suggested["properties"]["cached"]["const"], false);
+    assert_eq!(
+        suggested["required"],
+        json!(["project", "cached", "paths", "max_hunks", "max_hunk_lines"])
     );
 }
 

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -37,6 +37,210 @@ async fn register_structured_git_agent_at_path(
     crate::tool_runtime::agent_project_runtime_id(client_id, project_id)
 }
 
+async fn run_agent_git_commit_paths(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: String,
+    expected_head: String,
+    paths: Vec<String>,
+    message: &str,
+) -> ToolResult {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let message = message.to_string();
+        async move {
+            runtime
+                .git_commit_paths(project, expected_head, paths, message)
+                .await
+        }
+    });
+    let request = wait_for_patch_agent_request(runtime, client_id).await;
+    assert_eq!(request.kind, "run_internal_posix_script");
+    let script = request
+        .script
+        .as_ref()
+        .expect("git_commit_paths must use a typed internal script");
+    assert_eq!(script.language.as_str(), "sh");
+    assert!(script.script.contains("git update-ref"));
+    assert!(script.script.contains("git commit-tree"));
+    assert!(!script.script.contains("git push"));
+    let (exit_code, stdout, stderr) = run_agent_shell_request_locally(&request);
+    complete_patch_agent_request(
+        runtime,
+        client_id,
+        &request.request_id,
+        exit_code,
+        &stdout,
+        &stderr,
+    )
+    .await;
+    task.await.unwrap()
+}
+
+#[tokio::test]
+async fn git_commit_paths_commits_only_requested_paths_and_preserves_other_worktree_changes() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    fs::write(tmp.path().join("a.txt"), "base-a\n").unwrap();
+    fs::write(tmp.path().join("b.txt"), "base-b\n").unwrap();
+    git_test_command_ok(tmp.path(), "git add a.txt b.txt");
+    git_test_command_ok(tmp.path(), "git commit -m base");
+    let (_, stdout, _, _) = run_command_sync("git rev-parse HEAD", tmp.path(), 30);
+    let base = stdout.trim().to_string();
+
+    fs::write(tmp.path().join("a.txt"), "committed-a\n").unwrap();
+    fs::write(tmp.path().join("b.txt"), "still-dirty-b\n").unwrap();
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "commit-paths", "repo", tmp.path()).await;
+    let result = run_agent_git_commit_paths(
+        &runtime,
+        "commit-paths",
+        project,
+        base.clone(),
+        vec!["a.txt".to_string()],
+        "commit exact a",
+    )
+    .await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["committed"], true);
+    assert_eq!(result.output["previous_head"], base);
+    assert_eq!(result.output["committed_paths"], json!(["a.txt"]));
+    assert_eq!(result.output["hook_policy"], "bypassed_exact_tree");
+
+    let new_head = result.output["new_head"].as_str().unwrap();
+    let (_, changed, _, _) = run_command_sync(
+        &format!("git diff --name-only {} {}", base, new_head),
+        tmp.path(),
+        30,
+    );
+    assert_eq!(changed.trim(), "a.txt");
+    let (_, staged, _, _) = run_command_sync("git diff --cached --name-only", tmp.path(), 30);
+    assert!(
+        staged.trim().is_empty(),
+        "real index must remain clean: {staged}"
+    );
+    let (_, status, _, _) = run_command_sync("git status --short", tmp.path(), 30);
+    assert_eq!(status.trim(), "M b.txt");
+}
+
+#[tokio::test]
+async fn git_commit_paths_rejects_existing_staged_state_without_advancing_head() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    fs::write(tmp.path().join("a.txt"), "base-a\n").unwrap();
+    fs::write(tmp.path().join("b.txt"), "base-b\n").unwrap();
+    git_test_command_ok(tmp.path(), "git add a.txt b.txt");
+    git_test_command_ok(tmp.path(), "git commit -m base");
+    let (_, stdout, _, _) = run_command_sync("git rev-parse HEAD", tmp.path(), 30);
+    let base = stdout.trim().to_string();
+    fs::write(tmp.path().join("a.txt"), "staged-a\n").unwrap();
+    fs::write(tmp.path().join("b.txt"), "requested-b\n").unwrap();
+    git_test_command_ok(tmp.path(), "git add a.txt");
+
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "commit-staged-reject", "repo", tmp.path())
+            .await;
+    let result = run_agent_git_commit_paths(
+        &runtime,
+        "commit-staged-reject",
+        project,
+        base.clone(),
+        vec!["b.txt".to_string()],
+        "must reject staged",
+    )
+    .await;
+    assert!(!result.success);
+    assert_eq!(result.output["failure_kind"], "existing_staged");
+    assert_eq!(result.output["state_changed"], false);
+    let (_, head, _, _) = run_command_sync("git rev-parse HEAD", tmp.path(), 30);
+    assert_eq!(head.trim(), base);
+    let (_, staged, _, _) = run_command_sync("git diff --cached --name-only", tmp.path(), 30);
+    assert_eq!(staged.trim(), "a.txt");
+}
+
+#[tokio::test]
+async fn git_commit_paths_rejects_stale_expected_head_before_mutation() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+    fs::write(tmp.path().join("a.txt"), "base\n").unwrap();
+    git_test_command_ok(tmp.path(), "git add a.txt");
+    git_test_command_ok(tmp.path(), "git commit -m base");
+    let (_, stdout, _, _) = run_command_sync("git rev-parse HEAD", tmp.path(), 30);
+    let actual = stdout.trim().to_string();
+    fs::write(tmp.path().join("a.txt"), "dirty\n").unwrap();
+
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "commit-head-fence", "repo", tmp.path())
+            .await;
+    let stale = "f".repeat(40);
+    let result = run_agent_git_commit_paths(
+        &runtime,
+        "commit-head-fence",
+        project,
+        stale.clone(),
+        vec!["a.txt".to_string()],
+        "must not commit",
+    )
+    .await;
+    assert!(!result.success);
+    assert_eq!(result.output["failure_kind"], "head_mismatch");
+    assert_eq!(result.output["expected_head"], stale);
+    assert_eq!(result.output["actual_head"], actual);
+    assert_eq!(result.output["state_changed"], false);
+    let (_, head, _, _) = run_command_sync("git rev-parse HEAD", tmp.path(), 30);
+    assert_eq!(head.trim(), actual);
+}
+
+#[test]
+fn git_commit_paths_audit_keeps_message_private_and_exact_head_bounded() {
+    let private_message = "PRIVATE_COMMIT_MESSAGE_MUST_NOT_PERSIST";
+    let expected_head = "a".repeat(40);
+    let arguments = json!({
+        "project": "agent:oe:webcodex",
+        "expected_head": expected_head,
+        "paths": ["src/tool_runtime/git.rs"],
+        "message": private_message,
+    });
+    let raw = super::super::tool_audit::session_log_arguments_for_tool_request(
+        "git_commit_paths",
+        &arguments,
+    );
+    assert_eq!(raw["expected_head_valid"], true);
+    assert_eq!(raw["expected_head"], "a".repeat(40));
+    assert_eq!(raw["message_present"], true);
+    assert_eq!(raw["paths"], json!(["src/tool_runtime/git.rs"]));
+    assert!(!raw.to_string().contains(private_message));
+
+    let call = ToolCall::from_tool_name("git_commit_paths", arguments).unwrap();
+    let typed = call.session_log_arguments();
+    assert_eq!(typed["expected_head_valid"], true);
+    assert_eq!(typed["message_present"], true);
+    assert!(!typed.to_string().contains(private_message));
+}
+
+#[test]
+fn git_commit_marker_parser_keeps_mutation_evidence_strict() {
+    let expected = "a".repeat(40);
+    let new_head = "b".repeat(40);
+    let valid = parse_git_commit_marker(&format!(
+        "noise\n{GIT_COMMIT_RESULT_PREFIX} status=success previous={expected} new={new_head}\n"
+    ))
+    .unwrap();
+    assert_eq!(valid.status, "success");
+    assert_eq!(valid.previous_head.as_deref(), Some(expected.as_str()));
+    assert_eq!(valid.new_head.as_deref(), Some(new_head.as_str()));
+
+    let malformed = parse_git_commit_marker(&format!(
+        "{GIT_COMMIT_RESULT_PREFIX} status=success previous={expected} new=not-a-sha\n"
+    ))
+    .unwrap();
+    assert_eq!(malformed.status, "success");
+    assert!(malformed.new_head.is_none());
+}
+
 #[tokio::test]
 async fn git_restore_paths_restores_tracked_filename_containing_target() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -1114,7 +1114,7 @@ async fn run_process_slow_handoff_is_queryable_once_and_keeps_the_original_budge
         "running",
         None,
         None,
-        None,
+        Some("progress already available\n"),
         None,
         None,
     )
@@ -1130,6 +1130,13 @@ async fn run_process_slow_handoff_is_queryable_once_and_keeps_the_original_budge
     assert_eq!(handoff.output["command_completed"], false);
     assert_eq!(handoff.output["effective_timeout_secs"], 121);
     assert_eq!(handoff.output["sync_wait_secs"], 45);
+    assert_eq!(
+        handoff.output["stdout_tail"],
+        "progress already available\n"
+    );
+    assert_eq!(handoff.output["stdout_lines"], 1);
+    assert_eq!(handoff.output["stdout_truncated"], false);
+    assert_eq!(handoff.output["detected_summary"]["outcome"], "in_progress");
     let job_id = handoff.output["job_id"].as_str().unwrap().to_string();
     assert_eq!(request.job_id.as_deref(), Some(job_id.as_str()));
 

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -1372,7 +1372,7 @@ async fn tool_manifest_exact_fleet_tool_surfaces_exact_runner_targeting_route() 
     let runtime = test_runtime();
     let result = runtime
         .dispatch(ToolCall::ToolManifest {
-            tool_name: Some("list_agents".to_string()),
+            tool_name: Some("list_runners".to_string()),
             category: None,
             intent: None,
             include_recommended_flows: true,
@@ -1389,8 +1389,9 @@ async fn tool_manifest_exact_fleet_tool_surfaces_exact_runner_targeting_route() 
     let purpose = flow["purpose"].as_str().expect("discovery purpose");
     assert!(purpose.contains("runtime_status(client_id=...)"));
     assert!(purpose.contains("list_projects(client_id=...)"));
-    assert!(purpose.contains("list_agents"));
-    assert_eq!(flow["tools"], json!(["list_agents"]));
+    assert!(purpose.contains("list_runners"));
+    assert!(!purpose.contains("list_agents"));
+    assert_eq!(flow["tools"], json!(["list_runners"]));
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -1351,10 +1351,46 @@ async fn tool_manifest_exact_persistent_shell_tool_surfaces_its_reuse_flow() {
         .iter()
         .find(|flow| flow["name"] == "persistent_shell")
         .expect("persistent_shell flow");
-    assert!(flow["purpose"]
-        .as_str()
-        .is_some_and(|purpose| purpose.contains("repeated local or named-SSH commands")));
+    let purpose = flow["purpose"].as_str().expect("persistent_shell purpose");
+    assert!(purpose.contains("repeated local or named-SSH commands"));
+    for tool in [
+        "open_session_shell",
+        "session_shell_exec",
+        "session_shell_status",
+        "close_session_shell",
+        "run_process",
+    ] {
+        assert!(purpose.contains(tool), "persistent_shell purpose: {tool}");
+    }
+    // Exact manifests keep their returned tool set bounded to the requested tool,
+    // while the flow purpose names the sibling tools needed to complete the route.
     assert_eq!(flow["tools"], json!(["open_session_shell"]));
+}
+
+#[tokio::test]
+async fn tool_manifest_exact_fleet_tool_surfaces_exact_runner_targeting_route() {
+    let runtime = test_runtime();
+    let result = runtime
+        .dispatch(ToolCall::ToolManifest {
+            tool_name: Some("list_agents".to_string()),
+            category: None,
+            intent: None,
+            include_recommended_flows: true,
+            include_risk_summary: false,
+        })
+        .await;
+    assert!(result.success, "{:?}", result.error);
+    let flow = result.output["recommended_flows"]
+        .as_array()
+        .expect("exact fleet recommended flows")
+        .iter()
+        .find(|flow| flow["name"] == "discovery")
+        .expect("discovery flow");
+    let purpose = flow["purpose"].as_str().expect("discovery purpose");
+    assert!(purpose.contains("runtime_status(client_id=...)"));
+    assert!(purpose.contains("list_projects(client_id=...)"));
+    assert!(purpose.contains("list_agents"));
+    assert_eq!(flow["tools"], json!(["list_agents"]));
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -1332,6 +1332,32 @@ async fn tool_manifest_exact_tool_returns_input_contract_without_output_schema()
 }
 
 #[tokio::test]
+async fn tool_manifest_exact_persistent_shell_tool_surfaces_its_reuse_flow() {
+    let runtime = test_runtime();
+    let result = runtime
+        .dispatch(ToolCall::ToolManifest {
+            tool_name: Some("open_session_shell".to_string()),
+            category: None,
+            intent: None,
+            include_recommended_flows: true,
+            include_risk_summary: false,
+        })
+        .await;
+    assert!(result.success, "{:?}", result.error);
+    let flows = result.output["recommended_flows"]
+        .as_array()
+        .expect("exact persistent-shell recommended flows");
+    let flow = flows
+        .iter()
+        .find(|flow| flow["name"] == "persistent_shell")
+        .expect("persistent_shell flow");
+    assert!(flow["purpose"]
+        .as_str()
+        .is_some_and(|purpose| purpose.contains("repeated local or named-SSH commands")));
+    assert_eq!(flow["tools"], json!(["open_session_shell"]));
+}
+
+#[tokio::test]
 async fn tool_manifest_projects_canonical_semantic_contracts() {
     let runtime = test_runtime();
     for (tool_name, effect, risk, approval, idempotency, read_only) in [

--- a/src/tool_runtime/tests/schema/spot_checks.rs
+++ b/src/tool_runtime/tests/schema/spot_checks.rs
@@ -144,6 +144,15 @@ fn tool_specs_structured_validation_schema_and_output() {
             "test_count_unproven"
         ])
     );
+    assert_eq!(
+        cargo_test_output["test_count_assertion"]["properties"]["evidence_reason_code"]["enum"],
+        serde_json::json!([
+            "complete_summary",
+            "output_truncated",
+            "partial_harness_summary",
+            "no_complete_summary"
+        ])
+    );
     for name in ["job_status", "job_log"] {
         let output = &spec_named(&specs, name).output_schema["properties"]["output"]["properties"];
         assert_eq!(

--- a/src/tool_runtime/tests/startup_brief.rs
+++ b/src/tool_runtime/tests/startup_brief.rs
@@ -110,7 +110,7 @@ fn instruction_source<'a>(output: &'a Value, path: &str) -> &'a Value {
 fn assert_builtin_workflow(output: &Value) {
     let workflow = &output["workflow"];
     assert_eq!(workflow["contract"], "webcodex.coding_workflow");
-    assert_eq!(workflow["version"], 5);
+    assert_eq!(workflow["version"], 6);
     assert_eq!(workflow["authority"], "model_guidance_only");
     assert!(workflow["role_selection"]
         .as_str()
@@ -161,6 +161,21 @@ fn assert_builtin_workflow(output: &Value) {
     assert!(sidecar_guidance.contains("after the main tool"));
     assert!(sidecar_guidance.contains("never authorizes"));
     assert!(sidecar_guidance.contains("observation call before dependent mutation"));
+    let runner_targeting_guidance = workflow["model_protocol"]["runner_targeting"]
+        .as_str()
+        .expect("exact Runner targeting guidance");
+    assert!(runner_targeting_guidance.contains("exact Runner client_id"));
+    assert!(runner_targeting_guidance.contains("runtime_status(client_id=...)"));
+    assert!(runner_targeting_guidance.contains("list_projects(client_id=...)"));
+    assert!(runner_targeting_guidance.contains("before treating it as absent"));
+    let persistent_shell_guidance = workflow["model_protocol"]["persistent_shell"]
+        .as_str()
+        .expect("persistent shell guidance");
+    assert!(persistent_shell_guidance.contains("repeated commands in one Workflow Session"));
+    assert!(persistent_shell_guidance.contains("named SSH resource"));
+    assert!(persistent_shell_guidance.contains("open_session_shell"));
+    assert!(persistent_shell_guidance.contains("session_shell_exec"));
+    assert!(persistent_shell_guidance.contains("run_process"));
     let closeout_guidance = workflow["model_protocol"]["normal_closeout"]
         .as_str()
         .expect("normal closeout guidance");

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -483,6 +483,7 @@ fn cargo_test_run_metadata_counts_only_executed_tests() {
     assert!(metadata.tests_detected);
     assert_eq!(metadata.tests_run_count, Some(1));
     assert_eq!(metadata.zero_tests_run, Some(false));
+    assert_eq!(metadata.count_evidence_reason, "complete_summary");
 
     let measured_only = parse_cargo_test_run_metadata(
         "running 2 tests\n\
@@ -545,6 +546,32 @@ fn cargo_test_run_metadata_keeps_positive_aggregate_when_last_harness_is_zero() 
     assert_eq!(metadata.tests_failed, Some(0));
     assert_eq!(metadata.tests_run_count, Some(2788));
     assert_eq!(metadata.zero_tests_run, Some(false));
+    assert_eq!(metadata.count_evidence_reason, "complete_summary");
+}
+
+#[test]
+fn cargo_test_run_metadata_reports_precise_unproven_reason() {
+    let real_success = parse_cargo_test_run_metadata(
+        "running 224 tests\n\
+         test result: ok. 224 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n",
+    );
+    assert_eq!(real_success.tests_run_count, Some(224));
+    assert_eq!(real_success.count_evidence_reason, "complete_summary");
+
+    let partial_after_success = parse_cargo_test_run_metadata(
+        "running 224 tests\n\
+         test result: ok. 224 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n\
+         test result: ok. 0 passed;\n",
+    );
+    assert_eq!(partial_after_success.tests_run_count, None);
+    assert_eq!(
+        partial_after_success.count_evidence_reason,
+        "partial_harness_summary"
+    );
+
+    let no_complete = parse_cargo_test_run_metadata("running 224 tests\n");
+    assert_eq!(no_complete.tests_run_count, None);
+    assert_eq!(no_complete.count_evidence_reason, "no_complete_summary");
 }
 
 #[test]

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -778,6 +778,17 @@ async fn long_cargo_check_hands_off_with_immediately_observable_token() {
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["promoted_to_job"], true);
+    assert!(result.output["stdout_tail"]
+        .as_str()
+        .is_some_and(|tail| tail.contains("Checking demo v0.1.0")));
+    assert_eq!(
+        result.output["detected_summary"]["progress"]["reason_code"],
+        "cargo_checking"
+    );
+    assert_eq!(
+        result.output["detected_summary"]["progress"]["state"],
+        "working"
+    );
     assert_eq!(result.output["job_id"], job_id);
     let observation_token = result.output["observation_token"]
         .as_str()

--- a/src/tool_runtime/tests/validation_handoff/cargo_test_assertions.rs
+++ b/src/tool_runtime/tests/validation_handoff/cargo_test_assertions.rs
@@ -80,6 +80,10 @@ async fn fast_cargo_test_require_tests_rejects_ignored_only_and_records_failed_s
         result.output["test_count_assertion"]["reason_code"],
         "minimum_not_met"
     );
+    assert_eq!(
+        result.output["test_count_assertion"]["evidence_reason_code"],
+        "complete_summary"
+    );
     assert_eq!(result.output["tests_run_count"], 0);
     assert_eq!(result.output["zero_tests_run"], true);
     assert_eq!(result.output["test_count_assertion"]["actual_tests_run"], 0);
@@ -193,6 +197,10 @@ async fn handoff_cargo_test_count_failure_preserves_completed_job_and_failed_ses
     assert_eq!(
         status.output["validation"]["test_count_assertion"]["reason_code"],
         "minimum_not_met"
+    );
+    assert_eq!(
+        status.output["validation"]["test_count_assertion"]["evidence_reason_code"],
+        "complete_summary"
     );
     assert_eq!(
         status.output["validation"]["test_count_assertion"]["minimum_tests"],

--- a/src/tool_runtime/tool_audit.rs
+++ b/src/tool_runtime/tool_audit.rs
@@ -1199,6 +1199,14 @@ pub(crate) fn session_log_arguments_for_tool_request(tool_name: &str, arguments:
         "delete_project_files" | "git_restore_paths" | "discard_untracked" => {
             copy_keys(obj, &mut out, &["paths"]);
         }
+        "git_commit_paths" => {
+            copy_keys(obj, &mut out, &["paths"]);
+            insert_exact_git_commit_audit(obj, &mut out, "expected_head");
+            out.insert(
+                "message_present".to_string(),
+                Value::Bool(obj.get("message").and_then(Value::as_str).is_some()),
+            );
+        }
         "git_review_summary" => {
             insert_exact_git_commit_audit(obj, &mut out, "base_commit");
             insert_exact_git_commit_audit(obj, &mut out, "head_commit");
@@ -4325,6 +4333,21 @@ impl ToolCall {
                 "project": project,
                 "paths": paths,
             }),
+            Self::GitCommitPaths {
+                project,
+                expected_head,
+                paths,
+                ..
+            } => {
+                let expected_head = normalized_exact_git_commit_for_audit(expected_head);
+                serde_json::json!({
+                    "project": project,
+                    "paths": paths,
+                    "expected_head_valid": expected_head.is_some(),
+                    "expected_head": expected_head,
+                    "message_present": true,
+                })
+            }
             Self::GitStatus { project, .. } | Self::GitDiffSummary { project, .. } => {
                 serde_json::json!({
                     "project": project,

--- a/src/tool_runtime/tool_call.rs
+++ b/src/tool_runtime/tool_call.rs
@@ -724,6 +724,16 @@ pub enum ToolCall {
         session_id: Option<String>,
     },
 
+    /// Commit exactly requested changed paths behind an exact HEAD fence.
+    GitCommitPaths {
+        project: String,
+        expected_head: String,
+        paths: Vec<String>,
+        message: String,
+        #[serde(default)]
+        session_id: Option<String>,
+    },
+
     /// Run `git status` on a project.
     GitStatus {
         project: String,
@@ -2493,6 +2503,7 @@ impl ToolCall {
             Self::DeleteProjectFiles { .. } => "delete_project_files",
             Self::GitRestorePaths { .. } => "git_restore_paths",
             Self::DiscardUntracked { .. } => "discard_untracked",
+            Self::GitCommitPaths { .. } => "git_commit_paths",
             Self::GitStatus { .. } => "git_status",
             Self::GitDiff { .. } => "git_diff",
             Self::GitDiffHunks { .. } => "git_diff_hunks",
@@ -2615,6 +2626,7 @@ impl ToolCall {
             | Self::DeleteProjectFiles { session_id, .. }
             | Self::GitRestorePaths { session_id, .. }
             | Self::DiscardUntracked { session_id, .. }
+            | Self::GitCommitPaths { session_id, .. }
             | Self::GitStatus { session_id, .. }
             | Self::GitDiff { session_id, .. }
             | Self::GitDiffHunks { session_id, .. }
@@ -2748,6 +2760,7 @@ impl ToolCall {
             | Self::DeleteProjectFiles { project, .. }
             | Self::GitRestorePaths { project, .. }
             | Self::DiscardUntracked { project, .. }
+            | Self::GitCommitPaths { project, .. }
             | Self::GitStatus { project, .. }
             | Self::GitDiff { project, .. }
             | Self::GitDiffHunks { project, .. }


### PR DESCRIPTION
## Summary

- teach the built-in coding workflow to prefer exact Runner targeting when a `client_id` is already known instead of inferring absence from a broad fleet snapshot
- add a persistent-shell recommended flow for repeated commands in one Workflow Session, especially named SSH resources, without expanding the first-layer/local coding tool set
- make exact `tool_manifest` discovery name the sibling tools required to complete Runner-targeting and persistent-shell routes while keeping exact/filtered manifest tool lists bounded to tools actually returned
- advance `webcodex.coding_workflow` to v6 with additive `runner_targeting` and `persistent_shell` model-guidance fields

## Reviewer follow-up

Independent review found one discoverability gap in the initial implementation: exact `tool_manifest(tool_name=...)` correctly projected `recommended_flows.tools` down to the requested visible tool, but the flow purpose did not name the sibling tools needed to complete the route. That meant an exact `open_session_shell` lookup could still expose only an isolated tool name.

The follow-up commit keeps the existing filtered-manifest safety/compactness invariant and instead makes `manifest_purpose` explicitly name the complete sibling route. Regression coverage now verifies the same closure for exact persistent-shell and fleet-discovery lookups.

## Boundaries

- no change to execution authority, scopes, permissions, Runner routing, or tool behavior
- no expansion of `LOCAL_CODING_TOOL_NAMES`
- no promotion of persistent-shell tools into the first layer
- filtered/exact manifest `tools` continue to reference only tools actually returned
- the new workflow fields remain `authority = model_guidance_only`

## Validation

- `cargo test -p webcodex-tool-contracts` — 83 passed
- `cargo test -p webcodex tool_manifest` — 30 passed
- `cargo test -p webcodex startup_brief` — 21 passed
- exact tool-manifest routing subset — 5 passed
- `cargo fmt --all -- --check`
- `git diff --check`
