### PR TITLE
Skip stale unrelated allowed roots in Runner cwd checks

### DIFF
--- a/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
+++ b/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
@@ -1,5 +1,34 @@
 use super::*;
 
+#[test]
+fn cwd_allowed_skips_missing_unrelated_root_when_later_root_matches() {
+    let allowed = tempfile::tempdir().unwrap();
+    let missing = allowed.path().join("deleted-project");
+    let policy = RunnerPolicy {
+        allow_cwd_anywhere: false,
+        allowed_roots: vec![missing, allowed.path().to_path_buf()],
+        ..RunnerPolicy::default()
+    };
+
+    cwd_allowed(&policy, allowed.path())
+        .expect("a missing unrelated root must not block a later matching root");
+}
+
+#[test]
+fn cwd_allowed_remains_fail_closed_when_no_existing_root_matches() {
+    let allowed = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let missing = allowed.path().join("deleted-project");
+    let policy = RunnerPolicy {
+        allow_cwd_anywhere: false,
+        allowed_roots: vec![missing, allowed.path().to_path_buf()],
+        ..RunnerPolicy::default()
+    };
+
+    let error = cwd_allowed(&policy, outside.path()).unwrap_err();
+    assert!(error.contains("outside allowed_roots"), "{error}");
+}
+
 #[cfg(windows)]
 #[test]
 fn shell_job_filters_sensitive_env_case_insensitive() {

--- a/crates/webcodex-runner/src/webcodex_runner/shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shell.rs
@@ -1296,10 +1296,11 @@ pub(crate) fn cwd_allowed(policy: &RunnerPolicy, cwd: &Path) -> Result<(), Strin
     }
     let cwd = canonicalize_existing(cwd)?;
     for root in &policy.allowed_roots {
-        let root = canonicalize_existing(root)?;
-        // Case-insensitive component-wise containment on Windows.
-        if webcodex_runner_config::paths::path_is_within(&cwd, &root) {
-            return Ok(());
+        if let Ok(root) = canonicalize_existing(root) {
+            // Case-insensitive component-wise containment on Windows.
+            if webcodex_runner_config::paths::path_is_within(&cwd, &root) {
+                return Ok(());
+            }
         }
     }
     Err(format!(


### PR DESCRIPTION
## Summary
- skip configured allowed roots that cannot currently be canonicalized
- continue checking later valid roots instead of failing unrelated projects
- preserve fail-closed behavior when no valid root matches

## Problem
A deleted, moved, or temporarily unavailable entry in `policy.allowed_roots` currently makes `cwd_allowed` return before checking later roots. This can block every project routed through the Runner even when the requested cwd is under a different valid root.

This matches the existing behavior in `validate_project_path_policy`, which already ignores roots that cannot be canonicalized and still denies when no valid root matches.

## Tests
- `cargo test --locked -p webcodex-runner cwd_allowed_ -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check --locked -p webcodex-runner`