### PR TITLE
Reduce CI native overscheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,9 @@ jobs:
 
   contract:
     # Mandatory contract lane for every workflow invocation: pull requests and
-    # pushes to main. It runs independently of the cheap changes classifier.
-    # Keep it limited to deterministic, in-process/static checks so feedback stays fast.
+    # pushes to main. Heavy Rust/native jobs intentionally do not depend on this
+    # lane: they start in parallel, while the stable aggregate jobs below still
+    # require contract success before the workflow can pass.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -164,8 +165,8 @@ jobs:
 
   test-linux-rust:
     # Complete Linux Rust coverage is mandatory before merge, including owner PRs.
-    # Release readiness must not be the first place these package suites execute.
-    needs: contract
+    # Start it immediately in parallel with contract/frontend work; the stable
+    # `test` aggregate still requires both surfaces to succeed.
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -191,9 +192,8 @@ jobs:
         run: cargo test --locked ${{ matrix.packages }}
 
   test-linux-tooling:
-    # Release/tooling checks are cheap relative to native platform builds and are
-    # mandatory on every PR so release-prep failures are caught before merge.
-    needs: contract
+    # Release/tooling checks are mandatory on every PR, but do not need contract
+    # output. Start them in parallel; the stable `test` aggregate joins the results.
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -223,7 +223,7 @@ jobs:
   # Linux arm64 cfg/target coverage here so release-readiness does not need a
   # duplicate release-profile build merely to prove the native architecture.
   test-linux-arm64:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_linux_arm64 == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
@@ -263,7 +263,7 @@ jobs:
           fi
 
   test-macos-core:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_macos == 'true'
     # Native macOS core gates cover both published architectures plus the Runner
     # and Computer platform suites without mechanically building Desktop packages.
@@ -301,7 +301,7 @@ jobs:
         run: cargo test --locked -p webcodex-runner -p webcodex-computer
 
   test-macos-desktop:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_macos_desktop == 'true'
     # Keep Desktop package validation separate so process/plugin changes receive
     # native macOS coverage without paying the DMG build cost unless needed.
@@ -470,7 +470,7 @@ jobs:
   # running after the Computer runtime was split out of the Runner crate.
   # Core/library and packaging coverage can run independently in parallel.
   test-windows-core:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_windows_core == 'true'
     runs-on: windows-latest
     timeout-minutes: 45
@@ -493,7 +493,7 @@ jobs:
         run: cargo test --locked -p webcodex-runner-config -p webcodex-process -p webcodex-cli
 
   test-windows-runner:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_windows_runner == 'true'
     runs-on: windows-latest
     timeout-minutes: 45
@@ -509,7 +509,7 @@ jobs:
         run: cargo test --locked -p webcodex-runner -p webcodex-computer -- --test-threads=2
 
   test-windows-package:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_windows_package == 'true'
     runs-on: windows-latest
     timeout-minutes: 45
@@ -534,7 +534,7 @@ jobs:
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/npm_install_windows_smoke.ps1
 
   test-windows-desktop:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_windows_desktop == 'true'
     runs-on: windows-latest
     timeout-minutes: 60
@@ -633,7 +633,7 @@ jobs:
   # Keep native ARM64 compile coverage path-aware as well; full-native overrides
   # and explicit aarch64 cfg/target changes still require it before merge.
   test-windows-arm64:
-    needs: [contract, changes]
+    needs: changes
     if: needs.changes.outputs.needs_windows_arm64 == 'true'
     runs-on: windows-11-arm
     timeout-minutes: 30

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -31,30 +31,37 @@ The lanes above define test semantics; workflows decide when to run them.
 
 - `.github/workflows/ci.yml` is the ordinary repository gate. Its cheap `changes`
   job classifies the exact PR base...head path set before native scheduling, while
