### PR TITLE
Centralize terminal model result projection

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -84,7 +84,7 @@ fn full_operator_runtime_specs_for_auth(
 fn adaptive_runtime_gateway_tool_spec() -> ToolSpec {
     ToolSpec {
         name: ADAPTIVE_RUNTIME_GATEWAY_TOOL_NAME.to_string(),
-        description: "Call one model-visible gateway-only long-tail runtime tool through the adaptive surface. Tools discovered with availability=direct must be invoked directly; if the host has not loaded that callable, rediscover/load it instead of retrying through this gateway. Runtime argument validation, OAuth scope checks, project authority, permission gates, and tool effects remain unchanged.".to_string(),
+        description: "Call one gateway-admitted long-tail runtime tool through the adaptive surface. Tools discovered with availability=direct must be invoked directly; if the host has not loaded that callable, rediscover/load it instead of retrying through this gateway. Runtime argument validation, OAuth scope checks, project authority, permission gates, and tool effects remain unchanged.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -92,7 +92,7 @@ fn adaptive_runtime_gateway_tool_spec() -> ToolSpec {
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 128,
-                    "description": "Exact gateway-only model-visible runtime tool name obtained from bounded runtime discovery. Do not pass tools whose discovery availability is direct."
+                    "description": "Exact gateway-admitted runtime tool name obtained from bounded runtime discovery. Do not pass tools whose discovery availability is direct."
                 },
                 "arguments": {
                     "type": "object",

--- a/src/mcp_tests/http_transport.rs
+++ b/src/mcp_tests/http_transport.rs
@@ -343,6 +343,127 @@ async fn stateless_full_trace_preserves_raw_context_ack_and_records_clean_effect
     assert_eq!(final_response["result"]["isError"], false);
 }
 
+#[test]
+fn stateless_full_trace_correlates_only_hashed_openai_window() {
+    std::thread::Builder::new()
+        .name("mcp-stateless-window-trace".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build stateless window-trace test runtime")
+                .block_on(stateless_full_trace_correlates_only_hashed_openai_window_body());
+        })
+        .expect("spawn stateless window-trace test thread")
+        .join()
+        .expect("stateless window-trace test thread panicked");
+}
+
+async fn stateless_full_trace_correlates_only_hashed_openai_window_body() {
+    use std::collections::BTreeSet;
+
+    let trace_root = tempfile::tempdir().unwrap();
+    let mut env = crate::test_support::TestEnvGuard::new();
+    env.set("WEBCODEX_TOOL_REQUEST_TRACE", "full");
+    env.set(
+        "WEBCODEX_TOOL_REQUEST_TRACE_DIR",
+        trace_root.path().to_string_lossy().as_ref(),
+    );
+    env.set("WEBCODEX_TOOL_REQUEST_TRACE_MAX_TOTAL_BYTES", "8388608");
+
+    let config = test_config(Some("secret"));
+    let (_tmp, db) = test_db();
+    let runtime = Arc::new(test_runtime_with_surface(ModelSurface::FullOperatorRuntime));
+    let service = Service::new(build_test_router(config, db, runtime));
+    let raw_window = "openai-window-trace-opaque-secret";
+
+    for id in [51_i64, 52_i64] {
+        let mut params = mcp_2026_params(json!({"name": "list_tools", "arguments": {}}));
+        params["_meta"]["openai/session"] = json!(raw_window);
+        let (status, body) = stateless_2026_jsonrpc(
+            &service,
+            "secret",
+            Some(MCP_STATELESS_PROTOCOL_VERSION),
+            Some("tools/call"),
+            Some("list_tools"),
+            None,
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": params,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["result"]["isError"], false, "{body}");
+    }
+    crate::tool_request_trace::flush_full_trace_writer();
+
+    let mut trace_ids = BTreeSet::new();
+    let mut window_keys = BTreeSet::new();
+    let mut traced_requests = 0_usize;
+    for entry in std::fs::read_dir(trace_root.path()).unwrap().flatten() {
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let trace_dir = entry.path();
+        let Ok(events_text) = std::fs::read_to_string(trace_dir.join("events.jsonl")) else {
+            continue;
+        };
+        assert!(
+            !events_text.contains(raw_window),
+            "raw OpenAI window identity leaked into trace metadata"
+        );
+        let events = events_text
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        if let Some(parsed) = events.iter().find(|event| {
+            event["event"] == "mcp_tool_request_parsed" && event["tool_name"] == "list_tools"
+        }) {
+            traced_requests += 1;
+            let trace_id = parsed["server_trace_id"]
+                .as_str()
+                .expect("parsed trace event server_trace_id");
+            let window_key = parsed["client_window_key"]
+                .as_str()
+                .expect("parsed trace event hashed client window");
+            assert_eq!(parsed["client_window_source"], "openai-session");
+            assert_eq!(window_key.len(), 64);
+            assert!(window_key.bytes().all(|byte| byte.is_ascii_hexdigit()));
+            assert_ne!(window_key, raw_window);
+            trace_ids.insert(trace_id.to_string());
+            window_keys.insert(window_key.to_string());
+        }
+
+        for event in &events {
+            let Some(relative) = event.get("payload_path").and_then(Value::as_str) else {
+                continue;
+            };
+            let compressed = std::fs::read(trace_dir.join(relative)).unwrap();
+            let raw = zstd::stream::decode_all(compressed.as_slice()).unwrap();
+            assert!(
+                !String::from_utf8_lossy(&raw).contains(raw_window),
+                "raw OpenAI window identity leaked into compressed trace payload"
+            );
+        }
+    }
+
+    assert_eq!(traced_requests, 2, "expected one parsed event per request");
+    assert_eq!(
+        trace_ids.len(),
+        2,
+        "requests must keep distinct trace identities"
+    );
+    assert_eq!(
+        window_keys.len(),
+        1,
+        "the same ChatGPT window must produce one stable hashed correlation key"
+    );
+}
+
 #[tokio::test]
 async fn mcp_tools_call_writes_a_summary_action_audit_row() {
     // list_tools is a full-operator-only tool; select that surface so the

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -1046,6 +1046,51 @@ async fn adaptive_stateless_manifest_inventory_matches_extension_gateway_univers
 }
 
 #[tokio::test]
+async fn adaptive_stateless_discovery_intent_stays_curated() {
+    use crate::tool_runtime::tool_definition::TOOL_MANIFEST_INTENTS;
+
+    let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);
+    let outcome = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(7291)),
+            mcp_2026_params(json!({
+                "name": "tool_manifest",
+                "arguments": {
+                    "intent": "discovery",
+                    "include_recommended_flows": false,
+                    "include_risk_summary": false
+                }
+            })),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(value) = outcome else {
+        panic!("adaptive stateless discovery intent must succeed");
+    };
+    let output = &value["result"]["structuredContent"]["output"];
+    assert_eq!(output["intent"], "discovery");
+    let names = output["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    let expected = TOOL_MANIFEST_INTENTS
+        .iter()
+        .find(|intent| intent.name == "discovery")
+        .expect("canonical discovery intent")
+        .tools
+        .to_vec();
+    assert_eq!(
+        names, expected,
+        "Stateless operator extensions may expand the discoverable universe but must not implicitly expand the curated discovery intent"
+    );
+}
+
+#[tokio::test]
 async fn operator_extension_manifest_is_absent_without_stateless_capability_and_does_not_grant_scope(
 ) {
     let runtime = test_runtime_with_surface(ModelSurface::AdaptiveRuntime);

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -205,53 +205,122 @@ pub(super) fn sparsify_failure_model_result_metadata(tool_name: &str, result: &m
     }
 }
 
-pub(super) enum SearchModelProjection {
+enum SearchModelProjection {
     None,
-    Single { default_timeout: bool },
-    Batch { default_timeouts: Vec<bool> },
+    Single {
+        default_timeout: bool,
+    },
+    Batch {
+        default_timeouts: Vec<bool>,
+        max_result_bytes: Option<usize>,
+    },
 }
 
 impl SearchModelProjection {
-    pub(super) fn capture(call: &ToolCall) -> Self {
+    fn capture(call: &ToolCall) -> Self {
         match call {
             ToolCall::SearchProjectText { timeout_secs, .. } => Self::Single {
                 default_timeout: caller_uses_default_search_timeout(timeout_secs),
             },
-            ToolCall::SearchProjectTexts { queries, .. } => Self::Batch {
+            ToolCall::SearchProjectTexts {
+                queries,
+                max_result_bytes,
+                ..
+            } => Self::Batch {
                 default_timeouts: queries
                     .iter()
                     .map(|query| caller_uses_default_search_timeout(&query.timeout_secs))
                     .collect(),
+                max_result_bytes: *max_result_bytes,
             },
             _ => Self::None,
         }
     }
 }
 
-/// Batch response-budget inputs captured before the ToolCall is moved into
-/// canonical execution. Budgeting is intentionally deferred until after
-/// Session recording/decorations so the recorder keeps seeing the canonical
-/// result while the model-facing projection can account for sparse semantics.
-enum BatchResponseBudgetProjection {
+enum ModelFacingProjection {
     None,
-    ReadFiles { max_result_bytes: Option<usize> },
-    SearchProjectTexts { max_result_bytes: Option<usize> },
+    Read(super::read_files::ReadModelProjection),
+    Search(SearchModelProjection),
 }
 
-impl BatchResponseBudgetProjection {
-    fn capture(call: &ToolCall) -> Self {
-        match call {
-            ToolCall::ReadFiles {
-                max_result_bytes, ..
-            } => Self::ReadFiles {
-                max_result_bytes: *max_result_bytes,
-            },
-            ToolCall::SearchProjectTexts {
-                max_result_bytes, ..
-            } => Self::SearchProjectTexts {
-                max_result_bytes: *max_result_bytes,
-            },
-            _ => Self::None,
+/// Request facts needed only after canonical execution/recording has finished.
+/// Captured once before the ToolCall is moved, then consumed exactly once by the
+/// terminal model-facing projection stage. The concrete projection stays private
+/// so callers cannot branch on tool-specific result policy.
+pub(crate) struct ModelFacingProjectionPlan {
+    projection: ModelFacingProjection,
+}
+
+impl ModelFacingProjectionPlan {
+    pub(crate) fn capture(call: &ToolCall) -> Self {
+        let projection = match call {
+            ToolCall::ReadFile { .. } | ToolCall::ReadFiles { .. } => {
+                ModelFacingProjection::Read(super::read_files::ReadModelProjection::capture(call))
+            }
+            ToolCall::SearchProjectText { .. } | ToolCall::SearchProjectTexts { .. } => {
+                ModelFacingProjection::Search(SearchModelProjection::capture(call))
+            }
+            _ => ModelFacingProjection::None,
+        };
+        Self { projection }
+    }
+
+    pub(crate) fn bind_resolved_project(&mut self, resolved: Option<&ResolvedProject>) {
+        if let ModelFacingProjection::Read(projection) = &mut self.projection {
+            projection.bind_resolved_project(resolved);
+        }
+    }
+
+    /// Consume the plan at the only stage allowed to turn canonical execution
+    /// output into the final model-facing read/search shape. Session/audit
+    /// recorders must run before this method.
+    pub(crate) fn project(self, result: &mut ToolResult) {
+        let projection = self.projection;
+        match &projection {
+            ModelFacingProjection::Read(
+                projection @ super::read_files::ReadModelProjection::Batch {
+                    max_result_bytes, ..
+                },
+            ) => {
+                super::read_files::apply_model_facing_output_budget(
+                    result,
+                    *max_result_bytes,
+                    projection,
+                );
+                super::read_files::enforce_final_model_facing_hard_cap(result, projection);
+            }
+            ModelFacingProjection::Search(SearchModelProjection::Batch {
+                default_timeouts,
+                max_result_bytes,
+            }) => {
+                super::search_project_texts::apply_model_facing_output_budget(
+                    result,
+                    default_timeouts,
+                    *max_result_bytes,
+                );
+                super::search_project_texts::enforce_final_model_facing_hard_cap(
+                    result,
+                    default_timeouts,
+                );
+            }
+            _ => {}
+        }
+
+        match &projection {
+            ModelFacingProjection::Read(projection) => {
+                super::read_files::add_actionable_read_continuations(projection, result);
+                let tool_name = match projection {
+                    super::read_files::ReadModelProjection::Single { .. } => "read_file",
+                    super::read_files::ReadModelProjection::Batch { .. } => "read_files",
+                    super::read_files::ReadModelProjection::None => return,
+                };
+                sparsify_complete_read_success(tool_name, result);
+            }
+            ModelFacingProjection::Search(projection) => {
+                sparsify_search_success_for_model(projection, result)
+            }
+            ModelFacingProjection::None => {}
         }
     }
 }
@@ -430,10 +499,7 @@ pub(crate) fn sparsify_search_output_for_model(
     true
 }
 
-pub(super) fn sparsify_search_success_for_model(
-    projection: &SearchModelProjection,
-    result: &mut ToolResult,
-) {
+fn sparsify_search_success_for_model(projection: &SearchModelProjection, result: &mut ToolResult) {
     if !result.success {
         return;
     }
@@ -444,7 +510,9 @@ pub(super) fn sparsify_search_success_for_model(
         SearchModelProjection::Single { default_timeout } => {
             sparsify_search_output_for_model(output, *default_timeout, false);
         }
-        SearchModelProjection::Batch { default_timeouts } => {
+        SearchModelProjection::Batch {
+            default_timeouts, ..
+        } => {
             let complete_batch =
                 output
                     .get("items")
@@ -520,6 +588,7 @@ pub(crate) fn sparsify_search_batch_success_for_model(
     sparsify_search_success_for_model(
         &SearchModelProjection::Batch {
             default_timeouts: default_timeouts.to_vec(),
+            max_result_bytes: None,
         },
         result,
     );
@@ -799,7 +868,8 @@ impl ToolRuntime {
         context_request: Vec<String>,
         material_capabilities: super::context_projection::ContextMaterialCapabilities,
     ) -> ToolResult {
-        self.dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_read_projection(
+        let (mut result, projection) = self
+            .dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_result_projection(
             call,
             auth,
             transport,
@@ -810,15 +880,17 @@ impl ToolRuntime {
             material_capabilities,
             super::kernel::ToolProtocolCapabilities::default(),
         )
-        .await
-        .0
+        .await;
+        projection.project(&mut result);
+        result
     }
 
-    /// Kernel-only companion that returns the Read projection after the same
-    /// authoritative Project resolution used for execution. Other callers keep
-    /// the existing ToolResult-only API and cannot observe this internal state.
+    /// Kernel-only companion that returns the terminal model-facing projection
+    /// plan after the same authoritative Project resolution used for execution.
+    /// The returned ToolResult is still canonical with respect to read/search
+    /// budgeting and sparse projection so an outer recorder can consume it first.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_read_projection(
+    pub(crate) async fn dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_result_projection(
         &self,
         call: ToolCall,
         auth: Option<&AuthContext>,
@@ -829,8 +901,8 @@ impl ToolRuntime {
         context_request: Vec<String>,
         material_capabilities: super::context_projection::ContextMaterialCapabilities,
         protocol_capabilities: super::kernel::ToolProtocolCapabilities,
-    ) -> (ToolResult, super::read_files::ReadModelProjection) {
-        let mut read_projection = super::read_files::ReadModelProjection::capture(&call);
+    ) -> (ToolResult, ModelFacingProjectionPlan) {
+        let mut result_projection = ModelFacingProjectionPlan::capture(&call);
         // Edit usage telemetry retains only fixed safe classifications. For
         // apply_patch it captures the requested matching enum before the call is
         // moved, never the patch/path/content arguments.
@@ -846,7 +918,7 @@ impl ToolRuntime {
                 context_request.clone(),
                 material_capabilities,
                 protocol_capabilities,
-                &mut read_projection,
+                &mut result_projection,
             )
             .await;
         // Early project/session/auth failures can return before the normal
@@ -866,7 +938,7 @@ impl ToolRuntime {
         if let Some(guard) = edit_usage.as_mut() {
             guard.finish_with_result(&result);
         }
-        (result, read_projection)
+        (result, result_projection)
     }
 
     /// Everything the activity ledger needs from a call, captured before the
@@ -979,7 +1051,7 @@ impl ToolRuntime {
         context_request: Vec<String>,
         material_capabilities: super::context_projection::ContextMaterialCapabilities,
         protocol_capabilities: super::kernel::ToolProtocolCapabilities,
-        read_projection: &mut super::read_files::ReadModelProjection,
+        result_projection: &mut ModelFacingProjectionPlan,
     ) -> ToolResult {
         call = call
             .with_coding_agent_recording_session_id(recorder_metadata.recording_session_id.clone());
@@ -1049,7 +1121,7 @@ impl ToolRuntime {
         let resolved_project = project_resolution
             .as_ref()
             .and_then(|resolution| resolution.as_ref().ok());
-        read_projection.bind_resolved_project(resolved_project);
+        result_projection.bind_resolved_project(resolved_project);
         // Preserve the canonical project for activity attribution before the
         // session recorder consumes the resolved value below. Short aliases
         // must not turn a real Runner execution into a client-less row.
@@ -1375,8 +1447,6 @@ impl ToolRuntime {
         }
         let activity_context =
             Self::capture_workspace_activity_context(&call, activity_project.as_deref());
-        let search_projection = SearchModelProjection::capture(&call);
-        let batch_budget_projection = BatchResponseBudgetProjection::capture(&call);
         let validation_assertion_name = recorder_metadata.expectation.assertion_name.as_deref();
         let tool_name = call.tool_name();
         let trusted_recording_session_id = recorder_metadata
@@ -1465,55 +1535,7 @@ impl ToolRuntime {
             material_capabilities,
         )
         .await;
-        let defer_batch_sparsification = !inner_model_facing_recording
-            && !matches!(
-                &batch_budget_projection,
-                BatchResponseBudgetProjection::None
-            );
-        match &batch_budget_projection {
-            BatchResponseBudgetProjection::None => {}
-            BatchResponseBudgetProjection::ReadFiles { max_result_bytes } => {
-                super::read_files::apply_model_facing_output_budget(
-                    &mut result,
-                    *max_result_bytes,
-                    read_projection,
-                );
-                // Direct/business-Session dispatch has already added every
-                // model-facing Session overlay. Enforce the true final ceiling
-                // against that decorated result before sparse projection. Outer
-                // kernel recording defers sparsification and repeats this exact
-                // hard-cap pass after its own overlays are attached.
-                super::read_files::enforce_final_model_facing_hard_cap(
-                    &mut result,
-                    read_projection,
-                );
-            }
-            BatchResponseBudgetProjection::SearchProjectTexts { max_result_bytes } => {
-                let default_timeouts = match &search_projection {
-                    SearchModelProjection::Batch { default_timeouts } => {
-                        default_timeouts.as_slice()
-                    }
-                    _ => &[],
-                };
-                super::search_project_texts::apply_model_facing_output_budget(
-                    &mut result,
-                    default_timeouts,
-                    *max_result_bytes,
-                );
-                super::search_project_texts::enforce_final_model_facing_hard_cap(
-                    &mut result,
-                    default_timeouts,
-                );
-            }
-        }
         sparsify_terminal_structured_execution_success(tool_name, &mut result);
-        if !defer_batch_sparsification {
-            sparsify_search_success_for_model(&search_projection, &mut result);
-            if inner_model_facing_recording {
-                super::read_files::add_actionable_read_continuations(read_projection, &mut result);
-            }
-            sparsify_complete_read_success(tool_name, &mut result);
-        }
         result
     }
 

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -248,12 +248,12 @@ enum ModelFacingProjection {
 /// Captured once before the ToolCall is moved, then consumed exactly once by the
 /// terminal model-facing projection stage. The concrete projection stays private
 /// so callers cannot branch on tool-specific result policy.
-pub(crate) struct ModelFacingProjectionPlan {
+pub(super) struct ModelFacingProjectionPlan {
     projection: ModelFacingProjection,
 }
 
 impl ModelFacingProjectionPlan {
-    pub(crate) fn capture(call: &ToolCall) -> Self {
+    pub(super) fn capture(call: &ToolCall) -> Self {
         let projection = match call {
             ToolCall::ReadFile { .. } | ToolCall::ReadFiles { .. } => {
                 ModelFacingProjection::Read(super::read_files::ReadModelProjection::capture(call))
@@ -266,7 +266,7 @@ impl ModelFacingProjectionPlan {
         Self { projection }
     }
 
-    pub(crate) fn bind_resolved_project(&mut self, resolved: Option<&ResolvedProject>) {
+    pub(super) fn bind_resolved_project(&mut self, resolved: Option<&ResolvedProject>) {
         if let ModelFacingProjection::Read(projection) = &mut self.projection {
             projection.bind_resolved_project(resolved);
         }
@@ -275,52 +275,46 @@ impl ModelFacingProjectionPlan {
     /// Consume the plan at the only stage allowed to turn canonical execution
     /// output into the final model-facing read/search shape. Session/audit
     /// recorders must run before this method.
-    pub(crate) fn project(self, result: &mut ToolResult) {
-        let projection = self.projection;
-        match &projection {
-            ModelFacingProjection::Read(
-                projection @ super::read_files::ReadModelProjection::Batch {
-                    max_result_bytes, ..
-                },
-            ) => {
-                super::read_files::apply_model_facing_output_budget(
-                    result,
-                    *max_result_bytes,
-                    projection,
-                );
-                super::read_files::enforce_final_model_facing_hard_cap(result, projection);
-            }
-            ModelFacingProjection::Search(SearchModelProjection::Batch {
-                default_timeouts,
-                max_result_bytes,
-            }) => {
-                super::search_project_texts::apply_model_facing_output_budget(
-                    result,
-                    default_timeouts,
-                    *max_result_bytes,
-                );
-                super::search_project_texts::enforce_final_model_facing_hard_cap(
-                    result,
-                    default_timeouts,
-                );
-            }
-            _ => {}
-        }
-
-        match &projection {
+    pub(super) fn project(self, result: &mut ToolResult) {
+        match self.projection {
+            ModelFacingProjection::None => {}
             ModelFacingProjection::Read(projection) => {
-                super::read_files::add_actionable_read_continuations(projection, result);
-                let tool_name = match projection {
+                let tool_name = match &projection {
                     super::read_files::ReadModelProjection::Single { .. } => "read_file",
-                    super::read_files::ReadModelProjection::Batch { .. } => "read_files",
+                    super::read_files::ReadModelProjection::Batch {
+                        max_result_bytes, ..
+                    } => {
+                        super::read_files::apply_model_facing_output_budget(
+                            result,
+                            *max_result_bytes,
+                            &projection,
+                        );
+                        super::read_files::enforce_final_model_facing_hard_cap(result, &projection);
+                        "read_files"
+                    }
                     super::read_files::ReadModelProjection::None => return,
                 };
+                super::read_files::add_actionable_read_continuations(&projection, result);
                 sparsify_complete_read_success(tool_name, result);
             }
             ModelFacingProjection::Search(projection) => {
-                sparsify_search_success_for_model(projection, result)
+                if let SearchModelProjection::Batch {
+                    default_timeouts,
+                    max_result_bytes,
+                } = &projection
+                {
+                    super::search_project_texts::apply_model_facing_output_budget(
+                        result,
+                        default_timeouts,
+                        *max_result_bytes,
+                    );
+                    super::search_project_texts::enforce_final_model_facing_hard_cap(
+                        result,
+                        default_timeouts,
+                    );
+                }
+                sparsify_search_success_for_model(&projection, result);
             }
-            ModelFacingProjection::None => {}
         }
     }
 }
@@ -890,7 +884,7 @@ impl ToolRuntime {
     /// The returned ToolResult is still canonical with respect to read/search
     /// budgeting and sparse projection so an outer recorder can consume it first.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_result_projection(
+    pub(super) async fn dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_result_projection(
         &self,
         call: ToolCall,
         auth: Option<&AuthContext>,

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -936,17 +936,11 @@ impl ToolRuntime {
         }
 
         let project = tool_project(&call);
-        let deferred_search_projection = super::dispatch::SearchModelProjection::capture(&call);
-        let defer_batch_model_projection = context.session_id.is_some()
-            && matches!(
-                &call,
-                ToolCall::ReadFiles { .. } | ToolCall::SearchProjectTexts { .. }
-            );
         // Permission is evaluated once inside dispatch (pre-exec gate). Kernel
         // only reuses the attached decision for the outer recording session —
         // never re-evaluate (no second request id / inconsistent outcome).
-        let (mut result, deferred_read_projection) = self
-            .dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_read_projection(
+        let (mut result, result_projection) = self
+            .dispatch_with_auth_transport_options_and_metadata_with_recording_mode_and_context_with_result_projection(
                 call,
                 context.auth,
                 context.transport.into(),
@@ -997,50 +991,10 @@ impl ToolRuntime {
                 recorder_ack_requested,
             );
         }
-        if defer_batch_model_projection {
-            match request.tool_name.as_str() {
-                "read_files" => {
-                    super::read_files::enforce_final_model_facing_hard_cap(
-                        &mut result,
-                        &deferred_read_projection,
-                    );
-                }
-                "search_project_texts" => {
-                    let default_timeouts = match &deferred_search_projection {
-                        super::dispatch::SearchModelProjection::Batch { default_timeouts } => {
-                            default_timeouts.as_slice()
-                        }
-                        _ => &[],
-                    };
-                    super::search_project_texts::enforce_final_model_facing_hard_cap(
-                        &mut result,
-                        default_timeouts,
-                    );
-                }
-                _ => {}
-            }
-            // Dispatch deliberately kept the canonical batch envelope while an
-            // outer recording Session was pending. Only now, after final hard-cap
-            // enforcement has accounted for continuity/recovery/handoff/attention,
-            // project the response to the established sparse model-facing shape.
-            super::dispatch::sparsify_search_success_for_model(
-                &deferred_search_projection,
-                &mut result,
-            );
-            if request.tool_name == "read_files" {
-                super::read_files::add_actionable_read_continuations(
-                    &deferred_read_projection,
-                    &mut result,
-                );
-            }
-            super::dispatch::sparsify_complete_read_success(&request.tool_name, &mut result);
-        }
-        if context.session_id.is_some() && request.tool_name == "read_file" {
-            super::read_files::add_actionable_read_continuations(
-                &deferred_read_projection,
-                &mut result,
-            );
-        }
+        // Canonical execution evidence and every Session/context overlay are now
+        // complete. Consume the request-scoped plan exactly once to produce the
+        // final model-facing read/search result.
+        result_projection.project(&mut result);
         if request.tool_name == "tool_manifest" {
             super::surface::sparsify_tool_manifest_model_result(&mut result);
         }

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -1225,20 +1225,25 @@ async fn read_files_outer_recorder_observes_canonical_batch_before_primary_proje
     let runtime = ToolRuntime::new_for_tests();
     let client_id = "batch-canonical-before-projection";
     let project = register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
-    let session = runtime.sessions.start_session(
+    let recording_session = runtime.sessions.start_session(
         Some(project.clone()),
         Some("canonical batch evidence".to_string()),
+    );
+    let business_session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("inner business read".to_string()),
     );
     let auth = auth_context(None, true);
     let arguments = json!({
         "project": project,
         "items": [{"path": "a.rs"}, {"path": "b.rs"}],
+        "session_id": business_session.session_id,
         "max_result_bytes": 8192
     });
 
     let task = tokio::spawn({
         let runtime = runtime.clone();
-        let session_id = session.session_id.clone();
+        let session_id = recording_session.session_id.clone();
         let auth = auth.clone();
         async move {
             runtime
@@ -1261,7 +1266,7 @@ async fn read_files_outer_recorder_observes_canonical_batch_before_primary_proje
                 .await
         }
     });
-    let content = "x".repeat(12 * 1024);
+    let content = format!("{}\n", "x".repeat(3_000));
     for _ in 0..2 {
         let request = next_read_request(&runtime, client_id).await;
         complete_read(&runtime, client_id, &request, &content).await;
@@ -1270,17 +1275,34 @@ async fn read_files_outer_recorder_observes_canonical_batch_before_primary_proje
     let result = task.await.unwrap().result.expect("model-facing result");
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["output_truncated"], true);
-    assert!(result.output["returned_count"].as_u64().unwrap() < 2);
-
-    let summary = runtime
-        .sessions
-        .summary(&session.session_id, Some(20))
-        .unwrap();
-    let event = finished_event(&summary, "read_files");
+    assert_eq!(result.output["truncation_reason"], "batch_response_budget");
+    assert_eq!(result.output["returned_count"], 1);
+    assert_eq!(result.output["next_index"], 1);
     assert_eq!(
-        event.observed_paths,
+        result.output["continuation"]["suggested_call"]["arguments"]["session_id"],
+        business_session.session_id,
+        "model continuation must preserve the concrete business Session rather than inherit the outer recorder"
+    );
+
+    let recording_summary = runtime
+        .sessions
+        .summary(&recording_session.session_id, Some(20))
+        .unwrap();
+    let recording_event = finished_event(&recording_summary, "read_files");
+    assert_eq!(
+        recording_event.observed_paths,
         vec!["a.rs".to_string(), "b.rs".to_string()],
         "outer recorder must consume canonical batch evidence before the terminal model budget"
+    );
+    let business_summary = runtime
+        .sessions
+        .summary(&business_session.session_id, Some(20))
+        .unwrap();
+    let business_event = finished_event(&business_summary, "read_files");
+    assert_eq!(
+        business_event.observed_paths,
+        vec!["a.rs".to_string(), "b.rs".to_string()],
+        "concrete business Session must remain independently recorded with canonical evidence"
     );
 }
 

--- a/src/tool_runtime/tests/read_files.rs
+++ b/src/tool_runtime/tests/read_files.rs
@@ -1215,6 +1215,76 @@ async fn read_files_outer_recording_session_preserves_complete_sparse_shape() {
 }
 
 #[tokio::test]
+async fn read_files_outer_recorder_observes_canonical_batch_before_primary_projection() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolInvocationMetadata,
+        ToolProtocolCapabilities, ToolTransport,
+    };
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "batch-canonical-before-projection";
+    let project = register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("canonical batch evidence".to_string()),
+    );
+    let auth = auth_context(None, true);
+    let arguments = json!({
+        "project": project,
+        "items": [{"path": "a.rs"}, {"path": "b.rs"}],
+        "max_result_bytes": 8192
+    });
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .call_tool_with_invocation_metadata(
+                    ToolCallRequest {
+                        tool_name: "read_files".to_string(),
+                        arguments,
+                    },
+                    ToolCallContext {
+                        transport: ToolTransport::Mcp,
+                        session_id: Some(&session_id),
+                        auth: Some(&auth),
+                        window: None,
+                        record_oauth_scope_denials: false,
+                        host_file_import_trust: HostFileImportTrust::Untrusted,
+                    },
+                    ToolInvocationMetadata::default(),
+                    ToolProtocolCapabilities::default(),
+                )
+                .await
+        }
+    });
+    let content = "x".repeat(12 * 1024);
+    for _ in 0..2 {
+        let request = next_read_request(&runtime, client_id).await;
+        complete_read(&runtime, client_id, &request, &content).await;
+    }
+
+    let result = task.await.unwrap().result.expect("model-facing result");
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["output_truncated"], true);
+    assert!(result.output["returned_count"].as_u64().unwrap() < 2);
+
+    let summary = runtime
+        .sessions
+        .summary(&session.session_id, Some(20))
+        .unwrap();
+    let event = finished_event(&summary, "read_files");
+    assert_eq!(
+        event.observed_paths,
+        vec!["a.rs".to_string(), "b.rs".to_string()],
+        "outer recorder must consume canonical batch evidence before the terminal model budget"
+    );
+}
+
+#[tokio::test]
 async fn read_files_recovery_handoff_and_attention_overlays_stay_bounded() {
     use crate::tool_runtime::kernel::{
         HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolInvocationMetadata,

--- a/src/tool_runtime/tests/search_project_texts.rs
+++ b/src/tool_runtime/tests/search_project_texts.rs
@@ -2212,6 +2212,78 @@ async fn search_project_texts_outer_recording_session_preserves_complete_sparse_
 }
 
 #[tokio::test]
+async fn search_project_texts_outer_recorder_observes_canonical_batch_before_primary_projection() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolInvocationMetadata,
+        ToolProtocolCapabilities, ToolTransport,
+    };
+
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "search-canonical-before-projection";
+    let project = register_runner_project_at_path(&runtime, client_id, "demo", root.path()).await;
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("canonical search evidence".to_string()),
+    );
+    let auth = auth_context(None, true);
+    let arguments = json!({
+        "project": project,
+        "queries": [{"pattern": "needle-a"}, {"pattern": "needle-b"}],
+        "max_result_bytes": 8192
+    });
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .call_tool_with_invocation_metadata(
+                    ToolCallRequest {
+                        tool_name: "search_project_texts".to_string(),
+                        arguments,
+                    },
+                    ToolCallContext {
+                        transport: ToolTransport::Mcp,
+                        session_id: Some(&session_id),
+                        auth: Some(&auth),
+                        window: None,
+                        record_oauth_scope_denials: false,
+                        host_file_import_trust: HostFileImportTrust::Untrusted,
+                    },
+                    ToolInvocationMetadata::default(),
+                    ToolProtocolCapabilities::default(),
+                )
+                .await
+        }
+    });
+    for (pattern, path) in [("needle-a", "src/a.rs"), ("needle-b", "src/b.rs")] {
+        let request = wait_for_patch_agent_request(&runtime, client_id).await;
+        assert_eq!(request_pattern(&request), pattern);
+        let stdout = search_stdout("matches", path, &"z".repeat(12 * 1024));
+        complete_patch_agent_request(&runtime, client_id, &request.request_id, 0, &stdout, "")
+            .await;
+    }
+
+    let result = task.await.unwrap().result.expect("model-facing result");
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["output_truncated"], true);
+    assert!(result.output["returned_count"].as_u64().unwrap() < 2);
+
+    let summary = runtime
+        .sessions
+        .summary(&session.session_id, Some(20))
+        .unwrap();
+    let event = finished_event(&summary, "search_project_texts");
+    assert_eq!(
+        event.observed_paths,
+        vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+        "outer recorder must consume canonical search evidence before the terminal model budget"
+    );
+}
+
+#[tokio::test]
 async fn search_project_texts_outer_recording_session_keeps_final_response_under_hard_cap() {
     use crate::tool_runtime::kernel::{
         HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolInvocationMetadata,


### PR DESCRIPTION
## Summary

- Centralize `read_file` / `read_files` and `search_project_text` / `search_project_texts` terminal model-facing projection behind an opaque, request-scoped `ModelFacingProjectionPlan`.
- Preserve canonical execution evidence for permission/audit and both business/recording Workflow Session consumers before applying model-only batch budgets, final hard caps, continuations, and complete-success sparsification.
- Remove the former cross-layer defer protocol (`BatchResponseBudgetProjection`, `defer_batch_model_projection`, `defer_batch_sparsification`, deferred read/search projections, and the kernel read/search terminal switch).
- Keep business Session and outer recording Session identities independent; read continuation remains bound to the concrete business Session.

## Result pipeline

Before, dispatch and kernel jointly owned read/search projection ordering: request facts were captured in more than one layer, dispatch could apply primary batch projection before an outer recorder, and kernel had to repeat tool-specific final hard-cap/sparsification selection.

After:

`ToolCall -> capture opaque projection plan once -> canonical execution -> permission/audit/business Session/context consumers -> outer recording Session + continuity/recovery/attention overlays -> consume terminal projection plan once -> generic model metadata projection -> protocol framing`

The projection plan is intentionally internal/opaque: kernel can defer and consume it, but cannot branch on private read/search variants to recreate tool-specific projection policy.

## Regression coverage

Architecture regressions verify that model budget truncation does not remove canonical evidence from either the outer recording Session or the concrete business Session, and that continuation preserves the concrete business Session rather than inheriting the outer recorder.

A separate follow-up commit also lands two previously deferred, non-blocking review regressions:

- real Stateless MCP full-trace coverage proving two requests from the same `_meta["openai/session"]` get distinct `server_trace_id`s but the same 64-hex hashed `client_window_key`, while the raw opaque value appears in neither trace metadata nor compressed trace payloads;
- Adaptive Stateless `tool_manifest(intent="discovery")` remains the canonical curated intent even when the operator extension universe expands.

The adaptive gateway description is also corrected from “model-visible gateway-only” to “gateway-admitted”, matching the fact that protocol-admitted extensions may remain generic `ModelHidden` tools.

## Validation

Result-pipeline implementation/reviewer validation:

- `cargo test -p webcodex read_files` — 33 passed
- `cargo test -p webcodex search_project_texts` — 38 passed
- representative context/Session/hard-cap regressions passed
- `cargo check -p webcodex` — passed

Final follow-up validation:

- `stateless_full_trace_correlates_only_hashed_openai_window` — 1 passed
- `adaptive_stateless_discovery_intent_stays_curated` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo check -p webcodex` — passed, 0 warnings
- `git diff --check` / staged diff check — passed

The first run of the new window-trace regression used the unprefixed event name and failed as expected; the fixture was corrected to the real `mcp_tool_request_parsed` event and the same regression then passed. No production behavior was changed to satisfy that test.

## Commits

- `de128d02` Centralize terminal model result projection
- `dcba557d` Harden terminal model result projection
- `e6c9bc31` Add deferred tool surface regressions