### PR TITLE
Add structured Job activity observation semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 These are the always-on rules for ordinary repository work. Read only the linked sections needed for the current task. A deeper `AGENTS.md` governs its directory.
 
-## V1 active development
+## Active development
 
-V2 development is paused; V1 is the active product line and is not feature-frozen. Ordinary V1 work may add explicitly requested capabilities as well as correctness, reliability, and test improvements. Keep changes focused and do not weaken safety, credential, process-tree, transport, durability, or boundedness contracts.
+WebCodex is actively developed and is not feature-frozen. Ordinary work may add explicitly requested capabilities as well as correctness, reliability, and test improvements. Keep changes focused and do not weaken safety, credential, process-tree, transport, durability, or boundedness contracts.
 
 ## 1. Verify and preserve
 
@@ -24,7 +24,7 @@ V2 development is paused; V1 is the active product line and is not feature-froze
 - A feature that introduces a new externally reachable authority, credential audience, or replaceable runtime target creates a concrete present boundary. Model it explicitly when reusing an existing scope, identity, or lease would broaden existing credentials or allow stale requests to retarget; fewer concepts is not a reason to collapse distinct authority.
 - When two designs satisfy the current need, choose the one with fewer concepts, states, configuration paths, and maintenance costs.
 - For model-facing execution, prefer structured process/argv and durable Job/observation primitives over shell-text orchestration. Keep shell as an escape hatch; structured lifecycle state is the source of truth for retry safety.
-- Keep model-facing ToolSpec/OpenAPI operation descriptions concise and prefer 300 characters or fewer when semantics remain complete. Never delete necessary authority, retry, continuation, uncertainty, safety, or recovery semantics merely for brevity; the canonical tested hard ceiling is `MODEL_TOOL_DESCRIPTION_MAX_CHARS`.
+- Keep model-facing ToolSpec/OpenAPI operation descriptions accurate, self-contained, and reasonably concise. Do not compress descriptions merely to hit an arbitrary soft target; use up to `MODEL_TOOL_DESCRIPTION_MAX_CHARS` when needed to preserve selection, authority, effect, retry, continuation, uncertainty, safety, recovery, and other important model guidance. Shorter is better only when semantics remain equally precise.
 - Treat demonstrated host features such as MCP App orchestration as optional adapters. Core execution and Job semantics must remain protocol-, UI-, transport-, and OS-neutral.
 - Never assume a model-facing HTTP/MCP request has stable model-window or Workflow Session identity. Treat requests as stateless unless that exact adapter/protocol contract explicitly supplies a stable `ClientWindow`. Stateless MCP 2026 must not derive hidden continuity from `Mcp-Session-Id`, connection state, credentials, project identity, or prior requests. Transport/audit/session correlation ids are not Workflow Session, model-context-retention, or authority proofs by themselves; use explicit durable identifiers from their owning domain. Connector Tasks, Workflow Sessions, durable Agents/Conversations, and future Agent Tasks are distinct identities and must not be inferred from one another.
 

--- a/crates/webcodex-core/src/runner_protocol.rs
+++ b/crates/webcodex-core/src/runner_protocol.rs
@@ -1862,6 +1862,8 @@ pub struct RunnerJobUpdateRequest {
     /// plan. Project stdout/stderr never populates this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validation_progress: Option<ShellJobValidationProgress>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity: Option<ShellJobActivity>,
     #[serde(default)]
     pub finished: bool,
 }
@@ -2290,6 +2292,80 @@ pub struct ShellJobValidationProgress {
     pub failed_step: Option<String>,
 }
 
+/// Bounded Runner-owned observation of what an active Job is currently doing.
+/// Activity is advisory execution telemetry only: it never replaces canonical
+/// Job status, proves completion, or grants retry/continuation authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShellJobActivityState {
+    Working,
+    Waiting,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShellJobActivityPhase {
+    ProcessRunning,
+    ValidationFormat,
+    ValidationCheck,
+    ValidationTest,
+    CargoWaitingForBuildLock,
+    CargoCompiling,
+    CargoChecking,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShellJobActivitySource {
+    RunnerExecution,
+    ValidationPlan,
+    CargoOutput,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ShellJobActivity {
+    pub state: ShellJobActivityState,
+    pub phase: ShellJobActivityPhase,
+    pub source: ShellJobActivitySource,
+}
+
+impl ShellJobActivity {
+    /// Closed field-combination validation for protocol/reconciliation callers.
+    /// Provenance narrows interpretation but remains observation-only.
+    pub fn is_canonical(self) -> bool {
+        use ShellJobActivityPhase as Phase;
+        use ShellJobActivitySource as Source;
+        use ShellJobActivityState as State;
+
+        matches!(
+            (self.state, self.phase, self.source),
+            (
+                State::Working,
+                Phase::ProcessRunning,
+                Source::RunnerExecution
+            ) | (
+                State::Working,
+                Phase::ValidationFormat,
+                Source::ValidationPlan
+            ) | (
+                State::Working,
+                Phase::ValidationCheck,
+                Source::ValidationPlan
+            ) | (
+                State::Working,
+                Phase::ValidationTest,
+                Source::ValidationPlan
+            ) | (
+                State::Waiting,
+                Phase::CargoWaitingForBuildLock,
+                Source::CargoOutput
+            ) | (State::Working, Phase::CargoCompiling, Source::CargoOutput)
+                | (State::Working, Phase::CargoChecking, Source::CargoOutput)
+        )
+    }
+}
+
 /// Stable structured-validation identity retained for Job handoff, status,
 /// terminal projection, and server restart reconciliation. This is internal
 /// protocol metadata; it is not a model input and never contains shell text.
@@ -2536,6 +2612,8 @@ pub struct ShellJobSnapshot {
     pub stderr: ShellJobStreamSnapshot,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validation_progress: Option<ShellJobValidationProgress>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity: Option<ShellJobActivity>,
 }
 
 /// Register-time inventory. Terminal records are deliberately partial history,
@@ -2616,6 +2694,8 @@ pub struct ShellJobInfo {
     pub result: Option<RunnerJobResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validation_progress: Option<ShellJobValidationProgress>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity: Option<ShellJobActivity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validation: Option<ShellJobValidationMetadata>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3640,6 +3720,7 @@ mod envelope_tests {
                 },
                 stderr: ShellJobStreamSnapshot::default(),
                 validation_progress: None,
+                activity: None,
             }],
         }
     }
@@ -4238,6 +4319,7 @@ mod envelope_tests {
                 error: None,
                 command_execution_state: None,
                 validation_progress: None,
+                activity: None,
                 finished: false,
             },
         };
@@ -4261,12 +4343,15 @@ mod envelope_tests {
         }))
         .unwrap();
         assert_eq!(update.command_execution_state, None);
+        assert_eq!(update.activity, None);
 
         let inventory = reconciliation_inventory();
         let encoded = serde_json::to_value(&inventory).unwrap();
         assert!(encoded["jobs"][0].get("command_execution_state").is_none());
+        assert!(encoded["jobs"][0].get("activity").is_none());
         let decoded: ShellJobInventory = serde_json::from_value(encoded).unwrap();
         assert_eq!(decoded.jobs[0].command_execution_state, None);
+        assert_eq!(decoded.jobs[0].activity, None);
     }
 
     #[test]
@@ -4543,6 +4628,7 @@ mod envelope_tests {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         };
         let json = serde_json::to_string(&job).unwrap();
@@ -4690,6 +4776,43 @@ mod envelope_tests {
         );
         assert!(decoded.capabilities.shell);
         assert_eq!(token.as_deref(), Some("wc_agent_secret"));
+    }
+}
+
+#[cfg(test)]
+mod job_activity_contract_tests {
+    use super::*;
+
+    #[test]
+    fn job_activity_is_closed_bounded_structured_data() {
+        let activity: ShellJobActivity = serde_json::from_value(serde_json::json!({
+            "state": "working",
+            "phase": "validation_check",
+            "source": "validation_plan"
+        }))
+        .unwrap();
+        assert!(activity.is_canonical());
+
+        for invalid in [
+            serde_json::json!({
+                "state": "working",
+                "phase": "linking",
+                "source": "validation_plan"
+            }),
+            serde_json::json!({
+                "state": "working",
+                "phase": "validation_check",
+                "source": "arbitrary_stdout"
+            }),
+            serde_json::json!({
+                "state": "working",
+                "phase": "validation_check",
+                "source": "validation_plan",
+                "command": "Bearer secret must never fit here"
+            }),
+        ] {
+            assert!(serde_json::from_value::<ShellJobActivity>(invalid).is_err());
+        }
     }
 }
 

--- a/crates/webcodex-runner-registry/src/job_updates.rs
+++ b/crates/webcodex-runner-registry/src/job_updates.rs
@@ -26,11 +26,11 @@ use uuid::Uuid;
 use webcodex_core::runner_protocol::{
     validate_process_argv, validate_script_request, validation_infrastructure_failure_code,
     RunnerJobUpdateRequest, RunnerRequest, ShellCommandExecutionState, ShellJobActivity,
-    ShellJobActivityPhase, ShellJobActivitySource, ShellJobContext, ShellJobInfo, ShellJobOpRequest,
-    ShellJobStructuredExecutionMetadata, ShellJobValidationMetadata, ShellJobValidationStep,
-    ShellProcessArgv, ShellRunRequest, ShellScriptPayload, DETACHED_IDEMPOTENCY_KEY_MAX_BYTES,
-    PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES, STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS,
-    STRUCTURED_EXECUTION_TIMEOUT_MIN_SECS,
+    ShellJobActivityPhase, ShellJobActivitySource, ShellJobContext, ShellJobInfo,
+    ShellJobOpRequest, ShellJobStructuredExecutionMetadata, ShellJobValidationMetadata,
+    ShellJobValidationStep, ShellProcessArgv, ShellRunRequest, ShellScriptPayload,
+    DETACHED_IDEMPOTENCY_KEY_MAX_BYTES, PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES,
+    STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS, STRUCTURED_EXECUTION_TIMEOUT_MIN_SECS,
 };
 
 #[derive(Clone, Copy)]
