### PR TITLE
Improve tool discovery and routing projections

### DIFF
--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/discovery.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/discovery.rs
@@ -57,7 +57,7 @@ pub fn tool_manifest_input_schema() -> Value {
             },
             "include_risk_summary": {
                 "type": "boolean",
-                "description": "Include risk_summary in the output (default true)."
+                "description": "Request aggregate risk_summary where the selected projection exposes it (default true). Unfiltered/full discovery can return the aggregate; sparse filtered discovery omits it and carries per-tool risk only when needed for selection. This flag does not change authority, permission, or tool behavior."
             }
         },
         "required": [],

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/common.rs
@@ -266,11 +266,11 @@ pub fn search_match_schema() -> Value {
     let context_lines = array_schema(search_context_line_schema(), "Context lines.");
     let read_hint = json!({
         "type": "object",
-        "description": "Ready-to-use read_file/read_files item for bounded expansion around this match. Reuse the same project; this hint performs no read and contains no additional file content.",
+        "description": "Ready-to-use bounded expansion range around this match. Reuse the outer match path and the same project; canonical results also repeat path here, while sparse model-facing results omit that duplicate path. This hint performs no read and contains no additional file content.",
         "properties": {
             "path": {
                 "type": "string",
-                "description": "Same trusted project-relative file path as the match."
+                "description": "Same trusted project-relative file path as the match; omitted from sparse model-facing results when identical to the outer match path."
             },
             "start_line": {
                 "type": "integer",
@@ -283,12 +283,12 @@ pub fn search_match_schema() -> Value {
                 "description": "Deterministic bounded line count for read_file/read_files expansion."
             }
         },
-        "required": ["path", "start_line", "limit"],
+        "required": ["start_line", "limit"],
         "additionalProperties": false
     });
     json!({
         "type": "object",
-        "description": "Search match with path, 1-based line, preview, bounded context lines, and deterministic search-to-read continuation metadata.",
+        "description": "Search match with path, 1-based line, preview, optional requested context lines, and deterministic search-to-read continuation metadata. Canonical results include both context arrays even when empty; sparse model-facing results omit empty arrays only.",
         "properties": {
             "path": {
                 "type": "string",
@@ -306,7 +306,7 @@ pub fn search_match_schema() -> Value {
             "context_after": context_lines,
             "read_hint": read_hint,
         },
-        "required": ["path", "line", "preview", "context_before", "context_after", "read_hint"],
+        "required": ["path", "line", "preview", "read_hint"],
         "additionalProperties": true
     })
 }

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/discovery.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/discovery.rs
@@ -220,6 +220,84 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
         ])),
         "tool_manifest" => Some(wrapped_output_schema(vec![
             (
+                "name",
+                schema_type(
+                    "string",
+                    "Exact requested tool identity in the sparse model-facing exact projection.",
+                ),
+            ),
+            (
+                "description",
+                schema_type(
+                    "string",
+                    "Canonical ToolSpec description for exact lookup, or a bounded canonical-derived selection summary in filtered tool entries.",
+                ),
+            ),
+            (
+                "route",
+                json!({
+                    "type": "object",
+                    "description": "Current ModelSurface invocation route only. This never grants scope, project authority, feature availability, or permission.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "mode": {
+                            "type": "string",
+                            "enum": ["direct", "gateway", "unavailable"]
+                        },
+                        "via": {
+                            "type": "string",
+                            "const": "call_runtime_tool",
+                            "description": "Gateway entry point, present only when mode=gateway."
+                        }
+                    },
+                    "required": ["mode"]
+                }),
+            ),
+            (
+                "input_schema",
+                open_object_schema(
+                    "Exact tool input schema in the sparse model-facing exact projection; output schema remains omitted.",
+                ),
+            ),
+            (
+                "effect",
+                schema_type(
+                    "string",
+                    "Canonical business effect: observe, mutate, or execute.",
+                ),
+            ),
+            (
+                "risk",
+                schema_type(
+                    "string",
+                    "Canonical risk class when relevant to exact lookup or filtered selection.",
+                ),
+            ),
+            (
+                "approval",
+                schema_type(
+                    "string",
+                    "Canonical interactive approval policy in exact lookup.",
+                ),
+            ),
+            (
+                "idempotency",
+                schema_type(
+                    "string",
+                    "Canonical retry/idempotency contract in exact lookup.",
+                ),
+            ),
+            (
+                "authority",
+                open_object_schema(
+                    "Canonical required-scope policy in exact lookup. Route discovery never grants these scopes.",
+                ),
+            ),
+            (
+                "annotations",
+                open_object_schema("Canonical ToolSpec annotations in exact lookup."),
+            ),
+            (
                 "schema_version",
                 schema_type("integer", "Manifest schema version."),
             ),
@@ -248,7 +326,7 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             ),
             (
                 "tool_name",
-                nullable_schema("string", "Exact requested tool name in one-tool contract mode, or null."),
+                nullable_schema("string", "Compatibility/full canonical exact requested tool name. The default sparse model projection uses name instead."),
             ),
             (
                 "contract",
@@ -359,16 +437,16 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
             (
                 "categories",
                 open_object_schema(
-                    "Map of category name to the list of tool names in that category.",
+                    "Global category inventory in unfiltered discovery. Compatibility/full canonical results may also carry it for filtered/exact calls, but the default sparse model projection omits unrelated inventory.",
                 ),
             ),
             (
                 "tools",
                 array_schema(
                     open_object_schema(
-                        "Compact tool entry: name, category, accepted_flattened_args, deprecated_or_unsupported_args, provider, effect, risk, approval, idempotency, read_only, requires_project, path_hint, destructive, shell_like, authority, availability, gateway_tool. authority is the canonical required-scope policy; availability is MCP ModelSurface routing only, not authorization."
+                        "Default filtered model projection: name, bounded canonical-derived description, route, requires_project, effect, and risk only when non-observe. Compatibility/full canonical results may retain richer metadata."
                     ),
-                    "Compact tool entries without input/output schemas.",
+                    "Filtered selection entries without input/output schemas; unfiltered sparse discovery uses the categories inventory instead of duplicating all tool names here.",
                 ),
             ),
             (

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/files.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/files.rs
@@ -199,6 +199,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 }),
             ),
             (
+                "continuation",
+                search_refinement_continuation_schema(),
+            ),
+            (
                 "exit_code",
                 nullable_schema("integer", "Search command exit code, when available."),
             ),
@@ -314,6 +318,29 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
     }
 }
 
+fn search_refinement_continuation_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Model-facing recovery hint for a single truncated query. Search match order is not a stable cursor, so this requires query refinement rather than offset paging.",
+        "properties": {
+            "kind": {"type": "string", "const": "refine_query"},
+            "safe_cursor": {"type": "boolean", "const": false},
+            "refine_with": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 5,
+                "uniqueItems": true,
+                "items": {
+                    "type": "string",
+                    "enum": ["path", "include_globs", "pattern", "result_mode", "limit"]
+                }
+            }
+        },
+        "required": ["kind", "safe_cursor", "refine_with"]
+    })
+}
+
 fn search_project_texts_output_schema() -> Value {
     let search_success_properties = json!({
         "path": schema_type("string", "Effective project-relative search root; omitted for the default project root in sparse complete matches success."),
@@ -337,7 +364,8 @@ fn search_project_texts_output_schema() -> Value {
                 {"type": "string", "enum": ["limit", "output_bytes", "timeout", "transport"]},
                 {"type": "null"}
             ]
-        }
+        },
+        "continuation": search_refinement_continuation_schema()
     });
     let search_success_full = json!({
         "type": "object",
@@ -353,13 +381,53 @@ fn search_project_texts_output_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "path": search_success_properties["path"].clone(),
+            "pattern_mode": {"type": "string", "const": "literal"},
+            "effective_timeout_secs": search_success_properties["effective_timeout_secs"].clone(),
+            "context_before": search_success_properties["context_before"].clone(),
+            "context_after": search_success_properties["context_after"].clone(),
             "matches": search_success_properties["matches"].clone()
         },
         "required": ["matches"],
-        "description": "Sparse model-facing form for ordinary complete rg matches-mode success under the default timeout and zero context. Omitted metadata means the documented boring defaults."
+        "description": "Sparse model-facing form for complete rg matches-mode success. Literal mode, custom timeout, non-root path, and requested context counts remain explicit; boring defaults are omitted."
+    });
+    let search_success_sparse_files = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "path": search_success_properties["path"].clone(),
+            "result_mode": {"type": "string", "const": "files_with_matches"},
+            "pattern_mode": {"type": "string", "const": "literal"},
+            "effective_timeout_secs": search_success_properties["effective_timeout_secs"].clone(),
+            "context_before": search_success_properties["context_before"].clone(),
+            "context_after": search_success_properties["context_after"].clone(),
+            "files": search_success_properties["files"].clone()
+        },
+        "required": ["result_mode", "files"],
+        "description": "Sparse model-facing form for complete rg files_with_matches success; files are the primary result and redundant returned-file counts are omitted."
+    });
+    let search_success_sparse_count = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "path": search_success_properties["path"].clone(),
+            "result_mode": {"type": "string", "const": "count"},
+            "pattern_mode": {"type": "string", "const": "literal"},
+            "effective_timeout_secs": search_success_properties["effective_timeout_secs"].clone(),
+            "context_before": search_success_properties["context_before"].clone(),
+            "context_after": search_success_properties["context_after"].clone(),
+            "files": search_success_properties["files"].clone(),
+            "total_matches": {"type": "integer", "minimum": 0}
+        },
+        "required": ["result_mode", "total_matches"],
+        "description": "Sparse model-facing form for complete rg count success. total_matches is authoritative; optional files retain bounded per-path grouping and redundant count bookkeeping is omitted."
     });
     let search_success = json!({
-        "anyOf": [search_success_full, search_success_sparse_matches]
+        "anyOf": [
+            search_success_full,
+            search_success_sparse_matches,
+            search_success_sparse_files,
+            search_success_sparse_count
+        ]
     });
     let search_failure = json!({
         "type": "object",

--- a/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
+++ b/crates/webcodex-tool-contracts/src/tests/catalog_discovery.rs
@@ -87,6 +87,15 @@ fn tool_manifest_schema_exposes_compact_discovery_fields() {
         "tool_manifest input schema",
         present: ["category", "intent", "include_recommended_flows", "include_risk_summary"]
     );
+    let risk_summary_description = props["include_risk_summary"]["description"]
+        .as_str()
+        .expect("include_risk_summary description");
+    assert!(risk_summary_description.contains("where the selected projection exposes it"));
+    assert!(risk_summary_description.contains("Unfiltered/full discovery can return the aggregate"));
+    assert!(risk_summary_description.contains("sparse filtered discovery omits it"));
+    assert!(risk_summary_description
+        .contains("does not change authority, permission, or tool behavior"));
+    assert!(!risk_summary_description.contains("Include risk_summary in the output"));
     let output = spec.output_schema["properties"]["output"]["properties"]
         .as_object()
         .unwrap();

--- a/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
@@ -912,6 +912,7 @@ fn key_tool_output_schemas_include_expected_fields() {
         "total_matches",
         "truncated",
         "truncation_reason",
+        "continuation",
         "context_before",
         "context_after",
     ] {

--- a/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
+++ b/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
@@ -23,15 +23,31 @@ fn tool_specs_describe_default_coding_loop_preferences() {
         "default inspect/search tool",
         "rg-first",
         "grep fallback",
-        "structured output",
+        "pattern_mode=literal",
         "matches",
         "context",
-        "backend",
         "truncated",
+        "no safe match cursor",
+        "refine",
     ] {
         assert!(
             search_desc.contains(phrase),
             "search_project_text description should mention {phrase}: {search_desc}"
+        );
+    }
+
+    let batch_search_desc = desc("search_project_texts");
+    for phrase in [
+        "pattern_mode=literal",
+        "request context explicitly",
+        "whole-query",
+        "authoritative next_index",
+        "no safe match cursor",
+        "refined",
+    ] {
+        assert!(
+            batch_search_desc.contains(phrase),
+            "search_project_texts description should mention {phrase}: {batch_search_desc}"
         );
     }
 

--- a/crates/webcodex-tool-contracts/src/tool_definition/discovery.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/discovery.rs
@@ -170,7 +170,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Global runtime discovery; do not pass project. Filter by category/intent, or pass exact tool_name for one contract with description + input schema and no output schema. The returned tool may itself require project. Discovery never changes behavior, authority, permissions, execution, or verdicts.",
+            "Global runtime discovery; do not pass project. Filter by category/intent for sparse selection entries, or pass exact tool_name for one compact contract with description, route, input schema, and safety/authority hints but no output schema. Unfiltered discovery retains the global category inventory. Discovery never changes behavior, authority, permissions, execution, or verdicts.",
             tool_manifest_input_schema,
         )),
         30,

--- a/crates/webcodex-tool-contracts/src/tool_definition/files.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/files.rs
@@ -103,7 +103,7 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
             false,
             false,
         ),
