### PR TITLE
Expand Runner real-process test layering

### DIFF
--- a/crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs
@@ -710,7 +710,8 @@ fn tree_payload_request(temp: &Path) -> (DetachedStartRequest, PathBuf, PathBuf)
 
 #[cfg(unix)]
 #[test]
-fn accepted_handoff_keeps_payload_alive_after_owner_process_exits() {
+#[ignore = "runner real-process lane: detached supervisor outlives its owner process"]
+fn runner_real_process_accepted_handoff_keeps_payload_alive_after_owner_process_exits() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let state_root = temp.path().join("state");
@@ -762,7 +763,8 @@ fn owner_subprocess_entrypoint() {
 
 #[cfg(unix)]
 #[test]
-fn accepted_handoff_survives_owner_exit_before_ack() {
+#[ignore = "runner real-process lane: detached handoff survives owner loss after accept"]
+fn runner_real_process_accepted_handoff_survives_owner_exit_before_ack() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let state_root = temp.path().join("state");
@@ -840,7 +842,8 @@ fn accept_then_exit_owner_subprocess_entrypoint() {
 
 #[cfg(unix)]
 #[test]
-fn duplicate_handoff_never_spawns_a_second_payload() {
+#[ignore = "runner real-process lane: detached handoff owns a real payload process"]
+fn runner_real_process_duplicate_handoff_never_spawns_a_second_payload() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -869,7 +872,8 @@ fn duplicate_handoff_never_spawns_a_second_payload() {
 
 #[cfg(unix)]
 #[test]
-fn durable_update_sequence_advances_and_duplicate_handoff_does_not() {
+#[ignore = "runner real-process lane: detached update sequencing observes a live payload"]
+fn runner_real_process_durable_update_sequence_advances_and_duplicate_handoff_does_not() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -895,7 +899,8 @@ fn durable_update_sequence_advances_and_duplicate_handoff_does_not() {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
-fn restart_scan_reconciles_live_detached_execution_without_respawn() {
+#[ignore = "runner real-process lane: restart reconciliation observes a live detached supervisor"]
+fn runner_real_process_restart_scan_reconciles_live_detached_execution_without_respawn() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let state_root = temp.path().join("state");
@@ -929,7 +934,8 @@ fn restart_scan_reconciles_live_detached_execution_without_respawn() {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
-fn durable_stop_request_terminates_exact_supervisor_owned_tree() {
+#[ignore = "runner real-process lane: durable stop terminates a detached process tree"]
+fn runner_real_process_durable_stop_request_terminates_exact_supervisor_owned_tree() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -984,7 +990,8 @@ fn macos_native_process_start_identity_is_stable() {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
-fn stale_native_supervisor_identity_reconciles_to_lost_without_respawn() {
+#[ignore = "runner real-process lane: stale supervisor identity is checked against a live process"]
+fn runner_real_process_stale_native_supervisor_identity_reconciles_to_lost_without_respawn() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -1023,7 +1030,8 @@ fn stale_native_supervisor_identity_reconciles_to_lost_without_respawn() {
 
 #[cfg(unix)]
 #[test]
-fn supervisor_continuously_drains_and_bounds_both_output_streams() {
+#[ignore = "runner real-process lane: detached supervisor drains a real child process"]
+fn runner_real_process_supervisor_continuously_drains_and_bounds_both_output_streams() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -1042,7 +1050,8 @@ fn supervisor_continuously_drains_and_bounds_both_output_streams() {
 
 #[cfg(unix)]
 #[test]
-fn terminal_state_is_atomically_rereadable() {
+#[ignore = "runner real-process lane: terminal persistence races a real detached child"]
+fn runner_real_process_terminal_state_is_atomically_rereadable() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -1097,7 +1106,8 @@ fn linux_child_pids(pid: u32) -> Vec<u32> {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn pre_accept_owner_disconnect_is_terminal_and_replay_never_spawns() {
+#[ignore = "runner real-process lane: pre-accept disconnect controls a real supervisor process"]
+fn runner_real_process_pre_accept_owner_disconnect_is_terminal_and_replay_never_spawns() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -1165,7 +1175,8 @@ fn pre_accept_owner_disconnect_is_terminal_and_replay_never_spawns() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn pre_accept_supervisor_death_leaves_no_internal_or_payload_orphan() {
+#[ignore = "runner real-process lane: pre-accept supervisor death exercises real process cleanup"]
+fn runner_real_process_pre_accept_supervisor_death_leaves_no_internal_or_payload_orphan() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));
@@ -1219,7 +1230,8 @@ fn pre_accept_supervisor_death_leaves_no_internal_or_payload_orphan() {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
-fn supervisor_death_terminates_payload_process_tree() {
+#[ignore = "runner real-process lane: supervisor death terminates a real detached process tree"]
+fn runner_real_process_supervisor_death_terminates_payload_process_tree() {
     let _guard = test_env_lock();
     let temp = tempfile::tempdir().unwrap();
     let store = DetachedJobStore::new(temp.path().join("state"));

--- a/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs
@@ -1256,7 +1256,8 @@ fn lsp_default_args_apply_to_env_and_path_but_not_configured() {
 }
 
 #[test]
-fn lsp_crashed_connection_reaps_immediately_without_full_shutdown_deadline() {
+#[ignore = "runner real-process lane: crashed LSP child reap latency"]
+fn runner_real_process_lsp_crashed_connection_reaps_immediately_without_full_shutdown_deadline() {
     let _serial = super::super::serialize_fake_lsp_test();
     // Crashed-but-alive child must not wait the full shutdown timeout before
     // kill/wait. Use a deliberately large budget so the difference is obvious.
@@ -1315,7 +1316,8 @@ fn lsp_stderr_capture_is_bounded() {
 }
 
 #[test]
-fn lsp_graceful_leader_exit_still_reaps_surviving_descendant() {
+#[ignore = "runner real-process lane: LSP graceful leader exit reaps surviving descendant"]
+fn runner_real_process_lsp_graceful_leader_exit_still_reaps_surviving_descendant() {
     let _serial = super::super::serialize_fake_lsp_test();
     let fixture = Fixture::with_config(
         "shutdown_descendant",
@@ -1354,7 +1356,8 @@ fn lsp_graceful_leader_exit_still_reaps_surviving_descendant() {
 }
 
 #[test]
-fn lsp_shutdown_and_drop_reap_the_child_process() {
+#[ignore = "runner real-process lane: LSP shutdown and Drop reap child process"]
+fn runner_real_process_lsp_shutdown_and_drop_reap_the_child_process() {
     let _serial = super::super::serialize_fake_lsp_test();
     let fixture = Fixture::new("normal");
     let server = fixture
@@ -1389,7 +1392,8 @@ fn lsp_shutdown_and_drop_reap_the_child_process() {
 }
 
 #[test]
-fn lsp_shutdown_uses_single_deadline_against_hanging_server() {
+#[ignore = "runner real-process lane: hanging LSP shutdown honors one deadline"]
+fn runner_real_process_lsp_shutdown_uses_single_deadline_against_hanging_server() {
     let _serial = super::super::serialize_fake_lsp_test();
     // Shutdown timeout 200ms. Multiplied waits would approach 600–800ms+.
     let shutdown_timeout = Duration::from_millis(200);
@@ -1439,7 +1443,8 @@ fn lsp_shutdown_uses_single_deadline_against_hanging_server() {
 }
 
 #[test]
-fn lsp_multiple_hanging_servers_share_one_supervisor_deadline() {
+#[ignore = "runner real-process lane: multiple hanging LSP children share one shutdown deadline"]
+fn runner_real_process_lsp_multiple_hanging_servers_share_one_supervisor_deadline() {
     let _serial = super::super::serialize_fake_lsp_test();
     let shutdown_timeout = Duration::from_millis(200);
     let fixture = Fixture::with_config(
@@ -1565,7 +1570,8 @@ fn lsp_reaper_timeout_does_not_rearm_supervisor_drop_budget() {
 }
 
 #[test]
-fn lsp_initialize_timeout_cleanup_uses_configured_shutdown_budget() {
+#[ignore = "runner real-process lane: LSP initialize-timeout child cleanup budget"]
+fn runner_real_process_lsp_initialize_timeout_cleanup_uses_configured_shutdown_budget() {
     let _serial = super::super::serialize_fake_lsp_test();
     let shutdown_timeout = Duration::from_millis(150);
     let temp = tempfile::tempdir().unwrap();
@@ -1624,7 +1630,8 @@ fn lsp_initialize_timeout_cleanup_uses_configured_shutdown_budget() {
 }
 
 #[test]
-fn lsp_idle_cleanup_is_explicit_and_bounded() {
+#[ignore = "runner real-process lane: explicit idle LSP cleanup reaps child"]
+fn runner_real_process_lsp_idle_cleanup_is_explicit_and_bounded() {
     let _serial = super::super::serialize_fake_lsp_test();
     let fixture = Fixture::with_manual_cleanup("normal", 4, Duration::ZERO);
     let server = fixture
@@ -1665,7 +1672,8 @@ fn lsp_idle_cleanup_skips_active_pending_requests() {
 }
 
 #[test]
-fn lsp_idle_cleanup_reaps_crashed_alive_server_immediately() {
+#[ignore = "runner real-process lane: idle cleanup reaps crashed-but-live LSP child"]
+fn runner_real_process_lsp_idle_cleanup_reaps_crashed_alive_server_immediately() {
     let _serial = super::super::serialize_fake_lsp_test();
     let fixture =
         Fixture::with_manual_cleanup("malformed_alive_always", 4, Duration::from_secs(3600));
@@ -1688,7 +1696,8 @@ fn lsp_idle_cleanup_reaps_crashed_alive_server_immediately() {
 }
 
 #[test]
-fn lsp_background_reaper_reclaims_idle_capacity_without_explicit_cleanup() {
+#[ignore = "runner real-process lane: background LSP reaper reclaims idle child capacity"]
+fn runner_real_process_lsp_background_reaper_reclaims_idle_capacity_without_explicit_cleanup() {
     let _serial = super::super::serialize_fake_lsp_test();
     // Production agents never call cleanup_idle directly; idle_ttl must be
     // honored by the built-in background reaper or capacity leaks forever.

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -271,7 +271,9 @@ fn check_observes_edited_v2_without_replacing_current_v1() {
 }
 
 #[test]
-fn check_failures_are_structured_diagnostic_results_and_cleanup_process_trees() {
+#[ignore = "runner real-process lane: disposable plugin checks clean up failed candidate process trees"]
+fn runner_real_process_plugin_check_failures_are_structured_diagnostic_results_and_cleanup_process_trees(
+) {
     for (scenario, timeout_secs, phase, code) in [
         (
             "check_bad_version_tree",
@@ -529,7 +531,8 @@ fn candidate_gate_serializes_check_and_reload_without_blocking_current_providers
 }
 
 #[test]
-fn shutdown_interrupts_blocked_check_candidate_and_reaps_tree() {
+#[ignore = "runner real-process lane: plugin shutdown interrupts blocked candidate and reaps its tree"]
+fn runner_real_process_plugin_shutdown_interrupts_blocked_check_candidate_and_reaps_tree() {
     let fixture = CheckFixture::new("candidate_block_list_tree", 10);
     let _ = fs::remove_file(fixture.marker.with_extension("release"));
     let manager = Arc::clone(&fixture.manager);

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
@@ -341,7 +341,9 @@ fn output_schema_violation_is_completed_and_retires_provider() {
 }
 
 #[test]
-fn blocking_stdin_write_respects_total_deadline_and_retires_provider_tree() {
+#[ignore = "runner real-process lane: plugin blocked-stdin deadline and provider-tree retirement"]
+fn runner_real_process_plugin_blocking_stdin_write_respects_total_deadline_and_retires_provider_tree(
+) {
     let fixture = Fixture::new("block_after_preflight_tree", 1);
     let started = Instant::now();
     let response = fixture.call_with_arguments(maximum_bounded_arguments());
@@ -379,7 +381,9 @@ fn blocking_stdin_write_respects_total_deadline_and_retires_provider_tree() {
 }
 
 #[test]
-fn shutdown_terminates_process_tree_while_effectful_stdin_write_is_blocked() {
+#[ignore = "runner real-process lane: plugin shutdown terminates blocked provider process tree"]
+fn runner_real_process_plugin_shutdown_terminates_process_tree_while_effectful_stdin_write_is_blocked(
+) {
     let fixture = Fixture::new("block_after_preflight_tree", 10);
     let manager = Arc::clone(&fixture.manager);
     let provider = fixture.provider.clone();
@@ -532,12 +536,9 @@ fn provider_busy_is_not_started() {
             expected_schema: schema,
         })
     });
-    for _ in 0..100 {
-        if fixture.marker_count("call") == 1 {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
+    assert!(wait_until(Duration::from_secs(1), || {
+        fixture.marker_count("call") == 1
+    }));
     let discovery = fixture.list();
     assert!(
         discovery.error.is_none(),

--- a/crates/webcodex-runner/src/webcodex_runner/shutdown.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/shutdown.rs
@@ -210,6 +210,7 @@ fn elapsed_ms(started: Instant) -> u64 {
 pub(crate) struct ShutdownCoordinator {
     budget: Duration,
     requested: Arc<AtomicBool>,
+    requested_watch: tokio::sync::watch::Sender<bool>,
     signal_received: AtomicBool,
     started: Mutex<Option<ShutdownDeadline>>,
     report: OnceLock<ShutdownReport>,
@@ -218,9 +219,11 @@ pub(crate) struct ShutdownCoordinator {
 
 impl ShutdownCoordinator {
     pub(crate) fn new(budget: Duration) -> Self {
+        let (requested_watch, _) = tokio::sync::watch::channel(false);
         Self {
             budget,
             requested: Arc::new(AtomicBool::new(false)),
+            requested_watch,
             signal_received: AtomicBool::new(false),
             started: Mutex::new(None),
             report: OnceLock::new(),
@@ -232,6 +235,7 @@ impl ShutdownCoordinator {
         self.signal_received.store(true, Ordering::SeqCst);
         let first = !self.requested.swap(true, Ordering::SeqCst);
         self.ensure_deadline();
+        self.requested_watch.send_replace(true);
         if first {
             eprintln!("webcodex-runner shutdown signal received");
         }
@@ -241,6 +245,20 @@ impl ShutdownCoordinator {
     pub(crate) fn request_cleanup(&self) {
         self.requested.store(true, Ordering::SeqCst);
         self.ensure_deadline();
+        self.requested_watch.send_replace(true);
+    }
+
+    pub(crate) async fn wait_requested(&self) {
+        let mut requested = self.requested_watch.subscribe();
+        loop {
+            if *requested.borrow_and_update() {
+                return;
+            }
+            requested
+                .changed()
+                .await
+                .expect("ShutdownCoordinator retains its watch sender");
+        }
     }
 
     pub(crate) fn is_requested(&self) -> bool {
@@ -444,6 +462,23 @@ mod tests {
         assert!(lines[..lines.len() - 1]
             .iter()
             .all(|line| !line.contains("shutdown complete")));
+    }
+
+    #[tokio::test]
+    async fn shutdown_wait_observes_signal_without_polling() {
+        let coordinator = Arc::new(ShutdownCoordinator::new(Duration::from_secs(1)));
+        let waiting = Arc::clone(&coordinator);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let waiter = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            waiting.wait_requested().await;
+        });
+        started_rx.await.unwrap();
+        coordinator.request_signal();
+        tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .expect("shutdown waiter was not notified")
+            .unwrap();
     }
 
     #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -4005,7 +4005,9 @@ fn main() {
     }
 
     #[test]
-    fn windows_blocked_program_writer_timeout_drains_output_and_returns_bounded() {
+    #[ignore = "runner real-process lane: fake SSH blocks program delivery until timeout"]
+    fn runner_real_process_windows_blocked_program_writer_timeout_drains_output_and_returns_bounded(
+    ) {
         let policy = RunnerPolicy {
             max_output_bytes: 4 * 1024,
             ..RunnerPolicy::default()
@@ -4036,7 +4038,9 @@ fn main() {
     }
 
     #[test]
-    fn windows_blocked_program_writer_stop_is_outcome_unknown_and_reaps_client() {
+    #[ignore = "runner real-process lane: fake SSH blocked writer is stopped and reaped"]
+    fn runner_real_process_windows_blocked_program_writer_stop_is_outcome_unknown_and_reaps_client()
+    {
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("blocked-writer.pid");
         let host = format!("fake-never-read-stop={}", marker.display());
@@ -4206,7 +4210,8 @@ fn main() {
     }
 
     #[test]
-    fn windows_one_shot_post_dispatch_stop_is_outcome_unknown_and_reaps_tree() {
+    #[ignore = "runner real-process lane: one-shot fake SSH stop reaps a real process"]
+    fn runner_real_process_windows_one_shot_post_dispatch_stop_is_outcome_unknown_and_reaps_tree() {
         let temp = tempfile::tempdir().unwrap();
         let started_marker = temp.path().join("one-shot-stop.started");
         let stop_requested = Arc::new(AtomicBool::new(false));
@@ -4371,7 +4376,8 @@ fn main() {
     }
 
     #[test]
-    fn windows_background_ssh_post_spawn_rejection_reaps_owned_tree() {
+    #[ignore = "runner real-process lane: post-spawn rejection terminates a fake SSH process tree"]
+    fn runner_real_process_windows_background_ssh_post_spawn_rejection_reaps_owned_tree() {
         use std::io::{BufRead, BufReader};
 
         let temp = tempfile::tempdir().unwrap();
@@ -4421,7 +4427,8 @@ fn main() {
     }
 
     #[test]
-    fn windows_one_shot_timeout_reaps_the_managed_ssh_tree() {
+    #[ignore = "runner real-process lane: one-shot fake SSH timeout reaps a real process tree"]
+    fn runner_real_process_windows_one_shot_timeout_reaps_the_managed_ssh_tree() {
         let temp = tempfile::tempdir().unwrap();
         let delayed_marker = temp.path().join("one-shot-grandchild.marker");
         let result = run_ssh_shell_with_execution_state(
@@ -4454,7 +4461,8 @@ fn main() {
     }
 
     #[test]
-    fn windows_background_ssh_reuses_job_manager_lifecycle_and_bounds_output() {
+    #[ignore = "runner real-process lane: background fake SSH exercises repeated child-process lifecycle"]
+    fn runner_real_process_windows_background_ssh_reuses_job_manager_lifecycle_and_bounds_output() {
         let config = ssh_config("spe", None);
         let mut manager = crate::JobManager::new(1);
         manager.ssh_pool = fake_pool();
@@ -4586,7 +4594,8 @@ fn main() {
     }
 
     #[test]
-    fn windows_background_ssh_stop_and_timeout_reap_owned_trees() {
+    #[ignore = "runner real-process lane: background fake SSH stop and timeout reap process trees"]
+    fn runner_real_process_windows_background_ssh_stop_and_timeout_reap_owned_trees() {
         let temp = tempfile::tempdir().unwrap();
         let config = ssh_config("spe", None);
         let mut manager = crate::JobManager::new(1);
@@ -4663,7 +4672,8 @@ fn main() {
     }
 
     #[test]
-    fn windows_background_ssh_shutdown_drain_is_bounded_and_reaps_tree() {
+    #[ignore = "runner real-process lane: Runner shutdown drains and reaps a fake SSH tree"]
+    fn runner_real_process_windows_background_ssh_shutdown_drain_is_bounded_and_reaps_tree() {
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("shutdown-grandchild.marker");
         let mut manager = crate::JobManager::new(1);

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -249,9 +249,7 @@ impl RunnerRuntimeState {
     }
 
     async fn wait_for_shutdown(&self) {
-        while !self.shutdown_requested() {
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
+        self.coordinator.wait_requested().await;
     }
 
     #[cfg(any(unix, test))]

--- a/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
@@ -174,11 +174,44 @@ fn runtime_completion_log_follows_bounded_background_cleanup() {
     let cfg = test_runner_config("http://127.0.0.1:1".to_string());
     let runtime =
         RunnerRuntimeState::with_shutdown_budget(&cfg, PathBuf::new(), Duration::from_millis(500));
-    runtime.register_background_thread(thread::spawn(|| {
-        thread::sleep(Duration::from_millis(60));
+    let (background_ready_tx, background_ready_rx) = std::sync::mpsc::channel();
+    let (background_release_tx, background_release_rx) = std::sync::mpsc::channel();
+    runtime.register_background_thread(thread::spawn(move || {
+        background_ready_tx.send(()).unwrap();
+        background_release_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("test must release background cleanup");
     }));
+    background_ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("background cleanup fixture did not start");
 
-    let report = runtime.shutdown();
+    let shutdown_runtime = runtime.clone();
+    let (report_tx, report_rx) = std::sync::mpsc::channel();
+    let shutdown = thread::spawn(move || {
+        report_tx.send(shutdown_runtime.shutdown()).unwrap();
+    });
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !runtime.config.is_stopping() {
+        assert!(
+            Instant::now() < deadline,
+            "shutdown never entered stop-accepting phase"
+        );
+        thread::yield_now();
+    }
+    assert!(
+        matches!(
+            report_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ),
+        "shutdown completed while registered background cleanup was still blocked"
+    );
+    background_release_tx.send(()).unwrap();
+    let report = report_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("shutdown did not complete after background cleanup was released");
+    shutdown.join().unwrap();
+
     let background = report
         .phases
         .iter()
@@ -187,10 +220,6 @@ fn runtime_completion_log_follows_bounded_background_cleanup() {
     assert_eq!(
         background.status,
         super::super::shutdown::ShutdownPhaseStatus::Completed
-    );
-    assert!(
-        report.elapsed_ms >= 40,
-        "completion was recorded before background cleanup"
     );
     let lines = report.log_lines();
     assert!(
@@ -246,7 +275,7 @@ fn runtime_shutdown_wakes_and_joins_reload_listener() {
     let config = Arc::clone(&runtime.config);
     runtime.register_reload_thread(thread::spawn(move || {
         while !config.is_stopping() {
-            thread::sleep(Duration::from_millis(5));
+            thread::yield_now();
         }
     }));
     let report = runtime.shutdown();
@@ -5403,7 +5432,6 @@ async fn websocket_reconnect_backoff_is_interrupted_by_process_shutdown() {
         run_websocket_runner(cfg, false, "inst-backoff-shutdown", &runner_runtime)
     });
     closed_rx.await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
     let started = Instant::now();
     runtime.request_shutdown_signal();
     tokio::time::timeout(Duration::from_secs(2), runner)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -81,7 +81,9 @@ The lanes above define test semantics; workflows decide when to run them.
   tooling. macOS native coverage has core Runner/Computer, Runner real-process, and
   Desktop package jobs; the first two run on both published architectures while the
   Desktop job remains independently selected. Windows likewise separates the default
-  Runner/Computer suite from the real-process Runner group, so process-tree tests no
+  Runner/Computer suite from the real-process Runner group. That group now owns the
+  explicit shell/JobManager/Git/validation process-tree fixtures, detached-supervisor
+  lifecycle tests, and Windows fake-SSH stop/timeout/tree fixtures, so those tests no
   longer force the whole default suite to share their wall-clock/process-contention
   profile. The real-process jobs themselves use two libtest threads. The local-`sshd`
   SSH integration fixture remains Linux-only because it depends on Linux daemon
@@ -91,7 +93,7 @@ The lanes above define test semantics; workflows decide when to run them.
   main pushes force full-native classification, so that proof includes the explicit
   Runner real-process lanes on Linux, Windows, and both macOS architectures. Readiness
   then runs its release-specific E2E/eval and disposable Server-image checks instead
-  of duplicating the same process-tree suite. Follow [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md)
+  of duplicating the same real-child-process lifecycle suite. Follow [`RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md)
   and `.github/workflows/release-readiness.yml`.
 - Slow/manual and real-process lanes remain explicit targeted evidence unless
   a workflow names them. Do not infer that one lane ran merely because another CI

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -83,9 +83,11 @@ The lanes above define test semantics; workflows decide when to run them.
   Desktop job remains independently selected. Windows likewise separates the default
   Runner/Computer suite from the real-process Runner group. That group now owns the
   explicit shell/JobManager/Git/validation process-tree fixtures, detached-supervisor
-  lifecycle tests, and Windows fake-SSH stop/timeout/tree fixtures, so those tests no
-  longer force the whole default suite to share their wall-clock/process-contention
-  profile. The real-process jobs themselves use two libtest threads. The local-`sshd`
+  lifecycle tests, Windows fake-SSH stop/timeout/tree fixtures, selected Plugin
+  provider/check shutdown and process-tree fixtures, and LSP child shutdown/reap/
+  idle-cleanup fixtures. Ordinary Plugin protocol/catalog and LSP navigation/restart
+  coverage stays in the default Runner suite. The real-process jobs themselves use two
+  libtest threads. The local-`sshd`
   SSH integration fixture remains Linux-only because it depends on Linux daemon
   account/auth configuration.
 - Exact-source release acceptance is a separate trust boundary from ordinary CI.
@@ -127,6 +129,8 @@ The lanes above define test semantics; workflows decide when to run them.
   progress; prefer channels, notifications, or direct state inspection. Short
   negative probes, semantic grace windows, and exact count/protocol iterations
   may remain when they are the contract.
+  Async Runner shutdown waits are notification-driven by `ShutdownCoordinator`;
+  tests should signal that state directly rather than sleep for a presumed polling interval.
 - Ignored tests are not dead tests. Each ignored test should have a reason and a
   documented lane for running it intentionally.
   The `runner_real_process_` ignored tests belong to ordinary CI through their explicit

--- a/scripts/ci_path_risk.py
+++ b/scripts/ci_path_risk.py
@@ -291,6 +291,7 @@ def _classify_path(risk: Risk, path: str) -> None:
             risk.needs_runner_real_process = True
         runner_native_tokens = (
             "plugin",
+            "lsp",
             "shell",
             "process",
             "transport",

--- a/scripts/tests/test_ci_path_risk.py
+++ b/scripts/tests/test_ci_path_risk.py
@@ -70,10 +70,12 @@ class PathRiskFixtureTests(unittest.TestCase):
     def test_runner_process_owners_require_native_runner_and_real_process_lanes(self) -> None:
         for path in (
             "crates/webcodex-runner/src/webcodex_runner/coding_agent.rs",
+            "crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs",
             "crates/webcodex-runner/src/webcodex_runner/external_tools.rs",
             "crates/webcodex-runner/src/webcodex_runner/job_manager.rs",
             "crates/webcodex-runner/src/webcodex_runner/mcp_gateway.rs",
             "crates/webcodex-runner/src/webcodex_runner/projects.rs",
+            "crates/webcodex-runner/src/webcodex_runner/ssh.rs",
             "crates/webcodex-runner/src/webcodex_runner/validation/execute.rs",
         ):
             with self.subTest(path=path):

--- a/scripts/tests/test_ci_path_risk.py
+++ b/scripts/tests/test_ci_path_risk.py
@@ -73,6 +73,7 @@ class PathRiskFixtureTests(unittest.TestCase):
             "crates/webcodex-runner/src/webcodex_runner/detached_job/tests.rs",
             "crates/webcodex-runner/src/webcodex_runner/external_tools.rs",
             "crates/webcodex-runner/src/webcodex_runner/job_manager.rs",
+            "crates/webcodex-runner/src/webcodex_runner/lsp/tests.rs",
             "crates/webcodex-runner/src/webcodex_runner/mcp_gateway.rs",
             "crates/webcodex-runner/src/webcodex_runner/projects.rs",
             "crates/webcodex-runner/src/webcodex_runner/ssh.rs",


### PR DESCRIPTION
## Summary
- move detached supervisor/payload lifecycle tests into the existing runner_real_process CI lane
- move Windows fake-SSH stop/timeout/process-tree lifecycle tests out of the default Runner suite
- extend classifier contract coverage for detached-job and SSH paths and document the expanded lane ownership

## Validation
- cargo test -p webcodex-runner runner_real_process_ -- --ignored --test-threads=2 (Linux: 43 passed)
- cargo test -p webcodex-runner (Linux: 849 passed, 47 ignored)
- python3 -m unittest scripts.tests.test_ci_path_risk (27 passed)
- cargo fmt --all -- --check
- bash scripts/release_check.sh --static-only

This preserves the existing real-process lane and path-risk policy rather than adding another CI concept. Windows-only fake-SSH migrations are intended to be verified by the selected Windows real-process CI job.