### PR TITLE
Centralize Runner Job lifecycle semantics

### DIFF
--- a/crates/webcodex-connector-runtime/src/execution/monitor.rs
+++ b/crates/webcodex-connector-runtime/src/execution/monitor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 use webcodex_core::validation_bridge::sanitize_bridge_text;
 use webcodex_core::validation_evidence::{PARSER_KIND, PARSER_VERSION};
 use webcodex_store::MAX_ASSERTION_EVIDENCE_BYTES;
@@ -273,11 +274,9 @@ impl ExecutionService {
             .await
             .map_err(|error| ("executor_status_unavailable", error))?;
         let executor_failure_code = job.error.as_deref().and_then(executor_failure_code);
+        let lifecycle = RunnerJobLifecycle::from_wire(&job.status).ok();
         let terminal_candidate = executor_failure_code.is_some()
-            || matches!(
-                job.status.as_str(),
-                "completed" | "stopped" | "cancelled" | "timeout" | "timed_out" | "lost" | "failed"
-            );
+            || lifecycle.is_some_and(RunnerJobLifecycle::is_terminal);
         let mcp_task_output_tail = if terminal_candidate {
             self.bounded_output_tail(&execution, runner_access).await
         } else {
@@ -288,7 +287,7 @@ impl ExecutionService {
                 .record_connector_mcp_task_output_tail(execution_id, output_tail)
                 .map_err(|error| ("task_store_error", error.to_string()))?;
         }
-        if job.status == "lost" {
+        if lifecycle == Some(RunnerJobLifecycle::Lost) {
             return Err((
                 "executor_status_unavailable",
                 job.error
@@ -325,7 +324,7 @@ impl ExecutionService {
             None
         };
         let check_succeeded_completely = execution.kind == "check"
-            && job.status == "completed"
+            && lifecycle == Some(RunnerJobLifecycle::Completed)
             && job.exit_code == Some(0)
             && progress.is_some_and(|progress| {
                 progress.completed == execution.check_plan.len()

--- a/crates/webcodex-core/src/lib.rs
+++ b/crates/webcodex-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod plugin;
 pub mod project_context_contract;
 pub mod project_instructions;
 pub mod project_listing;
+pub mod runner_job_lifecycle;
 pub mod runner_operation;
 pub mod runner_protocol;
 pub mod runtime_contract;

--- a/crates/webcodex-core/src/runner_job_lifecycle.rs
+++ b/crates/webcodex-core/src/runner_job_lifecycle.rs
@@ -1,0 +1,175 @@
+//! Canonical semantics for the Runner Job wire lifecycle.
+//!
+//! Server recovery is an orthogonal overlay and is deliberately not represented
+//! here. In particular, `recovering` is a Server observation state, not a Runner
+//! lifecycle value.
+
+/// Accepted Runner Job lifecycle values.
+///
+/// Variant names preserve distinctions that are semantically relevant even when
+/// some consumers project multiple variants to the same higher-level state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerJobLifecycle {
+    Queued,
+    RunnerQueued,
+    StartedLegacy,
+    Running,
+    StopRequested,
+    Completed,
+    Failed,
+    Stopped,
+    Timeout,
+    TimedOut,
+    Lost,
+    Cancelled,
+}
+
+impl RunnerJobLifecycle {
+    /// Parse one exact Runner wire lifecycle value.
+    pub fn from_wire(status: &str) -> Result<Self, String> {
+        match status {
+            "queued" => Ok(Self::Queued),
+            "agent_queued" => Ok(Self::RunnerQueued),
+            "started" => Ok(Self::StartedLegacy),
+            "running" => Ok(Self::Running),
+            "stop_requested" => Ok(Self::StopRequested),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "stopped" => Ok(Self::Stopped),
+            "timeout" => Ok(Self::Timeout),
+            "timed_out" => Ok(Self::TimedOut),
+            "lost" => Ok(Self::Lost),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(format!("unknown Runner Job lifecycle status: {status}")),
+        }
+    }
+
+    /// Preserve the exact accepted wire spelling for this lifecycle value.
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::RunnerQueued => "agent_queued",
+            Self::StartedLegacy => "started",
+            Self::Running => "running",
+            Self::StopRequested => "stop_requested",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Stopped => "stopped",
+            Self::Timeout => "timeout",
+            Self::TimedOut => "timed_out",
+            Self::Lost => "lost",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed
+                | Self::Failed
+                | Self::Stopped
+                | Self::Timeout
+                | Self::TimedOut
+                | Self::Lost
+                | Self::Cancelled
+        )
+    }
+
+    /// Runner-owned active execution states used by recovery, reconciliation,
+    /// inventory retention, and stop delivery.
+    ///
+    /// `StartedLegacy` is deliberately excluded: it is historical broadly-active
+    /// vocabulary but was never Runner recovery-active. Server-side `Queued` is
+    /// likewise broadly active without yet being Runner-owned.
+    pub const fn is_runner_active(self) -> bool {
+        matches!(
+            self,
+            Self::RunnerQueued | Self::Running | Self::StopRequested
+        )
+    }
+
+    /// Broad lifecycle activity, independent of any Server recovery overlay.
+    pub const fn is_active(self) -> bool {
+        matches!(self, Self::Queued | Self::StartedLegacy) || self.is_runner_active()
+    }
+
+    /// Both accepted timeout spellings have the same timeout semantics while
+    /// retaining their exact wire representation.
+    pub const fn is_timed_out(self) -> bool {
+        matches!(self, Self::Timeout | Self::TimedOut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RunnerJobLifecycle;
+
+    #[test]
+    fn runner_job_lifecycle_wire_semantics_are_canonical() {
+        let cases = [
+            ("queued", RunnerJobLifecycle::Queued, false, true, false),
+            (
+                "agent_queued",
+                RunnerJobLifecycle::RunnerQueued,
+                false,
+                true,
+                true,
+            ),
+            (
+                "started",
+                RunnerJobLifecycle::StartedLegacy,
+                false,
+                true,
+                false,
+            ),
+            ("running", RunnerJobLifecycle::Running, false, true, true),
+            (
+                "stop_requested",
+                RunnerJobLifecycle::StopRequested,
+                false,
+                true,
+                true,
+            ),
+            (
+                "completed",
+                RunnerJobLifecycle::Completed,
+                true,
+                false,
+                false,
+            ),
+            ("failed", RunnerJobLifecycle::Failed, true, false, false),
+            ("stopped", RunnerJobLifecycle::Stopped, true, false, false),
+            ("timeout", RunnerJobLifecycle::Timeout, true, false, false),
+            (
+                "timed_out",
+                RunnerJobLifecycle::TimedOut,
+                true,
+                false,
+                false,
+            ),
+            ("lost", RunnerJobLifecycle::Lost, true, false, false),
+            (
+                "cancelled",
+                RunnerJobLifecycle::Cancelled,
+                true,
+                false,
+                false,
+            ),
+        ];
+
+        for (wire, expected, terminal, active, runner_active) in cases {
+            let parsed = RunnerJobLifecycle::from_wire(wire).unwrap();
+            assert_eq!(parsed, expected, "{wire}");
+            assert_eq!(parsed.as_wire(), wire, "{wire}");
+            assert_eq!(parsed.is_terminal(), terminal, "{wire}");
+            assert_eq!(parsed.is_active(), active, "{wire}");
+            assert_eq!(parsed.is_runner_active(), runner_active, "{wire}");
+        }
+
+        assert!(RunnerJobLifecycle::Timeout.is_timed_out());
+        assert!(RunnerJobLifecycle::TimedOut.is_timed_out());
+        assert!(!RunnerJobLifecycle::Failed.is_timed_out());
+        assert!(RunnerJobLifecycle::from_wire("unknown").is_err());
+        assert!(RunnerJobLifecycle::from_wire("recovering").is_err());
+    }
+}

--- a/crates/webcodex-runner-registry/src/job_status.rs
+++ b/crates/webcodex-runner-registry/src/job_status.rs
@@ -1,11 +1,12 @@
-/// Canonical Runner-registry definition of a broadly active Runner Job.
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
+
+/// Broad activity for the Registry's public Job status projection.
 ///
+/// `recovering` is a Server recovery overlay, not a Runner lifecycle value.
 /// `stop_requested` remains active until authoritative terminal truth arrives.
 pub fn job_status_is_active(status: &str) -> bool {
-    matches!(
-        status,
-        "running" | "queued" | "started" | "agent_queued" | "stop_requested" | "recovering"
-    )
+    status == "recovering"
+        || RunnerJobLifecycle::from_wire(status).is_ok_and(RunnerJobLifecycle::is_active)
 }
 
 #[cfg(test)]
@@ -35,5 +36,7 @@ mod tests {
         ] {
             assert!(!job_status_is_active(status), "{status}");
         }
+        assert!(!job_status_is_active("unknown"));
+        assert!(RunnerJobLifecycle::from_wire("recovering").is_err());
     }
 }

--- a/crates/webcodex-runner-registry/src/job_updates.rs
+++ b/crates/webcodex-runner-registry/src/job_updates.rs
@@ -326,6 +326,7 @@ fn invalid_progress(code: &'static str) -> Result<(), ValidationProtocolError> {
 fn validate_validation_progress(
     job: &ShellJobRecord,
     update: &RunnerJobUpdateRequest,
+    lifecycle: JobLifecycleState,
 ) -> Result<(), ValidationProtocolError> {
     if job.validation_steps.is_empty() {
         return if update.validation_progress.is_none() {
@@ -337,22 +338,31 @@ fn validate_validation_progress(
     if job.validation_steps.iter().collect::<HashSet<_>>().len() != job.validation_steps.len() {
         return invalid_progress("validation_plan_invalid");
     }
-    let status = update.status.trim();
-    if update.finished && !is_final_job_status(status) {
+    if update.finished && !lifecycle.is_terminal() {
         return invalid_progress("validation_progress_invalid");
     }
     let cancelling = matches!(
-        status,
-        "stopped" | "cancelled" | "timeout" | "timed_out" | "lost"
+        lifecycle,
+        JobLifecycleState::Stopped
+            | JobLifecycleState::Cancelled
+            | JobLifecycleState::Timeout
+            | JobLifecycleState::TimedOut
+            | JobLifecycleState::Lost
     );
     let Some(progress) = update.validation_progress.as_ref() else {
-        if matches!(status, "queued" | "agent_queued") || cancelling {
+        if matches!(
+            lifecycle,
+            JobLifecycleState::Queued | JobLifecycleState::RunnerQueued
+        ) || cancelling
+        {
             return Ok(());
         }
         return invalid_progress("validation_progress_missing");
     };
-    if matches!(status, "queued" | "agent_queued")
-        || progress.completed > job.validation_steps.len()
+    if matches!(
+        lifecycle,
+        JobLifecycleState::Queued | JobLifecycleState::RunnerQueued
+    ) || progress.completed > job.validation_steps.len()
     {
         return invalid_progress("validation_progress_invalid");
     }
@@ -370,7 +380,7 @@ fn validate_validation_progress(
         return invalid_progress("validation_progress_invalid");
     }
     let no_active_step = progress.current_step.is_none() && progress.failed_step.is_none();
-    let infrastructure_failure = status == "failed"
+    let infrastructure_failure = lifecycle == JobLifecycleState::Failed
         && update.finished
         && update.exit_code.is_none()
         && update
@@ -382,13 +392,13 @@ fn validate_validation_progress(
         no_active_step
     } else if infrastructure_failure {
         progress.completed < job.validation_steps.len() && no_active_step
-    } else if !is_final_job_status(status) {
+    } else if !lifecycle.is_terminal() {
         let expected = job.validation_steps.get(progress.completed);
         expected.map(String::as_str) == progress.current_step.as_deref()
             && progress.failed_step.is_none()
-    } else if status == "completed" && update.exit_code == Some(0) {
+    } else if lifecycle == JobLifecycleState::Completed && update.exit_code == Some(0) {
         progress.completed == job.validation_steps.len() && no_active_step
-    } else if status == "failed" {
+    } else if lifecycle == JobLifecycleState::Failed {
         let expected = job.validation_steps.get(progress.completed);
         expected.map(String::as_str) == progress.failed_step.as_deref()
             && progress.current_step.is_none()
@@ -397,7 +407,7 @@ fn validate_validation_progress(
     };
     if valid {
         Ok(())
-    } else if status == "completed" && update.exit_code == Some(0) {
+    } else if lifecycle == JobLifecycleState::Completed && update.exit_code == Some(0) {
         invalid_progress("validation_progress_incomplete")
     } else {
         invalid_progress("validation_progress_invalid")
@@ -416,14 +426,19 @@ fn validation_activity_phase(step: &str) -> Option<ShellJobActivityPhase> {
 fn validate_job_activity(
     job: &ShellJobRecord,
     update: &RunnerJobUpdateRequest,
+    lifecycle: JobLifecycleState,
 ) -> Result<(), ValidationProtocolError> {
     let Some(activity) = update.activity else {
         // Activity was added as an optional protocol field. Older Runners may
         // omit it without changing canonical Job lifecycle semantics.
         return Ok(());
     };
-    let status = update.status.trim();
-    if !activity.is_canonical() || !matches!(status, "running" | "stop_requested") {
+    if !activity.is_canonical()
+        || !matches!(
+            lifecycle,
+            JobLifecycleState::Running | JobLifecycleState::StopRequested
+        )
+    {
         return invalid_progress("job_activity_invalid");
     }
     match activity.source {
@@ -474,9 +489,9 @@ fn validate_job_activity(
 fn validate_command_execution_state(
     job: &ShellJobRecord,
     update: &RunnerJobUpdateRequest,
+    lifecycle: JobLifecycleState,
 ) -> Result<(), ValidationProtocolError> {
-    let status = update.status.trim();
-    let terminal = is_final_job_status(status);
+    let terminal = lifecycle.is_terminal();
     if !terminal && update.command_execution_state.is_some() {
         return invalid_progress("command_execution_state_on_active_job");
     }
@@ -488,14 +503,26 @@ fn validate_command_execution_state(
     };
     let valid = match state {
         ShellCommandExecutionState::NotStarted => {
-            matches!(status, "failed" | "stopped" | "cancelled" | "lost")
-                && job.started_at.is_none()
+            matches!(
+                lifecycle,
+                JobLifecycleState::Failed
+                    | JobLifecycleState::Stopped
+                    | JobLifecycleState::Cancelled
+                    | JobLifecycleState::Lost
+            ) && job.started_at.is_none()
         }
-        ShellCommandExecutionState::OutcomeUnknown => matches!(status, "failed" | "lost"),
-        ShellCommandExecutionState::TimedOut => matches!(status, "timeout" | "timed_out"),
-        ShellCommandExecutionState::Completed => {
-            matches!(status, "completed" | "failed" | "stopped" | "cancelled")
-        }
+        ShellCommandExecutionState::OutcomeUnknown => matches!(
+            lifecycle,
+            JobLifecycleState::Failed | JobLifecycleState::Lost
+        ),
+        ShellCommandExecutionState::TimedOut => lifecycle.is_timed_out(),
+        ShellCommandExecutionState::Completed => matches!(
+            lifecycle,
+            JobLifecycleState::Completed
+                | JobLifecycleState::Failed
+                | JobLifecycleState::Stopped
+                | JobLifecycleState::Cancelled
+        ),
     };
     if valid {
         Ok(())
@@ -1914,20 +1941,7 @@ impl RunnerRegistry {
                 format!("job update status '{}' is invalid", incoming_status)
             }
         })?;
-        if sequenced
-            && !matches!(
-                incoming_lifecycle,
-                JobLifecycleState::RunnerQueued
-                    | JobLifecycleState::Running
-                    | JobLifecycleState::StopRequested
-                    | JobLifecycleState::Completed
-                    | JobLifecycleState::Failed
-                    | JobLifecycleState::Stopped
-                    | JobLifecycleState::Timeout
-                    | JobLifecycleState::TimedOut
-                    | JobLifecycleState::Cancelled
-                    | JobLifecycleState::Lost
-            )
+        if sequenced && !(incoming_lifecycle.is_runner_active() || incoming_lifecycle.is_terminal())
         {
             return Err(format!(
                 "job_state_reconciliation update status '{}' is invalid",
@@ -2023,9 +2037,9 @@ impl RunnerRegistry {
                 &body.job_id,
                 &body,
             );
-            if let Err(error) = validate_validation_progress(job, &body)
-                .and_then(|_| validate_command_execution_state(job, &body))
-                .and_then(|_| validate_job_activity(job, &body))
+            if let Err(error) = validate_validation_progress(job, &body, incoming_lifecycle)
+                .and_then(|_| validate_command_execution_state(job, &body, incoming_lifecycle))
+                .and_then(|_| validate_job_activity(job, &body, incoming_lifecycle))
             {
                 let terminal_now = now_ts();
                 job.lifecycle = JobLifecycleState::Failed;

--- a/crates/webcodex-runner-registry/src/reconciliation.rs
+++ b/crates/webcodex-runner-registry/src/reconciliation.rs
@@ -182,12 +182,7 @@ fn validate_snapshot(
     }
     let lifecycle = parse_job_lifecycle(&snapshot.status)
         .map_err(|_| format!("job inventory status '{}' is invalid", snapshot.status))?;
-    let active = matches!(
-        lifecycle,
-        JobLifecycleState::RunnerQueued
-            | JobLifecycleState::Running
-            | JobLifecycleState::StopRequested
-    );
+    let active = lifecycle.is_runner_active();
     let terminal = lifecycle.is_terminal();
     if !active && !terminal {
         return Err(format!(

--- a/crates/webcodex-runner-registry/src/state.rs
+++ b/crates/webcodex-runner-registry/src/state.rs
@@ -10,6 +10,7 @@ use webcodex_core::coding_agent::{
 };
 use webcodex_core::mcp_gateway::McpGatewayResponse;
 use webcodex_core::plugin::PluginGatewayResponse;
+pub(super) use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle as JobLifecycleState;
 use webcodex_core::runner_operation::RunnerOperation;
 use webcodex_core::runner_protocol::{
     PersistentShellResult, RunnerBuildInfo, RunnerHostContext, RunnerPolicySummary,
@@ -264,87 +265,6 @@ pub enum ShellJobVisibility {
     Public,
     HiddenUntilHandoff,
     CleanupPending,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum JobLifecycleState {
-    Queued,
-    RunnerQueued,
-    StartedLegacy,
-    Running,
-    StopRequested,
-    Completed,
-    Failed,
-    Stopped,
-    Timeout,
-    TimedOut,
-    Lost,
-    Cancelled,
-}
-
-impl JobLifecycleState {
-    pub(super) fn from_wire(status: &str) -> Result<Self, String> {
-        match status {
-            "queued" => Ok(Self::Queued),
-            "agent_queued" => Ok(Self::RunnerQueued),
-            "started" => Ok(Self::StartedLegacy),
-            "running" => Ok(Self::Running),
-            "stop_requested" => Ok(Self::StopRequested),
-            "completed" => Ok(Self::Completed),
-            "failed" => Ok(Self::Failed),
-            "stopped" => Ok(Self::Stopped),
-            "timeout" => Ok(Self::Timeout),
-            "timed_out" => Ok(Self::TimedOut),
-            "lost" => Ok(Self::Lost),
-            "cancelled" => Ok(Self::Cancelled),
-            _ => Err(format!("unknown Runner Job lifecycle status: {status}")),
-        }
-    }
-
-    pub(super) const fn as_wire(self) -> &'static str {
-        match self {
-            Self::Queued => "queued",
-            Self::RunnerQueued => "agent_queued",
-            Self::StartedLegacy => "started",
-            Self::Running => "running",
-            Self::StopRequested => "stop_requested",
-            Self::Completed => "completed",
-            Self::Failed => "failed",
-            Self::Stopped => "stopped",
-            Self::Timeout => "timeout",
-            Self::TimedOut => "timed_out",
-            Self::Lost => "lost",
-            Self::Cancelled => "cancelled",
-        }
-    }
-
-    pub(super) const fn is_terminal(self) -> bool {
-        matches!(
-            self,
-            Self::Completed
-                | Self::Failed
-                | Self::Stopped
-                | Self::Timeout
-                | Self::TimedOut
-                | Self::Lost
-                | Self::Cancelled
-        )
-    }
-
-    /// Runner-owned active execution states. `StartedLegacy` is deliberately
-    /// excluded: the historical public vocabulary treats it as broadly active,
-    /// but it never participated in Runner recovery, reconciliation, or stop
-    /// delivery semantics.
-    pub(super) const fn is_runner_active(self) -> bool {
-        matches!(
-            self,
-            Self::RunnerQueued | Self::Running | Self::StopRequested
-        )
-    }
-
-    pub(super) const fn is_active(self) -> bool {
-        matches!(self, Self::Queued | Self::StartedLegacy) || self.is_runner_active()
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
+++ b/crates/webcodex-runner-registry/src/tests/job_lifecycle.rs
@@ -1,41 +1,22 @@
 use super::*;
 
 #[test]
-fn typed_job_lifecycle_preserves_exact_wire_contract_and_rejects_unknown() {
+fn registry_lifecycle_alias_consumes_core_contract_without_absorbing_recovery() {
     use crate::state::JobLifecycleState;
+    use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 
-    let cases = [
-        ("queued", JobLifecycleState::Queued, false, false),
-        ("agent_queued", JobLifecycleState::RunnerQueued, false, true),
-        ("started", JobLifecycleState::StartedLegacy, false, false),
-        ("running", JobLifecycleState::Running, false, true),
-        (
-            "stop_requested",
-            JobLifecycleState::StopRequested,
-            false,
-            true,
-        ),
-        ("completed", JobLifecycleState::Completed, true, false),
-        ("failed", JobLifecycleState::Failed, true, false),
-        ("stopped", JobLifecycleState::Stopped, true, false),
-        ("timeout", JobLifecycleState::Timeout, true, false),
-        ("timed_out", JobLifecycleState::TimedOut, true, false),
-        ("lost", JobLifecycleState::Lost, true, false),
-        ("cancelled", JobLifecycleState::Cancelled, true, false),
-    ];
-    for (wire, expected, terminal, runner_active) in cases {
-        let parsed = JobLifecycleState::from_wire(wire).unwrap();
-        assert_eq!(parsed, expected);
-        assert_eq!(parsed.as_wire(), wire);
-        assert_eq!(parsed.is_terminal(), terminal);
-        assert_eq!(parsed.is_runner_active(), runner_active);
-    }
+    let runner_queued = JobLifecycleState::from_wire("agent_queued").unwrap();
+    let started = JobLifecycleState::from_wire("started").unwrap();
+    assert_eq!(runner_queued, RunnerJobLifecycle::RunnerQueued);
+    assert!(runner_queued.is_runner_active());
+    assert_eq!(started, RunnerJobLifecycle::StartedLegacy);
+    assert!(started.is_active());
+    assert!(!started.is_runner_active());
+
     assert!(JobLifecycleState::from_wire("recovering").is_err());
+    assert!(crate::job_status_is_active("recovering"));
     assert!(JobLifecycleState::from_wire("mystery").is_err());
-    assert!(JobLifecycleState::Queued.is_active());
-    assert!(JobLifecycleState::StartedLegacy.is_active());
-    assert!(JobLifecycleState::RunnerQueued.is_active());
-    assert!(!JobLifecycleState::Completed.is_active());
+    assert!(!crate::job_status_is_active("mystery"));
 }
 
 #[tokio::test]

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -19,6 +19,7 @@ mod webcodex_runner;
 #[cfg(test)]
 use runner_operation::RunnerOperation;
 use runner_operation::{RunnerFileOperation, RunnerInvocationMetadata, RunnerJobOperation};
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 use webcodex_core::{
     apply_edits_shared, apply_patch_shared, artifact_policy, build_info, lsp_bridge, mcp_gateway,
     runner_operation, runner_protocol, validation_bridge,
@@ -2852,14 +2853,11 @@ fn cargo_activity_from_stderr(
 }
 
 fn runner_job_is_terminal(status: &str) -> bool {
-    matches!(
-        status,
-        "completed" | "failed" | "stopped" | "timeout" | "timed_out" | "lost" | "cancelled"
-    )
+    RunnerJobLifecycle::from_wire(status).is_ok_and(RunnerJobLifecycle::is_terminal)
 }
 
 fn runner_job_is_active(status: &str) -> bool {
-    matches!(status, "agent_queued" | "running" | "stop_requested")
+    RunnerJobLifecycle::from_wire(status).is_ok_and(RunnerJobLifecycle::is_runner_active)
 }
 
 fn job_prestart_lifecycle(operation: &RunnerJobOperation) -> Option<ShellCommandExecutionState> {
@@ -2928,10 +2926,16 @@ fn raw_shell_job_terminal_lifecycle(
     status: &str,
     exit_code: Option<i32>,
 ) -> ShellCommandExecutionState {
-    match status {
-        "timeout" | "timed_out" => ShellCommandExecutionState::TimedOut,
-        "completed" | "stopped" | "cancelled" => ShellCommandExecutionState::Completed,
-        "failed" if exit_code.is_some() => ShellCommandExecutionState::Completed,
+    match RunnerJobLifecycle::from_wire(status).ok() {
+        Some(lifecycle) if lifecycle.is_timed_out() => ShellCommandExecutionState::TimedOut,
+        Some(
+            RunnerJobLifecycle::Completed
+            | RunnerJobLifecycle::Stopped
+            | RunnerJobLifecycle::Cancelled,
+        ) => ShellCommandExecutionState::Completed,
+        Some(RunnerJobLifecycle::Failed) if exit_code.is_some() => {
+            ShellCommandExecutionState::Completed
+        }
         _ => ShellCommandExecutionState::OutcomeUnknown,
     }
 }
@@ -3477,10 +3481,16 @@ impl JobManager {
             job.snapshot.update_seq = job.snapshot.update_seq.saturating_add(1);
             if !delta.status.trim().is_empty() {
                 let incoming_status = delta.status.trim();
-                let would_regress_stop = job.snapshot.status == "stop_requested"
-                    && matches!(incoming_status, "agent_queued" | "running");
-                let would_regress_running =
-                    job.snapshot.status == "running" && incoming_status == "agent_queued";
+                let current_lifecycle = RunnerJobLifecycle::from_wire(&job.snapshot.status).ok();
+                let incoming_lifecycle = RunnerJobLifecycle::from_wire(incoming_status).ok();
+                let would_regress_stop = current_lifecycle
+                    == Some(RunnerJobLifecycle::StopRequested)
+                    && matches!(
+                        incoming_lifecycle,
+                        Some(RunnerJobLifecycle::RunnerQueued | RunnerJobLifecycle::Running)
+                    );
+                let would_regress_running = current_lifecycle == Some(RunnerJobLifecycle::Running)
+                    && incoming_lifecycle == Some(RunnerJobLifecycle::RunnerQueued);
                 if !would_regress_stop && !would_regress_running {
                     job.snapshot.status = incoming_status.to_string();
                 }
@@ -3491,16 +3501,18 @@ impl JobManager {
             if job.snapshot.started_at.is_none()
                 && job.snapshot.command_execution_state
                     != Some(ShellCommandExecutionState::NotStarted)
-                && matches!(
-                    job.snapshot.status.as_str(),
-                    "running"
-                        | "completed"
-                        | "failed"
-                        | "stopped"
-                        | "timeout"
-                        | "timed_out"
-                        | "cancelled"
-                )
+                && RunnerJobLifecycle::from_wire(&job.snapshot.status).is_ok_and(|lifecycle| {
+                    matches!(
+                        lifecycle,
+                        RunnerJobLifecycle::Running
+                            | RunnerJobLifecycle::Completed
+                            | RunnerJobLifecycle::Failed
+                            | RunnerJobLifecycle::Stopped
+                            | RunnerJobLifecycle::Timeout
+                            | RunnerJobLifecycle::TimedOut
+                            | RunnerJobLifecycle::Cancelled
+                    )
+                })
             {
                 job.snapshot.started_at = Some(now);
             }

--- a/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/detached_job.rs
@@ -27,6 +27,7 @@ use std::sync::mpsc;
 #[cfg(any(unix, windows))]
 use std::time::Instant;
 use uuid::Uuid;
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 use webcodex_core::runner_protocol::{
     validate_process_argv, ShellCommandExecutionState, ShellJobActivity, ShellJobActivityPhase,
     ShellJobActivitySource, ShellJobActivityState, ShellJobContext, ShellJobSnapshot,
@@ -1338,16 +1339,16 @@ pub(crate) fn snapshot_from_detached_record(
     }
     let terminal = record.terminal.as_ref();
     let status = match terminal.map(|value| value.status.as_str()) {
-        Some("handoff_failed") => "failed",
-        Some("supervisor_lost") => "lost",
-        Some("timeout") => "timeout",
-        Some("completed") => "completed",
-        Some("failed") => "failed",
-        Some("stopped") => "stopped",
+        Some("handoff_failed") => RunnerJobLifecycle::Failed,
+        Some("supervisor_lost") => RunnerJobLifecycle::Lost,
+        Some("timeout") => RunnerJobLifecycle::Timeout,
+        Some("completed") => RunnerJobLifecycle::Completed,
+        Some("failed") => RunnerJobLifecycle::Failed,
+        Some("stopped") => RunnerJobLifecycle::Stopped,
         Some(other) => return Err(format!("unsupported detached terminal status {other}")),
-        None if record.stop_requested => "stop_requested",
-        None if record.ownership_accepted_at_unix_ms.is_some() => "running",
-        None => "agent_queued",
+        None if record.stop_requested => RunnerJobLifecycle::StopRequested,
+        None if record.ownership_accepted_at_unix_ms.is_some() => RunnerJobLifecycle::Running,
+        None => RunnerJobLifecycle::RunnerQueued,
     };
     let command_execution_state = match terminal.map(|value| value.status.as_str()) {
         Some("handoff_failed") => Some(ShellCommandExecutionState::NotStarted),
@@ -1357,7 +1358,11 @@ pub(crate) fn snapshot_from_detached_record(
         Some(_) => None,
         None => None,
     };
-    let activity = matches!(status, "running" | "stop_requested").then_some(ShellJobActivity {
+    let activity = matches!(
+        status,
+        RunnerJobLifecycle::Running | RunnerJobLifecycle::StopRequested
+    )
+    .then_some(ShellJobActivity {
         state: ShellJobActivityState::Working,
         phase: ShellJobActivityPhase::ProcessRunning,
         source: ShellJobActivitySource::RunnerExecution,
@@ -1371,7 +1376,7 @@ pub(crate) fn snapshot_from_detached_record(
     Ok(ShellJobSnapshot {
         job_id: record.job_id.clone(),
         request_id: record.request_id.clone(),
-        status: status.to_string(),
+        status: status.as_wire().to_string(),
         update_seq: record.update_seq,
         created_at: record.created_at_unix_ms.div_euclid(1000),
         started_at: record

--- a/crates/webcodex-store/src/execution_model.rs
+++ b/crates/webcodex-store/src/execution_model.rs
@@ -1,5 +1,6 @@
 use rusqlite::{params, OptionalExtension};
 use serde_json::Value;
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 
 pub const MAX_ASSERTION_EVIDENCE_BYTES: usize = 16 * 1024;
 // Two already-bounded 256 KiB UTF-8 streams can expand substantially under
@@ -153,22 +154,7 @@ impl ConnectorExecution {
     }
 
     pub fn executor_status_recognized(status: &str) -> bool {
-        matches!(
-            status,
-            "queued"
-                | "agent_queued"
-                | "running"
-                | "started"
-                | "stop_requested"
-                | "recovering"
-                | "completed"
-                | "stopped"
-                | "cancelled"
-                | "timeout"
-                | "timed_out"
-                | "lost"
-                | "failed"
-        )
+        status == "recovering" || RunnerJobLifecycle::from_wire(status).is_ok()
     }
 }
 
@@ -235,19 +221,30 @@ pub(super) fn observed_state(
     if let Some(code) = observation.executor_failure_code {
         return failed("executor", code, "executor_protocol_violation");
     }
-    match observation.executor_status {
-        "queued" | "agent_queued" => active_state(execution, "queued"),
-        "running" | "started" => active_state(execution, "running"),
-        "stop_requested" => active_state(execution, "running"),
-        "recovering" => active_state(
+    if observation.executor_status == "recovering" {
+        return active_state(
             execution,
             if execution.state == "queued" {
                 "queued"
             } else {
                 "running"
             },
-        ),
-        "completed"
+        );
+    }
+    let Ok(lifecycle) = RunnerJobLifecycle::from_wire(observation.executor_status) else {
+        // Callers reject unrecognized observation status before this projection.
+        // Keep the historical conservative fallback for direct/internal callers.
+        return active_state(execution, "running");
+    };
+    match lifecycle {
+        RunnerJobLifecycle::Queued | RunnerJobLifecycle::RunnerQueued => {
+            active_state(execution, "queued")
+        }
+        RunnerJobLifecycle::Running | RunnerJobLifecycle::StartedLegacy => {
+            active_state(execution, "running")
+        }
+        RunnerJobLifecycle::StopRequested => active_state(execution, "running"),
+        RunnerJobLifecycle::Completed
             if execution.kind == "check"
                 && observation.exit_code == Some(0)
                 && observation.check_completed == Some(execution.check_plan.len())
@@ -255,7 +252,7 @@ pub(super) fn observed_state(
         {
             ("succeeded", None, None, Some("exit_zero"))
         }
-        "completed" if execution.kind == "check" => failed(
+        RunnerJobLifecycle::Completed if execution.kind == "check" => failed(
             "executor",
             if observation.check_completed.is_none() {
                 "validation_progress_missing"
@@ -264,22 +261,31 @@ pub(super) fn observed_state(
             },
             "executor_protocol_violation",
         ),
-        "completed" if observation.exit_code == Some(0) => {
+        RunnerJobLifecycle::Completed if observation.exit_code == Some(0) => {
             ("succeeded", None, None, Some("exit_zero"))
         }
-        "completed" if observation.exit_code.is_none() => unknown("executor_exit_code_missing"),
-        "stopped" | "cancelled"
+        RunnerJobLifecycle::Completed if observation.exit_code.is_none() => {
+            unknown("executor_exit_code_missing")
+        }
+        RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled
             if execution.state == "cancel_requested"
                 && execution.failure_code.as_deref() == Some("queue_deadline") =>
         {
             failed("queue", "queue_deadline", "queue_timeout")
         }
-        "stopped" | "cancelled" if execution.state == "cancel_requested" => {
+        RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled
+            if execution.state == "cancel_requested" =>
+        {
             ("cancelled", None, None, Some("user_cancelled"))
         }
-        "timeout" | "timed_out" => failed("executor", "command_timeout", "timeout"),
-        "lost" => unknown("executor_lost"),
-        "failed"
+        RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled => {
+            active_state(execution, "running")
+        }
+        RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut => {
+            failed("executor", "command_timeout", "timeout")
+        }
+        RunnerJobLifecycle::Lost => unknown("executor_lost"),
+        RunnerJobLifecycle::Failed
             if execution.kind == "check"
                 && observation.failed_check.is_some()
                 && observation
@@ -288,7 +294,7 @@ pub(super) fn observed_state(
         {
             failed("check", "assertion_failed", "nonzero_exit")
         }
-        "failed" if execution.kind == "check" => failed(
+        RunnerJobLifecycle::Failed if execution.kind == "check" => failed(
             "executor",
             if observation.check_completed.is_none() {
                 "validation_progress_missing"
@@ -297,8 +303,9 @@ pub(super) fn observed_state(
             },
             "executor_protocol_violation",
         ),
-        "failed" | "completed" => failed("command", "nonzero_exit", "nonzero_exit"),
-        _ => active_state(execution, "running"),
+        RunnerJobLifecycle::Failed | RunnerJobLifecycle::Completed => {
+            failed("command", "nonzero_exit", "nonzero_exit")
+        }
     }
 }
 
@@ -476,5 +483,137 @@ pub(super) fn execution_event_kind(state: &str) -> &'static str {
         "interrupted" => "execution_interrupted",
         "unknown" => "execution_unknown",
         _ => "execution_failed",
+    }
+}
+
+#[cfg(test)]
+mod runner_job_lifecycle_projection_tests {
+    use super::*;
+
+    fn execution(state: &str) -> ConnectorExecution {
+        ConnectorExecution {
+            execution_id: "execution".to_string(),
+            kind: "command".to_string(),
+            task_id: "task".to_string(),
+            run_id: "run".to_string(),
+            state: state.to_string(),
+            submitted_at: 1,
+            queued_at: None,
+            queue_deadline: 10,
+            started_at: None,
+            last_output_at: None,
+            finished_at: None,
+            stdout_cursor: 0,
+            stderr_cursor: 0,
+            exit_code: None,
+            failure_source: None,
+            failure_code: None,
+            terminal_reason: None,
+            operation_id: "operation".to_string(),
+            request_sha256: "request".to_string(),
+            executor_reference: None,
+            first_status_failure_at: None,
+            last_successful_observation_at: None,
+            status_failure_code: None,
+            check_plan: Vec::new(),
+            check_recipe: None,
+            check_completed: 0,
+            check_workspace_sha256: None,
+            validated_workspace_sha256: None,
+            failed_check: None,
+            assertion_evidence: None,
+            continuation_intent: ConnectorExecutionContinuationIntent::None,
+            continuation_armed_at: None,
+            continuation_delivery_state: ConnectorTerminalContinuationDeliveryState::Unclaimed,
+            mcp_task_materialized_at: None,
+            mcp_task_result_finalized_at: None,
+            mcp_task_output_tail: None,
+        }
+    }
+
+    fn observation(status: &str, exit_code: Option<i32>) -> ConnectorExecutionObservation<'_> {
+        ConnectorExecutionObservation {
+            executor_status: status,
+            stdout_cursor: 0,
+            stderr_cursor: 0,
+            exit_code,
+            started_at: None,
+            finished_at: None,
+            check_completed: None,
+            failed_check: None,
+            assertion_evidence: None,
+            validated_workspace_sha256: None,
+            executor_failure_code: None,
+            mcp_task_output_tail: None,
+            now: 2,
+        }
+    }
+
+    #[test]
+    fn runner_job_lifecycle_projects_to_connector_execution_semantics() {
+        let execution = execution("accepted");
+        let cases: [(&str, StateOutcome); 9] = [
+            ("queued", ("queued", None, None, None)),
+            ("agent_queued", ("queued", None, None, None)),
+            ("started", ("running", None, None, None)),
+            ("running", ("running", None, None, None)),
+            ("stop_requested", ("running", None, None, None)),
+            (
+                "timeout",
+                (
+                    "failed",
+                    Some("executor"),
+                    Some("command_timeout"),
+                    Some("timeout"),
+                ),
+            ),
+            (
+                "timed_out",
+                (
+                    "failed",
+                    Some("executor"),
+                    Some("command_timeout"),
+                    Some("timeout"),
+                ),
+            ),
+            (
+                "lost",
+                (
+                    "unknown",
+                    Some("executor"),
+                    Some("executor_lost"),
+                    Some("executor_terminal_unknown"),
+                ),
+            ),
+            ("completed", ("succeeded", None, None, Some("exit_zero"))),
+        ];
+
+        for (status, expected) in cases {
+            let exit_code = (status == "completed").then_some(0);
+            assert_eq!(
+                observed_state(&execution, &observation(status, exit_code)),
+                expected,
+                "{status}"
+            );
+        }
+    }
+
+    #[test]
+    fn runner_recovery_overlay_and_unknown_status_keep_boundary_specific_semantics() {
+        assert!(ConnectorExecution::executor_status_recognized("recovering"));
+        assert!(!ConnectorExecution::executor_status_recognized("unknown"));
+        assert_eq!(
+            observed_state(&execution("queued"), &observation("recovering", None)),
+            ("queued", None, None, None)
+        );
+        assert_eq!(
+            observed_state(&execution("running"), &observation("recovering", None)),
+            ("running", None, None, None)
+        );
+        assert_eq!(
+            observed_state(&execution("accepted"), &observation("unknown", None)),
+            ("running", None, None, None),
+            "direct/internal unknown fallback stays conservative; callers reject it before projection"
+        );
     }
 }

--- a/crates/webcodex-store/src/executions.rs
+++ b/crates/webcodex-store/src/executions.rs
@@ -18,6 +18,7 @@ use rusqlite::{params, Transaction};
 #[cfg(any(test, feature = "root-test-support"))]
 use rusqlite::{OptionalExtension, TransactionBehavior};
 use serde_json::json;
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 
 #[cfg(any(test, feature = "root-test-support"))]
 const TERMINAL_CONTINUATION_READY_PREDICATE: &str =
@@ -538,12 +539,19 @@ impl Database {
             touch_task(&tx, &execution.task_id, now)?;
             return commit_execution(tx, execution_id);
         }
-        let recognized = ConnectorExecution::executor_status_recognized(executor_status);
+        let lifecycle = RunnerJobLifecycle::from_wire(executor_status).ok();
+        let recognized = executor_status == "recovering" || lifecycle.is_some();
         let state = if execution.state == "cancel_requested" {
             "cancel_requested"
-        } else if matches!(executor_status, "queued" | "agent_queued") {
+        } else if matches!(
+            lifecycle,
+            Some(RunnerJobLifecycle::Queued | RunnerJobLifecycle::RunnerQueued)
+        ) {
             "queued"
-        } else if matches!(executor_status, "running" | "started") {
+        } else if matches!(
+            lifecycle,
+            Some(RunnerJobLifecycle::Running | RunnerJobLifecycle::StartedLegacy)
+        ) {
             "running"
         } else {
             execution.state.as_str()

--- a/crates/webcodex-store/src/executions.rs
+++ b/crates/webcodex-store/src/executions.rs
@@ -540,7 +540,7 @@ impl Database {
             return commit_execution(tx, execution_id);
         }
         let lifecycle = RunnerJobLifecycle::from_wire(executor_status).ok();
-        let recognized = executor_status == "recovering" || lifecycle.is_some();
+        let recognized = ConnectorExecution::executor_status_recognized(executor_status);
         let state = if execution.state == "cancel_requested" {
             "cancel_requested"
         } else if matches!(

--- a/crates/webcodex-workflow-session/src/session_store_tests.rs
+++ b/crates/webcodex-workflow-session/src/session_store_tests.rs
@@ -1257,3 +1257,100 @@ fn read_only_guards_block_write_and_shell_classifications() {
         .guard_denial(&read_only.session_id, session_tool_contract("read_file"))
         .is_none());
 }
+
+#[test]
+fn validation_job_terminal_projects_typed_runner_lifecycle_without_absorbing_active_or_recovery() {
+    let store = SessionStore::default();
+    let project = "agent:workflow-session:runner-lifecycle".to_string();
+    let session = store.start_session(Some(project.clone()), Some("runner lifecycle".to_string()));
+    let target = "target:0123456789abcdef01234567";
+    let cases = [
+        ("completed", Some(0), Some(true), "succeeded", None),
+        (
+            "completed",
+            Some(0),
+            Some(false),
+            "failed",
+            Some("validation_failed"),
+        ),
+        (
+            "failed",
+            Some(1),
+            Some(false),
+            "failed",
+            Some("command_exit_nonzero"),
+        ),
+        ("timeout", None, Some(false), "failed", Some("timeout")),
+        ("timed_out", None, Some(false), "failed", Some("timeout")),
+        ("stopped", None, Some(false), "failed", Some("cancelled")),
+        ("cancelled", None, Some(false), "failed", Some("cancelled")),
+        ("lost", None, Some(false), "failed", Some("execution_lost")),
+    ];
+
+    for (index, (job_status, exit_code, validation_passed, status, failure_kind)) in
+        cases.into_iter().enumerate()
+    {
+        let job_id = format!("job-lifecycle-{index}");
+        assert!(store.record_validation_job_terminal(
+            &session.session_id,
+            &job_id,
+            &[job_id.as_str()],
+            "cargo_check",
+            session_tool_contract("cargo_check"),
+            Some(project.clone()),
+            target,
+            None,
+            job_status,
+            exit_code,
+            validation_passed,
+            Some(90),
+            Some(100 + index as i64),
+            Some(10_000),
+            None,
+        ));
+        let summary = store.summary(&session.session_id, None).unwrap();
+        let event = summary
+            .events
+            .iter()
+            .rev()
+            .find(|event| event.job_id.as_deref() == Some(job_id.as_str()))
+            .expect("terminal validation event");
+        assert_eq!(event.status.as_deref(), Some(status), "{job_status}");
+        assert_eq!(event.failure_kind.as_deref(), failure_kind, "{job_status}");
+    }
+
+    for (index, status) in [
+        "queued",
+        "agent_queued",
+        "started",
+        "running",
+        "stop_requested",
+        "recovering",
+        "unknown",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let job_id = format!("nonterminal-lifecycle-{index}");
+        assert!(
+            !store.record_validation_job_terminal(
+                &session.session_id,
+                &job_id,
+                &[job_id.as_str()],
+                "cargo_check",
+                session_tool_contract("cargo_check"),
+                Some(project.clone()),
+                target,
+                None,
+                status,
+                None,
+                None,
+                Some(90),
+                Some(200 + index as i64),
+                Some(10_000),
+                None,
+            ),
+            "{status} must not materialize terminal validation evidence"
+        );
+    }
+}

--- a/crates/webcodex-workflow-session/src/store.rs
+++ b/crates/webcodex-workflow-session/src/store.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 use webcodex_core::validation_identity::{
     assertion_validation_identity, is_validation_execution_identity,
 };
@@ -1654,6 +1655,9 @@ impl SessionStore {
             // authoritative execution activity.
             return false;
         };
+        let Ok(job_lifecycle) = RunnerJobLifecycle::from_wire(job_status) else {
+            return false;
+        };
         if !is_valid_session_id(session_id)
             || !is_safe_job_id(job_id)
             || retained_terminal_job_ids.len() > MAX_MATERIALIZED_VALIDATION_JOB_IDS
@@ -1675,10 +1679,7 @@ impl SessionStore {
                     | "run_job"
             )
             || !valid_target
-            || !matches!(
-                job_status,
-                "completed" | "failed" | "timeout" | "timed_out" | "stopped" | "cancelled" | "lost"
-            )
+            || !job_lifecycle.is_terminal()
         {
             return false;
         }
@@ -1708,27 +1709,31 @@ impl SessionStore {
                     })
             })
             .unwrap_or_default();
-        let process_succeeded = job_status == "completed" && exit_code == Some(0);
+        let process_succeeded =
+            job_lifecycle == RunnerJobLifecycle::Completed && exit_code == Some(0);
         let succeeded = process_succeeded && validation_passed.unwrap_or(true);
-        let failure_kind = (!succeeded).then(|| match job_status {
-            "timeout" | "timed_out" => "timeout".to_string(),
-            "stopped" | "cancelled" => "cancelled".to_string(),
-            "lost" => "execution_lost".to_string(),
+        let failure_kind = (!succeeded).then(|| match job_lifecycle {
+            RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut => "timeout".to_string(),
+            RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled => "cancelled".to_string(),
+            RunnerJobLifecycle::Lost => "execution_lost".to_string(),
             _ if process_succeeded => "validation_failed".to_string(),
             _ => "command_exit_nonzero".to_string(),
         });
-        let terminal_execution_state = match job_status {
-            "completed" | "failed" => "completed",
-            "timeout" | "timed_out" => "timed_out",
-            "stopped" | "cancelled" => "cancelled",
-            "lost" => "outcome_unknown",
+        let terminal_execution_state = match job_lifecycle {
+            RunnerJobLifecycle::Completed | RunnerJobLifecycle::Failed => "completed",
+            RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut => "timed_out",
+            RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled => "cancelled",
+            RunnerJobLifecycle::Lost => "outcome_unknown",
             _ => "outcome_unknown",
         };
         let expectation_output = serde_json::json!({
             "job_id": job_id,
             "exit_code": exit_code,
             "execution_state": terminal_execution_state,
-            "command_completed": matches!(job_status, "completed" | "failed") && exit_code.is_some(),
+            "command_completed": matches!(
+                job_lifecycle,
+                RunnerJobLifecycle::Completed | RunnerJobLifecycle::Failed
+            ) && exit_code.is_some(),
         });
         let failure_expectation_result = classify_failure_expectation(
             succeeded,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,6 +101,12 @@ The Runner is the trust boundary closest to the repository:
   fact: active Jobs enter a bounded `recovering` state and are restored from
   the Runner's inventory when the same instance reconnects.
 
+Runner Job wire lifecycle vocabulary is interpreted once by the canonical typed
+contract in `webcodex-core`; the Runner, Registry, Store, Connector runtime, and
+Workflow Session then project that lifecycle into their own domain states. Server
+recovery remains an orthogonal Registry overlay, so `recovering` is an observed
+recovery state rather than a Runner wire lifecycle value.
+
 ## Security boundary
 
 ```mermaid

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -21,6 +21,7 @@ use crate::runner_protocol::{
     ShellCommandExecutionState, ShellJobOpRequest, ShellJobValidationMetadata,
     ShellJobValidationStep,
 };
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 use webcodex_core::runtime_contract::STRUCTURED_EXECUTION_SYNC_WAIT_MAX_SECS;
 pub(crate) use webcodex_validation::parse_cargo_test_run_metadata;
 
@@ -1155,8 +1156,10 @@ impl ToolRuntime {
         let stdout_truncated = stdout_source_truncated || bounded_stdout_truncated;
         let stderr_truncated = stderr_source_truncated || bounded_stderr_truncated;
         let exit_code = job.as_ref().and_then(|job| job.exit_code);
-        let timed_out = matches!(job_status, "timeout" | "timed_out");
-        let process_passed = job_status == "completed" && exit_code == Some(0);
+        let lifecycle = RunnerJobLifecycle::from_wire(job_status).ok();
+        let timed_out = lifecycle.is_some_and(RunnerJobLifecycle::is_timed_out);
+        let process_passed =
+            lifecycle == Some(RunnerJobLifecycle::Completed) && exit_code == Some(0);
         let mut payload = json!({
             "project": handoff.project,
             "command_summary": handoff.command_summary,
@@ -1668,7 +1671,12 @@ impl Drop for ValidationCleanupGuard {
 }
 
 fn validation_handoff_execution_state(status: &str, started: bool) -> (&'static str, bool) {
-    let pending_status = matches!(status, "queued" | "agent_queued" | "started");
+    let pending_status = matches!(
+        RunnerJobLifecycle::from_wire(status),
+        Ok(RunnerJobLifecycle::Queued
+            | RunnerJobLifecycle::RunnerQueued
+            | RunnerJobLifecycle::StartedLegacy)
+    );
     let command_started = !pending_status || started;
     (
         if command_started { "running" } else { "queued" },

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -15,10 +15,7 @@ use crate::runner_protocol::{
 };
 
 pub(crate) fn is_blocking_active_job_status(status: &str) -> bool {
-    status == "recovering"
-        || RunnerJobLifecycle::from_wire(status).is_ok_and(|lifecycle| {
-            lifecycle.is_active() && lifecycle != RunnerJobLifecycle::StopRequested
-        })
+    webcodex_runner_registry::job_status_is_active(status) && !is_stop_pending_job_status(status)
 }
 
 pub(crate) fn is_stop_pending_job_status(status: &str) -> bool {

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 
 use super::helpers::{
     command_rejected_message, explicit_shell_dispatch_command, is_safe_job_id,
@@ -14,21 +15,18 @@ use crate::runner_protocol::{
 };
 
 pub(crate) fn is_blocking_active_job_status(status: &str) -> bool {
-    matches!(
-        status,
-        "queued" | "running" | "started" | "agent_queued" | "recovering"
-    )
+    status == "recovering"
+        || RunnerJobLifecycle::from_wire(status).is_ok_and(|lifecycle| {
+            lifecycle.is_active() && lifecycle != RunnerJobLifecycle::StopRequested
+        })
 }
 
 pub(crate) fn is_stop_pending_job_status(status: &str) -> bool {
-    status == "stop_requested"
+    RunnerJobLifecycle::from_wire(status) == Ok(RunnerJobLifecycle::StopRequested)
 }
 
 pub(crate) fn is_terminal_job_status(status: &str) -> bool {
-    matches!(
-        status,
-        "completed" | "failed" | "stopped" | "lost" | "timeout" | "timed_out" | "cancelled"
-    )
+    RunnerJobLifecycle::from_wire(status).is_ok_and(RunnerJobLifecycle::is_terminal)
 }
 
 pub(crate) fn detected_job_summary(
@@ -120,13 +118,17 @@ pub(crate) fn detected_job_summary_with_activity(
             Some(purpose) => purpose,
         }
     };
-    let outcome = if !is_terminal_job_status(status) {
+    let lifecycle = RunnerJobLifecycle::from_wire(status).ok();
+    let outcome = if !lifecycle.is_some_and(RunnerJobLifecycle::is_terminal) {
         "in_progress"
-    } else if status == "completed" && exit_code == Some(0) {
+    } else if lifecycle == Some(RunnerJobLifecycle::Completed) && exit_code == Some(0) {
         "passed"
-    } else if matches!(status, "timeout" | "timed_out") {
+    } else if lifecycle.is_some_and(RunnerJobLifecycle::is_timed_out) {
         "timed_out"
-    } else if matches!(status, "stopped" | "cancelled") {
+    } else if matches!(
+        lifecycle,
+        Some(RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled)
+    ) {
         "cancelled"
     } else {
         "failed"
@@ -378,26 +380,36 @@ pub(crate) fn validation_job_projection_with_policy(
         "cargo_fmt" => "format",
         _ => "check",
     });
-    if !is_terminal_job_status(status) {
+    let lifecycle = RunnerJobLifecycle::from_wire(status).ok();
+    if !lifecycle.is_some_and(RunnerJobLifecycle::is_terminal) {
         let mut value = json!({
             "tool": tool,
             "kind": kind,
-            "state": if status == "queued" || status == "agent_queued" { "pending" } else { "running" },
+            "state": if matches!(
+                lifecycle,
+                Some(RunnerJobLifecycle::Queued | RunnerJobLifecycle::RunnerQueued)
+            ) { "pending" } else { "running" },
         });
         apply_cargo_test_execution_policy(&mut value, tool, require_tests, no_run);
         return Some(value);
     }
     if matches!(
-        status,
-        "timeout" | "timed_out" | "stopped" | "cancelled" | "lost"
+        lifecycle,
+        Some(
+            RunnerJobLifecycle::Timeout
+                | RunnerJobLifecycle::TimedOut
+                | RunnerJobLifecycle::Stopped
+                | RunnerJobLifecycle::Cancelled
+                | RunnerJobLifecycle::Lost
+        )
     ) {
         let evidence = structured_validation_evidence(tool, kind, stdout, stderr, true);
         let mut value = json!({
             "tool": tool,
             "kind": kind,
-            "state": match status {
-                "timeout" | "timed_out" => "timed_out",
-                "stopped" | "cancelled" => "cancelled",
+            "state": match lifecycle {
+                Some(RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut) => "timed_out",
+                Some(RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled) => "cancelled",
                 _ => "lost",
             },
             "passed": Value::Null,
@@ -423,7 +435,7 @@ pub(crate) fn validation_job_projection_with_policy(
         apply_cargo_test_execution_policy(&mut value, tool, require_tests, no_run);
         return Some(value);
     }
-    let process_passed = status == "completed" && exit_code == Some(0);
+    let process_passed = lifecycle == Some(RunnerJobLifecycle::Completed) && exit_code == Some(0);
     let evidence = structured_validation_evidence(tool, kind, stdout, stderr, truncated);
     let mut passed = process_passed;
     let mut value = json!({

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -5,9 +5,8 @@ use super::{permissions, ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
 use crate::runner_protocol::{RunnerView, ShellJobInfo};
 use serde_json::{json, Value};
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 
-const RUNNING_JOB_STATUSES: &[&str] = &["running", "started"];
-const RUNNER_QUEUED_JOB_STATUSES: &[&str] = &["queued", "agent_queued"];
 const LIST_RUNNERS_MAX_CLIENT_IDS: usize = 8;
 const TARGET_CLIENT_ID_MAX_CHARS: usize = 128;
 
@@ -1326,11 +1325,17 @@ fn active_jobs_for_client(runner_jobs: &[ShellJobInfo], client_id: &str) -> usiz
 }
 
 fn job_status_is_running(status: &str) -> bool {
-    RUNNING_JOB_STATUSES.contains(&status)
+    matches!(
+        RunnerJobLifecycle::from_wire(status),
+        Ok(RunnerJobLifecycle::Running | RunnerJobLifecycle::StartedLegacy)
+    )
 }
 
 fn job_status_is_runner_queued(status: &str) -> bool {
-    RUNNER_QUEUED_JOB_STATUSES.contains(&status)
+    matches!(
+        RunnerJobLifecycle::from_wire(status),
+        Ok(RunnerJobLifecycle::Queued | RunnerJobLifecycle::RunnerQueued)
+    )
 }
 
 fn job_concurrency_for_client(client: &RunnerView, runner_jobs: &[ShellJobInfo]) -> Value {

--- a/src/tool_runtime/structured_execution.rs
+++ b/src/tool_runtime/structured_execution.rs
@@ -7,6 +7,7 @@ use crate::runner_protocol::{
 };
 use std::sync::Arc;
 use std::time::Duration;
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 use webcodex_runner_registry::RunnerAccess;
 
 pub(crate) const STRUCTURED_EXECUTION_SYNC_WAIT_SECS: u64 = 10;
@@ -168,15 +169,25 @@ pub(crate) async fn await_hidden_structured_job(
 }
 
 fn continued_execution_state(status: &str, started: bool) -> (&'static str, bool) {
-    match status {
-        "queued" | "agent_queued" | "started" if started => ("running", true),
-        "queued" | "agent_queued" | "started" => ("queued", false),
-        "running" => ("running", true),
-        "stop_requested" if started => ("running", true),
-        "stop_requested" => ("queued", false),
-        // Recovery is a real retained Job contract, but it is not proof that
-        // the execution is presently running. Preserve uncertainty explicitly.
-        "recovering" => ("outcome_unknown", true),
+    // Recovery is a Server observation overlay, not Runner lifecycle truth, and
+    // does not prove that execution is presently running.
+    if status == "recovering" {
+        return ("outcome_unknown", true);
+    }
+    match RunnerJobLifecycle::from_wire(status).ok() {
+        Some(
+            RunnerJobLifecycle::Queued
+            | RunnerJobLifecycle::RunnerQueued
+            | RunnerJobLifecycle::StartedLegacy,
+        ) if started => ("running", true),
+        Some(
+            RunnerJobLifecycle::Queued
+            | RunnerJobLifecycle::RunnerQueued
+            | RunnerJobLifecycle::StartedLegacy,
+        ) => ("queued", false),
+        Some(RunnerJobLifecycle::Running) => ("running", true),
+        Some(RunnerJobLifecycle::StopRequested) if started => ("running", true),
+        Some(RunnerJobLifecycle::StopRequested) => ("queued", false),
         _ => ("outcome_unknown", true),
     }
 }

--- a/src/tool_runtime/validation_events.rs
+++ b/src/tool_runtime/validation_events.rs
@@ -5,6 +5,7 @@
 //! mutation, and model-facing ToolResult composition.
 
 use serde_json::{json, Value};
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 use webcodex_tool_runtime_contracts::tool_audit::{
     assertion_validation_identity, is_structured_validation_target_identity,
     is_validation_execution_identity,
@@ -175,8 +176,10 @@ impl ToolRuntime {
                 .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
+            let job_lifecycle = RunnerJobLifecycle::from_wire(job_status).ok();
             let exit_code = status.output.get("exit_code").and_then(Value::as_i64);
-            let succeeded = job_status == "completed" && exit_code == Some(0);
+            let succeeded =
+                job_lifecycle == Some(RunnerJobLifecycle::Completed) && exit_code == Some(0);
             observed.status = Some(if succeeded { "succeeded" } else { "failed" }.to_string());
             observed.exit_code = exit_code;
             observed.started_at = status.output.get("started_at").and_then(Value::as_i64);
@@ -185,10 +188,14 @@ impl ToolRuntime {
                 observed.timestamp = completed_at;
             }
             observed.duration_ms = status.output.get("duration_ms").and_then(Value::as_u64);
-            observed.failure_kind = (!succeeded).then(|| match job_status {
-                "timeout" | "timed_out" => "timeout".to_string(),
-                "stopped" | "cancelled" => "cancelled".to_string(),
-                "lost" => "execution_lost".to_string(),
+            observed.failure_kind = (!succeeded).then(|| match job_lifecycle {
+                Some(RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut) => {
+                    "timeout".to_string()
+                }
+                Some(RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled) => {
+                    "cancelled".to_string()
+                }
+                Some(RunnerJobLifecycle::Lost) => "execution_lost".to_string(),
                 _ => "command_exit_nonzero".to_string(),
             });
 
@@ -212,10 +219,10 @@ impl ToolRuntime {
                         .unwrap_or(Value::Null);
                 }
             }
-            output["execution_state"] = json!(match job_status {
-                "timeout" | "timed_out" => "timed_out",
-                "stopped" | "cancelled" => "cancelled",
-                "lost" => "lost",
+            output["execution_state"] = json!(match job_lifecycle {
+                Some(RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut) => "timed_out",
+                Some(RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled) => "cancelled",
+                Some(RunnerJobLifecycle::Lost) => "lost",
                 _ => "completed",
             });
             output["exit_code"] = status
@@ -293,18 +300,10 @@ impl ToolRuntime {
         let retained_terminal_job_ids = jobs
             .iter()
             .filter(|job| {
-                matches!(
-                    job.get("status").and_then(Value::as_str),
-                    Some(
-                        "completed"
-                            | "failed"
-                            | "timeout"
-                            | "timed_out"
-                            | "stopped"
-                            | "cancelled"
-                            | "lost"
-                    )
-                )
+                job.get("status")
+                    .and_then(Value::as_str)
+                    .and_then(|status| RunnerJobLifecycle::from_wire(status).ok())
+                    .is_some_and(RunnerJobLifecycle::is_terminal)
             })
             .filter_map(|job| job.get("job_id").and_then(Value::as_str))
             .collect::<Vec<_>>();
@@ -316,10 +315,9 @@ impl ToolRuntime {
                 .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
-            if !matches!(
-                status_name,
-                "completed" | "failed" | "timeout" | "timed_out" | "stopped" | "cancelled" | "lost"
-            ) {
+            if !RunnerJobLifecycle::from_wire(status_name)
+                .is_ok_and(RunnerJobLifecycle::is_terminal)
+            {
                 continue;
             }
             let status = self
@@ -339,6 +337,7 @@ impl ToolRuntime {
                 .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or(status_name);
+            let terminal_lifecycle = RunnerJobLifecycle::from_wire(terminal_status).ok();
             let (
                 tool_name,
                 validation_target_id,
@@ -466,10 +465,10 @@ impl ToolRuntime {
             if let Some(validation_tool) = validation_tool {
                 output["validation_tool"] = json!(validation_tool);
             }
-            output["execution_state"] = json!(match terminal_status {
-                "timeout" | "timed_out" => "timed_out",
-                "stopped" | "cancelled" => "cancelled",
-                "lost" => "lost",
+            output["execution_state"] = json!(match terminal_lifecycle {
+                Some(RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut) => "timed_out",
+                Some(RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled) => "cancelled",
+                Some(RunnerJobLifecycle::Lost) => "lost",
                 _ => "completed",
             });
             output["exit_code"] = status


### PR DESCRIPTION
## Summary

- add canonical `RunnerJobLifecycle` semantics in `webcodex-core` for the accepted Runner Job wire lifecycle vocabulary
- delegate Runner, Registry, Store, Connector Runtime, Workflow Session, and root runtime status classification to the typed lifecycle contract
- keep Server recovery projection (`recovering`) orthogonal to Runner lifecycle and preserve consumer-specific execution/failure mappings
- preserve exact existing wire spellings and semantics for `queued`, `agent_queued`, `started`, `timeout`, `timed_out`, and the remaining lifecycle states

## Architecture

`RunnerJobLifecycle` now owns exact wire parsing/round-trip plus terminal, broadly-active, Runner-active, and timeout classification. Registry recovery remains a separate overlay; `recovering` and unknown values are rejected by the Runner lifecycle parser. Higher layers consume the typed lifecycle while retaining their own Connector/Workflow/Shell projections.

## Validation

Independent reviewer reran:

- `cargo test -p webcodex-core runner_job_lifecycle_wire_semantics_are_canonical` — 1 passed
- `cargo test -p webcodex-runner-registry job_lifecycle` — 6 passed
- `cargo test -p webcodex-store runner_job_lifecycle` — 2 passed
- `cargo test -p webcodex-workflow-session validation_job_terminal` — 1 passed
- `cargo check --all-targets -p webcodex` — passed, 0 warnings
- `cargo fmt --all -- --check` — passed
- `git diff --check 3e53baca...a4bec0a2` — passed
- workspace hygiene — clean; active Jobs 0

Independent committed-range review found no blocker or reviewer fix requiring an additional commit.