### PR TITLE
Split Runner real-process tests from default CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
       needs_macos: ${{ steps.classify.outputs.needs_macos }}
       needs_macos_desktop: ${{ steps.classify.outputs.needs_macos_desktop }}
       needs_linux_arm64: ${{ steps.classify.outputs.needs_linux_arm64 }}
+      # PR classification executes the trusted base copy of ci_path_risk.py. During
+      # this one-field schema rollout, an older base has no dedicated output; only
+      # then inherit its existing native Runner/core/full signal so this PR can prove
+      # the new lane before the updated classifier reaches main.
+      needs_runner_real_process: ${{ steps.classify.outputs.needs_runner_real_process == 'true' || (steps.classify.outputs.needs_runner_real_process == '' && (steps.classify.outputs.needs_windows_runner == 'true' || steps.classify.outputs.needs_windows_core == 'true' || steps.classify.outputs.needs_full_native == 'true')) }}
       needs_desktop_package: ${{ steps.classify.outputs.needs_desktop_package }}
       needs_full_native: ${{ steps.classify.outputs.needs_full_native }}
       categories: ${{ steps.classify.outputs.categories }}
@@ -71,6 +76,7 @@ jobs:
                 needs_macos \
                 needs_macos_desktop \
                 needs_linux_arm64 \
+                needs_runner_real_process \
                 needs_desktop_package \
                 needs_full_native; do
                 echo "$key=true"
@@ -191,6 +197,20 @@ jobs:
       - name: Run ${{ matrix.shard }} Rust tests
         run: cargo test --locked ${{ matrix.packages }}
 
+  test-linux-runner-real-process:
+    needs: changes
+    if: needs.changes.outputs.needs_runner_real_process == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: linux-ci
+      - name: Run Runner real-process lifecycle tests
+        run: cargo test --locked -p webcodex-runner runner_real_process -- --ignored --test-threads=2
+
   test-linux-tooling:
     # Release/tooling checks are mandatory on every PR, but do not need contract
     # output. Start them in parallel; the stable `test` aggregate joins the results.
@@ -241,7 +261,7 @@ jobs:
           cargo check --locked -p webcodex -p webcodex-cli -p webcodex-runner
 
   test:
-    needs: [contract, test-linux-rust, test-linux-tooling]
+    needs: [contract, changes, test-linux-rust, test-linux-runner-real-process, test-linux-tooling]
     # Preserve the historical aggregate status check and always evaluate upstream
     # results so a failed or unexpectedly skipped Linux lane cannot disappear.
     if: always()
