### PR TITLE
Improve patch recovery and owner PR CI ergonomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Full native CI is mandatory for main, external contributors, and explicit
+  # owner opt-in. Owner PRs without run-ci stay on the required Linux fast path.
+  FULL_NATIVE_REQUESTED: ${{ github.event_name == 'push' || github.event.pull_request.user.login != github.repository_owner || contains(github.event.pull_request.labels.*.name, 'run-ci') }}
 
 jobs:
   contract:
@@ -249,9 +252,9 @@ jobs:
           version="$(node -p "require('./npm/webcodex/package.json').version")"
           built_at="$(git show -s --format=%ct HEAD)"
           export WEBCODEX_BUILT_AT="$built_at"
-          cargo build --locked --release -p webcodex -p webcodex-cli -p webcodex-runner
+          cargo build --locked --profile dogfood -p webcodex -p webcodex-cli -p webcodex-runner
           for name in webcodex webcodex-server webcodex-runner; do
-            binary="target/release/$name"
+            binary="target/dogfood/$name"
             actual="$($binary --version)"
             expected="$name $version (commit $short_source, dirty=false, built_at=$built_at)"
             test "$actual" = "$expected"
@@ -269,7 +272,7 @@ jobs:
           set -euo pipefail
           stage="$RUNNER_TEMP/webcodex-desktop-${{ matrix.platform }}-bundle"
           python3 scripts/prepare_desktop_bundle_macos.py \
-            --bin-dir target/release \
+            --bin-dir target/dogfood \
             --version "${{ steps.desktop_runtime.outputs.version }}" \
             --source-sha "${{ steps.desktop_runtime.outputs.source }}" \
             --built-at "${{ steps.desktop_runtime.outputs.built_at }}" \
@@ -435,10 +438,10 @@ jobs:
           $version = (node -e "console.log(require('./npm/webcodex/package.json').version)").Trim()
           $builtAt = [Int64]((git show -s --format=%ct HEAD).Trim())
           $env:WEBCODEX_BUILT_AT = "$builtAt"