-  the lightweight `contract` job remains mandatory for every configured pull
-  request and every push to `main`. The classifier is deterministic and local to
-  Git: it does not use commit messages or PR titles, and it emits per-platform and
-  per-package-lane requirements. The contract lane owns frontend
-  install/type/test/dist validation, workspace-boundary self-test/checks,
-  formatting, the heuristic test-inventory self-test/report (without count
-  thresholds), and focused registry/OpenAPI/MCP schema and metadata parity.
+  the `contract` job remains mandatory for every configured pull request and every
+  push to `main`. The classifier is deterministic and local to Git: it does not use
+  commit messages or PR titles, and it emits per-platform and per-package-lane
+  requirements. For changed Rust/Cargo files it searches only bounded platform-marker
+  lines from both the base and head file versions, so body-only changes inside an
+  existing platform cfg remain visible without serializing near-complete file diffs.
+  If that marker scan exceeds its bound, CI fails closed to native core plus
+  architecture compilation while preserving path-derived package/Desktop decisions;
+  only an untrustworthy changed-path inventory falls back to the complete native
+  matrix. The contract lane owns frontend install/type/test/dist validation,
+  workspace-boundary self-test/checks, formatting, the heuristic test-inventory
+  self-test/report (without count thresholds), and focused registry/OpenAPI/MCP
+  schema and metadata parity.
 - The heavy Linux Rust matrix `test-linux-rust` and Linux tooling lane
-  `test-linux-tooling` both depend on a successful `contract` job and now run for
-  every pull request as well as every push to `main`, including owner-authored PRs.
-  Release readiness must not be the first place complete Linux package suites or
-  release-tooling tests execute. The historical `test` job id remains the aggregate
-  Linux status check and always evaluates `contract` plus both Linux lanes, failing
-  unless every required result is `success`. Pushes to `main`, external-contributor
+  `test-linux-tooling` run for every pull request as well as every push to `main`,
+  including owner-authored PRs. They start in parallel with `contract` rather than
+  waiting for unrelated frontend/static work; the historical `test` aggregate still
+  requires `contract` plus both Linux lanes to succeed. Native child lanes likewise
+  wait only for the cheap `changes` classifier, while the stable macOS/Windows/native
+  aggregates retain the mandatory `contract` gate. Release readiness must not be the
+  first place complete Linux package suites or release-tooling tests execute. Pushes
+  to `main`, external-contributor
   PRs, and owner PRs carrying `run-ci` still force the complete native matrix. Other
   owner PRs are upgraded automatically according to changed-path risk: native
   process-owning Runner surfaces, shell, Plugin, Computer, platform-specific, and
   Desktop Rust ownership selects Windows and/or macOS lanes; `npm/webcodex/**`
   selects the native Windows package lane; packaging/signing/release and workflow
   policy surfaces select the corresponding package lanes or the full matrix.
-  For changed Rust files and Cargo manifests, classification inspects bounded full
-  diff context so a body-only edit inside an existing platform `cfg`/target section
-  cannot silently look platform-neutral; an over-bound context falls back to full
-  native. Ordinary Rust domain/control changes remain on the mandatory Linux gates.
+  Ordinary Rust domain/control changes remain on the mandatory Linux gates; native
+  package/install lanes are selected only by their own path risks or an explicit
+  full-native policy override, not merely because a broad Rust diff is large.
   The stable `test-macos`,
   `test-windows`, and `test-native` aggregates always resolve and verify each child
   lane is `success` when required or `skipped` when not required, avoiding a skipped

--- a/scripts/ci_path_risk.py
+++ b/scripts/ci_path_risk.py
@@ -15,10 +15,12 @@ from pathlib import PurePosixPath
 MAX_CHANGED_PATHS = 2048
 MAX_PATH_BYTES = 4096
 MAX_NAME_STATUS_BYTES = 1024 * 1024
-MAX_PLATFORM_DIFF_BYTES = 2 * 1024 * 1024
+MAX_PLATFORM_CONTEXT_BYTES = 2 * 1024 * 1024
+MAX_GIT_PATH_BATCH_BYTES = 64 * 1024
 MAX_GIT_STDERR_BYTES = 64 * 1024
 
 SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+PLATFORM_CONTEXT_GREP_RE = r"windows|macos|aarch64|target_os|target_family|target_arch"
 WINDOWS_CFG_RE = re.compile(
     r"(?:\bcfg!?\s*\([^\n)]*\bwindows\b|\btarget_(?:os|family)\s*=\s*\"windows\")"
 )
@@ -135,6 +137,15 @@ def _mark_macos(risk: Risk, category: str, *, desktop: bool = False) -> None:
     if desktop:
         risk.needs_macos_desktop = True
     risk.categories.add(category)
+
+
+def _mark_platform_context_bounded(risk: Risk) -> None:
+    """Fail closed on platform semantics without pulling in unrelated packaging."""
+    category = "platform-context-bounded"
+    _mark_windows_core(risk, category)
+    _mark_macos(risk, category)
+    risk.needs_linux_arm64 = True
+    risk.needs_windows_arm64 = True
 
 
 def _is_docs_or_text(path: str) -> bool:
@@ -320,11 +331,10 @@ def classify_changes(changes: list[Change], platform_diff: str = "") -> Risk:
         _validate_path(change.path)
         _classify_path(risk, change.path)
 
-    # `platform_diff` deliberately contains the complete bounded context of every
-    # changed Rust/Cargo manifest file, not only +/- lines. A body-only edit inside
-    # an existing `#[cfg(windows)]` block or target-specific Cargo dependency is
-    # still platform risk even when the cfg declaration itself is unchanged.
-    # Oversized context fails safe to full native in `classify_git_range`.
+    # `platform_diff` contains only platform-marker lines observed from the base and
+    # head versions of changed Rust/Cargo files. Looking at both revisions keeps a
+    # body-only edit inside an existing `#[cfg(windows)]` block or target-specific
+    # Cargo section visible even when the marker line itself did not change.
     if WINDOWS_CFG_RE.search(platform_diff) or MACOS_CFG_RE.search(platform_diff):
         _mark_windows_core(risk, "platform-cfg")
         _mark_macos(risk, "platform-cfg")
@@ -367,7 +377,12 @@ def _validate_path(path: str) -> None:
         raise DiffLimitExceeded("changed path is not a bounded repository-relative path")
 
 
-def _run_git_bounded(args: list[str], *, max_stdout_bytes: int) -> bytes:
+def _run_git_bounded(
+    args: list[str],
+    *,
+    max_stdout_bytes: int,
+    accepted_return_codes: tuple[int, ...] = (0,),
+) -> bytes:
     with subprocess.Popen(
         ["git", *args],
         stdout=subprocess.PIPE,
@@ -378,9 +393,9 @@ def _run_git_bounded(args: list[str], *, max_stdout_bytes: int) -> bytes:
         if len(stdout) > max_stdout_bytes:
             process.kill()
             process.wait()
-            raise DiffLimitExceeded("git diff output exceeds classifier bounds")
+            raise DiffLimitExceeded("git output exceeds classifier bounds")
         return_code = process.wait()
-        if return_code != 0:
+        if return_code not in accepted_return_codes:
             message = stdout[:MAX_GIT_STDERR_BYTES].decode("utf-8", errors="replace").strip()
             raise GitDiffError(message or f"git exited with status {return_code}")
         return stdout
@@ -420,26 +435,61 @@ def _git_changes(base: str, head: str) -> list[Change]:
     return changes
 
 
-def _git_platform_diff(base: str, head: str) -> str:
-    raw = _run_git_bounded(
-        [
-            "diff",
-            "--unified=1000000",
-            "--no-renames",
-            "--no-ext-diff",
-            "--no-textconv",
-            "--no-color",
-            f"{base}...{head}",
-            "--",
-            "*.rs",
-            ":(glob)**/Cargo.toml",
-            ":(exclude)docs/**",
-            ":(exclude)frontend/**",
-            ":(exclude)apps/desktop/src/**",
-        ],
-        max_stdout_bytes=MAX_PLATFORM_DIFF_BYTES,
+def _platform_context_paths(changes: list[Change], *, excluded_status: str) -> list[str]:
+    return sorted(
+        {
+            change.path
+            for change in changes
+            if change.status != excluded_status
+            and (change.path.endswith(".rs") or PurePosixPath(change.path).name == "Cargo.toml")
+            and not _is_docs_or_text(change.path)
+            and not _is_frontend_only(change.path)
+        }
     )
-    return raw.decode("utf-8", errors="replace")
+
+
+def _path_batches(paths: list[str]) -> list[list[str]]:
+    batches: list[list[str]] = []
+    batch: list[str] = []
+    batch_bytes = 0
+    for path in paths:
+        path_bytes = len(path.encode("utf-8")) + 1
+        if batch and batch_bytes + path_bytes > MAX_GIT_PATH_BATCH_BYTES:
+            batches.append(batch)
+            batch = []
+            batch_bytes = 0
+        batch.append(path)
+        batch_bytes += path_bytes
+    if batch:
+        batches.append(batch)
+    return batches
+
+
+def _git_platform_context(base: str, head: str, changes: list[Change]) -> str:
+    chunks: list[bytes] = []
+    remaining = MAX_PLATFORM_CONTEXT_BYTES
+    for revision, excluded_status in ((base, "A"), (head, "D")):
+        paths = _platform_context_paths(changes, excluded_status=excluded_status)
+        for batch in _path_batches(paths):
+            raw = _run_git_bounded(
+                [
+                    "grep",
+                    "-h",
+                    "-I",
+                    "-E",
+                    "-e",
+                    PLATFORM_CONTEXT_GREP_RE,
+                    revision,
+                    "--",
+                    *batch,
+                ],
+                max_stdout_bytes=remaining,
+                # git grep uses 1 for a valid search with no matches.
+                accepted_return_codes=(0, 1),
+            )
+            chunks.append(raw)
+            remaining -= len(raw)
+    return b"\n".join(chunks).decode("utf-8", errors="replace")
 
 
 def classify_git_range(base: str, head: str) -> Risk:
@@ -447,14 +497,28 @@ def classify_git_range(base: str, head: str) -> Risk:
         raise GitDiffError("base and head must be exact 40-hex Git commit ids")
     try:
         changes = _git_changes(base, head)
-        needs_platform_context = any(
-            change.path.endswith(".rs") or PurePosixPath(change.path).name == "Cargo.toml"
-            for change in changes
-        )
-        platform_diff = _git_platform_diff(base, head) if needs_platform_context else ""
-        return classify_changes(changes, platform_diff)
     except DiffLimitExceeded:
-        return Risk.full("bounded-fallback")
+        # If even the changed-path inventory is outside the trusted bound, there is
+        # no safe way to know which product surfaces changed.
+        return Risk.full("changed-path-bounded-fallback")
+
+    needs_platform_context = any(
+        change.path.endswith(".rs") or PurePosixPath(change.path).name == "Cargo.toml"
+        for change in changes
+    )
+    if not needs_platform_context:
+        return classify_changes(changes)
+
+    try:
+        platform_context = _git_platform_context(base, head, changes)
+    except DiffLimitExceeded:
+        # We still know the exact changed paths, so preserve their package/desktop
+        # classification and fail closed only for unknown native cfg/architecture
+        # semantics. Packaging lanes are not a substitute for platform compilation.
+        risk = classify_changes(changes)
+        _mark_platform_context_bounded(risk)
+        return risk.finalize()
+    return classify_changes(changes, platform_context)
 
 
 def _parse_bool(value: str) -> bool:

--- a/scripts/tests/test_ci_path_risk.py
+++ b/scripts/tests/test_ci_path_risk.py
@@ -221,19 +221,75 @@ class GitRangeIntegrationTests(unittest.TestCase):
             ["git", "rev-parse", "HEAD"], cwd=root, text=True
         ).strip()
 
-    def test_platform_diff_bound_falls_back_to_full_native(self) -> None:
+    def test_platform_context_bound_falls_back_to_native_core_without_packaging(self) -> None:
         change = risk.Change(status="M", path="src/runtime.rs")
         with (
             mock.patch.object(risk, "_git_changes", return_value=[change]),
             mock.patch.object(
                 risk,
-                "_git_platform_diff",
+                "_git_platform_context",
                 side_effect=risk.DiffLimitExceeded("fixture bound"),
             ),
         ):
             result = risk.classify_git_range("0" * 40, "1" * 40).outputs()
+        self.assertEqual(result["needs_full_native"], "false")
+        self.assertEqual(result["needs_windows_core"], "true")
+        self.assertEqual(result["needs_macos"], "true")
+        self.assertEqual(result["needs_linux_arm64"], "true")
+        self.assertEqual(result["needs_windows_arm64"], "true")
+        self.assertEqual(result["needs_windows_package"], "false")
+        self.assertEqual(result["needs_windows_desktop"], "false")
+        self.assertEqual(result["needs_macos_desktop"], "false")
+        self.assertIn("platform-context-bounded", result["categories"])
+
+    def test_changed_path_bound_still_falls_back_to_full_native(self) -> None:
+        with mock.patch.object(
+            risk,
+            "_git_changes",
+            side_effect=risk.DiffLimitExceeded("fixture path bound"),
+        ):
+            result = risk.classify_git_range("0" * 40, "1" * 40).outputs()
         self.assertEqual(result["needs_full_native"], "true")
-        self.assertIn("bounded-fallback", result["categories"])
+        self.assertIn("changed-path-bounded-fallback", result["categories"])
+
+    def test_broad_rust_change_does_not_escalate_to_packaging_or_arm64(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.init_repo(root)
+            sources = []
+            for index in range(14):
+                source = root / "src" / f"wide_{index:02}.rs"
+                source.parent.mkdir(parents=True, exist_ok=True)
+                source.write_text(
+                    f"pub const VALUE_{index}: usize = {index};\n" + "// filler\n" * 18000,
+                    encoding="utf-8",
+                )
+                sources.append(source)
+            runner = root / "crates" / "webcodex-runner" / "src" / "webcodex_runner" / "projects.rs"
+            runner.parent.mkdir(parents=True, exist_ok=True)
+            runner.write_text("pub fn managed() -> usize { 1 }\n" + "// runner filler\n" * 12000, encoding="utf-8")
+            sources.append(runner)
+            base = self.commit(root, "broad base")
+
+            for source in sources:
+                source.write_text(source.read_text(encoding="utf-8") + "// changed\n", encoding="utf-8")
+            head = self.commit(root, "broad rust change")
+
+            previous = Path.cwd()
+            try:
+                os.chdir(root)
+                result = risk.classify_git_range(base, head).outputs()
+            finally:
+                os.chdir(previous)
+
+            self.assertEqual(result["needs_full_native"], "false")
+            self.assertEqual(result["needs_windows_runner"], "true")
+            self.assertEqual(result["needs_macos"], "true")
+            self.assertEqual(result["needs_windows_package"], "false")
+            self.assertEqual(result["needs_windows_desktop"], "false")
+            self.assertEqual(result["needs_macos_desktop"], "false")
+            self.assertEqual(result["needs_linux_arm64"], "false")
+            self.assertEqual(result["needs_windows_arm64"], "false")
 
     def test_real_git_rename_is_observed_as_delete_plus_add_and_upgrades_risk(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/tests/test_release_readiness.py
+++ b/scripts/tests/test_release_readiness.py
@@ -338,8 +338,23 @@ class WorkflowContractTests(unittest.TestCase):
             end = min(following) if following else len(workflow)
             block = workflow[start:end]
             with self.subTest(job=job_name):
-                self.assertIn("needs: [contract, changes]", block)
+                self.assertIn("needs: changes", block)
+                self.assertNotIn("needs: [contract, changes]", block)
                 self.assertIn(f"if: needs.changes.outputs.{output_name} == 'true'", block)
+
+        for job_name in ("test-linux-rust", "test-linux-tooling"):
+            start = workflow.index(f"  {job_name}:\n")
+            end = workflow.find("\n  test-", start + 1)
+            block = workflow[start : end if end != -1 else len(workflow)]
+            with self.subTest(job=job_name):
+                self.assertNotIn("needs: contract", block)
+
+        for aggregate in ("test", "test-macos", "test-windows", "test-native"):
+            start = workflow.index(f"  {aggregate}:\n")
+            line_end = workflow.index("\n", workflow.index("    needs:", start))
+            needs_line = workflow[workflow.index("    needs:", start) : line_end]
+            with self.subTest(aggregate=aggregate):
+                self.assertIn("contract", needs_line)
 
         changes = workflow[workflow.index("  changes:\n"):workflow.index("  contract:\n")]
         for output in (


### PR DESCRIPTION
## Summary

- replace near-full Rust/Cargo diff context in the native-risk classifier with bounded platform-marker scans over the changed files at both base and head
- keep changed-path overflow fully fail-closed, but scope platform-context overflow to native core/architecture coverage instead of unrelated Desktop/package lanes
- start heavyweight Linux/native child jobs in parallel with the mandatory contract lane while preserving contract requirements in the stable aggregate checks
- update CI/testing documentation and deterministic regression coverage

## Evidence

- `python3 -m unittest scripts.tests.test_ci_path_risk scripts.tests.test_release_readiness` — 44 tests passed
- `bash scripts/release_check.sh --static-only` — passed, including 151 Python tooling tests
- historical managed-worktree PR range `19a83aaa...79b70e33` now classifies as Windows core + Runner and macOS core, without Desktop/package/ARM64 lanes; the old classifier had fallen back to full native
- this CI-policy PR itself still classifies `full-native`, preserving the trusted policy-change gate

## Scope

This PR intentionally does not refactor process/sleep/network-heavy test implementations. That is a separate follow-up after scheduling/classification is corrected.