### PR TITLE
Support Windows network project paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,6 +5177,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.8.23",
+ "toml_edit 0.22.27",
  "url",
  "uuid",
  "webcodex",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4374,6 +4374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "webcodex-core"
+version = "0.4.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+]
+
+[[package]]
 name = "webcodex-desktop"
 version = "0.4.0"
 dependencies = [
@@ -4388,6 +4398,7 @@ dependencies = [
  "tokio",
  "url",
  "webcodex-process",
+ "webcodex-runner-config",
  "windows-sys 0.61.2",
  "winreg 0.55.0",
 ]
@@ -4398,6 +4409,15 @@ version = "0.4.0"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "webcodex-runner-config"
+version = "0.4.0"
+dependencies = [
+ "serde",
+ "toml 0.8.2",
+ "webcodex-core",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-single-instance = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
 url = "2"
 webcodex-process = { path = "../../../crates/webcodex-process" }
+webcodex-runner-config = { path = "../../../crates/webcodex-runner-config" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/apps/desktop/src-tauri/src/webcodex/adapter.rs
+++ b/apps/desktop/src-tauri/src/webcodex/adapter.rs
@@ -498,6 +498,16 @@ impl WebCodexAdapter {
     }
 }
 
+fn default_allowed_root(canonical: &Path) -> PathBuf {
+    #[cfg(windows)]
+    if webcodex_runner_config::paths::is_windows_network_share_path(canonical) {
+        // The user selected this exact network project. Do not silently widen
+        // Desktop's grant to the parent directory or the containing share.
+        return canonical.to_path_buf();
+    }
+    canonical.parent().unwrap_or(canonical).to_path_buf()
+}
+
 pub async fn inspect_project_path(path: &str) -> DesktopResult<ProjectSelection> {
     let requested = PathBuf::from(path);
     let canonical = tokio::fs::canonicalize(&requested).await.map_err(|_| {
@@ -521,7 +531,7 @@ pub async fn inspect_project_path(path: &str) -> DesktopResult<ProjectSelection>
             "Choose a project directory.",
         ));
     }
-    let allowed_root = canonical.parent().unwrap_or(&canonical).to_path_buf();
+    let allowed_root = default_allowed_root(&canonical);
     let is_git_repository = tokio::fs::symlink_metadata(canonical.join(".git"))
         .await
         .is_ok();
@@ -832,6 +842,23 @@ mod tests {
             validate_login_output(&output, &project).unwrap_err().code,
             "webcodex_contract_invalid"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_network_project_uses_exact_root_while_local_disk_keeps_parent_root() {
+        let network = Path::new(r"\\?\UNC\server\share\repo");
+        assert!(webcodex_runner_config::paths::paths_equal(
+            &default_allowed_root(network),
+            network
+        ));
+        assert!(!webcodex_runner_config::paths::paths_equal(
+            &default_allowed_root(network),
+            Path::new(r"\\server\share")
+        ));
+
+        let local = Path::new(r"C:\work\repo");
+        assert_eq!(default_allowed_root(local), PathBuf::from(r"C:\work"));
     }
 
     #[test]

--- a/crates/webcodex-cli/Cargo.toml
+++ b/crates/webcodex-cli/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1"
 sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8"
+toml_edit = "0.22"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -540,6 +540,7 @@ pub(crate) fn stage_connection(
     staging: &Path,
     published_project_registry_dir: &Path,
     opts: &LoginOptions,
+    allowed_roots: &[PathBuf],
     server_url: &str,
     identity: &EnrolledIdentity,
     device: &str,
@@ -574,7 +575,7 @@ pub(crate) fn stage_connection(
         // point at its final path after that staging directory is renamed.
         project_registry_dir: published_project_registry_dir.to_path_buf(),
         output: paths.runner_config.clone(),
-        allowed_roots: opts.allowed_roots.clone(),
+        allowed_roots: allowed_roots.to_vec(),
         allow_cwd_anywhere: false,
         overwrite: true,
     })?;
@@ -980,6 +981,10 @@ pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
     let device = resolve_device_name(base, &opts)?;
     let mut output_allowed_roots =
         webcodex_runner_config::effective_allowed_roots(&opts.allowed_roots, false)?;
+    // Preserve the historical generated-config behavior unless explicit project
+    // selection adds network authority. In that case this becomes the persisted
+    // Runner policy, including any effective HOME root that existed beforehand.
+    let mut runner_allowed_roots = opts.allowed_roots.clone();
 
     // When --project is present, even the project record is fully validated and
     // staged before redemption. The staging directory contains no credentials at
@@ -996,7 +1001,10 @@ pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
             false,
             None,
         ) {
-            Ok((registration, roots)) => {
+            Ok((registration, roots, authority_changed)) => {
+                if authority_changed {
+                    runner_allowed_roots = roots.clone();
+                }
                 output_allowed_roots = roots;
                 prestaged = Some((staging, registration));
             }
@@ -1042,6 +1050,7 @@ pub(crate) async fn run_login(opts: LoginOptions) -> Result<String, String> {
         &staging,
         &paths.project_registry_dir,
         &opts,
+        &runner_allowed_roots,
         &server_url,
         &identity,
         &device,
@@ -1230,6 +1239,7 @@ mod tests {
             &staging,
             &paths.project_registry_dir,
             &opts,
+            &opts.allowed_roots,
             &canonical.url,
             &identity,
             &opts.device,
@@ -1395,6 +1405,7 @@ mod tests {
             &staging,
             &paths.project_registry_dir,
             &opts,
+            &opts.allowed_roots,
             &canonical.url,
             &identity,
             &opts.device,
@@ -1427,6 +1438,44 @@ mod tests {
             parsed["policy"]["allowed_roots"].as_array().unwrap()[0].as_str(),
             allowed_root.to_str()
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn staged_login_persists_exact_network_project_authority_override() {
+        let temp = canonical_test_tempdir();
+        let base = temp.path().join("config");
+        let opts = login_opts(&base, "https://api.example.com", false);
+        let canonical = canonical_server_url(&opts.server_url).unwrap();
+        let identity = identity();
+        let parent = resolve_connection_parent(&base, &canonical).unwrap();
+        let paths = ConnectionPaths::new(parent.join(user_slug(&identity.username).unwrap()));
+        let staging = create_staging_dir(&parent).unwrap();
+        let network_project = PathBuf::from(r"\\?\UNC\NAS\work\repo");
+        stage_connection(
+            &staging,
+            &paths.project_registry_dir,
+            &opts,
+            std::slice::from_ref(&network_project),
+            &canonical.url,
+            &identity,
+            &opts.device,
+            "t",
+        )
+        .unwrap();
+        let runner_config = std::fs::read_to_string(staging.join("runner.toml")).unwrap();
+        let parsed: toml::Value = toml::from_str(&runner_config).unwrap();
+        let roots = parsed["policy"]["allowed_roots"].as_array().unwrap();
+        assert_eq!(roots.len(), 1);
+        assert!(webcodex_runner_config::paths::paths_equal(
+            Path::new(roots[0].as_str().unwrap()),
+            &network_project
+        ));
+        assert!(!webcodex_runner_config::paths::paths_equal(
+            Path::new(roots[0].as_str().unwrap()),
+            Path::new(r"\\nas\work")
+        ));
+        let _ = discard_internal_dir(&staging);
     }
 
     #[cfg(unix)]
@@ -1472,6 +1521,7 @@ mod tests {
             &staging,
             &paths.project_registry_dir,
             &opts,
+            &opts.allowed_roots,
             "https://api.example.com",
             &identity,
             &opts.device,
@@ -2099,6 +2149,7 @@ mod tests {
             &staging,
             &final_dir.join("project-registry"),
             &opts,
+            &opts.allowed_roots,
             &canonical.url,
             &identity(),
             &opts.device,
@@ -2429,7 +2480,7 @@ mod tests {
 
     #[cfg(windows)]
     #[tokio::test]
-    async fn login_project_rejects_raw_unc_before_redemption_or_canonicalization() {
+    async fn login_project_allows_raw_unc_to_reach_canonicalization_before_redemption() {
         let temp = canonical_test_tempdir();
         let base = temp.path().join("config");
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -2454,14 +2505,17 @@ mod tests {
             print_mcp_config: false,
         };
         let error = run_login(opts).await.unwrap_err();
-        assert!(error.contains("not on a local disk drive"), "{error}");
         assert!(
-            !error.contains("does not exist or cannot be resolved"),
-            "raw UNC ingress must fail before project canonicalization: {error}"
+            error.contains("does not exist or cannot be resolved"),
+            "raw UNC ingress must reach project canonicalization: {error}"
+        );
+        assert!(
+            !error.contains("unsupported Windows project namespace"),
+            "{error}"
         );
         assert!(
             !error.contains("failed to send"),
-            "raw UNC ingress must fail before the one-shot pairing request: {error}"
+            "filesystem resolution must still happen before the one-shot pairing request: {error}"
         );
         let canonical = canonical_server_url(&format!("http://{address}")).unwrap();
         let parent = resolve_connection_parent(&base, &canonical).unwrap();
@@ -3067,6 +3121,7 @@ mod tests {
             &staging,
             &paths.project_registry_dir,
             &opts,
+            &opts.allowed_roots,
             &canonical.url,
             &identity,
             &opts.device,

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -53,27 +53,85 @@ fn canonical_existing_directory(path: &Path, label: &str) -> Result<PathBuf, Str
     Ok(canonical)
 }
 
-fn effective_canonical_roots(
-    configured: &[PathBuf],
-    allow_cwd_anywhere: bool,
-) -> Result<Vec<PathBuf>, String> {
-    let effective =
-        webcodex_runner_config::effective_allowed_roots(configured, allow_cwd_anywhere)?;
-    Ok(webcodex_runner_config::paths::canonicalize_usable_allowed_roots(&effective))
+#[derive(Debug)]
+struct PreparedProjectAuthority {
+    canonical_project: PathBuf,
+    allowed_roots: Vec<PathBuf>,
+    authority_changed: bool,
 }
 
-fn validate_project_authority(
+fn authorize_canonical_project(
+    canonical_project: &Path,
+    configured_roots: &[PathBuf],
+    allow_cwd_anywhere: bool,
+) -> Result<(Vec<PathBuf>, bool), String> {
+    let mut effective_roots =
+        webcodex_runner_config::effective_allowed_roots(configured_roots, allow_cwd_anywhere)?;
+    let mut canonical_roots =
+        webcodex_runner_config::paths::canonicalize_usable_allowed_roots(&effective_roots);
+
+    match webcodex_runner_config::paths::validate_project_path_policy(
+        canonical_project,
+        &canonical_roots,
+        allow_cwd_anywhere,
+    ) {
+        // Preserve the pre-existing local registration/output contract: callers
+        // see canonical usable roots when no authority extension was needed.
+        Ok(()) => Ok((canonical_roots, false)),
+        Err(error) => {
+            #[cfg(windows)]
+            if webcodex_runner_config::paths::is_windows_network_share_path(canonical_project) {
+                // Local CLI/Desktop project selection is an explicit user grant. Add only the
+                // canonical project itself; never infer authority for its parent/share.
+                effective_roots.push(canonical_project.to_path_buf());
+                canonical_roots.push(canonical_project.to_path_buf());
+                webcodex_runner_config::paths::validate_project_path_policy(
+                    canonical_project,
+                    &canonical_roots,
+                    allow_cwd_anywhere,
+                )?;
+                return Ok((effective_roots, true));
+            }
+
+            Err(error)
+        }
+    }
+}
+
+fn prepare_project_authority(
     project: &Path,
     configured_roots: &[PathBuf],
     allow_cwd_anywhere: bool,
-) -> Result<Vec<PathBuf>, String> {
-    let roots = effective_canonical_roots(configured_roots, allow_cwd_anywhere)?;
-    webcodex_runner_config::paths::validate_project_path_policy(
-        project,
-        &roots,
-        allow_cwd_anywhere,
-    )?;
-    Ok(roots)
+) -> Result<PreparedProjectAuthority, String> {
+    webcodex_runner_config::paths::validate_project_path_ingress(project)?;
+    let canonical_project = canonical_existing_directory(project, "project path")?;
+    let (allowed_roots, authority_changed) =
+        authorize_canonical_project(&canonical_project, configured_roots, allow_cwd_anywhere)?;
+    Ok(PreparedProjectAuthority {
+        canonical_project,
+        allowed_roots,
+        authority_changed,
+    })
+}
+
+fn register_canonical_project(
+    project_registry_dir: &Path,
+    canonical_project: PathBuf,
+    explicit_id: Option<&str>,
+) -> Result<ProjectRegistration, String> {
+    ensure_registry_directory(project_registry_dir)?;
+    let (record_path, project_file, already_registered) =
+        resolve_project(project_registry_dir, &canonical_project, explicit_id)?;
+    if !already_registered {
+        let content = render_project_file(&project_file)?;
+        atomic_write(&record_path, content.as_bytes(), false)?;
+    }
+    Ok(ProjectRegistration {
+        id: project_file.id,
+        path: canonical_project,
+        record_path,
+        already_registered,
+    })
 }
 
 fn ensure_registry_directory(path: &Path) -> Result<(), String> {
@@ -116,26 +174,17 @@ pub(crate) fn register_existing_project(
     configured_roots: &[PathBuf],
     allow_cwd_anywhere: bool,
     explicit_id: Option<&str>,
-) -> Result<(ProjectRegistration, Vec<PathBuf>), String> {
-    webcodex_runner_config::paths::validate_project_path_ingress(project)?;
-    let canonical_project = canonical_existing_directory(project, "project path")?;
-    let roots =
-        validate_project_authority(&canonical_project, configured_roots, allow_cwd_anywhere)?;
-    ensure_registry_directory(project_registry_dir)?;
-    let (record_path, project_file, already_registered) =
-        resolve_project(project_registry_dir, &canonical_project, explicit_id)?;
-    if !already_registered {
-        let content = render_project_file(&project_file)?;
-        atomic_write(&record_path, content.as_bytes(), false)?;
-    }
+) -> Result<(ProjectRegistration, Vec<PathBuf>, bool), String> {
+    let prepared = prepare_project_authority(project, configured_roots, allow_cwd_anywhere)?;
+    let registration = register_canonical_project(
+        project_registry_dir,
+        prepared.canonical_project,
+        explicit_id,
+    )?;
     Ok((
-        ProjectRegistration {
-            id: project_file.id,
-            path: canonical_project,
-            record_path,
-            already_registered,
-        },
-        roots,
+        registration,
+        prepared.allowed_roots,
+        prepared.authority_changed,
     ))
 }
 
@@ -156,6 +205,30 @@ fn read_registration_config(path: &Path) -> Result<RegistrationRunnerConfig, Str
         .map_err(|error| format!("failed to read Runner config {}: {error}", path.display()))?;
     toml::from_str(&content)
         .map_err(|error| format!("failed to parse Runner config {}: {error}", path.display()))
+}
+
+fn persist_registration_allowed_roots(path: &Path, roots: &[PathBuf]) -> Result<(), String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read Runner config {}: {error}", path.display()))?;
+    let mut document = content
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|error| format!("failed to parse Runner config {}: {error}", path.display()))?;
+    if document.get("policy").is_none() {
+        document["policy"] = toml_edit::table();
+    }
+    let policy = document["policy"].as_table_mut().ok_or_else(|| {
+        format!(
+            "Runner config {} has an invalid [policy] table",
+            path.display()
+        )
+    })?;
+    let mut allowed_roots = toml_edit::Array::new();
+    for root in roots {
+        allowed_roots.push(root.to_string_lossy().as_ref());
+    }
+    policy["allowed_roots"] = toml_edit::value(allowed_roots);
+    atomic_write(path, document.to_string().as_bytes(), true)?;
+    Ok(())
 }
 
 fn registration_project_registry_dir(config: &RegistrationRunnerConfig) -> Result<PathBuf, String> {
@@ -181,13 +254,21 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
     // to one registry path, and an omitted field uses the shared four-state
     // on-disk selection contract.
     let project_registry_dir = registration_project_registry_dir(&config)?;
-    let (registration, roots) = register_existing_project(
-        &project_registry_dir,
+    let prepared = prepare_project_authority(
         &opts.project,
         &config.policy.allowed_roots,
         config.policy.allow_cwd_anywhere,
-        None,
     )?;
+    if prepared.authority_changed {
+        // Persist the explicit user grant before publishing the project record so a
+        // newly registered network project cannot outlive the Runner authority it needs.
+        persist_registration_allowed_roots(&opts.config, &prepared.allowed_roots)?;
+    }
+    let authority_changed = prepared.authority_changed;
+    let roots = prepared.allowed_roots;
+    let registration =
+        register_canonical_project(&project_registry_dir, prepared.canonical_project, None)?;
+    let runner_reload_required = !registration.already_registered || authority_changed;
     if opts.json {
         return serde_json::to_string_pretty(&serde_json::json!({
             "runner_config": opts.config.to_string_lossy(),
@@ -205,7 +286,7 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
                 "allow_cwd_anywhere": config.policy.allow_cwd_anywhere,
                 "allowed_roots": roots.iter().map(|root| root.to_string_lossy().to_string()).collect::<Vec<_>>(),
             },
-            "runner_reload_required": !registration.already_registered,
+            "runner_reload_required": runner_reload_required,
         }))
         .map_err(|error| error.to_string());
     }
@@ -216,7 +297,7 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
         "--config".to_string(),
         opts.config.to_string_lossy().into_owned(),
     ]);
-    if registration.already_registered {
+    if !runner_reload_required {
         return Ok(format!(
             "Project already added:\n  {}\n\nNo Runner restart is required.\n",
             registration.path.display()
@@ -231,8 +312,13 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
             "Next:\n  Stop the foreground Runner with Ctrl-C, then run:\n    {runner_command}\n"
         )
     };
+    let action = if registration.already_registered {
+        "Project already added"
+    } else {
+        "Project added"
+    };
     Ok(format!(
-        "Project added:\n  {}\n\nRunner restart required.\n\n{restart_guidance}",
+        "{action}:\n  {}\n\nRunner restart required.\n\n{restart_guidance}",
         registration.path.display()
     ))
 }
@@ -533,19 +619,98 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn raw_unc_is_rejected_before_canonicalization_even_when_explicitly_allowed() {
+    fn raw_unc_and_verbatim_unc_proceed_to_project_canonicalization() {
         let tmp = canonical_test_tempdir();
         let registry = tmp.path().join("registry");
-        let unc = PathBuf::from(r"\\server\share\webcodex-unreachable-repo");
-
-        let error =
-            register_existing_project(&registry, &unc, &[unc.clone()], true, None).unwrap_err();
-        assert!(error.contains("not on a local disk drive"), "{error}");
-        assert!(
-            !error.contains("does not exist or cannot be resolved"),
-            "raw UNC ingress must fail before canonicalization: {error}"
-        );
+        for network in [
+            PathBuf::from(r"\\server\share\webcodex-unreachable-repo"),
+            PathBuf::from(r"\\?\UNC\server\share\webcodex-unreachable-repo"),
+        ] {
+            let error =
+                register_existing_project(&registry, &network, &[], true, None).unwrap_err();
+            assert!(
+                error.contains("does not exist or cannot be resolved"),
+                "supported network ingress must reach canonicalization: {error}"
+            );
+            assert!(
+                !error.contains("unsupported Windows project namespace"),
+                "{error}"
+            );
+        }
         assert!(!registry.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn unsupported_windows_namespaces_still_fail_before_filesystem_resolution() {
+        let tmp = canonical_test_tempdir();
+        let registry = tmp.path().join("registry");
+        for unsupported in [
+            PathBuf::from(r"\\.\device\repo"),
+            PathBuf::from(r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo"),
+        ] {
+            let error =
+                register_existing_project(&registry, &unsupported, &[], true, None).unwrap_err();
+            assert!(
+                error.contains("unsupported Windows project namespace"),
+                "{error}"
+            );
+            assert!(
+                !error.contains("does not exist or cannot be resolved"),
+                "{error}"
+            );
+        }
+        assert!(!registry.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn user_selected_network_project_authorizes_only_the_exact_canonical_root() {
+        let network = PathBuf::from(r"\\?\UNC\NAS\work\repo");
+        let configured = vec![PathBuf::from(r"C:\stale-local-root")];
+        let (roots, changed) = authorize_canonical_project(&network, &configured, true).unwrap();
+        assert!(
+            changed,
+            "explicit network project selection must extend local authority"
+        );
+        assert_eq!(roots.len(), configured.len() + 1);
+        assert!(roots
+            .iter()
+            .any(|root| webcodex_runner_config::paths::paths_equal(root, &network)));
+        assert!(!roots.iter().any(|root| {
+            webcodex_runner_config::paths::paths_equal(root, Path::new(r"\\nas\work"))
+                || webcodex_runner_config::paths::paths_equal(root, Path::new(r"\\nas\share"))
+        }));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn persisted_network_authority_keeps_the_exact_root_in_runner_config() {
+        let tmp = canonical_test_tempdir();
+        let registry = tmp.path().join("registry");
+        let config_path = tmp.path().join("runner.toml");
+        config_with_policy(
+            &config_path,
+            &registry,
+            &[PathBuf::from(r"C:\existing")],
+            false,
+        );
+        let network = PathBuf::from(r"\\?\UNC\NAS\work\repo");
+        persist_registration_allowed_roots(
+            &config_path,
+            &[PathBuf::from(r"C:\existing"), network.clone()],
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains("secret-not-printed"));
+        let parsed: toml::Value = toml::from_str(&content).unwrap();
+        let roots = parsed["policy"]["allowed_roots"].as_array().unwrap();
+        assert_eq!(roots.len(), 2);
+        assert!(roots.iter().any(|value| {
+            value.as_str().is_some_and(|root| {
+                webcodex_runner_config::paths::paths_equal(Path::new(root), &network)
+            })
+        }));
     }
 
     #[cfg(windows)]

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -65,9 +65,9 @@ fn authorize_canonical_project(
     configured_roots: &[PathBuf],
     allow_cwd_anywhere: bool,
 ) -> Result<(Vec<PathBuf>, bool), String> {
-    let mut effective_roots =
+    let effective_roots =
         webcodex_runner_config::effective_allowed_roots(configured_roots, allow_cwd_anywhere)?;
-    let mut canonical_roots =
+    let canonical_roots =
         webcodex_runner_config::paths::canonicalize_usable_allowed_roots(&effective_roots);
 
     match webcodex_runner_config::paths::validate_project_path_policy(
@@ -81,6 +81,8 @@ fn authorize_canonical_project(
         Err(error) => {
             #[cfg(windows)]
             if webcodex_runner_config::paths::is_windows_network_share_path(canonical_project) {
+                let mut effective_roots = effective_roots;
+                let mut canonical_roots = canonical_roots;
                 // Local CLI/Desktop project selection is an explicit user grant. Add only the
                 // canonical project itself; never infer authority for its parent/share.
                 effective_roots.push(canonical_project.to_path_buf());
@@ -216,7 +218,7 @@ fn persist_registration_allowed_roots(path: &Path, roots: &[PathBuf]) -> Result<
     if document.get("policy").is_none() {
         document["policy"] = toml_edit::table();
     }
-    let policy = document["policy"].as_table_mut().ok_or_else(|| {
+    let policy = document["policy"].as_table_like_mut().ok_or_else(|| {
         format!(
             "Runner config {} has an invalid [policy] table",
             path.display()
@@ -226,7 +228,7 @@ fn persist_registration_allowed_roots(path: &Path, roots: &[PathBuf]) -> Result<
     for root in roots {
         allowed_roots.push(root.to_string_lossy().as_ref());
     }
-    policy["allowed_roots"] = toml_edit::value(allowed_roots);
+    policy.insert("allowed_roots", toml_edit::value(allowed_roots));
     atomic_write(path, document.to_string().as_bytes(), true)?;
     Ok(())
 }
@@ -351,6 +353,27 @@ mod tests {
 
     fn config(path: &Path, project_registry_dir: &Path, root: &Path) {
         config_with_policy(path, project_registry_dir, &[root.to_path_buf()], false);
+    }
+
+    #[test]
+    fn persist_allowed_roots_supports_inline_policy_and_preserves_other_settings() {
+        let tmp = canonical_test_tempdir();
+        let config_path = tmp.path().join("runner.toml");
+        std::fs::write(
+            &config_path,
+            "# operator configuration\nclient_id = 'test'\npolicy = { allow_cwd_anywhere = true, allowed_roots = [], max_timeout_secs = 42 }\n",
+        )
+        .unwrap();
+        let roots = vec![tmp.path().join("project")];
+        persist_registration_allowed_roots(&config_path, &roots).unwrap();
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        let parsed: toml::Value = toml::from_str(&content).unwrap();
+        assert!(content.contains("# operator configuration"));
+        assert_eq!(parsed["client_id"].as_str(), Some("test"));
+        assert_eq!(parsed["policy"]["allow_cwd_anywhere"].as_bool(), Some(true));
+        assert_eq!(parsed["policy"]["max_timeout_secs"].as_integer(), Some(42));
+        let config = read_registration_config(&config_path).unwrap();
+        assert_eq!(config.policy.allowed_roots, roots);
     }
 
     #[test]

--- a/crates/webcodex-runner-config/src/paths.rs
+++ b/crates/webcodex-runner-config/src/paths.rs
@@ -288,51 +288,65 @@ fn normalized_components(path: &Path) -> Vec<String> {
         .collect()
 }
 
-/// True when `path` is a Windows absolute path rooted on a local disk drive:
-/// `C:\...` or its canonicalized `\\?\C:\...` form. Every other Windows prefix
-/// — `\\server\share` (UNC), `\\?\UNC\server\share` (verbatim UNC),
-/// `\\.\device` (device namespace) and arbitrary `\\?\` verbatim paths — is
-/// `false`.
-///
-/// This is the Windows **path prefix** rule, not a string prefix check:
-/// `std::path` parses the path grammar, so `\\server\share\repo` is
-/// classified by its `Prefix::UNC` component rather than by text matching.
+/// Windows project-path prefix classes used by ingress, canonical policy, and
+/// user-facing adapters. This is grammar-based classification through
+/// `std::path::Prefix`, never a textual prefix check.
 #[cfg(windows)]
-pub fn is_windows_local_disk_path(path: &Path) -> bool {
-    let mut components = path.components();
-    match components.next() {
-        Some(std::path::Component::Prefix(prefix)) => matches!(
-            prefix.kind(),
-            std::path::Prefix::Disk(_) | std::path::Prefix::VerbatimDisk(_)
-        ),
-        _ => false,
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowsProjectPathKind {
+    LocalDisk,
+    NetworkShare,
+    UnsupportedNamespace,
+}
+
+/// Classify an explicit Windows path prefix. Paths without a prefix return
+/// `None` so raw relative/no-prefix inputs can continue to canonicalization.
+#[cfg(windows)]
+pub fn windows_project_path_kind(path: &Path) -> Option<WindowsProjectPathKind> {
+    let std::path::Component::Prefix(prefix) = path.components().next()? else {
+        return None;
+    };
+    Some(match prefix.kind() {
+        std::path::Prefix::Disk(_) | std::path::Prefix::VerbatimDisk(_) => {
+            WindowsProjectPathKind::LocalDisk
+        }
+        std::path::Prefix::UNC(_, _) | std::path::Prefix::VerbatimUNC(_, _) => {
+            WindowsProjectPathKind::NetworkShare
+        }
+        std::path::Prefix::DeviceNS(_) | std::path::Prefix::Verbatim(_) => {
+            WindowsProjectPathKind::UnsupportedNamespace
+        }
+    })
 }
 
 #[cfg(windows)]
-fn windows_non_local_project_path_error(path: &Path) -> String {
+pub fn is_windows_local_disk_path(path: &Path) -> bool {
+    windows_project_path_kind(path) == Some(WindowsProjectPathKind::LocalDisk)
+}
+
+#[cfg(windows)]
+pub fn is_windows_network_share_path(path: &Path) -> bool {
+    windows_project_path_kind(path) == Some(WindowsProjectPathKind::NetworkShare)
+}
+
+#[cfg(windows)]
+fn windows_unsupported_project_path_error(path: &Path) -> String {
     format!(
-        "path {} is not on a local disk drive; UNC and other Windows network/device paths are not supported for projects",
+        "path {} uses an unsupported Windows project namespace; device and generic verbatim namespaces are not supported for projects",
         path.to_string_lossy()
     )
 }
 
 /// Validate the raw project path before any canonicalization or filesystem I/O.
 ///
-/// On Windows an explicit local-disk prefix (`Disk` / `VerbatimDisk`) may
-/// proceed, while explicit UNC, verbatim UNC, device namespace, and other
-/// unsupported prefixes fail closed. Paths with no prefix (including relative
-/// paths) proceed to canonicalization, where the canonical path policy requires
-/// a local disk. Non-Windows platforms have no corresponding raw-prefix fence.
+/// On Windows explicit local disks and network shares (`UNC` / `VerbatimUNC`)
+/// may proceed. Device namespaces and generic verbatim namespaces fail closed.
+/// Paths with no prefix (including relative paths) continue to canonicalization,
+/// where the canonical project policy applies. Non-Windows behavior is unchanged.
 pub fn validate_project_path_ingress(path: &Path) -> Result<(), String> {
     #[cfg(windows)]
-    if let Some(std::path::Component::Prefix(prefix)) = path.components().next() {
-        if !matches!(
-            prefix.kind(),
-            std::path::Prefix::Disk(_) | std::path::Prefix::VerbatimDisk(_)
-        ) {
-            return Err(windows_non_local_project_path_error(path));
-        }
+    if windows_project_path_kind(path) == Some(WindowsProjectPathKind::UnsupportedNamespace) {
+        return Err(windows_unsupported_project_path_error(path));
     }
 
     #[cfg(not(windows))]
@@ -343,8 +357,8 @@ pub fn validate_project_path_ingress(path: &Path) -> Result<(), String> {
 
 /// System directories that must never become project roots through the broad
 /// `allow_cwd_anywhere` relaxation. An explicit allowed root still authorizes
-/// these paths intentionally. Windows non-local-disk paths are rejected before
-/// this list is considered, so a UNC allowed root cannot bypass that boundary.
+/// these paths intentionally. Windows network shares require explicit allowed-root
+/// authority and never inherit authority from `allow_cwd_anywhere`.
 const DANGEROUS_PROJECT_ROOTS: &[&str] = &[
     "/",
     "/etc",
@@ -406,9 +420,9 @@ pub fn canonicalize_usable_allowed_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
 /// Authoritative pure path-policy check for Runner project registration.
 ///
 /// `canonical_path` and `canonical_allowed_roots` must already be canonicalized
-/// by the caller. Windows non-local-disk paths always fail. Explicit local roots
-/// authorize first; otherwise `allow_cwd_anywhere` relaxes only ordinary paths,
-/// never dangerous system roots or Windows drive roots.
+/// by the caller. Explicit roots authorize local-disk and network-share projects.
+/// `allow_cwd_anywhere` relaxes only ordinary local-disk paths: it never grants
+/// authority to a Windows network share, dangerous system root, or drive root.
 pub fn validate_project_path_policy(
     canonical_path: &Path,
     canonical_allowed_roots: &[PathBuf],
@@ -417,15 +431,27 @@ pub fn validate_project_path_policy(
     let path_str = canonical_path.to_string_lossy();
 
     #[cfg(windows)]
-    if !is_windows_local_disk_path(canonical_path) {
-        return Err(windows_non_local_project_path_error(canonical_path));
-    }
+    let windows_kind = match windows_project_path_kind(canonical_path) {
+        Some(WindowsProjectPathKind::LocalDisk) => WindowsProjectPathKind::LocalDisk,
+        Some(WindowsProjectPathKind::NetworkShare) => WindowsProjectPathKind::NetworkShare,
+        Some(WindowsProjectPathKind::UnsupportedNamespace) | None => {
+            return Err(windows_unsupported_project_path_error(canonical_path));
+        }
+    };
 
     if canonical_allowed_roots
         .iter()
         .any(|root| path_is_within(canonical_path, root))
     {
         return Ok(());
+    }
+
+    #[cfg(windows)]
+    if windows_kind == WindowsProjectPathKind::NetworkShare {
+        return Err(format!(
+            "path {} is outside allowed_roots; allow_cwd_anywhere does not authorize Windows network shares",
+            path_str
+        ));
     }
 
     if !allow_cwd_anywhere {
@@ -868,41 +894,54 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_local_disk_prefix_classification_is_strict_for_canonical_paths() {
-        for accepted in [
+    fn windows_project_prefix_classification_distinguishes_disk_network_and_namespace() {
+        for local in [
             r"C:\repo",
             r"c:\repo",
             r"\\?\C:\repo",
             r"C:\Users\alice\proj\",
         ] {
-            assert!(
-                is_windows_local_disk_path(Path::new(accepted)),
-                "{accepted} must be accepted as a local disk path"
+            assert_eq!(
+                windows_project_path_kind(Path::new(local)),
+                Some(WindowsProjectPathKind::LocalDisk),
+                "{local} must be classified as a local disk"
+            );
+            assert!(is_windows_local_disk_path(Path::new(local)));
+        }
+
+        for network in [r"\\server\share\repo", r"\\?\UNC\server\share\repo"] {
+            assert_eq!(
+                windows_project_path_kind(Path::new(network)),
+                Some(WindowsProjectPathKind::NetworkShare),
+                "{network} must be classified as a network share"
+            );
+            assert!(is_windows_network_share_path(Path::new(network)));
+        }
+
+        for unsupported in [
+            r"\\.\device\repo",
+            r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
+        ] {
+            assert_eq!(
+                windows_project_path_kind(Path::new(unsupported)),
+                Some(WindowsProjectPathKind::UnsupportedNamespace),
+                "{unsupported} must fail closed as an unsupported namespace"
             );
         }
 
-        for non_local_or_uncanonical in [
-            r"\\server\share\repo",
-            r"\\?\UNC\server\share\repo",
-            r"\\.\device\repo",
-            r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
-            r"\repo",
-            r"repo",
-            ".",
-        ] {
-            assert!(
-                !is_windows_local_disk_path(Path::new(non_local_or_uncanonical)),
-                "{non_local_or_uncanonical} must not satisfy the strict canonical local-disk predicate"
-            );
+        for unprefixed in [r"\repo", r"repo", "."] {
+            assert_eq!(windows_project_path_kind(Path::new(unprefixed)), None);
         }
     }
 
     #[cfg(windows)]
     #[test]
-    fn windows_raw_project_ingress_rejects_only_explicit_non_local_prefixes() {
+    fn windows_raw_project_ingress_allows_disk_and_network_share_prefixes() {
         for allowed in [
             r"C:\repo",
             r"\\?\C:\repo",
+            r"\\server\share\repo",
+            r"\\?\UNC\server\share\repo",
             ".",
             r"repo",
             r"some\repo",
@@ -914,13 +953,14 @@ mod tests {
         }
 
         for rejected in [
-            r"\\server\share\repo",
-            r"\\?\UNC\server\share\repo",
             r"\\.\device\repo",
             r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
         ] {
             let error = validate_project_path_ingress(Path::new(rejected)).unwrap_err();
-            assert!(error.contains("not on a local disk drive"), "{error}");
+            assert!(
+                error.contains("unsupported Windows project namespace"),
+                "{error}"
+            );
         }
     }
 
@@ -939,22 +979,48 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn project_path_policy_preserves_windows_local_disk_and_drive_root_fences() {
-        for non_local in [
-            r"\\server\share\repo",
-            r"\\?\UNC\server\share\repo",
+    fn project_path_policy_requires_explicit_network_authority_and_keeps_namespace_fences() {
+        let network = Path::new(r"\\?\UNC\SERVER\Share\Repo");
+        validate_project_path_policy(network, &[PathBuf::from(r"\\server\share")], false)
+            .expect("a matching explicit network root must authorize the project");
+        validate_project_path_policy(
+            Path::new(r"\\server\SHARE\Repo\Child"),
+            &[PathBuf::from(r"\\?\UNC\server\share\repo")],
+            false,
+        )
+        .expect("network containment must use Windows case-insensitive identity semantics");
+
+        for allow_cwd_anywhere in [false, true] {
+            let error = validate_project_path_policy(network, &[], allow_cwd_anywhere).unwrap_err();
+            assert!(error.contains("outside allowed_roots"), "{error}");
+            if allow_cwd_anywhere {
+                assert!(
+                    error.contains("does not authorize Windows network shares"),
+                    "{error}"
+                );
+            }
+        }
+
+        for unsupported in [
             r"\\.\device\repo",
             r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
         ] {
             let error = validate_project_path_policy(
-                Path::new(non_local),
-                &[PathBuf::from(non_local)],
+                Path::new(unsupported),
+                &[PathBuf::from(unsupported)],
                 true,
             )
             .unwrap_err();
-            assert!(error.contains("not on a local disk drive"), "{error}");
+            assert!(
+                error.contains("unsupported Windows project namespace"),
+                "{error}"
+            );
         }
+    }
 
+    #[cfg(windows)]
+    #[test]
+    fn project_path_policy_preserves_windows_local_disk_and_drive_root_fences() {
         let drive_root = Path::new(r"C:\");
         let error = validate_project_path_policy(drive_root, &[], true).unwrap_err();
         assert!(error.contains("Windows drive root"), "{error}");
@@ -1025,9 +1091,21 @@ mod tests {
                 Path::new(r"c:\users\alice")
             ));
             assert_eq!(
-                normalize_path_identity(Path::new(r"\\server\share\dir")),
-                normalize_path_identity(Path::new(r"\\?\UNC\server\share\dir")),
+                normalize_path_identity(Path::new(r"\\SERVER\Share\Repo\")),
+                normalize_path_identity(Path::new(r"\\?\UNC\server\share\repo")),
             );
+            assert!(paths_equal(
+                Path::new(r"\\SERVER\Share\Repo\"),
+                Path::new(r"\\?\UNC\server\share\repo")
+            ));
+            assert!(path_is_within(
+                Path::new(r"\\?\UNC\SERVER\Share\Repo\Child"),
+                Path::new(r"\\server\share\repo")
+            ));
+            assert!(!path_is_within(
+                Path::new(r"\\server\share2\repo"),
+                Path::new(r"\\server\share")
+            ));
         }
         #[cfg(unix)]
         {

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -1405,6 +1405,29 @@ fn managed_worktree_request(
     )
 }
 
+#[cfg(windows)]
+#[test]
+fn managed_worktree_network_source_requires_runner_authority_before_resolution() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("project-registry");
+    let source = Path::new(r"\\untrusted-host\share\webcodex-unreachable-repo");
+    let policy = RunnerPolicy {
+        allow_cwd_anywhere: true,
+        allowed_roots: Vec::new(),
+        ..RunnerPolicy::default()
+    };
+    let request = managed_worktree_request(
+        source,
+        serde_json::Value::Null,
+        "77777777-7777-4777-8777-777777777777",
+        None,
+    );
+
+    let result = handle_prepare_managed_worktree(&policy, &registry, &request);
+    assert_eq!(project_err(result), "path_outside_allowed_roots");
+    assert!(!registry.exists());
+}
+
 #[test]
 fn managed_worktree_bootstrap_is_detached_registered_and_same_operation_recovers() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/webcodex-runner/src/main_tests/project_creation.rs
+++ b/crates/webcodex-runner/src/main_tests/project_creation.rs
@@ -26,6 +26,32 @@ fn create_project_basic_creates_readme_and_gitignore() {
         .contains("Basic template"));
 }
 
+#[cfg(windows)]
+#[test]
+fn create_project_does_not_expand_to_network_shares() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_registry_dir = tmp.path().join("project-registry");
+    let policy = RunnerPolicy {
+        allow_cwd_anywhere: true,
+        ..RunnerPolicy::default()
+    };
+    let error = project_error_value(handle_project_op(
+        &policy,
+        &project_registry_dir,
+        &project_request(
+            "create_project",
+            serde_json::json!({
+                "id": "network",
+                "name": "Network",
+                "path": r"\\server\share\new-project",
+                "template": "empty"
+            }),
+        ),
+    ));
+    assert_eq!(error["error_code"], "windows_project_path_unsupported");
+    assert!(!project_registry_dir.exists());
+}
+
 #[test]
 fn create_project_rejects_existing_non_empty_directory() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/webcodex-runner/src/main_tests/project_registration.rs
+++ b/crates/webcodex-runner/src/main_tests/project_registration.rs
@@ -414,6 +414,40 @@ fn model_facing_network_ingress_requires_authority_before_filesystem_resolution(
 
 #[cfg(windows)]
 #[test]
+fn model_facing_network_ingress_rejects_parent_traversal_and_empty_roots() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("project-registry");
+    for (root, path) in [
+        (r"\\server\share\repo", r"\\server\share\repo\..\private"),
+        (
+            r"\\server\share\repo",
+            r"\\?\UNC\server\share\repo\..\private",
+        ),
+        ("", r"\\untrusted-host\share\repo"),
+    ] {
+        let policy = RunnerPolicy {
+            allow_cwd_anywhere: true,
+            allowed_roots: vec![PathBuf::from(root)],
+            ..RunnerPolicy::default()
+        };
+        let error = project_error_value(handle_resolve_or_register_project(
+            &policy,
+            &registry,
+            &project_request(
+                "resolve_or_register_project",
+                serde_json::json!({"path": path}),
+            ),
+        ));
+        assert_eq!(
+            error["error_kind"], "path_outside_allowed_roots",
+            "raw network ingress must reject {path:?} under {root:?} before target I/O"
+        );
+    }
+    assert!(!registry.exists());
+}
+
+#[cfg(windows)]
+#[test]
 fn resolve_or_register_project_rejects_unsupported_windows_namespaces() {
     let tmp = tempfile::tempdir().unwrap();
     let project_registry_dir = tmp.path().join("project-registry");

--- a/crates/webcodex-runner/src/main_tests/project_registration.rs
+++ b/crates/webcodex-runner/src/main_tests/project_registration.rs
@@ -358,10 +358,14 @@ fn resolve_or_register_project_rejects_invalid_non_directory_and_disallowed_path
 
 #[cfg(windows)]
 #[test]
-fn resolve_or_register_project_network_paths_reach_filesystem_resolution() {
+fn resolve_or_register_project_authorized_network_paths_reach_filesystem_resolution() {
     let tmp = tempfile::tempdir().unwrap();
     let project_registry_dir = tmp.path().join("project-registry");
-    let policy = project_policy(tmp.path());
+    let policy = RunnerPolicy {
+        allow_cwd_anywhere: true,
+        allowed_roots: vec![PathBuf::from(r"\\server\share")],
+        ..RunnerPolicy::default()
+    };
 
     for network_path in [
         r"\\server\share\webcodex-unreachable-repo",
@@ -377,10 +381,34 @@ fn resolve_or_register_project_network_paths_reach_filesystem_resolution() {
         ));
         assert_eq!(
             error["error_kind"], "project_path_not_found",
-            "supported network path {network_path} must reach filesystem resolution"
+            "authorized network path {network_path} must reach filesystem resolution"
         );
         assert_eq!(error["state_changed"], false);
     }
+    assert!(!project_registry_dir.exists());
+}
+
+#[cfg(windows)]
+#[test]
+fn model_facing_network_ingress_requires_authority_before_filesystem_resolution() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_registry_dir = tmp.path().join("project-registry");
+    let denied = RunnerPolicy {
+        allow_cwd_anywhere: true,
+        allowed_roots: Vec::new(),
+        ..RunnerPolicy::default()
+    };
+    let raw = Path::new(r"\\untrusted-host\share\webcodex-unreachable-repo");
+    let error = project_error_value(handle_resolve_or_register_project(
+        &denied,
+        &project_registry_dir,
+        &project_request(
+            "resolve_or_register_project",
+            serde_json::json!({"path": raw.to_string_lossy()}),
+        ),
+    ));
+    assert_eq!(error["error_kind"], "path_outside_allowed_roots");
+    assert_eq!(error["state_changed"], false);
     assert!(!project_registry_dir.exists());
 }
 
@@ -475,29 +503,39 @@ fn resolve_or_register_project_accepts_local_drive_and_verbatim_disk_identity() 
 
 #[cfg(windows)]
 #[test]
-fn register_project_network_path_reaches_filesystem_resolution() {
+fn register_project_network_path_requires_authority_before_filesystem_resolution() {
     let tmp = tempfile::tempdir().unwrap();
     let project_registry_dir = tmp.path().join("project-registry");
-    let policy = project_policy(tmp.path());
-
-    let result = handle_project_op(
-        &policy,
-        &project_registry_dir,
-        &project_request(
-            "register_project",
-            serde_json::json!({
-                "id": "demo",
-                "name": "Demo",
-                "path": r"\\server\share\webcodex-unreachable-repo",
-                "description": "UNC project",
-                "allow_patch": false
-            }),
-        ),
+    let path = r"\\server\share\webcodex-unreachable-repo";
+    let request = project_request(
+        "register_project",
+        serde_json::json!({
+            "id": "demo",
+            "name": "Demo",
+            "path": path,
+            "description": "UNC project",
+            "allow_patch": false
+        }),
     );
+
+    let denied = RunnerPolicy {
+        allow_cwd_anywhere: true,
+        allowed_roots: Vec::new(),
+        ..RunnerPolicy::default()
+    };
+    let denied_error =
+        project_error_value(handle_project_op(&denied, &project_registry_dir, &request));
+    assert_eq!(denied_error["error_code"], "path_outside_allowed_roots");
+
+    let allowed = RunnerPolicy {
+        allowed_roots: vec![PathBuf::from(r"\\server\share")],
+        ..RunnerPolicy::default()
+    };
+    let result = handle_project_op(&allowed, &project_registry_dir, &request);
     let error = result.error.as_deref().unwrap_or_default();
     assert!(
         error.contains("does not exist or cannot be canonicalized"),
-        "supported UNC registration must reach filesystem resolution: {error}"
+        "authorized UNC registration must reach filesystem resolution: {error}"
     );
     assert!(
         !error.contains("windows_project_path_unsupported"),

--- a/crates/webcodex-runner/src/main_tests/project_registration.rs
+++ b/crates/webcodex-runner/src/main_tests/project_registration.rs
@@ -358,16 +358,39 @@ fn resolve_or_register_project_rejects_invalid_non_directory_and_disallowed_path
 
 #[cfg(windows)]
 #[test]
-fn resolve_or_register_project_rejects_unc_and_non_local_disk_paths() {
+fn resolve_or_register_project_network_paths_reach_filesystem_resolution() {
     let tmp = tempfile::tempdir().unwrap();
     let project_registry_dir = tmp.path().join("project-registry");
     let policy = project_policy(tmp.path());
 
-    // The raw path check must fire before canonicalization: these shares do
-    // not exist, but the error is the platform rule, not "path not found".
-    for unc_path in [
-        r"\\server\share\repo",
-        r"\\?\UNC\server\share\repo",
+    for network_path in [
+        r"\\server\share\webcodex-unreachable-repo",
+        r"\\?\UNC\server\share\webcodex-unreachable-repo",
+    ] {
+        let error = project_error_value(handle_resolve_or_register_project(
+            &policy,
+            &project_registry_dir,
+            &project_request(
+                "resolve_or_register_project",
+                serde_json::json!({"path": network_path}),
+            ),
+        ));
+        assert_eq!(
+            error["error_kind"], "project_path_not_found",
+            "supported network path {network_path} must reach filesystem resolution"
+        );
+        assert_eq!(error["state_changed"], false);
+    }
+    assert!(!project_registry_dir.exists());
+}
+
+#[cfg(windows)]
+#[test]
+fn resolve_or_register_project_rejects_unsupported_windows_namespaces() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_registry_dir = tmp.path().join("project-registry");
+    let policy = project_policy(tmp.path());
+    for unsupported in [
         r"\\.\device\repo",
         r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\repo",
     ] {
@@ -376,38 +399,26 @@ fn resolve_or_register_project_rejects_unc_and_non_local_disk_paths() {
             &project_registry_dir,
             &project_request(
                 "resolve_or_register_project",
-                serde_json::json!({"path": unc_path}),
+                serde_json::json!({"path": unsupported}),
             ),
         ));
-        assert_eq!(
-            error["error_kind"], "unc_project_path_unsupported",
-            "{unc_path} must fail closed as an unsupported non-local-disk path"
-        );
+        assert_eq!(error["error_kind"], "windows_project_path_unsupported");
         assert_eq!(error["state_changed"], false);
     }
-    assert!(
-        !project_registry_dir.exists(),
-        "no registration may be attempted"
-    );
+    assert!(!project_registry_dir.exists());
+}
 
-    // An allowed_roots entry naming a UNC share must not bypass the rule.
-    let unc_allowed = RunnerPolicy {
-        allow_cwd_anywhere: false,
-        allowed_roots: vec![PathBuf::from(r"\\server\share\repo")],
+#[cfg(windows)]
+#[test]
+fn model_facing_policy_does_not_auto_authorize_network_share_with_allow_anywhere() {
+    let policy = RunnerPolicy {
+        allow_cwd_anywhere: true,
+        allowed_roots: Vec::new(),
         ..RunnerPolicy::default()
     };
-    let error = project_error_value(handle_resolve_or_register_project(
-        &unc_allowed,
-        &project_registry_dir,
-        &project_request(
-            "resolve_or_register_project",
-            serde_json::json!({"path": r"\\server\share\repo"}),
-        ),
-    ));
-    assert_eq!(
-        error["error_kind"], "unc_project_path_unsupported",
-        "a UNC allowed_root must not make a UNC project root acceptable"
-    );
+    let error = validate_project_path_policy(&policy, Path::new(r"\\server\share\repo"))
+        .expect_err("model-facing RunnerPolicy must not auto-authorize a network share");
+    assert!(error.contains("outside allowed_roots"), "{error}");
 }
 
 #[cfg(windows)]
@@ -464,12 +475,12 @@ fn resolve_or_register_project_accepts_local_drive_and_verbatim_disk_identity() 
 
 #[cfg(windows)]
 #[test]
-fn register_project_rejects_unc_paths() {
+fn register_project_network_path_reaches_filesystem_resolution() {
     let tmp = tempfile::tempdir().unwrap();
     let project_registry_dir = tmp.path().join("project-registry");
     let policy = project_policy(tmp.path());
 
-    let error = project_error_value(handle_project_op(
+    let result = handle_project_op(
         &policy,
         &project_registry_dir,
         &project_request(
@@ -477,13 +488,21 @@ fn register_project_rejects_unc_paths() {
             serde_json::json!({
                 "id": "demo",
                 "name": "Demo",
-                "path": r"\\server\share\repo",
+                "path": r"\\server\share\webcodex-unreachable-repo",
                 "description": "UNC project",
                 "allow_patch": false
             }),
         ),
-    ));
-    assert_eq!(error["error_code"], "unc_project_path_unsupported");
+    );
+    let error = result.error.as_deref().unwrap_or_default();
+    assert!(
+        error.contains("does not exist or cannot be canonicalized"),
+        "supported UNC registration must reach filesystem resolution: {error}"
+    );
+    assert!(
+        !error.contains("windows_project_path_unsupported"),
+        "{error}"
+    );
     assert!(!project_registry_dir.exists());
 }
 

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -778,19 +778,16 @@ impl RunnerProjectCache {
     }
 }
 
-/// Windows-only fail-closed rule: project roots must be on a local disk drive
-/// (`C:\repo`, `D:\repo`, or the canonicalized `\\?\C:\repo` form). UNC
-/// (`\\server\share\repo`), verbatim-UNC (`\\?\UNC\...`), device-namespace
-/// (`\\.\...`) and every other non-disk Windows path prefix is rejected with
-/// the stable `unc_project_path_unsupported` error before any filesystem
-/// access happens.
+/// Windows-only raw/canonical namespace fence. Local disks plus UNC and
+/// verbatim-UNC shares may proceed; device namespaces and generic verbatim
+/// namespaces fail closed with a stable error before filesystem access.
 ///
 /// The shared `webcodex_runner_config::paths::validate_project_path_ingress`
 /// owns the grammar-based prefix rule; it never falls back to a string
 /// `starts_with` check.
 fn validate_windows_project_root(path: &Path) -> Result<(), &'static str> {
     webcodex_runner_config::paths::validate_project_path_ingress(path)
-        .map_err(|_| "unc_project_path_unsupported")
+        .map_err(|_| "windows_project_path_unsupported")
 }
 
 /// Escape a string for use as a TOML basic string (double-quoted). NUL is
@@ -1330,9 +1327,9 @@ pub(crate) fn handle_resolve_or_register_project_operation(
             )
         }
     };
-    // The raw input path is checked before any filesystem access so a UNC
-    // path is rejected as `unc_project_path_unsupported` even when the share
-    // is unreachable (which would otherwise surface as `project_path_not_found`).
+    // Reject unsupported Windows namespaces before touching the filesystem.
+    // UNC/VerbatimUNC intentionally proceed so an unreachable share surfaces as
+    // the ordinary `project_path_not_found` availability result.
     if let Err(error_kind) = validate_windows_project_root(Path::new(path)) {
         return structured_project_error_cmd(
             start,
@@ -1352,9 +1349,8 @@ pub(crate) fn handle_resolve_or_register_project_operation(
             )
         }
     };
-    // The canonical form is checked too: Windows canonicalization rewrites
-    // reachable UNC paths into `\\?\UNC\...`, which the raw check may not
-    // have seen verbatim.
+    // Re-check the canonical form so canonicalization cannot introduce a device
+    // or other unsupported Windows namespace. VerbatimUNC remains supported.
     if let Err(error_kind) = validate_windows_project_root(&canonical_path) {
         return structured_project_error_cmd(
             start,
@@ -2770,11 +2766,16 @@ pub(crate) fn handle_project_operation(
     if path.is_empty() || path.contains('\0') || !Path::new(&path).is_absolute() {
         return err_cmd(start, "path must be a non-empty absolute path".to_string());
     }
-    // Windows supports local-drive project roots only; UNC and other
-    // non-disk prefixes fail closed here, before the directory is touched,
-    // so an unreachable share cannot masquerade as a missing directory.
+    // Existing project registration accepts local disks and network shares;
+    // special Windows namespaces still fail before filesystem access.
     if let Err(error_kind) = validate_windows_project_root(Path::new(&path)) {
         return project_error_cmd(start, error_kind);
+    }
+    #[cfg(windows)]
+    if create && webcodex_runner_config::paths::is_windows_network_share_path(Path::new(&path)) {
+        // Network project creation is deliberately outside this phase. Existing
+        // network directories can be registered when RunnerPolicy already grants them.
+        return project_error_cmd(start, "windows_project_path_unsupported");
     }
 
     let client_id = client_id.to_string();
@@ -2920,6 +2921,12 @@ pub(crate) fn handle_project_operation(
     };
     if let Err(error_kind) = validate_windows_project_root(&canonical_for_policy) {
         return project_error_cmd(start, error_kind);
+    }
+    #[cfg(windows)]
+    if webcodex_runner_config::paths::is_windows_network_share_path(&canonical_for_policy) {
+        // A mapped drive may canonicalize to VerbatimUNC. Keep create_project
+        // local-only even when the raw spelling looked like a drive letter.
+        return project_error_cmd(start, "windows_project_path_unsupported");
     }
     if validate_project_path_policy(policy, &canonical_for_policy).is_err() {
         return project_error_cmd(start, "path_outside_allowed_roots");

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -790,6 +790,47 @@ fn validate_windows_project_root(path: &Path) -> Result<(), &'static str> {
         .map_err(|_| "windows_project_path_unsupported")
 }
 
+/// Before a model-facing request dereferences a raw Windows network path, require
+/// it to fall under Runner authority that was already configured by the user.
+/// This prevents an untrusted `\\server\share` spelling from triggering SMB I/O
+/// (and possible OS authentication) merely to discover that policy rejects it.
+fn validate_model_network_project_ingress_authority(
+    policy: &RunnerPolicy,
+    path: &Path,
+) -> Result<(), &'static str> {
+    #[cfg(windows)]
+    {
+        if !webcodex_runner_config::paths::is_windows_network_share_path(path) {
+            return Ok(());
+        }
+        if policy
+            .allowed_roots
+            .iter()
+            .any(|root| webcodex_runner_config::paths::path_is_within(path, root))
+        {
+            return Ok(());
+        }
+        // A configured mapped drive may canonicalize to the same UNC share. It is
+        // safe to resolve configured roots here because those roots are already
+        // user-authorized; never canonicalize the untrusted target before this gate.
+        let canonical_roots =
+            webcodex_runner_config::paths::canonicalize_usable_allowed_roots(&policy.allowed_roots);
+        if canonical_roots
+            .iter()
+            .any(|root| webcodex_runner_config::paths::path_is_within(path, root))
+        {
+            return Ok(());
+        }
+        return Err("path_outside_allowed_roots");
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = (policy, path);
+        Ok(())
+    }
+}
+
 /// Escape a string for use as a TOML basic string (double-quoted). NUL is
 /// rejected up front by validation, so we only handle backslash, quote, and
 /// common control characters.
@@ -1327,10 +1368,20 @@ pub(crate) fn handle_resolve_or_register_project_operation(
             )
         }
     };
-    // Reject unsupported Windows namespaces before touching the filesystem.
-    // UNC/VerbatimUNC intentionally proceed so an unreachable share surfaces as
-    // the ordinary `project_path_not_found` availability result.
+    // Reject unsupported namespaces before filesystem access. Raw UNC/VerbatimUNC
+    // inputs must also be covered by pre-existing Runner authority before they may
+    // trigger SMB I/O; local CLI/Desktop onboarding owns any authority extension.
     if let Err(error_kind) = validate_windows_project_root(Path::new(path)) {
+        return structured_project_error_cmd(
+            start,
+            error_kind,
+            false,
+            serde_json::json!({"field": "path"}),
+        );
+    }
+    if let Err(error_kind) =
+        validate_model_network_project_ingress_authority(policy, Path::new(path))
+    {
         return structured_project_error_cmd(
             start,
             error_kind,
@@ -1926,6 +1977,11 @@ pub(crate) fn handle_prepare_managed_worktree_operation(
             None,
             None,
         );
+    }
+    if let Err(error_kind) =
+        validate_model_network_project_ingress_authority(policy, Path::new(path))
+    {
+        return managed_worktree_error(start, error_kind, false, Some(&base_ref), None, None);
     }
     let source = match canonicalize_existing(Path::new(path)) {
         Ok(source) if source.is_dir() && source.to_str().is_some() => source,
@@ -2770,6 +2826,13 @@ pub(crate) fn handle_project_operation(
     // special Windows namespaces still fail before filesystem access.
     if let Err(error_kind) = validate_windows_project_root(Path::new(&path)) {
         return project_error_cmd(start, error_kind);
+    }
+    if !create {
+        if let Err(error_kind) =
+            validate_model_network_project_ingress_authority(policy, Path::new(&path))
+        {
+            return project_error_cmd(start, error_kind);
+        }
     }
     #[cfg(windows)]
     if create && webcodex_runner_config::paths::is_windows_network_share_path(Path::new(&path)) {

--- a/crates/webcodex-runner/src/webcodex_runner/projects.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/projects.rs
@@ -803,11 +803,17 @@ fn validate_model_network_project_ingress_authority(
         if !webcodex_runner_config::paths::is_windows_network_share_path(path) {
             return Ok(());
         }
-        if policy
-            .allowed_roots
-            .iter()
-            .any(|root| webcodex_runner_config::paths::path_is_within(path, root))
+        // Containment below is lexical: a parent component could escape an
+        // authorized directory before the canonical policy gets a chance to run.
+        if path
+            .components()
+            .any(|component| component == std::path::Component::ParentDir)
         {
+            return Err("path_outside_allowed_roots");
+        }
+        if policy.allowed_roots.iter().any(|root| {
+            root.is_absolute() && webcodex_runner_config::paths::path_is_within(path, root)
+        }) {
             return Ok(());
         }
         // A configured mapped drive may canonicalize to the same UNC share. It is

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -73,6 +73,15 @@ evidence.
 | `webcodex pairing create` | Server/admin side: create a short-lived pairing code | Needs server bootstrap/admin auth. |
 | `webcodex logout <server-url> [--user USER|--all]` | Remove this device's credentials for a Server | With one saved user, the user is selected automatically. With multiple saved users, choose one with `--user USER` or explicitly choose all with `--all`; deletion still uses the existing confirmation/`--yes` flow. |
 
+On Windows, `login --project` and `project register` accept existing UNC network
+directories, including the `\\?\UNC\server\share\repo` form. Selecting a network
+project adds its exact canonical directory to the saved Runner `allowed_roots`
+when needed; it does not grant the parent directory or entire share. Restart an
+already-running Runner when the command reports that a reload is required.
+Model-facing registration requires preconfigured network authority even with
+`allow_cwd_anywhere = true`; use a direct path without `..` components.
+Creating new network projects with `create_project` remains unsupported.
+
 ### Runner lifecycle
 
 The Runner executable is `webcodex-runner`. Its canonical CLI lifecycle namespace


### PR DESCRIPTION
## Summary

- support existing Windows UNC / VerbatimUNC project paths while keeping device and generic verbatim namespaces fail-closed
- require explicit Runner network authority before model-facing UNC paths can trigger filesystem / SMB resolution; `allow_cwd_anywhere` does not grant network access
- persist exact canonical network project roots for user-driven CLI/Desktop onboarding, including inline TOML policy tables, without widening to the parent/share
- preserve stable UNC identity and Desktop display behavior; keep `create_project` on network targets unsupported
- document the Windows network-project behavior

Closes #340

## Validation

- `cargo test -p webcodex-cli webcodex_cli::project::tests -- --nocapture` — 18 passed
- `cargo test -p webcodex-runner project_registration -- --nocapture` — 16 passed
- `git diff --check origin/main...HEAD`
- earlier Windows SMB / mapped-drive dogfood verified mapped `O:` and raw UNC converge on the same project identity and support file/Git/shell operations