-          cargo build --locked --release -p webcodex -p webcodex-cli -p webcodex-runner
+          cargo build --locked --profile dogfood -p webcodex -p webcodex-cli -p webcodex-runner
           if ($LASTEXITCODE -ne 0) { throw "WebCodex runtime build failed" }
           foreach ($name in @("webcodex", "webcodex-server", "webcodex-runner")) {
-            $binary = Join-Path "target\release" "$name.exe"
+            $binary = Join-Path "target\dogfood" "$name.exe"
             $output = @(& $binary --version)
             $exitCode = $LASTEXITCODE
             if ($exitCode -ne 0 -or $output.Count -eq 0 -or -not $output[0]) {
@@ -459,7 +462,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $stage = Join-Path $env:GITHUB_WORKSPACE "target\desktop-ci-bundle"
           & .\scripts\prepare_desktop_bundle.ps1 `
-            -BinDir "target\release" `
+            -BinDir "target\dogfood" `
             -Version "${{ steps.runtime.outputs.version }}" `
             -SourceSha "${{ steps.runtime.outputs.source }}" `
             -BuiltAt ([Int64]"${{ steps.runtime.outputs.built_at }}") `
@@ -518,20 +521,14 @@ jobs:
 
   test-windows:
     needs: [contract, test-windows-core, test-windows-runner, test-windows-package, test-windows-desktop, test-windows-arm64]
-    # Preserve the historical required Windows status while moving the expensive
-    # work into parallel VMs. Eligible heavy runs inspect every lane even after a
-    # failure so branch protection cannot see a false-success aggregate.
-    if: >-
-      always() &&
-      (
-        github.event_name == 'push' ||
-        github.event.pull_request.user.login != github.repository_owner ||
-        contains(github.event.pull_request.labels.*.name, 'run-ci')
-      )
+    # Preserve the historical required Windows context in both modes. Full-native
+    # runs require every eligible lane to succeed; fast owner PRs instead prove
+    # that every heavy Windows lane was intentionally skipped by policy.
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require successful Windows lanes
+      - name: Validate Windows lane policy
         env:
           CONTRACT_RESULT: ${{ needs.contract.result }}
           CORE_RESULT: ${{ needs.test-windows-core.result }}
@@ -540,47 +537,64 @@ jobs:
           DESKTOP_RESULT: ${{ needs.test-windows-desktop.result }}
           ARM64_RESULT: ${{ needs.test-windows-arm64.result }}
         run: |
-          echo "contract=$CONTRACT_RESULT core=$CORE_RESULT runner=$RUNNER_RESULT package=$PACKAGE_RESULT desktop=$DESKTOP_RESULT arm64=$ARM64_RESULT"
-          if [ "$CONTRACT_RESULT" != success ] || \
-             [ "$CORE_RESULT" != success ] || \
-             [ "$RUNNER_RESULT" != success ] || \
-             [ "$PACKAGE_RESULT" != success ] || \
-             [ "$DESKTOP_RESULT" != success ] || \
-             [ "$ARM64_RESULT" != success ]; then
-            echo "required Windows CI lane did not succeed" >&2
+          echo "full_native=$FULL_NATIVE_REQUESTED contract=$CONTRACT_RESULT core=$CORE_RESULT runner=$RUNNER_RESULT package=$PACKAGE_RESULT desktop=$DESKTOP_RESULT arm64=$ARM64_RESULT"
+          if [ "$CONTRACT_RESULT" != success ]; then
+            echo "contract CI did not succeed" >&2
             exit 1
+          fi
+          if [ "$FULL_NATIVE_REQUESTED" = true ]; then
+            if [ "$CORE_RESULT" != success ] || \
+               [ "$RUNNER_RESULT" != success ] || \
+               [ "$PACKAGE_RESULT" != success ] || \
+               [ "$DESKTOP_RESULT" != success ] || \
+               [ "$ARM64_RESULT" != success ]; then
+              echo "requested Windows CI lane failed or was unexpectedly skipped" >&2
+              exit 1
+            fi
+          else
+            if [ "$CORE_RESULT" != skipped ] || \
+               [ "$RUNNER_RESULT" != skipped ] || \
+               [ "$PACKAGE_RESULT" != skipped ] || \
+               [ "$DESKTOP_RESULT" != skipped ] || \
+               [ "$ARM64_RESULT" != skipped ]; then
+              echo "fast owner PR expected every heavy Windows lane to be intentionally skipped" >&2
+              exit 1
+            fi
           fi
 
   test-native:
     needs: [contract, test-linux-arm64, test-macos, test-windows]
-    # Always publish one stable native-coverage result. Owner-authored PRs may
-    # still start cheaply, but skipped native lanes remain visibly unsatisfied
-    # until the PR opts into the heavy matrix with `run-ci`.
+    # Keep a stable required native aggregate. Fast owner PRs accept only the
+    # exact intentional-skip shape; full-native invocations require every heavy
+    # aggregate to succeed, so an eligible lane that is unexpectedly skipped is red.
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require successful native lanes
+      - name: Validate native lane policy
         env:
           CONTRACT_RESULT: ${{ needs.contract.result }}
           LINUX_ARM64_RESULT: ${{ needs.test-linux-arm64.result }}
           MACOS_RESULT: ${{ needs.test-macos.result }}
           WINDOWS_RESULT: ${{ needs.test-windows.result }}
         run: |
-          echo "contract=$CONTRACT_RESULT linux_arm64=$LINUX_ARM64_RESULT macos=$MACOS_RESULT windows=$WINDOWS_RESULT"
+          echo "full_native=$FULL_NATIVE_REQUESTED contract=$CONTRACT_RESULT linux_arm64=$LINUX_ARM64_RESULT macos=$MACOS_RESULT windows=$WINDOWS_RESULT"
           if [ "$CONTRACT_RESULT" != success ]; then
             echo "contract CI did not succeed" >&2
             exit 1
           fi
-          if [ "$LINUX_ARM64_RESULT" = skipped ] || \
-             [ "$MACOS_RESULT" = skipped ] || \
-             [ "$WINDOWS_RESULT" = skipped ]; then
-            echo "native CI was skipped; owner-authored PRs must add the run-ci label before merge" >&2
-            exit 1
-          fi
-          if [ "$LINUX_ARM64_RESULT" != success ] || \
-             [ "$MACOS_RESULT" != success ] || \
-             [ "$WINDOWS_RESULT" != success ]; then
-            echo "required native CI lane did not succeed" >&2
-            exit 1
+          if [ "$FULL_NATIVE_REQUESTED" = true ]; then
+            if [ "$LINUX_ARM64_RESULT" != success ] || \
+               [ "$MACOS_RESULT" != success ] || \
+               [ "$WINDOWS_RESULT" != success ]; then
+              echo "requested native CI lane failed or was unexpectedly skipped" >&2
+              exit 1
+            fi
+          else
+            if [ "$LINUX_ARM64_RESULT" != skipped ] || \
+               [ "$MACOS_RESULT" != skipped ] || \
+               [ "$WINDOWS_RESULT" != success ]; then
+              echo "fast owner PR native lane shape was not the intentional policy skip" >&2
+              exit 1
+            fi
           fi

--- a/crates/webcodex-core/src/apply_patch_shared.rs
+++ b/crates/webcodex-core/src/apply_patch_shared.rs
@@ -110,6 +110,20 @@ impl CodexPatchMatchSource {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodexPatchStrictMatchRejection {
+    pub match_mode: CodexPatchMatchMode,
+    pub match_source: CodexPatchMatchSource,
+    /// One-based source line where the rejected match candidate starts.
+    pub matched_start_line: usize,
+    /// Number of candidates at this selected match tier.
+    pub candidate_count: usize,
+    /// One-based first candidate position considered for this match tier.
+    pub search_start_line: usize,
+    /// Number of source lines in the canonicalized file used for matching.
+    pub source_line_count: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodexPatchChunkMatch {
     pub chunk_index: usize,
@@ -123,6 +137,9 @@ pub struct CodexPatchChunkMatch {
     /// True only when every text match used to position this chunk was exact
     /// and unique. Unanchored append performs no text match and is strict-safe.
     pub strict_match: bool,
+    /// The specific non-strict component that caused strict positioning to fail.
+    /// Ambiguity is preferred over a unique fuzzy component when both exist.
+    pub strict_rejection: Option<CodexPatchStrictMatchRejection>,
 }
 
 /// Body-free structural hint for a failed apply_patch text search.
@@ -500,6 +517,41 @@ impl SequenceMatch {
     }
 }
 
+fn strict_match_rejection_fact(
+    matched: SequenceMatch,
+    match_source: CodexPatchMatchSource,
+    search_start: usize,
+    source_line_count: usize,
+    pattern_len: usize,
+) -> Option<CodexPatchStrictMatchRejection> {
+    if matched.is_exact_unique() || pattern_len == 0 || pattern_len > source_line_count {
+        return None;
+    }
+    let last_start = source_line_count.checked_sub(pattern_len)?;
+    let effective_start = search_start.min(last_start);
+    Some(CodexPatchStrictMatchRejection {
+        match_mode: matched.mode,
+        match_source,
+        matched_start_line: matched.index.checked_add(1)?,
+        candidate_count: matched.candidate_count,
+        search_start_line: effective_start.checked_add(1)?,
+        source_line_count,
+    })
+}
+
+fn select_strict_match_rejection(
+    first: Option<CodexPatchStrictMatchRejection>,
+    second: Option<CodexPatchStrictMatchRejection>,
+) -> Option<CodexPatchStrictMatchRejection> {
+    let candidates = [first, second];
+    candidates
+        .iter()
+        .flatten()
+        .find(|candidate| candidate.candidate_count > 1)
+        .copied()
+        .or_else(|| candidates.into_iter().flatten().next())
+}
+
 fn seek_sequence(
     lines: &[String],
     pattern: &[String],
@@ -660,6 +712,7 @@ pub fn derive_codex_patch_update_with_matches(
     let mut line_index = 0usize;
     for (chunk_index, chunk) in chunks.iter().enumerate() {
         let mut context_match = None;
+        let context_search_start = line_index;
         if let Some(context) = chunk.change_context.as_ref() {
             let Some(matched_context) = seek_sequence(
                 &original_lines,
@@ -691,6 +744,15 @@ pub fn derive_codex_patch_update_with_matches(
                 original_lines.len()
             };
             replacements.push((insertion_index, 0, chunk.new_lines.clone()));
+            let strict_rejection = context_match.and_then(|matched| {
+                strict_match_rejection_fact(
+                    matched,
+                    CodexPatchMatchSource::ChangeContext,
+                    context_search_start,
+                    original_lines.len(),
+                    1,
+                )
+            });
             chunk_matches.push(CodexPatchChunkMatch {
                 chunk_index,
                 match_mode: context_match.map(|matched| matched.mode),
@@ -701,11 +763,13 @@ pub fn derive_codex_patch_update_with_matches(
                 },
                 matched_start_line: insertion_index + 1,
                 candidate_count: context_match.map(|matched| matched.candidate_count),
-                strict_match: context_match.is_none_or(SequenceMatch::is_exact_unique),
+                strict_match: strict_rejection.is_none(),
+                strict_rejection,
             });
             continue;
         }
 
+        let old_lines_search_start = line_index;
         let mut pattern = chunk.old_lines.as_slice();
         let mut replacement = chunk.new_lines.as_slice();
         let mut found = seek_sequence(&original_lines, pattern, line_index, chunk.is_end_of_file);
@@ -732,6 +796,24 @@ pub fn derive_codex_patch_update_with_matches(
         };
         let start = found.index;
         replacements.push((start, pattern.len(), replacement.to_vec()));
+        let context_rejection = context_match.and_then(|matched| {
+            strict_match_rejection_fact(
+                matched,
+                CodexPatchMatchSource::ChangeContext,
+                context_search_start,
+                original_lines.len(),
+                1,
+            )
+        });
+        let old_lines_rejection = strict_match_rejection_fact(
+            found,
+            CodexPatchMatchSource::OldLines,
+            old_lines_search_start,
+            original_lines.len(),
+            pattern.len(),
+        );
+        let strict_rejection =
+            select_strict_match_rejection(context_rejection, old_lines_rejection);
         chunk_matches.push(CodexPatchChunkMatch {
             chunk_index,
             match_mode: Some(
@@ -742,8 +824,8 @@ pub fn derive_codex_patch_update_with_matches(
             match_source: CodexPatchMatchSource::OldLines,
             matched_start_line: start + 1,
             candidate_count: Some(found.candidate_count),
-            strict_match: found.is_exact_unique()
-                && context_match.is_none_or(SequenceMatch::is_exact_unique),
+            strict_match: strict_rejection.is_none(),
+            strict_rejection,
         });
         line_index = start + pattern.len();
     }
@@ -939,6 +1021,49 @@ mod tests {
         assert_eq!(updated.chunk_matches[0].matched_start_line, 3);
         assert_eq!(updated.chunk_matches[0].candidate_count, Some(2));
         assert!(!updated.chunk_matches[0].strict_match);
+    }
+
+    #[test]
+    fn strict_rejection_fact_prefers_ambiguity_across_context_and_old_lines() {
+        let context_ambiguous = derive_codex_patch_update_with_matches(
+            "ctx\n foo \nctx\nother\n",
+            "file.txt",
+            &[CodexPatchChunk {
+                change_context: Some("ctx".to_string()),
+                old_lines: vec!["foo".to_string()],
+                new_lines: vec!["new".to_string()],
+                is_end_of_file: false,
+            }],
+        )
+        .unwrap();
+        let rejection = context_ambiguous.chunk_matches[0].strict_rejection.unwrap();
+        assert_eq!(rejection.match_source, CodexPatchMatchSource::ChangeContext);
+        assert_eq!(rejection.match_mode, CodexPatchMatchMode::Exact);
+        assert_eq!(rejection.candidate_count, 2);
+        assert_eq!(rejection.matched_start_line, 1);
+        assert_eq!(rejection.search_start_line, 1);
+        assert_eq!(rejection.source_line_count, 4);
+
+        let old_lines_ambiguous = derive_codex_patch_update_with_matches(
+            " ctx \ndup\nother\ndup\n",
+            "file.txt",
+            &[CodexPatchChunk {
+                change_context: Some("ctx".to_string()),
+                old_lines: vec!["dup".to_string()],
+                new_lines: vec!["new".to_string()],
+                is_end_of_file: false,
+            }],
+        )
+        .unwrap();
+        let rejection = old_lines_ambiguous.chunk_matches[0]
+            .strict_rejection
+            .unwrap();
+        assert_eq!(rejection.match_source, CodexPatchMatchSource::OldLines);
+        assert_eq!(rejection.match_mode, CodexPatchMatchMode::Exact);
+        assert_eq!(rejection.candidate_count, 2);
+        assert_eq!(rejection.matched_start_line, 2);
+        assert_eq!(rejection.search_start_line, 2);
+        assert_eq!(rejection.source_line_count, 4);
     }
 
     #[test]

--- a/crates/webcodex-runner/src/main_tests/apply_patch.rs
+++ b/crates/webcodex-runner/src/main_tests/apply_patch.rs
@@ -103,16 +103,50 @@ fn file_apply_patch_strict_matching_rejects_fuzzy_and_ambiguous_before_write() {
         assert_eq!(out["execution_state"], "not_started");
         assert_eq!(out["match_mode"], expected_mode);
         assert_eq!(out["candidate_count"], expected_candidates);
+        assert_eq!(out["search_start_line"], 1);
+        assert!(out["source_line_count"].as_u64().unwrap() >= expected_candidates);
         assert_eq!(out["strict_match"], false);
-        assert_eq!(
-            out["recovery_action"],
-            "refine_patch_or_relax_strict_matching"
-        );
+        assert_eq!(out["recovery_action"], "refine_strict_patch");
+        assert!(out["retry_guidance"]
+            .as_str()
+            .unwrap()
+            .contains("strict_matching=true"));
+        assert!(!out["retry_guidance"]
+            .as_str()
+            .unwrap()
+            .contains("strict_matching=false"));
         assert_eq!(
             std::fs::read_to_string(tmp.path().join("target.txt")).unwrap(),
             original
         );
     }
+}
+
+#[test]
+fn file_apply_patch_strict_matching_reports_the_ambiguous_component() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let original = "ctx\n foo \nctx\nother\n";
+    std::fs::write(tmp.path().join("target.txt"), original).unwrap();
+    let patch = "*** Begin Patch\n*** Update File: target.txt\n@@ ctx\n-foo\n+new\n*** End Patch";
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_patch_request_with_strict(tmp.path(), patch, false, true),
+    ));
+
+    assert_eq!(out["error_kind"], "strict_match_rejected");
+    assert_eq!(out["match_source"], "change_context");
+    assert_eq!(out["match_mode"], "exact");
+    assert_eq!(out["candidate_count"], 2);
+    assert_eq!(out["matched_start_line"], 1);
+    assert_eq!(out["search_start_line"], 1);
+    assert_eq!(out["source_line_count"], 4);
+    assert_eq!(out["strict_match"], false);
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("target.txt")).unwrap(),
+        original
+    );
 }
 
 #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -1240,6 +1240,7 @@ fn apply_patch_strict_match_rejection(
     matched: &CodexPatchChunkMatch,
     start: Instant,
 ) -> CommandResult {
+    let rejection = matched.strict_rejection;
     line_edit_stdout(
         serde_json::json!({
             "changed": false,
@@ -1249,13 +1250,15 @@ fn apply_patch_strict_match_rejection(
             "change_index": index,
             "path": path,
             "chunk_index": matched.chunk_index,
-            "match_mode": matched.match_mode.map(|mode| mode.as_str()),
-            "match_source": matched.match_source.as_str(),
-            "matched_start_line": matched.matched_start_line,
-            "candidate_count": matched.candidate_count,
+            "match_mode": rejection.map(|fact| fact.match_mode.as_str()),
+            "match_source": rejection.map(|fact| fact.match_source.as_str()),
+            "matched_start_line": rejection.map(|fact| fact.matched_start_line),
+            "candidate_count": rejection.map(|fact| fact.candidate_count),
+            "search_start_line": rejection.map(|fact| fact.search_start_line),
+            "source_line_count": rejection.map(|fact| fact.source_line_count),
             "strict_match": false,
-            "recovery_action": "refine_patch_or_relax_strict_matching",
-            "retry_guidance": "add exact unique context and retry strict_matching=true; use strict_matching=false only when ordinary Codex fuzzy/first-match positioning is acceptable",
+            "recovery_action": "refine_strict_patch",
+            "retry_guidance": "add exact unique context and retry with strict_matching=true; do not relax strict matching to recover from this rejection",
             "error": format!(
                 "Rejected strict Codex patch before write: {path} chunk {} was not positioned by exact unique matching. No files were modified.",
                 matched.chunk_index

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
@@ -86,14 +86,42 @@ fn apply_patch_match_diagnostic_schema() -> Value {
     })
 }
 
+fn apply_patch_strict_match_diagnostic_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Server-validated, body-free classification of a deterministic strict-match rejection. Runner target metadata is checked against the original parsed patch before projection. Ambiguous matches intentionally omit the selected Runner location by returning matched_start_line=null.",
+        "properties": {
+            "classification": {"type": "string", "enum": ["unique_fuzzy_candidate", "ambiguous_candidate"]},
+            "chunk_index": {"type": "integer", "minimum": 0},
+            "match_mode": {"type": "string", "enum": ["exact", "trim_end", "trim"]},
+            "match_source": {"type": "string", "enum": ["old_lines", "change_context"]},
+            "matched_start_line": {
+                "description": "Validated 1-based candidate location only for a unique fuzzy candidate; null for ambiguous candidates so no first match is presented as authoritative.",
+                "anyOf": [
+                    {"type": "integer", "minimum": 1},
+                    {"type": "null"}
+                ]
+            },
+            "candidate_count": {"type": "integer", "minimum": 1},
+            "expected_line_count": {"type": "integer", "minimum": 1},
+            "strict_match": {"type": "boolean", "const": false}
+        },
+        "required": [
+            "classification", "chunk_index", "match_mode", "match_source",
+            "matched_start_line", "candidate_count", "expected_line_count", "strict_match"
+        ]
+    })
+}
+
 fn apply_patch_recovery_schema() -> Value {
     json!({
         "type": "object",
         "additionalProperties": false,
-        "description": "Server-derived, body-free reread hint for a validated deterministic apply_patch context mismatch. Copy `items` into the direct `read_files` tool for the same project. It is emitted only when the failed target and structural diagnostic prove a no-write reread is safe; the Runner cannot choose the tool, path, or arguments.",
+        "description": "Server-derived, body-free reread hint for a validated deterministic no-write apply_patch rejection. Copy `items` into the direct `read_files` tool for the same project. It is emitted only when the failed target and structural facts prove a bounded reread is safe; the Runner cannot choose the tool, path, or arguments.",
         "properties": {
             "action": {"type": "string", "enum": ["read_files"]},
-            "reason": {"type": "string", "enum": ["context_mismatch"]},
+            "reason": {"type": "string", "enum": ["context_mismatch", "strict_match_rejected_unique_fuzzy"]},
             "items": {
                 "type": "array",
                 "minItems": 1,
@@ -317,7 +345,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("execution_state", json!({"type":"string","enum":["not_started","completed","outcome_unknown"],"description":"Transactional patch mutation effect state."})),
             ("error_kind", nullable_schema("string", "Stable parse, preflight, conflict, capability, transaction, or uncertainty classification.")),
             ("failure_kind", nullable_schema("string", "not_started, capability_unavailable, or outcome_unknown for delivery/admission failures.")),
-            ("recovery_action", nullable_schema("string", "Bounded next action such as regenerate_patch, reread_or_regenerate_patch, refine_patch_or_relax_strict_matching, upgrade_or_reconnect_runner, or inspect_workspace_before_retry.")),
+            ("recovery_action", nullable_schema("string", "Bounded next action such as regenerate_patch, reread_or_regenerate_patch, reread_and_regenerate_strict_patch, add_exact_unique_context, upgrade_or_reconnect_runner, or inspect_workspace_before_retry.")),
             ("rollback_complete", nullable_schema("boolean", "Whether a failed transactional apply fully restored all earlier changes.")),
             ("change_index", nullable_schema("integer", "Zero-based failed file-operation index when known.")),
             ("kind", nullable_schema("string", "Failed patch file-operation kind when known.")),
@@ -325,6 +353,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ("patch_line", nullable_schema("integer", "One-based patch line for a syntax error when known.")),
             ("expected_format", nullable_schema("string", "codex_patch for parse-format recovery; null otherwise.")),
             ("match_diagnostic", apply_patch_match_diagnostic_schema()),
+            ("strict_match_diagnostic", apply_patch_strict_match_diagnostic_schema()),
             ("recovery", apply_patch_recovery_schema()),
             ("retry_guidance", schema_type("string", "Bounded recovery guidance for deterministic no-mutation rejection.")),
         ])),

--- a/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
+++ b/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
@@ -357,13 +357,29 @@ fn edit_tool_surface_keeps_canonical_tools_visible_and_schemas_stable() {
         patch_output.get("match_diagnostic").is_some(),
         "apply_patch failures must expose body-free match diagnostics"
     );
+    let strict_diagnostic = patch_output
+        .get("strict_match_diagnostic")
+        .expect("apply_patch strict failures must expose validated body-free diagnostics");
+    assert_eq!(strict_diagnostic["additionalProperties"], false);
+    assert_eq!(
+        strict_diagnostic["properties"]["classification"]["enum"],
+        json!(["unique_fuzzy_candidate", "ambiguous_candidate"])
+    );
+    assert_eq!(
+        strict_diagnostic["properties"]["matched_start_line"]["anyOf"][1]["type"],
+        "null"
+    );
     let recovery = patch_output
         .get("recovery")
-        .expect("apply_patch must publish bounded context-mismatch recovery");
+        .expect("apply_patch must publish bounded reread recovery");
     assert_eq!(recovery["additionalProperties"], false);
     assert_eq!(
         recovery["properties"]["action"]["enum"],
         json!(["read_files"])
+    );
+    assert_eq!(
+        recovery["properties"]["reason"]["enum"],
+        json!(["context_mismatch", "strict_match_rejected_unique_fuzzy"])
     );
     assert_eq!(recovery["properties"]["items"]["maxItems"], 1);
     assert_eq!(
@@ -411,6 +427,9 @@ fn edit_tool_surface_keeps_canonical_tools_visible_and_schemas_stable() {
             "apply_patch edit summary must expose {field}"
         );
     }
+    assert!(patch_spec.description.contains("multiple chunks"));
+    assert!(patch_spec.description.contains("duplicate file operations"));
+    assert!(patch_spec.description.contains("never relax"));
     let unified_diff = &spec_named(&specs, "apply_unified_diff").input_schema["properties"];
     for field in ["project", "diff", "deny_sensitive_paths"] {
         assert!(

--- a/crates/webcodex-tool-contracts/src/tool_definition/patches.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/patches.rs
@@ -31,7 +31,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 true,
                 false,
                 ),
-                "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. A zero-write context_mismatch may include body-free match_diagnostic plus Server-derived recovery; when recovery.action=read_files, pass recovery.items to read_files for the same project before regenerating the whole patch. outcome_unknown requires workspace inspection first. Set strict_matching=true for exact-unique positioning. Use apply_text_edits for small exact edits; unified diff for external diffs.",
+                "Primary model edit path for contextual/multi-file Codex patches. Transactional with SHA rechecks, rollback, dry_run, recovery. Put multiple edits to the same file as multiple chunks inside one `*** Update File` operation; duplicate file operations for the same path are rejected. A deterministic zero-write context mismatch or validated unique-fuzzy strict rejection may include body-free diagnostics plus Server-derived recovery; when recovery.action=read_files, pass recovery.items to read_files for the same project, then regenerate the whole patch. Ambiguous strict rejection never selects the Runner's first candidate: expand exact unique context instead. outcome_unknown requires workspace inspection first. Set strict_matching=true for exact-unique positioning and never relax it as a recovery shortcut. Use apply_text_edits for small exact edits; unified diff for external diffs.",
                 apply_patch_input_schema,
             ),
             PERMISSION_RISK_PATCH,

--- a/crates/webcodex-tool-contracts/src/tool_spec.rs
+++ b/crates/webcodex-tool-contracts/src/tool_spec.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 /// Hard repository ceiling for model-facing ToolSpec and OpenAPI operation descriptions.
 /// Descriptions may use the full budget when selection, authority, retry, continuation,
 /// uncertainty, safety, or recovery semantics require it.
-pub const MODEL_TOOL_DESCRIPTION_MAX_CHARS: usize = 600;
+pub const MODEL_TOOL_DESCRIPTION_MAX_CHARS: usize = 900;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/scripts/tests/test_release_readiness.py
+++ b/scripts/tests/test_release_readiness.py
@@ -241,6 +241,7 @@ class WorkflowContractTests(unittest.TestCase):
 
     def test_owner_prs_run_complete_linux_ci_before_merge(self) -> None:
         workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        release_build = Path(".github/workflows/release-build.yml").read_text(encoding="utf-8")
 
         def job_block(name: str, next_name: str) -> str:
             start = workflow.index(f"  {name}:\n")
@@ -265,11 +266,70 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("runner: macos-15-intel", macos)
         self.assertIn("rust_host: x86_64-apple-darwin", macos)
         self.assertIn("contains(github.event.pull_request.labels.*.name, 'run-ci')", macos)
+        self.assertIn("cargo build --locked --profile dogfood -p webcodex -p webcodex-cli -p webcodex-runner", macos)
+        self.assertIn("--bin-dir target/dogfood", macos)
+        windows_desktop = job_block("test-windows-desktop", "test-windows-arm64")
+        self.assertIn("cargo build --locked --profile dogfood -p webcodex -p webcodex-cli -p webcodex-runner", windows_desktop)
+        self.assertIn('Join-Path "target\\dogfood"', windows_desktop)
         windows_arm64 = job_block("test-windows-arm64", "test-windows")
         self.assertIn("runs-on: windows-11-arm", windows_arm64)
         self.assertIn("aarch64-pc-windows-msvc", windows_arm64)
         self.assertIn("cargo check --locked -p webcodex -p webcodex-cli -p webcodex-runner", windows_arm64)
-        self.assertIn("if: always()", aggregate)
+        windows_aggregate = job_block("test-windows", "test-native")
+        native_aggregate = workflow[workflow.index("  test-native:\n"):]
+        for required_aggregate in (aggregate, windows_aggregate, native_aggregate):
+            self.assertIn("if: always()", required_aggregate)
+        self.assertIn("FULL_NATIVE_REQUESTED", windows_aggregate)
+        self.assertIn("requested Windows CI lane failed or was unexpectedly skipped", windows_aggregate)
+        self.assertIn("fast owner PR expected every heavy Windows lane to be intentionally skipped", windows_aggregate)
+        self.assertIn("FULL_NATIVE_REQUESTED", native_aggregate)
+        self.assertIn("requested native CI lane failed or was unexpectedly skipped", native_aggregate)
+        self.assertIn("fast owner PR native lane shape was not the intentional policy skip", native_aggregate)
+        self.assertIn("cargo build --locked --release -p webcodex -p webcodex-cli -p webcodex-runner", release_build)
+
+    def test_ci_native_policy_truth_table(self) -> None:
+        workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        expression = "FULL_NATIVE_REQUESTED: ${{ github.event_name == 'push' || github.event.pull_request.user.login != github.repository_owner || contains(github.event.pull_request.labels.*.name, 'run-ci') }}"
+        self.assertIn(expression, workflow)
+
+        def full_native_requested(event_name: str, actor: str, owner: str, labels: set[str]) -> bool:
+            return event_name == "push" or actor != owner or "run-ci" in labels
+
+        scenarios = (
+            ("owner PR without run-ci", "pull_request", "owner", "owner", set(), False),
+            ("owner PR with run-ci", "pull_request", "owner", "owner", {"run-ci"}, True),
+            ("external PR", "pull_request", "contributor", "owner", set(), True),
+            ("main push", "push", "owner", "owner", set(), True),
+        )
+        for name, event_name, actor, owner, labels, expected in scenarios:
+            with self.subTest(name=name):
+                self.assertEqual(full_native_requested(event_name, actor, owner, labels), expected)
+
+        def windows_aggregate_ok(full_native: bool, contract: str, lanes: tuple[str, ...]) -> bool:
+            expected = "success" if full_native else "skipped"
+            return contract == "success" and all(result == expected for result in lanes)
+
+        def native_aggregate_ok(
+            full_native: bool,
+            contract: str,
+            linux_arm64: str,
+            macos: str,
+            windows: str,
+        ) -> bool:
+            if contract != "success":
+                return False
+            if full_native:
+                return (linux_arm64, macos, windows) == ("success", "success", "success")
+            return (linux_arm64, macos, windows) == ("skipped", "skipped", "success")
+
+        skipped_windows = ("skipped",) * 5
+        successful_windows = ("success",) * 5
+        self.assertTrue(windows_aggregate_ok(False, "success", skipped_windows))
+        self.assertTrue(native_aggregate_ok(False, "success", "skipped", "skipped", "success"))
+        self.assertTrue(windows_aggregate_ok(True, "success", successful_windows))
+        self.assertTrue(native_aggregate_ok(True, "success", "success", "success", "success"))
+        self.assertFalse(windows_aggregate_ok(True, "success", ("skipped",) + successful_windows[1:]))
+        self.assertFalse(native_aggregate_ok(True, "success", "success", "skipped", "success"))
 
     def test_macos_ci_host_check_does_not_use_quiet_grep_under_pipefail(self) -> None:
         workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -1096,6 +1096,8 @@ fn sanitize_apply_patch_strict_rejection(
             "match_diagnostic",
             "capability",
             "recovery_action",
+            "recovery_kind",
+            "recovery_tool",
             "retry_guidance",
             "error",
         ] {
@@ -3096,11 +3098,15 @@ mod tests {
             "items": [{"path": "SOURCE_PRIVATE_TOKEN", "start_line": 1, "limit": 999999}]
         });
         payload["strict_match_diagnostic"] = json!({"source": "SOURCE_PRIVATE_TOKEN"});
+        payload["recovery_kind"] = json!("reobserve");
+        payload["recovery_tool"] = json!("list_jobs");
 
         let result = apply_patch_agent_stdout_result(&payload.to_string(), &patch, false, true);
         let serialized = serde_json::to_string(&result).unwrap();
         assert!(!serialized.contains("SOURCE_PRIVATE_TOKEN"));
         assert!(!serialized.contains("PATCH_PRIVATE_TOKEN"));
+        assert!(result.output.get("recovery_kind").is_none());
+        assert!(result.output.get("recovery_tool").is_none());
         assert_eq!(result.output["recovery"]["items"][0]["path"], "file.txt");
     }
 

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -655,6 +655,20 @@ const APPLY_PATCH_FAILURE_MATCH_DIAGNOSTIC_FIELDS: [&str; 10] = [
 const APPLY_PATCH_RECOVERY_MARGIN_BEFORE: usize = 8;
 const APPLY_PATCH_RECOVERY_MARGIN_AFTER: usize = 8;
 
+#[derive(Debug)]
+struct ValidatedApplyPatchStrictRejection {
+    change_index: usize,
+    chunk_index: usize,
+    path: String,
+    match_mode: &'static str,
+    match_source: &'static str,
+    matched_start_line: usize,
+    candidate_count: usize,
+    expected_line_count: usize,
+    source_line_count: usize,
+    classification: &'static str,
+}
+
 fn expected_apply_patch_failure_pattern_len(
     hunk: &crate::apply_patch_shared::CodexPatchHunk,
     chunk_index: usize,
@@ -673,6 +687,173 @@ fn expected_apply_patch_failure_pattern_len(
         }
         _ => None,
     }
+}
+
+fn validated_apply_patch_strict_rejection(
+    patch: &crate::apply_patch_shared::CodexPatch,
+    failure_output: &Value,
+    expected_strict_matching: bool,
+) -> Option<ValidatedApplyPatchStrictRejection> {
+    if !expected_strict_matching
+        || failure_output.get("changed").and_then(Value::as_bool) != Some(false)
+        || failure_output.get("state_changed").and_then(Value::as_bool) != Some(false)
+        || failure_output
+            .get("execution_state")
+            .and_then(Value::as_str)
+            != Some("not_started")
+        || failure_output.get("error_kind").and_then(Value::as_str) != Some("strict_match_rejected")
+        || failure_output.get("strict_match").and_then(Value::as_bool) != Some(false)
+    {
+        return None;
+    }
+
+    let change_index = failure_output
+        .get("change_index")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let hunk = patch.hunks.get(change_index)?;
+    if failure_output.get("path").and_then(Value::as_str) != Some(hunk.path()) {
+        return None;
+    }
+    let crate::apply_patch_shared::CodexPatchHunk::UpdateFile { chunks, .. } = hunk else {
+        return None;
+    };
+    let chunk_index = failure_output
+        .get("chunk_index")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let chunk = chunks.get(chunk_index)?;
+    let match_source = match failure_output.get("match_source").and_then(Value::as_str)? {
+        "old_lines" if !chunk.old_lines.is_empty() => "old_lines",
+        "change_context" if chunk.change_context.is_some() => "change_context",
+        _ => {
+            // Unanchored append performs no text matching and is strict-safe;
+            // other sources contradict the parsed chunk shape.
+            return None;
+        }
+    };
+    let expected_line_count =
+        expected_apply_patch_failure_pattern_len(hunk, chunk_index, match_source)?;
+    let match_mode = match failure_output.get("match_mode").and_then(Value::as_str)? {
+        "exact" => "exact",
+        "trim_end" => "trim_end",
+        "trim" => "trim",
+        _ => return None,
+    };
+    let matched_start_line = failure_output
+        .get("matched_start_line")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let search_start_line = failure_output
+        .get("search_start_line")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    let source_line_count = failure_output
+        .get("source_line_count")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    if matched_start_line == 0 || search_start_line == 0 || source_line_count < expected_line_count
+    {
+        return None;
+    }
+    let last_start_line = source_line_count
+        .checked_sub(expected_line_count)?
+        .checked_add(1)?;
+    if search_start_line > last_start_line
+        || matched_start_line < search_start_line
+        || matched_start_line > last_start_line
+    {
+        return None;
+    }
+    let max_candidate_count = last_start_line
+        .checked_sub(search_start_line)?
+        .checked_add(1)?;
+    let candidate_count = failure_output
+        .get("candidate_count")?
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())?;
+    if candidate_count == 0 || candidate_count > max_candidate_count {
+        return None;
+    }
+
+    let classification = if candidate_count == 1 {
+        if match_mode == "exact" {
+            // Exact + unique is strict-safe and therefore contradicts the
+            // reported rejection.
+            return None;
+        }
+        "unique_fuzzy_candidate"
+    } else {
+        "ambiguous_candidate"
+    };
+    Some(ValidatedApplyPatchStrictRejection {
+        change_index,
+        chunk_index,
+        path: hunk.path().to_string(),
+        match_mode,
+        match_source,
+        matched_start_line,
+        candidate_count,
+        expected_line_count,
+        classification,
+        source_line_count,
+    })
+}
+
+fn apply_patch_strict_rejection_recovery(
+    rejection: &ValidatedApplyPatchStrictRejection,
+) -> Option<Value> {
+    if rejection.classification != "unique_fuzzy_candidate" {
+        return None;
+    }
+    let start_line = rejection
+        .matched_start_line
+        .saturating_sub(APPLY_PATCH_RECOVERY_MARGIN_BEFORE)
+        .max(1);
+    let requested_limit = rejection
+        .expected_line_count
+        .saturating_add(APPLY_PATCH_RECOVERY_MARGIN_BEFORE)
+        .saturating_add(APPLY_PATCH_RECOVERY_MARGIN_AFTER)
+        .min(crate::apply_patch_shared::MAX_CODEX_PATCH_RECOVERY_READ_LINES)
+        .max(1);
+    let available_from_start = rejection
+        .source_line_count
+        .checked_sub(start_line)?
+        .checked_add(1)?;
+    let limit = requested_limit.min(available_from_start);
+    if limit == 0 {
+        return None;
+    }
+    Some(json!({
+        "action": "read_files",
+        "reason": "strict_match_rejected_unique_fuzzy",
+        "items": [{
+            "path": rejection.path.as_str(),
+            "start_line": start_line,
+            "limit": limit,
+        }],
+        "change_index": rejection.change_index,
+        "chunk_index": rejection.chunk_index,
+    }))
+}
+
+fn apply_patch_strict_rejection_diagnostic(
+    rejection: &ValidatedApplyPatchStrictRejection,
+) -> Value {
+    json!({
+        "classification": rejection.classification,
+        "chunk_index": rejection.chunk_index,
+        "match_mode": rejection.match_mode,
+        "match_source": rejection.match_source,
+        "matched_start_line": if rejection.classification == "unique_fuzzy_candidate" {
+            Some(rejection.matched_start_line)
+        } else {
+            None
+        },
+        "candidate_count": rejection.candidate_count,
+        "expected_line_count": rejection.expected_line_count,
+        "strict_match": false,
+    })
 }
 
 fn valid_apply_patch_failure_match_diagnostic(
@@ -878,10 +1059,101 @@ fn apply_patch_context_mismatch_recovery(
     }))
 }
 
-fn sanitize_apply_patch_failure_metadata(
-    output: &mut Value,
+fn sanitize_apply_patch_strict_rejection(
+    result: &mut ToolResult,
     patch: &crate::apply_patch_shared::CodexPatch,
+) -> bool {
+    if result.output.get("error_kind").and_then(Value::as_str) != Some("strict_match_rejected") {
+        return false;
+    }
+    let validated = validated_apply_patch_strict_rejection(patch, &result.output, true);
+    let (message, recovery_action, retry_guidance) = match validated.as_ref() {
+        Some(rejection) if rejection.classification == "unique_fuzzy_candidate" => (
+            "Rejected strict Codex patch before write: Server-validated positioning found one fuzzy candidate. No files were modified.".to_string(),
+            "reread_and_regenerate_strict_patch",
+            "read recovery.items, regenerate this chunk with exact unique context against the current source, and retry with strict_matching=true; do not relax strict matching",
+        ),
+        Some(_) => (
+            "Rejected strict Codex patch before write: Server-validated positioning is ambiguous, so no authoritative target location was selected. No files were modified.".to_string(),
+            "add_exact_unique_context",
+            "the current patch context matches multiple candidates; expand exact unique context and retry with strict_matching=true; do not select a candidate position or relax strict matching",
+        ),
+        None => (
+            "Rejected strict Codex patch before write: Runner strict-match metadata was invalid or contradictory and was suppressed. No files were modified.".to_string(),
+            "regenerate_strict_patch",
+            "do not trust the rejected target metadata; reread current source through normal read tooling as needed, regenerate exact unique context, and retry with strict_matching=true",
+        ),
+    };
+
+    if let Some(fields) = result.output.as_object_mut() {
+        fields.retain(|key, _| APPLY_PATCH_FAILURE_TOP_LEVEL_FIELDS.contains(&key.as_str()));
+        for key in [
+            "change_index",
+            "kind",
+            "path",
+            "patch_line",
+            "expected_format",
+            "match_diagnostic",
+            "capability",
+            "recovery_action",
+            "retry_guidance",
+            "error",
+        ] {
+            fields.remove(key);
+        }
+        fields.insert("recovery_action".to_string(), json!(recovery_action));
+        fields.insert("retry_guidance".to_string(), json!(retry_guidance));
+        fields.insert("error".to_string(), json!(message.as_str()));
+        if let Some(rejection) = validated.as_ref() {
+            fields.insert("change_index".to_string(), json!(rejection.change_index));
+            fields.insert("path".to_string(), json!(rejection.path.as_str()));
+            fields.insert(
+                "strict_match_diagnostic".to_string(),
+                apply_patch_strict_rejection_diagnostic(rejection),
+            );
+            if let Some(recovery) = apply_patch_strict_rejection_recovery(rejection) {
+                fields.insert("recovery".to_string(), recovery);
+            }
+        }
+    }
+    result.error = Some(message);
+    true
+}
+
+fn sanitize_apply_patch_failure_metadata(
+    result: &mut ToolResult,
+    patch: &crate::apply_patch_shared::CodexPatch,
+    expected_strict_matching: bool,
 ) {
+    if result.output.get("error_kind").and_then(Value::as_str) == Some("strict_match_rejected") {
+        if expected_strict_matching {
+            let _ = sanitize_apply_patch_strict_rejection(result, patch);
+        } else {
+            let message = "Rejected apply_patch result: Runner reported a strict-match rejection for a non-strict request; target metadata was suppressed.".to_string();
+            if let Some(fields) = result.output.as_object_mut() {
+                fields.retain(|key, _| {
+                    matches!(
+                        key.as_str(),
+                        "changed"
+                            | "state_changed"
+                            | "execution_state"
+                            | "error_kind"
+                            | "tool_failure"
+                    )
+                });
+                fields.insert("recovery_action".to_string(), json!("regenerate_patch"));
+                fields.insert(
+                    "retry_guidance".to_string(),
+                    json!("do not trust the rejected target metadata; regenerate the patch from current source before another write"),
+                );
+                fields.insert("error".to_string(), json!(message.as_str()));
+            }
+            result.error = Some(message);
+        }
+        return;
+    }
+
+    let output = &mut result.output;
     let recovery = apply_patch_context_mismatch_recovery(patch, output);
     let diagnostic_valid = output
         .get("match_diagnostic")
@@ -1123,7 +1395,7 @@ fn apply_patch_agent_stdout_result(
         expected_dry_run,
     );
     if !result.success {
-        sanitize_apply_patch_failure_metadata(&mut result.output, patch);
+        sanitize_apply_patch_failure_metadata(&mut result, patch, expected_strict_matching);
         return result;
     }
     sanitize_apply_patch_success_metadata(&mut result.output);
@@ -2337,6 +2609,32 @@ mod tests {
         })
     }
 
+    fn strict_rejection_payload(
+        match_mode: &str,
+        candidate_count: usize,
+        matched_start_line: usize,
+    ) -> Value {
+        json!({
+            "changed": false,
+            "state_changed": false,
+            "execution_state": "not_started",
+            "error_kind": "strict_match_rejected",
+            "change_index": 0,
+            "path": "file.txt",
+            "chunk_index": 0,
+            "match_mode": match_mode,
+            "match_source": "old_lines",
+            "matched_start_line": matched_start_line,
+            "candidate_count": candidate_count,
+            "strict_match": false,
+            "search_start_line": 1,
+            "source_line_count": 100,
+            "recovery_action": "RUNNER_MUST_NOT_CHOOSE_RECOVERY",
+            "retry_guidance": "RUNNER_MUST_NOT_CHOOSE_GUIDANCE",
+            "error": "RUNNER_MUST_NOT_CHOOSE_ERROR",
+        })
+    }
+
     #[test]
     fn apply_patch_strict_capability_rejection_names_exact_additive_capability() {
         let result = apply_patch_strict_matching_capability_rejection(
@@ -2584,6 +2882,226 @@ mod tests {
         .unwrap_or_else(|error| {
             panic!("apply_patch outcome_unknown must match output schema: {error}")
         });
+    }
+
+    #[test]
+    fn apply_patch_strict_unique_fuzzy_rejection_gets_validated_bounded_reread() {
+        let patch = one_update_patch();
+        let result = apply_patch_agent_stdout_result(
+            &strict_rejection_payload("trim", 1, 20).to_string(),
+            &patch,
+            false,
+            true,
+        );
+
+        assert!(!result.success);
+        assert_eq!(result.output["execution_state"], "not_started");
+        assert_eq!(result.output["state_changed"], false);
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["classification"],
+            "unique_fuzzy_candidate"
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["match_mode"],
+            "trim"
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["match_source"],
+            "old_lines"
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["matched_start_line"],
+            20
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["candidate_count"],
+            1
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["expected_line_count"],
+            1
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["strict_match"],
+            false
+        );
+        assert_eq!(result.output["recovery"]["action"], "read_files");
+        assert_eq!(
+            result.output["recovery"]["reason"],
+            "strict_match_rejected_unique_fuzzy"
+        );
+        assert_eq!(result.output["recovery"]["items"][0]["path"], "file.txt");
+        assert_eq!(result.output["recovery"]["items"][0]["start_line"], 12);
+        assert_eq!(result.output["recovery"]["items"][0]["limit"], 17);
+        assert_eq!(
+            result.output["recovery_action"],
+            "reread_and_regenerate_strict_patch"
+        );
+        assert!(result.output["retry_guidance"]
+            .as_str()
+            .unwrap()
+            .contains("strict_matching=true"));
+        assert!(!result.output["retry_guidance"]
+            .as_str()
+            .unwrap()
+            .contains("strict_matching=false"));
+        for raw_runner_field in [
+            "chunk_index",
+            "match_mode",
+            "match_source",
+            "matched_start_line",
+            "candidate_count",
+            "strict_match",
+        ] {
+            assert!(result.output.get(raw_runner_field).is_none());
+        }
+
+        let schema = crate::tool_runtime::registry::output_schema_for_tool("apply_patch");
+        crate::tool_runtime::startup_brief::validate_schema_instance_for_test(
+            &serde_json::to_value(&result).unwrap(),
+            &schema,
+        )
+        .unwrap_or_else(|error| panic!("strict recovery must match output schema: {error}"));
+    }
+
+    #[test]
+    fn apply_patch_strict_ambiguous_rejection_never_selects_runner_target() {
+        let patch = one_update_patch();
+        let result = apply_patch_agent_stdout_result(
+            &strict_rejection_payload("exact", 2, 20).to_string(),
+            &patch,
+            false,
+            true,
+        );
+
+        assert!(!result.success);
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["classification"],
+            "ambiguous_candidate"
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["candidate_count"],
+            2
+        );
+        assert!(result.output["strict_match_diagnostic"]["matched_start_line"].is_null());
+        assert!(result.output.get("recovery").is_none());
+        assert_eq!(result.output["recovery_action"], "add_exact_unique_context");
+        assert!(!result.output["error"].as_str().unwrap().contains("20"));
+        assert!(!result.output["retry_guidance"]
+            .as_str()
+            .unwrap()
+            .contains("strict_matching=false"));
+    }
+
+    #[test]
+    fn apply_patch_strict_ambiguous_context_fact_is_validated_against_chunk_shape() {
+        let patch = crate::apply_patch_shared::parse_codex_patch(
+            "*** Begin Patch\n*** Update File: file.txt\n@@ ctx\n-old\n+new\n*** End Patch",
+        )
+        .unwrap();
+        let mut payload = strict_rejection_payload("exact", 2, 1);
+        payload["match_source"] = json!("change_context");
+        payload["source_line_count"] = json!(4);
+
+        let result = apply_patch_agent_stdout_result(&payload.to_string(), &patch, false, true);
+        assert!(!result.success);
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["classification"],
+            "ambiguous_candidate"
+        );
+        assert_eq!(
+            result.output["strict_match_diagnostic"]["match_source"],
+            "change_context"
+        );
+        assert!(result.output["strict_match_diagnostic"]["matched_start_line"].is_null());
+        assert!(result.output.get("recovery").is_none());
+    }
+
+    #[test]
+    fn apply_patch_strict_recovery_suppresses_spoofed_or_contradictory_metadata() {
+        let patch = one_update_patch();
+        let mut cases = Vec::new();
+
+        let mut wrong_path = strict_rejection_payload("trim", 1, 20);
+        wrong_path["path"] = json!("other.txt");
+        cases.push((wrong_path, true));
+        let mut wrong_change = strict_rejection_payload("trim", 1, 20);
+        wrong_change["change_index"] = json!(1);
+        cases.push((wrong_change, true));
+        let mut wrong_chunk = strict_rejection_payload("trim", 1, 20);
+        wrong_chunk["chunk_index"] = json!(1);
+        cases.push((wrong_chunk, true));
+        let mut wrong_source = strict_rejection_payload("trim", 1, 20);
+        wrong_source["match_source"] = json!("change_context");
+        cases.push((wrong_source, true));
+        cases.push((strict_rejection_payload("exact", 1, 20), true));
+        let mut claimed_strict = strict_rejection_payload("trim", 1, 20);
+        claimed_strict["strict_match"] = json!(true);
+        cases.push((claimed_strict, true));
+        let mut out_of_range_line = strict_rejection_payload("trim", 1, 101);
+        out_of_range_line["source_line_count"] = json!(100);
+        cases.push((out_of_range_line, true));
+        let mut impossible_candidates = strict_rejection_payload("trim", 101, 20);
+        impossible_candidates["source_line_count"] = json!(100);
+        cases.push((impossible_candidates, true));
+        let mut before_search_start = strict_rejection_payload("trim", 1, 20);
+        before_search_start["search_start_line"] = json!(21);
+        cases.push((before_search_start, true));
+        cases.push((strict_rejection_payload("trim", 1, 20), false));
+
+        for (payload, strict_request) in cases {
+            let result = apply_patch_agent_stdout_result(
+                &payload.to_string(),
+                &patch,
+                false,
+                strict_request,
+            );
+            assert!(!result.success);
+            assert!(result.output.get("strict_match_diagnostic").is_none());
+            assert!(result.output.get("recovery").is_none());
+            assert!(result.output.get("path").is_none());
+            assert!(result.output.get("change_index").is_none());
+        }
+    }
+
+    #[test]
+    fn apply_patch_strict_recovery_is_suppressed_for_outcome_unknown() {
+        let patch = one_update_patch();
+        let mut payload = strict_rejection_payload("trim", 1, 20);
+        payload["changed"] = json!(true);
+        payload["state_changed"] = json!(true);
+
+        let result = apply_patch_agent_stdout_result(&payload.to_string(), &patch, false, true);
+        assert!(!result.success);
+        assert_eq!(result.output["execution_state"], "outcome_unknown");
+        assert_eq!(
+            result.output["recovery_action"],
+            "inspect_workspace_before_retry"
+        );
+        assert!(result.output.get("strict_match_diagnostic").is_none());
+        assert!(result.output.get("recovery").is_none());
+    }
+
+    #[test]
+    fn apply_patch_strict_recovery_never_leaks_source_or_patch_bodies() {
+        let patch = crate::apply_patch_shared::parse_codex_patch(
+            "*** Begin Patch\n*** Update File: file.txt\n-PATCH_PRIVATE_TOKEN\n+new\n*** End Patch",
+        )
+        .unwrap();
+        let mut payload = strict_rejection_payload("trim_end", 1, 4);
+        payload["error"] = json!("SOURCE_PRIVATE_TOKEN");
+        payload["future_body_field"] = json!("SOURCE_PRIVATE_TOKEN");
+        payload["recovery"] = json!({
+            "action": "read_files",
+            "items": [{"path": "SOURCE_PRIVATE_TOKEN", "start_line": 1, "limit": 999999}]
+        });
+        payload["strict_match_diagnostic"] = json!({"source": "SOURCE_PRIVATE_TOKEN"});
+
+        let result = apply_patch_agent_stdout_result(&payload.to_string(), &patch, false, true);
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("SOURCE_PRIVATE_TOKEN"));
+        assert!(!serialized.contains("PATCH_PRIVATE_TOKEN"));
+        assert_eq!(result.output["recovery"]["items"][0]["path"], "file.txt");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- strengthen `apply_patch` strict-match recovery with Server-validated, body-free recovery metadata
- keep ambiguous strict matches non-authoritative and require exact-unique regeneration
- sanitize Runner-provided recovery hints so `recovery_kind` / `recovery_tool` cannot override the Server-derived recovery path
- keep existing required CI contexts while making owner PRs without `run-ci` use the fast Linux path
- preserve full native CI for main pushes, external PRs, and owner PRs explicitly labeled `run-ci`
- use the existing `dogfood` profile for development Desktop runtime builds while leaving release builds on `--release`

## Validation

- focused strict `apply_patch` Server/Runner/Core/schema regressions passed during implementation
- reviewer follow-up: `cargo test -p webcodex --lib apply_patch_strict_` — 7 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` / staged diff check — passed
- CI workflow contract unit tests and `actionlint` passed during implementation
- final worktree clean

## CI rollout note

This PR intentionally starts without the `run-ci` label so the new owner fast-path required-context semantics can be exercised first. A later full-native run can be requested with `run-ci` to measure the macOS/Windows `dogfood` build improvement and verify the heavyweight matrix unchanged.