@@ -251,14 +271,25 @@ jobs:
       - name: Require successful Linux lanes
         env:
           CONTRACT_RESULT: ${{ needs.contract.result }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          NEEDS_REAL_PROCESS: ${{ needs.changes.outputs.needs_runner_real_process }}
           RUST_RESULT: ${{ needs.test-linux-rust.result }}
+          REAL_PROCESS_RESULT: ${{ needs.test-linux-runner-real-process.result }}
           TOOLING_RESULT: ${{ needs.test-linux-tooling.result }}
         run: |
-          echo "contract=$CONTRACT_RESULT rust=$RUST_RESULT tooling=$TOOLING_RESULT"
+          set -euo pipefail
+          echo "contract=$CONTRACT_RESULT changes=$CHANGES_RESULT rust=$RUST_RESULT real_process=$REAL_PROCESS_RESULT tooling=$TOOLING_RESULT needs_real_process=$NEEDS_REAL_PROCESS"
           if [ "$CONTRACT_RESULT" != success ] || \
+             [ "$CHANGES_RESULT" != success ] || \
              [ "$RUST_RESULT" != success ] || \
              [ "$TOOLING_RESULT" != success ]; then
             echo "required Linux CI lane did not succeed" >&2
+            exit 1
+          fi
+          expected_real_process=skipped
+          if [ "$NEEDS_REAL_PROCESS" = true ]; then expected_real_process=success; fi
+          if [ "$REAL_PROCESS_RESULT" != "$expected_real_process" ]; then
+            echo "Runner real-process Linux lane expected $expected_real_process, got $REAL_PROCESS_RESULT" >&2
             exit 1
           fi
 
@@ -299,6 +330,40 @@ jobs:
         run: cargo check --locked --workspace
       - name: Run native macOS Runner and Computer tests
         run: cargo test --locked -p webcodex-runner -p webcodex-computer
+
+  test-macos-runner-real-process:
+    needs: changes
+    if: needs.changes.outputs.needs_runner_real_process == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: darwin-arm64
+            runner: macos-15
+            host_arch: arm64
+            rust_host: aarch64-apple-darwin
+          - platform: darwin-x64
+            runner: macos-15-intel
+            host_arch: x86_64
+            rust_host: x86_64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: macos-runner-real-process-${{ matrix.platform }}
+      - name: Verify native macOS host
+        env:
+          EXPECTED_HOST_ARCH: ${{ matrix.host_arch }}
+          EXPECTED_RUST_HOST: ${{ matrix.rust_host }}
+        run: |
+          test "$(uname -m)" = "$EXPECTED_HOST_ARCH"
+          rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+          test "$rust_host" = "$EXPECTED_RUST_HOST"
+      - name: Run Runner real-process lifecycle tests
+        run: cargo test --locked -p webcodex-runner runner_real_process -- --ignored --test-threads=2
 
   test-macos-desktop:
     needs: changes
@@ -426,7 +491,7 @@ jobs:
             --signing-mode adhoc
 
   test-macos:
-    needs: [contract, changes, test-macos-core, test-macos-desktop]
+    needs: [contract, changes, test-macos-core, test-macos-runner-real-process, test-macos-desktop]
     # Stable aggregate context: every configured macOS sublane must either succeed
     # when required by policy or be intentionally skipped when not required.
     if: always()
@@ -438,12 +503,14 @@ jobs:
           CONTRACT_RESULT: ${{ needs.contract.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           NEEDS_CORE: ${{ needs.changes.outputs.needs_macos }}
+          NEEDS_REAL_PROCESS: ${{ needs.changes.outputs.needs_runner_real_process }}
           NEEDS_DESKTOP: ${{ needs.changes.outputs.needs_macos_desktop }}
           CORE_RESULT: ${{ needs.test-macos-core.result }}
+          REAL_PROCESS_RESULT: ${{ needs.test-macos-runner-real-process.result }}
           DESKTOP_RESULT: ${{ needs.test-macos-desktop.result }}
         run: |
           set -euo pipefail
-          echo "changes=$CHANGES_RESULT contract=$CONTRACT_RESULT core=$CORE_RESULT desktop=$DESKTOP_RESULT needs_core=$NEEDS_CORE needs_desktop=$NEEDS_DESKTOP"
+          echo "changes=$CHANGES_RESULT contract=$CONTRACT_RESULT core=$CORE_RESULT real_process=$REAL_PROCESS_RESULT desktop=$DESKTOP_RESULT needs_core=$NEEDS_CORE needs_real_process=$NEEDS_REAL_PROCESS needs_desktop=$NEEDS_DESKTOP"
           if [ "$CHANGES_RESULT" != success ] || [ "$CONTRACT_RESULT" != success ]; then
             echo "CI policy or contract classification did not succeed" >&2
             exit 1
@@ -460,15 +527,14 @@ jobs:
             fi
           }
           require_lane core "$NEEDS_CORE" "$CORE_RESULT"
+          require_lane real-process "$NEEDS_REAL_PROCESS" "$REAL_PROCESS_RESULT"
           require_lane desktop "$NEEDS_DESKTOP" "$DESKTOP_RESULT"
 
-  # Keep Windows process-heavy suites isolated on separate hosted VMs. The
-  # webcodex-runner lane caps libtest at two concurrent test functions: default
-  # parallelism can starve real PowerShell/process-tree startup on hosted Windows,
-  # while one thread needlessly serializes the entire mixed-cost Runner suite.
-  # Keep webcodex-computer in the same native lane so platform tests continue
-  # running after the Computer runtime was split out of the Runner crate.
-  # Core/library and packaging coverage can run independently in parallel.
+  # Windows Runner process-tree ownership now has its own explicitly selected
+  # real-process job below. Keep the remaining Runner/Computer suite at two libtest
+  # threads for now because SSH/Plugin/LSP and other subprocess fixtures still share
+  # this default lane; raise concurrency only after those costs are measured/separated.
+  # Core/library, Runner real-process, and packaging coverage run independently.
   test-windows-core:
     needs: changes
     if: needs.changes.outputs.needs_windows_core == 'true'
@@ -507,6 +573,20 @@ jobs:
         # Keep process contention bounded without forcing all 700+ Runner tests
         # through one test thread. Concurrency exercised inside each test is unchanged.
         run: cargo test --locked -p webcodex-runner -p webcodex-computer -- --test-threads=2
+
+  test-windows-runner-real-process:
+    needs: changes
+    if: needs.changes.outputs.needs_runner_real_process == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-runner-real-process-ci
+      - name: Run Runner real-process lifecycle tests
+        run: cargo test --locked -p webcodex-runner runner_real_process -- --ignored --test-threads=2
 
   test-windows-package:
     needs: changes
@@ -653,7 +733,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "cargo check failed with exit code $LASTEXITCODE" }
 
   test-windows:
-    needs: [contract, changes, test-windows-core, test-windows-runner, test-windows-package, test-windows-desktop, test-windows-arm64]
+    needs: [contract, changes, test-windows-core, test-windows-runner, test-windows-runner-real-process, test-windows-package, test-windows-desktop, test-windows-arm64]
     # Preserve the stable Windows aggregate while allowing each heavy lane to be
     # selected independently by the deterministic path-risk classifier.
     if: always()
@@ -666,17 +746,19 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           NEEDS_CORE: ${{ needs.changes.outputs.needs_windows_core }}
           NEEDS_RUNNER: ${{ needs.changes.outputs.needs_windows_runner }}
+          NEEDS_REAL_PROCESS: ${{ needs.changes.outputs.needs_runner_real_process }}
           NEEDS_PACKAGE: ${{ needs.changes.outputs.needs_windows_package }}
           NEEDS_DESKTOP: ${{ needs.changes.outputs.needs_windows_desktop }}
           NEEDS_ARM64: ${{ needs.changes.outputs.needs_windows_arm64 }}
           CORE_RESULT: ${{ needs.test-windows-core.result }}
           RUNNER_RESULT: ${{ needs.test-windows-runner.result }}
+          REAL_PROCESS_RESULT: ${{ needs.test-windows-runner-real-process.result }}
           PACKAGE_RESULT: ${{ needs.test-windows-package.result }}
           DESKTOP_RESULT: ${{ needs.test-windows-desktop.result }}
           ARM64_RESULT: ${{ needs.test-windows-arm64.result }}
         run: |
           set -euo pipefail
-          echo "changes=$CHANGES_RESULT contract=$CONTRACT_RESULT core=$CORE_RESULT runner=$RUNNER_RESULT package=$PACKAGE_RESULT desktop=$DESKTOP_RESULT arm64=$ARM64_RESULT"
+          echo "changes=$CHANGES_RESULT contract=$CONTRACT_RESULT core=$CORE_RESULT runner=$RUNNER_RESULT real_process=$REAL_PROCESS_RESULT package=$PACKAGE_RESULT desktop=$DESKTOP_RESULT arm64=$ARM64_RESULT"
           if [ "$CHANGES_RESULT" != success ] || [ "$CONTRACT_RESULT" != success ]; then
             echo "CI policy or contract classification did not succeed" >&2
             exit 1
@@ -694,6 +776,7 @@ jobs:
           }
           require_lane core "$NEEDS_CORE" "$CORE_RESULT"
           require_lane runner "$NEEDS_RUNNER" "$RUNNER_RESULT"
+          require_lane real-process "$NEEDS_REAL_PROCESS" "$REAL_PROCESS_RESULT"
           require_lane package "$NEEDS_PACKAGE" "$PACKAGE_RESULT"
           require_lane desktop "$NEEDS_DESKTOP" "$DESKTOP_RESULT"
           require_lane arm64 "$NEEDS_ARM64" "$ARM64_RESULT"

--- a/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
+++ b/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
@@ -237,7 +237,8 @@ fn shell_job_rejects_cwd_symlink_escape() {
 }
 
 #[test]
