### PR TITLE
Improve read continuation recovery

### DIFF
--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/files.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/files.rs
@@ -259,7 +259,7 @@ pub fn read_files_input_schema() -> Value {
         (
             "max_result_bytes",
             "integer",
-            "Optional primary model-facing batch projection budget in bytes. Defaults to 64 KiB; raise only for explicit broad/deep reads, up to 256 KiB. Independently bounded Session/continuity protocol overlays are preserved outside this budget.",
+            "Optional primary model-facing batch projection budget in bytes. Defaults to 64 KiB; raise only for explicit broad/deep reads, up to 256 KiB. If the current budget cannot return any part of the first remaining item, the result supplies a bounded increase_result_budget suggested call; otherwise batch continuation reuses the current budget. Independently bounded Session/continuity protocol overlays are preserved outside this budget.",
             false,
         ),
     ]));

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/files.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/files.rs
@@ -561,6 +561,131 @@ fn search_project_texts_output_schema() -> Value {
     })
 }
 
+fn read_suggested_call_schema(tool: &'static str, arguments: Value) -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "tool": {"type": "string", "const": tool},
+            "arguments": arguments
+        },
+        "required": ["tool", "arguments"]
+    })
+}
+
+fn suggested_read_file_arguments_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "project": schema_type("string", "Same accepted project argument used by the current read."),
+            "path": schema_type("string", "Same project-relative file path."),
+            "start_line": {"type": "integer", "minimum": 1},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 2000},
+            "with_line_numbers": {"type": "boolean"}
+        },
+        "required": ["project", "path", "start_line", "limit"]
+    })
+}
+
+fn read_range_continuation_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Actionable positional continuation for unread lines in one file. The cursor is deterministic for the observed file position, but it is not a frozen snapshot: compare the next call's full-file sha256 with source_sha256 before concatenating ranges as one unchanged source.",
+        "properties": {
+            "kind": {"type": "string", "const": "read_range"},
+            "safe_cursor": {"type": "boolean", "const": true},
+            "source_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+            "snapshot_stable": {"type": "boolean", "const": false},
+            "suggested_call": read_suggested_call_schema(
+                "read_file",
+                suggested_read_file_arguments_schema(),
+            )
+        },
+        "required": [
+            "kind", "safe_cursor", "source_sha256", "snapshot_stable", "suggested_call"
+        ]
+    })
+}
+
+fn suggested_read_files_arguments_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "project": schema_type("string", "Same accepted project argument used by the current batch."),
+            "items": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 8,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "path": schema_type("string", "Original project-relative path."),
+                        "start_line": schema_type("integer", "Original optional line offset, preserved exactly as accepted by read_files input normalization."),
+                        "limit": schema_type("integer", "Original optional line limit, preserved exactly as accepted by read_files input normalization.")
+                    },
+                    "required": ["path"]
+                }
+            },
+            "with_line_numbers": {"type": "boolean"},
+            "max_result_bytes": {
+                "type": "integer",
+                "minimum": webcodex_core::runtime_contract::MIN_READ_FILES_RESULT_BYTES,
+                "maximum": webcodex_core::runtime_contract::FILE_READ_MAX_SERIALIZED_OUTPUT_BYTES
+            }
+        },
+        "required": ["project", "items"]
+    })
+}
+
+fn read_batch_continuation_schema() -> Value {
+    let suggested_call =
+        read_suggested_call_schema("read_files", suggested_read_files_arguments_schema());
+    json!({
+        "oneOf": [
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Safe continuation for original batch items that were not returned. next_index is their original request index; suggested_call already slices the original items, so next_index is not passed as an input cursor.",
+                "properties": {
+                    "kind": {"type": "string", "const": "batch_items"},
+                    "safe_cursor": {"type": "boolean", "const": true},
+                    "next_index": {"type": "integer", "minimum": 0, "maximum": 7},
+                    "recommended_order": {
+                        "type": "string",
+                        "enum": ["next", "after_partial_item"]
+                    },
+                    "suggested_call": suggested_call.clone()
+                },
+                "required": [
+                    "kind", "safe_cursor", "next_index", "recommended_order", "suggested_call"
+                ]
+            },
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Budget refinement used only when the current primary result budget could not return any part of the first remaining item. This is not a cursor; the suggested budget is bounded by the existing 256 KiB hard cap.",
+                "properties": {
+                    "kind": {"type": "string", "const": "increase_result_budget"},
+                    "safe_cursor": {"type": "boolean", "const": false},
+                    "next_index": {"type": "integer", "const": 0},
+                    "suggested_max_result_bytes": {
+                        "type": "integer",
+                        "const": webcodex_core::runtime_contract::FILE_READ_MAX_SERIALIZED_OUTPUT_BYTES
+                    },
+                    "suggested_call": suggested_call
+                },
+                "required": [
+                    "kind", "safe_cursor", "next_index", "suggested_max_result_bytes", "suggested_call"
+                ]
+            }
+        ]
+    })
+}
+
 fn read_file_output_schema() -> Value {
     let default_limit = webcodex_core::runtime_contract::FILE_READ_DEFAULT_LIMIT;
     let success_properties = json!({
@@ -598,6 +723,7 @@ fn read_file_output_schema() -> Value {
                 {"type": "null"}
             ]
         },
+        "continuation": read_range_continuation_schema(),
         "session_hint": session_hint_schema(),
         "permission": permission_decision_schema()
     });
@@ -636,6 +762,7 @@ fn read_file_output_schema() -> Value {
         "end_line",
         "has_more",
         "next_start_line",
+        "continuation",
     ] {
         sparse_success_properties.remove(key);
     }
