### PR TITLE
Centralize heterogeneous gateway governance

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,24 @@ Runtime Console -----------------------> canonical Server HTTP/kernel paths abov
   registry, file/patch/artifact handling, shell execution, and LSP
   navigation.
 
+### Heterogeneous gateway governance
+
+The Kernel routes action-dependent gateways through
+`tool_runtime::specialized::try_dispatch_specialized_gateway` before the generic
+static ToolDefinition Session/permission lifecycle. This closed boundary
+classifies supported gateway names, uses the canonical typed `ToolCall` parser,
+and maps parse failures and shared governance denials to Kernel outcomes once.
+Ordinary tools fall through without specialized parsing or execution.
+
+`plugin_gateway` and `ssh_resource_gateway` own their action vocabulary, exact
+`SpecializedOperationPolicy`, execution protocols, uncertainty/recovery, and
+result conversion. They call the shared `govern_specialized_invocation` and
+`finish_specialized_invocation` lifecycle; the dispatcher does not repeat it.
+Static definitions retain their worst-case discovery policy. Trusted recording
+Session provenance is supported, while generic invocation continuity metadata
+receives no specialized semantics. Adding another heterogeneous gateway extends
+this closed dispatch boundary without adding a concrete Kernel policy branch.
+
 ### Cargo workspace ownership layers
 
 The checked-in [`workspace-boundaries.toml`](../workspace-boundaries.toml) is the

--- a/src/mcp_tests/ssh_resource.rs
+++ b/src/mcp_tests/ssh_resource.rs
@@ -600,3 +600,124 @@ async fn restricted_permission_denies_ssh_management_before_runner_dispatch() {
         .unwrap()
         .is_none());
 }
+
+#[tokio::test]
+async fn generic_runtime_ssh_resource_dispatch_preserves_native_requests_and_results() {
+    use crate::tool_runtime::kernel::{
+        HostFileImportTrust, ToolCallContext, ToolCallRequest, ToolTransport,
+    };
+    use webcodex_core::ssh_resource::SshResourceRequest;
+
+    let runtime = Arc::new(test_runtime());
+    let auth = ssh_auth();
+    register_managed_runner(&runtime, "instance-a").await;
+    let mut binding = String::new();
+    for (arguments, expected, response) in [
+        (
+            json!({"action":"list", "runner":"runner-a"}),
+            SshResourceRequest::List,
+            SshResourceResponse::List {
+                revision: 0,
+                resources: vec![],
+            },
+        ),
+        (
+            json!({"action":"register", "name":"test", "target":"user@host"}),
+            SshResourceRequest::Register {
+                expected_revision: 0,
+                name: "test".into(),
+                target: "user@host".into(),
+                default_cwd: None,
+            },
+            SshResourceResponse::Register {
+                revision: 1,
+                resource: "test".into(),
+                persisted: true,
+                active: false,
+                restart_required: true,
+            },
+        ),
+        (
+            json!({"action":"list", "runner":"runner-a"}),
+            SshResourceRequest::List,
+            SshResourceResponse::List {
+                revision: 1,
+                resources: vec![],
+            },
+        ),
+        (
+            json!({"action":"remove", "name":"test"}),
+            SshResourceRequest::Remove {
+                expected_revision: 1,
+                name: "test".into(),
+            },
+            SshResourceResponse::Remove {
+                revision: 2,
+                resource: "test".into(),
+                persisted: true,
+                active: true,
+                restart_required: true,
+            },
+        ),
+    ] {
+        let mut arguments = arguments;
+        let read = arguments["action"] == "list";
+        if !read {
+            arguments["binding"] = json!(binding);
+        }
+        let task = {
+            let runtime = Arc::clone(&runtime);
+            let auth = auth.clone();
+            tokio::spawn(async move {
+                runtime
+                    .call_tool_with_context(
+                        ToolCallRequest {
+                            tool_name: "ssh_resource".into(),
+                            arguments,
+                        },
+                        ToolCallContext {
+                            transport: ToolTransport::Api,
+                            session_id: None,
+                            auth: Some(&auth),
+                            window: None,
+                            record_oauth_scope_denials: true,
+                            host_file_import_trust: HostFileImportTrust::Untrusted,
+                        },
+                    )
+                    .await
+            })
+        };
+        let request = wait_for_request(&runtime, "instance-a").await;
+        assert_eq!(request.kind, "ssh_resource");
+        assert!(request.plugin_gateway.is_none());
+        assert_eq!(
+            serde_json::from_str::<SshResourceRequest>(request.content.as_deref().unwrap())
+                .unwrap(),
+            expected
+        );
+        complete_response(&runtime, request, "instance-a", response).await;
+        let outcome = task.await.unwrap();
+        assert!(outcome.success, "{outcome:?}");
+        assert!(outcome.error_status.is_none());
+        let output = outcome.result.unwrap().output;
+        if read {
+            binding = output["binding"].as_str().unwrap().to_string();
+        } else {
+            assert_eq!(output["persisted"], true);
+            assert_eq!(output["restart_required"], true);
+            assert!(!output.to_string().contains("user@host"));
+        }
+        assert!(
+            runtime
+                .runner_registry
+                .poll(RunnerPollRequest {
+                    client_id: "runner-a".into(),
+                    runner_instance_id: "instance-a".into(),
+                })
+                .await
+                .unwrap()
+                .is_none(),
+            "one kernel invocation must dispatch exactly once"
+        );
+    }
+}