-fn shell_job_timeout_returns_timeout_error() {
+#[ignore = "runner real-process lane: waits on a real shell timeout"]
+fn runner_real_process_shell_job_timeout_returns_timeout_error() {
     let tmp = tempfile::tempdir().unwrap();
     let cfg = test_config(tmp.path().join("config/project-registry"));
     let cwd = tmp.path().to_string_lossy().to_string();
@@ -270,7 +271,8 @@ fn long_lived_descendant_command(pid_file: &Path) -> String {
 
 #[cfg(unix)]
 #[test]
-fn shell_job_timeout_reaps_descendant_process_group() {
+#[ignore = "runner real-process lane: waits on a real shell timeout"]
+fn runner_real_process_shell_job_timeout_reaps_descendant_process_group() {
     let tmp = tempfile::tempdir().unwrap();
     let cfg = test_config(tmp.path().join("config/project-registry"));
     let cwd = tmp.path().to_string_lossy().to_string();
@@ -305,7 +307,8 @@ fn shell_job_timeout_reaps_descendant_process_group() {
 
 #[cfg(unix)]
 #[test]
-fn shell_job_timeout_profile_reaps_descendant_process_group() {
+#[ignore = "runner real-process lane: waits on a real shell timeout"]
+fn runner_real_process_shell_job_timeout_profile_reaps_descendant_process_group() {
     let tmp = tempfile::tempdir().unwrap();
     let shell = shell_with_profiles(Some("test"), vec![("test", ShellProfileConfig::default())]);
     let policy = unrestricted_test_policy();

--- a/crates/webcodex-runner/src/main_tests/shell_job_tree.rs
+++ b/crates/webcodex-runner/src/main_tests/shell_job_tree.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 #[test]
-fn shell_job_normal_success_preserves_output_and_exit_code() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_normal_success_preserves_output_and_exit_code() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();
@@ -42,7 +43,8 @@ fn shell_job_normal_success_preserves_output_and_exit_code() {
 }
 
 #[test]
-fn shell_job_timeout_kills_whole_tree() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_timeout_kills_whole_tree() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();
@@ -80,7 +82,8 @@ fn shell_job_timeout_kills_whole_tree() {
 }
 
 #[test]
-fn shell_job_stop_kills_whole_tree() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_stop_kills_whole_tree() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();
@@ -119,7 +122,8 @@ fn shell_job_stop_kills_whole_tree() {
 }
 
 #[test]
-fn shell_job_parent_exit_first_descendant_holds_pipe() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_parent_exit_first_descendant_holds_pipe() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();
@@ -175,7 +179,8 @@ fn shell_job_parent_exit_first_descendant_holds_pipe() {
 
 #[cfg(unix)]
 #[test]
-fn shell_job_unix_graceful_sigterm_responsive_tree() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_unix_graceful_sigterm_responsive_tree() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();
@@ -211,7 +216,8 @@ fn shell_job_unix_graceful_sigterm_responsive_tree() {
 
 #[cfg(unix)]
 #[test]
-fn shell_job_unix_sigterm_resistant_tree_escalates() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_unix_sigterm_resistant_tree_escalates() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();
@@ -251,7 +257,8 @@ fn shell_job_unix_sigterm_resistant_tree_escalates() {
 }
 
 #[test]
-fn shell_job_repeated_stop_is_idempotent() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_repeated_stop_is_idempotent() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();
@@ -300,7 +307,8 @@ fn shell_job_repeated_stop_is_idempotent() {
 }
 
 #[test]
-fn shell_job_timeout_racing_stop_is_bounded() {
+#[ignore = "runner real-process lane: spawns a real shell/process tree"]
+fn runner_real_process_shell_job_timeout_racing_stop_is_bounded() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().to_string_lossy().to_string();
     let helper = shell_tree_helper();

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -4364,7 +4364,8 @@ fn seed_running_job_tree(
 /// descendant that inherited the stdout pipe, and the stdout reader reaches
 /// EOF instead of blocking forever.
 #[test]
-fn job_stop_terminates_whole_tree_including_descendant() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_job_stop_terminates_whole_tree_including_descendant() {
     let temp = tempfile::tempdir().unwrap();
     let marker = temp.path().join("stop-grandchild.marker");
     let manager = JobManager::new(1);
@@ -4391,7 +4392,8 @@ fn job_stop_terminates_whole_tree_including_descendant() {
 /// reader join) must kill an orphaned descendant that keeps the stdout pipe
 /// open, and the output reader must reach EOF instead of being detached.
 #[test]
-fn job_cleanup_after_parent_exit_terminates_descendant_and_reaches_eof() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_job_cleanup_after_parent_exit_terminates_descendant_and_reaches_eof() {
     let temp = tempfile::tempdir().unwrap();
     let marker = temp.path().join("orphan.marker");
     let helper = job_tree_helper();
@@ -4472,7 +4474,8 @@ fn job_cleanup_after_parent_exit_terminates_descendant_and_reaches_eof() {
 /// A shutdown drain terminates every running job's whole tree, leaves a
 /// completed job untouched, and is bounded.
 #[test]
-fn job_stop_all_terminates_all_trees_and_preserves_completed_jobs() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_job_stop_all_terminates_all_trees_and_preserves_completed_jobs() {
     let manager = JobManager::new(2);
     let completed_stop = Arc::new(AtomicBool::new(false));
     {
@@ -4515,7 +4518,8 @@ fn job_stop_all_terminates_all_trees_and_preserves_completed_jobs() {
 /// Repeated stops are idempotent: the second stop must not panic and must not
 /// leave the tree running.
 #[test]
-fn job_stop_twice_is_idempotent() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_job_stop_twice_is_idempotent() {
     let temp = tempfile::tempdir().unwrap();
     let marker = temp.path().join("twice.marker");
     let manager = JobManager::new(1);
@@ -4532,7 +4536,8 @@ fn job_stop_twice_is_idempotent() {
 /// Stopping a job whose tree already exited naturally must not panic and must
 /// report success.
 #[test]
-fn job_stop_after_natural_exit_does_not_panic() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_job_stop_after_natural_exit_does_not_panic() {
     let (managed, _rx) = spawn_helper_raw("sleep", &["0", "0"]);
     let parent_pid = managed.id();
     let child = Arc::new(Mutex::new(managed));
@@ -4556,7 +4561,9 @@ fn job_stop_after_natural_exit_does_not_panic() {
 /// Dropping the last real JobManager owner must terminate an active tree even
 /// while a worker clone still holds the jobs map and ManagedChild Arc.
 #[test]
-fn last_job_manager_owner_drop_terminates_running_tree_with_worker_clone_alive() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_last_job_manager_owner_drop_terminates_running_tree_with_worker_clone_alive()
+{
     let temp = tempfile::tempdir().unwrap();
     let marker = temp.path().join("drop.marker");
     let manager = JobManager::new(1);
@@ -4577,7 +4584,8 @@ fn last_job_manager_owner_drop_terminates_running_tree_with_worker_clone_alive()
 
 /// Cleanup on an already-exited tree must be a no-op that never panics.
 #[test]
-fn cleanup_managed_tree_on_exited_tree_does_not_panic() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_cleanup_managed_tree_on_exited_tree_does_not_panic() {
     let (managed, _rx) = spawn_helper_raw("sleep", &["0", "0"]);
     let child = Arc::new(Mutex::new(managed));
     assert!(wait_until(Duration::from_secs(30), || lock_unpoison(
@@ -4596,7 +4604,8 @@ fn cleanup_managed_tree_on_exited_tree_does_not_panic() {
 /// A user stop racing Runner shutdown must not deadlock or panic, and both
 /// paths must converge on a fully-terminated tree.
 #[test]
-fn job_stop_racing_shutdown_does_not_panic() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_job_stop_racing_shutdown_does_not_panic() {
     let temp = tempfile::tempdir().unwrap();
     let marker = temp.path().join("race.marker");
     let manager = JobManager::new(1);
@@ -4620,7 +4629,8 @@ fn job_stop_racing_shutdown_does_not_panic() {
 /// a real `sh` for the full worker path, so it runs on Linux.
 #[cfg(target_os = "linux")]
 #[test]
-fn job_timeout_terminates_the_whole_tree() {
+#[ignore = "runner real-process lane: spawns the JobManager process-tree fixture"]
+fn runner_real_process_job_timeout_terminates_the_whole_tree() {
     let temp = tempfile::tempdir().unwrap();
     let marker = temp.path().join("timeout-grandchild.marker");
     let helper = job_tree_helper();

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -3348,7 +3348,8 @@ mod git_lifecycle_tests {
     /// A. Normal completion: a short-lived process exits successfully, its
     /// stdout/stderr are collected, and no cleanup stall occurs.
     #[test]
-    fn normal_completion_collects_output_and_returns_bounded() {
+    #[ignore = "runner real-process lane: spawns the Git ManagedChild process-tree fixture"]
+    fn runner_real_process_git_normal_completion_collects_output_and_returns_bounded() {
         let cwd = tempfile::tempdir().unwrap();
         let program = helper_binary();
         let started = Instant::now();
@@ -3377,7 +3378,8 @@ mod git_lifecycle_tests {
     /// its pipe-holding descendant must both die, with the timeout error
     /// unchanged.
     #[test]
-    fn timeout_terminates_whole_tree() {
+    #[ignore = "runner real-process lane: spawns the Git ManagedChild process-tree fixture"]
+    fn runner_real_process_git_timeout_terminates_whole_tree() {
         let parent_marker = unique_temp_path("timeout-parent");
         let alive_marker = unique_temp_path("timeout-desc");
         let cwd = tempfile::tempdir().unwrap();
@@ -3440,7 +3442,8 @@ mod git_lifecycle_tests {
     /// C. Runner shutdown terminates the whole tree with the shutdown error
     /// unchanged. Works on Windows and Linux.
     #[test]
-    fn runner_shutdown_terminates_whole_tree() {
+    #[ignore = "runner real-process lane: spawns the Git ManagedChild process-tree fixture"]
+    fn runner_real_process_git_runner_shutdown_terminates_whole_tree() {
         let parent_marker = unique_temp_path("shutdown-parent");
         let alive_marker = unique_temp_path("shutdown-desc");
         let cwd = tempfile::tempdir().unwrap();
@@ -3508,7 +3511,8 @@ mod git_lifecycle_tests {
     /// the surviving tree is terminated, the readers reach EOF, and
     /// run_git_bounded returns without an indefinite reader wait.
     #[test]
-    fn parent_exit_alone_does_not_finish_cleanup() {
+    #[ignore = "runner real-process lane: spawns the Git ManagedChild process-tree fixture"]
+    fn runner_real_process_git_parent_exit_alone_does_not_finish_cleanup() {
         let parent_marker = unique_temp_path("parent-first");
         let alive_marker = unique_temp_path("parent-first-desc");
         let cwd = tempfile::tempdir().unwrap();
@@ -3570,7 +3574,8 @@ mod git_lifecycle_tests {
     /// is nothing to escalate from there.)
     #[cfg(unix)]
     #[test]
-    fn sigterm_resistant_tree_is_forcefully_escalated() {
+    #[ignore = "runner real-process lane: spawns the Git ManagedChild process-tree fixture"]
+    fn runner_real_process_git_sigterm_resistant_tree_is_forcefully_escalated() {
         let parent_marker = unique_temp_path("resist-parent");
         let alive_marker = unique_temp_path("resist-desc");
         let cwd = tempfile::tempdir().unwrap();

--- a/crates/webcodex-runner/src/webcodex_runner/validation/execute.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/validation/execute.rs
@@ -585,7 +585,8 @@ mod tests {
 
     /// A. Normal completion: real exit code, stdout/stderr capture, no errors.
     #[test]
-    fn normal_completion_preserves_exit_code_and_capture() {
+    #[ignore = "runner real-process lane: spawns the validation process-tree fixture"]
+    fn runner_real_process_validation_normal_completion_preserves_exit_code_and_capture() {
         let cwd = tempfile::tempdir().unwrap();
         let captured = run_bounded(
             &helper_binary(),
@@ -609,7 +610,8 @@ mod tests {
     /// B. Timeout terminates the entire tree: parent AND descendant must both
     /// be gone, with the timeout semantics unchanged.
     #[test]
-    fn timeout_terminates_entire_tree() {
+    #[ignore = "runner real-process lane: spawns the validation process-tree fixture"]
+    fn runner_real_process_validation_timeout_terminates_entire_tree() {
         let parent_marker = unique_temp_path("timeout-parent");
         let alive_marker = unique_temp_path("timeout-desc");
         let cwd = tempfile::tempdir().unwrap();
@@ -666,7 +668,8 @@ mod tests {
     /// cleanup: the descendant is terminated, the reader reaches EOF, and
     /// run_bounded stays bounded.
     #[test]
-    fn parent_exit_alone_does_not_finish_cleanup() {
+    #[ignore = "runner real-process lane: spawns the validation process-tree fixture"]
+    fn runner_real_process_validation_parent_exit_alone_does_not_finish_cleanup() {
         let parent_marker = unique_temp_path("parent-first");
         let alive_marker = unique_temp_path("parent-first-desc");
         let cwd = tempfile::tempdir().unwrap();
@@ -716,7 +719,8 @@ mod tests {
     /// D. Runner shutdown terminates the whole tree with the shutdown
     /// semantics unchanged.
     #[test]
-    fn runner_shutdown_terminates_whole_tree() {
+    #[ignore = "runner real-process lane: spawns the validation process-tree fixture"]
+    fn runner_real_process_validation_runner_shutdown_terminates_whole_tree() {
         let parent_marker = unique_temp_path("shutdown-parent");
         let alive_marker = unique_temp_path("shutdown-desc");
         let cwd = tempfile::tempdir().unwrap();
@@ -780,7 +784,8 @@ mod tests {
     /// gets a bounded grace, then the whole tree is killed. Never unbounded.
     #[cfg(unix)]
     #[test]
-    fn sigterm_resistant_tree_is_forcefully_escalated() {
+    #[ignore = "runner real-process lane: spawns the validation process-tree fixture"]
+    fn runner_real_process_validation_sigterm_resistant_tree_is_forcefully_escalated() {
         let parent_marker = unique_temp_path("resist-parent");
         let alive_marker = unique_temp_path("resist-desc");
         let cwd = tempfile::tempdir().unwrap();
@@ -835,7 +840,8 @@ mod tests {
     /// F. Cleanup of an already-exited tree: no panic, no false infrastructure
     /// error, and it is idempotent.
     #[test]
-    fn already_exited_cleanup_is_not_an_error() {
+    #[ignore = "runner real-process lane: spawns the validation process-tree fixture"]
+    fn runner_real_process_validation_already_exited_cleanup_is_not_an_error() {
         // Normal completion runs cleanup after the tree already exited; the
         // AlreadyExited graceful path must not surface as a wait error.
         let cwd = tempfile::tempdir().unwrap();

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,6 +15,7 @@ tests with different cost profiles sharing the same default lane.
 | fast unit | Pure parsing, validation, helpers, local state machines, small fixtures. | No network, no global env mutation, no long sleeps. | `cargo test -p webcodex --lib tool_call` |
 | contract/schema | Keep metadata, registry, MCP `tools/list`, OpenAPI, and runtime tool names synchronized. | No external network; in-process services are preferred. | `cargo test -p webcodex --lib metadata`; `cargo test -p webcodex --lib mcp`; `cargo test -p webcodex --lib openapi` |
 | local integration | Exercise HTTP handlers, runtime dispatch, sessions, local agent registry, temp dirs, loopback listeners, and database fixtures. | Loopback only, isolated temp dirs, bounded waits, no shared mutable state without a lock. | `cargo test -p webcodex --lib runtime_http -- --nocapture`; `cargo test -p webcodex --lib session -- --nocapture` |
+| Runner real-process | Process-tree ownership, real shell timeout/stop, validation/Git `ManagedChild`, and JobManager descendant cleanup. These tests are ignored by the ordinary Runner suite and share the `runner_real_process_` name prefix. | Real local child processes only; no external network. Keep concurrency bounded because the assertions intentionally exercise OS scheduling and process teardown. | `cargo test --locked -p webcodex-runner runner_real_process -- --ignored --test-threads=2` |
 | slow/manual ignored | Valuable coverage that is local but slow, serial, large-input, or global-state-sensitive. | Explicit operator opt-in; often `--ignored` and `--test-threads=1`. | Run the specific ignored test/filter documented by its subsystem. |
 | e2e/deployment smoke | Prove that binaries, local services, GPT Actions schema, MCP, artifact transfer, and an agent can work together. | Temporary local services and loopback ports; real deployment only when explicitly requested. | `bash scripts/e2e_zero_config_ws.sh`; `bash scripts/smoke_deployment.sh`; `bash scripts/smoke_artifact_transfer.sh` |
 | reconnect continuity | Runner disconnect/reconnect layer independence, stale-not-ready observations, reconciliation-aware recovering/lost transitions, server-restart durable Session plus explicit-session continuity, meaningful-activity scoping, and version-mismatch diagnostics. | In-process fixtures, no external network. | `cargo test -p webcodex --lib reconnect` |
@@ -47,57 +48,51 @@ The lanes above define test semantics; workflows decide when to run them.
 - The heavy Linux Rust matrix `test-linux-rust` and Linux tooling lane
   `test-linux-tooling` run for every pull request as well as every push to `main`,
   including owner-authored PRs. They start in parallel with `contract` rather than
-  waiting for unrelated frontend/static work; the historical `test` aggregate still
-  requires `contract` plus both Linux lanes to succeed. Native child lanes likewise
-  wait only for the cheap `changes` classifier, while the stable macOS/Windows/native
-  aggregates retain the mandatory `contract` gate. Release readiness must not be the
-  first place complete Linux package suites or release-tooling tests execute. Pushes
-  to `main`, external-contributor
-  PRs, and owner PRs carrying `run-ci` still force the complete native matrix. Other
-  owner PRs are upgraded automatically according to changed-path risk: native
-  process-owning Runner surfaces, shell, Plugin, Computer, platform-specific, and
-  Desktop Rust ownership selects Windows and/or macOS lanes; `npm/webcodex/**`
-  selects the native Windows package lane; packaging/signing/release and workflow
-  policy surfaces select the corresponding package lanes or the full matrix.
+  waiting for unrelated frontend/static work. The ordinary Runner package run now
+  excludes the explicitly ignored `runner_real_process_` group; `changes` selects a
+  separate Linux real-process lane for Runner/process-ownership surfaces, and the
+  historical `test` aggregate requires that lane to be `success` when selected or
+  `skipped` otherwise. Native child lanes likewise wait only for the cheap `changes`
+  classifier, while the stable macOS/Windows/native aggregates retain the mandatory
+  `contract` gate. Pushes to `main`, external-contributor PRs, and owner PRs carrying
+  `run-ci` still force the complete native matrix **and** the Runner real-process
+  lanes. Other owner PRs are upgraded automatically according to changed-path risk:
+  native process-owning Runner surfaces select the real-process lane in addition to
+  Windows/macOS native Runner coverage; Computer, platform-specific, Desktop, npm,
+  packaging, signing, and release surfaces retain their existing independent lanes.
   Ordinary Rust domain/control changes remain on the mandatory Linux gates; native
-  package/install lanes are selected only by their own path risks or an explicit
-  full-native policy override, not merely because a broad Rust diff is large.
+  package/install or real-process lanes are selected only by their own path risks or
+  an explicit full-native policy override, not merely because a broad Rust diff is
+  large.
   The stable `test-macos`,
   `test-windows`, and `test-native` aggregates always resolve and verify each child
   lane is `success` when required or `skipped` when not required, avoiding a skipped
   required-check context that could leave branch protection pending.
-- Linux Rust execution is package-sharded without test-name filters: the server
-  package `webcodex`, the integration-rich Runner package `webcodex-runner`, and
-  the remaining workspace crates run as three complete package groups in
-  parallel. The remainder shard uses the workspace selector
+- Linux Rust execution remains package-sharded: the server package `webcodex`, the
+  Runner package `webcodex-runner`, and the remaining workspace crates run in
+  parallel. The Runner shard uses ordinary libtest semantics, so the named
+  real-process group is compiled but not executed there; the separate filtered
+  `--ignored` lane is its only ordinary-CI execution owner. The remainder shard uses
   `--workspace --exclude webcodex --exclude webcodex-runner`, so newly added
-  workspace members enter CI automatically rather than depending on a
-  hand-maintained package list. Each
-  workspace package therefore executes in exactly one Linux Rust group; sharding
-  is an execution optimization rather than a semantic coverage reduction. Package
-  boundaries do not imply that every test inside a shard has the same cost or
-  integration characteristics.
+  workspace members enter CI automatically rather than depending on a hand-maintained
+  package list. The split changes scheduling, not process-ownership coverage.
 - Linux tooling runs in parallel with the Rust shards and retains
   release-verification tooling, Markdown-link validation, and npm package-smoke
-  tooling; within the Linux heavy split, only this tooling lane installs Node
-  because those smoke scripts invoke Node/npm directly. macOS native coverage is
-  split into a core two-architecture Runner/Computer lane and a separately selected
-  two-architecture Desktop DMG/package lane, so process/Plugin changes do not
-  mechanically rebuild Desktop packages. macOS still owns release-surface
-  compilation and the native Runner suite on both published architectures,
-  including detached ownership/restart recovery. The local-`sshd`
+  tooling. macOS native coverage has core Runner/Computer, Runner real-process, and
+  Desktop package jobs; the first two run on both published architectures while the
+  Desktop job remains independently selected. Windows likewise separates the default
+  Runner/Computer suite from the real-process Runner group, so process-tree tests no
+  longer force the whole default suite to share their wall-clock/process-contention
+  profile. The real-process jobs themselves use two libtest threads. The local-`sshd`
   SSH integration fixture remains Linux-only because it depends on Linux daemon
-  account/auth configuration; Windows still owns its native library, CLI, Runner,
-  npm, and artifact-to-install coverage. The Windows Runner + Computer lane caps
-  libtest at two concurrent test functions so process startup remains bounded
-  without serializing the whole Runner suite.
+  account/auth configuration.
 - Exact-source release acceptance is a separate trust boundary from ordinary CI.
-  Its Stage 1 runs the canonical release contract, the complete locked Rust
-  workspace suite as package shards without test-name filters, frontend, E2E, and
-  eval in parallel. Stage 2 is blocked until every test-gate job succeeds, then
-  fans out only native release-profile and Server-image evidence in parallel. Follow [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md)
-  and `.github/workflows/release-readiness.yml`; sharding changes scheduling, not
-  semantic Rust test coverage or `scripts/release_check.sh`.
+  Release readiness first binds the exact source to a successful `main`-push CI run;
+  main pushes force full-native classification, so that proof includes the explicit
+  Runner real-process lanes on Linux, Windows, and both macOS architectures. Readiness
+  then runs its release-specific E2E/eval and disposable Server-image checks instead
+  of duplicating the same process-tree suite. Follow [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md)
+  and `.github/workflows/release-readiness.yml`.
 - Slow/manual and real-process lanes remain explicit targeted evidence unless
   a workflow names them. Do not infer that one lane ran merely because another CI
   job passed.
@@ -132,6 +127,9 @@ The lanes above define test semantics; workflows decide when to run them.
   may remain when they are the contract.
 - Ignored tests are not dead tests. Each ignored test should have a reason and a
   documented lane for running it intentionally.
+  The `runner_real_process_` ignored tests belong to ordinary CI through their explicit
+  real-process jobs; the separate real Codex/LSP ignored dogfood tests remain opt-in
+  and are intentionally excluded by the real-process name filter.
 
 ## `import_http` Coverage
 

--- a/scripts/ci_path_risk.py
+++ b/scripts/ci_path_risk.py
@@ -54,6 +54,7 @@ class Risk:
     needs_macos: bool = False
     needs_macos_desktop: bool = False
     needs_linux_arm64: bool = False
+    needs_runner_real_process: bool = False
     needs_full_native: bool = False
     categories: set[str] = field(default_factory=set)
     changed_count: int = 0
@@ -74,6 +75,7 @@ class Risk:
             self.needs_macos = True
             self.needs_macos_desktop = True
             self.needs_linux_arm64 = True
+            self.needs_runner_real_process = True
         return self
 
     def outputs(self) -> dict[str, str]:
@@ -100,6 +102,7 @@ class Risk:
             "needs_macos": _bool(self.needs_macos),
             "needs_macos_desktop": _bool(self.needs_macos_desktop),
             "needs_linux_arm64": _bool(self.needs_linux_arm64),
+            "needs_runner_real_process": _bool(self.needs_runner_real_process),
             "needs_desktop_package": _bool(needs_desktop_package),
             "needs_full_native": _bool(self.needs_full_native),
             "categories": categories,
@@ -273,6 +276,7 @@ def _classify_path(risk: Risk, path: str) -> None:
     if path.startswith("crates/webcodex-process/"):
         _mark_windows_core(risk, "native-process")
         _mark_macos(risk, "native-process")
+        risk.needs_runner_real_process = True
         return
     if path.startswith("crates/webcodex-persistent-shell/"):
         _mark_windows_core(risk, "persistent-shell")
@@ -283,6 +287,8 @@ def _classify_path(risk: Risk, path: str) -> None:
         _mark_macos(risk, "computer-runtime")
         return
     if path.startswith("crates/webcodex-runner/"):
+        if path == "crates/webcodex-runner/src/main_tests.rs":
+            risk.needs_runner_real_process = True
         runner_native_tokens = (
             "plugin",
             "shell",
@@ -296,12 +302,14 @@ def _classify_path(risk: Risk, path: str) -> None:
             "coding_agent",
             "external_tools",
             "mcp_gateway",
+            "job_manager",
             "projects",
             "validation",
         )
         if any(token in lower for token in runner_native_tokens):
             _mark_windows_runner(risk, "runner-native")
             _mark_macos(risk, "runner-native")
+            risk.needs_runner_real_process = True
             return
 
     # Platform-specific source outside the known ownership crates is still native

--- a/scripts/tests/test_ci_path_risk.py
+++ b/scripts/tests/test_ci_path_risk.py
@@ -28,6 +28,7 @@ class PathRiskFixtureTests(unittest.TestCase):
         self.assertEqual(result["needs_windows"], "false")
         self.assertEqual(result["needs_macos"], "false")
         self.assertEqual(result["needs_linux_arm64"], "false")
+        self.assertEqual(result["needs_runner_real_process"], "false")
 
     def test_desktop_rust_requires_windows_macos_and_desktop_packages(self) -> None:
         result = classify("apps/desktop/src-tauri/src/process/supervisor.rs")
@@ -40,12 +41,14 @@ class PathRiskFixtureTests(unittest.TestCase):
         result = classify("crates/webcodex-process/src/lib.rs")
         self.assertEqual(result["needs_windows_core"], "true")
         self.assertEqual(result["needs_macos"], "true")
+        self.assertEqual(result["needs_runner_real_process"], "true")
         self.assertEqual(result["needs_desktop_package"], "false")
 
     def test_runner_plugin_requires_windows_runner_and_macos(self) -> None:
         result = classify("crates/webcodex-runner/src/webcodex_runner/plugin.rs")
         self.assertEqual(result["needs_windows_runner"], "true")
         self.assertEqual(result["needs_macos"], "true")
+        self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_npm_installer_change_requires_native_windows_package_lane(self) -> None:
         result = classify("npm/webcodex/install.js")
@@ -54,19 +57,21 @@ class PathRiskFixtureTests(unittest.TestCase):
         self.assertEqual(result["needs_macos"], "false")
 
     def test_runner_shell_and_persistent_shell_require_windows_and_macos(self) -> None:
-        for path in (
-            "crates/webcodex-runner/src/webcodex_runner/shell.rs",
-            "crates/webcodex-persistent-shell/src/lib.rs",
-        ):
-            with self.subTest(path=path):
-                result = classify(path)
-                self.assertEqual(result["needs_windows"], "true")
-                self.assertEqual(result["needs_macos"], "true")
+        runner = classify("crates/webcodex-runner/src/webcodex_runner/shell.rs")
+        self.assertEqual(runner["needs_windows"], "true")
+        self.assertEqual(runner["needs_macos"], "true")
+        self.assertEqual(runner["needs_runner_real_process"], "true")
 
-    def test_runner_process_owners_require_native_runner_lane(self) -> None:
+        persistent = classify("crates/webcodex-persistent-shell/src/lib.rs")
+        self.assertEqual(persistent["needs_windows"], "true")
+        self.assertEqual(persistent["needs_macos"], "true")
+        self.assertEqual(persistent["needs_runner_real_process"], "false")
+
+    def test_runner_process_owners_require_native_runner_and_real_process_lanes(self) -> None:
         for path in (
             "crates/webcodex-runner/src/webcodex_runner/coding_agent.rs",
             "crates/webcodex-runner/src/webcodex_runner/external_tools.rs",
+            "crates/webcodex-runner/src/webcodex_runner/job_manager.rs",
             "crates/webcodex-runner/src/webcodex_runner/mcp_gateway.rs",
             "crates/webcodex-runner/src/webcodex_runner/projects.rs",
             "crates/webcodex-runner/src/webcodex_runner/validation/execute.rs",
@@ -75,6 +80,10 @@ class PathRiskFixtureTests(unittest.TestCase):
                 result = classify(path)
                 self.assertEqual(result["needs_windows_runner"], "true")
                 self.assertEqual(result["needs_macos"], "true")
+                self.assertEqual(result["needs_runner_real_process"], "true")
+
+        test_helpers = classify("crates/webcodex-runner/src/main_tests.rs")
+        self.assertEqual(test_helpers["needs_runner_real_process"], "true")
 
     def test_windows_installer_and_npm_package_choose_windows_package_lanes(self) -> None:
         desktop = classify("scripts/desktop_install_windows_smoke.ps1")
@@ -111,6 +120,7 @@ class PathRiskFixtureTests(unittest.TestCase):
             with self.subTest(path=path):
                 result = classify(path)
                 self.assertEqual(result["needs_full_native"], "true")
+                self.assertEqual(result["needs_runner_real_process"], "true")
                 self.assertEqual(result["needs_windows_arm64"], "true")
                 self.assertEqual(result["needs_linux_arm64"], "true")
                 self.assertEqual(result["needs_macos_desktop"], "true")
@@ -119,11 +129,13 @@ class PathRiskFixtureTests(unittest.TestCase):
         result = classify(".github/workflows/future-native-policy.yml")
         self.assertEqual(result["needs_full_native"], "true")
         self.assertIn("ci-policy", result["categories"])
+        self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_mixed_docs_and_process_uses_highest_risk(self) -> None:
         result = classify("docs/README.md", "crates/webcodex-process/src/windows.rs")
         self.assertEqual(result["needs_windows_core"], "true")
         self.assertEqual(result["needs_macos"], "true")
+        self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_rename_into_risky_path_classifies_destination(self) -> None:
         result = classify(
@@ -133,11 +145,13 @@ class PathRiskFixtureTests(unittest.TestCase):
         )
         self.assertEqual(result["needs_windows_core"], "true")
         self.assertEqual(result["needs_macos"], "true")
+        self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_deleted_risky_file_still_requires_native(self) -> None:
         result = classify("crates/webcodex-process/src/windows.rs", statuses=("D",))
         self.assertEqual(result["needs_windows_core"], "true")
         self.assertEqual(result["needs_macos"], "true")
+        self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_platform_cfg_change_upgrades_native_even_from_normal_rust_path(self) -> None:
         result = classify(
@@ -147,6 +161,7 @@ class PathRiskFixtureTests(unittest.TestCase):
         self.assertEqual(result["needs_windows_core"], "true")
         self.assertEqual(result["needs_macos"], "true")
         self.assertIn("platform-cfg", result["categories"])
+        self.assertEqual(result["needs_runner_real_process"], "false")
 
     def test_aarch64_cfg_requests_all_architecture_native_lanes(self) -> None:
         result = classify(
@@ -157,6 +172,7 @@ class PathRiskFixtureTests(unittest.TestCase):
         self.assertEqual(result["needs_windows_arm64"], "true")
         self.assertEqual(result["needs_macos"], "true")
         self.assertIn("aarch64-cfg", result["categories"])
+        self.assertEqual(result["needs_runner_real_process"], "false")
 
     def test_changed_paths_are_repository_relative_and_bounded(self) -> None:
         with self.assertRaises(risk.DiffLimitExceeded):
@@ -175,6 +191,7 @@ class InvocationOverrideFixtureTests(unittest.TestCase):
         result = forced.outputs()
         self.assertEqual(result["needs_full_native"], "true")
         self.assertIn("override-run-ci", result["reason"])
+        self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_push_main_forces_full_native(self) -> None:
         forced = risk.forced_risk_for_invocation(
@@ -183,6 +200,7 @@ class InvocationOverrideFixtureTests(unittest.TestCase):
         self.assertIsNotNone(forced)
         assert forced is not None
         self.assertEqual(forced.outputs()["needs_full_native"], "true")
+        self.assertEqual(forced.outputs()["needs_runner_real_process"], "true")
 
     def test_external_contributor_preserves_full_native_policy(self) -> None:
         forced = risk.forced_risk_for_invocation(
@@ -191,6 +209,7 @@ class InvocationOverrideFixtureTests(unittest.TestCase):
         self.assertIsNotNone(forced)
         assert forced is not None
         self.assertEqual(forced.outputs()["needs_full_native"], "true")
+        self.assertEqual(forced.outputs()["needs_runner_real_process"], "true")
 
     def test_owner_pr_without_override_uses_path_classifier(self) -> None:
         self.assertIsNone(
@@ -241,6 +260,7 @@ class GitRangeIntegrationTests(unittest.TestCase):
         self.assertEqual(result["needs_windows_desktop"], "false")
         self.assertEqual(result["needs_macos_desktop"], "false")
         self.assertIn("platform-context-bounded", result["categories"])
+        self.assertEqual(result["needs_runner_real_process"], "false")
 
     def test_changed_path_bound_still_falls_back_to_full_native(self) -> None:
         with mock.patch.object(
@@ -251,6 +271,7 @@ class GitRangeIntegrationTests(unittest.TestCase):
             result = risk.classify_git_range("0" * 40, "1" * 40).outputs()
         self.assertEqual(result["needs_full_native"], "true")
         self.assertIn("changed-path-bounded-fallback", result["categories"])
+        self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_broad_rust_change_does_not_escalate_to_packaging_or_arm64(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -290,6 +311,7 @@ class GitRangeIntegrationTests(unittest.TestCase):
             self.assertEqual(result["needs_macos_desktop"], "false")
             self.assertEqual(result["needs_linux_arm64"], "false")
             self.assertEqual(result["needs_windows_arm64"], "false")
+            self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_real_git_rename_is_observed_as_delete_plus_add_and_upgrades_risk(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -324,6 +346,7 @@ class GitRangeIntegrationTests(unittest.TestCase):
             )
             self.assertEqual(result["needs_windows_core"], "true")
             self.assertEqual(result["needs_macos"], "true")
+            self.assertEqual(result["needs_runner_real_process"], "true")
 
     def test_body_only_edit_inside_existing_windows_cfg_upgrades_native(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -352,6 +375,7 @@ class GitRangeIntegrationTests(unittest.TestCase):
             self.assertEqual(result["needs_windows_core"], "true")
             self.assertEqual(result["needs_macos"], "true")
             self.assertIn("platform-cfg", result["categories"])
+            self.assertEqual(result["needs_runner_real_process"], "false")
 
     def test_body_only_edit_inside_existing_target_cargo_section_upgrades_native(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -382,6 +406,7 @@ class GitRangeIntegrationTests(unittest.TestCase):
             self.assertEqual(result["needs_windows_core"], "true")
             self.assertEqual(result["needs_macos"], "true")
             self.assertIn("platform-cfg", result["categories"])
+            self.assertEqual(result["needs_runner_real_process"], "false")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_readiness.py
+++ b/scripts/tests/test_release_readiness.py
@@ -249,12 +249,15 @@ class WorkflowContractTests(unittest.TestCase):
             return workflow[start:end]
 
         changes = job_block("changes", "contract")
-        linux_rust = job_block("test-linux-rust", "test-linux-tooling")
+        linux_rust = job_block("test-linux-rust", "test-linux-runner-real-process")
+        linux_real_process = job_block("test-linux-runner-real-process", "test-linux-tooling")
         linux_tooling = job_block("test-linux-tooling", "test-linux-arm64")
         linux_arm64 = job_block("test-linux-arm64", "test")
         aggregate = job_block("test", "test-macos-core")
         self.assertNotIn("pull_request.user.login", linux_rust)
         self.assertNotIn("contains(github.event.pull_request.labels.*.name, 'run-ci')", linux_rust)
+        self.assertIn("needs.changes.outputs.needs_runner_real_process == 'true'", linux_real_process)
+        self.assertIn("runner_real_process -- --ignored --test-threads=2", linux_real_process)
         self.assertNotIn("pull_request.user.login", linux_tooling)
         self.assertNotIn("contains(github.event.pull_request.labels.*.name, 'run-ci')", linux_tooling)
         self.assertIn("runs-on: ubuntu-24.04-arm", linux_arm64)
@@ -274,7 +277,8 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("--run-ci", changes)
         self.assertNotIn("pull_request_target", workflow)
 
-        macos_core = job_block("test-macos-core", "test-macos-desktop")
+        macos_core = job_block("test-macos-core", "test-macos-runner-real-process")
+        macos_real_process = job_block("test-macos-runner-real-process", "test-macos-desktop")
         macos_desktop = job_block("test-macos-desktop", "test-macos")
         macos_aggregate = job_block("test-macos", "test-windows-core")
         self.assertIn("needs.changes.outputs.needs_macos == 'true'", macos_core)
@@ -284,18 +288,24 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("cargo check --locked --workspace", macos_core)
         self.assertIn("cargo test --locked -p webcodex-runner -p webcodex-computer", macos_core)
         self.assertNotIn("--bundles dmg", macos_core)
+        self.assertIn("needs.changes.outputs.needs_runner_real_process == 'true'", macos_real_process)
+        self.assertIn("platform: darwin-x64", macos_real_process)
+        self.assertIn("runner_real_process -- --ignored --test-threads=2", macos_real_process)
         self.assertIn("needs.changes.outputs.needs_macos_desktop == 'true'", macos_desktop)
         self.assertIn("cargo build --locked --profile dogfood -p webcodex -p webcodex-cli -p webcodex-runner", macos_desktop)
         self.assertIn("--bin-dir target/dogfood", macos_desktop)
         self.assertIn("--bundles dmg", macos_desktop)
 
         windows_core = job_block("test-windows-core", "test-windows-runner")
-        windows_runner = job_block("test-windows-runner", "test-windows-package")
+        windows_runner = job_block("test-windows-runner", "test-windows-runner-real-process")
+        windows_real_process = job_block("test-windows-runner-real-process", "test-windows-package")
         windows_package = job_block("test-windows-package", "test-windows-desktop")
         windows_desktop = job_block("test-windows-desktop", "test-windows-arm64")
         self.assertIn("needs.changes.outputs.needs_windows_core == 'true'", windows_core)
         self.assertIn("cargo check --locked --workspace", windows_core)
         self.assertIn("needs.changes.outputs.needs_windows_runner == 'true'", windows_runner)
+        self.assertIn("needs.changes.outputs.needs_runner_real_process == 'true'", windows_real_process)
+        self.assertIn("runner_real_process -- --ignored --test-threads=2", windows_real_process)
         self.assertIn("needs.changes.outputs.needs_windows_package == 'true'", windows_package)
         self.assertIn("needs.changes.outputs.needs_windows_desktop == 'true'", windows_desktop)
         self.assertIn("cargo build --locked --profile dogfood -p webcodex -p webcodex-cli -p webcodex-runner", windows_desktop)
@@ -310,7 +320,9 @@ class WorkflowContractTests(unittest.TestCase):
         for required_aggregate in (aggregate, macos_aggregate, windows_aggregate, native_aggregate):
             self.assertIn("if: always()", required_aggregate)
         self.assertIn("NEEDS_CORE: ${{ needs.changes.outputs.needs_macos }}", macos_aggregate)
+        self.assertIn("NEEDS_REAL_PROCESS: ${{ needs.changes.outputs.needs_runner_real_process }}", macos_aggregate)
         self.assertIn("NEEDS_CORE: ${{ needs.changes.outputs.needs_windows_core }}", windows_aggregate)
+        self.assertIn("NEEDS_REAL_PROCESS: ${{ needs.changes.outputs.needs_runner_real_process }}", windows_aggregate)
         self.assertIn("NEEDS_LINUX_ARM64: ${{ needs.changes.outputs.needs_linux_arm64 }}", native_aggregate)
         self.assertIn("expected=skipped", windows_aggregate)
         self.assertIn("expected_linux_arm64=skipped", native_aggregate)
@@ -321,10 +333,13 @@ class WorkflowContractTests(unittest.TestCase):
         workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
         pairs = {
             "test-linux-arm64": "needs_linux_arm64",
+            "test-linux-runner-real-process": "needs_runner_real_process",
             "test-macos-core": "needs_macos",
+            "test-macos-runner-real-process": "needs_runner_real_process",
             "test-macos-desktop": "needs_macos_desktop",
             "test-windows-core": "needs_windows_core",
             "test-windows-runner": "needs_windows_runner",
+            "test-windows-runner-real-process": "needs_runner_real_process",
             "test-windows-package": "needs_windows_package",
             "test-windows-desktop": "needs_windows_desktop",
             "test-windows-arm64": "needs_windows_arm64",
@@ -367,6 +382,11 @@ class WorkflowContractTests(unittest.TestCase):
             "reason",
         ):
             self.assertIn(f"{output}: ${{{{ steps.classify.outputs.{output} }}}}", changes)
+        self.assertIn("steps.classify.outputs.needs_runner_real_process == 'true'", changes)
+        self.assertIn("steps.classify.outputs.needs_runner_real_process == ''", changes)
+        self.assertIn("steps.classify.outputs.needs_windows_runner == 'true'", changes)
+        self.assertIn("steps.classify.outputs.needs_windows_core == 'true'", changes)
+        self.assertIn("steps.classify.outputs.needs_full_native == 'true'", changes)
 
     def test_macos_ci_host_check_does_not_use_quiet_grep_under_pipefail(self) -> None:
         workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Move the clearest Runner process-tree / real timeout lifecycle tests into an explicit `runner_real_process_` ignored group instead of running them inside every default Runner suite.
- Add path-aware `needs_runner_real_process` classification and independent Linux, Windows, and dual-architecture macOS CI jobs; stable aggregates require success when selected and `skipped` otherwise.
- Preserve full coverage for main pushes, external-contributor PRs, `run-ci`, and release readiness through the exact successful main-CI proof.
- Keep the PR classifier trust boundary intact: the workflow continues executing the trusted base classifier, with a bounded one-field rollout fallback so this PR itself can exercise the new lane before the field reaches main.

## Test split

On Linux the new group contains 31 tests covering shell process trees, real shell timeout/stop behavior, validation/Git `ManagedChild` lifecycle, and JobManager descendant cleanup. Platform cfg reduces that count on Windows/macOS. Existing real Codex/LSP dogfood ignored tests are excluded by the name filter.

## Validation

- `python3 -m unittest scripts.tests.test_ci_path_risk scripts.tests.test_release_readiness` — 44 passed
- `cargo test --locked -p webcodex-runner runner_real_process -- --list` — 31 selected on Linux
- default filtered selection — 31 ignored, 0 executed
- `cargo test --locked -p webcodex-runner runner_real_process -- --ignored --test-threads=2` — 31 passed in 19.46s
- `cargo test --locked -p webcodex-runner` — 861 passed, 35 ignored, 0 failed
- `bash scripts/release_check.sh --static-only` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

This is intentionally the first real-process layer only; detached-job, SSH, Plugin/LSP and other subprocess-heavy coverage remains in the default suite for a later measured split.