### PR TITLE
Harden native Plugin lifecycle concurrency

### DIFF
--- a/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
@@ -6,6 +6,7 @@ use std::env;
 use std::fs::OpenOptions;
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
@@ -13,6 +14,11 @@ fn main() -> io::Result<()> {
     let args = env::args().skip(1).collect::<Vec<_>>();
     let scenario = args.first().map(String::as_str).unwrap_or("normal");
     let marker = args.get(1).map(Path::new);
+    if scenario == "hold" {
+        loop {
+            thread::sleep(Duration::from_secs(60));
+        }
+    }
     append(marker, "start\n")?;
     if scenario == "execution_context" {
         append(
@@ -112,6 +118,26 @@ fn main() -> io::Result<()> {
                         r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"echo","description":"Native plugin echo","inputSchema":{{"type":"object","properties":{{"value":{{"type":"{value_type}"}}}}}}}}]}}}}"#
                     ),
                 )?;
+                if matches!(
+                    scenario,
+                    "block_after_preflight" | "block_after_preflight_tree"
+                ) && lists >= 2
+                {
+                    append(marker, "stdin-blocked\n")?;
+                    if scenario == "block_after_preflight_tree" {
+                        let child = Command::new(env::current_exe()?)
+                            .arg("hold")
+                            .stdin(Stdio::null())
+                            .stdout(Stdio::null())
+                            .stderr(Stdio::null())
+                            .spawn()?;
+                        append(marker, &format!("descendant-pid:{}\n", child.id()))?;
+                        drop(child);
+                    }
+                    loop {
+                        thread::sleep(Duration::from_secs(60));
+                    }
+                }
             }
             "tools/call" => {
                 calls += 1;

--- a/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
@@ -20,6 +20,9 @@ fn main() -> io::Result<()> {
         }
     }
     append(marker, "start\n")?;
