### PR TITLE
Close unused compatibility surfaces

### DIFF
--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -1049,10 +1049,6 @@ fn parse_token_generate(args: &[String]) -> Result<TokenGenerateOptions, String>
             _ => return Err(format!("unknown tokens generate flag: {}", flag)),
         }
     }
-    if kind == "agent" {
-        // v0.4-frozen alias originating before 0.4; new help only teaches Runner terminology.
-        kind = "runner".to_string();
-    }
     if kind != "api" && kind != "runner" {
         return Err("--kind must be 'api' or 'runner'".to_string());
     }
@@ -1336,7 +1332,7 @@ fn parse_ops_subcommand(args: &[String]) -> CliAction {
                 },
             }
         }
-        "runners" | "agents" => {
+        "runners" => {
             if args.get(1).is_some_and(|a| a == "--help" || a == "-h") {
                 return CliAction::Exit {
                     code: 0,

--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -1050,7 +1050,7 @@ fn parse_token_generate(args: &[String]) -> Result<TokenGenerateOptions, String>
         }
     }
     if kind == "agent" {
-        // Pre-0.4 compatibility alias; new help only teaches Runner terminology.
+        // v0.4-frozen alias originating before 0.4; new help only teaches Runner terminology.
         kind = "runner".to_string();
     }
     if kind != "api" && kind != "runner" {

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -692,7 +692,7 @@ pub(crate) fn render_login_result(
             "dir": paths.dir.to_string_lossy(),
             "user_token_file": paths.user_token.to_string_lossy(),
             "runner_config": paths.runner_config.to_string_lossy(),
-            // Machine-readable compatibility alias retained for pre-0.4 consumers.
+            // Published by v0.4.0; keep the machine-readable field frozen through 0.4.x.
             "agent_config": paths.runner_config.to_string_lossy(),
             "project_registry_dir": paths.project_registry_dir.to_string_lossy(),
             "projects_registry": paths.project_registry_dir.to_string_lossy(),
@@ -705,7 +705,7 @@ pub(crate) fn render_login_result(
             "credential_usage": {
                 "webcodex-user-token": "GPT Actions, MCP, and REST/project APIs",
                 "runner_config_token": "Runner transport only",
-                // Machine-readable compatibility alias retained for pre-0.4 consumers.
+                // Published by v0.4.0; keep the machine-readable field frozen through 0.4.x.
                 "agent_config_token": "Runner transport only",
             },
             "foreground_available": foreground_argv.is_some(),

--- a/crates/webcodex-cli/src/webcodex_cli/login.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/login.rs
@@ -692,10 +692,7 @@ pub(crate) fn render_login_result(
             "dir": paths.dir.to_string_lossy(),
             "user_token_file": paths.user_token.to_string_lossy(),
             "runner_config": paths.runner_config.to_string_lossy(),
-            // Published by v0.4.0; keep the machine-readable field frozen through 0.4.x.
-            "agent_config": paths.runner_config.to_string_lossy(),
             "project_registry_dir": paths.project_registry_dir.to_string_lossy(),
-            "projects_registry": paths.project_registry_dir.to_string_lossy(),
             "allowed_roots": allowed_roots.iter().map(|root| root.to_string_lossy().to_string()).collect::<Vec<_>>(),
             "project_registration": {
                 "registered": registration.is_some(),
@@ -705,8 +702,6 @@ pub(crate) fn render_login_result(
             "credential_usage": {
                 "webcodex-user-token": "GPT Actions, MCP, and REST/project APIs",
                 "runner_config_token": "Runner transport only",
-                // Published by v0.4.0; keep the machine-readable field frozen through 0.4.x.
-                "agent_config_token": "Runner transport only",
             },
             "foreground_available": foreground_argv.is_some(),
             "foreground_argv": &foreground_argv,
@@ -928,19 +923,11 @@ pub(crate) async fn redeem_pairing_code(
     opts: &LoginOptions,
     device: &str,
 ) -> Result<EnrolledIdentity, String> {
-    let mut body = serde_json::json!({
+    let body = serde_json::json!({
         "pairing_code": opts.code,
         "client_id": device,
         "transport": opts.transport,
-        "allow_cwd_anywhere": false,
     });
-    if !opts.allowed_roots.is_empty() {
-        body["allowed_roots"] = serde_json::json!(opts
-            .allowed_roots
-            .iter()
-            .map(|path| path.to_string_lossy().to_string())
-            .collect::<Vec<_>>());
-    }
 
     let value =
         super::http::post_json_unauthed(server_url, &opts.server_http, "/api/pairing/enroll", body)
@@ -2319,8 +2306,17 @@ mod tests {
             let body = request.split("\r\n\r\n").nth(1).unwrap();
             let value: serde_json::Value = serde_json::from_str(body).unwrap();
             assert_eq!(value["pairing_code"], CODE);
-            assert_eq!(value["allow_cwd_anywhere"], false);
-            assert_eq!(value["allowed_roots"].as_array().unwrap().len(), 1);
+            for absent in [
+                "project_registry_dir",
+                "projects_dir",
+                "allowed_roots",
+                "allow_cwd_anywhere",
+            ] {
+                assert!(
+                    value.get(absent).is_none(),
+                    "pairing request leaked {absent}: {value}"
+                );
+            }
             let body = serde_json::json!({
                 "username": "alice",
                 "user_token": USER_TOKEN,
@@ -2399,6 +2395,12 @@ mod tests {
                 .unwrap(),
             paths.project_registry_dir.canonicalize().unwrap()
         );
+        let local_allowed_roots = parsed["policy"]["allowed_roots"].as_array().unwrap();
+        assert_eq!(local_allowed_roots.len(), 1);
+        assert!(webcodex_runner_config::paths::paths_equal(
+            Path::new(local_allowed_roots[0].as_str().unwrap()),
+            &allowed_root
+        ));
         assert_no_internal_residue(paths.dir.parent().unwrap());
     }
 
@@ -2741,11 +2743,18 @@ mod tests {
             Some("https://api.example.com/mcp")
         );
         assert!(json_value.get("credential_usage").is_some(), "{json}");
-        assert_eq!(json_value["runner_config"], json_value["agent_config"]);
+        assert_eq!(
+            json_value["runner_config"],
+            paths.runner_config.to_string_lossy().as_ref()
+        );
+        assert!(json_value.get("agent_config").is_none());
         assert_eq!(
             json_value["credential_usage"]["runner_config_token"],
-            json_value["credential_usage"]["agent_config_token"]
+            "Runner transport only"
         );
+        assert!(json_value["credential_usage"]
+            .get("agent_config_token")
+            .is_none());
         assert_eq!(json_value["project_registration"]["registered"], false);
         assert_eq!(json_value["project_registration"]["count"], 0);
         assert_eq!(json_value["registered_projects"], serde_json::json!([]));
@@ -2753,10 +2762,8 @@ mod tests {
             json_value["project_registry_dir"],
             paths.project_registry_dir.to_string_lossy().as_ref()
         );
-        assert_eq!(
-            json_value["projects_registry"],
-            paths.project_registry_dir.to_string_lossy().as_ref()
-        );
+        assert!(json_value.get("projects_registry").is_none());
+        assert!(json_value.get("projects_dir").is_none());
         assert_eq!(
             json_value
                 .get("user_token_file")

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -274,7 +274,7 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
     if opts.json {
         return serde_json::to_string_pretty(&serde_json::json!({
             "runner_config": opts.config.to_string_lossy(),
-            // Machine-readable compatibility alias retained for pre-0.4 consumers.
+            // Published by v0.4.0; keep the machine-readable field frozen through 0.4.x.
             "agent_config": opts.config.to_string_lossy(),
             "project_registry_dir": project_registry_dir.to_string_lossy(),
             "projects_dir": project_registry_dir.to_string_lossy(),

--- a/crates/webcodex-cli/src/webcodex_cli/project.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/project.rs
@@ -274,10 +274,7 @@ pub(crate) fn run_project_register(opts: ProjectRegisterOptions) -> Result<Strin
     if opts.json {
         return serde_json::to_string_pretty(&serde_json::json!({
             "runner_config": opts.config.to_string_lossy(),
-            // Published by v0.4.0; keep the machine-readable field frozen through 0.4.x.
-            "agent_config": opts.config.to_string_lossy(),
             "project_registry_dir": project_registry_dir.to_string_lossy(),
-            "projects_dir": project_registry_dir.to_string_lossy(),
             "project": {
                 "id": registration.id,
                 "path": registration.path.to_string_lossy(),
@@ -396,7 +393,16 @@ mod tests {
         assert_eq!(first["project"]["id"], "demo");
         assert_eq!(first["project"]["already_registered"], false);
         assert_eq!(first["runner_reload_required"], true);
-        assert_eq!(first["runner_config"], first["agent_config"]);
+        assert_eq!(
+            first["runner_config"],
+            config_path.to_string_lossy().as_ref()
+        );
+        assert!(first.get("agent_config").is_none());
+        assert_eq!(
+            first["project_registry_dir"],
+            registry.to_string_lossy().as_ref()
+        );
+        assert!(first.get("projects_dir").is_none());
         assert!(registry.join("demo.toml").is_file());
         assert!(!first.to_string().contains("secret-not-printed"));
 

--- a/crates/webcodex-cli/src/webcodex_cli/runner_service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/runner_service.rs
@@ -552,7 +552,6 @@ pub(crate) async fn run_runner_status(opts: RunnerStatusOptions) -> Result<Strin
                 "display_name": metadata.display_name,
                 "transport": metadata.transport,
                 "project_registry_dir": metadata.project_registry_dir.to_string_lossy().to_string(),
-                "projects_dir": metadata.project_registry_dir.to_string_lossy().to_string(),
                 "allowed_roots": {
                     "count": metadata.allowed_roots.len(),
                     "summary": allowed_roots_summary(&metadata.allowed_roots),

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -97,14 +97,21 @@ fn ops_help_entrypoints_print_usage() {
 }
 
 #[test]
-fn legacy_ops_agents_alias_uses_canonical_runners_path() {
-    match cli_action(["ops", "agents", "--json"]) {
+fn ops_runners_is_canonical_and_agents_is_rejected() {
+    match cli_action(["ops", "runners", "--json"]) {
         CliAction::Ops(OpsCommand::Runners(opts)) => assert!(opts.json),
-        other => panic!("legacy ops agents alias did not use canonical Runners command: {other:?}"),
+        other => panic!("canonical ops runners path did not parse: {other:?}"),
     }
-    let help = cli_exit(["ops", "agents", "--help"]).unwrap();
-    assert!(help.contains("Usage: webcodex ops runners"));
-    assert!(!help.contains("Usage: webcodex ops agents"));
+    match cli_action(["ops", "agents", "--json"]) {
+        CliAction::Exit { code, stderr, .. } => {
+            assert_eq!(code, 2);
+            assert!(
+                stderr.contains("unknown ops subcommand: agents"),
+                "{stderr}"
+            );
+        }
+        other => panic!("legacy ops agents alias must be rejected: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/env.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/env.rs
@@ -86,10 +86,16 @@ fn token_generate_runner_prints_legacy_compatible_token_prefix() {
 }
 
 #[test]
-fn token_generate_agent_kind_is_a_legacy_runner_alias() {
+fn token_generate_agent_kind_is_rejected() {
     match cli_action(args(&["tokens", "generate", "--kind", "agent"])) {
-        CliAction::TokenGenerate(opts) => assert_eq!(opts.kind, "runner"),
-        other => panic!("expected Runner token generation alias, got {other:?}"),
+        CliAction::Exit { code, stderr, .. } => {
+            assert_eq!(code, 2);
+            assert!(
+                stderr.contains("--kind must be 'api' or 'runner'"),
+                "{stderr}"
+            );
+        }
+        other => panic!("expected rejected legacy token kind, got {other:?}"),
     }
 }
 

--- a/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/server/service.rs
@@ -1021,6 +1021,20 @@ fn hosted_profile_status_uses_xdg_config_and_never_invokes_systemctl() {
 
     let output = output.unwrap();
     assert!(output.contains("runner mode:          hosted local process"));
+    let json_opts =
+        parse_runner_status_with_identity(&args(&["--profile", "hosted", "--json"]), true).unwrap();
+    let json_output = runtime.block_on(run_runner_status(json_opts)).unwrap();
+    let json_output: serde_json::Value = serde_json::from_str(&json_output).unwrap();
+    assert_eq!(
+        json_output["config"]["project_registry_dir"],
+        profile_config
+            .parent()
+            .unwrap()
+            .join("project-registry")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert!(json_output["config"].get("projects_dir").is_none());
     assert!(!systemctl_called.exists());
 }
 

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -78,7 +78,6 @@ fn test_config(project_registry_dir: PathBuf) -> RunnerConfig {
         host_context: None,
         project_registry_dir: Some(project_registry_dir),
         legacy_projects_dir: None,
-        deprecated_temporary_projects_root: None,
         poll_interval_ms: 1000,
         capabilities: None,
         max_concurrent_jobs: None,

--- a/crates/webcodex-runner/src/main_tests/config_reload.rs
+++ b/crates/webcodex-runner/src/main_tests/config_reload.rs
@@ -90,7 +90,6 @@ fn reload_field_classification_is_exhaustive_and_allowlisted() {
         ..Default::default()
     });
     changed.project_registry_dir = Some(PathBuf::from("projects-b"));
-    changed.deprecated_temporary_projects_root = Some(PathBuf::from("/tmp/webcodex-temporary"));
     changed.poll_interval_ms += 1;
     changed.capabilities = Some(RunnerCapabilities::default());
     changed.max_concurrent_jobs = Some(4);

--- a/crates/webcodex-runner/src/main_tests/runner_config.rs
+++ b/crates/webcodex-runner/src/main_tests/runner_config.rs
@@ -151,9 +151,9 @@ fn runner_config_bounds_polling_idle_floor_but_not_unused_websocket_value() {
 }
 
 #[test]
-fn runner_config_rejects_relative_temporary_projects_root() {
+fn runner_config_ignores_obsolete_temporary_projects_root_without_runtime_semantics() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("agent.toml");
+    let path = tmp.path().join("runner.toml");
     std::fs::write(
         &path,
         r#"
@@ -161,34 +161,16 @@ server_url = "http://127.0.0.1:8000"
 token = "t"
 client_id = "oe"
 project_registry_dir = "project-registry"
-temporary_projects_root = "temporary"
+temporary_projects_root = "obsolete-and-relative"
+[policy]
+allow_cwd_anywhere = false
 "#,
     )
     .unwrap();
 
-    let err = load_config(&path).unwrap_err();
-    assert!(
-        err.contains("temporary_projects_root must be a non-empty absolute path"),
-        "{err}"
-    );
-}
-
-#[test]
-fn runner_config_accepts_absolute_legacy_temporary_projects_root_as_inert() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("runner.toml");
-    let legacy_root = tmp.path().join("legacy-temporary-projects");
-    let legacy_root = toml::Value::String(legacy_root.to_string_lossy().into_owned()).to_string();
-    std::fs::write(
-        &path,
-        format!(
-            "server_url = \"http://127.0.0.1:8000\"\ntoken = \"t\"\nclient_id = \"oe\"\nproject_registry_dir = \"project-registry\"\ntemporary_projects_root = {legacy_root}\n[policy]\nallow_cwd_anywhere = true\n"
-        ),
-    )
-    .unwrap();
-
     let cfg = load_config(&path).unwrap();
-    assert_eq!(cfg.deprecated_temporary_projects_root, None);
+    assert_eq!(cfg.client_id, "oe");
+    assert!(!cfg.policy.allow_cwd_anywhere);
 }
 
 #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/config.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/config.rs
@@ -62,9 +62,10 @@ pub(crate) struct RunnerConfig {
     /// field so runtime comparisons operate on one effective registry path.
     #[serde(default, rename = "projects_dir")]
     pub(crate) legacy_projects_dir: Option<PathBuf>,
-    /// Pre-0.4 managed-temporary-project setting retained only so old configs
-    /// are parsed explicitly. The feature is retired; load_config validates the
-    /// former path shape, reports the deprecation, and clears this inert field.
+    /// Pre-0.4-origin managed-temporary-project setting whose parse/validate/
+    /// warn/ignore behavior was accepted by v0.4.0 and is therefore frozen for
+    /// 0.4.x compatibility. The feature itself remains retired; load_config
+    /// clears this inert field before runtime semantics.
     #[serde(default, rename = "temporary_projects_root")]
     pub(crate) deprecated_temporary_projects_root: Option<PathBuf>,
     /// Minimum delay after an empty polling response. Repeated idle polls back

--- a/crates/webcodex-runner/src/webcodex_runner/config.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/config.rs
@@ -62,12 +62,6 @@ pub(crate) struct RunnerConfig {
     /// field so runtime comparisons operate on one effective registry path.
     #[serde(default, rename = "projects_dir")]
     pub(crate) legacy_projects_dir: Option<PathBuf>,
-    /// Pre-0.4-origin managed-temporary-project setting whose parse/validate/
-    /// warn/ignore behavior was accepted by v0.4.0 and is therefore frozen for
-    /// 0.4.x compatibility. The feature itself remains retired; load_config
-    /// clears this inert field before runtime semantics.
-    #[serde(default, rename = "temporary_projects_root")]
-    pub(crate) deprecated_temporary_projects_root: Option<PathBuf>,
     /// Minimum delay after an empty polling response. Repeated idle polls back
     /// off through the built-in schedule while never going below this value.
     #[serde(default = "default_poll_interval_ms")]
@@ -984,7 +978,7 @@ pub(crate) fn restart_required_fields(
         ($($field:ident),+ $(,)?) => {{
             let RunnerConfig {
                 policy: _, shell: _, ssh: _, plugins: _, tool_providers: _, legacy_projects_dir: _,
-                deprecated_temporary_projects_root: _, $($field: _),+
+                $($field: _),+
             } = candidate;
             [$((stringify!($field), startup.$field != candidate.$field)),+]
                 .into_iter()
@@ -1422,15 +1416,6 @@ pub(crate) fn load_config(path: &Path) -> Result<RunnerConfig, String> {
     validate_max_concurrent_jobs(cfg.max_concurrent_jobs)?;
     if let Some(host_context) = cfg.host_context.take() {
         cfg.host_context = Some(host_context.normalized()?);
-    }
-    if let Some(root) = cfg.deprecated_temporary_projects_root.as_ref() {
-        if root.as_os_str().is_empty() || !root.is_absolute() {
-            return Err("temporary_projects_root must be a non-empty absolute path".to_string());
-        }
-        eprintln!(
-            "webcodex-runner config warning: temporary_projects_root is deprecated and ignored"
-        );
-        cfg.deprecated_temporary_projects_root = None;
     }
     if let Some(transport) = cfg.transport.as_deref().map(str::trim) {
         if !transport.is_empty()

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -584,7 +584,6 @@ fn runner_config(
         host_context: None,
         project_registry_dir: Some(project_registry_dir.to_path_buf()),
         legacy_projects_dir: None,
-        deprecated_temporary_projects_root: None,
         poll_interval_ms: 1000,
         capabilities: None,
         max_concurrent_jobs: None,

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
@@ -195,7 +195,6 @@ fn runner_config(
         host_context: None,
         project_registry_dir: Some(project_registry_dir.to_path_buf()),
         legacy_projects_dir: None,
-        deprecated_temporary_projects_root: None,
         poll_interval_ms: 1000,
         capabilities: None,
         max_concurrent_jobs: None,

--- a/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
@@ -25,7 +25,6 @@ fn test_runner_config(server_url: String) -> RunnerConfig {
         host_context: None,
         project_registry_dir: None,
         legacy_projects_dir: None,
-        deprecated_temporary_projects_root: None,
         poll_interval_ms: 10,
         capabilities: Some(RunnerCapabilities {
             git: true,

--- a/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
@@ -11,13 +11,6 @@ use webcodex_core::runner_protocol::{normalize_cargo_value, normalize_rust_test_
 use webcodex_workflow_session::SessionExecutionContext;
 
 pub fn session_log_arguments_for_tool_request(tool_name: &str, arguments: &Value) -> Value {
-    // This retired wire name is deliberately not a ToolDefinition. The kernel
-    // records a bounded rejection summary before concrete ToolCall parsing, so
-    // keep one compatibility-only sanitizer without reviving it as tool identity.
-    if tool_name == "start_coding_task" {
-        return retired_start_coding_task_audit(arguments);
-    }
-
     let Some(definition) = webcodex_tool_contracts::lookup_tool_definition(tool_name) else {
         return empty_audit_projection();
     };
@@ -73,40 +66,6 @@ fn audit_tool_call_from_request(
         return None;
     }
     ToolCall::from_tool_name(tool_name, Value::Object(filtered)).ok()
-}
-
-fn retired_start_coding_task_audit(arguments: &Value) -> Value {
-    let Some(obj) = arguments.as_object() else {
-        return empty_audit_projection();
-    };
-    let mut out = serde_json::Map::new();
-    copy_keys(
-        obj,
-        &mut out,
-        &[
-            "project",
-            "client_id",
-            "title",
-            "mode",
-            "deny_write_tools",
-            "deny_shell_tools",
-            "detail",
-            "resume_session_id",
-            "session_id",
-        ],
-    );
-    out.insert(
-        "path_source_requested".to_string(),
-        Value::Bool(obj.contains_key("path")),
-    );
-    let context = obj
-        .get("execution_context")
-        .cloned()
-        .and_then(|value| serde_json::from_value::<SessionExecutionContext>(value).ok())
-        .map(|context| context.audit_summary())
-        .unwrap_or(Value::Null);
-    out.insert("execution_context".to_string(), context);
-    Value::Object(out)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
@@ -2567,19 +2567,6 @@ impl ToolCall {
         name: &str,
         arguments: Value,
     ) -> Result<(Self, ToolCallRecorderMetadata), String> {
-        // `list_agents` originated before 0.4 and remained accepted by v0.4.0.
-        // Keep the frozen alias ingress-only without registering a second
-        // ToolDefinition or allowing new discovery surfaces to teach that name.
-        let name = match name {
-            "list_agents" => "list_runners",
-            _ => name,
-        };
-        if name == "start_coding_task" {
-            return Err(
-                "tool 'start_coding_task' is no longer supported; use 'work_on_project'"
-                    .to_string(),
-            );
-        }
         if name == "create_project"
             && arguments
                 .as_object()

--- a/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
@@ -2567,8 +2567,8 @@ impl ToolCall {
         name: &str,
         arguments: Value,
     ) -> Result<(Self, ToolCallRecorderMetadata), String> {
-        // `list_agents` was the pre-0.4 model-facing name for execution Runners.
-        // Keep one ingress-only compatibility alias without registering a second
+        // `list_agents` originated before 0.4 and remained accepted by v0.4.0.
+        // Keep the frozen alias ingress-only without registering a second
         // ToolDefinition or allowing new discovery surfaces to teach that name.
         let name = match name {
             "list_agents" => "list_runners",

--- a/crates/webcodex-tool-runtime-contracts/src/tool_call_tests.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_call_tests.rs
@@ -169,13 +169,19 @@ fn ssh_resource_parses_as_canonical_gateway_with_closed_action_vocabulary() {
 }
 
 #[test]
-fn legacy_list_agents_alias_parses_to_canonical_list_runners() {
-    let call = ToolCall::from_tool_name(
+fn list_agents_live_ingress_is_rejected_without_second_definition() {
+    let error = ToolCall::from_tool_name(
         "list_agents",
         json!({"client_id": "special", "include_projects": false}),
     )
+    .expect_err("retired list_agents must not remain a live ingress alias");
+    assert!(error.contains("unknown tool 'list_agents'"), "{error}");
+
+    let call = ToolCall::from_tool_name(
+        "list_runners",
+        json!({"client_id": "special", "include_projects": false}),
+    )
     .unwrap();
-    assert_eq!(call.tool_name(), "list_runners");
     assert!(matches!(
         call,
         ToolCall::ListRunners {
@@ -1563,26 +1569,24 @@ fn from_tool_name_parses_project_management_tools() {
 }
 
 #[test]
-fn retired_start_coding_task_wire_name_is_rejected() {
+fn start_coding_task_uses_generic_unknown_tool_and_privacy_paths() {
     let error = ToolCall::from_tool_name("start_coding_task", json!({"project": "demo"}))
-        .expect_err("retired start_coding_task entry must fail closed");
-    assert!(error.contains("no longer supported"), "{error}");
-    assert!(error.contains("work_on_project"), "{error}");
+        .expect_err("retired start_coding_task must be an ordinary unknown tool");
+    assert!(
+        error.contains("unknown tool 'start_coding_task'"),
+        "{error}"
+    );
 
-    // Kernel audit recording happens before ToolCall parsing, so rejected
-    // legacy requests keep a bounded compatibility sanitizer without reviving
-    // a current ToolCall identity or retaining the raw path.
     let audit = crate::tool_audit::session_log_arguments_for_tool_request(
         "start_coding_task",
         &json!({
             "project": "agent:legacy:demo",
             "path": "/private/legacy/path",
-            "title": "legacy request"
+            "prompt": "PRIVATE_PROMPT",
+            "secret": "PRIVATE_SECRET"
         }),
     );
-    assert_eq!(audit["path_source_requested"], true);
-    assert!(audit.get("path").is_none());
-    assert!(!audit.to_string().contains("/private/legacy/path"));
+    assert_eq!(audit, json!({}));
 }
 
 #[test]

--- a/crates/webcodex-workflow-session/src/audit.rs
+++ b/crates/webcodex-workflow-session/src/audit.rs
@@ -32,10 +32,23 @@ pub fn session_input_summary_for_tool(tool_name: &str, arguments: &Value) -> Val
     let policy = match audit_policy_for_tool(canonical_name) {
         Some(policy) => policy.session_input,
         None if tool_name == "start_coding_task" => {
-            // Retired wire rejection compatibility only. The runtime rejection
-            // projector already emits a bounded body-free summary; keep the same
-            // final generic redaction while unknown open-world names fail closed.
-            return redact_and_bound_value(arguments);
+            // Historical Session ledgers may contain this retired identity. Current
+            // runtime ingress treats it as an ordinary unknown tool and persists no
+            // request arguments; restore/direct-Session compatibility keeps only a
+            // bounded historical projection and never restores a raw path.
+            let mut summary = redact_and_bound_value(arguments);
+            let Some(object) = summary.as_object_mut() else {
+                return json!({});
+            };
+            let path_source_requested = object.remove("path").is_some();
+            for field in ["prompt", "instruction", "reasoning"] {
+                object.remove(field);
+            }
+            object.insert(
+                "path_source_requested".to_string(),
+                Value::Bool(path_source_requested),
+            );
+            return summary;
         }
         None => return json!({}),
     };
@@ -241,6 +254,28 @@ mod tests {
         assert!(!session_input_summary_for_tool("list_agents", &raw)
             .to_string()
             .contains("PRIVATE_"));
+
+        let retired = session_input_summary_for_tool(
+            "start_coding_task",
+            &json!({
+                "project": "agent:legacy:demo",
+                "path": "/private/legacy/path",
+                "prompt": "PRIVATE_PROMPT",
+                "reasoning": "PRIVATE_REASONING",
+                "secret": "wc_agent_private_secret"
+            }),
+        );
+        assert_eq!(retired["project"], "agent:legacy:demo");
+        assert_eq!(retired["path_source_requested"], true);
+        assert!(retired.get("path").is_none());
+        assert!(retired.get("prompt").is_none());
+        assert!(retired.get("reasoning").is_none());
+        assert_eq!(retired["secret"], "[redacted]");
+        let serialized = retired.to_string();
+        assert!(!serialized.contains("/private/legacy/path"));
+        assert!(!serialized.contains("PRIVATE_PROMPT"));
+        assert!(!serialized.contains("PRIVATE_REASONING"));
+        assert!(!serialized.contains("wc_agent_private_secret"));
     }
 
     #[test]

--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -484,9 +484,11 @@ Public `list_projects.source` remains `agent_registered` / `auto_registered`.
 The pre-0.4 managed-temporary-project lifecycle is retired rather than carried
 into the `v0.4.0` product contract. Current project creation uses explicit
 `create_project`; existing directories use `work_on_project(path)` or
-`register_project`. For one pre-0.4 config compatibility window, the old
-`temporary_projects_root` key is parsed with its former absolute-path validation,
-then warned and ignored. Existing project-registry records whose generic
+`register_project`. The old `temporary_projects_root` key is a pre-0.4-origin compatibility input.
+Because `v0.4.0` accepted it, the 0.4.x compatibility floor preserves the exact
+bounded behavior: parse it with its former absolute-path validation, then warn
+and ignore it. This is input compatibility only, not an active
+managed-temporary-project feature. Existing project-registry records whose generic
 `kind = "managed_temporary"` value predates this cleanup remain readable as
 ordinary registrations; current Server projections do not treat that value as
 an active lifecycle. A legacy Server request containing the old

--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -329,12 +329,12 @@ seams; those controls are not a public tool argument or ToolCall identity.
 
 | Decision | Choice |
 |---|---|
-| Retired wire entry | `start_coding_task` and its direct/API compatibility schema fail closed; callers migrate to `work_on_project` |
+| Removed wire entry | `start_coding_task` has no current ToolDefinition or compatibility schema and follows ordinary unknown-tool rejection; `work_on_project` is canonical |
 | External projection | `work_on_project` returns one deterministic sparse startup projection and does not expose full runtime/connection/authority diagnostics |
 | Internal `standard` | Default bounded Coding brief used by shared startup plumbing: strict session/project/workspace, incremental repository instructions, bounded continuation evidence, semantic-navigation summary, blockers/warnings, and concrete next actions |
 | Internal `minimal` / `full` | Retained only as implementation-level projection modes for internal callers/tests; they are not generic HTTP/MCP tool inputs |
 | Rule snapshot lifecycle | Fresh sessions load bounded content; unchanged same-process continuations reuse the in-memory fingerprint snapshot without repeating content; source additions/deletions/content/truncation changes return new bounded content; explicit or restart-restored Sessions reload because durable storage never contains rule bodies |
-| Unknown/retired external fields | The retired tool name fails closed before legacy argument interpretation; `work_on_project` keeps its own strict schema |
+| Unknown/removed external fields | Unknown or removed tool names fail closed before legacy argument interpretation; `work_on_project` keeps its own strict schema |
 
 No alias or dual shape is kept for the removed flags (consistent with §2).
 
@@ -403,44 +403,24 @@ pre-0.4 persisted-state cleanup, Tool/runtime surface cleanup, and authority or
 configuration cleanup. That pre-0.4 freedom does not continue through the
 `0.4.x` patch series.
 
-Once `v0.4.0` is published, its users are concrete external consumers. The
-standing rule for `0.4.x` is compatibility-first:
+The `v0.4.0` tag is a compatibility reference point, not a blanket promise to
+retain every spelling that appeared in that release. During active development,
+compatibility code is retained when it has a concrete consumer: accepted
+persisted state, mixed-version Server/Runner operation, a current external
+workflow or installer, or a required fail-closed security/privacy migration
+boundary. An implementation plus tests that only assert that implementation
+exists is not by itself a consumer. Published-but-unused CLI/API aliases and
+duplicate machine-readable fields may therefore be removed after an exact
+consumer search.
 
-1. **CLI.** Canonical commands and flags published in `v0.4.0` are not deleted
-   or renamed in a `0.4.x` patch release. Additive options are allowed, and
-   human-oriented prose may improve. Documented machine-readable JSON or schema
-   shapes require an additive or explicit migration/version strategy rather
-   than an unannounced breaking reinterpretation.
-2. **Runner configuration.** A canonical `runner.toml` accepted by `v0.4.0`
-   remains parseable throughout `0.4.x`. New fields should be optional or have
-   safe defaults. Patch releases do not force a filename or field rename merely
-   to make Runner terminology more uniform.
-3. **Server/Runner protocol.** Protocol generation 2 is the `0.4` baseline.
-   `0.4.x` does not introduce another required generation or expand the
-   generation-2 baseline-required capability set. New requirements use additive
-   `RegistrationRequired` capabilities; when an otherwise-valid `0.4` Runner lacks
-   such a capability, that feature is unavailable/fails closed instead of
-   invalidating the entire Runner registration. First-party Server and Runner releases in
-   `0.4.x` should preserve rolling interoperability as far as security and
-   correctness allow.
-4. **Persisted state.** The durable DB, Workflow Session state, and other
-   relevant state accepted by `v0.4.0` form the migration floor for later
-   `0.4.x` releases. Shape evolution needs an explicit migration, default, or
-   version strategy. Migrations must be deterministic, idempotent, and
-   fail-closed; ambiguous old state must not be silently reinterpreted. This
-   decision does not require a generic migration framework before a concrete
-   state evolution needs one.
-5. **Model, HTTP, and MCP contracts.** Canonical model-visible tool names,
-   documented REST routes, MCP capability names, and documented serialized
-   field names released in `v0.4.0` evolve additively or migration-first during
-   `0.4.x`. A true removal or rename should normally wait for `v0.5.0`. The
-   `v0.4.0` MCP result-framing floor makes `structuredContent` the canonical
-   machine-readable `tools/call` result. `content.text` is a concise human
-   fallback, not a duplicate serialization of that result. This applies to all
-   MCP protocol eras WebCodex advertises; protocol-version support does not
-   preserve the pre-0.4 JSON-in-text duplication. `0.4.x` must keep this
-   structured-result ownership stable, including any transport-specific
-   post-framing output schema.
+Where a concrete consumer does exist, compatibility remains narrow and
+fail-closed. Protocol generation 2 remains the 0.4 Server/Runner rolling
+baseline; additive capabilities do not expand its required set, and absence is
+handled as unavailable rather than inferred authority. Durable DB, Workflow
+Session, and registry state is migrated or quarantined deterministically rather
+than silently reinterpreted. MCP `structuredContent` remains the canonical
+machine-readable `tools/call` result; `content.text` is only the concise human
+fallback.
 
 The product concept and public lifecycle namespace are **Runner**. Before the
 `v0.4.0` compatibility floor, the local primary config filename is normalized
@@ -484,11 +464,11 @@ Public `list_projects.source` remains `agent_registered` / `auto_registered`.
 The pre-0.4 managed-temporary-project lifecycle is retired rather than carried
 into the `v0.4.0` product contract. Current project creation uses explicit
 `create_project`; existing directories use `work_on_project(path)` or
-`register_project`. The old `temporary_projects_root` key is a pre-0.4-origin compatibility input.
-Because `v0.4.0` accepted it, the 0.4.x compatibility floor preserves the exact
-bounded behavior: parse it with its former absolute-path validation, then warn
-and ignore it. This is input compatibility only, not an active
-managed-temporary-project feature. Existing project-registry records whose generic
+`register_project`. The retired `temporary_projects_root` key no longer has a
+typed Runner configuration meaning. Runner configuration intentionally ignores
+obsolete unknown top-level keys, so an old file containing this key remains
+loadable without preserving its former validation, warning, or runtime field.
+Existing project-registry records whose generic
 `kind = "managed_temporary"` value predates this cleanup remain readable as
 ordinary registrations; current Server projections do not treat that value as
 an active lifecycle. A legacy Server request containing the old
@@ -496,11 +476,11 @@ an active lifecycle. A legacy Server request containing the old
 filesystem mutation. This retirement does not change protocol generation,
 baseline capabilities, `client_id`, `agent_project_id`, or runtime project ids.
 
-Other older `agent_*` names are compatibility vocabulary and remain frozen
-rather than being cosmetically duplicated. In particular,
-`WEBCODEX_AGENT_TOKEN`, `wc_agent_*`, `agent_instance_id`, runtime project ids
-of the form `agent:<client_id>:<project_id>`, and established DB/wire `agent_*`
-fields keep their existing names. This local filename migration does not imply
+Other older `agent_*` names below have concrete token, persisted-state, or wire
+consumers and are therefore retained rather than cosmetically duplicated. In
+particular, `WEBCODEX_AGENT_TOKEN`, `wc_agent_*`, `agent_instance_id`, runtime
+project ids of the form `agent:<client_id>:<project_id>`, and established
+DB/wire `agent_*` fields keep their existing names. This local filename migration does not imply
 a Server/Runner protocol-generation or wire-identity rename.
 
 Compatibility never requires retaining a known authentication bypass, unsafe

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -1453,11 +1453,13 @@ async fn full_operator_explicit_surface_lists_full_runtime_and_dispatches() {
     )
     .await;
     let McpOutcome::BadRequest(value) = called else {
-        panic!("retired start_coding_task must fail closed");
+        panic!("unknown start_coding_task must fail closed");
     };
     let message = value["error"]["message"].as_str().unwrap();
-    assert!(message.contains("no longer supported"), "{message}");
-    assert!(message.contains("work_on_project"), "{message}");
+    assert!(
+        message.contains("unknown tool 'start_coding_task'"),
+        "{message}"
+    );
 }
 
 #[tokio::test]

--- a/src/pairing_http.rs
+++ b/src/pairing_http.rs
@@ -69,18 +69,6 @@ pub(crate) struct PairingEnrollRequest {
     pub display_name: Option<String>,
     #[serde(default)]
     pub transport: Option<String>,
-    /// v0.4-frozen enrollment compatibility fields. v0.4.0 accepted these
-    /// config-shaped values but intentionally did not derive Runner filesystem
-    /// or configuration authority from them. Keep them parse-only in 0.4.x;
-    /// actual Runner configuration is established through its own boundary.
-    #[serde(default)]
-    pub project_registry_dir: Option<String>,
-    #[serde(default, rename = "projects_dir")]
-    pub legacy_projects_dir: Option<String>,
-    #[serde(default)]
-    pub allowed_roots: Option<Vec<String>>,
-    #[serde(default)]
-    pub allow_cwd_anywhere: Option<bool>,
 }
 
 fn clean_display_name(value: Option<String>) -> Result<Option<String>, String> {
@@ -341,16 +329,6 @@ pub(crate) async fn pairing_enroll(req: &mut Request, depot: &mut Depot, res: &m
             return;
         }
     };
-    // Preserve the v0.4 accepted input shape without reinterpreting these
-    // historical no-op fields as authority. Current and legacy registry names
-    // may both be present here because neither configures a Runner.
-    let _ = (
-        body.project_registry_dir,
-        body.legacy_projects_dir,
-        body.allowed_roots,
-        body.allow_cwd_anywhere,
-    );
-
     let Some(db) = crate::get_db(depot) else {
         res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
         res.render(json_error(
@@ -714,7 +692,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pairing_enroll_v04_noop_config_fields_do_not_expand_token_authority() {
+    async fn pairing_enroll_returns_expected_token_kinds_and_scopes() {
         let db = Arc::new(test_db());
         let now = chrono::Utc::now().timestamp();
         db.create_user(&UserRecord {
@@ -750,11 +728,7 @@ mod tests {
         let mut resp = TestClient::post("http://localhost/api/pairing/enroll")
             .json(&json!({
                 "pairing_code": code,
-                "client_id": "alice-laptop",
-                "project_registry_dir": "/must/not/become/authority/current",
-                "projects_dir": "/must/not/become/authority/legacy",
-                "allowed_roots": ["/must/not/become/authority"],
-                "allow_cwd_anywhere": true
+                "client_id": "alice-laptop"
             }))
             .send(&service)
             .await;

--- a/src/pairing_http.rs
+++ b/src/pairing_http.rs
@@ -69,6 +69,10 @@ pub(crate) struct PairingEnrollRequest {
     pub display_name: Option<String>,
     #[serde(default)]
     pub transport: Option<String>,
+    /// v0.4-frozen enrollment compatibility fields. v0.4.0 accepted these
+    /// config-shaped values but intentionally did not derive Runner filesystem
+    /// or configuration authority from them. Keep them parse-only in 0.4.x;
+    /// actual Runner configuration is established through its own boundary.
     #[serde(default)]
     pub project_registry_dir: Option<String>,
     #[serde(default, rename = "projects_dir")]
@@ -337,6 +341,9 @@ pub(crate) async fn pairing_enroll(req: &mut Request, depot: &mut Depot, res: &m
             return;
         }
     };
+    // Preserve the v0.4 accepted input shape without reinterpreting these
+    // historical no-op fields as authority. Current and legacy registry names
+    // may both be present here because neither configures a Runner.
     let _ = (
         body.project_registry_dir,
         body.legacy_projects_dir,
@@ -707,7 +714,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pairing_enroll_returns_expected_token_kinds_and_scopes() {
+    async fn pairing_enroll_v04_noop_config_fields_do_not_expand_token_authority() {
         let db = Arc::new(test_db());
         let now = chrono::Utc::now().timestamp();
         db.create_user(&UserRecord {
@@ -743,7 +750,11 @@ mod tests {
         let mut resp = TestClient::post("http://localhost/api/pairing/enroll")
             .json(&json!({
                 "pairing_code": code,
-                "client_id": "alice-laptop"
+                "client_id": "alice-laptop",
+                "project_registry_dir": "/must/not/become/authority/current",
+                "projects_dir": "/must/not/become/authority/legacy",
+                "allowed_roots": ["/must/not/become/authority"],
+                "allow_cwd_anywhere": true
             }))
             .send(&service)
             .await;

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -777,7 +777,7 @@ async fn flattened_tool_manifest_exact_name_survives_null_params_wrapper() {
 }
 
 #[tokio::test]
-async fn http_start_coding_task_retirement_precedes_flattened_legacy_params() {
+async fn http_start_coding_task_flattened_legacy_params_do_not_revive_unknown_tool() {
     let config = test_config(Some("secret"));
     let (_tmp, db) = test_db();
     let tmp_proj = tempfile::tempdir().unwrap();
@@ -804,16 +804,15 @@ async fn http_start_coding_task_retirement_precedes_flattened_legacy_params() {
     let body: Value = resp.take_json().await.unwrap();
     assert_eq!(body["status"], 400);
     let error = body["error"].as_str().unwrap_or_default();
-    assert!(error.contains("no longer supported"), "{body}");
-    assert!(error.contains("work_on_project"), "{body}");
+    assert!(error.contains("unknown tool 'start_coding_task'"), "{body}");
 }
 
 // =========================================================================
-// Retired compatibility tool entry
+// Removed tool identity
 // =========================================================================
 
 #[tokio::test]
-async fn http_start_coding_task_is_retired() {
+async fn http_start_coding_task_uses_ordinary_unknown_tool_path() {
     let (_tmp, service) = phase2_service();
     let mut resp = TestClient::post("http://localhost/api/tools/call")
         .bearer_auth("secret")
@@ -826,8 +825,10 @@ async fn http_start_coding_task_is_retired() {
     assert_eq!(effective_status(&resp), StatusCode::BAD_REQUEST);
     let body: Value = resp.take_json().await.unwrap();
     let error = body["error"].as_str().unwrap();
-    assert!(error.contains("no longer supported"), "{error}");
-    assert!(error.contains("work_on_project"), "{error}");
+    assert!(
+        error.contains("unknown tool 'start_coding_task'"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -137,17 +137,7 @@ pub(crate) fn check_runtime_tool_scope(
     auth: Option<&AuthContext>,
     tool_name: &str,
 ) -> Result<(), ToolCallErrorStatus> {
-    // `start_coding_task` is a retired wire/API name that is rejected by
-    // `ToolCall::from_tool_name` after this scope gate. Preserve its former
-    // runtime:read admission for one compatibility window so authorized legacy
-    // callers still reach the actionable retirement error without reviving a
-    // ToolDefinition or dispatch identity. All other unknown names remain
-    // fail-closed through the canonical metadata lookup below.
-    let policy = if tool_name == "start_coding_task" {
-        OAuthToolScopePolicy::Require(crate::auth::SCOPE_RUNTIME_READ)
-    } else {
-        crate::auth::scopes::oauth_scope_policy_for_runtime_tool(tool_name)
-    };
+    let policy = crate::auth::scopes::oauth_scope_policy_for_runtime_tool(tool_name);
     let Some(auth) = auth else {
         // Preserve historical unauthenticated compatibility for unrelated
         // internal tools, but explicit Memory and administrator authority is
@@ -1258,58 +1248,12 @@ mod tests {
         assert_eq!(finished.error_kind.as_deref(), Some("invalid_arguments"));
     }
 
-    #[tokio::test]
-    async fn retired_start_coding_task_keeps_preparse_runtime_read_admission() {
-        let runtime = test_runtime();
+    #[test]
+    fn start_coding_task_uses_generic_unknown_scope_policy() {
         let runtime_read = oauth(&[crate::auth::SCOPE_RUNTIME_READ]);
-        let outcome = runtime
-            .call_tool_with_context(
-                ToolCallRequest {
-                    tool_name: "start_coding_task".to_string(),
-                    arguments: json!({"project": "demo"}),
-                },
-                ToolCallContext {
-                    transport: ToolTransport::Mcp,
-                    session_id: None,
-                    auth: Some(&runtime_read),
-                    window: None,
-                    record_oauth_scope_denials: false,
-                    host_file_import_trust: HostFileImportTrust::Untrusted,
-                },
-            )
-            .await;
-        assert!(matches!(
-            outcome.error_status,
-            Some(ToolCallErrorStatus::InvalidArguments { ref message })
-                if message.contains("no longer supported") && message.contains("work_on_project")
-        ));
-
-        let no_runtime_read = oauth(&[]);
-        let denied = runtime
-            .call_tool_with_context(
-                ToolCallRequest {
-                    tool_name: "start_coding_task".to_string(),
-                    arguments: json!({"project": "demo"}),
-                },
-                ToolCallContext {
-                    transport: ToolTransport::Mcp,
-                    session_id: None,
-                    auth: Some(&no_runtime_read),
-                    window: None,
-                    record_oauth_scope_denials: false,
-                    host_file_import_trust: HostFileImportTrust::Untrusted,
-                },
-            )
-            .await;
         assert_eq!(
-            denied.error_status,
-            Some(ToolCallErrorStatus::InsufficientScope {
-                required_scope: Some(crate::auth::SCOPE_RUNTIME_READ),
-                description: format!(
-                    "missing required scope: {}",
-                    crate::auth::SCOPE_RUNTIME_READ
-                ),
-            })
+            check_runtime_tool_scope(Some(&runtime_read), "start_coding_task"),
+            check_runtime_tool_scope(Some(&runtime_read), "definitely_unknown_tool")
         );
     }
 

--- a/src/tool_runtime/projects.rs
+++ b/src/tool_runtime/projects.rs
@@ -260,7 +260,7 @@ impl ToolRuntime {
                     "enabled": !project.disabled,
                     "active_jobs": active_jobs,
                     "source": project_source(&project),
-                    // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
+                    // Runtime Console and CLI ops consume this established list_projects key.
                     "agent_status": runner_status,
                     "connected": connected,
                     "resolved_shell_profile": resolved_shell_profile,
@@ -285,7 +285,7 @@ impl ToolRuntime {
                     "revision": project.revision,
                     "active_jobs": active_jobs,
                     "source": project_source(&project),
-                    // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
+                    // Runtime Console and CLI ops consume this established list_projects key.
                     "agent_status": runner_status,
                     "connected": connected,
                     "last_seen": last_seen,

--- a/src/tool_runtime/projects.rs
+++ b/src/tool_runtime/projects.rs
@@ -260,7 +260,7 @@ impl ToolRuntime {
                     "enabled": !project.disabled,
                     "active_jobs": active_jobs,
                     "source": project_source(&project),
-                    // `agent_status` is the stable pre-0.4 serialized compatibility key.
+                    // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
                     "agent_status": runner_status,
                     "connected": connected,
                     "resolved_shell_profile": resolved_shell_profile,
@@ -285,7 +285,7 @@ impl ToolRuntime {
                     "revision": project.revision,
                     "active_jobs": active_jobs,
                     "source": project_source(&project),
-                    // `agent_status` is the stable pre-0.4 serialized compatibility key.
+                    // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
                     "agent_status": runner_status,
                     "connected": connected,
                     "last_seen": last_seen,

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -241,7 +241,7 @@ impl ToolRuntime {
                 .filter(|client| client.status == "stale")
                 .count();
             return ToolResult::ok(json!({
-                // `agents` is a stable pre-0.4 serialized compatibility key.
+                // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
                 "agents": runners,
                 "summary": {
                     "count": clients.len(),
@@ -253,7 +253,7 @@ impl ToolRuntime {
             }));
         }
         ToolResult::ok(json!({
-            // `agents` is a stable pre-0.4 serialized compatibility key.
+            // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
             "agents": runners,
             "clients": runner_health_clients(&clients, &runner_jobs, now),
             "summary": runner_health_summary(&clients, &runner_jobs, now),
@@ -417,7 +417,7 @@ impl ToolRuntime {
             })
             .count();
         let jobs = json!({
-            // `agent_known_count` is a stable pre-0.4 runtime_status compatibility key.
+            // Published v0.4 runtime_status key; retain the exact spelling through 0.4.x.
             "agent_known_count": runner_known_count,
             "active_count": active_count,
             "running_count": running_count,
@@ -631,7 +631,7 @@ impl ToolRuntime {
             "summary": runner_health_summary(&clients, &selected_jobs, now),
         });
         let jobs = json!({
-            // `agent_known_count` is a stable pre-0.4 runtime_status compatibility key.
+            // Published v0.4 runtime_status key; retain the exact spelling through 0.4.x.
             "agent_known_count": selected_jobs.len(),
             "active_count": runner_active,
             "running_count": running_count,

--- a/src/tool_runtime/runtime_info.rs
+++ b/src/tool_runtime/runtime_info.rs
@@ -241,7 +241,7 @@ impl ToolRuntime {
                 .filter(|client| client.status == "stale")
                 .count();
             return ToolResult::ok(json!({
-                // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
+                // Runtime Console, admin/ops, and status projections consume this established key.
                 "agents": runners,
                 "summary": {
                     "count": clients.len(),
@@ -253,7 +253,7 @@ impl ToolRuntime {
             }));
         }
         ToolResult::ok(json!({
-            // Published v0.4 serialized key; retain the exact spelling through 0.4.x.
+            // Runtime Console, admin/ops, and status projections consume this established key.
             "agents": runners,
             "clients": runner_health_clients(&clients, &runner_jobs, now),
             "summary": runner_health_summary(&clients, &runner_jobs, now),
@@ -417,8 +417,7 @@ impl ToolRuntime {
             })
             .count();
         let jobs = json!({
-            // Published v0.4 runtime_status key; retain the exact spelling through 0.4.x.
-            "agent_known_count": runner_known_count,
+            "count": runner_known_count,
             "active_count": active_count,
             "running_count": running_count,
             "queued_count": queued_count,
@@ -459,7 +458,7 @@ impl ToolRuntime {
             "auth_enabled": self.runtime_info.auth_enabled,
             "configured_public_url": self.runtime_info.configured_public_url,
             "projects": projects,
-            // `agents` remains the stable runtime_status JSON compatibility key.
+            // Runtime Console, admin HTTP, and CLI ops consume this established key.
             "agents": runners,
             "connection_layers": connection_layers,
             "version_compatibility": version_compatibility,
@@ -631,8 +630,7 @@ impl ToolRuntime {
             "summary": runner_health_summary(&clients, &selected_jobs, now),
         });
         let jobs = json!({
-            // Published v0.4 runtime_status key; retain the exact spelling through 0.4.x.
-            "agent_known_count": selected_jobs.len(),
+            "count": selected_jobs.len(),
             "active_count": runner_active,
             "running_count": running_count,
             "queued_count": queued_count,

--- a/src/tool_runtime/tests/coding_task.rs
+++ b/src/tool_runtime/tests/coding_task.rs
@@ -99,9 +99,8 @@ fn coding_task_tools_are_registered_in_metadata_and_openapi() {
     assert!(names.contains(&"finish_coding_task"));
 
     let retired = ToolCall::from_tool_name("start_coding_task", json!({"project": "demo"}))
-        .expect_err("retired start_coding_task wire entry must fail closed");
-    assert!(retired.contains("no longer supported"));
-    assert!(retired.contains("work_on_project"));
+        .expect_err("retired start_coding_task must be an ordinary unknown tool");
+    assert!(retired.contains("unknown tool 'start_coding_task'"));
     let finish = specs
         .iter()
         .find(|spec| spec.name == "finish_coding_task")
@@ -298,8 +297,8 @@ async fn coding_workflow_test_seam_keeps_internal_diagnostic_modes_without_tool_
     });
 
     let wire_error = ToolCall::from_tool_name("start_coding_task", params.clone())
-        .expect_err("retired wire entry must reject the internal advanced primitive");
-    assert!(wire_error.contains("work_on_project"));
+        .expect_err("retired wire entry must remain unknown despite internal test-seam arguments");
+    assert!(wire_error.contains("unknown tool 'start_coding_task'"));
     let result = coding_workflow_serviced(&runtime, client_id, params, &auth).await;
     assert!(result.success, "{:?}", result.error);
     assert_eq!(result.output["detail"], "minimal");
@@ -1129,14 +1128,16 @@ async fn coding_workflow_runner_offline_is_still_blocking() {
 }
 
 #[test]
-fn retired_start_coding_task_rejection_precedes_legacy_argument_validation() {
+fn start_coding_task_legacy_arguments_do_not_restore_live_identity() {
     let error = ToolCall::from_tool_name(
         "start_coding_task",
         json!({"project": "agent:demo:demo", "include_runtime_status": false}),
     )
-    .expect_err("retired entry must reject before legacy argument handling");
-    assert!(error.contains("no longer supported"), "{error}");
-    assert!(error.contains("work_on_project"), "{error}");
+    .expect_err("legacy arguments must not restore a retired tool identity");
+    assert!(
+        error.contains("unknown tool 'start_coding_task'"),
+        "{error}"
+    );
 }
 
 #[tokio::test]

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -2309,7 +2309,8 @@ async fn runtime_status_and_list_runners_filter_concurrency_counts_by_auth_group
         )
         .await;
     assert!(status_a.success, "{:?}", status_a.error);
-    assert_eq!(status_a.output["jobs"]["agent_known_count"], 2);
+    assert_eq!(status_a.output["jobs"]["count"], 2);
+    assert!(status_a.output["jobs"].get("agent_known_count").is_none());
     assert_eq!(status_a.output["jobs"]["active_count"], 2);
     assert_eq!(status_a.output["jobs"]["running_count"], 1);
     assert_eq!(status_a.output["jobs"]["queued_count"], 1);
@@ -2374,7 +2375,7 @@ async fn runtime_status_and_list_runners_filter_concurrency_counts_by_auth_group
         )
         .await;
     assert!(status_open.success, "{:?}", status_open.error);
-    assert_eq!(status_open.output["jobs"]["agent_known_count"], 1);
+    assert_eq!(status_open.output["jobs"]["count"], 1);
     assert_eq!(status_open.output["jobs"]["active_count"], 1);
     assert_eq!(status_open.output["jobs"]["running_count"], 0);
     assert_eq!(status_open.output["jobs"]["queued_count"], 1);
@@ -2390,7 +2391,7 @@ async fn runtime_status_and_list_runners_filter_concurrency_counts_by_auth_group
         )
         .await;
     assert!(status_bootstrap.success, "{:?}", status_bootstrap.error);
-    assert_eq!(status_bootstrap.output["jobs"]["agent_known_count"], 5);
+    assert_eq!(status_bootstrap.output["jobs"]["count"], 5);
     assert_eq!(status_bootstrap.output["jobs"]["active_count"], 5);
     assert_eq!(status_bootstrap.output["jobs"]["running_count"], 2);
     assert_eq!(status_bootstrap.output["jobs"]["queued_count"], 3);
@@ -2431,7 +2432,7 @@ async fn runtime_concurrency_counts_cover_all_visible_jobs_beyond_list_paginatio
             Some(&auth),
         )
         .await;
-    assert_eq!(status.output["jobs"]["agent_known_count"], 21);
+    assert_eq!(status.output["jobs"]["count"], 21);
     assert_eq!(status.output["jobs"]["active_count"], 21);
     assert_eq!(status.output["jobs"]["running_count"], 0);
     assert_eq!(status.output["jobs"]["queued_count"], 21);


### PR DESCRIPTION
## Summary

- remove unused current compatibility aliases (`--kind agent`, `ops agents`, live `list_agents`, and the live `start_coding_task` path) while keeping narrow historical Workflow Session interpretation where persisted evidence still needs it
- remove duplicate machine-readable CLI fields and replace the unused `jobs.agent_known_count` output with canonical `jobs.count`
- remove pairing config-shaped no-op fields and stop transporting local Runner filesystem authority through credential enrollment
- remove the inert typed `temporary_projects_root` Runner config shim while preserving actual persisted-state and mixed-version compatibility
- document compatibility ownership by concrete consumers rather than by release history alone

## Compatibility kept intentionally

Real consumers remain protected: `agent.toml` / `projects.d` persisted state and ambiguity fences, historical Connector `inspect` quarantine and Session evidence, Server↔Runner mixed-version wire adapters, and established DB/wire/runtime `agent_*` identities that still have production readers.

## Validation

Focused regression tests passed for the removed CLI aliases, pairing enrollment, historical Workflow Session audit, and live `list_agents` rejection. `cargo check -p webcodex`, `cargo check -p webcodex-cli`, and `cargo check -p webcodex-runner` pass. The Runner check still reports the pre-existing unrelated `DetachedJobStore::state_path_for_job` dead-code warning.

The branch is clean with no active Jobs. `origin/main` advanced by #356 after this branch was cut; that commit touches disjoint files, so this PR was not rebased solely for that update.