### PR TITLE
Add native Plugin check diagnostics

### DIFF
--- a/crates/webcodex-core/src/plugin.rs
+++ b/crates/webcodex-core/src/plugin.rs
@@ -29,6 +29,7 @@ pub const PLUGIN_MAX_JSON_DEPTH: usize = 16;
 pub const PLUGIN_MAX_JSON_NODES: usize = 4_096;
 pub const PLUGIN_MAX_JSON_STRING_BYTES: usize = 64 * 1024;
 pub const PLUGIN_STARTUP_CATALOG_MAX_BYTES: usize = 256 * 1024;
+pub const PLUGIN_MAX_CHECK_DETAIL_BYTES: usize = 512;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -40,6 +41,9 @@ pub enum PluginPlane {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
 pub enum PluginGatewayRequest {
+    Check {
+        provider_id: String,
+    },
     Reload,
     ProvidersList,
     ToolsList {
@@ -71,7 +75,7 @@ impl PluginGatewayRequest {
                 provider_instance_id,
                 ..
             } => Some((provider_id, provider_instance_id, *plane)),
-            Self::Reload | Self::ProvidersList => None,
+            Self::Check { .. } | Self::Reload | Self::ProvidersList => None,
         }
     }
 }
@@ -187,9 +191,59 @@ pub struct PluginReloadFailure {
     pub code: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginCheckPhase {
+    Config,
+    Environment,
+    Executable,
+    Spawn,
+    Stdio,
+    Initialize,
+    ToolsList,
+    Validation,
+    Ready,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginCheckToolSummary {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginStartupToolShape {
+    pub eligible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginCheckReport {
+    pub provider_id: String,
+    pub ready: bool,
+    pub phase: PluginCheckPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub tool_count: usize,
+    #[serde(default)]
+    pub tools: Vec<PluginCheckToolSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_tool_shape: Option<PluginStartupToolShape>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum PluginGatewayResponsePayload {
+    Checked {
+        report: PluginCheckReport,
+    },
     Providers {
         providers: Vec<PluginProviderView>,
         first_class_restart_required: bool,
@@ -301,6 +355,7 @@ fn validate_identifier(
 
 pub fn validate_request(request: &PluginGatewayRequest) -> Result<(), String> {
     match request {
+        PluginGatewayRequest::Check { provider_id } => validate_provider_id(provider_id),
         PluginGatewayRequest::Reload | PluginGatewayRequest::ProvidersList => Ok(()),
         PluginGatewayRequest::ToolsList {
             provider_id,
@@ -501,6 +556,7 @@ pub fn validate_response(response: &PluginGatewayResponse) -> Result<(), String>
     }
     if let Some(payload) = response.payload.as_ref() {
         match payload {
+            PluginGatewayResponsePayload::Checked { report } => validate_check_report(report)?,
             PluginGatewayResponsePayload::Providers { providers, .. } => {
                 validate_provider_views(providers)?
             }
@@ -520,6 +576,58 @@ pub fn validate_response(response: &PluginGatewayResponse) -> Result<(), String>
             }
             PluginGatewayResponsePayload::Tools { tools } => validate_tools(tools)?,
             PluginGatewayResponsePayload::ToolResult { result } => validate_tool_result(result)?,
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_check_report(report: &PluginCheckReport) -> Result<(), String> {
+    validate_provider_id(&report.provider_id)?;
+    if report.ready {
+        if report.phase != PluginCheckPhase::Ready
+            || report.code.is_some()
+            || report.detail.is_some()
+        {
+            return Err("ready Plugin check report has inconsistent status fields".to_string());
+        }
+        if report.startup_tool_shape.is_none() {
+            return Err("ready Plugin check report requires startup tool shape".to_string());
+        }
+    } else {
+        if report.phase == PluginCheckPhase::Ready || report.code.is_none() {
+            return Err("failed Plugin check report has inconsistent status fields".to_string());
+        }
+        if report.tool_count != 0 || !report.tools.is_empty() || report.startup_tool_shape.is_some()
+        {
+            return Err("failed Plugin check report must not retain tool inventory".to_string());
+        }
+    }
+    if let Some(code) = report.code.as_deref() {
+        validate_status_atom(code, "Plugin check code")?;
+    }
+    if let Some(detail) = report.detail.as_deref() {
+        if detail.is_empty() || detail.len() > PLUGIN_MAX_CHECK_DETAIL_BYTES {
+            return Err("Plugin check detail exceeds bound".to_string());
+        }
+        validate_text_controls(detail, "Plugin check detail")?;
+    }
+    if report.tool_count != report.tools.len() || report.tools.len() > PLUGIN_MAX_TOOL_COUNT {
+        return Err("Plugin check tool summary count is invalid".to_string());
+    }
+    for tool in &report.tools {
+        validate_tool_name(&tool.name)?;
+        if let Some(title) = tool.title.as_deref() {
+            if title.is_empty() || title.len() > PLUGIN_MAX_PROVIDER_NAME_BYTES {
+                return Err("Plugin check tool title is invalid".to_string());
+            }
+            validate_text_controls(title, "Plugin check tool title")?;
+        }
+    }
+    if let Some(shape) = report.startup_tool_shape.as_ref() {
+        match (shape.eligible, shape.code.as_deref()) {
+            (true, None) => {}
+            (false, Some(code)) => validate_status_atom(code, "Plugin startup tool shape code")?,
+            _ => return Err("Plugin startup tool shape status is inconsistent".to_string()),
         }
     }
     Ok(())
@@ -663,6 +771,48 @@ mod tests {
             expected_schema: tool().schema_observation(),
         };
         assert!(validate_request(&request).is_err());
+    }
+
+    #[test]
+    fn check_contract_is_typed_and_report_is_bounded() {
+        let request = PluginGatewayRequest::Check {
+            provider_id: "repo-tools".to_string(),
+        };
+        validate_request(&request).unwrap();
+
+        let report = PluginCheckReport {
+            provider_id: "repo-tools".to_string(),
+            ready: true,
+            phase: PluginCheckPhase::Ready,
+            code: None,
+            detail: None,
+            tool_count: 1,
+            tools: vec![PluginCheckToolSummary {
+                name: "echo".to_string(),
+                title: Some("Echo".to_string()),
+            }],
+            startup_tool_shape: Some(PluginStartupToolShape {
+                eligible: true,
+                code: None,
+            }),
+        };
+        validate_check_report(&report).unwrap();
+        validate_response(&PluginGatewayResponse::success(
+            PluginGatewayResponsePayload::Checked {
+                report: report.clone(),
+            },
+        ))
+        .unwrap();
+
+        let mut invalid = report;
+        invalid.detail = Some("x".repeat(PLUGIN_MAX_CHECK_DETAIL_BYTES + 1));
+        invalid.ready = false;
+        invalid.phase = PluginCheckPhase::Validation;
+        invalid.code = Some("plugin_tools_list_invalid".to_string());
+        invalid.tool_count = 0;
+        invalid.tools.clear();
+        invalid.startup_tool_shape = None;
+        assert!(validate_check_report(&invalid).is_err());
     }
 
     #[test]

--- a/crates/webcodex-core/src/plugin.rs
+++ b/crates/webcodex-core/src/plugin.rs
@@ -581,6 +581,43 @@ pub fn validate_response(response: &PluginGatewayResponse) -> Result<(), String>
     Ok(())
 }
 
+pub fn validate_response_for_request(
+    request: &PluginGatewayRequest,
+    response: &PluginGatewayResponse,
+) -> Result<(), String> {
+    validate_response(response)?;
+    if response.error.is_some() {
+        return Ok(());
+    }
+    match (request, response.payload.as_ref()) {
+        (
+            PluginGatewayRequest::Check { provider_id },
+            Some(PluginGatewayResponsePayload::Checked { report }),
+        ) => {
+            if report.provider_id != *provider_id {
+                return Err("Plugin check response provider_id does not match request".to_string());
+            }
+        }
+        (PluginGatewayRequest::Reload, Some(PluginGatewayResponsePayload::Reloaded { .. }))
+        | (
+            PluginGatewayRequest::ProvidersList,
+            Some(PluginGatewayResponsePayload::Providers { .. }),
+        )
+        | (
+            PluginGatewayRequest::ToolsList { .. },
+            Some(PluginGatewayResponsePayload::Tools { .. }),
+        )
+        | (
+            PluginGatewayRequest::ToolsCall { .. },
+            Some(PluginGatewayResponsePayload::ToolResult { .. }),
+        ) => {}
+        _ => {
+            return Err("Plugin gateway response kind does not match request operation".to_string())
+        }
+    }
+    Ok(())
+}
+
 pub fn validate_check_report(report: &PluginCheckReport) -> Result<(), String> {
     validate_provider_id(&report.provider_id)?;
     if report.ready {
@@ -803,6 +840,31 @@ mod tests {
             },
         ))
         .unwrap();
+        validate_response_for_request(
+            &request,
+            &PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked {
+                report: report.clone(),
+            }),
+        )
+        .unwrap();
+
+        let mut wrong_provider = report.clone();
+        wrong_provider.provider_id = "other-tools".to_string();
+        assert!(validate_response_for_request(
+            &request,
+            &PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked {
+                report: wrong_provider,
+            }),
+        )
+        .is_err());
+        assert!(validate_response_for_request(
+            &request,
+            &PluginGatewayResponse::success(PluginGatewayResponsePayload::Providers {
+                providers: vec![],
+                first_class_restart_required: false,
+            }),
+        )
+        .is_err());
 
         let mut invalid = report;
         invalid.detail = Some("x".repeat(PLUGIN_MAX_CHECK_DETAIL_BYTES + 1));

--- a/crates/webcodex-runner-registry/src/polling.rs
+++ b/crates/webcodex-runner-registry/src/polling.rs
@@ -13,7 +13,7 @@ use webcodex_core::mcp_gateway::{
     validate_response as validate_mcp_gateway_response, McpGatewayDispatchState, McpGatewayResponse,
 };
 use webcodex_core::plugin::{
-    validate_response as validate_plugin_gateway_response, PluginDispatchState,
+    validate_response_for_request as validate_plugin_gateway_response, PluginDispatchState,
     PluginGatewayResponse, PluginPlane,
 };
 use webcodex_core::runner_protocol::{
@@ -612,7 +612,15 @@ impl RunnerRegistry {
                         && body.stderr.is_none()
                         && body.duration_ms.is_none()
                         && body.error.is_none()
-                        && validate_plugin_gateway_response(&response).is_ok() =>
+                        && validate_plugin_gateway_response(
+                            pending
+                                .request
+                                .plugin_gateway
+                                .as_ref()
+                                .expect("checked above"),
+                            &response,
+                        )
+                        .is_ok() =>
                 {
                     response
                 }

--- a/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
+++ b/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
@@ -5,8 +5,9 @@ use crate::runner_protocol::{
 };
 use serde_json::json;
 use webcodex_core::plugin::{
-    PluginDispatchState, PluginGatewayRequest, PluginGatewayResponse, PluginGatewayResponsePayload,
-    PluginPlane, PluginSchemaObservation, PluginTool, StartupPluginProvider,
+    PluginCheckPhase, PluginCheckReport, PluginDispatchState, PluginGatewayRequest,
+    PluginGatewayResponse, PluginGatewayResponsePayload, PluginPlane, PluginSchemaObservation,
+    PluginTool, StartupPluginProvider,
 };
 
 fn plugin_tool() -> PluginTool {
@@ -199,6 +200,83 @@ async fn plugin_reload_can_target_exact_runner_with_zero_startup_plugins() {
     assert!(matches!(
         receiver.await.unwrap().payload,
         Some(PluginGatewayResponsePayload::Reloaded { .. })
+    ));
+}
+
+#[tokio::test]
+async fn plugin_check_targets_exact_runner_without_requiring_startup_provider_identity() {
+    let registry = RunnerRegistry::default();
+    registry
+        .register(plugin_registration(
+            "check-plugin-runner",
+            "check-instance",
+            vec![],
+        ))
+        .await
+        .unwrap();
+    let alice = auth_context(Some("alice"), false);
+    let (_request_id, receiver) = registry
+        .enqueue_plugin_gateway(
+            "check-plugin-runner",
+            "check-instance",
+            PluginGatewayRequest::Check {
+                provider_id: "repo-tools".to_string(),
+            },
+            Some(&alice),
+            "test".to_string(),
+        )
+        .await
+        .unwrap();
+    let request = registry
+        .poll(RunnerPollRequest {
+            client_id: "check-plugin-runner".to_string(),
+            runner_instance_id: "check-instance".to_string(),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        request.plugin_gateway,
+        Some(PluginGatewayRequest::Check { ref provider_id }) if provider_id == "repo-tools"
+    ));
+    registry
+        .complete(RunnerResultPayload {
+            result: RunnerResultRequest {
+                client_id: "check-plugin-runner".to_string(),
+                runner_instance_id: "check-instance".to_string(),
+                request_id: request.request_id,
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: None,
+                error: None,
+            },
+            command_execution_state: None,
+            mcp_gateway: None,
+            plugin_gateway: Some(PluginGatewayResponse::success(
+                PluginGatewayResponsePayload::Checked {
+                    report: PluginCheckReport {
+                        provider_id: "repo-tools".to_string(),
+                        ready: false,
+                        phase: PluginCheckPhase::Config,
+                        code: Some("plugin_not_configured".to_string()),
+                        detail: Some(
+                            "requested Plugin provider is not configured in current runner.toml"
+                                .to_string(),
+                        ),
+                        tool_count: 0,
+                        tools: vec![],
+                        startup_tool_shape: None,
+                    },
+                },
+            )),
+            coding_agent: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        receiver.await.unwrap().payload,
+        Some(PluginGatewayResponsePayload::Checked { .. })
     ));
 }
 

--- a/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
+++ b/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
@@ -281,6 +281,82 @@ async fn plugin_check_targets_exact_runner_without_requiring_startup_provider_id
 }
 
 #[tokio::test]
+async fn plugin_check_rejects_mismatched_provider_report_after_dispatch() {
+    let registry = RunnerRegistry::default();
+    registry
+        .register(plugin_registration(
+            "check-plugin-runner",
+            "check-instance",
+            vec![],
+        ))
+        .await
+        .unwrap();
+    let alice = auth_context(Some("alice"), false);
+    let (_request_id, receiver) = registry
+        .enqueue_plugin_gateway(
+            "check-plugin-runner",
+            "check-instance",
+            PluginGatewayRequest::Check {
+                provider_id: "repo-tools".to_string(),
+            },
+            Some(&alice),
+            "test".to_string(),
+        )
+        .await
+        .unwrap();
+    let request = registry
+        .poll(RunnerPollRequest {
+            client_id: "check-plugin-runner".to_string(),
+            runner_instance_id: "check-instance".to_string(),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    registry
+        .complete(RunnerResultPayload {
+            result: RunnerResultRequest {
+                client_id: "check-plugin-runner".to_string(),
+                runner_instance_id: "check-instance".to_string(),
+                request_id: request.request_id,
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: None,
+                error: None,
+            },
+            command_execution_state: None,
+            mcp_gateway: None,
+            plugin_gateway: Some(PluginGatewayResponse::success(
+                PluginGatewayResponsePayload::Checked {
+                    report: PluginCheckReport {
+                        provider_id: "other-tools".to_string(),
+                        ready: false,
+                        phase: PluginCheckPhase::Config,
+                        code: Some("plugin_not_configured".to_string()),
+                        detail: Some(
+                            "requested Plugin provider is not configured in current runner.toml"
+                                .to_string(),
+                        ),
+                        tool_count: 0,
+                        tools: vec![],
+                        startup_tool_shape: None,
+                    },
+                },
+            )),
+            coding_agent: None,
+        })
+        .await
+        .unwrap();
+    let response = receiver.await.unwrap();
+    assert_eq!(response.dispatch_state, PluginDispatchState::OutcomeUnknown);
+    assert_eq!(
+        response.error.as_ref().map(|error| error.code.as_str()),
+        Some("invalid_runner_response")
+    );
+    assert!(response.payload.is_none());
+}
+
+#[tokio::test]
 async fn plugin_enqueue_rechecks_owner_runner_and_startup_provider_identity() {
     let registry = RunnerRegistry::default();
     register_plugin_runner(&registry).await;

--- a/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
@@ -20,6 +20,9 @@ fn main() -> io::Result<()> {
         }
     }
     append(marker, "start\n")?;
+    if scenario.starts_with("check_") || scenario.starts_with("candidate_") {
+        append(marker, &format!("candidate-pid:{}\n", std::process::id()))?;
+    }
     if scenario == "reload_new" {
         append(marker, "reload-new-start\n")?;
     }
@@ -66,10 +69,23 @@ fn main() -> io::Result<()> {
         match method.as_str() {
             "initialize" => {
                 append(marker, "initialize\n")?;
-                if scenario == "init_crash" {
+                if scenario == "init_crash" || scenario == "check_init_crash" {
                     return Ok(());
                 }
-                let version = if scenario == "bad_version" {
+                if scenario == "check_init_timeout" {
+                    thread::sleep(Duration::from_secs(3));
+                }
+                if scenario == "check_bad_version_tree" {
+                    let child = Command::new(env::current_exe()?)
+                        .arg("hold")
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .spawn()?;
+                    append(marker, &format!("descendant-pid:{}\n", child.id()))?;
+                    drop(child);
+                }
+                let version = if matches!(scenario, "bad_version" | "check_bad_version_tree") {
                     "unsupported-plugin-v0"
                 } else {
                     "webcodex-plugin-v1"
@@ -84,15 +100,41 @@ fn main() -> io::Result<()> {
             "tools/list" => {
                 lists += 1;
                 append(marker, "list\n")?;
-                if scenario == "reload_block_list" && lists == 1 {
-                    append(marker, "reload-blocked\n")?;
+                if matches!(scenario, "reload_block_list" | "candidate_block_list_tree")
+                    && lists == 1
+                {
+                    append(
+                        marker,
+                        if scenario == "reload_block_list" {
+                            "reload-blocked\n"
+                        } else {
+                            "candidate-blocked\n"
+                        },
+                    )?;
+                    if scenario == "candidate_block_list_tree" {
+                        let child = Command::new(env::current_exe()?)
+                            .arg("hold")
+                            .stdin(Stdio::null())
+                            .stdout(Stdio::null())
+                            .stderr(Stdio::null())
+                            .spawn()?;
+                        append(marker, &format!("descendant-pid:{}\n", child.id()))?;
+                        drop(child);
+                    }
                     let release = marker
                         .map(|path| path.with_extension("release"))
-                        .expect("reload_block_list requires marker path");
+                        .expect("blocking candidate scenario requires marker path");
                     while !release.exists() {
                         thread::sleep(Duration::from_millis(10));
                     }
-                    append(marker, "reload-released\n")?;
+                    append(
+                        marker,
+                        if scenario == "reload_block_list" {
+                            "reload-released\n"
+                        } else {
+                            "candidate-released\n"
+                        },
+                    )?;
                 }
                 if scenario == "split_timeout" && lists >= 2 {
                     thread::sleep(Duration::from_millis(750));
@@ -111,11 +153,21 @@ fn main() -> io::Result<()> {
                     )?;
                     continue;
                 }
-                if scenario == "invalid_tools" {
+                if matches!(scenario, "invalid_tools" | "check_invalid_tools") {
                     send(
                         &mut writer,
                         &format!(
                             r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"echo","inputSchema":[]}}]}}}}"#
+                        ),
+                    )?;
+                    continue;
+                }
+                if scenario == "check_oversized_schema" {
+                    send(
+                        &mut writer,
+                        &format!(
+                            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"echo","inputSchema":{{"type":"object","description":"{}"}}}}]}}}}"#,
+                            "x".repeat(70 * 1024)
                         ),
                     )?;
                     continue;
@@ -125,10 +177,26 @@ fn main() -> io::Result<()> {
                 } else {
                     "string"
                 };
+                let tool_name = if scenario == "check_v2" { "echo_v2" } else { "echo" };
+                let startup_padding = if scenario == "check_startup_large_schema" {
+                    "x".repeat(40 * 1024)
+                } else {
+                    String::new()
+                };
+                if scenario == "check_success_tree" {
+                    let child = Command::new(env::current_exe()?)
+                        .arg("hold")
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .spawn()?;
+                    append(marker, &format!("descendant-pid:{}\n", child.id()))?;
+                    drop(child);
+                }
                 send(
                     &mut writer,
                     &format!(
-                        r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"echo","description":"Native plugin echo","inputSchema":{{"type":"object","properties":{{"value":{{"type":"{value_type}"}}}}}}}}]}}}}"#
+                        r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"{tool_name}","description":"Native plugin echo","inputSchema":{{"type":"object","description":"{startup_padding}","properties":{{"value":{{"type":"{value_type}"}}}}}}}}]}}}}"#
                     ),
                 )?;
                 if matches!(

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -18,9 +18,10 @@ use std::sync::{mpsc, Arc, Mutex, TryLockError};
 use std::time::{Duration, Instant};
 use webcodex_core::plugin::{
     validate_request, validate_startup_catalog, validate_startup_tool, validate_tool_result,
-    validate_tools, PluginDispatchState, PluginGatewayRequest, PluginGatewayResponse,
-    PluginGatewayResponsePayload, PluginPlane, PluginProviderView, PluginReloadFailure,
-    PluginSchemaObservation, PluginTool, PluginToolResult, StartupPluginProvider,
+    validate_tools, PluginCheckPhase, PluginCheckReport, PluginCheckToolSummary,
+    PluginDispatchState, PluginGatewayRequest, PluginGatewayResponse, PluginGatewayResponsePayload,
+    PluginPlane, PluginProviderView, PluginReloadFailure, PluginSchemaObservation,
+    PluginStartupToolShape, PluginTool, PluginToolResult, StartupPluginProvider,
     PLUGIN_MAX_MESSAGE_BYTES, PLUGIN_PROTOCOL_VERSION, PLUGIN_STARTUP_CATALOG_MAX_BYTES,
     PLUGIN_STARTUP_MAX_DIRECT_TOOLS,
 };
@@ -37,7 +38,7 @@ pub(crate) struct PluginManager {
     startup_config: PluginConfig,
     startup_shell: ShellConfig,
     dynamic: Mutex<DynamicState>,
-    reload_gate: Mutex<()>,
+    candidate_gate: Mutex<()>,
     config_path: PathBuf,
     prepared_profiles: PreparedShellProfileCache,
     next_generation: AtomicU64,
@@ -104,6 +105,89 @@ struct ProviderFailure {
     fatal: bool,
 }
 
+struct ProviderPreparationFailure {
+    phase: PluginCheckPhase,
+    code: &'static str,
+    detail: &'static str,
+}
+
+fn initialize_failure_detail(code: &str) -> &'static str {
+    match code {
+        "plugin_protocol_version_mismatch" => {
+            "Plugin initialize response did not confirm webcodex-plugin-v1"
+        }
+        "plugin_initialize_invalid" => "Plugin initialize result violates protocol bounds",
+        "plugin_timeout" => "Plugin initialize did not complete within the provider timeout",
+        "plugin_eof" => "Plugin process ended during initialize",
+        _ => "Plugin initialize did not complete successfully",
+    }
+}
+
+fn plugin_config_error_code(error: &str) -> &'static str {
+    if error.starts_with("failed to read config") {
+        "plugin_config_read_failed"
+    } else if error.starts_with("failed to parse config") {
+        "plugin_config_parse_failed"
+    } else {
+        "plugin_config_invalid"
+    }
+}
+
+fn plugin_config_check_detail(code: &str) -> &'static str {
+    match code {
+        "plugin_config_read_failed" => "runner.toml could not be read",
+        "plugin_config_parse_failed" => "runner.toml could not be parsed",
+        _ => "runner.toml failed Runner configuration validation",
+    }
+}
+
+fn failed_check_report(
+    provider_id: &str,
+    phase: PluginCheckPhase,
+    code: &str,
+    detail: &str,
+) -> PluginCheckReport {
+    PluginCheckReport {
+        provider_id: provider_id.to_string(),
+        ready: false,
+        phase,
+        code: Some(code.to_string()),
+        detail: Some(detail.to_string()),
+        tool_count: 0,
+        tools: Vec::new(),
+        startup_tool_shape: None,
+    }
+}
+
+fn startup_tool_shape(tools: &[PluginTool]) -> PluginStartupToolShape {
+    if tools.len() > PLUGIN_STARTUP_MAX_DIRECT_TOOLS {
+        return PluginStartupToolShape {
+            eligible: false,
+            code: Some("plugin_startup_tool_count_exceeded".to_string()),
+        };
+    }
+    if let Some(error) = tools
+        .iter()
+        .find_map(|tool| validate_startup_tool(tool).err())
+    {
+        return PluginStartupToolShape {
+            eligible: false,
+            code: Some(
+                if error.contains("startup tool") && error.contains("exceeds maximum") {
+                    "plugin_startup_schema_too_large"
+                } else {
+                    "plugin_startup_tool_invalid"
+                }
+                .to_string(),
+            ),
+        };
+    }
+    PluginStartupToolShape {
+        eligible: true,
+        code: None,
+    }
+}
+
 impl ProviderFailure {
     fn not_started(code: &'static str) -> Self {
         Self {
@@ -161,16 +245,17 @@ impl PluginManager {
                 &stopping,
             );
             let instance_id = entry.instance_id.clone();
+            let failure_code = failure.as_ref().map(|failure| failure.code.to_string());
             let mut advertised = StartupPluginProvider {
                 provider_id: provider.id.clone(),
                 provider_instance_id: instance_id,
                 name: provider.name.clone(),
-                status: if failure.is_some() {
+                status: if failure_code.is_some() {
                     "failed".to_string()
                 } else {
                     "ready".to_string()
                 },
-                error_code: failure.clone(),
+                error_code: failure_code,
                 tools: Vec::new(),
             };
 
@@ -212,7 +297,7 @@ impl PluginManager {
                 overlay: BTreeMap::new(),
                 first_class_restart_required: false,
             }),
-            reload_gate: Mutex::new(()),
+            candidate_gate: Mutex::new(()),
             config_path,
             prepared_profiles,
             next_generation: AtomicU64::new(2),
@@ -241,6 +326,7 @@ impl PluginManager {
             );
         }
         match request {
+            PluginGatewayRequest::Check { provider_id } => self.check_candidate(&provider_id),
             PluginGatewayRequest::Reload => self.reload_dynamic(),
             PluginGatewayRequest::ProvidersList => {
                 PluginGatewayResponse::success(PluginGatewayResponsePayload::Providers {
@@ -343,14 +429,105 @@ impl PluginManager {
             .collect()
     }
 
+    fn check_candidate(&self, provider_id: &str) -> PluginGatewayResponse {
+        let _candidate_guard = match self.candidate_gate.try_lock() {
+            Ok(guard) => guard,
+            Err(TryLockError::WouldBlock) => return gateway_error(
+                PluginDispatchState::NotStarted,
+                "plugin_check_busy",
+                "Another Plugin candidate operation is already running; this check was not started",
+            ),
+            Err(TryLockError::Poisoned(_)) => {
+                return gateway_error(
+                    PluginDispatchState::NotStarted,
+                    "plugin_check_state_failed",
+                    "Plugin candidate-operation state is unavailable; this check was not started",
+                )
+            }
+        };
+        let candidate = match load_config(&self.config_path) {
+            Ok(candidate) => candidate,
+            Err(error) => {
+                let code = plugin_config_error_code(&error);
+                return PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked {
+                    report: failed_check_report(
+                        provider_id,
+                        PluginCheckPhase::Config,
+                        code,
+                        plugin_config_check_detail(code),
+                    ),
+                });
+            }
+        };
+        let Some(provider) = candidate
+            .plugins
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+        else {
+            return PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked {
+                report: failed_check_report(
+                    provider_id,
+                    PluginCheckPhase::Config,
+                    "plugin_not_configured",
+                    "requested Plugin provider is not configured in current runner.toml",
+                ),
+            });
+        };
+        let generation = self.next_generation.fetch_add(1, Ordering::SeqCst);
+        let (entry, tools, failure) = prepare_provider(
+            provider,
+            &candidate.shell,
+            generation,
+            Duration::from_secs(candidate.plugins.request_timeout_secs),
+            &self.prepared_profiles,
+            &self.stopping,
+        );
+        if self.stopping.load(Ordering::SeqCst)
+            || failure
+                .as_ref()
+                .is_some_and(|failure| failure.code == "plugin_manager_stopping")
+        {
+            entry.shutdown();
+            return gateway_error(
+                PluginDispatchState::NotStarted,
+                "plugin_manager_stopping",
+                "Plugin manager began stopping during candidate check; no state was changed",
+            );
+        }
+        let report = if let Some(failure) = failure {
+            failed_check_report(provider_id, failure.phase, failure.code, failure.detail)
+        } else {
+            let tools = tools.unwrap_or_default();
+            PluginCheckReport {
+                provider_id: provider_id.to_string(),
+                ready: true,
+                phase: PluginCheckPhase::Ready,
+                code: None,
+                detail: None,
+                tool_count: tools.len(),
+                tools: tools
+                    .iter()
+                    .map(|tool| PluginCheckToolSummary {
+                        name: tool.name.clone(),
+                        title: tool.title.clone(),
+                    })
+                    .collect(),
+                startup_tool_shape: Some(startup_tool_shape(&tools)),
+            }
+        };
+        entry.shutdown();
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked { report })
+    }
+
     fn reload_dynamic(&self) -> PluginGatewayResponse {
-        let _reload_guard = match self.reload_gate.try_lock() {
+        let _candidate_guard = match self.candidate_gate.try_lock() {
             Ok(guard) => guard,
             Err(TryLockError::WouldBlock) => {
                 return gateway_error(
                     PluginDispatchState::NotStarted,
                     "plugin_reload_busy",
-                    "Another Plugin reload is already preparing candidates; this reload was not started",
+                    "Another Plugin candidate operation is already running; this reload was not started",
                 )
             }
             Err(TryLockError::Poisoned(_)) => {
@@ -364,13 +541,7 @@ impl PluginManager {
         let candidate = match load_config(&self.config_path) {
             Ok(candidate) => candidate,
             Err(error) => {
-                let code = if error.starts_with("failed to read config") {
-                    "plugin_config_read_failed"
-                } else if error.starts_with("failed to parse config") {
-                    "plugin_config_parse_failed"
-                } else {
-                    "plugin_config_invalid"
-                };
+                let code = plugin_config_error_code(&error);
                 return gateway_error(
                     PluginDispatchState::NotStarted,
                     code,
@@ -390,10 +561,10 @@ impl PluginManager {
                 &self.prepared_profiles,
                 &self.stopping,
             );
-            if let Some(code) = failure {
+            if let Some(failure) = failure {
                 failures.push(PluginReloadFailure {
                     provider_id: provider.id.clone(),
-                    code,
+                    code: failure.code.to_string(),
                 });
             } else {
                 prepared.insert(provider.id.clone(), entry);
@@ -650,7 +821,11 @@ fn prepare_provider(
     request_timeout: Duration,
     prepared_profiles: &PreparedShellProfileCache,
     stopping: &Arc<AtomicBool>,
-) -> (Arc<ProviderEntry>, Option<Vec<PluginTool>>, Option<String>) {
+) -> (
+    Arc<ProviderEntry>,
+    Option<Vec<PluginTool>>,
+    Option<ProviderPreparationFailure>,
+) {
     let process = Arc::new(ProviderProcess::new());
     let entry = Arc::new(ProviderEntry {
         config: config.clone(),
@@ -684,7 +859,11 @@ fn prepare_provider(
             return (
                 entry,
                 None,
-                Some("plugin_environment_prepare_failed".to_string()),
+                Some(ProviderPreparationFailure {
+                    phase: PluginCheckPhase::Environment,
+                    code: "plugin_environment_prepare_failed",
+                    detail: "configured shell/profile environment could not be prepared",
+                }),
             );
         }
     };
@@ -697,7 +876,20 @@ fn prepare_provider(
                 "plugin_executable_unavailable"
             };
             entry.retire(code);
-            return (entry, None, Some(code.to_string()));
+            let detail = if code == "plugin_executable_unsupported" {
+                "configured Plugin executable type is unsupported for the native Plugin ABI"
+            } else {
+                "configured Plugin executable could not be resolved in the prepared environment"
+            };
+            return (
+                entry,
+                None,
+                Some(ProviderPreparationFailure {
+                    phase: PluginCheckPhase::Executable,
+                    code,
+                    detail,
+                }),
+            );
         }
     };
     command
@@ -708,7 +900,15 @@ fn prepare_provider(
         Ok(child) => child,
         Err(_) => {
             entry.retire("plugin_spawn_failed");
-            return (entry, None, Some("plugin_spawn_failed".to_string()));
+            return (
+                entry,
+                None,
+                Some(ProviderPreparationFailure {
+                    phase: PluginCheckPhase::Spawn,
+                    code: "plugin_spawn_failed",
+                    detail: "configured Plugin executable could not be started",
+                }),
+            );
         }
     };
     let stdin = match child.child_mut().stdin.take() {
@@ -716,7 +916,15 @@ fn prepare_provider(
         None => {
             let _ = child.terminate_tree();
             entry.retire("plugin_stdio_unavailable");
-            return (entry, None, Some("plugin_stdio_unavailable".to_string()));
+            return (
+                entry,
+                None,
+                Some(ProviderPreparationFailure {
+                    phase: PluginCheckPhase::Stdio,
+                    code: "plugin_stdio_unavailable",
+                    detail: "Plugin protocol stdio pipes could not be created",
+                }),
+            );
         }
     };
     let stdout = match child.child_mut().stdout.take() {
@@ -724,7 +932,15 @@ fn prepare_provider(
         None => {
             let _ = child.terminate_tree();
             entry.retire("plugin_stdio_unavailable");
-            return (entry, None, Some("plugin_stdio_unavailable".to_string()));
+            return (
+                entry,
+                None,
+                Some(ProviderPreparationFailure {
+                    phase: PluginCheckPhase::Stdio,
+                    code: "plugin_stdio_unavailable",
+                    detail: "Plugin protocol stdio pipes could not be created",
+                }),
+            );
         }
     };
     let stderr = match child.child_mut().stderr.take() {
@@ -732,7 +948,15 @@ fn prepare_provider(
         None => {
             let _ = child.terminate_tree();
             entry.retire("plugin_stdio_unavailable");
-            return (entry, None, Some("plugin_stdio_unavailable".to_string()));
+            return (
+                entry,
+                None,
+                Some(ProviderPreparationFailure {
+                    phase: PluginCheckPhase::Stdio,
+                    code: "plugin_stdio_unavailable",
+                    detail: "Plugin protocol stdio pipes could not be created",
+                }),
+            );
         }
     };
     let stderr_thread_name = format!("wc-plugin-stderr-{}", config.id);
@@ -746,7 +970,15 @@ fn prepare_provider(
     {
         let _ = child.terminate_tree();
         entry.retire("plugin_reader_unavailable");
-        return (entry, None, Some("plugin_reader_unavailable".to_string()));
+        return (
+            entry,
+            None,
+            Some(ProviderPreparationFailure {
+                phase: PluginCheckPhase::Stdio,
+                code: "plugin_reader_unavailable",
+                detail: "Plugin stdout/stderr protocol workers could not be started",
+            }),
+        );
     }
     let (sender, incoming) = mpsc::sync_channel(PLUGIN_READER_QUEUE);
     let stdout_thread_name = format!("wc-plugin-{}", config.id);
@@ -757,7 +989,15 @@ fn prepare_provider(
     {
         let _ = child.terminate_tree();
         entry.retire("plugin_reader_unavailable");
-        return (entry, None, Some("plugin_reader_unavailable".to_string()));
+        return (
+            entry,
+            None,
+            Some(ProviderPreparationFailure {
+                phase: PluginCheckPhase::Stdio,
+                code: "plugin_reader_unavailable",
+                detail: "Plugin stdout/stderr protocol workers could not be started",
+            }),
+        );
     }
     let (writer, write_requests) = mpsc::sync_channel(PLUGIN_WRITER_QUEUE);
     let stdin_thread_name = format!("wc-plugin-stdin-{}", config.id);
@@ -768,13 +1008,29 @@ fn prepare_provider(
     {
         let _ = child.terminate_tree();
         entry.retire("plugin_writer_unavailable");
-        return (entry, None, Some("plugin_writer_unavailable".to_string()));
+        return (
+            entry,
+            None,
+            Some(ProviderPreparationFailure {
+                phase: PluginCheckPhase::Stdio,
+                code: "plugin_writer_unavailable",
+                detail: "Plugin stdin writer worker could not be started",
+            }),
+        );
     }
     process.install(child);
     if stopping.load(Ordering::SeqCst) {
         process.terminate();
         entry.retire("plugin_manager_stopping");
-        return (entry, None, Some("plugin_manager_stopping".to_string()));
+        return (
+            entry,
+            None,
+            Some(ProviderPreparationFailure {
+                phase: PluginCheckPhase::Initialize,
+                code: "plugin_manager_stopping",
+                detail: "Plugin manager began stopping during candidate preparation",
+            }),
+        );
     }
     let mut connection = ProviderConnection {
         process: Arc::clone(&process),
@@ -790,14 +1046,40 @@ fn prepare_provider(
     if let Err(failure) = connection.initialize(timeout) {
         process.terminate();
         entry.retire(failure.code);
-        return (entry, None, Some(failure.code.to_string()));
+        return (
+            entry,
+            None,
+            Some(ProviderPreparationFailure {
+                phase: PluginCheckPhase::Initialize,
+                code: failure.code,
+                detail: initialize_failure_detail(failure.code),
+            }),
+        );
     }
     let tools = match connection.tools_list(timeout) {
         Ok(tools) => tools,
         Err(failure) => {
             process.terminate();
             entry.retire(failure.code);
-            return (entry, None, Some(failure.code.to_string()));
+            let phase = if failure.code == "plugin_tools_list_invalid" {
+                PluginCheckPhase::Validation
+            } else {
+                PluginCheckPhase::ToolsList
+            };
+            let detail = if phase == PluginCheckPhase::Validation {
+                "Plugin tools/list result violates Tool schema or Plugin bounds"
+            } else {
+                "Plugin tools/list did not complete successfully"
+            };
+            return (
+                entry,
+                None,
+                Some(ProviderPreparationFailure {
+                    phase,
+                    code: failure.code,
+                    detail,
+                }),
+            );
         }
     };
     *entry.session.lock().unwrap() = Some(connection);
@@ -1161,3 +1443,7 @@ fn stale_provider() -> PluginGatewayResponse {
 #[cfg(test)]
 #[path = "plugin_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "plugin_check_tests.rs"]
+mod check_tests;

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -1,0 +1,524 @@
+use super::*;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use tempfile::TempDir;
+use webcodex_core::plugin::PluginGatewayResponsePayload;
+
+static FAKE_PLUGIN_CHECK: OnceLock<Mutex<Weak<FakeBinary>>> = OnceLock::new();
+
+struct FakeBinary {
+    _temp: TempDir,
+    path: PathBuf,
+}
+
+fn fake_binary() -> Arc<FakeBinary> {
+    let cache = FAKE_PLUGIN_CHECK.get_or_init(|| Mutex::new(Weak::new()));
+    let mut cached = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(binary) = cached.upgrade() {
+        return binary;
+    }
+    let temp = tempfile::tempdir().unwrap();
+    let output = temp.path().join(format!(
+        "webcodex-plugin-check-fake{}",
+        env::consts::EXE_SUFFIX
+    ));
+    let source =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/webcodex_runner/fake_plugin.rs");
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let result = Command::new(rustc)
+        .arg("--edition=2021")
+        .arg("--crate-name=webcodex_plugin_check_fake")
+        .arg(source)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let binary = Arc::new(FakeBinary {
+        _temp: temp,
+        path: output,
+    });
+    *cached = Arc::downgrade(&binary);
+    binary
+}
+
+struct CheckFixture {
+    manager: Arc<PluginManager>,
+    config_path: PathBuf,
+    marker: PathBuf,
+    fake: Arc<FakeBinary>,
+    _temp: TempDir,
+}
+
+impl CheckFixture {
+    fn new(candidate_scenario: &str, timeout_secs: u64) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("marker.log");
+        let fake = fake_binary();
+        let startup_plugins = PluginConfig {
+            request_timeout_secs: timeout_secs,
+            providers: vec![PluginProviderConfig {
+                id: "fake".to_string(),
+                name: "Fake Plugin".to_string(),
+                command: fake.path.to_string_lossy().into_owned(),
+                args: vec!["normal".to_string(), marker.to_string_lossy().into_owned()],
+                cwd: Some(temp.path().to_string_lossy().into_owned()),
+                profile: None,
+                timeout_secs: Some(timeout_secs),
+            }],
+        };
+        let config_path = temp.path().join("runner.toml");
+        write_runner_toml(
+            &config_path,
+            temp.path(),
+            &fake.path,
+            &marker,
+            candidate_scenario,
+            timeout_secs,
+        );
+        let config = runner_config(startup_plugins, ShellConfig::default(), temp.path());
+        let manager = Arc::new(PluginManager::new(&config, config_path.clone()));
+        Self {
+            manager,
+            config_path,
+            marker,
+            fake,
+            _temp: temp,
+        }
+    }
+
+    fn check(&self) -> PluginGatewayResponse {
+        self.manager.handle(PluginGatewayRequest::Check {
+            provider_id: "fake".to_string(),
+        })
+    }
+
+    fn rewrite_candidate(&self, scenario: &str, timeout_secs: u64) {
+        write_runner_toml(
+            &self.config_path,
+            self._temp.path(),
+            &self.fake.path,
+            &self.marker,
+            scenario,
+            timeout_secs,
+        );
+    }
+
+    fn marker_count(&self, value: &str) -> usize {
+        fs::read_to_string(&self.marker)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| *line == value)
+            .count()
+    }
+
+    fn marker_pids(&self, prefix: &str) -> Vec<u32> {
+        fs::read_to_string(&self.marker)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| line.strip_prefix(prefix)?.parse().ok())
+            .collect()
+    }
+}
+
+fn checked_report(response: PluginGatewayResponse) -> PluginCheckReport {
+    assert_eq!(response.dispatch_state, PluginDispatchState::Completed);
+    assert!(response.error.is_none());
+    let Some(PluginGatewayResponsePayload::Checked { report }) = response.payload else {
+        panic!("missing Plugin check report");
+    };
+    report
+}
+
+fn provider_state(manager: &PluginManager) -> (Vec<PluginProviderView>, bool) {
+    let response = manager.handle(PluginGatewayRequest::ProvidersList);
+    let Some(PluginGatewayResponsePayload::Providers {
+        providers,
+        first_class_restart_required,
+    }) = response.payload
+    else {
+        panic!("missing provider state: {:?}", response.error);
+    };
+    (providers, first_class_restart_required)
+}
+
+fn wait_until(timeout: Duration, condition: impl Fn() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    condition()
+}
+
+#[test]
+fn check_success_is_disposable_and_preserves_committed_plugin_state() {
+    let fixture = CheckFixture::new("check_success_tree", 2);
+    let startup_before = fixture.manager.startup_catalog();
+    let state_before = provider_state(&fixture.manager);
+
+    let report = checked_report(fixture.check());
+    assert!(report.ready);
+    assert_eq!(report.phase, PluginCheckPhase::Ready);
+    assert_eq!(report.tool_count, 1);
+    assert_eq!(report.tools[0].name, "echo");
+    assert!(report.startup_tool_shape.as_ref().unwrap().eligible);
+    assert_eq!(
+        fixture.marker_count("call"),
+        0,
+        "check must never call tools/call"
+    );
+    assert_eq!(fixture.manager.startup_catalog(), startup_before);
+    assert_eq!(provider_state(&fixture.manager), state_before);
+
+    let candidate_pid = fixture
+        .marker_pids("candidate-pid:")
+        .into_iter()
+        .next()
+        .unwrap();
+    let descendant_pid = fixture
+        .marker_pids("descendant-pid:")
+        .into_iter()
+        .next()
+        .unwrap();
+    assert!(wait_until(Duration::from_secs(2), || {
+        !crate::job_manager_tests::process_running(candidate_pid)
+            && !crate::job_manager_tests::process_running(descendant_pid)
+    }));
+}
+
+#[test]
+fn check_observes_edited_v2_without_replacing_current_dynamic_v1() {
+    let fixture = CheckFixture::new("normal", 2);
+    let first_reload = fixture.manager.handle(PluginGatewayRequest::Reload);
+    let Some(PluginGatewayResponsePayload::Reloaded { providers, .. }) = first_reload.payload
+    else {
+        panic!("initial dynamic reload failed: {:?}", first_reload.error);
+    };
+    let dynamic_v1 = providers[0].provider_instance_id.clone();
+    let startup = fixture.manager.startup_catalog();
+    let v1_schema = startup[0].tools[0].schema_observation();
+    let state_before_check = provider_state(&fixture.manager);
+
+    fixture.rewrite_candidate("check_v2", 2);
+    let report = checked_report(fixture.check());
+    assert!(report.ready);
+    assert_eq!(report.tools[0].name, "echo_v2");
+    assert_eq!(provider_state(&fixture.manager), state_before_check);
+
+    let v1_call = fixture.manager.handle(PluginGatewayRequest::ToolsCall {
+        plane: PluginPlane::Effective,
+        provider_id: "fake".to_string(),
+        provider_instance_id: dynamic_v1.clone(),
+        name: "echo".to_string(),
+        arguments: json!({"value":"still-v1"}),
+        expected_schema: v1_schema,
+    });
+    assert!(
+        v1_call.error.is_none(),
+        "check must not disturb current dynamic v1"
+    );
+
+    let reload_v2 = fixture.manager.handle(PluginGatewayRequest::Reload);
+    let Some(PluginGatewayResponsePayload::Reloaded { providers, .. }) = reload_v2.payload else {
+        panic!("v2 reload failed: {:?}", reload_v2.error);
+    };
+    let dynamic_v2 = providers[0].provider_instance_id.clone();
+    assert_ne!(dynamic_v2, dynamic_v1);
+    let tools = fixture.manager.handle(PluginGatewayRequest::ToolsList {
+        plane: PluginPlane::Effective,
+        provider_id: "fake".to_string(),
+        provider_instance_id: dynamic_v2,
+    });
+    let Some(PluginGatewayResponsePayload::Tools { tools }) = tools.payload else {
+        panic!("v2 tools/list failed: {:?}", tools.error);
+    };
+    assert_eq!(tools[0].name, "echo_v2");
+    fixture.manager.shutdown();
+}
+
+#[test]
+fn check_failures_are_structured_diagnostic_results_and_cleanup_process_trees() {
+    for (scenario, timeout_secs, phase, code) in [
+        (
+            "check_bad_version_tree",
+            2,
+            PluginCheckPhase::Initialize,
+            "plugin_protocol_version_mismatch",
+        ),
+        (
+            "check_init_timeout",
+            1,
+            PluginCheckPhase::Initialize,
+            "plugin_timeout",
+        ),
+        (
+            "check_init_crash",
+            2,
+            PluginCheckPhase::Initialize,
+            "plugin_eof",
+        ),
+        (
+            "check_invalid_tools",
+            2,
+            PluginCheckPhase::Validation,
+            "plugin_tools_list_invalid",
+        ),
+        (
+            "check_oversized_schema",
+            2,
+            PluginCheckPhase::Validation,
+            "plugin_tools_list_invalid",
+        ),
+    ] {
+        let fixture = CheckFixture::new(scenario, timeout_secs);
+        let report = checked_report(fixture.check());
+        assert!(!report.ready, "{scenario}");
+        assert_eq!(report.phase, phase, "{scenario}");
+        assert_eq!(report.code.as_deref(), Some(code), "{scenario}");
+        assert!(report.detail.is_some(), "{scenario}");
+        assert!(report.tools.is_empty(), "{scenario}");
+
+        for pid in fixture.marker_pids("candidate-pid:") {
+            assert!(wait_until(Duration::from_secs(2), || {
+                !crate::job_manager_tests::process_running(pid)
+            }));
+        }
+        for pid in fixture.marker_pids("descendant-pid:") {
+            assert!(wait_until(Duration::from_secs(2), || {
+                !crate::job_manager_tests::process_running(pid)
+            }));
+        }
+    }
+}
+
+#[test]
+fn check_reports_executable_config_and_startup_shape_without_sensitive_details() {
+    let fixture = CheckFixture::new("normal", 2);
+    write_runner_toml(
+        &fixture.config_path,
+        fixture._temp.path(),
+        Path::new("webcodex-plugin-definitely-missing-for-check"),
+        &fixture.marker,
+        "normal",
+        2,
+    );
+    let missing = checked_report(fixture.check());
+    assert!(!missing.ready);
+    assert_eq!(missing.phase, PluginCheckPhase::Executable);
+    assert_eq!(
+        missing.code.as_deref(),
+        Some("plugin_executable_unavailable")
+    );
+
+    write_runner_toml_without_plugins(&fixture.config_path, fixture._temp.path());
+    let absent = checked_report(fixture.check());
+    assert_eq!(absent.phase, PluginCheckPhase::Config);
+    assert_eq!(absent.code.as_deref(), Some("plugin_not_configured"));
+
+    fixture.rewrite_candidate("check_startup_large_schema", 2);
+    let shape = checked_report(fixture.check());
+    assert!(shape.ready);
+    let startup_shape = shape.startup_tool_shape.unwrap();
+    assert!(!startup_shape.eligible);
+    assert_eq!(
+        startup_shape.code.as_deref(),
+        Some("plugin_startup_schema_too_large")
+    );
+
+    fixture.rewrite_candidate("stderr", 2);
+    let response = fixture.check();
+    let encoded = serde_json::to_string(&response).unwrap();
+    assert!(!encoded.contains("diagnostic-only-secret-looking-stderr"));
+    assert!(!encoded.contains(fixture._temp.path().to_string_lossy().as_ref()));
+    let report = checked_report(response);
+    assert!(report.ready);
+}
+
+#[test]
+fn candidate_gate_serializes_check_and_reload_without_blocking_current_providers() {
+    let fixture = CheckFixture::new("normal", 2);
+    let first_reload = fixture.manager.handle(PluginGatewayRequest::Reload);
+    let Some(PluginGatewayResponsePayload::Reloaded { providers, .. }) = first_reload.payload
+    else {
+        panic!("initial reload failed: {:?}", first_reload.error);
+    };
+    let dynamic_v1 = providers[0].provider_instance_id.clone();
+    let startup = fixture.manager.startup_catalog();
+    let schema = startup[0].tools[0].schema_observation();
+
+    fixture.rewrite_candidate("candidate_block_list_tree", 10);
+    let _ = fs::remove_file(fixture.marker.with_extension("release"));
+    let manager = Arc::clone(&fixture.manager);
+    let check_a = std::thread::spawn(move || {
+        manager.handle(PluginGatewayRequest::Check {
+            provider_id: "fake".to_string(),
+        })
+    });
+    assert!(wait_until(Duration::from_secs(2), || {
+        fixture.marker_count("candidate-blocked") == 1
+    }));
+
+    let check_b = fixture.check();
+    assert_eq!(check_b.dispatch_state, PluginDispatchState::NotStarted);
+    assert_eq!(check_b.error.as_ref().unwrap().code, "plugin_check_busy");
+    let reload = fixture.manager.handle(PluginGatewayRequest::Reload);
+    assert_eq!(reload.dispatch_state, PluginDispatchState::NotStarted);
+    assert_eq!(reload.error.as_ref().unwrap().code, "plugin_reload_busy");
+
+    let current_call = fixture.manager.handle(PluginGatewayRequest::ToolsCall {
+        plane: PluginPlane::Effective,
+        provider_id: "fake".to_string(),
+        provider_instance_id: dynamic_v1.clone(),
+        name: "echo".to_string(),
+        arguments: json!({"value":"during-check"}),
+        expected_schema: schema.clone(),
+    });
+    assert!(current_call.error.is_none());
+    let direct_startup = fixture.manager.handle(PluginGatewayRequest::ToolsCall {
+        plane: PluginPlane::Startup,
+        provider_id: "fake".to_string(),
+        provider_instance_id: startup[0].provider_instance_id.clone(),
+        name: "echo".to_string(),
+        arguments: json!({"value":"startup-during-check"}),
+        expected_schema: schema,
+    });
+    assert!(direct_startup.error.is_none());
+    assert!(fixture
+        .manager
+        .handle(PluginGatewayRequest::ProvidersList)
+        .error
+        .is_none());
+
+    fs::write(fixture.marker.with_extension("release"), b"release").unwrap();
+    let report = checked_report(check_a.join().unwrap());
+    assert!(report.ready);
+    let (providers, _) = provider_state(&fixture.manager);
+    assert_eq!(providers[0].provider_instance_id, dynamic_v1);
+    for pid in fixture.marker_pids("descendant-pid:") {
+        assert!(wait_until(Duration::from_secs(2), || {
+            !crate::job_manager_tests::process_running(pid)
+        }));
+    }
+    fixture.manager.shutdown();
+}
+
+#[test]
+fn shutdown_interrupts_blocked_check_candidate_and_reaps_tree() {
+    let fixture = CheckFixture::new("candidate_block_list_tree", 10);
+    let _ = fs::remove_file(fixture.marker.with_extension("release"));
+    let manager = Arc::clone(&fixture.manager);
+    let check = std::thread::spawn(move || {
+        manager.handle(PluginGatewayRequest::Check {
+            provider_id: "fake".to_string(),
+        })
+    });
+    assert!(wait_until(Duration::from_secs(2), || {
+        fixture.marker_count("candidate-blocked") == 1
+            && !fixture.marker_pids("descendant-pid:").is_empty()
+    }));
+
+    let started = Instant::now();
+    fixture.manager.shutdown();
+    assert!(
+        started.elapsed() < Duration::from_millis(2500),
+        "shutdown waited for the candidate gate"
+    );
+    let response = check.join().unwrap();
+    assert_eq!(response.dispatch_state, PluginDispatchState::NotStarted);
+    assert_eq!(
+        response.error.as_ref().unwrap().code,
+        "plugin_manager_stopping"
+    );
+    for pid in fixture.marker_pids("descendant-pid:") {
+        assert!(wait_until(Duration::from_secs(2), || {
+            !crate::job_manager_tests::process_running(pid)
+        }));
+    }
+}
+
+fn runner_config(
+    plugins: PluginConfig,
+    shell: ShellConfig,
+    project_registry_dir: &Path,
+) -> RunnerConfig {
+    use super::super::config::{
+        default_websocket_connect_timeout_secs, AcpConfig, McpGatewayConfig, RunnerPolicy,
+        SshConfig, ToolProvidersConfig,
+    };
+    RunnerConfig {
+        server_url: "http://127.0.0.1:8000".to_string(),
+        token: "test-token".to_string(),
+        client_id: "plugin-check-test".to_string(),
+        display_name: None,
+        owner: Some("alice".to_string()),
+        hostname: None,
+        host_context: None,
+        project_registry_dir: Some(project_registry_dir.to_path_buf()),
+        legacy_projects_dir: None,
+        deprecated_temporary_projects_root: None,
+        poll_interval_ms: 1000,
+        capabilities: None,
+        max_concurrent_jobs: None,
+        policy: RunnerPolicy::default(),
+        transport: None,
+        websocket_connect_timeout_secs: default_websocket_connect_timeout_secs(),
+        quic: None,
+        shell,
+        ssh: SshConfig::default(),
+        tool_providers: ToolProvidersConfig::default(),
+        mcp_gateway: McpGatewayConfig::default(),
+        plugins,
+        acp: AcpConfig::default(),
+    }
+}
+
+fn write_runner_toml(
+    path: &Path,
+    project_registry_dir: &Path,
+    executable: &Path,
+    marker: &Path,
+    scenario: &str,
+    request_timeout_secs: u64,
+) {
+    fn quoted(value: &Path) -> String {
+        format!("{:?}", value.to_string_lossy().as_ref())
+    }
+    fs::write(
+        path,
+        format!(
+            "server_url = \"http://127.0.0.1:8000\"\ntoken = \"test-token\"\nclient_id = \"plugin-check-test\"\nproject_registry_dir = {}\n\n[plugins]\nrequest_timeout_secs = {request_timeout_secs}\n\n[[plugins.providers]]\nid = \"fake\"\nname = \"Fake Plugin\"\ncommand = {}\nargs = [\"{}\", {}]\ncwd = {}\ntimeout_secs = {request_timeout_secs}\n",
+            quoted(project_registry_dir),
+            quoted(executable),
+            scenario,
+            quoted(marker),
+            quoted(project_registry_dir),
+        ),
+    )
+    .unwrap();
+}
+
+fn write_runner_toml_without_plugins(path: &Path, project_registry_dir: &Path) {
+    fn quoted(value: &Path) -> String {
+        format!("{:?}", value.to_string_lossy().as_ref())
+    }
+    fs::write(
+        path,
+        format!(
+            "server_url = \"http://127.0.0.1:8000\"\ntoken = \"test-token\"\nclient_id = \"plugin-check-test\"\nproject_registry_dir = {}\n\n[plugins]\nrequest_timeout_secs = 2\n",
+            quoted(project_registry_dir),
+        ),
+    )
+    .unwrap();
+}

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -99,12 +99,35 @@ the provider under the same identity.
 After startup, Plugin development uses the dynamic plane:
 
 ```text
+plugin_tool(action="check", runner="my-runner", plugin="repo-tools")
 plugin_tool(action="reload", runner="my-runner")
 plugin_tool(action="list", runner="my-runner")
 plugin_tool(action="describe", runner="my-runner", plugin="repo-tools", tool="search_symbol")
     -> { ..., "binding": "wc_pbind_..." }
 plugin_tool(action="call", binding="wc_pbind_...", arguments={"query":"foo"})
 ```
+
+`check` is the recommended preflight before `reload`. The Runner rereads its
+current `runner.toml`, locates only the requested provider, prepares the same
+shell/profile environment used by the normal Plugin runtime, resolves and
+**really starts** the configured executable, performs `initialize` and
+`tools/list`, validates the normal Plugin protocol/bounds, then terminates that
+candidate process tree. It never calls provider `tools/call` and never commits
+the candidate into the dynamic overlay. Because a Native Plugin is an arbitrary
+local executable, its own startup/initialize/list behavior can still have
+external side effects; `check` is not a purely static config linter.
+
+A successful check returns `ready=true` plus bounded tool summaries containing
+only names and optional titles. A broken candidate is normally a successful
+check operation with `ready=false`, a structured `phase`, a stable error `code`,
+and a bounded WebCodex-generated `detail`. Plugin stderr remains Runner-local and
+is never included in the report.
+
+`startupToolShape.eligible=true` means only that this checked provider's own Tool
+definitions satisfy the stricter per-provider startup Tool bounds. It is **not**
+a guarantee of final first-class MCP exposure: actual startup admission also
+depends on whole-catalog bounds, and Server exposure still depends on reserved
+names and caller-visible name uniqueness.
 
 `call` has one dispatch identity: the opaque `binding` returned by that exact
 `describe`. It does not accept `runner`, `plugin`, or `tool` as call-time
@@ -114,9 +137,12 @@ that moment. The handle does not encode or expose those internal identities.
 
 `reload` is the cross-platform authoritative reload path on Windows, macOS, and
 Linux. The Runner rereads its own `runner.toml`; the Server does not upload an
-executable, environment, or raw Plugin config. Reload management is serialized:
-if another reload is already preparing candidates, the second reload is not
-queued and returns `plugin_reload_busy` with `NotStarted`.
+executable, environment, or raw Plugin config. Candidate management is
+serialized across both `check` and `reload`: a second check returns
+`plugin_check_busy`, while reload keeps the existing `plugin_reload_busy` result.
+Candidate operations are rejected with `NotStarted` instead of being queued.
+This gate does not block list/describe/call or direct startup tools from using the
+currently committed provider while a candidate is being prepared.
 
 A changed provider is initialized and listed successfully before it replaces
 the previous dynamic instance. A failed candidate leaves the previous working
@@ -127,6 +153,8 @@ This creates the normal development loop:
 
 ```text
 edit Plugin code/config
+    -> plugin_tool check
+    -> fix until the disposable candidate is ready
     -> plugin_tool reload
     -> plugin_tool describe
     -> receive opaque binding
@@ -140,6 +168,11 @@ If startup provider A is first-class and reload creates dynamic provider B,
 direct `search_symbol(...)` still calls A. A fresh dynamic `describe` observes B
 and its returned binding calls only that exact B instance. Only a Runner restart
 can replace the first-class startup binding.
+
+Running `check` before that reload does not replace A or the current dynamic
+provider, does not alter `firstClassRestartRequired`, does not create a binding,
+and does not change the direct MCP tool inventory. The successful check candidate
+is disposed instead of being reused by a later reload.
 
 ## WebCodex Plugin Protocol v1
 

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -91,12 +91,32 @@ direct call fail closed；不会在同一个 identity 下静默重启。
 Runner 启动后的 Plugin 开发统一走 dynamic plane：
 
 ```text
+plugin_tool(action="check", runner="my-runner", plugin="repo-tools")
 plugin_tool(action="reload", runner="my-runner")
 plugin_tool(action="list", runner="my-runner")
 plugin_tool(action="describe", runner="my-runner", plugin="repo-tools", tool="search_symbol")
     -> { ..., "binding": "wc_pbind_..." }
 plugin_tool(action="call", binding="wc_pbind_...", arguments={"query":"foo"})
 ```
+
+`check` 是开发时 `reload` 之前推荐使用的预检。Runner 会重新读取当前
+`runner.toml`，只定位 requested provider，使用正常 Plugin runtime 的同一套
+shell/profile environment preparation 和 native executable resolution，**真实启动**配置的
+executable，完成 `initialize`、`tools/list` 与普通 Plugin protocol/bounds validation，随后
+终止整个 disposable candidate process tree。WebCodex 在 check 中绝不会调用 provider
+`tools/call`，也不会把 candidate 提交到 dynamic overlay。由于 Native Plugin 本身就是任意
+本地 executable，其 startup/initialize/list 自身仍可能产生外部副作用，因此 `check` 不是
+纯静态配置 lint。
+
+成功预检返回 `ready=true`，tool summary 只包含 name 和可选 title。坏 candidate 通常仍然
+表示“check 操作成功完成了诊断”，因此返回 `ready=false`、结构化 `phase`、稳定 `code`
+以及有界、由 WebCodex 生成的安全 `detail`，而不是把所有坏 Plugin 都变成
+`plugin_tool isError=true`。Plugin stderr 始终留在 Runner 本机，不会进入 check report。
+
+`startupToolShape.eligible=true` 只表示这个 checked provider 自己的 Tool definitions 满足
+更严格的 provider-local startup Tool bounds；它**不保证**最终成为一级 MCP tool。实际
+startup admission 还受 whole-catalog bounds 影响，而 Server 一级暴露还取决于 reserved
+name 与 caller-visible name uniqueness。
 
 `call` 的 dispatch identity 只有这个 opaque `binding`；call 阶段不再接受
 `runner`、`plugin`、`tool` 作为路由字段。每次 describe 都会创建独立 binding，精确
@@ -105,8 +125,10 @@ plugin_tool(action="call", binding="wc_pbind_...", arguments={"query":"foo"})
 
 `reload` 是 Windows、macOS、Linux 都可用的 authoritative reload 入口。Runner
 自己重新读取自己的 `runner.toml`；Server 不会上传 executable、env 或 raw Plugin
-config。reload 管理操作严格串行：如果已经有一个 reload 正在准备 candidate，第二个
-reload 不排队，直接返回 `plugin_reload_busy` + `NotStarted`。
+config。candidate management 在 `check` 与 `reload` 之间共同串行：第二个 check 返回
+`plugin_check_busy`，reload 保持已有 `plugin_reload_busy`；都以 `NotStarted` 明确拒绝，
+不排队等待。candidate 准备期间不会长期持有 current dynamic/provider session，因此
+list/describe/call 与 startup direct tools 仍可继续使用当前已提交 provider。
 
 changed provider 会先准备 candidate，只有 initialize/list 成功后才替换旧 dynamic
 instance；candidate 失败会保留已有可工作的 dynamic instance。被删除的 provider 会从
@@ -116,6 +138,8 @@ dynamic view 中消失。这些操作都不会修改 frozen startup catalog。
 
 ```text
 修改 Plugin code/config
+    -> plugin_tool check
+    -> 修复直到 disposable candidate ready
     -> plugin_tool reload
     -> plugin_tool describe
     -> 收到 opaque binding
@@ -129,6 +153,10 @@ dynamic view 中消失。这些操作都不会修改 frozen startup catalog。
 B，那么直接 `search_symbol(...)` 仍然调用 A；新的 dynamic `describe` 会观察 B，返回的
 binding 也只会调用那个 exact B instance。只有 Runner restart 才能替换一级 startup
 绑定。
+
+在 reload 前运行 `check` 不会替换 A 或当前 dynamic provider，不会改变
+`firstClassRestartRequired`，不会创建 binding，也不会改变 direct MCP tool inventory。
+成功的 check candidate 会被销毁，不会偷偷复用成下一次 reload provider。
 
 ## WebCodex Plugin Protocol v1
 

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -185,6 +185,8 @@ mod model_ergonomics;
 mod model_surface;
 #[path = "mcp_tests/oauth_scope.rs"]
 mod oauth_scope;
+#[path = "mcp_tests/plugin_check.rs"]
+mod plugin_check;
 #[path = "mcp_tests/plugin_tools.rs"]
 mod plugin_tools;
 #[path = "mcp_tests/project_connector.rs"]

--- a/src/mcp_tests/plugin_check.rs
+++ b/src/mcp_tests/plugin_check.rs
@@ -1,0 +1,408 @@
+use super::*;
+use crate::runner_protocol::{RunnerPolicySummary, RunnerResultPayload};
+use std::sync::Arc;
+use webcodex_core::plugin::{
+    PluginCheckPhase, PluginCheckReport, PluginCheckToolSummary, PluginGatewayRequest,
+    PluginGatewayResponse, PluginGatewayResponsePayload, PluginStartupToolShape, PluginTool,
+    StartupPluginProvider,
+};
+
+fn plugin_auth(include_scope: bool) -> crate::auth::AuthContext {
+    let mut auth = mcp_export_api_auth("plugin-check-test-pat", "alice");
+    if include_scope {
+        auth.scopes
+            .push(crate::auth::SCOPE_PLUGIN_LOCAL.to_string());
+    }
+    auth
+}
+
+fn direct_tool(name: &str) -> PluginTool {
+    PluginTool {
+        name: name.to_string(),
+        title: Some("Search Symbol".to_string()),
+        description: Some("Search repository symbols".to_string()),
+        input_schema: json!({
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+            "additionalProperties": false
+        }),
+        output_schema: None,
+        annotations: Some(json!({"readOnlyHint": true})),
+    }
+}
+
+async fn register_plugin_runner(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    runner_instance_id: &str,
+    tool_name: &str,
+) {
+    let mut capabilities = RunnerCapabilities::default();
+    capabilities.native_tool_plugins = true;
+    runtime
+        .runner_registry
+        .register(crate::test_support::current_runner_registration(
+            RunnerRegisterRequest {
+                client_id: client_id.to_string(),
+                runner_instance_id: runner_instance_id.to_string(),
+                runner_protocol_generation: crate::runner_protocol::RUNNER_PROTOCOL_GENERATION_V2,
+                display_name: Some(format!("Plugin {client_id}")),
+                owner: Some("alice".to_string()),
+                hostname: None,
+                host_context: None,
+                capabilities,
+                policy: Some(RunnerPolicySummary {
+                    plugin_providers: Some(vec![StartupPluginProvider {
+                        provider_id: "repo-tools".to_string(),
+                        provider_instance_id: format!("startup-{runner_instance_id}"),
+                        name: "Repo Tools".to_string(),
+                        status: "ready".to_string(),
+                        error_code: None,
+                        tools: vec![direct_tool(tool_name)],
+                    }]),
+                    ..Default::default()
+                }),
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: None,
+                job_inventory: None,
+                coding_agent_providers: None,
+                coding_agent_inventory: None,
+            },
+        ))
+        .await
+        .unwrap();
+}
+
+async fn wait_for_plugin_request(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    runner_instance_id: &str,
+) -> crate::runner_protocol::RunnerRequest {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if let Some(request) = runtime
+            .runner_registry
+            .poll(RunnerPollRequest {
+                client_id: client_id.to_string(),
+                runner_instance_id: runner_instance_id.to_string(),
+            })
+            .await
+            .unwrap()
+        {
+            return request;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Plugin check did not dispatch"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn complete_plugin_request(
+    runtime: &ToolRuntime,
+    request: crate::runner_protocol::RunnerRequest,
+    runner_instance_id: &str,
+    response: PluginGatewayResponse,
+) {
+    runtime
+        .runner_registry
+        .complete(RunnerResultPayload {
+            result: RunnerResultRequest {
+                client_id: request.client_id,
+                runner_instance_id: runner_instance_id.to_string(),
+                request_id: request.request_id,
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                duration_ms: None,
+                error: None,
+            },
+            command_execution_state: None,
+            mcp_gateway: None,
+            plugin_gateway: Some(response),
+            coding_agent: None,
+        })
+        .await
+        .unwrap();
+}
+
+fn check_call(runner: &str, extra: Value) -> JsonRpcRequest {
+    let mut arguments = json!({
+        "action": "check",
+        "runner": runner,
+        "plugin": "repo-tools"
+    });
+    if let Some(extra) = extra.as_object() {
+        arguments.as_object_mut().unwrap().extend(extra.clone());
+    }
+    rpc(
+        "tools/call",
+        Some(json!(760)),
+        json!({
+            "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+            "arguments": arguments
+        }),
+    )
+}
+
+async fn tools_list(runtime: &ToolRuntime, auth: &crate::auth::AuthContext) -> Value {
+    match handle_mcp_request(
+        runtime,
+        rpc("tools/list", Some(json!(761)), json!({})),
+        Some(auth),
+    )
+    .await
+    {
+        McpOutcome::Ok(value) => value,
+        other => panic!("tools/list failed: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn plugin_check_tool_spec_and_argument_contract_fail_closed_before_dispatch() {
+    let spec = crate::plugin_gateway::tool_spec();
+    assert!(spec["inputSchema"]["properties"]["action"]["enum"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|action| action == "check"));
+    let description = spec["description"].as_str().unwrap();
+    assert!(description.contains("Prefer action=check before reload"));
+    assert!(description.contains("never calls tools/call"));
+
+    let runtime = test_runtime();
+    let no_scope = handle_mcp_request(
+        &runtime,
+        check_call("runner-a", json!({})),
+        Some(&plugin_auth(false)),
+    )
+    .await;
+    match no_scope {
+        McpOutcome::Forbidden { required_scope, .. } => {
+            assert_eq!(required_scope, Some(crate::auth::SCOPE_PLUGIN_LOCAL));
+        }
+        other => panic!("check without plugin:local must be forbidden: {other:?}"),
+    }
+
+    let auth = plugin_auth(true);
+    for extra in [
+        json!({"tool":"search_symbol"}),
+        json!({"binding":"wc_pbind_0123456789abcdef0123456789abcdef"}),
+        json!({"arguments":{}}),
+    ] {
+        let outcome =
+            handle_mcp_request(&runtime, check_call("runner-a", extra), Some(&auth)).await;
+        let McpOutcome::Ok(value) = outcome else {
+            panic!("invalid check arguments should render a tool result: {outcome:?}");
+        };
+        assert_eq!(value["result"]["isError"], true);
+        assert_eq!(
+            value["result"]["structuredContent"]["error"]["code"],
+            "invalid_arguments"
+        );
+    }
+
+    let missing_runner = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(762)),
+            json!({
+                "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                "arguments": {"action":"check","plugin":"repo-tools"}
+            }),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Ok(missing_runner) = missing_runner else {
+        panic!("missing runner should render a tool result");
+    };
+    assert_eq!(
+        missing_runner["result"]["structuredContent"]["error"]["code"],
+        "invalid_arguments"
+    );
+
+    let missing_plugin = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(763)),
+            json!({
+                "name": crate::plugin_gateway::PLUGIN_TOOL_NAME,
+                "arguments": {"action":"check","runner":"runner-a"}
+            }),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Ok(missing_plugin) = missing_plugin else {
+        panic!("missing plugin should render a tool result");
+    };
+    assert_eq!(
+        missing_plugin["result"]["structuredContent"]["error"]["code"],
+        "invalid_arguments"
+    );
+    assert!(runtime
+        .runner_registry
+        .poll(RunnerPollRequest {
+            client_id: "runner-a".to_string(),
+            runner_instance_id: "runner-instance-a".to_string(),
+        })
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn plugin_check_routes_exact_runner_renders_sanitized_report_and_preserves_direct_inventory()
+{
+    let runtime = Arc::new(test_runtime());
+    let auth = plugin_auth(true);
+    register_plugin_runner(&runtime, "runner-a", "runner-instance-a", "search_symbol").await;
+    register_plugin_runner(&runtime, "runner-b", "runner-instance-b", "other_symbol").await;
+    let before = tools_list(&runtime, &auth).await;
+    assert!(before["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|tool| tool["name"] == "search_symbol"));
+
+    let task_runtime = Arc::clone(&runtime);
+    let task_auth = auth.clone();
+    let task = tokio::spawn(async move {
+        handle_mcp_request(
+            &task_runtime,
+            check_call("runner-a", json!({})),
+            Some(&task_auth),
+        )
+        .await
+    });
+
+    let request = wait_for_plugin_request(&runtime, "runner-a", "runner-instance-a").await;
+    assert!(matches!(
+        request.plugin_gateway,
+        Some(PluginGatewayRequest::Check { ref provider_id }) if provider_id == "repo-tools"
+    ));
+    assert!(runtime
+        .runner_registry
+        .poll(RunnerPollRequest {
+            client_id: "runner-b".to_string(),
+            runner_instance_id: "runner-instance-b".to_string(),
+        })
+        .await
+        .unwrap()
+        .is_none());
+    complete_plugin_request(
+        &runtime,
+        request,
+        "runner-instance-a",
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked {
+            report: PluginCheckReport {
+                provider_id: "repo-tools".to_string(),
+                ready: true,
+                phase: PluginCheckPhase::Ready,
+                code: None,
+                detail: None,
+                tool_count: 1,
+                tools: vec![PluginCheckToolSummary {
+                    name: "search_symbol".to_string(),
+                    title: Some("Search Symbol".to_string()),
+                }],
+                startup_tool_shape: Some(PluginStartupToolShape {
+                    eligible: true,
+                    code: None,
+                }),
+            },
+        }),
+    )
+    .await;
+
+    let McpOutcome::Ok(value) = task.await.unwrap() else {
+        panic!("plugin check failed");
+    };
+    assert_eq!(value["result"]["isError"], false);
+    let report = &value["result"]["structuredContent"];
+    assert_eq!(report["runner"], "runner-a");
+    assert_eq!(report["plugin"], "repo-tools");
+    assert_eq!(report["ready"], true);
+    assert_eq!(report["phase"], "ready");
+    assert_eq!(report["toolCount"], 1);
+    assert_eq!(report["tools"][0]["name"], "search_symbol");
+    assert_eq!(report["startupToolShape"]["eligible"], true);
+    assert!(report.get("binding").is_none());
+    let encoded = serde_json::to_string(report).unwrap();
+    for forbidden in [
+        "runner-instance-a",
+        "provider_instance_id",
+        "runner_instance_id",
+        "command",
+        "argv",
+        "cwd",
+        "env",
+        "stderr",
+        "pid",
+    ] {
+        assert!(!encoded.contains(forbidden), "check leaked {forbidden}");
+    }
+
+    let after = tools_list(&runtime, &auth).await;
+    assert!(after["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|tool| tool["name"] == "search_symbol"));
+}
+
+#[tokio::test]
+async fn broken_plugin_candidate_is_a_successful_check_diagnostic_result() {
+    let runtime = Arc::new(test_runtime());
+    let auth = plugin_auth(true);
+    register_plugin_runner(&runtime, "runner-a", "runner-instance-a", "search_symbol").await;
+    let task_runtime = Arc::clone(&runtime);
+    let task_auth = auth.clone();
+    let task = tokio::spawn(async move {
+        handle_mcp_request(
+            &task_runtime,
+            check_call("runner-a", json!({})),
+            Some(&task_auth),
+        )
+        .await
+    });
+    let request = wait_for_plugin_request(&runtime, "runner-a", "runner-instance-a").await;
+    complete_plugin_request(
+        &runtime,
+        request,
+        "runner-instance-a",
+        PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked {
+            report: PluginCheckReport {
+                provider_id: "repo-tools".to_string(),
+                ready: false,
+                phase: PluginCheckPhase::Validation,
+                code: Some("plugin_tools_list_invalid".to_string()),
+                detail: Some(
+                    "Plugin tools/list result violates Tool schema or Plugin bounds".to_string(),
+                ),
+                tool_count: 0,
+                tools: vec![],
+                startup_tool_shape: None,
+            },
+        }),
+    )
+    .await;
+    let McpOutcome::Ok(value) = task.await.unwrap() else {
+        panic!("broken candidate check should still complete as a diagnostic result");
+    };
+    assert_eq!(value["result"]["isError"], false);
+    assert_eq!(value["result"]["structuredContent"]["ready"], false);
+    assert_eq!(
+        value["result"]["structuredContent"]["code"],
+        "plugin_tools_list_invalid"
+    );
+    assert_eq!(value["result"]["structuredContent"]["phase"], "validation");
+    assert!(value["result"]["structuredContent"]
+        .get("binding")
+        .is_none());
+}

--- a/src/plugin_gateway.rs
+++ b/src/plugin_gateway.rs
@@ -154,21 +154,21 @@ pub(crate) fn authorized(auth: Option<&AuthContext>) -> bool {
 pub(crate) fn tool_spec() -> Value {
     json!({
         "name": PLUGIN_TOOL_NAME,
-        "description": "Develop and call Runner-local WebCodex native Tool Plugins. Plugins are arbitrary local executables using the bounded WebCodex stdio protocol, not MCP servers. action=reload rereads the exact Runner's runner.toml into the dynamic plane; startup first-class tools remain unchanged until Runner restart. Dynamic calls use reload -> describe -> call: describe returns an opaque binding for that exact Runner/provider/schema observation, and call accepts only that binding plus arguments. Stale bindings never retarget or replay; describe again after replacement. Binding handles are not authorization and Runner/provider instance identities stay hidden.",
+        "description": "Develop and call Runner-local WebCodex native Tool Plugins. Plugins are arbitrary local executables using the bounded WebCodex stdio protocol, not MCP servers. Prefer action=check before reload while developing: check rereads the exact Runner's current runner.toml, really starts one disposable candidate through the Runner's normal Plugin environment/protocol path, initializes and lists tools, never calls tools/call, and never changes startup or dynamic Plugin state. action=reload commits validated candidates to the dynamic plane; startup first-class tools remain unchanged until Runner restart. Dynamic calls then use reload -> describe -> call: describe returns an opaque exact binding and call accepts only that binding plus arguments. Stale bindings never retarget or replay. Runner/provider instance identities and Plugin execution configuration stay hidden.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["list", "reload", "describe", "call"]
+                    "enum": ["list", "check", "reload", "describe", "call"]
                 },
                 "runner": {
                     "type": "string",
-                    "description": "Exact caller-visible Runner client id. Optional for list; required for reload and describe; not accepted for call."
+                    "description": "Exact caller-visible Runner client id. Optional for list; required for check, reload, and describe; not accepted for call."
                 },
                 "plugin": {
                     "type": "string",
-                    "description": "Logical Plugin provider id. Required only for describe; not accepted for call."
+                    "description": "Logical Plugin provider id. Required for check and describe; not accepted for call."
                 },
                 "tool": {
                     "type": "string",
@@ -217,6 +217,9 @@ pub(crate) async fn call(
         "list" => list(runtime, parsed, auth)
             .await
             .map(GatewaySuccess::Metadata),
+        "check" => check(runtime, parsed, auth)
+            .await
+            .map(GatewaySuccess::Metadata),
         "reload" => reload(runtime, parsed, auth)
             .await
             .map(GatewaySuccess::Metadata),
@@ -228,7 +231,7 @@ pub(crate) async fn call(
             .map(GatewaySuccess::ToolResult),
         _ => Err(GatewayError::local(
             "invalid_action",
-            "action must be one of list, reload, describe, or call",
+            "action must be one of list, check, reload, describe, or call",
         )),
     };
     render_gateway_result(result)
@@ -273,6 +276,43 @@ async fn list(
         })
         .collect::<Vec<_>>();
     Ok(json!({"runners": runners}))
+}
+
+async fn check(
+    runtime: &ToolRuntime,
+    args: PluginToolArguments,
+    auth: Option<&AuthContext>,
+) -> Result<Value, GatewayError> {
+    if args.tool.is_some() || args.binding.is_some() || args.arguments.is_some() {
+        return Err(GatewayError::local(
+            "invalid_arguments",
+            "action=check accepts only runner and plugin",
+        ));
+    }
+    let runner_id = required_runner(args.runner.as_deref())?;
+    let plugin_id = required_provider(args.plugin.as_deref())?;
+    let runner = resolve_runner(runtime, runner_id, auth).await?;
+    let response = execute_exact(
+        runtime,
+        &runner,
+        PluginGatewayRequest::Check {
+            provider_id: plugin_id.to_string(),
+        },
+        auth,
+    )
+    .await?;
+    if let Some(error) = response.error {
+        return Err(response_error(response.dispatch_state, error));
+    }
+    match response.payload {
+        Some(PluginGatewayResponsePayload::Checked { report }) => {
+            Ok(sanitize_check_report(&runner.client_id, report))
+        }
+        _ => Err(GatewayError::local(
+            "invalid_plugin_response",
+            "Runner returned an unexpected Plugin check response",
+        )),
+    }
 }
 
 async fn reload(
@@ -769,6 +809,55 @@ fn response_error(state: PluginDispatchState, error: PluginGatewayError) -> Gate
     }
 }
 
+fn sanitize_check_report(runner: &str, report: PluginCheckReport) -> Value {
+    let mut value = json!({
+        "runner": runner,
+        "plugin": report.provider_id,
+        "ready": report.ready,
+        "phase": check_phase_name(report.phase),
+        "toolCount": report.tool_count,
+        "tools": report
+            .tools
+            .into_iter()
+            .map(|tool| {
+                let mut summary = json!({"name": tool.name});
+                if let Some(title) = tool.title {
+                    summary["title"] = Value::String(title);
+                }
+                summary
+            })
+            .collect::<Vec<_>>()
+    });
+    if let Some(code) = report.code {
+        value["code"] = Value::String(code);
+    }
+    if let Some(detail) = report.detail {
+        value["detail"] = Value::String(detail);
+    }
+    if let Some(shape) = report.startup_tool_shape {
+        let mut startup_shape = json!({"eligible": shape.eligible});
+        if let Some(code) = shape.code {
+            startup_shape["code"] = Value::String(code);
+        }
+        value["startupToolShape"] = startup_shape;
+    }
+    value
+}
+
+fn check_phase_name(phase: PluginCheckPhase) -> &'static str {
+    match phase {
+        PluginCheckPhase::Config => "config",
+        PluginCheckPhase::Environment => "environment",
+        PluginCheckPhase::Executable => "executable",
+        PluginCheckPhase::Spawn => "spawn",
+        PluginCheckPhase::Stdio => "stdio",
+        PluginCheckPhase::Initialize => "initialize",
+        PluginCheckPhase::ToolsList => "tools_list",
+        PluginCheckPhase::Validation => "validation",
+        PluginCheckPhase::Ready => "ready",
+    }
+}
+
 fn sanitize_provider_view(provider: PluginProviderView) -> Value {
     json!({
         "plugin": provider.provider_id,
@@ -944,6 +1033,13 @@ mod tests {
         assert_eq!(spec["name"], PLUGIN_TOOL_NAME);
         assert!(spec.get("outputSchema").is_none());
         assert!(spec["inputSchema"]["properties"]["binding"].is_object());
+        assert!(spec["inputSchema"]["properties"]["plugin"].is_object());
+        assert!(spec["inputSchema"]["properties"]["runner"].is_object());
+        assert!(spec["inputSchema"]["properties"]["action"]["enum"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|action| action == "check"));
         assert_eq!(
             spec["inputSchema"]["properties"]["binding"]["pattern"],
             "^wc_pbind_[0-9a-f]{32}$"
@@ -957,6 +1053,6 @@ mod tests {
         assert!(!encoded.contains("revision"));
         assert!(!encoded.contains("command"));
         assert!(!encoded.contains("cwd"));
-        assert!(!encoded.contains("env"));
+        assert!(!encoded.contains("\"env\""));
     }
 }


### PR DESCRIPTION
## Summary

- add `plugin_tool(action="check")` as a disposable Native Plugin candidate preflight
- reuse the Runner's authoritative environment, process, initialize, tools/list, bounds, and process-tree lifecycle path
- return bounded structured phases/codes/tool summaries without exposing Plugin stderr or execution configuration
- serialize check/reload candidate preparation without blocking current committed Plugin calls
- preserve startup and dynamic provider identity; check never calls `tools/call`, creates bindings, or mutates direct inventory
- report provider-local startup Tool shape without claiming final first-class exposure
- reviewer hardening: correlate every successful Plugin gateway response with its exact request, including `Check.provider_id`, and fail invalid post-dispatch responses conservatively

## Validation

- `cargo test -p webcodex-runner plugin` — 24 passed
- `cargo test -p webcodex-core plugin` — 6 passed
- `cargo test -p webcodex-runner-registry plugin` — 7 passed
- `cargo test -p webcodex plugin` — 19 passed
- `cargo fmt --all -- --check`
- `git diff --check`

Implementation also passed all-target checks for the touched packages before the reviewer-only response-correlation follow-up. No feature deployment was performed.