### PR TITLE
Fix Windows internal POSIX shell routing

### DIFF
--- a/src/tool_runtime/files.rs
+++ b/src/tool_runtime/files.rs
@@ -11,7 +11,7 @@ use webcodex_workspace::file_read_range::{self, EffectiveRange, FileReadRange, R
 #[cfg(test)]
 use super::helpers::run_command_sync;
 use super::helpers::{
-    looks_like_command_timeout, shell_escape_simple, validate_limited_cleanup_paths,
+    bounded_tail, looks_like_command_timeout, shell_escape_simple, validate_limited_cleanup_paths,
     validate_project_relative_path,
 };
 use super::project_resolution::ResolvedProject;
@@ -51,7 +51,7 @@ pub(crate) use artifacts::{
 #[cfg(test)]
 pub(crate) use artifacts::{MAX_PROJECT_ARTIFACT_BYTES, MAX_PROJECT_ARTIFACT_UPLOAD_BYTES};
 #[cfg(test)]
-pub(crate) use inspection::parse_file_list_entries;
+pub(crate) use inspection::{parse_file_list_entries, LIST_TRACKED_STDERR_MAX_CHARS};
 #[cfg(test)]
 pub(crate) use mutations::{apply_text_edits_to_string, validate_edit_file_path};
 use search::search_head_resolution_shell;

--- a/src/tool_runtime/files/inspection.rs
+++ b/src/tool_runtime/files/inspection.rs
@@ -425,17 +425,18 @@ fn list_tracked_error(code: &str, message: String) -> ToolResult {
     ToolResult::err_with_output(message.clone(), json!({ "code": code, "message": message }))
 }
 
-/// First non-empty line of command stderr, bounded — enough to diagnose,
-/// short enough not to spend model context on a stack of Git noise.
-fn first_line(stderr: &str) -> String {
-    stderr
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .unwrap_or("")
-        .chars()
-        .take(200)
-        .collect()
+/// Bounded multi-line command stderr for tracked-file diagnostics. Keep the
+/// tail because shell parsers commonly put the actionable diagnostic after a
+/// location header. `bounded_tail` is UTF-8 safe and caps retained stderr even
+/// when a subprocess emits arbitrarily large diagnostics.
+pub(crate) const LIST_TRACKED_STDERR_MAX_CHARS: usize = 4 * 1024;
+
+fn list_tracked_stderr_excerpt(stderr: &str) -> String {
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        return "(no stderr)".to_string();
+    }
+    bounded_tail(stderr, LIST_TRACKED_STDERR_MAX_CHARS).0
 }
 
 /// Build the tracked-file listing command.
@@ -998,15 +999,12 @@ impl ToolRuntime {
         let (raw, exit_code, stderr) = {
             let (request_id, rx) = match self
                 .runner_registry
-                .enqueue_run(
-                    ShellRunRequest {
-                        client_id,
-                        cwd: Some(proj.path.clone()),
-                        command,
-                        stdin: None,
-                        timeout_secs: LIST_TRACKED_TIMEOUT_SECS,
-                        wait_timeout_secs: LIST_TRACKED_TIMEOUT_SECS + 5,
-                    },
+                .enqueue_internal_posix_script(
+                    client_id,
+                    Some(proj.path.clone()),
+                    command,
+                    LIST_TRACKED_TIMEOUT_SECS,
+                    LIST_TRACKED_TIMEOUT_SECS + 5,
                     "tool_runtime".to_string(),
                 )
                 .await
@@ -1059,8 +1057,8 @@ impl ToolRuntime {
                 return list_tracked_error(
                     "list_failed",
                     format!(
-                        "listing command failed with exit {code}: {}",
-                        first_line(&stderr)
+                        "listing command failed with exit {code}:\n{}",
+                        list_tracked_stderr_excerpt(&stderr)
                     ),
                 )
             }

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -3994,21 +3994,22 @@ impl ToolRuntime {
         let cmd = if diff_args.is_empty() {
             "git diff".to_string()
         } else {
+            // `args` is the existing pathspec list contract. Keep the `--`
+            // fence and POSIX word quoting exactly as before, but execute the
+            // generated command through the typed internal POSIX path so the
+            // quoting can never be parsed by the user's configured shell.
             let escaped: Vec<String> = diff_args.iter().map(|a| shell_escape_simple(a)).collect();
             format!("git diff -- {}", escaped.join(" "))
         };
         let client_id = proj.client_id.clone();
         let (req_id, rx) = match self
             .runner_registry
-            .enqueue_run(
-                ShellRunRequest {
-                    client_id,
-                    cwd: Some(proj.path.clone()),
-                    command: cmd,
-                    stdin: None,
-                    timeout_secs: 30,
-                    wait_timeout_secs: 32,
-                },
+            .enqueue_internal_posix_script(
+                client_id,
+                Some(proj.path.clone()),
+                cmd,
+                30,
+                32,
                 "tool_runtime".to_string(),
             )
             .await

--- a/src/tool_runtime/tests/files.rs
+++ b/src/tool_runtime/tests/files.rs
@@ -9,6 +9,161 @@ use serde_json::{json, Value};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(windows)]
+async fn run_windows_tracked_listing(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: String,
+    path: Option<String>,
+) -> (ToolResult, String) {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .list_project_tracked_files(project, path, None, None, Some(100), Some(0))
+                .await
+        }
+    });
+    let request = wait_for_patch_agent_request(runtime, client_id).await;
+    assert_eq!(request.kind, "run_internal_posix_script");
+    assert!(request.command.is_empty());
+    let payload = request
+        .script
+        .as_ref()
+        .expect("tracked listing must carry a typed internal POSIX program");
+    assert_eq!(
+        payload.language,
+        crate::runner_protocol::ShellScriptLanguage::Sh
+    );
+    let script = payload.script.clone();
+    let (exit_code, stdout, stderr) = run_runner_shell_request_locally(&request);
+    complete_patch_agent_request(
+        runtime,
+        client_id,
+        &request.request_id,
+        exit_code,
+        &stdout,
+        &stderr,
+    )
+    .await;
+    (task.await.unwrap(), script)
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_list_project_tracked_files_uses_internal_posix_and_preserves_scope() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+    std::fs::create_dir_all(repo.path().join("src/nested")).unwrap();
+    commit_file(repo.path(), "root.txt", "root\n", "root file");
+    commit_file(repo.path(), "src/a.rs", "pub fn a() {}\n", "src file");
+    commit_file(
+        repo.path(),
+        "src/nested/b.rs",
+        "pub fn b() {}\n",
+        "nested file",
+    );
+
+    let runtime = test_runtime();
+    let project =
+        register_runner_project_at_path(&runtime, "tracked-windows", "demo", repo.path()).await;
+    let (root, script) =
+        run_windows_tracked_listing(&runtime, "tracked-windows", project.clone(), None).await;
+    assert!(root.success, "{:?}", root.error);
+    assert!(script.contains("git ls-files -z --cached"));
+    assert!(
+        script.contains("head_cmd") && script.contains("-c 1048576"),
+        "tracked listing lost its raw-output cap: {script}"
+    );
+    let root_paths = root.output["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(root_paths, vec!["root.txt", "src/a.rs", "src/nested/b.rs"]);
+    assert_eq!(root.output["source"], "git_index");
+    assert_eq!(root.output["list_truncated"], false);
+
+    let (scoped, _) = run_windows_tracked_listing(
+        &runtime,
+        "tracked-windows",
+        project,
+        Some("src".to_string()),
+    )
+    .await;
+    assert!(scoped.success, "{:?}", scoped.error);
+    assert_eq!(scoped.output["path"], "src");
+    let scoped_paths = scoped.output["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(scoped_paths, vec!["src/a.rs", "src/nested/b.rs"]);
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_list_project_tracked_files_keeps_non_git_error_contract() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let project =
+        register_runner_project_at_path(&runtime, "tracked-non-git", "demo", project_dir.path())
+            .await;
+    let (result, _) = run_windows_tracked_listing(&runtime, "tracked-non-git", project, None).await;
+    assert!(!result.success);
+    assert_eq!(result.output["code"], "not_a_git_repository");
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn tracked_listing_failure_keeps_bounded_multiline_stderr() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let runtime = test_runtime();
+    let project =
+        register_runner_project_at_path(&runtime, "tracked-diagnostic", "demo", project_dir.path())
+            .await;
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .list_project_tracked_files(project, None, None, None, Some(100), Some(0))
+                .await
+        }
+    });
+    let request = wait_for_patch_agent_request(&runtime, "tracked-diagnostic").await;
+    assert_eq!(request.kind, "run_internal_posix_script");
+    let stderr = format!(
+        "EARLY_DIAGNOSTIC_MUST_BE_TRUNCATED\n{}\nACTIONABLE_SECOND_LINE\nACTIONABLE_LAST_LINE",
+        "x".repeat(LIST_TRACKED_STDERR_MAX_CHARS + 1024)
+    );
+    complete_patch_agent_request(
+        &runtime,
+        "tracked-diagnostic",
+        &request.request_id,
+        1,
+        "",
+        &stderr,
+    )
+    .await;
+    let result = task.await.unwrap();
+    assert!(!result.success);
+    let error = result.error.as_deref().unwrap_or_default();
+    assert!(error.contains("ACTIONABLE_SECOND_LINE"), "{error}");
+    assert!(error.contains("ACTIONABLE_LAST_LINE"), "{error}");
+    assert!(
+        error.contains('\n'),
+        "stderr excerpt must remain multi-line: {error}"
+    );
+    assert!(!error.contains("EARLY_DIAGNOSTIC_MUST_BE_TRUNCATED"));
+    assert!(
+        error.chars().count() <= LIST_TRACKED_STDERR_MAX_CHARS + 64,
+        "bounded stderr grew unexpectedly: {} chars",
+        error.chars().count()
+    );
+}
+
 #[tokio::test]
 async fn write_project_file_with_session_id_records_changed_path_without_content() {
     let runtime = runtime_with_agent_project("telemetry-write");

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -77,6 +77,110 @@ async fn run_runner_git_commit_paths(
     task.await.unwrap()
 }
 
+#[cfg(windows)]
+async fn run_windows_git_diff(
+    runtime: &ToolRuntime,
+    client_id: &str,
+    project: String,
+    args: Option<Vec<String>>,
+) -> (ToolResult, String) {
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.git_diff(project, args).await }
+    });
+    let request = wait_for_patch_agent_request(runtime, client_id).await;
+    assert_eq!(request.kind, "run_internal_posix_script");
+    assert!(request.command.is_empty());
+    let payload = request
+        .script
+        .as_ref()
+        .expect("git_diff must carry a typed internal POSIX program");
+    assert_eq!(
+        payload.language,
+        crate::runner_protocol::ShellScriptLanguage::Sh
+    );
+    let script = payload.script.clone();
+    let (exit_code, stdout, stderr) = run_runner_shell_request_locally(&request);
+    complete_patch_agent_request(
+        runtime,
+        client_id,
+        &request.request_id,
+        exit_code,
+        &stdout,
+        &stderr,
+    )
+    .await;
+    (task.await.unwrap(), script)
+}
+
+#[cfg(windows)]
+fn git_diff_argv_stdout(repo: &Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .arg("diff")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run direct git diff fixture command");
+    assert!(
+        output.status.success(),
+        "direct git diff failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_git_diff_posix_routing_preserves_literal_special_path_arguments() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+    for (path, content) in [
+        ("plain.txt", "plain base\n"),
+        ("space name.txt", "space base\n"),
+        ("quote'name.txt", "quote base\n"),
+    ] {
+        fs::write(repo.path().join(path), content).unwrap();
+    }
+    git_test_command_ok(repo.path(), "git add -- .");
+    git_test_command_ok(repo.path(), "git commit -m base");
+    fs::write(repo.path().join("plain.txt"), "plain changed\n").unwrap();
+    fs::write(repo.path().join("space name.txt"), "space changed\n").unwrap();
+    fs::write(repo.path().join("quote'name.txt"), "quote changed\n").unwrap();
+
+    let runtime = test_runtime();
+    let project =
+        register_structured_git_agent_at_path(&runtime, "git-diff-windows", "repo", repo.path())
+            .await;
+
+    let (all, all_script) =
+        run_windows_git_diff(&runtime, "git-diff-windows", project.clone(), None).await;
+    assert!(all.success, "{:?}", all.error);
+    assert_eq!(
+        all.output["stdout"].as_str().unwrap_or_default(),
+        git_diff_argv_stdout(repo.path(), &[])
+    );
+    assert_eq!(all_script, "git diff");
+
+    for path in ["plain.txt", "space name.txt", "quote'name.txt"] {
+        let (result, script) = run_windows_git_diff(
+            &runtime,
+            "git-diff-windows",
+            project.clone(),
+            Some(vec![path.to_string()]),
+        )
+        .await;
+        assert!(result.success, "path={path:?}: {:?}", result.error);
+        assert_eq!(result.output["exit_code"], 0);
+        assert_eq!(
+            result.output["stdout"].as_str().unwrap_or_default(),
+            git_diff_argv_stdout(repo.path(), &["--", path]),
+            "path={path:?}"
+        );
+        assert!(script.starts_with("git diff -- "));
+        assert!(!script.contains("powershell"));
+    }
+}
+
 #[tokio::test]
 async fn git_commit_paths_commits_only_requested_paths_and_preserves_other_worktree_changes() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- route `list_project_tracked_files` through the dedicated internal POSIX execution path instead of the Runner's configured shell, fixing PowerShell parse failures on Windows
- route `git_diff` pathspec commands through the same typed POSIX path so POSIX quoting is never interpreted by PowerShell
- preserve tracked-listing timeout, cancellation, output cap, exit-code, scope, and pagination contracts
- retain a bounded multi-line stderr tail so actionable parser/Git diagnostics are not reduced to a location-only first line
- add Windows regression coverage for tracked listings and Git paths containing spaces and apostrophes

Closes #352

## Validation

- Windows tracked-listing regressions: 2/2 passed
- bounded multi-line stderr regression: 1/1 passed
- Windows special-path `git_diff` regression: 1/1 passed
- `cargo check --all-targets -p webcodex`: passed
- `git diff --check origin/main...HEAD`: passed
- representative `git_review_summary_maps_exact_committed_range_without_raw_diff` rerun: passed in 6.43s

A full `cargo test -p webcodex` run during development reported 2433 passed / 3 failed. All three failures were existing `git_review_summary` tests hitting their hard-coded 10-second wait under Windows parallel-suite load; each exact test passed when rerun individually (approximately 6.5-8.4s). The changed code does not touch that review-summary path.