### PR TITLE
Compact job observation projection

### DIFF
--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
@@ -649,14 +649,14 @@ fn observe_jobs_output_schema() -> Value {
         "required": ["items", "wait"]
     });
     let successful_output = json!({
-        "anyOf": [batch_output.clone(), sparse_success_output]
+        "anyOf": [batch_output.clone(), sparse_success_output.clone()]
     });
     json!({
         "type": "object",
         "additionalProperties": false,
         "properties": {
             "success": {"type": "boolean"},
-            "output": {"anyOf": [successful_output.clone(), {"type": "object", "additionalProperties": true}, {"type": "null"}]},
+            "output": {"anyOf": [batch_output.clone(), sparse_success_output, {"type": "object", "additionalProperties": true}, {"type": "null"}]},
             "error": {"anyOf": [{"type": "string"}, {"type": "null"}]}
         },
         "required": ["success", "output"],

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/jobs.rs
@@ -488,6 +488,64 @@ fn observe_jobs_output_schema() -> Value {
             "activity", "detected_summary", "validation"
         ]
     });
+    let sparse_job_observation = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "job_id": schema_type("string", "Runtime Job id."),
+            "status": schema_type("string", "Canonical current Job status."),
+            "terminal": schema_type("boolean", "Canonical terminal classification; never inferred from batch counts."),
+            "changed": schema_type("boolean", "Whether lifecycle revision or Server epoch differs from the supplied observation token."),
+            "log_delta_status": {
+                "type": "string",
+                "enum": ["baseline", "delta", "unchanged", "reset"],
+                "description": "Exact canonical log projection class. reset remains an explicit bounded recovery tail, never ordinary delta."
+            },
+            "observation_token": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": webcodex_core::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN,
+                "description": "Opaque authoritative token copied unchanged from the canonical Job observation for the next after_observation_token."
+            },
+            "exit_code": schema_type("integer", "Terminal process exit code when available and meaningful."),
+            "command_execution_state": job_command_execution_state_schema(),
+            "activity": job_activity_schema(),
+            "stdout_tail": schema_type("string", "Bounded stdout baseline/delta/reset body. Omitted only when no stdout body needs presenting."),
+            "stderr_tail": schema_type("string", "Bounded stderr baseline/delta/reset body. Omitted only when no stderr body needs presenting."),
+            "stdout_lines": schema_type("integer", "Total observed stdout lines retained when exceptional reset/truncation diagnostics matter."),
+            "stderr_lines": schema_type("integer", "Total observed stderr lines retained when exceptional reset/truncation diagnostics matter."),
+            "stdout_returned_lines": schema_type("integer", "Returned stdout line count retained for exceptional reset/truncation diagnostics."),
+            "stderr_returned_lines": schema_type("integer", "Returned stderr line count retained for exceptional reset/truncation diagnostics."),
+            "stdout_truncated": schema_type("boolean", "True when stdout was bounded or unavailable; reset may retain false explicitly."),
+            "stderr_truncated": schema_type("boolean", "True when stderr was bounded or unavailable; reset may retain false explicitly."),
+            "stdout_delta_reset": schema_type("boolean", "True when stdout exact delta continuity reset; reset may retain false explicitly."),
+            "stderr_delta_reset": schema_type("boolean", "True when stderr exact delta continuity reset; reset may retain false explicitly."),
+            "stdout_retained_from_line": nullable_schema("integer", "First retained absolute stdout line when exceptional recovery evidence matters."),
+            "stderr_retained_from_line": nullable_schema("integer", "First retained absolute stderr line when exceptional recovery evidence matters."),
+            "earlier_stdout_unavailable": schema_type("boolean", "Whether earlier stdout is outside retained bounded logs; reset may retain false explicitly."),
+            "earlier_stderr_unavailable": schema_type("boolean", "Whether earlier stderr is outside retained bounded logs; reset may retain false explicitly."),
+            "recovery_state": nullable_schema("string", "Canonical bounded recovery state when present."),
+            "recovery_reason_code": nullable_schema("string", "Canonical bounded recovery reason code when present."),
+            "recovery_reason": nullable_schema("string", "Canonical bounded recovery explanation when present."),
+            "last_update_seq": nullable_schema("integer", "Protocol diagnostic retained only with exceptional reset/truncation evidence."),
+            "cursor": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "stdout": {"type": "integer", "minimum": 1},
+                    "stderr": {"type": "integer", "minimum": 1}
+                },
+                "required": ["stdout", "stderr"],
+                "description": "Diagnostic absolute cursor retained only with exceptional reset/truncation evidence; observation_token remains authoritative."
+            },
+            "ssh_resource": nullable_schema("string", "Named SSH resource when present on the observed Job."),
+            "purpose": nullable_schema("string", "Declared purpose retained on baseline/reset observations for disambiguation."),
+            "command_summary": nullable_schema("string", "Bounded safe command summary retained on baseline/reset observations for disambiguation."),
+            "detected_summary": {"type": "object", "additionalProperties": true},
+            "validation": validation_job_projection_schema()
+        },
+        "required": ["job_id", "status", "terminal", "changed", "log_delta_status", "observation_token"]
+    });
     let item = json!({
         "type": "object",
         "additionalProperties": false,
@@ -558,18 +616,53 @@ fn observe_jobs_output_schema() -> Value {
             "output_truncated", "next_index"
         ]
     });