--- a/src/runtime_http/tests/import_http_tests.rs
+++ b/src/runtime_http/tests/import_http_tests.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 const IMPORT_TEST_AGENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-const IMPORT_TEST_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+// The global import-network override is shared with MCP and DNS import fixtures.
+// Budget for queued full-suite contention while still failing a genuinely stuck wait.
+const IMPORT_TEST_LOCK_TIMEOUT: Duration = Duration::from_secs(60);
 const IMPORT_TEST_SERVER_IO_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn run_import_http_in_large_stack_test_thread<F, Fut>(test: F)

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -9,7 +9,6 @@ use super::{
 };
 use crate::auth::scopes::OAuthToolScopePolicy;
 use crate::auth::AuthContext;
-use crate::tool_runtime::specialized::SpecializedGovernanceDenial;
 use serde_json::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -425,132 +424,12 @@ impl ToolRuntime {
                 model_ergonomics: None,
             };
         }
-        // `plugin_tool` is a heterogeneous canonical gateway. Its static
-        // ToolDefinition intentionally describes worst-case visibility/risk,
-        // but exact execution policy comes from the validated `action`. Route
-        // it before the generic static Session/permission lifecycle so
-        // list/describe remain read-only and one invocation owns one ledger.
-        if request.tool_name == crate::plugin_gateway::PLUGIN_TOOL_NAME {
-            let concrete_arguments =
-                strip_tool_call_expectation_metadata(request.arguments.clone());
-            let call = match ToolCall::from_tool_name(&request.tool_name, concrete_arguments) {
-                Ok(call) => call,
-                Err(message) => {
-                    return ToolCallOutcome {
-                        success: false,
-                        result: None,
-                        error_status: Some(ToolCallErrorStatus::InvalidArguments { message }),
-                        project: None,
-                        model_ergonomics: None,
-                    }
-                }
-            };
-            let ToolCall::PluginTool(plugin) = call else {
-                unreachable!("plugin_tool parser must yield ToolCall::PluginTool");
-            };
-            return match crate::plugin_gateway::invoke(
-                self,
-                plugin,
-                context.session_id,
-                context.auth,
-                context.transport.into(),
-            )
-            .await
-            {
-                Ok(invocation) => {
-                    let result = invocation.to_tool_result();
-                    ToolCallOutcome {
-                        success: result.success,
-                        result: Some(result),
-                        error_status: None,
-                        project: None,
-                        model_ergonomics: None,
-                    }
-                }
-                Err(SpecializedGovernanceDenial::Scope {
-                    required_scope,
-                    description,
-                }) => ToolCallOutcome {
-                    success: false,
-                    result: None,
-                    error_status: Some(ToolCallErrorStatus::InsufficientScope {
-                        required_scope: Some(required_scope),
-                        description,
-                    }),
-                    project: None,
-                    model_ergonomics: None,
-                },
-                Err(SpecializedGovernanceDenial::Tool(result)) => ToolCallOutcome {
-                    success: result.success,
-                    result: Some(result),
-                    error_status: None,
-                    project: None,
-                    model_ergonomics: None,
-                },
-            };
-        }
-        // `ssh_resource` is the Adaptive secondary gateway for managed
-        // Runner-local SSH resources. Like plugin_tool, its static definition
-        // is worst-case policy while exact list/register/remove governance is
-        // derived from the validated action before generic static policy.
-        if request.tool_name == crate::ssh_resource_gateway::SSH_RESOURCE_TOOL_NAME {
-            let concrete_arguments =
-                strip_tool_call_expectation_metadata(request.arguments.clone());
-            let call = match ToolCall::from_tool_name(&request.tool_name, concrete_arguments) {
-                Ok(call) => call,
-                Err(message) => {
-                    return ToolCallOutcome {
-                        success: false,
-                        result: None,
-                        error_status: Some(ToolCallErrorStatus::InvalidArguments { message }),
-                        project: None,
-                        model_ergonomics: None,
-                    }
-                }
-            };
-            let ToolCall::SshResource(ssh_resource) = call else {
-                unreachable!("ssh_resource parser must yield ToolCall::SshResource");
-            };
-            return match crate::ssh_resource_gateway::invoke(
-                self,
-                ssh_resource,
-                context.session_id,
-                context.auth,
-                context.transport.into(),
-            )
-            .await
-            {
-                Ok(invocation) => {
-                    let result = invocation.to_tool_result();
-                    ToolCallOutcome {
-                        success: result.success,
-                        result: Some(result),
-                        error_status: None,
-                        project: None,
-                        model_ergonomics: None,
-                    }
-                }
-                Err(SpecializedGovernanceDenial::Scope {
-                    required_scope,
-                    description,
-                }) => ToolCallOutcome {
-                    success: false,
-                    result: None,
-                    error_status: Some(ToolCallErrorStatus::InsufficientScope {
-                        required_scope: Some(required_scope),
-                        description,
-                    }),
-                    project: None,
-                    model_ergonomics: None,
-                },
-                Err(SpecializedGovernanceDenial::Tool(result)) => ToolCallOutcome {
-                    success: result.success,
-                    result: Some(result),
-                    error_status: None,
-                    project: None,
-                    model_ergonomics: None,
-                },
-            };
+        // Action-dependent gateways resolve exact policy before the generic
+        // static Session/permission lifecycle and own one specialized ledger.
+        if let Some(outcome) =
+            super::specialized::try_dispatch_specialized_gateway(self, &request, context).await
+        {
+            return outcome;
         }
         let concrete_arguments = strip_tool_call_expectation_metadata(request.arguments.clone());
         let context_request = if capabilities.context_sidecar {

--- a/src/tool_runtime/specialized.rs
+++ b/src/tool_runtime/specialized.rs
@@ -18,6 +18,88 @@ use super::sessions::{
 use super::{ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
 
+/// The closed heterogeneous gateway boundary. `None` leaves ordinary tools
+/// untouched for the kernel's generic lifecycle. Recognized gateways never fall
+/// through, including on parse or governance denial.
+///
+/// Reuse the canonical typed ToolCall parser; action policy and native result
+/// conversion remain gateway-owned. Only trusted recorder/auth/transport context
+/// crosses this boundary: generic InvocationMetadata has no specialized meaning.
+pub(crate) async fn try_dispatch_specialized_gateway(
+    runtime: &ToolRuntime,
+    request: &super::kernel::ToolCallRequest,
+    context: super::kernel::ToolCallContext<'_>,
+) -> Option<super::kernel::ToolCallOutcome> {
+    use super::kernel::{ToolCallErrorStatus, ToolCallOutcome};
+    use super::sessions::strip_tool_call_expectation_metadata;
+    use super::ToolCall;
+
+    if !matches!(
+        request.tool_name.as_str(),
+        crate::plugin_gateway::PLUGIN_TOOL_NAME
+            | crate::ssh_resource_gateway::SSH_RESOURCE_TOOL_NAME
+    ) {
+        return None;
+    }
+
+    let arguments = strip_tool_call_expectation_metadata(request.arguments.clone());
+    let call = match ToolCall::from_tool_name(&request.tool_name, arguments) {
+        Ok(call) => call,
+        Err(message) => {
+            return Some(ToolCallOutcome {
+                success: false,
+                result: None,
+                error_status: Some(ToolCallErrorStatus::InvalidArguments { message }),
+                project: None,
+                model_ergonomics: None,
+            });
+        }
+    };
+    let invocation = match call {
+        ToolCall::PluginTool(call) => crate::plugin_gateway::invoke(
+            runtime,
+            call,
+            context.session_id,
+            context.auth,
+            context.transport.into(),
+        )
+        .await
+        .map(|invocation| invocation.to_tool_result()),
+        ToolCall::SshResource(call) => crate::ssh_resource_gateway::invoke(
+            runtime,
+            call,
+            context.session_id,
+            context.auth,
+            context.transport.into(),
+        )
+        .await
+        .map(|invocation| invocation.to_tool_result()),
+        _ => unreachable!("specialized gateway name must parse to its canonical ToolCall"),
+    };
+    Some(match invocation {
+        Ok(result) | Err(SpecializedGovernanceDenial::Tool(result)) => ToolCallOutcome {
+            success: result.success,
+            result: Some(result),
+            error_status: None,
+            project: None,
+            model_ergonomics: None,
+        },
+        Err(SpecializedGovernanceDenial::Scope {
+            required_scope,
+            description,
+        }) => ToolCallOutcome {
+            success: false,
+            result: None,
+            error_status: Some(ToolCallErrorStatus::InsufficientScope {
+                required_scope: Some(required_scope),
+                description,
+            }),
+            project: None,
+            model_ergonomics: None,
+        },
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SpecializedSource {
     Plugin,

--- a/src/tool_runtime/tests/mod.rs
+++ b/src/tool_runtime/tests/mod.rs
@@ -41,6 +41,7 @@ mod sessions_guards;
 mod sessions_instructions;
 mod sessions_resolver;
 mod skills;
+mod specialized_dispatch;
 mod startup_brief;
 mod sync_timeout;
 mod targeted_inventory;

--- a/src/tool_runtime/tests/specialized_dispatch.rs
+++ b/src/tool_runtime/tests/specialized_dispatch.rs
@@ -1,0 +1,181 @@
+//! Behavioral coverage of the shared pre-static-policy dispatch boundary.
+
+use super::super::kernel::{
+    HostFileImportTrust, ToolCallContext, ToolCallErrorStatus, ToolCallRequest, ToolTransport,
+};
+use super::super::specialized::try_dispatch_specialized_gateway;
+use super::super::ToolRuntime;
+use super::support::auth_context;
+use crate::auth::{
+    SCOPE_PLUGIN_INSPECT, SCOPE_PLUGIN_INVOKE, SCOPE_PLUGIN_MANAGE, SCOPE_SSH_LOCAL,
+};
+use serde_json::json;
+
+fn context() -> ToolCallContext<'static> {
+    ToolCallContext {
+        transport: ToolTransport::Api,
+        session_id: None,
+        auth: None,
+        window: None,
+        record_oauth_scope_denials: true,
+        host_file_import_trust: HostFileImportTrust::Untrusted,
+    }
+}
+
+#[tokio::test]
+async fn specialized_dispatch_leaves_ordinary_and_unknown_requests_untouched() {
+    let runtime = ToolRuntime::new_for_tests();
+    for tool_name in ["list_projects", "read_project_file", "unknown_gateway"] {
+        // Even malformed ordinary arguments belong to the generic lifecycle.
+        let request = ToolCallRequest {
+            tool_name: tool_name.to_string(),
+            arguments: json!(null),
+        };
+        assert!(
+            try_dispatch_specialized_gateway(&runtime, &request, context())
+                .await
+                .is_none()
+        );
+        assert_eq!(request.arguments, json!(null));
+    }
+}
+
+#[tokio::test]
+async fn specialized_dispatch_maps_each_gateway_action_scope_without_static_policy() {
+    let runtime = ToolRuntime::new_for_tests();
+    for (tool_name, arguments, scope) in [
+        (
+            "plugin_tool",
+            json!({"action":"list"}),
+            SCOPE_PLUGIN_INSPECT,
+        ),
+        (
+            "plugin_tool",
+            json!({"action":"describe", "runner":"runner", "plugin":"provider", "tool":"echo"}),
+            SCOPE_PLUGIN_INSPECT,
+        ),
+        (
+            "plugin_tool",
+            json!({"action":"call", "binding":"wc_pbind_00000000000000000000000000000000", "arguments":{}}),
+            SCOPE_PLUGIN_INVOKE,
+        ),
+        (
+            "plugin_tool",
+            json!({"action":"check", "runner":"runner", "plugin":"provider"}),
+            SCOPE_PLUGIN_MANAGE,
+        ),
+        (
+            "plugin_tool",
+            json!({"action":"reload", "runner":"runner"}),
+            SCOPE_PLUGIN_MANAGE,
+        ),
+        ("ssh_resource", json!({"action":"list"}), SCOPE_SSH_LOCAL),
+        (
+            "ssh_resource",
+            json!({"action":"register"}),
+            SCOPE_SSH_LOCAL,
+        ),
+        ("ssh_resource", json!({"action":"remove"}), SCOPE_SSH_LOCAL),
+    ] {
+        let request = ToolCallRequest {
+            tool_name: tool_name.to_string(),
+            arguments,
+        };
+        let outcome = try_dispatch_specialized_gateway(&runtime, &request, context())
+            .await
+            .unwrap();
+        assert!(!outcome.success);
+        assert!(outcome.result.is_none());
+        assert!(
+            matches!(outcome.error_status, Some(ToolCallErrorStatus::InsufficientScope {
+            required_scope: Some(required), ..
+        }) if required == scope),
+            "{request:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn specialized_dispatch_parse_failures_never_fall_through() {
+    let runtime = ToolRuntime::new_for_tests();
+    for tool_name in ["plugin_tool", "ssh_resource"] {
+        for arguments in [
+            json!(null),
+            json!({}),
+            json!({"action":"unknown"}),
+            json!({"action":"list", "binding":42}),
+        ] {
+            let request = ToolCallRequest {
+                tool_name: tool_name.to_string(),
+                arguments,
+            };
+            let outcome = try_dispatch_specialized_gateway(&runtime, &request, context())
+                .await
+                .unwrap();
+            assert!(!outcome.success);
+            assert!(outcome.result.is_none());
+            assert!(
+                matches!(
+                    outcome.error_status,
+                    Some(ToolCallErrorStatus::InvalidArguments { .. })
+                ),
+                "{request:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn specialized_dispatch_preserves_recording_authority_denial_as_tool_result() {
+    let runtime = ToolRuntime::new_for_tests();
+    let mut auth = auth_context(Some("alice"), false);
+    auth.scopes = vec![
+        SCOPE_PLUGIN_INSPECT.to_string(),
+        SCOPE_SSH_LOCAL.to_string(),
+    ];
+    let owner = auth_context(Some("bob"), false);
+    let fingerprint = super::super::workflow_session_authority_fingerprint(Some(&owner)).unwrap();
+    let session = runtime
+        .sessions
+        .start_session_with_options(
+            super::super::SessionCreateOptions::new(
+                None,
+                None,
+                super::super::SessionMode::Normal,
+                super::super::SessionGuards::default(),
+            )
+            .with_owner_authority_fingerprint(Some(fingerprint)),
+        )
+        .unwrap();
+    for (session_id, error_field, error_kind) in [
+        ("wc_sess_missing", "error_kind", "unknown_session_id"),
+        (
+            session.session_id.as_str(),
+            "failure_kind",
+            "session_authority_denied",
+        ),
+    ] {
+        for tool_name in ["plugin_tool", "ssh_resource"] {
+            let request = ToolCallRequest {
+                tool_name: tool_name.to_string(),
+                arguments: json!({"action":"list"}),
+            };
+            let outcome = try_dispatch_specialized_gateway(
+                &runtime,
+                &request,
+                ToolCallContext {
+                    auth: Some(&auth),
+                    session_id: Some(session_id),
+                    ..context()
+                },
+            )
+            .await
+            .unwrap();
+            assert!(!outcome.success);
+            assert!(outcome.error_status.is_none());
+            let result = outcome.result.unwrap();
+            assert_eq!(result.output[error_field], error_kind);
+            assert_eq!(result.output["dispatch_certainty"], "not_started");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- route action-dependent `plugin_tool` and `ssh_resource` through one closed specialized dispatch boundary before generic static ToolDefinition governance
- keep exact action policy, native execution protocol, uncertainty/recovery, and result conversion gateway-owned
- preserve one authoritative Session/permission lifecycle and fail closed on parse, scope, Session authority, guard, and permission denials
- document the heterogeneous gateway boundary and add focused exact-dispatch/governance coverage

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p webcodex`
- `cargo test -p webcodex specialized_` (8 passed)
- `cargo test -p webcodex generic_runtime_ssh_resource_dispatch_preserves_native_requests_and_results` (1 passed)
- `cargo test -p webcodex generic_runtime_plugin_` (2 passed)
- `git diff --check d8ea16c8..49c2df05`
- workspace hygiene: clean
