### PR TITLE
Freeze Native Plugin provider contracts

### DIFF
--- a/crates/webcodex-core/src/plugin.rs
+++ b/crates/webcodex-core/src/plugin.rs
@@ -7,6 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 
 pub const PLUGIN_PROTOCOL_VERSION: &str = "webcodex-plugin-v1";
@@ -30,6 +31,10 @@ pub const PLUGIN_MAX_JSON_NODES: usize = 4_096;
 pub const PLUGIN_MAX_JSON_STRING_BYTES: usize = 64 * 1024;
 pub const PLUGIN_STARTUP_CATALOG_MAX_BYTES: usize = 256 * 1024;
 pub const PLUGIN_MAX_CHECK_DETAIL_BYTES: usize = 512;
+pub const PLUGIN_SCHEMA_MAX_PROPERTIES: usize = 128;
+pub const PLUGIN_SCHEMA_MAX_REQUIRED: usize = 128;
+pub const PLUGIN_SCHEMA_MAX_ENUM_VALUES: usize = 128;
+pub const PLUGIN_CATALOG_DIGEST_PREFIX: &str = "sha256:";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -133,6 +138,36 @@ impl PluginTool {
     }
 }
 
+/// Canonical, validated catalog admitted from one exact Plugin provider process.
+/// Tool order is normalized by name and the digest is computed from a recursively
+/// key-sorted JSON projection, so map iteration order cannot change identity.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PluginCatalog {
+    tools: Vec<PluginTool>,
+    digest: String,
+}
+
+impl PluginCatalog {
+    pub fn admit(mut tools: Vec<PluginTool>) -> Result<Self, String> {
+        validate_tools(&tools)?;
+        tools.sort_by(|left, right| left.name.cmp(&right.name));
+        let digest = plugin_catalog_digest_from_canonical_tools(&tools)?;
+        Ok(Self { tools, digest })
+    }
+
+    pub fn tools(&self) -> &[PluginTool] {
+        &self.tools
+    }
+
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    pub fn tool(&self, name: &str) -> Option<&PluginTool> {
+        self.tools.iter().find(|tool| tool.name == name)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
 pub enum PluginContent {
@@ -153,10 +188,10 @@ pub struct PluginToolResult {
     pub is_error: bool,
 }
 
-/// Frozen, sanitized startup registration entry.  `tools` contains only the
-/// all-or-nothing first-class-admitted subset for this provider (currently the
-/// complete provider list or none); execution configuration never crosses the
-/// Runner boundary.
+/// Frozen, sanitized startup registration entry. `catalog_*` describes the exact
+/// immutable provider-instance catalog while `tools` contains only the bounded
+/// direct-eligible subset. Execution configuration never crosses the Runner
+/// boundary.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StartupPluginProvider {
@@ -166,6 +201,10 @@ pub struct StartupPluginProvider {
     pub status: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
+    #[serde(default)]
+    pub catalog_tool_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_digest: Option<String>,
     #[serde(default)]
     pub tools: Vec<PluginTool>,
 }
@@ -401,6 +440,494 @@ pub fn validate_request(request: &PluginGatewayRequest) -> Result<(), String> {
     }
 }
 
+fn plugin_catalog_digest_from_canonical_tools(tools: &[PluginTool]) -> Result<String, String> {
+    let value = serde_json::to_value(tools)
+        .map_err(|_| "plugin catalog could not be serialized".to_string())?;
+    let mut canonical = Vec::new();
+    write_canonical_json(&value, &mut canonical)?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex.plugin-catalog.v1\0");
+    hasher.update(&canonical);
+    Ok(format!(
+        "{PLUGIN_CATALOG_DIGEST_PREFIX}{:x}",
+        hasher.finalize()
+    ))
+}
+
+fn write_canonical_json(value: &Value, output: &mut Vec<u8>) -> Result<(), String> {
+    match value {
+        Value::Array(values) => {
+            output.push(b'[');
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                write_canonical_json(value, output)?;
+            }
+            output.push(b']');
+        }
+        Value::Object(values) => {
+            output.push(b'{');
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                output.extend(
+                    serde_json::to_vec(key)
+                        .map_err(|_| "plugin catalog key could not be serialized".to_string())?,
+                );
+                output.push(b':');
+                write_canonical_json(&values[key], output)?;
+            }
+            output.push(b'}');
+        }
+        _ => output.extend(
+            serde_json::to_vec(value)
+                .map_err(|_| "plugin catalog value could not be serialized".to_string())?,
+        ),
+    }
+    Ok(())
+}
+
+pub fn validate_plugin_catalog_digest(value: &str) -> Result<(), String> {
+    let Some(hex) = value.strip_prefix(PLUGIN_CATALOG_DIGEST_PREFIX) else {
+        return Err("plugin catalog digest must use sha256 namespace".to_string());
+    };
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("plugin catalog digest must contain 64 lowercase hex digits".to_string());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchemaProfileFailureKind {
+    Invalid,
+    UnsupportedKeyword,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SchemaProfileFailure {
+    kind: SchemaProfileFailureKind,
+    message: &'static str,
+}
+
+impl SchemaProfileFailure {
+    fn invalid(message: &'static str) -> Self {
+        Self {
+            kind: SchemaProfileFailureKind::Invalid,
+            message,
+        }
+    }
+
+    fn unsupported() -> Self {
+        Self {
+            kind: SchemaProfileFailureKind::UnsupportedKeyword,
+            message: "schema contains a keyword outside the Native Plugin Schema Profile",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PluginSchemaType {
+    Object,
+    Array,
+    String,
+    Number,
+    Integer,
+    Boolean,
+    Null,
+}
+
+fn parse_plugin_schema_type(value: &str) -> Option<PluginSchemaType> {
+    match value {
+        "object" => Some(PluginSchemaType::Object),
+        "array" => Some(PluginSchemaType::Array),
+        "string" => Some(PluginSchemaType::String),
+        "number" => Some(PluginSchemaType::Number),
+        "integer" => Some(PluginSchemaType::Integer),
+        "boolean" => Some(PluginSchemaType::Boolean),
+        "null" => Some(PluginSchemaType::Null),
+        _ => None,
+    }
+}
+
+fn preflight_plugin_schema_profile(
+    schema: &Value,
+    require_object_root: bool,
+) -> Result<(), SchemaProfileFailure> {
+    let schema_type = preflight_plugin_schema_node(schema, 0)?;
+    if require_object_root && schema_type != PluginSchemaType::Object {
+        return Err(SchemaProfileFailure::invalid(
+            "tool schema root type must be object",
+        ));
+    }
+    Ok(())
+}
+
+fn preflight_plugin_schema_node(
+    schema: &Value,
+    depth: usize,
+) -> Result<PluginSchemaType, SchemaProfileFailure> {
+    if depth > PLUGIN_MAX_JSON_DEPTH {
+        return Err(SchemaProfileFailure::invalid(
+            "schema exceeds profile nesting bound",
+        ));
+    }
+    let object = schema
+        .as_object()
+        .ok_or_else(|| SchemaProfileFailure::invalid("schema node must be an object"))?;
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "type"
+                | "title"
+                | "description"
+                | "properties"
+                | "required"
+                | "additionalProperties"
+                | "enum"
+                | "const"
+                | "minLength"
+                | "maxLength"
+                | "minItems"
+                | "maxItems"
+                | "items"
+        ) {
+            return Err(SchemaProfileFailure::unsupported());
+        }
+    }
+
+    let schema_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .and_then(parse_plugin_schema_type)
+        .ok_or_else(|| {
+            SchemaProfileFailure::invalid("schema type must be one supported scalar type")
+        })?;
+
+    for field in ["title", "description"] {
+        if let Some(value) = object.get(field) {
+            let text = value
+                .as_str()
+                .ok_or_else(|| SchemaProfileFailure::invalid("schema annotation must be string"))?;
+            if validate_text_controls(text, "schema annotation").is_err() {
+                return Err(SchemaProfileFailure::invalid(
+                    "schema annotation contains unsupported control characters",
+                ));
+            }
+        }
+    }
+
+    if let Some(values) = object.get("enum") {
+        let values = values
+            .as_array()
+            .ok_or_else(|| SchemaProfileFailure::invalid("schema enum must be an array"))?;
+        if values.is_empty() || values.len() > PLUGIN_SCHEMA_MAX_ENUM_VALUES {
+            return Err(SchemaProfileFailure::invalid(
+                "schema enum exceeds profile bounds",
+            ));
+        }
+    }
+
+    let has_object_keywords = object.contains_key("properties")
+        || object.contains_key("required")
+        || object.contains_key("additionalProperties");
+    if has_object_keywords && schema_type != PluginSchemaType::Object {
+        return Err(SchemaProfileFailure::invalid(
+            "object schema keywords require type object",
+        ));
+    }
+    if schema_type == PluginSchemaType::Object {
+        let properties = object.get("properties").map(|value| {
+            value
+                .as_object()
+                .ok_or_else(|| SchemaProfileFailure::invalid("properties must be an object"))
+        });
+        let properties = match properties {
+            Some(result) => Some(result?),
+            None => None,
+        };
+        if properties.is_some_and(|values| values.len() > PLUGIN_SCHEMA_MAX_PROPERTIES) {
+            return Err(SchemaProfileFailure::invalid(
+                "properties exceeds profile bounds",
+            ));
+        }
+        if let Some(properties) = properties {
+            for child in properties.values() {
+                preflight_plugin_schema_node(child, depth + 1)?;
+            }
+        }
+
+        if let Some(required) = object.get("required") {
+            let required = required
+                .as_array()
+                .ok_or_else(|| SchemaProfileFailure::invalid("required must be an array"))?;
+            if required.len() > PLUGIN_SCHEMA_MAX_REQUIRED {
+                return Err(SchemaProfileFailure::invalid(
+                    "required exceeds profile bounds",
+                ));
+            }
+            let mut names = HashSet::new();
+            for name in required {
+                let name = name.as_str().ok_or_else(|| {
+                    SchemaProfileFailure::invalid("required entries must be strings")
+                })?;
+                if !names.insert(name) {
+                    return Err(SchemaProfileFailure::invalid(
+                        "required entries must be unique",
+                    ));
+                }
+            }
+            if object.get("additionalProperties") == Some(&Value::Bool(false)) {
+                if let Some(properties) = properties {
+                    if names.iter().any(|name| !properties.contains_key(*name)) {
+                        return Err(SchemaProfileFailure::invalid(
+                            "required property is forbidden by additionalProperties false",
+                        ));
+                    }
+                } else if !names.is_empty() {
+                    return Err(SchemaProfileFailure::invalid(
+                        "required property is forbidden by additionalProperties false",
+                    ));
+                }
+            }
+        }
+        if object
+            .get("additionalProperties")
+            .is_some_and(|value| !value.is_boolean())
+        {
+            return Err(SchemaProfileFailure::invalid(
+                "additionalProperties must be boolean",
+            ));
+        }
+    }
+
+    let has_string_keywords = object.contains_key("minLength") || object.contains_key("maxLength");
+    if has_string_keywords && schema_type != PluginSchemaType::String {
+        return Err(SchemaProfileFailure::invalid(
+            "string schema keywords require type string",
+        ));
+    }
+    if schema_type == PluginSchemaType::String {
+        let minimum = bounded_schema_usize(object.get("minLength"), PLUGIN_MAX_JSON_STRING_BYTES)?;
+        let maximum = bounded_schema_usize(object.get("maxLength"), PLUGIN_MAX_JSON_STRING_BYTES)?;
+        if minimum
+            .zip(maximum)
+            .is_some_and(|(minimum, maximum)| minimum > maximum)
+        {
+            return Err(SchemaProfileFailure::invalid(
+                "minLength must not exceed maxLength",
+            ));
+        }
+    }
+
+    let has_array_keywords = object.contains_key("minItems")
+        || object.contains_key("maxItems")
+        || object.contains_key("items");
+    if has_array_keywords && schema_type != PluginSchemaType::Array {
+        return Err(SchemaProfileFailure::invalid(
+            "array schema keywords require type array",
+        ));
+    }
+    if schema_type == PluginSchemaType::Array {
+        let minimum = bounded_schema_usize(object.get("minItems"), PLUGIN_MAX_JSON_NODES)?;
+        let maximum = bounded_schema_usize(object.get("maxItems"), PLUGIN_MAX_JSON_NODES)?;
+        if minimum
+            .zip(maximum)
+            .is_some_and(|(minimum, maximum)| minimum > maximum)
+        {
+            return Err(SchemaProfileFailure::invalid(
+                "minItems must not exceed maxItems",
+            ));
+        }
+        if let Some(items) = object.get("items") {
+            preflight_plugin_schema_node(items, depth + 1)?;
+        }
+    }
+
+    Ok(schema_type)
+}
+
+fn bounded_schema_usize(
+    value: Option<&Value>,
+    maximum: usize,
+) -> Result<Option<usize>, SchemaProfileFailure> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())
+        .filter(|value| *value <= maximum)
+        .ok_or_else(|| SchemaProfileFailure::invalid("schema bound is invalid or too large"))?;
+    Ok(Some(value))
+}
+
+fn validate_plugin_tool_schema_profile(schema: &Value, field: &str) -> Result<(), String> {
+    if !schema.is_object() {
+        return Err(format!("{field} must be a JSON object"));
+    }
+    validate_json_value(schema, PLUGIN_MAX_SCHEMA_BYTES, field)?;
+    preflight_plugin_schema_profile(schema, true)
+        .map_err(|failure| format!("{field}: {}", failure.message))
+}
+
+pub fn validate_plugin_input_arguments(
+    input_schema: &Value,
+    arguments: &Value,
+) -> Result<(), String> {
+    validate_plugin_tool_schema_profile(input_schema, "tool inputSchema")?;
+    validate_json_value(arguments, PLUGIN_MAX_ARGUMENT_BYTES, "tool arguments")?;
+    if !plugin_schema_matches(input_schema, arguments, 0) {
+        return Err("tool arguments do not match the admitted Plugin Schema Profile".to_string());
+    }
+    Ok(())
+}
+
+pub fn validate_plugin_structured_output(
+    output_schema: &Value,
+    structured_content: &Value,
+) -> Result<(), String> {
+    validate_plugin_tool_schema_profile(output_schema, "tool outputSchema")?;
+    validate_json_value(
+        structured_content,
+        PLUGIN_MAX_STRUCTURED_CONTENT_BYTES,
+        "structuredContent",
+    )?;
+    if !plugin_schema_matches(output_schema, structured_content, 0) {
+        return Err(
+            "structuredContent does not match the admitted Plugin Schema Profile".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn plugin_schema_matches(schema: &Value, value: &Value, depth: usize) -> bool {
+    if depth > PLUGIN_MAX_JSON_DEPTH {
+        return false;
+    }
+    let Some(object) = schema.as_object() else {
+        return false;
+    };
+    let Some(schema_type) = object
+        .get("type")
+        .and_then(Value::as_str)
+        .and_then(parse_plugin_schema_type)
+    else {
+        return false;
+    };
+    let type_matches = match schema_type {
+        PluginSchemaType::Object => value.is_object(),
+        PluginSchemaType::Array => value.is_array(),
+        PluginSchemaType::String => value.is_string(),
+        PluginSchemaType::Number => value.is_number(),
+        PluginSchemaType::Integer => value
+            .as_number()
+            .is_some_and(|number| number.as_i64().is_some() || number.as_u64().is_some()),
+        PluginSchemaType::Boolean => value.is_boolean(),
+        PluginSchemaType::Null => value.is_null(),
+    };
+    if !type_matches {
+        return false;
+    }
+    if object
+        .get("const")
+        .is_some_and(|expected| expected != value)
+    {
+        return false;
+    }
+    if object
+        .get("enum")
+        .and_then(Value::as_array)
+        .is_some_and(|values| !values.iter().any(|expected| expected == value))
+    {
+        return false;
+    }
+
+    match schema_type {
+        PluginSchemaType::Object => {
+            let Some(value) = value.as_object() else {
+                return false;
+            };
+            if let Some(required) = object.get("required").and_then(Value::as_array) {
+                if required
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .any(|name| !value.contains_key(name))
+                {
+                    return false;
+                }
+            }
+            let properties = object.get("properties").and_then(Value::as_object);
+            let additional = object
+                .get("additionalProperties")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+            for (name, child_value) in value {
+                if let Some(child_schema) = properties.and_then(|properties| properties.get(name)) {
+                    if !plugin_schema_matches(child_schema, child_value, depth + 1) {
+                        return false;
+                    }
+                } else if !additional {
+                    return false;
+                }
+            }
+        }
+        PluginSchemaType::Array => {
+            let Some(values) = value.as_array() else {
+                return false;
+            };
+            if object
+                .get("minItems")
+                .and_then(Value::as_u64)
+                .is_some_and(|minimum| values.len() < minimum as usize)
+                || object
+                    .get("maxItems")
+                    .and_then(Value::as_u64)
+                    .is_some_and(|maximum| values.len() > maximum as usize)
+            {
+                return false;
+            }
+            if let Some(items) = object.get("items") {
+                if values
+                    .iter()
+                    .any(|value| !plugin_schema_matches(items, value, depth + 1))
+                {
+                    return false;
+                }
+            }
+        }
+        PluginSchemaType::String => {
+            let Some(text) = value.as_str() else {
+                return false;
+            };
+            let length = text.chars().count();
+            if object
+                .get("minLength")
+                .and_then(Value::as_u64)
+                .is_some_and(|minimum| length < minimum as usize)
+                || object
+                    .get("maxLength")
+                    .and_then(Value::as_u64)
+                    .is_some_and(|maximum| length > maximum as usize)
+            {
+                return false;
+            }
+        }
+        PluginSchemaType::Number
+        | PluginSchemaType::Integer
+        | PluginSchemaType::Boolean
+        | PluginSchemaType::Null => {}
+    }
+    true
+}
+
 pub fn validate_tools(tools: &[PluginTool]) -> Result<(), String> {
     if tools.len() > PLUGIN_MAX_TOOL_COUNT {
         return Err(format!(
@@ -459,6 +986,15 @@ pub fn diagnose_invalid_tools(tools: &[PluginTool]) -> PluginCheckDiagnostic {
                 invalid_code
             };
             return Some(diagnostic(code, Some(tool), Some(field)));
+        }
+        if field != "annotations" {
+            if let Err(failure) = preflight_plugin_schema_profile(value, true) {
+                let code = match failure.kind {
+                    SchemaProfileFailureKind::UnsupportedKeyword => "schema_keyword_unsupported",
+                    SchemaProfileFailureKind::Invalid => invalid_code,
+                };
+                return Some(diagnostic(code, Some(tool), Some(field)));
+            }
         }
         None
     }
@@ -523,19 +1059,9 @@ pub fn diagnose_invalid_tools(tools: &[PluginTool]) -> PluginCheckDiagnostic {
 }
 
 pub fn validate_schema_observation(observation: &PluginSchemaObservation) -> Result<(), String> {
-    if !observation.input_schema.is_object() {
-        return Err("tool inputSchema must be a JSON object".to_string());
-    }
-    validate_json_value(
-        &observation.input_schema,
-        PLUGIN_MAX_SCHEMA_BYTES,
-        "tool inputSchema",
-    )?;
+    validate_plugin_tool_schema_profile(&observation.input_schema, "tool inputSchema")?;
     if let Some(output) = observation.output_schema.as_ref() {
-        if !output.is_object() {
-            return Err("tool outputSchema must be a JSON object".to_string());
-        }
-        validate_json_value(output, PLUGIN_MAX_SCHEMA_BYTES, "tool outputSchema")?;
+        validate_plugin_tool_schema_profile(output, "tool outputSchema")?;
     }
     if let Some(annotations) = observation.annotations.as_ref() {
         if !annotations.is_object() {
@@ -576,7 +1102,7 @@ pub fn validate_startup_catalog(providers: &[StartupPluginProvider]) -> Result<(
     }
     let mut ids = HashSet::new();
     let mut instances = HashSet::new();
-    let mut total_tools = 0usize;
+    let mut total_direct_tools = 0usize;
     for provider in providers {
         validate_provider_id(&provider.provider_id)?;
         validate_provider_instance_id(&provider.provider_instance_id)?;
@@ -590,8 +1116,17 @@ pub fn validate_startup_catalog(providers: &[StartupPluginProvider]) -> Result<(
         if let Some(code) = provider.error_code.as_deref() {
             validate_status_atom(code, "startup plugin error code")?;
         }
-        total_tools = total_tools.saturating_add(provider.tools.len());
-        if total_tools > PLUGIN_STARTUP_MAX_DIRECT_TOOLS {
+        if provider.catalog_tool_count > PLUGIN_MAX_TOOL_COUNT {
+            return Err("startup plugin provider catalog count exceeds bound".to_string());
+        }
+        if let Some(digest) = provider.catalog_digest.as_deref() {
+            validate_plugin_catalog_digest(digest)?;
+        }
+        if provider.tools.len() > provider.catalog_tool_count {
+            return Err("startup direct subset exceeds provider catalog count".to_string());
+        }
+        total_direct_tools = total_direct_tools.saturating_add(provider.tools.len());
+        if total_direct_tools > PLUGIN_STARTUP_MAX_DIRECT_TOOLS {
             return Err("startup direct tool count exceeds bound".to_string());
         }
         for tool in &provider.tools {
@@ -828,6 +1363,9 @@ fn validate_check_diagnostic(diagnostic: &PluginCheckDiagnostic) -> Result<(), S
         ("invalid_tool_description", tool, Some("description")) => validate_tool(tool),
         ("input_schema_invalid", tool, Some("inputSchema")) => validate_tool(tool),
         ("output_schema_invalid", tool, Some("outputSchema")) => validate_tool(tool),
+        ("schema_keyword_unsupported", tool, Some("inputSchema" | "outputSchema")) => {
+            validate_tool(tool)
+        }
         ("annotations_invalid", tool, Some("annotations")) => validate_tool(tool),
         ("schema_bounds_exceeded", tool, Some("inputSchema" | "outputSchema" | "annotations")) => {
             validate_tool(tool)
@@ -955,16 +1493,23 @@ mod tests {
         }
     }
 
-    #[test]
-    fn startup_catalog_is_aggregate_bounded() {
-        let provider = StartupPluginProvider {
+    fn startup_provider(instance_id: &str, tools: Vec<PluginTool>) -> StartupPluginProvider {
+        let catalog = PluginCatalog::admit(tools.clone()).unwrap();
+        StartupPluginProvider {
             provider_id: "repo-tools".to_string(),
-            provider_instance_id: "instance_1".to_string(),
+            provider_instance_id: instance_id.to_string(),
             name: "Repo Tools".to_string(),
             status: "ready".to_string(),
             error_code: None,
-            tools: vec![tool()],
-        };
+            catalog_tool_count: catalog.tools().len(),
+            catalog_digest: Some(catalog.digest().to_string()),
+            tools,
+        }
+    }
+
+    #[test]
+    fn startup_catalog_is_aggregate_bounded() {
+        let provider = startup_provider("instance_1", vec![tool()]);
         validate_startup_catalog(&[provider]).unwrap();
     }
 
@@ -1074,6 +1619,135 @@ mod tests {
             is_error: false,
         };
         assert!(validate_tool_result(&oversized_result).is_err());
+    }
+
+    #[test]
+    fn catalog_digest_is_deterministic_for_canonical_validated_catalog() {
+        let mut alpha = tool();
+        alpha.name = "alpha".to_string();
+        alpha.input_schema = json!({
+            "properties": {
+                "value": {"maxLength": 8, "type": "string", "minLength": 1}
+            },
+            "additionalProperties": false,
+            "required": ["value"],
+            "type": "object"
+        });
+        let mut beta = tool();
+        beta.name = "beta".to_string();
+
+        let first = PluginCatalog::admit(vec![beta.clone(), alpha.clone()]).unwrap();
+        let second = PluginCatalog::admit(vec![alpha.clone(), beta.clone()]).unwrap();
+        assert_eq!(first.digest(), second.digest());
+        assert_eq!(
+            first
+                .tools()
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+
+        beta.description = Some("changed implementation contract".to_string());
+        let changed = PluginCatalog::admit(vec![alpha, beta]).unwrap();
+        assert_ne!(first.digest(), changed.digest());
+        validate_plugin_catalog_digest(first.digest()).unwrap();
+    }
+
+    #[test]
+    fn plugin_schema_profile_validates_supported_subset_and_instances() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["fast", "safe"],
+                    "minLength": 4,
+                    "maxLength": 4
+                },
+                "tags": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 2,
+                    "items": {"type": "string", "minLength": 1}
+                },
+                "fixed": {"type": "boolean", "const": true}
+            },
+            "required": ["mode", "fixed"],
+            "additionalProperties": false
+        });
+        validate_plugin_input_arguments(&schema, &json!({"mode":"fast","fixed":true,"tags":["x"]}))
+            .unwrap();
+        for invalid in [
+            json!({"mode":"slow","fixed":true}),
+            json!({"mode":"fast","fixed":false}),
+            json!({"mode":"fast","fixed":true,"tags":[]}),
+            json!({"mode":"fast","fixed":true,"extra":1}),
+        ] {
+            assert!(validate_plugin_input_arguments(&schema, &invalid).is_err());
+        }
+
+        validate_plugin_structured_output(
+            &json!({
+                "type":"object",
+                "properties":{"count":{"type":"integer"}},
+                "required":["count"],
+                "additionalProperties":false
+            }),
+            &json!({"count":2}),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn unsupported_schema_keyword_and_deep_schema_fail_admission_with_finite_diagnostic() {
+        let mut unsupported = tool();
+        unsupported.input_schema = json!({
+            "type": "object",
+            "$ref": "https://example.invalid/secret-schema"
+        });
+        assert!(validate_tools(&[unsupported.clone()]).is_err());
+        let diagnostic = diagnose_invalid_tools(&[unsupported]);
+        assert_eq!(diagnostic.code, "schema_keyword_unsupported");
+        assert_eq!(diagnostic.tool.as_deref(), Some("echo"));
+        assert_eq!(diagnostic.field.as_deref(), Some("inputSchema"));
+        let encoded = serde_json::to_string(&diagnostic).unwrap();
+        assert!(!encoded.contains("$ref"));
+        assert!(!encoded.contains("example.invalid"));
+
+        let mut schema = json!({"type":"string"});
+        for _ in 0..=(PLUGIN_MAX_JSON_DEPTH + 1) {
+            schema = json!({"type":"object","properties":{"child":schema}});
+        }
+        let mut deep = tool();
+        deep.input_schema = schema;
+        assert!(validate_tools(&[deep.clone()]).is_err());
+        assert_eq!(
+            diagnose_invalid_tools(&[deep]).code,
+            "schema_bounds_exceeded"
+        );
+    }
+
+    #[test]
+    fn full_startup_catalog_bound_is_separate_from_direct_subset_bound() {
+        let tools = (0..=PLUGIN_STARTUP_MAX_DIRECT_TOOLS)
+            .map(|index| PluginTool {
+                name: format!("tool_{index}"),
+                ..tool()
+            })
+            .collect::<Vec<_>>();
+        let catalog = PluginCatalog::admit(tools).unwrap();
+        let provider = StartupPluginProvider {
+            provider_id: "repo-tools".to_string(),
+            provider_instance_id: "instance_secondary".to_string(),
+            name: "Repo Tools".to_string(),
+            status: "ready_secondary".to_string(),
+            error_code: Some("first_class_catalog_too_large".to_string()),
+            catalog_tool_count: catalog.tools().len(),
+            catalog_digest: Some(catalog.digest().to_string()),
+            tools: Vec::new(),
+        };
+        validate_startup_catalog(&[provider]).unwrap();
     }
 
     #[test]
@@ -1237,15 +1911,9 @@ mod tests {
                 ..tool()
             })
             .collect::<Vec<_>>();
-        assert!(validate_startup_catalog(&[StartupPluginProvider {
-            provider_id: "repo-tools".to_string(),
-            provider_instance_id: "instance_1".to_string(),
-            name: "Repo Tools".to_string(),
-            status: "ready".to_string(),
-            error_code: None,
-            tools: too_many_tools,
-        }])
-        .is_err());
+        assert!(
+            validate_startup_catalog(&[startup_provider("instance_1", too_many_tools)]).is_err()
+        );
 
         let aggregate_tools = (0..10)
             .map(|index| PluginTool {
@@ -1257,14 +1925,8 @@ mod tests {
                 ..tool()
             })
             .collect::<Vec<_>>();
-        assert!(validate_startup_catalog(&[StartupPluginProvider {
-            provider_id: "repo-tools".to_string(),
-            provider_instance_id: "instance_2".to_string(),
-            name: "Repo Tools".to_string(),
-            status: "ready".to_string(),
-            error_code: None,
-            tools: aggregate_tools,
-        }])
-        .is_err());
+        assert!(
+            validate_startup_catalog(&[startup_provider("instance_2", aggregate_tools)]).is_err()
+        );
     }
 }

--- a/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
+++ b/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
@@ -31,6 +31,8 @@ fn startup_provider(instance_id: &str) -> StartupPluginProvider {
         name: "Repo Tools".to_string(),
         status: "ready".to_string(),
         error_code: None,
+        catalog_tool_count: 1,
+        catalog_digest: None,
         tools: vec![plugin_tool()],
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
@@ -244,6 +244,11 @@ fn main() -> io::Result<()> {
                 } else {
                     String::new()
                 };
+                if scenario == "check_stderr_at_list" {
+                    let mut stderr = io::stderr().lock();
+                    writeln!(stderr, "diagnostic-written-before-list-response")?;
+                    stderr.flush()?;
+                }
                 send(
                     &mut writer,
                     &format!(

--- a/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
@@ -53,6 +53,16 @@ fn main() -> io::Result<()> {
     }
     if scenario == "stderr" {
         eprintln!("diagnostic-only-secret-looking-stderr");
+    } else if scenario == "stderr_flood" {
+        let mut stderr = io::stderr().lock();
+        for index in 0..256usize {
+            writeln!(
+                stderr,
+                "stderr-flood-{index:03}-{}",
+                "x".repeat(2 * 1024)
+            )?;
+        }
+        stderr.flush()?;
     }
 
     let mut reader = BufReader::new(io::stdin().lock());
@@ -199,6 +209,15 @@ fn main() -> io::Result<()> {
                     )?;
                     continue;
                 }
+                if scenario == "check_unsupported_schema" {
+                    send(
+                        &mut writer,
+                        &format!(
+                            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"echo","inputSchema":{{"type":"object","$ref":"https://example.invalid/secret-schema"}}}}]}}}}"#
+                        ),
+                    )?;
+                    continue;
+                }
                 let value_type = if scenario == "schema_change" && lists >= 2 {
                     "number"
                 } else {
@@ -220,16 +239,21 @@ fn main() -> io::Result<()> {
                     append(marker, &format!("descendant-pid:{}\n", child.id()))?;
                     drop(child);
                 }
+                let output_schema = if scenario == "output_schema_invalid" {
+                    r#","outputSchema":{"type":"object","properties":{"call":{"type":"string"}},"required":["call"],"additionalProperties":false}"#.to_string()
+                } else {
+                    String::new()
+                };
                 send(
                     &mut writer,
                     &format!(
-                        r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"{tool_name}","description":"Native plugin echo","inputSchema":{{"type":"object","description":"{startup_padding}","properties":{{"value":{{"type":"{value_type}"}}}}}}}}]}}}}"#
+                        r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{{"name":"{tool_name}","description":"Native plugin echo","inputSchema":{{"type":"object","description":"{startup_padding}","properties":{{"value":{{"type":"{value_type}"}}}}}}{output_schema}}}]}}}}"#
                     ),
                 )?;
                 if matches!(
                     scenario,
                     "block_after_preflight" | "block_after_preflight_tree"
-                ) && lists >= 2
+                ) && lists >= 1
                 {
                     append(marker, "stdin-blocked\n")?;
                     if scenario == "block_after_preflight_tree" {

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -32,6 +32,7 @@ const PLUGIN_READER_QUEUE: usize = 16;
 const PLUGIN_WRITER_QUEUE: usize = 1;
 const PLUGIN_STOP_POLL: Duration = Duration::from_millis(25);
 const PLUGIN_TERMINATION_BUDGET: Duration = Duration::from_secs(1);
+const PLUGIN_STDERR_DRAIN_BUDGET: Duration = Duration::from_millis(100);
 const PLUGIN_STDERR_MAX_LINES: usize = 64;
 const PLUGIN_STDERR_MAX_LINE_BYTES: usize = 1024;
 const PLUGIN_STDERR_MAX_BYTES: usize = 32 * 1024;
@@ -74,6 +75,7 @@ struct ProviderEntry {
 struct ProviderProcess {
     child: Mutex<Option<ManagedChild>>,
     stderr: Arc<Mutex<PluginStderrDiagnostics>>,
+    stderr_drained: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -579,16 +581,16 @@ impl PluginManager {
             &self.prepared_profiles,
             &self.stopping,
         );
-        self.last_check_stderr
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(provider_id.to_string(), entry.process.stderr_snapshot());
         if self.stopping.load(Ordering::SeqCst)
             || failure
                 .as_ref()
                 .is_some_and(|failure| failure.code == "plugin_manager_stopping")
         {
             entry.shutdown();
+            self.last_check_stderr
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(provider_id.to_string(), entry.process.stderr_snapshot());
             return gateway_error(
                 PluginDispatchState::NotStarted,
                 "plugin_manager_stopping",
@@ -624,6 +626,10 @@ impl PluginManager {
             }
         };
         entry.shutdown();
+        self.last_check_stderr
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(provider_id.to_string(), entry.process.stderr_snapshot());
         PluginGatewayResponse::success(PluginGatewayResponsePayload::Checked { report })
     }
 
@@ -923,6 +929,7 @@ impl ProviderProcess {
         Self {
             child: Mutex::new(None),
             stderr: Arc::new(Mutex::new(PluginStderrDiagnostics::default())),
+            stderr_drained: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -951,6 +958,18 @@ impl ProviderProcess {
         if let Some(mut child) = child {
             terminate_provider_process(&mut child);
         }
+        self.wait_for_stderr_drain();
+    }
+
+    fn wait_for_stderr_drain(&self) {
+        let deadline = Instant::now() + PLUGIN_STDERR_DRAIN_BUDGET;
+        while !self.stderr_drained.load(Ordering::Acquire) {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(1).min(remaining));
+        }
     }
 }
 
@@ -964,6 +983,7 @@ impl Drop for ProviderProcess {
         if let Some(mut child) = child {
             terminate_provider_process(&mut child);
         }
+        self.wait_for_stderr_drain();
     }
 }
 
@@ -1121,11 +1141,17 @@ fn prepare_provider(
     };
     let stderr_thread_name = format!("wc-plugin-stderr-{}", config.id);
     let stderr_diagnostics = Arc::clone(&process.stderr);
+    let stderr_drained = Arc::clone(&process.stderr_drained);
+    stderr_drained.store(false, Ordering::Release);
     if std::thread::Builder::new()
         .name(stderr_thread_name)
-        .spawn(move || provider_stderr_reader(stderr, stderr_diagnostics))
+        .spawn(move || {
+            provider_stderr_reader(stderr, stderr_diagnostics);
+            stderr_drained.store(true, Ordering::Release);
+        })
         .is_err()
     {
+        process.stderr_drained.store(true, Ordering::Release);
         let _ = child.terminate_tree();
         entry.retire("plugin_reader_unavailable");
         return (

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -9,20 +9,21 @@ use super::config::{load_config, PluginConfig, PluginProviderConfig, RunnerConfi
 use super::shell::{PreparedExecutionEnvironment, PreparedShellProfileCache};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::process::{ChildStdin, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{mpsc, Arc, Mutex, TryLockError};
+use std::sync::{mpsc, Arc, Mutex, OnceLock, TryLockError};
 use std::time::{Duration, Instant};
 use webcodex_core::plugin::{
-    diagnose_invalid_tools, validate_request, validate_startup_catalog, validate_startup_tool,
-    validate_tool_result, validate_tools, PluginCheckDiagnostic, PluginCheckPhase,
-    PluginCheckReport, PluginCheckToolSummary, PluginDispatchState, PluginGatewayRequest,
-    PluginGatewayResponse, PluginGatewayResponsePayload, PluginPlane, PluginProviderView,
-    PluginReloadFailure, PluginSchemaObservation, PluginStartupToolShape, PluginTool,
-    PluginToolResult, StartupPluginProvider, PLUGIN_MAX_MESSAGE_BYTES, PLUGIN_PROTOCOL_VERSION,
+    diagnose_invalid_tools, validate_plugin_input_arguments, validate_plugin_structured_output,
+    validate_request, validate_startup_catalog, validate_startup_tool, validate_tool_result,
+    validate_tools, PluginCatalog, PluginCheckDiagnostic, PluginCheckPhase, PluginCheckReport,
+    PluginCheckToolSummary, PluginDispatchState, PluginGatewayRequest, PluginGatewayResponse,
+    PluginGatewayResponsePayload, PluginPlane, PluginProviderView, PluginReloadFailure,
+    PluginSchemaObservation, PluginStartupToolShape, PluginTool, PluginToolResult,
+    StartupPluginProvider, PLUGIN_MAX_MESSAGE_BYTES, PLUGIN_PROTOCOL_VERSION,
     PLUGIN_STARTUP_CATALOG_MAX_BYTES, PLUGIN_STARTUP_MAX_DIRECT_TOOLS,
 };
 use webcodex_process::ManagedChild;
@@ -31,6 +32,9 @@ const PLUGIN_READER_QUEUE: usize = 16;
 const PLUGIN_WRITER_QUEUE: usize = 1;
 const PLUGIN_STOP_POLL: Duration = Duration::from_millis(25);
 const PLUGIN_TERMINATION_BUDGET: Duration = Duration::from_secs(1);
+const PLUGIN_STDERR_MAX_LINES: usize = 64;
+const PLUGIN_STDERR_MAX_LINE_BYTES: usize = 1024;
+const PLUGIN_STDERR_MAX_BYTES: usize = 32 * 1024;
 
 pub(crate) struct PluginManager {
     startup: BTreeMap<String, Arc<ProviderEntry>>,
@@ -39,6 +43,7 @@ pub(crate) struct PluginManager {
     startup_shell: ShellConfig,
     dynamic: Mutex<DynamicState>,
     candidate_gate: Mutex<()>,
+    last_check_stderr: Mutex<BTreeMap<String, PluginStderrSnapshot>>,
     config_path: PathBuf,
     prepared_profiles: PreparedShellProfileCache,
     next_generation: AtomicU64,
@@ -62,11 +67,31 @@ struct ProviderEntry {
     failed: AtomicBool,
     error_code: Mutex<Option<String>>,
     process: Arc<ProviderProcess>,
+    catalog: OnceLock<PluginCatalog>,
     session: Mutex<Option<ProviderConnection>>,
 }
 
 struct ProviderProcess {
     child: Mutex<Option<ManagedChild>>,
+    stderr: Arc<Mutex<PluginStderrDiagnostics>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginStderrSnapshot {
+    pub(crate) lines: Vec<PluginStderrLine>,
+    pub(crate) aggregate_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginStderrLine {
+    pub(crate) text: String,
+    pub(crate) truncated: bool,
+}
+
+#[derive(Default)]
+struct PluginStderrDiagnostics {
+    lines: VecDeque<PluginStderrLine>,
+    aggregate_bytes: usize,
 }
 
 struct ProviderConnection {
@@ -269,6 +294,14 @@ impl PluginManager {
             );
             let instance_id = entry.instance_id.clone();
             let failure_code = failure.as_ref().map(|failure| failure.code.to_string());
+            let catalog_tool_count = entry
+                .catalog
+                .get()
+                .map_or(0, |catalog| catalog.tools().len());
+            let catalog_digest = entry
+                .catalog
+                .get()
+                .map(|catalog| catalog.digest().to_string());
             let mut advertised = StartupPluginProvider {
                 provider_id: provider.id.clone(),
                 provider_instance_id: instance_id,
@@ -279,6 +312,8 @@ impl PluginManager {
                     "ready".to_string()
                 },
                 error_code: failure_code,
+                catalog_tool_count,
+                catalog_digest,
                 tools: Vec::new(),
             };
 
@@ -325,6 +360,7 @@ impl PluginManager {
                 first_class_restart_required: false,
             }),
             candidate_gate: Mutex::new(()),
+            last_check_stderr: Mutex::new(BTreeMap::new()),
             config_path,
             prepared_profiles,
             next_generation: AtomicU64::new(2),
@@ -334,6 +370,34 @@ impl PluginManager {
 
     pub(crate) fn startup_catalog(&self) -> Vec<StartupPluginProvider> {
         self.startup_catalog.clone()
+    }
+
+    /// Runner-local diagnostic projection only. This is intentionally not part
+    /// of Plugin gateway responses or any Server-facing protocol contract.
+    #[allow(dead_code)]
+    pub(crate) fn local_stderr_diagnostics(
+        &self,
+        plane: PluginPlane,
+        provider_id: &str,
+        provider_instance_id: &str,
+    ) -> Option<PluginStderrSnapshot> {
+        self.resolve_provider(plane, provider_id, provider_instance_id)
+            .map(|provider| provider.process.stderr_snapshot())
+    }
+
+    /// Last disposable `check` candidate stderr for local operator tooling.
+    /// The projection is bounded/sanitized and is never serialized into a
+    /// PluginGatewayResponse.
+    #[allow(dead_code)]
+    pub(crate) fn local_check_stderr_diagnostics(
+        &self,
+        provider_id: &str,
+    ) -> Option<PluginStderrSnapshot> {
+        self.last_check_stderr
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(provider_id)
+            .cloned()
     }
 
     pub(crate) fn handle(&self, request: PluginGatewayRequest) -> PluginGatewayResponse {
@@ -375,8 +439,7 @@ impl PluginManager {
                 else {
                     return stale_provider();
                 };
-                match provider.with_connection(|connection, timeout| connection.tools_list(timeout))
-                {
+                match provider.frozen_tools() {
                     Ok(tools) => {
                         PluginGatewayResponse::success(PluginGatewayResponsePayload::Tools {
                             tools,
@@ -472,6 +535,10 @@ impl PluginManager {
                 )
             }
         };
+        self.last_check_stderr
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(provider_id);
         let candidate = match load_config(&self.config_path) {
             Ok(candidate) => candidate,
             Err(error) => {
@@ -512,6 +579,10 @@ impl PluginManager {
             &self.prepared_profiles,
             &self.stopping,
         );
+        self.last_check_stderr
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(provider_id.to_string(), entry.process.stderr_snapshot());
         if self.stopping.load(Ordering::SeqCst)
             || failure
                 .as_ref()
@@ -697,6 +768,19 @@ impl Drop for PluginManager {
 }
 
 impl ProviderEntry {
+    fn frozen_catalog(&self) -> Result<&PluginCatalog, ProviderFailure> {
+        if self.failed.load(Ordering::SeqCst) {
+            return Err(ProviderFailure::not_started("plugin_provider_unavailable"));
+        }
+        self.catalog
+            .get()
+            .ok_or_else(|| ProviderFailure::not_started("plugin_provider_unavailable"))
+    }
+
+    fn frozen_tools(&self) -> Result<Vec<PluginTool>, ProviderFailure> {
+        Ok(self.frozen_catalog()?.tools().to_vec())
+    }
+
     fn view(&self, plane: PluginPlane, startup_direct_tool_count: usize) -> PluginProviderView {
         let failed = self.failed.load(Ordering::SeqCst);
         PluginProviderView {
@@ -760,38 +844,40 @@ impl ProviderEntry {
         arguments: Value,
         expected_schema: &PluginSchemaObservation,
     ) -> Result<PluginToolResult, ProviderFailure> {
-        self.with_connection(|connection, timeout| {
-            let started = Instant::now();
-            let tools = connection.tools_list(timeout)?;
-            let Some(tool) = tools.iter().find(|tool| tool.name == name) else {
-                return Err(ProviderFailure {
-                    dispatch_state: PluginDispatchState::NotStarted,
-                    code: "plugin_tool_unavailable",
-                    fatal: false,
-                });
-            };
-            if &tool.schema_observation() != expected_schema {
-                return Err(ProviderFailure {
-                    dispatch_state: PluginDispatchState::NotStarted,
-                    code: "plugin_schema_changed",
-                    fatal: false,
-                });
+        let catalog = self.frozen_catalog()?;
+        let Some(tool) = catalog.tool(name) else {
+            return Err(ProviderFailure {
+                dispatch_state: PluginDispatchState::NotStarted,
+                code: "plugin_tool_unavailable",
+                fatal: false,
+            });
+        };
+        if &tool.schema_observation() != expected_schema {
+            return Err(ProviderFailure {
+                dispatch_state: PluginDispatchState::NotStarted,
+                code: "plugin_schema_changed",
+                fatal: false,
+            });
+        }
+        validate_plugin_input_arguments(&tool.input_schema, &arguments).map_err(|_| {
+            ProviderFailure {
+                dispatch_state: PluginDispatchState::NotStarted,
+                code: "plugin_arguments_schema_invalid",
+                fatal: false,
             }
-            let Some(remaining) = timeout
-                .checked_sub(started.elapsed())
-                .filter(|remaining| !remaining.is_zero())
-            else {
-                // The schema preflight completed successfully, so the provider
-                // connection is still trustworthy, but the model-requested
-                // effect must not start after the provider's total call budget
-                // has already been consumed.
-                return Err(ProviderFailure {
-                    dispatch_state: PluginDispatchState::NotStarted,
-                    code: "plugin_timeout",
-                    fatal: false,
-                });
-            };
-            connection.tools_call(name, arguments, remaining)
+        })?;
+        let output_schema = tool.output_schema.clone();
+        self.with_connection(move |connection, timeout| {
+            let result = connection.tools_call(name, arguments, timeout)?;
+            if let Some(output_schema) = output_schema.as_ref() {
+                let structured = result.structured_content.as_ref().ok_or_else(|| {
+                    ProviderFailure::completed("plugin_output_schema_violation", true)
+                })?;
+                validate_plugin_structured_output(output_schema, structured).map_err(|_| {
+                    ProviderFailure::completed("plugin_output_schema_violation", true)
+                })?;
+            }
+            Ok(result)
         })
     }
 
@@ -809,11 +895,42 @@ impl Drop for ProviderEntry {
     }
 }
 
+impl PluginStderrDiagnostics {
+    fn push_line(&mut self, text: String, truncated: bool) {
+        let bytes = text.len();
+        self.aggregate_bytes = self.aggregate_bytes.saturating_add(bytes);
+        self.lines.push_back(PluginStderrLine { text, truncated });
+        while self.lines.len() > PLUGIN_STDERR_MAX_LINES
+            || self.aggregate_bytes > PLUGIN_STDERR_MAX_BYTES
+        {
+            let Some(removed) = self.lines.pop_front() else {
+                break;
+            };
+            self.aggregate_bytes = self.aggregate_bytes.saturating_sub(removed.text.len());
+        }
+    }
+
+    fn snapshot(&self) -> PluginStderrSnapshot {
+        PluginStderrSnapshot {
+            lines: self.lines.iter().cloned().collect(),
+            aggregate_bytes: self.aggregate_bytes,
+        }
+    }
+}
+
 impl ProviderProcess {
     fn new() -> Self {
         Self {
             child: Mutex::new(None),
+            stderr: Arc::new(Mutex::new(PluginStderrDiagnostics::default())),
         }
+    }
+
+    fn stderr_snapshot(&self) -> PluginStderrSnapshot {
+        self.stderr
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .snapshot()
     }
 
     fn install(&self, child: ManagedChild) {
@@ -873,6 +990,7 @@ fn prepare_provider(
         failed: AtomicBool::new(false),
         error_code: Mutex::new(None),
         process: Arc::clone(&process),
+        catalog: OnceLock::new(),
         session: Mutex::new(None),
     });
     let cwd = config
@@ -1002,12 +1120,10 @@ fn prepare_provider(
         }
     };
     let stderr_thread_name = format!("wc-plugin-stderr-{}", config.id);
+    let stderr_diagnostics = Arc::clone(&process.stderr);
     if std::thread::Builder::new()
         .name(stderr_thread_name)
-        .spawn(move || {
-            let mut stderr = stderr;
-            let _ = std::io::copy(&mut stderr, &mut std::io::sink());
-        })
+        .spawn(move || provider_stderr_reader(stderr, stderr_diagnostics))
         .is_err()
     {
         let _ = child.terminate_tree();
@@ -1134,6 +1250,38 @@ fn prepare_provider(
             );
         }
     };
+    let catalog = match PluginCatalog::admit(tools) {
+        Ok(catalog) => catalog,
+        Err(_) => {
+            process.terminate();
+            entry.retire("plugin_tools_list_invalid");
+            return (
+                entry,
+                None,
+                Some(ProviderPreparationFailure {
+                    phase: PluginCheckPhase::Validation,
+                    code: "plugin_tools_list_invalid",
+                    detail: "Plugin tools/list result could not be admitted as a canonical catalog",
+                    diagnostic: None,
+                }),
+            );
+        }
+    };
+    let tools = catalog.tools().to_vec();
+    if entry.catalog.set(catalog).is_err() {
+        process.terminate();
+        entry.retire("plugin_provider_state_failed");
+        return (
+            entry,
+            None,
+            Some(ProviderPreparationFailure {
+                phase: PluginCheckPhase::Validation,
+                code: "plugin_provider_state_failed",
+                detail: "Plugin provider catalog state could not be frozen",
+                diagnostic: None,
+            }),
+        );
+    }
     *entry.session.lock().unwrap() = Some(connection);
     (entry, Some(tools), None)
 }
@@ -1169,11 +1317,6 @@ impl ProviderConnection {
             ));
         }
         Ok(())
-    }
-
-    fn tools_list(&mut self, timeout: Duration) -> Result<Vec<PluginTool>, ProviderFailure> {
-        self.tools_list_internal(timeout, false)
-            .map_err(|failure| failure.failure)
     }
 
     fn tools_list_with_diagnostic(
@@ -1385,6 +1528,50 @@ fn provider_stdin_writer(mut stdin: ChildStdin, requests: mpsc::Receiver<WriteRe
         if failed {
             return;
         }
+    }
+}
+
+fn provider_stderr_reader(mut stderr: impl Read, diagnostics: Arc<Mutex<PluginStderrDiagnostics>>) {
+    let mut buffer = [0u8; 4096];
+    let mut line = Vec::with_capacity(PLUGIN_STDERR_MAX_LINE_BYTES);
+    let mut truncated = false;
+    loop {
+        let read = match stderr.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => break,
+        };
+        for byte in &buffer[..read] {
+            if *byte == b'\n' {
+                let text = String::from_utf8(line.clone()).unwrap_or_default();
+                diagnostics
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push_line(text, truncated);
+                line.clear();
+                truncated = false;
+                continue;
+            }
+            if *byte == b'\r' {
+                continue;
+            }
+            if line.len() < PLUGIN_STDERR_MAX_LINE_BYTES {
+                line.push(match *byte {
+                    b'\t' => b' ',
+                    b' '..=b'~' => *byte,
+                    _ => b'?',
+                });
+            } else {
+                truncated = true;
+            }
+        }
+    }
+    if !line.is_empty() || truncated {
+        let text = String::from_utf8(line).unwrap_or_default();
+        diagnostics
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push_line(text, truncated);
     }
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -469,6 +469,21 @@ fn check_reports_executable_config_and_startup_shape_without_sensitive_details()
         .any(|line| line.text == "diagnostic-only-secret-looking-stderr"));
     let report = checked_report(response);
     assert!(report.ready);
+
+    fixture.rewrite_candidate("check_stderr_at_list", 2);
+    let late_response = fixture.check();
+    let late_encoded = serde_json::to_string(&late_response).unwrap();
+    assert!(!late_encoded.contains("diagnostic-written-before-list-response"));
+    let late_local = fixture
+        .manager
+        .local_check_stderr_diagnostics("fake")
+        .expect("completed check stderr projection");
+    assert!(late_local
+        .lines
+        .iter()
+        .any(|line| line.text == "diagnostic-written-before-list-response"));
+    let late_report = checked_report(late_response);
+    assert!(late_report.ready);
 }
 
 #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -223,7 +223,7 @@ fn check_observes_edited_v2_without_replacing_current_dynamic_v1() {
         provider_instance_id: dynamic_v1.clone(),
         name: "echo".to_string(),
         arguments: json!({"value":"still-v1"}),
-        expected_schema: v1_schema,
+        expected_schema: v1_schema.clone(),
     });
     assert!(
         v1_call.error.is_none(),
@@ -239,12 +239,39 @@ fn check_observes_edited_v2_without_replacing_current_dynamic_v1() {
     let tools = fixture.manager.handle(PluginGatewayRequest::ToolsList {
         plane: PluginPlane::Effective,
         provider_id: "fake".to_string(),
-        provider_instance_id: dynamic_v2,
+        provider_instance_id: dynamic_v2.clone(),
     });
     let Some(PluginGatewayResponsePayload::Tools { tools }) = tools.payload else {
         panic!("v2 tools/list failed: {:?}", tools.error);
     };
     assert_eq!(tools[0].name, "echo_v2");
+
+    let calls_before_stale = fixture.marker_count("call");
+    let stale_v1 = fixture.manager.handle(PluginGatewayRequest::ToolsCall {
+        plane: PluginPlane::Effective,
+        provider_id: "fake".to_string(),
+        provider_instance_id: dynamic_v1,
+        name: "echo".to_string(),
+        arguments: json!({"value":"stale-v1"}),
+        expected_schema: v1_schema,
+    });
+    assert_eq!(stale_v1.dispatch_state, PluginDispatchState::NotStarted);
+    assert_eq!(
+        stale_v1.error.as_ref().unwrap().code,
+        "stale_plugin_provider"
+    );
+    assert_eq!(
+        fixture.marker_count("call"),
+        calls_before_stale,
+        "a stale provider instance must never dispatch into the new provider"
+    );
+
+    let v2_list_again = fixture.manager.handle(PluginGatewayRequest::ToolsList {
+        plane: PluginPlane::Effective,
+        provider_id: "fake".to_string(),
+        provider_instance_id: dynamic_v2,
+    });
+    assert!(v2_list_again.error.is_none());
     fixture.manager.shutdown();
 }
 
@@ -277,6 +304,12 @@ fn check_failures_are_structured_diagnostic_results_and_cleanup_process_trees() 
         ),
         (
             "check_oversized_schema",
+            2,
+            PluginCheckPhase::Validation,
+            "plugin_tools_list_invalid",
+        ),
+        (
+            "check_unsupported_schema",
             2,
             PluginCheckPhase::Validation,
             "plugin_tools_list_invalid",
@@ -336,6 +369,12 @@ fn check_tool_validation_failures_have_safe_actionable_diagnostics() {
             Some("echo"),
             Some("inputSchema"),
         ),
+        (
+            "check_unsupported_schema",
+            "schema_keyword_unsupported",
+            Some("echo"),
+            Some("inputSchema"),
+        ),
     ] {
         let fixture = CheckFixture::new(scenario, 2);
         let report = checked_report(fixture.check());
@@ -363,6 +402,8 @@ fn check_tool_validation_failures_have_safe_actionable_diagnostics() {
             "provider_instance_id",
             "\"properties\"",
             "\"type\":\"object\"",
+            "example.invalid",
+            "$ref",
         ] {
             assert!(
                 !encoded.contains(forbidden),
@@ -418,6 +459,14 @@ fn check_reports_executable_config_and_startup_shape_without_sensitive_details()
     let encoded = serde_json::to_string(&response).unwrap();
     assert!(!encoded.contains("diagnostic-only-secret-looking-stderr"));
     assert!(!encoded.contains(fixture._temp.path().to_string_lossy().as_ref()));
+    let local = fixture
+        .manager
+        .local_check_stderr_diagnostics("fake")
+        .expect("local check stderr projection");
+    assert!(local
+        .lines
+        .iter()
+        .any(|line| line.text == "diagnostic-only-secret-looking-stderr"));
     let report = checked_report(response);
     assert!(report.ready);
 }

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
@@ -203,6 +203,8 @@ fn startup_is_eager_persistent_and_reused() {
     );
     assert_eq!(fixture.provider.status, "ready");
     assert_eq!(fixture.provider.tools.len(), 1);
+    assert_eq!(fixture.provider.catalog_tool_count, 1);
+    assert!(fixture.provider.catalog_digest.is_some());
 
     assert!(fixture.list().error.is_none());
     for expected in ["call-1", "call-2"] {
@@ -223,6 +225,11 @@ fn startup_is_eager_persistent_and_reused() {
         "provider must never silently respawn"
     );
     assert_eq!(fixture.marker_count("call"), 2);
+    assert_eq!(
+        fixture.marker_count("list"),
+        1,
+        "tools/list is an admission operation and must not repeat during discovery or calls"
+    );
 }
 
 #[test]
@@ -253,6 +260,8 @@ fn startup_secondary_admission_stays_separate_from_runtime_provider_health() {
         Some("plugin_startup_schema_too_large")
     );
     assert!(fixture.provider.tools.is_empty());
+    assert_eq!(fixture.provider.catalog_tool_count, 1);
+    assert!(fixture.provider.catalog_digest.is_some());
 
     let response = fixture.manager.handle(PluginGatewayRequest::ProvidersList);
     let Some(PluginGatewayResponsePayload::Providers { providers, .. }) = response.payload else {
@@ -266,27 +275,64 @@ fn startup_secondary_admission_stays_separate_from_runtime_provider_health() {
 }
 
 #[test]
-fn schema_change_is_not_started_and_never_dispatches_effect() {
+fn same_provider_instance_catalog_is_frozen_and_never_relists() {
     let fixture = Fixture::new("schema_change", 2);
     let response = fixture.call();
-    assert_eq!(response.dispatch_state, PluginDispatchState::NotStarted);
+    assert!(response.error.is_none());
+    assert_eq!(fixture.marker_count("call"), 1);
+    assert_eq!(fixture.marker_count("list"), 1);
+    let listed = fixture.list();
+    let Some(PluginGatewayResponsePayload::Tools { tools }) = listed.payload else {
+        panic!("missing frozen tools: {:?}", listed.error);
+    };
     assert_eq!(
-        response.error.as_ref().unwrap().code,
-        "plugin_schema_changed"
+        tools[0].input_schema["properties"]["value"]["type"],
+        "string"
     );
-    assert_eq!(fixture.marker_count("call"), 0);
+    assert_eq!(fixture.marker_count("list"), 1);
 }
 
 #[test]
-fn schema_preflight_and_effect_share_one_provider_timeout_budget() {
+fn tools_call_uses_full_timeout_without_catalog_relist() {
     let fixture = Fixture::new("split_timeout", 1);
     let response = fixture.call();
-    assert_eq!(response.dispatch_state, PluginDispatchState::OutcomeUnknown);
-    assert_eq!(response.error.as_ref().unwrap().code, "plugin_timeout");
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(fixture.marker_count("call"), 1);
+    assert_eq!(fixture.marker_count("list"), 1);
+}
+
+#[test]
+fn invalid_input_schema_is_not_started_and_provider_sees_no_call() {
+    let fixture = Fixture::new("normal", 2);
+    let response = fixture.call_with_arguments(json!({"value": 7}));
+    assert_eq!(response.dispatch_state, PluginDispatchState::NotStarted);
     assert_eq!(
-        fixture.marker_count("call"),
-        1,
-        "the effect starts only with the time remaining after schema preflight"
+        response.error.as_ref().unwrap().code,
+        "plugin_arguments_schema_invalid"
+    );
+    assert_eq!(fixture.marker_count("call"), 0);
+    assert_eq!(fixture.marker_count("list"), 1);
+
+    let valid = fixture.call_with_arguments(json!({"value": "valid"}));
+    assert!(valid.error.is_none());
+    assert_eq!(fixture.marker_count("call"), 1);
+}
+
+#[test]
+fn output_schema_violation_is_completed_and_retires_provider() {
+    let fixture = Fixture::new("output_schema_invalid", 2);
+    let response = fixture.call();
+    assert_eq!(response.dispatch_state, PluginDispatchState::Completed);
+    assert_eq!(
+        response.error.as_ref().unwrap().code,
+        "plugin_output_schema_violation"
+    );
+    assert_eq!(fixture.marker_count("call"), 1);
+    let retired = fixture.call();
+    assert_eq!(retired.dispatch_state, PluginDispatchState::NotStarted);
+    assert_eq!(
+        retired.error.as_ref().unwrap().code,
+        "plugin_provider_unavailable"
     );
 }
 
@@ -414,10 +460,60 @@ fn unsupported_result_is_completed_and_retires_protocol_broken_instance() {
 #[test]
 fn stderr_is_diagnostic_only_and_never_enters_catalog_or_result() {
     let fixture = Fixture::new("stderr", 2);
+    assert!(wait_until(Duration::from_secs(1), || {
+        fixture
+            .manager
+            .local_stderr_diagnostics(
+                PluginPlane::Startup,
+                &fixture.provider.provider_id,
+                &fixture.provider.provider_instance_id,
+            )
+            .is_some_and(|snapshot| {
+                snapshot
+                    .lines
+                    .iter()
+                    .any(|line| line.text == "diagnostic-only-secret-looking-stderr")
+            })
+    }));
     let catalog = serde_json::to_string(&fixture.manager.startup_catalog()).unwrap();
     assert!(!catalog.contains("diagnostic-only-secret-looking-stderr"));
     let result = serde_json::to_string(&fixture.call()).unwrap();
     assert!(!result.contains("diagnostic-only-secret-looking-stderr"));
+}
+
+#[test]
+fn stderr_flood_is_bounded_and_does_not_block_stdout_protocol() {
+    let fixture = Fixture::new("stderr_flood", 2);
+    let response = fixture.call();
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(fixture.marker_count("list"), 1);
+    assert_eq!(fixture.marker_count("call"), 1);
+    assert!(wait_until(Duration::from_secs(1), || {
+        fixture
+            .manager
+            .local_stderr_diagnostics(
+                PluginPlane::Startup,
+                &fixture.provider.provider_id,
+                &fixture.provider.provider_instance_id,
+            )
+            .is_some_and(|snapshot| !snapshot.lines.is_empty())
+    }));
+    let snapshot = fixture
+        .manager
+        .local_stderr_diagnostics(
+            PluginPlane::Startup,
+            &fixture.provider.provider_id,
+            &fixture.provider.provider_instance_id,
+        )
+        .unwrap();
+    assert!(snapshot.lines.len() <= PLUGIN_STDERR_MAX_LINES);
+    assert!(snapshot.aggregate_bytes <= PLUGIN_STDERR_MAX_BYTES);
+    assert!(snapshot
+        .lines
+        .iter()
+        .all(|line| line.text.len() <= PLUGIN_STDERR_MAX_LINE_BYTES && line.truncated));
+    let catalog = serde_json::to_string(&fixture.manager.startup_catalog()).unwrap();
+    assert!(!catalog.contains("stderr-flood"));
 }
 
 #[test]
@@ -442,10 +538,9 @@ fn provider_busy_is_not_started() {
         std::thread::sleep(Duration::from_millis(10));
     }
     let discovery = fixture.list();
-    assert_eq!(discovery.dispatch_state, PluginDispatchState::NotStarted);
-    assert_eq!(
-        discovery.error.as_ref().unwrap().code,
-        "plugin_provider_busy"
+    assert!(
+        discovery.error.is_none(),
+        "frozen catalog discovery must not contend on the live provider connection"
     );
     let second_call = fixture.call();
     assert_eq!(second_call.dispatch_state, PluginDispatchState::NotStarted);

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -10,6 +10,11 @@ stdout. It does **not** need to implement an MCP server or depend on an MCP SDK.
 The Plugin process runs on the Runner machine. The Server never receives its
 command, argv, cwd, prepared environment, PID, stderr, or local credentials.
 
+Native Plugins are **trusted local executables**. WebCodex does not sandbox,
+contain, sign, or otherwise make an untrusted executable safe. A Plugin has the
+same practical local-process trust implications as launching that executable
+directly with the prepared Runner environment.
+
 ## Configure a Plugin
 
 Plugins have their own `runner.toml` section; they are not MCP providers:
@@ -67,14 +72,27 @@ There are exactly two Plugin planes.
 ### Startup
 
 When the Runner process starts, it reads `[plugins]`, prepares each provider,
-starts it, performs `initialize`, calls `tools/list`, validates the bounded tool
-schemas, and freezes the successful startup catalog for that Runner instance.
-The admitted provider process remains persistent for direct calls.
+starts it, performs `initialize`, calls `tools/list` **once**, validates the
+bounded Tool schemas, canonicalizes the result, and freezes that catalog against
+the exact `provider_instance_id`. The admitted provider process remains
+persistent for calls, but ordinary discovery/call paths never ask that same
+instance to list again.
 
-The startup catalog is immutable for the lifetime of that Runner process.
+The frozen provider catalog is immutable for that provider-instance lifetime.
+Its canonical validated form has a stable SHA-256 catalog digest and exact Tool
+count for stale detection/audit. A catalog can change only through a new
+provider instance created by reload/restart. The startup plane itself remains
+immutable for the lifetime of the Runner process.
 Editing Plugin source or `runner.toml`, or using `plugin_tool reload`, does not
 change first-class tools. A Runner restart creates a new Runner/provider
 instance and performs startup admission again.
+
+The complete provider catalog and the startup direct-eligible subset are
+separate contracts. `PLUGIN_STARTUP_MAX_DIRECT_TOOLS` (currently 64) is a Runner
+safety cap for the direct subset, not a claim that a provider can expose only 64
+Tools and not a per-model/per-surface routing policy. A bounded provider catalog
+can therefore remain usable through `plugin_tool` even when no direct subset is
+admitted. Server-side surface budgets remain a separate governance concern.
 
 If a startup tool name is valid, bounded, unique across the caller-visible
 startup inventory, and does not conflict with a WebCodex-reserved tool name, it
@@ -111,16 +129,15 @@ plugin_tool(action="call", binding="wc_pbind_...", arguments={"query":"foo"})
 ```
 
 `list(runner, plugin)` is a runtime observation of the already committed/effective
-provider. It resolves the exact caller-visible Runner, observes the current
-provider instance, and asks only that instance for `tools/list`. It does not
-reread `runner.toml`, start a disposable candidate, run `check`, reload a
-provider, mutate the dynamic overlay, create a binding, or alter
-`firstClassRestartRequired`. If the exact Runner/provider is replaced between
-the provider observation and `tools/list`, discovery fails closed and tells the
-caller to re-list; WebCodex never silently resolves the same logical name to the
-replacement or replays the operation. Full schemas remain exclusive to
-`describe`; list returns only bounded discovery metadata such as tool names and
-optional titles.
+provider. It resolves the exact caller-visible Runner and provider instance, then
+reads that instance's frozen catalog locally. It does **not** issue another
+provider `tools/list` round trip, reread `runner.toml`, start a disposable
+candidate, run `check`, reload a provider, mutate the dynamic overlay, create a
+binding, or alter `firstClassRestartRequired`. If the exact Runner/provider was
+replaced, discovery fails closed and tells the caller to re-list; WebCodex never
+silently resolves the same logical name to the replacement or replays the
+operation. Full schemas remain exclusive to `describe`; list returns only
+bounded discovery metadata such as tool names and optional titles.
 
 Provider-list `status` describes current effective runtime health. When the
 logical provider also existed in the frozen startup catalog, `startupAdmission`
@@ -150,7 +167,10 @@ safe, a validated tool name and finite field label such as `inputSchema`.
 Diagnostics come only from WebCodex protocol parsing/validators; raw serde
 errors, protocol lines, schema fragments, Plugin stdout/stderr, executable
 configuration, environment, and process identities are never copied into the
-report. Plugin stderr remains Runner-local.
+report. Plugin stderr remains Runner-local. The Runner keeps only a bounded,
+control-sanitized local stderr ring for live providers and the most recent
+disposable `check` candidate; this local projection is not part of the Plugin
+gateway response.
 
 `startupToolShape.eligible=true` means only that this checked provider's own Tool
 definitions satisfy the stricter per-provider startup Tool bounds. It is **not**
@@ -250,6 +270,26 @@ Messages, schemas, arguments, JSON structure, tool counts, and results are
 bounded. Malformed or unsupported data fails closed instead of being truncated
 into a different tool contract.
 
+### Native Plugin Schema Profile v1
+
+`inputSchema` and `outputSchema` use a deliberately small WebCodex profile; they
+are **not** advertised as full JSON Schema 2020-12. Every schema node requires a
+single string `type`. Supported types are `object`, `array`, `string`, `number`,
+`integer`, `boolean`, and `null`. Supported keywords are:
+
+- all nodes: `type`, optional `title`, `description`, `enum`, `const`;
+- object: `properties`, `required`, boolean `additionalProperties`;
+- string: `minLength`, `maxLength`;
+- array: `minItems`, `maxItems`, `items`.
+
+Input/output schema roots must be `type: "object"`. Property counts, required
+entries, enum size, schema bytes/depth/nodes/strings, and declared length/item
+bounds are finite. Unknown keywords are rejected at provider admission rather
+than silently ignored. In particular v1 does not support `$ref`/remote refs,
+`$defs`, recursive refs, `pattern`, `format`, numeric `minimum`/`maximum`, schema
+forms of `additionalProperties`, union `type`, `anyOf`, `oneOf`, `allOf`, `not`,
+or arbitrary draft-specific keywords.
+
 See [`examples/native-tool-plugin.mjs`](../examples/native-tool-plugin.mjs) for
 a complete no-dependency Node example.
 
@@ -257,6 +297,15 @@ a complete no-dependency Node example.
 
 Each provider handles one request at a time. Concurrent calls receive a
 provider-busy result instead of being silently queued without bound.
+
+Before `tools/call` can enter the provider connection, WebCodex resolves the
+exact frozen catalog entry, checks the caller's exact schema observation, and
+validates `arguments` against that frozen input schema. Any failure here is
+`NotStarted`; the executable sees zero `tools/call` bytes. No `tools/list` is
+performed on this path. After a provider response arrives, ordinary text/result
+bounds still apply. When an `outputSchema` exists, `structuredContent` is also
+required to match that exact frozen output schema. A mismatch is a completed
+provider contract violation and retires that provider instance fail-closed.
 
 `plugin_tool call` requires an opaque binding from a preceding `describe`.
 Bindings are bounded server-side observations, not bearer authorization tokens:
@@ -268,18 +317,23 @@ binding to a newer same-named provider/tool, never manufactures a replacement
 binding, and never replays the call. Internal Runner/provider instance ids and
 schema revision machinery are not exposed in the handle.
 
-The provider timeout is one total request budget. It starts before request
-encoding/validation and covers bounded stdin queue admission, the complete
-frame write plus flush confirmation, and the response wait. A Plugin that stops
-reading stdin therefore cannot make `write_all` escape the provider timeout.
+After the local frozen-schema preflight succeeds, the provider timeout is one
+total RPC budget. It starts before provider-request encoding and covers bounded
+stdin queue admission, the complete frame write plus flush confirmation, and the
+response wait. A Plugin that stops reading stdin therefore cannot make
+`write_all` escape the provider timeout.
 For effectful `tools/call`, once a frame may have started writing, a write
 timeout/failure, connection loss, process death, or response timeout is
 `OutcomeUnknown`; WebCodex does not automatically retry or replay it. Failures
 proven to happen before any possible send are `NotStarted`.
 
-Plugin stdout is protocol-only. Plugin stderr is drained separately for local
-diagnostics and is never treated as protocol, inserted into a model result, or
-published in the startup registration catalog.
+Plugin stdout is protocol-only. Plugin stderr is drained continuously on a
+separate worker so stderr flooding cannot backpressure stdout protocol progress.
+The local ring retains at most 64 lines, 1 KiB per line, and 32 KiB aggregate;
+control/non-UTF-8 bytes are projected safely and overlong lines are marked
+truncated. Stderr is never treated as protocol, inserted into a model ToolResult
+or Workflow Session ledger, or automatically sent to the Server/startup
+registration catalog.
 
 ## OAuth
 

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -9,6 +9,10 @@ Native Tool Plugin 允许 WebCodex Runner 把任意本地可执行程序变成�
 Plugin 进程只运行在 Runner 所在机器。Server 不会收到它的 command path、argv、
 cwd、prepared environment、PID、stderr 或本地凭据。
 
+Native Plugin 是**受信任的本地 executable**。WebCodex 不会 sandbox、隔离、签名或把
+不可信 executable 自动变安全；启动 Plugin 与在 prepared Runner environment 下直接运行
+这个本地程序具有同等级别的本机信任含义。
+
 ## 配置 Plugin
 
 Plugin 使用独立的 `runner.toml` 配置，不复用 MCP provider：
@@ -63,13 +67,23 @@ Plugin 只有两个状态平面，没有额外 draft/stable/published 状态。
 ### Startup
 
 Runner 启动时读取 `[plugins]`，为每个 provider 准备环境并启动进程，依次完成
-`initialize`、`tools/list` 和 bounded schema validation，然后冻结当前 Runner
-instance 的 startup catalog。成功 admission 的 provider 进程会保持 persistent，供
-direct call 继续使用。
+`initialize`、**一次** `tools/list` 和 bounded schema validation，然后 canonicalize
+catalog，并把它冻结到 exact `provider_instance_id`。成功 admission 的 provider 进程会
+保持 persistent，但普通 list/describe/call 不会再要求同一个 provider instance 重新
+执行 `tools/list`。
 
-startup catalog 在这个 Runner 进程生命周期内 immutable。修改 Plugin 源码、
+冻结后的 provider catalog 在这个 provider-instance 生命周期内 immutable。canonical
+validated catalog 会生成稳定 SHA-256 digest，并保留 exact Tool count，供 stale detection、
+audit 和后续 surface pinning 使用。catalog 只能通过 reload/restart 产生新的 provider
+instance 后改变；startup plane 本身在整个 Runner process lifetime 中 immutable。修改 Plugin 源码、
 `runner.toml` 或执行 `plugin_tool reload` 都不会改变一级工具。只有 Runner restart
 才会创建新的 Runner/provider instance 并重新做 startup admission。
+
+完整 provider catalog 与 startup direct-eligible subset 是两个不同 contract。
+`PLUGIN_STARTUP_MAX_DIRECT_TOOLS`（当前为 64）只是 Runner 对 direct subset 的安全上限，
+不是“provider 最多只能有 64 个 Tool”，也不是每个 model/surface 的 routing budget。只要
+完整 provider catalog 仍在自身有界 contract 内，即使 direct subset 没有被 admission，
+它仍可通过 `plugin_tool` 使用；Server-side surface budget 属于独立 governance 层。
 
 如果 startup tool 名称合法、schema 在边界内、在当前 caller-visible startup
 inventory 中唯一，并且没有和 WebCodex reserved tool 冲突，它会直接进入 MCP
@@ -103,13 +117,13 @@ plugin_tool(action="call", binding="wc_pbind_...", arguments={"query":"foo"})
 ```
 
 `list(runner, plugin)` 只观察已经 committed/effective 的 runtime provider。它先解析
-caller-visible exact Runner，再观察当前 provider instance，只对这个 exact instance 发出
-`tools/list`。它不会重新读取 `runner.toml`、启动 disposable candidate、调用 `check`、
-reload provider、修改 dynamic overlay、创建 binding，也不会改变
-`firstClassRestartRequired`。如果 provider observation 与 `tools/list` 之间发生 Runner/provider
-replacement，discovery 会 fail closed 并要求重新 list；WebCodex 不会把同名 logical provider
-静默重解析到 replacement，也不会 replay。完整 schema 仍然只能由 `describe` 观察；list
-只返回 tool name、可选 title 等有界 discovery metadata。
+caller-visible exact Runner 和 provider instance，然后直接读取这个 instance 的 frozen
+catalog；**不会**再向 provider 发出 `tools/list` round trip。它也不会重新读取
+`runner.toml`、启动 disposable candidate、调用 `check`、reload provider、修改 dynamic
+overlay、创建 binding 或改变 `firstClassRestartRequired`。如果 exact Runner/provider 已被
+replacement，discovery 会 fail closed 并要求重新 list；WebCodex 不会把同名 logical
+provider 静默重解析到 replacement，也不会 replay。完整 schema 仍然只能由 `describe`
+观察；list 只返回 tool name、可选 title 等有界 discovery metadata。
 
 provider list 中的 `status` 只表示当前 effective runtime health。logical provider 如果也存在于
 frozen startup catalog，则 `startupAdmission` 单独表示冻结的 startup admission（`direct`、
@@ -134,7 +148,9 @@ executable，完成 `initialize`、`tools/list` 与普通 Plugin protocol/bounds
 `diagnostic`：使用有限、稳定的 WebCodex-defined code，并在安全时携带 validated tool name
 以及 `inputSchema` 等有限 field label。diagnostic 只来自 WebCodex protocol parser/validator；
 不会透传 raw serde error、protocol line、schema fragment、Plugin stdout/stderr、executable
-配置、environment 或 process identity。Plugin stderr 始终留在 Runner 本机。
+配置、environment 或 process identity。Plugin stderr 始终留在 Runner 本机。Runner 只为
+live provider 与最近一次 disposable `check` candidate 保留 bounded、control-sanitized 的
+本机 stderr ring；这个 local projection 不属于 Plugin gateway response。
 
 `startupToolShape.eligible=true` 只表示这个 checked provider 自己的 Tool definitions 满足
 更严格的 provider-local startup Tool bounds；它**不保证**最终成为一级 MCP tool。实际
@@ -222,6 +238,24 @@ streaming、pagination 或 arbitrary JSON-RPC tunneling。
 message、schema、arguments、JSON depth/node/string、tool count 和 result 都有明确边界；
 非法或超限数据 fail closed，不会通过截断把它变成另一份 Tool contract。
 
+### Native Plugin Schema Profile v1
+
+`inputSchema` / `outputSchema` 使用 WebCodex 明确定义的小型 profile，**不宣称**支持完整
+JSON Schema 2020-12。每个 schema node 都必须有单一字符串 `type`，支持：`object`、
+`array`、`string`、`number`、`integer`、`boolean`、`null`。支持的 keyword 只有：
+
+- 所有 node：`type`，以及可选 `title`、`description`、`enum`、`const`；
+- object：`properties`、`required`、boolean `additionalProperties`；
+- string：`minLength`、`maxLength`；
+- array：`minItems`、`maxItems`、`items`。
+
+input/output schema root 必须是 `type: "object"`。property 数量、required 数量、enum
+长度、schema bytes/depth/nodes/string 以及声明的 length/item bounds 都有有限上限。未知
+keyword 会在 provider admission 时明确拒绝，不会 silently ignore。v1 特别**不支持**
+`$ref` / remote ref、`$defs`、recursive ref、`pattern`、`format`、numeric
+`minimum` / `maximum`、schema 形式的 `additionalProperties`、union `type`、`anyOf`、
+`oneOf`、`allOf`、`not` 或任意 draft-specific keyword。
+
 完整无依赖 Node 示例见
 [`examples/native-tool-plugin.mjs`](../examples/native-tool-plugin.mjs)。
 
@@ -229,6 +263,14 @@ message、schema、arguments、JSON depth/node/string、tool count 和 result �
 
 每个 provider 同一时间只处理一个 request。并发请求会得到 provider-busy，而不是无限
 排队。
+
+`tools/call` 进入 provider connection 之前，WebCodex 会先从 exact frozen catalog
+解析 Tool、核对 caller 的 exact schema observation，再使用 frozen input schema 校验
+`arguments`。这里任何失败都是 `NotStarted`，provider executable 会看到 **0 个**
+`tools/call` byte；call path 也不会执行 `tools/list`。provider response 返回后仍执行已有
+text/result bounds；如果 Tool 声明了 `outputSchema`，则 `structuredContent` 必须存在并
+匹配 exact frozen output schema。违约属于已完成 dispatch 后的 provider contract failure，
+WebCodex 会 fail closed 并 retire 该 provider instance。
 
 `plugin_tool call` 必须使用前一次 `describe` 返回的 opaque binding。binding 是
 Server 端有界保存的一次 exact observation，不是 bearer authorization token：每次 call
@@ -239,15 +281,19 @@ WebCodex 不会把它 re-resolve 到新的同名 provider/tool，不会自动生
 replay。内部 Runner/provider instance id 和 schema revision 不会编码到 handle 里或暴露给
 模型。
 
-provider timeout 是一次 RPC 的总预算：从 request encode/validation 前开始，同时覆盖
-bounded stdin queue admission、完整 frame 的 write + flush confirmation，以及 response
-wait。因此 Plugin 即使停止读取 stdin，`write_all` 也不能逃逸 provider timeout。对于
+local frozen-schema preflight 成功后，provider timeout 才作为一次 RPC 的总预算开始：
+它从 provider request encode 前开始，同时覆盖 bounded stdin queue admission、完整
+frame 的 write + flush confirmation，以及 response wait。因此 Plugin 即使停止读取 stdin，
+`write_all` 也不能逃逸 provider timeout。对于
 effectful `tools/call`，只要 frame 已经可能开始写入，write timeout/failure、connection
 loss、process death 或 response timeout 都返回 `OutcomeUnknown`，不会自动 retry/replay；
 只有能证明任何 byte 都不可能发送的失败才是 `NotStarted`。
 
-stdout 只用于 protocol。stderr 单独 drain，仅作为本机 diagnostic，不会自动进入模型
-result，也不会进入 startup registration catalog。
+stdout 只用于 protocol。stderr 由独立 worker 持续 drain，因此 stderr flood 不会反向
+阻塞 stdout protocol。local ring 最多保留 64 行、每行 1 KiB、aggregate 32 KiB；control /
+非 UTF-8 byte 会做安全 projection，超长行会标记 truncated。stderr 不会被当作 protocol，
+不会进入 model ToolResult 或 Workflow Session ledger，也不会自动发送到 Server / startup
+registration catalog。
 
 ## OAuth
 

--- a/src/mcp_tests/oauth_scope.rs
+++ b/src/mcp_tests/oauth_scope.rs
@@ -49,6 +49,8 @@ async fn oauth_mcp_service_with_startup_plugin(
                         name: "Repo Tools".to_string(),
                         status: "ready".to_string(),
                         error_code: None,
+                        catalog_tool_count: 1,
+                        catalog_digest: None,
                         tools: vec![webcodex_core::plugin::PluginTool {
                             name: tool_name.to_string(),
                             title: None,

--- a/src/mcp_tests/plugin_check.rs
+++ b/src/mcp_tests/plugin_check.rs
@@ -59,6 +59,8 @@ async fn register_plugin_runner(
                         name: "Repo Tools".to_string(),
                         status: "ready".to_string(),
                         error_code: None,
+                        catalog_tool_count: 1,
+                        catalog_digest: None,
                         tools: vec![direct_tool(tool_name)],
                     }]),
                     ..Default::default()

--- a/src/mcp_tests/plugin_tools.rs
+++ b/src/mcp_tests/plugin_tools.rs
@@ -171,6 +171,8 @@ async fn register_plugin_runner_with_status(
                             "ready_secondary" => Some("first_class_catalog_too_large".to_string()),
                             _ => Some("plugin_initialize_failed".to_string()),
                         },
+                        catalog_tool_count: tools.len(),
+                        catalog_digest: None,
                         tools,
                     }]),
                     ..Default::default()


### PR DESCRIPTION
## Summary

- freeze each Native Plugin provider catalog at initialize time and bind it to the exact `provider_instance_id`
- remove per-call `tools/list`; runtime list/call operations consume the frozen canonical catalog
- add a deterministic domain-separated catalog digest and keep full provider catalogs separate from the startup direct subset
- define and enforce a bounded Native Plugin Schema Profile v1 for input arguments and structured output
- preserve dispatch certainty: pre-send/schema failures are `NotStarted`, post-send uncertainty is `OutcomeUnknown`, and output-schema violations are completed provider contract failures
- retain bounded Runner-local stderr diagnostics without exposing them through Server/model/session surfaces

## Independent review hardening

Reviewer follow-up commit `f2ac5628` fixes one diagnostics race: a disposable `plugin check` previously snapshotted stderr before terminating the candidate, so bytes already written to the stderr pipe could be missed if the drain worker had not consumed them yet. Provider termination now gives the stderr worker a bounded 100 ms drain window, and check snapshots are taken after that bounded shutdown. A fixture writes stderr before the `tools/list` response to cover this ordering while confirming the diagnostic never enters the gateway response.

## Validation

Implementation evidence included Core Plugin 13/13, Runner runtime 21/21, Runner check 7/7, workspace/all-target checks, formatting and diff hygiene.

Independent reviewer validation on the final content:
- `cargo fmt --all -- --check` — passed
- `cargo test -p webcodex-runner plugin::check_tests` — 7 passed
- `cargo test -p webcodex-runner plugin::tests` — 21 passed
- `git diff --check` / staged diff check — passed
- final worktree clean

## Scope notes

- Native Plugins remain trusted local executables, not a sandbox
- the catalog digest is a canonical tool-contract fingerprint, not an executable/package identity or signature
- Server-side Plugin authority/governance and per-surface direct exposure budgets are intentionally left to the parallel specialized-tool-governance closure