@@ -840,7 +967,8 @@ fn read_files_output_schema() -> Value {
             "path": schema_type("string", "Project-relative input path."),
             "success": {"type": "boolean"},
             "output": {"anyOf": [read_success.clone(), read_failure.clone()]},
-            "error": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+            "error": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            "continuation": read_range_continuation_schema()
         },
         "required": ["index", "path", "success", "output", "error"],
         "allOf": [{
@@ -862,6 +990,7 @@ fn read_files_output_schema() -> Value {
             "output_truncated": {"type": "boolean"},
             "next_index": {"anyOf": [{"type": "integer", "minimum": 0, "maximum": 7}, {"type": "null"}]},
             "truncation_reason": {"type": "string", "enum": ["batch_response_budget", "hard_result_cap"]},
+            "continuation": read_batch_continuation_schema(),
             "session_hint": session_hint_schema(),
             "permission": permission_decision_schema()
         },

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/files.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/files.rs
@@ -578,10 +578,15 @@ fn suggested_read_file_arguments_schema() -> Value {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-            "project": schema_type("string", "Same accepted project argument used by the current read."),
+            "project": schema_type("string", "Exact resolved Project id selected by the current read; shorthand is never replayed by recovery."),
             "path": schema_type("string", "Same project-relative file path."),
             "start_line": {"type": "integer", "minimum": 1},
             "limit": {"type": "integer", "minimum": 1, "maximum": 2000},
+            "session_id": {
+                "type": "string",
+                "pattern": "^wc_sess_[A-Za-z0-9_]+$",
+                "description": "Original explicit business Workflow Session id, present only when the triggering read_file call supplied one."
+            },
             "with_line_numbers": {"type": "boolean"}
         },
         "required": ["project", "path", "start_line", "limit"]
@@ -614,7 +619,7 @@ fn suggested_read_files_arguments_schema() -> Value {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-            "project": schema_type("string", "Same accepted project argument used by the current batch."),
+            "project": schema_type("string", "Exact resolved Project id selected by the current batch; shorthand is never replayed by recovery."),
             "items": {
                 "type": "array",
                 "minItems": 1,
@@ -629,6 +634,11 @@ fn suggested_read_files_arguments_schema() -> Value {
                     },
                     "required": ["path"]
                 }
+            },
+            "session_id": {
+                "type": "string",
+                "pattern": "^wc_sess_[A-Za-z0-9_]+$",
+                "description": "Original explicit business Workflow Session id, present only when the triggering read_files call supplied one."
             },
             "with_line_numbers": {"type": "boolean"},
             "max_result_bytes": {

--- a/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
@@ -425,6 +425,20 @@ fn read_continuation_output_schemas_accept_actionable_recovery_shapes() {
 }
 
 #[test]
+fn read_recovery_schemas_keep_transport_and_recorder_identifiers_private() {
+    for tool in ["read_file", "read_files"] {
+        let schema = output_schema_for_tool(tool);
+        let serialized = serde_json::to_string(&schema).unwrap();
+        for forbidden in ["window_id", "client_window", "recording_session_id"] {
+            assert!(
+                !serialized.contains(forbidden),
+                "{tool} recovery schema must not publish {forbidden}: {serialized}"
+            );
+        }
+    }
+}
+
+#[test]
 fn model_visible_tool_definitions_have_explicit_output_schema_coverage() {
     let specs = registered_tool_specs();
     let default_fields = default_output_schema_field_names();

--- a/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
@@ -303,6 +303,7 @@ fn read_continuation_output_schemas_accept_actionable_recovery_shapes() {
                         "arguments": {
                             "project": "agent:oe:demo",
                             "path": "src/lib.rs",
+                            "session_id": "wc_sess_demo",
                             "start_line": 3,
                             "limit": 1
                         }
@@ -373,6 +374,7 @@ fn read_continuation_output_schemas_accept_actionable_recovery_shapes() {
                         "tool": "read_files",
                         "arguments": {
                             "project": "agent:oe:demo",
+                            "session_id": "wc_sess_demo",
                             "items": [
                                 {"path": "src/1.rs"},
                                 {"path": "src/2.rs", "start_line": 4, "limit": 20}

--- a/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
@@ -276,6 +276,153 @@ fn observe_jobs_failure_item_schema_closes_recovery_metadata() {
 }
 
 #[test]
+fn read_continuation_output_schemas_accept_actionable_recovery_shapes() {
+    let read_file = output_schema_for_tool("read_file");
+    test_support::validate_schema_instance(
+        &json!({
+            "success": true,
+            "output": {
+                "text": "two",
+                "format": "plain",
+                "path": "src/lib.rs",
+                "sha256": "a".repeat(64),
+                "start_line": 2,
+                "limit": 1,
+                "total_lines": 3,
+                "returned_lines": 1,
+                "end_line": 2,
+                "has_more": true,
+                "next_start_line": 3,
+                "continuation": {
+                    "kind": "read_range",
+                    "safe_cursor": true,
+                    "source_sha256": "a".repeat(64),
+                    "snapshot_stable": false,
+                    "suggested_call": {
+                        "tool": "read_file",
+                        "arguments": {
+                            "project": "agent:oe:demo",
+                            "path": "src/lib.rs",
+                            "start_line": 3,
+                            "limit": 1
+                        }
+                    }
+                }
+            },
+            "error": null
+        }),
+        &read_file,
+    )
+    .unwrap();
+
+    let read_files = output_schema_for_tool("read_files");
+    test_support::validate_schema_instance(
+        &json!({
+            "success": true,
+            "output": {
+                "project": "agent:oe:demo",
+                "requested_count": 3,
+                "returned_count": 1,
+                "succeeded_count": 1,
+                "failed_count": 0,
+                "items": [{
+                    "index": 0,
+                    "path": "src/0.rs",
+                    "success": true,
+                    "output": {
+                        "text": "first",
+                        "format": "plain",
+                        "path": "src/0.rs",
+                        "sha256": "b".repeat(64),
+                        "start_line": 1,
+                        "limit": 100,
+                        "total_lines": 200,
+                        "returned_lines": 50,
+                        "end_line": 50,
+                        "has_more": true,
+                        "next_start_line": 51,
+                        "budget_truncated": true,
+                        "budget_next_limit": 50
+                    },
+                    "error": null,
+                    "continuation": {
+                        "kind": "read_range",
+                        "safe_cursor": true,
+                        "source_sha256": "b".repeat(64),
+                        "snapshot_stable": false,
+                        "suggested_call": {
+                            "tool": "read_file",
+                            "arguments": {
+                                "project": "agent:oe:demo",
+                                "path": "src/0.rs",
+                                "start_line": 51,
+                                "limit": 50
+                            }
+                        }
+                    }
+                }],
+                "output_truncated": true,
+                "next_index": 0,
+                "truncation_reason": "batch_response_budget",
+                "continuation": {
+                    "kind": "batch_items",
+                    "safe_cursor": true,
+                    "next_index": 1,
+                    "recommended_order": "after_partial_item",
+                    "suggested_call": {
+                        "tool": "read_files",
+                        "arguments": {
+                            "project": "agent:oe:demo",
+                            "items": [
+                                {"path": "src/1.rs"},
+                                {"path": "src/2.rs", "start_line": 4, "limit": 20}
+                            ]
+                        }
+                    }
+                }
+            },
+            "error": null
+        }),
+        &read_files,
+    )
+    .unwrap();
+
+    test_support::validate_schema_instance(
+        &json!({
+            "success": true,
+            "output": {
+                "project": "agent:oe:demo",
+                "requested_count": 1,
+                "returned_count": 0,
+                "succeeded_count": 0,
+                "failed_count": 0,
+                "items": [],
+                "output_truncated": true,
+                "next_index": 0,
+                "truncation_reason": "batch_response_budget",
+                "continuation": {
+                    "kind": "increase_result_budget",
+                    "safe_cursor": false,
+                    "next_index": 0,
+                    "suggested_max_result_bytes": 262144,
+                    "suggested_call": {
+                        "tool": "read_files",
+                        "arguments": {
+                            "project": "agent:oe:demo",
+                            "items": [{"path": "src/0.rs"}],
+                            "max_result_bytes": 262144
+                        }
+                    }
+                }
+            },
+            "error": null
+        }),
+        &read_files,
+    )
+    .unwrap();
+}
+
+#[test]
 fn model_visible_tool_definitions_have_explicit_output_schema_coverage() {
     let specs = registered_tool_specs();
     let default_fields = default_output_schema_field_names();
@@ -887,6 +1034,7 @@ fn key_tool_output_schemas_include_expected_fields() {
         "has_more",
         "next_start_line",
         "sha256",
+        "continuation",
     ] {
         assert!(
             has_output_field("read_file", field),

--- a/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
+++ b/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
@@ -25,11 +25,14 @@ fn tool_specs_describe_default_coding_loop_preferences() {
 
     let read_files_desc = desc("read_files");
     for phrase in [
+        "batch inspect tool",
+        "use read_file for one targeted range",
         "read_range",
         "batch_items",
         "next_index",
         "not a read_files input",
         "increase_result_budget",
+        "no fake continuation",
         "complete a current partial item",
         "256 kib",
         "exact resolved project",

--- a/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
+++ b/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
@@ -14,6 +14,8 @@ fn tool_specs_describe_default_coding_loop_preferences() {
         "read_range",
         "not snapshot-stable",
         "sha256",
+        "exact resolved project",
+        "business session_id",
     ] {
         assert!(
             read_file_desc.contains(phrase),
@@ -30,6 +32,8 @@ fn tool_specs_describe_default_coding_loop_preferences() {
         "increase_result_budget",
         "complete a current partial item",
         "256 kib",
+        "exact resolved project",
+        "business session_id",
     ] {
         assert!(
             read_files_desc.contains(phrase),

--- a/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
+++ b/crates/webcodex-tool-contracts/src/tests/registry_specs.rs
@@ -11,10 +11,29 @@ fn tool_specs_describe_default_coding_loop_preferences() {
         "default inspect tool",
         "targeted source reading",
         "line numbers",
+        "read_range",
+        "not snapshot-stable",
+        "sha256",
     ] {
         assert!(
             read_file_desc.contains(phrase),
             "read_file description should mention {phrase}: {read_file_desc}"
+        );
+    }
+
+    let read_files_desc = desc("read_files");
+    for phrase in [
+        "read_range",
+        "batch_items",
+        "next_index",
+        "not a read_files input",
+        "increase_result_budget",
+        "complete a current partial item",
+        "256 kib",
+    ] {
+        assert!(
+            read_files_desc.contains(phrase),
+            "read_files description should mention {phrase}: {read_files_desc}"
         );
     }
 

--- a/crates/webcodex-tool-contracts/src/tool_definition/files.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/files.rs
@@ -153,7 +153,7 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
             false,
             false,
         ),
-        "Default inspect tool for targeted source reading. Bounded UTF-8 range read with full-file sha256. Partial success returns a deterministic positional read_range continuation with a directly reusable read_file call; it is not snapshot-stable, so compare the next full-file sha256 before treating ranges as one unchanged source. Line numbers only change text. Oversized ranges fail range_too_large: shrink limit or narrow the range.",
+        "Default inspect tool for targeted source reading. Bounded UTF-8 range read with full-file sha256. Partial success returns a deterministic positional read_range continuation whose reusable read_file call binds the exact resolved Project id and preserves an explicitly supplied business session_id; shorthand is never replayed. The range cursor is not snapshot-stable, so compare the next full-file sha256 before treating ranges as one unchanged source. Line numbers only change text. Oversized ranges fail range_too_large: shrink limit or narrow the range.",
         read_file_input_schema,
     )),
     adaptive_runtime_direct(
@@ -176,7 +176,7 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Read 1 to 8 UTF-8 file ranges in request order with isolated failures and four Runner reads in flight. Partial items return deterministic positional read_range continuations; compare full-file sha256 before joining a later range because reads are not snapshot-stable. Result-budget omission returns an actionable batch_items continuation whose suggested read_files call already contains the remaining original items; next_index is recovery evidence, not a read_files input. When a budget cannot return any part of the first item, increase_result_budget explicitly recommends a bounded max_result_bytes refinement instead. Complete a current partial item before the later batch continuation. The primary batch projection defaults to ~64 KiB and remains capped at 256 KiB; Session/continuity overlays stay separately bounded.",
+            "Read 1 to 8 UTF-8 ranges in request order with isolated failures. Partial items return positional read_range continuations; recovery binds the exact resolved Project id and preserves an explicit business session_id, so shorthand is never replayed. Compare sha256 before joining ranges because reads are not snapshot-stable. Budget omission returns batch_items with remaining original items; next_index is evidence, not a read_files input. If no part of the first item fits, increase_result_budget suggests bounded max_result_bytes. Complete a current partial item before later batch recovery. Primary batch budget defaults to ~64 KiB, capped at 256 KiB; Session overlays remain bounded.",
             read_files_input_schema,
         )),
         50,

--- a/crates/webcodex-tool-contracts/src/tool_definition/files.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/files.rs
@@ -176,7 +176,7 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Read 1 to 8 UTF-8 ranges in request order with isolated failures. Partial items return positional read_range continuations; recovery binds the exact resolved Project id and preserves an explicit business session_id, so shorthand is never replayed. Compare sha256 before joining ranges because reads are not snapshot-stable. Budget omission returns batch_items with remaining original items; next_index is evidence, not a read_files input. If no part of the first item fits, increase_result_budget suggests bounded max_result_bytes. Complete a current partial item before later batch recovery. Primary batch budget defaults to ~64 KiB, capped at 256 KiB; Session overlays remain bounded.",
+            "Batch inspect tool for multiple known file ranges; use read_file for one targeted range. Reads 1 to 8 UTF-8 ranges in request order with isolated failures. Partial items return positional read_range continuations; recovery binds the exact resolved Project id and preserves an explicit business session_id, so shorthand is never replayed. Compare sha256 before joining ranges because reads are not snapshot-stable. Budget omission returns batch_items with remaining original items; next_index is evidence, not a read_files input. If no part of the first item fits, increase_result_budget suggests bounded max_result_bytes; zero progress at the hard cap exposes no fake continuation. Complete a current partial item before later batch recovery. Primary batch budget defaults to ~64 KiB, capped at 256 KiB; Session overlays remain bounded.",
             read_files_input_schema,
         )),
         50,

--- a/crates/webcodex-tool-contracts/src/tool_definition/files.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/files.rs
@@ -153,7 +153,7 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
             false,
             false,
         ),
-        "Default inspect tool for targeted source reading. Bounded UTF-8 range read with full-file sha256 and a continuation cursor (next_start_line); line numbers only change text. Oversized ranges fail range_too_large: shrink limit or narrow the range.",
+        "Default inspect tool for targeted source reading. Bounded UTF-8 range read with full-file sha256. Partial success returns a deterministic positional read_range continuation with a directly reusable read_file call; it is not snapshot-stable, so compare the next full-file sha256 before treating ranges as one unchanged source. Line numbers only change text. Oversized ranges fail range_too_large: shrink limit or narrow the range.",
         read_file_input_schema,
     )),
     adaptive_runtime_direct(
@@ -176,7 +176,7 @@ pub(super) const READ_DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Read 1 to 8 UTF-8 file ranges in request order with isolated failures and four Runner reads in flight. The primary batch projection defaults to ~64 KiB; max_result_bytes raises it to 256 KiB. Session/continuity overlays stay separately bounded. Partial reads return deterministic cursors.",
+            "Read 1 to 8 UTF-8 file ranges in request order with isolated failures and four Runner reads in flight. Partial items return deterministic positional read_range continuations; compare full-file sha256 before joining a later range because reads are not snapshot-stable. Result-budget omission returns an actionable batch_items continuation whose suggested read_files call already contains the remaining original items; next_index is recovery evidence, not a read_files input. When a budget cannot return any part of the first item, increase_result_budget explicitly recommends a bounded max_result_bytes refinement instead. Complete a current partial item before the later batch continuation. The primary batch projection defaults to ~64 KiB and remains capped at 256 KiB; Session/continuity overlays stay separately bounded.",
             read_files_input_schema,
         )),
         50,

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -799,6 +799,36 @@ impl ToolRuntime {
         context_request: Vec<String>,
         material_capabilities: super::context_projection::ContextMaterialCapabilities,
     ) -> ToolResult {
+        self.dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_read_projection(
+            call,
+            auth,
+            transport,
+            recorder_metadata,
+            window,
+            inner_model_facing_recording,
+            context_request,
+            material_capabilities,
+        )
+        .await
+        .0
+    }
+
+    /// Kernel-only companion that returns the Read projection after the same
+    /// authoritative Project resolution used for execution. Other callers keep
+    /// the existing ToolResult-only API and cannot observe this internal state.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_read_projection(
+        &self,
+        call: ToolCall,
+        auth: Option<&AuthContext>,
+        transport: sessions::SessionTransport,
+        recorder_metadata: sessions::ToolCallRecorderMetadata,
+        window: Option<&crate::client_window::ClientWindow>,
+        inner_model_facing_recording: bool,
+        context_request: Vec<String>,
+        material_capabilities: super::context_projection::ContextMaterialCapabilities,
+    ) -> (ToolResult, super::read_files::ReadModelProjection) {
+        let mut read_projection = super::read_files::ReadModelProjection::capture(&call);
         // Edit usage telemetry retains only fixed safe classifications. For
         // apply_patch it captures the requested matching enum before the call is
         // moved, never the patch/path/content arguments.
@@ -813,6 +843,7 @@ impl ToolRuntime {
                 inner_model_facing_recording,
                 context_request.clone(),
                 material_capabilities,
+                &mut read_projection,
             )
             .await;
         // Early project/session/auth failures can return before the normal
@@ -832,7 +863,7 @@ impl ToolRuntime {
         if let Some(guard) = edit_usage.as_mut() {
             guard.finish_with_result(&result);
         }
-        result
+        (result, read_projection)
     }
 
     /// Everything the activity ledger needs from a call, captured before the
@@ -944,6 +975,7 @@ impl ToolRuntime {
         inner_model_facing_recording: bool,
         context_request: Vec<String>,
         material_capabilities: super::context_projection::ContextMaterialCapabilities,
+        read_projection: &mut super::read_files::ReadModelProjection,
     ) -> ToolResult {
         call = call
             .with_coding_agent_recording_session_id(recorder_metadata.recording_session_id.clone());
@@ -986,6 +1018,7 @@ impl ToolRuntime {
         let resolved_project = project_resolution
             .as_ref()
             .and_then(|resolution| resolution.as_ref().ok());
+        read_projection.bind_resolved_project(resolved_project);
         // Preserve the canonical project for activity attribution before the
         // session recorder consumes the resolved value below. Short aliases
         // must not turn a real Runner execution into a client-less row.
@@ -1312,7 +1345,6 @@ impl ToolRuntime {
         let activity_context =
             Self::capture_workspace_activity_context(&call, activity_project.as_deref());
         let search_projection = SearchModelProjection::capture(&call);
-        let read_projection = super::read_files::ReadModelProjection::capture(&call);
         let batch_budget_projection = BatchResponseBudgetProjection::capture(&call);
         let validation_assertion_name = recorder_metadata.expectation.assertion_name.as_deref();
         let tool_name = call.tool_name();
@@ -1412,7 +1444,7 @@ impl ToolRuntime {
                 super::read_files::apply_model_facing_output_budget(
                     &mut result,
                     *max_result_bytes,
-                    &read_projection,
+                    read_projection,
                 );
                 // Direct/business-Session dispatch has already added every
                 // model-facing Session overlay. Enforce the true final ceiling
@@ -1421,7 +1453,7 @@ impl ToolRuntime {
                 // hard-cap pass after its own overlays are attached.
                 super::read_files::enforce_final_model_facing_hard_cap(
                     &mut result,
-                    &read_projection,
+                    read_projection,
                 );
             }
             BatchResponseBudgetProjection::SearchProjectTexts { max_result_bytes } => {
@@ -1446,7 +1478,7 @@ impl ToolRuntime {
         if !defer_batch_sparsification {
             sparsify_search_success_for_model(&search_projection, &mut result);
             if inner_model_facing_recording {
-                super::read_files::add_actionable_read_continuations(&read_projection, &mut result);
+                super::read_files::add_actionable_read_continuations(read_projection, &mut result);
             }
             sparsify_complete_read_success(tool_name, &mut result);
         }

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -1312,6 +1312,7 @@ impl ToolRuntime {
         let activity_context =
             Self::capture_workspace_activity_context(&call, activity_project.as_deref());
         let search_projection = SearchModelProjection::capture(&call);
+        let read_projection = super::read_files::ReadModelProjection::capture(&call);
         let batch_budget_projection = BatchResponseBudgetProjection::capture(&call);
         let validation_assertion_name = recorder_metadata.expectation.assertion_name.as_deref();
         let tool_name = call.tool_name();
@@ -1408,13 +1409,20 @@ impl ToolRuntime {
         match &batch_budget_projection {
             BatchResponseBudgetProjection::None => {}
             BatchResponseBudgetProjection::ReadFiles { max_result_bytes } => {
-                super::read_files::apply_model_facing_output_budget(&mut result, *max_result_bytes);
+                super::read_files::apply_model_facing_output_budget(
+                    &mut result,
+                    *max_result_bytes,
+                    &read_projection,
+                );
                 // Direct/business-Session dispatch has already added every
                 // model-facing Session overlay. Enforce the true final ceiling
                 // against that decorated result before sparse projection. Outer
                 // kernel recording defers sparsification and repeats this exact
                 // hard-cap pass after its own overlays are attached.
-                super::read_files::enforce_final_model_facing_hard_cap(&mut result);
+                super::read_files::enforce_final_model_facing_hard_cap(
+                    &mut result,
+                    &read_projection,
+                );
             }
             BatchResponseBudgetProjection::SearchProjectTexts { max_result_bytes } => {
                 let default_timeouts = match &search_projection {
@@ -1437,6 +1445,9 @@ impl ToolRuntime {
         sparsify_terminal_structured_execution_success(tool_name, &mut result);
         if !defer_batch_sparsification {
             sparsify_search_success_for_model(&search_projection, &mut result);
+            if inner_model_facing_recording {
+                super::read_files::add_actionable_read_continuations(&read_projection, &mut result);
+            }
             sparsify_complete_read_success(tool_name, &mut result);
         }
         result

--- a/src/tool_runtime/file_tools.rs
+++ b/src/tool_runtime/file_tools.rs
@@ -26,10 +26,17 @@ impl ToolRuntime {
                 start_line,
                 limit,
                 with_line_numbers,
-            } => {
-                self.read_file(project, path, start_line, limit, with_line_numbers)
-                    .await
-            }
+            } => match project_resolution {
+                Some(Ok(resolved)) => {
+                    self.read_file_resolved(&resolved, path, start_line, limit, with_line_numbers)
+                        .await
+                }
+                Some(Err(error)) => error.into_tool_result(),
+                None => {
+                    self.read_file(project, path, start_line, limit, with_line_numbers)
+                        .await
+                }
+            },
             ToolCall::ReadFiles {
                 project,
                 items,

--- a/src/tool_runtime/files/inspection.rs
+++ b/src/tool_runtime/files/inspection.rs
@@ -509,6 +509,32 @@ impl ToolRuntime {
         .await
     }
 
+    pub(crate) async fn read_file_resolved(
+        &self,
+        resolved: &ResolvedProject,
+        path: String,
+        start_line: Option<usize>,
+        limit: Option<usize>,
+        with_line_numbers: Option<bool>,
+    ) -> ToolResult {
+        let with_line_numbers = with_line_numbers.unwrap_or(false);
+        // Reuse the same path/sensitive checks as the legacy direct helper,
+        // but consume the authoritative Project resolved by dispatch instead
+        // of performing another registry lookup.
+        if let Some(failure) = validate_read_file_path(&path) {
+            return failure;
+        }
+        self.read_one_validated_project_file(
+            &resolved.config,
+            path,
+            start_line,
+            limit,
+            with_line_numbers,
+            None,
+        )
+        .await
+    }
+
     pub(crate) async fn read_one_resolved_project_file(
         &self,
         project: &ProjectConfig,

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -816,6 +816,7 @@ impl ToolRuntime {
 
         let project = tool_project(&call);
         let deferred_search_projection = super::dispatch::SearchModelProjection::capture(&call);
+        let deferred_read_projection = super::read_files::ReadModelProjection::capture(&call);
         let defer_batch_model_projection = context.session_id.is_some()
             && matches!(
                 &call,
@@ -878,7 +879,10 @@ impl ToolRuntime {
         if defer_batch_model_projection {
             match request.tool_name.as_str() {
                 "read_files" => {
-                    super::read_files::enforce_final_model_facing_hard_cap(&mut result);
+                    super::read_files::enforce_final_model_facing_hard_cap(
+                        &mut result,
+                        &deferred_read_projection,
+                    );
                 }
                 "search_project_texts" => {
                     let default_timeouts = match &deferred_search_projection {
@@ -902,7 +906,19 @@ impl ToolRuntime {
                 &deferred_search_projection,
                 &mut result,
             );
+            if request.tool_name == "read_files" {
+                super::read_files::add_actionable_read_continuations(
+                    &deferred_read_projection,
+                    &mut result,
+                );
+            }
             super::dispatch::sparsify_complete_read_success(&request.tool_name, &mut result);
+        }
+        if context.session_id.is_some() && request.tool_name == "read_file" {
+            super::read_files::add_actionable_read_continuations(
+                &deferred_read_projection,
+                &mut result,
+            );
         }
         if request.tool_name == "tool_manifest" {
             super::surface::sparsify_tool_manifest_model_result(&mut result);

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -816,7 +816,6 @@ impl ToolRuntime {
 
         let project = tool_project(&call);
         let deferred_search_projection = super::dispatch::SearchModelProjection::capture(&call);
-        let deferred_read_projection = super::read_files::ReadModelProjection::capture(&call);
         let defer_batch_model_projection = context.session_id.is_some()
             && matches!(
                 &call,
@@ -825,8 +824,8 @@ impl ToolRuntime {
         // Permission is evaluated once inside dispatch (pre-exec gate). Kernel
         // only reuses the attached decision for the outer recording session —
         // never re-evaluate (no second request id / inconsistent outcome).
-        let mut result = self
-            .dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context(
+        let (mut result, deferred_read_projection) = self
+            .dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_read_projection(
                 call,
                 context.auth,
                 context.transport.into(),

--- a/src/tool_runtime/read_files.rs
+++ b/src/tool_runtime/read_files.rs
@@ -26,11 +26,13 @@ pub(crate) enum ReadModelProjection {
     Single {
         project: String,
         path: String,
+        session_id: Option<String>,
         with_line_numbers: Option<bool>,
     },
     Batch {
         project: String,
         items: Vec<ReadFilesItem>,
+        session_id: Option<String>,
         with_line_numbers: Option<bool>,
         max_result_bytes: Option<usize>,
     },
@@ -42,26 +44,44 @@ impl ReadModelProjection {
             ToolCall::ReadFile {
                 project,
                 path,
+                session_id,
                 with_line_numbers,
                 ..
             } => Self::Single {
                 project: project.clone(),
                 path: path.clone(),
+                session_id: session_id.clone(),
                 with_line_numbers: *with_line_numbers,
             },
             ToolCall::ReadFiles {
                 project,
                 items,
+                session_id,
                 with_line_numbers,
                 max_result_bytes,
-                ..
             } => Self::Batch {
                 project: project.clone(),
                 items: items.clone(),
+                session_id: session_id.clone(),
                 with_line_numbers: *with_line_numbers,
                 max_result_bytes: *max_result_bytes,
             },
             _ => Self::None,
+        }
+    }
+
+    /// Replace shorthand with the exact Project identity selected by the same
+    /// authoritative resolver pass used for this call. Recovery must not
+    /// re-enter shorthand resolution and retarget after registry churn.
+    pub(crate) fn bind_resolved_project(&mut self, resolved: Option<&ResolvedProject>) {
+        let Some(resolved) = resolved else {
+            return;
+        };
+        match self {
+            Self::Single { project, .. } | Self::Batch { project, .. } => {
+                *project = resolved.resolved_id.clone();
+            }
+            Self::None => {}
         }
     }
 }
@@ -71,6 +91,7 @@ fn read_file_suggested_arguments(
     path: &str,
     start_line: usize,
     limit: usize,
+    session_id: Option<&str>,
     with_line_numbers: Option<bool>,
 ) -> Value {
     let mut arguments = json!({
@@ -79,6 +100,9 @@ fn read_file_suggested_arguments(
         "start_line": start_line,
         "limit": limit,
     });
+    if let Some(session_id) = session_id {
+        arguments["session_id"] = json!(session_id);
+    }
     if let Some(with_line_numbers) = with_line_numbers {
         arguments["with_line_numbers"] = json!(with_line_numbers);
     }
@@ -89,6 +113,7 @@ fn read_range_continuation(
     project: &str,
     path: &str,
     output: &serde_json::Map<String, Value>,
+    session_id: Option<&str>,
     with_line_numbers: Option<bool>,
 ) -> Option<Value> {
     if output.get("has_more").and_then(Value::as_bool) != Some(true) {
@@ -121,13 +146,19 @@ fn read_range_continuation(
                 path,
                 next_start_line,
                 limit,
+                session_id,
                 with_line_numbers,
             )
         }
     }))
 }
 
-fn add_item_read_continuation(item: &mut Value, project: &str, with_line_numbers: Option<bool>) {
+fn add_item_read_continuation(
+    item: &mut Value,
+    project: &str,
+    session_id: Option<&str>,
+    with_line_numbers: Option<bool>,
+) {
     if item.get("success").and_then(Value::as_bool) != Some(true) {
         return;
     }
@@ -137,7 +168,9 @@ fn add_item_read_continuation(item: &mut Value, project: &str, with_line_numbers
     let continuation = item
         .get("output")
         .and_then(Value::as_object)
-        .and_then(|output| read_range_continuation(project, &path, output, with_line_numbers));
+        .and_then(|output| {
+            read_range_continuation(project, &path, output, session_id, with_line_numbers)
+        });
     if let (Some(continuation), Some(item)) = (continuation, item.as_object_mut()) {
         item.insert("continuation".to_string(), continuation);
     }
@@ -146,6 +179,7 @@ fn add_item_read_continuation(item: &mut Value, project: &str, with_line_numbers
 fn read_files_suggested_arguments(
     project: &str,
     items: &[ReadFilesItem],
+    session_id: Option<&str>,
     with_line_numbers: Option<bool>,
     max_result_bytes: Option<usize>,
 ) -> Value {
@@ -166,6 +200,9 @@ fn read_files_suggested_arguments(
         "project": project,
         "items": suggested_items,
     });
+    if let Some(session_id) = session_id {
+        arguments["session_id"] = json!(session_id);
+    }
     if let Some(with_line_numbers) = with_line_numbers {
         arguments["with_line_numbers"] = json!(with_line_numbers);
     }
@@ -179,6 +216,7 @@ fn add_batch_read_continuation(
     output: &mut serde_json::Map<String, Value>,
     project: &str,
     original_items: &[ReadFilesItem],
+    session_id: Option<&str>,
     with_line_numbers: Option<bool>,
     max_result_bytes: Option<usize>,
 ) {
@@ -226,6 +264,7 @@ fn add_batch_read_continuation(
                     "arguments": read_files_suggested_arguments(
                         project,
                         original_items,
+                        session_id,
                         with_line_numbers,
                         Some(MAX_SERIALIZED_OUTPUT_BYTES),
                     )
@@ -251,6 +290,7 @@ fn add_batch_read_continuation(
                 "arguments": read_files_suggested_arguments(
                     project,
                     remaining,
+                    session_id,
                     with_line_numbers,
                     max_result_bytes,
                 )
@@ -276,10 +316,17 @@ pub(crate) fn add_actionable_read_continuations(
         ReadModelProjection::Single {
             project,
             path,
+            session_id,
             with_line_numbers,
         } => {
             let continuation = result.output.as_object().and_then(|output| {
-                read_range_continuation(project, path, output, *with_line_numbers)
+                read_range_continuation(
+                    project,
+                    path,
+                    output,
+                    session_id.as_deref(),
+                    *with_line_numbers,
+                )
             });
             if let (Some(continuation), Some(output)) =
                 (continuation, result.output.as_object_mut())
@@ -290,12 +337,18 @@ pub(crate) fn add_actionable_read_continuations(
         ReadModelProjection::Batch {
             project,
             items: original_items,
+            session_id,
             with_line_numbers,
             max_result_bytes,
         } => {
             if let Some(items) = result.output.get_mut("items").and_then(Value::as_array_mut) {
                 for item in items {
-                    add_item_read_continuation(item, project, *with_line_numbers);
+                    add_item_read_continuation(
+                        item,
+                        project,
+                        session_id.as_deref(),
+                        *with_line_numbers,
+                    );
                 }
             }
             if let Some(output) = result.output.as_object_mut() {
@@ -303,6 +356,7 @@ pub(crate) fn add_actionable_read_continuations(
                     output,
                     project,
                     original_items,
+                    session_id.as_deref(),
                     *with_line_numbers,
                     *max_result_bytes,
                 );
@@ -372,11 +426,17 @@ fn projected_read_item_len(item: &Value, projection: &ReadModelProjection) -> us
     let mut projected = item.clone();
     if let ReadModelProjection::Batch {
         project,
+        session_id,
         with_line_numbers,
         ..
     } = projection
     {
-        add_item_read_continuation(&mut projected, project, *with_line_numbers);
+        add_item_read_continuation(
+            &mut projected,
+            project,
+            session_id.as_deref(),
+            *with_line_numbers,
+        );
     }
     if projected["success"].as_bool() == Some(true) {
         let outer_path = projected
@@ -854,6 +914,7 @@ mod tests {
     fn batch_projection(count: usize, max_result_bytes: Option<usize>) -> ReadModelProjection {
         ReadModelProjection::Batch {
             project: "agent:oe:demo".to_string(),
+            session_id: None,
             items: (0..count)
                 .map(|index| ReadFilesItem {
                     path: format!("src/{index}.rs"),
@@ -1019,7 +1080,10 @@ mod tests {
         let first = vec!["x".repeat(140 * 1024)];
         let second = vec!["y".repeat(140 * 1024)];
         let third = vec!["z".to_string()];
-        let projection = batch_projection(3, Some(MAX_SERIALIZED_OUTPUT_BYTES));
+        let mut projection = batch_projection(3, Some(MAX_SERIALIZED_OUTPUT_BYTES));
+        if let ReadModelProjection::Batch { session_id, .. } = &mut projection {
+            *session_id = Some("wc_sess_batch_recovery".to_string());
+        }
         let output = apply_output_budget(
             "agent:oe:demo",
             3,
@@ -1044,6 +1108,10 @@ mod tests {
         assert_eq!(continuation["recommended_order"], "next");
         let suggested = &continuation["suggested_call"];
         assert_eq!(suggested["tool"], "read_files");
+        assert_eq!(
+            suggested["arguments"]["session_id"],
+            "wc_sess_batch_recovery"
+        );
         assert!(suggested["arguments"].get("next_index").is_none());
         assert_eq!(
             suggested["arguments"]["items"]
@@ -1063,9 +1131,11 @@ mod tests {
             next,
             ToolCall::ReadFiles {
                 ref items,
+                session_id: Some(ref next_session_id),
                 max_result_bytes: Some(bytes),
                 ..
             } if bytes == MAX_SERIALIZED_OUTPUT_BYTES
+                && next_session_id == "wc_sess_batch_recovery"
                 && items.iter().map(|item| item.path.as_str()).collect::<Vec<_>>()
                     == vec!["src/1.rs", "src/2.rs"]
         ));
@@ -1372,6 +1442,7 @@ mod tests {
         });
         let single_projection = ReadModelProjection::Single {
             project: "agent:oe:demo".to_string(),
+            session_id: None,
             path: "src/lib.rs".to_string(),
             with_line_numbers: None,
         };
@@ -1418,6 +1489,7 @@ mod tests {
         let partial_batch = batch_output("agent:oe:demo", 1, vec![partial_item], false, None, None);
         let partial_batch_projection = ReadModelProjection::Batch {
             project: "agent:oe:demo".to_string(),
+            session_id: None,
             items: vec![ReadFilesItem {
                 path: "src/0.rs".to_string(),
                 start_line: Some(11),

--- a/src/tool_runtime/read_files.rs
+++ b/src/tool_runtime/read_files.rs
@@ -248,29 +248,31 @@ fn add_batch_read_continuation(
     // item, replaying the same request at the same budget cannot make progress.
     // This is parameter refinement rather than a safe cursor: recommend the
     // existing hard maximum, never a value above it.
-    if next_index == 0
-        && returned_items.is_some_and(Vec::is_empty)
-        && max_result_bytes.unwrap_or(DEFAULT_READ_FILES_RESULT_BYTES) < MAX_SERIALIZED_OUTPUT_BYTES
-    {
-        output.insert(
-            "continuation".to_string(),
-            json!({
-                "kind": "increase_result_budget",
-                "safe_cursor": false,
-                "next_index": 0,
-                "suggested_max_result_bytes": MAX_SERIALIZED_OUTPUT_BYTES,
-                "suggested_call": {
-                    "tool": "read_files",
-                    "arguments": read_files_suggested_arguments(
-                        project,
-                        original_items,
-                        session_id,
-                        with_line_numbers,
-                        Some(MAX_SERIALIZED_OUTPUT_BYTES),
-                    )
-                }
-            }),
-        );
+    if next_index == 0 && returned_items.is_some_and(Vec::is_empty) {
+        if max_result_bytes.unwrap_or(DEFAULT_READ_FILES_RESULT_BYTES) < MAX_SERIALIZED_OUTPUT_BYTES
+        {
+            output.insert(
+                "continuation".to_string(),
+                json!({
+                    "kind": "increase_result_budget",
+                    "safe_cursor": false,
+                    "next_index": 0,
+                    "suggested_max_result_bytes": MAX_SERIALIZED_OUTPUT_BYTES,
+                    "suggested_call": {
+                        "tool": "read_files",
+                        "arguments": read_files_suggested_arguments(
+                            project,
+                            original_items,
+                            session_id,
+                            with_line_numbers,
+                            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+                        )
+                    }
+                }),
+            );
+        }
+        // At the hard cap the same zero-progress replay cannot prove forward
+        // progress. Omit recovery instead of advertising a fake safe cursor.
         return;
     }
 
@@ -1261,6 +1263,31 @@ mod tests {
                 ..
             } if bytes == MAX_SERIALIZED_OUTPUT_BYTES
         ));
+    }
+
+    #[test]
+    fn zero_progress_hard_cap_does_not_advertise_fake_batch_replay() {
+        let oversized_single_line = vec!["x".repeat(MAX_SERIALIZED_OUTPUT_BYTES + 1024)];
+        let projection = batch_projection(1, Some(MAX_SERIALIZED_OUTPUT_BYTES));
+        let output = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            vec![ranged_item(0, 1, &oversized_single_line)],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+            &projection,
+        );
+        assert_eq!(output["output_truncated"], true);
+        assert_eq!(output["truncation_reason"], "hard_result_cap");
+        assert_eq!(output["next_index"], 0);
+        assert!(output["items"].as_array().unwrap().is_empty());
+
+        let mut model = ToolResult::ok(output);
+        add_actionable_read_continuations(&projection, &mut model);
+        assert!(
+            model.output.get("continuation").is_none(),
+            "a hard-cap zero-progress replay is not actionable: {}",
+            model.output
+        );
     }
 
     #[test]

--- a/src/tool_runtime/read_files.rs
+++ b/src/tool_runtime/read_files.rs
@@ -1,7 +1,7 @@
 //! Bounded multi-file reads built from the canonical single-file read core.
 
 use super::project_resolution::ResolvedProject;
-use super::{ReadFilesItem, ToolResult, ToolRuntime};
+use super::{ReadFilesItem, ToolCall, ToolResult, ToolRuntime};
 use futures_util::{stream, StreamExt};
 use serde_json::{json, Value};
 use std::time::Duration;
@@ -15,6 +15,301 @@ pub(crate) const DEFAULT_READ_FILES_DEADLINE: Duration = Duration::from_secs(30)
 pub(crate) use webcodex_core::runtime_contract::{
     DEFAULT_READ_FILES_RESULT_BYTES, MIN_READ_FILES_RESULT_BYTES,
 };
+
+/// Read request facts captured before the ToolCall is moved into execution.
+/// Canonical read results remain independent of this projection; these facts
+/// exist only so a final model-facing partial result can provide a directly
+/// reusable next call without inventing a new cursor.
+#[derive(Clone, Debug)]
+pub(crate) enum ReadModelProjection {
+    None,
+    Single {
+        project: String,
+        path: String,
+        with_line_numbers: Option<bool>,
+    },
+    Batch {
+        project: String,
+        items: Vec<ReadFilesItem>,
+        with_line_numbers: Option<bool>,
+        max_result_bytes: Option<usize>,
+    },
+}
+
+impl ReadModelProjection {
+    pub(crate) fn capture(call: &ToolCall) -> Self {
+        match call {
+            ToolCall::ReadFile {
+                project,
+                path,
+                with_line_numbers,
+                ..
+            } => Self::Single {
+                project: project.clone(),
+                path: path.clone(),
+                with_line_numbers: *with_line_numbers,
+            },
+            ToolCall::ReadFiles {
+                project,
+                items,
+                with_line_numbers,
+                max_result_bytes,
+                ..
+            } => Self::Batch {
+                project: project.clone(),
+                items: items.clone(),
+                with_line_numbers: *with_line_numbers,
+                max_result_bytes: *max_result_bytes,
+            },
+            _ => Self::None,
+        }
+    }
+}
+
+fn read_file_suggested_arguments(
+    project: &str,
+    path: &str,
+    start_line: usize,
+    limit: usize,
+    with_line_numbers: Option<bool>,
+) -> Value {
+    let mut arguments = json!({
+        "project": project,
+        "path": path,
+        "start_line": start_line,
+        "limit": limit,
+    });
+    if let Some(with_line_numbers) = with_line_numbers {
+        arguments["with_line_numbers"] = json!(with_line_numbers);
+    }
+    arguments
+}
+
+fn read_range_continuation(
+    project: &str,
+    path: &str,
+    output: &serde_json::Map<String, Value>,
+    with_line_numbers: Option<bool>,
+) -> Option<Value> {
+    if output.get("has_more").and_then(Value::as_bool) != Some(true) {
+        return None;
+    }
+    let next_start_line = output.get("next_start_line")?.as_u64()? as usize;
+    let source_sha256 = output.get("sha256")?.as_str()?;
+    let total_lines = output.get("total_lines")?.as_u64()? as usize;
+    let remaining_lines = total_lines
+        .saturating_sub(next_start_line)
+        .saturating_add(1);
+    if remaining_lines == 0 {
+        return None;
+    }
+    let requested_limit = output
+        .get("budget_next_limit")
+        .and_then(Value::as_u64)
+        .or_else(|| output.get("limit").and_then(Value::as_u64))?
+        as usize;
+    let limit = requested_limit.min(remaining_lines).max(1);
+    Some(json!({
+        "kind": "read_range",
+        "safe_cursor": true,
+        "source_sha256": source_sha256,
+        "snapshot_stable": false,
+        "suggested_call": {
+            "tool": "read_file",
+            "arguments": read_file_suggested_arguments(
+                project,
+                path,
+                next_start_line,
+                limit,
+                with_line_numbers,
+            )
+        }
+    }))
+}
+
+fn add_item_read_continuation(item: &mut Value, project: &str, with_line_numbers: Option<bool>) {
+    if item.get("success").and_then(Value::as_bool) != Some(true) {
+        return;
+    }
+    let Some(path) = item.get("path").and_then(Value::as_str).map(str::to_string) else {
+        return;
+    };
+    let continuation = item
+        .get("output")
+        .and_then(Value::as_object)
+        .and_then(|output| read_range_continuation(project, &path, output, with_line_numbers));
+    if let (Some(continuation), Some(item)) = (continuation, item.as_object_mut()) {
+        item.insert("continuation".to_string(), continuation);
+    }
+}
+
+fn read_files_suggested_arguments(
+    project: &str,
+    items: &[ReadFilesItem],
+    with_line_numbers: Option<bool>,
+    max_result_bytes: Option<usize>,
+) -> Value {
+    let suggested_items = items
+        .iter()
+        .map(|item| {
+            let mut suggested = json!({"path": item.path});
+            if let Some(start_line) = item.start_line {
+                suggested["start_line"] = json!(start_line);
+            }
+            if let Some(limit) = item.limit {
+                suggested["limit"] = json!(limit);
+            }
+            suggested
+        })
+        .collect::<Vec<_>>();
+    let mut arguments = json!({
+        "project": project,
+        "items": suggested_items,
+    });
+    if let Some(with_line_numbers) = with_line_numbers {
+        arguments["with_line_numbers"] = json!(with_line_numbers);
+    }
+    if let Some(max_result_bytes) = max_result_bytes {
+        arguments["max_result_bytes"] = json!(max_result_bytes);
+    }
+    arguments
+}
+
+fn add_batch_read_continuation(
+    output: &mut serde_json::Map<String, Value>,
+    project: &str,
+    original_items: &[ReadFilesItem],
+    with_line_numbers: Option<bool>,
+    max_result_bytes: Option<usize>,
+) {
+    if output.get("output_truncated").and_then(Value::as_bool) != Some(true) {
+        return;
+    }
+    let Some(next_index) = output.get("next_index").and_then(Value::as_u64) else {
+        return;
+    };
+    let next_index = next_index as usize;
+    if next_index >= original_items.len() {
+        return;
+    }
+    let returned_items = output.get("items").and_then(Value::as_array);
+    let partial_current = returned_items.is_some_and(|items| {
+        items.iter().any(|item| {
+            item.get("index").and_then(Value::as_u64) == Some(next_index as u64)
+                && item.get("success").and_then(Value::as_bool) == Some(true)
+                && item
+                    .get("output")
+                    .and_then(|output| output.get("budget_truncated"))
+                    .and_then(Value::as_bool)
+                    == Some(true)
+        })
+    });
+    let first_unreturned_index = next_index.saturating_add(usize::from(partial_current));
+
+    // If the primary response budget could not return even part of its first
+    // item, replaying the same request at the same budget cannot make progress.
+    // This is parameter refinement rather than a safe cursor: recommend the
+    // existing hard maximum, never a value above it.
+    if next_index == 0
+        && returned_items.is_some_and(Vec::is_empty)
+        && max_result_bytes.unwrap_or(DEFAULT_READ_FILES_RESULT_BYTES) < MAX_SERIALIZED_OUTPUT_BYTES
+    {
+        output.insert(
+            "continuation".to_string(),
+            json!({
+                "kind": "increase_result_budget",
+                "safe_cursor": false,
+                "next_index": 0,
+                "suggested_max_result_bytes": MAX_SERIALIZED_OUTPUT_BYTES,
+                "suggested_call": {
+                    "tool": "read_files",
+                    "arguments": read_files_suggested_arguments(
+                        project,
+                        original_items,
+                        with_line_numbers,
+                        Some(MAX_SERIALIZED_OUTPUT_BYTES),
+                    )
+                }
+            }),
+        );
+        return;
+    }
+
+    if first_unreturned_index >= original_items.len() {
+        return;
+    }
+    let remaining = &original_items[first_unreturned_index..];
+    output.insert(
+        "continuation".to_string(),
+        json!({
+            "kind": "batch_items",
+            "safe_cursor": true,
+            "next_index": first_unreturned_index,
+            "recommended_order": if partial_current { "after_partial_item" } else { "next" },
+            "suggested_call": {
+                "tool": "read_files",
+                "arguments": read_files_suggested_arguments(
+                    project,
+                    remaining,
+                    with_line_numbers,
+                    max_result_bytes,
+                )
+            }
+        }),
+    );
+}
+
+/// Add actionable model-only continuation metadata to successful reads. The
+/// source cursor remains positional: `source_sha256` identifies the file that
+/// produced the current range, while `snapshot_stable=false` makes explicit
+/// that a later positional read must compare its newly returned full-file hash
+/// before the model treats both ranges as one unchanged snapshot.
+pub(crate) fn add_actionable_read_continuations(
+    projection: &ReadModelProjection,
+    result: &mut ToolResult,
+) {
+    if !result.success {
+        return;
+    }
+    match projection {
+        ReadModelProjection::None => {}
+        ReadModelProjection::Single {
+            project,
+            path,
+            with_line_numbers,
+        } => {
+            let continuation = result.output.as_object().and_then(|output| {
+                read_range_continuation(project, path, output, *with_line_numbers)
+            });
+            if let (Some(continuation), Some(output)) =
+                (continuation, result.output.as_object_mut())
+            {
+                output.insert("continuation".to_string(), continuation);
+            }
+        }
+        ReadModelProjection::Batch {
+            project,
+            items: original_items,
+            with_line_numbers,
+            max_result_bytes,
+        } => {
+            if let Some(items) = result.output.get_mut("items").and_then(Value::as_array_mut) {
+                for item in items {
+                    add_item_read_continuation(item, project, *with_line_numbers);
+                }
+            }
+            if let Some(output) = result.output.as_object_mut() {
+                add_batch_read_continuation(
+                    output,
+                    project,
+                    original_items,
+                    *with_line_numbers,
+                    *max_result_bytes,
+                );
+            }
+        }
+    }
+}
 
 fn normalized_result_budget(max_result_bytes: Option<usize>) -> usize {
     max_result_bytes
@@ -64,16 +359,25 @@ fn serialized_value_len(value: &Value) -> usize {
         .unwrap_or(usize::MAX)
 }
 
-fn projected_batch_serialized_len(output: &Value) -> usize {
+fn projected_batch_serialized_len(output: &Value, projection: &ReadModelProjection) -> usize {
     let mut projected = ToolResult::ok(output.clone());
+    add_actionable_read_continuations(projection, &mut projected);
     super::dispatch::sparsify_complete_read_success("read_files", &mut projected);
     serde_json::to_vec(&projected)
         .map(|bytes| bytes.len())
         .unwrap_or(usize::MAX)
 }
 
-fn projected_read_item_len(item: &Value) -> usize {
+fn projected_read_item_len(item: &Value, projection: &ReadModelProjection) -> usize {
     let mut projected = item.clone();
+    if let ReadModelProjection::Batch {
+        project,
+        with_line_numbers,
+        ..
+    } = projection
+    {
+        add_item_read_continuation(&mut projected, project, *with_line_numbers);
+    }
     if projected["success"].as_bool() == Some(true) {
         let outer_path = projected
             .get("path")
@@ -138,7 +442,11 @@ fn truncate_read_item(item: &Value, keep_lines: usize) -> Option<Value> {
     Some(projected)
 }
 
-fn truncate_read_item_to_fit(item: &Value, max_item_bytes: usize) -> Option<Value> {
+fn truncate_read_item_to_fit(
+    item: &Value,
+    max_item_bytes: usize,
+    projection: &ReadModelProjection,
+) -> Option<Value> {
     let returned_lines = item.get("output")?.get("returned_lines")?.as_u64()? as usize;
     if returned_lines <= 1 {
         return None;
@@ -152,7 +460,7 @@ fn truncate_read_item_to_fit(item: &Value, max_item_bytes: usize) -> Option<Valu
         let Some(candidate) = truncate_read_item(item, keep) else {
             break;
         };
-        if serialized_value_len(&candidate) <= max_item_bytes {
+        if projected_read_item_len(&candidate, projection) <= max_item_bytes {
             best = Some(candidate);
             low = keep.saturating_add(1);
         } else {
@@ -167,6 +475,7 @@ fn apply_output_budget(
     requested_count: usize,
     completed: Vec<Value>,
     max_result_bytes: Option<usize>,
+    projection: &ReadModelProjection,
 ) -> Value {
     let result_budget = normalized_result_budget(max_result_bytes);
     let payload_budget = result_budget.saturating_sub(MODEL_RESULT_ENVELOPE_RESERVE_BYTES);
@@ -181,7 +490,7 @@ fn apply_output_budget(
     // Budget the shape the model would actually receive after the existing
     // sparse projection. The canonical representation remains available for
     // Session recording and for any partial-item cursor construction below.
-    if projected_batch_serialized_len(&complete) <= payload_budget {
+    if projected_batch_serialized_len(&complete, projection) <= payload_budget {
         return complete;
     }
 
@@ -193,21 +502,24 @@ fn apply_output_budget(
     // The truncated empty shape fixes all outer-field byte costs up front.
     // Counts and indices are single digits for this 1..=8 batch, so each item
     // can then be accounted exactly by its own serialized size plus one comma.
-    let base_len = projected_batch_serialized_len(&batch_output(
-        project,
-        requested_count,
-        Vec::new(),
-        true,
-        Some(0),
-        Some(truncation_reason),
-    ));
+    let base_len = projected_batch_serialized_len(
+        &batch_output(
+            project,
+            requested_count,
+            Vec::new(),
+            true,
+            Some(0),
+            Some(truncation_reason),
+        ),
+        projection,
+    );
     let mut returned = Vec::with_capacity(completed.len());
     let mut returned_item_bytes = 0usize;
     let mut next_index = None;
 
     for item in completed {
         let index = item["index"].as_u64().unwrap_or(returned.len() as u64) as usize;
-        let item_len = projected_read_item_len(&item);
+        let item_len = projected_read_item_len(&item, projection);
         let candidate_item_count = returned.len() + 1;
         if projected_batch_len(
             base_len,
@@ -225,7 +537,7 @@ fn apply_output_budget(
             .saturating_sub(base_len)
             .saturating_sub(returned_item_bytes)
             .saturating_sub(separator_bytes);
-        if let Some(partial) = truncate_read_item_to_fit(&item, max_item_bytes) {
+        if let Some(partial) = truncate_read_item_to_fit(&item, max_item_bytes, projection) {
             returned.push(partial);
         }
         // A partial current item resumes from its next_start_line, while an
@@ -246,7 +558,7 @@ fn apply_output_budget(
     // Defensive exact serialization fallback. Normal accounting above is O(n)
     // plus an O(log lines) partial-item search; this loop should never execute
     // unless a future outer-field change invalidates the fixed-size arithmetic.
-    while projected_batch_serialized_len(&output) > payload_budget {
+    while projected_batch_serialized_len(&output, projection) > payload_budget {
         let Some(items) = output.get_mut("items").and_then(Value::as_array_mut) else {
             break;
         };
@@ -269,6 +581,7 @@ fn apply_output_budget(
 pub(crate) fn apply_model_facing_output_budget(
     result: &mut ToolResult,
     max_result_bytes: Option<usize>,
+    projection: &ReadModelProjection,
 ) {
     if !result.success {
         return;
@@ -294,7 +607,13 @@ pub(crate) fn apply_model_facing_output_budget(
         return;
     };
 
-    let budgeted = apply_output_budget(&project, requested_count, completed, max_result_bytes);
+    let budgeted = apply_output_budget(
+        &project,
+        requested_count,
+        completed,
+        max_result_bytes,
+        projection,
+    );
     let Some(root) = result.output.as_object_mut() else {
         return;
     };
@@ -318,8 +637,9 @@ pub(crate) fn apply_model_facing_output_budget(
     }
 }
 
-fn final_model_result_len(output: &Value) -> usize {
+fn final_model_result_len(output: &Value, projection: &ReadModelProjection) -> usize {
     let mut projected = ToolResult::ok(output.clone());
+    add_actionable_read_continuations(projection, &mut projected);
     super::dispatch::sparsify_complete_read_success("read_files", &mut projected);
     serde_json::to_vec(&projected)
         .map(|bytes| bytes.len())
@@ -364,8 +684,13 @@ fn mark_final_hard_cap_truncation(output: &mut Value, next_index: usize) {
 /// projection), so project/count/continuation metadata can remain truthful when
 /// final hard-cap pressure turns a previously complete response into a partial
 /// one.
-pub(crate) fn enforce_final_model_facing_hard_cap(result: &mut ToolResult) {
-    if !result.success || final_model_result_len(&result.output) <= MAX_SERIALIZED_OUTPUT_BYTES {
+pub(crate) fn enforce_final_model_facing_hard_cap(
+    result: &mut ToolResult,
+    projection: &ReadModelProjection,
+) {
+    if !result.success
+        || final_model_result_len(&result.output, projection) <= MAX_SERIALIZED_OUTPUT_BYTES
+    {
         return;
     }
     let Some(root) = result.output.as_object() else {
@@ -416,7 +741,8 @@ pub(crate) fn enforce_final_model_facing_hard_cap(result: &mut ToolResult) {
                         candidate_items[last_index] = partial;
                     }
                     mark_final_hard_cap_truncation(&mut candidate, index);
-                    if final_model_result_len(&candidate) <= MAX_SERIALIZED_OUTPUT_BYTES {
+                    if final_model_result_len(&candidate, projection) <= MAX_SERIALIZED_OUTPUT_BYTES
+                    {
                         best = Some(candidate);
                         low = keep.saturating_add(1);
                     } else {
@@ -440,7 +766,7 @@ pub(crate) fn enforce_final_model_facing_hard_cap(result: &mut ToolResult) {
                 .unwrap_or(index as u64) as usize
         };
         mark_final_hard_cap_truncation(&mut result.output, removed_index);
-        if final_model_result_len(&result.output) <= MAX_SERIALIZED_OUTPUT_BYTES {
+        if final_model_result_len(&result.output, projection) <= MAX_SERIALIZED_OUTPUT_BYTES {
             return;
         }
     }
@@ -525,6 +851,21 @@ impl ToolRuntime {
 mod tests {
     use super::*;
 
+    fn batch_projection(count: usize, max_result_bytes: Option<usize>) -> ReadModelProjection {
+        ReadModelProjection::Batch {
+            project: "agent:oe:demo".to_string(),
+            items: (0..count)
+                .map(|index| ReadFilesItem {
+                    path: format!("src/{index}.rs"),
+                    start_line: None,
+                    limit: None,
+                })
+                .collect(),
+            with_line_numbers: None,
+            max_result_bytes,
+        }
+    }
+
     fn ranged_item(index: usize, start_line: usize, lines: &[String]) -> Value {
         let returned_lines = lines.len();
         json!({
@@ -583,7 +924,8 @@ mod tests {
                 .collect::<Vec<_>>();
             let canonical = batch_output("agent:oe:demo", 8, completed.clone(), false, None, None);
             let canonical_bytes = serialized_batch_len(&canonical);
-            let sparse_bytes = projected_batch_serialized_len(&canonical);
+            let sparse_bytes =
+                projected_batch_serialized_len(&canonical, &batch_projection(8, None));
             if canonical_bytes > payload_budget && sparse_bytes <= payload_budget {
                 selected = Some((completed, canonical_bytes, sparse_bytes));
                 break;
@@ -602,7 +944,7 @@ mod tests {
             None,
             None,
         ));
-        apply_model_facing_output_budget(&mut result, None);
+        apply_model_facing_output_budget(&mut result, None, &batch_projection(8, None));
         assert_eq!(result.output["output_truncated"], false);
         assert!(result.output["next_index"].is_null());
         assert_eq!(result.output["items"].as_array().unwrap().len(), 8);
@@ -644,6 +986,7 @@ mod tests {
                 "error": null
             })
         };
+        let projection = batch_projection(2, Some(MAX_SERIALIZED_OUTPUT_BYTES));
         let output = apply_output_budget(
             "agent:oe:demo",
             2,
@@ -652,13 +995,202 @@ mod tests {
                 item(1, "y".repeat(140 * 1024)),
             ],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
+            &projection,
         );
         assert_eq!(output["returned_count"], 1);
         assert_eq!(output["output_truncated"], true);
         assert_eq!(output["next_index"], 1);
         assert_eq!(output["items"].as_array().unwrap().len(), 1);
-        let serialized = serde_json::to_vec(&ToolResult::ok(output)).unwrap();
+        let serialized = serde_json::to_vec(&ToolResult::ok(output.clone())).unwrap();
         assert!(serialized.len() <= MAX_SERIALIZED_OUTPUT_BYTES);
+        let mut model = ToolResult::ok(output);
+        add_actionable_read_continuations(&projection, &mut model);
+        super::super::dispatch::sparsify_complete_read_success("read_files", &mut model);
+        let serialized = serde_json::to_vec(&model).unwrap();
+        assert!(
+            serialized.len() <= MAX_SERIALIZED_OUTPUT_BYTES,
+            "actionable continuation must remain inside the 256 KiB hard cap: {} bytes",
+            serialized.len()
+        );
+    }
+
+    #[test]
+    fn omitted_batch_items_have_reusable_sliced_read_files_call() {
+        let first = vec!["x".repeat(140 * 1024)];
+        let second = vec!["y".repeat(140 * 1024)];
+        let third = vec!["z".to_string()];
+        let projection = batch_projection(3, Some(MAX_SERIALIZED_OUTPUT_BYTES));
+        let output = apply_output_budget(
+            "agent:oe:demo",
+            3,
+            vec![
+                ranged_item(0, 1, &first),
+                ranged_item(1, 1, &second),
+                ranged_item(2, 1, &third),
+            ],
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+            &projection,
+        );
+        assert_eq!(output["output_truncated"], true);
+        assert_eq!(output["next_index"], 1);
+        assert_eq!(output["items"].as_array().unwrap().len(), 1);
+
+        let mut model = ToolResult::ok(output);
+        add_actionable_read_continuations(&projection, &mut model);
+        let continuation = &model.output["continuation"];
+        assert_eq!(continuation["kind"], "batch_items");
+        assert_eq!(continuation["safe_cursor"], true);
+        assert_eq!(continuation["next_index"], 1);
+        assert_eq!(continuation["recommended_order"], "next");
+        let suggested = &continuation["suggested_call"];
+        assert_eq!(suggested["tool"], "read_files");
+        assert!(suggested["arguments"].get("next_index").is_none());
+        assert_eq!(
+            suggested["arguments"]["items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|item| item["path"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["src/1.rs", "src/2.rs"]
+        );
+        let next = ToolCall::from_tool_name(
+            suggested["tool"].as_str().unwrap(),
+            suggested["arguments"].clone(),
+        )
+        .expect("batch continuation suggested_call must parse");
+        assert!(matches!(
+            next,
+            ToolCall::ReadFiles {
+                ref items,
+                max_result_bytes: Some(bytes),
+                ..
+            } if bytes == MAX_SERIALIZED_OUTPUT_BYTES
+                && items.iter().map(|item| item.path.as_str()).collect::<Vec<_>>()
+                    == vec!["src/1.rs", "src/2.rs"]
+        ));
+    }
+
+    #[test]
+    fn partial_item_and_later_batch_items_expose_distinct_ordered_recovery() {
+        let lines = (0..900)
+            .map(|index| format!("第{index:04}行-{}", "界".repeat(40)))
+            .collect::<Vec<_>>();
+        let later = vec!["later".to_string()];
+        let last = vec!["last".to_string()];
+        let projection = batch_projection(3, None);
+        let output = apply_output_budget(
+            "agent:oe:demo",
+            3,
+            vec![
+                default_complete_item(0, &lines),
+                ranged_item(1, 1, &later),
+                ranged_item(2, 1, &last),
+            ],
+            None,
+            &projection,
+        );
+        // Canonical compatibility remains unchanged: the raw batch next_index
+        // still identifies the partial current item.
+        assert_eq!(output["next_index"], 0);
+        assert_eq!(output["items"].as_array().unwrap().len(), 1);
+        assert_eq!(output["items"][0]["output"]["budget_truncated"], true);
+
+        let mut model = ToolResult::ok(output);
+        add_actionable_read_continuations(&projection, &mut model);
+        let item_continuation = &model.output["items"][0]["continuation"];
+        assert_eq!(item_continuation["kind"], "read_range");
+        assert_eq!(item_continuation["safe_cursor"], true);
+        let expected_next_start = model.output["items"][0]["output"]["next_start_line"]
+            .as_u64()
+            .unwrap();
+        let expected_limit = model.output["items"][0]["output"]["budget_next_limit"]
+            .as_u64()
+            .unwrap();
+        assert_eq!(
+            item_continuation["suggested_call"]["arguments"]["start_line"],
+            expected_next_start
+        );
+        assert_eq!(
+            item_continuation["suggested_call"]["arguments"]["limit"],
+            expected_limit
+        );
+        ToolCall::from_tool_name(
+            item_continuation["suggested_call"]["tool"]
+                .as_str()
+                .unwrap(),
+            item_continuation["suggested_call"]["arguments"].clone(),
+        )
+        .expect("partial item continuation must parse");
+
+        let batch_continuation = &model.output["continuation"];
+        assert_eq!(batch_continuation["kind"], "batch_items");
+        assert_eq!(batch_continuation["safe_cursor"], true);
+        assert_eq!(batch_continuation["next_index"], 1);
+        assert_eq!(
+            batch_continuation["recommended_order"],
+            "after_partial_item"
+        );
+        let suggested = &batch_continuation["suggested_call"];
+        assert!(suggested["arguments"].get("next_index").is_none());
+        assert_eq!(
+            suggested["arguments"]["items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|item| item["path"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["src/1.rs", "src/2.rs"]
+        );
+        ToolCall::from_tool_name(
+            suggested["tool"].as_str().unwrap(),
+            suggested["arguments"].clone(),
+        )
+        .expect("later batch continuation must parse");
+    }
+
+    #[test]
+    fn zero_progress_primary_budget_recommends_bounded_budget_refinement() {
+        let huge_line = vec!["x".repeat(90 * 1024)];
+        let projection = batch_projection(1, None);
+        let output = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            vec![ranged_item(0, 1, &huge_line)],
+            None,
+            &projection,
+        );
+        assert_eq!(output["output_truncated"], true);
+        assert_eq!(output["next_index"], 0);
+        assert!(output["items"].as_array().unwrap().is_empty());
+
+        let mut model = ToolResult::ok(output);
+        add_actionable_read_continuations(&projection, &mut model);
+        let continuation = &model.output["continuation"];
+        assert_eq!(continuation["kind"], "increase_result_budget");
+        assert_eq!(continuation["safe_cursor"], false);
+        assert_eq!(continuation["next_index"], 0);
+        assert_eq!(
+            continuation["suggested_max_result_bytes"],
+            MAX_SERIALIZED_OUTPUT_BYTES
+        );
+        let suggested = &continuation["suggested_call"];
+        assert_eq!(
+            suggested["arguments"]["max_result_bytes"],
+            MAX_SERIALIZED_OUTPUT_BYTES
+        );
+        let next = ToolCall::from_tool_name(
+            suggested["tool"].as_str().unwrap(),
+            suggested["arguments"].clone(),
+        )
+        .expect("budget refinement suggested_call must parse");
+        assert!(matches!(
+            next,
+            ToolCall::ReadFiles {
+                max_result_bytes: Some(bytes),
+                ..
+            } if bytes == MAX_SERIALIZED_OUTPUT_BYTES
+        ));
     }
 
     #[test]
@@ -693,6 +1225,7 @@ mod tests {
                 item(2, "z".repeat(120 * 1024)),
             ],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
+            &batch_projection(3, Some(MAX_SERIALIZED_OUTPUT_BYTES)),
         );
         assert_eq!(output["returned_count"], 2);
         assert_eq!(output["next_index"], 2);
@@ -719,12 +1252,19 @@ mod tests {
             .collect::<Vec<_>>();
         let completed = vec![default_complete_item(0, &lines)];
 
-        let default = apply_output_budget("agent:oe:demo", 1, completed.clone(), None);
+        let default = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            completed.clone(),
+            None,
+            &batch_projection(1, None),
+        );
         let large = apply_output_budget(
             "agent:oe:demo",
             1,
             completed,
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
+            &batch_projection(1, Some(MAX_SERIALIZED_OUTPUT_BYTES)),
         );
         let partial = &default["items"][0]["output"];
         let kept = partial["returned_lines"].as_u64().unwrap() as usize;
@@ -749,7 +1289,13 @@ mod tests {
         let lines = (0..700)
             .map(|index| format!("line-{index:04}-{}", "x".repeat(90)))
             .collect::<Vec<_>>();
-        let first = apply_output_budget("agent:oe:demo", 1, vec![ranged_item(0, 11, &lines)], None);
+        let first = apply_output_budget(
+            "agent:oe:demo",
+            1,
+            vec![ranged_item(0, 11, &lines)],
+            None,
+            &batch_projection(1, None),
+        );
         let first_output = &first["items"][0]["output"];
         let kept = first_output["returned_lines"].as_u64().unwrap() as usize;
         let next_start = first_output["next_start_line"].as_u64().unwrap() as usize;
@@ -762,6 +1308,7 @@ mod tests {
             1,
             vec![ranged_item(0, next_start, &lines[kept..])],
             Some(MAX_SERIALIZED_OUTPUT_BYTES),
+            &batch_projection(1, Some(MAX_SERIALIZED_OUTPUT_BYTES)),
         );
         let joined = format!(
             "{}\n{}",
@@ -791,6 +1338,158 @@ mod tests {
         assert_eq!(output["next_start_line"], 36);
         assert_eq!(output["budget_next_limit"], 75);
         assert_eq!(output["budget_truncated"], true);
+    }
+
+    #[test]
+    fn read_continuation_byte_measurements_cover_complete_partial_and_batch_recovery() {
+        let default_limit =
+            webcodex_workspace::file_read_range::EffectiveRange::new(None, None).limit;
+        let sha = "e".repeat(64);
+        let canonical_bytes = |output: &Value| {
+            serde_json::to_vec(&ToolResult::ok(output.clone()))
+                .unwrap()
+                .len()
+        };
+        let model_bytes = |tool: &str, output: &Value, projection: &ReadModelProjection| {
+            let mut model = ToolResult::ok(output.clone());
+            add_actionable_read_continuations(projection, &mut model);
+            super::super::dispatch::sparsify_complete_read_success(tool, &mut model);
+            serde_json::to_vec(&model).unwrap().len()
+        };
+
+        let complete_single = json!({
+            "text": "one\ntwo",
+            "format": "plain",
+            "path": "src/lib.rs",
+            "sha256": sha,
+            "start_line": 1,
+            "limit": default_limit,
+            "total_lines": 2,
+            "returned_lines": 2,
+            "end_line": 2,
+            "has_more": false,
+            "next_start_line": null
+        });
+        let single_projection = ReadModelProjection::Single {
+            project: "agent:oe:demo".to_string(),
+            path: "src/lib.rs".to_string(),
+            with_line_numbers: None,
+        };
+        let complete_single_canonical = canonical_bytes(&complete_single);
+        let complete_single_model = model_bytes("read_file", &complete_single, &single_projection);
+
+        let partial_single = json!({
+            "text": "two",
+            "format": "plain",
+            "path": "src/lib.rs",
+            "sha256": "f".repeat(64),
+            "start_line": 2,
+            "limit": 1,
+            "total_lines": 3,
+            "returned_lines": 1,
+            "end_line": 2,
+            "has_more": true,
+            "next_start_line": 3
+        });
+        let partial_single_canonical = canonical_bytes(&partial_single);
+        let partial_single_model = model_bytes("read_file", &partial_single, &single_projection);
+
+        let complete_batch = batch_output(
+            "agent:oe:demo",
+            2,
+            vec![
+                default_complete_item(0, &["alpha".to_string()]),
+                default_complete_item(1, &["beta".to_string()]),
+            ],
+            false,
+            None,
+            None,
+        );
+        let complete_batch_projection = batch_projection(2, None);
+        let complete_batch_canonical = canonical_bytes(&complete_batch);
+        let complete_batch_model =
+            model_bytes("read_files", &complete_batch, &complete_batch_projection);
+
+        let mut partial_item = ranged_item(0, 11, &["line-11".to_string()]);
+        partial_item["output"]["limit"] = json!(1);
+        partial_item["output"]["total_lines"] = json!(20);
+        partial_item["output"]["has_more"] = json!(true);
+        partial_item["output"]["next_start_line"] = json!(12);
+        let partial_batch = batch_output("agent:oe:demo", 1, vec![partial_item], false, None, None);
+        let partial_batch_projection = ReadModelProjection::Batch {
+            project: "agent:oe:demo".to_string(),
+            items: vec![ReadFilesItem {
+                path: "src/0.rs".to_string(),
+                start_line: Some(11),
+                limit: Some(1),
+            }],
+            with_line_numbers: None,
+            max_result_bytes: None,
+        };
+        let partial_batch_canonical = canonical_bytes(&partial_batch);
+        let partial_batch_model =
+            model_bytes("read_files", &partial_batch, &partial_batch_projection);
+
+        let large_projection = batch_projection(2, Some(MAX_SERIALIZED_OUTPUT_BYTES));
+        let full_budget_batch = batch_output(
+            "agent:oe:demo",
+            2,
+            vec![
+                ranged_item(0, 1, &["x".repeat(140 * 1024)]),
+                ranged_item(1, 1, &["y".repeat(140 * 1024)]),
+            ],
+            false,
+            None,
+            None,
+        );
+        let budget_batch_canonical = canonical_bytes(&full_budget_batch);
+        let budgeted = apply_output_budget(
+            "agent:oe:demo",
+            2,
+            full_budget_batch["items"].as_array().unwrap().clone(),
+            Some(MAX_SERIALIZED_OUTPUT_BYTES),
+            &large_projection,
+        );
+        let budget_batch_model = model_bytes("read_files", &budgeted, &large_projection);
+
+        let partial_lines = (0..900)
+            .map(|index| format!("第{index:04}行-{}", "界".repeat(40)))
+            .collect::<Vec<_>>();
+        let partial_plus_later_full = batch_output(
+            "agent:oe:demo",
+            3,
+            vec![
+                default_complete_item(0, &partial_lines),
+                ranged_item(1, 1, &["later".to_string()]),
+                ranged_item(2, 1, &["last".to_string()]),
+            ],
+            false,
+            None,
+            None,
+        );
+        let partial_plus_later_projection = batch_projection(3, None);
+        let partial_plus_later_canonical = canonical_bytes(&partial_plus_later_full);
+        let partial_plus_later_budgeted = apply_output_budget(
+            "agent:oe:demo",
+            3,
+            partial_plus_later_full["items"].as_array().unwrap().clone(),
+            None,
+            &partial_plus_later_projection,
+        );
+        let partial_plus_later_model = model_bytes(
+            "read_files",
+            &partial_plus_later_budgeted,
+            &partial_plus_later_projection,
+        );
+
+        eprintln!(
+            "read_continuation_bytes complete_read_file={complete_single_canonical}->{complete_single_model} partial_read_file={partial_single_canonical}->{partial_single_model} complete_read_files={complete_batch_canonical}->{complete_batch_model} partial_item={partial_batch_canonical}->{partial_batch_model} batch_budget={budget_batch_canonical}->{budget_batch_model} partial_plus_batch={partial_plus_later_canonical}->{partial_plus_later_model}"
+        );
+
+        assert!(complete_single_model < complete_single_canonical);
+        assert!(complete_batch_model < complete_batch_canonical);
+        assert!(budget_batch_model <= MAX_SERIALIZED_OUTPUT_BYTES);
+        assert!(partial_plus_later_model <= DEFAULT_READ_FILES_RESULT_BYTES);
     }
 
     #[test]

--- a/src/tool_runtime/sessions/tests.rs
+++ b/src/tool_runtime/sessions/tests.rs
@@ -3365,7 +3365,11 @@ fn batch_budget_preserves_recorder_overlay_for_no_ack_read_batch() {
                 &recorded,
             )
         );
-        super::super::read_files::apply_model_facing_output_budget(&mut response, None);
+        super::super::read_files::apply_model_facing_output_budget(
+            &mut response,
+            None,
+            &super::super::read_files::ReadModelProjection::None,
+        );
         super::super::dispatch::sparsify_complete_read_success("read_files", &mut response);
         assert!(response.output.get("session_recorded").is_none());
         assert!(response.output.get("session_event_id").is_none());

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -302,6 +302,11 @@ async fn read_file_dispatch_partial_success_keeps_full_range_cursor() {
     let runtime = ToolRuntime::new_for_tests();
     let client_id = "read-partial-visible";
     let project = register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("read continuation session".to_string()),
+    );
+    let session_id = session.session_id.clone();
     let auth = auth_context(None, true);
     let content = "one\ntwo\nthree";
 
@@ -309,13 +314,14 @@ async fn read_file_dispatch_partial_success_keeps_full_range_cursor() {
         let runtime = runtime.clone();
         let project = project.clone();
         let auth = auth.clone();
+        let session_id = session_id.clone();
         async move {
             runtime
                 .dispatch_with_auth(
                     ToolCall::ReadFile {
                         project,
                         path: "src/lib.rs".to_string(),
-                        session_id: None,
+                        session_id: Some(session_id),
                         start_line: Some(2),
                         limit: Some(1),
                         with_line_numbers: None,
@@ -349,6 +355,10 @@ async fn read_file_dispatch_partial_success_keeps_full_range_cursor() {
         format!("{:x}", Sha256::digest(content.as_bytes()))
     );
     assert_eq!(continuation["suggested_call"]["tool"], "read_file");
+    assert_eq!(
+        continuation["suggested_call"]["arguments"]["session_id"],
+        session_id
+    );
     let next_call = ToolCall::from_tool_name(
         continuation["suggested_call"]["tool"].as_str().unwrap(),
         continuation["suggested_call"]["arguments"].clone(),
@@ -359,10 +369,13 @@ async fn read_file_dispatch_partial_success_keeps_full_range_cursor() {
         ToolCall::ReadFile {
             project: ref next_project,
             path: ref next_path,
+            session_id: Some(ref next_session_id),
             start_line: Some(3),
             limit: Some(1),
             ..
-        } if next_project == &project && next_path == "src/lib.rs"
+        } if next_project == &project
+            && next_path == "src/lib.rs"
+            && next_session_id == &session_id
     ));
 
     let schema = crate::tool_runtime::registry::output_schema_for_tool("read_file");
@@ -587,12 +600,18 @@ async fn read_files_partial_item_has_actionable_item_continuation() {
     let runtime = ToolRuntime::new_for_tests();
     let client_id = "read-batch-item-continuation";
     let project = register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("batch read continuation session".to_string()),
+    );
+    let session_id = session.session_id.clone();
     let auth = auth_context(None, true);
 
     let task = tokio::spawn({
         let runtime = runtime.clone();
         let project = project.clone();
         let auth = auth.clone();
+        let session_id = session_id.clone();
         async move {
             runtime
                 .dispatch_with_auth(
@@ -602,7 +621,7 @@ async fn read_files_partial_item_has_actionable_item_continuation() {
                             item("src/lib.rs", Some(2), Some(1)),
                             item("src/main.rs", None, None),
                         ],
-                        session_id: None,
+                        session_id: Some(session_id),
                         with_line_numbers: Some(true),
                         max_result_bytes: None,
                     },
@@ -631,6 +650,7 @@ async fn read_files_partial_item_has_actionable_item_continuation() {
     assert_eq!(continuation["safe_cursor"], true);
     assert_eq!(continuation["snapshot_stable"], false);
     let suggested = &continuation["suggested_call"];
+    assert_eq!(suggested["arguments"]["session_id"], session_id);
     let next_call = ToolCall::from_tool_name(
         suggested["tool"].as_str().unwrap(),
         suggested["arguments"].clone(),
@@ -641,11 +661,14 @@ async fn read_files_partial_item_has_actionable_item_continuation() {
         ToolCall::ReadFile {
             project: ref next_project,
             path: ref next_path,
+            session_id: Some(ref next_session_id),
             start_line: Some(3),
             limit: Some(1),
             with_line_numbers: Some(true),
             ..
-        } if next_project == &project && next_path == "src/lib.rs"
+        } if next_project == &project
+            && next_path == "src/lib.rs"
+            && next_session_id == &session_id
     ));
     assert!(items[1].get("continuation").is_none());
 

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -257,6 +257,7 @@ async fn read_file_dispatch_complete_success_is_sparse_after_session_recording()
         "end_line",
         "has_more",
         "next_start_line",
+        "continuation",
     ] {
         assert!(
             result.output.get(omitted).is_none(),
@@ -339,11 +340,95 @@ async fn read_file_dispatch_partial_success_keeps_full_range_cursor() {
     assert_eq!(result.output["end_line"], 2);
     assert_eq!(result.output["has_more"], true);
     assert_eq!(result.output["next_start_line"], 3);
+    let continuation = &result.output["continuation"];
+    assert_eq!(continuation["kind"], "read_range");
+    assert_eq!(continuation["safe_cursor"], true);
+    assert_eq!(continuation["snapshot_stable"], false);
+    assert_eq!(
+        continuation["source_sha256"],
+        format!("{:x}", Sha256::digest(content.as_bytes()))
+    );
+    assert_eq!(continuation["suggested_call"]["tool"], "read_file");
+    let next_call = ToolCall::from_tool_name(
+        continuation["suggested_call"]["tool"].as_str().unwrap(),
+        continuation["suggested_call"]["arguments"].clone(),
+    )
+    .expect("read_file continuation suggested_call must parse");
+    assert!(matches!(
+        next_call,
+        ToolCall::ReadFile {
+            project: ref next_project,
+            path: ref next_path,
+            start_line: Some(3),
+            limit: Some(1),
+            ..
+        } if next_project == &project && next_path == "src/lib.rs"
+    ));
 
     let schema = crate::tool_runtime::registry::output_schema_for_tool("read_file");
     let serialized = serde_json::to_value(&result).unwrap();
     crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
         .unwrap_or_else(|error| panic!("partial read_file success must match schema: {error}"));
+}
+
+#[tokio::test]
+async fn read_file_continuation_is_positional_not_snapshot_stable() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-source-change";
+    let project = register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+    let first_content = "one\ntwo\nthree";
+
+    let first = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFile {
+                        project,
+                        path: "src/lib.rs".to_string(),
+                        session_id: None,
+                        start_line: Some(1),
+                        limit: Some(1),
+                        with_line_numbers: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    complete_read(&runtime, client_id, &request, first_content).await;
+    let first = first.await.unwrap();
+    let first_sha = first.output["sha256"].as_str().unwrap().to_string();
+    let suggested = &first.output["continuation"]["suggested_call"];
+    let next_call = ToolCall::from_tool_name(
+        suggested["tool"].as_str().unwrap(),
+        suggested["arguments"].clone(),
+    )
+    .expect("positional continuation must parse");
+
+    // Insert a line before the cursor between calls. The next read is still a
+    // deterministic absolute line read, but it is intentionally not frozen to
+    // the first file snapshot.
+    let changed_content = "zero\none\ntwo\nthree";
+    let second = tokio::spawn({
+        let runtime = runtime.clone();
+        let auth = auth.clone();
+        async move { runtime.dispatch_with_auth(next_call, Some(&auth)).await }
+    });
+    let request = next_read_request(&runtime, client_id).await;
+    assert_eq!(request.start_line, Some(2));
+    complete_read(&runtime, client_id, &request, changed_content).await;
+    let second = second.await.unwrap();
+    assert!(second.success, "{:?}", second.error);
+    assert_eq!(second.output["text"], "one");
+    assert_ne!(second.output["sha256"], first_sha);
+    assert_eq!(first.output["continuation"]["source_sha256"], first_sha);
+    assert_eq!(first.output["continuation"]["snapshot_stable"], false);
 }
 
 #[tokio::test]
@@ -390,6 +475,7 @@ async fn read_file_dispatch_complete_explicit_range_keeps_full_range_metadata() 
     assert_eq!(result.output["end_line"], 2);
     assert_eq!(result.output["has_more"], false);
     assert!(result.output["next_start_line"].is_null());
+    assert!(result.output.get("continuation").is_none());
 
     let schema = crate::tool_runtime::registry::output_schema_for_tool("read_file");
     let serialized = serde_json::to_value(&result).unwrap();
@@ -496,6 +582,80 @@ async fn read_files_dispatch_complete_batch_is_sparse_and_schema_valid() {
 }
 
 #[tokio::test]
+async fn read_files_partial_item_has_actionable_item_continuation() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "read-batch-item-continuation";
+    let project = register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let auth = auth_context(None, true);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFiles {
+                        project,
+                        items: vec![
+                            item("src/lib.rs", Some(2), Some(1)),
+                            item("src/main.rs", None, None),
+                        ],
+                        session_id: None,
+                        with_line_numbers: Some(true),
+                        max_result_bytes: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    for _ in 0..2 {
+        let request = next_read_request(&runtime, client_id).await;
+        let content = match request.path.as_deref() {
+            Some("src/lib.rs") => "one\ntwo\nthree",
+            Some("src/main.rs") => "main",
+            other => panic!("unexpected read path: {other:?}"),
+        };
+        complete_read(&runtime, client_id, &request, content).await;
+    }
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["output_truncated"], false);
+    assert!(result.output.get("continuation").is_none());
+    let items = result.output["items"].as_array().unwrap();
+    let continuation = &items[0]["continuation"];
+    assert_eq!(continuation["kind"], "read_range");
+    assert_eq!(continuation["safe_cursor"], true);
+    assert_eq!(continuation["snapshot_stable"], false);
+    let suggested = &continuation["suggested_call"];
+    let next_call = ToolCall::from_tool_name(
+        suggested["tool"].as_str().unwrap(),
+        suggested["arguments"].clone(),
+    )
+    .expect("item continuation must parse");
+    assert!(matches!(
+        next_call,
+        ToolCall::ReadFile {
+            project: ref next_project,
+            path: ref next_path,
+            start_line: Some(3),
+            limit: Some(1),
+            with_line_numbers: Some(true),
+            ..
+        } if next_project == &project && next_path == "src/lib.rs"
+    ));
+    assert!(items[1].get("continuation").is_none());
+
+    let schema = crate::tool_runtime::registry::output_schema_for_tool("read_files");
+    let serialized = serde_json::to_value(&result).unwrap();
+    crate::tool_runtime::startup_brief::validate_schema_instance_for_test(&serialized, &schema)
+        .unwrap_or_else(|error| panic!("partial read_files item must match schema: {error}"));
+}
+
+#[tokio::test]
 async fn read_files_dispatch_large_default_batch_uses_sparse_fit_before_budget() {
     let root = tempfile::tempdir().unwrap();
     let runtime = ToolRuntime::new_for_tests();
@@ -571,7 +731,7 @@ async fn read_files_dispatch_mixed_batch_keeps_outer_and_failure_semantics() {
                 .dispatch_with_auth(
                     ToolCall::ReadFiles {
                         project,
-                        items: vec![item("good.txt", None, None), item(".env", None, None)],
+                        items: vec![item("good.txt", None, Some(1)), item(".env", None, None)],
                         session_id: None,
                         with_line_numbers: None,
                         max_result_bytes: None,
@@ -583,7 +743,7 @@ async fn read_files_dispatch_mixed_batch_keeps_outer_and_failure_semantics() {
     });
     let request = next_read_request(&runtime, client_id).await;
     assert_eq!(request.path.as_deref(), Some("good.txt"));
-    complete_read(&runtime, client_id, &request, "ok").await;
+    complete_read(&runtime, client_id, &request, "ok\nmore").await;
 
     let result = task.await.unwrap();
     assert!(result.success, "{:?}", result.error);
@@ -599,9 +759,15 @@ async fn read_files_dispatch_mixed_batch_keeps_outer_and_failure_semantics() {
     assert_eq!(items[0]["success"], true);
     assert_eq!(items[0]["path"], "good.txt");
     assert_eq!(items[0]["output"]["text"], "ok");
-    assert!(items[0]["output"].get("path").is_none());
-    assert!(items[0]["output"].get("format").is_none());
-    assert!(items[0]["output"].get("has_more").is_none());
+    assert_eq!(items[0]["output"]["has_more"], true);
+    assert_eq!(items[0]["output"]["next_start_line"], 2);
+    assert_eq!(items[0]["continuation"]["kind"], "read_range");
+    let suggested = &items[0]["continuation"]["suggested_call"];
+    ToolCall::from_tool_name(
+        suggested["tool"].as_str().unwrap(),
+        suggested["arguments"].clone(),
+    )
+    .expect("successful mixed-batch item continuation must remain parseable");
     assert_eq!(items[1]["success"], false);
     assert_eq!(items[1]["path"], ".env");
     assert_eq!(items[1]["output"]["error_kind"], "read_file_failed");

--- a/src/tool_runtime/tests/sessions_resolver.rs
+++ b/src/tool_runtime/tests/sessions_resolver.rs
@@ -112,6 +112,177 @@ async fn read_file_accepts_unique_short_id() {
 }
 
 #[tokio::test]
+async fn read_file_short_id_continuation_binds_resolved_project_across_registry_churn() {
+    let runtime = runtime_with_resolver_projects().await;
+    let auth = auth_context(None, true);
+    let first = tokio::spawn({
+        let runtime = runtime.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFile {
+                        project: "other-repo".to_string(),
+                        path: "README.md".to_string(),
+                        session_id: None,
+                        start_line: Some(1),
+                        limit: Some(1),
+                        with_line_numbers: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let req = wait_for_runner_request_for_client(&runtime, "workstation").await;
+    assert_eq!(req.cwd.as_deref(), Some("/root/git/workstation-other-repo"));
+    runtime
+        .runner_registry
+        .complete(RunnerResultRequest {
+            client_id: "workstation".to_string(),
+            runner_instance_id: "inst-workstation".to_string(),
+            request_id: req.request_id,
+            exit_code: Some(0),
+            stdout: Some(canonical_agent_file_read_range("one\ntwo", 1, 1)),
+            stderr: None,
+            duration_ms: Some(1),
+            error: None,
+        })
+        .await
+        .unwrap();
+    let first = first.await.unwrap();
+    assert!(first.success, "{:?}", first.error);
+    let suggested = &first.output["continuation"]["suggested_call"];
+    assert_eq!(
+        suggested["arguments"]["project"],
+        "agent:workstation:other-repo"
+    );
+    assert!(suggested["arguments"].get("session_id").is_none());
+    let next_call = ToolCall::from_tool_name(
+        suggested["tool"].as_str().unwrap(),
+        suggested["arguments"].clone(),
+    )
+    .expect("short-id continuation suggested_call must parse");
+
+    // Make the original shorthand ambiguous after the first read. The already
+    // constructed recovery call must remain bound to workstation.
+    register_agent_projects(
+        &runtime,
+        "laptop",
+        None,
+        crate::runner_protocol::RunnerCapabilities {
+            file_read: true,
+            git: true,
+            shell: true,
+            internal_posix_script: true,
+            ..Default::default()
+        },
+        vec![
+            named_registered_project(
+                "laptop",
+                "my-repo",
+                "My Repo",
+                "/root/git/laptop-my-repo",
+                190,
+            ),
+            named_registered_project(
+                "laptop",
+                "other-repo",
+                "Other Repo",
+                "/root/git/laptop-other-repo",
+                220,
+            ),
+        ],
+    )
+    .await;
+    let ambiguous = runtime
+        .resolve_project_input("other-repo")
+        .await
+        .unwrap_err();
+    assert_eq!(ambiguous.kind, ProjectResolverErrorKind::AmbiguousProject);
+
+    let second = tokio::spawn({
+        let runtime = runtime.clone();
+        let auth = auth.clone();
+        async move { runtime.dispatch_with_auth(next_call, Some(&auth)).await }
+    });
+    let req = wait_for_runner_request_for_client(&runtime, "workstation").await;
+    assert_eq!(req.cwd.as_deref(), Some("/root/git/workstation-other-repo"));
+    assert_eq!(req.start_line, Some(2));
+    runtime
+        .runner_registry
+        .complete(RunnerResultRequest {
+            client_id: "workstation".to_string(),
+            runner_instance_id: "inst-workstation".to_string(),
+            request_id: req.request_id,
+            exit_code: Some(0),
+            stdout: Some(canonical_agent_file_read_range("one\ntwo", 2, 1)),
+            stderr: None,
+            duration_ms: Some(1),
+            error: None,
+        })
+        .await
+        .unwrap();
+    let second = second.await.unwrap();
+    assert!(second.success, "{:?}", second.error);
+    assert_eq!(second.output["text"], "two");
+}
+
+#[tokio::test]
+async fn read_files_short_id_item_continuation_uses_resolved_project_id() {
+    let runtime = runtime_with_resolver_projects().await;
+    let auth = auth_context(None, true);
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::ReadFiles {
+                        project: "other-repo".to_string(),
+                        items: vec![ReadFilesItem {
+                            path: "README.md".to_string(),
+                            start_line: Some(1),
+                            limit: Some(1),
+                        }],
+                        session_id: None,
+                        with_line_numbers: None,
+                        max_result_bytes: None,
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let req = wait_for_runner_request_for_client(&runtime, "workstation").await;
+    runtime
+        .runner_registry
+        .complete(RunnerResultRequest {
+            client_id: "workstation".to_string(),
+            runner_instance_id: "inst-workstation".to_string(),
+            request_id: req.request_id,
+            exit_code: Some(0),
+            stdout: Some(canonical_agent_file_read_range("one\ntwo", 1, 1)),
+            stderr: None,
+            duration_ms: Some(1),
+            error: None,
+        })
+        .await
+        .unwrap();
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(
+        result.output["items"][0]["continuation"]["suggested_call"]["arguments"]["project"],
+        "agent:workstation:other-repo"
+    );
+    assert!(
+        result.output["items"][0]["continuation"]["suggested_call"]["arguments"]
+            .get("session_id")
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn git_status_accepts_unique_short_id() {
     let runtime = runtime_with_resolver_projects().await;
     let bootstrap = auth_context(None, true);


### PR DESCRIPTION
## Summary
- make partial `read_file` / `read_files` results expose parser-ready recovery after canonical Session recording
- bind reusable recovery calls to the exact resolved Project id, preserve only an explicitly supplied business `session_id`, and keep positional range recovery explicitly non-snapshot-stable via `sha256`
- separate current-item `read_range`, sliced `batch_items`, and bounded `increase_result_budget` recovery; avoid advertising a same-request replay when zero progress is already at the 256 KiB hard cap
- clarify `read_files` tool selection (`read_files` for multiple known ranges, `read_file` for one targeted range)
- add a contract regression keeping `window_id`, `client_window`, and `recording_session_id` out of read recovery output schemas

## Reviewer follow-up
- `read_files` description is now 836 characters, below the 900-character model ToolSpec limit while retaining selection and recovery semantics
- fixed a hard-cap zero-progress edge where a `batch_items` continuation could replay the same 256 KiB request without proving forward progress

## Validation
- `cargo test 'zero_progress_' -p webcodex`: 2 passed
- `cargo test 'read_files_' -p webcodex`: 17 passed
- `cargo test -p webcodex-tool-contracts`: 91 passed
- `cargo check --all-targets`: pass, 0 errors / 0 warnings
- `cargo fmt --all -- --check`: pass
- `git diff --check origin/main...HEAD`: pass