### PR TITLE
Close Runner V2 semantics behind typed operations

### DIFF
--- a/crates/webcodex-core/src/lib.rs
+++ b/crates/webcodex-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod plugin;
 pub mod project_context_contract;
 pub mod project_instructions;
 pub mod project_listing;
+pub mod runner_operation;
 pub mod runner_protocol;
 pub mod runtime_contract;
 pub mod sensitive_paths;

--- a/crates/webcodex-core/src/runner_operation.rs
+++ b/crates/webcodex-core/src/runner_operation.rs
@@ -1627,6 +1627,71 @@ mod tests {
         .unwrap()
     }
 
+    fn job_context(cwd: Option<&str>) -> ShellJobContext {
+        ShellJobContext {
+            runtime_project_id: None,
+            workflow_session_id: None,
+            ssh_resource: None,
+            project_cwd: None,
+            cwd: cwd.map(str::to_string),
+            purpose: Some("operation".to_string()),
+            shell: Some("configured".to_string()),
+            command_preview: "typed operation".to_string(),
+            validation_steps: Vec::new(),
+            validation: None,
+            structured_execution: None,
+        }
+    }
+
+    fn structured_job_context(
+        cwd: Option<&str>,
+        execution_source: &str,
+        language: Option<ShellScriptLanguage>,
+        script_bytes: Option<usize>,
+        arg_count: usize,
+        stdin_present: bool,
+    ) -> ShellJobContext {
+        let mut context = job_context(cwd);
+        context.shell = Some("direct_argv".to_string());
+        context.structured_execution = Some(ShellJobStructuredExecutionMetadata {
+            execution_source: execution_source.to_string(),
+            language,
+            script_bytes,
+            arg_count,
+            stdin_present,
+            validation_identity: None,
+            validation_tool: None,
+            assertion_name: None,
+        });
+        context
+    }
+
+    fn round_trip_kind(operation: RunnerOperation) -> RunnerRequest {
+        let expected_kind = operation.wire_kind();
+        let wire = RunnerRequest::from_operation(metadata(), operation)
+            .unwrap_or_else(|error| panic!("encode {expected_kind}: {error}"));
+        assert_eq!(wire.kind, expected_kind);
+        let decoded = wire
+            .decode_operation()
+            .unwrap_or_else(|error| panic!("decode {expected_kind}: {error}"));
+        assert_eq!(decoded.wire_kind(), expected_kind);
+        wire
+    }
+
+    fn file_payload(content: Option<&str>) -> RunnerFilePayload {
+        RunnerFilePayload {
+            cwd: Some("/repo".to_string()),
+            path: "path.txt".to_string(),
+            content: content.map(str::to_string),
+            max_bytes: None,
+            expected_sha256: None,
+            expected_prefix: None,
+            start_line: None,
+            end_line: None,
+            create_dirs: false,
+        }
+    }
+
     #[test]
     fn omitted_v2_kind_keeps_legacy_run_shell_default() {
         let value = serde_json::json!({
@@ -1763,5 +1828,594 @@ mod tests {
             wire.decode_operation().unwrap(),
             RunnerOperation::Project(_)
         ));
+    }
+
+    #[test]
+    fn every_current_runner_operation_kind_round_trips_through_v2() {
+        use std::collections::BTreeSet;
+
+        let script = ShellScriptPayload {
+            language: ShellScriptLanguage::Sh,
+            script: "printf ok".to_string(),
+            args: vec!["literal".to_string()],
+        };
+        let validation_step = ShellJobValidationStep {
+            name: "check".to_string(),
+            program: "cargo".to_string(),
+            args: vec!["check".to_string()],
+            env: Vec::new(),
+        };
+        let mut validation_context = job_context(Some("/repo"));
+        validation_context.validation_steps = vec!["check".to_string()];
+        let mut operations = vec![
+            RunnerOperation::RunShell(RunnerShellOperation {
+                cwd: Some("/repo".to_string()),
+                command: "printf ok".to_string(),
+                stdin: None,
+                timeout_secs: 30,
+                job_context: None,
+            }),
+            RunnerOperation::RunProcess(RunnerProcessOperation {
+                cwd: Some("/repo".to_string()),
+                process: ShellProcessArgv {
+                    executable: "printf".to_string(),
+                    args: vec!["ok".to_string()],
+                },
+                stdin: Some("input".to_string()),
+                timeout_secs: 30,
+            }),
+            RunnerOperation::RunScript(RunnerScriptOperation {
+                cwd: Some("/repo".to_string()),
+                script: script.clone(),
+                stdin: None,
+                timeout_secs: 30,
+            }),
+            RunnerOperation::RunInternalPosixScript(RunnerScriptOperation {
+                cwd: Some("/repo".to_string()),
+                script: ShellScriptPayload {
+                    language: ShellScriptLanguage::Sh,
+                    script: "printf internal".to_string(),
+                    args: Vec::new(),
+                },
+                stdin: None,
+                timeout_secs: 30,
+            }),
+            RunnerOperation::Job(RunnerJobOperation::StartShell(RunnerJobShellOperation {
+                job_id: "job-shell".to_string(),
+                cwd: Some("/repo".to_string()),
+                command: "printf job".to_string(),
+                timeout_secs: 60,
+                context: job_context(Some("/repo")),
+            })),
+            RunnerOperation::Job(RunnerJobOperation::StartValidation(
+                RunnerJobValidationOperation {
+                    job_id: "job-validation".to_string(),
+                    cwd: Some("/repo".to_string()),
+                    steps: vec![validation_step],
+                    timeout_secs: 60,
+                    context: validation_context,
+                },
+            )),
+            RunnerOperation::Job(RunnerJobOperation::StartProcess(
+                RunnerJobProcessOperation {
+                    job_id: "job-process".to_string(),
+                    cwd: Some("/repo".to_string()),
+                    process: ShellProcessArgv {
+                        executable: "process".to_string(),
+                        args: vec!["arg".to_string()],
+                    },
+                    stdin: None,
+                    timeout_secs: 60,
+                    context: structured_job_context(
+                        Some("/repo"),
+                        "run_process",
+                        None,
+                        None,
+                        1,
+                        false,
+                    ),
+                },
+            )),
+            RunnerOperation::Job(RunnerJobOperation::StartDetachedProcess(
+                RunnerJobProcessOperation {
+                    job_id: "job-detached".to_string(),
+                    cwd: Some("/repo".to_string()),
+                    process: ShellProcessArgv {
+                        executable: "process".to_string(),
+                        args: vec!["arg".to_string()],
+                    },
+                    stdin: None,
+                    timeout_secs: 60,
+                    context: structured_job_context(
+                        Some("/repo"),
+                        "run_detached_process",
+                        None,
+                        None,
+                        1,
+                        false,
+                    ),
+                },
+            )),
+            RunnerOperation::Job(RunnerJobOperation::StartScript(RunnerJobScriptOperation {
+                job_id: "job-script".to_string(),
+                cwd: Some("/repo".to_string()),
+                script: script.clone(),
+                stdin: None,
+                timeout_secs: 60,
+                context: structured_job_context(
+                    Some("/repo"),
+                    "run_script",
+                    Some(ShellScriptLanguage::Sh),
+                    Some(script.script.len()),
+                    script.args.len(),
+                    false,
+                ),
+            })),
+            RunnerOperation::Job(RunnerJobOperation::Stop {
+                job_id: "job-stop".to_string(),
+            }),
+            RunnerOperation::Validation {
+                payload: ValidationBridgeRequest {
+                    protocol_version: crate::validation_bridge::VALIDATION_BRIDGE_PROTOCOL_VERSION,
+                    adapter_id: "pyright".to_string(),
+                    language: "python".to_string(),
+                    validation_kind: "typecheck".to_string(),
+                    project_id: "demo".to_string(),
+                    cwd: None,
+                    targets: Vec::new(),
+                    timeout_secs: 60,
+                },
+                timeout_secs: 60,
+            },
+            RunnerOperation::Lsp {
+                payload: RunnerLspPayload {
+                    project_id: "demo".to_string(),
+                    request: crate::lsp_bridge::RunnerLspRequest::Status,
+                },
+                timeout_secs: 30,
+            },
+            RunnerOperation::PersistentShell(RunnerPersistentShellOperation {
+                request: PersistentShellRequest {
+                    action: "status".to_string(),
+                    shell_id: "shell-1".to_string(),
+                    workflow_session_id: "wc_sess_123456".to_string(),
+                    runtime_project_id: "agent:runner-1:demo".to_string(),
+                    cwd: None,
+                    shell: None,
+                    command: None,
+                    timeout_secs: None,
+                    purpose: None,
+                },
+                job_context: None,
+            }),
+            RunnerOperation::McpGateway(McpGatewayRequest::ToolsList {
+                provider_id: "provider".to_string(),
+                provider_instance_id: "instance".to_string(),
+            }),
+            RunnerOperation::PluginGateway(PluginGatewayRequest::Reload),
+            RunnerOperation::CodingAgent(crate::coding_agent::CodingAgentRequest::Start(
+                crate::coding_agent::CodingAgentStartRequest {
+                    run_id: "wc_agent_run_0123456789abcdef".to_string(),
+                    intent_fingerprint: "cafebabe".to_string(),
+                    authority_fingerprint: "auth_0123456789abcdef".to_string(),
+                    runtime_project_id: "agent:runner-1:demo".to_string(),
+                    project_root: "/repo".to_string(),
+                    provider_id: "codex".to_string(),
+                    provider_instance_id: "provider_123".to_string(),
+                    instruction: "inspect repository".to_string(),
+                    config: std::collections::BTreeMap::new(),
+                    timeout_secs: 60,
+                },
+            )),
+            RunnerOperation::SkillStore(crate::skill_store::SkillStoreRequest::ListActive),
+            RunnerOperation::SshResource(crate::ssh_resource::SshResourceRequest::List),
+            RunnerOperation::RunnerConfig(RunnerConfigOperationRequest {
+                action: crate::runner_protocol::RunnerConfigAction::Check,
+                expected_generation: None,
+            }),
+        ];
+
+        let file_operations = vec![
+            RunnerFileOperation::Read(file_payload(None)),
+            RunnerFileOperation::Write(file_payload(Some("body"))),
+            RunnerFileOperation::List(file_payload(None)),
+            RunnerFileOperation::ProjectOverview(file_payload(None)),
+            RunnerFileOperation::DeleteProjectFiles(file_payload(None)),
+            RunnerFileOperation::WriteProjectFile(file_payload(None)),
+            RunnerFileOperation::ApplyTextEdits(file_payload(None)),
+            RunnerFileOperation::ApplyPatch(file_payload(None)),
+            RunnerFileOperation::SaveProjectArtifact(file_payload(None)),
+            RunnerFileOperation::ReadProjectArtifactMetadata(file_payload(None)),
+            RunnerFileOperation::ReadProjectArtifact(file_payload(None)),
+            RunnerFileOperation::ReadProjectArtifactExportChunk(file_payload(None)),
+            RunnerFileOperation::ArtifactUploadBegin(file_payload(None)),
+            RunnerFileOperation::ArtifactUploadChunk(file_payload(None)),
+            RunnerFileOperation::ArtifactUploadFinish(file_payload(None)),
+            RunnerFileOperation::ArtifactUploadAbort(file_payload(None)),
+            RunnerFileOperation::CheckpointCreate(file_payload(None)),
+            RunnerFileOperation::CheckpointRestore(file_payload(None)),
+            RunnerFileOperation::SkillListPackages(file_payload(None)),
+            RunnerFileOperation::SkillReadFile(file_payload(None)),
+        ];
+        operations.extend(file_operations.into_iter().map(RunnerOperation::File));
+
+        for kind in [
+            RunnerProjectOperationKind::Register,
+            RunnerProjectOperationKind::Create,
+            RunnerProjectOperationKind::ResolveOrRegister,
+            RunnerProjectOperationKind::PrepareManagedWorktree,
+            RunnerProjectOperationKind::LifecycleEnable,
+            RunnerProjectOperationKind::LifecycleDisable,
+            RunnerProjectOperationKind::LifecycleUnregister,
+        ] {
+            operations.push(RunnerOperation::Project(RunnerProjectOperation {
+                kind,
+                payload: "{}".to_string(),
+            }));
+        }
+
+        for kind in [
+            RunnerComputerOperationKind::ListWindows,
+            RunnerComputerOperationKind::ListApplications,
+            RunnerComputerOperationKind::LaunchApplication,
+            RunnerComputerOperationKind::ListDisplays,
+            RunnerComputerOperationKind::SnapshotDisplay,
+            RunnerComputerOperationKind::ReadClipboard,
+            RunnerComputerOperationKind::WriteClipboard,
+            RunnerComputerOperationKind::PointerMove,
+            RunnerComputerOperationKind::PointerClick,
+            RunnerComputerOperationKind::Snapshot,
+            RunnerComputerOperationKind::SnapshotRegion,
+            RunnerComputerOperationKind::AccessibilityStatus,
+            RunnerComputerOperationKind::AccessibilityTree,
+            RunnerComputerOperationKind::ElementState,
+            RunnerComputerOperationKind::ActivateWindow,
+            RunnerComputerOperationKind::Control,
+            RunnerComputerOperationKind::ScrollToElement,
+            RunnerComputerOperationKind::KeyInput,
+            RunnerComputerOperationKind::InputText,
+        ] {
+            operations.push(RunnerOperation::Computer(RunnerComputerOperation {
+                kind,
+                payload: "{}".to_string(),
+                timeout_secs: 30,
+            }));
+        }
+
+        let expected = BTreeSet::from([
+            "run_shell",
+            "run_process",
+            "run_script",
+            "run_internal_posix_script",
+            "start_job",
+            "start_validation_job",
+            "start_process_job",
+            "start_detached_process_job",
+            "start_script_job",
+            "stop_job",
+            "file_read",
+            "file_write",
+            "file_list",
+            "file_project_overview",
+            "file_delete_project_files",
+            "file_write_project_file",
+            "file_apply_text_edits",
+            "file_apply_patch",
+            "file_save_project_artifact",
+            "file_read_project_artifact_metadata",
+            "file_read_project_artifact",
+            "file_read_project_artifact_export_chunk",
+            "file_artifact_upload_begin",
+            "file_artifact_upload_chunk",
+            "file_artifact_upload_finish",
+            "file_artifact_upload_abort",
+            "file_checkpoint_create",
+            "file_checkpoint_restore",
+            "file_skill_list_packages",
+            "file_skill_read_file",
+            "register_project",
+            "create_project",
+            "resolve_or_register_project",
+            "prepare_managed_worktree",
+            "project_lifecycle_enable",
+            "project_lifecycle_disable",
+            "project_lifecycle_unregister",
+            "computer_list_windows",
+            "computer_list_applications",
+            "computer_launch_application",
+            "computer_list_displays",
+            "computer_snapshot_display",
+            "computer_read_clipboard",
+            "computer_write_clipboard",
+            "computer_pointer_move",
+            "computer_pointer_click",
+            "computer_snapshot",
+            "computer_snapshot_region",
+            "computer_accessibility_status",
+            "computer_accessibility_tree",
+            "computer_element_state",
+            "computer_activate_window",
+            "computer_control",
+            "computer_scroll_to_element",
+            "computer_key_input",
+            "computer_input_text",
+            crate::validation_bridge::AGENT_VALIDATION_REQUEST_KIND,
+            crate::lsp_bridge::AGENT_LSP_REQUEST_KIND,
+            "persistent_shell",
+            "mcp_gateway",
+            "plugin_gateway",
+            "coding_agent",
+            "skill_store",
+            "ssh_resource",
+            RUNNER_CONFIG_REQUEST_KIND,
+        ]);
+        let seen = operations
+            .into_iter()
+            .map(|operation| round_trip_kind(operation).kind)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(seen, expected.into_iter().map(str::to_string).collect());
+    }
+
+    #[test]
+    fn representative_v2_json_shapes_keep_field_names_and_canonical_payload_placement() {
+        let shell = serde_json::to_value(round_trip_kind(RunnerOperation::RunShell(
+            RunnerShellOperation {
+                cwd: Some("/repo".to_string()),
+                command: "printf ok".to_string(),
+                stdin: None,
+                timeout_secs: 30,
+                job_context: None,
+            },
+        )))
+        .unwrap();
+        assert_eq!(shell["kind"], "run_shell");
+        assert_eq!(shell["command"], "printf ok");
+        assert!(shell.get("process").is_none());
+        assert!(shell.get("script").is_none());
+
+        let process = serde_json::to_value(round_trip_kind(RunnerOperation::RunProcess(
+            RunnerProcessOperation {
+                cwd: None,
+                process: ShellProcessArgv {
+                    executable: "printf".to_string(),
+                    args: vec!["ok".to_string()],
+                },
+                stdin: None,
+                timeout_secs: 30,
+            },
+        )))
+        .unwrap();
+        assert_eq!(process["kind"], "run_process");
+        assert!(process.get("process").is_some());
+        assert!(process.get("script").is_none());
+        assert_eq!(process["command"], "");
+
+        let script = ShellScriptPayload {
+            language: ShellScriptLanguage::Sh,
+            script: "printf script".to_string(),
+            args: Vec::new(),
+        };
+        let script_value = serde_json::to_value(round_trip_kind(RunnerOperation::RunScript(
+            RunnerScriptOperation {
+                cwd: None,
+                script,
+                stdin: None,
+                timeout_secs: 30,
+            },
+        )))
+        .unwrap();
+        assert_eq!(script_value["kind"], "run_script");
+        assert!(script_value.get("script").is_some());
+        assert!(script_value.get("process").is_none());
+        assert_eq!(script_value["command"], "");
+
+        let plugin = serde_json::to_value(round_trip_kind(RunnerOperation::PluginGateway(
+            PluginGatewayRequest::Reload,
+        )))
+        .unwrap();
+        assert_eq!(plugin["kind"], "plugin_gateway");
+        assert!(plugin.get("plugin_gateway").is_some());
+        assert!(plugin.get("mcp_gateway").is_none());
+        assert!(plugin.get("coding_agent").is_none());
+    }
+
+    #[test]
+    fn representative_specialized_and_job_v2_json_fields_are_stable() {
+        fn assert_field(operation: RunnerOperation, kind: &str, field: &str) {
+            let value = serde_json::to_value(round_trip_kind(operation)).unwrap();
+            assert_eq!(value["kind"], kind);
+            assert!(
+                value.get(field).is_some(),
+                "{kind} must keep V2 field {field}"
+            );
+        }
+
+        assert_field(
+            RunnerOperation::Validation {
+                payload: ValidationBridgeRequest {
+                    protocol_version: crate::validation_bridge::VALIDATION_BRIDGE_PROTOCOL_VERSION,
+                    adapter_id: "pyright".to_string(),
+                    language: "python".to_string(),
+                    validation_kind: "typecheck".to_string(),
+                    project_id: "demo".to_string(),
+                    cwd: None,
+                    targets: Vec::new(),
+                    timeout_secs: 60,
+                },
+                timeout_secs: 60,
+            },
+            crate::validation_bridge::AGENT_VALIDATION_REQUEST_KIND,
+            "validation",
+        );
+        assert_field(
+            RunnerOperation::Lsp {
+                payload: RunnerLspPayload {
+                    project_id: "demo".to_string(),
+                    request: crate::lsp_bridge::RunnerLspRequest::Status,
+                },
+                timeout_secs: 30,
+            },
+            crate::lsp_bridge::AGENT_LSP_REQUEST_KIND,
+            "lsp",
+        );
+        assert_field(
+            RunnerOperation::Job(RunnerJobOperation::StartShell(RunnerJobShellOperation {
+                job_id: "job-shell-json".to_string(),
+                cwd: Some("/repo".to_string()),
+                command: "printf job".to_string(),
+                timeout_secs: 60,
+                context: job_context(Some("/repo")),
+            })),
+            "start_job",
+            "job_context",
+        );
+        assert_field(
+            RunnerOperation::Job(RunnerJobOperation::StartDetachedProcess(
+                RunnerJobProcessOperation {
+                    job_id: "job-detached-json".to_string(),
+                    cwd: Some("/repo".to_string()),
+                    process: ShellProcessArgv {
+                        executable: "process".to_string(),
+                        args: vec!["arg".to_string()],
+                    },
+                    stdin: None,
+                    timeout_secs: 60,
+                    context: structured_job_context(
+                        Some("/repo"),
+                        "run_detached_process",
+                        None,
+                        None,
+                        1,
+                        false,
+                    ),
+                },
+            )),
+            "start_detached_process_job",
+            "process",
+        );
+        assert_field(
+            RunnerOperation::PersistentShell(RunnerPersistentShellOperation {
+                request: PersistentShellRequest {
+                    action: "status".to_string(),
+                    shell_id: "shell-json".to_string(),
+                    workflow_session_id: "wc_sess_123456".to_string(),
+                    runtime_project_id: "agent:runner-1:demo".to_string(),
+                    cwd: None,
+                    shell: None,
+                    command: None,
+                    timeout_secs: None,
+                    purpose: None,
+                },
+                job_context: None,
+            }),
+            "persistent_shell",
+            "persistent_shell",
+        );
+        assert_field(
+            RunnerOperation::McpGateway(McpGatewayRequest::ToolsList {
+                provider_id: "provider".to_string(),
+                provider_instance_id: "instance".to_string(),
+            }),
+            "mcp_gateway",
+            "mcp_gateway",
+        );
+        assert_field(
+            RunnerOperation::PluginGateway(PluginGatewayRequest::Reload),
+            "plugin_gateway",
+            "plugin_gateway",
+        );
+        assert_field(
+            RunnerOperation::CodingAgent(crate::coding_agent::CodingAgentRequest::Start(
+                crate::coding_agent::CodingAgentStartRequest {
+                    run_id: "wc_agent_run_0123456789abcdef".to_string(),
+                    intent_fingerprint: "cafebabe".to_string(),
+                    authority_fingerprint: "auth_0123456789abcdef".to_string(),
+                    runtime_project_id: "agent:runner-1:demo".to_string(),
+                    project_root: "/repo".to_string(),
+                    provider_id: "codex".to_string(),
+                    provider_instance_id: "provider_123".to_string(),
+                    instruction: "inspect repository".to_string(),
+                    config: std::collections::BTreeMap::new(),
+                    timeout_secs: 60,
+                },
+            )),
+            "coding_agent",
+            "coding_agent",
+        );
+        assert_field(
+            RunnerOperation::File(RunnerFileOperation::Write(file_payload(Some("body")))),
+            "file_write",
+            "path",
+        );
+        assert_field(
+            RunnerOperation::Project(RunnerProjectOperation {
+                kind: RunnerProjectOperationKind::Register,
+                payload: "{}".to_string(),
+            }),
+            "register_project",
+            "stdin",
+        );
+    }
+
+    #[test]
+    fn missing_or_cross_family_payloads_fail_closed() {
+        for (kind, expected) in [
+            ("run_process", "process payload"),
+            ("run_script", "script payload"),
+            (crate::lsp_bridge::AGENT_LSP_REQUEST_KIND, "lsp payload"),
+            ("persistent_shell", "persistent_shell payload"),
+            ("mcp_gateway", "mcp_gateway payload"),
+            ("plugin_gateway", "plugin_gateway payload"),
+            ("coding_agent", "coding_agent payload"),
+        ] {
+            let mut wire = shell_wire();
+            wire.kind = kind.to_string();
+            wire.command.clear();
+            wire.cwd = None;
+            let error = wire.decode_operation().unwrap_err();
+            assert!(error.contains(expected), "{kind}: {error}");
+        }
+
+        let mut raw_shell_with_process = shell_wire();
+        raw_shell_with_process.process = Some(ShellProcessArgv {
+            executable: "printf".to_string(),
+            args: Vec::new(),
+        });
+        assert!(raw_shell_with_process
+            .decode_operation()
+            .unwrap_err()
+            .contains("incompatible"));
+
+        let lsp = RunnerRequest::from_operation(
+            metadata(),
+            RunnerOperation::Lsp {
+                payload: RunnerLspPayload {
+                    project_id: "demo".to_string(),
+                    request: crate::lsp_bridge::RunnerLspRequest::Status,
+                },
+                timeout_secs: 30,
+            },
+        )
+        .unwrap();
+        let mut lsp_with_plugin = lsp;
+        lsp_with_plugin.plugin_gateway = Some(PluginGatewayRequest::Reload);
+        assert!(lsp_with_plugin
+            .decode_operation()
+            .unwrap_err()
+            .contains("conflicting"));
+
+        let mut plugin_with_mcp = RunnerRequest::from_operation(
+            metadata(),
+            RunnerOperation::PluginGateway(PluginGatewayRequest::Reload),
+        )
+        .unwrap();
+        plugin_with_mcp.mcp_gateway = Some(McpGatewayRequest::ToolsList {
+            provider_id: "provider".to_string(),
+            provider_instance_id: "instance".to_string(),
+        });
+        assert!(plugin_with_mcp
+            .decode_operation()
+            .unwrap_err()
+            .contains("conflicting"));
     }
 }

--- a/crates/webcodex-core/src/runner_operation.rs
+++ b/crates/webcodex-core/src/runner_operation.rs
@@ -1,0 +1,1708 @@
+//! Canonical semantic Runner operations and the V2 request wire adapter.
+//!
+//! `RunnerRequest` intentionally remains the compatibility DTO used by all V2
+//! transports. Production semantics should use `RunnerOperation`: the V2
+//! `kind + optional payload bag` is decoded and validated once at the boundary,
+//! then operation identity and its required payload travel together.
+
+use crate::coding_agent::{validate_request as validate_coding_agent_request, CodingAgentRequest};
+use crate::lsp_bridge::RunnerLspPayload;
+use crate::mcp_gateway::{validate_request as validate_mcp_gateway_request, McpGatewayRequest};
+use crate::plugin::{validate_request as validate_plugin_gateway_request, PluginGatewayRequest};
+use crate::runner_protocol::{
+    shell_computer_request_payload_max_bytes, validate_process_argv,
+    validate_raw_shell_wire_command, validate_script_request, PersistentShellRequest,
+    RunnerConfigOperationRequest, RunnerRequest, ShellFileOpRequest, ShellJobContext,
+    ShellJobStructuredExecutionMetadata, ShellJobValidationStep, ShellProcessArgv,
+    ShellScriptLanguage, ShellScriptPayload, PROCESS_CWD_MAX_BYTES, PROCESS_STDIN_MAX_BYTES,
+    RUNNER_CONFIG_REQUEST_KIND, RUNNER_CONFIG_REQUEST_MAX_BYTES,
+    STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS, STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS,
+    STRUCTURED_EXECUTION_TIMEOUT_MIN_SECS,
+};
+use crate::skill_store::SkillStoreRequest;
+use crate::ssh_resource::{SshResourceRequest, SSH_RESOURCE_REQUEST_MAX_BYTES};
+use crate::validation_bridge::{validate_bridge_request, ValidationBridgeRequest};
+
+/// Request/envelope metadata that is independent of operation semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerInvocationMetadata {
+    pub request_id: String,
+    pub client_id: String,
+    pub requested_by: String,
+    pub created_at: i64,
+}
+
+/// Canonical internal Runner invocation.
+#[derive(Debug, Clone)]
+pub struct RunnerInvocation {
+    pub metadata: RunnerInvocationMetadata,
+    pub operation: RunnerOperation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerShellOperation {
+    pub cwd: Option<String>,
+    pub command: String,
+    pub stdin: Option<String>,
+    pub timeout_secs: u64,
+    /// Present only for Session-bound SSH raw-shell execution.
+    pub job_context: Option<ShellJobContext>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerProcessOperation {
+    pub cwd: Option<String>,
+    pub process: ShellProcessArgv,
+    pub stdin: Option<String>,
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerScriptOperation {
+    pub cwd: Option<String>,
+    pub script: ShellScriptPayload,
+    pub stdin: Option<String>,
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerJobShellOperation {
+    pub job_id: String,
+    pub cwd: Option<String>,
+    pub command: String,
+    pub timeout_secs: u64,
+    pub context: ShellJobContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerJobValidationOperation {
+    pub job_id: String,
+    pub cwd: Option<String>,
+    pub steps: Vec<ShellJobValidationStep>,
+    pub timeout_secs: u64,
+    pub context: ShellJobContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerJobProcessOperation {
+    pub job_id: String,
+    pub cwd: Option<String>,
+    pub process: ShellProcessArgv,
+    pub stdin: Option<String>,
+    pub timeout_secs: u64,
+    pub context: ShellJobContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerJobScriptOperation {
+    pub job_id: String,
+    pub cwd: Option<String>,
+    pub script: ShellScriptPayload,
+    pub stdin: Option<String>,
+    pub timeout_secs: u64,
+    pub context: ShellJobContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunnerJobOperation {
+    StartShell(RunnerJobShellOperation),
+    StartValidation(RunnerJobValidationOperation),
+    StartProcess(RunnerJobProcessOperation),
+    StartDetachedProcess(RunnerJobProcessOperation),
+    StartScript(RunnerJobScriptOperation),
+    Stop { job_id: String },
+}
+
+impl RunnerJobOperation {
+    pub fn job_id(&self) -> &str {
+        match self {
+            Self::StartShell(operation) => &operation.job_id,
+            Self::StartValidation(operation) => &operation.job_id,
+            Self::StartProcess(operation) | Self::StartDetachedProcess(operation) => {
+                &operation.job_id
+            }
+            Self::StartScript(operation) => &operation.job_id,
+            Self::Stop { job_id } => job_id,
+        }
+    }
+
+    pub fn context(&self) -> Option<&ShellJobContext> {
+        match self {
+            Self::StartShell(operation) => Some(&operation.context),
+            Self::StartValidation(operation) => Some(&operation.context),
+            Self::StartProcess(operation) | Self::StartDetachedProcess(operation) => {
+                Some(&operation.context)
+            }
+            Self::StartScript(operation) => Some(&operation.context),
+            Self::Stop { .. } => None,
+        }
+    }
+
+    pub fn cwd(&self) -> Option<&str> {
+        match self {
+            Self::StartShell(operation) => operation.cwd.as_deref(),
+            Self::StartValidation(operation) => operation.cwd.as_deref(),
+            Self::StartProcess(operation) | Self::StartDetachedProcess(operation) => {
+                operation.cwd.as_deref()
+            }
+            Self::StartScript(operation) => operation.cwd.as_deref(),
+            Self::Stop { .. } => None,
+        }
+    }
+
+    pub fn is_detached_process(&self) -> bool {
+        matches!(self, Self::StartDetachedProcess(_))
+    }
+
+    pub fn is_start(&self) -> bool {
+        !matches!(self, Self::Stop { .. })
+    }
+
+    /// Derive the execution metadata that must be persisted in Job recovery
+    /// context. Correlation-only validation identity/tool/assertion fields are
+    /// copied from the admitted context; they never grant execution authority.
+    pub fn expected_structured_execution(&self) -> Option<ShellJobStructuredExecutionMetadata> {
+        let correlation = self
+            .context()
+            .and_then(|context| context.structured_execution.as_ref())
+            .map(|metadata| {
+                (
+                    metadata.validation_identity.clone(),
+                    metadata.validation_tool.clone(),
+                    metadata.assertion_name.clone(),
+                )
+            })
+            .unwrap_or((None, None, None));
+        match self {
+            Self::StartProcess(operation) => Some(ShellJobStructuredExecutionMetadata {
+                execution_source: "run_process".to_string(),
+                language: None,
+                script_bytes: None,
+                arg_count: operation.process.args.len(),
+                stdin_present: operation.stdin.is_some(),
+                validation_identity: correlation.0,
+                validation_tool: correlation.1,
+                assertion_name: correlation.2,
+            }),
+            Self::StartDetachedProcess(operation) => Some(ShellJobStructuredExecutionMetadata {
+                execution_source: "run_detached_process".to_string(),
+                language: None,
+                script_bytes: None,
+                arg_count: operation.process.args.len(),
+                stdin_present: operation.stdin.is_some(),
+                validation_identity: correlation.0,
+                validation_tool: correlation.1,
+                assertion_name: None,
+            }),
+            Self::StartScript(operation) => Some(ShellJobStructuredExecutionMetadata {
+                execution_source: "run_script".to_string(),
+                language: Some(operation.script.language),
+                script_bytes: Some(operation.script.script.len()),
+                arg_count: operation.script.args.len(),
+                stdin_present: operation.stdin.is_some(),
+                validation_identity: correlation.0,
+                validation_tool: correlation.1,
+                assertion_name: correlation.2,
+            }),
+            Self::StartShell(_) | Self::StartValidation(_) | Self::Stop { .. } => None,
+        }
+    }
+}
+
+/// Legacy V2 file-operation fields, now scoped under a closed file operation
+/// instead of sharing the top-level Runner request payload bag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerFilePayload {
+    pub cwd: Option<String>,
+    pub path: String,
+    pub content: Option<String>,
+    pub max_bytes: Option<usize>,
+    pub expected_sha256: Option<String>,
+    pub expected_prefix: Option<String>,
+    pub start_line: Option<usize>,
+    pub end_line: Option<usize>,
+    pub create_dirs: bool,
+}
+
+macro_rules! runner_file_operations {
+    ($(($variant:ident, $wire:literal, $server:literal)),+ $(,)?) => {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub enum RunnerFileOperation {
+            $($variant(RunnerFilePayload)),+
+        }
+
+        impl RunnerFileOperation {
+            pub fn wire_kind(&self) -> &'static str {
+                match self { $(Self::$variant(_) => $wire),+ }
+            }
+
+            pub fn server_op(&self) -> &'static str {
+                match self { $(Self::$variant(_) => $server),+ }
+            }
+
+            pub fn payload(&self) -> &RunnerFilePayload {
+                match self { $(Self::$variant(payload) => payload),+ }
+            }
+
+            fn from_wire_kind(kind: &str, payload: RunnerFilePayload) -> Result<Self, String> {
+                validate_file_payload(kind, &payload)?;
+                match kind {
+                    $($wire => Ok(Self::$variant(payload))),+,
+                    _ => Err(format!("unknown Runner V2 request kind: {kind}")),
+                }
+            }
+
+            pub fn from_server_request(body: &ShellFileOpRequest) -> Result<Self, String> {
+                let payload = RunnerFilePayload {
+                    cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
+                    path: body.path.trim().to_string(),
+                    content: body.content.clone(),
+                    max_bytes: body.max_bytes,
+                    expected_sha256: body.expected_sha256.clone(),
+                    expected_prefix: body.expected_prefix.clone(),
+                    start_line: body.start_line,
+                    end_line: body.end_line,
+                    create_dirs: body.create_dirs,
+                };
+                match body.op.as_str() {
+                    $($server => Self::from_wire_kind($wire, payload)),+,
+                    _ => Err(format!("unsupported Runner file operation: {}", body.op)),
+                }
+            }
+        }
+    };
+}
+
+runner_file_operations!(
+    (Read, "file_read", "read"),
+    (Write, "file_write", "write"),
+    (List, "file_list", "list"),
+    (ProjectOverview, "file_project_overview", "project_overview"),
+    (
+        DeleteProjectFiles,
+        "file_delete_project_files",
+        "delete_project_files"
+    ),
+    (
+        WriteProjectFile,
+        "file_write_project_file",
+        "write_project_file"
+    ),
+    (ApplyTextEdits, "file_apply_text_edits", "apply_text_edits"),
+    (ApplyPatch, "file_apply_patch", "apply_patch"),
+    (
+        SaveProjectArtifact,
+        "file_save_project_artifact",
+        "save_project_artifact"
+    ),
+    (
+        ReadProjectArtifactMetadata,
+        "file_read_project_artifact_metadata",
+        "read_project_artifact_metadata"
+    ),
+    (
+        ReadProjectArtifact,
+        "file_read_project_artifact",
+        "read_project_artifact"
+    ),
+    (
+        ReadProjectArtifactExportChunk,
+        "file_read_project_artifact_export_chunk",
+        "read_project_artifact_export_chunk"
+    ),
+    (
+        ArtifactUploadBegin,
+        "file_artifact_upload_begin",
+        "artifact_upload_begin"
+    ),
+    (
+        ArtifactUploadChunk,
+        "file_artifact_upload_chunk",
+        "artifact_upload_chunk"
+    ),
+    (
+        ArtifactUploadFinish,
+        "file_artifact_upload_finish",
+        "artifact_upload_finish"
+    ),
+    (
+        ArtifactUploadAbort,
+        "file_artifact_upload_abort",
+        "artifact_upload_abort"
+    ),
+    (
+        CheckpointCreate,
+        "file_checkpoint_create",
+        "checkpoint_create"
+    ),
+    (
+        CheckpointRestore,
+        "file_checkpoint_restore",
+        "checkpoint_restore"
+    ),
+    (
+        SkillListPackages,
+        "file_skill_list_packages",
+        "skill_list_packages"
+    ),
+    (SkillReadFile, "file_skill_read_file", "skill_read_file"),
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerProjectOperationKind {
+    Register,
+    Create,
+    ResolveOrRegister,
+    PrepareManagedWorktree,
+    LifecycleEnable,
+    LifecycleDisable,
+    LifecycleUnregister,
+}
+
+impl RunnerProjectOperationKind {
+    pub fn wire_kind(self) -> &'static str {
+        match self {
+            Self::Register => "register_project",
+            Self::Create => "create_project",
+            Self::ResolveOrRegister => "resolve_or_register_project",
+            Self::PrepareManagedWorktree => "prepare_managed_worktree",
+            Self::LifecycleEnable => "project_lifecycle_enable",
+            Self::LifecycleDisable => "project_lifecycle_disable",
+            Self::LifecycleUnregister => "project_lifecycle_unregister",
+        }
+    }
+
+    pub fn from_wire(kind: &str) -> Option<Self> {
+        Some(match kind {
+            "register_project" => Self::Register,
+            "create_project" => Self::Create,
+            "resolve_or_register_project" => Self::ResolveOrRegister,
+            "prepare_managed_worktree" => Self::PrepareManagedWorktree,
+            "project_lifecycle_enable" => Self::LifecycleEnable,
+            "project_lifecycle_disable" => Self::LifecycleDisable,
+            "project_lifecycle_unregister" => Self::LifecycleUnregister,
+            _ => return None,
+        })
+    }
+
+    pub fn disables_execution(self) -> bool {
+        matches!(self, Self::LifecycleDisable | Self::LifecycleUnregister)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerProjectOperation {
+    pub kind: RunnerProjectOperationKind,
+    /// Existing V2 JSON payload carried in `stdin`.
+    pub payload: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerComputerOperationKind {
+    ListWindows,
+    ListApplications,
+    LaunchApplication,
+    ListDisplays,
+    SnapshotDisplay,
+    ReadClipboard,
+    WriteClipboard,
+    PointerMove,
+    PointerClick,
+    Snapshot,
+    SnapshotRegion,
+    AccessibilityStatus,
+    AccessibilityTree,
+    ElementState,
+    ActivateWindow,
+    Control,
+    ScrollToElement,
+    KeyInput,
+    InputText,
+}
+
+impl RunnerComputerOperationKind {
+    pub fn wire_kind(self) -> &'static str {
+        match self {
+            Self::ListWindows => "computer_list_windows",
+            Self::ListApplications => "computer_list_applications",
+            Self::LaunchApplication => "computer_launch_application",
+            Self::ListDisplays => "computer_list_displays",
+            Self::SnapshotDisplay => "computer_snapshot_display",
+            Self::ReadClipboard => "computer_read_clipboard",
+            Self::WriteClipboard => "computer_write_clipboard",
+            Self::PointerMove => "computer_pointer_move",
+            Self::PointerClick => "computer_pointer_click",
+            Self::Snapshot => "computer_snapshot",
+            Self::SnapshotRegion => "computer_snapshot_region",
+            Self::AccessibilityStatus => "computer_accessibility_status",
+            Self::AccessibilityTree => "computer_accessibility_tree",
+            Self::ElementState => "computer_element_state",
+            Self::ActivateWindow => "computer_activate_window",
+            Self::Control => "computer_control",
+            Self::ScrollToElement => "computer_scroll_to_element",
+            Self::KeyInput => "computer_key_input",
+            Self::InputText => "computer_input_text",
+        }
+    }
+
+    pub fn from_wire(kind: &str) -> Option<Self> {
+        Some(match kind {
+            "computer_list_windows" => Self::ListWindows,
+            "computer_list_applications" => Self::ListApplications,
+            "computer_launch_application" => Self::LaunchApplication,
+            "computer_list_displays" => Self::ListDisplays,
+            "computer_snapshot_display" => Self::SnapshotDisplay,
+            "computer_read_clipboard" => Self::ReadClipboard,
+            "computer_write_clipboard" => Self::WriteClipboard,
+            "computer_pointer_move" => Self::PointerMove,
+            "computer_pointer_click" => Self::PointerClick,
+            "computer_snapshot" => Self::Snapshot,
+            "computer_snapshot_region" => Self::SnapshotRegion,
+            "computer_accessibility_status" => Self::AccessibilityStatus,
+            "computer_accessibility_tree" => Self::AccessibilityTree,
+            "computer_element_state" => Self::ElementState,
+            "computer_activate_window" => Self::ActivateWindow,
+            "computer_control" => Self::Control,
+            "computer_scroll_to_element" => Self::ScrollToElement,
+            "computer_key_input" => Self::KeyInput,
+            "computer_input_text" => Self::InputText,
+            _ => return None,
+        })
+    }
+
+    pub fn is_large_image(self) -> bool {
+        matches!(self, Self::Snapshot | Self::SnapshotDisplay)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerComputerOperation {
+    pub kind: RunnerComputerOperationKind,
+    /// Existing bounded JSON payload carried in `stdin`.
+    pub payload: String,
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RunnerPersistentShellOperation {
+    pub request: PersistentShellRequest,
+    pub job_context: Option<ShellJobContext>,
+}
+
+/// Closed canonical Runner operation. Variants carry the payload required to
+/// execute that operation; callers never reconstruct semantics from optional V2
+/// fields.
+#[derive(Debug, Clone)]
+pub enum RunnerOperation {
+    RunShell(RunnerShellOperation),
+    RunProcess(RunnerProcessOperation),
+    RunScript(RunnerScriptOperation),
+    RunInternalPosixScript(RunnerScriptOperation),
+    Job(RunnerJobOperation),
+    File(RunnerFileOperation),
+    Project(RunnerProjectOperation),
+    Computer(RunnerComputerOperation),
+    Validation {
+        payload: ValidationBridgeRequest,
+        timeout_secs: u64,
+    },
+    Lsp {
+        payload: RunnerLspPayload,
+        timeout_secs: u64,
+    },
+    PersistentShell(RunnerPersistentShellOperation),
+    McpGateway(McpGatewayRequest),
+    PluginGateway(PluginGatewayRequest),
+    CodingAgent(CodingAgentRequest),
+    SkillStore(SkillStoreRequest),
+    SshResource(SshResourceRequest),
+    RunnerConfig(RunnerConfigOperationRequest),
+}
+
+impl RunnerOperation {
+    pub fn wire_kind(&self) -> &'static str {
+        match self {
+            Self::RunShell(_) => "run_shell",
+            Self::RunProcess(_) => "run_process",
+            Self::RunScript(_) => "run_script",
+            Self::RunInternalPosixScript(_) => "run_internal_posix_script",
+            Self::Job(operation) => match operation {
+                RunnerJobOperation::StartShell(_) => "start_job",
+                RunnerJobOperation::StartValidation(_) => "start_validation_job",
+                RunnerJobOperation::StartProcess(_) => "start_process_job",
+                RunnerJobOperation::StartDetachedProcess(_) => "start_detached_process_job",
+                RunnerJobOperation::StartScript(_) => "start_script_job",
+                RunnerJobOperation::Stop { .. } => "stop_job",
+            },
+            Self::File(operation) => operation.wire_kind(),
+            Self::Project(operation) => operation.kind.wire_kind(),
+            Self::Computer(operation) => operation.kind.wire_kind(),
+            Self::Validation { .. } => crate::validation_bridge::AGENT_VALIDATION_REQUEST_KIND,
+            Self::Lsp { .. } => crate::lsp_bridge::AGENT_LSP_REQUEST_KIND,
+            Self::PersistentShell(_) => "persistent_shell",
+            Self::McpGateway(_) => "mcp_gateway",
+            Self::PluginGateway(_) => "plugin_gateway",
+            Self::CodingAgent(_) => "coding_agent",
+            Self::SkillStore(_) => "skill_store",
+            Self::SshResource(_) => "ssh_resource",
+            Self::RunnerConfig(_) => RUNNER_CONFIG_REQUEST_KIND,
+        }
+    }
+
+    pub fn job(&self) -> Option<&RunnerJobOperation> {
+        match self {
+            Self::Job(operation) => Some(operation),
+            _ => None,
+        }
+    }
+
+    pub fn is_large_native_image_request(&self) -> bool {
+        match self {
+            Self::Computer(operation) => operation.kind.is_large_image(),
+            Self::File(RunnerFileOperation::ReadProjectArtifact(payload)) => payload
+                .content
+                .as_deref()
+                .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok())
+                .and_then(|value| value.get("mcp_image").and_then(serde_json::Value::as_bool))
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+}
+
+impl RunnerRequest {
+    /// Decode and validate the V2 optional-field bag into one canonical closed
+    /// semantic operation. Explicit unknown kinds and conflicting payloads fail
+    /// closed. A *missing* `kind` still reaches this method as `run_shell`
+    /// because the historical serde default remains on `RunnerRequest.kind`.
+    pub fn decode_operation(&self) -> Result<RunnerOperation, String> {
+        decode_operation(self)
+    }
+
+    pub fn decode_invocation(&self) -> Result<RunnerInvocation, String> {
+        Ok(RunnerInvocation {
+            metadata: RunnerInvocationMetadata {
+                request_id: self.request_id.clone(),
+                client_id: self.client_id.clone(),
+                requested_by: self.requested_by.clone(),
+                created_at: self.created_at,
+            },
+            operation: self.decode_operation()?,
+        })
+    }
+
+    pub fn from_operation(
+        metadata: RunnerInvocationMetadata,
+        operation: RunnerOperation,
+    ) -> Result<Self, String> {
+        RunnerInvocation {
+            metadata,
+            operation,
+        }
+        .into_v2_request()
+    }
+}
+
+impl RunnerInvocation {
+    pub fn into_v2_request(self) -> Result<RunnerRequest, String> {
+        encode_operation(self.metadata, self.operation)
+    }
+}
+
+fn empty_wire(metadata: RunnerInvocationMetadata, kind: &str, timeout_secs: u64) -> RunnerRequest {
+    RunnerRequest {
+        request_id: metadata.request_id,
+        client_id: metadata.client_id,
+        kind: kind.to_string(),
+        job_id: None,
+        cwd: None,
+        path: None,
+        content: None,
+        max_bytes: None,
+        expected_sha256: None,
+        expected_prefix: None,
+        start_line: None,
+        end_line: None,
+        create_dirs: false,
+        command: String::new(),
+        process: None,
+        script: None,
+        stdin: None,
+        timeout_secs,
+        requested_by: metadata.requested_by,
+        created_at: metadata.created_at,
+        validation: None,
+        lsp: None,
+        job_context: None,
+        persistent_shell: None,
+        mcp_gateway: None,
+        plugin_gateway: None,
+        coding_agent: None,
+    }
+}
+
+fn encode_operation(
+    metadata: RunnerInvocationMetadata,
+    operation: RunnerOperation,
+) -> Result<RunnerRequest, String> {
+    let kind = operation.wire_kind();
+    let mut wire = empty_wire(metadata, kind, 30);
+    match operation {
+        RunnerOperation::RunShell(operation) => {
+            validate_raw_shell_wire_command(&operation.command)?;
+            wire.cwd = operation.cwd;
+            wire.command = operation.command;
+            wire.stdin = operation.stdin;
+            wire.timeout_secs = operation.timeout_secs;
+            wire.job_context = operation.job_context;
+        }
+        RunnerOperation::RunProcess(operation) => {
+            validate_direct_process(&operation)?;
+            wire.cwd = operation.cwd;
+            wire.process = Some(operation.process);
+            wire.stdin = operation.stdin;
+            wire.timeout_secs = operation.timeout_secs;
+        }
+        RunnerOperation::RunScript(operation) => {
+            validate_direct_script(&operation, false)?;
+            wire.cwd = operation.cwd;
+            wire.script = Some(operation.script);
+            wire.stdin = operation.stdin;
+            wire.timeout_secs = operation.timeout_secs;
+        }
+        RunnerOperation::RunInternalPosixScript(operation) => {
+            validate_direct_script(&operation, true)?;
+            wire.cwd = operation.cwd;
+            wire.script = Some(operation.script);
+            wire.timeout_secs = operation.timeout_secs;
+        }
+        RunnerOperation::Job(operation) => encode_job_operation(&mut wire, operation)?,
+        RunnerOperation::File(operation) => {
+            let payload = operation.payload().clone();
+            validate_file_payload(operation.wire_kind(), &payload)?;
+            wire.kind = operation.wire_kind().to_string();
+            wire.cwd = payload.cwd;
+            wire.path = Some(payload.path);
+            wire.content = payload.content;
+            wire.max_bytes = payload.max_bytes;
+            wire.expected_sha256 = payload.expected_sha256;
+            wire.expected_prefix = payload.expected_prefix;
+            wire.start_line = payload.start_line;
+            wire.end_line = payload.end_line;
+            wire.create_dirs = payload.create_dirs;
+            wire.timeout_secs = 30;
+        }
+        RunnerOperation::Project(operation) => {
+            validate_json_payload(&operation.payload, "project operation")?;
+            wire.kind = operation.kind.wire_kind().to_string();
+            wire.stdin = Some(operation.payload);
+            wire.timeout_secs = 30;
+        }
+        RunnerOperation::Computer(operation) => {
+            validate_computer_payload(operation.kind, &operation.payload)?;
+            wire.kind = operation.kind.wire_kind().to_string();
+            wire.stdin = Some(operation.payload);
+            wire.timeout_secs = operation.timeout_secs.max(1);
+        }
+        RunnerOperation::Validation {
+            payload,
+            timeout_secs,
+        } => {
+            validate_bridge_request(&payload)?;
+            wire.validation = Some(payload);
+            wire.timeout_secs = timeout_secs;
+        }
+        RunnerOperation::Lsp {
+            payload,
+            timeout_secs,
+        } => {
+            wire.lsp = Some(payload);
+            wire.timeout_secs = timeout_secs.max(1);
+        }
+        RunnerOperation::PersistentShell(operation) => {
+            validate_persistent_shell(&operation.request)?;
+            wire.cwd = operation.request.cwd.clone();
+            wire.command = operation.request.command.clone().unwrap_or_default();
+            wire.timeout_secs = operation.request.timeout_secs.unwrap_or(30);
+            wire.job_context = operation.job_context;
+            wire.persistent_shell = Some(operation.request);
+        }
+        RunnerOperation::McpGateway(operation) => {
+            validate_mcp_gateway_request(&operation)
+                .map_err(|error| format!("invalid MCP gateway request: {error}"))?;
+            wire.timeout_secs = 120;
+            wire.mcp_gateway = Some(operation);
+        }
+        RunnerOperation::PluginGateway(operation) => {
+            validate_plugin_gateway_request(&operation)
+                .map_err(|error| format!("invalid Plugin gateway request: {error}"))?;
+            wire.timeout_secs = 120;
+            wire.plugin_gateway = Some(operation);
+        }
+        RunnerOperation::CodingAgent(operation) => {
+            validate_coding_agent_request(&operation)
+                .map_err(|error| format!("invalid CodingAgent request: {error}"))?;
+            wire.timeout_secs = 120;
+            wire.coding_agent = Some(operation);
+        }
+        RunnerOperation::SkillStore(operation) => {
+            let content = serde_json::to_string(&operation)
+                .map_err(|error| format!("could not encode Skill store request: {error}"))?;
+            if content.len() > 32 * 1024 {
+                return Err("Skill store request exceeds V2 payload bound".to_string());
+            }
+            wire.content = Some(content);
+            wire.timeout_secs = 120;
+        }
+        RunnerOperation::SshResource(operation) => {
+            operation
+                .validate()
+                .map_err(|error| format!("invalid SSH resource request: {error}"))?;
+            let content = serde_json::to_string(&operation)
+                .map_err(|error| format!("could not encode SSH resource request: {error}"))?;
+            if content.len() > SSH_RESOURCE_REQUEST_MAX_BYTES {
+                return Err("SSH resource request exceeds V2 payload bound".to_string());
+            }
+            wire.content = Some(content);
+            wire.timeout_secs = 60;
+        }
+        RunnerOperation::RunnerConfig(operation) => {
+            operation
+                .validate()
+                .map_err(|error| format!("invalid Runner config request: {error}"))?;
+            let content = serde_json::to_string(&operation)
+                .map_err(|error| format!("could not encode Runner config request: {error}"))?;
+            if content.len() > RUNNER_CONFIG_REQUEST_MAX_BYTES {
+                return Err("Runner config request exceeds V2 payload bound".to_string());
+            }
+            wire.content = Some(content);
+            wire.timeout_secs = 30;
+        }
+    }
+    Ok(wire)
+}
+
+fn encode_job_operation(
+    wire: &mut RunnerRequest,
+    operation: RunnerJobOperation,
+) -> Result<(), String> {
+    wire.kind = match &operation {
+        RunnerJobOperation::StartShell(_) => "start_job",
+        RunnerJobOperation::StartValidation(_) => "start_validation_job",
+        RunnerJobOperation::StartProcess(_) => "start_process_job",
+        RunnerJobOperation::StartDetachedProcess(_) => "start_detached_process_job",
+        RunnerJobOperation::StartScript(_) => "start_script_job",
+        RunnerJobOperation::Stop { .. } => "stop_job",
+    }
+    .to_string();
+    match operation {
+        RunnerJobOperation::StartShell(operation) => {
+            validate_raw_shell_wire_command(&operation.command)?;
+            validate_job_context_coherence(operation.cwd.as_deref(), &operation.context)?;
+            wire.job_id = Some(operation.job_id);
+            wire.cwd = operation.cwd;
+            wire.command = operation.command;
+            wire.timeout_secs = operation.timeout_secs;
+            wire.job_context = Some(operation.context);
+        }
+        RunnerJobOperation::StartValidation(operation) => {
+            validate_validation_steps(&operation.steps)?;
+            validate_job_context_coherence(operation.cwd.as_deref(), &operation.context)?;
+            let names = operation
+                .steps
+                .iter()
+                .map(|step| step.name.clone())
+                .collect::<Vec<_>>();
+            if operation.context.validation_steps != names {
+                return Err("Job validation context does not match operation steps".to_string());
+            }
+            wire.job_id = Some(operation.job_id);
+            wire.cwd = operation.cwd;
+            wire.command = serde_json::to_string(&operation.steps)
+                .map_err(|error| format!("could not encode validation Job plan: {error}"))?;
+            wire.timeout_secs = operation.timeout_secs;
+            wire.job_context = Some(operation.context);
+        }
+        RunnerJobOperation::StartProcess(operation)
+        | RunnerJobOperation::StartDetachedProcess(operation) => {
+            validate_structured_job_common(
+                operation.cwd.as_deref(),
+                operation.stdin.as_deref(),
+                operation.timeout_secs,
+            )?;
+            validate_process_argv(&operation.process)?;
+            validate_job_context_coherence(operation.cwd.as_deref(), &operation.context)?;
+            wire.job_id = Some(operation.job_id);
+            wire.cwd = operation.cwd;
+            wire.process = Some(operation.process);
+            wire.stdin = operation.stdin;
+            wire.timeout_secs = operation.timeout_secs;
+            wire.job_context = Some(operation.context);
+        }
+        RunnerJobOperation::StartScript(operation) => {
+            validate_script_request(
+                &operation.script,
+                operation.stdin.as_deref(),
+                operation.cwd.as_deref(),
+                operation.timeout_secs,
+            )?;
+            validate_job_context_coherence(operation.cwd.as_deref(), &operation.context)?;
+            wire.job_id = Some(operation.job_id);
+            wire.cwd = operation.cwd;
+            wire.script = Some(operation.script);
+            wire.stdin = operation.stdin;
+            wire.timeout_secs = operation.timeout_secs;
+            wire.job_context = Some(operation.context);
+        }
+        RunnerJobOperation::Stop { job_id } => {
+            wire.job_id = Some(job_id);
+            wire.timeout_secs = 1;
+        }
+    }
+    Ok(())
+}
+
+fn decode_operation(wire: &RunnerRequest) -> Result<RunnerOperation, String> {
+    let no_special = || ensure_special_payloads_absent(wire);
+    match wire.kind.as_str() {
+        "run_shell" => {
+            no_special()?;
+            ensure_no_file_fields(wire)?;
+            if wire.job_id.is_some() {
+                return Err("run_shell does not accept job_id".to_string());
+            }
+            validate_raw_shell_wire_command(&wire.command)?;
+            Ok(RunnerOperation::RunShell(RunnerShellOperation {
+                cwd: wire.cwd.clone(),
+                command: wire.command.clone(),
+                stdin: wire.stdin.clone(),
+                timeout_secs: wire.timeout_secs,
+                job_context: wire.job_context.clone(),
+            }))
+        }
+        "run_process" => {
+            ensure_only_process_payload(wire)?;
+            ensure_no_file_fields(wire)?;
+            if wire.job_id.is_some() || wire.job_context.is_some() || !wire.command.is_empty() {
+                return Err("run_process contains incompatible execution fields".to_string());
+            }
+            let operation = RunnerProcessOperation {
+                cwd: wire.cwd.clone(),
+                process: wire
+                    .process
+                    .clone()
+                    .ok_or_else(|| "run_process requires process payload".to_string())?,
+                stdin: wire.stdin.clone(),
+                timeout_secs: wire.timeout_secs,
+            };
+            validate_direct_process(&operation)?;
+            Ok(RunnerOperation::RunProcess(operation))
+        }
+        "run_script" | "run_internal_posix_script" => {
+            ensure_only_script_payload(wire)?;
+            ensure_no_file_fields(wire)?;
+            if wire.job_id.is_some() || wire.job_context.is_some() || !wire.command.is_empty() {
+                return Err(format!(
+                    "{} contains incompatible execution fields",
+                    wire.kind
+                ));
+            }
+            let operation = RunnerScriptOperation {
+                cwd: wire.cwd.clone(),
+                script: wire
+                    .script
+                    .clone()
+                    .ok_or_else(|| format!("{} requires script payload", wire.kind))?,
+                stdin: wire.stdin.clone(),
+                timeout_secs: wire.timeout_secs,
+            };
+            let internal = wire.kind == "run_internal_posix_script";
+            validate_direct_script(&operation, internal)?;
+            Ok(if internal {
+                RunnerOperation::RunInternalPosixScript(operation)
+            } else {
+                RunnerOperation::RunScript(operation)
+            })
+        }
+        "start_job"
+        | "start_validation_job"
+        | "start_process_job"
+        | "start_detached_process_job"
+        | "start_script_job"
+        | "stop_job" => decode_job_operation(wire).map(RunnerOperation::Job),
+        kind if kind.starts_with("file_") => {
+            ensure_special_payloads_absent(wire)?;
+            if wire.job_id.is_some()
+                || wire.stdin.is_some()
+                || wire.job_context.is_some()
+                || !wire.command.is_empty()
+            {
+                return Err("file operation contains incompatible execution fields".to_string());
+            }
+            let path = wire
+                .path
+                .clone()
+                .ok_or_else(|| "file operation requires path".to_string())?;
+            RunnerFileOperation::from_wire_kind(
+                kind,
+                RunnerFilePayload {
+                    cwd: wire.cwd.clone(),
+                    path,
+                    content: wire.content.clone(),
+                    max_bytes: wire.max_bytes,
+                    expected_sha256: wire.expected_sha256.clone(),
+                    expected_prefix: wire.expected_prefix.clone(),
+                    start_line: wire.start_line,
+                    end_line: wire.end_line,
+                    create_dirs: wire.create_dirs,
+                },
+            )
+            .map(RunnerOperation::File)
+        }
+        kind if RunnerProjectOperationKind::from_wire(kind).is_some() => {
+            ensure_special_payloads_absent(wire)?;
+            ensure_no_file_fields(wire)?;
+            if wire.job_id.is_some()
+                || wire.cwd.is_some()
+                || !wire.command.is_empty()
+                || wire.job_context.is_some()
+            {
+                return Err("project operation contains incompatible execution fields".to_string());
+            }
+            let payload = wire
+                .stdin
+                .clone()
+                .ok_or_else(|| "project operation requires JSON payload".to_string())?;
+            validate_json_payload(&payload, "project operation")?;
+            Ok(RunnerOperation::Project(RunnerProjectOperation {
+                kind: RunnerProjectOperationKind::from_wire(kind).expect("checked project kind"),
+                payload,
+            }))
+        }
+        kind if RunnerComputerOperationKind::from_wire(kind).is_some() => {
+            ensure_special_payloads_absent(wire)?;
+            ensure_no_file_fields(wire)?;
+            if wire.job_id.is_some()
+                || wire.cwd.is_some()
+                || !wire.command.is_empty()
+                || wire.job_context.is_some()
+            {
+                return Err("computer operation contains incompatible execution fields".to_string());
+            }
+            let operation_kind =
+                RunnerComputerOperationKind::from_wire(kind).expect("checked computer kind");
+            let payload = wire
+                .stdin
+                .clone()
+                .ok_or_else(|| "computer operation requires JSON payload".to_string())?;
+            validate_computer_payload(operation_kind, &payload)?;
+            Ok(RunnerOperation::Computer(RunnerComputerOperation {
+                kind: operation_kind,
+                payload,
+                timeout_secs: wire.timeout_secs,
+            }))
+        }
+        crate::validation_bridge::AGENT_VALIDATION_REQUEST_KIND => {
+            ensure_only_validation_payload(wire)?;
+            ensure_empty_generic_execution_fields(wire, false)?;
+            let payload = wire
+                .validation
+                .clone()
+                .ok_or_else(|| "validation operation requires validation payload".to_string())?;
+            validate_bridge_request(&payload)?;
+            Ok(RunnerOperation::Validation {
+                payload,
+                timeout_secs: wire.timeout_secs,
+            })
+        }
+        crate::lsp_bridge::AGENT_LSP_REQUEST_KIND => {
+            ensure_only_lsp_payload(wire)?;
+            ensure_empty_generic_execution_fields(wire, false)?;
+            Ok(RunnerOperation::Lsp {
+                payload: wire
+                    .lsp
+                    .clone()
+                    .ok_or_else(|| "lsp operation requires lsp payload".to_string())?,
+                timeout_secs: wire.timeout_secs,
+            })
+        }
+        "persistent_shell" => {
+            ensure_only_persistent_shell_payload(wire)?;
+            ensure_no_file_fields(wire)?;
+            if wire.job_id.is_some() || wire.stdin.is_some() {
+                return Err("persistent_shell contains incompatible execution fields".to_string());
+            }
+            let request = wire
+                .persistent_shell
+                .clone()
+                .ok_or_else(|| "persistent_shell requires persistent_shell payload".to_string())?;
+            validate_persistent_shell(&request)?;
+            if wire.cwd != request.cwd
+                || wire.command != request.command.clone().unwrap_or_default()
+                || wire.timeout_secs != request.timeout_secs.unwrap_or(30)
+            {
+                return Err(
+                    "persistent_shell compatibility fields do not match typed payload".to_string(),
+                );
+            }
+            Ok(RunnerOperation::PersistentShell(
+                RunnerPersistentShellOperation {
+                    request,
+                    job_context: wire.job_context.clone(),
+                },
+            ))
+        }
+        "mcp_gateway" => {
+            ensure_only_mcp_payload(wire)?;
+            ensure_empty_generic_execution_fields(wire, false)?;
+            let operation = wire
+                .mcp_gateway
+                .clone()
+                .ok_or_else(|| "mcp_gateway requires mcp_gateway payload".to_string())?;
+            validate_mcp_gateway_request(&operation)
+                .map_err(|error| format!("invalid MCP gateway request: {error}"))?;
+            Ok(RunnerOperation::McpGateway(operation))
+        }
+        "plugin_gateway" => {
+            ensure_only_plugin_payload(wire)?;
+            ensure_empty_generic_execution_fields(wire, false)?;
+            let operation = wire
+                .plugin_gateway
+                .clone()
+                .ok_or_else(|| "plugin_gateway requires plugin_gateway payload".to_string())?;
+            validate_plugin_gateway_request(&operation)
+                .map_err(|error| format!("invalid Plugin gateway request: {error}"))?;
+            Ok(RunnerOperation::PluginGateway(operation))
+        }
+        "coding_agent" => {
+            ensure_only_coding_agent_payload(wire)?;
+            ensure_empty_generic_execution_fields(wire, false)?;
+            let operation = wire
+                .coding_agent
+                .clone()
+                .ok_or_else(|| "coding_agent requires coding_agent payload".to_string())?;
+            validate_coding_agent_request(&operation)
+                .map_err(|error| format!("invalid CodingAgent request: {error}"))?;
+            Ok(RunnerOperation::CodingAgent(operation))
+        }
+        "skill_store" => {
+            ensure_special_payloads_absent(wire)?;
+            ensure_empty_generic_execution_fields(wire, true)?;
+            let content = bounded_content(wire, 32 * 1024, "skill_store")?;
+            let operation = serde_json::from_str::<SkillStoreRequest>(content)
+                .map_err(|error| format!("invalid Skill store payload: {error}"))?;
+            Ok(RunnerOperation::SkillStore(operation))
+        }
+        "ssh_resource" => {
+            ensure_special_payloads_absent(wire)?;
+            ensure_empty_generic_execution_fields(wire, true)?;
+            let content = bounded_content(wire, SSH_RESOURCE_REQUEST_MAX_BYTES, "ssh_resource")?;
+            let operation = serde_json::from_str::<SshResourceRequest>(content)
+                .map_err(|error| format!("invalid SSH resource payload: {error}"))?;
+            operation
+                .validate()
+                .map_err(|error| format!("invalid SSH resource request: {error}"))?;
+            Ok(RunnerOperation::SshResource(operation))
+        }
+        RUNNER_CONFIG_REQUEST_KIND => {
+            ensure_special_payloads_absent(wire)?;
+            ensure_empty_generic_execution_fields(wire, true)?;
+            let content = bounded_content(wire, RUNNER_CONFIG_REQUEST_MAX_BYTES, "runner_config")?;
+            let operation = serde_json::from_str::<RunnerConfigOperationRequest>(content)
+                .map_err(|error| format!("invalid Runner config payload: {error}"))?;
+            operation
+                .validate()
+                .map_err(|error| format!("invalid Runner config request: {error}"))?;
+            Ok(RunnerOperation::RunnerConfig(operation))
+        }
+        kind => Err(format!("unknown Runner V2 request kind: {kind}")),
+    }
+}
+
+fn decode_job_operation(wire: &RunnerRequest) -> Result<RunnerJobOperation, String> {
+    ensure_no_file_fields(wire)?;
+    let job_id = wire
+        .job_id
+        .clone()
+        .ok_or_else(|| format!("{} requires job_id", wire.kind))?;
+    if wire.kind == "stop_job" {
+        ensure_special_payloads_absent(wire)?;
+        if wire.cwd.is_some()
+            || wire.stdin.is_some()
+            || wire.job_context.is_some()
+            || !wire.command.is_empty()
+        {
+            return Err("stop_job contains incompatible execution fields".to_string());
+        }
+        return Ok(RunnerJobOperation::Stop { job_id });
+    }
+    let context = wire
+        .job_context
+        .clone()
+        .ok_or_else(|| format!("{} requires job_context", wire.kind))?;
+    validate_job_context_coherence(wire.cwd.as_deref(), &context)?;
+    match wire.kind.as_str() {
+        "start_job" => {
+            ensure_special_payloads_absent(wire)?;
+            if wire.stdin.is_some() {
+                return Err("start_job does not accept stdin".to_string());
+            }
+            validate_raw_shell_wire_command(&wire.command)?;
+            Ok(RunnerJobOperation::StartShell(RunnerJobShellOperation {
+                job_id,
+                cwd: wire.cwd.clone(),
+                command: wire.command.clone(),
+                timeout_secs: wire.timeout_secs,
+                context,
+            }))
+        }
+        "start_validation_job" => {
+            ensure_special_payloads_absent(wire)?;
+            if wire.stdin.is_some() {
+                return Err("start_validation_job does not accept stdin".to_string());
+            }
+            let steps = serde_json::from_str::<Vec<ShellJobValidationStep>>(&wire.command)
+                .map_err(|error| format!("invalid validation Job plan: {error}"))?;
+            validate_validation_steps(&steps)?;
+            let names = steps
+                .iter()
+                .map(|step| step.name.clone())
+                .collect::<Vec<_>>();
+            if context.validation_steps != names {
+                return Err("validation Job plan does not match recovery context".to_string());
+            }
+            Ok(RunnerJobOperation::StartValidation(
+                RunnerJobValidationOperation {
+                    job_id,
+                    cwd: wire.cwd.clone(),
+                    steps,
+                    timeout_secs: wire.timeout_secs,
+                    context,
+                },
+            ))
+        }
+        "start_process_job" | "start_detached_process_job" => {
+            ensure_only_process_payload(wire)?;
+            if !wire.command.is_empty() || context.ssh_resource.is_some() {
+                return Err("typed process Job contains incompatible execution fields".to_string());
+            }
+            let process = wire
+                .process
+                .clone()
+                .ok_or_else(|| format!("{} requires process payload", wire.kind))?;
+            validate_process_argv(&process)?;
+            validate_structured_job_common(
+                wire.cwd.as_deref(),
+                wire.stdin.as_deref(),
+                wire.timeout_secs,
+            )?;
+            let operation = RunnerJobProcessOperation {
+                job_id,
+                cwd: wire.cwd.clone(),
+                process,
+                stdin: wire.stdin.clone(),
+                timeout_secs: wire.timeout_secs,
+                context,
+            };
+            let job = if wire.kind == "start_detached_process_job" {
+                RunnerJobOperation::StartDetachedProcess(operation)
+            } else {
+                RunnerJobOperation::StartProcess(operation)
+            };
+            if job
+                .context()
+                .and_then(|ctx| ctx.structured_execution.clone())
+                != job.expected_structured_execution()
+            {
+                return Err(
+                    "process Job recovery metadata does not match typed operation".to_string(),
+                );
+            }
+            Ok(job)
+        }
+        "start_script_job" => {
+            ensure_only_script_payload(wire)?;
+            if !wire.command.is_empty() || context.ssh_resource.is_some() {
+                return Err("typed script Job contains incompatible execution fields".to_string());
+            }
+            let script = wire
+                .script
+                .clone()
+                .ok_or_else(|| "start_script_job requires script payload".to_string())?;
+            validate_script_request(
+                &script,
+                wire.stdin.as_deref(),
+                wire.cwd.as_deref(),
+                wire.timeout_secs,
+            )?;
+            let job = RunnerJobOperation::StartScript(RunnerJobScriptOperation {
+                job_id,
+                cwd: wire.cwd.clone(),
+                script,
+                stdin: wire.stdin.clone(),
+                timeout_secs: wire.timeout_secs,
+                context,
+            });
+            if job
+                .context()
+                .and_then(|ctx| ctx.structured_execution.clone())
+                != job.expected_structured_execution()
+            {
+                return Err(
+                    "script Job recovery metadata does not match typed operation".to_string(),
+                );
+            }
+            Ok(job)
+        }
+        _ => unreachable!("decode_job_operation called for non-job kind"),
+    }
+}
+
+fn validate_direct_process(operation: &RunnerProcessOperation) -> Result<(), String> {
+    validate_process_argv(&operation.process)?;
+    validate_direct_structured_common(
+        operation.cwd.as_deref(),
+        operation.stdin.as_deref(),
+        operation.timeout_secs,
+    )
+}
+
+fn validate_direct_script(operation: &RunnerScriptOperation, internal: bool) -> Result<(), String> {
+    validate_script_request(
+        &operation.script,
+        operation.stdin.as_deref(),
+        operation.cwd.as_deref(),
+        operation.timeout_secs,
+    )?;
+    if operation.timeout_secs > STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS {
+        return Err(format!(
+            "timeout_secs must be between 1 and {STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS}"
+        ));
+    }
+    if internal
+        && (operation.stdin.is_some()
+            || operation.script.language != ShellScriptLanguage::Sh
+            || !operation.script.args.is_empty())
+    {
+        return Err("internal POSIX script requires sh, no args, and no stdin".to_string());
+    }
+    Ok(())
+}
+
+fn validate_direct_structured_common(
+    cwd: Option<&str>,
+    stdin: Option<&str>,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    validate_structured_text_fields(cwd, stdin)?;
+    if timeout_secs == 0 || timeout_secs > STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS {
+        return Err(format!(
+            "timeout_secs must be between 1 and {STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_structured_job_common(
+    cwd: Option<&str>,
+    stdin: Option<&str>,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    validate_structured_text_fields(cwd, stdin)?;
+    if !(STRUCTURED_EXECUTION_TIMEOUT_MIN_SECS..=STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS)
+        .contains(&timeout_secs)
+    {
+        return Err(format!(
+            "timeout_secs must be between {STRUCTURED_EXECUTION_TIMEOUT_MIN_SECS} and {STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_structured_text_fields(cwd: Option<&str>, stdin: Option<&str>) -> Result<(), String> {
+    if let Some(stdin) = stdin {
+        if stdin.len() > PROCESS_STDIN_MAX_BYTES || stdin.contains('\0') {
+            return Err("stdin is invalid or oversized".to_string());
+        }
+    }
+    if let Some(cwd) = cwd {
+        if cwd.len() > PROCESS_CWD_MAX_BYTES || cwd.contains('\0') {
+            return Err("cwd is invalid or oversized".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn validate_validation_steps(steps: &[ShellJobValidationStep]) -> Result<(), String> {
+    if !(1..=3).contains(&steps.len())
+        || steps.iter().any(|step| !step.is_canonical())
+        || steps.iter().enumerate().any(|(index, step)| {
+            steps[..index]
+                .iter()
+                .any(|earlier| earlier.name == step.name)
+        })
+    {
+        return Err("invalid structured validation plan".to_string());
+    }
+    Ok(())
+}
+
+fn validate_job_context_coherence(
+    cwd: Option<&str>,
+    context: &ShellJobContext,
+) -> Result<(), String> {
+    if context.cwd.as_deref() != cwd {
+        return Err("job recovery context cwd does not match operation cwd".to_string());
+    }
+    if context.ssh_resource.is_some() && context.workflow_session_id.is_none() {
+        return Err("job recovery SSH resource requires Workflow Session".to_string());
+    }
+    Ok(())
+}
+
+fn validate_file_payload(kind: &str, payload: &RunnerFilePayload) -> Result<(), String> {
+    if payload.path.is_empty() || payload.path.contains('\0') {
+        return Err("file operation path is required and cannot contain NUL".to_string());
+    }
+    if payload.cwd.as_deref().is_some_and(|cwd| cwd.contains('\0')) {
+        return Err("file operation cwd cannot contain NUL".to_string());
+    }
+    let write = kind == "file_write";
+    if !write
+        && (payload.expected_sha256.is_some()
+            || payload.expected_prefix.is_some()
+            || payload.create_dirs)
+    {
+        return Err(
+            "write-only compatibility fields are present on non-write file operation".to_string(),
+        );
+    }
+    if write && payload.content.is_none() {
+        return Err("file_write requires content".to_string());
+    }
+    if kind == "file_read" {
+        match (payload.start_line, payload.end_line) {
+            (Some(start), Some(end)) if start > 0 && end >= start => {}
+            (None, None) => {}
+            _ => return Err("file_read line range is invalid".to_string()),
+        }
+    } else if payload.start_line.is_some() || payload.end_line.is_some() {
+        // skill_read_file historically uses both fields.
+        if kind != "file_skill_read_file"
+            || payload.start_line.is_none()
+            || payload.end_line.is_none()
+            || payload.start_line == Some(0)
+            || payload
+                .end_line
+                .zip(payload.start_line)
+                .is_some_and(|(end, start)| end < start)
+        {
+            return Err("line range is incompatible with file operation".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn validate_json_payload(payload: &str, label: &str) -> Result<(), String> {
+    if payload.contains('\0') {
+        return Err(format!("{label} payload cannot contain NUL"));
+    }
+    serde_json::from_str::<serde_json::Value>(payload)
+        .map(|_| ())
+        .map_err(|error| format!("{label} payload is not valid JSON: {error}"))
+}
+
+fn validate_computer_payload(
+    kind: RunnerComputerOperationKind,
+    payload: &str,
+) -> Result<(), String> {
+    if payload.len() > shell_computer_request_payload_max_bytes(kind.wire_kind()) {
+        return Err("computer request payload exceeds V2 bound".to_string());
+    }
+    validate_json_payload(payload, "computer operation")
+}
+
+fn validate_persistent_shell(request: &PersistentShellRequest) -> Result<(), String> {
+    if !matches!(
+        request.action.as_str(),
+        "open" | "exec" | "status" | "close"
+    ) {
+        return Err("unsupported persistent shell action".to_string());
+    }
+    if request.shell_id.is_empty()
+        || request.workflow_session_id.is_empty()
+        || request.runtime_project_id.trim().is_empty()
+        || request
+            .command
+            .as_deref()
+            .is_some_and(|command| command.contains('\0'))
+    {
+        return Err("persistent shell payload is invalid".to_string());
+    }
+    Ok(())
+}
+
+fn bounded_content<'a>(
+    wire: &'a RunnerRequest,
+    max_bytes: usize,
+    label: &str,
+) -> Result<&'a str, String> {
+    let content = wire
+        .content
+        .as_deref()
+        .ok_or_else(|| format!("{label} requires content payload"))?;
+    if content.len() > max_bytes || content.contains('\0') {
+        return Err(format!("{label} content payload is invalid or oversized"));
+    }
+    Ok(content)
+}
+
+fn ensure_no_file_fields(wire: &RunnerRequest) -> Result<(), String> {
+    if wire.path.is_some()
+        || wire.content.is_some()
+        || wire.max_bytes.is_some()
+        || wire.expected_sha256.is_some()
+        || wire.expected_prefix.is_some()
+        || wire.start_line.is_some()
+        || wire.end_line.is_some()
+        || wire.create_dirs
+    {
+        return Err(format!("{} contains incompatible file fields", wire.kind));
+    }
+    Ok(())
+}
+
+fn ensure_special_payloads_absent(wire: &RunnerRequest) -> Result<(), String> {
+    if wire.process.is_some()
+        || wire.script.is_some()
+        || wire.validation.is_some()
+        || wire.lsp.is_some()
+        || wire.persistent_shell.is_some()
+        || wire.mcp_gateway.is_some()
+        || wire.plugin_gateway.is_some()
+        || wire.coding_agent.is_some()
+    {
+        return Err(format!("{} contains incompatible typed payload", wire.kind));
+    }
+    Ok(())
+}
+
+fn ensure_only_process_payload(wire: &RunnerRequest) -> Result<(), String> {
+    if wire.script.is_some()
+        || wire.validation.is_some()
+        || wire.lsp.is_some()
+        || wire.persistent_shell.is_some()
+        || wire.mcp_gateway.is_some()
+        || wire.plugin_gateway.is_some()
+        || wire.coding_agent.is_some()
+    {
+        return Err(format!(
+            "{} conflicts with non-process typed payload",
+            wire.kind
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_only_script_payload(wire: &RunnerRequest) -> Result<(), String> {
+    if wire.process.is_some()
+        || wire.validation.is_some()
+        || wire.lsp.is_some()
+        || wire.persistent_shell.is_some()
+        || wire.mcp_gateway.is_some()
+        || wire.plugin_gateway.is_some()
+        || wire.coding_agent.is_some()
+    {
+        return Err(format!(
+            "{} conflicts with non-script typed payload",
+            wire.kind
+        ));
+    }
+    Ok(())
+}
+
+macro_rules! ensure_only_payload {
+    ($name:ident, $allowed:ident) => {
+        fn $name(wire: &RunnerRequest) -> Result<(), String> {
+            if wire.process.is_some()
+                || wire.script.is_some()
+                || wire.validation.is_some() && stringify!($allowed) != "validation"
+                || wire.lsp.is_some() && stringify!($allowed) != "lsp"
+                || wire.persistent_shell.is_some() && stringify!($allowed) != "persistent_shell"
+                || wire.mcp_gateway.is_some() && stringify!($allowed) != "mcp_gateway"
+                || wire.plugin_gateway.is_some() && stringify!($allowed) != "plugin_gateway"
+                || wire.coding_agent.is_some() && stringify!($allowed) != "coding_agent"
+            {
+                return Err(format!("{} contains conflicting typed payloads", wire.kind));
+            }
+            Ok(())
+        }
+    };
+}
+
+ensure_only_payload!(ensure_only_validation_payload, validation);
+ensure_only_payload!(ensure_only_lsp_payload, lsp);
+ensure_only_payload!(ensure_only_persistent_shell_payload, persistent_shell);
+ensure_only_payload!(ensure_only_mcp_payload, mcp_gateway);
+ensure_only_payload!(ensure_only_plugin_payload, plugin_gateway);
+ensure_only_payload!(ensure_only_coding_agent_payload, coding_agent);
+
+fn ensure_empty_generic_execution_fields(
+    wire: &RunnerRequest,
+    allow_content: bool,
+) -> Result<(), String> {
+    if wire.job_id.is_some()
+        || wire.cwd.is_some()
+        || wire.path.is_some()
+        || (!allow_content && wire.content.is_some())
+        || wire.max_bytes.is_some()
+        || wire.expected_sha256.is_some()
+        || wire.expected_prefix.is_some()
+        || wire.start_line.is_some()
+        || wire.end_line.is_some()
+        || wire.create_dirs
+        || !wire.command.is_empty()
+        || wire.stdin.is_some()
+        || wire.job_context.is_some()
+    {
+        return Err(format!(
+            "{} contains incompatible generic fields",
+            wire.kind
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata() -> RunnerInvocationMetadata {
+        RunnerInvocationMetadata {
+            request_id: "req-1".to_string(),
+            client_id: "runner-1".to_string(),
+            requested_by: "tester".to_string(),
+            created_at: 123,
+        }
+    }
+
+    fn shell_wire() -> RunnerRequest {
+        RunnerRequest::from_operation(
+            metadata(),
+            RunnerOperation::RunShell(RunnerShellOperation {
+                cwd: Some("/tmp".to_string()),
+                command: "printf ok".to_string(),
+                stdin: None,
+                timeout_secs: 30,
+                job_context: None,
+            }),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn omitted_v2_kind_keeps_legacy_run_shell_default() {
+        let value = serde_json::json!({
+            "request_id": "req-1",
+            "client_id": "runner-1",
+            "command": "printf ok",
+            "timeout_secs": 30,
+            "requested_by": "tester",
+            "created_at": 123
+        });
+        let wire: RunnerRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(wire.kind, "run_shell");
+        assert!(matches!(
+            wire.decode_operation().unwrap(),
+            RunnerOperation::RunShell(_)
+        ));
+    }
+
+    #[test]
+    fn explicit_unknown_kind_fails_closed() {
+        let mut wire = shell_wire();
+        wire.kind = "future_magic_operation".to_string();
+        assert!(wire
+            .decode_operation()
+            .unwrap_err()
+            .contains("unknown Runner V2 request kind"));
+    }
+
+    #[test]
+    fn conflicting_process_and_script_payloads_fail_closed() {
+        let process = RunnerProcessOperation {
+            cwd: None,
+            process: ShellProcessArgv {
+                executable: "printf".to_string(),
+                args: vec!["ok".to_string()],
+            },
+            stdin: None,
+            timeout_secs: 30,
+        };
+        let mut wire =
+            RunnerRequest::from_operation(metadata(), RunnerOperation::RunProcess(process))
+                .unwrap();
+        wire.script = Some(ShellScriptPayload {
+            language: ShellScriptLanguage::Sh,
+            script: "printf no".to_string(),
+            args: Vec::new(),
+        });
+        assert!(wire.decode_operation().unwrap_err().contains("conflicts"));
+    }
+
+    #[test]
+    fn canonical_process_round_trip_has_no_shell_or_script_payload() {
+        let operation = RunnerOperation::RunProcess(RunnerProcessOperation {
+            cwd: Some("subdir".to_string()),
+            process: ShellProcessArgv {
+                executable: "argv-helper".to_string(),
+                args: vec!["literal space".to_string()],
+            },
+            stdin: Some("input".to_string()),
+            timeout_secs: 60,
+        });
+        let wire = RunnerRequest::from_operation(metadata(), operation).unwrap();
+        assert_eq!(wire.kind, "run_process");
+        assert!(wire.command.is_empty());
+        assert!(wire.script.is_none());
+        assert!(wire.process.is_some());
+        assert!(matches!(
+            wire.decode_operation().unwrap(),
+            RunnerOperation::RunProcess(_)
+        ));
+    }
+
+    #[test]
+    fn canonical_file_and_project_operations_round_trip() {
+        let file = RunnerFileOperation::Read(RunnerFilePayload {
+            cwd: Some("/repo".to_string()),
+            path: "src/lib.rs".to_string(),
+            content: None,
+            max_bytes: Some(4096),
+            expected_sha256: None,
+            expected_prefix: None,
+            start_line: Some(1),
+            end_line: Some(20),
+            create_dirs: false,
+        });
+        let wire = RunnerRequest::from_operation(metadata(), RunnerOperation::File(file)).unwrap();
+        assert_eq!(wire.kind, "file_read");
+        assert!(matches!(
+            wire.decode_operation().unwrap(),
+            RunnerOperation::File(RunnerFileOperation::Read(_))
+        ));
+
+        let project = RunnerProjectOperation {
+            kind: RunnerProjectOperationKind::Register,
+            payload: "{\"path\":\"/repo\"}".to_string(),
+        };
+        let wire =
+            RunnerRequest::from_operation(metadata(), RunnerOperation::Project(project)).unwrap();
+        assert_eq!(wire.kind, "register_project");
+        assert!(wire.command.is_empty());
+        assert!(matches!(
+            wire.decode_operation().unwrap(),
+            RunnerOperation::Project(_)
+        ));
+    }
+}

--- a/crates/webcodex-core/src/runner_operation.rs
+++ b/crates/webcodex-core/src/runner_operation.rs
@@ -44,6 +44,9 @@ pub struct RunnerShellOperation {
     pub cwd: Option<String>,
     pub command: String,
     pub stdin: Option<String>,
+    /// Historical V2 `run_shell.max_bytes`, consumed by the external-search
+    /// provider route as a per-request output cap. Native raw shell ignores it.
+    pub max_bytes: Option<usize>,
     pub timeout_secs: u64,
     /// Present only for Session-bound SSH raw-shell execution.
     pub job_context: Option<ShellJobContext>,
@@ -657,6 +660,7 @@ fn encode_operation(
             wire.cwd = operation.cwd;
             wire.command = operation.command;
             wire.stdin = operation.stdin;
+            wire.max_bytes = operation.max_bytes;
             wire.timeout_secs = operation.timeout_secs;
             wire.job_context = operation.job_context;
         }
@@ -871,7 +875,7 @@ fn decode_operation(wire: &RunnerRequest) -> Result<RunnerOperation, String> {
     match wire.kind.as_str() {
         "run_shell" => {
             no_special()?;
-            ensure_no_file_fields(wire)?;
+            ensure_no_file_fields_except_max_bytes(wire)?;
             if wire.job_id.is_some() {
                 return Err("run_shell does not accept job_id".to_string());
             }
@@ -880,6 +884,7 @@ fn decode_operation(wire: &RunnerRequest) -> Result<RunnerOperation, String> {
                 cwd: wire.cwd.clone(),
                 command: wire.command.clone(),
                 stdin: wire.stdin.clone(),
+                max_bytes: wire.max_bytes,
                 timeout_secs: wire.timeout_secs,
                 job_context: wire.job_context.clone(),
             }))
@@ -1476,6 +1481,20 @@ fn ensure_no_file_fields(wire: &RunnerRequest) -> Result<(), String> {
     Ok(())
 }
 
+fn ensure_no_file_fields_except_max_bytes(wire: &RunnerRequest) -> Result<(), String> {
+    if wire.path.is_some()
+        || wire.content.is_some()
+        || wire.expected_sha256.is_some()
+        || wire.expected_prefix.is_some()
+        || wire.start_line.is_some()
+        || wire.end_line.is_some()
+        || wire.create_dirs
+    {
+        return Err(format!("{} contains incompatible file fields", wire.kind));
+    }
+    Ok(())
+}
+
 fn ensure_special_payloads_absent(wire: &RunnerRequest) -> Result<(), String> {
     if wire.process.is_some()
         || wire.script.is_some()
@@ -1620,6 +1639,7 @@ mod tests {
                 cwd: Some("/tmp".to_string()),
                 command: "printf ok".to_string(),
                 stdin: None,
+                max_bytes: None,
                 timeout_secs: 30,
                 job_context: None,
             }),
@@ -1852,6 +1872,7 @@ mod tests {
                 cwd: Some("/repo".to_string()),
                 command: "printf ok".to_string(),
                 stdin: None,
+                max_bytes: None,
                 timeout_secs: 30,
                 job_context: None,
             }),
@@ -2163,6 +2184,7 @@ mod tests {
                 cwd: Some("/repo".to_string()),
                 command: "printf ok".to_string(),
                 stdin: None,
+                max_bytes: Some(4096),
                 timeout_secs: 30,
                 job_context: None,
             },
@@ -2170,6 +2192,7 @@ mod tests {
         .unwrap();
         assert_eq!(shell["kind"], "run_shell");
         assert_eq!(shell["command"], "printf ok");
+        assert_eq!(shell["max_bytes"], 4096);
         assert!(shell.get("process").is_none());
         assert!(shell.get("script").is_none());
 

--- a/crates/webcodex-core/src/runner_operation.rs
+++ b/crates/webcodex-core/src/runner_operation.rs
@@ -232,6 +232,10 @@ macro_rules! runner_file_operations {
         }
 
         impl RunnerFileOperation {
+            pub fn is_wire_kind(kind: &str) -> bool {
+                matches!(kind, $($wire)|+)
+            }
+
             pub fn wire_kind(&self) -> &'static str {
                 match self { $(Self::$variant(_) => $wire),+ }
             }
@@ -1017,7 +1021,7 @@ fn decode_operation(wire: &RunnerRequest) -> Result<RunnerOperation, String> {
         }
         crate::lsp_bridge::AGENT_LSP_REQUEST_KIND => {
             ensure_only_lsp_payload(wire)?;
-            ensure_empty_generic_execution_fields(wire, false)?;
+            ensure_lsp_legacy_compatible_generic_fields(wire)?;
             Ok(RunnerOperation::Lsp {
                 payload: wire
                     .lsp
@@ -1573,6 +1577,29 @@ fn ensure_empty_generic_execution_fields(
     Ok(())
 }
 
+/// Historical V2 LSP requests could carry legacy shell `cwd`/`command`
+/// baggage. The LSP handler deliberately ignored both fields, and existing
+/// rolling-compatibility regression coverage depends on that behavior. Keep
+/// this allowance local to LSP decoding; canonical encoding still emits
+/// neither field, and all other execution/file/job fields remain fail-closed.
+fn ensure_lsp_legacy_compatible_generic_fields(wire: &RunnerRequest) -> Result<(), String> {
+    if wire.job_id.is_some()
+        || wire.path.is_some()
+        || wire.content.is_some()
+        || wire.max_bytes.is_some()
+        || wire.expected_sha256.is_some()
+        || wire.expected_prefix.is_some()
+        || wire.start_line.is_some()
+        || wire.end_line.is_some()
+        || wire.create_dirs
+        || wire.stdin.is_some()
+        || wire.job_context.is_some()
+    {
+        return Err("lsp contains incompatible generic fields".to_string());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1670,6 +1697,38 @@ mod tests {
             wire.decode_operation().unwrap(),
             RunnerOperation::RunProcess(_)
         ));
+    }
+
+    #[test]
+    fn legacy_lsp_shell_baggage_decodes_but_encoder_stays_canonical() {
+        let operation = RunnerOperation::Lsp {
+            payload: RunnerLspPayload {
+                project_id: "demo".to_string(),
+                request: crate::lsp_bridge::RunnerLspRequest::Status,
+            },
+            timeout_secs: 30,
+        };
+        let canonical = RunnerRequest::from_operation(metadata(), operation).unwrap();
+        assert_eq!(canonical.kind, crate::lsp_bridge::AGENT_LSP_REQUEST_KIND);
+        assert!(canonical.cwd.is_none());
+        assert!(canonical.command.is_empty());
+
+        let mut legacy = canonical.clone();
+        legacy.cwd = Some("/historical/ignored/cwd".to_string());
+        legacy.command = "printf must-not-run".to_string();
+        assert!(matches!(
+            legacy.decode_operation().unwrap(),
+            RunnerOperation::Lsp { .. }
+        ));
+
+        legacy.process = Some(ShellProcessArgv {
+            executable: "printf".to_string(),
+            args: vec!["conflict".to_string()],
+        });
+        assert!(legacy
+            .decode_operation()
+            .unwrap_err()
+            .contains("conflicting"));
     }
 
     #[test]

--- a/crates/webcodex-runner-registry/src/job_updates.rs
+++ b/crates/webcodex-runner-registry/src/job_updates.rs
@@ -23,6 +23,11 @@ use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use tokio::sync::Notify;
 use uuid::Uuid;
+use webcodex_core::runner_operation::{
+    RunnerInvocationMetadata, RunnerJobOperation, RunnerJobProcessOperation,
+    RunnerJobScriptOperation, RunnerJobShellOperation, RunnerJobValidationOperation,
+    RunnerOperation,
+};
 use webcodex_core::runner_protocol::{
     validate_process_argv, validate_script_request, validation_infrastructure_failure_code,
     RunnerJobUpdateRequest, RunnerRequest, ShellCommandExecutionState, ShellJobActivity,
@@ -687,18 +692,11 @@ impl RunnerRegistry {
                     .to_string(),
             );
         }
-        let (
-            request_kind,
-            request_command,
-            request_process,
-            request_script,
-            request_stdin,
-            safe_command_preview,
-            structured_metadata,
-            job_kind,
-        ) = match structured_execution {
+        let (safe_command_preview, structured_metadata, job_kind) = match structured_execution
+            .as_ref()
+        {
             Some(StructuredJobExecution::Process(process)) => {
-                validate_process_argv(&process)?;
+                validate_process_argv(process)?;
                 validate_structured_job_common(
                     normalized_job_cwd.as_deref(),
                     structured_stdin.as_deref(),
@@ -716,19 +714,10 @@ impl RunnerRegistry {
                     validation_tool: validation_tool.clone(),
                     assertion_name: assertion_name.clone(),
                 };
-                (
-                    "start_process_job",
-                    String::new(),
-                    Some(process),
-                    None,
-                    structured_stdin,
-                    preview,
-                    Some(safe),
-                    "run_process",
-                )
+                (preview, Some(safe), "run_process")
             }
             Some(StructuredJobExecution::DetachedProcess(process)) => {
-                validate_process_argv(&process)?;
+                validate_process_argv(process)?;
                 validate_structured_job_common(
                     normalized_job_cwd.as_deref(),
                     structured_stdin.as_deref(),
@@ -745,20 +734,11 @@ impl RunnerRegistry {
                     validation_tool: validation_tool.clone(),
                     assertion_name: None,
                 };
-                (
-                    "start_detached_process_job",
-                    String::new(),
-                    Some(process),
-                    None,
-                    structured_stdin,
-                    preview,
-                    Some(safe),
-                    "run_detached_process",
-                )
+                (preview, Some(safe), "run_detached_process")
             }
             Some(StructuredJobExecution::Script(script)) => {
                 validate_script_request(
-                    &script,
+                    script,
                     structured_stdin.as_deref(),
                     normalized_job_cwd.as_deref(),
                     timeout_secs,
@@ -778,16 +758,7 @@ impl RunnerRegistry {
                     validation_tool: validation_tool.clone(),
                     assertion_name: assertion_name.clone(),
                 };
-                (
-                    "start_script_job",
-                    String::new(),
-                    None,
-                    Some(script),
-                    structured_stdin,
-                    preview,
-                    Some(safe),
-                    "run_script",
-                )
+                (preview, Some(safe), "run_script")
             }
             None => {
                 let run = ShellRunRequest {
@@ -799,17 +770,6 @@ impl RunnerRegistry {
                     wait_timeout_secs: 0,
                 };
                 validate_run_request(&run)?;
-                let request_kind = if validation_steps.is_empty() {
-                    "start_job"
-                } else {
-                    "start_validation_job"
-                };
-                let request_command = if validation_steps.is_empty() {
-                    command.clone()
-                } else {
-                    serde_json::to_string(&validation_steps)
-                        .map_err(|error| format!("could not serialize validation plan: {error}"))?
-                };
                 let preview = if validation_steps.is_empty() {
                     command_preview(&run.command)
                 } else {
@@ -822,27 +782,23 @@ impl RunnerRegistry {
                             .join(", ")
                     )
                 };
-                (
-                    request_kind,
-                    request_command,
-                    None,
-                    None,
-                    None,
-                    preview,
-                    None,
-                    "shell",
-                )
+                (preview, None, "shell")
             }
         };
+        let detached_request = matches!(
+            structured_execution.as_ref(),
+            Some(StructuredJobExecution::DetachedProcess(_))
+        );
         let detached_idempotency_key = metadata.detached_idempotency_key.as_deref();
-        let detached_request = request_kind == "start_detached_process_job";
         if detached_request != detached_idempotency_key.is_some() {
             return Err(
                 "detached idempotency_key must be present exactly for detached process Job starts"
                     .to_string(),
             );
         }
-        let detached_intent = if detached_request {
+        let detached_intent = if let Some(StructuredJobExecution::DetachedProcess(process)) =
+            structured_execution.as_ref()
+        {
             Some(DetachedIdempotencyIntent {
                 project_id: metadata.project_id.clone(),
                 session_id: metadata.session_id.clone(),
@@ -850,11 +806,8 @@ impl RunnerRegistry {
                 cwd: normalized_job_cwd.clone(),
                 purpose: metadata.purpose.clone(),
                 shell: metadata.shell.clone(),
-                process: request_process
-                    .as_ref()
-                    .expect("detached request has typed process")
-                    .clone(),
-                stdin: request_stdin.clone(),
+                process: process.clone(),
+                stdin: structured_stdin.clone(),
                 timeout_secs,
             })
         } else {
@@ -887,35 +840,64 @@ impl RunnerRegistry {
             validation: validation.clone(),
             structured_execution: structured_metadata.clone(),
         };
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: request_kind.to_string(),
-            job_id: Some(job_id.clone()),
-            cwd: normalized_job_cwd.clone(),
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: request_command,
-            process: request_process,
-            script: request_script,
-            stdin: request_stdin,
-            timeout_secs,
-            requested_by,
-            created_at,
-            validation: None,
-            lsp: None,
-            job_context: Some(job_context),
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
+        let job_operation = match structured_execution {
+            Some(StructuredJobExecution::Process(process)) => {
+                RunnerJobOperation::StartProcess(RunnerJobProcessOperation {
+                    job_id: job_id.clone(),
+                    cwd: normalized_job_cwd.clone(),
+                    process,
+                    stdin: structured_stdin.clone(),
+                    timeout_secs,
+                    context: job_context,
+                })
+            }
+            Some(StructuredJobExecution::DetachedProcess(process)) => {
+                RunnerJobOperation::StartDetachedProcess(RunnerJobProcessOperation {
+                    job_id: job_id.clone(),
+                    cwd: normalized_job_cwd.clone(),
+                    process,
+                    stdin: structured_stdin.clone(),
+                    timeout_secs,
+                    context: job_context,
+                })
+            }
+            Some(StructuredJobExecution::Script(script)) => {
+                RunnerJobOperation::StartScript(RunnerJobScriptOperation {
+                    job_id: job_id.clone(),
+                    cwd: normalized_job_cwd.clone(),
+                    script,
+                    stdin: structured_stdin.clone(),
+                    timeout_secs,
+                    context: job_context,
+                })
+            }
+            None if validation_steps.is_empty() => {
+                RunnerJobOperation::StartShell(RunnerJobShellOperation {
+                    job_id: job_id.clone(),
+                    cwd: normalized_job_cwd.clone(),
+                    command: command.clone(),
+                    timeout_secs,
+                    context: job_context,
+                })
+            }
+            None => RunnerJobOperation::StartValidation(RunnerJobValidationOperation {
+                job_id: job_id.clone(),
+                cwd: normalized_job_cwd.clone(),
+                steps: validation_steps.clone(),
+                timeout_secs,
+                context: job_context,
+            }),
         };
+        debug_assert_eq!(job_operation.is_detached_process(), detached_request);
+        let request = RunnerRequest::from_operation(
+            RunnerInvocationMetadata {
+                request_id: request_id.clone(),
+                client_id: client_id.clone(),
+                requested_by,
+                created_at,
+            },
+            RunnerOperation::Job(job_operation),
+        )?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&client_id) else {
             return Err(format!("unknown shell client: {}", client_id));
@@ -942,7 +924,7 @@ impl RunnerRegistry {
                 "capability_unavailable: runner {client_id} does not support structured_execution_jobs"
             ));
         }
-        if request.kind == "start_detached_process_job"
+        if detached_request
             && !runner
                 .runner_features
                 .supports(RunnerFeature::DetachedProcessJobs)
@@ -1301,35 +1283,17 @@ impl RunnerRegistry {
         ) && job.status != "stop_requested"
         {
             let stop_request_id = next_request_id();
-            let request = RunnerRequest {
-                request_id: stop_request_id.clone(),
-                client_id: job.client_id.clone(),
-                kind: "stop_job".to_string(),
-                job_id: Some(job_id.to_string()),
-                cwd: None,
-                path: None,
-                content: None,
-                max_bytes: None,
-                expected_sha256: None,
-                expected_prefix: None,
-                start_line: None,
-                end_line: None,
-                create_dirs: false,
-                command: String::new(),
-                process: None,
-                script: None,
-                stdin: None,
-                timeout_secs: 1,
-                requested_by: "tool_runtime_cleanup".to_string(),
-                created_at: now_ts(),
-                validation: None,
-                lsp: None,
-                job_context: None,
-                mcp_gateway: None,
-                plugin_gateway: None,
-                coding_agent: None,
-                persistent_shell: None,
-            };
+            let request = RunnerRequest::from_operation(
+                RunnerInvocationMetadata {
+                    request_id: stop_request_id.clone(),
+                    client_id: job.client_id.clone(),
+                    requested_by: "tool_runtime_cleanup".to_string(),
+                    created_at: now_ts(),
+                },
+                RunnerOperation::Job(RunnerJobOperation::Stop {
+                    job_id: job_id.to_string(),
+                }),
+            )?;
             enqueue_pending_request_locked(
                 self.telemetry.as_ref(),
                 &mut inner,
@@ -1835,35 +1799,17 @@ impl RunnerRegistry {
             "agent_queued" | "running" | "stop_requested" => {
                 let stop_request_id = next_request_id();
                 let client_id = job.client_id.clone();
-                let request = RunnerRequest {
-                    request_id: stop_request_id.clone(),
-                    client_id: client_id.clone(),
-                    kind: "stop_job".to_string(),
-                    job_id: Some(job_id.to_string()),
-                    cwd: None,
-                    path: None,
-                    content: None,
-                    max_bytes: None,
-                    expected_sha256: None,
-                    expected_prefix: None,
-                    start_line: None,
-                    end_line: None,
-                    create_dirs: false,
-                    command: String::new(),
-                    process: None,
-                    script: None,
-                    stdin: None,
-                    timeout_secs: 1,
-                    requested_by,
-                    created_at: now_ts(),
-                    validation: None,
-                    lsp: None,
-                        job_context: None,
-                    mcp_gateway: None,
-                    plugin_gateway: None,
-                    coding_agent: None,
-                    persistent_shell: None,
-                };
+                let request = RunnerRequest::from_operation(
+                    RunnerInvocationMetadata {
+                        request_id: stop_request_id.clone(),
+                        client_id: client_id.clone(),
+                        requested_by,
+                        created_at: now_ts(),
+                    },
+                    RunnerOperation::Job(RunnerJobOperation::Stop {
+                        job_id: job_id.to_string(),
+                    }),
+                )?;
                 enqueue_pending_request_locked(
                     self.telemetry.as_ref(),
                     &mut inner,

--- a/crates/webcodex-runner-registry/src/jobs.rs
+++ b/crates/webcodex-runner-registry/src/jobs.rs
@@ -15,6 +15,7 @@ use webcodex_core::runner_protocol::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum PendingRequestEnqueueError {
+    InvalidOperation { message: String },
     UnknownRunner { client_id: String },
     RunnerOffline { client_id: String },
     QueueFull { client_id: String, limit: usize },
@@ -23,6 +24,9 @@ pub(super) enum PendingRequestEnqueueError {
 impl fmt::Display for PendingRequestEnqueueError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidOperation { message } => {
+                write!(formatter, "invalid canonical Runner operation: {message}")
+            }
             Self::UnknownRunner { client_id } => {
                 write!(formatter, "unknown shell client: {client_id}")
             }

--- a/crates/webcodex-runner-registry/src/polling.rs
+++ b/crates/webcodex-runner-registry/src/polling.rs
@@ -16,6 +16,7 @@ use webcodex_core::plugin::{
     validate_response_for_request as validate_plugin_gateway_response, PluginDispatchState,
     PluginGatewayResponse,
 };
+use webcodex_core::runner_operation::{RunnerJobOperation, RunnerOperation};
 use webcodex_core::runner_protocol::{
     RunnerPersistentShellResultRequest, RunnerPollRequest, RunnerRequest, RunnerResultPayload,
     ShellCommandExecutionState, ShellRunResponse,
@@ -93,13 +94,10 @@ impl RunnerRegistry {
             let stale_runner_config_error =
                 inner.pending_by_id.get(&request_id).and_then(|pending| {
                     match (
-                        pending.request.kind.as_str(),
+                        &pending.operation,
                         pending.expected_runner_config_runner_instance_id.as_deref(),
                     ) {
-                        (
-                            webcodex_core::runner_protocol::RUNNER_CONFIG_REQUEST_KIND,
-                            Some(expected),
-                        ) => {
+                        (RunnerOperation::RunnerConfig(_), Some(expected)) => {
                             let Some(runner) = inner.runners.get(&body.client_id) else {
                                 return Some((
                                     "runner_replaced",
@@ -123,12 +121,10 @@ impl RunnerRegistry {
                                     .to_string(),
                             ))
                         }
-                        (webcodex_core::runner_protocol::RUNNER_CONFIG_REQUEST_KIND, None) => {
-                            Some((
-                                "runner_replaced",
-                                "Runner config exact-process fence is missing".to_string(),
-                            ))
-                        }
+                        (RunnerOperation::RunnerConfig(_), None) => Some((
+                            "runner_replaced",
+                            "Runner config exact-process fence is missing".to_string(),
+                        )),
                         (_, Some(_)) => Some((
                             "runner_replaced",
                             "Runner config exact-process fence is inconsistent".to_string(),
@@ -161,10 +157,10 @@ impl RunnerRegistry {
             let stale_ssh_resource_error =
                 inner.pending_by_id.get(&request_id).and_then(|pending| {
                     match (
-                        pending.request.kind.as_str(),
+                        &pending.operation,
                         pending.expected_ssh_resource_runner_instance_id.as_deref(),
                     ) {
-                        ("ssh_resource", Some(expected_runner)) => {
+                        (RunnerOperation::SshResource(_), Some(expected_runner)) => {
                             let Some(runner) = inner.runners.get(&body.client_id) else {
                                 return Some((
                                     "runner_replaced",
@@ -187,7 +183,7 @@ impl RunnerRegistry {
                                     .to_string(),
                             ))
                         }
-                        ("ssh_resource", None) => Some((
+                        (RunnerOperation::SshResource(_), None) => Some((
                             "runner_replaced",
                             "SSH resource exact Runner fence is missing".to_string(),
                         )),
@@ -223,13 +219,13 @@ impl RunnerRegistry {
             let stale_bridge_error =
                 inner.pending_by_id.get(&request_id).and_then(|pending| {
                     match (
-                        pending.request.mcp_gateway.as_ref(),
+                        &pending.operation,
                         pending.expected_mcp_gateway_runner_instance_id.as_deref(),
                         pending.expected_mcp_gateway_provider_id.as_deref(),
                         pending.expected_mcp_gateway_provider_instance_id.as_deref(),
                     ) {
                         (
-                            Some(operation),
+                            RunnerOperation::McpGateway(operation),
                             Some(expected_runner),
                             Some(expected_provider),
                             Some(expected_provider_instance),
@@ -274,7 +270,7 @@ impl RunnerRegistry {
                                     .to_string(),
                             ))
                         }
-                        (None, None, None, None) => None,
+                        (_, None, None, None) => None,
                         _ => Some((
                             "stale_provider",
                             "stale_mcp_gateway: pending exact bridge fence is incomplete"
@@ -318,7 +314,7 @@ impl RunnerRegistry {
                 continue;
             }
             let stale_plugin_error = inner.pending_by_id.get(&request_id).and_then(|pending| {
-                let Some(operation) = pending.request.plugin_gateway.as_ref() else {
+                let RunnerOperation::PluginGateway(operation) = &pending.operation else {
                     return None;
                 };
                 let Some(fence) = inner.plugin_gateway_fences.get(&request_id) else {
@@ -397,8 +393,8 @@ impl RunnerRegistry {
             }
             let stale_skill_store_error =
                 inner.pending_by_id.get(&request_id).and_then(|pending| {
-                    match (pending.request.kind.as_str(), pending.skill_store_fence.as_ref()) {
-                        ("skill_store", Some(fence)) => {
+                    match (&pending.operation, pending.skill_store_fence.as_ref()) {
+                        (RunnerOperation::SkillStore(_), Some(fence)) => {
                             let Some(runner) = inner.runners.get(&body.client_id) else {
                                 return Some(
                                     "stale_runner: Skill store target Runner disappeared before dispatch"
@@ -423,7 +419,7 @@ impl RunnerRegistry {
                                 )
                             })
                         }
-                        ("skill_store", None) => Some(
+                        (RunnerOperation::SkillStore(_), None) => Some(
                             "stale_runner: Skill store exact dispatch fence is missing".to_string(),
                         ),
                         (_, Some(_)) => Some(
@@ -459,7 +455,7 @@ impl RunnerRegistry {
             }
             let stale_coding_agent_error =
                 inner.pending_by_id.get(&request_id).and_then(|pending| {
-                    if pending.request.coding_agent.is_none() {
+                    if !matches!(&pending.operation, RunnerOperation::CodingAgent(_)) {
                         return None;
                     }
                     let Some(fence) = inner.coding_agent_fences.get(&request_id) else {
@@ -565,13 +561,22 @@ impl RunnerRegistry {
                 inner.persistent_waiters.remove(&request_id);
                 continue;
             }
-            let Some((request, job_id)) = inner.pending_by_id.get_mut(&request_id).map(|pending| {
-                pending.dispatched = true;
-                (pending.request.clone(), pending.job_id.clone())
-            }) else {
+            let Some((request, operation, job_id)) =
+                inner.pending_by_id.get_mut(&request_id).map(|pending| {
+                    pending.dispatched = true;
+                    (
+                        pending.request.clone(),
+                        pending.operation.clone(),
+                        pending.job_id.clone(),
+                    )
+                })
+            else {
                 continue;
             };
-            if request.kind == "stop_job" {
+            if matches!(
+                &operation,
+                RunnerOperation::Job(RunnerJobOperation::Stop { .. })
+            ) {
                 inner.pending_by_id.remove(&request_id);
                 return Ok(Some(request));
             }
@@ -653,13 +658,19 @@ impl RunnerRegistry {
         if pending.request.client_id != body.client_id {
             return Err("request_id does not belong to client_id".to_string());
         }
-        if pending.request.coding_agent.is_none() && payload.coding_agent.is_some() {
+        if !matches!(&pending.operation, RunnerOperation::CodingAgent(_))
+            && payload.coding_agent.is_some()
+        {
             return Err("unexpected CodingAgentRun result for non-coding request".to_string());
         }
-        if pending.request.mcp_gateway.is_none() && payload.mcp_gateway.is_some() {
+        if !matches!(&pending.operation, RunnerOperation::McpGateway(_))
+            && payload.mcp_gateway.is_some()
+        {
             return Err("unexpected MCP gateway result for non-bridge request".to_string());
         }
-        if pending.request.plugin_gateway.is_none() && payload.plugin_gateway.is_some() {
+        if !matches!(&pending.operation, RunnerOperation::PluginGateway(_))
+            && payload.plugin_gateway.is_some()
+        {
             return Err("unexpected Plugin gateway result for non-Plugin request".to_string());
         }
         self.telemetry
@@ -678,7 +689,7 @@ impl RunnerRegistry {
                 body.request_id
             ));
         };
-        if pending.request.mcp_gateway.is_some() {
+        if matches!(&pending.operation, RunnerOperation::McpGateway(_)) {
             let response = match mcp_gateway {
                 Some(response)
                     if command_execution_state.is_none()
@@ -712,7 +723,7 @@ impl RunnerRegistry {
             self.telemetry.runner_result_finalized(&trace_request_id);
             return Ok(());
         }
-        if pending.request.plugin_gateway.is_some() {
+        if let RunnerOperation::PluginGateway(plugin_request) = &pending.operation {
             let response = match plugin_gateway {
                 Some(response)
                     if command_execution_state.is_none()
@@ -723,15 +734,7 @@ impl RunnerRegistry {
                         && body.stderr.is_none()
                         && body.duration_ms.is_none()
                         && body.error.is_none()
-                        && validate_plugin_gateway_response(
-                            pending
-                                .request
-                                .plugin_gateway
-                                .as_ref()
-                                .expect("checked above"),
-                            &response,
-                        )
-                        .is_ok() =>
+                        && validate_plugin_gateway_response(plugin_request, &response).is_ok() =>
                 {
                     response
                 }
@@ -757,7 +760,7 @@ impl RunnerRegistry {
             self.telemetry.runner_result_finalized(&trace_request_id);
             return Ok(());
         }
-        if pending.request.coding_agent.is_some() {
+        if let RunnerOperation::CodingAgent(coding_request) = &pending.operation {
             let response = match coding_agent {
                 Some(response)
                     if command_execution_state.is_none()
@@ -767,15 +770,7 @@ impl RunnerRegistry {
                         && body.stderr.is_none()
                         && body.duration_ms.is_none()
                         && body.error.is_none()
-                        && validate_coding_agent_response(
-                            pending
-                                .request
-                                .coding_agent
-                                .as_ref()
-                                .expect("checked above"),
-                            &response,
-                        )
-                        .is_ok() =>
+                        && validate_coding_agent_response(coding_request, &response).is_ok() =>
                 {
                     response
                 }
@@ -806,7 +801,7 @@ impl RunnerRegistry {
         let request_id = body.request_id.clone();
         let client_id = body.client_id.clone();
         let error = body.error.clone();
-        let stdout = if is_large_native_image_request(&pending.request) {
+        let stdout = if pending.operation.is_large_native_image_request() {
             truncate_output_to(
                 body.stdout,
                 webcodex_core::artifact_policy::MAX_MCP_IMAGE_RESPONSE_BYTES,
@@ -913,9 +908,10 @@ impl RunnerRegistry {
         if pending.request.client_id != body.client_id {
             return Err("request_id does not belong to client_id".to_string());
         }
-        let expected = pending.request.persistent_shell.as_ref().ok_or_else(|| {
-            "request_id does not belong to a persistent shell request".to_string()
-        })?;
+        let RunnerOperation::PersistentShell(operation) = &pending.operation else {
+            return Err("request_id does not belong to a persistent shell request".to_string());
+        };
+        let expected = &operation.request;
         if expected.shell_id != body.result.shell_id
             || expected.workflow_session_id != body.result.workflow_session_id
             || expected.runtime_project_id != body.result.runtime_project_id
@@ -987,20 +983,4 @@ fn truncate_persistent_shell_stream(value: &mut String) -> bool {
     }
     *value = value[start..].to_string();
     true
-}
-
-fn is_large_native_image_request(request: &RunnerRequest) -> bool {
-    if matches!(
-        request.kind.as_str(),
-        "computer_snapshot" | "computer_snapshot_display"
-    ) {
-        return true;
-    }
-    request.kind == "file_read_project_artifact"
-        && request
-            .content
-            .as_deref()
-            .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok())
-            .and_then(|payload| payload.get("mcp_image").and_then(|value| value.as_bool()))
-            .unwrap_or(false)
 }

--- a/crates/webcodex-runner-registry/src/polling.rs
+++ b/crates/webcodex-runner-registry/src/polling.rs
@@ -270,7 +270,11 @@ impl RunnerRegistry {
                                     .to_string(),
                             ))
                         }
-                        (_, None, None, None) => None,
+                        (operation, None, None, None)
+                            if !matches!(operation, RunnerOperation::McpGateway(_)) =>
+                        {
+                            None
+                        }
                         _ => Some((
                             "stale_provider",
                             "stale_mcp_gateway: pending exact bridge fence is incomplete"

--- a/crates/webcodex-runner-registry/src/requests.rs
+++ b/crates/webcodex-runner-registry/src/requests.rs
@@ -21,7 +21,7 @@ use webcodex_core::coding_agent::{
     validate_request as validate_coding_agent_request, CodingAgentDispatchState,
     CodingAgentRequest, CodingAgentResponse,
 };
-use webcodex_core::lsp_bridge::{RunnerLspPayload, RunnerLspRequest, AGENT_LSP_REQUEST_KIND};
+use webcodex_core::lsp_bridge::{RunnerLspPayload, RunnerLspRequest};
 use webcodex_core::mcp_gateway::{
     validate_request as validate_mcp_gateway_request, McpGatewayDispatchState, McpGatewayRequest,
     McpGatewayResponse,
@@ -29,6 +29,12 @@ use webcodex_core::mcp_gateway::{
 use webcodex_core::plugin::{
     validate_request as validate_plugin_gateway_request, PluginDispatchState, PluginGatewayRequest,
     PluginGatewayResponse,
+};
+use webcodex_core::runner_operation::{
+    RunnerComputerOperation, RunnerComputerOperationKind, RunnerFileOperation,
+    RunnerInvocationMetadata, RunnerOperation, RunnerPersistentShellOperation,
+    RunnerProcessOperation, RunnerProjectOperation, RunnerProjectOperationKind,
+    RunnerScriptOperation, RunnerShellOperation,
 };
 use webcodex_core::runner_protocol::{
     shell_computer_request_payload_max_bytes, PersistentShellRequest, PersistentShellResult,
@@ -42,8 +48,7 @@ use webcodex_core::runner_protocol::{
     RUNNER_CAPABILITY_FILE_WRITE, RUNNER_CAPABILITY_INTERNAL_POSIX_SCRIPT,
     RUNNER_CAPABILITY_PERSISTENT_SHELL, RUNNER_CAPABILITY_SSH_PERSISTENT_SHELL,
     RUNNER_CAPABILITY_STRUCTURED_FILE_DELETE, RUNNER_CAPABILITY_STRUCTURED_PROCESS_ARGV,
-    RUNNER_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD, RUNNER_CONFIG_REQUEST_KIND,
-    RUNNER_CONFIG_REQUEST_MAX_BYTES,
+    RUNNER_CAPABILITY_STRUCTURED_SCRIPT_PAYLOAD, RUNNER_CONFIG_REQUEST_MAX_BYTES,
 };
 use webcodex_core::skill_store::SkillStoreRequest;
 use webcodex_core::ssh_resource::{SshResourceRequest, SSH_RESOURCE_REQUEST_MAX_BYTES};
@@ -101,6 +106,9 @@ impl std::error::Error for EnqueueLspError {}
 impl From<PendingRequestEnqueueError> for EnqueueLspError {
     fn from(error: PendingRequestEnqueueError) -> Self {
         match error {
+            PendingRequestEnqueueError::InvalidOperation { message } => {
+                Self::InvalidRequest { message }
+            }
             PendingRequestEnqueueError::UnknownRunner { client_id } => {
                 Self::UnknownRunner { client_id }
             }
@@ -142,6 +150,9 @@ pub(super) fn enqueue_pending_request_locked(
     waiter: Option<oneshot::Sender<ShellRunResponse>>,
     job_id: Option<String>,
 ) -> Result<(), PendingRequestEnqueueError> {
+    let operation = request
+        .decode_operation()
+        .map_err(|message| PendingRequestEnqueueError::InvalidOperation { message })?;
     ensure_dispatch_supported_locked(inner, client_id)?;
     ensure_queue_capacity_locked(inner, client_id)?;
     let runner = inner.runners.get(client_id);
@@ -169,6 +180,7 @@ pub(super) fn enqueue_pending_request_locked(
         request_id,
         PendingShellRequest {
             request,
+            operation,
             waiter,
             job_id,
             expected_runner_owner: None,
@@ -345,6 +357,37 @@ fn apply_text_edits_capability_requirements(body: &ShellFileOpRequest) -> (bool,
     (requires_occurrence, requires_line_scope)
 }
 
+fn encode_runner_operation(
+    request_id: &str,
+    client_id: &str,
+    requested_by: String,
+    operation: RunnerOperation,
+) -> Result<RunnerRequest, String> {
+    RunnerRequest::from_operation(
+        RunnerInvocationMetadata {
+            request_id: request_id.to_string(),
+            client_id: client_id.to_string(),
+            requested_by,
+            created_at: now_ts(),
+        },
+        operation,
+    )
+}
+
+fn encode_file_operation(
+    request_id: &str,
+    body: &ShellFileOpRequest,
+    requested_by: String,
+) -> Result<RunnerRequest, String> {
+    let operation = RunnerFileOperation::from_server_request(body)?;
+    encode_runner_operation(
+        request_id,
+        &body.client_id,
+        requested_by,
+        RunnerOperation::File(operation),
+    )
+}
+
 impl RunnerRegistry {
     pub async fn enqueue_file_op(
         &self,
@@ -397,36 +440,7 @@ impl RunnerRegistry {
     ) -> Result<(String, oneshot::Receiver<ShellRunResponse>), String> {
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let kind = format!("file_{}", body.op);
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind,
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         enqueue_pending_request_locked(
             self.telemetry.as_ref(),
@@ -459,35 +473,7 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind: "file_apply_text_edits".to_string(),
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
@@ -534,35 +520,7 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind: "file_apply_text_edits".to_string(),
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
@@ -617,35 +575,7 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind: "file_apply_patch".to_string(),
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
@@ -716,35 +646,7 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind: "file_save_project_artifact".to_string(),
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         self.prune_expired_shared_key_runners_locked(&mut inner, now_ts());
         let current = inner
@@ -806,35 +708,7 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind: "file_read_project_artifact_metadata".to_string(),
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
@@ -895,35 +769,7 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind: "file_read_project_artifact_export_chunk".to_string(),
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
@@ -975,36 +821,7 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let kind = format!("file_{}", body.op);
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind,
-            job_id: None,
-            cwd: body.cwd.clone().map(|cwd| cwd.trim().to_string()),
-            path: Some(body.path.trim().to_string()),
-            content: body.content.clone(),
-            max_bytes: body.max_bytes,
-            expected_sha256: body.expected_sha256.clone(),
-            expected_prefix: body.expected_prefix.clone(),
-            start_line: body.start_line,
-            end_line: body.end_line,
-            create_dirs: body.create_dirs,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+        let request = encode_file_operation(&request_id, &body, requested_by)?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&body.client_id) else {
             return Err(format!("unknown shell client: {}", body.client_id));
@@ -1062,35 +879,17 @@ impl RunnerRegistry {
         let normalized_cwd = cwd.map(|cwd| cwd.trim().to_string());
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: "run_process".to_string(),
-            job_id: None,
-            cwd: normalized_cwd,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: Some(process),
-            script: None,
-            stdin,
-            timeout_secs,
+        let request = encode_runner_operation(
+            &request_id,
+            &client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+            RunnerOperation::RunProcess(RunnerProcessOperation {
+                cwd: normalized_cwd,
+                process,
+                stdin,
+                timeout_secs,
+            }),
+        )?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
@@ -1138,35 +937,17 @@ impl RunnerRegistry {
         let normalized_cwd = cwd.map(|cwd| cwd.trim().to_string());
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: "run_script".to_string(),
-            job_id: None,
-            cwd: normalized_cwd,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: Some(script),
-            stdin,
-            timeout_secs,
+        let request = encode_runner_operation(
+            &request_id,
+            &client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+            RunnerOperation::RunScript(RunnerScriptOperation {
+                cwd: normalized_cwd,
+                script,
+                stdin,
+                timeout_secs,
+            }),
+        )?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
@@ -1223,35 +1004,17 @@ impl RunnerRegistry {
         let normalized_cwd = cwd.map(|cwd| cwd.trim().to_string());
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: "run_internal_posix_script".to_string(),
-            job_id: None,
-            cwd: normalized_cwd,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: Some(script),
-            stdin: None,
-            timeout_secs,
+        let request = encode_runner_operation(
+            &request_id,
+            &client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+            RunnerOperation::RunInternalPosixScript(RunnerScriptOperation {
+                cwd: normalized_cwd,
+                script,
+                stdin: None,
+                timeout_secs,
+            }),
+        )?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
@@ -1313,41 +1076,23 @@ impl RunnerRegistry {
             });
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: body.client_id.clone(),
-            kind: "run_shell".to_string(),
-            job_id: None,
-            cwd: normalized_cwd,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: body.command.clone(),
-            process: None,
-            script: None,
-            stdin: body.stdin.clone(),
-            timeout_secs: body.timeout_secs,
-            requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: ssh_context,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
-        let mut inner = self.inner.lock().await;
-        if request
-            .job_context
+        let has_ssh_context = ssh_context
             .as_ref()
-            .is_some_and(|context| context.ssh_resource.is_some())
-        {
+            .is_some_and(|context| context.ssh_resource.is_some());
+        let request = encode_runner_operation(
+            &request_id,
+            &body.client_id,
+            requested_by,
+            RunnerOperation::RunShell(RunnerShellOperation {
+                cwd: normalized_cwd,
+                command: body.command.clone(),
+                stdin: body.stdin.clone(),
+                timeout_secs: body.timeout_secs,
+                job_context: ssh_context,
+            }),
+        )?;
+        let mut inner = self.inner.lock().await;
+        if has_ssh_context {
             let Some(runner) = inner.runners.get(&body.client_id) else {
                 return Err(format!("unknown shell client: {}", body.client_id));
             };
@@ -1456,35 +1201,13 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.to_string(),
-            kind: "skill_store".to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: Some(content),
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 120,
+        let request = encode_runner_operation(
+            &request_id,
+            client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            persistent_shell: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-        };
+            RunnerOperation::SkillStore(operation),
+        )
+        .map_err(|_| "invalid Skill store request".to_string())?;
         let mut inner = self.inner.lock().await;
         let runner = inner
             .runners
@@ -1552,35 +1275,12 @@ impl RunnerRegistry {
         let expected_provider_instance_id = operation.provider_instance_id().to_string();
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.to_string(),
-            kind: "mcp_gateway".to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 120,
+        let request = encode_runner_operation(
+            &request_id,
+            client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            persistent_shell: None,
-            mcp_gateway: Some(operation),
-            plugin_gateway: None,
-            coding_agent: None,
-        };
+            RunnerOperation::McpGateway(operation),
+        )?;
         let mut inner = self.inner.lock().await;
         let runner = inner
             .runners
@@ -1650,35 +1350,12 @@ impl RunnerRegistry {
                 });
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.to_string(),
-            kind: "plugin_gateway".to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 120,
+        let request = encode_runner_operation(
+            &request_id,
+            client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            persistent_shell: None,
-            mcp_gateway: None,
-            plugin_gateway: Some(operation),
-            coding_agent: None,
-        };
+            RunnerOperation::PluginGateway(operation),
+        )?;
         let mut inner = self.inner.lock().await;
         let runner = inner
             .runners
@@ -1740,35 +1417,13 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.to_string(),
-            kind: "ssh_resource".to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: Some(content),
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 60,
+        let request = encode_runner_operation(
+            &request_id,
+            client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            persistent_shell: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-        };
+            RunnerOperation::SshResource(operation),
+        )
+        .map_err(|_| "ssh_resource_invalid: request was not started".to_string())?;
         let mut inner = self.inner.lock().await;
         let runner = inner
             .runners
@@ -1830,35 +1485,13 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.to_string(),
-            kind: RUNNER_CONFIG_REQUEST_KIND.to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: Some(content),
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 30,
+        let request = encode_runner_operation(
+            &request_id,
+            client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            persistent_shell: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-        };
+            RunnerOperation::RunnerConfig(operation),
+        )
+        .map_err(|_| "invalid_runner_config_request: request was not started".to_string())?;
         let mut inner = self.inner.lock().await;
         let runner = inner
             .runners
@@ -1924,35 +1557,12 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.to_string(),
-            kind: "coding_agent".to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 120,
+        let request = encode_runner_operation(
+            &request_id,
+            client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            persistent_shell: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: Some(operation),
-        };
+            RunnerOperation::CodingAgent(operation),
+        )?;
         let mut inner = self.inner.lock().await;
         let runner = inner
             .runners
@@ -2051,35 +1661,15 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let wire_request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: "persistent_shell".to_string(),
-            job_id: None,
-            cwd: request.cwd.clone(),
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: request.command.clone().unwrap_or_default(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: request.timeout_secs.unwrap_or(30),
+        let wire_request = encode_runner_operation(
+            &request_id,
+            &client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: job_context.clone(),
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: Some(request),
-        };
+            RunnerOperation::PersistentShell(RunnerPersistentShellOperation {
+                request,
+                job_context: job_context.clone(),
+            }),
+        )?;
         let mut inner = self.inner.lock().await;
         let Some(runner) = inner.runners.get(&client_id) else {
             return Err(format!("unknown shell client: {client_id}"));
@@ -2161,35 +1751,17 @@ impl RunnerRegistry {
         };
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: kind.to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: Some(payload),
-            timeout_secs: 30,
+        let operation_kind = RunnerProjectOperationKind::from_wire(kind)
+            .ok_or_else(|| format!("unsupported project op kind: {kind}"))?;
+        let request = encode_runner_operation(
+            &request_id,
+            &client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+            RunnerOperation::Project(RunnerProjectOperation {
+                kind: operation_kind,
+                payload,
+            }),
+        )?;
         let mut inner = self.inner.lock().await;
         if let Some(required_feature) = required_feature {
             let runner = inner
@@ -2263,35 +1835,18 @@ impl RunnerRegistry {
         }
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: kind.to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: Some(payload),
-            timeout_secs: timeout_secs.max(1),
+        let operation_kind = RunnerComputerOperationKind::from_wire(kind)
+            .ok_or_else(|| "invalid computer request kind".to_string())?;
+        let request = encode_runner_operation(
+            &request_id,
+            &client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: None,
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+            RunnerOperation::Computer(RunnerComputerOperation {
+                kind: operation_kind,
+                payload,
+                timeout_secs: timeout_secs.max(1),
+            }),
+        )?;
         let mut inner = self.inner.lock().await;
         self.prune_expired_shared_key_runners_locked(&mut inner, now_ts());
         let current = inner
@@ -2345,35 +1900,16 @@ impl RunnerRegistry {
         };
         let request_id = next_request_id();
         let (tx, rx) = oneshot::channel();
-        let request = RunnerRequest {
-            request_id: request_id.clone(),
-            client_id: client_id.clone(),
-            kind: AGENT_LSP_REQUEST_KIND.to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: None,
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: timeout_secs.max(1),
+        let request = encode_runner_operation(
+            &request_id,
+            &client_id,
             requested_by,
-            created_at: now_ts(),
-            validation: None,
-            lsp: Some(payload),
-            job_context: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
-            persistent_shell: None,
-        };
+            RunnerOperation::Lsp {
+                payload,
+                timeout_secs: timeout_secs.max(1),
+            },
+        )
+        .map_err(|message| EnqueueLspError::InvalidRequest { message })?;
         let mut inner = self.inner.lock().await;
         self.prune_expired_shared_key_runners_locked(&mut inner, now_ts());
         // This check is the authoritative TOCTOU fence: capability validation

--- a/crates/webcodex-runner-registry/src/requests.rs
+++ b/crates/webcodex-runner-registry/src/requests.rs
@@ -1087,6 +1087,7 @@ impl RunnerRegistry {
                 cwd: normalized_cwd,
                 command: body.command.clone(),
                 stdin: body.stdin.clone(),
+                max_bytes: None,
                 timeout_secs: body.timeout_secs,
                 job_context: ssh_context,
             }),

--- a/crates/webcodex-runner-registry/src/requests.rs
+++ b/crates/webcodex-runner-registry/src/requests.rs
@@ -158,9 +158,9 @@ pub(super) fn enqueue_pending_request_locked(
     let runner = inner.runners.get(client_id);
     telemetry.request_enqueued(
         &request,
+        &operation,
         &request_id,
         client_id,
-        &request.kind,
         request.job_id.as_deref().or(job_id.as_deref()),
         runner.map(|record| record.runner_instance_id.as_str()),
         runner.map(|record| record.transport.as_str()),

--- a/crates/webcodex-runner-registry/src/state.rs
+++ b/crates/webcodex-runner-registry/src/state.rs
@@ -10,6 +10,7 @@ use webcodex_core::coding_agent::{
 };
 use webcodex_core::mcp_gateway::McpGatewayResponse;
 use webcodex_core::plugin::PluginGatewayResponse;
+use webcodex_core::runner_operation::RunnerOperation;
 use webcodex_core::runner_protocol::{
     PersistentShellResult, RunnerBuildInfo, RunnerHostContext, RunnerPolicySummary,
     RunnerProjectSummary, RunnerRequest, RunnerView, ShellCommandExecutionState, ShellJobActivity,
@@ -208,6 +209,10 @@ pub(super) struct SkillStoreDispatchFence {
 #[derive(Debug)]
 pub(super) struct PendingShellRequest {
     pub(super) request: RunnerRequest,
+    /// Canonical semantic operation decoded exactly once when the V2 wire DTO is admitted.
+    /// Registry fencing/result correlation must use this field rather than reinterpreting
+    /// `request.kind + optional payloads`.
+    pub(super) operation: RunnerOperation,
     pub(super) waiter: Option<oneshot::Sender<ShellRunResponse>>,
     pub(super) job_id: Option<String>,
     /// Optional Control-side project-placement fence for synchronous requests

--- a/crates/webcodex-runner-registry/src/telemetry.rs
+++ b/crates/webcodex-runner-registry/src/telemetry.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use webcodex_core::runner_operation::RunnerOperation;
 use webcodex_core::runner_protocol::{RunnerJobUpdateRequest, RunnerRequest, RunnerResultPayload};
 
 /// Fail-open telemetry callbacks invoked only from authoritative registry
@@ -10,9 +11,9 @@ pub trait RunnerRegistryTelemetry: Debug + Send + Sync {
     fn request_enqueued(
         &self,
         request: &RunnerRequest,
+        operation: &RunnerOperation,
         request_id: &str,
         client_id: &str,
-        kind: &str,
         job_id: Option<&str>,
         runner_instance_id: Option<&str>,
         runner_transport: Option<&str>,
@@ -41,9 +42,9 @@ impl RunnerRegistryTelemetry for NoopRunnerRegistryTelemetry {
     fn request_enqueued(
         &self,
         _request: &RunnerRequest,
+        _operation: &RunnerOperation,
         _request_id: &str,
         _client_id: &str,
-        _kind: &str,
         _job_id: Option<&str>,
         _agent_instance_id: Option<&str>,
         _runner_transport: Option<&str>,

--- a/crates/webcodex-runner-registry/src/tests/mcp_gateway.rs
+++ b/crates/webcodex-runner-registry/src/tests/mcp_gateway.rs
@@ -268,6 +268,49 @@ async fn bridge_dequeue_rechecks_exact_runner_instance_after_replacement() {
 }
 
 #[tokio::test]
+async fn bridge_dequeue_rejects_missing_exact_target_fence() {
+    let registry = RunnerRegistry::default();
+    register_bridge_runner(&registry).await;
+    let alice = auth_context(Some("alice"), false);
+    let (request_id, mut receiver) = registry
+        .enqueue_mcp_gateway(
+            "bridge-runner",
+            "bridge-instance",
+            list_request("provider-instance"),
+            Some(&alice),
+            "test".to_string(),
+        )
+        .await
+        .unwrap();
+
+    // Dequeue must fail closed even if admission's exact target fence is lost.
+    {
+        let mut inner = registry.inner.lock().await;
+        let pending = inner.pending_by_id.get_mut(&request_id).unwrap();
+        pending.expected_mcp_gateway_runner_instance_id = None;
+        pending.expected_mcp_gateway_provider_id = None;
+        pending.expected_mcp_gateway_provider_instance_id = None;
+    }
+    let polled = registry
+        .poll(RunnerPollRequest {
+            client_id: "bridge-runner".to_string(),
+            runner_instance_id: "bridge-instance".to_string(),
+        })
+        .await
+        .unwrap();
+    assert!(
+        polled.is_none(),
+        "unfenced bridge work must not be dispatched"
+    );
+    let response = receiver.try_recv().unwrap();
+    assert_eq!(response.dispatch_state, McpGatewayDispatchState::NotStarted);
+    assert_eq!(response.error.as_ref().unwrap().code, "stale_provider");
+    let inner = registry.inner.lock().await;
+    assert!(!inner.pending_by_id.contains_key(&request_id));
+    assert!(!inner.mcp_gateway_waiters.contains_key(&request_id));
+}
+
+#[tokio::test]
 async fn bridge_dequeue_rechecks_exact_provider_instance_after_inventory_change() {
     let registry = RunnerRegistry::default();
     register_bridge_runner(&registry).await;

--- a/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
+++ b/crates/webcodex-runner-registry/src/tests/plugin_gateway.rs
@@ -78,6 +78,42 @@ async fn plugin_registration_needs_only_native_plugin_capability_not_provider_in
 }
 
 #[tokio::test]
+async fn typed_operation_decode_does_not_grant_runner_capability() {
+    let operation = PluginGatewayRequest::Reload;
+    let wire = webcodex_core::runner_protocol::RunnerRequest::from_operation(
+        webcodex_core::runner_operation::RunnerInvocationMetadata {
+            request_id: "typed-operation-capability-proof".to_string(),
+            client_id: "no-plugin-runner".to_string(),
+            requested_by: "test".to_string(),
+            created_at: 0,
+        },
+        webcodex_core::runner_operation::RunnerOperation::PluginGateway(operation.clone()),
+    )
+    .unwrap();
+    assert!(matches!(
+        wire.decode_operation().unwrap(),
+        webcodex_core::runner_operation::RunnerOperation::PluginGateway(_)
+    ));
+
+    let registry = RunnerRegistry::default();
+    let mut registration = plugin_registration("no-plugin-runner", "no-plugin-instance");
+    registration.capabilities.native_tool_plugins = false;
+    registry.register(registration).await.unwrap();
+    let alice = auth_context(Some("alice"), false);
+    let error = registry
+        .enqueue_plugin_gateway(
+            "no-plugin-runner",
+            "no-plugin-instance",
+            operation,
+            Some(&alice),
+            "test".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error, "exact Runner does not support native Tool Plugins");
+}
+
+#[tokio::test]
 async fn plugin_reload_can_target_exact_plugin_capable_runner_without_registration_catalog() {
     let registry = RunnerRegistry::default();
     registry

--- a/crates/webcodex-runner-registry/src/tests/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/tests/reconciliation.rs
@@ -8,6 +8,9 @@ use super::{
     clamp_grace, job_recovery_grace_secs, now_ts, RunnerRegistry, RUNNER_ONLINE_WINDOW_SECS,
     JOB_RECOVERY_GRACE_SECS, MAX_OUTPUT_BYTES,
 };
+use webcodex_core::runner_operation::{
+    RunnerInvocationMetadata, RunnerJobOperation, RunnerOperation,
+};
 use crate::runner_protocol::{
     PersistentShellResult, RunnerJobUpdateRequest, RunnerPollRequest,
     RunnerProjectSummary, RunnerRequest, RunnerCapabilities,
@@ -1588,10 +1591,18 @@ async fn terminal_observed_future_inventory_ended_at_cannot_bypass_prune() {
 
     let original_request_id = request.request_id.clone();
     let control_request_id = format!("control-{}", job.job_id);
-    let mut control_request: RunnerRequest = request.clone();
-    control_request.request_id = control_request_id.clone();
-    control_request.kind = "stop_job".to_string();
-    control_request.job_id = Some(job.job_id.clone());
+    let control_request = RunnerRequest::from_operation(
+        RunnerInvocationMetadata {
+            request_id: control_request_id.clone(),
+            client_id: request.client_id.clone(),
+            requested_by: request.requested_by.clone(),
+            created_at: request.created_at,
+        },
+        RunnerOperation::Job(RunnerJobOperation::Stop {
+            job_id: job.job_id.clone(),
+        }),
+    )
+    .unwrap();
     let (persistent_tx, _persistent_rx) = tokio::sync::oneshot::channel::<PersistentShellResult>();
     {
         let mut inner = registry_b.inner.lock().await;
@@ -1602,6 +1613,7 @@ async fn terminal_observed_future_inventory_ended_at_cannot_bypass_prune() {
             original_request_id.clone(),
             PendingShellRequest {
                 request: request.clone(),
+                operation: request.decode_operation().unwrap(),
                 waiter: None,
                 job_id: Some(job.job_id.clone()),
                 expected_runner_owner: None,
@@ -1622,7 +1634,8 @@ async fn terminal_observed_future_inventory_ended_at_cannot_bypass_prune() {
         inner.pending_by_id.insert(
             control_request_id.clone(),
             PendingShellRequest {
-                request: control_request,
+                request: control_request.clone(),
+                operation: control_request.decode_operation().unwrap(),
                 waiter: None,
                 job_id: Some(job.job_id.clone()),
                 expected_runner_owner: None,

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -16,9 +16,9 @@ use webcodex_runner::shutdown::{lock_unpoison, ActivityTracker, BackgroundThread
 mod job_manager_tests;
 mod webcodex_runner;
 
-use runner_operation::RunnerFileOperation;
 #[cfg(test)]
 use runner_operation::RunnerOperation;
+use runner_operation::{RunnerFileOperation, RunnerInvocationMetadata, RunnerJobOperation};
 use webcodex_core::{
     apply_edits_shared, apply_patch_shared, artifact_policy, build_info, lsp_bridge, mcp_gateway,
     runner_operation, runner_protocol, validation_bridge,
@@ -217,7 +217,40 @@ struct PendingJobStart {
     shell: ShellConfig,
     ssh: SshConfig,
     project_registry_dir: PathBuf,
-    request: RunnerRequest,
+    metadata: RunnerInvocationMetadata,
+    operation: RunnerJobOperation,
+}
+
+#[cfg(test)]
+impl PendingJobStart {
+    fn from_wire(
+        generation: u64,
+        policy: RunnerPolicy,
+        shell: ShellConfig,
+        ssh: SshConfig,
+        project_registry_dir: PathBuf,
+        request: RunnerRequest,
+    ) -> Self {
+        let invocation = request
+            .decode_invocation()
+            .expect("test Job wire request must decode to a canonical invocation");
+        let RunnerOperation::Job(operation) = invocation.operation else {
+            panic!("test PendingJobStart requires a Job operation");
+        };
+        assert!(
+            operation.is_start(),
+            "test PendingJobStart requires a start operation"
+        );
+        Self {
+            generation,
+            policy,
+            shell,
+            ssh,
+            project_registry_dir,
+            metadata: invocation.metadata,
+            operation,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2828,20 +2861,34 @@ fn runner_job_is_active(status: &str) -> bool {
     matches!(status, "agent_queued" | "running" | "stop_requested")
 }
 
-fn job_prestart_lifecycle_for_kind(kind: &str) -> Option<ShellCommandExecutionState> {
+fn job_prestart_lifecycle(operation: &RunnerJobOperation) -> Option<ShellCommandExecutionState> {
+    match operation {
+        RunnerJobOperation::StartShell(_)
+        | RunnerJobOperation::StartProcess(_)
+        | RunnerJobOperation::StartDetachedProcess(_)
+        | RunnerJobOperation::StartScript(_) => Some(ShellCommandExecutionState::NotStarted),
+        RunnerJobOperation::StartValidation(_) | RunnerJobOperation::Stop { .. } => None,
+    }
+}
+
+/// Compatibility-only lifecycle projection for malformed V2 Job requests that
+/// fail before a canonical operation can be constructed. Production Job
+/// execution never uses this string registry.
+pub(crate) fn decode_failure_prestart_lifecycle(
+    request: &RunnerRequest,
+) -> Option<ShellCommandExecutionState> {
     matches!(
-        kind,
+        request.kind.as_str(),
         "start_job" | "start_process_job" | "start_detached_process_job" | "start_script_job"
     )
     .then_some(ShellCommandExecutionState::NotStarted)
 }
 
-fn structured_prestart_lifecycle(request: &RunnerRequest) -> Option<ShellCommandExecutionState> {
-    job_prestart_lifecycle_for_kind(request.kind.as_str())
-}
-
-fn post_spawn_interruption_lifecycle_for_kind(kind: &str) -> Option<ShellCommandExecutionState> {
-    (kind == "start_job").then_some(ShellCommandExecutionState::OutcomeUnknown)
+fn post_spawn_interruption_lifecycle(
+    operation: &RunnerJobOperation,
+) -> Option<ShellCommandExecutionState> {
+    matches!(operation, RunnerJobOperation::StartShell(_))
+        .then_some(ShellCommandExecutionState::OutcomeUnknown)
 }
 
 fn post_spawn_interruption_reason(
@@ -2860,13 +2907,17 @@ fn post_spawn_interruption_reason(
     }
 }
 
-fn post_spawn_interruption_delta(kind: &str, duration_ms: u64, error: &str) -> RunnerJobDelta {
+fn post_spawn_interruption_delta(
+    operation: &RunnerJobOperation,
+    duration_ms: u64,
+    error: &str,
+) -> RunnerJobDelta {
     RunnerJobDelta {
         status: "failed".to_string(),
         exit_code: None,
         duration_ms: Some(duration_ms),
         error: Some(error.to_string()),
-        command_execution_state: post_spawn_interruption_lifecycle_for_kind(kind),
+        command_execution_state: post_spawn_interruption_lifecycle(operation),
         finished: true,
         ..Default::default()
     }
@@ -3124,15 +3175,21 @@ fn validate_detached_recovery_context(
     Ok(())
 }
 
-fn validate_runner_job_context(
+fn validate_runner_job_context_operation(
     context: &ShellJobContext,
-    request: &RunnerRequest,
+    operation: &RunnerJobOperation,
     client_id: &str,
 ) -> Result<(), String> {
     const MAX_CONTEXT_FIELD_CHARS: usize = 1_024;
     const MAX_COMMAND_PREVIEW_CHARS: usize = 121;
     let bounded =
         |value: &str, max_chars: usize| !value.contains('\0') && value.chars().count() <= max_chars;
+    if !operation.is_start() {
+        return Err("stop_job is not a Job start operation".to_string());
+    }
+    if operation.context() != Some(context) {
+        return Err("job recovery context does not match the typed Job operation".to_string());
+    }
     if !bounded(&context.command_preview, MAX_COMMAND_PREVIEW_CHARS)
         || context.command_preview.contains(['\r', '\n'])
     {
@@ -3151,7 +3208,7 @@ fn validate_runner_job_context(
             ));
         }
     }
-    if context.cwd != request.cwd {
+    if context.cwd.as_deref() != operation.cwd() {
         return Err("job recovery context cwd does not match the execution request".to_string());
     }
     if context.ssh_resource.is_some() && context.workflow_session_id.is_none() {
@@ -3180,12 +3237,29 @@ fn validate_runner_job_context(
     }) {
         return Err("job recovery context shell is invalid".to_string());
     }
-    if request.kind == "start_job" {
-        runner_protocol::validate_raw_shell_wire_command(&request.command)?;
-    }
-    let validation_context = request.kind == "start_validation_job";
-    if (validation_context && !(1..=3).contains(&context.validation_steps.len()))
-        || (!validation_context && !context.validation_steps.is_empty())
+
+    let validation_steps = match operation {
+        RunnerJobOperation::StartValidation(operation) => {
+            let names = operation
+                .steps
+                .iter()
+                .map(|step| step.name.clone())
+                .collect::<Vec<_>>();
+            if !(1..=3).contains(&operation.steps.len())
+                || operation.steps.iter().any(|step| !step.is_canonical())
+                || operation.steps.iter().enumerate().any(|(index, step)| {
+                    operation.steps[..index]
+                        .iter()
+                        .any(|earlier| earlier.name == step.name)
+                })
+            {
+                return Err("invalid structured validation plan".to_string());
+            }
+            names
+        }
+        _ => Vec::new(),
+    };
+    if context.validation_steps != validation_steps
         || context
             .validation_steps
             .iter()
@@ -3199,6 +3273,7 @@ fn validate_runner_job_context(
     {
         return Err("job recovery context validation_steps are invalid".to_string());
     }
+    let validation_context = matches!(operation, RunnerJobOperation::StartValidation(_));
     if context.validation.as_ref().is_some_and(|metadata| {
         !validation_context
             || !metadata.is_valid()
@@ -3218,98 +3293,39 @@ fn validate_runner_job_context(
     {
         return Err("job recovery context structured execution metadata is invalid".to_string());
     }
-    // validation_identity / validation_tool / assertion_name are server-admission-derived
-    // validation correlation metadata. The Runner validates their closed shape above,
-    // then preserves them while checking the execution fields it can authoritatively
-    // derive from the typed request. None of them grant execution authority.
-    let (validation_identity, validation_tool, assertion_name) = context
-        .structured_execution
-        .as_ref()
-        .map(|metadata| {
-            (
-                metadata.validation_identity.clone(),
-                metadata.validation_tool.clone(),
-                metadata.assertion_name.clone(),
-            )
-        })
-        .unwrap_or((None, None, None));
-    let expected_structured = match request.kind.as_str() {
-        "start_process_job" => {
-            if !request.command.is_empty()
-                || request.script.is_some()
-                || request.process.is_none()
-                || context.ssh_resource.is_some()
-            {
+
+    match operation {
+        RunnerJobOperation::StartShell(operation) => {
+            runner_protocol::validate_raw_shell_wire_command(&operation.command)?;
+        }
+        RunnerJobOperation::StartProcess(operation)
+        | RunnerJobOperation::StartDetachedProcess(operation) => {
+            if context.ssh_resource.is_some() {
                 return Err("typed process Job request shape is invalid".to_string());
             }
-            let process = request.process.as_ref().expect("checked process payload");
-            runner_protocol::validate_process_argv(process)?;
-            validate_runner_structured_common(request)?;
-            Some(runner_protocol::ShellJobStructuredExecutionMetadata {
-                execution_source: "run_process".to_string(),
-                language: None,
-                script_bytes: None,
-                arg_count: process.args.len(),
-                stdin_present: request.stdin.is_some(),
-                validation_identity: validation_identity.clone(),
-                validation_tool: validation_tool.clone(),
-                assertion_name: assertion_name.clone(),
-            })
+            runner_protocol::validate_process_argv(&operation.process)?;
+            validate_runner_structured_common(
+                operation.cwd.as_deref(),
+                operation.stdin.as_deref(),
+                operation.timeout_secs,
+            )?;
         }
-        "start_detached_process_job" => {
-            if !request.command.is_empty()
-                || request.script.is_some()
-                || request.process.is_none()
-                || context.ssh_resource.is_some()
-            {
-                return Err("typed detached process Job request shape is invalid".to_string());
-            }
-            let process = request
-                .process
-                .as_ref()
-                .expect("checked detached process payload");
-            runner_protocol::validate_process_argv(process)?;
-            validate_runner_structured_common(request)?;
-            Some(runner_protocol::ShellJobStructuredExecutionMetadata {
-                execution_source: "run_detached_process".to_string(),
-                language: None,
-                script_bytes: None,
-                arg_count: process.args.len(),
-                stdin_present: request.stdin.is_some(),
-                validation_identity: validation_identity.clone(),
-                validation_tool: validation_tool.clone(),
-                assertion_name: None,
-            })
-        }
-        "start_script_job" => {
-            if !request.command.is_empty()
-                || request.process.is_some()
-                || request.script.is_none()
-                || context.ssh_resource.is_some()
-            {
+        RunnerJobOperation::StartScript(operation) => {
+            if context.ssh_resource.is_some() {
                 return Err("typed script Job request shape is invalid".to_string());
             }
-            let script = request.script.as_ref().expect("checked script payload");
             runner_protocol::validate_script_request(
-                script,
-                request.stdin.as_deref(),
-                request.cwd.as_deref(),
-                request.timeout_secs,
+                &operation.script,
+                operation.stdin.as_deref(),
+                operation.cwd.as_deref(),
+                operation.timeout_secs,
             )?;
-            Some(runner_protocol::ShellJobStructuredExecutionMetadata {
-                execution_source: "run_script".to_string(),
-                language: Some(script.language),
-                script_bytes: Some(script.script.len()),
-                arg_count: script.args.len(),
-                stdin_present: request.stdin.is_some(),
-                validation_identity: validation_identity.clone(),
-                validation_tool: validation_tool.clone(),
-                assertion_name: assertion_name.clone(),
-            })
         }
-        _ => None,
-    };
-    if context.structured_execution != expected_structured {
+        RunnerJobOperation::StartValidation(_) => {}
+        RunnerJobOperation::Stop { .. } => unreachable!("stop rejected above"),
+    }
+
+    if context.structured_execution != operation.expected_structured_execution() {
         return Err(
             "job recovery context structured execution metadata does not match request".to_string(),
         );
@@ -3340,8 +3356,28 @@ fn validate_runner_job_context(
     Ok(())
 }
 
-fn validate_runner_structured_common(request: &RunnerRequest) -> Result<(), String> {
-    if let Some(stdin) = request.stdin.as_deref() {
+#[cfg(test)]
+fn validate_runner_job_context(
+    context: &ShellJobContext,
+    request: &RunnerRequest,
+    client_id: &str,
+) -> Result<(), String> {
+    let mut request = request.clone();
+    request.job_context = Some(context.clone());
+    match request.decode_operation()? {
+        runner_operation::RunnerOperation::Job(operation) => {
+            validate_runner_job_context_operation(context, &operation, client_id)
+        }
+        _ => Err("request is not a Runner Job operation".to_string()),
+    }
+}
+
+fn validate_runner_structured_common(
+    cwd: Option<&str>,
+    stdin: Option<&str>,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    if let Some(stdin) = stdin {
         if stdin.len() > runner_protocol::PROCESS_STDIN_MAX_BYTES {
             return Err(format!(
                 "stdin is too large; maximum is {} bytes",
@@ -3352,7 +3388,7 @@ fn validate_runner_structured_common(request: &RunnerRequest) -> Result<(), Stri
             return Err("stdin cannot contain NUL bytes".to_string());
         }
     }
-    if let Some(cwd) = request.cwd.as_deref() {
+    if let Some(cwd) = cwd {
         if cwd.len() > runner_protocol::PROCESS_CWD_MAX_BYTES {
             return Err(format!(
                 "cwd is too long; maximum is {} bytes",
@@ -3365,7 +3401,7 @@ fn validate_runner_structured_common(request: &RunnerRequest) -> Result<(), Stri
     }
     if !(runner_protocol::STRUCTURED_EXECUTION_TIMEOUT_MIN_SECS
         ..=runner_protocol::STRUCTURED_EXECUTION_TIMEOUT_MAX_SECS)
-        .contains(&request.timeout_secs)
+        .contains(&timeout_secs)
     {
         return Err(format!(
             "timeout_secs must be between {} and {}",
@@ -3588,20 +3624,18 @@ impl JobManager {
 
     fn fail_job(
         &self,
-        request: &RunnerRequest,
+        operation: &RunnerJobOperation,
         error: String,
         validation_progress: Option<ShellJobValidationProgress>,
     ) {
-        let Some(job_id) = request.job_id.as_deref() else {
-            return;
-        };
+        let job_id = operation.job_id();
         self.update_and_send(
             job_id,
             RunnerJobDelta {
                 status: "failed".to_string(),
                 duration_ms: Some(0),
                 error: Some(error),
-                command_execution_state: structured_prestart_lifecycle(request),
+                command_execution_state: job_prestart_lifecycle(operation),
                 validation_progress,
                 finished: true,
                 ..Default::default()
@@ -4054,46 +4088,27 @@ impl JobManager {
         self.workers.active()
     }
 
-    fn shutdown_rejection(&self, request: &RunnerRequest) {
-        self.fail_job(request, "runner is shutting down".to_string(), None);
+    fn shutdown_rejection(&self, operation: &RunnerJobOperation) {
+        self.fail_job(operation, "runner is shutting down".to_string(), None);
     }
 
     fn enqueue(&self, sink: RunnerSink, start: PendingJobStart) {
-        let Some(job_id) = start.request.job_id.clone() else {
+        if !start.operation.is_start() {
+            return;
+        }
+        let job_id = start.operation.job_id().to_string();
+        let Some(context) = start.operation.context().cloned() else {
             return;
         };
-        let Some(context) = start.request.job_context.clone() else {
-            let command_execution_state = structured_prestart_lifecycle(&start.request);
-            let _ = sink.send_job_update(&RunnerJobUpdateRequest {
-                client_id: sink.client_id().to_string(),
-                runner_instance_id: sink.runner_instance_id().to_string(),
-                job_id,
-                request_id: Some(start.request.request_id),
-                update_seq: Some(1),
-                status: "failed".to_string(),
-                stdout_chunk: None,
-                stderr_chunk: None,
-                stdout_tail: None,
-                stderr_tail: None,
-                log_snapshot: None,
-                exit_code: None,
-                duration_ms: Some(0),
-                error: Some("job start request is missing recovery context".to_string()),
-                command_execution_state,
-                validation_progress: None,
-                activity: None,
-                finished: true,
-            });
-            return;
-        };
-        if let Err(error) = validate_runner_job_context(&context, &start.request, sink.client_id())
+        if let Err(error) =
+            validate_runner_job_context_operation(&context, &start.operation, sink.client_id())
         {
-            let command_execution_state = structured_prestart_lifecycle(&start.request);
+            let command_execution_state = job_prestart_lifecycle(&start.operation);
             let _ = sink.send_job_update(&RunnerJobUpdateRequest {
                 client_id: sink.client_id().to_string(),
                 runner_instance_id: sink.runner_instance_id().to_string(),
                 job_id,
-                request_id: Some(start.request.request_id),
+                request_id: Some(start.metadata.request_id.clone()),
                 update_seq: Some(1),
                 status: "failed".to_string(),
                 stdout_chunk: None,
@@ -4155,21 +4170,21 @@ impl JobManager {
                     runner_instance_id,
                     snapshot: ShellJobSnapshot {
                         job_id: job_id.clone(),
-                        request_id: start.request.request_id.clone(),
+                        request_id: start.metadata.request_id.clone(),
                         status: if terminal {
                             "failed".to_string()
                         } else {
                             "agent_queued".to_string()
                         },
                         update_seq: u64::from(terminal),
-                        created_at: start.request.created_at,
+                        created_at: start.metadata.created_at,
                         started_at: None,
                         ended_at: terminal.then_some(now),
                         exit_code: None,
                         duration_ms: terminal.then_some(0),
                         error: immediate_failure.clone(),
                         command_execution_state: terminal
-                            .then(|| structured_prestart_lifecycle(&start.request))
+                            .then(|| job_prestart_lifecycle(&start.operation))
                             .flatten(),
                         context,
                         stdout: ShellJobStreamSnapshot::default(),
@@ -4209,40 +4224,20 @@ impl JobManager {
 
     fn start_now(&self, start: PendingJobStart) {
         if self.shutting_down.load(Ordering::SeqCst) {
-            self.shutdown_rejection(&start.request);
+            self.shutdown_rejection(&start.operation);
             return;
         }
-        if start.request.kind == "start_detached_process_job" {
-            let PendingJobStart {
-                generation,
-                policy,
-                shell,
-                project_registry_dir,
-                request,
-                ..
-            } = start;
-            self.start_detached_process_job(
-                generation,
-                policy,
-                shell,
-                project_registry_dir,
-                request,
-            );
-        } else if matches!(
-            start.request.kind.as_str(),
-            "start_process_job" | "start_script_job"
-        ) {
-            let PendingJobStart {
-                generation,
-                policy,
-                shell,
-                project_registry_dir,
-                request,
-                ..
-            } = start;
-            self.start_structured_job(generation, policy, shell, project_registry_dir, request);
-        } else {
-            self.start_shell_job(start);
+        match &start.operation {
+            RunnerJobOperation::StartDetachedProcess(_) => self.start_detached_process_job(start),
+            RunnerJobOperation::StartProcess(_) | RunnerJobOperation::StartScript(_) => {
+                self.start_structured_job(start)
+            }
+            RunnerJobOperation::StartShell(_) | RunnerJobOperation::StartValidation(_) => {
+                self.start_shell_job(start)
+            }
+            RunnerJobOperation::Stop { .. } => {
+                unreachable!("stop Job operation cannot enter the start queue")
+            }
         }
     }
 
@@ -4265,7 +4260,7 @@ impl JobManager {
                     let reserved = jobs
                         .values()
                         .filter(|job| {
-                            job.client_id == queued_start.request.client_id
+                            job.client_id == queued_start.metadata.client_id
                                 && job.slot_reserved
                                 && runner_job_is_active(&job.snapshot.status)
                         })
@@ -4276,10 +4271,9 @@ impl JobManager {
                     }
                 }
                 if let Some(idx) = selected {
-                    if let Some(job_id) = queued[idx].request.job_id.as_deref() {
-                        if let Some(job) = jobs.get_mut(job_id) {
-                            job.slot_reserved = true;
-                        }
+                    let job_id = queued[idx].operation.job_id();
+                    if let Some(job) = jobs.get_mut(job_id) {
+                        job.slot_reserved = true;
                     }
                     queued.remove(idx)
                 } else {
@@ -4293,17 +4287,20 @@ impl JobManager {
         }
     }
 
-    fn start_detached_process_job(
-        &self,
-        generation: u64,
-        policy: RunnerPolicy,
-        shell: ShellConfig,
-        project_registry_dir: PathBuf,
-        request: RunnerRequest,
-    ) {
-        let Some(job_id) = request.job_id.clone() else {
-            return;
-        };
+    fn start_detached_process_job(&self, start: PendingJobStart) {
+        let PendingJobStart {
+            generation,
+            policy,
+            shell,
+            project_registry_dir,
+            metadata,
+            operation,
+            ..
+        } = start;
+        let job_id = operation.job_id().to_string();
+        if !matches!(operation, RunnerJobOperation::StartDetachedProcess(_)) {
+            unreachable!("detached Job starter received non-detached operation");
+        }
         let (stop_requested, runner_instance_id) = {
             let _lifecycle = lock_unpoison(&self.lifecycle);
             if self.shutting_down.load(Ordering::SeqCst) {
@@ -4322,29 +4319,16 @@ impl JobManager {
         };
         let (Some(stop_requested), Some(runner_instance_id)) = (stop_requested, runner_instance_id)
         else {
-            self.shutdown_rejection(&request);
-            return;
-        };
-        let Some(process) = request.process.clone() else {
-            self.fail_job(
-                &request,
-                "typed detached process Job request is missing its payload".to_string(),
-                None,
-            );
-            return;
-        };
-        let Some(context) = request.job_context.clone() else {
-            self.fail_job(
-                &request,
-                "detached process Job request is missing recovery context".to_string(),
-                None,
-            );
+            self.shutdown_rejection(&operation);
             return;
         };
         let manager = self.clone_for_worker();
         let worker_guard = self.workers.enter();
         std::thread::spawn(move || {
             let _worker_guard = worker_guard;
+            let RunnerJobOperation::StartDetachedProcess(request) = &operation else {
+                unreachable!("detached Job starter received non-detached operation");
+            };
             let prepared = match prepare_detached_process_launch(
                 generation,
                 &policy,
@@ -4352,14 +4336,14 @@ impl JobManager {
                 &project_registry_dir,
                 &manager.prepared_profiles,
                 request.cwd.as_deref(),
-                &process.executable,
-                &process.args,
+                &request.process.executable,
+                &request.process.args,
                 request.timeout_secs,
                 Some(stop_requested.as_ref()),
             ) {
                 Ok(prepared) => prepared,
                 Err(error) => {
-                    manager.fail_job(&request, error, None);
+                    manager.fail_job(&operation, error, None);
                     manager.start_available_queued();
                     return;
                 }
@@ -4382,20 +4366,20 @@ impl JobManager {
                 manager.start_available_queued();
                 return;
             }
-            let store = match manager.detached_store_for_start(&request.client_id) {
+            let store = match manager.detached_store_for_start(&metadata.client_id) {
                 Ok(store) => store,
                 Err(error) => {
-                    manager.fail_job(&request, error, None);
+                    manager.fail_job(&operation, error, None);
                     manager.start_available_queued();
                     return;
                 }
             };
             let detached_request = DetachedStartRequest {
                 job_id: job_id.clone(),
-                request_id: request.request_id.clone(),
-                client_id: request.client_id.clone(),
+                request_id: metadata.request_id.clone(),
+                client_id: metadata.client_id.clone(),
                 runner_instance_id,
-                context,
+                context: request.context.clone(),
                 launch: DetachedLaunchSpec {
                     process: prepared.process,
                     cwd: Some(prepared.cwd),
@@ -4414,7 +4398,7 @@ impl JobManager {
                                 tracing::error!(job_id = %job_id, error = %sync_error, "detached Job failed-start durable sync failed closed");
                             }
                         }
-                        Err(_) => manager.fail_job(&request, error, None),
+                        Err(_) => manager.fail_job(&operation, error, None),
                     }
                     manager.start_available_queued();
                     return;
@@ -4461,17 +4445,22 @@ impl JobManager {
         });
     }
 
-    fn start_structured_job(
-        &self,
-        generation: u64,
-        policy: RunnerPolicy,
-        shell: ShellConfig,
-        project_registry_dir: PathBuf,
-        request: RunnerRequest,
-    ) {
-        let Some(job_id) = request.job_id.clone() else {
-            return;
-        };
+    fn start_structured_job(&self, start: PendingJobStart) {
+        let PendingJobStart {
+            generation,
+            policy,
+            shell,
+            project_registry_dir,
+            operation,
+            ..
+        } = start;
+        let job_id = operation.job_id().to_string();
+        if !matches!(
+            operation,
+            RunnerJobOperation::StartProcess(_) | RunnerJobOperation::StartScript(_)
+        ) {
+            unreachable!("structured Job starter received non process/script operation");
+        }
         let stop_requested = {
             let _lifecycle = lock_unpoison(&self.lifecycle);
             if self.shutting_down.load(Ordering::SeqCst) {
@@ -4486,19 +4475,9 @@ impl JobManager {
             }
         };
         let Some(stop_requested) = stop_requested else {
-            self.shutdown_rejection(&request);
+            self.shutdown_rejection(&operation);
             return;
         };
-        if (request.kind == "start_process_job" && request.process.is_none())
-            || (request.kind == "start_script_job" && request.script.is_none())
-        {
-            self.fail_job(
-                &request,
-                "typed structured Job request is missing its payload".to_string(),
-                None,
-            );
-            return;
-        }
         let manager = self.clone_for_worker();
         let worker_guard = self.workers.enter();
         std::thread::spawn(move || {
@@ -4515,9 +4494,8 @@ impl JobManager {
                     },
                 );
             };
-            let result = match request.kind.as_str() {
-                "start_process_job" => {
-                    let process = request.process.as_ref().expect("validated process payload");
+            let result = match &operation {
+                RunnerJobOperation::StartProcess(request) => {
                     run_process_with_profiles_and_execution_state_with_start_hook(
                         generation,
                         &policy,
@@ -4525,16 +4503,15 @@ impl JobManager {
                         &project_registry_dir,
                         &manager.prepared_profiles,
                         request.cwd.as_deref(),
-                        &process.executable,
-                        &process.args,
+                        &request.process.executable,
+                        &request.process.args,
                         request.stdin.as_deref(),
                         request.timeout_secs,
                         Some(stop_requested.as_ref()),
                         Some(&on_started),
                     )
                 }
-                "start_script_job" => {
-                    let script = request.script.as_ref().expect("validated script payload");
+                RunnerJobOperation::StartScript(request) => {
                     run_script_with_profiles_and_execution_state_with_start_hook(
                         generation,
                         &policy,
@@ -4542,14 +4519,14 @@ impl JobManager {
                         &project_registry_dir,
                         &manager.prepared_profiles,
                         request.cwd.as_deref(),
-                        script,
+                        &request.script,
                         request.stdin.as_deref(),
                         request.timeout_secs,
                         Some(stop_requested.as_ref()),
                         Some(&on_started),
                     )
                 }
-                _ => unreachable!("structured Job dispatcher received legacy request"),
+                _ => unreachable!("structured Job starter received non process/script operation"),
             };
             let execution_state = result.execution_state;
             let stopped = stop_requested.load(Ordering::SeqCst)
@@ -4591,80 +4568,49 @@ impl JobManager {
             shell,
             ssh,
             project_registry_dir,
-            request,
+            metadata: _,
+            operation,
         } = start;
-        let Some(job_id) = request.job_id.clone() else {
-            return;
+        let (job_id, cwd, raw_command, steps, timeout_secs, context, validation) = match &operation
+        {
+            RunnerJobOperation::StartShell(request) => (
+                request.job_id.clone(),
+                request.cwd.clone(),
+                Some(request.command.clone()),
+                Vec::new(),
+                request.timeout_secs,
+                request.context.clone(),
+                false,
+            ),
+            RunnerJobOperation::StartValidation(request) => (
+                request.job_id.clone(),
+                request.cwd.clone(),
+                None,
+                request.steps.clone(),
+                request.timeout_secs,
+                request.context.clone(),
+                true,
+            ),
+            _ => unreachable!("shell Job starter received non shell/validation operation"),
         };
         if !policy.allow_raw_shell {
             self.fail_job(
-                &request,
+                &operation,
                 "raw shell is disabled by local Runner policy".to_string(),
                 None,
             );
             return;
         }
-        if request
-            .job_context
-            .as_ref()
-            .is_some_and(|context| context.ssh_resource.is_some())
-        {
-            self.start_ssh_shell_job(generation, policy, ssh, request);
+        if context.ssh_resource.is_some() {
+            self.start_ssh_shell_job(generation, policy, ssh, operation);
             return;
         }
-        let cwd_path = request
-            .cwd
+        let cwd_path = cwd
             .as_deref()
             .map(PathBuf::from)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")));
         if let Err(e) = cwd_allowed(&policy, &cwd_path) {
-            self.fail_job(&request, e, None);
-            return;
-        }
-        let validation = request.kind == "start_validation_job";
-        let steps = if validation {
-            match serde_json::from_str::<Vec<ShellJobValidationStep>>(&request.command) {
-                Ok(steps)
-                    if (1..=3).contains(&steps.len())
-                        && steps.iter().all(ShellJobValidationStep::is_canonical)
-                        && steps.iter().enumerate().all(|(index, step)| {
-                            !steps[..index]
-                                .iter()
-                                .any(|earlier| earlier.name == step.name)
-                        }) =>
-                {
-                    steps
-                }
-                _ => {
-                    self.fail_job(
-                        &request,
-                        "invalid structured validation plan".to_string(),
-                        None,
-                    );
-                    return;
-                }
-            }
-        } else {
-            Vec::new()
-        };
-        if validation
-            && request.job_context.as_ref().is_none_or(|context| {
-                context.validation_steps
-                    != steps
-                        .iter()
-                        .map(|step| step.name.clone())
-                        .collect::<Vec<_>>()
-            })
-        {
-            self.fail_job(
-                &request,
-                "structured validation plan does not match recovery context".to_string(),
-                Some(ShellJobValidationProgress {
-                    completed: 0,
-                    current_step: None,
-                    failed_step: None,
-                }),
-            );
+            self.fail_job(&operation, e, None);
             return;
         }
         let prepared_profile = match resolve_prepared_shell_profile(
@@ -4672,13 +4618,13 @@ impl JobManager {
             &shell,
             &project_registry_dir,
             &cwd_path,
-            request.cwd.is_some(),
+            cwd.is_some(),
             &self.prepared_profiles,
             Some(self.shutting_down.as_ref()),
         ) {
             Ok(profile) => profile,
             Err(e) => {
-                self.fail_job(&request, e, None);
+                self.fail_job(&operation, e, None);
                 return;
             }
         };
@@ -4694,7 +4640,7 @@ impl JobManager {
             })
         {
             self.fail_job(
-                &request,
+                &operation,
                 VALIDATION_TOOL_UNAVAILABLE_CODE.to_string(),
                 Some(ShellJobValidationProgress {
                     completed: 0,
@@ -4715,17 +4661,18 @@ impl JobManager {
                     &steps[index].args,
                 )
             } else {
+                let raw_command = raw_command
+                    .as_deref()
+                    .expect("typed raw shell Job carries command text");
                 match prepared_profile.as_deref() {
-                    Some(profile) => {
-                        configured_prepared_shell_job_command(profile, &request.command)
-                    }
-                    None => configured_shell_job_command(&shell, &request.command),
+                    Some(profile) => configured_prepared_shell_job_command(profile, raw_command),
+                    None => configured_shell_job_command(&shell, raw_command),
                 }
             };
             let mut command = match configured {
                 Ok(command) => command,
                 Err(error) => {
-                    self.fail_job(&request, error, None);
+                    self.fail_job(&operation, error, None);
                     return;
                 }
             };
@@ -4757,7 +4704,7 @@ impl JobManager {
             }
         };
         let Some(stop_requested) = stop_requested else {
-            self.shutdown_rejection(&request);
+            self.shutdown_rejection(&operation);
             return;
         };
         // Preserve the pre-start proof boundary explicitly. A stop/shutdown
@@ -4765,11 +4712,11 @@ impl JobManager {
         // fence below is intentionally repeated after spawn because that later
         // race can no longer claim NotStarted.
         if stop_requested.load(Ordering::SeqCst) {
-            self.fail_job(&request, "job stopped before start".to_string(), None);
+            self.fail_job(&operation, "job stopped before start".to_string(), None);
             return;
         }
         if self.shutting_down.load(Ordering::SeqCst) {
-            self.shutdown_rejection(&request);
+            self.shutdown_rejection(&operation);
             return;
         }
         let start = Instant::now();
@@ -4780,7 +4727,7 @@ impl JobManager {
             Err(e) => {
                 if validation {
                     self.fail_job(
-                        &request,
+                        &operation,
                         VALIDATION_STEP_SPAWN_FAILED_CODE.to_string(),
                         Some(ShellJobValidationProgress {
                             completed: 0,
@@ -4798,7 +4745,7 @@ impl JobManager {
                             )
                         })
                         .unwrap_or_else(|| format!("failed to spawn command: {}", e));
-                    self.fail_job(&request, error, None);
+                    self.fail_job(&operation, error, None);
                 }
                 return;
             }
@@ -4833,7 +4780,7 @@ impl JobManager {
             self.update_and_send(
                 &job_id,
                 post_spawn_interruption_delta(
-                    request.kind.as_str(),
+                    &operation,
                     start.elapsed().as_millis() as u64,
                     error,
                 ),
@@ -4865,7 +4812,7 @@ impl JobManager {
         let worker_guard = self.workers.enter();
         std::thread::spawn(move || {
             let _worker_guard = worker_guard;
-            let timeout_secs = request.timeout_secs.min(policy.max_timeout_secs).max(1);
+            let timeout_secs = timeout_secs.min(policy.max_timeout_secs).max(1);
             let mut step_index = 0;
             let (final_status, out, err, final_progress) = loop {
                 const OUTPUT_CHANNEL_CAPACITY: usize = 64;
@@ -5158,38 +5105,32 @@ impl JobManager {
         generation: u64,
         policy: RunnerPolicy,
         ssh: SshConfig,
-        request: RunnerRequest,
+        operation: RunnerJobOperation,
     ) {
-        let Some(job_id) = request.job_id.clone() else {
+        let request = match &operation {
+            RunnerJobOperation::StartShell(request) => request,
+            RunnerJobOperation::StartValidation(_) => {
+                self.fail_job(
+                    &operation,
+                    "ssh_resource_unsupported_for_request: SSH resources do not support structured validation jobs; command was not started".to_string(),
+                    None,
+                );
+                return;
+            }
+            _ => unreachable!("SSH Job starter received non shell/validation operation"),
+        };
+        let job_id = request.job_id.clone();
+        let Some(resource_name) = request.context.ssh_resource.as_deref() else {
             return;
         };
-        let Some(resource_name) = request
-            .job_context
-            .as_ref()
-            .and_then(|context| context.ssh_resource.as_deref())
-        else {
-            return;
-        };
-        let Some(session_id) = request
-            .job_context
-            .as_ref()
-            .and_then(|context| context.workflow_session_id.as_deref())
-        else {
+        let Some(session_id) = request.context.workflow_session_id.as_deref() else {
             self.fail_job(
-                &request,
+                &operation,
                 "ssh_session_required: an SSH resource requires a Workflow Session id; command was not started".to_string(),
                 None,
             );
             return;
         };
-        if request.kind != "start_job" {
-            self.fail_job(
-                &request,
-                "ssh_resource_unsupported_for_request: SSH resources do not support structured validation jobs; command was not started".to_string(),
-                None,
-            );
-            return;
-        }
         let prepared = match self.ssh_pool.prepare_job_command(
             generation,
             &ssh,
@@ -5200,14 +5141,14 @@ impl JobManager {
         ) {
             Ok(prepared) => prepared,
             Err(error) => {
-                self.fail_job(&request, error, None);
+                self.fail_job(&operation, error, None);
                 return;
             }
         };
         let transport = prepared.transport.clone();
         let program_delivery = prepared.program_delivery;
         let mut command = prepared.command;
-        if program_delivery.requires_stdin() || request.stdin.is_some() {
+        if program_delivery.requires_stdin() {
             command.stdin(Stdio::piped());
         } else {
             command.stdin(Stdio::null());
@@ -5228,7 +5169,7 @@ impl JobManager {
             }
         };
         let Some(stop_requested) = stop_requested else {
-            self.shutdown_rejection(&request);
+            self.shutdown_rejection(&operation);
             return;
         };
         let start = Instant::now();
@@ -5237,7 +5178,7 @@ impl JobManager {
             Ok(child) => child,
             Err(error) => {
                 self.fail_job(
-                    &request,
+                    &operation,
                     format!(
                         "ssh_command_spawn_failed: could not start local ssh client: {error}; command was not started"
                     ),
@@ -5274,7 +5215,7 @@ impl JobManager {
             self.update_and_send(
                 &job_id,
                 post_spawn_interruption_delta(
-                    request.kind.as_str(),
+                    &operation,
                     start.elapsed().as_millis() as u64,
                     error,
                 ),
@@ -5293,6 +5234,7 @@ impl JobManager {
         let ssh_pool = self.ssh_pool.clone();
         let output_limit_bytes = policy.max_output_bytes;
         let worker_guard = self.workers.enter();
+        let timeout_secs = request.timeout_secs.min(policy.max_timeout_secs).max(1);
         std::thread::spawn(move || {
             let _worker_guard = worker_guard;
             const OUTPUT_CHANNEL_CAPACITY: usize = 64;
@@ -5318,13 +5260,7 @@ impl JobManager {
             // Readers must already be draining before program/caller stdin can
             // block. The writer is tracked and polled by this same Job worker.
             let mut writer_start_error = None;
-            let mut stdin_writer = match program_delivery.spawn_writer(
-                child_stdin.take(),
-                request
-                    .stdin
-                    .as_deref()
-                    .map(|input| input.as_bytes().to_vec()),
-            ) {
+            let mut stdin_writer = match program_delivery.spawn_writer(child_stdin.take(), None) {
                 Ok(writer) => writer,
                 Err(error) => {
                     writer_start_error = Some(error);
@@ -5332,7 +5268,6 @@ impl JobManager {
                     None
                 }
             };
-            let timeout_secs = request.timeout_secs.min(policy.max_timeout_secs).max(1);
             let mut transport_stderr = String::new();
             let (mut status, mut exit_code, mut error, interrupted_after_dispatch) = loop {
                 let mut out = String::new();
@@ -5517,7 +5452,7 @@ impl JobManager {
             let mut queued = lock_unpoison(&self.queued);
             if let Some(pos) = queued
                 .iter()
-                .position(|queued_start| queued_start.request.job_id.as_deref() == Some(job_id))
+                .position(|queued_start| queued_start.operation.job_id() == job_id)
             {
                 queued.remove(pos)
             } else {
@@ -5525,7 +5460,7 @@ impl JobManager {
             }
         };
         if let Some(queued_start) = queued_job {
-            let PendingJobStart { request, .. } = queued_start;
+            let operation = queued_start.operation;
             self.update_and_send(
                 job_id,
                 RunnerJobDelta {
@@ -5534,7 +5469,7 @@ impl JobManager {
                     exit_code: Some(-1),
                     duration_ms: Some(0),
                     error: Some("job stopped before start".to_string()),
-                    command_execution_state: structured_prestart_lifecycle(&request),
+                    command_execution_state: job_prestart_lifecycle(&operation),
                     finished: true,
                     ..Default::default()
                 },

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -16,9 +16,12 @@ use webcodex_runner::shutdown::{lock_unpoison, ActivityTracker, BackgroundThread
 mod job_manager_tests;
 mod webcodex_runner;
 
+use runner_operation::RunnerFileOperation;
+#[cfg(test)]
+use runner_operation::RunnerOperation;
 use webcodex_core::{
     apply_edits_shared, apply_patch_shared, artifact_policy, build_info, lsp_bridge, mcp_gateway,
-    runner_protocol, validation_bridge,
+    runner_operation, runner_protocol, validation_bridge,
 };
 use webcodex_runner_config as runner_config;
 use webcodex_workspace::{project_overview, workspace_checkpoint};
@@ -66,16 +69,20 @@ use webcodex_runner::{
 use webcodex_runner::{
     client_profile_runner_config, configured_prepared_shell_job_command,
     configured_shell_job_command, configured_validation_job_command, cwd_allowed,
-    default_config_path, dispatch_request, err_cmd, handle_apply_patch_file_request,
-    handle_apply_text_edits_file_request, handle_artifact_file_request, handle_basic_file_request,
-    handle_checkpoint_file_request, handle_write_project_file_request, hostname,
-    is_artifact_request_kind, is_basic_file_request_kind, is_checkpoint_request_kind,
-    is_project_op, is_structured_edit_request_kind, load_config, max_concurrent_jobs, ok_cmd,
-    prepare_detached_process_launch, project_registry_dir, resolve_prepared_shell_profile,
-    resolve_requested_path, run_runner, validate_client_profile,
-    validate_structured_edit_runner_path, CommandResult, HotRunnerConfig, HttpSendConfig,
-    PreparedShellProfile, PreparedShellProfileCache, ReloadableRunnerConfig, RunnerConfig,
-    RunnerPolicy, RunnerProjectCache, RunnerSink, ShellConfig, SubmitResultError,
+    default_config_path, dispatch_request_with_outcome, err_cmd, handle_apply_patch_file_request,
+    handle_apply_text_edits_file_request, handle_artifact_file_operation,
+    handle_basic_file_request, handle_checkpoint_file_request, handle_write_project_file_request,
+    hostname, load_config, max_concurrent_jobs, ok_cmd, prepare_detached_process_launch,
+    project_registry_dir, resolve_prepared_shell_profile, resolve_requested_path, run_runner,
+    validate_client_profile, validate_structured_edit_runner_path, CommandResult, HotRunnerConfig,
+    HttpSendConfig, PreparedShellProfile, PreparedShellProfileCache, ReloadableRunnerConfig,
+    RunnerConfig, RunnerDispatchOutcome, RunnerPolicy, RunnerProjectCache, RunnerSink, ShellConfig,
+    SubmitResultError,
+};
+#[cfg(test)]
+use webcodex_runner::{
+    dispatch_request, is_artifact_request_kind, is_basic_file_request_kind,
+    is_checkpoint_request_kind, is_structured_edit_request_kind,
 };
 use webcodex_runner::{is_transport_failure, SshConfig, SshConnectionPool};
 use webcodex_runner::{
@@ -1185,7 +1192,6 @@ pub(crate) const POLLING_DISPATCH_MAX_IN_FLIGHT: usize = 2;
 
 struct PollingDispatch {
     request_id: String,
-    project_cache_invalidation_required: bool,
     sink: RunnerSink,
     config: Arc<HotRunnerConfig>,
     runtime: Arc<ReloadableRunnerConfig>,
@@ -1197,8 +1203,8 @@ struct PollingDispatch {
 }
 
 impl PollingDispatch {
-    fn run(self) -> Result<bool, SubmitResultError> {
-        dispatch_request(
+    fn run(self) -> Result<RunnerDispatchOutcome, SubmitResultError> {
+        dispatch_request_with_outcome(
             &self.sink,
             &self.config,
             &self.runtime,
@@ -1213,8 +1219,7 @@ impl PollingDispatch {
 
 struct PollingDispatchCompletion {
     request_id: String,
-    project_cache_invalidation_required: bool,
-    dispatch_result: Result<bool, SubmitResultError>,
+    dispatch_result: Result<RunnerDispatchOutcome, SubmitResultError>,
 }
 
 /// Sends a completion even if a worker unwinds. It is declared before the
@@ -1223,25 +1228,19 @@ struct PollingDispatchCompletion {
 struct PollingDispatchCompletionOnDrop {
     completion_tx: mpsc::SyncSender<PollingDispatchCompletion>,
     request_id: String,
-    project_cache_invalidation_required: bool,
-    dispatch_result: Option<Result<bool, SubmitResultError>>,
+    dispatch_result: Option<Result<RunnerDispatchOutcome, SubmitResultError>>,
 }
 
 impl PollingDispatchCompletionOnDrop {
-    fn new(
-        completion_tx: mpsc::SyncSender<PollingDispatchCompletion>,
-        request_id: String,
-        project_cache_invalidation_required: bool,
-    ) -> Self {
+    fn new(completion_tx: mpsc::SyncSender<PollingDispatchCompletion>, request_id: String) -> Self {
         Self {
             completion_tx,
             request_id,
-            project_cache_invalidation_required,
             dispatch_result: None,
         }
     }
 
-    fn complete(&mut self, result: Result<bool, SubmitResultError>) {
+    fn complete(&mut self, result: Result<RunnerDispatchOutcome, SubmitResultError>) {
         self.dispatch_result = Some(result);
     }
 }
@@ -1255,7 +1254,6 @@ impl Drop for PollingDispatchCompletionOnDrop {
         });
         let _ = self.completion_tx.send(PollingDispatchCompletion {
             request_id: std::mem::take(&mut self.request_id),
-            project_cache_invalidation_required: self.project_cache_invalidation_required,
             dispatch_result,
         });
     }
@@ -1302,15 +1300,11 @@ impl PollingDispatchSupervisor {
         let completion_tx = self.completion_tx.clone();
         let dispatch_guard = self.dispatches.enter();
         let request_id = dispatch.request_id.clone();
-        let project_cache_invalidation_required = dispatch.project_cache_invalidation_required;
         let handle = std::thread::Builder::new()
             .name("webcodex-poll-dispatch".to_string())
             .spawn(move || {
-                let mut completion = PollingDispatchCompletionOnDrop::new(
-                    completion_tx,
-                    request_id,
-                    project_cache_invalidation_required,
-                );
+                let mut completion =
+                    PollingDispatchCompletionOnDrop::new(completion_tx, request_id);
                 let _dispatch_guard = dispatch_guard;
                 completion.complete(dispatch.run());
             })
@@ -1335,10 +1329,15 @@ impl PollingDispatchSupervisor {
             0
         });
         let _request_id = completion.request_id;
-        if completion.project_cache_invalidation_required && completion.dispatch_result.is_ok() {
-            project_cache.invalidate();
+        match completion.dispatch_result {
+            Ok(outcome) => {
+                if outcome.project_cache_invalidation_required {
+                    project_cache.invalidate();
+                }
+                Ok(outcome.handled)
+            }
+            Err(error) => Err(error),
         }
-        completion.dispatch_result
     }
 
     /// Inspect every completion currently available. This is called before
@@ -2302,6 +2301,7 @@ fn register(
     }
 }
 
+#[cfg(test)]
 fn is_file_request_kind(kind: &str) -> bool {
     is_basic_file_request_kind(kind)
         || is_structured_edit_request_kind(kind)
@@ -2309,18 +2309,16 @@ fn is_file_request_kind(kind: &str) -> bool {
         || is_checkpoint_request_kind(kind)
 }
 
-fn handle_file_request(policy: &RunnerPolicy, request: &RunnerRequest) -> CommandResult {
-    let Some(path) = request.path.as_deref() else {
-        return CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some("file request missing path".to_string()),
-        };
-    };
+fn handle_file_operation(policy: &RunnerPolicy, operation: &RunnerFileOperation) -> CommandResult {
+    let request = operation.payload();
+    let path = request.path.as_str();
     let start = Instant::now();
-    if is_structured_edit_request_kind(&request.kind) {
+    if matches!(
+        operation,
+        RunnerFileOperation::WriteProjectFile(_)
+            | RunnerFileOperation::ApplyTextEdits(_)
+            | RunnerFileOperation::ApplyPatch(_)
+    ) {
         if let Err(e) = validate_structured_edit_runner_path(path) {
             return CommandResult {
                 exit_code: None,
@@ -2343,34 +2341,51 @@ fn handle_file_request(policy: &RunnerPolicy, request: &RunnerRequest) -> Comman
             }
         }
     };
-    match request.kind.as_str() {
-        "file_write_project_file" => handle_write_project_file_request(request, &resolved, start),
-        "file_apply_text_edits" => handle_apply_text_edits_file_request(policy, request, start),
-        "file_apply_patch" => handle_apply_patch_file_request(policy, request, start),
-        "file_save_project_artifact"
-        | "file_read_project_artifact_metadata"
-        | "file_read_project_artifact"
-        | "file_read_project_artifact_export_chunk"
-        | "file_artifact_upload_begin"
-        | "file_artifact_upload_chunk"
-        | "file_artifact_upload_finish"
-        | "file_artifact_upload_abort" => handle_artifact_file_request(request, &resolved, start),
-        "file_checkpoint_create" | "file_checkpoint_restore" => {
-            handle_checkpoint_file_request(request, &resolved, start)
+    match operation {
+        RunnerFileOperation::WriteProjectFile(_) => {
+            handle_write_project_file_request(request, &resolved, start)
         }
-        "file_read"
-        | "file_write"
-        | "file_list"
-        | "file_project_overview"
-        | "file_delete_project_files"
-        | "file_skill_list_packages"
-        | "file_skill_read_file" => handle_basic_file_request(policy, request, &resolved, start),
+        RunnerFileOperation::ApplyTextEdits(_) => {
+            handle_apply_text_edits_file_request(policy, request, start)
+        }
+        RunnerFileOperation::ApplyPatch(_) => {
+            handle_apply_patch_file_request(policy, request, start)
+        }
+        RunnerFileOperation::SaveProjectArtifact(_)
+        | RunnerFileOperation::ReadProjectArtifactMetadata(_)
+        | RunnerFileOperation::ReadProjectArtifact(_)
+        | RunnerFileOperation::ReadProjectArtifactExportChunk(_)
+        | RunnerFileOperation::ArtifactUploadBegin(_)
+        | RunnerFileOperation::ArtifactUploadChunk(_)
+        | RunnerFileOperation::ArtifactUploadFinish(_)
+        | RunnerFileOperation::ArtifactUploadAbort(_) => {
+            handle_artifact_file_operation(operation, &resolved, start)
+        }
+        RunnerFileOperation::CheckpointCreate(_) | RunnerFileOperation::CheckpointRestore(_) => {
+            handle_checkpoint_file_request(operation, &resolved, start)
+        }
+        RunnerFileOperation::Read(_)
+        | RunnerFileOperation::Write(_)
+        | RunnerFileOperation::List(_)
+        | RunnerFileOperation::ProjectOverview(_)
+        | RunnerFileOperation::DeleteProjectFiles(_)
+        | RunnerFileOperation::SkillListPackages(_)
+        | RunnerFileOperation::SkillReadFile(_) => {
+            handle_basic_file_request(policy, operation, &resolved, start)
+        }
+    }
+}
+
+#[cfg(test)]
+fn handle_file_request(policy: &RunnerPolicy, request: &RunnerRequest) -> CommandResult {
+    match request.decode_operation() {
+        Ok(RunnerOperation::File(operation)) => handle_file_operation(policy, &operation),
         _ => CommandResult {
             exit_code: None,
             stdout: None,
             stderr: None,
-            duration_ms: Some(start.elapsed().as_millis() as u64),
-            error: Some(format!("unknown file request kind: {}", request.kind)),
+            duration_ms: Some(0),
+            error: Some("invalid file request".to_string()),
         },
     }
 }
@@ -5687,7 +5702,6 @@ fn handle_one_poll(
     let Some(request) = response.request else {
         return Ok((false, inventory_status));
     };
-    let project_op = is_project_op(&request.kind);
     let hot = runtime.snapshot();
     let runtime = Arc::clone(runtime);
     let jobs = jobs.clone();
@@ -5699,7 +5713,6 @@ fn handle_one_poll(
     let lsp = lsp.clone();
     let dispatch = PollingDispatch {
         request_id: request.request_id.clone(),
-        project_cache_invalidation_required: project_op,
         sink,
         config: hot,
         runtime,
@@ -5760,12 +5773,14 @@ fn handle_one_poll(
             }
         }
     };
-    if project_op && result.is_ok() {
-        project_cache.invalidate();
+    if let Ok(outcome) = &result {
+        if outcome.project_cache_invalidation_required {
+            project_cache.invalidate();
+        }
     }
     let _ = polling_dispatches.background_threads.reap_finished();
     result
-        .map(|_| (true, inventory_status))
+        .map(|outcome| (outcome.handled, inventory_status))
         .map_err(PollError::from_submit)
 }
 

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -1220,14 +1220,14 @@ fn job_manager_stop_all_clears_queue_and_requests_running_stop() {
 
     jobs.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: cfg.policy.clone(),
-            shell: cfg.shell.clone(),
-            ssh: cfg.ssh.clone(),
-            project_registry_dir: project_registry_dir(&cfg).unwrap(),
+        PendingJobStart::from_wire(
+            1,
+            cfg.policy.clone(),
+            cfg.shell.clone(),
+            cfg.ssh.clone(),
+            project_registry_dir(&cfg).unwrap(),
             request,
-        },
+        ),
     );
     match wait_for_job_envelope(&mut rx, "queued status was sent") {
         RunnerEnvelope::JobUpdate { payload } => {
@@ -1252,14 +1252,14 @@ fn job_manager_stop_all_clears_queue_and_requests_running_stop() {
     let (rejected_sink, mut rejected_rx) = ws_sink("ws-client");
     jobs.enqueue(
         rejected_sink,
-        PendingJobStart {
-            generation: 1,
-            policy: cfg.policy.clone(),
-            shell: cfg.shell.clone(),
-            ssh: cfg.ssh.clone(),
-            project_registry_dir: project_registry_dir(&cfg).unwrap(),
-            request: rejected_request,
-        },
+        PendingJobStart::from_wire(
+            1,
+            cfg.policy.clone(),
+            cfg.shell.clone(),
+            cfg.ssh.clone(),
+            project_registry_dir(&cfg).unwrap(),
+            rejected_request,
+        ),
     );
     assert!(jobs.queued.lock().unwrap().is_empty());
     let rejected = (0..2)

--- a/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
+++ b/crates/webcodex-runner/src/main_tests/shell_job_execution.rs
@@ -84,6 +84,13 @@ fn shell_job_filters_sensitive_env_case_insensitive() {
     }
 }
 
+fn decoded_job_operation(request: RunnerRequest) -> RunnerJobOperation {
+    match request.decode_operation().expect("valid typed Job fixture") {
+        RunnerOperation::Job(operation) => operation,
+        _ => panic!("expected Job operation"),
+    }
+}
+
 #[test]
 fn raw_shell_job_lifecycle_distinguishes_terminal_truth_without_error_text_matching() {
     assert_eq!(
@@ -110,23 +117,35 @@ fn raw_shell_job_lifecycle_distinguishes_terminal_truth_without_error_text_match
 
 #[test]
 fn raw_shell_job_prestart_rejection_is_explicitly_not_started() {
+    let temp = tempfile::tempdir().unwrap();
+    let operation = decoded_job_operation(shell_job_request(temp.path(), "printf ok"));
     assert_eq!(
-        job_prestart_lifecycle_for_kind("start_job"),
+        job_prestart_lifecycle(&operation),
         Some(ShellCommandExecutionState::NotStarted)
     );
-    assert_eq!(job_prestart_lifecycle_for_kind("run_shell"), None);
 }
 
 #[test]
 fn raw_shell_job_post_spawn_interruption_never_reuses_not_started_proof() {
+    let temp = tempfile::tempdir().unwrap();
+    let shell = decoded_job_operation(shell_job_request(temp.path(), "printf ok"));
     assert_eq!(
-        post_spawn_interruption_lifecycle_for_kind("start_job"),
+        post_spawn_interruption_lifecycle(&shell),
         Some(ShellCommandExecutionState::OutcomeUnknown)
     );
-    assert_eq!(
-        post_spawn_interruption_lifecycle_for_kind("start_validation_job"),
-        None
-    );
+
+    let step = ShellJobValidationStep {
+        name: "check".to_string(),
+        program: "cargo".to_string(),
+        args: vec!["check".to_string(), "--all-targets".to_string()],
+        env: Vec::new(),
+    };
+    let mut validation = shell_job_request(temp.path(), "");
+    validation.kind = "start_validation_job".to_string();
+    validation.command = serde_json::to_string(&[step]).unwrap();
+    validation.job_context.as_mut().unwrap().validation_steps = vec!["check".to_string()];
+    let validation = decoded_job_operation(validation);
+    assert_eq!(post_spawn_interruption_lifecycle(&validation), None);
 }
 
 #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/artifacts.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/artifacts.rs
@@ -5,6 +5,7 @@ use crate::artifact_policy::{
     has_safe_octet_stream_artifact_extension, octet_stream_safe_extension_error, DOCX_MIME,
     MAX_MCP_IMAGE_BYTES, PPTX_MIME, XLSX_MIME,
 };
+#[cfg(test)]
 use crate::runner_protocol::RunnerRequest;
 use base64::{engine::general_purpose, Engine as _};
 use flate2::read::DeflateDecoder;
@@ -17,6 +18,9 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+#[cfg(test)]
+use webcodex_core::runner_operation::RunnerOperation;
+use webcodex_core::runner_operation::{RunnerFileOperation, RunnerFilePayload};
 use xml::reader::{EventReader, XmlEvent};
 
 const DEFAULT_MAX_ARTIFACT_BYTES: usize = 10 * 1024 * 1024;
@@ -40,6 +44,7 @@ const MAX_OOXML_CONTENT_TYPE_EVENTS: usize = 4096;
 const OOXML_CONTENT_TYPES_NAMESPACE: &str =
     "http://schemas.openxmlformats.org/package/2006/content-types";
 
+#[cfg(test)]
 pub(crate) fn is_artifact_request_kind(kind: &str) -> bool {
     matches!(
         kind,
@@ -81,7 +86,7 @@ fn is_sensitive_artifact_path(path: &str) -> bool {
     webcodex_core::sensitive_paths::is_bulk_skipped_path(path)
 }
 
-fn parse_json_payload(request: &RunnerRequest) -> Result<Value, String> {
+fn parse_json_payload(request: &RunnerFilePayload) -> Result<Value, String> {
     let Some(content) = request.content.as_deref() else {
         return Err("invalid json: missing file-op payload".to_string());
     };
@@ -172,7 +177,7 @@ fn validate_upload_id(upload_id: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn project_root(request: &RunnerRequest) -> Result<std::path::PathBuf, String> {
+fn project_root(request: &RunnerFilePayload) -> Result<std::path::PathBuf, String> {
     let Some(cwd) = request.cwd.as_deref() else {
         return Err("artifact request missing project root".to_string());
     };
@@ -1347,30 +1352,35 @@ fn read_limited(path: &Path, max_bytes: usize) -> Result<Vec<u8>, String> {
     Ok(data)
 }
 
-pub(crate) fn handle_artifact_file_request(
-    request: &RunnerRequest,
+pub(crate) fn handle_artifact_file_operation(
+    operation: &RunnerFileOperation,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    match request.kind.as_str() {
-        "file_save_project_artifact" => handle_save_project_artifact(request, resolved, start),
-        "file_read_project_artifact_metadata" => {
+    let request = operation.payload();
+    match operation {
+        RunnerFileOperation::SaveProjectArtifact(_) => {
+            handle_save_project_artifact(request, resolved, start)
+        }
+        RunnerFileOperation::ReadProjectArtifactMetadata(_) => {
             handle_read_project_artifact_metadata(request, resolved, start)
         }
-        "file_read_project_artifact" => handle_read_project_artifact(request, resolved, start),
-        "file_read_project_artifact_export_chunk" => {
+        RunnerFileOperation::ReadProjectArtifact(_) => {
+            handle_read_project_artifact(request, resolved, start)
+        }
+        RunnerFileOperation::ReadProjectArtifactExportChunk(_) => {
             handle_read_project_artifact_export_chunk(request, resolved, start)
         }
-        "file_artifact_upload_begin"
-        | "file_artifact_upload_chunk"
-        | "file_artifact_upload_finish"
-        | "file_artifact_upload_abort" => {
+        RunnerFileOperation::ArtifactUploadBegin(_)
+        | RunnerFileOperation::ArtifactUploadChunk(_)
+        | RunnerFileOperation::ArtifactUploadFinish(_)
+        | RunnerFileOperation::ArtifactUploadAbort(_) => {
             let _upload_guard = match ARTIFACT_UPLOAD_STATE_LOCK.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
                     return line_edit_stdout(
                         upload_error(
-                            request.path.as_deref(),
+                            Some(request.path.as_str()),
                             None,
                             "artifact upload state lock unavailable",
                         ),
@@ -1378,20 +1388,20 @@ pub(crate) fn handle_artifact_file_request(
                     )
                 }
             };
-            match request.kind.as_str() {
-                "file_artifact_upload_begin" => {
+            match operation {
+                RunnerFileOperation::ArtifactUploadBegin(_) => {
                     handle_artifact_upload_begin(request, resolved, start)
                 }
-                "file_artifact_upload_chunk" => {
+                RunnerFileOperation::ArtifactUploadChunk(_) => {
                     handle_artifact_upload_chunk(request, resolved, start)
                 }
-                "file_artifact_upload_finish" => {
+                RunnerFileOperation::ArtifactUploadFinish(_) => {
                     handle_artifact_upload_finish(request, resolved, start)
                 }
-                "file_artifact_upload_abort" => {
+                RunnerFileOperation::ArtifactUploadAbort(_) => {
                     handle_artifact_upload_abort(request, resolved, start)
                 }
-                _ => unreachable!("upload request kind already matched"),
+                _ => unreachable!("upload operation already typed"),
             }
         }
         _ => CommandResult {
@@ -1399,17 +1409,37 @@ pub(crate) fn handle_artifact_file_request(
             stdout: None,
             stderr: None,
             duration_ms: Some(start.elapsed().as_millis() as u64),
-            error: Some(format!("unknown artifact request kind: {}", request.kind)),
+            error: Some("file operation is not an artifact request".to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn handle_artifact_file_request(
+    request: &RunnerRequest,
+    resolved: &Path,
+    start: Instant,
+) -> CommandResult {
+    match request.decode_operation() {
+        Ok(RunnerOperation::File(operation)) => {
+            handle_artifact_file_operation(&operation, resolved, start)
+        }
+        _ => CommandResult {
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            duration_ms: Some(start.elapsed().as_millis() as u64),
+            error: Some("invalid artifact wire request".to_string()),
         },
     }
 }
 
 fn handle_save_project_artifact(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(save_error(None, e), start),
@@ -1503,11 +1533,11 @@ fn handle_save_project_artifact(
 }
 
 fn handle_artifact_upload_begin(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(upload_error(None, None, e), start),
@@ -1714,11 +1744,11 @@ fn handle_artifact_upload_begin(
 }
 
 fn handle_artifact_upload_chunk(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(upload_error(None, None, e), start),
@@ -1936,11 +1966,11 @@ fn handle_artifact_upload_chunk(
 }
 
 fn handle_artifact_upload_finish(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(upload_error(None, None, e), start),
@@ -2077,11 +2107,11 @@ fn handle_artifact_upload_finish(
 }
 
 fn handle_artifact_upload_abort(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(upload_error(None, None, e), start),
@@ -2159,11 +2189,11 @@ fn handle_artifact_upload_abort(
 }
 
 fn handle_read_project_artifact_metadata(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(metadata_error(None, e), start),
@@ -2311,11 +2341,11 @@ fn handle_read_project_artifact_metadata(
 }
 
 fn handle_read_project_artifact_export_chunk(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(read_error(None, e), start),
@@ -2452,11 +2482,11 @@ fn handle_read_project_artifact_export_chunk(
 }
 
 fn handle_read_project_artifact(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => return line_edit_stdout(read_error(None, e), start),

--- a/crates/webcodex-runner/src/webcodex_runner/checkpoints.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/checkpoints.rs
@@ -1,32 +1,34 @@
-use super::output::{err_cmd, ok_cmd, CommandResult};
-use crate::runner_protocol::RunnerRequest;
+use super::output::{ok_cmd, CommandResult};
 use crate::workspace_checkpoint::{create_workspace_checkpoint, restore_workspace_checkpoint};
 use serde_json::{json, Value};
 use std::path::Path;
 use std::time::Instant;
+use webcodex_core::runner_operation::{RunnerFileOperation, RunnerFilePayload};
 
+#[cfg(test)]
 pub(crate) fn is_checkpoint_request_kind(kind: &str) -> bool {
     matches!(kind, "file_checkpoint_create" | "file_checkpoint_restore")
 }
 
 pub(crate) fn handle_checkpoint_file_request(
-    request: &RunnerRequest,
+    operation: &RunnerFileOperation,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
+    let request = operation.payload();
     let payload = match parse_payload(request) {
         Ok(payload) => payload,
         Err(err) => return ok_cmd(start, checkpoint_error("invalid_checkpoint_payload", err)),
     };
-    let output = match request.kind.as_str() {
-        "file_checkpoint_create" => {
+    let output = match operation {
+        RunnerFileOperation::CheckpointCreate(_) => {
             let include_untracked = payload
                 .get("include_untracked")
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
             create_workspace_checkpoint(resolved, include_untracked)
         }
-        "file_checkpoint_restore" => {
+        RunnerFileOperation::CheckpointRestore(_) => {
             let Some(checkpoint) = payload.get("checkpoint") else {
                 return ok_cmd(
                     start,
@@ -36,16 +38,16 @@ pub(crate) fn handle_checkpoint_file_request(
             restore_workspace_checkpoint(resolved, checkpoint)
         }
         _ => {
-            return err_cmd(
+            return ok_cmd(
                 start,
-                format!("unknown checkpoint request kind: {}", request.kind),
+                checkpoint_error("invalid_checkpoint_payload", "not a checkpoint operation"),
             )
         }
     };
     ok_cmd(start, output)
 }
 
-fn parse_payload(request: &RunnerRequest) -> Result<Value, String> {
+fn parse_payload(request: &RunnerFilePayload) -> Result<Value, String> {
     let content = request
         .content
         .as_deref()

--- a/crates/webcodex-runner/src/webcodex_runner/computer.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/computer.rs
@@ -1,6 +1,9 @@
 use super::{err_cmd, ok_cmd, CommandResult};
 use crate::artifact_policy::MAX_MCP_IMAGE_BYTES;
-use crate::runner_protocol::{shell_computer_request_payload_max_bytes, RunnerRequest};
+#[cfg(test)]
+use crate::runner_protocol::shell_computer_request_payload_max_bytes;
+#[cfg(test)]
+use crate::runner_protocol::RunnerRequest;
 use serde_json::Value;
 use std::sync::OnceLock;
 use std::time::Instant;
@@ -9,6 +12,9 @@ use webcodex_computer::{
     DEFAULT_ACCESSIBILITY_DEPTH, DEFAULT_ACCESSIBILITY_NODES, MAX_APPLICATIONS, MAX_DISPLAYS,
     MAX_WINDOWS,
 };
+#[cfg(test)]
+use webcodex_core::runner_operation::RunnerOperation;
+use webcodex_core::runner_operation::{RunnerComputerOperation, RunnerComputerOperationKind};
 
 fn computer_runtime() -> &'static ComputerRuntime {
     static COMPUTER: OnceLock<ComputerRuntime> = OnceLock::new();
@@ -19,29 +25,9 @@ fn computer_runtime() -> &'static ComputerRuntime {
     })
 }
 
+#[cfg(test)]
 pub(crate) fn is_computer_request_kind(kind: &str) -> bool {
-    matches!(
-        kind,
-        "computer_list_windows"
-            | "computer_list_applications"
-            | "computer_launch_application"
-            | "computer_list_displays"
-            | "computer_snapshot_display"
-            | "computer_read_clipboard"
-            | "computer_write_clipboard"
-            | "computer_pointer_move"
-            | "computer_pointer_click"
-            | "computer_snapshot"
-            | "computer_snapshot_region"
-            | "computer_accessibility_status"
-            | "computer_accessibility_tree"
-            | "computer_element_state"
-            | "computer_activate_window"
-            | "computer_control"
-            | "computer_scroll_to_element"
-            | "computer_key_input"
-            | "computer_input_text"
-    )
+    RunnerComputerOperationKind::from_wire(kind).is_some()
 }
 
 fn ensure_exact_payload_fields(payload: &Value, expected: &[&str]) -> Result<(), String> {
@@ -75,46 +61,19 @@ fn optional_snapshot_dimension(payload: &Value, field: &str) -> Result<Option<u3
     }
 }
 
-pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult {
+pub(crate) fn handle_computer_operation(operation: &RunnerComputerOperation) -> CommandResult {
     let start = Instant::now();
-    let payload_max_bytes = shell_computer_request_payload_max_bytes(&request.kind);
-    let payload = match request.stdin.as_deref() {
-        Some(payload) if payload.len() <= payload_max_bytes && !payload.contains('\0') => {
-            match serde_json::from_str::<Value>(payload) {
-                Ok(value) => value,
-                Err(_) => {
-                    return err_cmd(
-                        start,
-                        "invalid_request: computer payload is not valid JSON".to_string(),
-                    )
-                }
-            }
-        }
-        _ => {
+    let payload = match serde_json::from_str::<Value>(&operation.payload) {
+        Ok(value) => value,
+        Err(_) => {
             return err_cmd(
                 start,
-                "invalid_request: computer payload is required and bounded".to_string(),
+                "invalid_request: computer payload is not valid JSON".to_string(),
             )
         }
     };
-    if !request.command.is_empty()
-        || request.cwd.is_some()
-        || request.path.is_some()
-        || request.content.is_some()
-        || request.process.is_some()
-        || request.script.is_some()
-        || request.job_id.is_some()
-        || request.lsp.is_some()
-        || request.job_context.is_some()
-        || request.persistent_shell.is_some()
-    {
-        return err_cmd(
-            start,
-            "invalid_request: computer request contains unrelated execution fields".to_string(),
-        );
-    }
-    let result = match request.kind.as_str() {
-        "computer_list_windows" => {
+    let result = match operation.kind {
+        RunnerComputerOperationKind::ListWindows => {
             let limit = payload
                 .get("limit")
                 .and_then(Value::as_u64)
@@ -123,40 +82,48 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                 .clamp(1, MAX_WINDOWS);
             computer_runtime().list_windows(limit)
         }
-        "computer_list_displays" => ensure_exact_payload_fields(&payload, &["limit"])
-            .and_then(|()| {
-                payload
-                    .get("limit")
-                    .and_then(Value::as_u64)
-                    .and_then(|value| usize::try_from(value).ok())
-                    .filter(|limit| (1..=MAX_DISPLAYS).contains(limit))
-                    .ok_or_else(|| {
-                        "invalid_request: display discovery limit is invalid".to_string()
-                    })
-            })
-            .and_then(|limit| computer_runtime().list_displays(limit)),
-        "computer_list_applications" => ensure_exact_payload_fields(&payload, &["limit"])
-            .and_then(|()| {
-                payload
-                    .get("limit")
-                    .and_then(Value::as_u64)
-                    .and_then(|value| usize::try_from(value).ok())
-                    .filter(|limit| (1..=MAX_APPLICATIONS).contains(limit))
-                    .ok_or_else(|| {
-                        "invalid_request: application discovery limit is invalid".to_string()
-                    })
-            })
-            .and_then(|limit| computer_runtime().list_applications(limit)),
-        "computer_launch_application" => ensure_exact_payload_fields(&payload, &["application_id"])
-            .and_then(|()| {
-                payload
-                    .get("application_id")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| "invalid_request: application_id is required".to_string())
-            })
-            .and_then(|application_id| computer_runtime().launch_application(application_id)),
-        "computer_accessibility_status" => computer_runtime().accessibility_status(),
-        "computer_accessibility_tree" => {
+        RunnerComputerOperationKind::ListDisplays => {
+            ensure_exact_payload_fields(&payload, &["limit"])
+                .and_then(|()| {
+                    payload
+                        .get("limit")
+                        .and_then(Value::as_u64)
+                        .and_then(|value| usize::try_from(value).ok())
+                        .filter(|limit| (1..=MAX_DISPLAYS).contains(limit))
+                        .ok_or_else(|| {
+                            "invalid_request: display discovery limit is invalid".to_string()
+                        })
+                })
+                .and_then(|limit| computer_runtime().list_displays(limit))
+        }
+        RunnerComputerOperationKind::ListApplications => {
+            ensure_exact_payload_fields(&payload, &["limit"])
+                .and_then(|()| {
+                    payload
+                        .get("limit")
+                        .and_then(Value::as_u64)
+                        .and_then(|value| usize::try_from(value).ok())
+                        .filter(|limit| (1..=MAX_APPLICATIONS).contains(limit))
+                        .ok_or_else(|| {
+                            "invalid_request: application discovery limit is invalid".to_string()
+                        })
+                })
+                .and_then(|limit| computer_runtime().list_applications(limit))
+        }
+        RunnerComputerOperationKind::LaunchApplication => {
+            ensure_exact_payload_fields(&payload, &["application_id"])
+                .and_then(|()| {
+                    payload
+                        .get("application_id")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "invalid_request: application_id is required".to_string())
+                })
+                .and_then(|application_id| computer_runtime().launch_application(application_id))
+        }
+        RunnerComputerOperationKind::AccessibilityStatus => {
+            computer_runtime().accessibility_status()
+        }
+        RunnerComputerOperationKind::AccessibilityTree => {
             let surface_id = payload
                 .get("surface_id")
                 .and_then(Value::as_str)
@@ -175,7 +142,7 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                 computer_runtime().accessibility_tree(surface_id, max_depth, max_nodes)
             })
         }
-        "computer_element_state" => {
+        RunnerComputerOperationKind::ElementState => {
             ensure_exact_payload_fields(&payload, &["surface_id", "element_id"]).and_then(|()| {
                 let surface_id = payload
                     .get("surface_id")
@@ -188,15 +155,17 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                 computer_runtime().element_state(surface_id, element_id)
             })
         }
-        "computer_activate_window" => ensure_exact_payload_fields(&payload, &["surface_id"])
-            .and_then(|()| {
-                payload
-                    .get("surface_id")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| "invalid_request: surface_id is required".to_string())
-            })
-            .and_then(|surface_id| computer_runtime().activate_window(surface_id)),
-        "computer_control" => {
+        RunnerComputerOperationKind::ActivateWindow => {
+            ensure_exact_payload_fields(&payload, &["surface_id"])
+                .and_then(|()| {
+                    payload
+                        .get("surface_id")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "invalid_request: surface_id is required".to_string())
+                })
+                .and_then(|surface_id| computer_runtime().activate_window(surface_id))
+        }
+        RunnerComputerOperationKind::Control => {
             ensure_exact_payload_fields(&payload, &["surface_id", "element_id", "action"]).and_then(
                 |()| {
                     let surface_id = payload
@@ -222,7 +191,7 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                 },
             )
         }
-        "computer_scroll_to_element" => {
+        RunnerComputerOperationKind::ScrollToElement => {
             ensure_exact_payload_fields(&payload, &["surface_id", "element_id"]).and_then(|()| {
                 let surface_id = payload
                     .get("surface_id")
@@ -235,17 +204,19 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                 computer_runtime().scroll_to_element(surface_id, element_id)
             })
         }
-        "computer_read_clipboard" => ensure_exact_payload_fields(&payload, &[])
+        RunnerComputerOperationKind::ReadClipboard => ensure_exact_payload_fields(&payload, &[])
             .and_then(|()| computer_runtime().read_clipboard()),
-        "computer_write_clipboard" => ensure_exact_payload_fields(&payload, &["text"])
-            .and_then(|()| {
-                payload
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| "invalid_request: clipboard text is required".to_string())
-            })
-            .and_then(|text| computer_runtime().write_clipboard(text)),
-        "computer_key_input" => {
+        RunnerComputerOperationKind::WriteClipboard => {
+            ensure_exact_payload_fields(&payload, &["text"])
+                .and_then(|()| {
+                    payload
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "invalid_request: clipboard text is required".to_string())
+                })
+                .and_then(|text| computer_runtime().write_clipboard(text))
+        }
+        RunnerComputerOperationKind::KeyInput => {
             ensure_exact_payload_fields(&payload, &["surface_id", "key", "modifiers"]).and_then(
                 |()| {
                     let surface_id = payload
@@ -272,7 +243,7 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                 },
             )
         }
-        "computer_pointer_move" | "computer_pointer_click" => {
+        RunnerComputerOperationKind::PointerMove | RunnerComputerOperationKind::PointerClick => {
             ensure_exact_payload_fields(&payload, &["display_id", "snapshot_generation", "x", "y"])
                 .and_then(|()| {
                     let display_id = payload
@@ -298,15 +269,15 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                         .and_then(Value::as_u64)
                         .and_then(|value| u32::try_from(value).ok())
                         .ok_or_else(|| "invalid_request: y must be a u32".to_string())?;
-                    let action = if request.kind == "computer_pointer_move" {
-                        PointerAction::Move
-                    } else {
-                        PointerAction::Click
+                    let action = match operation.kind {
+                        RunnerComputerOperationKind::PointerMove => PointerAction::Move,
+                        RunnerComputerOperationKind::PointerClick => PointerAction::Click,
+                        _ => unreachable!("pointer branch is typed"),
                     };
                     computer_runtime().pointer_effect(action, display_id, snapshot_generation, x, y)
                 })
         }
-        "computer_input_text" => {
+        RunnerComputerOperationKind::InputText => {
             ensure_exact_payload_fields(&payload, &["surface_id", "element_id", "text"]).and_then(
                 |()| {
                     let surface_id = payload
@@ -331,7 +302,7 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                 },
             )
         }
-        "computer_snapshot_display" => {
+        RunnerComputerOperationKind::SnapshotDisplay => {
             ensure_exact_payload_fields(&payload, &["display_id", "max_width", "max_height"])
                 .and_then(|()| {
                     let display_id = payload
@@ -343,15 +314,17 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
                     computer_runtime().snapshot_display(display_id, max_width, max_height)
                 })
         }
-        "computer_snapshot" => ensure_exact_payload_fields(&payload, &["surface_id"])
-            .and_then(|()| {
-                payload
-                    .get("surface_id")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| "invalid_request: surface_id is required".to_string())
-            })
-            .and_then(|surface_id| computer_runtime().snapshot(surface_id, None, None, None)),
-        "computer_snapshot_region" => ensure_exact_payload_fields(
+        RunnerComputerOperationKind::Snapshot => {
+            ensure_exact_payload_fields(&payload, &["surface_id"])
+                .and_then(|()| {
+                    payload
+                        .get("surface_id")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "invalid_request: surface_id is required".to_string())
+                })
+                .and_then(|surface_id| computer_runtime().snapshot(surface_id, None, None, None))
+        }
+        RunnerComputerOperationKind::SnapshotRegion => ensure_exact_payload_fields(
             &payload,
             &["surface_id", "region", "max_width", "max_height"],
         )
@@ -371,11 +344,50 @@ pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult 
             }
             computer_runtime().snapshot(surface_id, region, max_width, max_height)
         }),
-        _ => Err("invalid_request: unsupported computer request kind".to_string()),
     };
     match result {
         Ok(result) => ok_cmd(start, result),
         Err(error) => err_cmd(start, error),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn handle_computer_request(request: &RunnerRequest) -> CommandResult {
+    let start = Instant::now();
+    if !request.command.is_empty()
+        || request.cwd.is_some()
+        || request.path.is_some()
+        || request.content.is_some()
+        || request.process.is_some()
+        || request.script.is_some()
+        || request.job_id.is_some()
+        || request.lsp.is_some()
+        || request.job_context.is_some()
+        || request.persistent_shell.is_some()
+    {
+        return err_cmd(
+            start,
+            "invalid_request: computer request contains unrelated execution fields".to_string(),
+        );
+    }
+    let Some(raw) = request.stdin.as_deref() else {
+        return err_cmd(
+            start,
+            "invalid_request: computer payload is required and bounded".to_string(),
+        );
+    };
+    if raw.contains('\0') || serde_json::from_str::<Value>(raw).is_err() {
+        return err_cmd(
+            start,
+            "invalid_request: computer payload is not valid JSON".to_string(),
+        );
+    }
+    match request.decode_operation() {
+        Ok(RunnerOperation::Computer(operation)) => handle_computer_operation(&operation),
+        _ => err_cmd(
+            start,
+            "invalid_request: unsupported computer request kind".to_string(),
+        ),
     }
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
@@ -180,7 +180,7 @@ fn submit_invalid_job_start(sink: &RunnerSink, request: &RunnerRequest, error: S
     } else {
         format!("invalid Runner Job request: {error}")
     };
-    let command_execution_state = crate::structured_prestart_lifecycle(request);
+    let command_execution_state = crate::decode_failure_prestart_lifecycle(request);
     let _ = sink.send_job_update(&RunnerJobUpdateRequest {
         client_id: sink.client_id().to_string(),
         runner_instance_id: sink.runner_instance_id().to_string(),
@@ -370,6 +370,7 @@ pub(crate) fn dispatch_request_with_outcome(
     };
     let project_cache_invalidation_required =
         matches!(&invocation.operation, RunnerOperation::Project(_));
+    let invocation_metadata = invocation.metadata.clone();
     let request_id = invocation.metadata.request_id.clone();
     let client_id = invocation.metadata.client_id.clone();
     let policy = &config.policy;
@@ -636,21 +637,14 @@ pub(crate) fn dispatch_request_with_outcome(
             sink.submit_result_with_metadata(request_id, result, config, runtime)
                 .map(|_| true)
         }
-        RunnerOperation::Job(operation) => match operation {
-            RunnerJobOperation::Stop { job_id } => {
+        RunnerOperation::Job(operation) => {
+            if let RunnerJobOperation::Stop { job_id } = &operation {
                 jobs.install_sink(sink.clone());
-                if let Err(error) = jobs.stop(&job_id) {
+                if let Err(error) = jobs.stop(job_id) {
                     eprintln!("webcodex-runner stop_job error: {error}");
                 }
                 Ok(true)
-            }
-            RunnerJobOperation::StartShell(_)
-            | RunnerJobOperation::StartValidation(_)
-            | RunnerJobOperation::StartProcess(_)
-            | RunnerJobOperation::StartDetachedProcess(_)
-            | RunnerJobOperation::StartScript(_) => {
-                // Commit 4 removes this temporary wire handoff inside JobManager;
-                // semantic dispatch has already been closed here.
+            } else {
                 jobs.enqueue(
                     sink.clone(),
                     PendingJobStart {
@@ -659,12 +653,13 @@ pub(crate) fn dispatch_request_with_outcome(
                         shell: shell.clone(),
                         ssh: config.ssh.clone(),
                         project_registry_dir: project_registry_dir.to_path_buf(),
-                        request,
+                        metadata: invocation_metadata,
+                        operation,
                     },
                 );
                 Ok(true)
             }
-        },
+        }
     };
     dispatch_result.map(|handled| RunnerDispatchOutcome {
         handled,

--- a/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
@@ -1,11 +1,12 @@
 use super::external_tools::ExternalRoute;
-use super::lsp::{handle_lsp_request, is_lsp_request_kind, LspSupervisor};
+use super::lsp::{handle_lsp_operation, LspSupervisor};
 use super::transport::ResultSubmission;
-use super::validation::{handle_validation_request, is_validation_request_kind};
+use super::validation::handle_validation_request;
 use super::{
-    handle_computer_request, handle_prepare_managed_worktree, handle_project_lifecycle_op,
-    handle_project_op, handle_resolve_or_register_project, handle_skill_store_request,
-    is_computer_request_kind, run_internal_posix_script_with_profiles_and_execution_state,
+    handle_computer_operation, handle_prepare_managed_worktree_operation,
+    handle_project_lifecycle_operation, handle_project_operation,
+    handle_resolve_or_register_project_operation, handle_skill_store_request,
+    run_internal_posix_script_with_profiles_and_execution_state,
     run_internal_search_script_with_profiles_and_execution_state,
     run_process_with_profiles_and_execution_state, run_script_with_profiles_and_execution_state,
     run_shell_with_profiles_and_execution_state, run_ssh_shell_with_execution_state, CommandResult,
@@ -13,15 +14,17 @@ use super::{
     ShellCommandResult, SubmitResultError,
 };
 use crate::runner_protocol::{
-    validate_process_argv, validate_raw_shell_wire_command, validate_script_request,
-    RunnerConfigAction, RunnerConfigOperationRequest, RunnerRequest, ShellProcessArgv,
-    ShellScriptPayload, EXTERNAL_SEARCH_REQUEST_PREFIX, PROCESS_CWD_MAX_BYTES,
-    PROCESS_STDIN_MAX_BYTES, RUNNER_CONFIG_REQUEST_KIND, RUNNER_CONFIG_REQUEST_MAX_BYTES,
-    RUNNER_CONFIG_RESPONSE_MAX_BYTES, STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS,
+    PersistentShellResult, RunnerConfigAction, RunnerConfigOperationRequest,
+    RunnerJobUpdateRequest, RunnerRequest, EXTERNAL_SEARCH_REQUEST_PREFIX,
+    RUNNER_CONFIG_RESPONSE_MAX_BYTES,
 };
-use crate::{handle_file_request, is_file_request_kind, JobManager, PendingJobStart};
+use crate::{handle_file_operation, JobManager, PendingJobStart};
 use std::path::Path;
 use std::sync::atomic::Ordering;
+use webcodex_core::runner_operation::{
+    RunnerFileOperation, RunnerJobOperation, RunnerOperation, RunnerProjectOperation,
+    RunnerProjectOperationKind, RunnerShellOperation,
+};
 
 fn internal_search_script(command: &str) -> Option<&str> {
     let rest = command.strip_prefix(EXTERNAL_SEARCH_REQUEST_PREFIX)?;
@@ -29,53 +32,38 @@ fn internal_search_script(command: &str) -> Option<&str> {
     (!script.is_empty()).then_some(script)
 }
 
-fn handle_runner_config_request(
-    runtime: &ReloadableRunnerConfig,
-    request: &RunnerRequest,
-) -> CommandResult {
-    let invalid = || {
-        CommandResult {
+fn invalid_command(message: impl Into<String>) -> CommandResult {
+    CommandResult {
         exit_code: None,
         stdout: None,
         stderr: None,
         duration_ms: Some(0),
-        error: Some(
-            "invalid_runner_config_request: bounded typed config operation is required; request was not started"
-                .to_string(),
-        ),
+        error: Some(message.into()),
     }
+}
+
+fn handle_runner_config_operation(
+    runtime: &ReloadableRunnerConfig,
+    operation: &RunnerConfigOperationRequest,
+) -> CommandResult {
+    let invalid = || {
+        invalid_command(
+            "invalid_runner_config_request: bounded typed config operation is required; request was not started",
+        )
     };
-    let Some(content) = request.content.as_deref() else {
-        return invalid();
-    };
-    if content.len() > RUNNER_CONFIG_REQUEST_MAX_BYTES {
-        return invalid();
-    }
-    let Ok(operation) = serde_json::from_str::<RunnerConfigOperationRequest>(content) else {
-        return invalid();
-    };
-    if operation.validate().is_err() {
-        return invalid();
-    }
     let response = match operation.action {
         RunnerConfigAction::Check => runtime.check_config(),
-        RunnerConfigAction::Reload => runtime.reload_config(
-            operation
-                .expected_generation
-                .expect("validated reload operation has generation"),
-        ),
+        RunnerConfigAction::Reload => {
+            let Some(expected_generation) = operation.expected_generation else {
+                return invalid();
+            };
+            runtime.reload_config(expected_generation)
+        }
     };
     if response.validate().is_err() {
-        return CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "invalid_runner_config_response: Runner config operation result was rejected"
-                    .to_string(),
-            ),
-        };
+        return invalid_command(
+            "invalid_runner_config_response: Runner config operation result was rejected",
+        );
     }
     let Ok(stdout) = serde_json::to_string(&response) else {
         return invalid();
@@ -90,6 +78,12 @@ fn handle_runner_config_request(
         duration_ms: Some(0),
         error: None,
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RunnerDispatchOutcome {
+    pub(crate) handled: bool,
+    pub(crate) project_cache_invalidation_required: bool,
 }
 
 pub(super) fn runner_tool_trace_enabled() -> bool {
@@ -110,20 +104,13 @@ fn run_native_shell_or_internal_search(
     runtime: &ReloadableRunnerConfig,
     jobs: &JobManager,
     project_registry_dir: &Path,
-    request: &RunnerRequest,
+    operation: &RunnerShellOperation,
 ) -> ShellCommandResult {
-    if request.command.lines().next() == Some(EXTERNAL_SEARCH_REQUEST_PREFIX) {
-        let Some(script) = internal_search_script(&request.command) else {
-            return ShellCommandResult::not_started(CommandResult {
-                exit_code: None,
-                stdout: None,
-                stderr: None,
-                duration_ms: Some(0),
-                error: Some(
-                    "invalid_internal_search_request: generated search script is missing; command was not started"
-                        .to_string(),
-                ),
-            });
+    if operation.command.lines().next() == Some(EXTERNAL_SEARCH_REQUEST_PREFIX) {
+        let Some(script) = internal_search_script(&operation.command) else {
+            return ShellCommandResult::not_started(invalid_command(
+                "invalid_internal_search_request: generated search script is missing; command was not started",
+            ));
         };
         return run_internal_search_script_with_profiles_and_execution_state(
             config.generation,
@@ -131,9 +118,9 @@ fn run_native_shell_or_internal_search(
             &config.shell,
             project_registry_dir,
             &jobs.prepared_profiles,
-            request.cwd.as_deref(),
+            operation.cwd.as_deref(),
             script,
-            request.timeout_secs,
+            operation.timeout_secs,
             Some(runtime.shutdown_flag()),
         );
     }
@@ -143,19 +130,206 @@ fn run_native_shell_or_internal_search(
         &config.shell,
         project_registry_dir,
         &jobs.prepared_profiles,
-        request.cwd.as_deref(),
-        &request.command,
-        request.stdin.as_deref(),
-        request.timeout_secs,
+        operation.cwd.as_deref(),
+        &operation.command,
+        operation.stdin.as_deref(),
+        operation.timeout_secs,
         Some(runtime.shutdown_flag()),
     )
 }
 
-/// Execute a single agent request (shell/file/job/lsp/validation) and send the
-/// result over the active transport. This is the shared dispatch path used by
-/// both the polling loop (`handle_one_poll`) and the WebSocket loop. It contains
-/// no transport-specific code: all outgoing traffic goes through `sink`.
-pub(crate) fn dispatch_request(
+fn invalid_persistent_shell_result(
+    request: &RunnerRequest,
+    message: String,
+) -> Option<PersistentShellResult> {
+    let operation = request.persistent_shell.as_ref()?;
+    Some(PersistentShellResult {
+        shell_id: operation.shell_id.clone(),
+        workflow_session_id: operation.workflow_session_id.clone(),
+        runtime_project_id: operation.runtime_project_id.clone(),
+        shell_state: "unknown".to_string(),
+        execution_state: "rejected".to_string(),
+        command_started: false,
+        command_completed: false,
+        exit_code: None,
+        stdout: String::new(),
+        stderr: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        duration_ms: 0,
+        cwd: None,
+        initial_cwd: None,
+        shell: None,
+        profile: None,
+        created_at: None,
+        last_activity_at: None,
+        busy: false,
+        already_closed: false,
+        close_reason: None,
+        error_code: Some("persistent_shell_invalid_request".to_string()),
+        error: Some(message),
+    })
+}
+
+fn submit_invalid_job_start(sink: &RunnerSink, request: &RunnerRequest, error: String) -> bool {
+    let Some(job_id) = request.job_id.clone() else {
+        return false;
+    };
+    let error = if error.contains("requires job_context") {
+        "job start request is missing recovery context".to_string()
+    } else {
+        format!("invalid Runner Job request: {error}")
+    };
+    let command_execution_state = crate::structured_prestart_lifecycle(request);
+    let _ = sink.send_job_update(&RunnerJobUpdateRequest {
+        client_id: sink.client_id().to_string(),
+        runner_instance_id: sink.runner_instance_id().to_string(),
+        job_id,
+        request_id: Some(request.request_id.clone()),
+        update_seq: Some(1),
+        status: "failed".to_string(),
+        stdout_chunk: None,
+        stderr_chunk: None,
+        stdout_tail: None,
+        stderr_tail: None,
+        log_snapshot: None,
+        exit_code: None,
+        duration_ms: Some(0),
+        error: Some(error),
+        command_execution_state,
+        validation_progress: None,
+        activity: None,
+        finished: true,
+    });
+    true
+}
+
+/// Decoder failures are handled at the V2 boundary. The small amount of `kind`
+/// matching here selects the existing result channel only; it never dispatches
+/// execution semantics or recovers an operation from optional payload fields.
+fn submit_decode_failure(
+    sink: &RunnerSink,
+    config: &HotRunnerConfig,
+    runtime: &ReloadableRunnerConfig,
+    request: RunnerRequest,
+    error: String,
+) -> Result<bool, SubmitResultError> {
+    let request_id = request.request_id.clone();
+    match request.kind.as_str() {
+        "start_job"
+        | "start_validation_job"
+        | "start_process_job"
+        | "start_detached_process_job"
+        | "start_script_job" => {
+            if submit_invalid_job_start(sink, &request, error.clone()) {
+                Ok(true)
+            } else {
+                sink.submit_result_with_metadata(
+                    request_id,
+                    invalid_command(format!(
+                        "invalid_runner_operation: {error}; command was not started"
+                    )),
+                    config,
+                    runtime,
+                )
+                .map(|_| true)
+            }
+        }
+        "coding_agent" => sink
+            .submit_coding_agent_result(
+                request_id,
+                webcodex_core::coding_agent::CodingAgentResponse::error(
+                    webcodex_core::coding_agent::CodingAgentDispatchState::NotStarted,
+                    "invalid_coding_agent_request",
+                    error,
+                    Some("invalid_input"),
+                    Some("fix_input"),
+                ),
+            )
+            .map(|_| true),
+        "mcp_gateway" => sink
+            .submit_mcp_gateway_result(
+                request_id,
+                crate::mcp_gateway::McpGatewayResponse::error(
+                    crate::mcp_gateway::McpGatewayDispatchState::NotStarted,
+                    "invalid_bridge_request",
+                    error,
+                ),
+            )
+            .map(|_| true),
+        "plugin_gateway" => sink
+            .submit_plugin_gateway_result(
+                request_id,
+                webcodex_core::plugin::PluginGatewayResponse::error(
+                    webcodex_core::plugin::PluginDispatchState::NotStarted,
+                    "invalid_plugin_request",
+                    error,
+                ),
+            )
+            .map(|_| true),
+        "persistent_shell" => {
+            if let Some(result) = invalid_persistent_shell_result(&request, error.clone()) {
+                sink.submit_persistent_shell_result(request_id, result)
+                    .map(|_| true)
+            } else {
+                sink.submit_result_with_metadata(
+                    request_id,
+                    invalid_command(format!(
+                        "invalid_request: {error}; command was not started"
+                    )),
+                    config,
+                    runtime,
+                )
+                .map(|_| true)
+            }
+        }
+        "run_shell" => sink
+            .submit_shell_result_with_metadata(
+                request_id,
+                ShellCommandResult::not_started(invalid_command(format!(
+                    "invalid_raw_shell_request: {error}; command was not started"
+                ))),
+                config,
+                runtime,
+            )
+            .map(|_| true),
+        "run_process" | "run_script" | "run_internal_posix_script" => sink
+            .submit_shell_result_with_metadata(
+                request_id,
+                ShellCommandResult::not_started(invalid_command(format!(
+                    "invalid_runner_operation: {error}; command was not started"
+                ))),
+                config,
+                runtime,
+            )
+            .map(|_| true),
+        kind if kind.starts_with("file_") && !RunnerFileOperation::is_wire_kind(kind) => sink
+            .submit_result_with_metadata(
+                request_id,
+                invalid_command(
+                    "unsupported_file_request_kind: unsupported file request kind; command was not started",
+                ),
+                config,
+                runtime,
+            )
+            .map(|_| true),
+        _ => sink
+            .submit_result_with_metadata(
+                request_id,
+                invalid_command(format!(
+                    "invalid_runner_operation: {error}; command was not started"
+                )),
+                config,
+                runtime,
+            )
+            .map(|_| true),
+    }
+}
+
+/// Execute one V2 request through the transport-neutral typed Runner ingress.
+/// Polling, WebSocket, and QUIC all reach this function with the same wire DTO;
+/// operation semantics are decoded exactly once before this exhaustive match.
+pub(crate) fn dispatch_request_with_outcome(
     sink: &RunnerSink,
     config: &HotRunnerConfig,
     runtime: &ReloadableRunnerConfig,
@@ -164,7 +338,7 @@ pub(crate) fn dispatch_request(
     project_registry_dir: &Path,
     lsp: &LspSupervisor,
     request: RunnerRequest,
-) -> Result<bool, SubmitResultError> {
+) -> Result<RunnerDispatchOutcome, SubmitResultError> {
     if runner_tool_trace_enabled() {
         tracing::info!(
             event = "runner_tool_dispatch_started",
@@ -177,532 +351,265 @@ pub(crate) fn dispatch_request(
         );
     }
     if runtime.shutdown_flag().load(Ordering::SeqCst) {
-        return Ok(false);
+        return Ok(RunnerDispatchOutcome {
+            handled: false,
+            project_cache_invalidation_required: false,
+        });
     }
-    if request.kind == "coding_agent" {
-        let request_id = request.request_id.clone();
-        let response = match (runtime.coding_agents(), request.coding_agent) {
-            (Some(manager), Some(operation)) => manager.handle(operation, project_registry_dir),
-            (None, _) => webcodex_core::coding_agent::CodingAgentResponse::error(
-                webcodex_core::coding_agent::CodingAgentDispatchState::NotStarted,
-                "coding_agent_unavailable",
-                "Runner ACP coding-agent execution is not configured/available",
-                Some("unavailable"),
-                Some("reobserve"),
-            ),
-            (Some(_), None) => webcodex_core::coding_agent::CodingAgentResponse::error(
-                webcodex_core::coding_agent::CodingAgentDispatchState::NotStarted,
-                "invalid_coding_agent_request",
-                "Typed CodingAgentRun operation is required; request was not started",
-                Some("invalid_input"),
-                Some("fix_input"),
-            ),
-        };
-        return sink
-            .submit_coding_agent_result(request_id, response)
-            .map(|_| true);
-    }
-    if request.coding_agent.is_some() {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "invalid_request: coding_agent payload is valid only for coding_agent requests; command was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == "mcp_gateway" {
-        let request_id = request.request_id.clone();
-        let response = match request.mcp_gateway {
-            Some(operation) => runtime.mcp_gateway().handle(operation),
-            None => crate::mcp_gateway::McpGatewayResponse::error(
-                crate::mcp_gateway::McpGatewayDispatchState::NotStarted,
-                "invalid_bridge_request",
-                "Typed bridge operation is required; request was not started",
-            ),
-        };
-        return sink
-            .submit_mcp_gateway_result(request_id, response)
-            .map(|_| true);
-    }
-    if request.mcp_gateway.is_some() {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "invalid_request: bridge payload is valid only for mcp_gateway requests; command was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == "plugin_gateway" {
-        let request_id = request.request_id.clone();
-        let response = match request.plugin_gateway {
-            Some(operation) => runtime.plugins().handle(operation),
-            None => webcodex_core::plugin::PluginGatewayResponse::error(
-                webcodex_core::plugin::PluginDispatchState::NotStarted,
-                "invalid_plugin_request",
-                "Typed native Plugin operation is required; request was not started",
-            ),
-        };
-        return sink
-            .submit_plugin_gateway_result(request_id, response)
-            .map(|_| true);
-    }
-    if request.plugin_gateway.is_some() {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "invalid_request: plugin_gateway payload is valid only for plugin_gateway requests; command was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == RUNNER_CONFIG_REQUEST_KIND {
-        let request_id = request.request_id.clone();
-        let result = handle_runner_config_request(runtime, &request);
-        // A reload may have replaced the snapshot passed into dispatch_request.
-        // Project config/provider status from this completion must therefore use
-        // the authoritative post-operation generation.
-        let current = runtime.snapshot();
-        return sink
-            .submit_result_with_metadata(request_id, result, &current, runtime)
-            .map(|_| true);
-    }
-    if request.kind.starts_with("runner_config") {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "invalid_runner_config_request: unsupported config operation; request was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == "ssh_resource" {
-        let request_id = request.request_id.clone();
-        let response = runtime
-            .managed_ssh()
-            .handle_wire(&config.static_ssh, request.content.as_deref());
-        let result = CommandResult {
-            exit_code: Some(0),
-            stdout: Some(
-                serde_json::to_string(&response)
-                    .expect("managed SSH resource response serialization is infallible"),
-            ),
-            stderr: None,
-            duration_ms: Some(0),
-            error: None,
-        };
-        return sink
-            .submit_result_with_metadata(request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind.starts_with("ssh_resource") {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "ssh_resource_invalid: unsupported managed SSH resource request; command was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == "skill_store" {
-        let request_id = request.request_id.clone();
-        let result = handle_skill_store_request(
-            runtime.client_id(),
-            runtime.server_url(),
-            &config.policy,
-            &request,
-        );
-        return sink
-            .submit_result_with_metadata(request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind.starts_with("skill_store") {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "invalid_request: unsupported Skill store request kind; command was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    // Computer operations are an explicit typed protocol surface. Unknown
-    // computer_* requests must never reach external providers or shell fallback.
-    if request.kind.starts_with("computer_") && !is_computer_request_kind(&request.kind) {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "invalid_request: unsupported computer request kind; command was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if is_computer_request_kind(&request.kind) {
-        let request_id = request.request_id.clone();
-        let result = handle_computer_request(&request);
-        return sink
-            .submit_result_with_metadata(request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    // File operations are an explicit protocol surface. Unknown `file_*`
-    // requests must fail before provider routing or any shell fallback.
-    if request.kind.starts_with("file_") && !is_file_request_kind(&request.kind) {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "unsupported_file_request_kind: unsupported file request kind; command was not started"
-                    .to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
+
+    let invocation = match request.decode_invocation() {
+        Ok(invocation) => invocation,
+        Err(error) => {
+            return submit_decode_failure(sink, config, runtime, request, error).map(|handled| {
+                RunnerDispatchOutcome {
+                    handled,
+                    project_cache_invalidation_required: false,
+                }
+            })
+        }
+    };
+    let project_cache_invalidation_required =
+        matches!(&invocation.operation, RunnerOperation::Project(_));
+    let request_id = invocation.metadata.request_id.clone();
+    let client_id = invocation.metadata.client_id.clone();
     let policy = &config.policy;
     let shell = &config.shell;
-    let external_tools = &config.external_tools;
-    let ssh_resource = request
-        .job_context
-        .as_ref()
-        .and_then(|context| context.ssh_resource.as_deref());
-    let ssh_session_id = request
-        .job_context
-        .as_ref()
-        .and_then(|context| context.workflow_session_id.as_deref());
-    if request.kind == "run_process" {
-        let request_id = request.request_id.clone();
-        let result = if ssh_resource.is_some() {
-            ShellCommandResult::not_started(CommandResult {
-                exit_code: None,
-                stdout: None,
+
+    let dispatch_result = match invocation.operation {
+        RunnerOperation::CodingAgent(operation) => {
+            let response = match runtime.coding_agents() {
+                Some(manager) => manager.handle(operation, project_registry_dir),
+                None => webcodex_core::coding_agent::CodingAgentResponse::error(
+                    webcodex_core::coding_agent::CodingAgentDispatchState::NotStarted,
+                    "coding_agent_unavailable",
+                    "Runner ACP coding-agent execution is not configured/available",
+                    Some("unavailable"),
+                    Some("reobserve"),
+                ),
+            };
+            sink.submit_coding_agent_result(request_id, response)
+                .map(|_| true)
+        }
+        RunnerOperation::McpGateway(operation) => sink
+            .submit_mcp_gateway_result(request_id, runtime.mcp_gateway().handle(operation))
+            .map(|_| true),
+        RunnerOperation::PluginGateway(operation) => sink
+            .submit_plugin_gateway_result(request_id, runtime.plugins().handle(operation))
+            .map(|_| true),
+        RunnerOperation::RunnerConfig(operation) => {
+            let result = handle_runner_config_operation(runtime, &operation);
+            // A reload may have replaced the snapshot passed into dispatch_request.
+            let current = runtime.snapshot();
+            sink.submit_result_with_metadata(request_id, result, &current, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::SshResource(operation) => {
+            let response = runtime.managed_ssh().handle(&config.static_ssh, operation);
+            let result = CommandResult {
+                exit_code: Some(0),
+                stdout: Some(
+                    serde_json::to_string(&response)
+                        .expect("managed SSH resource response serialization is infallible"),
+                ),
                 stderr: None,
                 duration_ms: Some(0),
-                error: Some(
-                    "structured_process_ssh_unsupported: native argv is unavailable for SSH resources; command was not started"
-                        .to_string(),
-                ),
-            })
-        } else {
-            match validate_run_process_request(&request) {
-                Ok(process) => run_process_with_profiles_and_execution_state(
-                    config.generation,
-                    policy,
-                    shell,
-                    project_registry_dir,
-                    &jobs.prepared_profiles,
-                    request.cwd.as_deref(),
-                    &process.executable,
-                    &process.args,
-                    request.stdin.as_deref(),
-                    request.timeout_secs,
-                    Some(runtime.shutdown_flag()),
-                ),
-                Err(error) => ShellCommandResult::not_started(CommandResult {
-                    exit_code: None,
-                    stdout: None,
-                    stderr: None,
-                    duration_ms: Some(0),
-                    error: Some(format!(
-                        "invalid_structured_process_request: {error}; command was not started"
-                    )),
-                }),
-            }
-        };
-        return sink
-            .submit_shell_result_with_metadata(request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == "run_script" {
-        let request_id = request.request_id.clone();
-        let result = if ssh_resource.is_some() {
-            ShellCommandResult::not_started(CommandResult {
-                exit_code: None,
-                stdout: None,
-                stderr: None,
-                duration_ms: Some(0),
-                error: Some(
-                    "structured_script_ssh_unsupported: typed script payloads are unavailable for SSH resources; command was not started"
-                        .to_string(),
-                ),
-            })
-        } else {
-            match validate_run_script_request(&request) {
-                Ok(script) => run_script_with_profiles_and_execution_state(
-                    config.generation,
-                    policy,
-                    shell,
-                    project_registry_dir,
-                    &jobs.prepared_profiles,
-                    request.cwd.as_deref(),
-                    script,
-                    request.stdin.as_deref(),
-                    request.timeout_secs,
-                    Some(runtime.shutdown_flag()),
-                ),
-                Err(error) => ShellCommandResult::not_started(CommandResult {
-                    exit_code: None,
-                    stdout: None,
-                    stderr: None,
-                    duration_ms: Some(0),
-                    error: Some(format!(
-                        "invalid_structured_script_request: {error}; command was not started"
-                    )),
-                }),
-            }
-        };
-        return sink
-            .submit_shell_result_with_metadata(request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == "run_internal_posix_script" {
-        let request_id = request.request_id.clone();
-        let result = if ssh_resource.is_some() {
-            ShellCommandResult::not_started(CommandResult {
-                exit_code: None,
-                stdout: None,
-                stderr: None,
-                duration_ms: Some(0),
-                error: Some(
-                    "internal_posix_script_ssh_unsupported: generated internal programs are unavailable for SSH resources; command was not started"
-                        .to_string(),
-                ),
-            })
-        } else {
-            match validate_internal_posix_script_request(&request) {
-                Ok(script) => run_internal_posix_script_with_profiles_and_execution_state(
-                    config.generation,
-                    policy,
-                    shell,
-                    project_registry_dir,
-                    &jobs.prepared_profiles,
-                    request.cwd.as_deref(),
-                    script,
-                    request.timeout_secs,
-                    Some(runtime.shutdown_flag()),
-                ),
-                Err(error) => ShellCommandResult::not_started(CommandResult {
-                    exit_code: None,
-                    stdout: None,
-                    stderr: None,
-                    duration_ms: Some(0),
-                    error: Some(format!(
-                        "invalid_internal_posix_script_request: {error}; command was not started"
-                    )),
-                }),
-            }
-        };
-        return sink
-            .submit_shell_result_with_metadata(request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    if request.kind == "persistent_shell" {
-        let request_id = request.request_id.clone();
-        let operation = request.persistent_shell.clone();
-        let result = persistent_shells.handle(
-            policy,
-            shell,
-            &config.ssh,
-            config.generation,
-            project_registry_dir,
-            &request,
-        );
-        let submitted = sink.submit_persistent_shell_result(request_id, result);
-        if !matches!(&submitted, Ok(ResultSubmission::Accepted)) {
-            if let Some(operation) = operation {
+                error: None,
+            };
+            sink.submit_result_with_metadata(request_id, result, config, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::SkillStore(operation) => {
+            let result = handle_skill_store_request(
+                runtime.client_id(),
+                runtime.server_url(),
+                policy,
+                operation,
+            );
+            sink.submit_result_with_metadata(request_id, result, config, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::Computer(operation) => {
+            let result = handle_computer_operation(&operation);
+            sink.submit_result_with_metadata(request_id, result, config, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::RunProcess(operation) => {
+            let result = run_process_with_profiles_and_execution_state(
+                config.generation,
+                policy,
+                shell,
+                project_registry_dir,
+                &jobs.prepared_profiles,
+                operation.cwd.as_deref(),
+                &operation.process.executable,
+                &operation.process.args,
+                operation.stdin.as_deref(),
+                operation.timeout_secs,
+                Some(runtime.shutdown_flag()),
+            );
+            sink.submit_shell_result_with_metadata(request_id, result, config, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::RunScript(operation) => {
+            let result = run_script_with_profiles_and_execution_state(
+                config.generation,
+                policy,
+                shell,
+                project_registry_dir,
+                &jobs.prepared_profiles,
+                operation.cwd.as_deref(),
+                &operation.script,
+                operation.stdin.as_deref(),
+                operation.timeout_secs,
+                Some(runtime.shutdown_flag()),
+            );
+            sink.submit_shell_result_with_metadata(request_id, result, config, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::RunInternalPosixScript(operation) => {
+            let result = run_internal_posix_script_with_profiles_and_execution_state(
+                config.generation,
+                policy,
+                shell,
+                project_registry_dir,
+                &jobs.prepared_profiles,
+                operation.cwd.as_deref(),
+                &operation.script.script,
+                operation.timeout_secs,
+                Some(runtime.shutdown_flag()),
+            );
+            sink.submit_shell_result_with_metadata(request_id, result, config, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::PersistentShell(operation) => {
+            let identity = (
+                operation.request.shell_id.clone(),
+                operation.request.workflow_session_id.clone(),
+                operation.request.runtime_project_id.clone(),
+            );
+            let result = persistent_shells.handle_operation(
+                policy,
+                shell,
+                &config.ssh,
+                config.generation,
+                project_registry_dir,
+                &client_id,
+                &operation,
+            );
+            let submitted = sink.submit_persistent_shell_result(request_id, result);
+            if !matches!(&submitted, Ok(ResultSubmission::Accepted)) {
                 let _ = persistent_shells.close_exact(
-                    &operation.shell_id,
-                    &operation.workflow_session_id,
-                    &operation.runtime_project_id,
+                    &identity.0,
+                    &identity.1,
+                    &identity.2,
                     "persistent_shell_result_not_accepted",
                 );
             }
+            submitted.map(|_| true)
         }
-        return submitted.map(|_| true);
-    }
-    if request.kind == "run_shell" {
-        if let Err(error) = validate_raw_shell_wire_command(&request.command) {
-            let result = ShellCommandResult::not_started(CommandResult {
-                exit_code: None,
-                stdout: None,
-                stderr: None,
-                duration_ms: Some(0),
-                error: Some(format!(
-                    "invalid_raw_shell_request: {error}; command was not started"
-                )),
-            });
-            return sink
-                .submit_shell_result_with_metadata(request.request_id, result, config, runtime)
-                .map(|_| true);
-        }
-    }
-
-    if ssh_resource.is_some()
-        && !matches!(
-            request.kind.as_str(),
-            "run_shell"
-                | "start_job"
-                | "start_validation_job"
-                | "start_process_job"
-                | "start_script_job"
-        )
-    {
-        let result = CommandResult {
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            duration_ms: Some(0),
-            error: Some(
-                "ssh_resource_unsupported_for_request: SSH resources are only available to run_shell and run_job; command was not started".to_string(),
-            ),
-        };
-        return sink
-            .submit_result_with_metadata(request.request_id, result, config, runtime)
-            .map(|_| true);
-    }
-    let external_route = if ssh_resource.is_some() {
-        ExternalRoute::Native
-    } else {
-        external_tools.route_with_shutdown(policy, &request, Some(runtime.shutdown_flag()))
-    };
-    match external_route {
-        ExternalRoute::Handled(result) => {
-            return sink
-                .submit_result_with_metadata(request.request_id, result, config, runtime)
-                .map(|_| true);
-        }
-        ExternalRoute::NativeFallback(fallback) => {
-            let request_id = request.request_id.clone();
-            if is_file_request_kind(&request.kind) {
-                let result = handle_file_request(policy, &request);
-                external_tools.complete_native_fallback(fallback, &result);
-                return sink
-                    .submit_result_with_metadata(request_id, result, config, runtime)
-                    .map(|_| true);
-            }
-            let result = run_native_shell_or_internal_search(
-                config,
-                runtime,
-                jobs,
-                project_registry_dir,
-                &request,
-            );
-            external_tools.complete_native_fallback(fallback, &result.result);
-            return sink
-                .submit_shell_result_with_metadata(request_id, result, config, runtime)
-                .map(|_| true);
-        }
-        ExternalRoute::Native => {}
-    }
-    match request.kind.as_str() {
-        "start_job"
-        | "start_validation_job"
-        | "start_process_job"
-        | "start_detached_process_job"
-        | "start_script_job" => {
-            jobs.enqueue(
-                sink.clone(),
-                PendingJobStart {
-                    generation: config.generation,
-                    policy: policy.clone(),
-                    shell: shell.clone(),
-                    ssh: config.ssh.clone(),
-                    project_registry_dir: project_registry_dir.to_path_buf(),
-                    request,
-                },
-            );
-            Ok(true)
-        }
-        "stop_job" => {
-            jobs.install_sink(sink.clone());
-            if let Some(job_id) = request.job_id.as_deref() {
-                if let Err(e) = jobs.stop(job_id) {
-                    eprintln!("webcodex-runner stop_job error: {}", e);
+        RunnerOperation::RunShell(operation) => {
+            let ssh_resource = operation
+                .job_context
+                .as_ref()
+                .and_then(|context| context.ssh_resource.as_deref());
+            let ssh_session_id = operation
+                .job_context
+                .as_ref()
+                .and_then(|context| context.workflow_session_id.as_deref());
+            if let Some(resource) = ssh_resource {
+                let result = match ssh_session_id {
+                    Some(session_id) => run_ssh_shell_with_execution_state(
+                        &jobs.ssh_pool,
+                        config.generation,
+                        &config.ssh,
+                        policy,
+                        resource,
+                        session_id,
+                        operation.cwd.as_deref(),
+                        &operation.command,
+                        operation.stdin.as_deref(),
+                        operation.timeout_secs,
+                        Some(runtime.shutdown_flag()),
+                    ),
+                    None => ShellCommandResult::not_started(invalid_command(
+                        "ssh_session_required: an SSH resource requires a Workflow Session id; command was not started",
+                    )),
+                };
+                sink.submit_shell_result_with_metadata(request_id, result, config, runtime)
+                    .map(|_| true)
+            } else {
+                match config.external_tools.route_with_shutdown(
+                    policy,
+                    &operation,
+                    Some(runtime.shutdown_flag()),
+                ) {
+                    ExternalRoute::Handled(result) => sink
+                        .submit_result_with_metadata(request_id, result, config, runtime)
+                        .map(|_| true),
+                    ExternalRoute::NativeFallback(fallback) => {
+                        let result = run_native_shell_or_internal_search(
+                            config,
+                            runtime,
+                            jobs,
+                            project_registry_dir,
+                            &operation,
+                        );
+                        config
+                            .external_tools
+                            .complete_native_fallback(fallback, &result.result);
+                        sink.submit_shell_result_with_metadata(request_id, result, config, runtime)
+                            .map(|_| true)
+                    }
+                    ExternalRoute::Native => {
+                        let result = run_native_shell_or_internal_search(
+                            config,
+                            runtime,
+                            jobs,
+                            project_registry_dir,
+                            &operation,
+                        );
+                        sink.submit_shell_result_with_metadata(request_id, result, config, runtime)
+                            .map(|_| true)
+                    }
                 }
             }
-            Ok(true)
         }
-        kind if is_file_request_kind(kind) => {
-            let request_id = request.request_id.clone();
-            let result = handle_file_request(policy, &request);
+        RunnerOperation::File(operation) => {
+            let result = handle_file_operation(policy, &operation);
             sink.submit_result_with_metadata(request_id, result, config, runtime)
                 .map(|_| true)
         }
-        "register_project" | "create_project" => {
-            let request_id = request.request_id.clone();
-            let result = handle_project_op(policy, project_registry_dir, &request);
-            sink.submit_result_with_metadata(request_id, result, config, runtime)
-                .map(|_| true)
-        }
-        "resolve_or_register_project" => {
-            let request_id = request.request_id.clone();
-            let result = handle_resolve_or_register_project(policy, project_registry_dir, &request);
-            sink.submit_result_with_metadata(request_id, result, config, runtime)
-                .map(|_| true)
-        }
-        "prepare_managed_worktree" => {
-            let request_id = request.request_id.clone();
-            let result = handle_prepare_managed_worktree(policy, project_registry_dir, &request);
-            sink.submit_result_with_metadata(request_id, result, config, runtime)
-                .map(|_| true)
-        }
-        "project_lifecycle_enable"
-        | "project_lifecycle_disable"
-        | "project_lifecycle_unregister" => {
-            let request_id = request.request_id.clone();
-            let result = handle_project_lifecycle_op(policy, project_registry_dir, &request);
-            if result.exit_code == Some(0)
-                && matches!(
-                    request.kind.as_str(),
-                    "project_lifecycle_disable" | "project_lifecycle_unregister"
-                )
-            {
-                if let Some(project_id) = lifecycle_project_id(&request) {
-                    let runtime_project_id = format!("agent:{}:{}", request.client_id, project_id);
+        RunnerOperation::Project(operation) => {
+            let kind = operation.kind;
+            let result = match kind {
+                RunnerProjectOperationKind::Register | RunnerProjectOperationKind::Create => {
+                    handle_project_operation(policy, project_registry_dir, &client_id, &operation)
+                }
+                RunnerProjectOperationKind::ResolveOrRegister => {
+                    handle_resolve_or_register_project_operation(
+                        policy,
+                        project_registry_dir,
+                        &client_id,
+                        &operation,
+                    )
+                }
+                RunnerProjectOperationKind::PrepareManagedWorktree => {
+                    handle_prepare_managed_worktree_operation(
+                        policy,
+                        project_registry_dir,
+                        &client_id,
+                        &operation,
+                    )
+                }
+                RunnerProjectOperationKind::LifecycleEnable
+                | RunnerProjectOperationKind::LifecycleDisable
+                | RunnerProjectOperationKind::LifecycleUnregister => {
+                    handle_project_lifecycle_operation(policy, project_registry_dir, &operation)
+                }
+            };
+            if result.exit_code == Some(0) && kind.disables_execution() {
+                if let Some(project_id) = lifecycle_project_id(&operation) {
+                    let runtime_project_id = format!("agent:{client_id}:{project_id}");
                     persistent_shells
                         .close_project(&runtime_project_id, "project_execution_disabled");
                 }
@@ -710,173 +617,92 @@ pub(crate) fn dispatch_request(
             sink.submit_result_with_metadata(request_id, result, config, runtime)
                 .map(|_| true)
         }
-        kind if is_lsp_request_kind(kind) => {
-            // Explicit LSP branch — must never fall through to shell execution.
-            let request_id = request.request_id.clone();
-            let result = handle_lsp_request(policy, project_registry_dir, lsp, &request);
+        RunnerOperation::Lsp {
+            payload,
+            timeout_secs,
+        } => {
+            let result =
+                handle_lsp_operation(policy, project_registry_dir, lsp, &payload, timeout_secs);
             sink.submit_result_with_metadata(request_id, result, config, runtime)
                 .map(|_| true)
         }
-        kind if is_validation_request_kind(kind) => {
-            // Explicit validation bridge branch — never fall through to shell.
-            let request_id = request.request_id.clone();
+        RunnerOperation::Validation { payload, .. } => {
             let result = handle_validation_request(
                 policy,
                 project_registry_dir,
-                &request,
+                &payload,
                 Some(runtime.shutdown_flag()),
             );
             sink.submit_result_with_metadata(request_id, result, config, runtime)
                 .map(|_| true)
         }
-        _ => {
-            let request_id = request.request_id.clone();
-            let result = match (ssh_resource, ssh_session_id) {
-                (Some(resource), Some(session_id)) => run_ssh_shell_with_execution_state(
-                    &jobs.ssh_pool,
-                    config.generation,
-                    &config.ssh,
-                    policy,
-                    resource,
-                    session_id,
-                    request.cwd.as_deref(),
-                    &request.command,
-                    request.stdin.as_deref(),
-                    request.timeout_secs,
-                    Some(runtime.shutdown_flag()),
-                        ),
-                (Some(_), None) => ShellCommandResult::not_started(CommandResult {
-                    exit_code: None,
-                    stdout: None,
-                    stderr: None,
-                    duration_ms: Some(0),
-                    error: Some(
-                        "ssh_session_required: an SSH resource requires a Workflow Session id; command was not started".to_string(),
-                    ),
-                }),
-                (None, _) => run_native_shell_or_internal_search(
-                    config,
-                    runtime,
-                    jobs,
-                    project_registry_dir,
-                    &request,
-                ),
-            };
-            sink.submit_shell_result_with_metadata(request_id, result, config, runtime)
-                .map(|_| true)
-        }
-    }
+        RunnerOperation::Job(operation) => match operation {
+            RunnerJobOperation::Stop { job_id } => {
+                jobs.install_sink(sink.clone());
+                if let Err(error) = jobs.stop(&job_id) {
+                    eprintln!("webcodex-runner stop_job error: {error}");
+                }
+                Ok(true)
+            }
+            RunnerJobOperation::StartShell(_)
+            | RunnerJobOperation::StartValidation(_)
+            | RunnerJobOperation::StartProcess(_)
+            | RunnerJobOperation::StartDetachedProcess(_)
+            | RunnerJobOperation::StartScript(_) => {
+                // Commit 4 removes this temporary wire handoff inside JobManager;
+                // semantic dispatch has already been closed here.
+                jobs.enqueue(
+                    sink.clone(),
+                    PendingJobStart {
+                        generation: config.generation,
+                        policy: policy.clone(),
+                        shell: shell.clone(),
+                        ssh: config.ssh.clone(),
+                        project_registry_dir: project_registry_dir.to_path_buf(),
+                        request,
+                    },
+                );
+                Ok(true)
+            }
+        },
+    };
+    dispatch_result.map(|handled| RunnerDispatchOutcome {
+        handled,
+        project_cache_invalidation_required,
+    })
 }
 
-fn validate_run_process_request(request: &RunnerRequest) -> Result<&ShellProcessArgv, String> {
-    if request.job_id.is_some() {
-        return Err("job_id is not supported by synchronous run_process".to_string());
-    }
-    if !request.command.is_empty() {
-        return Err("command must be empty when process is present".to_string());
-    }
-    if request.script.is_some() {
-        return Err("script must be absent when process is present".to_string());
-    }
-    let process = request
-        .process
-        .as_ref()
-        .ok_or_else(|| "process payload is required".to_string())?;
-    validate_process_argv(process)?;
-    if let Some(stdin) = request.stdin.as_deref() {
-        if stdin.len() > PROCESS_STDIN_MAX_BYTES {
-            return Err(format!(
-                "stdin is too large; maximum is {PROCESS_STDIN_MAX_BYTES} bytes"
-            ));
-        }
-        if stdin.contains('\0') {
-            return Err("stdin cannot contain NUL bytes".to_string());
-        }
-    }
-    if let Some(cwd) = request.cwd.as_deref() {
-        if cwd.len() > PROCESS_CWD_MAX_BYTES {
-            return Err(format!(
-                "cwd is too long; maximum is {PROCESS_CWD_MAX_BYTES} bytes"
-            ));
-        }
-        if cwd.contains('\0') {
-            return Err("cwd cannot contain NUL bytes".to_string());
-        }
-    }
-    if request.timeout_secs == 0
-        || request.timeout_secs > STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS
-    {
-        return Err(format!(
-            "timeout_secs must be between 1 and {STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS}"
-        ));
-    }
-    Ok(process)
+#[cfg(test)]
+pub(crate) fn dispatch_request(
+    sink: &RunnerSink,
+    config: &HotRunnerConfig,
+    runtime: &ReloadableRunnerConfig,
+    jobs: &JobManager,
+    persistent_shells: &PersistentShellManager,
+    project_registry_dir: &Path,
+    lsp: &LspSupervisor,
+    request: RunnerRequest,
+) -> Result<bool, SubmitResultError> {
+    dispatch_request_with_outcome(
+        sink,
+        config,
+        runtime,
+        jobs,
+        persistent_shells,
+        project_registry_dir,
+        lsp,
+        request,
+    )
+    .map(|outcome| outcome.handled)
 }
 
-fn validate_run_script_request(request: &RunnerRequest) -> Result<&ShellScriptPayload, String> {
-    if request.job_id.is_some() {
-        return Err("job_id is not supported by synchronous run_script".to_string());
-    }
-    if !request.command.is_empty() {
-        return Err("command must be empty when script is present".to_string());
-    }
-    if request.process.is_some() {
-        return Err("process must be absent when script is present".to_string());
-    }
-    let script = request
-        .script
-        .as_ref()
-        .ok_or_else(|| "script payload is required".to_string())?;
-    validate_script_request(
-        script,
-        request.stdin.as_deref(),
-        request.cwd.as_deref(),
-        request.timeout_secs,
-    )?;
-    if request.timeout_secs > STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS {
-        return Err(format!(
-            "timeout_secs must be between 1 and {STRUCTURED_EXECUTION_DIRECT_SYNC_TIMEOUT_MAX_SECS}"
-        ));
-    }
-    Ok(script)
-}
-
-fn validate_internal_posix_script_request(request: &RunnerRequest) -> Result<&str, String> {
-    let script = validate_run_script_request(request)?;
-    if request.stdin.is_some() {
-        return Err("stdin must be absent for an internal POSIX script".to_string());
-    }
-    if script.language != crate::runner_protocol::ShellScriptLanguage::Sh {
-        return Err("internal POSIX script language must be sh".to_string());
-    }
-    if !script.args.is_empty() {
-        return Err("internal POSIX script args must be empty".to_string());
-    }
-    Ok(&script.script)
-}
-
-fn lifecycle_project_id(request: &RunnerRequest) -> Option<String> {
-    request
-        .stdin
-        .as_deref()
-        .and_then(|payload| serde_json::from_str::<serde_json::Value>(payload).ok())
+fn lifecycle_project_id(operation: &RunnerProjectOperation) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(&operation.payload)
+        .ok()
         .and_then(|payload| {
             payload
                 .get("project_id")
                 .and_then(|project_id| project_id.as_str())
                 .map(str::to_string)
         })
-}
-
-pub(crate) fn is_project_op(kind: &str) -> bool {
-    matches!(
-        kind,
-        "register_project"
-            | "create_project"
-            | "resolve_or_register_project"
-            | "prepare_managed_worktree"
-            | "project_lifecycle_enable"
-            | "project_lifecycle_disable"
-            | "project_lifecycle_unregister"
-    )
 }

--- a/crates/webcodex-runner/src/webcodex_runner/external_tools.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/external_tools.rs
@@ -8,8 +8,10 @@ use super::output::CommandResult;
 use super::shell::cwd_allowed;
 use super::shutdown::{lock_unpoison, SHUTDOWN_POLL_INTERVAL};
 use super::RunnerPolicy;
+#[cfg(test)]
+use crate::runner_protocol::RunnerRequest;
 use crate::runner_protocol::{
-    ClaudeCodeProviderStatus, ProviderCallSummary, RunnerRequest, ToolProvidersStatus,
+    ClaudeCodeProviderStatus, ProviderCallSummary, ToolProvidersStatus,
     EXTERNAL_SEARCH_REQUEST_PREFIX,
 };
 use serde_json::{json, Value};
@@ -24,6 +26,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
+#[cfg(test)]
+use webcodex_core::runner_operation::RunnerOperation;
+use webcodex_core::runner_operation::RunnerShellOperation;
 
 use webcodex_process::{GracefulTermination, ManagedChild};
 
@@ -227,28 +232,31 @@ impl ExternalToolRouter {
 
     #[cfg(test)]
     pub(crate) fn route(&self, policy: &RunnerPolicy, request: &RunnerRequest) -> ExternalRoute {
-        self.route_with_shutdown(policy, request, None)
+        match request.decode_operation() {
+            Ok(RunnerOperation::RunShell(operation)) => {
+                self.route_with_shutdown(policy, &operation, None)
+            }
+            _ => ExternalRoute::Native,
+        }
     }
 
     pub(crate) fn route_with_shutdown(
         &self,
         policy: &RunnerPolicy,
-        request: &RunnerRequest,
+        operation: &RunnerShellOperation,
         shutdown: Option<&AtomicBool>,
     ) -> ExternalRoute {
         if self.strategy == ToolProviderStrategy::Native {
             return ExternalRoute::Native;
         }
-        let capability = match request.kind.as_str() {
-            "run_shell"
-                if request.command.lines().next() == Some(EXTERNAL_SEARCH_REQUEST_PREFIX) =>
-            {
-                ProviderCapability::SearchProjectText
-            }
-            _ => return ExternalRoute::Native,
+        let capability = if operation.command.lines().next() == Some(EXTERNAL_SEARCH_REQUEST_PREFIX)
+        {
+            ProviderCapability::SearchProjectText
+        } else {
+            return ExternalRoute::Native;
         };
         let started = Instant::now();
-        let raw = request.stdin.as_deref();
+        let raw = operation.stdin.as_deref();
         let payload = match raw
             .ok_or_else(request_error)
             .and_then(|raw| serde_json::from_str(raw).map_err(|_| request_error()))
@@ -256,7 +264,7 @@ impl ExternalToolRouter {
             Ok(payload) => payload,
             Err(error) => return self.failure_or_native(capability, error, started),
         };
-        let checked = validate_context(policy, request, capability, &payload);
+        let checked = validate_context(policy, operation.cwd.as_deref(), capability, &payload);
         let (root, target) = match checked {
             Ok(checked) => checked,
             Err(error) => {
@@ -278,12 +286,8 @@ impl ExternalToolRouter {
         let context = ToolExecutionContext {
             project_root: &root,
             target,
-            max_output_bytes: request
-                .max_bytes
-                .unwrap_or(MAX_MCP_OUTPUT_BYTES)
-                .min(policy.max_output_bytes)
-                .min(MAX_MCP_OUTPUT_BYTES),
-            timeout_secs: request.timeout_secs.max(1).min(policy.max_timeout_secs),
+            max_output_bytes: MAX_MCP_OUTPUT_BYTES.min(policy.max_output_bytes),
+            timeout_secs: operation.timeout_secs.max(1).min(policy.max_timeout_secs),
         };
         match self
             .claude
@@ -432,11 +436,11 @@ fn normalized_search_exit_code(stdout: &str) -> i32 {
 
 fn validate_context(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    cwd: Option<&str>,
     _capability: ProviderCapability,
     payload: &Value,
 ) -> Result<(PathBuf, PathBuf), ProviderError> {
-    let root = request.cwd.as_deref().ok_or_else(path_error)?;
+    let root = cwd.ok_or_else(path_error)?;
     let root = Path::new(root).canonicalize().map_err(|_| path_error())?;
     cwd_allowed(policy, &root).map_err(|_| path_error())?;
     let relative = payload.get("path").and_then(Value::as_str).unwrap_or(".");

--- a/crates/webcodex-runner/src/webcodex_runner/external_tools.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/external_tools.rs
@@ -26,8 +26,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-#[cfg(test)]
-use webcodex_core::runner_operation::RunnerOperation;
 use webcodex_core::runner_operation::RunnerShellOperation;
 
 use webcodex_process::{GracefulTermination, ManagedChild};
@@ -232,12 +230,18 @@ impl ExternalToolRouter {
 
     #[cfg(test)]
     pub(crate) fn route(&self, policy: &RunnerPolicy, request: &RunnerRequest) -> ExternalRoute {
-        match request.decode_operation() {
-            Ok(RunnerOperation::RunShell(operation)) => {
-                self.route_with_shutdown(policy, &operation, None)
-            }
-            _ => ExternalRoute::Native,
+        if request.kind != "run_shell" {
+            return ExternalRoute::Native;
         }
+        let operation = RunnerShellOperation {
+            cwd: request.cwd.clone(),
+            command: request.command.clone(),
+            stdin: request.stdin.clone(),
+            max_bytes: request.max_bytes,
+            timeout_secs: request.timeout_secs,
+            job_context: request.job_context.clone(),
+        };
+        self.route_with_shutdown(policy, &operation, None)
     }
 
     pub(crate) fn route_with_shutdown(
@@ -286,7 +290,11 @@ impl ExternalToolRouter {
         let context = ToolExecutionContext {
             project_root: &root,
             target,
-            max_output_bytes: MAX_MCP_OUTPUT_BYTES.min(policy.max_output_bytes),
+            max_output_bytes: operation
+                .max_bytes
+                .unwrap_or(MAX_MCP_OUTPUT_BYTES)
+                .min(policy.max_output_bytes)
+                .min(MAX_MCP_OUTPUT_BYTES),
             timeout_secs: operation.timeout_secs.max(1).min(policy.max_timeout_secs),
         };
         match self

--- a/crates/webcodex-runner/src/webcodex_runner/files.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/files.rs
@@ -3,11 +3,11 @@ use super::output::CommandResult;
 use super::shell::cwd_allowed;
 use crate::project_overview::build_project_overview;
 use crate::runner_config::DEFAULT_MAX_OUTPUT_BYTES;
-use crate::runner_protocol::RunnerRequest;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
+use webcodex_core::runner_operation::{RunnerFileOperation, RunnerFilePayload};
 use webcodex_workspace::file_read_range::{self, ReadFileReason};
 
 pub(crate) fn sha256_hex_bytes(bytes: &[u8]) -> String {
@@ -51,6 +51,7 @@ pub(crate) fn resolve_requested_path(
     Ok(resolved)
 }
 
+#[cfg(test)]
 pub(crate) fn is_basic_file_request_kind(kind: &str) -> bool {
     matches!(
         kind,
@@ -66,18 +67,25 @@ pub(crate) fn is_basic_file_request_kind(kind: &str) -> bool {
 
 pub(crate) fn handle_basic_file_request(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    operation: &RunnerFileOperation,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    match request.kind.as_str() {
-        "file_read" => handle_file_read_request(policy, request, resolved, start),
-        "file_write" => handle_file_write_request(policy, request, resolved, start),
-        "file_list" => handle_file_list_request(resolved, start),
-        "file_skill_list_packages" => handle_skill_list_packages_request(request, resolved, start),
-        "file_skill_read_file" => handle_skill_read_file_request(policy, request, resolved, start),
-        "file_project_overview" => handle_project_overview_request(request, start),
-        "file_delete_project_files" => {
+    let request = operation.payload();
+    match operation {
+        RunnerFileOperation::Read(_) => handle_file_read_request(policy, request, resolved, start),
+        RunnerFileOperation::Write(_) => {
+            handle_file_write_request(policy, request, resolved, start)
+        }
+        RunnerFileOperation::List(_) => handle_file_list_request(resolved, start),
+        RunnerFileOperation::SkillListPackages(_) => {
+            handle_skill_list_packages_request(request, resolved, start)
+        }
+        RunnerFileOperation::SkillReadFile(_) => {
+            handle_skill_read_file_request(policy, request, resolved, start)
+        }
+        RunnerFileOperation::ProjectOverview(_) => handle_project_overview_request(request, start),
+        RunnerFileOperation::DeleteProjectFiles(_) => {
             handle_delete_project_files_request(request, resolved, start)
         }
         _ => CommandResult {
@@ -85,7 +93,7 @@ pub(crate) fn handle_basic_file_request(
             stdout: None,
             stderr: None,
             duration_ms: Some(start.elapsed().as_millis() as u64),
-            error: Some(format!("unknown file request kind: {}", request.kind)),
+            error: Some("file operation is not a basic file request".to_string()),
         },
     }
 }
@@ -135,7 +143,7 @@ fn delete_project_files_error(start: Instant, message: &'static str) -> CommandR
 }
 
 fn handle_delete_project_files_request(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved_project_root: &Path,
     start: Instant,
 ) -> CommandResult {
@@ -241,7 +249,7 @@ struct ProjectOverviewRunnerOptions {
     limit: Option<usize>,
 }
 
-fn handle_project_overview_request(request: &RunnerRequest, start: Instant) -> CommandResult {
+fn handle_project_overview_request(request: &RunnerFilePayload, start: Instant) -> CommandResult {
     let Some(project_root) = request.cwd.as_deref() else {
         return CommandResult {
             exit_code: None,
@@ -251,7 +259,7 @@ fn handle_project_overview_request(request: &RunnerRequest, start: Instant) -> C
             error: Some("project_overview request missing project root".to_string()),
         };
     };
-    let requested_path = request.path.as_deref().unwrap_or(".");
+    let requested_path = request.path.as_str();
     let options = match request.content.as_deref() {
         Some(payload) => match serde_json::from_str::<ProjectOverviewRunnerOptions>(payload) {
             Ok(options) => options,
@@ -304,7 +312,7 @@ fn read_file_reason_message(reason: ReadFileReason) -> String {
 }
 
 fn ensure_file_read_target_in_project(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
 ) -> Result<(), ReadFileReason> {
     let project_root = request.cwd.as_deref().ok_or(ReadFileReason::InvalidPath)?;
@@ -325,7 +333,7 @@ fn ensure_file_read_target_in_project(
 
 fn handle_file_read_request(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
@@ -571,11 +579,11 @@ fn canonical_skill_resource_request_path(package_root: &str, path: &str) -> bool
 }
 
 fn handle_skill_list_packages_request(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    if request.path.as_deref() != Some(".agents/skills") {
+    if request.path != ".agents/skills" {
         return skill_command_error(start, "skill_path_invalid");
     }
     let options = match request
@@ -653,7 +661,7 @@ fn handle_skill_list_packages_request(
 
 fn handle_skill_read_file_request(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
@@ -673,10 +681,7 @@ fn handle_skill_read_file_request(
         _ => return skill_command_error(start, "skill_path_invalid"),
     };
     if !canonical_skill_package_root(&options.package_root)
-        || !request
-            .path
-            .as_deref()
-            .is_some_and(|path| canonical_skill_resource_request_path(&options.package_root, path))
+        || !canonical_skill_resource_request_path(&options.package_root, &request.path)
     {
         return skill_command_error(start, "skill_path_invalid");
     }
@@ -716,7 +721,7 @@ fn handle_skill_read_file_request(
     {
         return skill_command_error(start, "skill_path_escape");
     }
-    let requested_project_relative = request.path.as_deref().unwrap_or_default();
+    let requested_project_relative = request.path.as_str();
     let canonical_project_relative = match target.strip_prefix(&project_root) {
         Ok(relative) => relative.to_string_lossy(),
         Err(_) => return skill_command_error(start, "skill_path_escape"),
@@ -798,7 +803,7 @@ fn file_read_error_message(error: &std::io::Error) -> String {
 
 fn handle_file_write_request(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {

--- a/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/job_manager_tests.rs
@@ -1120,13 +1120,13 @@ fn enqueue_structured_process_job_with_policy(
     let context = structured_process_context(cwd, args.len(), stdin.is_some());
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
+        PendingJobStart::from_wire(
+            1,
             policy,
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: cwd.join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            cwd.join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": format!("request-{job_id}"),
                 "client_id": "structured-agent",
                 "kind": "start_process_job",
@@ -1145,7 +1145,7 @@ fn enqueue_structured_process_job_with_policy(
                 "job_context": context,
             }))
             .unwrap(),
-        },
+        ),
     );
 }
 
@@ -1162,16 +1162,16 @@ fn enqueue_detached_process_job(
     let context = detached_process_context(cwd, args.len(), stdin.is_some());
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: cwd.join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            cwd.join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": format!("request-{job_id}"),
                 "client_id": "structured-agent",
                 "kind": "start_detached_process_job",
@@ -1189,7 +1189,7 @@ fn enqueue_detached_process_job(
                 "job_context": context,
             }))
             .unwrap(),
-        },
+        ),
     );
 }
 
@@ -1288,16 +1288,16 @@ fn enqueue_shell_job(
 ) {
     manager.enqueue(
         sink.clone(),
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: cwd.join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            cwd.join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": format!("request-{job_id}"),
                 "client_id": "backpressure-agent",
                 "kind": "start_job",
@@ -1310,7 +1310,7 @@ fn enqueue_shell_job(
                 "job_context": test_job_context(cwd, Vec::new()),
             }))
             .unwrap(),
-        },
+        ),
     );
 }
 
@@ -1378,16 +1378,16 @@ fn enqueue_gated_structured_job_for_project(
     context.runtime_project_id = Some(runtime_project_id.to_string());
     manager.enqueue(
         sink.clone(),
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: cwd.join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            cwd.join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": format!("request-{}", job.job_id),
                 "client_id": "structured-agent",
                 "kind": "start_process_job",
@@ -1404,7 +1404,7 @@ fn enqueue_gated_structured_job_for_project(
                 "job_context": context,
             }))
             .unwrap(),
-        },
+        ),
     );
 }
 
@@ -1757,22 +1757,27 @@ fn phase_e2_prestart_structured_failure_releases_slot_for_queued_job() {
         "job_id": failed_job_id,
         "cwd": temp.path(),
         "command": "",
+        "process": {
+            "executable": temp.path().join("missing-prestart-executable"),
+            "args": [],
+        },
         "timeout_secs": 20,
         "requested_by": "test",
         "created_at": chrono::Utc::now().timestamp(),
         "job_context": structured_process_context(temp.path(), 0, false),
     }))
     .unwrap();
-    manager.start_structured_job(
+    manager.start_structured_job(PendingJobStart::from_wire(
         1,
         RunnerPolicy {
             allow_cwd_anywhere: true,
             ..RunnerPolicy::default()
         },
         ShellConfig::default(),
+        SshConfig::default(),
         temp.path().join("project-registry"),
         failed_request,
-    );
+    ));
 
     assert!(
         wait_until(Duration::from_secs(10), || queued.started.exists()),
@@ -1836,7 +1841,7 @@ fn phase_e2_stopped_queued_job_never_executes_after_slot_release() {
     assert!(!stopped.active.exists());
     assert!(lock_unpoison(&manager.queued)
         .iter()
-        .all(|entry| entry.request.job_id.as_deref() != Some(stopped.job_id.as_str())));
+        .all(|entry| entry.operation.job_id() != stopped.job_id));
 }
 
 #[cfg(unix)]
@@ -1875,16 +1880,16 @@ fn phase_e2_validation_job_shares_the_same_job_manager_slot_limit() {
     shell.path_prepend.push(bin);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
             shell,
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "request-validation-shared-slot",
                 "client_id": "structured-agent",
                 "kind": "start_validation_job",
@@ -1897,7 +1902,7 @@ fn phase_e2_validation_job_shares_the_same_job_manager_slot_limit() {
                 "job_context": test_job_context(temp.path(), vec!["check".to_string()]),
             }))
             .unwrap(),
-        },
+        ),
     );
     assert!(!validation_marker.exists());
     assert_eq!(
@@ -2756,16 +2761,16 @@ fn phase_f_windows_shell_job_stream_reconstructs_split_utf8_and_oem() {
     let marker_arg = marker.to_string_lossy().replace('\'', "''");
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "request-phase-f-stream",
                 "client_id": "structured-agent",
                 "kind": "start_job",
@@ -2778,7 +2783,7 @@ fn phase_f_windows_shell_job_stream_reconstructs_split_utf8_and_oem() {
                 "job_context": test_job_context(temp.path(), Vec::new()),
             }))
             .unwrap(),
-        },
+        ),
     );
     assert!(
         wait_until(Duration::from_secs(30), || marker.exists()),
@@ -2801,16 +2806,16 @@ fn phase_f_windows_shell_job_stream_reconstructs_split_utf8_and_oem() {
     let marker_arg = oem_marker.to_string_lossy().replace('\'', "''");
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "request-phase-f-oem-stream",
                 "client_id": "structured-agent",
                 "kind": "start_job",
@@ -2825,7 +2830,7 @@ fn phase_f_windows_shell_job_stream_reconstructs_split_utf8_and_oem() {
                 "job_context": test_job_context(temp.path(), Vec::new()),
             }))
             .unwrap(),
-        },
+        ),
     );
     assert!(
         wait_until(Duration::from_secs(30), || oem_marker.exists()),
@@ -2923,17 +2928,17 @@ fn structured_script_job_keeps_its_temporary_file_until_terminal_then_removes_it
     assert_eq!(request.script.as_ref().unwrap().script, script);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
+            ShellConfig::default(),
+            SshConfig::default(),
+            temp.path().join("project-registry"),
             request,
-        },
+        ),
     );
 
     assert!(wait_until(Duration::from_secs(30), || {
@@ -3001,17 +3006,17 @@ fn structured_script_job_drains_large_output_without_log_observation_and_runs_on
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 max_output_bytes: 16 * 1024,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "request-structured-script-chatty",
                 "client_id": "structured-agent",
                 "kind": "start_script_job",
@@ -3029,7 +3034,7 @@ fn structured_script_job_drains_large_output_without_log_observation_and_runs_on
                 "job_context": context,
             }))
             .unwrap(),
-        },
+        ),
     );
 
     wait_for_job_workers(&manager);
@@ -3188,18 +3193,18 @@ fn run_fail_fast_validation_job(attempt: usize) -> FailFastAttempt {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 // These tests run jobs in a temp dir; the boundary itself is
                 // covered separately, and RunnerPolicy::default() is fail-closed.
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
             shell,
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": format!("validation-request-{attempt}"),
                 "client_id": "validation-agent",
                 "kind": "start_validation_job",
@@ -3218,7 +3223,7 @@ fn run_fail_fast_validation_job(attempt: usize) -> FailFastAttempt {
                 )
             }))
             .unwrap(),
-        },
+        ),
     );
     let updates = collect_job_updates(&mut rx, Duration::from_secs(120));
     FailFastAttempt {
@@ -3261,16 +3266,16 @@ fn validation_job_exposes_activity_during_silent_step_and_clears_terminal() {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
             shell,
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "silent-validation-request",
                 "client_id": "validation-agent",
                 "kind": "start_validation_job",
@@ -3283,7 +3288,7 @@ fn validation_job_exposes_activity_during_silent_step_and_clears_terminal() {
                 "job_context": test_job_context(temp.path(), vec!["check".to_string()]),
             }))
             .unwrap(),
-        },
+        ),
     );
 
     assert!(
@@ -3721,16 +3726,16 @@ fn noisy_validation_progress_delivery_stays_ordered_after_transport_backpressure
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
             shell,
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "validation-backpressure-request",
                 "client_id": "validation-agent",
                 "kind": "start_validation_job",
@@ -3746,7 +3751,7 @@ fn noisy_validation_progress_delivery_stays_ordered_after_transport_backpressure
                 )
             }))
             .unwrap(),
-        },
+        ),
     );
 
     assert!(
@@ -3925,18 +3930,18 @@ fn validation_spawn_failure_is_infrastructure_without_failed_assertion() {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 // These tests run jobs in a temp dir; the boundary itself is
                 // covered separately, and RunnerPolicy::default() is fail-closed.
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
             shell,
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "spawn-failure-request",
                 "client_id": "validation-agent",
                 "kind": "start_validation_job",
@@ -3954,7 +3959,7 @@ fn validation_spawn_failure_is_infrastructure_without_failed_assertion() {
                 "job_context": test_job_context(temp.path(), vec!["check".to_string()])
             }))
             .unwrap(),
-        },
+        ),
     );
     let update = collect_job_updates(&mut rx, Duration::from_secs(5))
         .into_iter()
@@ -4650,16 +4655,16 @@ fn runner_real_process_job_timeout_terminates_the_whole_tree() {
     let manager = JobManager::new(1);
     manager.enqueue(
         sink,
-        PendingJobStart {
-            generation: 1,
-            policy: RunnerPolicy {
+        PendingJobStart::from_wire(
+            1,
+            RunnerPolicy {
                 allow_cwd_anywhere: true,
                 ..RunnerPolicy::default()
             },
-            shell: ShellConfig::default(),
-            ssh: SshConfig::default(),
-            project_registry_dir: temp.path().join("project-registry"),
-            request: serde_json::from_value(json!({
+            ShellConfig::default(),
+            SshConfig::default(),
+            temp.path().join("project-registry"),
+            serde_json::from_value(json!({
                 "request_id": "timeout-request",
                 "client_id": "timeout-agent",
                 "kind": "start_job",
@@ -4672,7 +4677,7 @@ fn runner_real_process_job_timeout_terminates_the_whole_tree() {
                 "job_context": test_job_context(temp.path(), Vec::new())
             }))
             .unwrap(),
-        },
+        ),
     );
 
     let updates = collect_job_updates(&mut rx, Duration::from_secs(20));

--- a/crates/webcodex-runner/src/webcodex_runner/lsp/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/lsp/mod.rs
@@ -4,7 +4,7 @@ mod position;
 mod protocol;
 mod supervisor;
 
-pub(crate) use navigation::{handle_lsp_request, is_lsp_request_kind};
+pub(crate) use navigation::handle_lsp_operation;
 pub(crate) use supervisor::LspSupervisor;
 
 // The documented Windows ManagedChild spawn path uses a system-wide Toolhelp

--- a/crates/webcodex-runner/src/webcodex_runner/lsp/navigation.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/lsp/navigation.rs
@@ -17,6 +17,8 @@ use super::supervisor::{
     classify_uri_against_project_root, LspError, LspServerStatus, LspSupervisor, PositionEncoding,
     ProjectUriClassification,
 };
+#[cfg(test)]
+use crate::lsp_bridge::AGENT_LSP_REQUEST_KIND;
 use crate::lsp_bridge::{
     bound_error_message, error_codes, redact_absolute_paths, validate_call_hierarchy_bounds,
     CallHierarchyDirection, CallHierarchyEdgeDirection, CallHierarchyResult,
@@ -25,10 +27,11 @@ use crate::lsp_bridge::{
     PublicCallHierarchyEdge, PublicCallHierarchySymbol, PublicDiagnostic, PublicHover,
     PublicLocation, PublicPosition, PublicRange, PublicSymbol, PublicWorkspaceSymbol,
     RunnerLspPayload, RunnerLspRequest, RunnerLspResultEnvelope, WorkspaceSymbolsResult,
-    AGENT_LSP_REQUEST_KIND, MAX_CALL_HIERARCHY_CALL_ENTRIES_INSPECTED_PER_RPC,
-    MAX_CALL_HIERARCHY_CALL_SITES_PER_EDGE, MAX_CALL_HIERARCHY_PREPARE_ITEMS_INSPECTED,
+    MAX_CALL_HIERARCHY_CALL_ENTRIES_INSPECTED_PER_RPC, MAX_CALL_HIERARCHY_CALL_SITES_PER_EDGE,
+    MAX_CALL_HIERARCHY_PREPARE_ITEMS_INSPECTED,
     MAX_CALL_HIERARCHY_RAW_CALL_SITE_RANGES_INSPECTED_PER_ENTRY, MAX_CALL_HIERARCHY_ROOTS,
 };
+#[cfg(test)]
 use crate::runner_protocol::RunnerRequest;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -46,26 +49,21 @@ const MAX_DIAGNOSTIC_TOTAL_TEXT_CHARS: usize = 64 * 1024;
 const DIAGNOSTICS_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 const MAX_HOVER_VALUE_CHARS: usize = 16 * 1024;
 const MAX_WORKSPACE_SYMBOL_FIELD_CHARS: usize = 256;
+#[cfg(test)]
 pub(crate) fn is_lsp_request_kind(kind: &str) -> bool {
     kind == AGENT_LSP_REQUEST_KIND
 }
 
-pub(crate) fn handle_lsp_request(
+pub(crate) fn handle_lsp_operation(
     policy: &RunnerPolicy,
     project_registry_dir: &Path,
     supervisor: &LspSupervisor,
-    request: &RunnerRequest,
+    payload: &RunnerLspPayload,
+    timeout_secs: u64,
 ) -> CommandResult {
     let start = Instant::now();
-    let Some(payload) = request.lsp.as_ref() else {
-        return lsp_error_cmd(
-            start,
-            error_codes::MISSING_LSP_PAYLOAD,
-            "LSP request missing typed payload",
-        );
-    };
     let operation_deadline = start
-        .checked_add(Duration::from_secs(request.timeout_secs.max(1)))
+        .checked_add(Duration::from_secs(timeout_secs.max(1)))
         .unwrap_or(start);
     match execute_lsp(
         policy,
@@ -91,6 +89,29 @@ pub(crate) fn handle_lsp_request(
             error: None,
         },
     }
+}
+
+#[cfg(test)]
+pub(crate) fn handle_lsp_request(
+    policy: &RunnerPolicy,
+    project_registry_dir: &Path,
+    supervisor: &LspSupervisor,
+    request: &RunnerRequest,
+) -> CommandResult {
+    let Some(payload) = request.lsp.as_ref() else {
+        return lsp_error_cmd(
+            Instant::now(),
+            error_codes::MISSING_LSP_PAYLOAD,
+            "LSP request missing typed payload",
+        );
+    };
+    handle_lsp_operation(
+        policy,
+        project_registry_dir,
+        supervisor,
+        payload,
+        request.timeout_secs,
+    )
 }
 
 fn execute_lsp(
@@ -2148,6 +2169,7 @@ fn sanitize_path_message(message: impl Into<String>) -> String {
     bound_error_message(message.into())
 }
 
+#[cfg(test)]
 fn lsp_error_cmd(start: Instant, code: &str, message: &str) -> CommandResult {
     let envelope = RunnerLspResultEnvelope::err(code, message);
     CommandResult {

--- a/crates/webcodex-runner/src/webcodex_runner/managed_ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/managed_ssh.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use webcodex_core::ssh_resource::{
     normalize_ssh_resource_default_cwd, normalize_ssh_resource_target, validate_ssh_resource_name,
     SshResourceInventoryEntry, SshResourceRequest, SshResourceResponse, SshResourceSource,
-    MANAGED_SSH_REGISTRY_MAX_BYTES, MANAGED_SSH_RESOURCE_MAX_COUNT, SSH_RESOURCE_REQUEST_MAX_BYTES,
+    MANAGED_SSH_REGISTRY_MAX_BYTES, MANAGED_SSH_RESOURCE_MAX_COUNT,
 };
 
 const STORE_VERSION: u32 = 1;
@@ -112,42 +112,7 @@ impl ManagedSshResourceStore {
         Ok(merged)
     }
 
-    pub(crate) fn handle_wire(
-        &self,
-        static_active: &SshConfig,
-        content: Option<&str>,
-    ) -> SshResourceResponse {
-        let Some(content) = content else {
-            return safe_error(
-                "ssh_resource_invalid",
-                "Managed SSH resource request is missing",
-            );
-        };
-        if content.len() > SSH_RESOURCE_REQUEST_MAX_BYTES {
-            return safe_error(
-                "ssh_resource_invalid",
-                "Managed SSH resource request is too large",
-            );
-        }
-        let request: SshResourceRequest = match serde_json::from_str(content) {
-            Ok(request) => request,
-            Err(_) => {
-                return safe_error(
-                    "ssh_resource_invalid",
-                    "Managed SSH resource request is invalid",
-                )
-            }
-        };
-        if request.validate().is_err() {
-            return safe_error(
-                "ssh_resource_invalid",
-                "Managed SSH resource request is invalid",
-            );
-        }
-        self.handle(static_active, request)
-    }
-
-    fn handle(
+    pub(crate) fn handle(
         &self,
         static_active: &SshConfig,
         request: SshResourceRequest,

--- a/crates/webcodex-runner/src/webcodex_runner/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/mod.rs
@@ -31,9 +31,13 @@ pub(crate) mod transport;
 pub(crate) mod util;
 pub(crate) mod validation;
 
-pub(crate) use artifacts::{handle_artifact_file_request, is_artifact_request_kind};
-pub(crate) use checkpoints::{handle_checkpoint_file_request, is_checkpoint_request_kind};
-pub(crate) use computer::{handle_computer_request, is_computer_request_kind};
+pub(crate) use artifacts::handle_artifact_file_operation;
+#[cfg(test)]
+pub(crate) use artifacts::is_artifact_request_kind;
+pub(crate) use checkpoints::handle_checkpoint_file_request;
+#[cfg(test)]
+pub(crate) use checkpoints::is_checkpoint_request_kind;
+pub(crate) use computer::handle_computer_operation;
 pub(crate) use config::SshConfig;
 pub(crate) use config::{
     client_profile_runner_config, default_config_path, hostname, load_config, max_concurrent_jobs,
@@ -46,25 +50,31 @@ pub(crate) use config::{
     default_websocket_connect_timeout_secs, QuicClientConfig, ShellProfileConfig,
     CLIENT_PROFILE_ERROR, DEFAULT_MAX_CONCURRENT_JOBS,
 };
-pub(super) use dispatch::{dispatch_request, is_project_op};
+#[cfg(test)]
+pub(super) use dispatch::dispatch_request;
+pub(super) use dispatch::{dispatch_request_with_outcome, RunnerDispatchOutcome};
+#[cfg(test)]
+pub(crate) use files::is_basic_file_request_kind;
 #[cfg(test)]
 pub(crate) use files::sha256_hex_bytes;
-pub(crate) use files::{
-    handle_basic_file_request, is_basic_file_request_kind, resolve_requested_path,
-};
+pub(crate) use files::{handle_basic_file_request, resolve_requested_path};
 pub(crate) use lsp::LspSupervisor;
 pub(crate) use output::{err_cmd, ok_cmd, CommandResult, ShellCommandResult};
+#[cfg(test)]
+pub(crate) use patches::is_structured_edit_request_kind;
 pub(crate) use patches::{
     handle_apply_patch_file_request, handle_apply_text_edits_file_request,
-    handle_write_project_file_request, is_structured_edit_request_kind,
-    validate_structured_edit_runner_path,
+    handle_write_project_file_request, validate_structured_edit_runner_path,
 };
 pub(crate) use persistent_shell::PersistentShellManager;
 #[cfg(test)]
-pub(crate) use projects::load_runner_project_summaries_from_dir;
 pub(crate) use projects::{
     handle_prepare_managed_worktree, handle_project_lifecycle_op, handle_project_op,
-    handle_resolve_or_register_project, RunnerProjectCache,
+    handle_resolve_or_register_project, load_runner_project_summaries_from_dir,
+};
+pub(crate) use projects::{
+    handle_prepare_managed_worktree_operation, handle_project_lifecycle_operation,
+    handle_project_operation, handle_resolve_or_register_project_operation, RunnerProjectCache,
 };
 #[cfg(test)]
 pub(crate) use projects::{

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -1,13 +1,14 @@
 use super::config::RunnerPolicy;
 use super::files::{resolve_requested_path, sha256_hex_bytes};
 use super::output::{line_edit_stdout, CommandResult};
-use crate::runner_protocol::RunnerRequest;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
+use webcodex_core::runner_operation::RunnerFilePayload;
 
+#[cfg(test)]
 pub(crate) fn is_structured_edit_request_kind(kind: &str) -> bool {
     matches!(
         kind,
@@ -91,7 +92,7 @@ fn write_file_atomic(path: &Path, content: &str) -> Result<(), String> {
     write_file_atomic_strict(path, content, ".pd-line")
 }
 
-fn parse_json_payload(request: &RunnerRequest) -> Result<serde_json::Value, String> {
+fn parse_json_payload(request: &RunnerFilePayload) -> Result<serde_json::Value, String> {
     serde_json::from_str(request.content.as_deref().unwrap_or_default())
         .map_err(|e| format!("invalid json: {}", e))
 }
@@ -159,11 +160,11 @@ fn write_project_file_apply_error(
 }
 
 pub(crate) fn handle_write_project_file_request(
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     resolved: &Path,
     start: Instant,
 ) -> CommandResult {
-    let path = request.path.as_deref().unwrap_or_default();
+    let path = request.path.as_str();
     let payload = match parse_json_payload(request) {
         Ok(payload) => payload,
         Err(e) => {
@@ -1166,7 +1167,7 @@ fn execute_planned_file_changes(
 
 fn resolve_unique_patch_path(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     touched: &mut HashSet<PathBuf>,
     index: usize,
     kind: &str,
@@ -1316,7 +1317,7 @@ fn apply_patch_matching_mode_rejection(
 
 pub(crate) fn handle_apply_patch_file_request(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     start: Instant,
 ) -> CommandResult {
     let payload: ApplyPatchPayload =
@@ -1585,7 +1586,7 @@ pub(crate) fn handle_apply_patch_file_request(
 
 pub(crate) fn handle_apply_text_edits_file_request(
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    request: &RunnerFilePayload,
     start: Instant,
 ) -> CommandResult {
     let payload: ApplyTextEditsPayload =

--- a/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
@@ -12,11 +12,14 @@ use super::shell::shell_quote;
 use super::shell::shell_quote_powershell;
 use super::shell::{base_shell_env, cwd_allowed};
 use super::ssh::SshConnectionPool;
+#[cfg(test)]
+use crate::runner_protocol::RunnerRequest;
 use crate::runner_protocol::{
-    PersistentShellRequest, PersistentShellResult, RunnerRequest, RAW_SHELL_COMMAND_MAX_BYTES,
+    PersistentShellRequest, PersistentShellResult, RAW_SHELL_COMMAND_MAX_BYTES,
 };
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use webcodex_core::runner_operation::RunnerPersistentShellOperation;
 #[cfg(any(unix, windows))]
 use webcodex_persistent_shell::canonical_dialect;
 use webcodex_persistent_shell::{
@@ -46,59 +49,47 @@ impl PersistentShellManager {
         }
     }
 
-    pub(crate) fn handle(
+    pub(crate) fn handle_operation(
         &self,
         policy: &RunnerPolicy,
         shell: &ShellConfig,
         ssh: &SshConfig,
         ssh_generation: u64,
         project_registry_dir: &Path,
-        request: &RunnerRequest,
+        client_id: &str,
+        request: &RunnerPersistentShellOperation,
     ) -> PersistentShellResult {
         self.processes.update_limits(limits(shell));
         let ssh_resource = request
             .job_context
             .as_ref()
             .and_then(|context| context.ssh_resource.as_deref());
-        let Some(operation) = request.persistent_shell.as_ref() else {
-            return error_result(
-                "",
-                "",
-                "",
-                "persistent_shell_invalid_request",
-                "persistent shell payload is required",
-            );
-        };
+        let operation = &request.request;
         if operation.action == "close" {
             return self.close(operation);
         }
 
-        let project = match validate_boundary(
-            policy,
-            shell,
-            project_registry_dir,
-            &request.client_id,
-            operation,
-        ) {
-            Ok(project) => project,
-            Err((code, message)) => {
-                if operation.action != "open" {
-                    let _ = self.processes.close(
+        let project =
+            match validate_boundary(policy, shell, project_registry_dir, client_id, operation) {
+                Ok(project) => project,
+                Err((code, message)) => {
+                    if operation.action != "open" {
+                        let _ = self.processes.close(
+                            &operation.shell_id,
+                            &operation.workflow_session_id,
+                            &operation.runtime_project_id,
+                            code,
+                        );
+                    }
+                    return error_result(
                         &operation.shell_id,
                         &operation.workflow_session_id,
                         &operation.runtime_project_id,
                         code,
+                        message,
                     );
                 }
-                return error_result(
-                    &operation.shell_id,
-                    &operation.workflow_session_id,
-                    &operation.runtime_project_id,
-                    code,
-                    message,
-                );
-            }
-        };
+            };
 
         match operation.action.as_str() {
             "open" => {
@@ -107,13 +98,13 @@ impl PersistentShellManager {
                         policy,
                         ssh,
                         ssh_generation,
-                        request,
+                        client_id,
                         operation,
                         resource,
                         &project,
                     )
                 } else {
-                    self.open(policy, shell, request, operation, &project)
+                    self.open(policy, shell, client_id, operation, &project)
                 }
             }
             "exec" => {
@@ -146,7 +137,7 @@ impl PersistentShellManager {
         policy: &RunnerPolicy,
         ssh: &SshConfig,
         ssh_generation: u64,
-        request: &RunnerRequest,
+        client_id: &str,
         operation: &PersistentShellRequest,
         resource_name: &str,
         _project: &RunnerProjectShellContext,
@@ -214,7 +205,7 @@ impl PersistentShellManager {
             workflow_session_id: operation.workflow_session_id.clone(),
             runtime_project_id: operation.runtime_project_id.clone(),
             executor: EXECUTOR_SSH.to_string(),
-            client_id: Some(request.client_id.clone()),
+            client_id: Some(client_id.to_string()),
         };
         // The bootstrap is the initialization command: it reserves FD 7/8 on the
         // remote shell (so the shared command wrapper's markers always reach the
@@ -246,7 +237,7 @@ impl PersistentShellManager {
         _policy: &RunnerPolicy,
         _ssh: &SshConfig,
         _ssh_generation: u64,
-        _request: &RunnerRequest,
+        _client_id: &str,
         operation: &PersistentShellRequest,
         _resource_name: &str,
         _project: &RunnerProjectShellContext,
@@ -392,11 +383,11 @@ impl PersistentShellManager {
         &self,
         policy: &RunnerPolicy,
         shell: &ShellConfig,
-        request: &RunnerRequest,
+        client_id: &str,
         operation: &PersistentShellRequest,
         project: &RunnerProjectShellContext,
     ) -> PersistentShellResult {
-        let launch = match build_launch(policy, shell, request, operation, project) {
+        let launch = match build_launch(policy, shell, client_id, operation, project) {
             Ok(launch) => launch,
             Err((code, message)) => {
                 return error_result(
@@ -598,6 +589,39 @@ impl PersistentShellManager {
 
     pub(crate) fn close_project(&self, runtime_project_id: &str, reason: &str) -> usize {
         self.processes.close_project(runtime_project_id, reason)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn handle(
+        &self,
+        policy: &RunnerPolicy,
+        shell: &ShellConfig,
+        ssh: &SshConfig,
+        ssh_generation: u64,
+        project_registry_dir: &Path,
+        request: &RunnerRequest,
+    ) -> PersistentShellResult {
+        let Some(operation) = request.persistent_shell.clone() else {
+            return error_result(
+                "",
+                "",
+                "",
+                "persistent_shell_invalid_request",
+                "persistent shell payload is required",
+            );
+        };
+        self.handle_operation(
+            policy,
+            shell,
+            ssh,
+            ssh_generation,
+            project_registry_dir,
+            &request.client_id,
+            &RunnerPersistentShellOperation {
+                request: operation,
+                job_context: request.job_context.clone(),
+            },
+        )
     }
 
     pub(crate) fn close_exact(
@@ -819,7 +843,7 @@ fn selected_profile<'a>(
 fn build_launch(
     policy: &RunnerPolicy,
     shell: &ShellConfig,
-    request: &RunnerRequest,
+    client_id: &str,
     operation: &PersistentShellRequest,
     project: &RunnerProjectShellContext,
 ) -> Result<ShellLaunch, (&'static str, String)> {
@@ -827,7 +851,7 @@ fn build_launch(
     cwd_allowed(policy, &cwd).map_err(|message| ("persistent_shell_cwd_denied", message))?;
     build_launch_at_cwd(
         shell,
-        request,
+        client_id,
         operation,
         project,
         cwd,
@@ -837,7 +861,7 @@ fn build_launch(
 
 fn build_launch_at_cwd(
     shell: &ShellConfig,
-    request: &RunnerRequest,
+    client_id: &str,
     operation: &PersistentShellRequest,
     project: &RunnerProjectShellContext,
     cwd: PathBuf,
@@ -933,7 +957,7 @@ fn build_launch_at_cwd(
             workflow_session_id: operation.workflow_session_id.clone(),
             runtime_project_id: operation.runtime_project_id.clone(),
             executor: EXECUTOR_AGENT.to_string(),
-            client_id: Some(request.client_id.clone()),
+            client_id: Some(client_id.to_string()),
         },
         dialect,
         profile: profile_name,

--- a/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/persistent_shell.rs
@@ -1824,8 +1824,15 @@ mod windows_tests {
         };
         let open = request("open", "wc_shell_profile_mapping", None);
         let operation = open.persistent_shell.as_ref().unwrap();
-        let launch =
-            build_launch_at_cwd(&shell, &open, operation, &project, cwd.clone(), 4096).unwrap();
+        let launch = build_launch_at_cwd(
+            &shell,
+            open.client_id.as_str(),
+            operation,
+            &project,
+            cwd.clone(),
+            4096,
+        )
+        .unwrap();
         assert_eq!(launch.program, "pwsh.exe");
         assert_eq!(launch.dialect, "powershell");
         assert_eq!(launch.args, vec!["-NoProfile", "-NonInteractive"]);
@@ -1842,7 +1849,7 @@ mod windows_tests {
         explicit.persistent_shell.as_mut().unwrap().shell = Some("bash".to_string());
         let error = build_launch_at_cwd(
             &ShellConfig::default(),
-            &explicit,
+            explicit.client_id.as_str(),
             explicit.persistent_shell.as_ref().unwrap(),
             &RunnerProjectShellContext {
                 id: "demo".to_string(),
@@ -1865,7 +1872,7 @@ mod windows_tests {
         let invalid = request("open", "wc_shell_bad_args", None);
         let error = build_launch_at_cwd(
             &invalid_shell,
-            &invalid,
+            invalid.client_id.as_str(),
             invalid.persistent_shell.as_ref().unwrap(),
             &default_project,
             cwd,

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -2,7 +2,9 @@ use super::config::{
     default_true, project_registry_dir, validate_shell_profile_name, RunnerConfig, RunnerPolicy,
 };
 use super::shell::canonicalize_existing;
-use crate::runner_protocol::{RunnerProjectSummary, RunnerRequest};
+use crate::runner_protocol::RunnerProjectSummary;
+#[cfg(test)]
+use crate::runner_protocol::RunnerRequest;
 use crate::{err_cmd, ok_cmd, write_created_file};
 use crate::{CommandResult, CreatedProjectPaths};
 use serde::{Deserialize, Serialize};
@@ -16,6 +18,9 @@ use std::sync::mpsc;
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
+#[cfg(test)]
+use webcodex_core::runner_operation::RunnerOperation;
+use webcodex_core::runner_operation::{RunnerProjectOperation, RunnerProjectOperationKind};
 use webcodex_process::{GracefulTermination, ManagedChild};
 use webcodex_runner_config::paths::paths_equal;
 
@@ -1197,7 +1202,7 @@ fn choose_auto_project_id(
 }
 
 fn path_resolution_success(
-    request: &RunnerRequest,
+    client_id: &str,
     project: &RunnerProjectFile,
     canonical_path: &Path,
     outcome: &'static str,
@@ -1205,9 +1210,9 @@ fn path_resolution_success(
     project_record_path: Option<&Path>,
 ) -> serde_json::Value {
     serde_json::json!({
-        "id": format!("agent:{}:{}", request.client_id, project.id),
+        "id": format!("agent:{}:{}", client_id, project.id),
         "agent_project_id": project.id,
-        "client_id": request.client_id,
+        "client_id": client_id,
         "name": project.name,
         "path": canonical_path.to_string_lossy(),
         "kind": project_wire_kind(project),
@@ -1229,7 +1234,7 @@ fn path_resolution_success(
 
 fn existing_path_resolution_result(
     start: Instant,
-    request: &RunnerRequest,
+    client_id: &str,
     canonical_path: &Path,
     matches: Vec<RunnerProjectFile>,
 ) -> Option<CommandResult> {
@@ -1259,7 +1264,7 @@ fn existing_path_resolution_result(
     Some(ok_cmd(
         start,
         path_resolution_success(
-            request,
+            client_id,
             &project,
             canonical_path,
             "reused_existing_registration",
@@ -1272,10 +1277,11 @@ fn existing_path_resolution_result(
 /// Resolve an existing Runner registration by canonical path or atomically
 /// persist a new one. This is an internal Server↔Runner operation, not a
 /// model-visible runtime tool.
-pub(crate) fn handle_resolve_or_register_project(
+pub(crate) fn handle_resolve_or_register_project_operation(
     policy: &RunnerPolicy,
     project_registry_dir: &Path,
-    request: &RunnerRequest,
+    client_id: &str,
+    operation: &RunnerProjectOperation,
 ) -> CommandResult {
     let start = Instant::now();
     let _registry_guard = match project_registry_write_lock().lock() {
@@ -1289,10 +1295,8 @@ pub(crate) fn handle_resolve_or_register_project(
             )
         }
     };
-    let payload = match request
-        .stdin
-        .as_deref()
-        .and_then(|payload| serde_json::from_str::<serde_json::Value>(payload).ok())
+    let payload = match serde_json::from_str::<serde_json::Value>(&operation.payload)
+        .ok()
         .and_then(|payload| payload.as_object().cloned())
     {
         Some(payload) => payload,
@@ -1391,7 +1395,8 @@ pub(crate) fn handle_resolve_or_register_project(
         }
     };
     let matches = projects_matching_canonical_path(&projects, &canonical_path);
-    if let Some(result) = existing_path_resolution_result(start, request, &canonical_path, matches)
+    if let Some(result) =
+        existing_path_resolution_result(start, client_id, &canonical_path, matches)
     {
         return result;
     }
@@ -1427,7 +1432,7 @@ pub(crate) fn handle_resolve_or_register_project(
                 if let Ok(projects) = load_project_files_for_path_resolution(project_registry_dir) {
                     let matches = projects_matching_canonical_path(&projects, &canonical_path);
                     if let Some(result) =
-                        existing_path_resolution_result(start, request, &canonical_path, matches)
+                        existing_path_resolution_result(start, client_id, &canonical_path, matches)
                     {
                         return result;
                     }
@@ -1462,7 +1467,7 @@ pub(crate) fn handle_resolve_or_register_project(
     ok_cmd(
         start,
         path_resolution_success(
-            request,
+            client_id,
             &project,
             &canonical_path,
             "auto_registered",
@@ -1632,7 +1637,7 @@ fn managed_worktree_project_toml(
 
 fn managed_worktree_success(
     start: Instant,
-    request: &RunnerRequest,
+    client_id: &str,
     project: &RunnerProjectFile,
     worktree: &Path,
     base_ref: &str,
@@ -1645,9 +1650,9 @@ fn managed_worktree_success(
     ok_cmd(
         start,
         serde_json::json!({
-            "id": format!("agent:{}:{}", request.client_id, project.id),
+            "id": format!("agent:{}:{}", client_id, project.id),
             "agent_project_id": project.id,
-            "client_id": request.client_id,
+            "client_id": client_id,
             "name": project.name,
             "path": worktree.to_string_lossy(),
             "kind": project_wire_kind(project),
@@ -1674,7 +1679,7 @@ fn resume_managed_worktree(
     start: Instant,
     policy: &RunnerPolicy,
     project_registry_dir: &Path,
-    request: &RunnerRequest,
+    client_id: &str,
     source_root: &Path,
     source_dirty: bool,
     requested_base_ref: Option<&str>,
@@ -1832,7 +1837,7 @@ fn resume_managed_worktree(
         .unwrap_or(requested_base_ref.unwrap_or("HEAD"));
     managed_worktree_success(
         start,
-        request,
+        client_id,
         &project,
         &worktree,
         projected_base_ref,
@@ -1847,10 +1852,11 @@ fn resume_managed_worktree(
 /// Internal Server↔Runner operation that owns Git/ref/path semantics for managed
 /// worktrees. It is intentionally not model-visible; successful output is fed
 /// back through the ordinary registered runtime Project authority path.
-pub(crate) fn handle_prepare_managed_worktree(
+pub(crate) fn handle_prepare_managed_worktree_operation(
     policy: &RunnerPolicy,
     project_registry_dir: &Path,
-    request: &RunnerRequest,
+    client_id: &str,
+    operation: &RunnerProjectOperation,
 ) -> CommandResult {
     let start = Instant::now();
     let _registry_guard = match project_registry_write_lock().lock() {
@@ -1859,10 +1865,8 @@ pub(crate) fn handle_prepare_managed_worktree(
             return managed_worktree_error(start, "operation_failed", false, None, None, None)
         }
     };
-    let Some(payload) = request
-        .stdin
-        .as_deref()
-        .and_then(|payload| serde_json::from_str::<serde_json::Value>(payload).ok())
+    let Some(payload) = serde_json::from_str::<serde_json::Value>(&operation.payload)
+        .ok()
         .and_then(|payload| payload.as_object().cloned())
     else {
         return managed_worktree_error(start, "invalid_request", false, None, None, None);
@@ -1986,7 +1990,7 @@ pub(crate) fn handle_prepare_managed_worktree(
             start,
             policy,
             project_registry_dir,
-            request,
+            client_id,
             &source_root,
             source_dirty,
             requested_base_ref.as_deref(),
@@ -2297,7 +2301,7 @@ pub(crate) fn handle_prepare_managed_worktree(
         }
         return managed_worktree_success(
             start,
-            request,
+            client_id,
             &project,
             &canonical_worktree,
             &base_ref,
@@ -2380,7 +2384,7 @@ pub(crate) fn handle_prepare_managed_worktree(
     };
     managed_worktree_success(
         start,
-        request,
+        client_id,
         &project,
         &canonical_worktree,
         &base_ref,
@@ -2469,28 +2473,23 @@ fn unregister_project_config(path: &Path) -> Result<(), ProjectUnregisterError> 
 
 /// Structured, non-shell project lifecycle mutation. Unregister only removes
 /// the registry TOML and never touches the project path or Git data.
-pub(crate) fn handle_project_lifecycle_op(
+pub(crate) fn handle_project_lifecycle_operation(
     policy: &RunnerPolicy,
     project_registry_dir: &Path,
-    request: &RunnerRequest,
+    operation: &RunnerProjectOperation,
 ) -> CommandResult {
     let _registry_guard = match project_registry_write_lock().lock() {
         Ok(guard) => guard,
         Err(_) => return project_error_cmd(Instant::now(), "operation_failed"),
     };
     let start = Instant::now();
-    let action = request
-        .kind
-        .strip_prefix("project_lifecycle_")
-        .unwrap_or("");
-    if !matches!(action, "enable" | "disable" | "unregister") {
-        return project_error_cmd(start, "unsupported_runner_version");
-    }
-    let payload: serde_json::Value = match request
-        .stdin
-        .as_deref()
-        .and_then(|v| serde_json::from_str(v).ok())
-    {
+    let action = match operation.kind {
+        RunnerProjectOperationKind::LifecycleEnable => "enable",
+        RunnerProjectOperationKind::LifecycleDisable => "disable",
+        RunnerProjectOperationKind::LifecycleUnregister => "unregister",
+        _ => return project_error_cmd(start, "unsupported_runner_version"),
+    };
+    let payload: serde_json::Value = match serde_json::from_str(&operation.payload).ok() {
         Some(v) => v,
         None => return project_error_cmd(start, "invalid_request"),
     };
@@ -2657,7 +2656,7 @@ fn validate_recovered_create_side_effects(
 }
 
 fn recovered_project_result(
-    kind: &str,
+    create: bool,
     runtime_id: &str,
     client_id: &str,
     project: &RunnerProjectFile,
@@ -2672,8 +2671,8 @@ fn recovered_project_result(
         "created_directory": false, "created_config": false, "overwritten": false,
         "allow_patch": project.allow_patch, "template": template,
         "git_initialized": git_init, "recovered": true, "changed": false,
-        "operation": if kind == "create_project" { "create" } else { "register" },
-        "outcome": if kind == "create_project" { "created" } else { "registered" },
+        "operation": if create { "create" } else { "register" },
+        "outcome": if create { "created" } else { "registered" },
         "revision": project_revision(project),
     })
 }
@@ -2683,19 +2682,21 @@ fn recovered_project_result(
 /// policy, writes `project_registry_dir/<id>.toml` atomically (and for
 /// `create_project` creates the directory / templates / optional git init),
 /// and returns structured JSON in `CommandResult.stdout`.
-pub(crate) fn handle_project_op(
+pub(crate) fn handle_project_operation(
     policy: &RunnerPolicy,
     project_registry_dir: &Path,
-    request: &RunnerRequest,
+    client_id: &str,
+    operation: &RunnerProjectOperation,
 ) -> CommandResult {
     let _registry_guard = match project_registry_write_lock().lock() {
         Ok(guard) => guard,
         Err(_) => return project_error_cmd(Instant::now(), "operation_failed"),
     };
     let start = Instant::now();
-    let kind = request.kind.as_str();
-    let payload = match request.stdin.as_deref() {
-        Some(s) if !s.is_empty() => s,
+    let kind = operation.kind.wire_kind();
+    let create = operation.kind == RunnerProjectOperationKind::Create;
+    let payload = match operation.payload.as_str() {
+        s if !s.is_empty() => s,
         _ => {
             return CommandResult {
                 exit_code: None,
@@ -2776,7 +2777,7 @@ pub(crate) fn handle_project_op(
         return project_error_cmd(start, error_kind);
     }
 
-    let client_id = request.client_id.clone();
+    let client_id = client_id.to_string();
     let runtime_id = format!("agent:{}:{}", client_id, id);
 
     let toml_content = build_project_toml(&id, &name, &path, &description, allow_patch);
@@ -2793,11 +2794,11 @@ pub(crate) fn handle_project_op(
         .get("adopt_existing_empty")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    if kind == "create_project" && template != "empty" && template != "basic" {
+    if create && template != "empty" && template != "basic" {
         return project_error_cmd(start, "invalid_request");
     }
 
-    if kind == "register_project" {
+    if !create {
         // The directory must exist and be a directory.
         let path_buf = PathBuf::from(&path);
         let canonical = match path_buf.canonicalize() {
@@ -2834,7 +2835,7 @@ pub(crate) fn handle_project_op(
                     return ok_cmd(
                         start,
                         recovered_project_result(
-                            kind,
+                            create,
                             &runtime_id,
                             &client_id,
                             &project,
@@ -2941,7 +2942,7 @@ pub(crate) fn handle_project_op(
                 return ok_cmd(
                     start,
                     recovered_project_result(
-                        kind,
+                        create,
                         &runtime_id,
                         &client_id,
                         &project,
@@ -3073,6 +3074,81 @@ pub(crate) fn handle_project_op(
         "operation": "create", "outcome": "created", "changed": true, "recovered": false,
     });
     ok_cmd(start, result)
+}
+
+#[cfg(test)]
+fn test_project_operation(
+    request: &RunnerRequest,
+) -> Result<RunnerProjectOperation, CommandResult> {
+    match request.decode_operation() {
+        Ok(RunnerOperation::Project(operation)) => Ok(operation),
+        _ => Err(project_error_cmd(
+            Instant::now(),
+            "unsupported_runner_version",
+        )),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn handle_project_op(
+    policy: &RunnerPolicy,
+    project_registry_dir: &Path,
+    request: &RunnerRequest,
+) -> CommandResult {
+    let operation = match test_project_operation(request) {
+        Ok(operation) => operation,
+        Err(result) => return result,
+    };
+    handle_project_operation(policy, project_registry_dir, &request.client_id, &operation)
+}
+
+#[cfg(test)]
+pub(crate) fn handle_resolve_or_register_project(
+    policy: &RunnerPolicy,
+    project_registry_dir: &Path,
+    request: &RunnerRequest,
+) -> CommandResult {
+    let operation = match test_project_operation(request) {
+        Ok(operation) => operation,
+        Err(result) => return result,
+    };
+    handle_resolve_or_register_project_operation(
+        policy,
+        project_registry_dir,
+        &request.client_id,
+        &operation,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn handle_prepare_managed_worktree(
+    policy: &RunnerPolicy,
+    project_registry_dir: &Path,
+    request: &RunnerRequest,
+) -> CommandResult {
+    let operation = match test_project_operation(request) {
+        Ok(operation) => operation,
+        Err(result) => return result,
+    };
+    handle_prepare_managed_worktree_operation(
+        policy,
+        project_registry_dir,
+        &request.client_id,
+        &operation,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn handle_project_lifecycle_op(
+    policy: &RunnerPolicy,
+    project_registry_dir: &Path,
+    request: &RunnerRequest,
+) -> CommandResult {
+    let operation = match test_project_operation(request) {
+        Ok(operation) => operation,
+        Err(result) => return result,
+    };
+    handle_project_lifecycle_operation(policy, project_registry_dir, &operation)
 }
 
 #[cfg(test)]

--- a/crates/webcodex-runner/src/webcodex_runner/skill_store.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/skill_store.rs
@@ -2,7 +2,6 @@ use super::artifacts::validate_artifact_runner_path;
 use super::config::RunnerPolicy;
 use super::output::CommandResult;
 use super::shell::cwd_allowed;
-use crate::runner_protocol::RunnerRequest;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -1533,22 +1532,14 @@ pub(crate) fn handle_skill_store_request(
     client_id: &str,
     server_url: &str,
     policy: &RunnerPolicy,
-    request: &RunnerRequest,
+    request: SkillStoreRequest,
 ) -> CommandResult {
     let start = Instant::now();
-    let parsed = match request
-        .content
-        .as_deref()
-        .and_then(|content| serde_json::from_str::<SkillStoreRequest>(content).ok())
-    {
-        Some(request) => request,
-        None => return error_result(start, "skill_store_invalid_request"),
-    };
     let store = match SkillStore::for_runner(client_id, server_url) {
         Ok(store) => store,
         Err(_) => return error_result(start, "skill_store_unavailable"),
     };
-    let result = match parsed {
+    let result = match request {
         SkillStoreRequest::ListActive => store
             .list_active()
             .and_then(|value| serialize_response(value)),

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -3627,6 +3627,17 @@ fn main() {
         .expect("build Windows SSH job request")
     }
 
+    fn ssh_job_operation(job_id: &str) -> webcodex_core::runner_operation::RunnerJobOperation {
+        let request = ssh_job_request(job_id, "printf ignored", 30);
+        let webcodex_core::runner_operation::RunnerOperation::Job(operation) = request
+            .decode_operation()
+            .expect("Windows SSH start_job fixture must decode")
+        else {
+            panic!("Windows SSH start_job fixture decoded as a non-Job operation");
+        };
+        operation
+    }
+
     fn wait_for_job_update(
         rx: &mut tokio::sync::mpsc::Receiver<crate::runner_protocol::RunnerEnvelope>,
         job_id: &str,
@@ -4340,6 +4351,7 @@ fn main() {
 
     #[test]
     fn windows_background_ssh_post_spawn_rejections_are_outcome_unknown() {
+        let operation = ssh_job_operation("post-spawn-rejection");
         for (shutting_down, stop_requested, job_record_present, expected_error) in [
             (
                 true,
@@ -4362,7 +4374,7 @@ fn main() {
             )
             .expect("post-spawn interruption is rejected");
             assert_eq!(error, expected_error);
-            let delta = crate::post_spawn_interruption_delta("start_job", 7, error);
+            let delta = crate::post_spawn_interruption_delta(&operation, 7, error);
             assert_eq!(delta.status, "failed");
             assert_eq!(delta.exit_code, None);
             assert_eq!(delta.duration_ms, Some(7));
@@ -4379,6 +4391,8 @@ fn main() {
     #[ignore = "runner real-process lane: post-spawn rejection terminates a fake SSH process tree"]
     fn runner_real_process_windows_background_ssh_post_spawn_rejection_reaps_owned_tree() {
         use std::io::{BufRead, BufReader};
+
+        let operation = ssh_job_operation("post-spawn-real-process-rejection");
 
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("post-spawn-grandchild.marker");
@@ -4417,7 +4431,7 @@ fn main() {
         );
         assert!(!marker.exists(), "terminated grandchild reached marker");
 
-        let delta = crate::post_spawn_interruption_delta("start_job", 0, error);
+        let delta = crate::post_spawn_interruption_delta(&operation, 0, error);
         assert_eq!(
             delta.command_execution_state,
             Some(ShellCommandExecutionState::OutcomeUnknown)

--- a/crates/webcodex-runner/src/webcodex_runner/ssh.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/ssh.rs
@@ -2348,14 +2348,14 @@ mod tests {
         };
         manager.enqueue(
             sink.clone(),
-            crate::PendingJobStart {
-                generation: 11,
-                policy: RunnerPolicy::default(),
-                shell: crate::webcodex_runner::ShellConfig::default(),
-                ssh: config.clone(),
-                project_registry_dir: PathBuf::new(),
-                request: ssh_job_request("ssh-job-complete", "tmp", "printf job-ok"),
-            },
+            crate::PendingJobStart::from_wire(
+                11,
+                RunnerPolicy::default(),
+                crate::webcodex_runner::ShellConfig::default(),
+                config.clone(),
+                PathBuf::new(),
+                ssh_job_request("ssh-job-complete", "tmp", "printf job-ok"),
+            ),
         );
         let completed = wait_for_job_update(&mut rx, "ssh-job-complete", |update| update.finished);
         assert_eq!(completed.status, "completed", "{completed:?}");
@@ -2375,14 +2375,14 @@ mod tests {
 
         manager.enqueue(
             sink.clone(),
-            crate::PendingJobStart {
-                generation: 11,
-                policy: RunnerPolicy::default(),
-                shell: crate::webcodex_runner::ShellConfig::default(),
-                ssh: config.clone(),
-                project_registry_dir: PathBuf::new(),
-                request: ssh_job_request("ssh-job-stop", "tmp", "sleep 30"),
-            },
+            crate::PendingJobStart::from_wire(
+                11,
+                RunnerPolicy::default(),
+                crate::webcodex_runner::ShellConfig::default(),
+                config.clone(),
+                PathBuf::new(),
+                ssh_job_request("ssh-job-stop", "tmp", "sleep 30"),
+            ),
         );
         let running =
             wait_for_job_update(&mut rx, "ssh-job-stop", |update| update.status == "running");
@@ -2406,14 +2406,14 @@ mod tests {
 
         manager.enqueue(
             sink,
-            crate::PendingJobStart {
-                generation: 11,
-                policy: RunnerPolicy::default(),
-                shell: crate::webcodex_runner::ShellConfig::default(),
-                ssh: config,
-                project_registry_dir: PathBuf::new(),
-                request: ssh_job_request("ssh-job-missing", "missing", "printf never-started"),
-            },
+            crate::PendingJobStart::from_wire(
+                11,
+                RunnerPolicy::default(),
+                crate::webcodex_runner::ShellConfig::default(),
+                config,
+                PathBuf::new(),
+                ssh_job_request("ssh-job-missing", "missing", "printf never-started"),
+            ),
         );
         let missing = wait_for_job_update(&mut rx, "ssh-job-missing", |update| update.finished);
         assert_eq!(missing.status, "failed", "{missing:?}");
@@ -3662,14 +3662,14 @@ fn main() {
     ) {
         manager.enqueue(
             sink,
-            crate::PendingJobStart {
-                generation: 11,
+            crate::PendingJobStart::from_wire(
+                11,
                 policy,
-                shell: crate::webcodex_runner::ShellConfig::default(),
-                ssh: config,
-                project_registry_dir: PathBuf::new(),
-                request: ssh_job_request(job_id, command, timeout_secs),
-            },
+                crate::webcodex_runner::ShellConfig::default(),
+                config,
+                PathBuf::new(),
+                ssh_job_request(job_id, command, timeout_secs),
+            ),
         );
     }
 

--- a/crates/webcodex-runner/src/webcodex_runner/transport.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport.rs
@@ -27,7 +27,7 @@ use crate::runner_protocol::{
     PROJECT_INVENTORY_PAGE_MAX_SERIALIZED_BYTES, PROJECT_INVENTORY_PAGE_MAX_SUMMARIES,
 };
 use crate::{
-    build_register_request_with_provider_status, dispatch_request, handle_one_poll, is_project_op,
+    build_register_request_with_provider_status, dispatch_request_with_outcome, handle_one_poll,
     register, CommandResult, JobManager, PollingDispatchSupervisor, PollingRecoveryAction,
     RegisterRecoveryAction, RunnerHttpError, RunnerHttpErrorKind,
 };
@@ -3134,7 +3134,6 @@ fn handle_stream_envelope(
 ) -> Option<String> {
     match envelope {
         RunnerEnvelope::Request { request } => {
-            let project_op = is_project_op(&request.kind);
             let sink = sink.clone();
             let config = Arc::clone(&runtime.config);
             let hot = config.snapshot();
@@ -3149,7 +3148,7 @@ fn handle_stream_envelope(
             let project_inventory_refresh_tx = project_inventory_refresh_tx.clone();
             tokio::task::spawn_blocking(move || {
                 let _dispatch_guard = dispatch_guard;
-                let dispatch_result = dispatch_request(
+                let dispatch_result = dispatch_request_with_outcome(
                     &sink,
                     &hot,
                     &config,
@@ -3159,7 +3158,10 @@ fn handle_stream_envelope(
                     &lsp,
                     request,
                 );
-                if project_op && dispatch_result.is_ok() {
+                if dispatch_result
+                    .as_ref()
+                    .is_ok_and(|outcome| outcome.project_cache_invalidation_required)
+                {
                     // Capacity one deliberately coalesces multiple project
                     // mutations. A queued dirty signal already guarantees a
                     // fresh full observation; never block request completion on

--- a/crates/webcodex-runner/src/webcodex_runner/validation/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/validation/mod.rs
@@ -18,34 +18,21 @@ use super::config::RunnerPolicy;
 use super::output::CommandResult;
 use super::projects::load_runner_project_summaries_from_dir;
 use super::shell::cwd_allowed;
-use crate::runner_protocol::RunnerRequest;
 use crate::validation_bridge::{
     failure_kinds, validate_bridge_request, ValidationBridgeRequest, ValidationBridgeResponse,
-    ValidationBridgeResultEnvelope, AGENT_VALIDATION_REQUEST_KIND,
-    VALIDATION_BRIDGE_PROTOCOL_VERSION,
+    ValidationBridgeResultEnvelope, VALIDATION_BRIDGE_PROTOCOL_VERSION,
 };
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
-pub(crate) fn is_validation_request_kind(kind: &str) -> bool {
-    kind == AGENT_VALIDATION_REQUEST_KIND
-}
-
 pub(crate) fn handle_validation_request(
     policy: &RunnerPolicy,
     project_registry_dir: &Path,
-    request: &RunnerRequest,
+    payload: &ValidationBridgeRequest,
     shutdown: Option<&AtomicBool>,
 ) -> CommandResult {
     let start = Instant::now();
-    let Some(payload) = request.validation.as_ref() else {
-        return validation_error_cmd(
-            start,
-            failure_kinds::MISSING_VALIDATION_PAYLOAD,
-            "validation request missing typed payload",
-        );
-    };
     match execute_validation_with_shutdown(policy, project_registry_dir, payload, shutdown) {
         Ok(response) => {
             let envelope = ValidationBridgeResultEnvelope::ok(response);
@@ -192,17 +179,6 @@ fn validate_project_root(
             "project root is not accessible",
         )
     })
-}
-
-fn validation_error_cmd(start: Instant, code: &str, message: &str) -> CommandResult {
-    let envelope = ValidationBridgeResultEnvelope::err(code, message);
-    CommandResult {
-        exit_code: Some(0),
-        stdout: Some(envelope.to_stdout_json()),
-        stderr: Some(String::new()),
-        duration_ms: Some(start.elapsed().as_millis() as u64),
-        error: None,
-    }
 }
 
 /// Empty response skeleton used by adapters for early failures.

--- a/src/runner_http/telemetry.rs
+++ b/src/runner_http/telemetry.rs
@@ -1,6 +1,7 @@
 use super::RunnerRegistry;
 use serde_json::{json, Value};
 use std::sync::Arc;
+use webcodex_core::runner_operation::RunnerOperation;
 use webcodex_core::runner_protocol::{RunnerJobUpdateRequest, RunnerRequest, RunnerResultPayload};
 use webcodex_core::ssh_resource::SshResourceRequest;
 use webcodex_runner_registry::RunnerRegistryTelemetry;
@@ -12,17 +13,18 @@ impl RunnerRegistryTelemetry for ToolRequestTraceRunnerRegistryTelemetry {
     fn request_enqueued(
         &self,
         request: &RunnerRequest,
+        operation: &RunnerOperation,
         request_id: &str,
         client_id: &str,
-        kind: &str,
         job_id: Option<&str>,
         runner_instance_id: Option<&str>,
         runner_transport: Option<&str>,
         runner_version: Option<&str>,
         runner_git_commit: Option<&str>,
     ) {
-        if kind == "ssh_resource" {
-            let payload = ssh_resource_trace_payload(request);
+        let kind = operation.wire_kind();
+        if let RunnerOperation::SshResource(ssh_operation) = operation {
+            let payload = ssh_resource_trace_payload(request_id, client_id, ssh_operation);
             crate::tool_request_trace::record_runner_request_enqueued(
                 &payload,
                 request_id,
@@ -71,22 +73,21 @@ impl RunnerRegistryTelemetry for ToolRequestTraceRunnerRegistryTelemetry {
     }
 }
 
-fn ssh_resource_trace_payload(request: &RunnerRequest) -> Value {
-    let parsed = request
-        .content
-        .as_deref()
-        .and_then(|content| serde_json::from_str::<SshResourceRequest>(content).ok());
-    let (action, resource_name, target_present, default_cwd_present) = match parsed {
-        Some(SshResourceRequest::List) => ("list", None, false, false),
-        Some(SshResourceRequest::Register {
+fn ssh_resource_trace_payload(
+    request_id: &str,
+    client_id: &str,
+    request: &SshResourceRequest,
+) -> Value {
+    let (action, resource_name, target_present, default_cwd_present) = match request {
+        SshResourceRequest::List => ("list", None, false, false),
+        SshResourceRequest::Register {
             name, default_cwd, ..
-        }) => ("register", Some(name), true, default_cwd.is_some()),
-        Some(SshResourceRequest::Remove { name, .. }) => ("remove", Some(name), false, false),
-        None => ("invalid", None, request.content.is_some(), false),
+        } => ("register", Some(name.as_str()), true, default_cwd.is_some()),
+        SshResourceRequest::Remove { name, .. } => ("remove", Some(name.as_str()), false, false),
     };
     json!({
-        "request_id": request.request_id,
-        "client_id": request.client_id,
+        "request_id": request_id,
+        "client_id": client_id,
         "kind": "ssh_resource",
         "action": action,
         "resource_name": resource_name,
@@ -107,47 +108,19 @@ mod tests {
     fn ssh_resource_trace_projection_never_contains_target_or_default_cwd() {
         let target = "17724@w10";
         let cwd = "C:/private/work";
-        let request = RunnerRequest {
-            request_id: "request-1".to_string(),
-            client_id: "runner-1".to_string(),
-            kind: "ssh_resource".to_string(),
-            job_id: None,
-            cwd: None,
-            path: None,
-            content: Some(
-                serde_json::to_string(&SshResourceRequest::Register {
-                    expected_revision: 7,
-                    name: "w10".to_string(),
-                    target: target.to_string(),
-                    default_cwd: Some(cwd.to_string()),
-                })
-                .unwrap(),
-            ),
-            max_bytes: None,
-            expected_sha256: None,
-            expected_prefix: None,
-            start_line: None,
-            end_line: None,
-            create_dirs: false,
-            command: String::new(),
-            process: None,
-            script: None,
-            stdin: None,
-            timeout_secs: 60,
-            requested_by: "ssh_resource".to_string(),
-            created_at: 1,
-            validation: None,
-            lsp: None,
-            job_context: None,
-            persistent_shell: None,
-            mcp_gateway: None,
-            plugin_gateway: None,
-            coding_agent: None,
+        let request = SshResourceRequest::Register {
+            expected_revision: 7,
+            name: "w10".to_string(),
+            target: target.to_string(),
+            default_cwd: Some(cwd.to_string()),
         };
-        let payload = ssh_resource_trace_payload(&request);
+        let payload = ssh_resource_trace_payload("request-1", "runner-1", &request);
         let serialized = serde_json::to_string(&payload).unwrap();
         assert!(!serialized.contains(target));
         assert!(!serialized.contains(cwd));
+        assert_eq!(payload["request_id"], "request-1");
+        assert_eq!(payload["client_id"], "runner-1");
+        assert_eq!(payload["kind"], "ssh_resource");
         assert_eq!(payload["action"], "register");
         assert_eq!(payload["resource_name"], "w10");
         assert_eq!(payload["target_present"], true);


### PR DESCRIPTION
## Summary
- introduce a closed `RunnerOperation` semantic model with a canonical V2 wire encoder/decoder
- build Server/Registry requests from typed operations and decode once at Runner ingress before exhaustive dispatch
- derive Job recovery, lifecycle, process/script/validation/detached/SSH semantics from `RunnerJobOperation`
- add exhaustive V2 round-trip, representative JSON parity, conflict fail-closed, and capability-independence invariants
- preserve the historical `run_shell.max_bytes` external-search output-limit compatibility path

## Validation
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo check --all-targets -p webcodex` — 0 errors / 0 warnings
- `cargo test -p webcodex-runner` — 837 passed / 0 failed / 60 ignored
- `cargo test -p webcodex-runner-registry` — 243 passed / 0 failed
- `cargo test runner_operation -p webcodex-core` — 10 passed / 0 failed
- root Server QUIC registration/protocol tests — 3 passed / 0 failed
- root Server QUIC request/result round-trip — 1 passed / 0 failed
- root Server same-instance replacement/Job preservation — 1 passed / 0 failed