+    let sparse_success_output = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "items": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 8,
+                "items": sparse_job_observation
+            },
+            "wait": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "outcome": {
+                        "type": "string",
+                        "enum": ["immediate", "updated", "terminal", "timeout"]
+                    },
+                    "waited_ms": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Non-zero shared wait duration; omitted when the canonical value is zero."
+                    }
+                },
+                "required": ["outcome"],
+                "description": "The one shared-wait fact for an ordinary all-success, non-truncated compact batch."
+            },
+            "session_hint": session_hint_schema(),
+            "permission": permission_decision_schema()
+        },
+        "required": ["items", "wait"]
+    });
+    let successful_output = json!({
+        "anyOf": [batch_output.clone(), sparse_success_output]
+    });
     json!({
         "type": "object",
         "additionalProperties": false,
         "properties": {
             "success": {"type": "boolean"},
-            "output": {"anyOf": [batch_output.clone(), {"type": "object", "additionalProperties": true}, {"type": "null"}]},
+            "output": {"anyOf": [successful_output.clone(), {"type": "object", "additionalProperties": true}, {"type": "null"}]},
             "error": {"anyOf": [{"type": "string"}, {"type": "null"}]}
         },
         "required": ["success", "output"],
         "allOf": [{
             "if": {"properties": {"success": {"const": true}}, "required": ["success"]},
-            "then": {"properties": {"output": batch_output, "error": {"type": "null"}}},
+            "then": {"properties": {"output": successful_output, "error": {"type": "null"}}},
             "else": {"required": ["error"], "properties": {"error": {"type": "string"}}}
         }]
     })

--- a/crates/webcodex-tool-contracts/src/tool_definition/jobs.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/jobs.rs
@@ -326,7 +326,7 @@ pub(super) const EXECUTION_DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 false,
             ),
-            "Observe 1 to 8 existing Jobs with bounded baseline/delta logs and isolated item errors. Optionally performs one shared wait for the batch and returns when any relevant Job changes; final items are non-waiting snapshots. Return each opaque observation token unchanged on follow-up. unknown_job exposes recovery_tool=list_jobs for direct caller-visible Job re-observation. Never launches, retries, stops, or subscribes.",
+            "Observe 1 to 8 existing Jobs with bounded baseline/delta logs and isolated item errors. Optionally performs one shared wait for the batch and returns when any relevant Job changes; final items are non-waiting snapshots. Ordinary all-success observations may use a compact result projection; each opaque observation token is returned unchanged. reset remains explicit bounded recovery rather than exact delta. unknown_job exposes recovery_tool=list_jobs for direct caller-visible Job re-observation. Never launches, retries, stops, or subscribes.",
             observe_jobs_input_schema,
         ),
         80,

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -940,6 +940,9 @@ impl ToolRuntime {
             }
         }
         super::dispatch::sparsify_success_model_result_metadata(&request.tool_name, &mut result);
+        if request.tool_name == "observe_jobs" {
+            super::observe_jobs::sparsify_observe_jobs_model_result(&mut result);
+        }
         ToolCallOutcome {
             success: result.success,
             result: Some(result),

--- a/src/tool_runtime/observe_jobs.rs
+++ b/src/tool_runtime/observe_jobs.rs
@@ -269,6 +269,251 @@ fn apply_output_budget(
     ))
 }
 
