### PR TITLE
Improve apply_patch context mismatch recovery

### DIFF
--- a/crates/webcodex-core/src/apply_patch_shared.rs
+++ b/crates/webcodex-core/src/apply_patch_shared.rs
@@ -12,6 +12,7 @@ use std::fmt;
 pub const MAX_CODEX_PATCH_BYTES: usize = 256 * 1024;
 pub const MAX_CODEX_PATCH_FILE_CHANGES: usize = 64;
 pub const MAX_CODEX_PATCH_CHUNKS_PER_FILE: usize = 256;
+pub const MAX_CODEX_PATCH_RECOVERY_READ_LINES: usize = 64;
 
 const BEGIN_PATCH_MARKER: &str = "*** Begin Patch";
 const END_PATCH_MARKER: &str = "*** End Patch";

--- a/crates/webcodex-runner/src/main_tests/apply_patch.rs
+++ b/crates/webcodex-runner/src/main_tests/apply_patch.rs
@@ -289,6 +289,10 @@ fn file_apply_patch_context_conflict_keeps_whole_batch_unchanged() {
     assert_eq!(out["match_diagnostic"]["closest_start_line"], 1);
     assert_eq!(out["match_diagnostic"]["closest_exact_line_matches"], 0);
     assert_eq!(out["match_diagnostic"]["first_exact_mismatch_offset"], 1);
+    assert!(
+        out.get("recovery").is_none(),
+        "Runner must return canonical structural facts only; Server derives model-facing recovery"
+    );
     assert_eq!(
         std::fs::read_to_string(tmp.path().join("first.txt")).unwrap(),
         "one\n"

--- a/crates/webcodex-runner/src/main_tests/project_creation.rs
+++ b/crates/webcodex-runner/src/main_tests/project_creation.rs
@@ -109,6 +109,34 @@ fn create_project_created_config_and_overwritten_semantics_are_accurate() {
 }
 
 #[test]
+fn create_project_empty_template_with_description_creates_no_project_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("empty-with-description");
+    let project_registry_dir = tmp.path().join("project-registry");
+    let policy = project_policy(tmp.path());
+    let req = project_request(
+        "create_project",
+        serde_json::json!({
+            "id": "empty-with-description",
+            "name": "Empty With Description",
+            "path": project_dir.to_string_lossy(),
+            "description": "Registration metadata only",
+            "template": "empty"
+        }),
+    );
+
+    let value = project_ok(handle_project_op(&policy, &project_registry_dir, &req));
+    assert_eq!(value["created_directory"], true);
+    assert!(project_dir.is_dir());
+    assert!(std::fs::read_dir(&project_dir).unwrap().next().is_none());
+
+    let recovered = project_ok(handle_project_op(&policy, &project_registry_dir, &req));
+    assert_eq!(recovered["recovered"], true);
+    assert_eq!(recovered["changed"], false);
+    assert!(std::fs::read_dir(&project_dir).unwrap().next().is_none());
+}
+
+#[test]
 fn create_project_cleanup_removes_only_files_created_on_failure() {
     let tmp = tempfile::tempdir().unwrap();
     let project_dir = tmp.path().join("existing-empty");

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -1703,7 +1703,6 @@ fn matching_existing_project(
 fn validate_recovered_create_side_effects(
     path: &Path,
     template: &str,
-    description: Option<&str>,
     git_init: bool,
 ) -> Result<(), &'static str> {
     if !path.is_dir() {
@@ -1715,9 +1714,6 @@ fn validate_recovered_create_side_effects(
     if template == "basic"
         && (!path.join("README.md").is_file() || !path.join(".gitignore").is_file())
     {
-        return Err("project_already_exists");
-    }
-    if template == "empty" && description.is_some() && !path.join("README.md").is_file() {
         return Err("project_already_exists");
     }
     Ok(())
@@ -2000,12 +1996,9 @@ pub(crate) fn handle_project_op(
             allow_patch,
         ) {
             Ok(Some(project)) => {
-                if let Err(code) = validate_recovered_create_side_effects(
-                    &path_buf,
-                    &template,
-                    description.as_deref(),
-                    git_init,
-                ) {
+                if let Err(code) =
+                    validate_recovered_create_side_effects(&path_buf, &template, git_init)
+                {
                     return project_error_cmd(start, code);
                 }
                 return ok_cmd(
@@ -2079,18 +2072,9 @@ pub(crate) fn handle_project_op(
             created_paths.cleanup();
             return err_cmd(start, format!("failed to write .gitignore: {}", e));
         }
-    } else if template == "empty" {
-        // For empty template, optionally create README.md if description is provided.
-        if let Some(ref desc) = description {
-            let readme = format!("# {}\n\n{}\n", name, desc);
-            let readme_path = path_buf.join("README.md");
-            if let Err(e) = write_created_file(&readme_path, readme.as_bytes(), &mut created_paths)
-            {
-                created_paths.cleanup();
-                return err_cmd(start, format!("failed to write README.md: {}", e));
-            }
-        }
     }
+    // `empty` itself generates no project files. Description stays registration
+    // metadata; `git_init` remains a separate explicit filesystem side effect.
 
     // git init.
     let mut git_initialized = false;

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/projects.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/projects.rs
@@ -75,7 +75,7 @@ pub fn create_project_input_schema() -> Value {
         (
             "description",
             "string",
-            "Optional project description.",
+            "Optional project registration description. The 'empty' template never creates project files from this metadata; the 'basic' template also includes it in generated README.md content.",
             false,
         ),
         (
@@ -87,7 +87,7 @@ pub fn create_project_input_schema() -> Value {
         (
             "template",
             "string",
-            "Template: 'empty' (default) or 'basic'.",
+            "Template: 'empty' (default; generates no project files) or 'basic' (generates README.md and .gitignore). git_init is a separate explicit side effect.",
             false,
         ),
         (

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
@@ -90,16 +90,28 @@ fn apply_patch_recovery_schema() -> Value {
     json!({
         "type": "object",
         "additionalProperties": false,
-        "description": "Server-derived, body-free ready-to-call reread window for a validated deterministic apply_patch context mismatch. It is emitted only when the failed target and structural diagnostic prove a no-write reread is safe; the Runner cannot choose the tool, path, or arguments.",
+        "description": "Server-derived, body-free reread hint for a validated deterministic apply_patch context mismatch. Copy `items` into the direct `read_files` tool for the same project. It is emitted only when the failed target and structural diagnostic prove a no-write reread is safe; the Runner cannot choose the tool, path, or arguments.",
         "properties": {
-            "action": {"type": "string", "enum": ["read_file"]},
+            "action": {"type": "string", "enum": ["read_files"]},
             "reason": {"type": "string", "enum": ["context_mismatch"]},
-            "path": {"type": "string", "minLength": 1},
-            "start_line": {"type": "integer", "minimum": 1},
-            "limit": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": webcodex_core::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
+            "items": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "path": {"type": "string", "minLength": 1},
+                        "start_line": {"type": "integer", "minimum": 1},
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": webcodex_core::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
+                        }
+                    },
+                    "required": ["path", "start_line", "limit"]
+                }
             },
             "change_index": {
                 "type": "integer",
@@ -113,7 +125,7 @@ fn apply_patch_recovery_schema() -> Value {
             }
         },
         "required": [
-            "action", "reason", "path", "start_line", "limit", "change_index", "chunk_index"
+            "action", "reason", "items", "change_index", "chunk_index"
         ]
     })
 }

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
@@ -86,6 +86,38 @@ fn apply_patch_match_diagnostic_schema() -> Value {
     })
 }
 
+fn apply_patch_recovery_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Server-derived, body-free ready-to-call reread window for a validated deterministic apply_patch context mismatch. It is emitted only when the failed target and structural diagnostic prove a no-write reread is safe; the Runner cannot choose the tool, path, or arguments.",
+        "properties": {
+            "action": {"type": "string", "enum": ["read_file"]},
+            "reason": {"type": "string", "enum": ["context_mismatch"]},
+            "path": {"type": "string", "minLength": 1},
+            "start_line": {"type": "integer", "minimum": 1},
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": webcodex_core::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
+            },
+            "change_index": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": webcodex_core::apply_patch_shared::MAX_CODEX_PATCH_FILE_CHANGES - 1
+            },
+            "chunk_index": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": webcodex_core::apply_patch_shared::MAX_CODEX_PATCH_CHUNKS_PER_FILE - 1
+            }
+        },
+        "required": [
+            "action", "reason", "path", "start_line", "limit", "change_index", "chunk_index"
+        ]
+    })
+}
+
 fn apply_patch_file_summary_schema() -> Value {
     json!({
         "type": "array",
@@ -281,6 +313,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("patch_line", nullable_schema("integer", "One-based patch line for a syntax error when known.")),
             ("expected_format", nullable_schema("string", "codex_patch for parse-format recovery; null otherwise.")),
             ("match_diagnostic", apply_patch_match_diagnostic_schema()),
+            ("recovery", apply_patch_recovery_schema()),
             ("retry_guidance", schema_type("string", "Bounded recovery guidance for deterministic no-mutation rejection.")),
         ])),
         "apply_text_edits" => Some(wrapped_output_schema(vec![

--- a/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
+++ b/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
@@ -304,10 +304,11 @@ fn edit_tool_surface_keeps_canonical_tools_visible_and_schemas_stable() {
     assert_eq!(recovery["additionalProperties"], false);
     assert_eq!(
         recovery["properties"]["action"]["enum"],
-        json!(["read_file"])
+        json!(["read_files"])
     );
+    assert_eq!(recovery["properties"]["items"]["maxItems"], 1);
     assert_eq!(
-        recovery["properties"]["limit"]["maximum"],
+        recovery["properties"]["items"]["items"]["properties"]["limit"]["maximum"],
         webcodex_core::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
     );
     let patch_files = &patch_output["files"];

--- a/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
+++ b/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
@@ -298,6 +298,18 @@ fn edit_tool_surface_keeps_canonical_tools_visible_and_schemas_stable() {
         patch_output.get("match_diagnostic").is_some(),
         "apply_patch failures must expose body-free match diagnostics"
     );
+    let recovery = patch_output
+        .get("recovery")
+        .expect("apply_patch must publish bounded context-mismatch recovery");
+    assert_eq!(recovery["additionalProperties"], false);
+    assert_eq!(
+        recovery["properties"]["action"]["enum"],
+        json!(["read_file"])
+    );
+    assert_eq!(
+        recovery["properties"]["limit"]["maximum"],
+        webcodex_core::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
+    );
     let patch_files = &patch_output["files"];
     assert_eq!(patch_files["type"], "array");
     let file_properties = patch_files["items"]["properties"]

--- a/crates/webcodex-tool-contracts/src/tool_definition/patches.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/patches.rs
@@ -31,7 +31,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 true,
                 false,
                 ),
-                "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. Inspect strict_match on success and body-free match_diagnostic on context mismatch; set strict_matching=true to require exact-unique positioning. Use apply_text_edits for small exact edits; unified diff for external diffs.",
+                "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. A zero-write context_mismatch may include body-free match_diagnostic plus Server-derived recovery; when recovery.action=read_file, reread that bounded window before regenerating the whole patch. outcome_unknown still requires workspace inspection before another write. Set strict_matching=true to require exact-unique positioning. Use apply_text_edits for small exact edits; unified diff for external diffs.",
                 apply_patch_input_schema,
             ),
             PERMISSION_RISK_PATCH,

--- a/crates/webcodex-tool-contracts/src/tool_definition/patches.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/patches.rs
@@ -31,7 +31,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 true,
                 false,
                 ),
-                "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. A zero-write context_mismatch may include body-free match_diagnostic plus Server-derived recovery; when recovery.action=read_file, reread that bounded window before regenerating the whole patch. outcome_unknown still requires workspace inspection before another write. Set strict_matching=true to require exact-unique positioning. Use apply_text_edits for small exact edits; unified diff for external diffs.",
+                "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. A zero-write context_mismatch may include body-free match_diagnostic plus Server-derived recovery; when recovery.action=read_files, pass recovery.items to read_files for the same project before regenerating the whole patch. outcome_unknown requires workspace inspection first. Set strict_matching=true for exact-unique positioning. Use apply_text_edits for small exact edits; unified diff for external diffs.",
                 apply_patch_input_schema,
             ),
             PERMISSION_RISK_PATCH,

--- a/docs/CODING_WORKFLOW.md
+++ b/docs/CODING_WORKFLOW.md
@@ -156,6 +156,13 @@ placement instead of silently downgrading. The Server validates successful
 Runner match metadata against its parsed patch; missing or contradictory
 success metadata is surfaced as `outcome_unknown`, not as clean success.
 
+For a deterministic zero-write `context_mismatch`, a current Runner may also
+return a body-free `match_diagnostic`. The Server validates it against the parsed
+patch before exposing it. When the result includes `recovery.action=read_files`,
+pass `recovery.items` to `read_files` for the same project, inspect that bounded
+current-source window, then regenerate the whole patch. Do not use this recovery
+path for `outcome_unknown`; reconcile the workspace first.
+
 **Prefer structured validation.** Use focused tools such as `cargo_test`,
 `go_test`, or other structured validation when they express the check you need.
 Use a shell only when the structured surface does not cover the validation.

--- a/docs/CODING_WORKFLOW.zh-CN.md
+++ b/docs/CODING_WORKFLOW.zh-CN.md
@@ -127,6 +127,12 @@ WebCodex 0.4 要求 Runner 在任何 `apply_patch` dispatch 前显式声明
 校验 Runner 的 success match metadata；success metadata 缺失或互相矛盾时返回
 `outcome_unknown`，不会把它当成 clean success。
 
+对于确定性的 zero-write `context_mismatch`，当前 Runner 还可能返回不含正文的
+`match_diagnostic`。Server 会用已解析的 patch 校验后才暴露它。若结果包含
+`recovery.action=read_files`，把 `recovery.items` 传给同一项目的 `read_files`，读取该 bounded
+当前源码窗口，再重新生成整份 patch。`outcome_unknown` 不属于这条恢复路径，必须先
+reconcile workspace。
+
 **优先 structured validation。** 当 `cargo_test`、`go_test` 或其他 structured validation
 能够表达目标检查时，优先使用它们；只有结构化 surface 无法覆盖时才用 shell。结构化
 结果能给 Session ledger 更安全的 evidence，而不必解析任意 command text。

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1784,9 +1784,9 @@ fn schemas() -> Value {
                 "id": {"type": "string", "description": "Project id (ASCII letters, digits, '-', '_'; no slash)."},
                 "name": {"type": "string", "description": "Human-readable project name."},
                 "path": {"type": "string", "description": "Absolute directory path on the Runner host."},
-                "description": {"type": "string", "description": "Optional project description."},
+                "description": {"type": "string", "description": "Optional project registration description. The 'empty' template never creates project files from this metadata; the 'basic' template also includes it in generated README.md content."},
                 "allow_patch": {"type": "boolean", "description": "Allow patch operations on this project (default true)."},
-                "template": {"type": "string", "description": "Template: 'empty' (default) or 'basic'."},
+                "template": {"type": "string", "description": "Template: 'empty' (default; generates no project files) or 'basic' (generates README.md and .gitignore). git_init is a separate explicit side effect."},
                 "git_init": {"type": "boolean", "description": "Initialize git in the new directory (default false)."},
                 "allow_existing_empty": {"type": "boolean", "description": "Allow registering an existing empty directory (default false)."},
                 "overwrite": {"type": "boolean", "description": "Overwrite an existing project config file (default false)."}

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -652,6 +652,9 @@ const APPLY_PATCH_FAILURE_MATCH_DIAGNOSTIC_FIELDS: [&str; 10] = [
     "first_exact_mismatch_offset",
 ];
 
+const APPLY_PATCH_RECOVERY_MARGIN_BEFORE: usize = 8;
+const APPLY_PATCH_RECOVERY_MARGIN_AFTER: usize = 8;
+
 fn expected_apply_patch_failure_pattern_len(
     hunk: &crate::apply_patch_shared::CodexPatchHunk,
     chunk_index: usize,
@@ -777,10 +780,89 @@ fn valid_apply_patch_failure_match_diagnostic(
     closest_start_valid && mismatch_valid
 }
 
+fn apply_patch_context_mismatch_recovery(
+    patch: &crate::apply_patch_shared::CodexPatch,
+    failure_output: &Value,
+) -> Option<Value> {
+    if failure_output.get("changed").and_then(Value::as_bool) != Some(false)
+        || failure_output.get("state_changed").and_then(Value::as_bool) != Some(false)
+        || failure_output
+            .get("execution_state")
+            .and_then(Value::as_str)
+            != Some("not_started")
+        || failure_output.get("error_kind").and_then(Value::as_str) != Some("context_mismatch")
+    {
+        return None;
+    }
+
+    let diagnostic = failure_output.get("match_diagnostic")?;
+    if !valid_apply_patch_failure_match_diagnostic(diagnostic, patch, failure_output) {
+        return None;
+    }
+    let change_index = failure_output
+        .get("change_index")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let hunk = patch.hunks.get(change_index)?;
+    let path = hunk.path();
+    let diagnostic = diagnostic.as_object()?;
+    let chunk_index = diagnostic
+        .get("chunk_index")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let search_start_line = diagnostic
+        .get("search_start_line")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let expected_line_count = diagnostic
+        .get("expected_line_count")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let available_line_count = diagnostic
+        .get("available_line_count")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let closest_start_line = diagnostic
+        .get("closest_start_line")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+
+    let total_line_count = search_start_line
+        .checked_sub(1)?
+        .checked_add(available_line_count)?;
+    if total_line_count == 0 || closest_start_line > total_line_count {
+        return None;
+    }
+
+    let start_line = closest_start_line
+        .saturating_sub(APPLY_PATCH_RECOVERY_MARGIN_BEFORE)
+        .max(1);
+    let requested_limit = expected_line_count
+        .saturating_add(APPLY_PATCH_RECOVERY_MARGIN_BEFORE)
+        .saturating_add(APPLY_PATCH_RECOVERY_MARGIN_AFTER)
+        .min(crate::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES);
+    let available_from_start = total_line_count.checked_sub(start_line)?.checked_add(1)?;
+    let limit = requested_limit.min(available_from_start);
+    if limit == 0 {
+        return None;
+    }
+
+    Some(json!({
+        "action": "read_file",
+        "reason": "context_mismatch",
+        "path": path,
+        "start_line": start_line,
+        "limit": limit,
+        "change_index": change_index,
+        "chunk_index": chunk_index,
+    }))
+}
+
 fn sanitize_apply_patch_failure_metadata(
     output: &mut Value,
     patch: &crate::apply_patch_shared::CodexPatch,
 ) {
+    let recovery = apply_patch_context_mismatch_recovery(patch, output);
     let diagnostic_valid = output
         .get("match_diagnostic")
         .is_none_or(|value| valid_apply_patch_failure_match_diagnostic(value, patch, output));
@@ -790,6 +872,9 @@ fn sanitize_apply_patch_failure_metadata(
     fields.retain(|key, _| APPLY_PATCH_FAILURE_TOP_LEVEL_FIELDS.contains(&key.as_str()));
     if !diagnostic_valid {
         fields.remove("match_diagnostic");
+    }
+    if let Some(recovery) = recovery {
+        fields.insert("recovery".to_string(), recovery);
     }
 }
 
@@ -2193,6 +2278,45 @@ mod tests {
         .unwrap()
     }
 
+    fn update_patch_with_old_line_count(count: usize) -> crate::apply_patch_shared::CodexPatch {
+        assert!(count > 0);
+        let mut patch = String::from("*** Begin Patch\n*** Update File: file.txt\n");
+        for index in 0..count {
+            patch.push_str(&format!("-old-{index}\n"));
+        }
+        patch.push_str("+new\n*** End Patch");
+        crate::apply_patch_shared::parse_codex_patch(&patch).unwrap()
+    }
+
+    fn context_mismatch_payload(
+        expected_line_count: usize,
+        search_start_line: usize,
+        available_line_count: usize,
+        closest_start_line: Option<usize>,
+    ) -> Value {
+        json!({
+            "changed": false,
+            "state_changed": false,
+            "execution_state": "not_started",
+            "error_kind": "context_mismatch",
+            "change_index": 0,
+            "path": "file.txt",
+            "error": "Rejected Codex patch before write: context mismatch. No files were modified.",
+            "match_diagnostic": {
+                "chunk_index": 0,
+                "match_source": "old_lines",
+                "search_start_line": search_start_line,
+                "expected_line_count": expected_line_count,
+                "available_line_count": available_line_count,
+                "closest_start_line": closest_start_line,
+                "closest_exact_line_matches": 0,
+                "closest_trim_end_line_matches": 0,
+                "closest_trim_line_matches": 0,
+                "first_exact_mismatch_offset": 1
+            }
+        })
+    }
+
     #[test]
     fn apply_patch_strict_capability_rejection_names_exact_additive_capability() {
         let result = apply_patch_strict_matching_capability_rejection(
@@ -2242,6 +2366,13 @@ mod tests {
         let result = apply_patch_agent_stdout_result(&valid.to_string(), &patch, false, true);
         assert!(!result.success);
         assert_eq!(result.output["match_diagnostic"]["closest_start_line"], 5);
+        assert_eq!(result.output["recovery"]["action"], "read_file");
+        assert_eq!(result.output["recovery"]["reason"], "context_mismatch");
+        assert_eq!(result.output["recovery"]["path"], "file.txt");
+        assert_eq!(result.output["recovery"]["start_line"], 1);
+        assert_eq!(result.output["recovery"]["limit"], 10);
+        assert_eq!(result.output["recovery"]["change_index"], 0);
+        assert_eq!(result.output["recovery"]["chunk_index"], 0);
         assert!(result.output.get("future_body_field").is_none());
         assert!(!serde_json::to_string(&result.output)
             .unwrap()
@@ -2266,6 +2397,14 @@ mod tests {
         let mut impossible_order = valid;
         impossible_order["match_diagnostic"]["closest_exact_line_matches"] = json!(1);
         cases.push(impossible_order);
+        let mut out_of_range_candidate = context_mismatch_payload(1, 3, 8, Some(11));
+        out_of_range_candidate["recovery"] = json!({
+            "action": "read_file",
+            "path": "other.txt",
+            "start_line": 999999,
+            "limit": 999999
+        });
+        cases.push(out_of_range_candidate);
 
         for invalid in cases {
             let result = apply_patch_agent_stdout_result(&invalid.to_string(), &patch, false, true);
@@ -2273,10 +2412,127 @@ mod tests {
             assert_eq!(result.output["execution_state"], "not_started");
             assert_eq!(result.output["state_changed"], false);
             assert!(result.output.get("match_diagnostic").is_none());
+            assert!(result.output.get("recovery").is_none());
             assert!(!serde_json::to_string(&result.output)
                 .unwrap()
                 .contains("must-not-survive"));
         }
+    }
+
+    #[test]
+    fn apply_patch_context_recovery_uses_deterministic_bounded_read_windows() {
+        let patch = update_patch_with_old_line_count(5);
+        let result = apply_patch_agent_stdout_result(
+            &context_mismatch_payload(5, 120, 50, Some(130)).to_string(),
+            &patch,
+            false,
+            false,
+        );
+        let schema = crate::tool_runtime::registry::output_schema_for_tool("apply_patch");
+        crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+            &serde_json::to_value(&result).unwrap(),
+            &schema,
+        )
+        .unwrap_or_else(|error| panic!("apply_patch recovery must match output schema: {error}"));
+        assert_eq!(result.output["recovery"]["start_line"], 122);
+        assert_eq!(result.output["recovery"]["limit"], 21);
+
+        let near_start = apply_patch_agent_stdout_result(
+            &context_mismatch_payload(5, 1, 20, Some(1)).to_string(),
+            &patch,
+            false,
+            false,
+        );
+        assert_eq!(near_start.output["recovery"]["start_line"], 1);
+        assert_eq!(near_start.output["recovery"]["limit"], 20);
+
+        let eof_partial = apply_patch_agent_stdout_result(
+            &context_mismatch_payload(5, 11, 2, Some(12)).to_string(),
+            &patch,
+            false,
+            false,
+        );
+        let recovery = &eof_partial.output["recovery"];
+        assert_eq!(recovery["start_line"], 4);
+        assert_eq!(recovery["limit"], 9);
+        assert_eq!(
+            recovery["start_line"].as_u64().unwrap() + recovery["limit"].as_u64().unwrap() - 1,
+            12
+        );
+
+        let large_patch = update_patch_with_old_line_count(100);
+        let large = apply_patch_agent_stdout_result(
+            &context_mismatch_payload(100, 1, 300, Some(100)).to_string(),
+            &large_patch,
+            false,
+            false,
+        );
+        assert_eq!(
+            large.output["recovery"]["limit"],
+            crate::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
+        );
+    }
+
+    #[test]
+    fn apply_patch_context_recovery_does_not_invent_candidate_or_leak_bodies() {
+        let patch = update_patch_with_old_line_count(3);
+        let no_candidate = apply_patch_agent_stdout_result(
+            &context_mismatch_payload(3, 5, 0, None).to_string(),
+            &patch,
+            false,
+            false,
+        );
+        assert!(no_candidate.output.get("match_diagnostic").is_some());
+        assert!(no_candidate.output.get("recovery").is_none());
+
+        let private_patch = crate::apply_patch_shared::parse_codex_patch(
+            "*** Begin Patch\n*** Update File: file.txt\n-PATCH_PRIVATE_TOKEN\n+new\n*** End Patch",
+        )
+        .unwrap();
+        let mut payload = context_mismatch_payload(1, 1, 3, Some(2));
+        payload["future_body_field"] = json!("SOURCE_PRIVATE_TOKEN");
+        payload["recovery"] = json!({
+            "action": "read_file",
+            "reason": "context_mismatch",
+            "path": "SOURCE_PRIVATE_TOKEN",
+            "start_line": 1,
+            "limit": 999999,
+            "change_index": 0,
+            "chunk_index": 0
+        });
+        let result =
+            apply_patch_agent_stdout_result(&payload.to_string(), &private_patch, false, false);
+        let serialized = serde_json::to_string(&result.output).unwrap();
+        assert!(!serialized.contains("SOURCE_PRIVATE_TOKEN"));
+        assert!(!serialized.contains("PATCH_PRIVATE_TOKEN"));
+        assert_eq!(result.output["recovery"]["path"], "file.txt");
+        assert!(result.output["recovery"]["limit"].as_u64().unwrap() <= 64);
+    }
+
+    #[test]
+    fn apply_patch_context_recovery_is_suppressed_for_outcome_unknown() {
+        let patch = one_update_patch();
+        let mut payload = context_mismatch_payload(1, 1, 3, Some(2));
+        payload["changed"] = json!(true);
+        payload["recovery"] = json!({"action": "read_file", "path": "other.txt"});
+
+        let result = apply_patch_agent_stdout_result(&payload.to_string(), &patch, false, false);
+        assert!(!result.success);
+        assert_eq!(result.output["execution_state"], "outcome_unknown");
+        assert_eq!(
+            result.output["recovery_action"],
+            "inspect_workspace_before_retry"
+        );
+        assert!(result.output.get("match_diagnostic").is_none());
+        assert!(result.output.get("recovery").is_none());
+        let schema = crate::tool_runtime::registry::output_schema_for_tool("apply_patch");
+        crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+            &serde_json::to_value(&result).unwrap(),
+            &schema,
+        )
+        .unwrap_or_else(|error| {
+            panic!("apply_patch outcome_unknown must match output schema: {error}")
+        });
     }
 
     #[test]

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -826,6 +826,10 @@ fn apply_patch_context_mismatch_recovery(
         .get("closest_start_line")?
         .as_u64()
         .and_then(|value| usize::try_from(value).ok())?;
+    let first_exact_mismatch_offset = diagnostic
+        .get("first_exact_mismatch_offset")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
 
     let total_line_count = search_start_line
         .checked_sub(1)?
@@ -834,13 +838,27 @@ fn apply_patch_context_mismatch_recovery(
         return None;
     }
 
-    let start_line = closest_start_line
+    let mismatch_line = closest_start_line
+        .checked_add(first_exact_mismatch_offset.checked_sub(1)?)?
+        .min(total_line_count);
+    let initial_start_line = closest_start_line
         .saturating_sub(APPLY_PATCH_RECOVERY_MARGIN_BEFORE)
         .max(1);
     let requested_limit = expected_line_count
         .saturating_add(APPLY_PATCH_RECOVERY_MARGIN_BEFORE)
         .saturating_add(APPLY_PATCH_RECOVERY_MARGIN_AFTER)
         .min(crate::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES);
+    // Short hunks retain context around the candidate start. Once the bounded
+    // read cap applies, shift only as far as needed to include the first known
+    // mismatch plus useful trailing context; otherwise a large stale hunk can
+    // return a window containing only lines that still match.
+    let desired_end_line = mismatch_line
+        .saturating_add(APPLY_PATCH_RECOVERY_MARGIN_AFTER)
+        .min(total_line_count);
+    let mismatch_centered_start = desired_end_line
+        .saturating_sub(requested_limit.saturating_sub(1))
+        .max(1);
+    let start_line = initial_start_line.max(mismatch_centered_start);
     let available_from_start = total_line_count.checked_sub(start_line)?.checked_add(1)?;
     let limit = requested_limit.min(available_from_start);
     if limit == 0 {
@@ -2471,6 +2489,28 @@ mod tests {
             large.output["recovery"]["limit"],
             crate::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
         );
+
+        let mut distant_mismatch_payload = context_mismatch_payload(100, 1, 300, Some(100));
+        distant_mismatch_payload["match_diagnostic"]["closest_exact_line_matches"] = json!(99);
+        distant_mismatch_payload["match_diagnostic"]["closest_trim_end_line_matches"] = json!(99);
+        distant_mismatch_payload["match_diagnostic"]["closest_trim_line_matches"] = json!(99);
+        distant_mismatch_payload["match_diagnostic"]["first_exact_mismatch_offset"] = json!(90);
+        let distant_mismatch = apply_patch_agent_stdout_result(
+            &distant_mismatch_payload.to_string(),
+            &large_patch,
+            false,
+            false,
+        );
+        let recovery = &distant_mismatch.output["recovery"];
+        assert_eq!(recovery["start_line"], 134);
+        assert_eq!(
+            recovery["limit"],
+            crate::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
+        );
+        let mismatch_line = 100 + 90 - 1;
+        let recovery_start = recovery["start_line"].as_u64().unwrap() as usize;
+        let recovery_end = recovery_start + recovery["limit"].as_u64().unwrap() as usize - 1;
+        assert!((recovery_start..=recovery_end).contains(&mismatch_line));
     }
 
     #[test]

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -866,11 +866,13 @@ fn apply_patch_context_mismatch_recovery(
     }
 
     Some(json!({
-        "action": "read_file",
+        "action": "read_files",
         "reason": "context_mismatch",
-        "path": path,
-        "start_line": start_line,
-        "limit": limit,
+        "items": [{
+            "path": path,
+            "start_line": start_line,
+            "limit": limit,
+        }],
         "change_index": change_index,
         "chunk_index": chunk_index,
     }))
@@ -2384,11 +2386,15 @@ mod tests {
         let result = apply_patch_agent_stdout_result(&valid.to_string(), &patch, false, true);
         assert!(!result.success);
         assert_eq!(result.output["match_diagnostic"]["closest_start_line"], 5);
-        assert_eq!(result.output["recovery"]["action"], "read_file");
+        let recovery_action = result.output["recovery"]["action"].as_str().unwrap();
+        assert_eq!(recovery_action, "read_files");
+        assert!(
+            crate::tool_runtime::tool_definition::is_adaptive_runtime_direct_tool(recovery_action)
+        );
         assert_eq!(result.output["recovery"]["reason"], "context_mismatch");
-        assert_eq!(result.output["recovery"]["path"], "file.txt");
-        assert_eq!(result.output["recovery"]["start_line"], 1);
-        assert_eq!(result.output["recovery"]["limit"], 10);
+        assert_eq!(result.output["recovery"]["items"][0]["path"], "file.txt");
+        assert_eq!(result.output["recovery"]["items"][0]["start_line"], 1);
+        assert_eq!(result.output["recovery"]["items"][0]["limit"], 10);
         assert_eq!(result.output["recovery"]["change_index"], 0);
         assert_eq!(result.output["recovery"]["chunk_index"], 0);
         assert!(result.output.get("future_body_field").is_none());
@@ -2452,8 +2458,8 @@ mod tests {
             &schema,
         )
         .unwrap_or_else(|error| panic!("apply_patch recovery must match output schema: {error}"));
-        assert_eq!(result.output["recovery"]["start_line"], 122);
-        assert_eq!(result.output["recovery"]["limit"], 21);
+        assert_eq!(result.output["recovery"]["items"][0]["start_line"], 122);
+        assert_eq!(result.output["recovery"]["items"][0]["limit"], 21);
 
         let near_start = apply_patch_agent_stdout_result(
             &context_mismatch_payload(5, 1, 20, Some(1)).to_string(),
@@ -2461,8 +2467,8 @@ mod tests {
             false,
             false,
         );
-        assert_eq!(near_start.output["recovery"]["start_line"], 1);
-        assert_eq!(near_start.output["recovery"]["limit"], 20);
+        assert_eq!(near_start.output["recovery"]["items"][0]["start_line"], 1);
+        assert_eq!(near_start.output["recovery"]["items"][0]["limit"], 20);
 
         let eof_partial = apply_patch_agent_stdout_result(
             &context_mismatch_payload(5, 11, 2, Some(12)).to_string(),
@@ -2470,7 +2476,7 @@ mod tests {
             false,
             false,
         );
-        let recovery = &eof_partial.output["recovery"];
+        let recovery = &eof_partial.output["recovery"]["items"][0];
         assert_eq!(recovery["start_line"], 4);
         assert_eq!(recovery["limit"], 9);
         assert_eq!(
@@ -2486,7 +2492,7 @@ mod tests {
             false,
         );
         assert_eq!(
-            large.output["recovery"]["limit"],
+            large.output["recovery"]["items"][0]["limit"],
             crate::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES
         );
 
@@ -2501,7 +2507,7 @@ mod tests {
             false,
             false,
         );
-        let recovery = &distant_mismatch.output["recovery"];
+        let recovery = &distant_mismatch.output["recovery"]["items"][0];
         assert_eq!(recovery["start_line"], 134);
         assert_eq!(
             recovery["limit"],
@@ -2545,8 +2551,13 @@ mod tests {
         let serialized = serde_json::to_string(&result.output).unwrap();
         assert!(!serialized.contains("SOURCE_PRIVATE_TOKEN"));
         assert!(!serialized.contains("PATCH_PRIVATE_TOKEN"));
-        assert_eq!(result.output["recovery"]["path"], "file.txt");
-        assert!(result.output["recovery"]["limit"].as_u64().unwrap() <= 64);
+        assert_eq!(result.output["recovery"]["items"][0]["path"], "file.txt");
+        assert!(
+            result.output["recovery"]["items"][0]["limit"]
+                .as_u64()
+                .unwrap()
+                <= 64
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add bounded body-free context mismatch diagnostics and Server-derived reread recovery for apply_patch
- keep empty project creation side-effect free
- keep recovery directly callable on adaptive runtime via read_files
- document the zero-write recovery path

## Validation
- cargo test -p webcodex apply_patch_ --offline
- cargo test -p webcodex-tool-contracts --offline
- cargo test -p webcodex --offline
- focused core/runner coverage from the implementation review