### PR TITLE
Close post-extraction dependency edges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5319,7 +5319,6 @@ dependencies = [
  "tracing",
  "uuid",
  "webcodex-core",
- "webcodex-workflow-session",
 ]
 
 [[package]]
@@ -5337,7 +5336,6 @@ dependencies = [
  "tracing",
  "uuid",
  "webcodex-core",
- "webcodex-workspace",
 ]
 
 [[package]]

--- a/crates/webcodex-core/src/lib.rs
+++ b/crates/webcodex-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod job_observation;
 pub mod lsp_bridge;
 pub mod mcp_gateway;
 pub mod memory_contract;
+pub mod project_context_contract;
 pub mod project_instructions;
 pub mod project_listing;
 pub mod runner_protocol;

--- a/crates/webcodex-core/src/project_context_contract.rs
+++ b/crates/webcodex-core/src/project_context_contract.rs
@@ -1,0 +1,67 @@
+//! Durable, side-effect-free project-context fingerprint contracts.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectContextFingerprint {
+    pub schema_version: u32,
+    /// Hash of the canonical absolute project path. The path itself is never
+    /// serialized into continuity state.
+    pub project_root_sha256: String,
+    pub target_directory: String,
+    pub git: GitContextFingerprint,
+    pub rules: Vec<ContextFileFingerprint>,
+    pub manifests: Vec<ContextFileFingerprint>,
+    #[serde(default)]
+    pub completeness: FingerprintCompleteness,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FingerprintCompleteness {
+    #[serde(default = "default_true")]
+    pub complete: bool,
+    #[serde(default)]
+    pub partial_slices: Vec<String>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+impl Default for FingerprintCompleteness {
+    fn default() -> Self {
+        Self {
+            complete: true,
+            partial_slices: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitContextFingerprint {
+    pub available: bool,
+    pub branch: Option<String>,
+    pub head: Option<String>,
+    pub worktree_sha256: Option<String>,
+    pub dirty: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextFileFingerprint {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+    #[serde(default = "default_true")]
+    pub complete: bool,
+    #[serde(default = "default_full_hash_kind")]
+    pub hash_kind: String,
+    #[serde(default)]
+    pub modified_unix_nanos: Option<u64>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_full_hash_kind() -> String {
+    "full".to_string()
+}

--- a/crates/webcodex-core/src/validation_identity.rs
+++ b/crates/webcodex-core/src/validation_identity.rs
@@ -1,10 +1,15 @@
 //! Stable validation identity parsing used across audit and Workflow Session layers.
 
+use crate::runner_protocol::{
+    normalize_cargo_value, normalize_go_test_packages, normalize_rust_test_filter,
+    CARGO_TEST_MIN_TESTS_MAX,
+};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 const STRUCTURED_VALIDATION_TARGET_PREFIX: &str = "target:";
-const VALIDATION_IDENTITY_HEX_LEN: usize = 24;
-const GENERIC_VALIDATION_IDENTITY_PREFIX: &str = "command:";
+pub const VALIDATION_IDENTITY_HEX_LEN: usize = 24;
+pub const GENERIC_VALIDATION_IDENTITY_PREFIX: &str = "command:";
 const ASSERTION_VALIDATION_IDENTITY_PREFIX: &str = "assertion:";
 
 pub fn is_structured_validation_target_identity(value: &str) -> bool {
@@ -42,6 +47,153 @@ pub fn assertion_validation_identity(assertion_name: &str) -> String {
         "{ASSERTION_VALIDATION_IDENTITY_PREFIX}{}",
         &digest[..VALIDATION_IDENTITY_HEX_LEN]
     )
+}
+
+pub fn structured_validation_target_identity(tool_name: &str, arguments: &Value) -> Option<String> {
+    let obj = arguments.as_object()?;
+    let cwd = normalized_validation_target_cwd(obj.get("cwd"))?;
+    let semantic = match tool_name {
+        "cargo_fmt" => serde_json::json!({
+            "tool": tool_name,
+            "kind": "format",
+            "cwd": cwd,
+            "check": obj.get("check").and_then(Value::as_bool).unwrap_or(false),
+        }),
+        "cargo_check" => {
+            if obj.get("features_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("features").is_none()
+            {
+                return None;
+            }
+            let features = normalized_cargo_target_value(obj.get("features"))?;
+            let package = normalized_cargo_target_value(obj.get("package"))?;
+            serde_json::json!({
+                "tool": tool_name,
+                "kind": "check",
+                "cwd": cwd,
+                "package": package,
+                "features": features,
+                "all_targets": obj.get("all_targets").and_then(Value::as_bool).unwrap_or(true),
+                "all_features": obj.get("all_features").and_then(Value::as_bool).unwrap_or(false),
+                "no_default_features": obj.get("no_default_features").and_then(Value::as_bool).unwrap_or(false),
+            })
+        }
+        "cargo_test" => {
+            if obj.get("filter_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("filter").is_none()
+            {
+                return None;
+            }
+            if obj.get("features_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("features").is_none()
+            {
+                return None;
+            }
+            let filter = normalized_rust_test_target_filter(obj.get("filter"))?;
+            let features = normalized_cargo_target_value(obj.get("features"))?;
+            let package = normalized_cargo_target_value(obj.get("package"))?;
+            let require_tests = obj
+                .get("require_tests")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let min_tests = obj.get("min_tests").and_then(Value::as_u64);
+            if min_tests.is_some_and(|minimum| !(1..=CARGO_TEST_MIN_TESTS_MAX).contains(&minimum)) {
+                return None;
+            }
+            let minimum_tests = match (require_tests, min_tests) {
+                (true, Some(minimum)) => Some(minimum.max(1)),
+                (true, None) => Some(1),
+                (false, minimum) => minimum,
+            };
+            serde_json::json!({
+                "tool": tool_name,
+                "kind": "test",
+                "cwd": cwd,
+                "package": package,
+                "filter": filter,
+                "features": features,
+                "all_targets": obj.get("all_targets").and_then(Value::as_bool).unwrap_or(false),
+                "all_features": obj.get("all_features").and_then(Value::as_bool).unwrap_or(false),
+                "no_default_features": obj.get("no_default_features").and_then(Value::as_bool).unwrap_or(false),
+                "no_run": obj.get("no_run").and_then(Value::as_bool).unwrap_or(false),
+                "minimum_tests": minimum_tests,
+            })
+        }
+        "go_test" => {
+            if obj.get("packages_present").and_then(Value::as_bool) == Some(true)
+                && obj.get("packages").is_none()
+            {
+                return None;
+            }
+            let packages = normalized_go_test_target_packages(obj.get("packages"))?;
+            serde_json::json!({
+                "tool": tool_name,
+                "kind": "test",
+                "cwd": cwd,
+                "packages": packages,
+            })
+        }
+        _ => return None,
+    };
+    let encoded = serde_json::to_vec(&semantic).ok()?;
+    let digest = format!("{:x}", Sha256::digest(encoded));
+    Some(format!(
+        "{STRUCTURED_VALIDATION_TARGET_PREFIX}{}",
+        &digest[..VALIDATION_IDENTITY_HEX_LEN]
+    ))
+}
+
+fn normalized_validation_target_cwd(value: Option<&Value>) -> Option<String> {
+    let Some(value) = value else {
+        return Some(".".to_string());
+    };
+    if value.is_null() {
+        return Some(".".to_string());
+    }
+    let raw = value.as_str()?;
+    let trimmed = raw.trim().trim_start_matches("./").trim_end_matches('/');
+    Some(if trimmed.is_empty() || trimmed == "." {
+        ".".to_string()
+    } else {
+        trimmed.to_string()
+    })
+}
+
+fn normalized_cargo_target_value(value: Option<&Value>) -> Option<Option<String>> {
+    let Some(value) = value else {
+        return Some(None);
+    };
+    if value.is_null() {
+        return Some(None);
+    }
+    normalize_cargo_value(value.as_str()?).ok()
+}
+
+fn normalized_rust_test_target_filter(value: Option<&Value>) -> Option<Option<String>> {
+    let Some(value) = value else {
+        return Some(None);
+    };
+    if value.is_null() {
+        return Some(None);
+    }
+    normalize_rust_test_filter(value.as_str()?).ok()
+}
+
+fn normalized_go_test_target_packages(value: Option<&Value>) -> Option<Vec<String>> {
+    let packages = match value {
+        None | Some(Value::Null) => None,
+        Some(Value::Array(values)) => Some(
+            values
+                .iter()
+                .map(Value::as_str)
+                .collect::<Option<Vec<_>>>()?
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>(),
+        ),
+        Some(_) => return None,
+    };
+    normalize_go_test_packages(packages.as_deref()).ok()
 }
 
 #[cfg(test)]

--- a/crates/webcodex-core/src/workflow_session_contract.rs
+++ b/crates/webcodex-core/src/workflow_session_contract.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+pub const SESSION_ID_PREFIX: &str = "wc_sess_";
 pub const TOOL_CALL_CONTEXT_REQUEST_INTERNAL_FIELD: &str = "__webcodex_stateless_context_request";
 
 pub const MAX_MODEL_VALIDATION_ASSERTION_NAME_CHARS: usize =
@@ -32,6 +33,15 @@ pub const TOOL_CALL_EXPECTATION_METADATA_FIELDS: &[&str] = &[
 
 pub fn is_tool_call_expectation_metadata_field(field: &str) -> bool {
     TOOL_CALL_EXPECTATION_METADATA_FIELDS.contains(&field)
+}
+
+pub fn is_valid_session_id(session_id: &str) -> bool {
+    session_id.starts_with(SESSION_ID_PREFIX)
+        && session_id.len() > SESSION_ID_PREFIX.len()
+        && session_id
+            .as_bytes()
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || *b == b'_')
 }
 
 pub const EXPLORATION_TOOL_NAMES: &[&str] = &[

--- a/crates/webcodex-runner-registry/Cargo.toml
+++ b/crates/webcodex-runner-registry/Cargo.toml
@@ -9,7 +9,6 @@ root-test-support = []
 
 [dependencies]
 webcodex-core = { path = "../webcodex-core" }
-webcodex-workflow-session = { path = "../webcodex-workflow-session" }
 chrono = "0.4"
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/webcodex-runner-registry/src/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/reconciliation.rs
@@ -134,7 +134,7 @@ fn validate_context(
         .workflow_session_id
         .as_deref()
         .is_some_and(|session_id| {
-            !webcodex_workflow_session::is_valid_session_id(session_id)
+            !webcodex_core::workflow_session_contract::is_valid_session_id(session_id)
                 || session_id.chars().count() > 128
         })
     {

--- a/crates/webcodex-store/Cargo.toml
+++ b/crates/webcodex-store/Cargo.toml
@@ -9,7 +9,6 @@ root-test-support = []
 
 [dependencies]
 webcodex-core = { path = "../webcodex-core" }
-webcodex-workspace = { path = "../webcodex-workspace" }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"

--- a/crates/webcodex-store/src/task_kernel.rs
+++ b/crates/webcodex-store/src/task_kernel.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashSet;
 use uuid::Uuid;
-use webcodex_workspace::project_context::ProjectContextFingerprint;
+use webcodex_core::project_context_contract::ProjectContextFingerprint;
 
 pub struct ConnectorBinding<'a> {
     pub project_id: &'a str,

--- a/crates/webcodex-store/src/task_kernel_tests.rs
+++ b/crates/webcodex-store/src/task_kernel_tests.rs
@@ -48,7 +48,7 @@ fn fingerprint(root_sha256: &str, target_path: &str) -> ProjectContextFingerprin
         schema_version: 2,
         project_root_sha256: root_sha256.to_string(),
         target_directory: target_path.to_string(),
-        git: webcodex_workspace::project_context::GitContextFingerprint {
+        git: webcodex_core::project_context_contract::GitContextFingerprint {
             available: true,
             branch: Some("main".to_string()),
             head: Some("0123456789abcdef".to_string()),
@@ -57,7 +57,7 @@ fn fingerprint(root_sha256: &str, target_path: &str) -> ProjectContextFingerprin
         },
         rules: Vec::new(),
         manifests: Vec::new(),
-        completeness: webcodex_workspace::project_context::FingerprintCompleteness::default(),
+        completeness: webcodex_core::project_context_contract::FingerprintCompleteness::default(),
     }
 }
 

--- a/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
@@ -7,10 +7,7 @@ use super::tool_inputs::{is_checkpoint_kind, is_checkpoint_validation_status};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use webcodex_core::audit_preview::{command_preview, process_preview};
-use webcodex_core::runner_protocol::{
-    normalize_cargo_value, normalize_go_test_packages, normalize_rust_test_filter,
-    CARGO_TEST_MIN_TESTS_MAX,
-};
+use webcodex_core::runner_protocol::{normalize_cargo_value, normalize_rust_test_filter};
 use webcodex_workflow_session::SessionExecutionContext;
 
 pub fn session_log_arguments_for_tool_request(tool_name: &str, arguments: &Value) -> Value {
@@ -2142,9 +2139,6 @@ fn insert_exact_git_commit_audit(
     }
 }
 
-const STRUCTURED_VALIDATION_TARGET_PREFIX: &str = "target:";
-const STRUCTURED_VALIDATION_TARGET_HEX_LEN: usize = 24;
-
 fn insert_structured_validation_target(
     tool_name: &str,
     arguments: &serde_json::Map<String, Value>,
@@ -2157,106 +2151,13 @@ fn insert_structured_validation_target(
     }
 }
 
-pub fn structured_validation_target_identity(tool_name: &str, arguments: &Value) -> Option<String> {
-    let obj = arguments.as_object()?;
-    let cwd = normalized_validation_target_cwd(obj.get("cwd"))?;
-    let semantic = match tool_name {
-        "cargo_fmt" => serde_json::json!({
-            "tool": tool_name,
-            "kind": "format",
-            "cwd": cwd,
-            "check": obj.get("check").and_then(Value::as_bool).unwrap_or(false),
-        }),
-        "cargo_check" => {
-            if obj.get("features_present").and_then(Value::as_bool) == Some(true)
-                && obj.get("features").is_none()
-            {
-                return None;
-            }
-            let features = normalized_cargo_target_value(obj.get("features"))?;
-            let package = normalized_cargo_target_value(obj.get("package"))?;
-            serde_json::json!({
-                "tool": tool_name,
-                "kind": "check",
-                "cwd": cwd,
-                "package": package,
-                "features": features,
-                "all_targets": obj.get("all_targets").and_then(Value::as_bool).unwrap_or(true),
-                "all_features": obj.get("all_features").and_then(Value::as_bool).unwrap_or(false),
-                "no_default_features": obj.get("no_default_features").and_then(Value::as_bool).unwrap_or(false),
-            })
-        }
-        "cargo_test" => {
-            if obj.get("filter_present").and_then(Value::as_bool) == Some(true)
-                && obj.get("filter").is_none()
-            {
-                return None;
-            }
-            if obj.get("features_present").and_then(Value::as_bool) == Some(true)
-                && obj.get("features").is_none()
-            {
-                return None;
-            }
-            let filter = normalized_rust_test_target_filter(obj.get("filter"))?;
-            let features = normalized_cargo_target_value(obj.get("features"))?;
-            let package = normalized_cargo_target_value(obj.get("package"))?;
-            let require_tests = obj
-                .get("require_tests")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            let min_tests = obj.get("min_tests").and_then(Value::as_u64);
-            if min_tests.is_some_and(|minimum| !(1..=CARGO_TEST_MIN_TESTS_MAX).contains(&minimum)) {
-                return None;
-            }
-            let minimum_tests = match (require_tests, min_tests) {
-                (true, Some(minimum)) => Some(minimum.max(1)),
-                (true, None) => Some(1),
-                (false, minimum) => minimum,
-            };
-            serde_json::json!({
-                "tool": tool_name,
-                "kind": "test",
-                "cwd": cwd,
-                "package": package,
-                "filter": filter,
-                "features": features,
-                "all_targets": obj.get("all_targets").and_then(Value::as_bool).unwrap_or(false),
-                "all_features": obj.get("all_features").and_then(Value::as_bool).unwrap_or(false),
-                "no_default_features": obj.get("no_default_features").and_then(Value::as_bool).unwrap_or(false),
-                "no_run": obj.get("no_run").and_then(Value::as_bool).unwrap_or(false),
-                "minimum_tests": minimum_tests,
-            })
-        }
-        "go_test" => {
-            if obj.get("packages_present").and_then(Value::as_bool) == Some(true)
-                && obj.get("packages").is_none()
-            {
-                return None;
-            }
-            let packages = normalized_go_test_target_packages(obj.get("packages"))?;
-            serde_json::json!({
-                "tool": tool_name,
-                "kind": "test",
-                "cwd": cwd,
-                "packages": packages,
-            })
-        }
-        _ => return None,
-    };
-    let encoded = serde_json::to_vec(&semantic).ok()?;
-    let digest = format!("{:x}", Sha256::digest(encoded));
-    Some(format!(
-        "{STRUCTURED_VALIDATION_TARGET_PREFIX}{}",
-        &digest[..STRUCTURED_VALIDATION_TARGET_HEX_LEN]
-    ))
-}
-
 pub use webcodex_core::validation_identity::{
     assertion_validation_identity, is_structured_validation_target_identity,
-    is_validation_execution_identity,
+    is_validation_execution_identity, structured_validation_target_identity,
 };
-
-const GENERIC_VALIDATION_IDENTITY_PREFIX: &str = "command:";
+use webcodex_core::validation_identity::{
+    GENERIC_VALIDATION_IDENTITY_PREFIX, VALIDATION_IDENTITY_HEX_LEN,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenericValidationIdentity {
@@ -2294,7 +2195,7 @@ fn generic_validation_digest<'a>(
     let digest = format!("{:x}", hasher.finalize());
     format!(
         "{GENERIC_VALIDATION_IDENTITY_PREFIX}{}",
-        &digest[..STRUCTURED_VALIDATION_TARGET_HEX_LEN]
+        &digest[..VALIDATION_IDENTITY_HEX_LEN]
     )
 }
 
@@ -2483,59 +2384,6 @@ pub fn run_script_validation_identity(
         identity: generic_validation_digest("run_script", purpose, cwd, parts),
         validation_tool: None,
     })
-}
-
-fn normalized_validation_target_cwd(value: Option<&Value>) -> Option<String> {
-    let Some(value) = value else {
-        return Some(".".to_string());
-    };
-    if value.is_null() {
-        return Some(".".to_string());
-    }
-    let raw = value.as_str()?;
-    let trimmed = raw.trim().trim_start_matches("./").trim_end_matches('/');
-    Some(if trimmed.is_empty() || trimmed == "." {
-        ".".to_string()
-    } else {
-        trimmed.to_string()
-    })
-}
-
-fn normalized_cargo_target_value(value: Option<&Value>) -> Option<Option<String>> {
-    let Some(value) = value else {
-        return Some(None);
-    };
-    if value.is_null() {
-        return Some(None);
-    }
-    normalize_cargo_value(value.as_str()?).ok()
-}
-
-fn normalized_rust_test_target_filter(value: Option<&Value>) -> Option<Option<String>> {
-    let Some(value) = value else {
-        return Some(None);
-    };
-    if value.is_null() {
-        return Some(None);
-    }
-    normalize_rust_test_filter(value.as_str()?).ok()
-}
-
-fn normalized_go_test_target_packages(value: Option<&Value>) -> Option<Vec<String>> {
-    let packages = match value {
-        None | Some(Value::Null) => None,
-        Some(Value::Array(values)) => Some(
-            values
-                .iter()
-                .map(Value::as_str)
-                .collect::<Option<Vec<_>>>()?
-                .into_iter()
-                .map(str::to_string)
-                .collect::<Vec<_>>(),
-        ),
-        Some(_) => return None,
-    };
-    normalize_go_test_packages(packages.as_deref()).ok()
 }
 
 #[cfg(test)]

--- a/crates/webcodex-validation/Cargo.toml
+++ b/crates/webcodex-validation/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 
 [dependencies]
 webcodex-core = { path = "../webcodex-core" }
-webcodex-tool-runtime-contracts = { path = "../webcodex-tool-runtime-contracts" }
 webcodex-workflow-session = { path = "../webcodex-workflow-session" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -16,4 +15,5 @@ toml = "0.8"
 [dev-dependencies]
 tempfile = "3"
 webcodex-tool-contracts = { path = "../webcodex-tool-contracts", features = ["root-test-support"] }
+webcodex-tool-runtime-contracts = { path = "../webcodex-tool-runtime-contracts" }
 webcodex-workflow-session = { path = "../webcodex-workflow-session", features = ["root-test-support"] }

--- a/crates/webcodex-validation/src/evidence.rs
+++ b/crates/webcodex-validation/src/evidence.rs
@@ -14,7 +14,7 @@ use webcodex_core::validation_evidence::{
     ValidationDiagnostics, PARSER_KIND, PARSER_LIMITATIONS, PARSER_VERSION,
     VALIDATION_OUTPUT_METADATA_ABSENT_REASON,
 };
-use webcodex_tool_runtime_contracts::tool_audit::{
+use webcodex_core::validation_identity::{
     assertion_validation_identity, is_structured_validation_target_identity,
     is_validation_execution_identity, structured_validation_target_identity,
 };

--- a/crates/webcodex-workflow-session/src/events.rs
+++ b/crates/webcodex-workflow-session/src/events.rs
@@ -6,16 +6,15 @@ use webcodex_core::lsp_bridge::{
     LocationsResult, WorkspaceSymbolsResult,
 };
 use webcodex_core::workflow_session_contract::is_tool_call_expectation_metadata_field as shared_is_tool_call_expectation_metadata_field;
-pub use webcodex_core::workflow_session_contract::EXPLORATION_TOOL_NAMES;
+pub use webcodex_core::workflow_session_contract::{is_valid_session_id, EXPLORATION_TOOL_NAMES};
 
 use super::model::{
     PersistentShellEventEvidence, SessionContextRevisionAck, SessionEvent, SessionSummary,
     ToolCallExpectation, ToolCallRecorderMetadata, ToolCallSessionMessageResolution,
     LOGICAL_INVOCATION_ID_PREFIX, LOGICAL_INVOCATION_ROLE_BUSINESS,
     LOGICAL_INVOCATION_ROLE_RECORDER, MAX_MODEL_VALIDATION_ASSERTION_NAME_CHARS,
-    MAX_OBSERVED_PATHS_PER_EVENT, MAX_VALIDATION_EXCERPT_CHARS, SESSION_ID_PREFIX,
-    TOOL_ACCEPTED_EXIT_CODES_FIELD, TOOL_ASSERTION_NAME_FIELD,
-    TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
+    MAX_OBSERVED_PATHS_PER_EVENT, MAX_VALIDATION_EXCERPT_CHARS, TOOL_ACCEPTED_EXIT_CODES_FIELD,
+    TOOL_ASSERTION_NAME_FIELD, TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_INTERNAL_FIELD,
     TOOL_CALL_ACK_SESSION_MESSAGE_IDS_INTERNAL_FIELD, TOOL_CALL_EXPECTATION_METADATA_FIELDS,
     TOOL_CALL_RECORDING_SESSION_ID_FIELD, TOOL_CALL_SESSION_MESSAGE_RESOLUTION_INTERNAL_FIELD,
     TOOL_EXPECTATION_RESULT_MATCHED, TOOL_EXPECTATION_RESULT_MATCHED_RESULT,
@@ -102,15 +101,6 @@ impl ToolCallRecorderMetadata {
             },
         }
     }
-}
-
-pub fn is_valid_session_id(session_id: &str) -> bool {
-    session_id.starts_with(SESSION_ID_PREFIX)
-        && session_id.len() > SESSION_ID_PREFIX.len()
-        && session_id
-            .as_bytes()
-            .iter()
-            .all(|b| b.is_ascii_alphanumeric() || *b == b'_')
 }
 
 pub(super) fn is_valid_logical_invocation_id(value: &str) -> bool {

--- a/crates/webcodex-workflow-session/src/model.rs
+++ b/crates/webcodex-workflow-session/src/model.rs
@@ -9,7 +9,7 @@ use webcodex_core::project_instructions::{
 };
 use webcodex_core::workflow_session_contract::{ExecutionShell, PermissionDecision, SessionMode};
 pub use webcodex_core::workflow_session_contract::{
-    MAX_MODEL_VALIDATION_ASSERTION_NAME_CHARS, MAX_TOOL_CALL_ACK_MESSAGE_IDS,
+    MAX_MODEL_VALIDATION_ASSERTION_NAME_CHARS, MAX_TOOL_CALL_ACK_MESSAGE_IDS, SESSION_ID_PREFIX,
     SESSION_INBOX_HIGH_GUIDANCE_ATTENTION_INSTRUCTION,
     SESSION_INBOX_HIGH_GUIDANCE_ATTENTION_REASON, TOOL_ACCEPTED_EXIT_CODES_FIELD,
     TOOL_ASSERTION_NAME_FIELD, TOOL_CALL_ACK_SESSION_CONTEXT_REVISION_FIELD,
@@ -20,7 +20,6 @@ pub use webcodex_core::workflow_session_contract::{
     TOOL_EXPECTED_FAILURE_KIND_FIELD, TOOL_RESULT_EXPECTATION_FIELD,
 };
 
-pub const SESSION_ID_PREFIX: &str = "wc_sess_";
 pub const EVENT_ID_PREFIX: &str = "evt_";
 pub const CALL_ID_PREFIX: &str = "wc_call_";
 pub const LOGICAL_INVOCATION_ID_PREFIX: &str = "wc_inv_";

--- a/crates/webcodex-workspace/src/project_context.rs
+++ b/crates/webcodex-workspace/src/project_context.rs
@@ -15,6 +15,10 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
+pub use webcodex_core::project_context_contract::{
+    ContextFileFingerprint, FingerprintCompleteness, GitContextFingerprint,
+    ProjectContextFingerprint,
+};
 
 const FINGERPRINT_SCHEMA_VERSION: u32 = 2;
 pub const MAX_UNTRACKED_FILE_COUNT: usize = 512;
@@ -125,62 +129,6 @@ impl CaptureState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ProjectContextFingerprint {
-    pub schema_version: u32,
-    /// Hash of the canonical absolute project path. The path itself is never
-    /// serialized into continuity state.
-    pub project_root_sha256: String,
-    pub target_directory: String,
-    pub git: GitContextFingerprint,
-    pub rules: Vec<ContextFileFingerprint>,
-    pub manifests: Vec<ContextFileFingerprint>,
-    #[serde(default)]
-    pub completeness: FingerprintCompleteness,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FingerprintCompleteness {
-    #[serde(default = "default_true")]
-    pub complete: bool,
-    #[serde(default)]
-    pub partial_slices: Vec<String>,
-    #[serde(default)]
-    pub warnings: Vec<String>,
-}
-
-impl Default for FingerprintCompleteness {
-    fn default() -> Self {
-        Self {
-            complete: true,
-            partial_slices: Vec::new(),
-            warnings: Vec::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct GitContextFingerprint {
-    pub available: bool,
-    pub branch: Option<String>,
-    pub head: Option<String>,
-    pub worktree_sha256: Option<String>,
-    pub dirty: Option<bool>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ContextFileFingerprint {
-    pub path: String,
-    pub sha256: String,
-    pub bytes: u64,
-    #[serde(default = "default_true")]
-    pub complete: bool,
-    #[serde(default = "default_full_hash_kind")]
-    pub hash_kind: String,
-    #[serde(default)]
-    pub modified_unix_nanos: Option<u64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContextRefreshSummary {
     pub reused: Vec<String>,
     pub refreshed: Vec<String>,
@@ -201,14 +149,6 @@ pub struct ContextFileRefresh {
     pub removed: Vec<String>,
     #[serde(default)]
     pub unknown: Vec<String>,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-fn default_full_hash_kind() -> String {
-    "full".to_string()
 }
 
 pub fn capture_project_context(


### PR DESCRIPTION
## Summary
- move Workflow Session ID validation into the shared core contract so Runner Registry no longer depends on Workflow Session
- move structured validation target identity ownership into core so Validation no longer has a production dependency on Tool Runtime contracts
- move project-context fingerprint DTOs into core so Store no longer depends on Workspace
- preserve existing Workflow Session, Tool Runtime, and Workspace APIs through re-exports to avoid namespace churn

## Validation
- affected crate test suites passed
- webcodex-workflow-session: 163 passed
- webcodex-workspace: 61 passed
- webcodex-validation: 83 passed
- webcodex-tool-runtime-contracts: 66 passed
- webcodex-connector-runtime: 67 passed
- cargo check -p webcodex
- git diff --check
- Cargo dependency graph verified the three targeted production edges are removed
