### PR TITLE
Separate Job lifecycle, recovery, and observation state

### DIFF
--- a/crates/webcodex-runner-registry/src/job_updates.rs
+++ b/crates/webcodex-runner-registry/src/job_updates.rs
@@ -1269,7 +1269,7 @@ impl RunnerRegistry {
             .get_mut(job_id)
             .expect("job exists")
             .visibility = ShellJobVisibility::CleanupPending;
-        if !job.recovery.recovering()
+        if !job.recovery_active()
             && job.lifecycle.is_runner_active()
             && job.lifecycle != JobLifecycleState::StopRequested
         {
@@ -1772,7 +1772,7 @@ impl RunnerRegistry {
         {
             return Err(format!("unknown shell job: {}", job_id));
         }
-        if job.recovery.recovering() {
+        if job.recovery_active() {
             return Err(
                 "runner_unavailable_recovering: wait for same-instance job reconciliation before retrying stop_job"
                     .to_string(),
@@ -1799,9 +1799,7 @@ impl RunnerRegistry {
             JobLifecycleState::StopRequested => {
                 Ok(job_view(inner.jobs_by_id.get(job_id).expect("job exists")))
             }
-            JobLifecycleState::RunnerQueued
-            | JobLifecycleState::StartedLegacy
-            | JobLifecycleState::Running => {
+            JobLifecycleState::RunnerQueued | JobLifecycleState::Running => {
                 let stop_request_id = next_request_id();
                 let client_id = job.client_id.clone();
                 let request = RunnerRequest::from_operation(
@@ -1997,7 +1995,7 @@ impl RunnerRegistry {
                         .to_string(),
                 );
             }
-            if job.recovery.recovering() && sequenced && body.log_snapshot.is_none() {
+            if job.recovery_active() && sequenced && body.log_snapshot.is_none() {
                 return Err(
                     "recovering job update requires an authoritative log_snapshot or register inventory"
                         .to_string(),
@@ -2046,7 +2044,7 @@ impl RunnerRegistry {
                 }
                 request_id_to_remove = job.request_id.clone();
             } else {
-                let was_recovering = job.recovery.recovering();
+                let was_recovering = job.recovery_active();
                 if let Some(snapshot) = body.log_snapshot {
                     super::jobs::replace_log_from_snapshot(&mut job.stdout, &snapshot.stdout);
                     super::jobs::replace_log_from_snapshot(&mut job.stderr, &snapshot.stderr);

--- a/crates/webcodex-runner-registry/src/job_updates.rs
+++ b/crates/webcodex-runner-registry/src/job_updates.rs
@@ -3,15 +3,18 @@ use super::access_control::{
 };
 use super::jobs::{
     append_log_limited, assert_active_instance_locked, command_preview, is_final_job_status,
-    job_view, notify_job_update, observe_job_terminal, process_preview, refresh_job_status_locked,
-    replace_log_limited, script_preview, select_log_lines,
+    job_view, notify_job_update, observe_job_terminal, parse_job_lifecycle, process_preview,
+    refresh_job_status_locked, replace_log_limited, script_preview, select_log_lines,
 };
 use super::reconciliation::validate_stream_snapshot;
 use super::requests::{
     enqueue_pending_request_locked, next_request_id, notify_runner_locked,
     remove_pending_request_locked,
 };
-use super::state::{DetachedIdempotencyIntent, ShellJobRecord, ShellJobVisibility};
+use super::state::{
+    DetachedIdempotencyIntent, JobLifecycleState, JobObservationState, JobRecoveryPhase,
+    JobRecoveryReason, JobRecoveryState, ShellJobRecord, ShellJobVisibility,
+};
 use super::validation::{validate_id, validate_run_request, validate_runner_instance_id};
 use super::{
     now_ts, RunnerFeature, RunnerRegistry, DETACHED_IDEMPOTENCY_CONFLICT,
@@ -21,7 +24,6 @@ use crate::DetachedInitiatorIdentity;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
-use tokio::sync::Notify;
 use uuid::Uuid;
 use webcodex_core::runner_operation::{
     RunnerInvocationMetadata, RunnerJobOperation, RunnerJobProcessOperation,
@@ -174,8 +176,8 @@ fn frozen_shell_job_log_projection(
         let mut view = job_view(job);
         view.observation_token = webcodex_core::job_observation::JobObservationToken::new_legacy(
             job.job_id.clone(),
-            job.observation_epoch.to_string(),
-            job.public_revision.load(Ordering::Relaxed),
+            job.observation.epoch.to_string(),
+            job.observation.revision.load(Ordering::Relaxed),
         )
         .ok()
         .map(|token| token.encode());
@@ -202,7 +204,7 @@ fn frozen_shell_job_log_projection(
         );
     }
 
-    let epoch_matches = after.is_none_or(|token| token.epoch == job.observation_epoch.as_ref());
+    let epoch_matches = after.is_none_or(|token| token.epoch == job.observation.epoch.as_ref());
     let base_mode = match after {
         None => webcodex_core::job_observation::JobLogSelectionMode::Baseline,
         Some(token) if token.is_legacy() || !epoch_matches => {
@@ -246,8 +248,8 @@ fn frozen_shell_job_log_projection(
     let mut view = job_view(job);
     view.observation_token = webcodex_core::job_observation::JobObservationToken::new(
         job.job_id.clone(),
-        job.observation_epoch.to_string(),
-        job.public_revision.load(Ordering::Relaxed),
+        job.observation.epoch.to_string(),
+        job.observation.revision.load(Ordering::Relaxed),
         stdout.next_line as u64,
         stderr.next_line as u64,
     )
@@ -280,9 +282,8 @@ fn frozen_shell_job_log_projection(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct JobPublicMutationSignature {
-    status: String,
-    recovery_state: Option<String>,
-    recovery_reason_code: Option<String>,
+    lifecycle: JobLifecycleState,
+    recovery: JobRecoveryState,
     last_update_seq: u64,
     stdout: super::state::ShellJobLogState,
     stderr: super::state::ShellJobLogState,
@@ -300,9 +301,8 @@ struct JobPublicMutationSignature {
 
 fn public_mutation_signature(job: &ShellJobRecord) -> JobPublicMutationSignature {
     JobPublicMutationSignature {
-        status: job.status.clone(),
-        recovery_state: job.recovery_state.clone(),
-        recovery_reason_code: job.recovery_reason_code.clone(),
+        lifecycle: job.lifecycle,
+        recovery: job.recovery.clone(),
         last_update_seq: job.last_update_seq,
         stdout: job.stdout.clone(),
         stderr: job.stderr.clone(),
@@ -314,8 +314,8 @@ fn public_mutation_signature(job: &ShellJobRecord) -> JobPublicMutationSignature
         command_execution_state: job.command_execution_state,
         validation_progress: job.validation_progress.clone(),
         activity: job.activity,
-        recovered_after_server_restart: job.recovered_after_server_restart,
-        reconciled_at: job.reconciled_at,
+        recovered_after_server_restart: job.recovery.recovered_after_server_restart,
+        reconciled_at: job.recovery.reconciled_at,
     }
 }
 
@@ -1073,11 +1073,10 @@ impl RunnerRegistry {
             shell: metadata.shell,
             command_preview: safe_command_preview,
             detached_idempotency_intent: detached_intent,
-            status: "queued".to_string(),
+            lifecycle: JobLifecycleState::Queued,
             created_at,
             started_at: None,
             ended_at: None,
-            terminal_observed_at: None,
             exit_code: None,
             duration_ms: None,
             stdout: Default::default(),
@@ -1093,15 +1092,8 @@ impl RunnerRegistry {
             last_update_seq: 0,
             visibility: metadata.visibility,
 
-            recovery_state: None,
-            recovered_after_server_restart: false,
-            reconciled_at: None,
-            recovery_reason_code: None,
-            recovering_since: None,
-            recovery_original_status: None,
-            observation_epoch: self.observation_epoch.clone(),
-            public_revision: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            update_notify: std::sync::Arc::new(Notify::new()),
+            recovery: JobRecoveryState::default(),
+            observation: JobObservationState::new(self.observation_epoch.clone()),
         };
         inner.request_to_job.insert(request_id, job_id.clone());
         inner.jobs_by_id.insert(job_id.clone(), job);
@@ -1137,7 +1129,7 @@ impl RunnerRegistry {
         // A terminal update may race the sync-wait deadline. Keep terminal
         // records hidden so the initiating structured tool call returns its
         // terminal result instead of handing off an already-finished Job.
-        if !is_final_job_status(&job.status) {
+        if !job.lifecycle.is_terminal() {
             let view = job_view(job);
             if view.observation_token.is_none() {
                 return Err(format!(
@@ -1260,7 +1252,7 @@ impl RunnerRegistry {
         {
             return Err(format!("unknown shell job: {job_id}"));
         }
-        if job.status == "queued" {
+        if job.lifecycle == JobLifecycleState::Queued {
             if let Some(request_id) = job.request_id.as_deref() {
                 remove_pending_request_locked(&mut inner, request_id);
                 inner.request_to_job.remove(request_id);
@@ -1268,7 +1260,7 @@ impl RunnerRegistry {
             inner.jobs_by_id.remove(job_id);
             return Ok(true);
         }
-        if is_final_job_status(&job.status) {
+        if job.lifecycle.is_terminal() {
             inner.jobs_by_id.remove(job_id);
             return Ok(true);
         }
@@ -1277,10 +1269,9 @@ impl RunnerRegistry {
             .get_mut(job_id)
             .expect("job exists")
             .visibility = ShellJobVisibility::CleanupPending;
-        if matches!(
-            job.status.as_str(),
-            "agent_queued" | "running" | "stop_requested"
-        ) && job.status != "stop_requested"
+        if !job.recovery.recovering()
+            && job.lifecycle.is_runner_active()
+            && job.lifecycle != JobLifecycleState::StopRequested
         {
             let stop_request_id = next_request_id();
             let request = RunnerRequest::from_operation(
@@ -1304,7 +1295,7 @@ impl RunnerRegistry {
                 Some(job_id.to_string()),
             )?;
             let record = inner.jobs_by_id.get_mut(job_id).expect("job exists");
-            record.status = "stop_requested".to_string();
+            record.lifecycle = JobLifecycleState::StopRequested;
             record.error = Some("internal structured execution cleanup requested".to_string());
             notify_runner_locked(&inner, &job.client_id);
         }
@@ -1350,8 +1341,7 @@ impl RunnerRegistry {
         let Some(request_id) = job.request_id.clone() else {
             return false;
         };
-        if job.visibility != ShellJobVisibility::HiddenUntilHandoff
-            || !is_final_job_status(&job.status)
+        if job.visibility != ShellJobVisibility::HiddenUntilHandoff || !job.lifecycle.is_terminal()
         {
             return false;
         }
@@ -1491,7 +1481,7 @@ impl RunnerRegistry {
             .filter(|job| job.visibility == ShellJobVisibility::Public)
             .filter(|job| shell_job_visible_to_auth(auth, &inner, job))
             .filter(|job| job.project_id.as_deref() == Some(runtime_project_id))
-            .filter(|job| crate::job_status_is_active(&job.status))
+            .filter(|job| job.lifecycle.is_active())
             .count()
     }
 
@@ -1512,7 +1502,7 @@ impl RunnerRegistry {
             .values()
             .filter(|job| shell_job_visible_to_auth(auth, &inner, job))
             .filter(|job| job.project_id.as_deref() == Some(runtime_project_id))
-            .filter(|job| crate::job_status_is_active(&job.status))
+            .filter(|job| job.lifecycle.is_active())
             .count();
         if active == 0 {
             *inner
@@ -1552,7 +1542,11 @@ impl RunnerRegistry {
             .jobs_by_id
             .values()
             .filter(|job| job.client_id == client_id)
-            .filter(|job| status.map(|status| status == job.status).unwrap_or(true))
+            .filter(|job| {
+                status
+                    .map(|status| status == job.public_status())
+                    .unwrap_or(true)
+            })
             .cloned()
             .collect::<Vec<_>>();
         jobs.sort_by_key(|job| std::cmp::Reverse(job.created_at));
@@ -1631,11 +1625,11 @@ impl RunnerRegistry {
             {
                 return Err(format!("unknown shell job: {}", job_id));
             }
-            let revision = job.public_revision.load(Ordering::Relaxed);
+            let revision = job.observation.revision.load(Ordering::Relaxed);
             let changed = after.as_ref().is_some_and(|token| {
-                token.epoch != job.observation_epoch.as_ref() || token.revision != revision
+                token.epoch != job.observation.epoch.as_ref() || token.revision != revision
             });
-            let terminal = is_final_job_status(&job.status);
+            let terminal = job.lifecycle.is_terminal();
             if wait_secs.is_none() || after.is_none() || changed || terminal {
                 let wait_outcome = if changed {
                     if waited {
@@ -1664,7 +1658,7 @@ impl RunnerRegistry {
                 ));
             }
 
-            let update_notify = job.update_notify.clone();
+            let update_notify = job.observation.notify.clone();
             let notified = update_notify.notified();
             drop(inner);
 
@@ -1678,11 +1672,11 @@ impl RunnerRegistry {
             {
                 return Err(format!("unknown shell job: {}", job_id));
             }
-            let revision = job.public_revision.load(Ordering::Relaxed);
+            let revision = job.observation.revision.load(Ordering::Relaxed);
             let changed = after.as_ref().is_some_and(|token| {
-                token.epoch != job.observation_epoch.as_ref() || token.revision != revision
+                token.epoch != job.observation.epoch.as_ref() || token.revision != revision
             });
-            let terminal = is_final_job_status(&job.status);
+            let terminal = job.lifecycle.is_terminal();
             if changed || terminal {
                 let wait = JobLogWait {
                     wait_outcome: if terminal {
@@ -1724,11 +1718,11 @@ impl RunnerRegistry {
                 {
                     return Err(format!("unknown shell job: {}", job_id));
                 }
-                let revision = job.public_revision.load(Ordering::Relaxed);
+                let revision = job.observation.revision.load(Ordering::Relaxed);
                 let changed = after.as_ref().is_some_and(|token| {
-                    token.epoch != job.observation_epoch.as_ref() || token.revision != revision
+                    token.epoch != job.observation.epoch.as_ref() || token.revision != revision
                 });
-                let terminal = is_final_job_status(&job.status);
+                let terminal = job.lifecycle.is_terminal();
                 let wait = JobLogWait {
                     wait_outcome: if terminal {
                         JobLogWaitOutcome::Terminal
@@ -1778,15 +1772,21 @@ impl RunnerRegistry {
         {
             return Err(format!("unknown shell job: {}", job_id));
         }
-        match job.status.as_str() {
-            "queued" => {
+        if job.recovery.recovering() {
+            return Err(
+                "runner_unavailable_recovering: wait for same-instance job reconciliation before retrying stop_job"
+                    .to_string(),
+            );
+        }
+        match job.lifecycle {
+            JobLifecycleState::Queued => {
                 if let Some(request_id) = &job.request_id {
                     remove_pending_request_locked(&mut inner, request_id);
                     inner.request_to_job.remove(request_id);
                 }
                 let job = inner.jobs_by_id.get_mut(job_id).expect("job exists");
                 let terminal_now = now_ts();
-                job.status = "stopped".to_string();
+                job.lifecycle = JobLifecycleState::Stopped;
                 observe_job_terminal(job, terminal_now);
                 job.ended_at = Some(terminal_now);
                 job.error = Some("job stopped before Runner picked it up".to_string());
@@ -1796,7 +1796,12 @@ impl RunnerRegistry {
                 notify_job_update(job);
                 Ok(job_view(job))
             }
-            "agent_queued" | "running" | "stop_requested" => {
+            JobLifecycleState::StopRequested => {
+                Ok(job_view(inner.jobs_by_id.get(job_id).expect("job exists")))
+            }
+            JobLifecycleState::RunnerQueued
+            | JobLifecycleState::StartedLegacy
+            | JobLifecycleState::Running => {
                 let stop_request_id = next_request_id();
                 let client_id = job.client_id.clone();
                 let request = RunnerRequest::from_operation(
@@ -1820,17 +1825,13 @@ impl RunnerRegistry {
                     Some(job_id.to_string()),
                 )?;
                 let job = inner.jobs_by_id.get_mut(job_id).expect("job exists");
-                job.status = "stop_requested".to_string();
+                job.lifecycle = JobLifecycleState::StopRequested;
                 job.error = Some("stop requested".to_string());
                 notify_job_update(job);
                 let notify_runner_id = job.client_id.clone();
                 notify_runner_locked(&inner, &notify_runner_id);
                 Ok(job_view(inner.jobs_by_id.get(job_id).expect("job exists")))
             }
-            "recovering" => Err(
-                "runner_unavailable_recovering: wait for same-instance job reconciliation before retrying stop_job"
-                    .to_string(),
-            ),
             _ => Ok(job_view(inner.jobs_by_id.get(job_id).expect("job exists"))),
         }
     }
@@ -1905,19 +1906,29 @@ impl RunnerRegistry {
                     .to_string(),
             );
         }
+        let incoming_lifecycle = parse_job_lifecycle(incoming_status).map_err(|_| {
+            if sequenced {
+                format!(
+                    "job_state_reconciliation update status '{}' is invalid",
+                    incoming_status
+                )
+            } else {
+                format!("job update status '{}' is invalid", incoming_status)
+            }
+        })?;
         if sequenced
             && !matches!(
-                incoming_status,
-                "agent_queued"
-                    | "running"
-                    | "stop_requested"
-                    | "completed"
-                    | "failed"
-                    | "stopped"
-                    | "timeout"
-                    | "timed_out"
-                    | "cancelled"
-                    | "lost"
+                incoming_lifecycle,
+                JobLifecycleState::RunnerQueued
+                    | JobLifecycleState::Running
+                    | JobLifecycleState::StopRequested
+                    | JobLifecycleState::Completed
+                    | JobLifecycleState::Failed
+                    | JobLifecycleState::Stopped
+                    | JobLifecycleState::Timeout
+                    | JobLifecycleState::TimedOut
+                    | JobLifecycleState::Cancelled
+                    | JobLifecycleState::Lost
             )
         {
             return Err(format!(
@@ -1925,13 +1936,13 @@ impl RunnerRegistry {
                 incoming_status
             ));
         }
-        if sequenced && body.finished != is_final_job_status(incoming_status) {
+        if sequenced && body.finished != incoming_lifecycle.is_terminal() {
             return Err(
                 "job_state_reconciliation update has inconsistent finished/status".to_string(),
             );
         }
         if sequenced
-            && !is_final_job_status(incoming_status)
+            && !incoming_lifecycle.is_terminal()
             && (body.exit_code.is_some() || body.duration_ms.is_some())
         {
             return Err(
@@ -1939,7 +1950,10 @@ impl RunnerRegistry {
                     .to_string(),
             );
         }
-        if sequenced && incoming_status == "completed" && body.exit_code != Some(0) {
+        if sequenced
+            && incoming_lifecycle == JobLifecycleState::Completed
+            && body.exit_code != Some(0)
+        {
             return Err(
                 "completed job_state_reconciliation update requires exit_code=0".to_string(),
             );
@@ -1983,7 +1997,7 @@ impl RunnerRegistry {
                         .to_string(),
                 );
             }
-            if job.status == "recovering" && sequenced && body.log_snapshot.is_none() {
+            if job.recovery.recovering() && sequenced && body.log_snapshot.is_none() {
                 return Err(
                     "recovering job update requires an authoritative log_snapshot or register inventory"
                         .to_string(),
@@ -1993,7 +2007,7 @@ impl RunnerRegistry {
             if sequenced && incoming_seq.is_some_and(|sequence| sequence <= job.last_update_seq) {
                 return Ok(job_view(job));
             }
-            if is_final_job_status(&job.status) {
+            if job.lifecycle.is_terminal() {
                 // Terminal class is server-authoritative once accepted.
                 return Ok(job_view(job));
             }
@@ -2016,7 +2030,7 @@ impl RunnerRegistry {
                 .and_then(|_| validate_job_activity(job, &body))
             {
                 let terminal_now = now_ts();
-                job.status = "failed".to_string();
+                job.lifecycle = JobLifecycleState::Failed;
                 observe_job_terminal(job, terminal_now);
                 job.ended_at = Some(terminal_now);
                 job.exit_code = body.exit_code;
@@ -2032,7 +2046,7 @@ impl RunnerRegistry {
                 }
                 request_id_to_remove = job.request_id.clone();
             } else {
-                let was_recovering = job.status == "recovering";
+                let was_recovering = job.recovery.recovering();
                 if let Some(snapshot) = body.log_snapshot {
                     super::jobs::replace_log_from_snapshot(&mut job.stdout, &snapshot.stdout);
                     super::jobs::replace_log_from_snapshot(&mut job.stderr, &snapshot.stderr);
@@ -2051,22 +2065,28 @@ impl RunnerRegistry {
                 if job.started_at.is_none()
                     && body.command_execution_state != Some(ShellCommandExecutionState::NotStarted)
                     && matches!(
-                        incoming_status,
-                        "running" | "completed" | "failed" | "stopped" | "timeout"
+                        incoming_lifecycle,
+                        JobLifecycleState::Running
+                            | JobLifecycleState::Completed
+                            | JobLifecycleState::Failed
+                            | JobLifecycleState::Stopped
+                            | JobLifecycleState::Timeout
                     )
                 {
                     job.started_at = Some(now_ts());
                 }
-                if !incoming_status.is_empty() && !is_final_job_status(&job.status) {
-                    job.status = if incoming_status == "queued" && job.started_at.is_some() {
-                        "agent_queued".to_string()
+                if !job.lifecycle.is_terminal() {
+                    job.lifecycle = if incoming_lifecycle == JobLifecycleState::Queued
+                        && job.started_at.is_some()
+                    {
+                        JobLifecycleState::RunnerQueued
                     } else {
-                        incoming_status.to_string()
+                        incoming_lifecycle
                     };
                 }
-                if is_final_job_status(incoming_status) {
+                if incoming_lifecycle.is_terminal() {
                     let terminal_now = now_ts();
-                    job.status = incoming_status.to_string();
+                    job.lifecycle = incoming_lifecycle;
                     observe_job_terminal(job, terminal_now);
                     job.ended_at = Some(terminal_now);
                     job.exit_code = body.exit_code;
@@ -2074,19 +2094,23 @@ impl RunnerRegistry {
                     job.error = body.error;
                     job.command_execution_state = body.command_execution_state;
                     job.activity = None;
-                    job.recovery_state = job.reconciled_at.map(|_| "reconciled".to_string());
-                    job.recovering_since = None;
-                    job.recovery_original_status = None;
+                    if !was_recovering {
+                        job.recovery.phase = job
+                            .recovery
+                            .reconciled_at
+                            .map(|_| JobRecoveryPhase::Reconciled);
+                    }
+                    job.recovery.recovering_since = None;
                     request_id_to_remove = job.request_id.clone();
                 } else if body.error.is_some() {
                     job.error = body.error;
                 }
-                if body.finished && !is_final_job_status(&job.status) {
+                if body.finished && !job.lifecycle.is_terminal() {
                     let terminal_now = now_ts();
-                    job.status = if job.error.is_none() && job.exit_code == Some(0) {
-                        "completed".to_string()
+                    job.lifecycle = if job.error.is_none() && job.exit_code == Some(0) {
+                        JobLifecycleState::Completed
                     } else {
-                        "failed".to_string()
+                        JobLifecycleState::Failed
                     };
                     observe_job_terminal(job, terminal_now);
                     job.ended_at = Some(terminal_now);
@@ -2094,12 +2118,10 @@ impl RunnerRegistry {
                     request_id_to_remove = job.request_id.clone();
                 }
                 if was_recovering {
-                    job.recovery_state = Some("reconciled".to_string());
-                    job.reconciled_at = Some(now_ts());
-                    job.recovery_reason_code =
-                        Some("same_instance_update_reconciliation".to_string());
-                    job.recovering_since = None;
-                    job.recovery_original_status = None;
+                    job.recovery.phase = Some(JobRecoveryPhase::Reconciled);
+                    job.recovery.reconciled_at = Some(now_ts());
+                    job.recovery.reason = Some(JobRecoveryReason::SameInstanceUpdateReconciliation);
+                    job.recovery.recovering_since = None;
                 }
             }
             if let Some(sequence) = incoming_seq {
@@ -2108,8 +2130,8 @@ impl RunnerRegistry {
             if public_mutation_signature(job) != before {
                 notify_job_update(job);
             }
-            remove_cleanup_terminal = job.visibility == ShellJobVisibility::CleanupPending
-                && is_final_job_status(&job.status);
+            remove_cleanup_terminal =
+                job.visibility == ShellJobVisibility::CleanupPending && job.lifecycle.is_terminal();
             job_view(job)
         };
         if let Some(request_id) = request_id_to_remove {

--- a/crates/webcodex-runner-registry/src/jobs.rs
+++ b/crates/webcodex-runner-registry/src/jobs.rs
@@ -1,4 +1,7 @@
-use super::state::{RunnerRegistryInner, ShellJobLogState, ShellJobRecord};
+use super::state::{
+    JobLifecycleState, JobRecoveryPhase, JobRecoveryReason, RunnerRegistryInner, ShellJobLogState,
+    ShellJobRecord,
+};
 use super::{
     now_ts, RunnerFeature, MAX_OUTPUT_BYTES, MAX_QUEUED_REQUESTS_PER_RUNNER,
     RUNNER_ONLINE_WINDOW_SECS,
@@ -202,7 +205,7 @@ pub(super) fn job_view(job: &ShellJobRecord) -> ShellJobInfo {
         job.started_at
             .map(|started_at| job.ended_at.unwrap_or(now).saturating_sub(started_at) as u64)
     };
-    let result = if is_final_job_status(&job.status) {
+    let result = if job.lifecycle.is_terminal() {
         Some(RunnerJobResult {
             shell: Some(RunnerShellJobResult {
                 cwd: job.cwd.clone(),
@@ -228,7 +231,7 @@ pub(super) fn job_view(job: &ShellJobRecord) -> ShellJobInfo {
         purpose: job.purpose.clone(),
         shell: job.shell.clone(),
         command_preview: job.command_preview.clone(),
-        status: job.status.clone(),
+        status: job.public_status().to_string(),
         created_at: job.created_at,
         started_at: job.started_at,
         ended_at: job.ended_at,
@@ -243,17 +246,18 @@ pub(super) fn job_view(job: &ShellJobRecord) -> ShellJobInfo {
         validation_progress: job.validation_progress.clone(),
         activity: job.activity,
         validation: job.validation.clone(),
-        recovery_state: job.recovery_state.clone(),
-        recovered_after_server_restart: job.recovered_after_server_restart,
-        reconciled_at: job.reconciled_at,
-        recovery_reason_code: job.recovery_reason_code.clone(),
+        recovery_state: job.recovery.public_state().map(str::to_string),
+        recovered_after_server_restart: job.recovery.recovered_after_server_restart,
+        reconciled_at: job.recovery.reconciled_at,
+        recovery_reason_code: job.recovery.public_reason().map(str::to_string),
         // General lifecycle views do not project log bodies, so they retain a
         // cursor-less legacy token. `job_log_for_auth` replaces this with a
         // cursor-aware v2 token for its frozen returned log snapshot.
         observation_token: webcodex_core::job_observation::JobObservationToken::new_legacy(
             job.job_id.clone(),
-            job.observation_epoch.to_string(),
-            job.public_revision
+            job.observation.epoch.to_string(),
+            job.observation
+                .revision
                 .load(std::sync::atomic::Ordering::Relaxed),
         )
         .ok()
@@ -450,11 +454,12 @@ pub(super) fn select_log_lines(
     )
 }
 
+pub(super) fn parse_job_lifecycle(status: &str) -> Result<JobLifecycleState, String> {
+    JobLifecycleState::from_wire(status)
+}
+
 pub(super) fn is_final_job_status(status: &str) -> bool {
-    matches!(
-        status,
-        "completed" | "failed" | "stopped" | "timeout" | "timed_out" | "lost" | "cancelled"
-    )
+    JobLifecycleState::from_wire(status).is_ok_and(JobLifecycleState::is_terminal)
 }
 
 /// Record the first time this Server process observes a Job in a terminal
@@ -462,8 +467,8 @@ pub(super) fn is_final_job_status(status: &str) -> bool {
 /// the Runner-reported `ended_at` execution timestamp. Replays and duplicate
 /// terminal transitions are idempotent.
 pub(super) fn observe_job_terminal(job: &mut ShellJobRecord, now: i64) {
-    if is_final_job_status(&job.status) && job.terminal_observed_at.is_none() {
-        job.terminal_observed_at = Some(now);
+    if job.lifecycle.is_terminal() && job.observation.terminal_observed_at.is_none() {
+        job.observation.terminal_observed_at = Some(now);
     }
 }
 
@@ -475,40 +480,38 @@ pub(super) fn observe_job_terminal(job: &mut ShellJobRecord, now: i64) {
 /// every wake, so spurious broadcasts are harmless.
 pub(super) fn notify_job_update(job: &ShellJobRecord) {
     use std::sync::atomic::Ordering;
-    job.public_revision.fetch_add(1, Ordering::Relaxed);
-    job.update_notify.notify_waiters();
+    job.observation.revision.fetch_add(1, Ordering::Relaxed);
+    job.observation.notify.notify_waiters();
 }
 
 pub(super) fn is_runner_active_job_status(status: &str) -> bool {
-    matches!(
-        status,
-        "agent_queued" | "running" | "stop_requested" | "recovering"
-    )
+    JobLifecycleState::from_wire(status).is_ok_and(JobLifecycleState::is_runner_active)
 }
 
-pub(super) fn begin_job_recovery(job: &mut ShellJobRecord, now: i64, reason_code: &str) {
-    if is_final_job_status(&job.status) || job.status == "queued" {
+pub(super) fn begin_job_recovery(job: &mut ShellJobRecord, now: i64, reason: JobRecoveryReason) {
+    if job.lifecycle.is_terminal() || job.lifecycle == JobLifecycleState::Queued {
         return;
     }
-    if job.status != "recovering" {
-        job.recovery_original_status = Some(job.status.clone());
-        job.status = "recovering".to_string();
-        job.recovering_since = Some(now);
+    if !job.recovery.recovering() {
+        job.recovery.recovering_since = Some(now);
     }
-    job.recovery_state = Some("recovering".to_string());
-    job.recovery_reason_code = Some(reason_code.to_string());
+    job.recovery.phase = Some(JobRecoveryPhase::Recovering);
+    job.recovery.reason = Some(reason);
     job.ended_at = None;
-    // Once the Runner connection is lost, the previous activity may be stale.
-    // Reconciliation restores current activity from authoritative inventory.
     job.activity = None;
     notify_job_update(job);
 }
 
-pub(super) fn mark_job_lost(job: &mut ShellJobRecord, now: i64, reason_code: &str, message: &str) {
-    if is_final_job_status(&job.status) {
+pub(super) fn mark_job_lost(
+    job: &mut ShellJobRecord,
+    now: i64,
+    reason: JobRecoveryReason,
+    message: &str,
+) {
+    if job.lifecycle.is_terminal() {
         return;
     }
-    job.status = "lost".to_string();
+    job.lifecycle = JobLifecycleState::Lost;
     job.activity = None;
     observe_job_terminal(job, now);
     if job.ended_at.is_none() {
@@ -522,16 +525,11 @@ pub(super) fn mark_job_lost(job: &mut ShellJobRecord, now: i64, reason_code: &st
             ShellCommandExecutionState::NotStarted
         });
     }
-    job.recovery_state = matches!(
-        reason_code,
-        "runner_inventory_missing"
-            | "runner_instance_replaced"
-            | "runner_recovery_deadline_exceeded"
-    )
-    .then(|| "lost_after_reconcile".to_string());
-    job.recovery_reason_code = Some(reason_code.to_string());
-    job.recovering_since = None;
-    job.recovery_original_status = None;
+    job.recovery.phase = reason
+        .implies_lost_after_reconcile()
+        .then_some(JobRecoveryPhase::LostAfterReconcile);
+    job.recovery.reason = Some(reason);
+    job.recovery.recovering_since = None;
     notify_job_update(job);
 }
 
@@ -618,11 +616,11 @@ pub(super) fn refresh_job_status_locked(inner: &mut RunnerRegistryInner, job_id:
     let Some(job) = inner.jobs_by_id.get(job_id) else {
         return;
     };
-    if is_final_job_status(&job.status) || !is_runner_active_job_status(&job.status) {
+    if job.lifecycle.is_terminal() || !job.lifecycle.is_runner_active() {
         return;
     }
-    if job.status == "recovering" {
-        let expired = job.recovering_since.is_some_and(|since| {
+    if job.recovery.recovering() {
+        let expired = job.recovery.recovering_since.is_some_and(|since| {
             now_ts().saturating_sub(since) >= super::job_recovery_grace_secs()
         });
         if expired {
@@ -630,7 +628,7 @@ pub(super) fn refresh_job_status_locked(inner: &mut RunnerRegistryInner, job_id:
                 mark_job_lost(
                     job,
                     now_ts(),
-                    "runner_recovery_deadline_exceeded",
+                    JobRecoveryReason::RunnerRecoveryDeadlineExceeded,
                     "runner did not reconcile the job before the recovery deadline",
                 );
             }
@@ -648,12 +646,12 @@ pub(super) fn refresh_job_status_locked(inner: &mut RunnerRegistryInner, job_id:
     });
     if let Some(job) = inner.jobs_by_id.get_mut(job_id) {
         if recoverable {
-            begin_job_recovery(job, now_ts(), "runner_transport_stale");
+            begin_job_recovery(job, now_ts(), JobRecoveryReason::RunnerTransportStale);
         } else {
             mark_job_lost(
                 job,
                 now_ts(),
-                "runner_disconnected_without_reconciliation",
+                JobRecoveryReason::RunnerDisconnectedWithoutReconciliation,
                 "runner went stale while job was running",
             );
         }

--- a/crates/webcodex-runner-registry/src/jobs.rs
+++ b/crates/webcodex-runner-registry/src/jobs.rs
@@ -619,7 +619,7 @@ pub(super) fn refresh_job_status_locked(inner: &mut RunnerRegistryInner, job_id:
     if job.lifecycle.is_terminal() || !job.lifecycle.is_runner_active() {
         return;
     }
-    if job.recovery.recovering() {
+    if job.recovery_active() {
         let expired = job.recovery.recovering_since.is_some_and(|since| {
             now_ts().saturating_sub(since) >= super::job_recovery_grace_secs()
         });

--- a/crates/webcodex-runner-registry/src/polling.rs
+++ b/crates/webcodex-runner-registry/src/polling.rs
@@ -3,6 +3,7 @@ use super::jobs::{
     truncate_output, truncate_output_to,
 };
 use super::requests::{remove_pending_request_locked, take_pending_request_locked};
+use super::state::JobLifecycleState;
 use super::validation::{validate_id, validate_runner_instance_id};
 use super::{now_ts, RunnerFeature, RunnerRegistry};
 use webcodex_core::coding_agent::{
@@ -586,8 +587,8 @@ impl RunnerRegistry {
             }
             if let Some(job_id) = job_id {
                 if let Some(job) = inner.jobs_by_id.get_mut(&job_id) {
-                    if job.status == "queued" {
-                        job.status = "agent_queued".to_string();
+                    if job.lifecycle == JobLifecycleState::Queued {
+                        job.lifecycle = JobLifecycleState::RunnerQueued;
                         // Dispatch proves only that the Runner accepted the
                         // Job request. A typed structured Job becomes started
                         // only when the Runner reports `running` after a
@@ -824,10 +825,10 @@ impl RunnerRegistry {
             inner.request_to_job.remove(&request_id);
             if let Some(job) = inner.jobs_by_id.get_mut(job_id) {
                 let terminal_now = now_ts();
-                job.status = if success {
-                    "completed".to_string()
+                job.lifecycle = if success {
+                    JobLifecycleState::Completed
                 } else {
-                    "failed".to_string()
+                    JobLifecycleState::Failed
                 };
                 observe_job_terminal(job, terminal_now);
                 job.ended_at = Some(terminal_now);

--- a/crates/webcodex-runner-registry/src/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/reconciliation.rs
@@ -1,8 +1,12 @@
 use super::jobs::{
     command_preview, is_final_job_status, is_runner_active_job_status, mark_job_lost,
-    notify_job_update, observe_job_terminal, replace_log_from_snapshot, COMMAND_PREVIEW_MAX_CHARS,
+    notify_job_update, observe_job_terminal, parse_job_lifecycle, replace_log_from_snapshot,
+    COMMAND_PREVIEW_MAX_CHARS,
 };
-use super::state::{RunnerRegistryInner, ShellJobLogState, ShellJobRecord, ShellJobVisibility};
+use super::state::{
+    JobLifecycleState, JobObservationState, JobRecoveryPhase, JobRecoveryReason, JobRecoveryState,
+    RunnerRegistryInner, ShellJobLogState, ShellJobRecord, ShellJobVisibility,
+};
 use super::validation::validate_id;
 use super::{job_recovery_grace_secs, RunnerRegistry};
 use crate::RunnerAccessGroup;
@@ -176,11 +180,15 @@ fn validate_snapshot(
     if snapshot.update_seq == 0 {
         return Err("job inventory update_seq must be greater than zero".to_string());
     }
+    let lifecycle = parse_job_lifecycle(&snapshot.status)
+        .map_err(|_| format!("job inventory status '{}' is invalid", snapshot.status))?;
     let active = matches!(
-        snapshot.status.as_str(),
-        "agent_queued" | "running" | "stop_requested"
+        lifecycle,
+        JobLifecycleState::RunnerQueued
+            | JobLifecycleState::Running
+            | JobLifecycleState::StopRequested
     );
-    let terminal = is_final_job_status(&snapshot.status);
+    let terminal = lifecycle.is_terminal();
     if !active && !terminal {
         return Err(format!(
             "job inventory status '{}' is invalid",
@@ -208,11 +216,13 @@ fn validate_snapshot(
     if terminal && snapshot.ended_at.is_none() {
         return Err("terminal job inventory snapshot requires ended_at".to_string());
     }
-    if snapshot.status == "completed" && snapshot.exit_code != Some(0) {
+    if lifecycle == JobLifecycleState::Completed && snapshot.exit_code != Some(0) {
         return Err("completed job inventory snapshot requires exit_code=0".to_string());
     }
-    if matches!(snapshot.status.as_str(), "running" | "stop_requested")
-        && snapshot.started_at.is_none()
+    if matches!(
+        lifecycle,
+        JobLifecycleState::Running | JobLifecycleState::StopRequested
+    ) && snapshot.started_at.is_none()
     {
         return Err("running job inventory snapshot requires started_at".to_string());
     }
@@ -242,19 +252,31 @@ fn validate_snapshot(
             ShellCommandExecutionState::NotStarted => {
                 snapshot.started_at.is_none()
                     && matches!(
-                        snapshot.status.as_str(),
-                        "failed" | "stopped" | "cancelled" | "lost"
+                        lifecycle,
+                        JobLifecycleState::Failed
+                            | JobLifecycleState::Stopped
+                            | JobLifecycleState::Cancelled
+                            | JobLifecycleState::Lost
                     )
             }
             ShellCommandExecutionState::OutcomeUnknown => {
-                matches!(snapshot.status.as_str(), "failed" | "lost")
+                matches!(
+                    lifecycle,
+                    JobLifecycleState::Failed | JobLifecycleState::Lost
+                )
             }
             ShellCommandExecutionState::TimedOut => {
-                matches!(snapshot.status.as_str(), "timeout" | "timed_out")
+                matches!(
+                    lifecycle,
+                    JobLifecycleState::Timeout | JobLifecycleState::TimedOut
+                )
             }
             ShellCommandExecutionState::Completed => matches!(
-                snapshot.status.as_str(),
-                "completed" | "failed" | "stopped" | "cancelled"
+                lifecycle,
+                JobLifecycleState::Completed
+                    | JobLifecycleState::Failed
+                    | JobLifecycleState::Stopped
+                    | JobLifecycleState::Cancelled
             ),
         };
         if !consistent {
@@ -285,30 +307,34 @@ fn validate_snapshot(
     if !snapshot.context.validation_steps.is_empty() {
         let steps = &snapshot.context.validation_steps;
         let progress = snapshot.validation_progress.as_ref();
-        let structurally_valid = match snapshot.status.as_str() {
-            "agent_queued" => progress.is_none(),
-            "running" | "stop_requested" => progress.is_some_and(|progress| {
-                progress.completed < steps.len()
-                    && progress.current_step.as_ref() == steps.get(progress.completed)
-                    && progress.failed_step.is_none()
-            }),
-            "completed" => progress.is_some_and(|progress| {
+        let structurally_valid = match lifecycle {
+            JobLifecycleState::RunnerQueued => progress.is_none(),
+            JobLifecycleState::Running | JobLifecycleState::StopRequested => {
+                progress.is_some_and(|progress| {
+                    progress.completed < steps.len()
+                        && progress.current_step.as_ref() == steps.get(progress.completed)
+                        && progress.failed_step.is_none()
+                })
+            }
+            JobLifecycleState::Completed => progress.is_some_and(|progress| {
                 progress.completed == steps.len()
                     && progress.current_step.is_none()
                     && progress.failed_step.is_none()
             }),
-            "failed" => progress.is_none_or(|progress| {
+            JobLifecycleState::Failed => progress.is_none_or(|progress| {
                 progress.current_step.is_none()
                     && progress.failed_step.as_ref().is_none_or(|failed| {
                         progress.completed < steps.len()
                             && steps.get(progress.completed) == Some(failed)
                     })
             }),
-            "stopped" | "timeout" | "timed_out" | "cancelled" | "lost" => {
-                progress.is_none_or(|progress| {
-                    progress.current_step.is_none() && progress.failed_step.is_none()
-                })
-            }
+            JobLifecycleState::Stopped
+            | JobLifecycleState::Timeout
+            | JobLifecycleState::TimedOut
+            | JobLifecycleState::Cancelled
+            | JobLifecycleState::Lost => progress.is_none_or(|progress| {
+                progress.current_step.is_none() && progress.failed_step.is_none()
+            }),
             _ => false,
         };
         if !structurally_valid {
@@ -317,7 +343,10 @@ fn validate_snapshot(
     }
     if let Some(activity) = snapshot.activity {
         if !activity.is_canonical()
-            || !matches!(snapshot.status.as_str(), "running" | "stop_requested")
+            || !matches!(
+                lifecycle,
+                JobLifecycleState::Running | JobLifecycleState::StopRequested
+            )
         {
             return Err("job inventory activity is invalid for status".to_string());
         }
@@ -535,7 +564,7 @@ pub(super) fn preflight_inventory_locked(
             ));
         }
         if detached_instance_transfer
-            && !is_final_job_status(&existing.status)
+            && !existing.lifecycle.is_terminal()
             && snapshot.update_seq < existing.last_update_seq
         {
             return Err(format!(
@@ -544,8 +573,8 @@ pub(super) fn preflight_inventory_locked(
             ));
         }
         let would_apply = snapshot.update_seq > existing.last_update_seq
-            || (snapshot.update_seq == existing.last_update_seq && existing.status == "recovering");
-        if !is_final_job_status(&existing.status) && would_apply {
+            || (snapshot.update_seq == existing.last_update_seq && existing.recovery.recovering());
+        if !existing.lifecycle.is_terminal() && would_apply {
             let existing_progress = existing
                 .validation_progress
                 .as_ref()
@@ -645,11 +674,11 @@ fn record_from_snapshot(
         // Runner inventory. Same-key retries after Server restart recover this
         // logical Job instead of guessing that a resent body matches.
         detached_idempotency_intent: None,
-        status: snapshot.status.clone(),
+        lifecycle: JobLifecycleState::from_wire(&snapshot.status)
+            .expect("validated job inventory lifecycle"),
         created_at: snapshot.created_at,
         started_at: snapshot.started_at,
         ended_at: snapshot.ended_at,
-        terminal_observed_at: None,
         exit_code: snapshot.exit_code,
         duration_ms: snapshot.duration_ms,
         stdout: ShellJobLogState::default(),
@@ -664,15 +693,14 @@ fn record_from_snapshot(
         activity: snapshot.activity,
         visibility: super::state::ShellJobVisibility::Public,
         last_update_seq: snapshot.update_seq,
-        recovery_state: Some("reconciled".to_string()),
-        recovered_after_server_restart: true,
-        reconciled_at: Some(now),
-        recovery_reason_code: Some("server_restart_reconciliation".to_string()),
-        recovering_since: None,
-        recovery_original_status: None,
-        observation_epoch,
-        public_revision: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-        update_notify: std::sync::Arc::new(tokio::sync::Notify::new()),
+        recovery: JobRecoveryState {
+            phase: Some(JobRecoveryPhase::Reconciled),
+            recovered_after_server_restart: true,
+            reconciled_at: Some(now),
+            reason: Some(JobRecoveryReason::ServerRestartReconciliation),
+            recovering_since: None,
+        },
+        observation: JobObservationState::new(observation_epoch),
     };
     observe_job_terminal(&mut record, now);
     record
@@ -682,9 +710,10 @@ fn apply_snapshot(
     job: &mut ShellJobRecord,
     snapshot: &ShellJobSnapshot,
     now: i64,
-    recovery_reason_code: &str,
+    recovery_reason: JobRecoveryReason,
 ) {
-    job.status = snapshot.status.clone();
+    job.lifecycle =
+        JobLifecycleState::from_wire(&snapshot.status).expect("validated job inventory lifecycle");
     observe_job_terminal(job, now);
     job.started_at = snapshot.started_at;
     job.ended_at = snapshot.ended_at;
@@ -699,11 +728,10 @@ fn apply_snapshot(
     replace_log_from_snapshot(&mut job.stdout, &snapshot.stdout);
     replace_log_from_snapshot(&mut job.stderr, &snapshot.stderr);
     job.last_update_seq = snapshot.update_seq;
-    job.recovery_state = Some("reconciled".to_string());
-    job.reconciled_at = Some(now);
-    job.recovery_reason_code = Some(recovery_reason_code.to_string());
-    job.recovering_since = None;
-    job.recovery_original_status = None;
+    job.recovery.phase = Some(JobRecoveryPhase::Reconciled);
+    job.recovery.reconciled_at = Some(now);
+    job.recovery.reason = Some(recovery_reason);
+    job.recovery.recovering_since = None;
     notify_job_update(job);
 }
 
@@ -712,7 +740,7 @@ fn remove_cleanup_terminal_jobs_locked(inner: &mut RunnerRegistryInner) {
         .jobs_by_id
         .iter()
         .filter(|(_, job)| {
-            job.visibility == ShellJobVisibility::CleanupPending && is_final_job_status(&job.status)
+            job.visibility == ShellJobVisibility::CleanupPending && job.lifecycle.is_terminal()
         })
         .map(|(job_id, _)| job_id.clone())
         .collect::<Vec<_>>();
@@ -745,11 +773,10 @@ impl RunnerRegistry {
             .jobs_by_id
             .iter()
             .filter_map(|(job_id, job)| {
-                if job.visibility != ShellJobVisibility::Public || !is_final_job_status(&job.status)
-                {
+                if job.visibility != ShellJobVisibility::Public || !job.lifecycle.is_terminal() {
                     return None;
                 }
-                match job.terminal_observed_at {
+                match job.observation.terminal_observed_at {
                     None => Some(TerminalSweepAction::Observe(job_id.clone())),
                     Some(observed_at)
                         if now.saturating_sub(observed_at) >= JOB_TERMINAL_RETENTION_SECS =>
@@ -841,7 +868,7 @@ pub(super) fn expire_recovering_jobs_locked(
         .jobs_by_id
         .iter()
         .filter_map(|(job_id, job)| {
-            if job.status != "recovering" {
+            if !job.recovery.recovering() {
                 return None;
             }
             if let Some(client_id) = client_filter {
@@ -850,6 +877,7 @@ pub(super) fn expire_recovering_jobs_locked(
                 }
             }
             let expired = job
+                .recovery
                 .recovering_since
                 .is_some_and(|since| now.saturating_sub(since) >= grace);
             expired.then(|| {
@@ -879,11 +907,11 @@ pub(super) fn expire_recovering_jobs_locked(
             // interleave (we hold the mutex for the whole call), but the filter
             // above ran on borrowed references; defend against the job having
             // already left `recovering` by any path.
-            if job.status == "recovering" {
+            if job.recovery.recovering() {
                 mark_job_lost(
                     job,
                     now,
-                    "runner_recovery_deadline_exceeded",
+                    JobRecoveryReason::RunnerRecoveryDeadlineExceeded,
                     "runner did not reconcile the job before the recovery deadline",
                 );
             }
@@ -963,7 +991,7 @@ pub(super) fn reconcile_inventory_locked(
         .filter(|(job_id, job)| {
             job.client_id == client_id
                 && job.runner_instance_id == runner_instance_id
-                && is_runner_active_job_status(&job.status)
+                && job.lifecycle.is_runner_active()
                 && !inventory_ids.contains(job_id.as_str())
         })
         .map(|(job_id, job)| (job_id.clone(), job.request_id.clone()))
@@ -978,7 +1006,7 @@ pub(super) fn reconcile_inventory_locked(
             mark_job_lost(
                 job,
                 now,
-                "runner_inventory_missing",
+                JobRecoveryReason::RunnerInventoryMissing,
                 "runner complete active inventory did not contain this job",
             );
         }
@@ -998,7 +1026,7 @@ pub(super) fn reconcile_inventory_locked(
                 )
             });
         if let Some(existing) = inner.jobs_by_id.get_mut(&snapshot.job_id) {
-            if is_final_job_status(&existing.status) {
+            if existing.lifecycle.is_terminal() {
                 // A server-authoritative terminal state (deadline, replacement,
                 // or a previously accepted terminal result) never revives or
                 // changes terminal class.
@@ -1010,7 +1038,7 @@ pub(super) fn reconcile_inventory_locked(
                 continue;
             }
             if snapshot.update_seq == existing.last_update_seq
-                && existing.status != "recovering"
+                && !existing.recovery.recovering()
                 && !detached_instance_transfer
             {
                 continue;
@@ -1018,12 +1046,12 @@ pub(super) fn reconcile_inventory_locked(
             if detached_instance_transfer {
                 existing.runner_instance_id = runner_instance_id.to_string();
             }
-            let recovery_reason_code = if detached_instance_transfer {
-                "detached_instance_transfer"
+            let recovery_reason = if detached_instance_transfer {
+                JobRecoveryReason::DetachedInstanceTransfer
             } else {
-                "same_instance_reconciliation"
+                JobRecoveryReason::SameInstanceReconciliation
             };
-            apply_snapshot(existing, snapshot, now, recovery_reason_code);
+            apply_snapshot(existing, snapshot, now, recovery_reason);
             summary.updated += 1;
         } else if suppress_unknown_terminal {
             summary.suppressed_terminal += 1;
@@ -1070,7 +1098,7 @@ pub(super) fn terminate_instance_jobs_locked(
             });
             job.client_id == client_id
                 && job.runner_instance_id == runner_instance_id
-                && (job.status == "queued" || is_runner_active_job_status(&job.status))
+                && (job.lifecycle == JobLifecycleState::Queued || job.lifecycle.is_runner_active())
                 && !detached_instance_transfer
         })
         .map(|(job_id, job)| (job_id.clone(), job.request_id.clone()))
@@ -1084,7 +1112,7 @@ pub(super) fn terminate_instance_jobs_locked(
             mark_job_lost(
                 job,
                 now,
-                "runner_instance_replaced",
+                JobRecoveryReason::RunnerInstanceReplaced,
                 "runner instance was replaced before the job completed or reconciled",
             );
         }

--- a/crates/webcodex-runner-registry/src/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/reconciliation.rs
@@ -573,7 +573,7 @@ pub(super) fn preflight_inventory_locked(
             ));
         }
         let would_apply = snapshot.update_seq > existing.last_update_seq
-            || (snapshot.update_seq == existing.last_update_seq && existing.recovery.recovering());
+            || (snapshot.update_seq == existing.last_update_seq && existing.recovery_active());
         if !existing.lifecycle.is_terminal() && would_apply {
             let existing_progress = existing
                 .validation_progress
@@ -868,7 +868,7 @@ pub(super) fn expire_recovering_jobs_locked(
         .jobs_by_id
         .iter()
         .filter_map(|(job_id, job)| {
-            if !job.recovery.recovering() {
+            if !job.recovery_active() {
                 return None;
             }
             if let Some(client_id) = client_filter {
@@ -907,7 +907,7 @@ pub(super) fn expire_recovering_jobs_locked(
             // interleave (we hold the mutex for the whole call), but the filter
             // above ran on borrowed references; defend against the job having
             // already left `recovering` by any path.
-            if job.recovery.recovering() {
+            if job.recovery_active() {
                 mark_job_lost(
                     job,
                     now,
@@ -1038,7 +1038,7 @@ pub(super) fn reconcile_inventory_locked(
                 continue;
             }
             if snapshot.update_seq == existing.last_update_seq
-                && !existing.recovery.recovering()
+                && !existing.recovery_active()
                 && !detached_instance_transfer
             {
                 continue;

--- a/crates/webcodex-runner-registry/src/runners.rs
+++ b/crates/webcodex-runner-registry/src/runners.rs
@@ -1,5 +1,5 @@
 use super::access_control::{assert_runner_access, runner_visible_to_access};
-use super::jobs::{begin_job_recovery, is_final_job_status, mark_job_lost, offline_last_seen};
+use super::jobs::{begin_job_recovery, mark_job_lost, offline_last_seen};
 use super::project_inventory::{
     expire_staging, pending_inventory_state, preserve_authoritative_pending,
 };
@@ -8,7 +8,10 @@ use super::reconciliation::{
     validate_job_inventory_without_project_membership,
 };
 use super::requests::resolve_disconnected_sync_requests_locked;
-use super::state::{NotifierEntry, RunnerRecord, RunnerRegistryInner, RunnerSemanticView};
+use super::state::{
+    JobLifecycleState, JobRecoveryReason, NotifierEntry, RunnerRecord, RunnerRegistryInner,
+    RunnerSemanticView,
+};
 use super::validation::{
     normalize_tool_providers, trim_string, validate_id, validate_optional_field,
     validate_runner_instance_id,
@@ -836,7 +839,7 @@ impl RunnerRegistry {
                 mark_job_lost(
                     job,
                     now,
-                    "shared_key_runner_expired",
+                    JobRecoveryReason::SharedKeyRunnerExpired,
                     "shared-key runner registration expired after being offline",
                 );
             }
@@ -1017,11 +1020,9 @@ impl RunnerRegistry {
                 if job.client_id != client_id {
                     return None;
                 }
-                if is_final_job_status(&job.status)
-                    || !matches!(
-                        job.status.as_str(),
-                        "queued" | "agent_queued" | "running" | "stop_requested"
-                    )
+                if job.lifecycle.is_terminal()
+                    || !(job.lifecycle == JobLifecycleState::Queued
+                        || job.lifecycle.is_runner_active())
                 {
                     return None;
                 }
@@ -1034,17 +1035,17 @@ impl RunnerRegistry {
                 .get(&job_id)
                 .and_then(|j| j.request_id.clone());
             if let Some(job) = inner.jobs_by_id.get_mut(&job_id) {
-                if recoverable && job.status != "queued" {
-                    begin_job_recovery(job, now, "runner_transport_disconnected");
+                if recoverable && job.lifecycle != JobLifecycleState::Queued {
+                    begin_job_recovery(job, now, JobRecoveryReason::RunnerTransportDisconnected);
                 } else {
-                    let (reason, message) = if job.status == "queued" {
+                    let (reason, message) = if job.lifecycle == JobLifecycleState::Queued {
                         (
-                            "runner_request_not_dispatched",
+                            JobRecoveryReason::RunnerRequestNotDispatched,
                             "Runner transport disconnected before the queued request was dispatched",
                         )
                     } else {
                         (
-                            "runner_disconnected_without_reconciliation",
+                            JobRecoveryReason::RunnerDisconnectedWithoutReconciliation,
                             "Runner transport disconnected without reconciliation support",
                         )
                     };

--- a/crates/webcodex-runner-registry/src/state.rs
+++ b/crates/webcodex-runner-registry/src/state.rs
@@ -266,6 +266,188 @@ pub enum ShellJobVisibility {
     CleanupPending,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum JobLifecycleState {
+    Queued,
+    RunnerQueued,
+    StartedLegacy,
+    Running,
+    StopRequested,
+    Completed,
+    Failed,
+    Stopped,
+    Timeout,
+    TimedOut,
+    Lost,
+    Cancelled,
+}
+
+impl JobLifecycleState {
+    pub(super) fn from_wire(status: &str) -> Result<Self, String> {
+        match status {
+            "queued" => Ok(Self::Queued),
+            "agent_queued" => Ok(Self::RunnerQueued),
+            "started" => Ok(Self::StartedLegacy),
+            "running" => Ok(Self::Running),
+            "stop_requested" => Ok(Self::StopRequested),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "stopped" => Ok(Self::Stopped),
+            "timeout" => Ok(Self::Timeout),
+            "timed_out" => Ok(Self::TimedOut),
+            "lost" => Ok(Self::Lost),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(format!("unknown Runner Job lifecycle status: {status}")),
+        }
+    }
+
+    pub(super) const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::RunnerQueued => "agent_queued",
+            Self::StartedLegacy => "started",
+            Self::Running => "running",
+            Self::StopRequested => "stop_requested",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Stopped => "stopped",
+            Self::Timeout => "timeout",
+            Self::TimedOut => "timed_out",
+            Self::Lost => "lost",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub(super) const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed
+                | Self::Failed
+                | Self::Stopped
+                | Self::Timeout
+                | Self::TimedOut
+                | Self::Lost
+                | Self::Cancelled
+        )
+    }
+
+    pub(super) const fn is_runner_active(self) -> bool {
+        matches!(
+            self,
+            Self::RunnerQueued | Self::StartedLegacy | Self::Running | Self::StopRequested
+        )
+    }
+
+    pub(super) const fn is_active(self) -> bool {
+        matches!(self, Self::Queued) || self.is_runner_active()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum JobRecoveryPhase {
+    Recovering,
+    Reconciled,
+    LostAfterReconcile,
+}
+
+impl JobRecoveryPhase {
+    pub(super) const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Recovering => "recovering",
+            Self::Reconciled => "reconciled",
+            Self::LostAfterReconcile => "lost_after_reconcile",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum JobRecoveryReason {
+    RunnerTransportDisconnected,
+    RunnerTransportStale,
+    RunnerRequestNotDispatched,
+    RunnerDisconnectedWithoutReconciliation,
+    SharedKeyRunnerExpired,
+    RunnerInventoryMissing,
+    RunnerInstanceReplaced,
+    RunnerRecoveryDeadlineExceeded,
+    ServerRestartReconciliation,
+    SameInstanceReconciliation,
+    SameInstanceUpdateReconciliation,
+    DetachedInstanceTransfer,
+}
+
+impl JobRecoveryReason {
+    pub(super) const fn as_wire(self) -> &'static str {
+        match self {
+            Self::RunnerTransportDisconnected => "runner_transport_disconnected",
+            Self::RunnerTransportStale => "runner_transport_stale",
+            Self::RunnerRequestNotDispatched => "runner_request_not_dispatched",
+            Self::RunnerDisconnectedWithoutReconciliation => {
+                "runner_disconnected_without_reconciliation"
+            }
+            Self::SharedKeyRunnerExpired => "shared_key_runner_expired",
+            Self::RunnerInventoryMissing => "runner_inventory_missing",
+            Self::RunnerInstanceReplaced => "runner_instance_replaced",
+            Self::RunnerRecoveryDeadlineExceeded => "runner_recovery_deadline_exceeded",
+            Self::ServerRestartReconciliation => "server_restart_reconciliation",
+            Self::SameInstanceReconciliation => "same_instance_reconciliation",
+            Self::SameInstanceUpdateReconciliation => "same_instance_update_reconciliation",
+            Self::DetachedInstanceTransfer => "detached_instance_transfer",
+        }
+    }
+
+    pub(super) const fn implies_lost_after_reconcile(self) -> bool {
+        matches!(
+            self,
+            Self::RunnerInventoryMissing
+                | Self::RunnerInstanceReplaced
+                | Self::RunnerRecoveryDeadlineExceeded
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct JobRecoveryState {
+    pub(super) phase: Option<JobRecoveryPhase>,
+    pub(super) recovered_after_server_restart: bool,
+    pub(super) reconciled_at: Option<i64>,
+    pub(super) reason: Option<JobRecoveryReason>,
+    pub(super) recovering_since: Option<i64>,
+}
+
+impl JobRecoveryState {
+    pub(super) fn recovering(&self) -> bool {
+        self.phase == Some(JobRecoveryPhase::Recovering)
+    }
+
+    pub(super) fn public_state(&self) -> Option<&'static str> {
+        self.phase.map(JobRecoveryPhase::as_wire)
+    }
+
+    pub(super) fn public_reason(&self) -> Option<&'static str> {
+        self.reason.map(JobRecoveryReason::as_wire)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct JobObservationState {
+    pub(super) epoch: Arc<str>,
+    pub(super) revision: Arc<AtomicU64>,
+    pub(super) notify: Arc<Notify>,
+    pub(super) terminal_observed_at: Option<i64>,
+}
+
+impl JobObservationState {
+    pub(super) fn new(epoch: Arc<str>) -> Self {
+        Self {
+            epoch,
+            revision: Arc::new(AtomicU64::new(0)),
+            notify: Arc::new(Notify::new()),
+            terminal_observed_at: None,
+        }
+    }
+}
+
 /// Server-process-local exact intent retained only to prove same-key detached
 /// replays. It is never serialized into Runner protocol, durable state, audit,
 /// or Session evidence; restart reconstruction deliberately restores `None`.
@@ -307,7 +489,7 @@ pub(super) struct ShellJobRecord {
     /// keep this `None`, forcing exact logical-Job recovery instead of guessing
     /// that a resent body matches after Server restart.
     pub(super) detached_idempotency_intent: Option<DetachedIdempotencyIntent>,
-    pub(super) status: String,
+    pub(super) lifecycle: JobLifecycleState,
     pub(super) created_at: i64,
     pub(super) started_at: Option<i64>,
     pub(super) ended_at: Option<i64>,
@@ -315,7 +497,6 @@ pub(super) struct ShellJobRecord {
     /// observed the Job in a terminal state. Runner-reported execution
     /// timestamps remain in `ended_at` for public results and diagnostics,
     /// but never control Server registry retention.
-    pub(super) terminal_observed_at: Option<i64>,
     pub(super) exit_code: Option<i32>,
     pub(super) duration_ms: Option<u64>,
     pub(super) stdout: ShellJobLogState,
@@ -332,28 +513,20 @@ pub(super) struct ShellJobRecord {
     pub(super) activity: Option<ShellJobActivity>,
     pub(super) visibility: ShellJobVisibility,
     pub(super) last_update_seq: u64,
-    pub(super) recovery_state: Option<String>,
-    pub(super) recovered_after_server_restart: bool,
-    pub(super) reconciled_at: Option<i64>,
-    pub(super) recovery_reason_code: Option<String>,
-    pub(super) recovering_since: Option<i64>,
-    pub(super) recovery_original_status: Option<String>,
-    /// Server-owned generation for the complete public Job snapshot. Unlike
-    /// `last_update_seq`, this also advances for accepted legacy/unsequenced
-    /// updates and server-side recovery/status changes. It is intentionally
-    /// process-local: waiters use it only while this record is alive, while the
-    /// Runner-owned sequence retains its protocol and restart semantics.
-    /// Process-local server epoch used to invalidate observation tokens after restart.
-    pub(super) observation_epoch: Arc<str>,
-    pub(super) public_revision: Arc<AtomicU64>,
-    /// Observer update notifier. Shared with every snapshot of the record and
-    /// notified (broadcast) whenever anything that changes the public Job
-    /// snapshot or `last_update_seq` happens: an accepted `agent:job_update`,
-    /// log/validation progress, terminal transitions, disconnect/recovery,
-    /// reconciliation, or a stop request that changed status. Bounded
-    /// `job_log`/`job_tail` waiters re-check the authoritative snapshot after
-    /// every wake, so spurious wakes are harmless. Never persisted.
-    pub(super) update_notify: Arc<Notify>,
+    pub(super) recovery: JobRecoveryState,
+    /// Process-local observation ownership. It can wake readers but never grants
+    /// execution authority or mutates lifecycle state.
+    pub(super) observation: JobObservationState,
+}
+
+impl ShellJobRecord {
+    pub(super) fn public_status(&self) -> &'static str {
+        if self.recovery.recovering() {
+            "recovering"
+        } else {
+            self.lifecycle.as_wire()
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/webcodex-runner-registry/src/state.rs
+++ b/crates/webcodex-runner-registry/src/state.rs
@@ -331,15 +331,19 @@ impl JobLifecycleState {
         )
     }
 
+    /// Runner-owned active execution states. `StartedLegacy` is deliberately
+    /// excluded: the historical public vocabulary treats it as broadly active,
+    /// but it never participated in Runner recovery, reconciliation, or stop
+    /// delivery semantics.
     pub(super) const fn is_runner_active(self) -> bool {
         matches!(
             self,
-            Self::RunnerQueued | Self::StartedLegacy | Self::Running | Self::StopRequested
+            Self::RunnerQueued | Self::Running | Self::StopRequested
         )
     }
 
     pub(super) const fn is_active(self) -> bool {
-        matches!(self, Self::Queued) || self.is_runner_active()
+        matches!(self, Self::Queued | Self::StartedLegacy) || self.is_runner_active()
     }
 }
 
@@ -434,6 +438,9 @@ pub(super) struct JobObservationState {
     pub(super) epoch: Arc<str>,
     pub(super) revision: Arc<AtomicU64>,
     pub(super) notify: Arc<Notify>,
+    /// First time this Server process observed the Job in a terminal execution
+    /// lifecycle. Runner-reported `ended_at` remains the public execution time
+    /// and never controls Server registry retention.
     pub(super) terminal_observed_at: Option<i64>,
 }
 
@@ -493,10 +500,6 @@ pub(super) struct ShellJobRecord {
     pub(super) created_at: i64,
     pub(super) started_at: Option<i64>,
     pub(super) ended_at: Option<i64>,
-    /// Server-process-local lifecycle clock: the first time this Server
-    /// observed the Job in a terminal state. Runner-reported execution
-    /// timestamps remain in `ended_at` for public results and diagnostics,
-    /// but never control Server registry retention.
     pub(super) exit_code: Option<i32>,
     pub(super) duration_ms: Option<u64>,
     pub(super) stdout: ShellJobLogState,
@@ -520,8 +523,16 @@ pub(super) struct ShellJobRecord {
 }
 
 impl ShellJobRecord {
+    /// Recovery is an orthogonal provenance/availability dimension, but it only
+    /// controls active-Job behavior while the underlying execution lifecycle is
+    /// still Runner-owned. A terminal lifecycle remains authoritative even when
+    /// compatibility recovery metadata from the preceding disconnect is retained.
+    pub(super) fn recovery_active(&self) -> bool {
+        self.lifecycle.is_runner_active() && self.recovery.recovering()
+    }
+
     pub(super) fn public_status(&self) -> &'static str {
-        if self.recovery.recovering() {
+        if self.recovery_active() {
             "recovering"
         } else {
             self.lifecycle.as_wire()

--- a/crates/webcodex-runner-registry/src/tests/connection_lease.rs
+++ b/crates/webcodex-runner-registry/src/tests/connection_lease.rs
@@ -266,7 +266,7 @@ async fn stale_connection_poll_cannot_steal_new_request() {
             "stale poll must not mark request dispatched"
         );
         assert_eq!(
-            inner.jobs_by_id.get(&job.job_id).unwrap().status,
+            inner.jobs_by_id.get(&job.job_id).unwrap().public_status(),
             "queued",
             "stale poll must not transition the job"
         );

--- a/crates/webcodex-runner-registry/src/tests/instance_lease.rs
+++ b/crates/webcodex-runner-registry/src/tests/instance_lease.rs
@@ -642,7 +642,7 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
         crate::runner_protocol::ShellJobSnapshot {
             job_id: record.job_id.clone(),
             request_id: record.request_id.clone().unwrap(),
-            status: record.status.clone(),
+            status: record.public_status().to_string(),
             update_seq: record.last_update_seq,
             created_at: record.created_at,
             started_at: record.started_at,
@@ -703,10 +703,10 @@ async fn lease_replacement_transfers_exact_detached_inventory_to_new_instance() 
         let inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
         assert_eq!(record.runner_instance_id, "inst-b");
-        assert_eq!(record.status, "running");
+        assert_eq!(record.public_status(), "running");
         assert_eq!(record.last_update_seq, snapshot.update_seq);
         assert_eq!(
-            record.recovery_reason_code.as_deref(),
+            record.recovery.public_reason(),
             Some("detached_instance_transfer")
         );
     }

--- a/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
@@ -1,5 +1,39 @@
 use super::*;
 
+#[test]
+fn typed_job_lifecycle_preserves_exact_wire_contract_and_rejects_unknown() {
+    use crate::state::JobLifecycleState;
+
+    let cases = [
+        ("queued", JobLifecycleState::Queued, false, false),
+        ("agent_queued", JobLifecycleState::RunnerQueued, false, true),
+        ("started", JobLifecycleState::StartedLegacy, false, true),
+        ("running", JobLifecycleState::Running, false, true),
+        (
+            "stop_requested",
+            JobLifecycleState::StopRequested,
+            false,
+            true,
+        ),
+        ("completed", JobLifecycleState::Completed, true, false),
+        ("failed", JobLifecycleState::Failed, true, false),
+        ("stopped", JobLifecycleState::Stopped, true, false),
+        ("timeout", JobLifecycleState::Timeout, true, false),
+        ("timed_out", JobLifecycleState::TimedOut, true, false),
+        ("lost", JobLifecycleState::Lost, true, false),
+        ("cancelled", JobLifecycleState::Cancelled, true, false),
+    ];
+    for (wire, expected, terminal, runner_active) in cases {
+        let parsed = JobLifecycleState::from_wire(wire).unwrap();
+        assert_eq!(parsed, expected);
+        assert_eq!(parsed.as_wire(), wire);
+        assert_eq!(parsed.is_terminal(), terminal);
+        assert_eq!(parsed.is_runner_active(), runner_active);
+    }
+    assert!(JobLifecycleState::from_wire("recovering").is_err());
+    assert!(JobLifecycleState::from_wire("mystery").is_err());
+}
+
 #[tokio::test]
 async fn terminal_observed_poll_complete_and_log() {
     let registry = RunnerRegistry::default();
@@ -89,8 +123,8 @@ async fn terminal_observed_poll_complete_and_log() {
     {
         let inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
-        assert!(record.terminal_observed_at.is_some());
-        assert_eq!(record.terminal_observed_at, record.ended_at);
+        assert!(record.observation.terminal_observed_at.is_some());
+        assert_eq!(record.observation.terminal_observed_at, record.ended_at);
     }
     assert_eq!(
         done.codex
@@ -193,6 +227,16 @@ async fn job_update_rejects_mismatched_request_id_without_mutating_target_job() 
         "queued"
     );
 
+    let mut invalid = update(request_b.clone());
+    invalid.status = "mystery".to_string();
+    let error = registry.update_job(invalid).await.unwrap_err();
+    assert!(error.contains("job update status 'mystery' is invalid"));
+    assert_eq!(
+        registry.get_job(&job_b.job_id).await.unwrap().status,
+        "queued",
+        "unknown legacy wire status must fail closed without mutating the job"
+    );
+
     let accepted = registry.update_job(update(request_b)).await.unwrap();
     assert_eq!(accepted.status, "running");
 }
@@ -247,8 +291,8 @@ async fn terminal_observed_queued_stop_records_server_time() {
     {
         let inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
-        assert!(record.terminal_observed_at.is_some());
-        assert_eq!(record.terminal_observed_at, record.ended_at);
+        assert!(record.observation.terminal_observed_at.is_some());
+        assert_eq!(record.observation.terminal_observed_at, record.ended_at);
     }
     let polled = registry
         .poll(RunnerPollRequest {
@@ -317,6 +361,11 @@ async fn registry_shell_job_stop_running_delivers_stop_to_client() {
         .await
         .unwrap();
     assert_eq!(stop_requested.status, "stop_requested");
+    let duplicate = registry
+        .stop_job(&job.job_id, "test".to_string())
+        .await
+        .unwrap();
+    assert_eq!(duplicate.status, "stop_requested");
     let stop = registry
         .poll(RunnerPollRequest {
             client_id: "oe".to_string(),
@@ -327,6 +376,17 @@ async fn registry_shell_job_stop_running_delivers_stop_to_client() {
         .unwrap();
     assert_eq!(stop.kind, "stop_job");
     assert_eq!(stop.job_id.as_deref(), Some(job.job_id.as_str()));
+    assert!(
+        registry
+            .poll(RunnerPollRequest {
+                client_id: "oe".to_string(),
+                runner_instance_id: "inst".to_string(),
+            })
+            .await
+            .unwrap()
+            .is_none(),
+        "duplicate stop must not enqueue a second Runner operation"
+    );
 }
 
 #[tokio::test]

--- a/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
@@ -7,7 +7,7 @@ fn typed_job_lifecycle_preserves_exact_wire_contract_and_rejects_unknown() {
     let cases = [
         ("queued", JobLifecycleState::Queued, false, false),
         ("agent_queued", JobLifecycleState::RunnerQueued, false, true),
-        ("started", JobLifecycleState::StartedLegacy, false, true),
+        ("started", JobLifecycleState::StartedLegacy, false, false),
         ("running", JobLifecycleState::Running, false, true),
         (
             "stop_requested",
@@ -32,6 +32,10 @@ fn typed_job_lifecycle_preserves_exact_wire_contract_and_rejects_unknown() {
     }
     assert!(JobLifecycleState::from_wire("recovering").is_err());
     assert!(JobLifecycleState::from_wire("mystery").is_err());
+    assert!(JobLifecycleState::Queued.is_active());
+    assert!(JobLifecycleState::StartedLegacy.is_active());
+    assert!(JobLifecycleState::RunnerQueued.is_active());
+    assert!(!JobLifecycleState::Completed.is_active());
 }
 
 #[tokio::test]

--- a/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_log_wait.rs
@@ -609,7 +609,8 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
             .jobs_by_id
             .get(&job.job_id)
             .unwrap()
-            .public_revision
+            .observation
+            .revision
             .load(std::sync::atomic::Ordering::Relaxed)
     };
 
@@ -658,7 +659,8 @@ async fn job_log_wait_activity_only_legacy_transition_advances_revision_and_wake
             .jobs_by_id
             .get(&job.job_id)
             .unwrap()
-            .public_revision
+            .observation
+            .revision
             .load(std::sync::atomic::Ordering::Relaxed)
     };
     assert!(revision_after > revision_before);

--- a/crates/webcodex-runner-registry/src/tests/project_unregister.rs
+++ b/crates/webcodex-runner-registry/src/tests/project_unregister.rs
@@ -66,7 +66,7 @@ async fn project_active_job_query_is_not_truncated_and_unregister_fences_starts(
     {
         let mut inner = registry.inner.lock().await;
         let job = inner.jobs_by_id.get_mut(&target_job.job_id).unwrap();
-        job.status = "completed".to_string();
+        job.lifecycle = super::super::state::JobLifecycleState::Completed;
         job.ended_at = Some(now_ts());
     }
     assert_eq!(

--- a/crates/webcodex-runner-registry/src/tests/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/tests/reconciliation.rs
@@ -3,7 +3,10 @@ use super::reconciliation::{
     reconcile_inventory_locked, recovery_timeout_sweep, validate_job_inventory,
     validate_job_inventory_without_project_membership, RECOVERY_SWEEP_PASS_CAP,
 };
-use super::state::{PendingShellRequest, ShellJobVisibility};
+use super::state::{
+    JobLifecycleState, JobRecoveryPhase, JobRecoveryReason, PendingShellRequest,
+    ShellJobVisibility,
+};
 use super::{
     clamp_grace, job_recovery_grace_secs, now_ts, RunnerRegistry, RUNNER_ONLINE_WINDOW_SECS,
     JOB_RECOVERY_GRACE_SECS, MAX_OUTPUT_BYTES,
@@ -1494,10 +1497,10 @@ async fn terminal_observed_inventory_replay_is_idempotent() {
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
         (
             record
-                .terminal_observed_at
+                .observation.terminal_observed_at
                 .expect("terminal inventory is observed by the Server"),
             record
-                .public_revision
+                .observation.revision
                 .load(std::sync::atomic::Ordering::Relaxed),
         )
     };
@@ -1511,13 +1514,13 @@ async fn terminal_observed_inventory_replay_is_idempotent() {
         let inner = registry_b.inner.lock().await;
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
         assert_eq!(
-            record.terminal_observed_at,
+            record.observation.terminal_observed_at,
             Some(first_terminal_observed_at),
             "terminal inventory replay must not extend Server retention"
         );
         assert_eq!(
             record
-                .public_revision
+                .observation.revision
                 .load(std::sync::atomic::Ordering::Relaxed),
             first_revision,
             "idempotent terminal replay must not publish a new revision"
@@ -1529,17 +1532,17 @@ async fn terminal_observed_inventory_replay_is_idempotent() {
             .jobs_by_id
             .get_mut(&job.job_id)
             .unwrap()
-            .terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
+            .observation.terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
     }
     let aged_observation = {
         let inner = registry_b.inner.lock().await;
-        inner.jobs_by_id[&job.job_id].terminal_observed_at
+        inner.jobs_by_id[&job.job_id].observation.terminal_observed_at
     };
     register(&registry_b, INSTANCE_A, inventory).await;
     {
         let inner = registry_b.inner.lock().await;
         assert_eq!(
-            inner.jobs_by_id[&job.job_id].terminal_observed_at, aged_observation,
+            inner.jobs_by_id[&job.job_id].observation.terminal_observed_at, aged_observation,
             "replay at the retention boundary must not re-anchor the deadline"
         );
     }
@@ -1583,7 +1586,7 @@ async fn terminal_observed_future_inventory_ended_at_cannot_bypass_prune() {
     let observed_at = {
         let inner = registry_b.inner.lock().await;
         inner.jobs_by_id[&job.job_id]
-            .terminal_observed_at
+            .observation.terminal_observed_at
             .expect("terminal inventory observation time")
     };
     assert!((before_register..=after_register).contains(&observed_at));
@@ -1660,7 +1663,7 @@ async fn terminal_observed_future_inventory_ended_at_cannot_bypass_prune() {
             .jobs_by_id
             .get_mut(&job.job_id)
             .unwrap()
-            .terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
+            .observation.terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
     }
     registry_b.record_hidden_cleanup_intent(job.job_id.clone(), None);
 
@@ -1705,7 +1708,7 @@ async fn terminal_observed_completed_job_is_retained_then_pruned() {
     let observed_at = {
         let inner = registry.inner.lock().await;
         inner.jobs_by_id[&job.job_id]
-            .terminal_observed_at
+            .observation.terminal_observed_at
             .expect("normal completed job has Server observation time")
     };
     assert!(observed_at <= now_ts());
@@ -1731,7 +1734,7 @@ async fn terminal_observed_completed_job_is_retained_then_pruned() {
             .jobs_by_id
             .get_mut(&job.job_id)
             .unwrap()
-            .terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
+            .observation.terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
     }
     recovery_timeout_sweep(&registry).await;
     assert!(!registry
@@ -1770,7 +1773,7 @@ async fn terminal_observed_hidden_until_handoff_is_not_pruned_by_public_retentio
         let mut inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get_mut(&job.job_id).unwrap();
         assert_eq!(record.visibility, ShellJobVisibility::HiddenUntilHandoff);
-        record.terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
+        record.observation.terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
     }
 
     recovery_timeout_sweep(&registry).await;
@@ -1781,7 +1784,7 @@ async fn terminal_observed_hidden_until_handoff_is_not_pruned_by_public_retentio
         .get(&job.job_id)
         .expect("hidden terminal jobs use the hidden cleanup lifecycle");
     assert_eq!(record.visibility, ShellJobVisibility::HiddenUntilHandoff);
-    assert_eq!(record.status, "completed");
+    assert_eq!(record.public_status(), "completed");
 }
 
 #[tokio::test]
@@ -1798,9 +1801,9 @@ async fn terminal_observed_missing_internal_time_is_backfilled_before_prune() {
         let mut inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get_mut(&job.job_id).unwrap();
         record.ended_at = Some(ancient_ended_at);
-        record.terminal_observed_at = None;
+        record.observation.terminal_observed_at = None;
         record
-            .public_revision
+            .observation.revision
             .load(std::sync::atomic::Ordering::Relaxed)
     };
     let before_sweep = now_ts();
@@ -1814,12 +1817,12 @@ async fn terminal_observed_missing_internal_time_is_backfilled_before_prune() {
             .jobs_by_id
             .get(&job.job_id)
             .expect("missing observation is initialized, not immediately pruned");
-        let observed_at = record.terminal_observed_at.unwrap();
+        let observed_at = record.observation.terminal_observed_at.unwrap();
         assert!((before_sweep..=after_sweep).contains(&observed_at));
         assert_eq!(record.ended_at, Some(ancient_ended_at));
         assert_eq!(
             record
-                .public_revision
+                .observation.revision
                 .load(std::sync::atomic::Ordering::Relaxed),
             revision_before,
             "internal lifecycle backfill is not a public Job mutation"
@@ -1833,7 +1836,7 @@ async fn terminal_observed_missing_internal_time_is_backfilled_before_prune() {
             .jobs_by_id
             .get_mut(&job.job_id)
             .unwrap()
-            .terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
+            .observation.terminal_observed_at = Some(now_ts() - JOB_TERMINAL_RETENTION_SECS);
     }
     recovery_timeout_sweep(&registry).await;
     assert!(registry.get_job(&job.job_id).await.is_err());
@@ -1864,10 +1867,10 @@ async fn terminal_observed_sequenced_terminal_classes_are_recorded_once() {
             let record = inner.jobs_by_id.get(&job.job_id).unwrap();
             (
                 record
-                    .terminal_observed_at
+                    .observation.terminal_observed_at
                     .expect("terminal update has Server observation time"),
                 record
-                    .public_revision
+                    .observation.revision
                     .load(std::sync::atomic::Ordering::Relaxed),
             )
         };
@@ -1895,10 +1898,10 @@ async fn terminal_observed_sequenced_terminal_classes_are_recorded_once() {
         assert_eq!(replayed.last_update_seq, first.last_update_seq);
         let inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
-        assert_eq!(record.terminal_observed_at, Some(observed_at));
+        assert_eq!(record.observation.terminal_observed_at, Some(observed_at));
         assert_eq!(
             record
-                .public_revision
+                .observation.revision
                 .load(std::sync::atomic::Ordering::Relaxed),
             revision
         );
@@ -1927,6 +1930,13 @@ async fn job_reconciliation_same_instance_replaces_tail_without_duplicates() {
         "recovering"
     );
 
+    {
+        let inner = registry.inner.lock().await;
+        let record = inner.jobs_by_id.get(&job.job_id).unwrap();
+        assert_eq!(record.lifecycle, JobLifecycleState::Running);
+        assert_eq!(record.recovery.phase, Some(JobRecoveryPhase::Recovering));
+    }
+
     let reconciled =
         snapshot_from_request(&job, &request, "running", 2, stream("one\ntwo\n", 1, false));
     register(
@@ -1945,6 +1955,13 @@ async fn job_reconciliation_same_instance_replaces_tail_without_duplicates() {
         running.recovery_reason_code.as_deref(),
         Some("same_instance_reconciliation")
     );
+
+    {
+        let inner = registry.inner.lock().await;
+        let record = inner.jobs_by_id.get(&job.job_id).unwrap();
+        assert_eq!(record.lifecycle, JobLifecycleState::Running);
+        assert_eq!(record.recovery.phase, Some(JobRecoveryPhase::Reconciled));
+    }
 
     registry
         .update_job(update(
@@ -2215,6 +2232,7 @@ async fn job_reconciliation_recovery_deadline_and_unavailable_stop_are_explicit(
             .jobs_by_id
             .get_mut(&job.job_id)
             .unwrap()
+            .recovery
             .recovering_since = Some(now_ts() - JOB_RECOVERY_GRACE_SECS);
     }
     let late_snapshot = snapshot_from_request(
@@ -2656,7 +2674,7 @@ async fn job_reconciliation_malformed_inventory_does_not_mutate_registry() {
         Some(&queued.job_id)
     );
     assert_eq!(
-        inner.jobs_by_id.get(&queued.job_id).unwrap().status,
+        inner.jobs_by_id.get(&queued.job_id).unwrap().public_status(),
         "queued"
     );
 }
@@ -2750,7 +2768,7 @@ async fn drive_into_recovering(registry: &RunnerRegistry, job_id: &str, instance
 async fn age_recovering_since(registry: &RunnerRegistry, job_id: &str, offset_secs: i64) {
     let mut inner = registry.inner.lock().await;
     let job = inner.jobs_by_id.get_mut(job_id).expect("job exists");
-    job.recovering_since = Some(now_ts() - offset_secs);
+    job.recovery.recovering_since = Some(now_ts() - offset_secs);
 }
 
 #[tokio::test]
@@ -2803,7 +2821,7 @@ async fn cleanup_pending_recovering_job_stays_tracked_until_lost_then_is_removed
     {
         let inner = registry.inner.lock().await;
         let retained = inner.jobs_by_id.get(&job.job_id).expect("job retained");
-        assert_eq!(retained.status, "recovering");
+        assert_eq!(retained.public_status(), "recovering");
         assert_eq!(retained.visibility, ShellJobVisibility::CleanupPending);
     }
     assert!(registry.get_job(&job.job_id).await.is_err());
@@ -2856,10 +2874,10 @@ async fn terminal_observed_recovery_sweep_is_idempotent() {
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
         (
             record
-                .terminal_observed_at
+                .observation.terminal_observed_at
                 .expect("lost transition has Server observation time"),
             record
-                .public_revision
+                .observation.revision
                 .load(std::sync::atomic::Ordering::Relaxed),
         )
     };
@@ -2880,13 +2898,13 @@ async fn terminal_observed_recovery_sweep_is_idempotent() {
     let inner = registry.inner.lock().await;
     let record = inner.jobs_by_id.get(&job.job_id).unwrap();
     assert_eq!(
-        record.terminal_observed_at,
+        record.observation.terminal_observed_at,
         Some(first_terminal_observed_at),
         "repeated recovery sweep must not extend retention"
     );
     assert_eq!(
         record
-            .public_revision
+            .observation.revision
             .load(std::sync::atomic::Ordering::Relaxed),
         first_revision,
         "no public revision without a public state change"
@@ -2914,7 +2932,7 @@ async fn recovery_sweep_skips_terminal_and_already_lost_jobs() {
     {
         let mut inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get_mut(&job.job_id).unwrap();
-        record.recovering_since = Some(now_ts() - job_recovery_grace_secs() - 10);
+        record.recovery.recovering_since = Some(now_ts() - job_recovery_grace_secs() - 10);
     }
     recovery_timeout_sweep(&registry).await;
     let completed = registry.get_job(&job.job_id).await.unwrap();
@@ -2929,7 +2947,7 @@ async fn recovery_sweep_skips_terminal_and_already_lost_jobs() {
         super::jobs::mark_job_lost(
             record,
             now_ts(),
-            "runner_inventory_missing",
+            JobRecoveryReason::RunnerInventoryMissing,
             "runner complete active inventory did not contain this job",
         );
     }
@@ -3005,7 +3023,7 @@ async fn recovery_sweep_pass_cap_bounds_a_single_pass() {
                 inner
                     .jobs_by_id
                     .get(id.as_str())
-                    .is_some_and(|j| j.status == "lost")
+                    .is_some_and(|j| j.public_status() == "lost")
             })
             .count()
     };
@@ -3022,7 +3040,7 @@ async fn recovery_sweep_pass_cap_bounds_a_single_pass() {
                 inner
                     .jobs_by_id
                     .get(id.as_str())
-                    .is_some_and(|j| j.status == "lost")
+                    .is_some_and(|j| j.public_status() == "lost")
             })
             .count()
     };
@@ -3093,9 +3111,9 @@ async fn terminal_observed_late_update_after_timeout_is_idempotent() {
         let inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
         (
-            record.terminal_observed_at.unwrap(),
+            record.observation.terminal_observed_at.unwrap(),
             record
-                .public_revision
+                .observation.revision
                 .load(std::sync::atomic::Ordering::Relaxed),
         )
     };
@@ -3130,13 +3148,13 @@ async fn terminal_observed_late_update_after_timeout_is_idempotent() {
     let inner = registry.inner.lock().await;
     let record = inner.jobs_by_id.get(&job.job_id).unwrap();
     assert_eq!(
-        record.terminal_observed_at,
+        record.observation.terminal_observed_at,
         Some(first_terminal_observed_at),
         "late updates must not extend retention"
     );
     assert_eq!(
         record
-            .public_revision
+            .observation.revision
             .load(std::sync::atomic::Ordering::Relaxed),
         first_revision
     );

--- a/crates/webcodex-runner-registry/src/tests/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/tests/reconciliation.rs
@@ -267,6 +267,77 @@ fn update(
 }
 
 #[tokio::test]
+async fn terminal_protocol_violation_during_recovery_keeps_execution_terminal_authoritative() {
+    let registry = RunnerRegistry::default();
+    register(&registry, INSTANCE_A, empty_inventory()).await;
+    let (job, _) = start_and_take_over(&registry, INSTANCE_A).await;
+    registry
+        .update_job(update(INSTANCE_A, &job.job_id, 1, "running", None, false))
+        .await
+        .unwrap();
+    registry.reconcile_disconnect(CLIENT_ID, INSTANCE_A).await;
+
+    {
+        let inner = registry.inner.lock().await;
+        let record = inner.jobs_by_id.get(&job.job_id).unwrap();
+        assert_eq!(record.lifecycle, JobLifecycleState::Running);
+        assert_eq!(record.recovery.phase, Some(JobRecoveryPhase::Recovering));
+        assert!(record.recovery_active());
+    }
+
+    // A same-instance sequenced update while recovering must carry an
+    // authoritative log snapshot. Deliberately attach validation progress to a
+    // non-validation Job so executor protocol validation terminalizes it.
+    let mut invalid = update(INSTANCE_A, &job.job_id, 2, "running", None, false);
+    invalid.log_snapshot = Some(ShellJobLogSnapshot {
+        stdout: ShellJobStreamSnapshot::default(),
+        stderr: ShellJobStreamSnapshot::default(),
+    });
+    invalid.validation_progress = Some(ShellJobValidationProgress {
+        completed: 0,
+        current_step: None,
+        failed_step: None,
+    });
+    let failed = registry.update_job(invalid).await.unwrap();
+    assert_eq!(failed.status, "failed");
+    assert_eq!(failed.recovery_state.as_deref(), Some("recovering"));
+    assert!(failed
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("executor protocol violation")));
+
+    {
+        let mut inner = registry.inner.lock().await;
+        let record = inner.jobs_by_id.get_mut(&job.job_id).unwrap();
+        assert_eq!(record.lifecycle, JobLifecycleState::Failed);
+        assert_eq!(record.recovery.phase, Some(JobRecoveryPhase::Recovering));
+        assert!(
+            !record.recovery_active(),
+            "terminal execution lifecycle must fence retained recovery metadata"
+        );
+        record.recovery.recovering_since = Some(now_ts() - job_recovery_grace_secs() - 1);
+    }
+
+    // Terminal Job operations must retain the pre-refactor behavior even though
+    // the compatibility recovery metadata is still projected.
+    let stopped = registry
+        .stop_job(&job.job_id, "tester".to_string())
+        .await
+        .unwrap();
+    assert_eq!(stopped.status, "failed");
+    let duplicate = registry
+        .update_job(update(INSTANCE_A, &job.job_id, 3, "running", None, false))
+        .await
+        .unwrap();
+    assert_eq!(duplicate.status, "failed");
+
+    recovery_timeout_sweep(&registry).await;
+    let after_sweep = registry.get_job(&job.job_id).await.unwrap();
+    assert_eq!(after_sweep.status, "failed");
+    assert_eq!(after_sweep.recovery_state.as_deref(), Some("recovering"));
+}
+
+#[tokio::test]
 async fn validation_progress_accepts_coalesced_sequence_gaps_without_skipping_steps() {
     let registry = RunnerRegistry::default();
     register(&registry, INSTANCE_A, empty_inventory()).await;

--- a/crates/webcodex-runner-registry/src/tests/shared_key_ttl.rs
+++ b/crates/webcodex-runner-registry/src/tests/shared_key_ttl.rs
@@ -102,7 +102,8 @@ async fn shared_key_offline_ttl_prunes_only_expired_clients_and_all_associated_s
             .jobs_by_id
             .get(&job.job_id)
             .unwrap()
-            .public_revision
+            .observation
+            .revision
             .clone()
     };
     let revision_before = job_revision.load(std::sync::atomic::Ordering::Relaxed);
@@ -167,13 +168,15 @@ async fn shared_key_offline_ttl_prunes_only_expired_clients_and_all_associated_s
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
         (
             record
+                .observation
                 .terminal_observed_at
                 .expect("TTL prune records Server terminal observation time"),
             record.ended_at,
             record.error.clone(),
-            record.recovery_reason_code.clone(),
+            record.recovery.reason,
             record
-                .public_revision
+                .observation
+                .revision
                 .load(std::sync::atomic::Ordering::Relaxed),
         )
     };
@@ -181,18 +184,19 @@ async fn shared_key_offline_ttl_prunes_only_expired_clients_and_all_associated_s
     {
         let inner = registry.inner.lock().await;
         let record = inner.jobs_by_id.get(&job.job_id).unwrap();
-        assert_eq!(record.status, "lost");
+        assert_eq!(record.public_status(), "lost");
         assert_eq!(record.ended_at, first_ended_at);
         assert_eq!(record.error, first_error);
-        assert_eq!(record.recovery_reason_code, first_reason);
+        assert_eq!(record.recovery.reason, first_reason);
         assert_eq!(
-            record.terminal_observed_at,
+            record.observation.terminal_observed_at,
             Some(first_terminal_observed_at),
             "repeated TTL prune must not extend retention"
         );
         assert_eq!(
             record
-                .public_revision
+                .observation
+                .revision
                 .load(std::sync::atomic::Ordering::Relaxed),
             first_revision,
             "repeated TTL prune must not publish a duplicate terminal update"
@@ -226,7 +230,7 @@ async fn shared_key_offline_ttl_prunes_only_expired_clients_and_all_associated_s
             .jobs_by_id
             .get(&job.job_id)
             .expect("lost Job retained");
-        assert_eq!(retained.status, "lost");
+        assert_eq!(retained.public_status(), "lost");
         assert_eq!(retained.client_id, "ttl-expired");
         assert!(inner
             .unregistering_projects
@@ -268,6 +272,7 @@ async fn shared_key_offline_ttl_prunes_only_expired_clients_and_all_associated_s
             .jobs_by_id
             .get_mut(&job.job_id)
             .unwrap()
+            .observation
             .terminal_observed_at =
             Some(now_ts() - crate::runner_protocol::JOB_TERMINAL_RETENTION_SECS);
     }


### PR DESCRIPTION
## Summary

Close the Server Job state ownership debt where `ShellJobRecord.status` simultaneously represented execution and recovery.

- replace the registry's free-form Job status source of truth with typed `JobLifecycleState`
- model recovery as an orthogonal typed phase with typed recovery reasons
- remove `recovery_original_status`; recovery no longer destroys/restores execution state
- centralize observation epoch/revision/notifier/terminal-observed timestamp in `JobObservationState`
- keep Runner V2/public status and recovery strings unchanged through compatibility decode/projection
- fail closed on unknown Runner Job status before mutating authoritative state
- preserve stop, reconciliation, restart reconstruction, instance lease, detached transfer, hidden terminal, log cursor, and observation wake semantics

## Compatibility

Runner wire DTOs and public/model-facing Job surfaces remain string-based. `agent_queued`, both `timeout`/`timed_out` aliases, `recovering`, recovery reason codes, observation token syntax, and existing REST/MCP/OpenAPI shapes are unchanged.

`list_jobs(status=...)` continues filtering against projected public status, so `Running + Recovering` still appears as `recovering` externally.

## Invariants / regression coverage

- exhaustive lifecycle wire mapping and terminal/runner-active classification
- unknown legacy Runner status fails closed without mutating an existing Job
- `Running + Recovering` retains the underlying `Running` lifecycle
- same-instance reconciliation becomes `Running + Reconciled` without restoring an old status string
- missing inventory / instance replacement / recovery deadline remain lost transitions
- terminal Jobs cannot revive through reconciliation or stale updates
- queued stop stays local; active stop enqueues one typed stop; duplicate stop does not enqueue twice
- recovering cleanup/stop remains conservative and does not retarget a replacement Runner
- observation revision/wake/no-op/token reset semantics remain covered by the existing Job log tests
- `observe_jobs` remains a batch composer over canonical single-Job observation

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p webcodex-runner-registry --all-targets`
- `cargo test -p webcodex-runner-registry` — 245 passed
- `cargo check -p webcodex --all-targets`
- `cargo test -p webcodex observe_jobs` — 23 passed
- `cargo test -p webcodex job_log` — 4 passed
- `cargo test -p webcodex fresh_started_evidence_prevents_false_queued_validation_handoff` — 1 passed
- `git diff --check origin/main...HEAD`

A direct `job_status` test-name filter matches no root tests; the registry suite and model-facing Job/observe focused suites provide the relevant coverage instead.