-        "Default inspect/search tool for project text. Uses rg-first with grep fallback. Regex is default; prefer pattern_mode=literal for exact identifiers, snippets, and paths. Supports matches/files_with_matches/count and context. Structured output reports backend, truncated, and failure metadata.",
+        "Default inspect/search tool for project text. Uses rg-first with grep fallback. Regex is default; prefer pattern_mode=literal for exact identifiers, snippets, and paths, and request context explicitly when needed. Supports matches/files_with_matches/count. A truncated single search has no safe match cursor: refine the query/path/globs/mode/limit instead of inventing an offset. Failure and fallback diagnostics remain explicit.",
         search_project_text_input_schema,
     )),
     adaptive_runtime_direct(
@@ -126,7 +126,7 @@ pub(super) const SEARCH_DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Run 1 to 8 independent project-text searches with isolated failures and at most two Runner requests in flight. Each query defaults to regex; prefer pattern_mode=literal for identifiers, snippets, paths, and exact text. Budget continuation is whole-query via next_index.",
+            "Run 1 to 8 independent project-text searches with isolated failures and at most two Runner requests in flight. Each query defaults to regex; prefer pattern_mode=literal for identifiers, snippets, paths, and exact text, and request context explicitly. Batch continuation is whole-query via authoritative next_index; an individual truncated query has no safe match cursor and should be refined instead.",
             search_project_texts_input_schema,
         )),
         40,

--- a/docs/agent/openapi-guidelines.md
+++ b/docs/agent/openapi-guidelines.md
@@ -58,8 +58,10 @@ or implementation-only fields into the model-facing Action schema.
 - `listRuntimeTools` full detail discovery includes expanded schemas and may be
   too large for GPT Actions. Daily discovery should prefer
   `callRuntimeTool(tool="tool_manifest")`; once the exact target is known, pass
-  `tool_name=<exact-name>` to that manifest call to retrieve only its description,
-  input schema, and annotations. Full output schemas stay out of this exact view.
+  `tool_name=<exact-name>` to that manifest call to retrieve its description, input
+  schema, current invocation route, and decision-relevant effect/risk/authority
+  metadata. Full output schemas and duplicate inventory bookkeeping stay out of
+  this exact view.
   Focused `listRuntimeTools` calls should be reserved for schema/debug work and
   pass `summary_only=true` with `category`, `features`, or `limit`. Prefer
   `runtime_status` or the tool manifest for the current tool count; the

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -21,9 +21,7 @@ use crate::tool_runtime::specialized::SpecializedGovernanceDenial;
 use crate::tool_runtime::tool_definition::{
     is_adaptive_runtime_direct_tool, runtime_tool_accepts_context_ack, LOCAL_CODING_TOOL_NAMES,
 };
-#[cfg(test)]
-use crate::tool_runtime::ToolResult;
-use crate::tool_runtime::{registered_tool_specs, ToolCall, ToolRuntime, ToolSpec};
+use crate::tool_runtime::{registered_tool_specs, ToolCall, ToolResult, ToolRuntime, ToolSpec};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
@@ -143,18 +141,48 @@ fn adaptive_runtime_gateway_tool_spec() -> ToolSpec {
     }
 }
 