+    if scenario == "reload_new" {
+        append(marker, "reload-new-start\n")?;
+    }
     if scenario == "execution_context" {
         append(
             marker,
@@ -81,6 +84,16 @@ fn main() -> io::Result<()> {
             "tools/list" => {
                 lists += 1;
                 append(marker, "list\n")?;
+                if scenario == "reload_block_list" && lists == 1 {
+                    append(marker, "reload-blocked\n")?;
+                    let release = marker
+                        .map(|path| path.with_extension("release"))
+                        .expect("reload_block_list requires marker path");
+                    while !release.exists() {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    append(marker, "reload-released\n")?;
+                }
                 if scenario == "split_timeout" && lists >= 2 {
                     thread::sleep(Duration::from_millis(750));
                 }

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -37,6 +37,7 @@ pub(crate) struct PluginManager {
     startup_config: PluginConfig,
     startup_shell: ShellConfig,
     dynamic: Mutex<DynamicState>,
+    reload_gate: Mutex<()>,
     config_path: PathBuf,
     prepared_profiles: PreparedShellProfileCache,
     next_generation: AtomicU64,
@@ -211,6 +212,7 @@ impl PluginManager {
                 overlay: BTreeMap::new(),
                 first_class_restart_required: false,
             }),
+            reload_gate: Mutex::new(()),
             config_path,
             prepared_profiles,
             next_generation: AtomicU64::new(2),
@@ -342,6 +344,23 @@ impl PluginManager {
     }
 
     fn reload_dynamic(&self) -> PluginGatewayResponse {
+        let _reload_guard = match self.reload_gate.try_lock() {
+            Ok(guard) => guard,
+            Err(TryLockError::WouldBlock) => {
+                return gateway_error(
+                    PluginDispatchState::NotStarted,
+                    "plugin_reload_busy",
+                    "Another Plugin reload is already preparing candidates; this reload was not started",
+                )
+            }
+            Err(TryLockError::Poisoned(_)) => {
+                return gateway_error(
+                    PluginDispatchState::NotStarted,
+                    "plugin_reload_state_failed",
+                    "Plugin reload state is unavailable; dynamic state was unchanged",
+                )
+            }
+        };
         let candidate = match load_config(&self.config_path) {
             Ok(candidate) => candidate,
             Err(error) => {
@@ -388,6 +407,14 @@ impl PluginManager {
             .map(|provider| provider.id.clone())
             .collect();
         let mut dynamic = self.dynamic.lock().unwrap();
+        if self.stopping.load(Ordering::SeqCst) {
+            drop(dynamic);
+            return gateway_error(
+                PluginDispatchState::NotStarted,
+                "plugin_manager_stopping",
+                "Plugin manager began stopping before reload commit; dynamic state was unchanged",
+            );
+        }
         let previous_ids: BTreeSet<_> = self
             .startup
             .keys()

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -415,6 +415,12 @@ impl PluginManager {
                 "Plugin manager began stopping before reload commit; dynamic state was unchanged",
             );
         }
+        // Replacing an entry may drop the last ProviderEntry Arc, whose Drop
+        // performs bounded process-tree termination. Keep that cleanup outside
+        // the dynamic-state mutex so unrelated list/describe/call operations do
+        // not wait on old-provider process teardown during an otherwise atomic
+        // reload commit.
+        let mut retired = Vec::new();
         let previous_ids: BTreeSet<_> = self
             .startup
             .keys()
@@ -423,13 +429,18 @@ impl PluginManager {
             .collect();
         for provider_id in previous_ids {
             if !configured.contains(&provider_id) {
-                dynamic.overlay.insert(provider_id, DynamicEntry::Removed);
+                if let Some(previous) = dynamic.overlay.insert(provider_id, DynamicEntry::Removed) {
+                    retired.push(previous);
+                }
             }
         }
         for (provider_id, provider) in prepared {
-            dynamic
+            if let Some(previous) = dynamic
                 .overlay
-                .insert(provider_id, DynamicEntry::Provider(provider));
+                .insert(provider_id, DynamicEntry::Provider(provider))
+            {
+                retired.push(previous);
+            }
         }
         dynamic.first_class_restart_required = candidate.plugins != self.startup_config
             || candidate.shell != self.startup_shell
@@ -439,6 +450,7 @@ impl PluginManager {
                 .any(|entry| matches!(entry, DynamicEntry::Provider(_) | DynamicEntry::Removed));
         let restart_required = dynamic.first_class_restart_required;
         drop(dynamic);
+        drop(retired);
 
         PluginGatewayResponse::success(PluginGatewayResponsePayload::Reloaded {
             providers: self.provider_views(),

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -27,6 +27,9 @@ use webcodex_core::plugin::{
 use webcodex_process::ManagedChild;
 
 const PLUGIN_READER_QUEUE: usize = 16;
+const PLUGIN_WRITER_QUEUE: usize = 1;
+const PLUGIN_STOP_POLL: Duration = Duration::from_millis(25);
+const PLUGIN_TERMINATION_BUDGET: Duration = Duration::from_secs(1);
 
 pub(crate) struct PluginManager {
     startup: BTreeMap<String, Arc<ProviderEntry>>,
@@ -37,7 +40,7 @@ pub(crate) struct PluginManager {
     config_path: PathBuf,
     prepared_profiles: PreparedShellProfileCache,
     next_generation: AtomicU64,
-    stopping: AtomicBool,
+    stopping: Arc<AtomicBool>,
 }
 
 struct DynamicState {
@@ -56,14 +59,30 @@ struct ProviderEntry {
     timeout: Duration,
     failed: AtomicBool,
     error_code: Mutex<Option<String>>,
+    process: Arc<ProviderProcess>,
     session: Mutex<Option<ProviderConnection>>,
 }
 
+struct ProviderProcess {
+    child: Mutex<Option<ManagedChild>>,
+}
+
 struct ProviderConnection {
-    child: ManagedChild,
-    stdin: ChildStdin,
+    process: Arc<ProviderProcess>,
+    stopping: Arc<AtomicBool>,
+    writer: mpsc::SyncSender<WriteRequest>,
     incoming: mpsc::Receiver<ReaderEvent>,
     next_id: u64,
+}
+
+struct WriteRequest {
+    frame: Vec<u8>,
+    ack: mpsc::Sender<WriteAck>,
+}
+
+enum WriteAck {
+    Written,
+    Failed,
 }
 
 enum ReaderEvent {
@@ -105,6 +124,14 @@ impl ProviderFailure {
         }
     }
 
+    fn before_send_timeout() -> Self {
+        Self {
+            dispatch_state: PluginDispatchState::NotStarted,
+            code: "plugin_timeout",
+            fatal: false,
+        }
+    }
+
     fn completed(code: &'static str, fatal: bool) -> Self {
         Self {
             dispatch_state: PluginDispatchState::Completed,
@@ -117,6 +144,7 @@ impl ProviderFailure {
 impl PluginManager {
     pub(crate) fn new(startup: &RunnerConfig, config_path: PathBuf) -> Self {
         let prepared_profiles = PreparedShellProfileCache::default();
+        let stopping = Arc::new(AtomicBool::new(false));
         let request_timeout = Duration::from_secs(startup.plugins.request_timeout_secs);
         let mut startup_entries = BTreeMap::new();
         let mut startup_catalog = Vec::with_capacity(startup.plugins.providers.len());
@@ -129,7 +157,7 @@ impl PluginManager {
                 1,
                 request_timeout,
                 &prepared_profiles,
-                None,
+                &stopping,
             );
             let instance_id = entry.instance_id.clone();
             let mut advertised = StartupPluginProvider {
@@ -186,7 +214,7 @@ impl PluginManager {
             config_path,
             prepared_profiles,
             next_generation: AtomicU64::new(2),
-            stopping: AtomicBool::new(false),
+            stopping,
         }
     }
 
@@ -341,7 +369,7 @@ impl PluginManager {
                 generation,
                 Duration::from_secs(candidate.plugins.request_timeout_secs),
                 &self.prepared_profiles,
-                Some(&self.stopping),
+                &self.stopping,
             );
             if let Some(code) = failure {
                 failures.push(PluginReloadFailure {
@@ -399,11 +427,19 @@ impl PluginManager {
         for provider in self.startup.values() {
             provider.shutdown();
         }
-        let dynamic = self.dynamic.lock().unwrap();
-        for entry in dynamic.overlay.values() {
-            if let DynamicEntry::Provider(provider) = entry {
-                provider.shutdown();
-            }
+        let dynamic_providers = {
+            let dynamic = self.dynamic.lock().unwrap();
+            dynamic
+                .overlay
+                .values()
+                .filter_map(|entry| match entry {
+                    DynamicEntry::Provider(provider) => Some(Arc::clone(provider)),
+                    DynamicEntry::Removed => None,
+                })
+                .collect::<Vec<_>>()
+        };
+        for provider in dynamic_providers {
+            provider.shutdown();
         }
     }
 }
@@ -464,9 +500,7 @@ impl ProviderEntry {
             Err(error) => {
                 if error.fatal {
                     self.retire(error.code);
-                    if let Some(connection) = session.as_mut() {
-                        connection.terminate();
-                    }
+                    self.process.terminate();
                     *session = None;
                 }
                 Err(error)
@@ -516,11 +550,56 @@ impl ProviderEntry {
     }
 
     fn shutdown(&self) {
-        if let Ok(mut session) = self.session.lock() {
-            if let Some(connection) = session.as_mut() {
-                connection.terminate();
-            }
+        self.process.terminate();
+        if let Ok(mut session) = self.session.try_lock() {
             *session = None;
+        }
+    }
+}
+
+impl Drop for ProviderEntry {
+    fn drop(&mut self) {
+        self.process.terminate();
+    }
+}
+
+impl ProviderProcess {
+    fn new() -> Self {
+        Self {
+            child: Mutex::new(None),
+        }
+    }
+
+    fn install(&self, child: ManagedChild) {
+        let mut slot = self
+            .child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        debug_assert!(slot.is_none());
+        *slot = Some(child);
+    }
+
+    fn terminate(&self) {
+        let child = self
+            .child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(mut child) = child {
+            terminate_provider_process(&mut child);
+        }
+    }
+}
+
+impl Drop for ProviderProcess {
+    fn drop(&mut self) {
+        let child = self
+            .child
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(mut child) = child {
+            terminate_provider_process(&mut child);
         }
     }
 }
@@ -531,8 +610,9 @@ fn prepare_provider(
     generation: u64,
     request_timeout: Duration,
     prepared_profiles: &PreparedShellProfileCache,
-    stop_requested: Option<&AtomicBool>,
+    stopping: &Arc<AtomicBool>,
 ) -> (Arc<ProviderEntry>, Option<Vec<PluginTool>>, Option<String>) {
+    let process = Arc::new(ProviderProcess::new());
     let entry = Arc::new(ProviderEntry {
         config: config.clone(),
         instance_id: uuid::Uuid::new_v4().simple().to_string(),
@@ -542,6 +622,7 @@ fn prepare_provider(
             .unwrap_or(request_timeout),
         failed: AtomicBool::new(false),
         error_code: Mutex::new(None),
+        process: Arc::clone(&process),
         session: Mutex::new(None),
     });
     let cwd = config
@@ -556,7 +637,7 @@ fn prepare_provider(
         config.profile.as_deref(),
         &cwd,
         prepared_profiles,
-        stop_requested,
+        Some(stopping.as_ref()),
     ) {
         Ok(environment) => environment,
         Err(_) => {
@@ -639,9 +720,27 @@ fn prepare_provider(
         entry.retire("plugin_reader_unavailable");
         return (entry, None, Some("plugin_reader_unavailable".to_string()));
     }
+    let (writer, write_requests) = mpsc::sync_channel(PLUGIN_WRITER_QUEUE);
+    let stdin_thread_name = format!("wc-plugin-stdin-{}", config.id);
+    if std::thread::Builder::new()
+        .name(stdin_thread_name)
+        .spawn(move || provider_stdin_writer(stdin, write_requests))
+        .is_err()
+    {
+        let _ = child.terminate_tree();
+        entry.retire("plugin_writer_unavailable");
+        return (entry, None, Some("plugin_writer_unavailable".to_string()));
+    }
+    process.install(child);
+    if stopping.load(Ordering::SeqCst) {
+        process.terminate();
+        entry.retire("plugin_manager_stopping");
+        return (entry, None, Some("plugin_manager_stopping".to_string()));
+    }
     let mut connection = ProviderConnection {
-        child,
-        stdin,
+        process: Arc::clone(&process),
+        stopping: Arc::clone(stopping),
+        writer,
         incoming,
         next_id: 1,
     };
@@ -650,14 +749,14 @@ fn prepare_provider(
         .map(Duration::from_secs)
         .unwrap_or(request_timeout);
     if let Err(failure) = connection.initialize(timeout) {
-        connection.terminate();
+        process.terminate();
         entry.retire(failure.code);
         return (entry, None, Some(failure.code.to_string()));
     }
     let tools = match connection.tools_list(timeout) {
         Ok(tools) => tools,
         Err(failure) => {
-            connection.terminate();
+            process.terminate();
             entry.retire(failure.code);
             return (entry, None, Some(failure.code.to_string()));
         }
@@ -734,6 +833,10 @@ impl ProviderConnection {
         timeout: Duration,
         effectful: bool,
     ) -> Result<Value, ProviderFailure> {
+        // The deadline is created before any request-side validation or
+        // serialization. Queue admission, the complete write+flush ack, and the
+        // response wait all consume this same absolute budget.
+        let deadline = Instant::now() + timeout;
         match self.incoming.try_recv() {
             Err(mpsc::TryRecvError::Empty) => {}
             Err(mpsc::TryRecvError::Disconnected) | Ok(ReaderEvent::Eof) => {
@@ -761,18 +864,75 @@ impl ProviderConnection {
             return Err(ProviderFailure::not_started("plugin_request_too_large"));
         }
         encoded.push(b'\n');
-        self.stdin
-            .write_all(&encoded)
-            .and_then(|_| self.stdin.flush())
-            .map_err(|_| ProviderFailure::after_send("plugin_stdin_failed", effectful))?;
+        if deadline.saturating_duration_since(Instant::now()).is_zero() {
+            return Err(ProviderFailure::before_send_timeout());
+        }
 
-        let deadline = Instant::now() + timeout;
+        let (ack_sender, ack_receiver) = mpsc::channel();
+        let mut write_request = WriteRequest {
+            frame: encoded,
+            ack: ack_sender,
+        };
         loop {
+            if self.stopping.load(Ordering::SeqCst) {
+                return Err(ProviderFailure::not_started("plugin_manager_stopping"));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(ProviderFailure::before_send_timeout());
+            }
+            match self.writer.try_send(write_request) {
+                Ok(()) => break,
+                Err(mpsc::TrySendError::Full(request)) => {
+                    write_request = request;
+                    std::thread::sleep(Duration::from_millis(1).min(remaining));
+                }
+                Err(mpsc::TrySendError::Disconnected(_)) => {
+                    return Err(ProviderFailure::not_started("plugin_stdin_failed"));
+                }
+            }
+        }
+
+        // Once the bounded queue accepted the frame, an effectful request may
+        // already have started writing. A timeout or transport failure before
+        // the full write+flush ack is therefore OutcomeUnknown for effects.
+        loop {
+            if self.stopping.load(Ordering::SeqCst) {
+                self.process.terminate();
+                return Err(ProviderFailure::after_send(
+                    "plugin_manager_stopping",
+                    effectful,
+                ));
+            }
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err(ProviderFailure::after_send("plugin_timeout", effectful));
             }
-            let response = match self.incoming.recv_timeout(remaining) {
+            match ack_receiver.recv_timeout(remaining.min(PLUGIN_STOP_POLL)) {
+                Ok(WriteAck::Written) => break,
+                Ok(WriteAck::Failed) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err(ProviderFailure::after_send(
+                        "plugin_stdin_failed",
+                        effectful,
+                    ));
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            }
+        }
+
+        loop {
+            if self.stopping.load(Ordering::SeqCst) {
+                self.process.terminate();
+                return Err(ProviderFailure::after_send(
+                    "plugin_manager_stopping",
+                    effectful,
+                ));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(ProviderFailure::after_send("plugin_timeout", effectful));
+            }
+            let response = match self.incoming.recv_timeout(remaining.min(PLUGIN_STOP_POLL)) {
                 Ok(ReaderEvent::Message(Ok(response))) => response,
                 Ok(ReaderEvent::Message(Err(fault))) => {
                     return Err(ProviderFailure::after_send(
@@ -783,38 +943,43 @@ impl ProviderConnection {
                 Ok(ReaderEvent::Eof) | Err(mpsc::RecvTimeoutError::Disconnected) => {
                     return Err(ProviderFailure::after_send("plugin_eof", effectful));
                 }
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    return Err(ProviderFailure::after_send("plugin_timeout", effectful));
-                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
             };
             return validate_rpc_response(response, id, effectful);
         }
     }
+}
 
-    fn terminate(&mut self) {
-        let deadline = Instant::now() + Duration::from_secs(1);
-        let _ = self.child.terminate_tree();
-        let _ = self
-            .child
-            .wait_tree_exit(deadline.saturating_duration_since(Instant::now()));
-        loop {
-            match self.child.try_wait() {
-                Ok(Some(_)) | Err(_) => return,
-                Ok(None) => {
-                    let remaining = deadline.saturating_duration_since(Instant::now());
-                    if remaining.is_zero() {
-                        return;
-                    }
-                    std::thread::sleep(Duration::from_millis(10).min(remaining));
+fn terminate_provider_process(child: &mut ManagedChild) {
+    let deadline = Instant::now() + PLUGIN_TERMINATION_BUDGET;
+    let _ = child.terminate_tree();
+    let _ = child.wait_tree_exit(deadline.saturating_duration_since(Instant::now()));
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return;
                 }
+                std::thread::sleep(Duration::from_millis(10).min(remaining));
             }
         }
     }
 }
 
-impl Drop for ProviderConnection {
-    fn drop(&mut self) {
-        self.terminate();
+fn provider_stdin_writer(mut stdin: ChildStdin, requests: mpsc::Receiver<WriteRequest>) {
+    while let Ok(request) = requests.recv() {
+        let result = stdin.write_all(&request.frame).and_then(|_| stdin.flush());
+        let failed = result.is_err();
+        let _ = request.ack.send(if failed {
+            WriteAck::Failed
+        } else {
+            WriteAck::Written
+        });
+        if failed {
+            return;
+        }
     }
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
@@ -3,9 +3,11 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::sync::{mpsc, Arc, Mutex, OnceLock, Weak};
 use tempfile::TempDir;
-use webcodex_core::plugin::{PluginContent, PluginGatewayResponsePayload};
+use webcodex_core::plugin::{
+    PluginContent, PluginGatewayResponsePayload, PLUGIN_MAX_ARGUMENT_BYTES,
+};
 
 static FAKE_PLUGIN: OnceLock<Mutex<Weak<FakeBinary>>> = OnceLock::new();
 
@@ -100,13 +102,17 @@ impl Fixture {
     }
 
     fn call(&self) -> PluginGatewayResponse {
+        self.call_with_arguments(json!({"value":"hello"}))
+    }
+
+    fn call_with_arguments(&self, arguments: Value) -> PluginGatewayResponse {
         let schema = self.provider.tools[0].schema_observation();
         self.manager.handle(PluginGatewayRequest::ToolsCall {
             plane: PluginPlane::Startup,
             provider_id: self.provider.provider_id.clone(),
             provider_instance_id: self.provider.provider_instance_id.clone(),
             name: "echo".to_string(),
-            arguments: json!({"value":"hello"}),
+            arguments,
             expected_schema: schema,
         })
     }
@@ -118,6 +124,35 @@ impl Fixture {
             .filter(|line| *line == value)
             .count()
     }
+
+    fn marker_pid(&self, prefix: &str) -> Option<u32> {
+        fs::read_to_string(&self.marker)
+            .ok()?
+            .lines()
+            .find_map(|line| line.strip_prefix(prefix)?.parse().ok())
+    }
+}
+
+fn maximum_bounded_arguments() -> Value {
+    let empty = json!({"value":""});
+    let overhead = serde_json::to_vec(&empty).unwrap().len();
+    let arguments = json!({"value":"x".repeat(PLUGIN_MAX_ARGUMENT_BYTES - overhead)});
+    assert_eq!(
+        serde_json::to_vec(&arguments).unwrap().len(),
+        PLUGIN_MAX_ARGUMENT_BYTES
+    );
+    arguments
+}
+
+fn wait_until(timeout: Duration, condition: impl Fn() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    condition()
 }
 
 fn runner_config(
@@ -232,6 +267,96 @@ fn schema_preflight_and_effect_share_one_provider_timeout_budget() {
         1,
         "the effect starts only with the time remaining after schema preflight"
     );
+}
+
+#[test]
+fn blocking_stdin_write_respects_total_deadline_and_retires_provider_tree() {
+    let fixture = Fixture::new("block_after_preflight_tree", 1);
+    let started = Instant::now();
+    let response = fixture.call_with_arguments(maximum_bounded_arguments());
+    let elapsed = started.elapsed();
+
+    assert_eq!(response.dispatch_state, PluginDispatchState::OutcomeUnknown);
+    assert_eq!(response.error.as_ref().unwrap().code, "plugin_timeout");
+    assert!(
+        elapsed < Duration::from_millis(2500),
+        "blocked stdin write exceeded the provider deadline plus termination slack: {elapsed:?}"
+    );
+    assert_eq!(fixture.marker_count("stdin-blocked"), 1);
+    assert_eq!(fixture.marker_count("call"), 0);
+
+    let descendant_pid = fixture
+        .marker_pid("descendant-pid:")
+        .expect("fixture descendant pid");
+    assert!(wait_until(Duration::from_secs(1), || {
+        !crate::job_manager_tests::process_running(descendant_pid)
+    }));
+
+    let retired = fixture.call();
+    assert_eq!(retired.dispatch_state, PluginDispatchState::NotStarted);
+    assert_eq!(
+        retired.error.as_ref().unwrap().code,
+        "plugin_provider_unavailable"
+    );
+
+    let shutdown_started = Instant::now();
+    fixture.manager.shutdown();
+    assert!(
+        shutdown_started.elapsed() < Duration::from_millis(1500),
+        "shutdown of an already-retired blocked writer must remain bounded"
+    );
+}
+
+#[test]
+fn shutdown_terminates_process_tree_while_effectful_stdin_write_is_blocked() {
+    let fixture = Fixture::new("block_after_preflight_tree", 10);
+    let manager = Arc::clone(&fixture.manager);
+    let provider = fixture.provider.clone();
+    let arguments = maximum_bounded_arguments();
+    let (sender, receiver) = mpsc::channel();
+    let request = std::thread::spawn(move || {
+        let response = manager.handle(PluginGatewayRequest::ToolsCall {
+            plane: PluginPlane::Startup,
+            provider_id: provider.provider_id.clone(),
+            provider_instance_id: provider.provider_instance_id.clone(),
+            name: "echo".to_string(),
+            arguments,
+            expected_schema: provider.tools[0].schema_observation(),
+        });
+        let _ = sender.send(response);
+    });
+
+    assert!(wait_until(Duration::from_secs(2), || {
+        fixture.marker_count("stdin-blocked") == 1
+    }));
+    assert!(wait_until(Duration::from_secs(2), || {
+        fixture.marker_pid("descendant-pid:").is_some()
+    }));
+    // Give the writer worker an opportunity to enter OS pipe backpressure after
+    // the preflight response has been delivered.
+    std::thread::sleep(Duration::from_millis(50));
+
+    let shutdown_started = Instant::now();
+    fixture.manager.shutdown();
+    let shutdown_elapsed = shutdown_started.elapsed();
+    assert!(
+        shutdown_elapsed < Duration::from_millis(2500),
+        "shutdown waited on the request/session lock: {shutdown_elapsed:?}"
+    );
+
+    let response = receiver
+        .recv_timeout(Duration::from_secs(2))
+        .expect("blocked request must be released by process-tree termination");
+    request.join().unwrap();
+    assert_eq!(response.dispatch_state, PluginDispatchState::OutcomeUnknown);
+    assert!(matches!(
+        response.error.as_ref().map(|error| error.code.as_str()),
+        Some("plugin_manager_stopping") | Some("plugin_stdin_failed") | Some("plugin_eof")
+    ));
+    let descendant_pid = fixture.marker_pid("descendant-pid:").unwrap();
+    assert!(wait_until(Duration::from_secs(1), || {
+        !crate::job_manager_tests::process_running(descendant_pid)
+    }));
 }
 
 #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
@@ -617,6 +617,199 @@ fn direct_startup_catalog_remains_frozen_across_dynamic_reload() {
 }
 
 #[test]
+fn concurrent_reload_is_busy_while_existing_dynamic_calls_continue_and_later_reload_wins() {
+    let temp = tempfile::tempdir().unwrap();
+    let marker = temp.path().join("marker.log");
+    let release = marker.with_extension("release");
+    let fake = fake_binary();
+    let startup_plugins = PluginConfig {
+        request_timeout_secs: 2,
+        providers: vec![PluginProviderConfig {
+            id: "fake".to_string(),
+            name: "Fake Plugin".to_string(),
+            command: fake.path.to_string_lossy().into_owned(),
+            args: vec!["normal".to_string(), marker.to_string_lossy().into_owned()],
+            cwd: Some(temp.path().to_string_lossy().into_owned()),
+            profile: None,
+            timeout_secs: None,
+        }],
+    };
+    let config_path = temp.path().join("runner.toml");
+    write_runner_toml(&config_path, temp.path(), &fake.path, &marker, "normal");
+    let config = runner_config(startup_plugins, ShellConfig::default(), temp.path());
+    let manager = Arc::new(PluginManager::new(&config, config_path.clone()));
+    let startup = manager.startup_catalog();
+    let expected_schema = startup[0].tools[0].schema_observation();
+
+    let first_reload = manager.handle(PluginGatewayRequest::Reload);
+    let Some(PluginGatewayResponsePayload::Reloaded { providers, .. }) = first_reload.payload
+    else {
+        panic!("initial dynamic reload failed: {:?}", first_reload.error);
+    };
+    let dynamic_v1 = providers[0].provider_instance_id.clone();
+
+    let _ = fs::remove_file(&release);
+    write_runner_toml_with_timeout(
+        &config_path,
+        temp.path(),
+        &fake.path,
+        &marker,
+        "reload_block_list",
+        10,
+    );
+    let reload_manager = Arc::clone(&manager);
+    let reload_a = std::thread::spawn(move || reload_manager.handle(PluginGatewayRequest::Reload));
+    assert!(wait_until(Duration::from_secs(2), || {
+        fs::read_to_string(&marker)
+            .unwrap_or_default()
+            .lines()
+            .any(|line| line == "reload-blocked")
+    }));
+
+    // A has already read the old config and is blocked preparing its candidate.
+    // Publish a different config while A owns the reload gate.
+    write_runner_toml_with_timeout(
+        &config_path,
+        temp.path(),
+        &fake.path,
+        &marker,
+        "reload_new",
+        2,
+    );
+    let busy_started = Instant::now();
+    let busy = manager.handle(PluginGatewayRequest::Reload);
+    assert_eq!(busy.dispatch_state, PluginDispatchState::NotStarted);
+    assert_eq!(busy.error.as_ref().unwrap().code, "plugin_reload_busy");
+    assert!(
+        busy_started.elapsed() < Duration::from_secs(1),
+        "a second reload must fail busy instead of waiting for candidate preparation"
+    );
+
+    let current = manager.handle(PluginGatewayRequest::ProvidersList);
+    let Some(PluginGatewayResponsePayload::Providers { providers, .. }) = current.payload else {
+        panic!("current dynamic provider list failed: {:?}", current.error);
+    };
+    assert_eq!(providers[0].provider_instance_id, dynamic_v1);
+    let call_while_reloading = manager.handle(PluginGatewayRequest::ToolsCall {
+        plane: PluginPlane::Effective,
+        provider_id: "fake".to_string(),
+        provider_instance_id: dynamic_v1.clone(),
+        name: "echo".to_string(),
+        arguments: json!({"value":"during-reload"}),
+        expected_schema: expected_schema.clone(),
+    });
+    assert!(
+        call_while_reloading.error.is_none(),
+        "candidate preparation must not hold the dynamic-state lock or block the current provider"
+    );
+    assert_eq!(manager.startup_catalog(), startup);
+
+    fs::write(&release, b"release").unwrap();
+    let completed_a = reload_a.join().unwrap();
+    let Some(PluginGatewayResponsePayload::Reloaded { providers, .. }) = completed_a.payload else {
+        panic!("reload A failed after release: {:?}", completed_a.error);
+    };
+    let dynamic_a = providers[0].provider_instance_id.clone();
+    assert_ne!(dynamic_a, dynamic_v1);
+    assert_eq!(
+        fs::read_to_string(&marker)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| *line == "reload-new-start")
+            .count(),
+        0,
+        "busy reload B must not have started a candidate from the new config"
+    );
+
+    let reload_c = manager.handle(PluginGatewayRequest::Reload);
+    let Some(PluginGatewayResponsePayload::Reloaded { providers, .. }) = reload_c.payload else {
+        panic!("later reload C failed: {:?}", reload_c.error);
+    };
+    let dynamic_c = providers[0].provider_instance_id.clone();
+    assert_ne!(dynamic_c, dynamic_a);
+    assert_eq!(
+        fs::read_to_string(&marker)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| *line == "reload-new-start")
+            .count(),
+        1,
+        "reload C must read and prepare the new config after A releases the gate"
+    );
+    assert_eq!(manager.startup_catalog(), startup);
+
+    let final_view = manager.handle(PluginGatewayRequest::ProvidersList);
+    let Some(PluginGatewayResponsePayload::Providers { providers, .. }) = final_view.payload else {
+        panic!("final provider list failed: {:?}", final_view.error);
+    };
+    assert_eq!(providers[0].provider_instance_id, dynamic_c);
+    manager.shutdown();
+}
+
+#[test]
+fn shutdown_during_blocked_reload_does_not_wait_for_gate_or_allow_late_commit() {
+    let temp = tempfile::tempdir().unwrap();
+    let marker = temp.path().join("marker.log");
+    let fake = fake_binary();
+    let startup_plugins = PluginConfig {
+        request_timeout_secs: 2,
+        providers: vec![PluginProviderConfig {
+            id: "fake".to_string(),
+            name: "Fake Plugin".to_string(),
+            command: fake.path.to_string_lossy().into_owned(),
+            args: vec!["normal".to_string(), marker.to_string_lossy().into_owned()],
+            cwd: Some(temp.path().to_string_lossy().into_owned()),
+            profile: None,
+            timeout_secs: None,
+        }],
+    };
+    let config_path = temp.path().join("runner.toml");
+    write_runner_toml_with_timeout(
+        &config_path,
+        temp.path(),
+        &fake.path,
+        &marker,
+        "reload_block_list",
+        10,
+    );
+    let config = runner_config(startup_plugins, ShellConfig::default(), temp.path());
+    let manager = Arc::new(PluginManager::new(&config, config_path));
+    let reload_manager = Arc::clone(&manager);
+    let reload = std::thread::spawn(move || reload_manager.handle(PluginGatewayRequest::Reload));
+    assert!(wait_until(Duration::from_secs(2), || {
+        fs::read_to_string(&marker)
+            .unwrap_or_default()
+            .lines()
+            .any(|line| line == "reload-blocked")
+    }));
+
+    let shutdown_started = Instant::now();
+    manager.shutdown();
+    assert!(
+        shutdown_started.elapsed() < Duration::from_millis(1500),
+        "shutdown must not wait for the reload gate held by candidate preparation"
+    );
+    let reload_response = reload.join().unwrap();
+    assert_eq!(
+        reload_response.dispatch_state,
+        PluginDispatchState::NotStarted
+    );
+    assert_eq!(
+        reload_response.error.as_ref().unwrap().code,
+        "plugin_manager_stopping"
+    );
+    assert_eq!(
+        fs::read_to_string(&marker)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| *line == "reload-released")
+            .count(),
+        0,
+        "the blocked candidate must terminate from manager stopping rather than reaching commit"
+    );
+}
+
+#[test]
 fn failed_dynamic_candidate_keeps_previous_instance_and_removal_is_tombstoned() {
     let temp = tempfile::tempdir().unwrap();
     let marker = temp.path().join("marker.log");
@@ -714,13 +907,24 @@ fn write_runner_toml(
     marker: &Path,
     scenario: &str,
 ) {
+    write_runner_toml_with_timeout(path, project_registry_dir, executable, marker, scenario, 2);
+}
+
+fn write_runner_toml_with_timeout(
+    path: &Path,
+    project_registry_dir: &Path,
+    executable: &Path,
+    marker: &Path,
+    scenario: &str,
+    request_timeout_secs: u64,
+) {
     fn quoted(value: &Path) -> String {
         format!("{:?}", value.to_string_lossy().as_ref())
     }
     fs::write(
         path,
         format!(
-            "server_url = \"http://127.0.0.1:8000\"\ntoken = \"test-token\"\nclient_id = \"plugin-test\"\nproject_registry_dir = {}\n\n[plugins]\nrequest_timeout_secs = 2\n\n[[plugins.providers]]\nid = \"fake\"\nname = \"Fake Plugin\"\ncommand = {}\nargs = [\"{}\", {}]\ncwd = {}\n",
+            "server_url = \"http://127.0.0.1:8000\"\ntoken = \"test-token\"\nclient_id = \"plugin-test\"\nproject_registry_dir = {}\n\n[plugins]\nrequest_timeout_secs = {request_timeout_secs}\n\n[[plugins.providers]]\nid = \"fake\"\nname = \"Fake Plugin\"\ncommand = {}\nargs = [\"{}\", {}]\ncwd = {}\n",
             quoted(project_registry_dir),
             quoted(executable),
             scenario,

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -86,7 +86,8 @@ search_symbol({"query":"RunnerRegistry"})
 ```
 
 Duplicate or reserved names are not exposed directly. They remain reachable
-through `plugin_tool` with an explicit Runner and Plugin provider.
+through the dynamic `plugin_tool` describe/binding flow with an explicit Runner
+and Plugin provider at describe time.
 
 A provider process failure does not prevent the Runner itself from registering.
 If an admitted startup provider later fails, WebCodex retires that exact
@@ -101,12 +102,21 @@ After startup, Plugin development uses the dynamic plane:
 plugin_tool(action="reload", runner="my-runner")
 plugin_tool(action="list", runner="my-runner")
 plugin_tool(action="describe", runner="my-runner", plugin="repo-tools", tool="search_symbol")
-plugin_tool(action="call", runner="my-runner", plugin="repo-tools", tool="search_symbol", arguments={"query":"foo"})
+    -> { ..., "binding": "wc_pbind_..." }
+plugin_tool(action="call", binding="wc_pbind_...", arguments={"query":"foo"})
 ```
+
+`call` has one dispatch identity: the opaque `binding` returned by that exact
+`describe`. It does not accept `runner`, `plugin`, or `tool` as call-time
+routing fields. Each describe creates an independent binding for the exact
+Runner instance, provider instance, tool name, and schema observation seen at
+that moment. The handle does not encode or expose those internal identities.
 
 `reload` is the cross-platform authoritative reload path on Windows, macOS, and
 Linux. The Runner rereads its own `runner.toml`; the Server does not upload an
-executable, environment, or raw Plugin config.
+executable, environment, or raw Plugin config. Reload management is serialized:
+if another reload is already preparing candidates, the second reload is not
+queued and returns `plugin_reload_busy` with `NotStarted`.
 
 A changed provider is initialized and listed successfully before it replaces
 the previous dynamic instance. A failed candidate leaves the previous working
@@ -118,15 +128,18 @@ This creates the normal development loop:
 ```text
 edit Plugin code/config
     -> plugin_tool reload
-    -> describe/call the dynamic Plugin
+    -> plugin_tool describe
+    -> receive opaque binding
+    -> plugin_tool call(binding, arguments)
     -> finish debugging
     -> restart Runner
     -> new startup admission / first-class promotion
 ```
 
 If startup provider A is first-class and reload creates dynamic provider B,
-direct `search_symbol(...)` still calls A. `plugin_tool call` uses B. Only a
-Runner restart can replace the first-class binding.
+direct `search_symbol(...)` still calls A. A fresh dynamic `describe` observes B
+and its returned binding calls only that exact B instance. Only a Runner restart
+can replace the first-class startup binding.
 
 ## WebCodex Plugin Protocol v1
 
@@ -182,15 +195,24 @@ a complete no-dependency Node example.
 Each provider handles one request at a time. Concurrent calls receive a
 provider-busy result instead of being silently queued without bound.
 
-`plugin_tool call` requires a preceding `describe`. WebCodex records the exact
-Runner instance, provider instance, tool name, and observed schema internally.
-If the provider or schema changes before the call, the call is `NotStarted` and
-must be described again. Those internal instance identifiers are not exposed to
-the model.
+`plugin_tool call` requires an opaque binding from a preceding `describe`.
+Bindings are bounded server-side observations, not bearer authorization tokens:
+every call still requires current `plugin:local` authority and current access to
+the logical Runner. A binding can also be evicted. If its Runner/provider
+instance disappears, the tool is removed, or its schema changes, the stale call
+fails `NotStarted` and must be described again. WebCodex never re-resolves the
+binding to a newer same-named provider/tool, never manufactures a replacement
+binding, and never replays the call. Internal Runner/provider instance ids and
+schema revision machinery are not exposed in the handle.
 
-For effectful `tools/call`, a transport/process failure after the request may
-have been sent is reported as `OutcomeUnknown`; WebCodex does not automatically
-retry or replay it. Failures known to happen before send are `NotStarted`.
+The provider timeout is one total request budget. It starts before request
+encoding/validation and covers bounded stdin queue admission, the complete
+frame write plus flush confirmation, and the response wait. A Plugin that stops
+reading stdin therefore cannot make `write_all` escape the provider timeout.
+For effectful `tools/call`, once a frame may have started writing, a write
+timeout/failure, connection loss, process death, or response timeout is
+`OutcomeUnknown`; WebCodex does not automatically retry or replay it. Failures
+proven to happen before any possible send are `NotStarted`.
 
 Plugin stdout is protocol-only. Plugin stderr is drained separately for local
 diagnostics and is never treated as protocol, inserted into a model result, or

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -79,8 +79,8 @@ inventory 中唯一，并且没有和 WebCodex reserved tool 冲突，它会直�
 search_symbol({"query":"RunnerRegistry"})
 ```
 
-重名或 reserved-name 冲突不会做一级暴露，但仍然可以通过指定 Runner + Plugin 的
-`plugin_tool` 使用。
+重名或 reserved-name 冲突不会做一级暴露，但仍然可以在 `plugin_tool` dynamic
+流程中，于 describe 阶段明确指定 Runner + Plugin 后获得 binding 使用。
 
 单个 startup provider 启动失败不会拖死整个 Runner registration。已经 admission 的
 startup provider 如果之后失效，WebCodex 会 retire 这个 exact provider instance，
@@ -94,12 +94,19 @@ Runner 启动后的 Plugin 开发统一走 dynamic plane：
 plugin_tool(action="reload", runner="my-runner")
 plugin_tool(action="list", runner="my-runner")
 plugin_tool(action="describe", runner="my-runner", plugin="repo-tools", tool="search_symbol")
-plugin_tool(action="call", runner="my-runner", plugin="repo-tools", tool="search_symbol", arguments={"query":"foo"})
+    -> { ..., "binding": "wc_pbind_..." }
+plugin_tool(action="call", binding="wc_pbind_...", arguments={"query":"foo"})
 ```
+
+`call` 的 dispatch identity 只有这个 opaque `binding`；call 阶段不再接受
+`runner`、`plugin`、`tool` 作为路由字段。每次 describe 都会创建独立 binding，精确
+记录当时观察到的 Runner instance、provider instance、tool name 和 schema；handle
+本身不会编码或暴露这些内部 identity。
 
 `reload` 是 Windows、macOS、Linux 都可用的 authoritative reload 入口。Runner
 自己重新读取自己的 `runner.toml`；Server 不会上传 executable、env 或 raw Plugin
-config。
+config。reload 管理操作严格串行：如果已经有一个 reload 正在准备 candidate，第二个
+reload 不排队，直接返回 `plugin_reload_busy` + `NotStarted`。
 
 changed provider 会先准备 candidate，只有 initialize/list 成功后才替换旧 dynamic
 instance；candidate 失败会保留已有可工作的 dynamic instance。被删除的 provider 会从
@@ -110,15 +117,18 @@ dynamic view 中消失。这些操作都不会修改 frozen startup catalog。
 ```text
 修改 Plugin code/config
     -> plugin_tool reload
-    -> describe/call dynamic Plugin
+    -> plugin_tool describe
+    -> 收到 opaque binding
+    -> plugin_tool call(binding, arguments)
     -> 调试完成
     -> restart Runner
     -> 新 startup admission / 一级工具 promotion
 ```
 
 如果 startup provider A 已经提供一级 `search_symbol`，reload 后产生 dynamic provider
-B，那么直接 `search_symbol(...)` 仍然调用 A；`plugin_tool call` 使用 B。只有 Runner
-restart 才能替换一级绑定。
+B，那么直接 `search_symbol(...)` 仍然调用 A；新的 dynamic `describe` 会观察 B，返回的
+binding 也只会调用那个 exact B instance。只有 Runner restart 才能替换一级 startup
+绑定。
 
 ## WebCodex Plugin Protocol v1
 
@@ -168,14 +178,21 @@ message、schema、arguments、JSON depth/node/string、tool count 和 result �
 每个 provider 同一时间只处理一个 request。并发请求会得到 provider-busy，而不是无限
 排队。
 
-`plugin_tool call` 必须先 `describe`。WebCodex 在内部记录 exact Runner instance、
-provider instance、tool name 和 schema observation；如果 call 前 provider/schema 已变化，
-请求会以 `NotStarted` 失败并要求重新 describe，不会 retarget。内部 instance id 不暴露
-给模型。
+`plugin_tool call` 必须使用前一次 `describe` 返回的 opaque binding。binding 是
+Server 端有界保存的一次 exact observation，不是 bearer authorization token：每次 call
+仍然重新要求当前 credential 具有 `plugin:local`，并且当前 caller 仍有权访问对应 logical
+Runner。binding 也可能因为容量上限被 eviction。Runner/provider instance 被替换、tool 被
+删除或 schema 改变时，旧 binding 以 `NotStarted` fail closed，必须重新 describe；
+WebCodex 不会把它 re-resolve 到新的同名 provider/tool，不会自动生成新 binding，也不会
+replay。内部 Runner/provider instance id 和 schema revision 不会编码到 handle 里或暴露给
+模型。
 
-对于 effectful `tools/call`，如果 request 可能已经发送后才发生 transport/process
-failure，会返回 `OutcomeUnknown`，WebCodex 不会自动 retry/replay；明确发生在 send 之前
-的失败是 `NotStarted`。
+provider timeout 是一次 RPC 的总预算：从 request encode/validation 前开始，同时覆盖
+bounded stdin queue admission、完整 frame 的 write + flush confirmation，以及 response
+wait。因此 Plugin 即使停止读取 stdin，`write_all` 也不能逃逸 provider timeout。对于
+effectful `tools/call`，只要 frame 已经可能开始写入，write timeout/failure、connection
+loss、process death 或 response timeout 都返回 `OutcomeUnknown`，不会自动 retry/replay；
+只有能证明任何 byte 都不可能发送的失败才是 `NotStarted`。
 
 stdout 只用于 protocol。stderr 单独 drain，仅作为本机 diagnostic，不会自动进入模型
 result，也不会进入 startup registration catalog。

--- a/src/mcp_tests/oauth_scope.rs
+++ b/src/mcp_tests/oauth_scope.rs
@@ -273,8 +273,8 @@ async fn oauth2_native_plugin_catalog_and_call_require_explicit_plugin_scope() {
     assert_eq!(status, StatusCode::OK, "body: {body:?}");
     assert_eq!(body["result"]["isError"], true);
     assert_eq!(
-        body["result"]["structuredContent"]["error"]["code"],
-        "describe_required"
+        body["result"]["structuredContent"]["error"]["code"], "invalid_arguments",
+        "the pre-binding call shape must be rejected instead of treated as a describe lookup"
     );
 }
 

--- a/src/mcp_tests/plugin_tools.rs
+++ b/src/mcp_tests/plugin_tools.rs
@@ -61,7 +61,11 @@ async fn complete_plugin_request(
 }
 
 fn plugin_auth(include_scope: bool) -> crate::auth::AuthContext {
-    let mut auth = mcp_export_api_auth("plugin-test-pat", "alice");
+    plugin_auth_for("alice", include_scope)
+}
+
+fn plugin_auth_for(owner: &str, include_scope: bool) -> crate::auth::AuthContext {
+    let mut auth = mcp_export_api_auth("plugin-test-pat", owner);
     if include_scope {
         auth.scopes
             .push(crate::auth::SCOPE_PLUGIN_LOCAL.to_string());
@@ -200,6 +204,122 @@ async fn tools_list(
         McpOutcome::Ok(value) => value,
         other => panic!("tools/list failed: {other:?}"),
     }
+}
+
+async fn describe_dynamic_binding(
+    runtime: &Arc<ToolRuntime>,
+    auth: &crate::auth::AuthContext,
+    runner_id: &str,
+    runner_instance_id: &str,
+    provider: PluginProviderView,
+    tool: PluginTool,
+    rpc_id: u64,
+) -> (String, Value) {
+    let request_runtime = Arc::clone(runtime);
+    let request_auth = auth.clone();
+    let runner = runner_id.to_string();
+    let plugin = provider.provider_id.clone();
+    let tool_name = tool.name.clone();
+    let task = tokio::spawn(async move {
+        handle_mcp_request(
+            &request_runtime,
+            rpc(
+                "tools/call",
+                Some(json!(rpc_id)),
+                json!({
+                    "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                    "arguments": {
+                        "action":"describe",
+                        "runner":runner,
+                        "plugin":plugin,
+                        "tool":tool_name
+                    }
+                }),
+            ),
+            Some(&request_auth),
+        )
+        .await
+    });
+
+    let providers_request =
+        wait_for_plugin_request(&runtime.runner_registry, runner_id, runner_instance_id).await;
+    assert!(matches!(
+        providers_request.plugin_gateway,
+        Some(PluginGatewayRequest::ProvidersList)
+    ));
+    complete_plugin_request(
+        runtime,
+        providers_request,
+        runner_instance_id,
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::Providers {
+            providers: vec![provider.clone()],
+            first_class_restart_required: true,
+        }),
+    )
+    .await;
+
+    let tools_request =
+        wait_for_plugin_request(&runtime.runner_registry, runner_id, runner_instance_id).await;
+    assert!(matches!(
+        tools_request.plugin_gateway,
+        Some(PluginGatewayRequest::ToolsList {
+            plane: PluginPlane::Effective,
+            ref provider_id,
+            ref provider_instance_id,
+        }) if provider_id == &provider.provider_id
+            && provider_instance_id == &provider.provider_instance_id
+    ));
+    complete_plugin_request(
+        runtime,
+        tools_request,
+        runner_instance_id,
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::Tools { tools: vec![tool] }),
+    )
+    .await;
+
+    let McpOutcome::Ok(result) = task.await.unwrap() else {
+        panic!("plugin_tool describe did not complete successfully");
+    };
+    assert_eq!(result["result"]["isError"], false);
+    let binding = result["result"]["structuredContent"]["binding"]
+        .as_str()
+        .expect("describe must return opaque binding")
+        .to_string();
+    assert!(binding.starts_with("wc_pbind_"));
+    let encoded = serde_json::to_string(&result["result"]["structuredContent"]).unwrap();
+    assert!(!encoded.contains(runner_instance_id));
+    assert!(!encoded.contains(&provider.provider_instance_id));
+    (binding, result)
+}
+
+fn spawn_binding_call(
+    runtime: &Arc<ToolRuntime>,
+    auth: &crate::auth::AuthContext,
+    binding: String,
+    arguments: Value,
+    rpc_id: u64,
+) -> tokio::task::JoinHandle<McpOutcome> {
+    let request_runtime = Arc::clone(runtime);
+    let request_auth = auth.clone();
+    tokio::spawn(async move {
+        handle_mcp_request(
+            &request_runtime,
+            rpc(
+                "tools/call",
+                Some(json!(rpc_id)),
+                json!({
+                    "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                    "arguments": {
+                        "action":"call",
+                        "binding":binding,
+                        "arguments":arguments
+                    }
+                }),
+            ),
+            Some(&request_auth),
+        )
+        .await
+    })
 }
 
 #[tokio::test]
@@ -695,30 +815,19 @@ async fn plugin_tool_reload_describe_call_binds_exact_dynamic_provider_and_forge
         describe_result["result"]["structuredContent"]["plugin"],
         "repo-tools"
     );
+    let binding = describe_result["result"]["structuredContent"]["binding"]
+        .as_str()
+        .expect("describe binding")
+        .to_string();
+    assert!(binding.starts_with("wc_pbind_"));
 
-    let call_runtime = Arc::clone(&runtime);
-    let call_auth = auth.clone();
-    let call_task = tokio::spawn(async move {
-        handle_mcp_request(
-            &call_runtime,
-            rpc(
-                "tools/call",
-                Some(json!(722)),
-                json!({
-                    "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
-                    "arguments": {
-                        "action":"call",
-                        "runner":"runner-a",
-                        "plugin":"repo-tools",
-                        "tool":"search_symbol",
-                        "arguments":{"query":"PluginManager"}
-                    }
-                }),
-            ),
-            Some(&call_auth),
-        )
-        .await
-    });
+    let call_task = spawn_binding_call(
+        &runtime,
+        &auth,
+        binding.clone(),
+        json!({"query":"PluginManager"}),
+        722,
+    );
     let call_request =
         wait_for_plugin_request(&runtime.runner_registry, "runner-a", "runner-instance-a").await;
     let Some(PluginGatewayRequest::ToolsCall {
@@ -763,29 +872,13 @@ async fn plugin_tool_reload_describe_call_binds_exact_dynamic_provider_and_forge
         "found PluginManager"
     );
 
-    let replacement_runtime = Arc::clone(&runtime);
-    let replacement_auth = auth.clone();
-    let replacement_task = tokio::spawn(async move {
-        handle_mcp_request(
-            &replacement_runtime,
-            rpc(
-                "tools/call",
-                Some(json!(723)),
-                json!({
-                    "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
-                    "arguments": {
-                        "action":"call",
-                        "runner":"runner-a",
-                        "plugin":"repo-tools",
-                        "tool":"search_symbol",
-                        "arguments":{"query":"stale"}
-                    }
-                }),
-            ),
-            Some(&replacement_auth),
-        )
-        .await
-    });
+    let replacement_task = spawn_binding_call(
+        &runtime,
+        &auth,
+        binding.clone(),
+        json!({"query":"stale"}),
+        723,
+    );
     let replacement_request =
         wait_for_plugin_request(&runtime.runner_registry, "runner-a", "runner-instance-a").await;
     assert!(matches!(
@@ -825,9 +918,7 @@ async fn plugin_tool_reload_describe_call_binds_exact_dynamic_provider_and_forge
                 "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
                 "arguments": {
                     "action":"call",
-                    "runner":"runner-a",
-                    "plugin":"repo-tools",
-                    "tool":"search_symbol",
+                    "binding":binding,
                     "arguments":{"query":"must-describe-again"}
                 }
             }),
@@ -848,6 +939,455 @@ async fn plugin_tool_reload_describe_call_binds_exact_dynamic_provider_and_forge
         .poll(RunnerPollRequest {
             client_id: "runner-a".to_string(),
             runner_instance_id: "runner-instance-a".to_string(),
+        })
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn plugin_binding_a_never_retargets_across_reload_and_binding_b_still_calls_v2() {
+    let runtime = Arc::new(test_runtime());
+    let auth = plugin_auth(true);
+    register_plugin_runner(
+        &runtime,
+        "runner-a",
+        "runner-instance-a",
+        "repo-tools",
+        "startup-provider-instance",
+        vec![plugin_tool("search_symbol")],
+    )
+    .await;
+
+    let provider_v1 = PluginProviderView {
+        provider_id: "repo-tools".to_string(),
+        provider_instance_id: "dynamic-provider-v1".to_string(),
+        name: "Repo Tools".to_string(),
+        plane: PluginPlane::Effective,
+        status: "ready".to_string(),
+        error_code: None,
+        startup_direct_tool_count: 1,
+    };
+    let provider_v2 = PluginProviderView {
+        provider_instance_id: "dynamic-provider-v2".to_string(),
+        ..provider_v1.clone()
+    };
+
+    let (binding_a, _) = describe_dynamic_binding(
+        &runtime,
+        &auth,
+        "runner-a",
+        "runner-instance-a",
+        provider_v1.clone(),
+        plugin_tool("search_symbol"),
+        730,
+    )
+    .await;
+
+    let reload_runtime = Arc::clone(&runtime);
+    let reload_auth = auth.clone();
+    let reload_task = tokio::spawn(async move {
+        handle_mcp_request(
+            &reload_runtime,
+            rpc(
+                "tools/call",
+                Some(json!(731)),
+                json!({
+                    "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                    "arguments": {"action":"reload","runner":"runner-a"}
+                }),
+            ),
+            Some(&reload_auth),
+        )
+        .await
+    });
+    let reload_request =
+        wait_for_plugin_request(&runtime.runner_registry, "runner-a", "runner-instance-a").await;
+    assert!(matches!(
+        reload_request.plugin_gateway,
+        Some(PluginGatewayRequest::Reload)
+    ));
+    complete_plugin_request(
+        &runtime,
+        reload_request,
+        "runner-instance-a",
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::Reloaded {
+            providers: vec![provider_v2.clone()],
+            failures: vec![],
+            first_class_restart_required: true,
+        }),
+    )
+    .await;
+    let McpOutcome::Ok(reload_result) = reload_task.await.unwrap() else {
+        panic!("reload failed");
+    };
+    assert_eq!(reload_result["result"]["isError"], false);
+
+    let (binding_b, _) = describe_dynamic_binding(
+        &runtime,
+        &auth,
+        "runner-a",
+        "runner-instance-a",
+        provider_v2.clone(),
+        plugin_tool("search_symbol"),
+        732,
+    )
+    .await;
+    assert_ne!(binding_a, binding_b);
+
+    let stale_a = spawn_binding_call(&runtime, &auth, binding_a, json!({"query":"stale-a"}), 733);
+    let request_a =
+        wait_for_plugin_request(&runtime.runner_registry, "runner-a", "runner-instance-a").await;
+    assert!(matches!(
+        request_a.plugin_gateway,
+        Some(PluginGatewayRequest::ToolsCall {
+            plane: PluginPlane::Effective,
+            ref provider_instance_id,
+            ref name,
+            ..
+        }) if provider_instance_id == "dynamic-provider-v1" && name == "search_symbol"
+    ));
+    complete_plugin_request(
+        &runtime,
+        request_a,
+        "runner-instance-a",
+        PluginGatewayResponse::error(
+            PluginDispatchState::NotStarted,
+            "stale_plugin_provider",
+            "v1 was replaced",
+        ),
+    )
+    .await;
+    let McpOutcome::Ok(stale_result) = stale_a.await.unwrap() else {
+        panic!("stale binding should render a normal Plugin tool error");
+    };
+    assert_eq!(
+        stale_result["result"]["structuredContent"]["error"]["code"],
+        "plugin_replaced"
+    );
+    assert_eq!(
+        stale_result["result"]["structuredContent"]["dispatchState"],
+        "not_started"
+    );
+
+    let live_b = spawn_binding_call(&runtime, &auth, binding_b, json!({"query":"live-b"}), 734);
+    let request_b =
+        wait_for_plugin_request(&runtime.runner_registry, "runner-a", "runner-instance-a").await;
+    let Some(PluginGatewayRequest::ToolsCall {
+        plane,
+        provider_instance_id,
+        name,
+        arguments,
+        ..
+    }) = request_b.plugin_gateway.clone()
+    else {
+        panic!("binding B did not dispatch a typed call");
+    };
+    assert_eq!(plane, PluginPlane::Effective);
+    assert_eq!(provider_instance_id, "dynamic-provider-v2");
+    assert_eq!(name, "search_symbol");
+    assert_eq!(arguments, json!({"query":"live-b"}));
+    complete_plugin_request(
+        &runtime,
+        request_b,
+        "runner-instance-a",
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::ToolResult {
+            result: PluginToolResult {
+                content: vec![PluginContent::Text {
+                    text: "v2-ok".to_string(),
+                }],
+                structured_content: Some(json!({"version":2})),
+                is_error: false,
+            },
+        }),
+    )
+    .await;
+    let McpOutcome::Ok(live_result) = live_b.await.unwrap() else {
+        panic!("binding B call failed");
+    };
+    assert_eq!(live_result["result"]["content"][0]["text"], "v2-ok");
+}
+
+#[tokio::test]
+async fn plugin_binding_rechecks_scope_and_runner_owner_without_invalidating_owner_binding() {
+    let runtime = Arc::new(test_runtime());
+    let alice = plugin_auth_for("alice", true);
+    register_plugin_runner(
+        &runtime,
+        "runner-a",
+        "runner-instance-a",
+        "repo-tools",
+        "startup-provider-instance",
+        vec![plugin_tool("search_symbol")],
+    )
+    .await;
+    let provider = PluginProviderView {
+        provider_id: "repo-tools".to_string(),
+        provider_instance_id: "dynamic-provider-instance".to_string(),
+        name: "Repo Tools".to_string(),
+        plane: PluginPlane::Effective,
+        status: "ready".to_string(),
+        error_code: None,
+        startup_direct_tool_count: 1,
+    };
+    let (binding, _) = describe_dynamic_binding(
+        &runtime,
+        &alice,
+        "runner-a",
+        "runner-instance-a",
+        provider,
+        plugin_tool("search_symbol"),
+        740,
+    )
+    .await;
+
+    let no_scope = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(741)),
+            json!({
+                "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                "arguments": {
+                    "action":"call",
+                    "binding":binding.clone(),
+                    "arguments":{"query":"no-scope"}
+                }
+            }),
+        ),
+        Some(&plugin_auth_for("alice", false)),
+    )
+    .await;
+    assert!(matches!(no_scope, McpOutcome::Forbidden { .. }));
+
+    let bob = plugin_auth_for("bob", true);
+    let bob_result = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(742)),
+            json!({
+                "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                "arguments": {
+                    "action":"call",
+                    "binding":binding.clone(),
+                    "arguments":{"query":"private"}
+                }
+            }),
+        ),
+        Some(&bob),
+    )
+    .await;
+    let McpOutcome::Ok(bob_result) = bob_result else {
+        panic!("owner isolation should render a Plugin tool error");
+    };
+    assert_eq!(bob_result["result"]["isError"], true);
+    assert_eq!(
+        bob_result["result"]["structuredContent"]["error"]["code"],
+        "describe_required"
+    );
+    assert!(runtime
+        .runner_registry
+        .poll(RunnerPollRequest {
+            client_id: "runner-a".to_string(),
+            runner_instance_id: "runner-instance-a".to_string(),
+        })
+        .await
+        .unwrap()
+        .is_none());
+
+    let alice_call = spawn_binding_call(
+        &runtime,
+        &alice,
+        binding,
+        json!({"query":"still-alice"}),
+        743,
+    );
+    let request =
+        wait_for_plugin_request(&runtime.runner_registry, "runner-a", "runner-instance-a").await;
+    assert!(matches!(
+        request.plugin_gateway,
+        Some(PluginGatewayRequest::ToolsCall { .. })
+    ));
+    complete_plugin_request(
+        &runtime,
+        request,
+        "runner-instance-a",
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::ToolResult {
+            result: PluginToolResult {
+                content: vec![PluginContent::Text {
+                    text: "alice-ok".to_string(),
+                }],
+                structured_content: None,
+                is_error: false,
+            },
+        }),
+    )
+    .await;
+    let McpOutcome::Ok(alice_result) = alice_call.await.unwrap() else {
+        panic!("Alice's binding was incorrectly invalidated by Bob");
+    };
+    assert_eq!(alice_result["result"]["content"][0]["text"], "alice-ok");
+}
+
+#[tokio::test]
+async fn plugin_binding_runner_replacement_and_schema_change_fail_closed() {
+    let runtime = Arc::new(test_runtime());
+    let auth = plugin_auth(true);
+    register_plugin_runner(
+        &runtime,
+        "runner-a",
+        "runner-instance-a",
+        "repo-tools",
+        "startup-provider-instance",
+        vec![plugin_tool("search_symbol")],
+    )
+    .await;
+    let provider = PluginProviderView {
+        provider_id: "repo-tools".to_string(),
+        provider_instance_id: "dynamic-provider-instance".to_string(),
+        name: "Repo Tools".to_string(),
+        plane: PluginPlane::Effective,
+        status: "ready".to_string(),
+        error_code: None,
+        startup_direct_tool_count: 1,
+    };
+
+    let (runner_binding, _) = describe_dynamic_binding(
+        &runtime,
+        &auth,
+        "runner-a",
+        "runner-instance-a",
+        provider.clone(),
+        plugin_tool("search_symbol"),
+        750,
+    )
+    .await;
+    register_plugin_runner(
+        &runtime,
+        "runner-a",
+        "runner-instance-b",
+        "repo-tools",
+        "replacement-startup-provider",
+        vec![plugin_tool("search_symbol")],
+    )
+    .await;
+    let replaced = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(751)),
+            json!({
+                "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                "arguments": {
+                    "action":"call",
+                    "binding":runner_binding,
+                    "arguments":{"query":"old-runner"}
+                }
+            }),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Ok(replaced) = replaced else {
+        panic!("runner replacement should render a Plugin tool error");
+    };
+    assert_eq!(
+        replaced["result"]["structuredContent"]["error"]["code"],
+        "plugin_replaced"
+    );
+    assert_eq!(
+        replaced["result"]["structuredContent"]["dispatchState"],
+        "not_started"
+    );
+    assert!(runtime
+        .runner_registry
+        .poll(RunnerPollRequest {
+            client_id: "runner-a".to_string(),
+            runner_instance_id: "runner-instance-b".to_string(),
+        })
+        .await
+        .unwrap()
+        .is_none());
+
+    let (schema_binding, _) = describe_dynamic_binding(
+        &runtime,
+        &auth,
+        "runner-a",
+        "runner-instance-b",
+        provider,
+        plugin_tool("search_symbol"),
+        752,
+    )
+    .await;
+    let schema_call = spawn_binding_call(
+        &runtime,
+        &auth,
+        schema_binding.clone(),
+        json!({"query":"schema-change"}),
+        753,
+    );
+    let schema_request =
+        wait_for_plugin_request(&runtime.runner_registry, "runner-a", "runner-instance-b").await;
+    assert!(matches!(
+        schema_request.plugin_gateway,
+        Some(PluginGatewayRequest::ToolsCall {
+            ref provider_instance_id,
+            ..
+        }) if provider_instance_id == "dynamic-provider-instance"
+    ));
+    complete_plugin_request(
+        &runtime,
+        schema_request,
+        "runner-instance-b",
+        PluginGatewayResponse::error(
+            PluginDispatchState::NotStarted,
+            "plugin_schema_changed",
+            "schema changed",
+        ),
+    )
+    .await;
+    let McpOutcome::Ok(schema_result) = schema_call.await.unwrap() else {
+        panic!("schema change should render a Plugin tool error");
+    };
+    assert_eq!(
+        schema_result["result"]["structuredContent"]["error"]["code"],
+        "plugin_schema_changed"
+    );
+    assert_eq!(
+        schema_result["result"]["structuredContent"]["dispatchState"],
+        "not_started"
+    );
+
+    let second = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(754)),
+            json!({
+                "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                "arguments": {
+                    "action":"call",
+                    "binding":schema_binding,
+                    "arguments":{"query":"must-describe-again"}
+                }
+            }),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Ok(second) = second else {
+        panic!("evicted stale binding should render a normal Plugin tool error");
+    };
+    assert_eq!(
+        second["result"]["structuredContent"]["error"]["code"],
+        "describe_required"
+    );
+    assert!(runtime
+        .runner_registry
+        .poll(RunnerPollRequest {
+            client_id: "runner-a".to_string(),
+            runner_instance_id: "runner-instance-b".to_string(),
         })
         .await
         .unwrap()

--- a/src/plugin_gateway.rs
+++ b/src/plugin_gateway.rs
@@ -3,7 +3,7 @@
 //! Plugin processes and their executable configuration never cross the Runner
 //! boundary.  This module resolves only caller-visible logical identities,
 //! stores bounded describe observations, and dispatches the closed typed Plugin
-//! gateway with exact Runner/provider fences.
+//! gateway with opaque exact Runner/provider/schema bindings.
 
 pub(crate) use webcodex_core::plugin::*;
 
@@ -16,70 +16,69 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 pub(crate) const PLUGIN_TOOL_NAME: &str = "plugin_tool";
-const MAX_SCHEMA_OBSERVATIONS: usize = 512;
+const MAX_PLUGIN_BINDINGS: usize = 512;
 const GATEWAY_WAIT_TIMEOUT: Duration = Duration::from_secs(125);
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct ObservationKey {
-    runner: String,
-    plugin: String,
-    tool: String,
-}
-
 #[derive(Debug, Clone)]
-struct ObservedBinding {
+struct PluginBinding {
     client_id: String,
     runner_instance_id: String,
     provider_id: String,
     provider_instance_id: String,
+    tool_name: String,
     schema: PluginSchemaObservation,
 }
 
 #[derive(Default)]
-struct ObservationStore {
-    values: HashMap<ObservationKey, ObservedBinding>,
-    order: VecDeque<ObservationKey>,
+struct BindingStore {
+    values: HashMap<String, PluginBinding>,
+    order: VecDeque<String>,
 }
 
 #[derive(Default)]
 pub(crate) struct PluginGatewayRuntime {
-    observations: Mutex<ObservationStore>,
+    bindings: Mutex<BindingStore>,
 }
 
 impl PluginGatewayRuntime {
-    fn remember(&self, key: ObservationKey, value: ObservedBinding) {
+    fn remember(&self, value: PluginBinding) -> String {
         let mut store = self
-            .observations
+            .bindings
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if !store.values.contains_key(&key) {
-            store.order.push_back(key.clone());
-        }
-        store.values.insert(key, value);
-        while store.values.len() > MAX_SCHEMA_OBSERVATIONS {
+        let binding = loop {
+            let candidate = format!("wc_pbind_{}", uuid::Uuid::new_v4().simple());
+            if !store.values.contains_key(&candidate) {
+                break candidate;
+            }
+        };
+        store.order.push_back(binding.clone());
+        store.values.insert(binding.clone(), value);
+        while store.values.len() > MAX_PLUGIN_BINDINGS {
             let Some(oldest) = store.order.pop_front() else {
                 break;
             };
             store.values.remove(&oldest);
         }
+        binding
     }
 
-    fn observed(&self, key: &ObservationKey) -> Option<ObservedBinding> {
-        self.observations
+    fn binding(&self, binding: &str) -> Option<PluginBinding> {
+        self.bindings
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .values
-            .get(key)
+            .get(binding)
             .cloned()
     }
 
-    fn forget(&self, key: &ObservationKey) {
+    fn forget(&self, binding: &str) {
         let mut store = self
-            .observations
+            .bindings
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        store.values.remove(key);
-        store.order.retain(|candidate| candidate != key);
+        store.values.remove(binding);
+        store.order.retain(|candidate| candidate != binding);
     }
 }
 
@@ -143,6 +142,8 @@ struct PluginToolArguments {
     #[serde(default)]
     tool: Option<String>,
     #[serde(default)]
+    binding: Option<String>,
+    #[serde(default)]
     arguments: Option<Value>,
 }
 
@@ -153,7 +154,7 @@ pub(crate) fn authorized(auth: Option<&AuthContext>) -> bool {
 pub(crate) fn tool_spec() -> Value {
     json!({
         "name": PLUGIN_TOOL_NAME,
-        "description": "Develop and call Runner-local WebCodex native Tool Plugins. Plugins are arbitrary local executables using the bounded WebCodex stdio protocol, not MCP servers. action=reload rereads the exact Runner's runner.toml into the dynamic plane; startup first-class tools remain unchanged until Runner restart. Use describe before call. Runner/provider instance identities are intentionally hidden.",
+        "description": "Develop and call Runner-local WebCodex native Tool Plugins. Plugins are arbitrary local executables using the bounded WebCodex stdio protocol, not MCP servers. action=reload rereads the exact Runner's runner.toml into the dynamic plane; startup first-class tools remain unchanged until Runner restart. Dynamic calls use reload -> describe -> call: describe returns an opaque binding for that exact Runner/provider/schema observation, and call accepts only that binding plus arguments. Stale bindings never retarget or replay; describe again after replacement. Binding handles are not authorization and Runner/provider instance identities stay hidden.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -163,19 +164,24 @@ pub(crate) fn tool_spec() -> Value {
                 },
                 "runner": {
                     "type": "string",
-                    "description": "Exact caller-visible Runner client id. Required for reload, describe, and call."
+                    "description": "Exact caller-visible Runner client id. Optional for list; required for reload and describe; not accepted for call."
                 },
                 "plugin": {
                     "type": "string",
-                    "description": "Logical Plugin provider id. Required for describe and call."
+                    "description": "Logical Plugin provider id. Required only for describe; not accepted for call."
                 },
                 "tool": {
                     "type": "string",
-                    "description": "Logical Plugin tool name. Required for describe and call."
+                    "description": "Logical Plugin tool name. Required only for describe; not accepted for call."
+                },
+                "binding": {
+                    "type": "string",
+                    "pattern": "^wc_pbind_[0-9a-f]{32}$",
+                    "description": "Opaque exact-observation handle returned by action=describe. Required for call. It does not grant authorization."
                 },
                 "arguments": {
                     "type": "object",
-                    "description": "Arguments for action=call, matching the most recent action=describe schema."
+                    "description": "Required for action=call. Arguments must match the schema returned by the describe that created binding."
                 }
             },
             "required": ["action"],
@@ -233,7 +239,11 @@ async fn list(
     args: PluginToolArguments,
     auth: Option<&AuthContext>,
 ) -> Result<Value, GatewayError> {
-    if args.plugin.is_some() || args.tool.is_some() || args.arguments.is_some() {
+    if args.plugin.is_some()
+        || args.tool.is_some()
+        || args.binding.is_some()
+        || args.arguments.is_some()
+    {
         return Err(GatewayError::local(
             "invalid_arguments",
             "action=list accepts only optional runner",
@@ -270,7 +280,11 @@ async fn reload(
     args: PluginToolArguments,
     auth: Option<&AuthContext>,
 ) -> Result<Value, GatewayError> {
-    if args.plugin.is_some() || args.tool.is_some() || args.arguments.is_some() {
+    if args.plugin.is_some()
+        || args.tool.is_some()
+        || args.binding.is_some()
+        || args.arguments.is_some()
+    {
         return Err(GatewayError::local(
             "invalid_arguments",
             "action=reload accepts only runner",
@@ -305,10 +319,10 @@ async fn describe(
     args: PluginToolArguments,
     auth: Option<&AuthContext>,
 ) -> Result<Value, GatewayError> {
-    if args.arguments.is_some() {
+    if args.binding.is_some() || args.arguments.is_some() {
         return Err(GatewayError::local(
             "invalid_arguments",
-            "action=describe does not accept arguments",
+            "action=describe accepts only runner, plugin, and tool",
         ));
     }
     let runner_id = required_runner(args.runner.as_deref())?;
@@ -350,25 +364,20 @@ async fn describe(
                 "the requested tool is not present on the current effective Plugin provider",
             )
         })?;
-    runtime.plugin_gateway.remember(
-        ObservationKey {
-            runner: runner.client_id.clone(),
-            plugin: provider.provider_id.clone(),
-            tool: tool.name.clone(),
-        },
-        ObservedBinding {
-            client_id: runner.client_id.clone(),
-            runner_instance_id: runner.runner_instance_id.clone(),
-            provider_id: provider.provider_id.clone(),
-            provider_instance_id: provider.provider_instance_id.clone(),
-            schema: tool.schema_observation(),
-        },
-    );
+    let binding = runtime.plugin_gateway.remember(PluginBinding {
+        client_id: runner.client_id.clone(),
+        runner_instance_id: runner.runner_instance_id.clone(),
+        provider_id: provider.provider_id.clone(),
+        provider_instance_id: provider.provider_instance_id.clone(),
+        tool_name: tool.name.clone(),
+        schema: tool.schema_observation(),
+    });
     Ok(json!({
         "runner": runner.client_id,
         "plugin": provider.provider_id,
         "pluginName": provider.name,
-        "tool": tool
+        "tool": tool,
+        "binding": binding
     }))
 }
 
@@ -377,9 +386,13 @@ async fn call_plugin(
     args: PluginToolArguments,
     auth: Option<&AuthContext>,
 ) -> Result<PluginToolResult, GatewayError> {
-    let runner_id = required_runner(args.runner.as_deref())?;
-    let plugin_id = required_provider(args.plugin.as_deref())?;
-    let tool_name = required_tool(args.tool.as_deref())?;
+    if args.runner.is_some() || args.plugin.is_some() || args.tool.is_some() {
+        return Err(GatewayError::local(
+            "invalid_arguments",
+            "action=call accepts only binding and arguments",
+        ));
+    }
+    let binding_id = required_binding(args.binding.as_deref())?.to_string();
     let arguments = args.arguments.ok_or_else(|| {
         GatewayError::local("invalid_arguments", "action=call requires arguments")
     })?;
@@ -392,44 +405,55 @@ async fn call_plugin(
     validate_json_value(&arguments, PLUGIN_MAX_ARGUMENT_BYTES, "tool arguments").map_err(|_| {
         GatewayError::local("invalid_arguments", "tool arguments exceed Plugin bounds")
     })?;
-    let observation_key = ObservationKey {
-        runner: runner_id.to_string(),
-        plugin: plugin_id.to_string(),
-        tool: tool_name.to_string(),
-    };
     let observed = runtime
         .plugin_gateway
-        .observed(&observation_key)
-        .ok_or_else(|| {
-            GatewayError::local(
-                "describe_required",
-                "describe this Plugin tool before calling it so WebCodex can bind the exact Runner, provider instance, and schema",
-            )
-            .recovery(
-                "Call plugin_tool with action=describe for this runner, plugin, and tool, then retry with the described schema.",
-            )
-        })?;
-    // Deliberately do not re-list/re-resolve the provider here.  The observed
-    // exact identities are the only legal dispatch target for this call.
-    let runner = ResolvedPluginRunner {
-        client_id: observed.client_id.clone(),
-        runner_instance_id: observed.runner_instance_id.clone(),
-        display_name: None,
-    };
-    let response = execute_exact(
+        .binding(&binding_id)
+        .ok_or_else(describe_required_error)?;
+
+    // A binding identifies the observation; it does not grant authority. Resolve
+    // the logical Runner against the current credential again, then require the
+    // exact Runner instance that produced the describe observation.
+    let runner = resolve_runner(runtime, &observed.client_id, auth)
+        .await
+        .map_err(|_| describe_required_error())?;
+    if runner.runner_instance_id != observed.runner_instance_id {
+        runtime.plugin_gateway.forget(&binding_id);
+        return Err(GatewayError::local(
+            "plugin_replaced",
+            "the exact Runner instance described by this binding is no longer current",
+        )
+        .recovery("Re-describe this Plugin tool. WebCodex did not retarget or replay the call."));
+    }
+
+    // Deliberately do not re-list/re-resolve the provider here. The exact
+    // provider instance, tool name, and schema from this binding are the only
+    // legal dispatch target.
+    let response = match execute_exact(
         runtime,
         &runner,
         PluginGatewayRequest::ToolsCall {
             plane: PluginPlane::Effective,
             provider_id: observed.provider_id.clone(),
             provider_instance_id: observed.provider_instance_id.clone(),
-            name: tool_name.to_string(),
+            name: observed.tool_name.clone(),
             arguments,
             expected_schema: observed.schema,
         },
         auth,
     )
-    .await?;
+    .await
+    {
+        Ok(response) => response,
+        Err(mut error) => {
+            if error.code == "plugin_replaced" {
+                runtime.plugin_gateway.forget(&binding_id);
+                error.recovery = Some(
+                    "Re-describe this Plugin tool. WebCodex did not retarget or replay the call.",
+                );
+            }
+            return Err(error);
+        }
+    };
     let state = response.dispatch_state;
     if let Some(error) = response.error {
         if matches!(
@@ -439,7 +463,7 @@ async fn call_plugin(
                 | "stale_plugin_provider"
                 | "plugin_provider_unavailable"
         ) {
-            runtime.plugin_gateway.forget(&observation_key);
+            runtime.plugin_gateway.forget(&binding_id);
         }
         let mut error = response_error(state, error);
         if matches!(
@@ -781,6 +805,39 @@ fn required_tool(value: Option<&str>) -> Result<&str, GatewayError> {
     Ok(value)
 }
 
+fn required_binding(value: Option<&str>) -> Result<&str, GatewayError> {
+    let value = value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| GatewayError::local("invalid_arguments", "action=call requires binding"))?;
+    let Some(random) = value.strip_prefix("wc_pbind_") else {
+        return Err(GatewayError::local(
+            "invalid_arguments",
+            "binding is not a valid opaque Plugin binding",
+        ));
+    };
+    if random.len() != 32
+        || !random
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(GatewayError::local(
+            "invalid_arguments",
+            "binding is not a valid opaque Plugin binding",
+        ));
+    }
+    Ok(value)
+}
+
+fn describe_required_error() -> GatewayError {
+    GatewayError::local(
+        "describe_required",
+        "this Plugin binding is unavailable to the current credential or is no longer retained",
+    )
+    .recovery(
+        "Call plugin_tool with action=describe for the intended runner, plugin, and tool, then call with the returned binding. WebCodex did not retarget or replay the call.",
+    )
+}
+
 fn render_gateway_result(result: Result<GatewaySuccess, GatewayError>) -> Value {
     match result {
         Ok(GatewaySuccess::Metadata(value)) => gateway_success_result(value),
@@ -836,12 +893,65 @@ fn dispatch_state_name(state: PluginDispatchState) -> &'static str {
 mod tests {
     use super::*;
 
+    fn test_binding(provider: &str, tool: &str) -> PluginBinding {
+        PluginBinding {
+            client_id: "runner-a".to_string(),
+            runner_instance_id: "runner-instance-a".to_string(),
+            provider_id: provider.to_string(),
+            provider_instance_id: format!("{provider}-instance"),
+            tool_name: tool.to_string(),
+            schema: PluginSchemaObservation {
+                input_schema: json!({"type":"object"}),
+                output_schema: None,
+                annotations: None,
+            },
+        }
+    }
+
+    #[test]
+    fn plugin_bindings_are_independent_and_evicted_fifo() {
+        let runtime = PluginGatewayRuntime::default();
+        let first = runtime.remember(test_binding("provider-a", "tool-a"));
+        let second = runtime.remember(test_binding("provider-b", "tool-b"));
+        assert_ne!(first, second);
+        assert!(first.starts_with("wc_pbind_"));
+        assert!(second.starts_with("wc_pbind_"));
+        assert_eq!(runtime.binding(&first).unwrap().tool_name, "tool-a");
+        assert_eq!(runtime.binding(&second).unwrap().tool_name, "tool-b");
+
+        runtime.forget(&first);
+        assert!(runtime.binding(&first).is_none());
+        assert_eq!(
+            runtime.binding(&second).unwrap().provider_id,
+            "provider-b",
+            "forgetting one exact binding must not disturb another provider/tool binding"
+        );
+
+        let oldest = runtime.remember(test_binding("oldest", "tool"));
+        for index in 0..MAX_PLUGIN_BINDINGS {
+            runtime.remember(test_binding(&format!("provider-{index}"), "tool"));
+        }
+        assert!(
+            runtime.binding(&oldest).is_none(),
+            "binding store must remain bounded with deterministic oldest eviction"
+        );
+    }
+
     #[test]
     fn fixed_plugin_tool_catalog_hides_runtime_identity_and_provider_defined_output_schema() {
         let spec = tool_spec();
         let encoded = serde_json::to_string(&spec).unwrap();
         assert_eq!(spec["name"], PLUGIN_TOOL_NAME);
         assert!(spec.get("outputSchema").is_none());
+        assert!(spec["inputSchema"]["properties"]["binding"].is_object());
+        assert_eq!(
+            spec["inputSchema"]["properties"]["binding"]["pattern"],
+            "^wc_pbind_[0-9a-f]{32}$"
+        );
+        assert!(spec["description"]
+            .as_str()
+            .unwrap()
+            .contains("call accepts only that binding plus arguments"));
         assert!(!encoded.contains("provider_instance_id"));
         assert!(!encoded.contains("runner_instance_id"));
         assert!(!encoded.contains("revision"));


### PR DESCRIPTION
## Summary

- bound native Plugin request writes and shutdown under one total deadline
- replace shared describe observations with opaque exact bindings
- serialize dynamic Plugin reloads and fence shutdown races
- keep startup first-class Plugin bindings immutable
- avoid old-provider process teardown while holding dynamic state lock

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p webcodex-runner plugin` — 18 passed
- `cargo test -p webcodex plugin` — 16 passed
- `cargo check --all-targets -p webcodex-runner`

The implementation handoff also reported full Runner, Runner Registry, and Server suites passing before the reviewer-only follow-up commit. The reviewer follow-up only moves old-provider drop/teardown outside the dynamic-state lock; focused Runner Plugin tests were rerun on the final HEAD.

No deployment or restart is included.