@@ -410,7 +410,7 @@ fn validation_activity_phase(step: &str) -> Option<ShellJobActivityPhase> {
 
 fn validate_job_activity(
     job: &ShellJobRecord,
-    update: &ShellAgentJobUpdateRequest,
+    update: &RunnerJobUpdateRequest,
 ) -> Result<(), ValidationProtocolError> {
     let Some(activity) = update.activity else {
         // Activity was added as an optional protocol field. Older Runners may

--- a/crates/webcodex-runner-registry/src/job_updates.rs
+++ b/crates/webcodex-runner-registry/src/job_updates.rs
@@ -25,11 +25,11 @@ use tokio::sync::Notify;
 use uuid::Uuid;
 use webcodex_core::runner_protocol::{
     validate_process_argv, validate_script_request, validation_infrastructure_failure_code,
-    RunnerJobUpdateRequest, RunnerRequest, ShellCommandExecutionState, ShellJobContext,
-    ShellJobInfo, ShellJobOpRequest, ShellJobStructuredExecutionMetadata,
-    ShellJobValidationMetadata, ShellJobValidationStep, ShellProcessArgv, ShellRunRequest,
-    ShellScriptPayload, DETACHED_IDEMPOTENCY_KEY_MAX_BYTES, PROCESS_CWD_MAX_BYTES,
-    PROCESS_STDIN_MAX_BYTES, STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS,
+    RunnerJobUpdateRequest, RunnerRequest, ShellCommandExecutionState, ShellJobActivity,
+    ShellJobActivityPhase, ShellJobActivitySource, ShellJobContext, ShellJobInfo, ShellJobOpRequest,
+    ShellJobStructuredExecutionMetadata, ShellJobValidationMetadata, ShellJobValidationStep,
+    ShellProcessArgv, ShellRunRequest, ShellScriptPayload, DETACHED_IDEMPOTENCY_KEY_MAX_BYTES,
+    PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES, STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS,
     STRUCTURED_EXECUTION_TIMEOUT_MIN_SECS,
 };
 
@@ -288,6 +288,7 @@ struct JobPublicMutationSignature {
     duration_ms: Option<u64>,
     command_execution_state: Option<ShellCommandExecutionState>,
     validation_progress: Option<webcodex_core::runner_protocol::ShellJobValidationProgress>,
+    activity: Option<ShellJobActivity>,
     recovered_after_server_restart: bool,
     reconciled_at: Option<i64>,
 }
@@ -307,6 +308,7 @@ fn public_mutation_signature(job: &ShellJobRecord) -> JobPublicMutationSignature
         duration_ms: job.duration_ms,
         command_execution_state: job.command_execution_state,
         validation_progress: job.validation_progress.clone(),
+        activity: job.activity,
         recovered_after_server_restart: job.recovered_after_server_restart,
         reconciled_at: job.reconciled_at,
     }
@@ -395,6 +397,73 @@ fn validate_validation_progress(
     } else {
         invalid_progress("validation_progress_invalid")
     }
+}
+
+fn validation_activity_phase(step: &str) -> Option<ShellJobActivityPhase> {
+    match step {
+        "format" => Some(ShellJobActivityPhase::ValidationFormat),
+        "check" => Some(ShellJobActivityPhase::ValidationCheck),
+        "test" => Some(ShellJobActivityPhase::ValidationTest),
+        _ => None,
+    }
+}
+
+fn validate_job_activity(
+    job: &ShellJobRecord,
+    update: &ShellAgentJobUpdateRequest,
+) -> Result<(), ValidationProtocolError> {
+    let Some(activity) = update.activity else {
+        // Activity was added as an optional protocol field. Older Runners may
+        // omit it without changing canonical Job lifecycle semantics.
+        return Ok(());
+    };
+    let status = update.status.trim();
+    if !activity.is_canonical() || !matches!(status, "running" | "stop_requested") {
+        return invalid_progress("job_activity_invalid");
+    }
+    match activity.source {
+        ShellJobActivitySource::RunnerExecution => {
+            if !job.validation_steps.is_empty()
+                || activity.phase != ShellJobActivityPhase::ProcessRunning
+            {
+                return invalid_progress("job_activity_invalid");
+            }
+        }
+        ShellJobActivitySource::ValidationPlan => {
+            let Some(current_step) = update
+                .validation_progress
+                .as_ref()
+                .and_then(|progress| progress.current_step.as_deref())
+            else {
+                return invalid_progress("job_activity_invalid");
+            };
+            if validation_activity_phase(current_step) != Some(activity.phase) {
+                return invalid_progress("job_activity_invalid");
+            }
+        }
+        ShellJobActivitySource::CargoOutput => {
+            let Some(progress) = update.validation_progress.as_ref() else {
+                return invalid_progress("job_activity_invalid");
+            };
+            if progress.current_step.is_none() || job.validation_steps.is_empty() {
+                return invalid_progress("job_activity_invalid");
+            }
+            // First-class validation metadata retains exact canonical argv, so
+            // verify Cargo provenance when that stronger evidence is available.
+            // Multi-step checks_run plans retain only step names server-side;
+            // there the trusted Runner remains the bounded provenance boundary.
+            if let Some(validation) = job.validation.as_ref() {
+                if validation
+                    .steps
+                    .get(progress.completed)
+                    .is_none_or(|step| step.program != "cargo" || !step.is_canonical())
+                {
+                    return invalid_progress("job_activity_invalid");
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_command_execution_state(
@@ -1025,6 +1094,7 @@ impl RunnerRegistry {
             validation_steps: validation_step_names,
             validation,
             validation_progress: None,
+            activity: None,
             last_update_seq: 0,
             visibility: metadata.visibility,
 
@@ -1982,6 +2052,7 @@ impl RunnerRegistry {
             );
             if let Err(error) = validate_validation_progress(job, &body)
                 .and_then(|_| validate_command_execution_state(job, &body))
+                .and_then(|_| validate_job_activity(job, &body))
             {
                 let terminal_now = now_ts();
                 job.status = "failed".to_string();
@@ -1990,6 +2061,7 @@ impl RunnerRegistry {
                 job.exit_code = body.exit_code;
                 job.duration_ms = body.duration_ms;
                 job.error = Some(format!("executor protocol violation: {}", error.0));
+                job.activity = None;
                 if job.structured_execution.is_some() {
                     job.command_execution_state = Some(if job.started_at.is_some() {
                         ShellCommandExecutionState::OutcomeUnknown
@@ -2011,6 +2083,9 @@ impl RunnerRegistry {
                 }
                 if body.validation_progress.is_some() {
                     job.validation_progress = body.validation_progress.clone();
+                }
+                if body.activity.is_some() {
+                    job.activity = body.activity;
                 }
                 if job.started_at.is_none()
                     && body.command_execution_state != Some(ShellCommandExecutionState::NotStarted)
@@ -2037,6 +2112,7 @@ impl RunnerRegistry {
                     job.duration_ms = body.duration_ms;
                     job.error = body.error;
                     job.command_execution_state = body.command_execution_state;
+                    job.activity = None;
                     job.recovery_state = job.reconciled_at.map(|_| "reconciled".to_string());
                     job.recovering_since = None;
                     job.recovery_original_status = None;
@@ -2053,6 +2129,7 @@ impl RunnerRegistry {
                     };
                     observe_job_terminal(job, terminal_now);
                     job.ended_at = Some(terminal_now);
+                    job.activity = None;
                     request_id_to_remove = job.request_id.clone();
                 }
                 if was_recovering {

--- a/crates/webcodex-runner-registry/src/jobs.rs
+++ b/crates/webcodex-runner-registry/src/jobs.rs
@@ -320,6 +320,7 @@ pub(super) fn job_view(job: &ShellJobRecord) -> ShellJobInfo {
         codex: job.codex.clone(),
         result,
         validation_progress: job.validation_progress.clone(),
+        activity: job.activity,
         validation: job.validation.clone(),
         recovery_state: job.recovery_state.clone(),
         recovered_after_server_restart: job.recovered_after_server_restart,
@@ -576,6 +577,9 @@ pub(super) fn begin_job_recovery(job: &mut ShellJobRecord, now: i64, reason_code
     job.recovery_state = Some("recovering".to_string());
     job.recovery_reason_code = Some(reason_code.to_string());
     job.ended_at = None;
+    // Once the Runner connection is lost, the previous activity may be stale.
+    // Reconciliation restores current activity from authoritative inventory.
+    job.activity = None;
     notify_job_update(job);
 }
 
@@ -584,6 +588,7 @@ pub(super) fn mark_job_lost(job: &mut ShellJobRecord, now: i64, reason_code: &st
         return;
     }
     job.status = "lost".to_string();
+    job.activity = None;
     observe_job_terminal(job, now);
     if job.ended_at.is_none() {
         job.ended_at = Some(now);

--- a/crates/webcodex-runner-registry/src/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/reconciliation.rs
@@ -8,8 +8,8 @@ use super::{job_recovery_grace_secs, RunnerRegistry};
 use crate::RunnerAccessGroup;
 use std::collections::HashSet;
 use webcodex_core::runner_protocol::{
-    RunnerProjectSummary, ShellCommandExecutionState, ShellJobActivityPhase, ShellJobActivitySource,
-    ShellJobInventory, ShellJobSnapshot, ShellJobStreamSnapshot,
+    RunnerProjectSummary, ShellCommandExecutionState, ShellJobActivityPhase,
+    ShellJobActivitySource, ShellJobInventory, ShellJobSnapshot, ShellJobStreamSnapshot,
     JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_JOBS, JOB_INVENTORY_MAX_SERIALIZED_BYTES,
     JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS,
 };

--- a/crates/webcodex-runner-registry/src/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/reconciliation.rs
@@ -8,10 +8,10 @@ use super::{job_recovery_grace_secs, RunnerRegistry};
 use crate::RunnerAccessGroup;
 use std::collections::HashSet;
 use webcodex_core::runner_protocol::{
-    RunnerProjectSummary, ShellCommandExecutionState, ShellJobInventory, ShellJobSnapshot,
-    ShellJobStreamSnapshot, JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_JOBS,
-    JOB_INVENTORY_MAX_SERIALIZED_BYTES, JOB_INVENTORY_MAX_TERMINAL_JOBS,
-    JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS,
+    RunnerProjectSummary, ShellCommandExecutionState, ShellJobActivityPhase, ShellJobActivitySource,
+    ShellJobInventory, ShellJobSnapshot, ShellJobStreamSnapshot,
+    JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_JOBS, JOB_INVENTORY_MAX_SERIALIZED_BYTES,
+    JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS,
 };
 
 const MAX_CONTEXT_FIELD_CHARS: usize = 1_024;
@@ -315,6 +315,67 @@ fn validate_snapshot(
             return Err("job inventory validation_progress does not match status".to_string());
         }
     }
+    if let Some(activity) = snapshot.activity {
+        if !activity.is_canonical()
+            || !matches!(snapshot.status.as_str(), "running" | "stop_requested")
+        {
+            return Err("job inventory activity is invalid for status".to_string());
+        }
+        match activity.source {
+            ShellJobActivitySource::RunnerExecution => {
+                if !snapshot.context.validation_steps.is_empty()
+                    || activity.phase != ShellJobActivityPhase::ProcessRunning
+                {
+                    return Err(
+                        "job inventory activity is inconsistent with execution kind".to_string()
+                    );
+                }
+            }
+            ShellJobActivitySource::ValidationPlan => {
+                let expected = match snapshot
+                    .validation_progress
+                    .as_ref()
+                    .and_then(|progress| progress.current_step.as_deref())
+                {
+                    Some("format") => Some(ShellJobActivityPhase::ValidationFormat),
+                    Some("check") => Some(ShellJobActivityPhase::ValidationCheck),
+                    Some("test") => Some(ShellJobActivityPhase::ValidationTest),
+                    _ => None,
+                };
+                if expected != Some(activity.phase) {
+                    return Err(
+                        "job inventory activity is inconsistent with validation progress"
+                            .to_string(),
+                    );
+                }
+            }
+            ShellJobActivitySource::CargoOutput => {
+                let Some(progress) = snapshot.validation_progress.as_ref() else {
+                    return Err(
+                        "job inventory Cargo activity requires validation progress".to_string()
+                    );
+                };
+                if progress.current_step.is_none() || snapshot.context.validation_steps.is_empty() {
+                    return Err(
+                        "job inventory Cargo activity requires an active validation step"
+                            .to_string(),
+                    );
+                }
+                if let Some(validation) = snapshot.context.validation.as_ref() {
+                    if validation
+                        .steps
+                        .get(progress.completed)
+                        .is_none_or(|step| step.program != "cargo" || !step.is_canonical())
+                    {
+                        return Err(
+                            "job inventory Cargo activity is inconsistent with validation metadata"
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+    }
     Ok(active)
 }
 
@@ -600,6 +661,7 @@ fn record_from_snapshot(
         validation_steps: context.validation_steps.clone(),
         validation: context.validation.clone(),
         validation_progress: snapshot.validation_progress.clone(),
+        activity: snapshot.activity,
         visibility: super::state::ShellJobVisibility::Public,
         last_update_seq: snapshot.update_seq,
         recovery_state: Some("reconciled".to_string()),
@@ -632,6 +694,7 @@ fn apply_snapshot(
     job.command_execution_state = snapshot.command_execution_state;
     job.structured_execution = snapshot.context.structured_execution.clone();
     job.validation_progress = snapshot.validation_progress.clone();
+    job.activity = snapshot.activity;
     job.validation = snapshot.context.validation.clone();
     replace_log_from_snapshot(&mut job.stdout, &snapshot.stdout);
     replace_log_from_snapshot(&mut job.stderr, &snapshot.stderr);

--- a/crates/webcodex-runner-registry/src/state.rs
+++ b/crates/webcodex-runner-registry/src/state.rs
@@ -11,9 +11,9 @@ use webcodex_core::coding_agent::{
 use webcodex_core::mcp_gateway::McpGatewayResponse;
 use webcodex_core::runner_protocol::{
     PersistentShellResult, RunnerBuildInfo, RunnerHostContext, RunnerPolicySummary,
-    RunnerProjectSummary, RunnerRequest, RunnerView, ShellCommandExecutionState,
-    ShellJobActivity, ShellJobCodexMetadata, ShellJobStructuredExecutionMetadata,
-    ShellJobValidationProgress, ShellProcessArgv, ShellProjectInventoryStatus, ShellRunResponse,
+    RunnerProjectSummary, RunnerRequest, RunnerView, ShellCommandExecutionState, ShellJobActivity,
+    ShellJobCodexMetadata, ShellJobStructuredExecutionMetadata, ShellJobValidationProgress,
+    ShellProcessArgv, ShellProjectInventoryStatus, ShellRunResponse,
     JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_TERMINAL_RETENTION_SECS,
 };
 

--- a/crates/webcodex-runner-registry/src/state.rs
+++ b/crates/webcodex-runner-registry/src/state.rs
@@ -12,8 +12,8 @@ use webcodex_core::mcp_gateway::McpGatewayResponse;
 use webcodex_core::runner_protocol::{
     PersistentShellResult, RunnerBuildInfo, RunnerHostContext, RunnerPolicySummary,
     RunnerProjectSummary, RunnerRequest, RunnerView, ShellCommandExecutionState,
-    ShellJobCodexMetadata, ShellJobStructuredExecutionMetadata, ShellJobValidationProgress,
-    ShellProcessArgv, ShellProjectInventoryStatus, ShellRunResponse,
+    ShellJobActivity, ShellJobCodexMetadata, ShellJobStructuredExecutionMetadata,
+    ShellJobValidationProgress, ShellProcessArgv, ShellProjectInventoryStatus, ShellRunResponse,
     JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_TERMINAL_RETENTION_SECS,
 };
 
@@ -307,6 +307,9 @@ pub(super) struct ShellJobRecord {
     pub(super) validation_steps: Vec<String>,
     pub(super) validation: Option<webcodex_core::runner_protocol::ShellJobValidationMetadata>,
     pub(super) validation_progress: Option<ShellJobValidationProgress>,
+    /// Last Runner-authoritative bounded activity for an active Job. Cleared on
+    /// terminal/recovery transitions; never used as execution authority.
+    pub(super) activity: Option<ShellJobActivity>,
     pub(super) visibility: ShellJobVisibility,
     pub(super) last_update_seq: u64,
     pub(super) recovery_state: Option<String>,

--- a/crates/webcodex-runner-registry/src/tests/connection_lease.rs
+++ b/crates/webcodex-runner-registry/src/tests/connection_lease.rs
@@ -706,6 +706,7 @@ async fn late_job_update_on_stale_connection_is_accepted_without_refreshing_live
                 error: None,
                 command_execution_state: None,
                 validation_progress: None,
+                activity: None,
                 finished: false,
             },
             "conn-a",
@@ -748,6 +749,7 @@ async fn late_job_update_on_stale_connection_is_accepted_without_refreshing_live
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await

--- a/crates/webcodex-runner-registry/src/tests/instance_lease.rs
+++ b/crates/webcodex-runner-registry/src/tests/instance_lease.rs
@@ -260,6 +260,7 @@ async fn lease_stale_instance_job_update_rejected() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -289,6 +290,7 @@ async fn lease_stale_instance_job_update_rejected() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -319,6 +321,7 @@ async fn lease_stale_instance_job_update_rejected() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await;
@@ -459,6 +462,7 @@ async fn lease_reconcile_disconnect_stale_instance_is_noop() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -632,6 +636,7 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -668,6 +673,7 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
             stdout: Default::default(),
             stderr: Default::default(),
             validation_progress: record.validation_progress.clone(),
+            activity: record.activity,
         }
     };
 
@@ -729,6 +735,7 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -753,6 +760,7 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await

--- a/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
@@ -182,6 +182,7 @@ async fn job_update_rejects_mismatched_request_id_without_mutating_target_job() 
         error: None,
         command_execution_state: None,
         validation_progress: None,
+        activity: None,
         finished: false,
     };
 

--- a/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
@@ -411,17 +411,13 @@ async fn job_log_wait_sequenced_update_changes_token_even_when_tail_is_same() {
 async fn job_log_wait_recovery_transition_between_calls_is_immediate() {
     let registry = RunnerRegistry::default();
     let job = start_wait_job(&registry).await;
-    registry
-        .update_job(wait_job_update(
-            "inst-wait",
-            &job.job_id,
-            1,
-            "running",
-            None,
-            false,
-        ))
-        .await
-        .unwrap();
+    let mut running = wait_job_update("inst-wait", &job.job_id, 1, "running", None, false);
+    running.activity = Some(crate::shell_protocol::ShellJobActivity {
+        state: crate::shell_protocol::ShellJobActivityState::Working,
+        phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
+        source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+    });
+    registry.update_job(running).await.unwrap();
     let token = registry
         .get_job(&job.job_id)
         .await
@@ -437,6 +433,7 @@ async fn job_log_wait_recovery_transition_between_calls_is_immediate() {
     assert!(wait.changed);
     assert_eq!(info.status, "recovering");
     assert_eq!(info.recovery_state.as_deref(), Some("recovering"));
+    assert_eq!(info.activity, None);
 }
 
 #[tokio::test]
@@ -665,6 +662,26 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
             .load(std::sync::atomic::Ordering::Relaxed)
     };
     assert!(revision_after > revision_before);
+}
+
+#[tokio::test]
+async fn noncanonical_activity_fails_job_closed_without_retaining_activity() {
+    let registry = ShellClientRegistry::default();
+    let job = start_wait_job(&registry).await;
+    let mut update = wait_job_update("inst-wait", &job.job_id, 1, "running", None, false);
+    update.activity = Some(crate::shell_protocol::ShellJobActivity {
+        state: crate::shell_protocol::ShellJobActivityState::Waiting,
+        phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
+        source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+    });
+
+    let failed = registry.update_job(update).await.unwrap();
+    assert_eq!(failed.status, "failed");
+    assert_eq!(failed.activity, None);
+    assert!(failed
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("job_activity_invalid")));
 }
 
 #[tokio::test]

--- a/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
@@ -412,10 +412,10 @@ async fn job_log_wait_recovery_transition_between_calls_is_immediate() {
     let registry = RunnerRegistry::default();
     let job = start_wait_job(&registry).await;
     let mut running = wait_job_update("inst-wait", &job.job_id, 1, "running", None, false);
-    running.activity = Some(crate::shell_protocol::ShellJobActivity {
-        state: crate::shell_protocol::ShellJobActivityState::Working,
-        phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
-        source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+    running.activity = Some(crate::runner_protocol::ShellJobActivity {
+        state: crate::runner_protocol::ShellJobActivityState::Working,
+        phase: crate::runner_protocol::ShellJobActivityPhase::ProcessRunning,
+        source: crate::runner_protocol::ShellJobActivitySource::RunnerExecution,
     });
     registry.update_job(running).await.unwrap();
     let token = registry
@@ -534,15 +534,15 @@ async fn job_log_wait_legacy_update_between_calls_and_noop_replacement() {
 
 #[tokio::test]
 async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wakes_waiter() {
-    let registry = ShellClientRegistry::default();
-    let capabilities = ShellClientCapabilities {
+    let registry = RunnerRegistry::default();
+    let capabilities = RunnerCapabilities {
         async_jobs: true,
         async_shell_jobs: true,
         jobs: true,
         ..Default::default()
     };
     registry
-        .register(current_runner_registration(ShellClientRegisterRequest {
+        .register(current_runner_registration(RunnerRegisterRequest {
             process_started_at: None,
             build: None,
             job_concurrency_limit: None,
@@ -550,8 +550,8 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
             coding_agent_providers: None,
             coding_agent_inventory: None,
             client_id: "activity-legacy".to_string(),
-            agent_instance_id: "activity-legacy-inst".to_string(),
-            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
+            runner_instance_id: "activity-legacy-inst".to_string(),
+            runner_protocol_generation: crate::runner_protocol::RUNNER_PROTOCOL_GENERATION_V2,
             display_name: None,
             owner: Some("alice".to_string()),
             hostname: None,
@@ -580,9 +580,9 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
         )
         .await
         .unwrap();
-    let base_update = || ShellAgentJobUpdateRequest {
+    let base_update = || RunnerJobUpdateRequest {
         client_id: "activity-legacy".into(),
-        agent_instance_id: "activity-legacy-inst".into(),
+        runner_instance_id: "activity-legacy-inst".into(),
         update_seq: None,
         job_id: job.job_id.clone(),
         request_id: None,
@@ -632,10 +632,10 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
     });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     let mut activity_update = base_update();
-    activity_update.activity = Some(crate::shell_protocol::ShellJobActivity {
-        state: crate::shell_protocol::ShellJobActivityState::Working,
-        phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
-        source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+    activity_update.activity = Some(crate::runner_protocol::ShellJobActivity {
+        state: crate::runner_protocol::ShellJobActivityState::Working,
+        phase: crate::runner_protocol::ShellJobActivityPhase::ProcessRunning,
+        source: crate::runner_protocol::ShellJobActivitySource::RunnerExecution,
     });
     registry.update_job(activity_update).await.unwrap();
 
@@ -646,10 +646,10 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
     assert_eq!(stderr.as_deref(), Some(""));
     assert_eq!(
         observed.activity,
-        Some(crate::shell_protocol::ShellJobActivity {
-            state: crate::shell_protocol::ShellJobActivityState::Working,
-            phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
-            source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+        Some(crate::runner_protocol::ShellJobActivity {
+            state: crate::runner_protocol::ShellJobActivityState::Working,
+            phase: crate::runner_protocol::ShellJobActivityPhase::ProcessRunning,
+            source: crate::runner_protocol::ShellJobActivitySource::RunnerExecution,
         })
     );
     let revision_after = {
@@ -666,13 +666,13 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
 
 #[tokio::test]
 async fn noncanonical_activity_fails_job_closed_without_retaining_activity() {
-    let registry = ShellClientRegistry::default();
+    let registry = RunnerRegistry::default();
     let job = start_wait_job(&registry).await;
     let mut update = wait_job_update("inst-wait", &job.job_id, 1, "running", None, false);
-    update.activity = Some(crate::shell_protocol::ShellJobActivity {
-        state: crate::shell_protocol::ShellJobActivityState::Waiting,
-        phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
-        source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+    update.activity = Some(crate::runner_protocol::ShellJobActivity {
+        state: crate::runner_protocol::ShellJobActivityState::Waiting,
+        phase: crate::runner_protocol::ShellJobActivityPhase::ProcessRunning,
+        source: crate::runner_protocol::ShellJobActivitySource::RunnerExecution,
     });
 
     let failed = registry.update_job(update).await.unwrap();

--- a/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
@@ -46,6 +46,7 @@ fn wait_job_update(
         error: None,
         command_execution_state: None,
         validation_progress: None,
+        activity: None,
         finished,
     }
 }
@@ -364,6 +365,7 @@ async fn job_log_wait_sequenced_update_changes_token_even_when_tail_is_same() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -392,6 +394,7 @@ async fn job_log_wait_sequenced_update_changes_token_even_when_tail_is_same() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -502,6 +505,7 @@ async fn job_log_wait_legacy_update_between_calls_and_noop_replacement() {
         error: None,
         command_execution_state: None,
         validation_progress: None,
+        activity: None,
         finished: false,
     };
     registry.update_job(update()).await.unwrap();
@@ -525,6 +529,142 @@ async fn job_log_wait_legacy_update_between_calls_and_noop_replacement() {
     assert_eq!(response_token.stdout_cursor, Some(2));
     assert_eq!(response_token.stderr_cursor, Some(1));
     assert_eq!(current.last_update_seq, Some(0));
+    assert!(
+        current.activity.is_none(),
+        "older Runner updates may omit activity"
+    );
+}
+
+#[tokio::test]
+async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wakes_waiter() {
+    let registry = ShellClientRegistry::default();
+    let capabilities = ShellClientCapabilities {
+        async_jobs: true,
+        async_shell_jobs: true,
+        jobs: true,
+        ..Default::default()
+    };
+    registry
+        .register(current_runner_registration(ShellClientRegisterRequest {
+            process_started_at: None,
+            build: None,
+            job_concurrency_limit: None,
+            job_inventory: None,
+            coding_agent_providers: None,
+            coding_agent_inventory: None,
+            client_id: "activity-legacy".to_string(),
+            agent_instance_id: "activity-legacy-inst".to_string(),
+            agent_protocol_generation: crate::shell_protocol::AGENT_PROTOCOL_GENERATION_V2,
+            display_name: None,
+            owner: Some("alice".to_string()),
+            hostname: None,
+            host_context: None,
+            capabilities,
+            policy: None,
+        }))
+        .await
+        .unwrap();
+    let job = registry
+        .start_job(
+            ShellJobOpRequest {
+                op: "start".into(),
+                client_id: Some("activity-legacy".into()),
+                cwd: Some("/tmp".into()),
+                command: Some("sleep 10".into()),
+                timeout_secs: Some(30),
+                job_id: None,
+                since_stdout_line: None,
+                since_stderr_line: None,
+                tail_lines: None,
+                limit: None,
+                codex: None,
+            },
+            "tester".into(),
+        )
+        .await
+        .unwrap();
+    let base_update = || ShellAgentJobUpdateRequest {
+        client_id: "activity-legacy".into(),
+        agent_instance_id: "activity-legacy-inst".into(),
+        update_seq: None,
+        job_id: job.job_id.clone(),
+        request_id: None,
+        status: "running".into(),
+        stdout_chunk: None,
+        stderr_chunk: None,
+        stdout_tail: None,
+        stderr_tail: None,
+        log_snapshot: None,
+        exit_code: None,
+        duration_ms: None,
+        error: None,
+        command_execution_state: None,
+        validation_progress: None,
+        activity: None,
+        finished: false,
+    };
+    registry.update_job(base_update()).await.unwrap();
+    let baseline = registry.get_job(&job.job_id).await.unwrap();
+    let token = baseline.observation_token.clone().unwrap();
+    let revision_before = {
+        let inner = registry.inner.lock().await;
+        inner
+            .jobs_by_id
+            .get(&job.job_id)
+            .unwrap()
+            .public_revision
+            .load(std::sync::atomic::Ordering::Relaxed)
+    };
+
+    let waiting_registry = registry.clone();
+    let waiting_job_id = job.job_id.clone();
+    let waiting_token = token.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_registry
+            .job_log_for_auth(
+                None,
+                &waiting_job_id,
+                None,
+                None,
+                None,
+                Some(&waiting_token),
+                Some(5),
+            )
+            .await
+            .unwrap()
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let mut activity_update = base_update();
+    activity_update.activity = Some(crate::shell_protocol::ShellJobActivity {
+        state: crate::shell_protocol::ShellJobActivityState::Working,
+        phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
+        source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+    });
+    registry.update_job(activity_update).await.unwrap();
+
+    let (observed, stdout, stderr, _, _, wait) = waiter.await.unwrap();
+    assert_eq!(wait.wait_outcome, JobLogWaitOutcome::Updated);
+    assert!(wait.changed);
+    assert_eq!(stdout.as_deref(), Some(""));
+    assert_eq!(stderr.as_deref(), Some(""));
+    assert_eq!(
+        observed.activity,
+        Some(crate::shell_protocol::ShellJobActivity {
+            state: crate::shell_protocol::ShellJobActivityState::Working,
+            phase: crate::shell_protocol::ShellJobActivityPhase::ProcessRunning,
+            source: crate::shell_protocol::ShellJobActivitySource::RunnerExecution,
+        })
+    );
+    let revision_after = {
+        let inner = registry.inner.lock().await;
+        inner
+            .jobs_by_id
+            .get(&job.job_id)
+            .unwrap()
+            .public_revision
+            .load(std::sync::atomic::Ordering::Relaxed)
+    };
+    assert!(revision_after > revision_before);
 }
 
 #[tokio::test]
@@ -616,6 +756,7 @@ async fn agent_job_log_observation_is_baseline_then_independent_deltas() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -813,6 +954,7 @@ async fn agent_job_log_replays_partial_lines_until_each_stream_completes() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -850,6 +992,7 @@ async fn agent_job_log_replays_partial_lines_until_each_stream_completes() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await

--- a/crates/webcodex-runner-registry/src/tests/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/tests/reconciliation.rs
@@ -190,6 +190,7 @@ fn snapshot_from_request(
         stdout,
         stderr: ShellJobStreamSnapshot::default(),
         validation_progress: None,
+        activity: None,
     }
 }
 
@@ -218,6 +219,7 @@ fn update(
         error: None,
         command_execution_state: None,
         validation_progress: None,
+        activity: None,
         finished,
     }
 }
@@ -277,6 +279,16 @@ async fn validation_progress_accepts_coalesced_sequence_gaps_without_skipping_st
                              completed: usize,
                              current_step: Option<&str>,
                              finished: bool| {
+        let activity = current_step.map(|step| crate::runner_protocol::ShellJobActivity {
+            state: crate::runner_protocol::ShellJobActivityState::Working,
+            phase: match step {
+                "format" => crate::runner_protocol::ShellJobActivityPhase::ValidationFormat,
+                "check" => crate::runner_protocol::ShellJobActivityPhase::ValidationCheck,
+                "test" => crate::runner_protocol::ShellJobActivityPhase::ValidationTest,
+                other => panic!("unexpected validation step: {other}"),
+            },
+            source: crate::runner_protocol::ShellJobActivitySource::ValidationPlan,
+        });
         RunnerJobUpdateRequest {
             client_id: CLIENT_ID.to_string(),
             runner_instance_id: INSTANCE_A.to_string(),
@@ -298,6 +310,7 @@ async fn validation_progress_accepts_coalesced_sequence_gaps_without_skipping_st
                 current_step: current_step.map(str::to_string),
                 failed_step: None,
             }),
+            activity,
             finished,
         }
     };
@@ -306,15 +319,38 @@ async fn validation_progress_accepts_coalesced_sequence_gaps_without_skipping_st
         validation_update(2, "running", 0, Some("format"), false),
         validation_update(37, "running", 1, Some("check"), false),
         validation_update(81, "running", 2, Some("test"), false),
-        validation_update(144, "completed", 3, None, true),
     ] {
         registry.update_job(update).await.unwrap();
     }
+    let before_stale = registry.get_job(&job.job_id).await.unwrap();
+    assert_eq!(before_stale.last_update_seq, Some(81));
+    assert_eq!(
+        before_stale.activity,
+        Some(crate::runner_protocol::ShellJobActivity {
+            state: crate::runner_protocol::ShellJobActivityState::Working,
+            phase: crate::runner_protocol::ShellJobActivityPhase::ValidationTest,
+            source: crate::runner_protocol::ShellJobActivitySource::ValidationPlan,
+        })
+    );
+
+    registry
+        .update_job(validation_update(37, "running", 1, Some("check"), false))
+        .await
+        .unwrap();
+    let after_stale = registry.get_job(&job.job_id).await.unwrap();
+    assert_eq!(after_stale.last_update_seq, Some(81));
+    assert_eq!(after_stale.activity, before_stale.activity);
+
+    registry
+        .update_job(validation_update(144, "completed", 3, None, true))
+        .await
+        .unwrap();
 
     let completed = registry.get_job(&job.job_id).await.unwrap();
     assert_eq!(completed.status, "completed");
     assert_eq!(completed.exit_code, Some(0));
     assert_eq!(completed.last_update_seq, Some(144));
+    assert_eq!(completed.activity, None);
     assert_eq!(
         completed.validation_progress,
         Some(ShellJobValidationProgress {
@@ -393,6 +429,12 @@ async fn cargo_test_count_assertion_survives_inventory_roundtrip_and_server_rest
         current_step: Some("test".to_string()),
         failed_step: None,
     });
+    snapshot.activity = Some(crate::runner_protocol::ShellJobActivity {
+        state: crate::runner_protocol::ShellJobActivityState::Working,
+        phase: crate::runner_protocol::ShellJobActivityPhase::ValidationTest,
+        source: crate::runner_protocol::ShellJobActivitySource::ValidationPlan,
+    });
+    let expected_activity = snapshot.activity;
     let inventory: ShellJobInventory = serde_json::from_value(
         serde_json::to_value(ShellJobInventory {
             active_complete: true,
@@ -411,6 +453,7 @@ async fn cargo_test_count_assertion_survives_inventory_roundtrip_and_server_rest
         Some(target)
     );
     assert_eq!(restored.status, "running");
+    assert_eq!(restored.activity, expected_activity);
     assert!(restored.recovered_after_server_restart);
 }
 
@@ -2111,6 +2154,7 @@ fn standalone_snapshot(job_id: &str, status: &str) -> ShellJobSnapshot {
         stdout: ShellJobStreamSnapshot::default(),
         stderr: ShellJobStreamSnapshot::default(),
         validation_progress: None,
+        activity: None,
     }
 }
 

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -27,15 +27,14 @@ use runner_protocol::{
     validation_infrastructure_failure_code, RunnerCapabilities, RunnerJobUpdateRequest,
     RunnerPolicySummary, RunnerPollPayload, RunnerPollRequest, RunnerPollResponse,
     RunnerProjectSummary, RunnerRegisterRequest, RunnerRegisterResponse, RunnerRequest,
-    ShellCommandExecutionState, ShellJobActivity,
-    ShellJobActivityPhase, ShellJobActivitySource, ShellJobActivityState, ShellJobContext,
-    ShellJobInventory, ShellJobLogSnapshot, ShellJobSnapshot, ShellJobStreamSnapshot,
-    ShellJobValidationProgress, ShellJobValidationStep, ShellProfileSummaryEntry,
-    ShellProfilesSummary, ShellProjectInventoryPage, ShellProjectInventoryStatus,
-    JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_SERIALIZED_BYTES,
+    ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase, ShellJobActivitySource,
+    ShellJobActivityState, ShellJobContext, ShellJobInventory, ShellJobLogSnapshot,
+    ShellJobSnapshot, ShellJobStreamSnapshot, ShellJobValidationProgress, ShellJobValidationStep,
+    ShellProfileSummaryEntry, ShellProfilesSummary, ShellProjectInventoryPage,
+    ShellProjectInventoryStatus, JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_SERIALIZED_BYTES,
     JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS,
-    RUNNER_PROTOCOL_GENERATION_V2, VALIDATION_STEP_SPAWN_FAILED_CODE, VALIDATION_STEP_WAIT_FAILED_CODE,
-    VALIDATION_TOOL_UNAVAILABLE_CODE,
+    RUNNER_PROTOCOL_GENERATION_V2, VALIDATION_STEP_SPAWN_FAILED_CODE,
+    VALIDATION_STEP_WAIT_FAILED_CODE, VALIDATION_TOOL_UNAVAILABLE_CODE,
 };
 
 #[cfg(test)]

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -92,8 +92,9 @@ const RUNNER_POLL_PATH: &str = "/api/shell/agent/poll";
 /// finite bound.
 const RUNNER_HTTP_RESPONSE_BODY_MAX_BYTES: usize = 32 * 1024 * 1024;
 
-/// At most the validated Job state machine's semantic transitions are retained
-/// for live delivery. Output-only updates are coalesced separately below.
+/// At most the validated Job state machine's required semantic transitions are
+/// retained for live delivery. Output and advisory current-activity-only
+/// updates are coalesced separately below.
 const JOB_UPDATE_REQUIRED_PENDING_MAX: usize = 8;
 const JOB_UPDATE_DELIVERY_RETRY: Duration = Duration::from_millis(JOB_UPDATE_INTERVAL_MS);
 
@@ -2706,8 +2707,10 @@ fn validation_step_activity(step: &ShellJobValidationStep) -> ShellJobActivity {
 }
 
 /// Recognize only a tiny bounded subset of Cargo's own stderr progress while a
-/// canonical structured Cargo validation step is running. This is advisory
-/// activity provenance, not validation/completion evidence.
+/// canonical structured Cargo validation step is running. Clear phase-boundary
+/// lines return to the step's canonical validation-plan activity so transient
+/// Cargo detail cannot remain sticky after that detail has ended. This is
+/// advisory activity provenance, not validation/completion evidence.
 fn cargo_activity_from_stderr(
     step: &ShellJobValidationStep,
     stderr: &str,
@@ -2715,32 +2718,40 @@ fn cargo_activity_from_stderr(
     if step.program != "cargo" || !step.is_canonical() {
         return None;
     }
+    let validation_activity = validation_step_activity(step);
     let mut observed = None;
     for line in stderr.lines() {
         let line = line.trim_start();
-        let (state, phase) = if line.contains("Blocking waiting for file lock on build directory") {
-            (
-                ShellJobActivityState::Waiting,
-                ShellJobActivityPhase::CargoWaitingForBuildLock,
-            )
+        let activity = if line.contains("Blocking waiting for file lock on build directory") {
+            ShellJobActivity {
+                state: ShellJobActivityState::Waiting,
+                phase: ShellJobActivityPhase::CargoWaitingForBuildLock,
+                source: ShellJobActivitySource::CargoOutput,
+            }
         } else if line.starts_with("Compiling ") {
-            (
-                ShellJobActivityState::Working,
-                ShellJobActivityPhase::CargoCompiling,
-            )
+            ShellJobActivity {
+                state: ShellJobActivityState::Working,
+                phase: ShellJobActivityPhase::CargoCompiling,
+                source: ShellJobActivitySource::CargoOutput,
+            }
         } else if line.starts_with("Checking ") {
-            (
-                ShellJobActivityState::Working,
-                ShellJobActivityPhase::CargoChecking,
-            )
+            ShellJobActivity {
+                state: ShellJobActivityState::Working,
+                phase: ShellJobActivityPhase::CargoChecking,
+                source: ShellJobActivitySource::CargoOutput,
+            }
+        } else if line.starts_with("Finished ")
+            || (step.name == "test"
+                && (line.starts_with("Running unittests ")
+                    || line.starts_with("Running tests/")
+                    || line.starts_with("Running benches/")
+                    || line.starts_with("Doc-tests ")))
+        {
+            validation_activity
         } else {
             continue;
         };
-        observed = Some(ShellJobActivity {
-            state,
-            phase,
-            source: ShellJobActivitySource::CargoOutput,
-        });
+        observed = Some(activity);
     }
     observed
 }
@@ -3355,7 +3366,6 @@ impl JobManager {
             }
             let previous_status = job.snapshot.status.clone();
             let previous_progress = job.snapshot.validation_progress.clone();
-            let previous_activity = job.snapshot.activity;
             let explicit_semantic =
                 delta.finished || delta.command_execution_state.is_some() || delta.error.is_some();
             let now = chrono::Utc::now().timestamp();
@@ -3416,12 +3426,12 @@ impl JobManager {
             }
             let semantic = explicit_semantic
                 || job.snapshot.status != previous_status
-                || job.snapshot.validation_progress != previous_progress
-                || job.snapshot.activity != previous_activity;
+                || job.snapshot.validation_progress != previous_progress;
             // Each sequenced update carries the current authoritative bounded
-            // tails. Delivery may coalesce output-only attempts, but semantic
-            // markers preserve their sequence while using the latest retained
-            // authoritative log snapshot at send time.
+            // tails and activity. Delivery may coalesce output/activity-only
+            // attempts, but required semantic markers preserve their sequence
+            // while using the latest retained authoritative snapshot at send
+            // time.
             (
                 job_update_from_snapshot(&job.client_id, &job.runner_instance_id, &job.snapshot),
                 semantic,

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -27,13 +27,15 @@ use runner_protocol::{
     validation_infrastructure_failure_code, RunnerCapabilities, RunnerJobUpdateRequest,
     RunnerPolicySummary, RunnerPollPayload, RunnerPollRequest, RunnerPollResponse,
     RunnerProjectSummary, RunnerRegisterRequest, RunnerRegisterResponse, RunnerRequest,
-    ShellCommandExecutionState, ShellJobContext, ShellJobInventory, ShellJobLogSnapshot,
-    ShellJobSnapshot, ShellJobStreamSnapshot, ShellJobValidationProgress, ShellJobValidationStep,
-    ShellProfileSummaryEntry, ShellProfilesSummary, ShellProjectInventoryPage,
-    ShellProjectInventoryStatus, JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_SERIALIZED_BYTES,
+    ShellCommandExecutionState, ShellJobActivity,
+    ShellJobActivityPhase, ShellJobActivitySource, ShellJobActivityState, ShellJobContext,
+    ShellJobInventory, ShellJobLogSnapshot, ShellJobSnapshot, ShellJobStreamSnapshot,
+    ShellJobValidationProgress, ShellJobValidationStep, ShellProfileSummaryEntry,
+    ShellProfilesSummary, ShellProjectInventoryPage, ShellProjectInventoryStatus,
+    JOB_INVENTORY_MAX_ACTIVE_JOBS, JOB_INVENTORY_MAX_SERIALIZED_BYTES,
     JOB_INVENTORY_MAX_TERMINAL_JOBS, JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS,
-    RUNNER_PROTOCOL_GENERATION_V2, VALIDATION_STEP_SPAWN_FAILED_CODE,
-    VALIDATION_STEP_WAIT_FAILED_CODE, VALIDATION_TOOL_UNAVAILABLE_CODE,
+    RUNNER_PROTOCOL_GENERATION_V2, VALIDATION_STEP_SPAWN_FAILED_CODE, VALIDATION_STEP_WAIT_FAILED_CODE,
+    VALIDATION_TOOL_UNAVAILABLE_CODE,
 };
 
 #[cfg(test)]
@@ -315,6 +317,7 @@ struct PendingJobUpdateDelivery {
     error: Option<String>,
     command_execution_state: Option<ShellCommandExecutionState>,
     validation_progress: Option<ShellJobValidationProgress>,
+    activity: Option<ShellJobActivity>,
     finished: bool,
 }
 
@@ -328,6 +331,7 @@ impl PendingJobUpdateDelivery {
             error: update.error.clone(),
             command_execution_state: update.command_execution_state.clone(),
             validation_progress: update.validation_progress.clone(),
+            activity: update.activity,
             finished: update.finished,
         }
     }
@@ -424,6 +428,7 @@ fn job_update_from_delivery(
     update.error = pending.error.clone();
     update.command_execution_state = pending.command_execution_state.clone();
     update.validation_progress = pending.validation_progress.clone();
+    update.activity = pending.activity;
     update.finished = pending.finished;
     update
 }
@@ -544,6 +549,7 @@ fn test_job_snapshot(job_id: &str) -> ShellJobSnapshot {
         stdout: ShellJobStreamSnapshot::default(),
         stderr: ShellJobStreamSnapshot::default(),
         validation_progress: None,
+        activity: None,
     }
 }
 
@@ -2673,7 +2679,70 @@ struct RunnerJobDelta {
     command_execution_state: Option<ShellCommandExecutionState>,
     stream_limit_bytes: Option<usize>,
     validation_progress: Option<ShellJobValidationProgress>,
+    activity: Option<ShellJobActivity>,
     finished: bool,
+}
+
+fn process_running_activity() -> ShellJobActivity {
+    ShellJobActivity {
+        state: ShellJobActivityState::Working,
+        phase: ShellJobActivityPhase::ProcessRunning,
+        source: ShellJobActivitySource::RunnerExecution,
+    }
+}
+
+fn validation_step_activity(step: &ShellJobValidationStep) -> ShellJobActivity {
+    let phase = match step.name.as_str() {
+        "format" => ShellJobActivityPhase::ValidationFormat,
+        "check" => ShellJobActivityPhase::ValidationCheck,
+        "test" => ShellJobActivityPhase::ValidationTest,
+        _ => unreachable!("canonical validation step name"),
+    };
+    ShellJobActivity {
+        state: ShellJobActivityState::Working,
+        phase,
+        source: ShellJobActivitySource::ValidationPlan,
+    }
+}
+
+/// Recognize only a tiny bounded subset of Cargo's own stderr progress while a
+/// canonical structured Cargo validation step is running. This is advisory
+/// activity provenance, not validation/completion evidence.
+fn cargo_activity_from_stderr(
+    step: &ShellJobValidationStep,
+    stderr: &str,
+) -> Option<ShellJobActivity> {
+    if step.program != "cargo" || !step.is_canonical() {
+        return None;
+    }
+    let mut observed = None;
+    for line in stderr.lines() {
+        let line = line.trim_start();
+        let (state, phase) = if line.contains("Blocking waiting for file lock on build directory") {
+            (
+                ShellJobActivityState::Waiting,
+                ShellJobActivityPhase::CargoWaitingForBuildLock,
+            )
+        } else if line.starts_with("Compiling ") {
+            (
+                ShellJobActivityState::Working,
+                ShellJobActivityPhase::CargoCompiling,
+            )
+        } else if line.starts_with("Checking ") {
+            (
+                ShellJobActivityState::Working,
+                ShellJobActivityPhase::CargoChecking,
+            )
+        } else {
+            continue;
+        };
+        observed = Some(ShellJobActivity {
+            state,
+            phase,
+            source: ShellJobActivitySource::CargoOutput,
+        });
+    }
+    observed
 }
 
 fn runner_job_is_terminal(status: &str) -> bool {
@@ -2768,6 +2837,7 @@ fn job_update_from_snapshot(
         error: snapshot.error.clone(),
         command_execution_state: snapshot.command_execution_state,
         validation_progress: snapshot.validation_progress.clone(),
+        activity: snapshot.activity,
         finished: runner_job_is_terminal(&snapshot.status),
     }
 }
@@ -3285,6 +3355,7 @@ impl JobManager {
             }
             let previous_status = job.snapshot.status.clone();
             let previous_progress = job.snapshot.validation_progress.clone();
+            let previous_activity = job.snapshot.activity;
             let explicit_semantic =
                 delta.finished || delta.command_execution_state.is_some() || delta.error.is_some();
             let now = chrono::Utc::now().timestamp();
@@ -3328,7 +3399,12 @@ impl JobManager {
             if delta.validation_progress.is_some() {
                 job.snapshot.validation_progress = delta.validation_progress.clone();
             }
+            if let Some(activity) = delta.activity {
+                debug_assert!(activity.is_canonical());
+                job.snapshot.activity = Some(activity);
+            }
             if runner_job_is_terminal(&job.snapshot.status) || delta.finished {
+                job.snapshot.activity = None;
                 job.snapshot.ended_at.get_or_insert(now);
                 job.snapshot.exit_code = delta.exit_code;
                 job.snapshot.duration_ms = delta.duration_ms;
@@ -3340,7 +3416,8 @@ impl JobManager {
             }
             let semantic = explicit_semantic
                 || job.snapshot.status != previous_status
-                || job.snapshot.validation_progress != previous_progress;
+                || job.snapshot.validation_progress != previous_progress
+                || job.snapshot.activity != previous_activity;
             // Each sequenced update carries the current authoritative bounded
             // tails. Delivery may coalesce output-only attempts, but semantic
             // markers preserve their sequence while using the latest retained
@@ -3410,6 +3487,7 @@ impl JobManager {
                         error: snapshot.error.clone(),
                         command_execution_state: snapshot.command_execution_state.clone(),
                         validation_progress: snapshot.validation_progress.clone(),
+                        activity: snapshot.activity,
                         finished: runner_job_is_terminal(&snapshot.status),
                     };
                     let _ = queue.enqueue(marker, true);
@@ -3932,6 +4010,7 @@ impl JobManager {
                 error: Some("job start request is missing recovery context".to_string()),
                 command_execution_state,
                 validation_progress: None,
+                activity: None,
                 finished: true,
             });
             return;
@@ -3956,6 +4035,7 @@ impl JobManager {
                 error: Some(error),
                 command_execution_state,
                 validation_progress: None,
+                activity: None,
                 finished: true,
             });
             return;
@@ -4024,6 +4104,7 @@ impl JobManager {
                         stdout: ShellJobStreamSnapshot::default(),
                         stderr: ShellJobStreamSnapshot::default(),
                         validation_progress: None,
+                        activity: None,
                     },
                     child: None,
                     stop_requested: Arc::new(AtomicBool::new(false)),
@@ -4697,6 +4778,11 @@ impl JobManager {
                     current_step: Some(steps[0].name.clone()),
                     failed_step: None,
                 }),
+                activity: Some(if validation {
+                    validation_step_activity(&steps[0])
+                } else {
+                    process_running_activity()
+                }),
                 ..Default::default()
             },
         );
@@ -4740,6 +4826,9 @@ impl JobManager {
                         }
                     }
                     if !out.is_empty() || !err.is_empty() {
+                        let activity = validation
+                            .then(|| cargo_activity_from_stderr(&steps[step_index], &err))
+                            .flatten();
                         manager.update_and_send(
                             &job_id,
                             RunnerJobDelta {
@@ -4753,6 +4842,7 @@ impl JobManager {
                                         failed_step: None,
                                     }
                                 }),
+                                activity,
                                 ..Default::default()
                             },
                         );
@@ -4938,6 +5028,8 @@ impl JobManager {
                                 current_step: Some(steps[step_index].name.clone()),
                                 failed_step: None,
                             }),
+                            activity: validation
+                                .then(|| validation_step_activity(&steps[step_index])),
                             ..Default::default()
                         },
                     );
@@ -4977,6 +5069,7 @@ impl JobManager {
                     command_execution_state,
                     stream_limit_bytes: None,
                     validation_progress: final_progress,
+                    activity: None,
                     finished: true,
                 },
             );

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -4439,6 +4439,7 @@ impl JobManager {
                     &started_job_id,
                     RunnerJobDelta {
                         status: "running".to_string(),
+                        activity: Some(process_running_activity()),
                         ..Default::default()
                     },
                 );

--- a/crates/webcodex-runner/src/main_tests/runner_sink.rs
+++ b/crates/webcodex-runner/src/main_tests/runner_sink.rs
@@ -63,6 +63,7 @@ fn sink_send_job_update_sends_job_update_envelope() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         };
         sink.send_job_update(&body).unwrap();
@@ -123,6 +124,7 @@ fn sink_try_send_job_update_preserves_full_ws_and_quic_queue_for_retry() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         };
 

--- a/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
@@ -28,7 +28,8 @@ use std::sync::mpsc;
 use std::time::Instant;
 use uuid::Uuid;
 use webcodex_core::runner_protocol::{
-    validate_process_argv, ShellCommandExecutionState, ShellJobContext, ShellJobSnapshot,
+    validate_process_argv, ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase,
+    ShellJobActivitySource, ShellJobActivityState, ShellJobContext, ShellJobSnapshot,
     ShellJobStreamSnapshot, ShellProcessArgv, JOB_INVENTORY_MAX_JOBS,
     JOB_SNAPSHOT_STREAM_MAX_BYTES, JOB_TERMINAL_RETENTION_SECS, PROCESS_CWD_MAX_BYTES,
     PROCESS_STDIN_MAX_BYTES, STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS,
@@ -1356,6 +1357,11 @@ pub(crate) fn snapshot_from_detached_record(
         Some(_) => None,
         None => None,
     };
+    let activity = matches!(status, "running" | "stop_requested").then_some(ShellJobActivity {
+        state: ShellJobActivityState::Working,
+        phase: ShellJobActivityPhase::ProcessRunning,
+        source: ShellJobActivitySource::RunnerExecution,
+    });
     let stream = |output: &DetachedOutputState| ShellJobStreamSnapshot {
         tail: output.tail.clone(),
         first_retained_line: output.first_retained_line,
@@ -1381,6 +1387,7 @@ pub(crate) fn snapshot_from_detached_record(
         stdout: stream(&record.stdout),
         stderr: stream(&record.stderr),
         validation_progress: None,
+        activity,
     })
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -3227,6 +3227,166 @@ fn run_fail_fast_validation_job(attempt: usize) -> FailFastAttempt {
 
 #[cfg(unix)]
 #[test]
+fn validation_job_exposes_activity_during_silent_step_and_clears_terminal() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let bin = temp.path().join("bin");
+    std::fs::create_dir(&bin).unwrap();
+    let cargo = bin.join("cargo");
+    let started = temp.path().join("silent-validation.started");
+    let release = temp.path().join("silent-validation.release");
+    std::fs::write(
+        &cargo,
+        format!(
+            "#!/bin/sh\n: > {}\nwhile [ ! -e {} ]; do sleep 0.05; done\n",
+            sh_quote(&started),
+            sh_quote(&release),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&cargo, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    let steps = vec![ShellJobValidationStep {
+        name: "check".into(),
+        program: "cargo".into(),
+        args: vec!["check".into(), "--all-targets".into()],
+        env: Vec::new(),
+    }];
+    let mut shell = ShellConfig::default();
+    shell.path_prepend.push(bin);
+    let (sink, _rx) = structured_test_sink("validation-agent", "validation-instance");
+    let manager = JobManager::new(1);
+    manager.enqueue(
+        sink,
+        PendingJobStart {
+            generation: 1,
+            policy: RunnerPolicy {
+                allow_cwd_anywhere: true,
+                ..RunnerPolicy::default()
+            },
+            shell,
+            ssh: SshConfig::default(),
+            project_registry_dir: temp.path().join("project-registry"),
+            request: serde_json::from_value(json!({
+                "request_id": "silent-validation-request",
+                "client_id": "validation-agent",
+                "kind": "start_validation_job",
+                "job_id": "silent-validation-job",
+                "cwd": temp.path(),
+                "command": serde_json::to_string(&steps).unwrap(),
+                "timeout_secs": 30,
+                "requested_by": "test",
+                "created_at": chrono::Utc::now().timestamp(),
+                "job_context": test_job_context(temp.path(), vec!["check".to_string()]),
+            }))
+            .unwrap(),
+        },
+    );
+
+    assert!(
+        wait_until(Duration::from_secs(10), || started.exists()),
+        "silent validation step did not start"
+    );
+    let expected = Some(ShellJobActivity {
+        state: ShellJobActivityState::Working,
+        phase: ShellJobActivityPhase::ValidationCheck,
+        source: ShellJobActivitySource::ValidationPlan,
+    });
+    let running = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "silent-validation-job")
+        .unwrap();
+    assert_eq!(running.status, "running");
+    assert!(running.stdout.tail.is_empty());
+    assert!(running.stderr.tail.is_empty());
+    assert_eq!(running.activity, expected);
+
+    std::thread::sleep(Duration::from_millis(150));
+    let still_silent = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "silent-validation-job")
+        .unwrap();
+    assert!(still_silent.stdout.tail.is_empty());
+    assert!(still_silent.stderr.tail.is_empty());
+    assert_eq!(still_silent.activity, expected);
+
+    std::fs::write(&release, b"go").unwrap();
+    wait_for_job_workers(&manager);
+    let terminal = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "silent-validation-job")
+        .unwrap();
+    assert_eq!(terminal.status, "completed");
+    assert_eq!(terminal.activity, None);
+}
+
+#[test]
+fn arbitrary_process_output_cannot_forge_cargo_activity() {
+    let manager = JobManager::new(1);
+    let mut snapshot = test_job_snapshot("activity-spoof-job");
+    snapshot.activity = Some(process_running_activity());
+    lock_unpoison(&manager.jobs).insert(
+        snapshot.job_id.clone(),
+        RunningJob {
+            client_id: "test-agent".into(),
+            agent_instance_id: "test-instance".into(),
+            snapshot,
+            child: None,
+            stop_requested: Arc::new(AtomicBool::new(false)),
+            slot_reserved: true,
+        },
+    );
+    manager.record_update(
+        "activity-spoof-job",
+        RunnerJobDelta {
+            stdout_chunk: Some("Compiling forged-package\n".into()),
+            stderr_chunk: Some("Blocking waiting for file lock on build directory\n".into()),
+            ..Default::default()
+        },
+    );
+    let retained = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|snapshot| snapshot.job_id == "activity-spoof-job")
+        .unwrap();
+    assert_eq!(retained.activity, Some(process_running_activity()));
+
+    let cargo_step = ShellJobValidationStep {
+        name: "check".into(),
+        program: "cargo".into(),
+        args: vec!["check".into(), "--all-targets".into()],
+        env: Vec::new(),
+    };
+    assert_eq!(
+        cargo_activity_from_stderr(&cargo_step, "Compiling webcodex-core\n"),
+        Some(ShellJobActivity {
+            state: ShellJobActivityState::Working,
+            phase: ShellJobActivityPhase::CargoCompiling,
+            source: ShellJobActivitySource::CargoOutput,
+        })
+    );
+    let non_cargo_step = ShellJobValidationStep {
+        name: "check".into(),
+        program: "sh".into(),
+        args: vec!["-c".into(), "true".into()],
+        env: Vec::new(),
+    };
+    assert_eq!(
+        cargo_activity_from_stderr(&non_cargo_step, "Compiling forged-package\n"),
+        None
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn noisy_validation_progress_delivery_stays_ordered_after_transport_backpressure() {
     use std::os::unix::fs::PermissionsExt;
 
@@ -3357,10 +3517,15 @@ fn noisy_validation_progress_delivery_stays_ordered_after_transport_backpressure
         if update.finished {
             assert_eq!(progress.completed, expected_steps.len());
             assert!(progress.current_step.is_none());
+            assert_eq!(update.activity, None);
         } else {
             assert_eq!(
                 progress.current_step.as_deref(),
                 expected_steps.get(progress.completed).copied()
+            );
+            assert_eq!(
+                update.activity,
+                Some(validation_step_activity(&steps[progress.completed]))
             );
         }
         let stdout_cursor = update

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -3387,6 +3387,286 @@ fn arbitrary_process_output_cannot_forge_cargo_activity() {
     );
 }
 
+#[test]
+fn cargo_activity_returns_to_validation_plan_after_fine_phase_ends() {
+    let manager = JobManager::new(1);
+    let step = ShellJobValidationStep {
+        name: "test".into(),
+        program: "cargo".into(),
+        args: vec!["test".into()],
+        env: Vec::new(),
+    };
+    let validation_activity = validation_step_activity(&step);
+    let mut snapshot = test_job_snapshot("cargo-current-activity");
+    snapshot.context.validation_steps = vec!["test".into()];
+    snapshot.validation_progress = Some(ShellJobValidationProgress {
+        completed: 0,
+        current_step: Some("test".into()),
+        failed_step: None,
+    });
+    snapshot.activity = Some(validation_activity);
+    lock_unpoison(&manager.jobs).insert(
+        snapshot.job_id.clone(),
+        RunningJob {
+            client_id: "test-agent".into(),
+            agent_instance_id: "test-instance".into(),
+            snapshot,
+            child: None,
+            stop_requested: Arc::new(AtomicBool::new(false)),
+            slot_reserved: true,
+        },
+    );
+
+    let compiling = cargo_activity_from_stderr(&step, "Compiling webcodex v0.3.9\n").unwrap();
+    manager.record_update(
+        "cargo-current-activity",
+        RunnerJobDelta {
+            status: "running".into(),
+            activity: Some(compiling),
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        manager
+            .inventory()
+            .jobs
+            .into_iter()
+            .find(|job| job.job_id == "cargo-current-activity")
+            .unwrap()
+            .activity,
+        Some(compiling)
+    );
+
+    let phase_ended = cargo_activity_from_stderr(
+        &step,
+        "Finished `test` profile [unoptimized] target(s) in 0.10s\nRunning unittests src/lib.rs\n",
+    )
+    .unwrap();
+    assert_eq!(phase_ended, validation_activity);
+    manager.record_update(
+        "cargo-current-activity",
+        RunnerJobDelta {
+            status: "running".into(),
+            activity: Some(phase_ended),
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        manager
+            .inventory()
+            .jobs
+            .into_iter()
+            .find(|job| job.job_id == "cargo-current-activity")
+            .unwrap()
+            .activity,
+        Some(validation_activity)
+    );
+
+    manager.record_update(
+        "cargo-current-activity",
+        RunnerJobDelta {
+            status: "completed".into(),
+            exit_code: Some(0),
+            validation_progress: Some(ShellJobValidationProgress {
+                completed: 1,
+                current_step: None,
+                failed_step: None,
+            }),
+            finished: true,
+            ..Default::default()
+        },
+    );
+    let terminal = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|job| job.job_id == "cargo-current-activity")
+        .unwrap();
+    assert_eq!(terminal.status, "completed");
+    assert_eq!(terminal.activity, None);
+}
+
+#[test]
+fn activity_only_delivery_coalesces_without_consuming_required_semantic_queue() {
+    let manager = JobManager::new(1);
+    let check = ShellJobValidationStep {
+        name: "check".into(),
+        program: "cargo".into(),
+        args: vec!["check".into(), "--all-targets".into()],
+        env: Vec::new(),
+    };
+    let test = ShellJobValidationStep {
+        name: "test".into(),
+        program: "cargo".into(),
+        args: vec!["test".into()],
+        env: Vec::new(),
+    };
+    let mut snapshot = test_job_snapshot("activity-backpressure");
+    snapshot.context.validation_steps = vec!["check".into(), "test".into()];
+    snapshot.validation_progress = Some(ShellJobValidationProgress {
+        completed: 0,
+        current_step: Some("check".into()),
+        failed_step: None,
+    });
+    snapshot.activity = Some(validation_step_activity(&check));
+    lock_unpoison(&manager.jobs).insert(
+        snapshot.job_id.clone(),
+        RunningJob {
+            client_id: "test-agent".into(),
+            agent_instance_id: "test-instance".into(),
+            snapshot,
+            child: None,
+            stop_requested: Arc::new(AtomicBool::new(false)),
+            slot_reserved: true,
+        },
+    );
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    tx.try_send(AgentEnvelope::Ping { ts: 11 }).unwrap();
+    manager.install_sink(RunnerSink::WebSocket {
+        tx,
+        client_id: "test-agent".into(),
+        agent_instance_id: "test-instance".into(),
+    });
+
+    let compiling = ShellJobActivity {
+        state: ShellJobActivityState::Working,
+        phase: ShellJobActivityPhase::CargoCompiling,
+        source: ShellJobActivitySource::CargoOutput,
+    };
+    let checking = ShellJobActivity {
+        state: ShellJobActivityState::Working,
+        phase: ShellJobActivityPhase::CargoChecking,
+        source: ShellJobActivitySource::CargoOutput,
+    };
+    for index in 0..64 {
+        manager.update_and_send(
+            "activity-backpressure",
+            RunnerJobDelta {
+                status: "running".into(),
+                activity: Some(if index % 2 == 0 { compiling } else { checking }),
+                ..Default::default()
+            },
+        );
+    }
+    {
+        let pending = lock_unpoison(&manager.pending_job_updates);
+        let queue = pending
+            .get("activity-backpressure")
+            .expect("coalesced activity pending delivery");
+        assert!(queue.required.is_empty());
+        assert_eq!(queue.output_only.as_ref().unwrap().activity, Some(checking));
+        assert!(!queue.suspended_until_reconciliation);
+    }
+    assert_eq!(
+        manager
+            .inventory()
+            .jobs
+            .into_iter()
+            .find(|job| job.job_id == "activity-backpressure")
+            .unwrap()
+            .activity,
+        Some(checking)
+    );
+
+    manager.update_and_send(
+        "activity-backpressure",
+        RunnerJobDelta {
+            status: "running".into(),
+            validation_progress: Some(ShellJobValidationProgress {
+                completed: 1,
+                current_step: Some("test".into()),
+                failed_step: None,
+            }),
+            activity: Some(validation_step_activity(&test)),
+            ..Default::default()
+        },
+    );
+    {
+        let pending = lock_unpoison(&manager.pending_job_updates);
+        let queue = pending.get("activity-backpressure").unwrap();
+        assert_eq!(queue.required.len(), 1);
+        assert!(queue.output_only.is_none());
+        assert!(!queue.suspended_until_reconciliation);
+    }
+
+    for index in 0..64 {
+        manager.update_and_send(
+            "activity-backpressure",
+            RunnerJobDelta {
+                status: "running".into(),
+                activity: Some(if index % 2 == 0 { checking } else { compiling }),
+                ..Default::default()
+            },
+        );
+    }
+    {
+        let pending = lock_unpoison(&manager.pending_job_updates);
+        let queue = pending.get("activity-backpressure").unwrap();
+        assert_eq!(queue.required.len(), 1);
+        assert_eq!(
+            queue.output_only.as_ref().unwrap().activity,
+            Some(compiling)
+        );
+        assert!(!queue.suspended_until_reconciliation);
+    }
+    assert_eq!(
+        manager
+            .inventory()
+            .jobs
+            .into_iter()
+            .find(|job| job.job_id == "activity-backpressure")
+            .unwrap()
+            .activity,
+        Some(compiling)
+    );
+
+    manager.update_and_send(
+        "activity-backpressure",
+        RunnerJobDelta {
+            status: "completed".into(),
+            exit_code: Some(0),
+            validation_progress: Some(ShellJobValidationProgress {
+                completed: 2,
+                current_step: None,
+                failed_step: None,
+            }),
+            finished: true,
+            ..Default::default()
+        },
+    );
+    {
+        let pending = lock_unpoison(&manager.pending_job_updates);
+        let queue = pending.get("activity-backpressure").unwrap();
+        assert_eq!(queue.required.len(), 2);
+        assert!(queue.output_only.is_none());
+        assert!(!queue.suspended_until_reconciliation);
+    }
+    let terminal = manager
+        .inventory()
+        .jobs
+        .into_iter()
+        .find(|job| job.job_id == "activity-backpressure")
+        .unwrap();
+    assert_eq!(terminal.status, "completed");
+    assert_eq!(terminal.activity, None);
+
+    assert!(matches!(rx.try_recv(), Ok(AgentEnvelope::Ping { ts: 11 })));
+    let updates = collect_job_updates(&mut rx, Duration::from_secs(5));
+    assert_eq!(updates.len(), 2, "{updates:?}");
+    assert_eq!(
+        updates[0].validation_progress,
+        Some(ShellJobValidationProgress {
+            completed: 1,
+            current_step: Some("test".into()),
+            failed_step: None,
+        })
+    );
+    assert_eq!(updates[0].activity, Some(validation_step_activity(&test)));
+    assert_eq!(updates[1].status, "completed");
+    assert_eq!(updates[1].activity, None);
+    assert!(updates[1].finished);
+}
+
 #[cfg(unix)]
 #[test]
 fn noisy_validation_progress_delivery_stays_ordered_after_transport_backpressure() {

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -3338,7 +3338,7 @@ fn arbitrary_process_output_cannot_forge_cargo_activity() {
         snapshot.job_id.clone(),
         RunningJob {
             client_id: "test-agent".into(),
-            agent_instance_id: "test-instance".into(),
+            runner_instance_id: "test-instance".into(),
             snapshot,
             child: None,
             stop_requested: Arc::new(AtomicBool::new(false)),
@@ -3409,7 +3409,7 @@ fn cargo_activity_returns_to_validation_plan_after_fine_phase_ends() {
         snapshot.job_id.clone(),
         RunningJob {
             client_id: "test-agent".into(),
-            agent_instance_id: "test-instance".into(),
+            runner_instance_id: "test-instance".into(),
             snapshot,
             child: None,
             stop_requested: Arc::new(AtomicBool::new(false)),
@@ -3513,7 +3513,7 @@ fn activity_only_delivery_coalesces_without_consuming_required_semantic_queue() 
         snapshot.job_id.clone(),
         RunningJob {
             client_id: "test-agent".into(),
-            agent_instance_id: "test-instance".into(),
+            runner_instance_id: "test-instance".into(),
             snapshot,
             child: None,
             stop_requested: Arc::new(AtomicBool::new(false)),
@@ -3521,11 +3521,11 @@ fn activity_only_delivery_coalesces_without_consuming_required_semantic_queue() 
         },
     );
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-    tx.try_send(AgentEnvelope::Ping { ts: 11 }).unwrap();
+    tx.try_send(RunnerEnvelope::Ping { ts: 11 }).unwrap();
     manager.install_sink(RunnerSink::WebSocket {
         tx,
         client_id: "test-agent".into(),
-        agent_instance_id: "test-instance".into(),
+        runner_instance_id: "test-instance".into(),
     });
 
     let compiling = ShellJobActivity {
@@ -3650,7 +3650,7 @@ fn activity_only_delivery_coalesces_without_consuming_required_semantic_queue() 
     assert_eq!(terminal.status, "completed");
     assert_eq!(terminal.activity, None);
 
-    assert!(matches!(rx.try_recv(), Ok(AgentEnvelope::Ping { ts: 11 })));
+    assert!(matches!(rx.try_recv(), Ok(RunnerEnvelope::Ping { ts: 11 })));
     let updates = collect_job_updates(&mut rx, Duration::from_secs(5));
     assert_eq!(updates.len(), 2, "{updates:?}");
     assert_eq!(

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -1506,6 +1506,7 @@ fn phase_e2_default_four_gates_fifth_and_promotes_same_job_once() {
         .expect("promoted fifth Job retains its record");
     assert_eq!(promoted.status, "running");
     assert_eq!(promoted.request_id, "request-default-5");
+    assert_eq!(promoted.activity, Some(process_running_activity()));
 
     for job in &jobs[1..] {
         job.release();
@@ -1521,6 +1522,7 @@ fn phase_e2_default_four_gates_fifth_and_promotes_same_job_once() {
             .unwrap();
         assert_eq!(snapshot.status, "completed");
         assert_eq!(snapshot.request_id, format!("request-{}", job.job_id));
+        assert!(snapshot.activity.is_none());
     }
 }
 

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
@@ -23,6 +23,39 @@ pub fn nullable_schema(kind: &str, description: &str) -> Value {
     })
 }
 
+pub fn job_activity_schema() -> Value {
+    json!({
+        "anyOf": [
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "state": {"type": "string", "enum": ["working", "waiting"]},
+                    "phase": {
+                        "type": "string",
+                        "enum": [
+                            "process_running",
+                            "validation_format",
+                            "validation_check",
+                            "validation_test",
+                            "cargo_waiting_for_build_lock",
+                            "cargo_compiling",
+                            "cargo_checking"
+                        ]
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": ["runner_execution", "validation_plan", "cargo_output"]
+                    }
+                },
+                "required": ["state", "phase", "source"]
+            },
+            {"type": "null"}
+        ],
+        "description": "Runner-owned bounded current activity for an active Job. Observation only: it never replaces canonical status, proves completion, or grants retry/continuation authority. null means unavailable, terminal, or temporarily untrusted during recovery."
+    })
+}
+
 pub fn exploration_tool_name_schema() -> Value {
     json!({
         "anyOf": [

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
@@ -280,6 +280,24 @@ fn structured_execution_lifecycle_constraints(execution_source: &str) -> Value {
     ])
 }
 
+fn require_success_output_field(schema: &mut Value, field: &str) {
+    schema["allOf"]
+        .as_array_mut()
+        .expect("wrapped output schema allOf")
+        .push(json!({
+            "if": {
+                "properties": {"success": {"const": true}},
+                "required": ["success"]
+            },
+            "then": {
+                "required": ["output"],
+                "properties": {
+                    "output": {"required": [field]}
+                }
+            }
+        }));
+}
+
 fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
     vec![
         (
@@ -1152,7 +1170,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 schema_type("boolean", "True when command_preview is bounded and secret-like command text is replaced with [redacted]."),
             ),
             ]);
-            schema["properties"]["output"]["required"] = json!(["activity"]);
+            require_success_output_field(&mut schema, "activity");
             Some(schema)
         }
         "observe_jobs" => Some(observe_jobs_output_schema()),
@@ -1327,7 +1345,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 ),
             ),
             ]);
-            schema["properties"]["output"]["required"] = json!(["activity"]);
+            require_success_output_field(&mut schema, "activity");
             Some(schema)
         }
         _ => None,

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
@@ -94,6 +94,13 @@ fn structured_execution_lifecycle_constraints(execution_source: &str) -> Value {
             }
         },
         {
+            "if": {
+                "properties": {"promoted_to_job": {"const": true}},
+                "required": ["promoted_to_job"]
+            },
+            "then": {"required": ["activity"]}
+        },
+        {
             "if": {"required": ["async_handoff_available"]},
             "then": {
                 "if": {
@@ -460,7 +467,7 @@ fn observe_jobs_output_schema() -> Value {
             "log_delta_status", "stdout_delta_reset", "stderr_delta_reset",
             "observation_token", "cursor", "changed",
             "terminal", "executor", "cwd", "shell", "purpose", "command_summary",
-            "detected_summary", "validation"
+            "activity", "detected_summary", "validation"
         ]
     });
     let item = json!({
@@ -1026,7 +1033,8 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 schema_type("string", "Ownership basis: project_and_session or unknown_session_project_only."),
             ),
         ])),
-        "job_status" => Some(wrapped_output_schema(vec![
+        "job_status" => {
+            let mut schema = wrapped_output_schema(vec![
             ("job_id", schema_type("string", "Runtime job id.")),
             ("project", nullable_schema("string", "Project id, when known.")),
             (
@@ -1143,9 +1151,13 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 "command_preview_bounded",
                 schema_type("boolean", "True when command_preview is bounded and secret-like command text is replaced with [redacted]."),
             ),
-        ])),
+            ]);
+            schema["properties"]["output"]["required"] = json!(["activity"]);
+            Some(schema)
+        }
         "observe_jobs" => Some(observe_jobs_output_schema()),
-        "job_log" | "job_tail" => Some(wrapped_output_schema(vec![
+        "job_log" | "job_tail" => {
+            let mut schema = wrapped_output_schema(vec![
             ("job_id", schema_type("string", "Runtime job id.")),
             (
                 "session_id",
@@ -1314,7 +1326,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                     "Compact detected operation/build/check/test summary from bounded evidence.",
                 ),
             ),
-        ])),
+            ]);
+            schema["properties"]["output"]["required"] = json!(["activity"]);
+            Some(schema)
+        }
         _ => None,
     }
 }
@@ -1486,7 +1501,8 @@ fn job_summary_schema() -> Value {
             "created_at",
             "started_at",
             "ended_at",
-            "exit_code"
+            "exit_code",
+            "activity"
         ],
         "additionalProperties": true
     })

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
@@ -1,8 +1,9 @@
 use serde_json::{json, Value};
 
 use super::common::{
-    array_schema, cargo_test_count_assertion_schema, nullable_schema, permission_decision_schema,
-    recovery_kind_schema, schema_type, session_hint_schema, wrapped_output_schema,
+    array_schema, cargo_test_count_assertion_schema, job_activity_schema, nullable_schema,
+    permission_decision_schema, recovery_kind_schema, schema_type, session_hint_schema,
+    wrapped_output_schema,
 };
 
 fn validation_job_projection_schema() -> Value {
@@ -309,6 +310,7 @@ fn structured_continuation_properties() -> Vec<(&'static str, Value)> {
                 "Current Job observation token when a continuation was exposed.",
             ),
         ),
+        ("activity", job_activity_schema()),
         (
             "effective_timeout_secs",
             schema_type(
@@ -391,6 +393,7 @@ fn observe_jobs_output_schema() -> Value {
             "exit_code": nullable_schema("integer", "Process exit code, when terminal and available."),
             "command_execution_state": job_command_execution_state_schema(),
             "structured_execution": job_structured_execution_metadata_schema(),
+            "activity": job_activity_schema(),
             "stdout_tail": schema_type("string", "Bounded stdout baseline, delta, conservative partial-line replay, or reset-recovery tail. A previously observed unterminated final line may repeat until its line boundary is observed."),
             "stderr_tail": schema_type("string", "Bounded stderr baseline, delta, conservative partial-line replay, or reset-recovery tail. A previously observed unterminated final line may repeat until its line boundary is observed."),
             "stdout_lines": schema_type("integer", "Total observed stdout line count."),
@@ -427,8 +430,6 @@ fn observe_jobs_output_schema() -> Value {
                 },
                 "required": ["stdout", "stderr"]
             },
-            "wait_outcome": schema_type("string", "Canonical per-Job internal observation outcome; outer wake_reason is the batch wait fact."),
-            "waited_ms": schema_type("integer", "Canonical per-Job internal wait time. Final batch snapshots are non-waiting."),
             "changed": schema_type("boolean", "Whether the lifecycle revision or Server epoch differs from the item's supplied token. Token format upgrades alone do not set changed."),
             "terminal": schema_type("boolean", "Canonical terminal classification."),
             "executor": {
@@ -457,7 +458,7 @@ fn observe_jobs_output_schema() -> Value {
             "job_id", "status", "exit_code", "stdout_tail", "stderr_tail",
             "stdout_lines", "stderr_lines", "stdout_truncated", "stderr_truncated",
             "log_delta_status", "stdout_delta_reset", "stderr_delta_reset",
-            "observation_token", "cursor", "wait_outcome", "waited_ms", "changed",
+            "observation_token", "cursor", "changed",
             "terminal", "executor", "cwd", "shell", "purpose", "command_summary",
             "detected_summary", "validation"
         ]
@@ -506,11 +507,19 @@ fn observe_jobs_output_schema() -> Value {
             "succeeded_count": {"type": "integer", "minimum": 0, "maximum": 8},
             "failed_count": {"type": "integer", "minimum": 0, "maximum": 8},
             "items": {"type": "array", "maxItems": 8, "items": item},
-            "wake_reason": {
-                "type": "string",
-                "enum": ["immediate", "updated", "terminal", "item_error", "timeout"]
+            "wait": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "outcome": {
+                        "type": "string",
+                        "enum": ["immediate", "updated", "terminal", "item_error", "timeout"]
+                    },
+                    "waited_ms": {"type": "integer", "minimum": 0}
+                },
+                "required": ["outcome", "waited_ms"],
+                "description": "The single shared-wait fact for this batch. Final item outputs are snapshots and do not expose a second wait outcome."
             },
-            "waited_ms": {"type": "integer", "minimum": 0},
             "changed_count": {"type": "integer", "minimum": 0, "maximum": 8},
             "terminal_count": {"type": "integer", "minimum": 0, "maximum": 8},
             "output_truncated": {"type": "boolean"},
@@ -520,7 +529,7 @@ fn observe_jobs_output_schema() -> Value {
         },
         "required": [
             "requested_count", "returned_count", "succeeded_count", "failed_count",
-            "items", "wake_reason", "waited_ms", "changed_count", "terminal_count",
+            "items", "wait", "changed_count", "terminal_count",
             "output_truncated", "next_index"
         ]
     });
@@ -1053,6 +1062,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 "structured_execution",
                 job_structured_execution_metadata_schema(),
             ),
+            ("activity", job_activity_schema()),
             (
                 "recovery_state",
                 nullable_schema("string", "Bounded recovery state such as recovering or reconciled."),
@@ -1179,6 +1189,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 "structured_execution",
                 job_structured_execution_metadata_schema(),
             ),
+            ("activity", job_activity_schema()),
             (
                 "stdout_tail",
                 schema_type("string", "Bounded stdout baseline, automatic delta, conservative partial-line replay, explicit cursor segment, or reset-recovery tail. An unterminated final line may repeat until its line boundary is observed."),
@@ -1459,6 +1470,7 @@ fn job_summary_schema() -> Value {
             "exit_code": nullable_schema("integer", "Process exit code, when available."),
             "command_execution_state": job_command_execution_state_schema(),
             "structured_execution": job_structured_execution_metadata_schema(),
+            "activity": job_activity_schema(),
             "recovery_state": nullable_schema("string", "Bounded recovery state, when applicable."),
             "recovered_after_server_restart": schema_type("boolean", "True when rebuilt from a same-runner inventory."),
             "reconciled_at": nullable_schema("integer", "Latest reconciliation timestamp."),

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/testing.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/testing.rs
@@ -1,7 +1,7 @@
 use serde_json::{json, Value};
 
 use super::common::{
-    cargo_test_count_assertion_schema, nullable_schema, open_object_schema,
+    cargo_test_count_assertion_schema, job_activity_schema, nullable_schema, open_object_schema,
     permission_decision_schema, schema_type, session_hint_schema,
 };
 
@@ -109,6 +109,7 @@ fn cargo_output_schema(tool_name: &str) -> Value {
                     "description": "Current opaque observation token for the exact public Job snapshot returned by a promoted validation handoff."
                 }),
             ),
+            ("activity", job_activity_schema()),
             (
                 "promoted_to_job",
                 schema_type("boolean", "True only when the validation was promoted to a Job and the same command continues running."),
@@ -252,7 +253,7 @@ fn cargo_output_schema(tool_name: &str) -> Value {
                             "project", "command_summary", "cwd", "shell", "executor",
                             "execution_source", "purpose", "promoted_to_job", "terminal",
                             "command_started", "command_completed", "execution_state", "job_id",
-                            "job_status", "observation_token", "effective_timeout_secs", "sync_wait_secs",
+                            "job_status", "observation_token", "activity", "effective_timeout_secs", "sync_wait_secs",
                             "stdout_tail", "stderr_tail", "stdout_lines", "stderr_lines",
                             "stdout_truncated", "stderr_truncated"
                         ],

--- a/crates/webcodex-tool-contracts/src/tool_definition/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/jobs.rs
@@ -320,7 +320,7 @@ pub(super) const EXECUTION_DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Observe 1 to 8 Jobs with bounded baseline/delta logs and isolated errors. Return each opaque token unchanged for compact follow-ups. Optionally wait once for any change; never launches, retries, stops, or subscribes.",
+            "Observe 1 to 8 existing Jobs with bounded baseline/delta logs and isolated item errors. Optionally performs one shared wait for the batch and returns when any relevant Job changes; final items are non-waiting snapshots. Return each opaque observation token unchanged on follow-up. This tool only observes: it never launches, retries, stops, or subscribes to Jobs.",
             observe_jobs_input_schema,
         ),
         80,

--- a/src/project_entry_tests.rs
+++ b/src/project_entry_tests.rs
@@ -602,6 +602,7 @@ async fn complete_project_job(
                 current_step: None,
                 failed_step: None,
             }),
+            activity: None,
             finished: true,
         })
         .await

--- a/src/runner_quic.rs
+++ b/src/runner_quic.rs
@@ -1137,6 +1137,7 @@ mod tests {
                     error: None,
                     command_execution_state: None,
                     validation_progress: None,
+                    activity: None,
                     finished: false,
                 },
             },

--- a/src/runtime_http/tests/import_http_tests.rs
+++ b/src/runtime_http/tests/import_http_tests.rs
@@ -13,6 +13,31 @@ const IMPORT_TEST_AGENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const IMPORT_TEST_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
 const IMPORT_TEST_SERVER_IO_TIMEOUT: Duration = Duration::from_secs(30);
 
+fn run_import_http_in_large_stack_test_thread<F, Fut>(test: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()>,
+{
+    // The host-ref artifact import fixture retains the HTTP/import runtime and
+    // upload protocol state across several awaits. Keep that integration stack
+    // local to the test instead of requiring a suite-wide RUST_MIN_STACK.
+    let result = std::thread::Builder::new()
+        .name("runtime-http-import-test".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build isolated runtime HTTP import test runtime")
+                .block_on(test());
+        })
+        .expect("spawn isolated runtime HTTP import test thread")
+        .join();
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 async fn lock_import_http_test() -> tokio::sync::MutexGuard<'static, ()> {
     tokio::time::timeout(
         IMPORT_TEST_LOCK_TIMEOUT,
@@ -425,8 +450,7 @@ async fn import_http_accepts_office_mime_and_extension_policy() {
     }
 }
 
-#[tokio::test]
-async fn runtime_conversation_import_host_ref_saves_pptx_through_artifact_path() {
+async fn runtime_conversation_import_host_ref_saves_pptx_through_artifact_path_body() {
     use crate::auth::{AuthContext, AuthKind};
     use crate::runner_protocol::RunnerCapabilities;
     use crate::tool_runtime::kernel::{
@@ -522,6 +546,13 @@ async fn runtime_conversation_import_host_ref_saves_pptx_through_artifact_path()
         std::fs::read(tmp.path().join("paper/export/import-test.pptx")).unwrap(),
         pptx
     );
+}
+
+#[test]
+fn runtime_conversation_import_host_ref_saves_pptx_through_artifact_path() {
+    run_import_http_in_large_stack_test_thread(|| {
+        runtime_conversation_import_host_ref_saves_pptx_through_artifact_path_body()
+    });
 }
 
 #[tokio::test]

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -1104,13 +1104,14 @@ impl ToolRuntime {
             latest_status.as_str(),
             observation.job.started_at.is_some(),
         );
-        let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
+        let detected_summary = crate::tool_runtime::jobs::detected_job_summary_with_activity(
             Some(&handoff.command_summary),
             Some(&handoff.purpose),
             &latest_status,
             observation.job.exit_code.map(i64::from),
             &observation.stdout_tail,
             &observation.stderr_tail,
+            observation.job.activity.as_ref(),
         );
         let payload = json!({
             "execution_source": handoff.execution_source,
@@ -1119,6 +1120,7 @@ impl ToolRuntime {
             "job_id": handoff.job_id,
             "job_status": latest_status,
             "observation_token": observation_token,
+            "activity": observation.job.activity,
             "promoted_to_job": true,
             "command_started": command_started,
             "command_completed": false,

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -9,6 +9,7 @@ use super::{ExecutionPurpose, ExecutionShell, ToolRuntime};
 use crate::auth::AuthContext;
 use crate::runner_http::{command_preview, ShellJobStartMetadata, COMMAND_PREVIEW_MAX_CHARS};
 use crate::runner_protocol::{
+    ShellJobActivity, ShellJobActivityPhase, ShellJobActivitySource, ShellJobActivityState,
     ShellJobInfo, ShellJobOpRequest, ShellJobStructuredExecutionMetadata, ShellJobValidationStep,
 };
 
@@ -37,6 +38,68 @@ pub(crate) fn detected_job_summary(
     exit_code: Option<i64>,
     stdout: &str,
     stderr: &str,
+) -> Value {
+    detected_job_summary_with_activity(
+        command_summary,
+        purpose,
+        status,
+        exit_code,
+        stdout,
+        stderr,
+        None,
+    )
+}
+
+fn activity_progress_projection(activity: &ShellJobActivity) -> Value {
+    let state = match activity.state {
+        ShellJobActivityState::Working => "working",
+        ShellJobActivityState::Waiting => "waiting",
+    };
+    let (reason_code, summary) = match activity.phase {
+        ShellJobActivityPhase::ProcessRunning => {
+            ("process_running", "Process execution in progress")
+        }
+        ShellJobActivityPhase::ValidationFormat => (
+            "validation_format",
+            "Structured format validation in progress",
+        ),
+        ShellJobActivityPhase::ValidationCheck => (
+            "validation_check",
+            "Structured check validation in progress",
+        ),
+        ShellJobActivityPhase::ValidationTest => {
+            ("validation_test", "Structured test validation in progress")
+        }
+        ShellJobActivityPhase::CargoWaitingForBuildLock => (
+            "cargo_waiting_for_build_lock",
+            "Waiting for Cargo build lock",
+        ),
+        ShellJobActivityPhase::CargoCompiling => {
+            ("cargo_compiling", "Cargo compilation in progress")
+        }
+        ShellJobActivityPhase::CargoChecking => ("cargo_checking", "Cargo checking in progress"),
+    };
+    let source = match activity.source {
+        ShellJobActivitySource::RunnerExecution => "runner_execution",
+        ShellJobActivitySource::ValidationPlan => "validation_plan",
+        ShellJobActivitySource::CargoOutput => "cargo_output",
+    };
+    json!({
+        "state": state,
+        "reason_code": reason_code,
+        "summary": summary,
+        "source": source,
+    })
+}
+
+pub(crate) fn detected_job_summary_with_activity(
+    command_summary: Option<&str>,
+    purpose: Option<&str>,
+    status: &str,
+    exit_code: Option<i64>,
+    stdout: &str,
+    stderr: &str,
+    activity: Option<&ShellJobActivity>,
 ) -> Value {
     let normalized = command_summary
         .unwrap_or_default()
@@ -75,7 +138,9 @@ pub(crate) fn detected_job_summary(
     if outcome == "in_progress" {
         let lower = format!("{stdout}\n{stderr}").to_ascii_lowercase();
         let cargo_command = normalized == "cargo" || normalized.starts_with("cargo ");
-        let progress = if cargo_command && lower.contains("blocking waiting for file lock") {
+        let progress = if let Some(activity) = activity {
+            Some(activity_progress_projection(activity))
+        } else if cargo_command && lower.contains("blocking waiting for file lock") {
             Some(json!({
                 "state": "waiting",
                 "reason_code": "cargo_build_lock",
@@ -124,7 +189,10 @@ pub(crate) fn detected_job_summary(
 
 #[cfg(test)]
 mod detected_summary_tests {
-    use super::detected_job_summary;
+    use super::{detected_job_summary, detected_job_summary_with_activity};
+    use crate::shell_protocol::{
+        ShellJobActivity, ShellJobActivityPhase, ShellJobActivitySource, ShellJobActivityState,
+    };
 
     #[test]
     fn cargo_progress_is_advisory_and_command_scoped() {
@@ -158,6 +226,30 @@ mod detected_summary_tests {
             "",
         );
         assert!(unrelated.get("progress").is_none());
+    }
+
+    #[test]
+    fn structured_activity_takes_precedence_over_conflicting_log_heuristics() {
+        let activity = ShellJobActivity {
+            state: ShellJobActivityState::Waiting,
+            phase: ShellJobActivityPhase::CargoWaitingForBuildLock,
+            source: ShellJobActivitySource::CargoOutput,
+        };
+        let detected = detected_job_summary_with_activity(
+            Some("cargo check -p webcodex"),
+            Some("validation"),
+            "running",
+            None,
+            "",
+            "Checking webcodex v0.3.9\n",
+            Some(&activity),
+        );
+        assert_eq!(detected["progress"]["state"], "waiting");
+        assert_eq!(
+            detected["progress"]["reason_code"],
+            "cargo_waiting_for_build_lock"
+        );
+        assert_eq!(detected["progress"]["source"], "cargo_output");
     }
 }
 
@@ -484,6 +576,7 @@ pub(crate) fn agent_job_summary_value(job: &ShellJobInfo) -> Value {
         "exit_code": job.exit_code,
         "command_execution_state": job.command_execution_state,
         "structured_execution": model_facing_structured_execution_metadata(job.structured_execution.as_ref()),
+        "activity": job.activity,
         "recovery_state": job.recovery_state,
         "recovered_after_server_restart": job.recovered_after_server_restart,
         "reconciled_at": job.reconciled_at,
@@ -1010,6 +1103,7 @@ impl ToolRuntime {
                     "error": job.error,
                     "command_execution_state": job.command_execution_state,
                     "structured_execution": model_facing_structured_execution_metadata(job.structured_execution.as_ref()),
+                    "activity": job.activity,
                     "recovery_state": job.recovery_state,
                     "recovered_after_server_restart": job.recovered_after_server_restart,
                     "reconciled_at": job.reconciled_at,
@@ -1152,13 +1246,14 @@ impl ToolRuntime {
                 let stderr = stderr.unwrap_or_default();
                 let command_summary = job.command_preview.clone();
                 let purpose = job.purpose.clone().unwrap_or_else(|| "other".to_string());
-                let detected_summary = detected_job_summary(
+                let detected_summary = detected_job_summary_with_activity(
                     Some(&command_summary),
                     Some(&purpose),
                     &job.status,
                     job.exit_code.map(i64::from),
                     &wait.analysis_stdout,
                     &wait.analysis_stderr,
+                    job.activity.as_ref(),
                 );
                 let validation_tool = job
                     .validation
@@ -1194,6 +1289,7 @@ impl ToolRuntime {
                     "exit_code": job.exit_code,
                     "command_execution_state": job.command_execution_state,
                     "structured_execution": model_facing_structured_execution_metadata(job.structured_execution.as_ref()),
+                    "activity": job.activity,
                     "stdout_tail": stdout,
                     "stderr_tail": stderr,
                     "stdout_lines": next_stdout_line.saturating_sub(1),
@@ -2152,6 +2248,7 @@ mod recovery_projection_tests {
             codex: None,
             result: None,
             validation_progress: None,
+            activity: None,
             validation: None,
             recovery_state: None,
             recovered_after_server_restart: false,
@@ -2202,6 +2299,7 @@ mod recovery_projection_tests {
             codex: None,
             result: None,
             validation_progress: None,
+            activity: None,
             validation: None,
             recovery_state: Some("lost_after_reconcile".to_string()),
             recovered_after_server_restart: true,

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -190,7 +190,7 @@ pub(crate) fn detected_job_summary_with_activity(
 #[cfg(test)]
 mod detected_summary_tests {
     use super::{detected_job_summary, detected_job_summary_with_activity};
-    use crate::shell_protocol::{
+    use crate::runner_protocol::{
         ShellJobActivity, ShellJobActivityPhase, ShellJobActivitySource, ShellJobActivityState,
     };
 

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -85,8 +85,9 @@ pub(crate) mod validation_parser;
 pub(crate) mod validation_profile;
 
 /// Hard repository ceiling for model-facing ToolSpec and OpenAPI operation descriptions.
-/// Prefer 300 characters or fewer when semantics remain complete; brevity must not
-/// remove required authority, retry, continuation, uncertainty, safety, or recovery semantics.
+/// Keep descriptions accurate, self-contained, and reasonably concise; use the full budget when
+/// needed to preserve selection, authority, effect, retry, continuation, uncertainty, safety, or
+/// recovery semantics.
 #[cfg(test)]
 pub(crate) const MODEL_TOOL_DESCRIPTION_MAX_CHARS: usize = 600;
 

--- a/src/tool_runtime/observe_jobs.rs
+++ b/src/tool_runtime/observe_jobs.rs
@@ -96,11 +96,20 @@ fn observation_recovery(error_kind: &str) -> (RecoveryKind, Option<RecoveryTool>
 
 fn batch_item(observed: ObservedJob) -> Value {
     if observed.result.success {
+        let mut output = observed.result.output;
+        if let Some(output) = output.as_object_mut() {
+            // observe_jobs owns one shared wait for the batch. The final item
+            // refreshes are snapshots only; leaking job_log's internal
+            // non-waiting metadata would present a second, contradictory wait
+            // fact to the model.
+            output.remove("wait_outcome");
+            output.remove("waited_ms");
+        }
         json!({
             "index": observed.index,
             "job_id": observed.job_id,
             "success": true,
-            "output": observed.result.output,
+            "output": output,
             "error_kind": null,
             "error": null,
         })
@@ -168,8 +177,10 @@ fn batch_output(
         "succeeded_count": succeeded_count,
         "failed_count": returned_count - succeeded_count,
         "items": items,
-        "wake_reason": wake_reason.as_str(),
-        "waited_ms": waited_ms,
+        "wait": {
+            "outcome": wake_reason.as_str(),
+            "waited_ms": waited_ms,
+        },
         "changed_count": changed_count,
         "terminal_count": terminal_count,
         "output_truncated": output_truncated,
@@ -533,6 +544,8 @@ mod tests {
             "error": null,
         });
         let output = apply_output_budget(1, vec![item], WakeReason::Immediate, 0).unwrap();
+        assert_eq!(output["wait"]["outcome"], "immediate");
+        assert_eq!(output["wait"]["waited_ms"], 0);
         assert_eq!(output["returned_count"], 1);
         assert_eq!(output["items"][0]["success"], false);
         assert_eq!(output["items"][0]["error_kind"], "output_budget_exceeded");
@@ -570,6 +583,7 @@ mod tests {
         assert_eq!(output["returned_count"], 2);
         assert_eq!(output["output_truncated"], true);
         assert_eq!(output["next_index"], 2);
+        assert_eq!(output["wait"]["outcome"], "immediate");
         assert!(
             serde_json::to_vec(&ToolResult::ok(output)).unwrap().len()
                 <= MAX_SERIALIZED_OUTPUT_BYTES

--- a/src/tool_runtime/process.rs
+++ b/src/tool_runtime/process.rs
@@ -793,14 +793,16 @@ impl ToolRuntime {
                     execution_state,
                     command_started,
                 }) => {
-                    let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
-                        Some(&summary),
-                        Some(declared_purpose.as_str()),
-                        &observation.job.status,
-                        observation.job.exit_code.map(i64::from),
-                        &observation.stdout_tail,
-                        &observation.stderr_tail,
-                    );
+                    let detected_summary =
+                        crate::tool_runtime::jobs::detected_job_summary_with_activity(
+                            Some(&summary),
+                            Some(declared_purpose.as_str()),
+                            &observation.job.status,
+                            observation.job.exit_code.map(i64::from),
+                            &observation.stdout_tail,
+                            &observation.stderr_tail,
+                            observation.job.activity.as_ref(),
+                        );
                     ToolResult::ok(json!({
                         "execution_state": execution_state,
                         "command_started": command_started,
@@ -814,6 +816,7 @@ impl ToolRuntime {
                         "job_id": observation.job.job_id,
                         "job_status": observation.job.status,
                         "observation_token": observation.job.observation_token,
+                        "activity": observation.job.activity,
                         "effective_timeout_secs": timeout,
                         "sync_wait_secs": budget.sync_wait_secs,
                         "async_handoff_available": true,

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -1521,6 +1521,7 @@ mod phase_e2_status_tests {
                 codex: None,
                 result: None,
                 validation_progress: None,
+                activity: None,
                 validation: None,
                 recovery_state: None,
                 recovered_after_server_restart: false,

--- a/src/tool_runtime/script.rs
+++ b/src/tool_runtime/script.rs
@@ -244,14 +244,16 @@ impl ToolRuntime {
                     execution_state,
                     command_started,
                 }) => {
-                    let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
-                        Some(&summary),
-                        Some(declared_purpose.as_str()),
-                        &observation.job.status,
-                        observation.job.exit_code.map(i64::from),
-                        &observation.stdout_tail,
-                        &observation.stderr_tail,
-                    );
+                    let detected_summary =
+                        crate::tool_runtime::jobs::detected_job_summary_with_activity(
+                            Some(&summary),
+                            Some(declared_purpose.as_str()),
+                            &observation.job.status,
+                            observation.job.exit_code.map(i64::from),
+                            &observation.stdout_tail,
+                            &observation.stderr_tail,
+                            observation.job.activity.as_ref(),
+                        );
                     ToolResult::ok(json!({
                         "execution_state": execution_state,
                         "command_started": command_started,
@@ -265,6 +267,7 @@ impl ToolRuntime {
                         "job_id": observation.job.job_id,
                         "job_status": observation.job.status,
                         "observation_token": observation.job.observation_token,
+                        "activity": observation.job.activity,
                         "effective_timeout_secs": timeout,
                         "sync_wait_secs": budget.sync_wait_secs,
                         "async_handoff_available": true,

--- a/src/tool_runtime/shell.rs
+++ b/src/tool_runtime/shell.rs
@@ -647,13 +647,14 @@ impl ToolRuntime {
                         execution_state,
                         command_started,
                     }) => {
-                        let detected_summary = crate::tool_runtime::jobs::detected_job_summary(
+                        let detected_summary = crate::tool_runtime::jobs::detected_job_summary_with_activity(
                             Some(&command_summary),
                             Some(declared_purpose.as_str()),
                             &observation.job.status,
                             observation.job.exit_code.map(i64::from),
                             &observation.stdout_tail,
                             &observation.stderr_tail,
+                            observation.job.activity.as_ref(),
                         );
                         ToolResult::ok(json!({
                         "execution_state": execution_state,
@@ -668,6 +669,7 @@ impl ToolRuntime {
                         "job_id": observation.job.job_id,
                         "job_status": observation.job.status,
                         "observation_token": observation.job.observation_token,
+                        "activity": observation.job.activity,
                         "effective_timeout_secs": timeout,
                         "sync_wait_secs": STRUCTURED_EXECUTION_SYNC_WAIT_SECS,
                         "async_handoff_available": true,

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -405,6 +405,8 @@ async fn long_run_shell_hands_off_same_job_once_and_status_log_stop_observe_it()
     assert_eq!(result.output["shell"], "bash");
     assert_eq!(result.output["cwd"], ".");
     assert!(result.output["observation_token"].is_string());
+    assert!(result.output.as_object().unwrap().contains_key("activity"));
+    assert!(result.output["activity"].is_null());
     assert_run_shell_result_matches_schema(&result);
     assert!(
         probe_patch_agent_request(&runtime, client_id)
@@ -437,16 +439,49 @@ async fn long_run_shell_hands_off_same_job_once_and_status_log_stop_observe_it()
     assert!(status.success, "{:?}", status.error);
     assert_eq!(status.output["job_id"], job_id);
     assert_eq!(status.output["status"], "running");
+    assert!(status.output.as_object().unwrap().contains_key("activity"));
+    assert!(status.output["activity"].is_null());
 
     let log = runtime
         .job_log_for_auth(job_id.clone(), None, Some(40), Some(&auth), None, None)
         .await;
     assert!(log.success, "{:?}", log.error);
     assert_eq!(log.output["job_id"], job_id);
+    assert!(log.output.as_object().unwrap().contains_key("activity"));
+    assert!(log.output["activity"].is_null());
     assert!(log.output["stdout_tail"]
         .as_str()
         .unwrap_or_default()
         .contains("durable-shell"));
+
+    let listed = runtime
+        .list_jobs_for_auth_with_filters(None, None, None, None, Some(&auth))
+        .await;
+    assert!(listed.success, "{:?}", listed.error);
+    let listed_job = listed.output["jobs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|job| job["job_id"] == job_id)
+        .expect("durable shell Job in list_jobs");
+    assert!(listed_job.as_object().unwrap().contains_key("activity"));
+    assert!(listed_job["activity"].is_null());
+
+    let observed = runtime
+        .observe_jobs_for_auth(
+            vec![ObserveJobsItem {
+                job_id: job_id.clone(),
+                after_observation_token: None,
+            }],
+            40,
+            None,
+            Some(&auth),
+        )
+        .await;
+    assert!(observed.success, "{:?}", observed.error);
+    let observed_job = &observed.output["items"][0]["output"];
+    assert!(observed_job.as_object().unwrap().contains_key("activity"));
+    assert!(observed_job["activity"].is_null());
 
     let stopped = runtime
         .dispatch_with_auth(

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -279,6 +279,7 @@ async fn update_agent_shell_job(
             error: error.map(str::to_string),
             command_execution_state,
             validation_progress: None,
+            activity: None,
             finished,
         })
         .await
@@ -1642,6 +1643,7 @@ async fn mark_next_agent_job_running(runtime: &ToolRuntime, client_id: &str) -> 
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -2,7 +2,11 @@
 
 use super::super::*;
 use super::support::*;
-use crate::runner_protocol::RunnerCapabilities;
+use crate::runner_protocol::{
+    RunnerCapabilities, RunnerJobUpdateRequest, RunnerRequest, ShellJobActivity,
+    ShellJobActivityPhase,
+    ShellJobActivitySource, ShellJobActivityState,
+};
 use serde_json::json;
 use std::time::{Duration, Instant};
 
@@ -47,6 +51,69 @@ async fn register_and_start_agent_job(
     let request = wait_for_patch_agent_request(runtime, client_id).await;
     assert_eq!(request.job_id.as_deref(), Some(job_id.as_str()));
     (job_id, request, auth)
+}
+
+fn process_activity() -> ShellJobActivity {
+    ShellJobActivity {
+        state: ShellJobActivityState::Working,
+        phase: ShellJobActivityPhase::ProcessRunning,
+        source: ShellJobActivitySource::RunnerExecution,
+    }
+}
+
+async fn update_observed_job(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    request: &RunnerRequest,
+    status: &str,
+    stdout_chunk: Option<&str>,
+    activity: Option<ShellJobActivity>,
+    finished: bool,
+) {
+    runtime
+        .runner_registry
+        .update_job(RunnerJobUpdateRequest {
+            client_id: client_id.to_string(),
+            runner_instance_id: "inst".to_string(),
+            update_seq: None,
+            job_id: request.job_id.clone().expect("Job request id"),
+            request_id: Some(request.request_id.clone()),
+            status: status.to_string(),
+            stdout_chunk: stdout_chunk.map(str::to_string),
+            stderr_chunk: None,
+            stdout_tail: None,
+            stderr_tail: None,
+            log_snapshot: None,
+            exit_code: finished.then_some(0),
+            duration_ms: finished.then_some(25),
+            error: None,
+            command_execution_state: None,
+            validation_progress: None,
+            activity,
+            finished,
+        })
+        .await
+        .unwrap();
+}
+
+async fn observation_token(
+    runtime: &ToolRuntime,
+    job_id: &str,
+    auth: &crate::auth::AuthContext,
+) -> String {
+    runtime
+        .job_log_for_auth(job_id.to_string(), None, Some(40), Some(auth), None, None)
+        .await
+        .output["observation_token"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+fn assert_item_has_no_wait_metadata(item: &serde_json::Value) {
+    let output = item["output"].as_object().expect("successful Job snapshot");
+    assert!(!output.contains_key("wait_outcome"));
+    assert!(!output.contains_key("waited_ms"));
 }
 
 async fn start_owned_agent_job(
@@ -207,12 +274,16 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
         spec.input_schema["properties"]["items"]["items"]["additionalProperties"],
         false
     );
+    let output = &spec.output_schema["properties"]["output"]["anyOf"][0];
     assert_eq!(
-        spec.output_schema["properties"]["output"]["anyOf"][0]["properties"]["wake_reason"]["enum"],
+        output["properties"]["wait"]["properties"]["outcome"]["enum"],
         json!(["immediate", "updated", "terminal", "item_error", "timeout"])
     );
-    let observation = &spec.output_schema["properties"]["output"]["anyOf"][0]["properties"]
-        ["items"]["items"]["properties"]["output"]["anyOf"][0];
+    assert!(output["properties"].get("wake_reason").is_none());
+    assert!(output["properties"].get("waited_ms").is_none());
+    let observation = &output["properties"]["items"]["items"]["properties"]["output"]["anyOf"][0];
+    assert!(observation["properties"].get("wait_outcome").is_none());
+    assert!(observation["properties"].get("waited_ms").is_none());
     assert_eq!(
         observation["properties"]["log_delta_status"]["enum"],
         json!(["baseline", "delta", "unchanged", "reset"])
@@ -356,6 +427,9 @@ async fn observe_jobs_mixed_success_result_matches_declared_output_schema_and_en
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["succeeded_count"], 1);
     assert_eq!(result.output["failed_count"], 1);
+    assert_eq!(result.output["wait"]["outcome"], "item_error");
+    assert_eq!(result.output["wait"]["waited_ms"], 0);
+    assert_item_has_no_wait_metadata(&result.output["items"][0]);
     assert!(probe_patch_agent_request(&runtime, "observe-no-enqueue")
         .await
         .is_none());
@@ -366,6 +440,226 @@ async fn observe_jobs_mixed_success_result_matches_declared_output_schema_and_en
         super::super::startup_brief::validate_schema_instance_for_test(&value, &schema).is_ok(),
         "mixed observe_jobs result did not satisfy output schema: {value}"
     );
+}
+
+#[tokio::test]
+async fn observe_jobs_missing_baseline_is_immediate_and_projects_activity_without_item_wait() {
+    let runtime = test_runtime();
+    let (job_id, request, auth) = register_and_start_agent_job(&runtime, "observe-immediate").await;
+    update_observed_job(
+        &runtime,
+        "observe-immediate",
+        &request,
+        "running",
+        None,
+        Some(process_activity()),
+        false,
+    )
+    .await;
+
+    let result = runtime
+        .dispatch_with_auth(
+            ToolCall::ObserveJobs {
+                items: vec![item(&job_id, None)],
+                tail_lines: 40,
+                wait_secs: Some(60),
+            },
+            Some(&auth),
+        )
+        .await;
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["wait"]["outcome"], "immediate");
+    assert_eq!(result.output["wait"]["waited_ms"], 0);
+    assert_eq!(result.output["items"][0]["output"]["status"], "running");
+    assert_eq!(
+        result.output["items"][0]["output"]["activity"],
+        serde_json::to_value(process_activity()).unwrap()
+    );
+    assert_item_has_no_wait_metadata(&result.output["items"][0]);
+}
+
+#[tokio::test]
+async fn observe_jobs_timeout_waits_once_for_multiple_active_jobs() {
+    let runtime = test_runtime();
+    let (job_a, request_a, auth) =
+        register_and_start_agent_job(&runtime, "observe-timeout-a").await;
+    let (job_b, request_b, _) = register_and_start_agent_job(&runtime, "observe-timeout-b").await;
+    let (job_c, request_c, _) = register_and_start_agent_job(&runtime, "observe-timeout-c").await;
+    for (client, request) in [
+        ("observe-timeout-a", &request_a),
+        ("observe-timeout-b", &request_b),
+        ("observe-timeout-c", &request_c),
+    ] {
+        update_observed_job(
+            &runtime,
+            client,
+            request,
+            "running",
+            None,
+            Some(process_activity()),
+            false,
+        )
+        .await;
+    }
+    let token_a = observation_token(&runtime, &job_a, &auth).await;
+    let token_b = observation_token(&runtime, &job_b, &auth).await;
+    let token_c = observation_token(&runtime, &job_c, &auth).await;
+
+    let started = Instant::now();
+    let result = runtime
+        .dispatch_with_auth(
+            ToolCall::ObserveJobs {
+                items: vec![
+                    item(&job_a, Some(token_a)),
+                    item(&job_b, Some(token_b)),
+                    item(&job_c, Some(token_c)),
+                ],
+                tail_lines: 40,
+                wait_secs: Some(1),
+            },
+            Some(&auth),
+        )
+        .await;
+    let elapsed = started.elapsed();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["wait"]["outcome"], "timeout");
+    assert!(result.output["wait"]["waited_ms"].as_u64().unwrap() > 0);
+    assert!(
+        elapsed < Duration::from_millis(2500),
+        "three Jobs must share one ~1s wait instead of multiplying it: {elapsed:?}"
+    );
+    assert_eq!(result.output["items"].as_array().unwrap().len(), 3);
+    for item in result.output["items"].as_array().unwrap() {
+        assert_eq!(item["output"]["status"], "running");
+        assert_item_has_no_wait_metadata(item);
+    }
+}
+
+#[tokio::test]
+async fn observe_jobs_one_item_update_wakes_shared_wait_and_refreshes_all_snapshots() {
+    let runtime = test_runtime();
+    let (job_a, request_a, auth) = register_and_start_agent_job(&runtime, "observe-update-a").await;
+    let (job_b, request_b, _) = register_and_start_agent_job(&runtime, "observe-update-b").await;
+    update_observed_job(
+        &runtime,
+        "observe-update-a",
+        &request_a,
+        "running",
+        None,
+        Some(process_activity()),
+        false,
+    )
+    .await;
+    update_observed_job(
+        &runtime,
+        "observe-update-b",
+        &request_b,
+        "running",
+        None,
+        Some(process_activity()),
+        false,
+    )
+    .await;
+    let token_a = observation_token(&runtime, &job_a, &auth).await;
+    let token_b = observation_token(&runtime, &job_b, &auth).await;
+
+    let waiting_runtime = runtime.clone();
+    let waiting_auth = auth.clone();
+    let waiting_a = job_a.clone();
+    let waiting_b = job_b.clone();
+    let task = tokio::spawn(async move {
+        waiting_runtime
+            .dispatch_with_auth(
+                ToolCall::ObserveJobs {
+                    items: vec![
+                        item(&waiting_a, Some(token_a)),
+                        item(&waiting_b, Some(token_b)),
+                    ],
+                    tail_lines: 40,
+                    wait_secs: Some(5),
+                },
+                Some(&waiting_auth),
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(75)).await;
+    update_observed_job(
+        &runtime,
+        "observe-update-b",
+        &request_b,
+        "running",
+        Some("second changed\n"),
+        Some(process_activity()),
+        false,
+    )
+    .await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["wait"]["outcome"], "updated");
+    assert!(result.output["wait"]["waited_ms"].as_u64().unwrap() < 5_000);
+    assert_eq!(result.output["items"][0]["output"]["status"], "running");
+    assert_eq!(result.output["items"][1]["output"]["status"], "running");
+    assert_eq!(result.output["items"][1]["output"]["changed"], true);
+    assert!(result.output["items"][1]["output"]["stdout_tail"]
+        .as_str()
+        .unwrap()
+        .contains("second changed"));
+    for item in result.output["items"].as_array().unwrap() {
+        assert_item_has_no_wait_metadata(item);
+    }
+}
+
+#[tokio::test]
+async fn observe_jobs_terminal_transition_wakes_shared_wait() {
+    let runtime = test_runtime();
+    let (job_id, request, auth) = register_and_start_agent_job(&runtime, "observe-terminal").await;
+    update_observed_job(
+        &runtime,
+        "observe-terminal",
+        &request,
+        "running",
+        None,
+        Some(process_activity()),
+        false,
+    )
+    .await;
+    let token = observation_token(&runtime, &job_id, &auth).await;
+
+    let waiting_runtime = runtime.clone();
+    let waiting_auth = auth.clone();
+    let waiting_job = job_id.clone();
+    let task = tokio::spawn(async move {
+        waiting_runtime
+            .dispatch_with_auth(
+                ToolCall::ObserveJobs {
+                    items: vec![item(&waiting_job, Some(token))],
+                    tail_lines: 40,
+                    wait_secs: Some(5),
+                },
+                Some(&waiting_auth),
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(75)).await;
+    update_observed_job(
+        &runtime,
+        "observe-terminal",
+        &request,
+        "completed",
+        None,
+        None,
+        true,
+    )
+    .await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["wait"]["outcome"], "terminal");
+    assert_eq!(result.output["terminal_count"], 1);
+    assert_eq!(result.output["items"][0]["output"]["terminal"], true);
+    assert!(result.output["items"][0]["output"]["activity"].is_null());
+    assert_item_has_no_wait_metadata(&result.output["items"][0]);
 }
 
 #[test]

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -293,6 +293,7 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
         crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN
     );
     for required in [
+        "activity",
         "log_delta_status",
         "stdout_delta_reset",
         "stderr_delta_reset",
@@ -306,6 +307,11 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
             "observe_jobs item output must require {required}"
         );
     }
+    assert!(observation["properties"]["activity"]["anyOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|schema| schema["type"] == "null"));
 
     let definition = super::super::tool_definition::lookup_tool_definition("observe_jobs").unwrap();
     assert!(definition.visibility.is_model_visible());

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -4,8 +4,7 @@ use super::super::*;
 use super::support::*;
 use crate::runner_protocol::{
     RunnerCapabilities, RunnerJobUpdateRequest, RunnerRequest, ShellJobActivity,
-    ShellJobActivityPhase,
-    ShellJobActivitySource, ShellJobActivityState,
+    ShellJobActivityPhase, ShellJobActivitySource, ShellJobActivityState,
 };
 use serde_json::json;
 use std::time::{Duration, Instant};

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -4,8 +4,8 @@ use super::super::*;
 use super::support::*;
 use crate::runner_protocol::{
     RunnerCapabilities, RunnerJobUpdateRequest, RunnerResultPayload, RunnerResultRequest,
-    ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase,
-    ShellJobActivitySource, ShellJobActivityState,
+    ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase, ShellJobActivitySource,
+    ShellJobActivityState,
 };
 use crate::tool_runtime::kernel::{ToolCallContext, ToolCallRequest, ToolTransport};
 use serde_json::json;

--- a/src/tool_runtime/tests/process.rs
+++ b/src/tool_runtime/tests/process.rs
@@ -4,7 +4,8 @@ use super::super::*;
 use super::support::*;
 use crate::runner_protocol::{
     RunnerCapabilities, RunnerJobUpdateRequest, RunnerResultPayload, RunnerResultRequest,
-    ShellCommandExecutionState,
+    ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase,
+    ShellJobActivitySource, ShellJobActivityState,
 };
 use crate::tool_runtime::kernel::{ToolCallContext, ToolCallRequest, ToolTransport};
 use serde_json::json;
@@ -155,6 +156,13 @@ async fn update_process_job(
     stderr: Option<&str>,
     error: Option<&str>,
 ) {
+    let activity = (state.is_none() && matches!(status, "running" | "stop_requested")).then_some(
+        ShellJobActivity {
+            state: ShellJobActivityState::Working,
+            phase: ShellJobActivityPhase::ProcessRunning,
+            source: ShellJobActivitySource::RunnerExecution,
+        },
+    );
     runtime
         .runner_registry
         .update_job(RunnerJobUpdateRequest {
@@ -174,6 +182,7 @@ async fn update_process_job(
             error: error.map(str::to_string),
             command_execution_state: state,
             validation_progress: None,
+            activity,
             finished: state.is_some(),
         })
         .await
@@ -637,6 +646,11 @@ async fn detached_process_lost_initiation_after_server_restart_recovers_same_job
                     stdout: Default::default(),
                     stderr: Default::default(),
                     validation_progress: None,
+                    activity: Some(ShellJobActivity {
+                        state: ShellJobActivityState::Working,
+                        phase: ShellJobActivityPhase::ProcessRunning,
+                        source: ShellJobActivitySource::RunnerExecution,
+                    }),
                 }],
             }),
             coding_agent_providers: None,
@@ -1137,6 +1151,18 @@ async fn run_process_slow_handoff_is_queryable_once_and_keeps_the_original_budge
     assert_eq!(handoff.output["stdout_lines"], 1);
     assert_eq!(handoff.output["stdout_truncated"], false);
     assert_eq!(handoff.output["detected_summary"]["outcome"], "in_progress");
+    assert_eq!(
+        handoff.output["activity"],
+        json!({
+            "state": "working",
+            "phase": "process_running",
+            "source": "runner_execution"
+        })
+    );
+    assert_eq!(
+        handoff.output["detected_summary"]["progress"]["reason_code"],
+        "process_running"
+    );
     let job_id = handoff.output["job_id"].as_str().unwrap().to_string();
     assert_eq!(request.job_id.as_deref(), Some(job_id.as_str()));
 
@@ -1152,6 +1178,7 @@ async fn run_process_slow_handoff_is_queryable_once_and_keeps_the_original_budge
     assert!(status.success, "{:?}", status.error);
     assert_eq!(status.output["job_id"], job_id);
     assert_eq!(status.output["status"], "running");
+    assert_eq!(status.output["activity"], handoff.output["activity"]);
     assert!(status.output["command_execution_state"].is_null());
     assert_eq!(
         status.output["structured_execution"]["execution_source"],
@@ -1202,6 +1229,7 @@ async fn run_process_slow_handoff_is_queryable_once_and_keeps_the_original_budge
         .await;
     assert!(terminal.success, "{:?}", terminal.error);
     assert_eq!(terminal.output["status"], "completed");
+    assert!(terminal.output["activity"].is_null());
     assert_eq!(terminal.output["command_execution_state"], "completed");
     assert_eq!(
         terminal.output["structured_execution"]["execution_source"],

--- a/src/tool_runtime/tests/schema/spot_checks.rs
+++ b/src/tool_runtime/tests/schema/spot_checks.rs
@@ -195,6 +195,90 @@ fn tool_specs_structured_validation_schema_and_output() {
     );
 }
 
+fn schema_tree_requires_field(schema: &serde_json::Value, field: &str) -> bool {
+    match schema {
+        serde_json::Value::Object(object) => {
+            object.get("required").is_some_and(|required| {
+                required
+                    .as_array()
+                    .is_some_and(|required| required.iter().any(|name| name == field))
+            }) || object
+                .values()
+                .any(|value| schema_tree_requires_field(value, field))
+        }
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|value| schema_tree_requires_field(value, field)),
+        _ => false,
+    }
+}
+
+#[test]
+fn job_activity_is_required_nullable_on_stable_model_surfaces() {
+    let specs = registered_tool_specs();
+    for name in [
+        "run_process",
+        "run_script",
+        "run_shell",
+        "cargo_fmt",
+        "cargo_check",
+        "cargo_test",
+        "go_test",
+        "job_status",
+        "job_log",
+        "list_jobs",
+        "observe_jobs",
+    ] {
+        let spec = spec_named(&specs, name);
+        assert!(
+            schema_tree_requires_field(&spec.output_schema, "activity"),
+            "{name} must require activity on its stable Job projection"
+        );
+    }
+
+    for name in ["job_status", "job_log"] {
+        let spec = spec_named(&specs, name);
+        let activity = &spec.output_schema["properties"]["output"]["properties"]["activity"];
+        assert!(activity["anyOf"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|schema| schema["type"] == "null"));
+        let with_null = serde_json::json!({"success": true, "output": {"activity": null}});
+        crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+            &with_null,
+            &spec.output_schema,
+        )
+        .unwrap_or_else(|error| panic!("{name} must accept activity=null: {error}"));
+        let missing = serde_json::json!({"success": true, "output": {}});
+        assert!(
+            crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+                &missing,
+                &spec.output_schema
+            )
+            .is_err(),
+            "{name} must reject a missing activity field"
+        );
+    }
+
+    let list = spec_named(&specs, "list_jobs");
+    let summary = &list.output_schema["properties"]["output"]["properties"]["jobs"]["items"];
+    assert!(summary["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|field| field == "activity"));
+
+    let observe = spec_named(&specs, "observe_jobs");
+    let observation = &observe.output_schema["properties"]["output"]["anyOf"][0]["properties"]
+        ["items"]["items"]["properties"]["output"]["anyOf"][0];
+    assert!(observation["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|field| field == "activity"));
+}
+
 #[test]
 fn tool_specs_schema_spot_checks() {
     let cases: Vec<(&str, Vec<&str>, Vec<&str>)> = vec![

--- a/src/tool_runtime/tests/schema/spot_checks.rs
+++ b/src/tool_runtime/tests/schema/spot_checks.rs
@@ -259,6 +259,25 @@ fn job_activity_is_required_nullable_on_stable_model_surfaces() {
             .is_err(),
             "{name} must reject a missing activity field"
         );
+        let failure = serde_json::json!({
+            "success": false,
+            "output": {
+                "error_kind": "unknown_job",
+                "failure_kind": "job_not_found",
+                "job_id": "missing-job",
+                "state_changed": false,
+                "recovery_kind": "reobserve",
+                "recovery_tool": "list_jobs"
+            },
+            "error": "unknown job: missing-job"
+        });
+        crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+            &failure,
+            &spec.output_schema,
+        )
+        .unwrap_or_else(|error| {
+            panic!("{name} failure output must not require Job activity: {error}")
+        });
     }
 
     let list = spec_named(&specs, "list_jobs");

--- a/src/tool_runtime/tests/script.rs
+++ b/src/tool_runtime/tests/script.rs
@@ -131,6 +131,7 @@ async fn update_script_job(
             error: error.map(str::to_string),
             command_execution_state: state,
             validation_progress: None,
+            activity: None,
             finished: state.is_some(),
         })
         .await

--- a/src/tool_runtime/tests/startup_brief.rs
+++ b/src/tool_runtime/tests/startup_brief.rs
@@ -993,6 +993,7 @@ async fn startup_uses_project_scoped_lifecycle_aware_job_summary() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -1131,6 +1132,7 @@ async fn startup_uses_project_scoped_lifecycle_aware_job_summary() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await

--- a/src/tool_runtime/tests/support/runner.rs
+++ b/src/tool_runtime/tests/support/runner.rs
@@ -932,6 +932,7 @@ pub(in crate::tool_runtime::tests) async fn seed_session_projection_job(
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -980,6 +981,7 @@ pub(in crate::tool_runtime::tests) async fn finish_session_projection_job(
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await

--- a/src/tool_runtime/tests/validation_events.rs
+++ b/src/tool_runtime/tests/validation_events.rs
@@ -2149,6 +2149,7 @@ async fn completed_run_job_validation_enters_handoff_from_job_authority() {
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await
@@ -2283,6 +2284,7 @@ async fn promoted_run_process_cargo_test_materializes_canonical_validation_evide
             error: None,
             command_execution_state: Some(crate::runner_protocol::ShellCommandExecutionState::Completed),
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -2605,6 +2605,11 @@ fn cargo_output_schema_enforces_handoff_terminal_and_rejection_branches() {
             "job_id": "job-123",
             "job_status": "running",
             "observation_token": "observation",
+            "activity": {
+                "state": "working",
+                "phase": "validation_test",
+                "source": "validation_plan"
+            },
             "promoted_to_job": true,
             "command_started": true,
             "command_completed": false,
@@ -2629,6 +2634,7 @@ fn cargo_output_schema_enforces_handoff_terminal_and_rejection_branches() {
         ("passed", 4),
         ("timeout failure", 5),
         ("missing observation_token", 6),
+        ("missing activity", 7),
     ] {
         let mut invalid = handoff.clone();
         let output = invalid["output"].as_object_mut().unwrap();
@@ -2653,6 +2659,9 @@ fn cargo_output_schema_enforces_handoff_terminal_and_rejection_branches() {
             }
             6 => {
                 output.remove("observation_token");
+            }
+            7 => {
+                output.remove("activity");
             }
             _ => unreachable!(),
         }

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -12,8 +12,8 @@ use super::support::*;
 use crate::runner_http::{ShellJobStartMetadata, ShellJobVisibility};
 use crate::runner_protocol::{
     RunnerCapabilities, RunnerJobUpdateRequest, RunnerResultPayload, RunnerResultRequest,
-    ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase,
-    ShellJobActivitySource, ShellJobActivityState, ShellJobOpRequest, ShellJobValidationMetadata,
+    ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase, ShellJobActivitySource,
+    ShellJobActivityState, ShellJobOpRequest, ShellJobValidationMetadata,
     ShellJobValidationProgress, ShellJobValidationStep, JOB_INVENTORY_MAX_TERMINAL_JOBS,
 };
 use crate::tool_runtime::sessions::{SessionTransport, DEFAULT_MAX_EVENTS_PER_SESSION};

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -12,7 +12,8 @@ use super::support::*;
 use crate::runner_http::{ShellJobStartMetadata, ShellJobVisibility};
 use crate::runner_protocol::{
     RunnerCapabilities, RunnerJobUpdateRequest, RunnerResultPayload, RunnerResultRequest,
-    ShellCommandExecutionState, ShellJobOpRequest, ShellJobValidationMetadata,
+    ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase,
+    ShellJobActivitySource, ShellJobActivityState, ShellJobOpRequest, ShellJobValidationMetadata,
     ShellJobValidationProgress, ShellJobValidationStep, JOB_INVENTORY_MAX_TERMINAL_JOBS,
 };
 use crate::tool_runtime::sessions::{SessionTransport, DEFAULT_MAX_EVENTS_PER_SESSION};
@@ -107,6 +108,19 @@ fn cargo_test_update(
     progress: ShellJobValidationProgress,
     finished: bool,
 ) -> RunnerJobUpdateRequest {
+    let activity = progress
+        .current_step
+        .as_deref()
+        .map(|step| ShellJobActivity {
+            state: ShellJobActivityState::Working,
+            phase: match step {
+                "format" => ShellJobActivityPhase::ValidationFormat,
+                "check" => ShellJobActivityPhase::ValidationCheck,
+                "test" => ShellJobActivityPhase::ValidationTest,
+                other => panic!("unexpected validation step: {other}"),
+            },
+            source: ShellJobActivitySource::ValidationPlan,
+        });
     RunnerJobUpdateRequest {
         client_id: client_id.to_string(),
         runner_instance_id: "inst".to_string(),
@@ -124,6 +138,7 @@ fn cargo_test_update(
         error: None,
         command_execution_state: None,
         validation_progress: Some(progress),
+        activity,
         finished,
     }
 }
@@ -782,11 +797,23 @@ async fn long_cargo_check_hands_off_with_immediately_observable_token() {
         .is_some_and(|tail| tail.contains("Checking demo v0.1.0")));
     assert_eq!(
         result.output["detected_summary"]["progress"]["reason_code"],
-        "cargo_checking"
+        "validation_check"
     );
     assert_eq!(
         result.output["detected_summary"]["progress"]["state"],
         "working"
+    );
+    assert_eq!(
+        result.output["detected_summary"]["progress"]["source"],
+        "validation_plan"
+    );
+    assert_eq!(
+        result.output["activity"],
+        json!({
+            "state": "working",
+            "phase": "validation_check",
+            "source": "validation_plan"
+        })
     );
     assert_eq!(result.output["job_id"], job_id);
     let observation_token = result.output["observation_token"]
@@ -806,6 +833,10 @@ async fn long_cargo_check_hands_off_with_immediately_observable_token() {
         .await;
     assert!(observed.success, "{:?}", observed.error);
     assert_eq!(observed.output["items"][0]["success"], true);
+    assert_eq!(
+        observed.output["items"][0]["output"]["activity"],
+        result.output["activity"]
+    );
     assert_agent_observation_upgrades_without_changing_snapshot(
         &job_id,
         &observation_token,
@@ -885,6 +916,14 @@ async fn long_cargo_test_hands_off_to_queryable_job() {
     assert_eq!(result.output["promoted_to_job"], true);
     assert_eq!(result.output["execution_state"], "running");
     assert_eq!(result.output["job_status"], "running");
+    assert_eq!(
+        result.output["activity"],
+        json!({
+            "state": "working",
+            "phase": "validation_test",
+            "source": "validation_plan"
+        })
+    );
     assert_eq!(result.output["command_started"], true);
     assert_eq!(result.output["command_completed"], false);
     assert_eq!(result.output["effective_timeout_secs"], 1800);
@@ -910,6 +949,10 @@ async fn long_cargo_test_hands_off_to_queryable_job() {
         .await;
     assert!(observed.success, "{:?}", observed.error);
     assert_eq!(observed.output["items"][0]["success"], true);
+    assert_eq!(
+        observed.output["items"][0]["output"]["activity"],
+        result.output["activity"]
+    );
     assert_agent_observation_upgrades_without_changing_snapshot(
         &job_id,
         &observation_token,
@@ -925,6 +968,7 @@ async fn long_cargo_test_hands_off_to_queryable_job() {
     assert!(status.success);
     assert_eq!(status.output["status"], "running");
     assert_eq!(status.output["active"], true);
+    assert_eq!(status.output["activity"], result.output["activity"]);
     assert_eq!(status.output["validation"]["tool"], "cargo_test");
     assert_eq!(status.output["validation"]["kind"], "test");
     assert_eq!(status.output["validation"]["state"], "running");
@@ -936,6 +980,7 @@ async fn long_cargo_test_hands_off_to_queryable_job() {
         .as_str()
         .unwrap_or("")
         .contains("running 1 test"));
+    assert_eq!(log.output["activity"], result.output["activity"]);
     assert_eq!(log.output["validation"], status.output["validation"]);
     let observed = runtime
         .observe_jobs_for_auth(
@@ -949,6 +994,10 @@ async fn long_cargo_test_hands_off_to_queryable_job() {
         )
         .await;
     assert!(observed.success, "{:?}", observed.error);
+    assert_eq!(
+        observed.output["items"][0]["output"]["activity"],
+        result.output["activity"]
+    );
     assert_eq!(
         observed.output["items"][0]["output"]["validation"],
         log.output["validation"]

--- a/src/tool_runtime/tests/validation_identity.rs
+++ b/src/tool_runtime/tests/validation_identity.rs
@@ -140,6 +140,7 @@ async fn promoted_run_shell_preserves_assertion_identity_in_terminal_validation_
             error: None,
             command_execution_state: None,
             validation_progress: None,
+            activity: None,
             finished: false,
         })
         .await
@@ -170,6 +171,7 @@ async fn promoted_run_shell_preserves_assertion_identity_in_terminal_validation_
                 crate::runner_protocol::ShellCommandExecutionState::Completed,
             ),
             validation_progress: None,
+            activity: None,
             finished: true,
         })
         .await


### PR DESCRIPTION
## Summary

- add closed, bounded Runner-owned Job `activity` telemetry for active process and structured validation Jobs
- persist activity across silent periods and reconnect inventory while clearing it on terminal/recovery transitions
- constrain Cargo-derived activity to canonical structured validation steps and keep existing log heuristics as old-Runner fallback only
- simplify `observe_jobs` to one batch-level shared wait fact while preserving `job_log` per-Job wait metadata
- refresh repository/model-facing guidance without changing the 600-character hard ToolSpec description ceiling

## Reviewer follow-up

Independent review found that the real Runner `start_process_job` / `start_script_job` path set `status=running` but did not publish `process_running` activity; Server-level tests had been injecting that activity through a fixture. Commit `d84a3552` fixes the real Runner `on_started` emission and extends the Runner `JobManager` regression test to require `process_running` while active and `activity=None` after terminal completion.

## Validation

- `cargo test -p webcodex-runner phase_e2_default_four_gates_fifth_and_promotes_same_job_once` — 1 passed, 0 failed
- `cargo check --all-targets -p webcodex-runner` — passed; only the pre-existing `DetachedJobStore::state_path_for_job` dead-code warning remains
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

No deploy, restart, or merge performed.