### PR TITLE
Fix Desktop local enrollment for mixed-case OS usernames

### DIFF
--- a/apps/desktop/src-tauri/src/platform/mod.rs
+++ b/apps/desktop/src-tauri/src/platform/mod.rs
@@ -19,9 +19,71 @@ pub fn current_username() -> String {
     std::env::var("USERNAME")
         .or_else(|_| std::env::var("USER"))
         .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+        .map(|value| normalize_local_username(&value))
         .unwrap_or_else(|| "desktop".to_string())
+}
+
+fn normalize_local_username(value: &str) -> String {
+    // This is a name for Desktop's locally authorized pairing, not an OS
+    // authentication identity. Names the Server already accepts keep their
+    // original characters, including every '-' the user already has.
+    let trimmed = value.trim();
+    if is_server_valid_username(trimmed) {
+        return trimmed.to_string();
+    }
+    // Runs of unsupported characters collapse into one generated separator.
+    // The user's own '-' characters are never folded as separators and are
+    // not stripped at the edges; the whole result is still capped at 64
+    // characters, so an original '-' can still be lost to that truncation.
+    #[derive(PartialEq)]
+    enum Part {
+        Kept(char),
+        GeneratedSeparator,
+    }
+    let mut parts: Vec<Part> = Vec::with_capacity(trimmed.len().min(64));
+    for character in trimmed.chars() {
+        let lowered = character.to_ascii_lowercase();
+        if is_username_character(lowered) {
+            parts.push(Part::Kept(lowered));
+        } else if parts.last() != Some(&Part::GeneratedSeparator) {
+            parts.push(Part::GeneratedSeparator);
+        }
+    }
+    // Only separators generated above may be trimmed at the edges.
+    while parts.first() == Some(&Part::GeneratedSeparator) {
+        parts.remove(0);
+    }
+    while parts.last() == Some(&Part::GeneratedSeparator) {
+        parts.pop();
+    }
+    let mut normalized: Vec<Part> = parts.into_iter().take(64).collect();
+    while normalized.last() == Some(&Part::GeneratedSeparator) {
+        normalized.pop();
+    }
+    let normalized: String = normalized
+        .into_iter()
+        .map(|part| match part {
+            Part::Kept(character) => character,
+            Part::GeneratedSeparator => '-',
+        })
+        .collect();
+    if normalized.is_empty() {
+        "desktop".to_string()
+    } else {
+        normalized
+    }
+}
+
+fn is_server_valid_username(value: &str) -> bool {
+    // Accepts the same usernames as the Server's validate_username:
+    // non-empty, at most 64 characters, and only lowercase ASCII letters,
+    // digits, '_' and '-'. The Server also rejects '..' explicitly, which
+    // this character set cannot produce.
+    !value.is_empty() && value.chars().count() <= 64 && value.chars().all(is_username_character)
+}
+
+fn is_username_character(character: char) -> bool {
+    character.is_ascii_lowercase() || character.is_ascii_digit() || matches!(character, '_' | '-')
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,6 +155,55 @@ pub(crate) fn proxy_is_loopback(url: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn local_username_normalization_matches_server_username_rules() {
+        // Already-valid names pass through unchanged.
+        assert_eq!(normalize_local_username("alice"), "alice");
+        assert_eq!(normalize_local_username("alice--dev"), "alice--dev");
+        assert_eq!(normalize_local_username("alice_dev"), "alice_dev");
+        assert_eq!(normalize_local_username("alice-"), "alice-");
+        assert_eq!(normalize_local_username("-alice"), "-alice");
+        assert_eq!(normalize_local_username("valid_name-2"), "valid_name-2");
+        // Case is folded to lowercase; surrounding whitespace is trimmed.
+        assert_eq!(normalize_local_username("Alice"), "alice");
+        assert_eq!(normalize_local_username("  alice\t"), "alice");
+        // Unsupported characters collapse into one generated '-' per run
+        // while the user's own '-' characters stay untouched.
+        assert_eq!(normalize_local_username("Alice Smith"), "alice-smith");
+        assert_eq!(normalize_local_username("Alice  Smith"), "alice-smith");
+        assert_eq!(normalize_local_username("alice.smith"), "alice-smith");
+        assert_eq!(
+            normalize_local_username("DOMAIN\\Jane Doe"),
+            "domain-jane-doe"
+        );
+        assert_eq!(normalize_local_username("alice..dev"), "alice-dev");
+        assert_eq!(normalize_local_username("alice.-dev"), "alice--dev");
+        assert_eq!(normalize_local_username("alice-."), "alice-");
+        // The result always fits the Server's 64-character limit.
+        assert_eq!(normalize_local_username(&"A".repeat(65)), "a".repeat(64));
+        // Names with nothing supported left fall back explicitly.
+        assert_eq!(normalize_local_username("用户"), "desktop");
+        assert_eq!(normalize_local_username(""), "desktop");
+        assert_eq!(normalize_local_username(" \t "), "desktop");
+    }
+
+    #[test]
+    fn local_username_normalization_preserves_existing_valid_names() {
+        for name in [
+            "alice",
+            "alice--dev",
+            "alice-",
+            "-alice",
+            "_",
+            "--",
+            "user_123",
+        ] {
+            assert_eq!(normalize_local_username(name), name);
+        }
+        let maximum_length = "a".repeat(64);
+        assert_eq!(normalize_local_username(&maximum_length), maximum_length);
+    }
 
     #[test]
     fn proxy_server_normalization_accepts_common_windows_shapes() {

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -3121,11 +3121,60 @@ mod tests {
         let _ = std::fs::remove_dir_all(data_dir);
     }
 
+    /// Serializes tests that mutate process environment variables.
+    ///
+    /// Env mutation is process-global, so env-mutating tests in this test
+    /// binary hold one shared lock for their whole body. Desktop is its own
+    /// Cargo workspace, so this per-crate `TEST_ENV_LOCK` follows the
+    /// convention documented in docs/TESTING.md.
+    static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Restores one process environment variable when the guard is dropped,
+    /// including through panic unwinding. Holding `TEST_ENV_LOCK` for the
+    /// guard's lifetime also serializes env mutation across sibling tests;
+    /// poisoning is tolerated because the RAII restore already fixed the
+    /// environment before the lock is released.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+        _test_env_lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let test_env_lock = TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self {
+                key,
+                previous,
+                _test_env_lock: test_env_lock,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[tokio::test]
     #[ignore = "requires current-source dogfood binaries and a temporary project"]
     async fn native_local_full_dogfood_reuses_enrollment_and_stops_owned_runtime() {
         let project = std::env::var("WEBCODEX_DESKTOP_DOGFOOD_PROJECT")
             .expect("WEBCODEX_DESKTOP_DOGFOOD_PROJECT must point to the temporary fixture");
+        // The Server only accepts lowercase local pairing usernames. Pin a
+        // mixed-case OS username so the compatibility path is exercised on
+        // every machine, not only where the login name already fails. The
+        // guard restores the previous value on every exit path, including
+        // panics, so this override never leaks to sibling tests.
+        let _username_guard = EnvVarGuard::set("USERNAME", "Alice Dogfood");
         // macOS exposes its temporary root through /var -> /private/var.
         // Resolve the fixture root, not the credential-store security checks.
         let temporary_root = std::env::temp_dir()
@@ -3214,6 +3263,39 @@ mod tests {
             first_user_token == second_user_token,
             "local restart must reuse enrollment instead of rotating the managed user token"
         );
+        // The supervisor refuses to spawn while an owned runtime process is
+        // still active, and the saved identity only matches an unchanged
+        // project, so switching projects stops the runtime first and pairs
+        // again through the same username path as first setup.
+        core.stop_local_runtime(&cancellation)
+            .await
+            .expect("stop runtime before switching project");
+        let second_project = data_dir.join("second-project");
+        std::fs::create_dir_all(&second_project).expect("create second project fixture");
+        let expected_project = core
+            .adapter
+            .inspect_project(&second_project.to_string_lossy())
+            .await
+            .expect("inspect second project fixture");
+        let switched = match core
+            .configure_local_setup(Some(&second_project.to_string_lossy()), &cancellation)
+            .await
+        {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let readiness = core.snapshot.readiness.clone();
+                core.supervisor.lock().await.stop_all().await;
+                let _ = std::fs::remove_dir_all(&data_dir);
+                panic!("switch project setup failed: {error:?}; readiness={readiness:?}");
+            }
+        };
+        assert_eq!(switched.readiness.server, ServerReadiness::Ready);
+        assert_eq!(switched.readiness.runner, RunnerReadiness::Ready);
+        assert_eq!(switched.readiness.project, ProjectReadiness::Ready);
+        assert!(same_project(
+            &core.config.project.as_ref().expect("selected project").path,
+            &expected_project.path,
+        ));
         core.stop_local_runtime(&cancellation)
             .await
             .expect("stop restarted local runtime");

--- a/docs/desktop-install.md
+++ b/docs/desktop-install.md
@@ -91,6 +91,8 @@ On first use, Desktop prepares its local Server + Runner. Windows initially has 
 
 This is an intentional authority boundary: the default Desktop project does not grant access to unrelated directories or the whole disk.
 
+For local pairing, Desktop derives a Server-compatible username from your OS username: names the Server already accepts are kept as-is; otherwise ASCII letters are lowercased, each run of unsupported characters becomes a single `-`, the name's own `-` characters are preserved, leading and trailing generated separators are removed, and the result is limited to 64 characters. Names with nothing left use `desktop`. This local pairing name is not an OS login identity; existing saved enrollment is reused on restart.
+
 ![Local runtime example](desktop-install/image-20260906171904811.png)
 
 ## 5. Configure Tunnel networking if needed

--- a/docs/desktop-install.zh-CN.md
+++ b/docs/desktop-install.zh-CN.md
@@ -81,6 +81,8 @@ launchctl setenv CONTROL_PLANE_API_KEY "$CONTROL_PLANE_API_KEY"
 
 首次启动后，Desktop 会准备本机 Server + Runner。Windows 会先把 Desktop 安装目录注册为默认项目；macOS 使用 Desktop 自己的 workspace。真正开发时，请在“项目”页面**显式添加你的代码仓库目录**。
 
+本地配对时，Desktop 会将操作系统用户名转换为 Server 接受的名称：原本合法的名称保持不变；否则 ASCII 字母转为小写，连续的不支持字符合并为一个 `-`，名称中原有的 `-` 保持原样，去掉首尾生成的 `-`，结果限制为 64 个字符；转换后为空时使用 `desktop`。这个本地配对名称不是操作系统登录身份；重启时会复用已保存的注册身份。
+
 这是有意的安全边界：默认项目不会自动获得其他目录或整块磁盘的访问权限。
 
 ![本机运行环境示例](desktop-install/image-20260906171904811.png)


### PR DESCRIPTION
## Problem

Desktop passes the OS username directly to local pairing creation (`platform::current_username` -> `webcodex pairing create --username ...`). On Windows, a mixed-case username such as `Alice` is rejected by the Server's lowercase username validation (`validate_username` in `src/auth/pat.rs`), so first-time local setup and project reconfiguration can fail with `webcodex_command_failed`.

## Changes

- `apps/desktop/src-tauri/src/platform/mod.rs`: derive a Server-compatible local pairing username instead of passing the OS username through:
  - Names the Server already accepts (its `validate_username` accepted set) pass through unchanged, including their own `-` characters.
  - Otherwise: surrounding whitespace is trimmed, ASCII uppercase folds to lowercase, each run of unsupported characters becomes a single generated `-`, and generated edge separators are removed. The user's own `-` characters are never folded as separators and are not stripped at the edges; the whole result is still capped at 64 characters, so an original `-` can still be lost to that truncation. Empty results fall back to `desktop`.
  - Only newly generated local pairings use the derived name; saved enrollment identities continue to be reused on restart. The Server-side validation rules are unchanged.
- `apps/desktop/src-tauri/src/state.rs`: extend the native local dogfood test with a pinned mixed-case OS username (`Alice Dogfood`, scoped with an environment-variable guard) and a project-switch re-enrollment phase with failure-path cleanup. The guard holds the test binary's `TEST_ENV_LOCK` per `docs/TESTING.md`, so the override is serialized against sibling tests and restored on normal and panic-unwind paths.
- `docs/desktop-install.md` / `docs/desktop-install.zh-CN.md`: document the derived pairing name and that it is not an OS login identity.

Normalization maps different OS usernames to the same pairing name (for example, names with nothing supported left all fall back to `desktop`); this is a deterministic local pairing convenience, not a uniqueness guarantee.

## Out of scope

Improving the diagnostic detail behind the generic `webcodex_command_failed` error is a separate concern and is intentionally left out of this focused fix.

## Validation

Windows x86_64, PowerShell 7.6.5, stable Rust, base `5a4da8ff`:

- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`: the repository-wide check still reports two pre-existing formatting diffs in untouched files (`webcodex/adapter.rs`, `webcodex/cli.rs`). All files touched by this PR are rustfmt-clean; the two unrelated diffs were verified byte-identical to base `5a4da8ff` using a temporary worktree.
- `cargo check --locked --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets`: pass (remaining warnings are pre-existing in untouched files).
- `cargo test --locked --manifest-path apps/desktop/src-tauri/Cargo.toml --lib platform::tests`: 4 passed.
- `cargo build --locked --profile dogfood -p webcodex -p webcodex-cli -p webcodex-runner`: pass.
- Real-process enrollment test with dogfood binaries, a temporary project and isolated app-data (bounded waits, process cleanup on success and failure paths): `cargo test --locked --manifest-path apps/desktop/src-tauri/Cargo.toml --lib native_local_full_dogfood_reuses_enrollment_and_stops_owned_runtime -- --ignored` -> 1 passed (16.85s):
  - first-time local setup with a mixed-case OS username (`Alice Dogfood` -> `alice-dogfood`): Server/Runner/project all Ready;
  - restart: saved enrollment reused, managed user token not rotated;
  - project switch: owned runtime stopped, re-pairing against the new project succeeds, all Ready.

This change affects the identity boundary between Desktop's local pairing names and the Server's username validation; the real-process enrollment test above is the focused regression evidence for that boundary.

CI results will be recorded once the checks complete.
