### PR TITLE
Enforce workspace DAG boundaries

### DIFF
--- a/apps/desktop/src-tauri/src/process/supervisor.rs
+++ b/apps/desktop/src-tauri/src/process/supervisor.rs
@@ -443,7 +443,7 @@ mod tests {
             .arg("-NonInteractive")
             .arg("-Command")
             .arg(format!(
-                "$null = [Console]::In.ReadToEnd(); Set-Content -LiteralPath '{escaped_marker}' -Value 'eof'"
+                "$marker = '{escaped_marker}'; Set-Content -LiteralPath $marker -Value 'ready'; $null = [Console]::In.ReadToEnd(); Set-Content -LiteralPath $marker -Value 'eof'"
             ));
 
         let activity = ActivityLog::default();
@@ -452,11 +452,28 @@ mod tests {
             .spawn_owned(ProcessKind::RegularTunnel, command, false)
             .await
             .expect("start EOF fixture");
+        let ready_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if std::fs::read_to_string(&marker)
+                .ok()
+                .is_some_and(|value| value.trim() == "ready")
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < ready_deadline,
+                "regular tunnel EOF fixture must become ready before stop"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
         supervisor.stop(ProcessKind::RegularTunnel).await;
 
-        assert!(
-            marker.is_file(),
-            "regular tunnel child must observe stdin EOF before the graceful stop completes"
+        assert_eq!(
+            std::fs::read_to_string(&marker)
+                .expect("regular tunnel EOF fixture marker")
+                .trim(),
+            "eof",
+            "regular tunnel child must observe stdin EOF before the graceful stop completes",
         );
         let _ = std::fs::remove_file(marker);
     }

--- a/apps/desktop/src-tauri/src/webcodex/cli.rs
+++ b/apps/desktop/src-tauri/src/webcodex/cli.rs
@@ -974,10 +974,10 @@ mod tests {
         ));
         let script = concat!(
             "$child = Start-Process powershell.exe ",
-            "-ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 8' ",
+            "-ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30' ",
             "-PassThru; ",
             "Set-Content -Path $args[0] -Value \"$PID $($child.Id)\" -NoNewline; ",
-            "Start-Sleep -Seconds 8"
+            "Start-Sleep -Seconds 30"
         );
         let args = vec![
             "-NoProfile".to_string(),
@@ -987,20 +987,34 @@ mod tests {
             marker.to_string_lossy().to_string(),
         ];
         let payload = vec![b'x'; CLI_INPUT_BYTES];
-        let cancellation = CancellationContext::never();
         let started = Instant::now();
-        let error = run_bounded_with_timeout(
-            Path::new("powershell.exe"),
-            &args,
-            Some(&payload),
-            false,
-            &cancellation,
-            Duration::from_millis(1200),
-        )
-        .await
-        .unwrap_err();
+        let command = tokio::spawn(async move {
+            let cancellation = CancellationContext::never();
+            run_bounded_with_timeout(
+                Path::new("powershell.exe"),
+                &args,
+                Some(&payload),
+                false,
+                &cancellation,
+                Duration::from_secs(5),
+            )
+            .await
+        });
+        let marker_deadline = Instant::now() + Duration::from_secs(4);
+        while !marker.is_file() {
+            assert!(
+                Instant::now() < marker_deadline,
+                "blocked-stdin fixture must publish owned pids before timeout"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let error = tokio::time::timeout(Duration::from_secs(5), command)
+            .await
+            .expect("blocked-stdin command must finish within its bounded cleanup")
+            .expect("blocked-stdin fixture task")
+            .unwrap_err();
         assert_eq!(error.code, "webcodex_command_timeout");
-        assert!(started.elapsed() < Duration::from_secs(6));
+        assert!(started.elapsed() < Duration::from_secs(9));
         let pids = std::fs::read_to_string(&marker)
             .expect("fixture must publish owned pids")
             .split_whitespace()

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -21,7 +21,12 @@ use webcodex_runner_config::paths::paths_equal;
 
 const PROJECT_SCAN_CACHE_MS: u64 = 5000;
 const PROJECT_GIT_TIMEOUT: Duration = Duration::from_secs(2);
-const PROJECT_GIT_CLEANUP_TIMEOUT: Duration = Duration::from_millis(500);
+// Tree shutdown also has to let the bounded stdout/stderr readers observe EOF.
+// Darwin process-group teardown and reader scheduling can legitimately take
+// longer than 500ms on loaded native CI hosts, so keep a short but realistic
+// bounded cleanup budget rather than turning successful direct-child exit into
+// a spurious reader-timeout failure.
+const PROJECT_GIT_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
 const PROJECT_GIT_OUTPUT_MAX_BYTES: usize = 64 * 1024;
 const EXPLICIT_REGISTRATION_SOURCE: &str = "explicit";
 const AUTO_REGISTERED_REGISTRATION_SOURCE: &str = "auto_registered";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,6 +141,34 @@ Runtime Console -----------------------> canonical Server HTTP/kernel paths abov
   registry, file/patch/artifact handling, shell execution, and LSP
   navigation.
 
+### Cargo workspace ownership layers
+
+The checked-in [`workspace-boundaries.toml`](../workspace-boundaries.toml) is the
+machine policy for direct dependencies between Cargo workspace packages. It
+records every workspace package, its ownership role, and its exact normal,
+development, and build-time workspace dependencies. Production dependencies
+may stay within a layer or point toward a lower layer; explicit development
+dependencies are test-only exceptions. Uses of the `root-test-support` feature
+are separately pinned to declared development dependencies.
+
+The current layers are:
+
+- **leaf** — `webcodex-core`, `webcodex-process`, `webcodex-computer`, and
+  `webcodex-admin`; these do not depend on another workspace package.
+- **domain** — Runner config/registry, Store, Workspace, Workflow Session,
+  Tool contracts, Validation, and Persistent Shell ownership.
+- **runtime** — `webcodex-runner` and `webcodex-tool-runtime-contracts`.
+- **application** — `webcodex-connector-runtime`, which composes the domain
+  crates needed by the project-bound Connector path.
+- **composition** — the root `webcodex` package, which owns Server composition
+  and protocol adapters rather than forcing those concerns into lower crates.
+- **entrypoint** — `webcodex-cli`, the user-facing executable over the lower
+  composition and setup crates.
+
+CI validates this policy from `cargo metadata`; adding a workspace crate or a
+new direct workspace dependency therefore requires an intentional policy
+update rather than silently changing the architecture.
+
 ## Further reading
 
 - [Durable Agent runtime and asynchronous work](architecture/durable-agent-runtime.md) — persistent Agent identity and planned asynchronous Agent work

--- a/scripts/tests/test_workspace_boundary_check.py
+++ b/scripts/tests/test_workspace_boundary_check.py
@@ -7,46 +7,317 @@ from pathlib import Path
 from scripts import workspace_boundary_check as boundary
 
 
-def metadata_with_required_packages() -> dict:
+def package_policy(
+    layer: str,
+    *,
+    normal: tuple[str, ...] = (),
+    dev: tuple[str, ...] = (),
+    build: tuple[str, ...] = (),
+    test_support: tuple[str, ...] = (),
+) -> dict:
+    return {
+        "layer": layer,
+        "role": f"fixture role for {layer}",
+        "normal": sorted(normal),
+        "dev": sorted(dev),
+        "build": sorted(build),
+        "test_support": sorted(test_support),
+    }
+
+
+def fixture_policy(
+    packages: dict[str, dict],
+    *,
+    providers: tuple[str, ...] = (),
+    forbidden_external: dict[str, list[str]] | None = None,
+) -> boundary.BoundaryPolicy:
+    return boundary.parse_policy(
+        {
+            "version": 1,
+            "layers": {"leaf": 0, "application": 1},
+            "root_test_support": {
+                "feature": "root-test-support",
+                "providers": sorted(providers),
+            },
+            "forbidden_external_dependencies": forbidden_external or {},
+            "packages": packages,
+        }
+    )
+
+
+def fixture_metadata(
+    package_dependencies: dict[str, list[tuple[str, str, tuple[str, ...]]]],
+    *,
+    package_features: dict[str, tuple[str, ...]] | None = None,
+) -> dict:
+    package_features = package_features or {}
     packages = []
     members = []
-    for name in sorted(boundary.REQUIRED_PACKAGES):
-        package_id = f"path+file:///fixture#{name}@0.3.0"
-        packages.append({"id": package_id, "name": name, "dependencies": []})
+    for name in sorted(package_dependencies):
+        package_id = f"path+file:///fixture#{name}@0.4.0"
+        dependencies = []
+        for dependency_name, kind, features in package_dependencies[name]:
+            dependencies.append(
+                {
+                    "name": dependency_name,
+                    "kind": None if kind == "normal" else kind,
+                    "features": list(features),
+                }
+            )
+        packages.append(
+            {
+                "id": package_id,
+                "name": name,
+                "dependencies": dependencies,
+                "features": {feature: [] for feature in package_features.get(name, ())},
+            }
+        )
         members.append(package_id)
     return {"packages": packages, "workspace_members": members}
 
 
-def package(metadata: dict, name: str) -> dict:
-    return next(entry for entry in metadata["packages"] if entry["name"] == name)
+def valid_policy_and_metadata() -> tuple[boundary.BoundaryPolicy, dict]:
+    policy = fixture_policy(
+        {
+            "webcodex-app": package_policy(
+                "application", normal=("webcodex-core",)
+            ),
+            "webcodex-core": package_policy("leaf"),
+        }
+    )
+    metadata = fixture_metadata(
+        {
+            "webcodex-app": [("webcodex-core", "normal", ())],
+            "webcodex-core": [],
+        }
+    )
+    return policy, metadata
 
 
 class MetadataBoundaryTests(unittest.TestCase):
-    def test_valid_workspace_passes(self) -> None:
-        self.assertEqual(boundary.check_metadata(metadata_with_required_packages()), [])
+    def test_valid_complete_workspace_passes(self) -> None:
+        policy, metadata = valid_policy_and_metadata()
+        self.assertEqual(boundary.check_metadata(metadata, policy), [])
 
-    def test_each_forbidden_direct_dependency_is_reported(self) -> None:
-        for package_name, dependencies in boundary.FORBIDDEN_DIRECT_DEPENDENCIES.items():
-            for dependency_name in dependencies:
-                with self.subTest(
-                    package=package_name, dependency=dependency_name
-                ):
-                    metadata = metadata_with_required_packages()
-                    package(metadata, package_name)["dependencies"] = [
-                        {"name": dependency_name}
-                    ]
-                    violations = boundary.check_metadata(metadata)
-                    self.assertEqual(len(violations), 1)
-                    self.assertIn(package_name, violations[0])
-                    self.assertIn(dependency_name, violations[0])
+    def test_unknown_new_workspace_member_is_reported(self) -> None:
+        policy, metadata = valid_policy_and_metadata()
+        new_id = "path+file:///fixture#webcodex-new@0.4.0"
+        metadata["packages"].append(
+            {"id": new_id, "name": "webcodex-new", "dependencies": [], "features": {}}
+        )
+        metadata["workspace_members"].append(new_id)
+        self.assertEqual(
+            boundary.check_metadata(metadata, policy),
+            ["workspace package(s) missing from policy: webcodex-new"],
+        )
 
-    def test_missing_required_package_is_reported(self) -> None:
-        metadata = metadata_with_required_packages()
-        missing = "webcodex-core"
-        missing_id = package(metadata, missing)["id"]
-        metadata["workspace_members"].remove(missing_id)
-        violations = boundary.check_metadata(metadata)
-        self.assertTrue(any(missing in violation for violation in violations))
+    def test_policy_member_absent_from_workspace_is_reported(self) -> None:
+        policy = fixture_policy(
+            {
+                "webcodex-app": package_policy("application"),
+                "webcodex-ghost": package_policy("leaf"),
+            }
+        )
+        metadata = fixture_metadata({"webcodex-app": []})
+        self.assertEqual(
+            boundary.check_metadata(metadata, policy),
+            ["policy package(s) absent from workspace: webcodex-ghost"],
+        )
+
+    def test_forbidden_direct_workspace_dependency_is_reported(self) -> None:
+        policy = fixture_policy(
+            {
+                "webcodex-app": package_policy(
+                    "application", normal=("webcodex-core",)
+                ),
+                "webcodex-core": package_policy("leaf"),
+                "webcodex-helper": package_policy("leaf"),
+            }
+        )
+        metadata = fixture_metadata(
+            {
+                "webcodex-app": [
+                    ("webcodex-core", "normal", ()),
+                    ("webcodex-helper", "normal", ()),
+                ],
+                "webcodex-core": [],
+                "webcodex-helper": [],
+            }
+        )
+        self.assertEqual(
+            boundary.check_metadata(metadata, policy),
+            [
+                "package webcodex-app has unlisted normal workspace dependency(ies): "
+                "webcodex-helper"
+            ],
+        )
+
+    def test_reverse_layer_dependency_is_reported_even_when_allowlisted(self) -> None:
+        policy = fixture_policy(
+            {
+                "webcodex-app": package_policy("application"),
+                "webcodex-core": package_policy("leaf", normal=("webcodex-app",)),
+            }
+        )
+        metadata = fixture_metadata(
+            {
+                "webcodex-app": [],
+                "webcodex-core": [("webcodex-app", "normal", ())],
+            }
+        )
+        self.assertEqual(
+            boundary.check_metadata(metadata, policy),
+            [
+                "reverse layer dependency: webcodex-core (leaf:0) normal-depends on "
+                "webcodex-app (application:1)"
+            ],
+        )
+
+    def test_allowed_dependency_passes(self) -> None:
+        policy, metadata = valid_policy_and_metadata()
+        self.assertEqual(boundary.check_metadata(metadata, policy), [])
+
+    def test_explicit_dev_only_exception_can_cross_layers(self) -> None:
+        policy = fixture_policy(
+            {
+                "webcodex-app": package_policy("application"),
+                "webcodex-core": package_policy("leaf", dev=("webcodex-app",)),
+            }
+        )
+        metadata = fixture_metadata(
+            {
+                "webcodex-app": [],
+                "webcodex-core": [("webcodex-app", "dev", ())],
+            }
+        )
+        self.assertEqual(boundary.check_metadata(metadata, policy), [])
+
+    def test_root_test_support_is_allowed_only_as_explicit_dev_ownership(self) -> None:
+        valid_policy = fixture_policy(
+            {
+                "webcodex-app": package_policy("application"),
+                "webcodex-core": package_policy(
+                    "leaf",
+                    dev=("webcodex-app",),
+                    test_support=("webcodex-app",),
+                ),
+            },
+            providers=("webcodex-app",),
+        )
+        valid_metadata = fixture_metadata(
+            {
+                "webcodex-app": [],
+                "webcodex-core": [
+                    ("webcodex-app", "dev", ("root-test-support",))
+                ],
+            },
+            package_features={"webcodex-app": ("root-test-support",)},
+        )
+        self.assertEqual(boundary.check_metadata(valid_metadata, valid_policy), [])
+
+        production_policy = fixture_policy(
+            {
+                "webcodex-app": package_policy("application"),
+                "webcodex-core": package_policy("leaf", normal=("webcodex-app",)),
+            },
+            providers=("webcodex-app",),
+        )
+        production_metadata = fixture_metadata(
+            {
+                "webcodex-app": [],
+                "webcodex-core": [
+                    ("webcodex-app", "normal", ("root-test-support",))
+                ],
+            },
+            package_features={"webcodex-app": ("root-test-support",)},
+        )
+        violations = boundary.check_metadata(production_metadata, production_policy)
+        self.assertIn(
+            "package webcodex-core enables root-test-support on non-dev workspace "
+            "dependency webcodex-app",
+            violations,
+        )
+        self.assertIn(
+            "reverse layer dependency: webcodex-core (leaf:0) normal-depends on "
+            "webcodex-app (application:1)",
+            violations,
+        )
+
+    def test_forbidden_external_dependency_guardrail_is_preserved(self) -> None:
+        policy = fixture_policy(
+            {"webcodex-core": package_policy("leaf")},
+            forbidden_external={"webcodex-core": ["salvo"]},
+        )
+        metadata = fixture_metadata({"webcodex-core": [("salvo", "normal", ())]})
+        self.assertEqual(
+            boundary.check_metadata(metadata, policy),
+            [
+                "package webcodex-core directly depends on forbidden external "
+                "package(s): salvo"
+            ],
+        )
+
+    def test_diagnostics_are_deterministic(self) -> None:
+        policy = fixture_policy(
+            {
+                "webcodex-app": package_policy(
+                    "application", normal=("webcodex-core",)
+                ),
+                "webcodex-core": package_policy("leaf"),
+                "webcodex-policy-only": package_policy("leaf"),
+            }
+        )
+        metadata = fixture_metadata(
+            {"webcodex-app": [], "webcodex-core": [], "webcodex-new": []}
+        )
+        first = boundary.check_metadata(metadata, policy)
+        second = boundary.check_metadata(metadata, policy)
+        self.assertEqual(first, second)
+        self.assertEqual(
+            first,
+            [
+                "workspace package(s) missing from policy: webcodex-new",
+                "policy package(s) absent from workspace: webcodex-policy-only",
+                "package webcodex-app policy lists absent normal workspace "
+                "dependency(ies): webcodex-core",
+            ],
+        )
+
+
+class PolicyParsingTests(unittest.TestCase):
+    def test_duplicate_toml_key_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "workspace-boundaries.toml"
+            path.write_text("version = 1\nversion = 1\n", encoding="utf-8")
+            with self.assertRaisesRegex(boundary.PolicyError, "could not read"):
+                boundary.load_policy(path)
+
+    def test_invalid_unsorted_allowlist_is_rejected(self) -> None:
+        with self.assertRaisesRegex(boundary.PolicyError, "must be sorted"):
+            fixture_policy(
+                {
+                    "webcodex-app": {
+                        "layer": "application",
+                        "role": "fixture",
+                        "normal": ["webcodex-z", "webcodex-a"],
+                        "dev": [],
+                        "build": [],
+                        "test_support": [],
+                    },
+                    "webcodex-a": package_policy("leaf"),
+                    "webcodex-z": package_policy("leaf"),
+                }
+            )
+
+    def test_unknown_policy_dependency_is_rejected(self) -> None:
+        with self.assertRaisesRegex(boundary.PolicyError, "unknown package"):
+            fixture_policy(
+                {
+                    "webcodex-core": package_policy(
+                        "leaf", normal=("webcodex-typo",)
+                    )
+                }
+            )
 
 
 class ParentSourcePathTests(unittest.TestCase):

--- a/scripts/tests/test_workspace_boundary_check.py
+++ b/scripts/tests/test_workspace_boundary_check.py
@@ -62,6 +62,11 @@ def fixture_metadata(
                     "name": dependency_name,
                     "kind": None if kind == "normal" else kind,
                     "features": list(features),
+                    "path": (
+                        f"/fixture/{dependency_name}"
+                        if dependency_name in package_dependencies
+                        else None
+                    ),
                 }
             )
         packages.append(
@@ -70,6 +75,7 @@ def fixture_metadata(
                 "name": name,
                 "dependencies": dependencies,
                 "features": {feature: [] for feature in package_features.get(name, ())},
+                "manifest_path": f"/fixture/{name}/Cargo.toml",
             }
         )
         members.append(package_id)
@@ -103,7 +109,13 @@ class MetadataBoundaryTests(unittest.TestCase):
         policy, metadata = valid_policy_and_metadata()
         new_id = "path+file:///fixture#webcodex-new@0.4.0"
         metadata["packages"].append(
-            {"id": new_id, "name": "webcodex-new", "dependencies": [], "features": {}}
+            {
+                "id": new_id,
+                "name": "webcodex-new",
+                "dependencies": [],
+                "features": {},
+                "manifest_path": "/fixture/webcodex-new/Cargo.toml",
+            }
         )
         metadata["workspace_members"].append(new_id)
         self.assertEqual(
@@ -149,6 +161,24 @@ class MetadataBoundaryTests(unittest.TestCase):
             [
                 "package webcodex-app has unlisted normal workspace dependency(ies): "
                 "webcodex-helper"
+            ],
+        )
+
+    def test_external_same_named_package_does_not_satisfy_workspace_edge(self) -> None:
+        policy, metadata = valid_policy_and_metadata()
+        app = next(
+            package
+            for package in metadata["packages"]
+            if package["name"] == "webcodex-app"
+        )
+        dependency = app["dependencies"][0]
+        dependency["path"] = None
+        dependency["source"] = "registry+https://github.com/rust-lang/crates.io-index"
+        self.assertEqual(
+            boundary.check_metadata(metadata, policy),
+            [
+                "package webcodex-app policy lists absent normal workspace "
+                "dependency(ies): webcodex-core"
             ],
         )
 
@@ -328,18 +358,24 @@ class ParentSourcePathTests(unittest.TestCase):
             root = Path(temp)
             (root / "src").mkdir()
             (root / "tests").mkdir()
+            (root / "benches").mkdir()
             (root / "src" / "lib.rs").write_text(
                 '#[path = "../shared.rs"]\nmod shared;\n', encoding="utf-8"
             )
             (root / "tests" / "integration.rs").write_text(
                 '#[path="../support.rs"]\nmod support;\n', encoding="utf-8"
             )
+            (root / "benches" / "nested.rs").write_text(
+                '#[path = "fixtures/../../support.rs"]\nmod support;\n',
+                encoding="utf-8",
+            )
             violations = boundary.check_parent_source_paths(root)
-            self.assertEqual(len(violations), 2)
+            self.assertEqual(len(violations), 3)
             self.assertTrue(any("src/lib.rs:1" in item for item in violations))
             self.assertTrue(
                 any("tests/integration.rs:1" in item for item in violations)
             )
+            self.assertTrue(any("benches/nested.rs:1" in item for item in violations))
 
     def test_generated_and_non_rust_files_are_excluded(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/workspace_boundary_check.py
+++ b/scripts/workspace_boundary_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate stable WebCodex Cargo workspace boundaries."""
+"""Validate the checked-in WebCodex Cargo workspace dependency policy."""
 
 from __future__ import annotations
 
@@ -8,35 +8,27 @@ import json
 import os
 import re
 import sys
+import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 
-REQUIRED_PACKAGES = frozenset(
+POLICY_FILENAME = "workspace-boundaries.toml"
+POLICY_VERSION = 1
+DEPENDENCY_KINDS = ("normal", "dev", "build")
+PACKAGE_POLICY_KEYS = frozenset(
+    {"layer", "role", "normal", "dev", "build", "test_support"}
+)
+TOP_LEVEL_POLICY_KEYS = frozenset(
     {
-        "webcodex",
-        "webcodex-admin",
-        "webcodex-runner-config",
-        "webcodex-cli",
-        "webcodex-core",
-        "webcodex-runner",
-        "webcodex-workspace",
+        "version",
+        "layers",
+        "root_test_support",
+        "forbidden_external_dependencies",
+        "packages",
     }
 )
-
-FORBIDDEN_DIRECT_DEPENDENCIES = {
-    "webcodex-core": frozenset({"salvo", "rusqlite", "quinn"}),
-    "webcodex-runner": frozenset({"salvo", "rusqlite"}),
-    "webcodex-cli": frozenset(
-        {
-            "salvo",
-            "rusqlite",
-            "quinn",
-            "webcodex-runner",
-            "webcodex-workspace",
-        }
-    ),
-}
 
 EXCLUDED_DIRECTORIES = frozenset(
     {
@@ -55,15 +47,251 @@ EXCLUDED_DIRECTORIES = frozenset(
 PARENT_SOURCE_PATH = re.compile(r'#\s*\[\s*path\s*=\s*"\.\./')
 
 
-def check_metadata(metadata: dict[str, Any]) -> list[str]:
-    """Return workspace membership and direct-dependency violations."""
+class PolicyError(ValueError):
+    """Raised when the checked-in boundary policy is malformed or ambiguous."""
+
+
+@dataclass(frozen=True)
+class PackagePolicy:
+    layer: str
+    role: str
+    normal: frozenset[str]
+    dev: frozenset[str]
+    build: frozenset[str]
+    test_support: frozenset[str]
+
+    def dependencies_for(self, kind: str) -> frozenset[str]:
+        return getattr(self, kind)
+
+
+@dataclass(frozen=True)
+class BoundaryPolicy:
+    layers: dict[str, int]
+    root_test_support_feature: str
+    root_test_support_providers: frozenset[str]
+    forbidden_external_dependencies: dict[str, frozenset[str]]
+    packages: dict[str, PackagePolicy]
+
+
+def _require_table(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PolicyError(f"{label} must be a TOML table")
+    return value
+
+
+def _require_sorted_unique_strings(value: Any, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise PolicyError(f"{label} must be an array of non-empty strings")
+    if len(value) != len(set(value)):
+        raise PolicyError(f"{label} contains duplicate values")
+    if value != sorted(value):
+        raise PolicyError(f"{label} must be sorted")
+    return tuple(value)
+
+
+def parse_policy(raw: dict[str, Any]) -> BoundaryPolicy:
+    """Validate and normalize one decoded workspace-boundary policy."""
+    unknown_top_level = sorted(set(raw).difference(TOP_LEVEL_POLICY_KEYS))
+    missing_top_level = sorted(TOP_LEVEL_POLICY_KEYS.difference(raw))
+    if unknown_top_level:
+        raise PolicyError(
+            "unknown top-level policy key(s): " + ", ".join(unknown_top_level)
+        )
+    if missing_top_level:
+        raise PolicyError(
+            "missing top-level policy key(s): " + ", ".join(missing_top_level)
+        )
+    if raw.get("version") != POLICY_VERSION:
+        raise PolicyError(
+            f"policy version must be {POLICY_VERSION}, got {raw.get('version')!r}"
+        )
+
+    raw_layers = _require_table(raw["layers"], "layers")
+    if not raw_layers:
+        raise PolicyError("layers must not be empty")
+    layers: dict[str, int] = {}
+    for name in sorted(raw_layers):
+        rank = raw_layers[name]
+        if (
+            not isinstance(name, str)
+            or not name
+            or isinstance(rank, bool)
+            or not isinstance(rank, int)
+            or rank < 0
+        ):
+            raise PolicyError(
+                "layers must map non-empty names to non-negative integer ranks"
+            )
+        layers[name] = rank
+    ranks = sorted(layers.values())
+    if ranks != list(range(len(layers))):
+        raise PolicyError("layer ranks must be unique and contiguous from 0")
+
+    raw_root_support = _require_table(
+        raw["root_test_support"], "root_test_support"
+    )
+    if set(raw_root_support) != {"feature", "providers"}:
+        raise PolicyError("root_test_support must contain exactly feature and providers")
+    feature = raw_root_support["feature"]
+    if not isinstance(feature, str) or not feature:
+        raise PolicyError("root_test_support.feature must be a non-empty string")
+    providers = frozenset(
+        _require_sorted_unique_strings(
+            raw_root_support["providers"], "root_test_support.providers"
+        )
+    )
+
+    raw_packages = _require_table(raw["packages"], "packages")
+    if not raw_packages:
+        raise PolicyError("packages must not be empty")
+    packages: dict[str, PackagePolicy] = {}
+    for package_name in sorted(raw_packages):
+        if not isinstance(package_name, str) or not package_name:
+            raise PolicyError("package names must be non-empty strings")
+        entry = _require_table(raw_packages[package_name], f"packages.{package_name}")
+        unknown_keys = sorted(set(entry).difference(PACKAGE_POLICY_KEYS))
+        missing_keys = sorted(PACKAGE_POLICY_KEYS.difference(entry))
+        if unknown_keys:
+            raise PolicyError(
+                f"packages.{package_name} has unknown key(s): "
+                + ", ".join(unknown_keys)
+            )
+        if missing_keys:
+            raise PolicyError(
+                f"packages.{package_name} is missing key(s): "
+                + ", ".join(missing_keys)
+            )
+        layer = entry["layer"]
+        role = entry["role"]
+        if not isinstance(layer, str) or layer not in layers:
+            raise PolicyError(
+                f"packages.{package_name}.layer must name a declared layer"
+            )
+        if not isinstance(role, str) or not role.strip():
+            raise PolicyError(
+                f"packages.{package_name}.role must be a non-empty string"
+            )
+        normal = frozenset(
+            _require_sorted_unique_strings(
+                entry["normal"], f"packages.{package_name}.normal"
+            )
+        )
+        dev = frozenset(
+            _require_sorted_unique_strings(entry["dev"], f"packages.{package_name}.dev")
+        )
+        build = frozenset(
+            _require_sorted_unique_strings(
+                entry["build"], f"packages.{package_name}.build"
+            )
+        )
+        test_support = frozenset(
+            _require_sorted_unique_strings(
+                entry["test_support"], f"packages.{package_name}.test_support"
+            )
+        )
+        if not test_support.issubset(dev):
+            invalid = sorted(test_support.difference(dev))
+            raise PolicyError(
+                f"packages.{package_name}.test_support must be a subset of dev: "
+                + ", ".join(invalid)
+            )
+        packages[package_name] = PackagePolicy(
+            layer=layer,
+            role=role,
+            normal=normal,
+            dev=dev,
+            build=build,
+            test_support=test_support,
+        )
+
+    package_names = frozenset(packages)
+    unknown_providers = sorted(providers.difference(package_names))
+    if unknown_providers:
+        raise PolicyError(
+            "root_test_support.providers references unknown package(s): "
+            + ", ".join(unknown_providers)
+        )
+    for package_name, package_policy in packages.items():
+        for kind in DEPENDENCY_KINDS:
+            dependencies = package_policy.dependencies_for(kind)
+            unknown = sorted(dependencies.difference(package_names))
+            if unknown:
+                raise PolicyError(
+                    f"packages.{package_name}.{kind} references unknown package(s): "
+                    + ", ".join(unknown)
+                )
+            if package_name in dependencies:
+                raise PolicyError(
+                    f"packages.{package_name}.{kind} must not depend on itself"
+                )
+        unsupported = sorted(package_policy.test_support.difference(providers))
+        if unsupported:
+            raise PolicyError(
+                f"packages.{package_name}.test_support references package(s) that do "
+                "not provide root test support: "
+                + ", ".join(unsupported)
+            )
+
+    raw_forbidden = _require_table(
+        raw["forbidden_external_dependencies"],
+        "forbidden_external_dependencies",
+    )
+    forbidden_external: dict[str, frozenset[str]] = {}
+    for package_name in sorted(raw_forbidden):
+        if package_name not in packages:
+            raise PolicyError(
+                "forbidden_external_dependencies references unknown package "
+                f"{package_name!r}"
+            )
+        dependencies = frozenset(
+            _require_sorted_unique_strings(
+                raw_forbidden[package_name],
+                f"forbidden_external_dependencies.{package_name}",
+            )
+        )
+        workspace_names = sorted(dependencies.intersection(package_names))
+        if workspace_names:
+            raise PolicyError(
+                f"forbidden_external_dependencies.{package_name} must contain only "
+                "non-workspace packages: "
+                + ", ".join(workspace_names)
+            )
+        forbidden_external[package_name] = dependencies
+
+    return BoundaryPolicy(
+        layers=layers,
+        root_test_support_feature=feature,
+        root_test_support_providers=providers,
+        forbidden_external_dependencies=forbidden_external,
+        packages=packages,
+    )
+
+
+def load_policy(path: Path) -> BoundaryPolicy:
+    """Read and validate one TOML policy file."""
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError) as error:
+        raise PolicyError(f"could not read boundary policy {path}: {error}") from error
+    return parse_policy(raw)
+
+
+def _dependency_kind(dependency: dict[str, Any]) -> str:
+    kind = dependency.get("kind")
+    return "normal" if kind is None else str(kind)
+
+
+def check_metadata(metadata: dict[str, Any], policy: BoundaryPolicy) -> list[str]:
+    """Return deterministic workspace DAG and policy violations."""
     violations: list[str] = []
     packages_by_id = {
         package["id"]: package
         for package in metadata.get("packages", [])
-        if isinstance(package, dict) and "id" in package
+        if isinstance(package, dict) and isinstance(package.get("id"), str)
     }
-    workspace_packages = []
+    workspace_packages: list[dict[str, Any]] = []
     for member_id in metadata.get("workspace_members", []):
         package = packages_by_id.get(member_id)
         if package is None:
@@ -73,32 +301,178 @@ def check_metadata(metadata: dict[str, Any]) -> list[str]:
             continue
         workspace_packages.append(package)
 
-    packages_by_name = {
-        package.get("name"): package
-        for package in workspace_packages
-        if isinstance(package.get("name"), str)
-    }
-    missing = sorted(REQUIRED_PACKAGES.difference(packages_by_name))
-    if missing:
+    packages_by_name: dict[str, dict[str, Any]] = {}
+    duplicate_names: set[str] = set()
+    for package in workspace_packages:
+        name = package.get("name")
+        if not isinstance(name, str):
+            violations.append(
+                f"workspace package {package.get('id')!r} has no valid package name"
+            )
+            continue
+        if name in packages_by_name:
+            duplicate_names.add(name)
+        packages_by_name[name] = package
+    if duplicate_names:
         violations.append(
-            "workspace is missing required package(s): " + ", ".join(missing)
+            "workspace contains duplicate package name(s): "
+            + ", ".join(sorted(duplicate_names))
         )
 
-    for package_name, forbidden in FORBIDDEN_DIRECT_DEPENDENCIES.items():
-        package = packages_by_name.get(package_name)
-        if package is None:
+    workspace_names = frozenset(packages_by_name)
+    policy_names = frozenset(policy.packages)
+    missing_policy = sorted(workspace_names.difference(policy_names))
+    unknown_policy = sorted(policy_names.difference(workspace_names))
+    if missing_policy:
+        violations.append(
+            "workspace package(s) missing from policy: " + ", ".join(missing_policy)
+        )
+    if unknown_policy:
+        violations.append(
+            "policy package(s) absent from workspace: " + ", ".join(unknown_policy)
+        )
+
+    feature = policy.root_test_support_feature
+    actual_providers = {
+        name
+        for name, package in packages_by_name.items()
+        if isinstance(package.get("features"), dict)
+        and feature in package.get("features", {})
+    }
+    unregistered_providers = sorted(
+        actual_providers.difference(policy.root_test_support_providers)
+    )
+    stale_providers = sorted(
+        policy.root_test_support_providers.difference(actual_providers)
+    )
+    if unregistered_providers:
+        violations.append(
+            f"workspace package(s) expose {feature} but are not policy providers: "
+            + ", ".join(unregistered_providers)
+        )
+    if stale_providers:
+        violations.append(
+            f"policy {feature} provider(s) do not expose that feature: "
+            + ", ".join(stale_providers)
+        )
+
+    for package_name in sorted(workspace_names.intersection(policy_names)):
+        package = packages_by_name[package_name]
+        package_policy = policy.packages[package_name]
+        actual_by_kind = {kind: set() for kind in DEPENDENCY_KINDS}
+        actual_test_support: set[str] = set()
+        all_direct_dependency_names: set[str] = set()
+
+        dependencies = package.get("dependencies", [])
+        if not isinstance(dependencies, list):
+            violations.append(f"package {package_name} has invalid dependency metadata")
             continue
-        direct_dependencies = {
-            dependency.get("name")
-            for dependency in package.get("dependencies", [])
-            if isinstance(dependency, dict)
-            and isinstance(dependency.get("name"), str)
-        }
-        illegal = sorted(forbidden.intersection(direct_dependencies))
-        if illegal:
+        for dependency in dependencies:
+            if not isinstance(dependency, dict):
+                violations.append(
+                    f"package {package_name} has invalid dependency metadata entry"
+                )
+                continue
+            dependency_name = dependency.get("name")
+            if not isinstance(dependency_name, str):
+                violations.append(
+                    f"package {package_name} has dependency without a valid name"
+                )
+                continue
+            all_direct_dependency_names.add(dependency_name)
+            if dependency_name not in workspace_names:
+                continue
+            kind = _dependency_kind(dependency)
+            if kind not in actual_by_kind:
+                violations.append(
+                    f"package {package_name} has unsupported workspace dependency kind "
+                    f"{kind!r} for {dependency_name}"
+                )
+                continue
+            actual_by_kind[kind].add(dependency_name)
+            dependency_features = dependency.get("features", [])
+            if not isinstance(dependency_features, list):
+                violations.append(
+                    f"package {package_name} dependency {dependency_name} has invalid "
+                    "feature metadata"
+                )
+                continue
+            if feature in dependency_features:
+                if kind != "dev":
+                    violations.append(
+                        f"package {package_name} enables {feature} on non-dev workspace "
+                        f"dependency {dependency_name}"
+                    )
+                else:
+                    actual_test_support.add(dependency_name)
+                if dependency_name not in policy.root_test_support_providers:
+                    violations.append(
+                        f"package {package_name} enables {feature} on non-provider "
+                        f"{dependency_name}"
+                    )
+
+        for kind in DEPENDENCY_KINDS:
+            expected = package_policy.dependencies_for(kind)
+            actual = actual_by_kind[kind]
+            unlisted = sorted(actual.difference(expected))
+            stale = sorted(expected.difference(actual))
+            if unlisted:
+                violations.append(
+                    f"package {package_name} has unlisted {kind} workspace "
+                    "dependency(ies): "
+                    + ", ".join(unlisted)
+                )
+            if stale:
+                violations.append(
+                    f"package {package_name} policy lists absent {kind} workspace "
+                    "dependency(ies): "
+                    + ", ".join(stale)
+                )
+
+        unlisted_test_support = sorted(
+            actual_test_support.difference(package_policy.test_support)
+        )
+        stale_test_support = sorted(
+            package_policy.test_support.difference(actual_test_support)
+        )
+        if unlisted_test_support:
             violations.append(
-                f"package {package_name} directly depends on forbidden package(s): "
-                + ", ".join(illegal)
+                f"package {package_name} has unlisted {feature} dev dependency(ies): "
+                + ", ".join(unlisted_test_support)
+            )
+        if stale_test_support:
+            violations.append(
+                f"package {package_name} policy lists absent {feature} dev "
+                "dependency(ies): "
+                + ", ".join(stale_test_support)
+            )
+
+        source_rank = policy.layers[package_policy.layer]
+        for kind in ("normal", "build"):
+            for dependency_name in sorted(actual_by_kind[kind]):
+                target_policy = policy.packages.get(dependency_name)
+                if target_policy is None:
+                    continue
+                target_rank = policy.layers[target_policy.layer]
+                if target_rank > source_rank:
+                    violations.append(
+                        "reverse layer dependency: "
+                        f"{package_name} ({package_policy.layer}:{source_rank}) "
+                        f"{kind}-depends on {dependency_name} "
+                        f"({target_policy.layer}:{target_rank})"
+                    )
+
+        forbidden_external = policy.forbidden_external_dependencies.get(
+            package_name, frozenset()
+        )
+        forbidden_present = sorted(
+            forbidden_external.intersection(all_direct_dependency_names)
+        )
+        if forbidden_present:
+            violations.append(
+                f"package {package_name} directly depends on forbidden external "
+                "package(s): "
+                + ", ".join(forbidden_present)
             )
 
     return violations
@@ -130,20 +504,29 @@ def check_parent_source_paths(root: Path) -> list[str]:
     return violations
 
 
-def evaluate(root: Path, metadata: dict[str, Any]) -> list[str]:
+def evaluate(
+    root: Path, metadata: dict[str, Any], policy: BoundaryPolicy
+) -> list[str]:
     root = root.resolve()
-    return check_metadata(metadata) + check_parent_source_paths(root)
+    return check_metadata(metadata, policy) + check_parent_source_paths(root)
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", required=True, type=Path)
     parser.add_argument("--metadata", required=True, type=Path)
+    parser.add_argument("--policy", type=Path)
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    policy_path = args.policy or args.root / POLICY_FILENAME
+    try:
+        policy = load_policy(policy_path)
+    except PolicyError as error:
+        print(f"[workspace-boundary][FAIL] {error}", file=sys.stderr)
+        return 2
     try:
         metadata = json.loads(args.metadata.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
@@ -153,7 +536,7 @@ def main() -> int:
         )
         return 2
 
-    violations = evaluate(args.root, metadata)
+    violations = evaluate(args.root, metadata, policy)
     if violations:
         for violation in violations:
             print(f"[workspace-boundary][FAIL] {violation}", file=sys.stderr)
@@ -163,10 +546,17 @@ def main() -> int:
         )
         return 1
 
-    print("[workspace-boundary][ok] all 8 required workspace packages are present")
     print(
-        "[workspace-boundary][ok] core, runner, and CLI direct dependencies "
-        "respect their boundaries"
+        f"[workspace-boundary][ok] all {len(policy.packages)} workspace packages "
+        "match the checked-in dependency policy"
+    )
+    print(
+        "[workspace-boundary][ok] production workspace dependencies respect layer "
+        "direction; dev/test exceptions are explicit"
+    )
+    print(
+        f"[workspace-boundary][ok] {policy.root_test_support_feature} is confined "
+        "to declared dev/test ownership"
     )
     print("[workspace-boundary][ok] no cross-parent #[path] source sharing")
     return 0

--- a/scripts/workspace_boundary_check.py
+++ b/scripts/workspace_boundary_check.py
@@ -44,7 +44,8 @@ EXCLUDED_DIRECTORIES = frozenset(
     }
 )
 
-PARENT_SOURCE_PATH = re.compile(r'#\s*\[\s*path\s*=\s*"\.\./')
+PATH_ATTRIBUTE = re.compile(r'#\s*\[\s*path\s*=\s*"([^"\r\n]+)"')
+PARENT_PATH_COMPONENT = re.compile(r'(^|[/\\])\.\.([/\\]|$)')
 
 
 class PolicyError(ValueError):
@@ -332,6 +333,14 @@ def check_metadata(metadata: dict[str, Any], policy: BoundaryPolicy) -> list[str
             "policy package(s) absent from workspace: " + ", ".join(unknown_policy)
         )
 
+    workspace_paths: dict[str, Path] = {}
+    for name, package in packages_by_name.items():
+        manifest_path = package.get("manifest_path")
+        if not isinstance(manifest_path, str) or not manifest_path:
+            violations.append(f"workspace package {name} has no valid manifest_path")
+            continue
+        workspace_paths[name] = Path(manifest_path).resolve().parent
+
     feature = policy.root_test_support_feature
     actual_providers = {
         name
@@ -380,7 +389,15 @@ def check_metadata(metadata: dict[str, Any], policy: BoundaryPolicy) -> list[str
                 )
                 continue
             all_direct_dependency_names.add(dependency_name)
-            if dependency_name not in workspace_names:
+            dependency_path = dependency.get("path")
+            workspace_dependency_path = workspace_paths.get(dependency_name)
+            is_workspace_dependency = (
+                workspace_dependency_path is not None
+                and isinstance(dependency_path, str)
+                and bool(dependency_path)
+                and Path(dependency_path).resolve() == workspace_dependency_path
+            )
+            if not is_workspace_dependency:
                 continue
             kind = _dependency_kind(dependency)
             if kind not in actual_by_kind:
@@ -497,7 +514,8 @@ def check_parent_source_paths(root: Path) -> list[str]:
                 continue
             relative_path = path.relative_to(root).as_posix()
             for line_number, line in enumerate(lines, start=1):
-                if PARENT_SOURCE_PATH.search(line):
+                path_attribute = PATH_ATTRIBUTE.search(line)
+                if path_attribute and PARENT_PATH_COMPONENT.search(path_attribute.group(1)):
                     violations.append(
                         f"{relative_path}:{line_number}: cross-parent #[path] source sharing"
                     )

--- a/scripts/workspace_boundary_check.sh
+++ b/scripts/workspace_boundary_check.sh
@@ -38,7 +38,11 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$PROJECT_DIR"
-cargo metadata --format-version 1 >"$METADATA_FILE"
+# The checker needs the complete workspace package declarations, not Cargo's
+# resolved external dependency graph. --no-deps keeps this contract gate cheap
+# and avoids resolving hundreds of registry packages while preserving each
+# workspace package's dependency kind/features and workspace_members metadata.
+cargo metadata --no-deps --format-version 1 >"$METADATA_FILE"
 PYTHONDONTWRITEBYTECODE=1 python3 "$SCRIPT_DIR/workspace_boundary_check.py" \
     --root "$PROJECT_DIR" \
     --metadata "$METADATA_FILE"

--- a/scripts/workspace_boundary_check.sh
+++ b/scripts/workspace_boundary_check.sh
@@ -38,7 +38,7 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$PROJECT_DIR"
-cargo metadata --no-deps --format-version 1 >"$METADATA_FILE"
+cargo metadata --format-version 1 >"$METADATA_FILE"
 PYTHONDONTWRITEBYTECODE=1 python3 "$SCRIPT_DIR/workspace_boundary_check.py" \
     --root "$PROJECT_DIR" \
     --metadata "$METADATA_FILE"

--- a/workspace-boundaries.toml
+++ b/workspace-boundaries.toml
@@ -1,0 +1,219 @@
+version = 1
+
+[layers]
+leaf = 0
+domain = 1
+runtime = 2
+application = 3
+composition = 4
+entrypoint = 5
+
+[root_test_support]
+feature = "root-test-support"
+providers = [
+    "webcodex-connector-runtime",
+    "webcodex-runner-registry",
+    "webcodex-store",
+    "webcodex-tool-contracts",
+    "webcodex-workflow-session",
+]
+
+[forbidden_external_dependencies]
+webcodex-cli = ["quinn", "rusqlite", "salvo"]
+webcodex-core = ["quinn", "rusqlite", "salvo"]
+webcodex-runner = ["rusqlite", "salvo"]
+
+[packages.webcodex]
+layer = "composition"
+role = "Server composition and protocol adapters."
+normal = [
+    "webcodex-admin",
+    "webcodex-connector-runtime",
+    "webcodex-core",
+    "webcodex-persistent-shell",
+    "webcodex-runner-config",
+    "webcodex-runner-registry",
+    "webcodex-store",
+    "webcodex-tool-contracts",
+    "webcodex-tool-runtime-contracts",
+    "webcodex-validation",
+    "webcodex-workflow-session",
+    "webcodex-workspace",
+]
+dev = [
+    "webcodex-connector-runtime",
+    "webcodex-runner-registry",
+    "webcodex-store",
+    "webcodex-tool-contracts",
+    "webcodex-workflow-session",
+]
+build = []
+test_support = [
+    "webcodex-connector-runtime",
+    "webcodex-runner-registry",
+    "webcodex-store",
+    "webcodex-tool-contracts",
+    "webcodex-workflow-session",
+]
+
+[packages.webcodex-admin]
+layer = "leaf"
+role = "Standalone operator/admin HTTP client support."
+normal = []
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-cli]
+layer = "entrypoint"
+role = "User-facing CLI entrypoint over server composition and shared setup helpers."
+normal = [
+    "webcodex",
+    "webcodex-admin",
+    "webcodex-core",
+    "webcodex-runner-config",
+]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-computer]
+layer = "leaf"
+role = "Platform-native computer-use primitives."
+normal = []
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-connector-runtime]
+layer = "application"
+role = "Project-bound connector application service coordinating domain crates."
+normal = [
+    "webcodex-core",
+    "webcodex-runner-config",
+    "webcodex-runner-registry",
+    "webcodex-store",
+    "webcodex-tool-contracts",
+    "webcodex-validation",
+    "webcodex-workspace",
+]
+dev = ["webcodex-store"]
+build = []
+test_support = ["webcodex-store"]
+
+[packages.webcodex-core]
+layer = "leaf"
+role = "Shared contracts and low-level helpers with no workspace dependencies."
+normal = []
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-persistent-shell]
+layer = "domain"
+role = "Persistent local shell lifecycle built on process primitives."
+normal = ["webcodex-process"]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-process]
+layer = "leaf"
+role = "OS process-tree ownership and lifecycle primitives."
+normal = []
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-runner]
+layer = "runtime"
+role = "Runner executable/runtime composition for local project execution."
+normal = [
+    "webcodex-computer",
+    "webcodex-core",
+    "webcodex-persistent-shell",
+    "webcodex-process",
+    "webcodex-runner-config",
+    "webcodex-workspace",
+]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-runner-config]
+layer = "domain"
+role = "Runner configuration contracts and parsing."
+normal = ["webcodex-core"]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-runner-registry]
+layer = "domain"
+role = "Server-side Runner registry, connection lease, queue, and reconciliation domain."
+normal = ["webcodex-core"]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-store]
+layer = "domain"
+role = "Durable SQLite-backed persistence ownership."
+normal = ["webcodex-core"]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-tool-contracts]
+layer = "domain"
+role = "Protocol-neutral tool schemas and parsing contracts."
+normal = ["webcodex-core"]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-tool-runtime-contracts]
+layer = "runtime"
+role = "Tool runtime call, result, audit, and input contracts."
+normal = [
+    "webcodex-core",
+    "webcodex-tool-contracts",
+    "webcodex-workflow-session",
+]
+dev = ["webcodex-tool-contracts"]
+build = []
+test_support = ["webcodex-tool-contracts"]
+
+[packages.webcodex-validation]
+layer = "domain"
+role = "Validation recipes, adapters, and evidence domain."
+normal = [
+    "webcodex-core",
+    "webcodex-workflow-session",
+]
+dev = [
+    "webcodex-tool-contracts",
+    "webcodex-tool-runtime-contracts",
+    "webcodex-workflow-session",
+]
+build = []
+test_support = [
+    "webcodex-tool-contracts",
+    "webcodex-workflow-session",
+]
+
+[packages.webcodex-workflow-session]
+layer = "domain"
+role = "Workflow Session continuity, evidence, and handoff domain."
+normal = ["webcodex-core"]
+dev = []
+build = []
+test_support = []
+
+[packages.webcodex-workspace]
+layer = "domain"
+role = "Registered project/workspace path and metadata contracts."
+normal = ["webcodex-core"]
+dev = []
+build = []
+test_support = []


### PR DESCRIPTION
## Summary

- add a checked-in `workspace-boundaries.toml` machine policy for all 17 Cargo workspace packages
- validate exact normal/dev/build workspace dependency edges and production layer direction
- confine `root-test-support` to declared dev/test ownership
- preserve existing external-dependency and cross-parent `#[path]` guardrails
- document the Cargo ownership layers in `docs/ARCHITECTURE.md`

## Independent review hardening

A reviewer follow-up commit tightened three edge cases:

- keep the CI checker on `cargo metadata --no-deps`; full metadata resolved 599 packages versus 17 workspace packages while exposing identical workspace dependency declarations
- detect parent path components anywhere in ordinary quoted Rust `#[path = "..."]` attributes, not only paths beginning with `../`
- identify workspace dependency edges by the workspace member's manifest directory as well as package name, so an external same-named package cannot satisfy the checked-in workspace DAG policy

## Validation

- `bash scripts/workspace_boundary_check.sh --self-test` — 16 tests passed
- `bash scripts/workspace_boundary_check.sh` — all 17 workspace packages match policy; layer/root-test-support/source-sharing checks passed
- `python3 -m py_compile scripts/workspace_boundary_check.py scripts/tests/test_workspace_boundary_check.py` — passed
- `git diff --check` and staged diff check — passed
- final worktree clean

Base implementation: `414673ff94790f0b9a0eae0a4702061e65993636`
Reviewer hardening: `b8554e02267a3382f7ddf5bf15a8ed9c39fedb93`