+fn copy_non_null(
+    source: &serde_json::Map<String, Value>,
+    target: &mut serde_json::Map<String, Value>,
+    key: &str,
+) {
+    if let Some(value) = source.get(key).filter(|value| !value.is_null()) {
+        target.insert(key.to_string(), value.clone());
+    }
+}
+
+fn copy_present(
+    source: &serde_json::Map<String, Value>,
+    target: &mut serde_json::Map<String, Value>,
+    key: &str,
+) {
+    if let Some(value) = source.get(key) {
+        target.insert(key.to_string(), value.clone());
+    }
+}
+
+fn sparse_success_item(item: &Value) -> Option<Value> {
+    let item = item.as_object()?;
+    if item.get("success").and_then(Value::as_bool) != Some(true)
+        || !item.get("error_kind").is_some_and(Value::is_null)
+        || !item.get("error").is_some_and(Value::is_null)
+        || item.get("recovery_kind").is_some()
+        || item.get("recovery_tool").is_some()
+    {
+        return None;
+    }
+    let job_id = item.get("job_id")?.as_str()?.to_string();
+    let observation = item.get("output")?.as_object()?;
+    if observation.get("job_id")?.as_str()? != job_id {
+        return None;
+    }
+    let status = observation.get("status")?.as_str()?.to_string();
+    let terminal = observation.get("terminal")?.as_bool()?;
+    let changed = observation.get("changed")?.as_bool()?;
+    let log_delta_status = observation.get("log_delta_status")?.as_str()?;
+    if !matches!(
+        log_delta_status,
+        "baseline" | "delta" | "unchanged" | "reset"
+    ) {
+        return None;
+    }
+    let observation_token = observation.get("observation_token")?.as_str()?;
+    if observation_token.is_empty() {
+        return None;
+    }
+    let stdout_tail = observation.get("stdout_tail")?.as_str()?;
+    let stderr_tail = observation.get("stderr_tail")?.as_str()?;
+    let stdout_truncated = observation.get("stdout_truncated")?.as_bool()?;
+    let stderr_truncated = observation.get("stderr_truncated")?.as_bool()?;
+    let stdout_delta_reset = observation.get("stdout_delta_reset")?.as_bool()?;
+    let stderr_delta_reset = observation.get("stderr_delta_reset")?.as_bool()?;
+    let earlier_stdout_unavailable = observation
+        .get("earlier_stdout_unavailable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let earlier_stderr_unavailable = observation
+        .get("earlier_stderr_unavailable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut sparse = serde_json::Map::new();
+    sparse.insert("job_id".to_string(), json!(job_id));
+    sparse.insert("status".to_string(), json!(status));
+    sparse.insert("terminal".to_string(), json!(terminal));
+    sparse.insert("changed".to_string(), json!(changed));
+    sparse.insert("log_delta_status".to_string(), json!(log_delta_status));
+    sparse.insert("observation_token".to_string(), json!(observation_token));
+
+    for key in [
+        "exit_code",
+        "command_execution_state",
+        "activity",
+        "detected_summary",
+        "validation",
+        "ssh_resource",
+    ] {
+        copy_non_null(observation, &mut sparse, key);
+    }
+
+    if log_delta_status != "unchanged" {
+        copy_present(observation, &mut sparse, "stdout_tail");
+        copy_present(observation, &mut sparse, "stderr_tail");
+    } else {
+        if !stdout_tail.is_empty() {
+            copy_present(observation, &mut sparse, "stdout_tail");
+        }
+        if !stderr_tail.is_empty() {
+            copy_present(observation, &mut sparse, "stderr_tail");
+        }
+    }
+
+    for (key, present) in [
+        ("stdout_truncated", stdout_truncated),
+        ("stderr_truncated", stderr_truncated),
+        ("stdout_delta_reset", stdout_delta_reset),
+        ("stderr_delta_reset", stderr_delta_reset),
+        ("earlier_stdout_unavailable", earlier_stdout_unavailable),
+        ("earlier_stderr_unavailable", earlier_stderr_unavailable),
+    ] {
+        if present {
+            copy_present(observation, &mut sparse, key);
+        }
+    }
+    for key in ["recovery_state", "recovery_reason_code", "recovery_reason"] {
+        copy_non_null(observation, &mut sparse, key);
+    }
+
+    let exceptional_log_evidence = log_delta_status == "reset"
+        || stdout_truncated
+        || stderr_truncated
+        || stdout_delta_reset
+        || stderr_delta_reset
+        || earlier_stdout_unavailable
+        || earlier_stderr_unavailable
+        || observation
+            .get("recovery_state")
+            .is_some_and(|value| !value.is_null())
+        || observation
+            .get("recovery_reason_code")
+            .is_some_and(|value| !value.is_null())
+        || observation
+            .get("recovery_reason")
+            .is_some_and(|value| !value.is_null());
+    if exceptional_log_evidence {
+        for key in [
+            "stdout_lines",
+            "stderr_lines",
+            "stdout_returned_lines",
+            "stderr_returned_lines",
+            "stdout_retained_from_line",
+            "stderr_retained_from_line",
+            "cursor",
+            "last_update_seq",
+        ] {
+            copy_non_null(observation, &mut sparse, key);
+        }
+        if log_delta_status == "reset" {
+            for key in [
+                "stdout_truncated",
+                "stderr_truncated",
+                "stdout_delta_reset",
+                "stderr_delta_reset",
+                "earlier_stdout_unavailable",
+                "earlier_stderr_unavailable",
+            ] {
+                copy_present(observation, &mut sparse, key);
+            }
+        }
+    }
+
+    if matches!(log_delta_status, "baseline" | "reset") {
+        for key in ["purpose", "command_summary"] {
+            copy_non_null(observation, &mut sparse, key);
+        }
+    }
+    Some(Value::Object(sparse))
+}
+
+/// Final model-facing projection for ordinary successful Job observations.
+/// The canonical batch and canonical single-Job snapshots remain unchanged for
+/// budgeting, Session/audit recording, operator diagnostics, and internal use.
+pub(crate) fn sparsify_observe_jobs_model_result(result: &mut ToolResult) {
+    if !result.success {
+        return;
+    }
+    let Some(output) = result.output.as_object_mut() else {
+        return;
+    };
+    if output.get("output_truncated").and_then(Value::as_bool) != Some(false)
+        || !output.get("next_index").is_some_and(Value::is_null)
+    {
+        return;
+    }
+    let Some(items) = output.get("items").and_then(Value::as_array) else {
+        return;
+    };
+    if items.is_empty() || items.len() > MAX_OBSERVE_JOBS_ITEMS {
+        return;
+    }
+    let count = items.len() as u64;
+    if output.get("requested_count").and_then(Value::as_u64) != Some(count)
+        || output.get("returned_count").and_then(Value::as_u64) != Some(count)
+        || output.get("succeeded_count").and_then(Value::as_u64) != Some(count)
+        || output.get("failed_count").and_then(Value::as_u64) != Some(0)
+    {
+        return;
+    }
+    let Some(wait) = output.get("wait").and_then(Value::as_object) else {
+        return;
+    };
+    let Some(wait_outcome) = wait.get("outcome").and_then(Value::as_str) else {
+        return;
+    };
+    if !matches!(
+        wait_outcome,
+        "immediate" | "updated" | "terminal" | "timeout"
+    ) {
+        // item_error is intentionally kept in the canonical batch shape.
+        return;
+    }
+    let Some(waited_ms) = wait.get("waited_ms").and_then(Value::as_u64) else {
+        return;
+    };
+
+    let mut sparse_items = Vec::with_capacity(items.len());
+    let mut changed_count = 0u64;
+    let mut terminal_count = 0u64;
+    for item in items {
+        let Some(sparse) = sparse_success_item(item) else {
+            return;
+        };
+        changed_count += u64::from(sparse.get("changed").and_then(Value::as_bool) == Some(true));
+        terminal_count += u64::from(sparse.get("terminal").and_then(Value::as_bool) == Some(true));
+        sparse_items.push(sparse);
+    }
+    if output.get("changed_count").and_then(Value::as_u64) != Some(changed_count)
+        || output.get("terminal_count").and_then(Value::as_u64) != Some(terminal_count)
+    {
+        return;
+    }
+
+    output.insert("items".to_string(), Value::Array(sparse_items));
+    for key in [
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "changed_count",
+        "terminal_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        output.remove(key);
+    }
+    if waited_ms == 0 {
+        if let Some(wait) = output.get_mut("wait").and_then(Value::as_object_mut) {
+            wait.remove("waited_ms");
+        }
+    }
+}
+
 impl ToolRuntime {
     fn validate_observe_jobs_input(
         items: &[ObserveJobsItem],

--- a/src/tool_runtime/tests/coding_task_semantic_navigation.rs
+++ b/src/tool_runtime/tests/coding_task_semantic_navigation.rs
@@ -354,7 +354,11 @@ async fn coding_task_semantic_navigation_timeout_uses_one_budget_and_cancels_wai
     let task = spawn_start(&runtime, project, SessionMode::Normal);
     let request = next_semantic_status_request(&runtime, "timeout-agent").await;
     let result = finish_start_servicing_locally(&runtime, "timeout-agent", task).await;
-    assert!(started.elapsed() < Duration::from_millis(2_000));
+    // This wall-clock bound includes the normal Git startup inspection that
+    // follows the 25ms semantic-navigation probe. Keep it well below the
+    // helper's 10-second liveness deadline so a lost probe budget still fails,
+    // but leave enough scheduler headroom for the full Windows test suite.
+    assert!(started.elapsed() < Duration::from_secs(5));
     assert!(result.success, "{result:?}");
     let semantic = &result.output["semantic_navigation"];
     assert_eq!(semantic["status"], "probe_timeout");

--- a/src/tool_runtime/tests/hygiene.rs
+++ b/src/tool_runtime/tests/hygiene.rs
@@ -37,11 +37,16 @@ async fn dispatch_hygiene_with_agent(
     });
 
     let forbidden = ["python3", "-c"].join(" ");
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    // A hygiene check can issue both the fixed diagnostic script and a bounded
+    // size-probe script. On Windows each local POSIX-shell startup is noticeably
+    // more expensive, especially while the full Rust test suite is running in
+    // parallel, so the old 10-second harness deadline was below the production
+    // per-script timeout and could fail despite healthy bounded execution.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
     while !task.is_finished() {
         assert!(
             tokio::time::Instant::now() < deadline,
-            "hygiene check did not finish within 10 seconds for client {client_id}"
+            "hygiene check did not finish within 30 seconds for client {client_id}"
         );
         if let Some(req) = probe_patch_agent_request(runtime, client_id).await {
             assert_eq!(req.kind, "run_internal_posix_script");

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -11,6 +11,31 @@ use crate::runner_protocol::{
 };
 use serde_json::json;
 
+fn run_jobs_test_in_large_stack_thread<F, Fut>(test: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()>,
+{
+    // Some end-to-end Job fixtures retain several auth identities, Job handles,
+    // and the generic dispatch future across many awaits. Keep that integration
+    // stack local to the fixture instead of raising RUST_MIN_STACK for the suite.
+    let result = std::thread::Builder::new()
+        .name("runtime-job-test".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build isolated runtime Job test runtime")
+                .block_on(test());
+        })
+        .expect("spawn isolated runtime Job test thread")
+        .join();
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 #[tokio::test]
 async fn run_shell_session_events_record_exit_without_stdio_bodies() {
     let runtime = runtime_with_agent_project("telemetry-shell");
@@ -1813,8 +1838,14 @@ async fn managed_user_job_inventory_and_counts_do_not_cross_owner() {
     assert_eq!(bootstrap_ids, expected);
 }
 
-#[tokio::test]
-async fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group() {
+#[test]
+fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group() {
+    run_jobs_test_in_large_stack_thread(
+        shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group_body,
+    );
+}
+
+async fn shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group_body() {
     let runtime = test_runtime();
     let shared_a = shared_key_auth_context("hash-a");
     let shared_b = shared_key_auth_context("hash-b");

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -378,9 +378,8 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
         spec.input_schema["properties"]["items"]["items"]["additionalProperties"],
         false
     );
-    let successful_output = &spec.output_schema["properties"]["output"]["anyOf"][0];
-    let output = &successful_output["anyOf"][0];
-    let sparse_output = &successful_output["anyOf"][1];
+    let output = &spec.output_schema["properties"]["output"]["anyOf"][0];
+    let sparse_output = &spec.output_schema["properties"]["output"]["anyOf"][1];
     assert_eq!(
         output["properties"]["wait"]["properties"]["outcome"]["enum"],
         json!(["immediate", "updated", "terminal", "item_error", "timeout"])

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -1,5 +1,6 @@
 //! Phase D bounded batch Job observation.
 
+use super::super::kernel::{HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolTransport};
 use super::super::*;
 use super::support::*;
 use crate::runner_protocol::{
@@ -561,6 +562,89 @@ fn observe_jobs_compact_projection_single_running_unchanged_keeps_actionable_sta
     ] {
         assert!(item.get(omitted).is_none(), "mechanical {omitted} leaked");
     }
+}
+
+#[tokio::test]
+async fn observe_jobs_kernel_model_surface_applies_compact_projection() {
+    let runtime = test_runtime();
+    let (job_id, request, auth) =
+        register_and_start_agent_job(&runtime, "observe-kernel-projection").await;
+    update_observed_job(
+        &runtime,
+        "observe-kernel-projection",
+        &request,
+        "running",
+        None,
+        Some(process_activity()),
+        false,
+    )
+    .await;
+
+    let outcome = runtime
+        .call_tool_with_context(
+            ToolCallRequest {
+                tool_name: "observe_jobs".to_string(),
+                arguments: json!({
+                    "items": [{"job_id": job_id}],
+                    "tail_lines": 40
+                }),
+            },
+            ToolCallContext {
+                transport: ToolTransport::Api,
+                session_id: None,
+                auth: Some(&auth),
+                window: None,
+                record_oauth_scope_denials: true,
+                host_file_import_trust: HostFileImportTrust::Untrusted,
+            },
+        )
+        .await;
+    assert!(outcome.error_status.is_none(), "{:?}", outcome.error_status);
+    let result = outcome
+        .result
+        .expect("model-facing observe_jobs ToolResult");
+    assert!(result.success, "{:?}", result.error);
+
+    let output = result
+        .output
+        .as_object()
+        .expect("compact observe_jobs output");
+    for omitted in [
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "changed_count",
+        "terminal_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        assert!(output.get(omitted).is_none(), "kernel leaked {omitted}");
+    }
+    assert_eq!(result.output["wait"]["outcome"], "immediate");
+    assert!(result.output["wait"].get("waited_ms").is_none());
+
+    let item = &result.output["items"][0];
+    assert_eq!(item["job_id"], job_id);
+    assert_eq!(item["status"], "running");
+    assert_eq!(item["terminal"], false);
+    assert_eq!(item["log_delta_status"], "baseline");
+    assert!(item["observation_token"]
+        .as_str()
+        .is_some_and(|token| !token.is_empty()));
+    assert_eq!(
+        item["activity"],
+        serde_json::to_value(process_activity()).unwrap()
+    );
+    assert!(item.get("output").is_none());
+    assert!(item.get("success").is_none());
+
+    let schema = super::super::registry::output_schema_for_tool("observe_jobs");
+    let value = serde_json::to_value(&result).unwrap();
+    assert!(
+        super::super::startup_brief::validate_schema_instance_for_test(&value, &schema).is_ok(),
+        "kernel-projected observe_jobs result did not satisfy output schema: {value}"
+    );
 }
 
 #[test]

--- a/src/tool_runtime/tests/observe_jobs.rs
+++ b/src/tool_runtime/tests/observe_jobs.rs
@@ -6,7 +6,7 @@ use crate::runner_protocol::{
     RunnerCapabilities, RunnerJobUpdateRequest, RunnerRequest, ShellJobActivity,
     ShellJobActivityPhase, ShellJobActivitySource, ShellJobActivityState,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 use std::time::{Duration, Instant};
 
 fn item(job_id: &str, token: Option<String>) -> ObserveJobsItem {
@@ -113,6 +113,111 @@ fn assert_item_has_no_wait_metadata(item: &serde_json::Value) {
     let output = item["output"].as_object().expect("successful Job snapshot");
     assert!(!output.contains_key("wait_outcome"));
     assert!(!output.contains_key("waited_ms"));
+}
+
+fn canonical_observation(
+    job_id: &str,
+    status: &str,
+    log_delta_status: &str,
+    stdout_tail: &str,
+    stderr_tail: &str,
+    changed: bool,
+    terminal: bool,
+) -> Value {
+    json!({
+        "job_id": job_id,
+        "status": status,
+        "exit_code": null,
+        "command_execution_state": null,
+        "structured_execution": null,
+        "activity": null,
+        "stdout_tail": stdout_tail,
+        "stderr_tail": stderr_tail,
+        "stdout_lines": 4,
+        "stderr_lines": 2,
+        "stdout_returned_lines": stdout_tail.lines().count(),
+        "stderr_returned_lines": stderr_tail.lines().count(),
+        "stdout_truncated": false,
+        "stderr_truncated": false,
+        "stdout_retained_from_line": null,
+        "stderr_retained_from_line": null,
+        "earlier_stdout_unavailable": false,
+        "earlier_stderr_unavailable": false,
+        "recovery_state": null,
+        "recovery_reason_code": null,
+        "recovery_reason": null,
+        "observation_token": format!("wjob1:a:{job_id}:fixture_epoch:7"),
+        "log_delta_status": log_delta_status,
+        "stdout_delta_reset": false,
+        "stderr_delta_reset": false,
+        "last_update_seq": 7,
+        "cursor": {"stdout": 5, "stderr": 3},
+        "changed": changed,
+        "terminal": terminal,
+        "executor": "agent",
+        "session_id": null,
+        "ssh_resource": null,
+        "cwd": ".",
+        "shell": "direct_argv",
+        "purpose": "build",
+        "command_summary": "cargo check -p webcodex --lib",
+        "detected_summary": {
+            "kind": "check",
+            "outcome": if terminal { "passed" } else { "in_progress" }
+        },
+        "validation": null
+    })
+}
+
+fn canonical_success_item(index: usize, observation: Value) -> Value {
+    let job_id = observation["job_id"].as_str().unwrap().to_string();
+    json!({
+        "index": index,
+        "job_id": job_id,
+        "success": true,
+        "output": observation,
+        "error_kind": null,
+        "error": null
+    })
+}
+
+fn canonical_batch(items: Vec<Value>, wait_outcome: &str, waited_ms: u64) -> ToolResult {
+    let returned_count = items.len();
+    let succeeded_count = items.iter().filter(|item| item["success"] == true).count();
+    let changed_count = items
+        .iter()
+        .filter(|item| item["success"] == true && item["output"]["changed"] == true)
+        .count();
+    let terminal_count = items
+        .iter()
+        .filter(|item| item["success"] == true && item["output"]["terminal"] == true)
+        .count();
+    ToolResult::ok(json!({
+        "requested_count": returned_count,
+        "returned_count": returned_count,
+        "succeeded_count": succeeded_count,
+        "failed_count": returned_count - succeeded_count,
+        "items": items,
+        "wait": {"outcome": wait_outcome, "waited_ms": waited_ms},
+        "changed_count": changed_count,
+        "terminal_count": terminal_count,
+        "output_truncated": false,
+        "next_index": null
+    }))
+}
+
+fn compact_projection(canonical: &ToolResult) -> ToolResult {
+    let mut projected = ToolResult {
+        success: canonical.success,
+        output: canonical.output.clone(),
+        error: canonical.error.clone(),
+    };
+    super::super::observe_jobs::sparsify_observe_jobs_model_result(&mut projected);
+    projected
+}
+
+fn serialized_result_bytes(result: &ToolResult) -> usize {
+    serde_json::to_vec(result).unwrap().len()
 }
 
 async fn start_owned_agent_job(
@@ -273,7 +378,9 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
         spec.input_schema["properties"]["items"]["items"]["additionalProperties"],
         false
     );
-    let output = &spec.output_schema["properties"]["output"]["anyOf"][0];
+    let successful_output = &spec.output_schema["properties"]["output"]["anyOf"][0];
+    let output = &successful_output["anyOf"][0];
+    let sparse_output = &successful_output["anyOf"][1];
     assert_eq!(
         output["properties"]["wait"]["properties"]["outcome"]["enum"],
         json!(["immediate", "updated", "terminal", "item_error", "timeout"])
@@ -311,6 +418,29 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
         .unwrap()
         .iter()
         .any(|schema| schema["type"] == "null"));
+    let sparse_observation = &sparse_output["properties"]["items"]["items"];
+    for required in [
+        "job_id",
+        "status",
+        "terminal",
+        "changed",
+        "log_delta_status",
+        "observation_token",
+    ] {
+        assert!(sparse_observation["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|field| field == required));
+    }
+    assert_eq!(
+        sparse_observation["properties"]["observation_token"]["maxLength"],
+        crate::job_observation::MAX_JOB_OBSERVATION_TOKEN_LEN
+    );
+    assert_eq!(
+        sparse_output["properties"]["wait"]["required"],
+        json!(["outcome"])
+    );
 
     let definition = super::super::tool_definition::lookup_tool_definition("observe_jobs").unwrap();
     assert!(definition.visibility.is_model_visible());
@@ -367,6 +497,388 @@ fn observe_jobs_schema_catalog_permission_and_audit_are_public_and_token_safe() 
         }),
     );
     assert!(!serde_json::to_string(&defensive).unwrap().contains(opaque));
+}
+
+#[test]
+fn observe_jobs_compact_projection_single_running_unchanged_keeps_actionable_state() {
+    let mut observation = canonical_observation(
+        "job-unchanged",
+        "running",
+        "unchanged",
+        "",
+        "",
+        false,
+        false,
+    );
+    observation["activity"] = serde_json::to_value(process_activity()).unwrap();
+    let token = observation["observation_token"].clone();
+    let canonical = canonical_batch(vec![canonical_success_item(0, observation)], "immediate", 0);
+    assert_eq!(
+        super::super::tool_audit::session_log_result_for_tool("observe_jobs", &canonical.output),
+        canonical.output,
+        "Session/audit must consume the full canonical observe_jobs result"
+    );
+
+    let projected = compact_projection(&canonical);
+    let output = projected.output.as_object().unwrap();
+    for omitted in [
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "changed_count",
+        "terminal_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        assert!(output.get(omitted).is_none(), "mechanical {omitted} leaked");
+    }
+    assert_eq!(projected.output["wait"]["outcome"], "immediate");
+    assert!(projected.output["wait"].get("waited_ms").is_none());
+    let item = &projected.output["items"][0];
+    assert_eq!(item["job_id"], "job-unchanged");
+    assert_eq!(item["status"], "running");
+    assert_eq!(item["terminal"], false);
+    assert_eq!(item["changed"], false);
+    assert_eq!(item["log_delta_status"], "unchanged");
+    assert_eq!(item["observation_token"], token);
+    assert_eq!(
+        item["activity"],
+        serde_json::to_value(process_activity()).unwrap()
+    );
+    for omitted in [
+        "index",
+        "success",
+        "output",
+        "error_kind",
+        "error",
+        "executor",
+        "cursor",
+        "last_update_seq",
+        "stdout_lines",
+        "stderr_lines",
+        "stdout_tail",
+        "stderr_tail",
+    ] {
+        assert!(item.get(omitted).is_none(), "mechanical {omitted} leaked");
+    }
+}
+
+#[test]
+fn observe_jobs_compact_projection_delta_keeps_bodies_and_token() {
+    let observation = canonical_observation(
+        "job-delta",
+        "running",
+        "delta",
+        "new stdout\n",
+        "new stderr\n",
+        true,
+        false,
+    );
+    let token = observation["observation_token"].clone();
+    let canonical = canonical_batch(vec![canonical_success_item(0, observation)], "updated", 84);
+    let projected = compact_projection(&canonical);
+    let item = &projected.output["items"][0];
+    assert_eq!(item["log_delta_status"], "delta");
+    assert_eq!(item["stdout_tail"], "new stdout\n");
+    assert_eq!(item["stderr_tail"], "new stderr\n");
+    assert_eq!(item["observation_token"], token);
+    assert_eq!(projected.output["wait"]["outcome"], "updated");
+    assert_eq!(projected.output["wait"]["waited_ms"], 84);
+    assert!(item.get("stdout_lines").is_none());
+    assert!(item.get("cursor").is_none());
+}
+
+#[test]
+fn observe_jobs_compact_projection_terminal_keeps_validation_evidence() {
+    let mut observation = canonical_observation(
+        "job-terminal",
+        "completed",
+        "delta",
+        "test result: ok\n",
+        "",
+        true,
+        true,
+    );
+    observation["exit_code"] = json!(0);
+    observation["command_execution_state"] = json!("completed");
+    observation["detected_summary"] = json!({
+        "kind": "test",
+        "outcome": "passed",
+        "tests_passed": 28,
+        "tests_failed": 0
+    });
+    observation["validation"] = json!({
+        "tool": "cargo_test",
+        "kind": "test",
+        "state": "completed",
+        "passed": true,
+        "truncated": false
+    });
+    let token = observation["observation_token"].clone();
+    let canonical = canonical_batch(vec![canonical_success_item(0, observation)], "terminal", 91);
+    let projected = compact_projection(&canonical);
+    let item = &projected.output["items"][0];
+    assert_eq!(item["terminal"], true);
+    assert_eq!(item["status"], "completed");
+    assert_eq!(item["exit_code"], 0);
+    assert_eq!(item["command_execution_state"], "completed");
+    assert_eq!(item["detected_summary"]["outcome"], "passed");
+    assert_eq!(item["validation"]["passed"], true);
+    assert_eq!(item["observation_token"], token);
+}
+
+#[test]
+fn observe_jobs_compact_projection_reset_keeps_recovery_and_loss_evidence() {
+    let mut observation = canonical_observation(
+        "job-reset",
+        "running",
+        "reset",
+        "bounded recovery stdout\n",
+        "bounded recovery stderr\n",
+        true,
+        false,
+    );
+    observation["stdout_delta_reset"] = json!(true);
+    observation["stderr_delta_reset"] = json!(true);
+    observation["stderr_truncated"] = json!(true);
+    observation["earlier_stdout_unavailable"] = json!(true);
+    observation["stdout_retained_from_line"] = json!(41);
+    observation["stderr_retained_from_line"] = json!(22);
+    observation["recovery_state"] = json!("recovered");
+    observation["recovery_reason_code"] = json!("server_epoch_changed");
+    observation["recovery_reason"] = json!("Exact delta history was unavailable.");
+    let token = observation["observation_token"].clone();
+    let canonical = canonical_batch(vec![canonical_success_item(0, observation)], "updated", 12);
+    let projected = compact_projection(&canonical);
+    let item = &projected.output["items"][0];
+    assert_eq!(item["log_delta_status"], "reset");
+    assert_eq!(item["stdout_delta_reset"], true);
+    assert_eq!(item["stderr_delta_reset"], true);
+    assert_eq!(item["stderr_truncated"], true);
+    assert_eq!(item["earlier_stdout_unavailable"], true);
+    assert_eq!(item["stdout_retained_from_line"], 41);
+    assert_eq!(item["cursor"], json!({"stdout": 5, "stderr": 3}));
+    assert_eq!(item["recovery_reason_code"], "server_epoch_changed");
+    assert_eq!(item["observation_token"], token);
+    assert_eq!(item["command_summary"], "cargo check -p webcodex --lib");
+    assert_eq!(item["purpose"], "build");
+}
+
+#[test]
+fn observe_jobs_compact_projection_multi_success_preserves_order_and_one_wait() {
+    let items = (0..4)
+        .map(|index| {
+            canonical_success_item(
+                index,
+                canonical_observation(
+                    &format!("job-{index}"),
+                    "running",
+                    "unchanged",
+                    "",
+                    "",
+                    false,
+                    false,
+                ),
+            )
+        })
+        .collect();
+    let canonical = canonical_batch(items, "timeout", 1_002);
+    let projected = compact_projection(&canonical);
+    let items = projected.output["items"].as_array().unwrap();
+    assert_eq!(items.len(), 4);
+    assert_eq!(
+        items
+            .iter()
+            .map(|item| item["job_id"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["job-0", "job-1", "job-2", "job-3"]
+    );
+    assert_eq!(projected.output["wait"]["outcome"], "timeout");
+    assert_eq!(projected.output["wait"]["waited_ms"], 1_002);
+    assert!(projected.output.get("terminal_count").is_none());
+}
+
+#[test]
+fn observe_jobs_compact_projection_preserves_mixed_failure_and_budget_recovery() {
+    let success = canonical_success_item(
+        0,
+        canonical_observation("job-ok", "running", "unchanged", "", "", false, false),
+    );
+    let failure = json!({
+        "index": 1,
+        "job_id": "missing-job",
+        "success": false,
+        "output": null,
+        "error_kind": "unknown_job",
+        "recovery_kind": "reobserve",
+        "recovery_tool": "list_jobs",
+        "error": "unknown job: missing-job"
+    });
+    let mixed = canonical_batch(vec![success.clone(), failure], "item_error", 0);
+    assert_eq!(
+        serde_json::to_value(compact_projection(&mixed)).unwrap(),
+        serde_json::to_value(&mixed).unwrap()
+    );
+    assert_eq!(mixed.output["items"][1]["recovery_tool"], "list_jobs");
+
+    let mut truncated = canonical_batch(vec![success], "immediate", 0);
+    truncated.output["output_truncated"] = json!(true);
+    truncated.output["next_index"] = json!(1);
+    assert_eq!(
+        serde_json::to_value(compact_projection(&truncated)).unwrap(),
+        serde_json::to_value(&truncated).unwrap()
+    );
+    assert_eq!(truncated.output["next_index"], 1);
+}
+
+#[test]
+fn observe_jobs_canonical_and_compact_success_both_match_output_schema() {
+    let canonical = canonical_batch(
+        vec![canonical_success_item(
+            0,
+            canonical_observation("job-schema", "running", "unchanged", "", "", false, false),
+        )],
+        "immediate",
+        0,
+    );
+    let projected = compact_projection(&canonical);
+    let schema = super::super::registry::output_schema_for_tool("observe_jobs");
+    for (label, result) in [("canonical", canonical), ("compact", projected)] {
+        let value = serde_json::to_value(&result).unwrap();
+        assert!(
+            super::super::startup_brief::validate_schema_instance_for_test(&value, &schema).is_ok(),
+            "{label} observe_jobs result did not satisfy output schema: {value}"
+        );
+    }
+}
+
+#[test]
+fn observe_jobs_projection_reports_deterministic_byte_measurements() {
+    let unchanged = canonical_batch(
+        vec![canonical_success_item(
+            0,
+            canonical_observation(
+                "job-measure-u",
+                "running",
+                "unchanged",
+                "",
+                "",
+                false,
+                false,
+            ),
+        )],
+        "immediate",
+        0,
+    );
+    let delta = canonical_batch(
+        vec![canonical_success_item(
+            0,
+            canonical_observation(
+                "job-measure-d",
+                "running",
+                "delta",
+                &format!("{}\n", "stdout".repeat(20)),
+                &format!("{}\n", "stderr".repeat(6)),
+                true,
+                false,
+            ),
+        )],
+        "updated",
+        75,
+    );
+    let mut terminal_observation = canonical_observation(
+        "job-measure-t",
+        "completed",
+        "delta",
+        "28 passed\n",
+        "",
+        true,
+        true,
+    );
+    terminal_observation["exit_code"] = json!(0);
+    terminal_observation["validation"] = json!({
+        "tool": "cargo_test", "kind": "test", "state": "completed",
+        "passed": true, "truncated": false, "tests_passed": 28, "tests_failed": 0
+    });
+    let terminal = canonical_batch(
+        vec![canonical_success_item(0, terminal_observation)],
+        "terminal",
+        88,
+    );
+    let four = canonical_batch(
+        (0..4)
+            .map(|index| {
+                canonical_success_item(
+                    index,
+                    canonical_observation(
+                        &format!("job-measure-{index}"),
+                        "running",
+                        "unchanged",
+                        "",
+                        "",
+                        false,
+                        false,
+                    ),
+                )
+            })
+            .collect(),
+        "timeout",
+        1_000,
+    );
+    let mixed = canonical_batch(
+        vec![
+            canonical_success_item(
+                0,
+                canonical_observation(
+                    "job-measure-ok",
+                    "running",
+                    "unchanged",
+                    "",
+                    "",
+                    false,
+                    false,
+                ),
+            ),
+            json!({
+                "index": 1, "job_id": "missing-measure", "success": false,
+                "output": null, "error_kind": "unknown_job", "recovery_kind": "reobserve",
+                "recovery_tool": "list_jobs", "error": "unknown job: missing-measure"
+            }),
+        ],
+        "item_error",
+        0,
+    );
+
+    for (name, canonical) in [
+        ("one_running_unchanged", unchanged),
+        ("one_delta", delta),
+        ("one_terminal_validation", terminal),
+        ("four_running", four),
+        ("mixed_success_unknown", mixed),
+    ] {
+        let projected = compact_projection(&canonical);
+        let canonical_bytes = serialized_result_bytes(&canonical);
+        let projected_bytes = serialized_result_bytes(&projected);
+        let reduction = if canonical_bytes == 0 {
+            0.0
+        } else {
+            100.0 * (canonical_bytes.saturating_sub(projected_bytes)) as f64
+                / canonical_bytes as f64
+        };
+        println!(
+            "OBSERVE_JOBS_PROJECTION_BYTES {name} canonical={canonical_bytes} projected={projected_bytes} reduction_pct={reduction:.1}"
+        );
+        assert!(projected_bytes <= canonical_bytes);
+        if name != "mixed_success_unknown" {
+            assert!(projected_bytes < canonical_bytes);
+        } else {
+            assert_eq!(
+                serde_json::to_value(&projected).unwrap(),
+                serde_json::to_value(&canonical).unwrap()
+            );
+        }
+    }
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -340,7 +340,7 @@ async fn fast_go_test_uses_exact_structured_argv_cwd_and_records_session_evidenc
     let client_id = "vhandoff-go-fast";
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join("project");
-    let scoped = root.join("internal/nodeapp");
+    let scoped = root.join("internal").join("nodeapp");
     std::fs::create_dir_all(&scoped).unwrap();
     let runtime = test_runtime().with_validation_sync_wait(std::time::Duration::from_millis(300));
     register_agent_with_projects(


### PR DESCRIPTION
## Summary
- compact ordinary all-success `observe_jobs` results at the final model-facing projection while preserving canonical Job snapshots for budgeting, Session/audit recording, and internal diagnostics
- keep opaque observation tokens, lifecycle state, delta/reset semantics, validation evidence, and exceptional truncation/recovery diagnostics actionable; mixed failures and truncated batches remain canonical
- preserve the canonical `observe_jobs` output schema as the first discovery variant while admitting the compact success variant
- fix the CI stack overflow in `shared_key_runtime_job_tools_filter_agent_jobs_by_auth_group` by isolating that heavy integration fixture on the repository's established bounded 8 MiB test thread pattern rather than raising suite-wide `RUST_MIN_STACK`

## Reviewer fixes
- restored stable discovery paths for canonical Job executor and shared-wait schema metadata after introducing the compact output variant
- verified the reported test is stack-capacity-sensitive rather than an infinite recursion; a pre-fix 1 MiB libtest stack reproduced the overflow, while the fixed fixture passes with the libtest process constrained to 1 MiB because its body runs on the isolated 8 MiB thread

## Validation
- `cargo test -p webcodex --lib`: 2411 passed
- `cargo test 'tool_runtime::tests::jobs::' -p webcodex`: 38 passed
- `cargo test 'observe_jobs_' -p webcodex`: 18 passed
- `cargo test -p webcodex-tool-contracts`: 89 passed
- `cargo check --all-targets`: pass, 0 errors / 0 warnings
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass
- read-only `git merge-tree --write-tree HEAD origin/main`: clean against current main