-fn adaptive_runtime_gateway_target_allowed(target: &str, stateless_2026: bool) -> bool {
-    if target == ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME || is_adaptive_runtime_direct_tool(target) {
-        return false;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdaptiveRuntimeGatewayTargetRoute {
+    Gateway,
+    Direct,
+    Recursive,
+    Unknown,
+}
+
+fn adaptive_runtime_gateway_target_route(
+    target: &str,
+    stateless_2026: bool,
+) -> AdaptiveRuntimeGatewayTargetRoute {
+    if target == ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME {
+        return AdaptiveRuntimeGatewayTargetRoute::Recursive;
     }
+    match ModelSurface::AdaptiveRuntime.runtime_tool_invocation_route(target) {
+        (crate::model_surface::TOOL_SURFACE_AVAILABILITY_DIRECT, None) => {
+            return AdaptiveRuntimeGatewayTargetRoute::Direct;
+        }
+        (
+            crate::model_surface::TOOL_SURFACE_AVAILABILITY_GATEWAY,
+            Some(ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME),
+        ) => {
+            return AdaptiveRuntimeGatewayTargetRoute::Gateway;
+        }
+        _ => {}
+    }
+    // MCP/SSH adapters and stateless operator extensions are intentionally not
+    // registered ToolDefinition routes. Preserve their existing gateway-only
+    // admission without teaching ordinary runtime tools a second route table.
     if target == crate::mcp_gateway::MCP_TOOL_NAME
         || target == crate::ssh_resource_gateway::SSH_RESOURCE_TOOL_NAME
     {
-        return true;
+        return AdaptiveRuntimeGatewayTargetRoute::Gateway;
     }
-    adaptive_runtime_gateway_target_specs(stateless_2026)
+    if adaptive_runtime_gateway_target_specs(stateless_2026)
         .iter()
         .any(|spec| spec.name == target)
+    {
+        return AdaptiveRuntimeGatewayTargetRoute::Gateway;
+    }
+    AdaptiveRuntimeGatewayTargetRoute::Unknown
 }
 
 fn unwrap_adaptive_runtime_gateway_arguments(
@@ -172,11 +200,6 @@ fn unwrap_adaptive_runtime_gateway_arguments(
         .ok_or_else(|| {
             "adaptive runtime gateway field 'tool' must be a non-empty string".to_string()
         })?;
-    if !adaptive_runtime_gateway_target_allowed(&target, stateless_2026) {
-        return Err(format!(
-            "tool '{target}' is not available through the adaptive runtime gateway"
-        ));
-    }
     let mut target_arguments = outer.remove("arguments").unwrap_or_else(|| json!({}));
     if target_arguments.is_null() {
         target_arguments = json!({});
@@ -208,6 +231,39 @@ fn unwrap_adaptive_runtime_gateway_arguments(
         }
     }
     Ok((target, target_arguments))
+}
+
+fn adaptive_runtime_gateway_route_failure(target: &str) -> ToolResult {
+    ToolResult::err_with_output(
+        format!("tool '{target}' must be invoked directly on the adaptive runtime surface"),
+        json!({
+            "error_kind": "wrong_invocation_route",
+            "execution_state": "not_started",
+            "state_changed": false,
+            "target_tool": target,
+            "correct_route": {
+                "mode": "direct"
+            },
+            "recovery": {
+                "tool": target,
+                "route": {"mode": "direct"}
+            },
+            "recovery_kind": "fix_input"
+        }),
+    )
+}
+
+fn adaptive_runtime_gateway_unknown_target(target: &str) -> ToolResult {
+    ToolResult::err_with_output(
+        format!("unknown adaptive runtime tool '{target}'"),
+        json!({
+            "error_kind": "unknown_tool",
+            "execution_state": "not_started",
+            "state_changed": false,
+            "target_tool": target,
+            "recovery_kind": "fix_input"
+        }),
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -1188,8 +1244,72 @@ pub(super) async fn handle_call(
                     return McpOutcome::BadRequest(rpc_error(id, -32602, message));
                 }
             };
-        params.name = target;
-        params.arguments = arguments;
+        match adaptive_runtime_gateway_target_route(&target, stateless_2026) {
+            AdaptiveRuntimeGatewayTargetRoute::Gateway => {
+                params.name = target;
+                params.arguments = arguments;
+            }
+            AdaptiveRuntimeGatewayTargetRoute::Direct => {
+                if let Err(ToolCallErrorStatus::InsufficientScope {
+                    required_scope,
+                    description,
+                }) = check_runtime_tool_scope(auth, &target)
+                {
+                    if let Some(lc) = lifecycle.as_deref() {
+                        lc.dispatch_failed("forbidden");
+                        lc.dispatch_finished(false, Some(false), "forbidden");
+                    }
+                    return scope_forbidden(auth, required_scope, description);
+                }
+                if let Some(lc) = lifecycle.as_deref() {
+                    lc.dispatch_failed("wrong_invocation_route");
+                    lc.dispatch_finished(false, Some(false), "wrong_invocation_route");
+                }
+                let completion = ModelErgonomicsTimer::start(&target).map(|timer| timer.finish());
+                let rendered = mcp_runtime_tool_result_fallback(
+                    adaptive_runtime_gateway_route_failure(&target),
+                );
+                if let (Some(slot), Some(completion)) =
+                    (model_ergonomics_out.as_deref_mut(), completion.as_ref())
+                {
+                    *slot = rendered.get("structuredContent").and_then(|structured| {
+                        completion.record_for_structured_content(structured)
+                    });
+                }
+                return McpOutcome::Ok(rpc_result(
+                    id,
+                    if stateless_2026 {
+                        mcp_stateless_result(rendered, false)
+                    } else {
+                        rendered
+                    },
+                ));
+            }
+            AdaptiveRuntimeGatewayTargetRoute::Unknown => {
+                if let Some(lc) = lifecycle.as_deref() {
+                    lc.dispatch_failed("unknown_tool");
+                    lc.dispatch_finished(false, Some(false), "unknown_tool");
+                }
+                let rendered = mcp_runtime_tool_result_fallback(
+                    adaptive_runtime_gateway_unknown_target(&target),
+                );
+                return McpOutcome::Ok(rpc_result(
+                    id,
+                    if stateless_2026 {
+                        mcp_stateless_result(rendered, false)
+                    } else {
+                        rendered
+                    },
+                ));
+            }
+            AdaptiveRuntimeGatewayTargetRoute::Recursive => {
+                return McpOutcome::BadRequest(rpc_error(
+                    id,
+                    -32602,
+                    "call_runtime_tool cannot target itself through the adaptive runtime gateway",
+                ));
+            }
+        }
     }
     if let Some(lc) = lifecycle.as_deref() {
         let audit = if params.name == crate::plugin_gateway::PLUGIN_TOOL_NAME {

--- a/src/mcp_tests/model_ergonomics.rs
+++ b/src/mcp_tests/model_ergonomics.rs
@@ -176,6 +176,99 @@ async fn http_mcp_tools_list_stateless_audit_measures_final_compact_result_and_s
         .is_empty());
 }
 
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn http_mcp_wrong_route_then_corrected_call_is_queryable_without_new_telemetry_schema() {
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::AdaptiveRuntime));
+    let service = Service::new(build_test_router(config, db.clone(), runtime));
+
+    let mut wrong = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .add_header(
+            MCP_NAME_HEADER,
+            crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+            true,
+        )
+        .add_header("x-action-session-id", "wrong-route-recovery", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 301,
+            "method": "tools/call",
+            "params": mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {"tool": "runtime_status", "arguments": {"summary_only": true}}
+            }))
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&wrong), StatusCode::OK);
+    let wrong_body: Value = wrong.take_json().await.unwrap();
+    assert_eq!(wrong_body["result"]["structuredContent"]["success"], false);
+    assert_eq!(
+        wrong_body["result"]["structuredContent"]["output"]["error_kind"],
+        "wrong_invocation_route"
+    );
+
+    let mut corrected = TestClient::post("http://localhost/mcp")
+        .bearer_auth("secret")
+        .add_header(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_STATELESS_PROTOCOL_VERSION,
+            true,
+        )
+        .add_header(MCP_METHOD_HEADER, "tools/call", true)
+        .add_header(MCP_NAME_HEADER, "runtime_status", true)
+        .add_header("x-action-session-id", "wrong-route-recovery", true)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 302,
+            "method": "tools/call",
+            "params": mcp_2026_params(json!({
+                "name": "runtime_status",
+                "arguments": {"summary_only": true}
+            }))
+        }))
+        .send(&service)
+        .await;
+    assert_eq!(effective_status(&corrected), StatusCode::OK);
+    let corrected_body: Value = corrected.take_json().await.unwrap();
+    assert_eq!(
+        corrected_body["result"]["structuredContent"]["success"],
+        true
+    );
+
+    let events = db.list_action_events("wrong-route-recovery", 10).unwrap();
+    assert_eq!(events.len(), 2);
+    let telemetry = events
+        .iter()
+        .filter_map(|event| serde_json::from_str::<Value>(&event.summary_json).ok())
+        .filter_map(|summary| summary.get("model_ergonomics").cloned())
+        .collect::<Vec<_>>();
+    assert_eq!(telemetry.len(), 2);
+    let wrong = telemetry
+        .iter()
+        .find(|record| record["error_kind"] == "wrong_invocation_route")
+        .expect("wrong-route telemetry");
+    assert_eq!(wrong["tool_name"], "runtime_status");
+    assert_eq!(wrong["success"], false);
+    assert_eq!(wrong["execution_state"], "not_started");
+    assert!(wrong["serialized_result_bytes"].as_u64().is_some());
+    let corrected = telemetry
+        .iter()
+        .find(|record| record["success"] == true)
+        .expect("corrected success telemetry");
+    assert_eq!(corrected["tool_name"], "runtime_status");
+    assert!(corrected["error_kind"].is_null());
+}
+
 #[tokio::test]
 async fn http_mcp_tools_list_audit_sink_failure_is_non_blocking() {
     let config = test_config(Some("secret"));

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -913,10 +913,103 @@ async fn adaptive_runtime_tool_manifest_unfiltered_keeps_global_category_discove
     assert!(output["available_intents"]
         .as_array()
         .is_some_and(|intents| !intents.is_empty()));
+    assert!(output["risk_summary"]
+        .as_object()
+        .is_some_and(|summary| !summary.is_empty()));
     assert!(
         output.get("tools").is_none(),
         "unfiltered discovery should not duplicate all category names"
     );
+
+    let without_risk_summary = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(72431)),
+            mcp_2026_params(json!({
+                "name": "tool_manifest",
+                "arguments": {"include_risk_summary": false}
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(without_risk_summary) = without_risk_summary else {
+        panic!("unfiltered tool_manifest without risk summary must succeed");
+    };
+    assert!(
+        without_risk_summary["result"]["structuredContent"]["output"]
+            .get("risk_summary")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn adaptive_runtime_tool_manifest_category_projection_avoids_duplicate_filter_metadata() {
+    let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let canonical = runtime
+        .dispatch(crate::tool_runtime::ToolCall::ToolManifest {
+            tool_name: None,
+            category: Some("file".to_string()),
+            intent: None,
+            include_recommended_flows: true,
+            include_risk_summary: true,
+        })
+        .await;
+    assert_eq!(canonical.output["category"], "file");
+    assert_eq!(canonical.output["categories_requested"], json!(["file"]));
+
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(72432)),
+            mcp_2026_params(json!({
+                "name": "tool_manifest",
+                "arguments": {"category": "file"}
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = outcome else {
+        panic!("category-filtered tool_manifest must succeed");
+    };
+    let output = &value["result"]["structuredContent"]["output"];
+    assert_eq!(output["category"], "file");
+    assert!(output.get("categories_requested").is_none());
+    assert!(output.get("categories").is_none());
+    assert!(output.get("risk_summary").is_none());
+
+    let tools = output["tools"].as_array().expect("category sparse tools");
+    let canonical_tools = canonical.output["tools"]
+        .as_array()
+        .expect("canonical category tools");
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool["name"].clone())
+            .collect::<Vec<_>>(),
+        canonical_tools
+            .iter()
+            .map(|tool| tool["name"].clone())
+            .collect::<Vec<_>>(),
+        "category filtering must preserve canonical tool order"
+    );
+    for tool in tools {
+        assert!(tool["description"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty()));
+        assert!(matches!(
+            tool["route"]["mode"].as_str(),
+            Some("direct" | "gateway")
+        ));
+        assert!(tool["requires_project"].is_boolean());
+        assert!(tool["effect"].is_string());
+        if tool["effect"] != "observe" {
+            assert!(tool["risk"].is_string());
+        }
+    }
 }
 
 #[tokio::test]

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -545,16 +545,9 @@ async fn adaptive_runtime_gateway_uses_long_tail_target_checkpoint_policy_once()
 }
 
 #[tokio::test]
-async fn adaptive_runtime_gateway_rejects_recursive_and_unknown_targets() {
+async fn adaptive_runtime_gateway_returns_exact_route_recovery_without_dispatching_direct_tools() {
     let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
-    for target in [
-        crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
-        "runtime_status",
-        "read_files",
-        "work_on_project",
-        "start_coding_task",
-        "not_a_real_webcodex_tool",
-    ] {
+    for target in ["runtime_status", "read_files", "work_on_project"] {
         let outcome = handle_mcp_request(
             &runtime,
             rpc(
@@ -568,30 +561,200 @@ async fn adaptive_runtime_gateway_rejects_recursive_and_unknown_targets() {
             None,
         )
         .await;
-        match outcome {
-            McpOutcome::BadRequest(value) => {
-                assert_eq!(value["error"]["code"], -32602);
-                assert_eq!(
-                    value["error"]["message"],
-                    format!(
-                        "tool '{target}' is not available through the adaptive runtime gateway"
-                    )
-                );
-            }
-            other => panic!("target {target} must fail closed, got {other:?}"),
-        }
+        let McpOutcome::Ok(value) = outcome else {
+            panic!("known direct target {target} should return structured recovery");
+        };
+        let structured = &value["result"]["structuredContent"];
+        assert_eq!(structured["success"], false);
+        let output = &structured["output"];
+        assert_eq!(output["error_kind"], "wrong_invocation_route");
+        assert_eq!(output["execution_state"], "not_started");
+        assert_eq!(output["state_changed"], false);
+        assert_eq!(output["target_tool"], target);
+        assert_eq!(output["correct_route"]["mode"], "direct");
+        assert_eq!(output["recovery"]["tool"], target);
+        assert_eq!(output["recovery"]["route"]["mode"], "direct");
+        assert_eq!(output["recovery_kind"], "fix_input");
     }
+
+    let unknown = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7231)),
+            mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {"tool": "not_a_real_webcodex_tool", "arguments": {}}
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = unknown else {
+        panic!("unknown gateway target should return a structured unknown-tool result");
+    };
+    let output = &value["result"]["structuredContent"]["output"];
+    assert_eq!(output["error_kind"], "unknown_tool");
+    assert_eq!(output["execution_state"], "not_started");
+    assert_eq!(output["state_changed"], false);
+    assert!(output.get("correct_route").is_none());
+
+    let recursive = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7232)),
+            mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {
+                    "tool": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                    "arguments": {}
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::BadRequest(value) = recursive else {
+        panic!("recursive adaptive gateway target must remain invalid arguments");
+    };
+    assert_eq!(value["error"]["code"], -32602);
 }
 
 #[tokio::test]
-async fn adaptive_runtime_tool_manifest_describes_one_long_tail_contract_without_expanding_surface()
-{
+async fn adaptive_runtime_gateway_route_classification_does_not_mask_target_scope_denials() {
     let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let mut auth = crate::auth::AuthContext::new(crate::auth::AuthKind::OAuth2Token);
+    auth.scopes = vec![crate::auth::SCOPE_RUNTIME_READ.to_string()];
+
+    let direct_target = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7233)),
+            mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {
+                    "tool": "read_files",
+                    "arguments": {"project": "missing-project", "items": [{"path": "src/lib.rs"}]}
+                }
+            })),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Forbidden {
+        required_scope,
+        body,
+    } = direct_target
+    else {
+        panic!("wrong-route read_files must not mask its canonical scope denial");
+    };
+    assert_eq!(required_scope, Some(crate::auth::SCOPE_PROJECT_READ));
+    assert!(body.to_string().contains(crate::auth::SCOPE_PROJECT_READ));
+    assert!(!body.to_string().contains("wrong_invocation_route"));
+
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7234)),
+            mcp_2026_params(json!({
+                "name": crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME,
+                "arguments": {
+                    "tool": "read_file",
+                    "arguments": {"project": "missing-project", "path": "src/lib.rs"}
+                }
+            })),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Forbidden {
+        required_scope,
+        body,
+    } = outcome
+    else {
+        panic!("gateway-routed read_file must retain its canonical scope denial");
+    };
+    assert_eq!(required_scope, Some(crate::auth::SCOPE_PROJECT_READ));
+    assert!(body.to_string().contains(crate::auth::SCOPE_PROJECT_READ));
+    assert!(!body.to_string().contains("wrong_invocation_route"));
+}
+
+#[tokio::test]
+async fn adaptive_runtime_tool_manifest_exact_projection_is_sparse_and_routes_explicitly() {
+    let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let canonical_direct = runtime
+        .dispatch(crate::tool_runtime::ToolCall::ToolManifest {
+            tool_name: Some("read_files".to_string()),
+            category: None,
+            intent: None,
+            include_recommended_flows: true,
+            include_risk_summary: true,
+        })
+        .await;
     let described = handle_mcp_request(
         &runtime,
         rpc(
             "tools/call",
             Some(json!(724)),
+            mcp_2026_params(json!({
+                "name": "tool_manifest",
+                "arguments": {
+                    "tool_name": "read_files"
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = described else {
+        panic!("adaptive tool_manifest exact contract must succeed");
+    };
+    let output = &value["result"]["structuredContent"]["output"];
+    assert_eq!(output["name"], "read_files");
+    assert!(output["description"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+    assert_eq!(output["route"]["mode"], "direct");
+    assert!(output["route"].get("via").is_none());
+    assert_eq!(output["input_schema"]["type"], "object");
+    assert!(output["input_schema"]["properties"]["items"].is_object());
+    assert_eq!(output["effect"], "observe");
+    assert!(output["authority"]["scopes"].is_array());
+    assert!(output["annotations"].is_object());
+    for redundant in [
+        "tool_name",
+        "contract",
+        "tools",
+        "count",
+        "returned_count",
+        "filtered_count",
+        "categories",
+        "available_intents",
+        "gateway_tool",
+    ] {
+        assert!(
+            output.get(redundant).is_none(),
+            "exact sparse manifest retained redundant field {redundant}: {output}"
+        );
+    }
+    let canonical_bytes = serde_json::to_vec(&canonical_direct).unwrap().len();
+    let sparse_bytes = serde_json::to_vec(&value["result"]["structuredContent"])
+        .unwrap()
+        .len();
+    eprintln!("tool_manifest_exact_bytes before={canonical_bytes} after={sparse_bytes}");
+    assert!(
+        sparse_bytes < canonical_bytes,
+        "{canonical_bytes} -> {sparse_bytes}"
+    );
+
+    let gateway = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7241)),
             mcp_2026_params(json!({
                 "name": "tool_manifest",
                 "arguments": {
@@ -604,51 +767,16 @@ async fn adaptive_runtime_tool_manifest_describes_one_long_tail_contract_without
         None,
     )
     .await;
-    let McpOutcome::Ok(value) = described else {
-        panic!("adaptive tool_manifest exact contract must succeed");
+    let McpOutcome::Ok(value) = gateway else {
+        panic!("adaptive tool_manifest gateway contract must succeed");
     };
-    let output = &value["result"]["structuredContent"]["output"];
-    assert_eq!(output["tool_name"], "run_script");
-    assert_eq!(output["contract"]["name"], "run_script");
-    assert_eq!(output["contract"]["availability"], "gateway");
+    let gateway_output = &value["result"]["structuredContent"]["output"];
+    assert_eq!(gateway_output["name"], "run_script");
+    assert_eq!(gateway_output["route"]["mode"], "gateway");
     assert_eq!(
-        output["contract"]["gateway_tool"],
+        gateway_output["route"]["via"],
         crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME
     );
-    assert_eq!(output["tools"][0]["availability"], "gateway");
-    assert_eq!(
-        output["tools"][0]["gateway_tool"],
-        crate::mcp::tools::ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME
-    );
-    assert_eq!(output["contract"]["input_schema"]["type"], "object");
-    assert!(output["contract"]["input_schema"]["properties"]["script"].is_object());
-    assert!(output["contract"].get("output_schema").is_none());
-
-    let direct = handle_mcp_request(
-        &runtime,
-        rpc(
-            "tools/call",
-            Some(json!(7241)),
-            mcp_2026_params(json!({
-                "name": "tool_manifest",
-                "arguments": {
-                    "tool_name": "runtime_status",
-                    "include_recommended_flows": false,
-                    "include_risk_summary": false
-                }
-            })),
-        ),
-        None,
-    )
-    .await;
-    let McpOutcome::Ok(value) = direct else {
-        panic!("adaptive tool_manifest direct contract must succeed");
-    };
-    let direct_output = &value["result"]["structuredContent"]["output"];
-    assert_eq!(direct_output["contract"]["availability"], "direct");
-    assert!(direct_output["contract"]["gateway_tool"].is_null());
-    assert_eq!(direct_output["tools"][0]["availability"], "direct");
-    assert!(direct_output["tools"][0]["gateway_tool"].is_null());
 
     let listed = handle_mcp_request(
         &runtime,
@@ -664,6 +792,131 @@ async fn adaptive_runtime_tool_manifest_describes_one_long_tail_contract_without
         .unwrap()
         .iter()
         .any(|tool| tool["name"] == "run_script"));
+}
+
+#[tokio::test]
+async fn adaptive_runtime_tool_manifest_filtered_projection_is_selection_focused() {
+    let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let canonical = runtime
+        .dispatch(crate::tool_runtime::ToolCall::ToolManifest {
+            tool_name: None,
+            category: None,
+            intent: Some("exploration".to_string()),
+            include_recommended_flows: true,
+            include_risk_summary: true,
+        })
+        .await;
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7242)),
+            mcp_2026_params(json!({
+                "name": "tool_manifest",
+                "arguments": {"intent": "exploration"}
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = outcome else {
+        panic!("intent-filtered tool_manifest must succeed");
+    };
+    let output = &value["result"]["structuredContent"]["output"];
+    assert_eq!(output["intent"], "exploration");
+    assert!(output.get("categories").is_none());
+    assert!(output.get("available_intents").is_none());
+    assert!(output.get("risk_summary").is_none());
+    assert!(output.get("count").is_none());
+    assert!(output.get("returned_count").is_none());
+    assert!(output.get("filtered_count").is_none());
+    assert!(output.get("truncated").is_none());
+    let tools = output["tools"].as_array().expect("filtered sparse tools");
+    assert_eq!(
+        tools.len(),
+        canonical.output["tools"].as_array().unwrap().len()
+    );
+    for tool in tools {
+        assert!(tool["name"].is_string());
+        let description = tool["description"].as_str().expect("selection description");
+        assert!(!description.is_empty());
+        assert!(description.chars().count() <= 180, "{description}");
+        assert!(matches!(
+            tool["route"]["mode"].as_str(),
+            Some("direct" | "gateway")
+        ));
+        assert!(tool["requires_project"].is_boolean());
+        assert!(tool["effect"].is_string());
+        for verbose in [
+            "accepted_flattened_args",
+            "deprecated_or_unsupported_args",
+            "provider",
+            "approval",
+            "idempotency",
+            "path_hint",
+            "shell_like",
+            "authority",
+            "availability",
+            "gateway_tool",
+        ] {
+            assert!(tool.get(verbose).is_none(), "{verbose} leaked into {tool}");
+        }
+    }
+    let canonical_names = canonical.output["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].clone())
+        .collect::<Vec<_>>();
+    let sparse_names = tools
+        .iter()
+        .map(|tool| tool["name"].clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        sparse_names, canonical_names,
+        "intent ordering must stay deterministic"
+    );
+    let canonical_bytes = serde_json::to_vec(&canonical).unwrap().len();
+    let sparse_bytes = serde_json::to_vec(&value["result"]["structuredContent"])
+        .unwrap()
+        .len();
+    eprintln!("tool_manifest_exploration_bytes before={canonical_bytes} after={sparse_bytes}");
+    assert!(
+        sparse_bytes < canonical_bytes,
+        "{canonical_bytes} -> {sparse_bytes}"
+    );
+}
+
+#[tokio::test]
+async fn adaptive_runtime_tool_manifest_unfiltered_keeps_global_category_discovery() {
+    let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7243)),
+            mcp_2026_params(json!({"name": "tool_manifest", "arguments": {}})),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = outcome else {
+        panic!("unfiltered tool_manifest must succeed");
+    };
+    let output = &value["result"]["structuredContent"]["output"];
+    assert!(output["tool_count"]
+        .as_u64()
+        .is_some_and(|count| count > 100));
+    assert!(output["categories"]
+        .as_object()
+        .is_some_and(|categories| !categories.is_empty()));
+    assert!(output["available_intents"]
+        .as_array()
+        .is_some_and(|intents| !intents.is_empty()));
+    assert!(
+        output.get("tools").is_none(),
+        "unfiltered discovery should not duplicate all category names"
+    );
 }
 
 #[tokio::test]

--- a/src/mcp_tests/plugin_tools.rs
+++ b/src/mcp_tests/plugin_tools.rs
@@ -1818,7 +1818,7 @@ async fn any_plugin_scope_exposes_only_the_stable_gateway() {
 }
 
 #[tokio::test]
-async fn tool_manifest_returns_canonical_static_plugin_tool_contract_without_runner_inventory() {
+async fn tool_manifest_returns_sparse_static_plugin_tool_contract_without_runner_inventory() {
     let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
     let auth = plugin_auth_with_scopes(&[
         crate::auth::SCOPE_PLUGIN_INSPECT,
@@ -1845,18 +1845,15 @@ async fn tool_manifest_returns_canonical_static_plugin_tool_contract_without_run
         panic!("tool_manifest(plugin_tool) must succeed without any Runner inventory");
     };
     let output = &value["result"]["structuredContent"]["output"];
-    assert_eq!(output["tool_name"], crate::plugin_gateway::PLUGIN_TOOL_NAME);
+    assert_eq!(output["name"], crate::plugin_gateway::PLUGIN_TOOL_NAME);
+    assert_eq!(output["route"]["mode"], "direct");
+    assert!(output["route"].get("via").is_none());
     assert_eq!(
-        output["contract"]["name"],
-        crate::plugin_gateway::PLUGIN_TOOL_NAME
-    );
-    assert_eq!(output["contract"]["availability"], "direct");
-    assert_eq!(
-        output["contract"]["input_schema"]["properties"]["binding"]["pattern"],
+        output["input_schema"]["properties"]["binding"]["pattern"],
         "^wc_pbind_[0-9a-f]{32}$"
     );
-    assert_eq!(output["tools"][0]["authority"]["policy"], "require_any");
-    let scopes = output["tools"][0]["authority"]["scopes"]
+    assert_eq!(output["authority"]["policy"], "require_any");
+    let scopes = output["authority"]["scopes"]
         .as_array()
         .expect("Plugin gateway authority scopes");
     for scope in [
@@ -1883,7 +1880,7 @@ async fn tool_manifest_returns_canonical_static_plugin_tool_contract_without_run
         .iter()
         .find(|tool| tool["name"] == crate::plugin_gateway::PLUGIN_TOOL_NAME)
         .expect("plugin_tool after Runner registration");
-    assert_eq!(gateway["inputSchema"], output["contract"]["input_schema"]);
+    assert_eq!(gateway["inputSchema"], output["input_schema"]);
     assert!(!listed["result"]["tools"]
         .as_array()
         .unwrap()
@@ -1900,7 +1897,7 @@ async fn tool_manifest_returns_canonical_static_plugin_tool_contract_without_run
     for field in ["action", "runner", "plugin", "tool", "binding", "arguments"] {
         assert_eq!(
             stateless_gateway["inputSchema"]["properties"][field],
-            output["contract"]["input_schema"]["properties"][field],
+            output["input_schema"]["properties"][field],
             "Stateless MCP must preserve canonical Plugin business schema for {field}"
         );
     }

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::auth::AuthContext;
 use crate::tool_runtime::project_resolution::{ProjectResolverError, ResolvedProject};
-use serde_json::Value;
+use serde_json::{json, Value};
 
 /// Add the Phase A lifecycle tuple to a definite pre-execution structured
 /// execution denial without changing generic denial helpers used by unrelated
@@ -206,42 +206,20 @@ pub(super) fn sparsify_failure_model_result_metadata(tool_name: &str, result: &m
 
 pub(super) enum SearchModelProjection {
     None,
-    SingleDefault,
-    Batch { default_queries: Vec<bool> },
+    Single { default_timeout: bool },
+    Batch { default_timeouts: Vec<bool> },
 }
 
 impl SearchModelProjection {
     pub(super) fn capture(call: &ToolCall) -> Self {
         match call {
-            ToolCall::SearchProjectText {
-                pattern_mode,
-                result_mode,
-                timeout_secs,
-                context_before,
-                context_after,
-                ..
-            } if caller_uses_default_search_controls(
-                pattern_mode,
-                result_mode,
-                timeout_secs,
-                context_before,
-                context_after,
-            ) =>
-            {
-                Self::SingleDefault
-            }
+            ToolCall::SearchProjectText { timeout_secs, .. } => Self::Single {
+                default_timeout: caller_uses_default_search_timeout(timeout_secs),
+            },
             ToolCall::SearchProjectTexts { queries, .. } => Self::Batch {
-                default_queries: queries
+                default_timeouts: queries
                     .iter()
-                    .map(|query| {
-                        caller_uses_default_search_controls(
-                            &query.pattern_mode,
-                            &query.result_mode,
-                            &query.timeout_secs,
-                            &query.context_before,
-                            &query.context_after,
-                        )
-                    })
+                    .map(|query| caller_uses_default_search_timeout(&query.timeout_secs))
                     .collect(),
             },
             _ => Self::None,
@@ -277,64 +255,118 @@ impl BatchResponseBudgetProjection {
     }
 }
 
-fn caller_uses_default_search_controls(
-    pattern_mode: &Option<super::SearchPatternMode>,
-    result_mode: &Option<super::SearchResultMode>,
-    timeout_secs: &Option<i64>,
-    context_before: &Option<usize>,
-    context_after: &Option<usize>,
-) -> bool {
-    pattern_mode
+fn caller_uses_default_search_timeout(timeout_secs: &Option<i64>) -> bool {
+    timeout_secs
         .as_ref()
-        .is_none_or(|mode| matches!(mode, super::SearchPatternMode::Regex))
-        && result_mode
-            .as_ref()
-            .is_none_or(|mode| matches!(mode, super::SearchResultMode::Matches))
-        && timeout_secs
-            .as_ref()
-            .copied()
-            .unwrap_or(super::files::DEFAULT_SEARCH_TIMEOUT_SECS as i64)
-            == super::files::DEFAULT_SEARCH_TIMEOUT_SECS as i64
-        && context_before.as_ref().copied().unwrap_or(0) == 0
-        && context_after.as_ref().copied().unwrap_or(0) == 0
+        .copied()
+        .unwrap_or(super::files::DEFAULT_SEARCH_TIMEOUT_SECS as i64)
+        == super::files::DEFAULT_SEARCH_TIMEOUT_SECS as i64
 }
 
-/// Project an ordinary complete default text search down to its actual records.
-/// Session/event extraction sees the complete result before this model-facing
-/// pass. Fallbacks, partial results, non-default modes, timeouts, and context
-/// requests stay explicit. Batch defaults may inherit a smaller remaining
-/// timeout from the shared outer deadline without making that derived value
-/// model-relevant.
-pub(crate) fn sparsify_complete_default_search_output(
+fn sparsify_search_match_items(output: &mut serde_json::Map<String, Value>) {
+    let Some(matches) = output.get_mut("matches").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for item in matches {
+        let Some(item) = item.as_object_mut() else {
+            continue;
+        };
+        for key in ["context_before", "context_after"] {
+            if item
+                .get(key)
+                .and_then(Value::as_array)
+                .is_some_and(Vec::is_empty)
+            {
+                item.remove(key);
+            }
+        }
+        let path = item.get("path").and_then(Value::as_str).map(str::to_string);
+        let Some(read_hint) = item.get_mut("read_hint").and_then(Value::as_object_mut) else {
+            continue;
+        };
+        if path
+            .as_deref()
+            .is_some_and(|path| read_hint.get("path").and_then(Value::as_str) == Some(path))
+        {
+            read_hint.remove("path");
+        }
+    }
+}
+
+fn add_search_refinement_continuation(output: &mut serde_json::Map<String, Value>) {
+    if output.get("truncated").and_then(Value::as_bool) != Some(true)
+        || !matches!(
+            output.get("truncation_reason").and_then(Value::as_str),
+            Some("limit" | "output_bytes")
+        )
+    {
+        return;
+    }
+    output.entry("continuation".to_string()).or_insert_with(|| {
+        json!({
+            "kind": "refine_query",
+            "safe_cursor": false,
+            "refine_with": ["path", "include_globs", "pattern", "result_mode", "limit"]
+        })
+    });
+}
+
+/// Project successful text-search presentation after Session/event consumers
+/// have seen canonical evidence. Complete rg results keep only mode-relevant
+/// records and explicit non-default controls. Fallback/truncated successes retain
+/// diagnostic metadata; match items still drop only empty context and duplicate
+/// read-hint paths. A default batch timeout may shrink under the shared absolute
+/// deadline without making that derived value model-relevant.
+pub(crate) fn sparsify_search_output_for_model(
     output: &mut serde_json::Map<String, Value>,
+    default_timeout: bool,
     allow_batch_deadline_reduction: bool,
 ) -> bool {
-    let Some(matches_len) = output
-        .get("matches")
-        .and_then(Value::as_array)
-        .map(Vec::len)
-    else {
-        return false;
-    };
+    sparsify_search_match_items(output);
+    add_search_refinement_continuation(output);
+
     let exit_code = output.get("exit_code").and_then(Value::as_i64);
-    let effective_timeout = output.get("effective_timeout_secs").and_then(Value::as_u64);
-    let default_timeout = if allow_batch_deadline_reduction {
-        effective_timeout.is_some_and(|timeout| {
-            (1..=super::files::DEFAULT_SEARCH_TIMEOUT_SECS).contains(&timeout)
-        })
-    } else {
-        effective_timeout == Some(super::files::DEFAULT_SEARCH_TIMEOUT_SECS)
+    let result_mode = output
+        .get("result_mode")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let mode_consistent = match result_mode.as_deref() {
+        Some("matches") => output
+            .get("matches")
+            .and_then(Value::as_array)
+            .is_some_and(|matches| {
+                output.get("count").and_then(Value::as_u64) == Some(matches.len() as u64)
+            }),
+        Some("files_with_matches") => {
+            output
+                .get("files")
+                .and_then(Value::as_array)
+                .is_some_and(|files| {
+                    output.get("returned_file_count").and_then(Value::as_u64)
+                        == Some(files.len() as u64)
+                })
+        }
+        Some("count") => output
+            .get("files")
+            .and_then(Value::as_array)
+            .is_some_and(|files| {
+                output.get("returned_file_count").and_then(Value::as_u64)
+                    == Some(files.len() as u64)
+                    && output.get("count_complete").and_then(Value::as_bool) == Some(true)
+                    && output.get("returned_match_count").and_then(Value::as_u64)
+                        == output.get("total_matches").and_then(Value::as_u64)
+            }),
+        _ => false,
     };
     let ordinary_complete = output.get("backend").and_then(Value::as_str) == Some("rg")
-        && output.get("pattern_mode").and_then(Value::as_str) == Some("regex")
-        && output.get("result_mode").and_then(Value::as_str) == Some("matches")
-        && default_timeout
-        && output.get("context_before").and_then(Value::as_u64) == Some(0)
-        && output.get("context_after").and_then(Value::as_u64) == Some(0)
+        && matches!(
+            output.get("pattern_mode").and_then(Value::as_str),
+            Some("regex" | "literal")
+        )
+        && mode_consistent
         && output.get("truncated").and_then(Value::as_bool) == Some(false)
         && output.get("truncation_reason").is_some_and(Value::is_null)
-        && matches!(exit_code, Some(0 | 1))
-        && output.get("count").and_then(Value::as_u64) == Some(matches_len as u64);
+        && matches!(exit_code, Some(0 | 1));
     if !ordinary_complete {
         return false;
     }
@@ -343,17 +375,53 @@ pub(crate) fn sparsify_complete_default_search_output(
         "project",
         "pattern",
         "backend",
-        "result_mode",
-        "pattern_mode",
-        "effective_timeout_secs",
         "exit_code",
-        "context_before",
-        "context_after",
-        "count",
         "truncated",
         "truncation_reason",
     ] {
         output.remove(key);
+    }
+    if output.get("pattern_mode").and_then(Value::as_str) == Some("regex") {
+        output.remove("pattern_mode");
+    }
+    match result_mode.as_deref() {
+        Some("matches") => {
+            output.remove("result_mode");
+            output.remove("count");
+        }
+        Some("files_with_matches") => {
+            output.remove("returned_file_count");
+        }
+        Some("count") => {
+            output.remove("returned_file_count");
+            output.remove("returned_match_count");
+            output.remove("count_complete");
+            if output
+                .get("files")
+                .and_then(Value::as_array)
+                .is_some_and(Vec::is_empty)
+            {
+                output.remove("files");
+            }
+        }
+        _ => {}
+    }
+    for key in ["context_before", "context_after"] {
+        if output.get(key).and_then(Value::as_u64) == Some(0) {
+            output.remove(key);
+        }
+    }
+    let effective_timeout = output.get("effective_timeout_secs").and_then(Value::as_u64);
+    let timeout_is_boring_default = default_timeout
+        && if allow_batch_deadline_reduction {
+            effective_timeout.is_some_and(|timeout| {
+                (1..=super::files::DEFAULT_SEARCH_TIMEOUT_SECS).contains(&timeout)
+            })
+        } else {
+            effective_timeout == Some(super::files::DEFAULT_SEARCH_TIMEOUT_SECS)
+        };
+    if timeout_is_boring_default {
+        output.remove("effective_timeout_secs");
     }
     if output.get("path").and_then(Value::as_str) == Some(".") {
         output.remove("path");
@@ -361,7 +429,7 @@ pub(crate) fn sparsify_complete_default_search_output(
     true
 }
 
-pub(super) fn sparsify_complete_default_search_success(
+pub(super) fn sparsify_search_success_for_model(
     projection: &SearchModelProjection,
     result: &mut ToolResult,
 ) {
@@ -372,10 +440,10 @@ pub(super) fn sparsify_complete_default_search_success(
         return;
     };
     match projection {
-        SearchModelProjection::SingleDefault => {
-            sparsify_complete_default_search_output(output, false);
+        SearchModelProjection::Single { default_timeout } => {
+            sparsify_search_output_for_model(output, *default_timeout, false);
         }
-        SearchModelProjection::Batch { default_queries } => {
+        SearchModelProjection::Batch { default_timeouts } => {
             let complete_batch =
                 output
                     .get("items")
@@ -413,14 +481,18 @@ pub(super) fn sparsify_complete_default_search_success(
                 let Some(index) = item.get("index").and_then(Value::as_u64) else {
                     continue;
                 };
-                if default_queries.get(index as usize).copied() != Some(true) {
-                    continue;
-                }
                 let Some(search_output) = item.get_mut("output").and_then(Value::as_object_mut)
                 else {
                     continue;
                 };
-                sparsify_complete_default_search_output(search_output, true);
+                sparsify_search_output_for_model(
+                    search_output,
+                    default_timeouts
+                        .get(index as usize)
+                        .copied()
+                        .unwrap_or(false),
+                    true,
+                );
             }
             if complete_batch {
                 for key in [
@@ -440,13 +512,13 @@ pub(super) fn sparsify_complete_default_search_success(
     }
 }
 
-pub(crate) fn sparsify_complete_default_search_batch_success(
-    default_queries: &[bool],
+pub(crate) fn sparsify_search_batch_success_for_model(
+    default_timeouts: &[bool],
     result: &mut ToolResult,
 ) {
-    sparsify_complete_default_search_success(
+    sparsify_search_success_for_model(
         &SearchModelProjection::Batch {
-            default_queries: default_queries.to_vec(),
+            default_timeouts: default_timeouts.to_vec(),
         },
         result,
     );
@@ -1344,24 +1416,26 @@ impl ToolRuntime {
                 super::read_files::enforce_final_model_facing_hard_cap(&mut result);
             }
             BatchResponseBudgetProjection::SearchProjectTexts { max_result_bytes } => {
-                let default_queries = match &search_projection {
-                    SearchModelProjection::Batch { default_queries } => default_queries.as_slice(),
+                let default_timeouts = match &search_projection {
+                    SearchModelProjection::Batch { default_timeouts } => {
+                        default_timeouts.as_slice()
+                    }
                     _ => &[],
                 };
                 super::search_project_texts::apply_model_facing_output_budget(
                     &mut result,
-                    default_queries,
+                    default_timeouts,
                     *max_result_bytes,
                 );
                 super::search_project_texts::enforce_final_model_facing_hard_cap(
                     &mut result,
-                    default_queries,
+                    default_timeouts,
                 );
             }
         }
         sparsify_terminal_structured_execution_success(tool_name, &mut result);
         if !defer_batch_sparsification {
-            sparsify_complete_default_search_success(&search_projection, &mut result);
+            sparsify_search_success_for_model(&search_projection, &mut result);
             sparsify_complete_read_success(tool_name, &mut result);
         }
         result

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -881,15 +881,15 @@ impl ToolRuntime {
                     super::read_files::enforce_final_model_facing_hard_cap(&mut result);
                 }
                 "search_project_texts" => {
-                    let default_queries = match &deferred_search_projection {
-                        super::dispatch::SearchModelProjection::Batch { default_queries } => {
-                            default_queries.as_slice()
+                    let default_timeouts = match &deferred_search_projection {
+                        super::dispatch::SearchModelProjection::Batch { default_timeouts } => {
+                            default_timeouts.as_slice()
                         }
                         _ => &[],
                     };
                     super::search_project_texts::enforce_final_model_facing_hard_cap(
                         &mut result,
-                        default_queries,
+                        default_timeouts,
                     );
                 }
                 _ => {}
@@ -898,7 +898,7 @@ impl ToolRuntime {
             // outer recording Session was pending. Only now, after final hard-cap
             // enforcement has accounted for continuity/recovery/handoff/attention,
             // project the response to the established sparse model-facing shape.
-            super::dispatch::sparsify_complete_default_search_success(
+            super::dispatch::sparsify_search_success_for_model(
                 &deferred_search_projection,
                 &mut result,
             );

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -904,6 +904,9 @@ impl ToolRuntime {
             );
             super::dispatch::sparsify_complete_read_success(&request.tool_name, &mut result);
         }
+        if request.tool_name == "tool_manifest" {
+            super::surface::sparsify_tool_manifest_model_result(&mut result);
+        }
         // Final model-facing projection: authoritative permission decisions and
         // recorder events have already been consumed by the Session ledger.
         super::dispatch::sparsify_failure_model_result_metadata(&request.tool_name, &mut result);

--- a/src/tool_runtime/search_project_texts.rs
+++ b/src/tool_runtime/search_project_texts.rs
@@ -99,22 +99,19 @@ fn serialized_value_len(value: &Value) -> usize {
         .unwrap_or(usize::MAX)
 }
 
-fn projected_batch_serialized_len(output: &Value, default_queries: &[bool]) -> usize {
+fn projected_batch_serialized_len(output: &Value, default_timeouts: &[bool]) -> usize {
     let mut projected = ToolResult::ok(output.clone());
-    super::dispatch::sparsify_complete_default_search_batch_success(
-        default_queries,
-        &mut projected,
-    );
+    super::dispatch::sparsify_search_batch_success_for_model(default_timeouts, &mut projected);
     serde_json::to_vec(&projected)
         .map(|bytes| bytes.len())
         .unwrap_or(usize::MAX)
 }
 
-fn projected_search_item_len(item: &Value, default_query: bool) -> usize {
+fn projected_search_item_len(item: &Value, default_timeout: bool) -> usize {
     let mut projected = item.clone();
-    if default_query && projected["success"].as_bool() == Some(true) {
+    if projected["success"].as_bool() == Some(true) {
         if let Some(output) = projected.get_mut("output").and_then(Value::as_object_mut) {
-            super::dispatch::sparsify_complete_default_search_output(output, true);
+            super::dispatch::sparsify_search_output_for_model(output, default_timeout, true);
         }
     }
     serialized_value_len(&projected)
@@ -135,7 +132,7 @@ fn apply_output_budget(
     project: &str,
     requested_count: usize,
     completed: Vec<Value>,
-    default_queries: &[bool],
+    default_timeouts: &[bool],
     max_result_bytes: Option<usize>,
 ) -> Value {
     let result_budget = normalized_result_budget(max_result_bytes);
@@ -151,7 +148,7 @@ fn apply_output_budget(
     // First evaluate the exact sparse model projection. Canonical search
     // metadata stays intact unless that final applicable projection itself
     // exceeds the response budget.
-    if projected_batch_serialized_len(&complete, default_queries) <= payload_budget {
+    if projected_batch_serialized_len(&complete, default_timeouts) <= payload_budget {
         return complete;
     }
 
@@ -169,7 +166,7 @@ fn apply_output_budget(
             Some(0),
             Some(truncation_reason),
         ),
-        default_queries,
+        default_timeouts,
     );
     let mut returned = Vec::with_capacity(completed.len());
     let mut returned_item_bytes = 0usize;
@@ -178,7 +175,7 @@ fn apply_output_budget(
     for item in completed {
         let index = item["index"].as_u64().unwrap_or(returned.len() as u64) as usize;
         let item_len =
-            projected_search_item_len(&item, default_queries.get(index).copied().unwrap_or(false));
+            projected_search_item_len(&item, default_timeouts.get(index).copied().unwrap_or(false));
         let candidate_item_count = returned.len() + 1;
         if projected_batch_len(
             base_len,
@@ -206,7 +203,7 @@ fn apply_output_budget(
         next_index,
         Some(truncation_reason),
     );
-    while projected_batch_serialized_len(&output, default_queries) > payload_budget {
+    while projected_batch_serialized_len(&output, default_timeouts) > payload_budget {
         let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
             break;
         };
@@ -383,7 +380,7 @@ fn batch_item(index: usize, mut result: ToolResult) -> Value {
 
 pub(crate) fn apply_model_facing_output_budget(
     result: &mut ToolResult,
-    default_queries: &[bool],
+    default_timeouts: &[bool],
     max_result_bytes: Option<usize>,
 ) {
     if !result.success {
@@ -414,7 +411,7 @@ pub(crate) fn apply_model_facing_output_budget(
         &project,
         requested_count,
         completed,
-        default_queries,
+        default_timeouts,
         max_result_bytes,
     );
     let Some(root) = result.output.as_object_mut() else {
@@ -440,12 +437,9 @@ pub(crate) fn apply_model_facing_output_budget(
     }
 }
 
-fn final_model_result_len(output: &Value, default_queries: &[bool]) -> usize {
+fn final_model_result_len(output: &Value, default_timeouts: &[bool]) -> usize {
     let mut projected = ToolResult::ok(output.clone());
-    super::dispatch::sparsify_complete_default_search_batch_success(
-        default_queries,
-        &mut projected,
-    );
+    super::dispatch::sparsify_search_batch_success_for_model(default_timeouts, &mut projected);
     serde_json::to_vec(&projected)
         .map(|bytes| bytes.len())
         .unwrap_or(usize::MAX)
@@ -486,10 +480,10 @@ fn mark_final_hard_cap_truncation(output: &mut Value, next_index: usize) {
 /// omitted query.
 pub(crate) fn enforce_final_model_facing_hard_cap(
     result: &mut ToolResult,
-    default_queries: &[bool],
+    default_timeouts: &[bool],
 ) {
     if !result.success
-        || final_model_result_len(&result.output, default_queries) <= MAX_SERIALIZED_OUTPUT_BYTES
+        || final_model_result_len(&result.output, default_timeouts) <= MAX_SERIALIZED_OUTPUT_BYTES
     {
         return;
     }
@@ -517,7 +511,7 @@ pub(crate) fn enforce_final_model_facing_hard_cap(
             removed["index"].as_u64().unwrap_or(0) as usize
         };
         mark_final_hard_cap_truncation(&mut result.output, removed_index);
-        if final_model_result_len(&result.output, default_queries) <= MAX_SERIALIZED_OUTPUT_BYTES {
+        if final_model_result_len(&result.output, default_timeouts) <= MAX_SERIALIZED_OUTPUT_BYTES {
             return;
         }
     }
@@ -693,10 +687,7 @@ mod tests {
             assert_eq!(actual["output"]["matches"], expected["output"]["matches"]);
         }
 
-        super::super::dispatch::sparsify_complete_default_search_batch_success(
-            &[true; 8],
-            &mut result,
-        );
+        super::super::dispatch::sparsify_search_batch_success_for_model(&[true; 8], &mut result);
         assert!(result.output.get("output_truncated").is_none());
         assert!(result.output.get("next_index").is_none());
         assert_eq!(result.output["items"].as_array().unwrap().len(), 8);

--- a/src/tool_runtime/surface.rs
+++ b/src/tool_runtime/surface.rs
@@ -19,6 +19,32 @@ use super::tool_spec::ToolSpec;
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap};
 
+const TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS: usize = 180;
+const TOOL_MANIFEST_CANONICAL_KEYS: &[&str] = &[
+    "schema_version",
+    "tool_count",
+    "count",
+    "returned_count",
+    "total_count",
+    "filtered_count",
+    "tool_name",
+    "contract",
+    "category",
+    "intent",
+    "available_intents",
+    "filtered",
+    "categories_requested",
+    "limit",
+    "truncated",
+    "truncation_reason",
+    "limit_applied",
+    "requested_limit",
+    "categories",
+    "tools",
+    "risk_summary",
+    "recommended_flows",
+];
+
 pub(crate) fn registered_tool_categories() -> Value {
     let mut categories = serde_json::Map::new();
     for group in TOOL_DISCOVERY_GROUPS {
@@ -518,6 +544,194 @@ fn manifest_authority(policy: ToolAuthorityPolicy) -> Value {
             "scopes": [],
         }),
     }
+}
+
+fn manifest_route_projection(availability: Option<&str>, gateway_tool: Option<&Value>) -> Value {
+    let mode = availability.unwrap_or("unavailable");
+    let mut route = serde_json::Map::new();
+    route.insert("mode".to_string(), Value::String(mode.to_string()));
+    if mode == "gateway" {
+        if let Some(via) = gateway_tool.and_then(Value::as_str) {
+            route.insert("via".to_string(), Value::String(via.to_string()));
+        }
+    }
+    Value::Object(route)
+}
+
+fn selection_description(description: &str) -> String {
+    let description = description.trim();
+    if description.chars().count() <= TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS {
+        return description.to_string();
+    }
+    if let Some(end) = description.char_indices().find_map(|(index, ch)| {
+        let end = index + ch.len_utf8();
+        (matches!(ch, '.' | '!' | '?')
+            && description[..end].chars().count() <= TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS)
+            .then_some(end)
+    }) {
+        return description[..end].trim().to_string();
+    }
+
+    let byte_end = description
+        .char_indices()
+        .nth(TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS - 1)
+        .map(|(index, ch)| index + ch.len_utf8())
+        .unwrap_or(description.len());
+    let prefix = &description[..byte_end];
+    let cut = prefix
+        .char_indices()
+        .rev()
+        .find_map(|(index, ch)| ch.is_whitespace().then_some(index))
+        .filter(|index| *index > TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS / 2)
+        .unwrap_or(byte_end);
+    format!("{}…", description[..cut].trim_end())
+}
+
+/// Project the canonical manifest only after Session/audit consumers have seen
+/// it. This preserves the compatibility/full diagnostic result internally while
+/// making ordinary model discovery answer only the next selection/call decision.
+/// Unknown output sidecars are preserved verbatim.
+pub(super) fn sparsify_tool_manifest_model_result(result: &mut ToolResult) {
+    if !result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object() else {
+        return;
+    };
+    let canonical = output.clone();
+    let mut projected = serde_json::Map::new();
+
+    if let Some(contract) = canonical.get("contract").and_then(Value::as_object) {
+        for key in [
+            "name",
+            "description",
+            "input_schema",
+            "effect",
+            "risk",
+            "approval",
+            "idempotency",
+            "annotations",
+        ] {
+            if let Some(value) = contract.get(key) {
+                projected.insert(key.to_string(), value.clone());
+            }
+        }
+        projected.insert(
+            "route".to_string(),
+            manifest_route_projection(
+                contract.get("availability").and_then(Value::as_str),
+                contract.get("gateway_tool"),
+            ),
+        );
+        if let Some(authority) = canonical
+            .get("tools")
+            .and_then(Value::as_array)
+            .and_then(|tools| tools.first())
+            .and_then(|tool| tool.get("authority"))
+        {
+            projected.insert("authority".to_string(), authority.clone());
+        }
+        if let Some(flows) = canonical
+            .get("recommended_flows")
+            .and_then(Value::as_array)
+            .filter(|flows| !flows.is_empty())
+        {
+            projected.insert("recommended_flows".to_string(), Value::Array(flows.clone()));
+        }
+    } else if canonical.get("filtered").and_then(Value::as_bool) == Some(true) {
+        let specs = registered_tool_specs();
+        let descriptions: HashMap<&str, &str> = specs
+            .iter()
+            .map(|spec| (spec.name.as_str(), spec.description.as_str()))
+            .collect();
+        let tools = canonical
+            .get("tools")
+            .and_then(Value::as_array)
+            .map(|tools| {
+                tools
+                    .iter()
+                    .filter_map(Value::as_object)
+                    .map(|tool| {
+                        let mut entry = serde_json::Map::new();
+                        if let Some(name) = tool.get("name").and_then(Value::as_str) {
+                            entry.insert("name".to_string(), Value::String(name.to_string()));
+                            if let Some(description) = descriptions.get(name) {
+                                entry.insert(
+                                    "description".to_string(),
+                                    Value::String(selection_description(description)),
+                                );
+                            }
+                        }
+                        entry.insert(
+                            "route".to_string(),
+                            manifest_route_projection(
+                                tool.get("availability").and_then(Value::as_str),
+                                tool.get("gateway_tool"),
+                            ),
+                        );
+                        if let Some(requires_project) = tool.get("requires_project") {
+                            entry.insert("requires_project".to_string(), requires_project.clone());
+                        }
+                        if let Some(effect) = tool.get("effect") {
+                            entry.insert("effect".to_string(), effect.clone());
+                        }
+                        if tool.get("effect").and_then(Value::as_str) != Some("observe") {
+                            if let Some(risk) = tool.get("risk") {
+                                entry.insert("risk".to_string(), risk.clone());
+                            }
+                        }
+                        Value::Object(entry)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        projected.insert("tools".to_string(), Value::Array(tools));
+        for key in ["intent", "category", "categories_requested"] {
+            if let Some(value) = canonical.get(key).filter(|value| !value.is_null()) {
+                projected.insert(key.to_string(), value.clone());
+            }
+        }
+        if canonical.get("truncated").and_then(Value::as_bool) == Some(true) {
+            for key in [
+                "truncated",
+                "truncation_reason",
+                "returned_count",
+                "filtered_count",
+                "limit",
+            ] {
+                if let Some(value) = canonical.get(key) {
+                    projected.insert(key.to_string(), value.clone());
+                }
+            }
+        }
+        if let Some(flows) = canonical
+            .get("recommended_flows")
+            .and_then(Value::as_array)
+            .filter(|flows| !flows.is_empty())
+        {
+            projected.insert("recommended_flows".to_string(), Value::Array(flows.clone()));
+        }
+    } else {
+        for key in [
+            "schema_version",
+            "tool_count",
+            "categories",
+            "available_intents",
+            "risk_summary",
+            "recommended_flows",
+        ] {
+            if let Some(value) = canonical.get(key) {
+                projected.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+
+    for (key, value) in canonical {
+        if !TOOL_MANIFEST_CANONICAL_KEYS.contains(&key.as_str()) {
+            projected.insert(key, value);
+        }
+    }
+    result.output = Value::Object(projected);
 }
 
 pub(super) fn compact_manifest_tool_entry(

--- a/src/tool_runtime/surface.rs
+++ b/src/tool_runtime/surface.rs
@@ -560,21 +560,30 @@ fn manifest_route_projection(availability: Option<&str>, gateway_tool: Option<&V
 
 fn selection_description(description: &str) -> String {
     let description = description.trim();
-    if description.chars().count() <= TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS {
-        return description.to_string();
-    }
     if let Some(end) = description.char_indices().find_map(|(index, ch)| {
         let end = index + ch.len_utf8();
-        (matches!(ch, '.' | '!' | '?')
-            && description[..end].chars().count() <= TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS)
+        if !matches!(ch, '.' | '!' | '?')
+            || description[..end].chars().count() > TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS
+        {
+            return None;
+        }
+        description[end..]
+            .chars()
+            .next()
+            .is_none_or(char::is_whitespace)
             .then_some(end)
     }) {
         return description[..end].trim().to_string();
     }
 
+    if description.chars().count() <= TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS {
+        return description.to_string();
+    }
+
+    let content_limit = TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS - 1;
     let byte_end = description
         .char_indices()
-        .nth(TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS - 1)
+        .nth(content_limit - 1)
         .map(|(index, ch)| index + ch.len_utf8())
         .unwrap_or(description.len());
     let prefix = &description[..byte_end];
@@ -585,6 +594,60 @@ fn selection_description(description: &str) -> String {
         .filter(|index| *index > TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS / 2)
         .unwrap_or(byte_end);
     format!("{}…", description[..cut].trim_end())
+}
+
+#[cfg(test)]
+mod selection_description_tests {
+    use super::*;
+
+    #[test]
+    fn selection_description_ignores_periods_inside_technical_tokens() {
+        assert_eq!(
+            selection_description(
+                "Inspect startup-bound runner.toml path. This never changes authority."
+            ),
+            "Inspect startup-bound runner.toml path."
+        );
+        assert_eq!(
+            selection_description("Read foo.rs safely. Then continue."),
+            "Read foo.rs safely."
+        );
+        assert_eq!(
+            selection_description("Supports v0.4.0 clients. Newer versions are also accepted."),
+            "Supports v0.4.0 clients."
+        );
+    }
+
+    #[test]
+    fn selection_description_prefers_real_sentence_boundary() {
+        assert_eq!(
+            selection_description("First sentence. Second sentence."),
+            "First sentence."
+        );
+    }
+
+    #[test]
+    fn selection_description_fallback_is_bounded_and_unicode_safe() {
+        let ascii = "selection token ".repeat(30);
+        let ascii_summary = selection_description(&ascii);
+        assert!(ascii_summary.ends_with('…'));
+        assert!(
+            ascii_summary.chars().count() <= TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS,
+            "{ascii_summary}"
+        );
+
+        let unicode = "界".repeat(240);
+        let unicode_summary = selection_description(&unicode);
+        assert!(unicode_summary.ends_with('…'));
+        assert!(
+            unicode_summary.chars().count() <= TOOL_MANIFEST_SELECTION_DESCRIPTION_MAX_CHARS,
+            "{unicode_summary}"
+        );
+        assert!(unicode_summary
+            .trim_end_matches('…')
+            .chars()
+            .all(|ch| ch == '界'));
+    }
 }
 
 /// Project the canonical manifest only after Session/audit consumers have seen
@@ -686,7 +749,7 @@ pub(super) fn sparsify_tool_manifest_model_result(result: &mut ToolResult) {
             })
             .unwrap_or_default();
         projected.insert("tools".to_string(), Value::Array(tools));
-        for key in ["intent", "category", "categories_requested"] {
+        for key in ["intent", "category"] {
             if let Some(value) = canonical.get(key).filter(|value| !value.is_null()) {
                 projected.insert(key.to_string(), value.clone());
             }

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -3334,11 +3334,22 @@ async fn search_project_text_count_distinguishes_complete_and_truncated_totals()
     )
     .await;
     assert!(complete.success, "{:?}", complete.error);
-    assert_eq!(complete.output["returned_file_count"], 2);
-    assert_eq!(complete.output["returned_match_count"], 3);
-    assert_eq!(complete.output["count_complete"], true);
+    assert_eq!(complete.output["result_mode"], "count");
     assert_eq!(complete.output["total_matches"], 3);
-    assert_eq!(complete.output["truncated"], false);
+    for omitted in [
+        "backend",
+        "returned_file_count",
+        "returned_match_count",
+        "count_complete",
+        "truncated",
+        "truncation_reason",
+    ] {
+        assert!(
+            complete.output.get(omitted).is_none(),
+            "{omitted}: {}",
+            complete.output
+        );
+    }
     // Both files are present regardless of traversal order.
     let mut complete_files = complete.output["files"]
         .as_array()
@@ -3878,8 +3889,8 @@ async fn search_project_text_context_does_not_enqueue_python_helper() {
 
     assert!(result.success, "{:?}", result.error);
     assert!(matches!(
-        result.output["backend"].as_str(),
-        Some("rg" | "grep")
+        result.output.get("backend").and_then(Value::as_str),
+        None | Some("grep")
     ));
     assert_eq!(result.output["context_before"], 1);
     assert_eq!(result.output["context_after"], 1);

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -80,6 +80,26 @@ fn tool_manifest_and_list_tools_limit_truncation_reports_limit_reason() {
         .contains("ResponseTooLarge"));
 }
 
+#[test]
+fn tool_manifest_sparse_filtered_projection_only_keeps_truncation_metadata_when_needed() {
+    let runtime = test_runtime();
+    let canonical = runtime
+        .compact_tool_manifest_payload_bounded(None, Some("coding".to_string()), Some(3))
+        .expect("limited coding manifest");
+    let mut result = crate::tool_runtime::ToolResult::ok(canonical);
+    crate::tool_runtime::surface::sparsify_tool_manifest_model_result(&mut result);
+
+    assert_eq!(result.output["truncated"], true);
+    assert_eq!(result.output["truncation_reason"], "limit");
+    assert_eq!(result.output["returned_count"], 3);
+    assert!(result.output["filtered_count"].as_u64().unwrap() > 3);
+    assert_eq!(result.output["limit"], 3);
+    assert!(result.output.get("categories").is_none());
+    assert!(result.output.get("tool_count").is_none());
+    assert!(result.output.get("count").is_none());
+    assert!(result.output.get("total_count").is_none());
+}
+
 fn output_schema_properties(spec: &ToolSpec) -> &serde_json::Map<String, Value> {
     spec.output_schema["properties"]["output"]["properties"]
         .as_object()

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -3,6 +3,7 @@
 use super::super::*;
 use super::support::*;
 use crate::runner_protocol::{RunnerPollRequest, RunnerRequest, RunnerResultRequest};
+use crate::tool_runtime::files::{search_project_text_output, SearchOptions, SearchRequest};
 use serde_json::{json, Value};
 use std::time::Duration;
 
@@ -113,6 +114,359 @@ async fn run_single_agent_batch_response(
     let result = task.await.unwrap();
     assert_no_agent_request(&runtime, client_id).await;
     result
+}
+
+fn canonical_search_result(
+    pattern: &str,
+    pattern_mode: Option<SearchPatternMode>,
+    result_mode: SearchResultMode,
+    limit: usize,
+    context_before: usize,
+    context_after: usize,
+    stdout: &str,
+    exit_code: i32,
+) -> ToolResult {
+    let options = SearchOptions::normalize_with_pattern_mode(
+        SearchRequest {
+            pattern: pattern.to_string(),
+            path: None,
+            limit: Some(limit),
+            context_before: Some(context_before),
+            context_after: Some(context_after),
+            include_globs: None,
+            exclude_globs: None,
+            result_mode: Some(result_mode),
+            timeout_secs: None,
+        },
+        pattern_mode,
+    )
+    .expect("canonical search options");
+    search_project_text_output("demo", &options, stdout, Some(exit_code), "")
+}
+
+fn project_single_search(canonical: &ToolResult) -> ToolResult {
+    let mut projected = ToolResult::ok(canonical.output.clone());
+    let output = projected
+        .output
+        .as_object_mut()
+        .expect("canonical search output object");
+    crate::tool_runtime::dispatch::sparsify_search_output_for_model(output, true, false);
+    projected
+}
+
+fn serialized_output_bytes(result: &ToolResult) -> usize {
+    serde_json::to_vec(&result.output).unwrap().len()
+}
+
+#[test]
+fn search_project_text_model_projection_compacts_default_matches_and_measures_bytes() {
+    let marker = "{\"webcodex_search\":{\"backend\":\"rg\",\"feature_unavailable\":false}}\n";
+    let one_stdout = format!("{marker}src/foo.rs:123:needle\n");
+    let one = canonical_search_result(
+        "needle",
+        None,
+        SearchResultMode::Matches,
+        20,
+        0,
+        0,
+        &one_stdout,
+        0,
+    );
+    assert!(one.success, "{:?}", one.error);
+    assert_eq!(one.output["matches"][0]["context_before"], json!([]));
+    assert_eq!(one.output["matches"][0]["context_after"], json!([]));
+    assert_eq!(one.output["matches"][0]["read_hint"]["path"], "src/foo.rs");
+    let one_sparse = project_single_search(&one);
+    let one_match = &one_sparse.output["matches"][0];
+    assert_eq!(one_match["path"], "src/foo.rs");
+    assert_eq!(one_match["line"], 123);
+    assert_eq!(one_match["preview"], "needle");
+    assert!(one_match.get("context_before").is_none());
+    assert!(one_match.get("context_after").is_none());
+    assert!(one_match["read_hint"].get("path").is_none());
+    assert_eq!(one_match["read_hint"]["start_line"], 103);
+    assert_eq!(one_match["read_hint"]["limit"], 80);
+    for omitted in [
+        "project",
+        "pattern",
+        "backend",
+        "result_mode",
+        "pattern_mode",
+        "effective_timeout_secs",
+        "exit_code",
+        "context_before",
+        "context_after",
+        "count",
+        "truncated",
+        "truncation_reason",
+    ] {
+        assert!(
+            one_sparse.output.get(omitted).is_none(),
+            "{omitted}: {}",
+            one_sparse.output
+        );
+    }
+    let one_canonical_bytes = serialized_output_bytes(&one);
+    let one_sparse_bytes = serialized_output_bytes(&one_sparse);
+    eprintln!(
+        "search_single_default_match_bytes canonical={one_canonical_bytes} sparse={one_sparse_bytes}"
+    );
+    assert!(one_sparse_bytes < one_canonical_bytes);
+
+    let mut ten_stdout = marker.to_string();
+    for index in 0..10 {
+        ten_stdout.push_str(&format!("src/foo.rs\0{}:needle-{index}\n", index + 1));
+    }
+    let ten = canonical_search_result(
+        "needle",
+        None,
+        SearchResultMode::Matches,
+        20,
+        0,
+        0,
+        &ten_stdout,
+        0,
+    );
+    assert!(ten.success, "{:?}", ten.error);
+    let ten_sparse = project_single_search(&ten);
+    let matches = ten_sparse.output["matches"].as_array().unwrap();
+    assert_eq!(matches.len(), 10);
+    for item in matches {
+        assert!(item.get("context_before").is_none());
+        assert!(item.get("context_after").is_none());
+        assert!(item["read_hint"].get("path").is_none());
+    }
+    let ten_canonical_bytes = serialized_output_bytes(&ten);
+    let ten_sparse_bytes = serialized_output_bytes(&ten_sparse);
+    eprintln!(
+        "search_ten_default_matches_bytes canonical={ten_canonical_bytes} sparse={ten_sparse_bytes}"
+    );
+    assert!(ten_sparse_bytes < ten_canonical_bytes);
+}
+
+#[test]
+fn search_project_text_model_projection_preserves_requested_context_and_unicode() {
+    let marker = "{\"webcodex_search\":{\"backend\":\"rg\",\"feature_unavailable\":false}}\n";
+    let stdout = format!(
+        "{marker}src/foo.rs\0{}-before 界\nsrc/foo.rs\0{}:target 界\nsrc/foo.rs\0{}-after 界\n",
+        122, 123, 124
+    );
+    let canonical = canonical_search_result(
+        "target",
+        None,
+        SearchResultMode::Matches,
+        20,
+        1,
+        1,
+        &stdout,
+        0,
+    );
+    assert!(canonical.success, "{:?}", canonical.error);
+    let sparse = project_single_search(&canonical);
+    assert_eq!(sparse.output["context_before"], 1);
+    assert_eq!(sparse.output["context_after"], 1);
+    let item = &sparse.output["matches"][0];
+    assert_eq!(item["line"], 123);
+    assert_eq!(item["preview"], "target 界");
+    assert_eq!(
+        item["context_before"],
+        json!([{"line": 122, "text": "before 界"}])
+    );
+    assert_eq!(
+        item["context_after"],
+        json!([{"line": 124, "text": "after 界"}])
+    );
+    assert!(item["read_hint"].get("path").is_none());
+    assert_eq!(item["read_hint"]["start_line"], 103);
+    assert!(sparse.output.get("backend").is_none());
+    assert!(sparse.output.get("truncated").is_none());
+
+    let canonical_bytes = serialized_output_bytes(&canonical);
+    let sparse_bytes = serialized_output_bytes(&sparse);
+    eprintln!("search_context_match_bytes canonical={canonical_bytes} sparse={sparse_bytes}");
+    assert!(sparse_bytes < canonical_bytes);
+}
+
+#[test]
+fn search_project_text_model_projection_compacts_files_count_and_guides_truncation() {
+    let marker = "{\"webcodex_search\":{\"backend\":\"rg\",\"feature_unavailable\":false}}\n";
+
+    let files_stdout = format!("{marker}src/a.rs\nsrc/b.rs\n");
+    let files = canonical_search_result(
+        "needle",
+        None,
+        SearchResultMode::FilesWithMatches,
+        20,
+        0,
+        0,
+        &files_stdout,
+        0,
+    );
+    let files_sparse = project_single_search(&files);
+    assert_eq!(files_sparse.output["result_mode"], "files_with_matches");
+    assert_eq!(
+        files_sparse.output["files"],
+        json!([{"path": "src/a.rs"}, {"path": "src/b.rs"}])
+    );
+    for omitted in [
+        "backend",
+        "returned_file_count",
+        "truncated",
+        "truncation_reason",
+        "context_before",
+        "context_after",
+    ] {
+        assert!(
+            files_sparse.output.get(omitted).is_none(),
+            "{omitted}: {}",
+            files_sparse.output
+        );
+    }
+    let files_canonical_bytes = serialized_output_bytes(&files);
+    let files_sparse_bytes = serialized_output_bytes(&files_sparse);
+    eprintln!(
+        "search_files_with_matches_bytes canonical={files_canonical_bytes} sparse={files_sparse_bytes}"
+    );
+    assert!(files_sparse_bytes < files_canonical_bytes);
+
+    let count_stdout = format!("{marker}src/a.rs:2\nsrc/b.rs:1\n");
+    let count = canonical_search_result(
+        "needle",
+        None,
+        SearchResultMode::Count,
+        20,
+        0,
+        0,
+        &count_stdout,
+        0,
+    );
+    let count_sparse = project_single_search(&count);
+    assert_eq!(count_sparse.output["result_mode"], "count");
+    assert_eq!(count_sparse.output["total_matches"], 3);
+    assert_eq!(
+        count_sparse.output["files"],
+        json!([
+            {"path": "src/a.rs", "match_count": 2},
+            {"path": "src/b.rs", "match_count": 1}
+        ])
+    );
+    for omitted in [
+        "backend",
+        "returned_file_count",
+        "returned_match_count",
+        "count_complete",
+        "truncated",
+        "truncation_reason",
+    ] {
+        assert!(
+            count_sparse.output.get(omitted).is_none(),
+            "{omitted}: {}",
+            count_sparse.output
+        );
+    }
+
+    let empty_count =
+        canonical_search_result("absent", None, SearchResultMode::Count, 20, 0, 0, marker, 1);
+    let empty_count_sparse = project_single_search(&empty_count);
+    assert_eq!(empty_count_sparse.output["result_mode"], "count");
+    assert_eq!(empty_count_sparse.output["total_matches"], 0);
+    assert!(empty_count_sparse.output.get("files").is_none());
+    assert!(empty_count_sparse.output.get("matches").is_none());
+
+    let truncated_stdout = format!("{marker}src/a.rs:1:first\nsrc/a.rs:2:second\n");
+    let truncated = canonical_search_result(
+        "needle",
+        None,
+        SearchResultMode::Matches,
+        1,
+        0,
+        0,
+        &truncated_stdout,
+        0,
+    );
+    assert_eq!(truncated.output["truncated"], true);
+    assert_eq!(truncated.output["truncation_reason"], "limit");
+    let truncated_sparse = project_single_search(&truncated);
+    assert_eq!(truncated_sparse.output["backend"], "rg");
+    assert_eq!(truncated_sparse.output["result_mode"], "matches");
+    assert_eq!(truncated_sparse.output["truncated"], true);
+    assert_eq!(truncated_sparse.output["truncation_reason"], "limit");
+    assert_eq!(
+        truncated_sparse.output["continuation"]["kind"],
+        "refine_query"
+    );
+    assert_eq!(
+        truncated_sparse.output["continuation"]["safe_cursor"],
+        false
+    );
+    assert!(truncated_sparse.output.get("next_index").is_none());
+    assert!(truncated_sparse.output.get("match_offset").is_none());
+    assert!(truncated_sparse.output.get("next_match").is_none());
+    assert!(truncated_sparse.output["matches"][0]["read_hint"]
+        .get("path")
+        .is_none());
+    assert!(truncated_sparse.output["matches"][0]
+        .get("context_before")
+        .is_none());
+    assert!(truncated_sparse.output["matches"][0]
+        .get("context_after")
+        .is_none());
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("search_project_text");
+    let serialized = serde_json::to_value(&truncated_sparse).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| {
+            panic!("truncated sparse search success must match schema: {error}")
+        });
+}
+
+#[tokio::test]
+async fn search_project_texts_four_query_projection_measures_canonical_vs_sparse_bytes() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-four-query-bytes";
+    register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let queries = (0..4)
+        .map(|index| query(&format!("needle-{index}"), None))
+        .collect::<Vec<_>>();
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .search_project_texts("demo".to_string(), queries)
+                .await
+        }
+    });
+    for _ in 0..4 {
+        let request = wait_for_patch_agent_request(&runtime, client_id).await;
+        let pattern = request_pattern(&request);
+        complete_search_success(&runtime, client_id, &request, &format!("src/{pattern}.rs")).await;
+    }
+    let canonical = task.await.unwrap();
+    assert!(canonical.success, "{:?}", canonical.error);
+    assert_eq!(canonical.output["items"].as_array().unwrap().len(), 4);
+    assert_eq!(canonical.output["output_truncated"], false);
+    assert!(canonical.output["next_index"].is_null());
+
+    let mut sparse = ToolResult::ok(canonical.output.clone());
+    crate::tool_runtime::dispatch::sparsify_search_batch_success_for_model(&[true; 4], &mut sparse);
+    assert!(sparse.output.get("project").is_none());
+    assert!(sparse.output.get("requested_count").is_none());
+    assert!(sparse.output.get("next_index").is_none());
+    let items = sparse.output["items"].as_array().unwrap();
+    assert_eq!(items.len(), 4);
+    for item in items {
+        assert!(item["output"].get("backend").is_none());
+        let search_match = &item["output"]["matches"][0];
+        assert!(search_match.get("context_before").is_none());
+        assert!(search_match.get("context_after").is_none());
+        assert!(search_match["read_hint"].get("path").is_none());
+    }
+
+    let canonical_bytes = serialized_output_bytes(&canonical);
+    let sparse_bytes = serialized_output_bytes(&sparse);
+    eprintln!("search_four_query_batch_bytes canonical={canonical_bytes} sparse={sparse_bytes}");
+    assert!(sparse_bytes < canonical_bytes);
 }
 
 #[test]
@@ -394,7 +748,7 @@ async fn search_project_text_default_success_is_sparse_after_session_recording()
 }
 
 #[tokio::test]
-async fn search_project_text_nondefault_success_keeps_effective_metadata() {
+async fn search_project_text_nondefault_success_keeps_effective_selection_metadata() {
     let root = tempfile::tempdir().unwrap();
     let runtime = ToolRuntime::new_for_tests();
     let client_id = "search-noteworthy-single";
@@ -433,15 +787,24 @@ async fn search_project_text_nondefault_success_keeps_effective_metadata() {
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["path"], "src");
-    assert_eq!(result.output["backend"], "rg");
-    assert_eq!(result.output["result_mode"], "matches");
-    assert_eq!(result.output["pattern_mode"], "regex");
     assert_eq!(result.output["effective_timeout_secs"], 5);
     assert_eq!(result.output["context_before"], 1);
-    assert_eq!(result.output["context_after"], 0);
-    assert_eq!(result.output["count"], 1);
-    assert_eq!(result.output["truncated"], false);
-    assert!(result.output["truncation_reason"].is_null());
+    assert_eq!(result.output["matches"].as_array().unwrap().len(), 1);
+    for omitted in [
+        "backend",
+        "result_mode",
+        "pattern_mode",
+        "context_after",
+        "count",
+        "truncated",
+        "truncation_reason",
+    ] {
+        assert!(
+            result.output.get(omitted).is_none(),
+            "{omitted}: {}",
+            result.output
+        );
+    }
 }
 
 #[tokio::test]
@@ -488,8 +851,13 @@ async fn search_project_text_literal_mode_keeps_effective_metadata() {
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["pattern_mode"], "literal");
-    assert_eq!(result.output["backend"], "rg");
+    assert!(result.output.get("backend").is_none());
     assert_eq!(result.output["matches"][0]["path"], "src/a.rs");
+    assert!(result.output["matches"][0].get("context_before").is_none());
+    assert!(result.output["matches"][0].get("context_after").is_none());
+    assert!(result.output["matches"][0]["read_hint"]
+        .get("path")
+        .is_none());
 }
 
 #[tokio::test]
@@ -534,7 +902,7 @@ async fn search_project_texts_literal_query_preserves_mode_to_runner_and_output(
         result.output["items"][0]["output"]["pattern_mode"],
         "literal"
     );
-    assert_eq!(result.output["items"][0]["output"]["backend"], "rg");
+    assert!(result.output["items"][0]["output"].get("backend").is_none());
 }
 
 #[tokio::test]
@@ -645,7 +1013,14 @@ async fn search_project_texts_default_matches_items_are_sparse_and_schema_valid(
     for item in items {
         assert_eq!(item["success"], true);
         assert!(item["error"].is_null());
-        assert!(item["output"]["matches"].as_array().is_some());
+        let matches = item["output"]["matches"].as_array().unwrap();
+        assert_eq!(matches.len(), 1);
+        let search_match = &matches[0];
+        assert!(search_match.get("context_before").is_none());
+        assert!(search_match.get("context_after").is_none());
+        assert!(search_match["read_hint"].get("path").is_none());
+        assert!(search_match["read_hint"]["start_line"].is_u64());
+        assert_eq!(search_match["read_hint"]["limit"], 80);
         for omitted in [
             "path",
             "backend",


### PR DESCRIPTION
## Summary

- return actionable recovery when the Adaptive Runtime gateway is used for a direct tool, without dispatching or replaying the target effect
- make exact and filtered `tool_manifest` model projections smaller while retaining the current invocation route, input contract, and decision-relevant effect/risk/authority metadata
- compact search success projections while retaining non-default controls, truncation/recovery information, failure provenance, and Session observation evidence
- clarify the maintainer documentation for the exact `tool_manifest` projection

## Review notes

- OAuth scope checks remain authoritative before wrong-route recovery is returned
- hidden/unavailable tools are not exposed through route classification
- canonical/audit evidence is consumed before model-facing result sparsification
- no additional routing table or secondary tool-registry source is introduced

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p webcodex-tool-contracts` — 89 passed
- `cargo test --lib adaptive_runtime_gateway` — 3 passed
- `cargo test --lib adaptive_runtime_tool_manifest` — 4 passed
- `cargo test --lib wrong_route_then_corrected` — 1 passed
- `cargo test --lib search_project_texts` — 37 passed
- `cargo test --lib tool_manifest` — 35 passed
- `git diff --check origin/main...HEAD`
- `workspace_hygiene_check` — clean

Reviewer follow-up commit: `6957e574` (`Clarify exact tool manifest projection docs`).