### PR TITLE
Type durable Store lifecycle contracts

### DIFF
--- a/crates/webcodex-connector-runtime/src/execution.rs
+++ b/crates/webcodex-connector-runtime/src/execution.rs
@@ -13,8 +13,9 @@ use webcodex_core::runner_protocol::ShellJobValidationStep;
 use webcodex_runner_registry::{RunnerAccess, RunnerRegistry};
 use webcodex_store::Database;
 use webcodex_store::{
-    ConnectorExecution, ConnectorExecutionFailure, ConnectorExecutionObservation,
-    ConnectorExecutionReservation, ConnectorTaskSnapshot, ConnectorTaskStoreError,
+    ConnectorExecution, ConnectorExecutionFailure, ConnectorExecutionKind,
+    ConnectorExecutionObservation, ConnectorExecutionReservation, ConnectorExecutionState,
+    ConnectorTaskSnapshot, ConnectorTaskStoreError,
 };
 
 const DEFAULT_YIELD_MS: u64 = 8_000;
@@ -215,7 +216,7 @@ impl ExecutionService {
                 )?
             }
         };
-        if execution.state != "starting" {
+        if execution.state != ConnectorExecutionState::Starting {
             return Ok(execution);
         }
         let submission = match host
@@ -262,7 +263,7 @@ impl ExecutionService {
             &submission.status,
             chrono::Utc::now().timestamp(),
         )?;
-        if attached.state == "cancel_requested"
+        if attached.state == ConnectorExecutionState::CancelRequested
             && self.dispatch_cancel(&task, &attached, host.as_ref()).await == CancelDispatch::Failed
         {
             return self.db.finish_connector_execution(
@@ -328,7 +329,7 @@ impl ExecutionService {
                     .await?;
             }
         }
-        if execution.state == "cancelled" {
+        if execution.state == ConnectorExecutionState::Cancelled {
             self.release_cancelled_workspace(task).await;
         }
         Ok(Some(execution))
@@ -533,16 +534,22 @@ pub(crate) fn execution_projection(
         .or(execution.started_at)
         .or(execution.queued_at)
         .unwrap_or(execution.submitted_at);
-    let capability_outcome = match execution.state.as_str() {
-        "succeeded" => "completed",
-        "failed" => "failed",
-        "cancelled" => "cancelled",
-        "interrupted" | "unknown" => "needs_attention",
-        _ => "in_progress",
+    let capability_outcome = match execution.state {
+        ConnectorExecutionState::Succeeded => "completed",
+        ConnectorExecutionState::Failed => "failed",
+        ConnectorExecutionState::Cancelled => "cancelled",
+        ConnectorExecutionState::Interrupted | ConnectorExecutionState::Unknown => {
+            "needs_attention"
+        }
+        ConnectorExecutionState::Accepted
+        | ConnectorExecutionState::Queued
+        | ConnectorExecutionState::Starting
+        | ConnectorExecutionState::Running
+        | ConnectorExecutionState::CancelRequested => "in_progress",
     };
     let queue_reason = if execution.failure_source.as_deref() == Some("queue") {
         Some("queue_deadline")
-    } else if execution.state == "queued" {
+    } else if execution.state == ConnectorExecutionState::Queued {
         Some("executor_queue")
     } else {
         None
@@ -603,19 +610,28 @@ fn recipe_projection(execution: &ConnectorExecution) -> Value {
 }
 
 fn assertion_status(execution: &ConnectorExecution) -> &'static str {
-    if execution.kind != "check" {
+    if execution.kind != ConnectorExecutionKind::Check {
         return "not_run";
     }
-    match execution.state.as_str() {
-        "succeeded" => "passed",
-        "failed" if execution.failure_source.as_deref() == Some("check") => "failed",
-        "accepted" | "queued" | "starting" | "running" | "cancel_requested" => "in_progress",
-        _ => "not_run",
+    match execution.state {
+        ConnectorExecutionState::Succeeded => "passed",
+        ConnectorExecutionState::Failed if execution.failure_source.as_deref() == Some("check") => {
+            "failed"
+        }
+        ConnectorExecutionState::Accepted
+        | ConnectorExecutionState::Queued
+        | ConnectorExecutionState::Starting
+        | ConnectorExecutionState::Running
+        | ConnectorExecutionState::CancelRequested => "in_progress",
+        ConnectorExecutionState::Failed
+        | ConnectorExecutionState::Cancelled
+        | ConnectorExecutionState::Interrupted
+        | ConnectorExecutionState::Unknown => "not_run",
     }
 }
 
 fn check_results(execution: &ConnectorExecution) -> Value {
-    if execution.kind != "check" {
+    if execution.kind != ConnectorExecutionKind::Check {
         return Value::Null;
     }
     let assertion = assertion_status(execution);
@@ -654,23 +670,27 @@ fn execution_next_action(execution: &ConnectorExecution) -> &'static str {
     if execution.failure_code.as_deref() == Some("workspace_provenance_mismatch") {
         return "inspect_workspace_changes_then_rerun_checks";
     }
-    match execution.state.as_str() {
-        "accepted" | "queued" | "starting" | "running" => "review_or_cancel",
-        "cancel_requested" => "wait_for_cancellation",
-        "succeeded" | "failed" => "continue_or_finish",
-        "cancelled" => "start_a_new_task",
-        "interrupted" => "resume_or_reject_on_the_host",
-        "unknown" => "inspect_executor_state_before_continuing",
-        _ => "review_task",
+    match execution.state {
+        ConnectorExecutionState::Accepted
+        | ConnectorExecutionState::Queued
+        | ConnectorExecutionState::Starting
+        | ConnectorExecutionState::Running => "review_or_cancel",
+        ConnectorExecutionState::CancelRequested => "wait_for_cancellation",
+        ConnectorExecutionState::Succeeded | ConnectorExecutionState::Failed => {
+            "continue_or_finish"
+        }
+        ConnectorExecutionState::Cancelled => "start_a_new_task",
+        ConnectorExecutionState::Interrupted => "resume_or_reject_on_the_host",
+        ConnectorExecutionState::Unknown => "inspect_executor_state_before_continuing",
     }
 }
 
 fn execution_signature(
     execution: Option<&ConnectorExecution>,
-) -> Option<(&str, usize, usize, Option<i64>)> {
+) -> Option<(ConnectorExecutionState, usize, usize, Option<i64>)> {
     execution.map(|execution| {
         (
-            execution.state.as_str(),
+            execution.state,
             execution.stdout_cursor,
             execution.stderr_cursor,
             execution.first_status_failure_at,
@@ -854,7 +874,7 @@ mod service_tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(cancelled.state, "cancel_requested");
+        assert_eq!(cancelled.state, ConnectorExecutionState::CancelRequested);
         assert!(cancelled.executor_reference.is_none());
         assert_eq!(host.stops.load(Ordering::SeqCst), 0);
     }
@@ -900,7 +920,7 @@ mod service_tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(pending.state, "cancel_requested");
+        assert_eq!(pending.state, ConnectorExecutionState::CancelRequested);
         assert!(pending.executor_reference.is_none());
         assert_eq!(host.stops.load(Ordering::SeqCst), 0);
         gate.release_attach().await;
@@ -985,7 +1005,7 @@ mod service_tests {
             .db
             .attach_connector_executor(&execution.execution_id, "job-stop", "running", 5)
             .unwrap();
-        assert_eq!(attached.state, "running");
+        assert_eq!(attached.state, ConnectorExecutionState::Running);
         let host = Arc::new(TestHost::default());
         host.stop_unknown.store(true, Ordering::SeqCst);
         let cancelled = fx
@@ -994,7 +1014,7 @@ mod service_tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(cancelled.state, "unknown");
+        assert_eq!(cancelled.state, ConnectorExecutionState::Unknown);
         assert_eq!(
             cancelled.failure_code.as_deref(),
             Some("cancel_transport_unknown")

--- a/crates/webcodex-connector-runtime/src/execution/monitor.rs
+++ b/crates/webcodex-connector-runtime/src/execution/monitor.rs
@@ -134,19 +134,21 @@ impl ExecutionService {
             };
             let now = chrono::Utc::now().timestamp();
             if execution.is_terminal() {
-                if execution.state == "cancelled" {
+                if execution.state == ConnectorExecutionState::Cancelled {
                     self.release_cancelled_workspace(task).await;
                 }
                 return;
             }
-            let current = if execution.state == "queued" && now >= execution.queue_deadline {
+            let current = if execution.state == ConnectorExecutionState::Queued
+                && now >= execution.queue_deadline
+            {
                 self.db
                     .request_connector_queue_timeout(&execution_id, now)
                     .unwrap_or(execution)
             } else {
                 execution
             };
-            if current.state == "cancel_requested" {
+            if current.state == ConnectorExecutionState::CancelRequested {
                 let _ = self.dispatch_cancel(&task, &current, host.as_ref()).await;
             }
             match self
@@ -157,7 +159,7 @@ impl ExecutionService {
                     status_failures = 0;
                     first_status_failure = None;
                     if updated.is_terminal() {
-                        if updated.state == "cancelled" {
+                        if updated.state == ConnectorExecutionState::Cancelled {
                             self.release_cancelled_workspace(task).await;
                         }
                         return;
@@ -227,8 +229,11 @@ impl ExecutionService {
                 .min(self.monitor_timing.failure_poll_max);
         }
         if matches!(
-            execution.state.as_str(),
-            "accepted" | "starting" | "queued" | "cancel_requested"
+            execution.state,
+            ConnectorExecutionState::Accepted
+                | ConnectorExecutionState::Starting
+                | ConnectorExecutionState::Queued
+                | ConnectorExecutionState::CancelRequested
         ) {
             return self.monitor_timing.fast_poll;
         }
@@ -303,27 +308,28 @@ impl ExecutionService {
         let progress = job.validation_progress.as_ref();
         let check_completed = progress.map(|progress| progress.completed);
         let failed_check = progress.and_then(|progress| progress.failed_step.as_deref());
-        let assertion_evidence = if execution.kind == "check" && failed_check.is_some() {
-            let (_, full_stdout, full_stderr, _, _, _) = self
-                .runner_registry
-                .job_log_for_auth(Some(runner_access), job_id, None, None, None, None, None)
-                .await
-                .unwrap_or_else(|_| (job.clone(), None, None, 1, 1, Default::default()));
-            let stdout = full_stdout.unwrap_or_default();
-            let stderr = full_stderr.unwrap_or_default();
-            failed_check.map(|check| {
-                durable_assertion_evidence(
-                    check,
-                    execution.check_recipe.as_ref(),
-                    job.exit_code,
-                    &stdout,
-                    &stderr,
-                )
-            })
-        } else {
-            None
-        };
-        let check_succeeded_completely = execution.kind == "check"
+        let assertion_evidence =
+            if execution.kind == ConnectorExecutionKind::Check && failed_check.is_some() {
+                let (_, full_stdout, full_stderr, _, _, _) = self
+                    .runner_registry
+                    .job_log_for_auth(Some(runner_access), job_id, None, None, None, None, None)
+                    .await
+                    .unwrap_or_else(|_| (job.clone(), None, None, 1, 1, Default::default()));
+                let stdout = full_stdout.unwrap_or_default();
+                let stderr = full_stderr.unwrap_or_default();
+                failed_check.map(|check| {
+                    durable_assertion_evidence(
+                        check,
+                        execution.check_recipe.as_ref(),
+                        job.exit_code,
+                        &stdout,
+                        &stderr,
+                    )
+                })
+            } else {
+                None
+            };
+        let check_succeeded_completely = execution.kind == ConnectorExecutionKind::Check
             && lifecycle == Some(RunnerJobLifecycle::Completed)
             && job.exit_code == Some(0)
             && progress.is_some_and(|progress| {

--- a/crates/webcodex-connector-runtime/src/host_tests.rs
+++ b/crates/webcodex-connector-runtime/src/host_tests.rs
@@ -6,8 +6,9 @@ use std::process::Command;
 use std::sync::{Arc, Barrier};
 use webcodex_runner_registry::RunnerRegistry;
 use webcodex_store::{
-    ConnectorBinding, ConnectorTaskResult, ConnectorTaskStoreError, Database, NewConnectorResult,
-    NewConnectorTask,
+    ConnectorBinding, ConnectorResultDecisionRecoveryState, ConnectorResultDecisionStatus,
+    ConnectorRunState, ConnectorTaskMode, ConnectorTaskResult, ConnectorTaskState,
+    ConnectorTaskStoreError, Database, NewConnectorResult, NewConnectorTask,
 };
 
 const TASK_ID: &str = "wc_task_f123456789abcdef0123456789abcdef";
@@ -305,7 +306,7 @@ fn finalization_failure_is_recovered_once_after_reopen() {
             .unwrap()
             .unwrap()
             .decision_status,
-        "pending"
+        ConnectorResultDecisionStatus::Pending
     );
     let Fixture { temp, context, db } = fx;
     drop(db);
@@ -326,7 +327,7 @@ fn finalization_failure_is_recovered_once_after_reopen() {
             .unwrap()
             .unwrap()
             .decision_status,
-        "accepted"
+        ConnectorResultDecisionStatus::Accepted
     );
     assert_eq!(fs::read_to_string(target(&context)).unwrap(), "after\n");
     assert_eq!(
@@ -434,8 +435,11 @@ fn unrecoverable_accept_is_quarantined_while_other_intents_recover_and_runtime_s
         .recovery
         .as_ref()
         .expect("stale intent must be observable");
-    assert_eq!(bad.decision_status, "pending");
-    assert_eq!(recovery.state, "needs_attention");
+    assert_eq!(bad.decision_status, ConnectorResultDecisionStatus::Pending);
+    assert_eq!(
+        recovery.state,
+        ConnectorResultDecisionRecoveryState::NeedsAttention
+    );
     assert_eq!(
         recovery.error_code.as_deref(),
         Some("target_checkout_changed")
@@ -450,14 +454,15 @@ fn unrecoverable_accept_is_quarantined_while_other_intents_recover_and_runtime_s
             .unwrap()
             .unwrap()
             .decision_status,
-        "rejected"
+        ConnectorResultDecisionStatus::Rejected
     );
     let queue = reopened
         .local_reviewable_tasks(&context.project_id, false, 20)
         .unwrap();
     assert!(queue
         .iter()
-        .any(|task| task.task_id == TASK_ID && task.task_status == "needs_attention"));
+        .any(|task| task.task_id == TASK_ID
+            && task.task_status == ConnectorTaskState::NeedsAttention));
     assert_decision_error(
         WorkspaceManager::decide_connector_result_local(
             &reopened,
@@ -499,13 +504,16 @@ fn unrecoverable_accept_is_quarantined_while_other_intents_recover_and_runtime_s
         10,
     )
     .unwrap();
-    assert_eq!(rejected.decision_status, "rejected");
+    assert_eq!(
+        rejected.decision_status,
+        ConnectorResultDecisionStatus::Rejected
+    );
     assert!(rejected.recovery.is_none());
     let task = reopened
         .local_connector_task(TASK_ID, &context.project_id)
         .unwrap();
-    assert_eq!(task.task_status, "rejected");
-    assert_eq!(task.run_status, "completed");
+    assert_eq!(task.task_status, ConnectorTaskState::Rejected);
+    assert_eq!(task.run_status, ConnectorRunState::Completed);
     let (stored_task_status, stored_run_status, finished_at): (String, String, Option<i64>) =
         reopened
             .conn_for_tests()
@@ -619,7 +627,7 @@ fn interrupted_no_result_reject_is_the_only_identity_exception() {
             .unwrap()
             .unwrap()
             .decision_status,
-        "rejected"
+        ConnectorResultDecisionStatus::Rejected
     );
 }
 
@@ -637,7 +645,7 @@ fn persisted_read_only_isolated_result_cannot_be_accepted() {
         .db
         .local_connector_task(TASK_ID, &fx.context.project_id)
         .unwrap();
-    assert_eq!(malformed.mode, "read_only");
+    assert_eq!(malformed.mode, ConnectorTaskMode::ReadOnly);
     assert!(malformed.isolated);
 
     assert_decision_error(
@@ -651,7 +659,7 @@ fn persisted_read_only_isolated_result_cannot_be_accepted() {
             .unwrap()
             .unwrap()
             .decision_status,
-        "pending"
+        ConnectorResultDecisionStatus::Pending
     );
 }
 
@@ -676,13 +684,16 @@ fn legacy_inspect_interrupted_task_can_be_rejected_but_never_accepted() {
     let rejected = fx
         .decide(None, LocalResultDecision::Reject, 6)
         .expect("legacy inspect cleanup must remain rejectable");
-    assert_eq!(rejected.decision_status, "rejected");
+    assert_eq!(
+        rejected.decision_status,
+        ConnectorResultDecisionStatus::Rejected
+    );
     let task = fx
         .db
         .local_connector_task(TASK_ID, &fx.context.project_id)
         .unwrap();
-    assert_eq!(task.mode, "inspect");
-    assert_eq!(task.task_status, "rejected");
+    assert_eq!(task.mode, ConnectorTaskMode::InspectLegacy);
+    assert_eq!(task.task_status, ConnectorTaskState::Rejected);
     assert_eq!(fs::read_to_string(target(&fx.context)).unwrap(), "before\n");
 }
 
@@ -744,7 +755,10 @@ fn reject_reason_reaches_the_model_as_guidance_once() {
         5,
     )
     .unwrap();
-    assert_eq!(rejected.decision_status, "rejected");
+    assert_eq!(
+        rejected.decision_status,
+        ConnectorResultDecisionStatus::Rejected
+    );
     let payload: String = fixture
         .db
         .conn_for_tests()
@@ -825,7 +839,7 @@ fn connector_tasks_for_subject_scopes_to_the_owner() {
         .unwrap();
     assert_eq!(mine.len(), 1);
     assert_eq!(mine[0].task_id, TASK_ID);
-    assert_eq!(mine[0].task_status, "ready_for_review");
+    assert_eq!(mine[0].task_status, ConnectorTaskState::ReadyForReview);
     assert_eq!(mine[0].next_action, "review_and_accept");
     assert_eq!(mine[0].unread_guidance, 0, "no guidance recorded yet");
 

--- a/crates/webcodex-connector-runtime/src/projections.rs
+++ b/crates/webcodex-connector-runtime/src/projections.rs
@@ -17,7 +17,7 @@ use sha2::{Digest, Sha256};
 use webcodex_core::apply_edits_shared::ApplyFileChangeInput;
 use webcodex_store::{
     ConnectorApproval, ConnectorApprovalGate, ConnectorTaskResult, ConnectorTaskSnapshot,
-    ConnectorTaskStoreError, ConnectorWindowBinding,
+    ConnectorTaskState, ConnectorTaskStoreError, ConnectorWindowBinding,
 };
 use webcodex_validation::RecipeError;
 use webcodex_workspace::project_context::{ContextRefreshSummary, ProjectContextFingerprint};
@@ -984,15 +984,16 @@ pub(super) fn bounded_goal(goal: &str) -> String {
 }
 
 /// The host queue speaks reviewer verbs; the model needs capability verbs.
-pub(super) fn model_next_action(task_status: &str, host_action: &str) -> &'static str {
+pub(super) fn model_next_action(
+    task_status: ConnectorTaskState,
+    host_action: &str,
+) -> &'static str {
     match host_action {
         "in_progress" => "task_resume",
         "review_and_accept" => "task_review_then_ask_the_owner_to_decide_locally",
         "resume_or_reject" => "ask_the_owner_to_resume_or_reject_on_the_host",
-        _ => match task_status {
-            "rejected" => "task_resume_for_the_rejection_reason",
-            _ => "task_start_new_work",
-        },
+        _ if task_status == ConnectorTaskState::Rejected => "task_resume_for_the_rejection_reason",
+        _ => "task_start_new_work",
     }
 }
 

--- a/crates/webcodex-connector-runtime/src/runtime.rs
+++ b/crates/webcodex-connector-runtime/src/runtime.rs
@@ -39,9 +39,10 @@ use webcodex_core::runner_protocol::{
 use webcodex_runner_registry::{command_preview, RunnerRegistry};
 use webcodex_store::{
     ConnectorApprovalGate, ConnectorBinding, ConnectorEditOperationGate, ConnectorExecution,
-    ConnectorExecutionReservation, ConnectorTaskContinuation, ConnectorTaskResult,
-    ConnectorTaskSnapshot, ConnectorTaskStoreError, ConnectorWorkspaceTransition, Database,
-    NewConnectorResult, NewConnectorTask,
+    ConnectorExecutionReservation, ConnectorExecutionState, ConnectorResultDecisionStatus,
+    ConnectorRunState, ConnectorTaskContinuation, ConnectorTaskMode, ConnectorTaskResult,
+    ConnectorTaskSnapshot, ConnectorTaskState, ConnectorTaskStoreError,
+    ConnectorWorkspaceTransition, Database, NewConnectorResult, NewConnectorTask,
 };
 use webcodex_validation::{resolve_validation_recipe, RecipeId, SemanticCheck};
 use webcodex_workspace::project_context::{
@@ -721,7 +722,7 @@ impl ConnectorRuntime {
                 Err(error) => return store_error_outcome(error, None),
             };
             if let Some(task) = existing {
-                if task.mode == "inspect" {
+                if task.mode == ConnectorTaskMode::InspectLegacy {
                     return Self::retired_inspect_task_outcome(&task);
                 }
                 if let Some(outcome) = Self::invalid_mode_transition_outcome(&task, mode) {
@@ -729,7 +730,9 @@ impl ConnectorRuntime {
                 }
                 let refresh =
                     compare_project_context(Some(&existing_context.fingerprint), &fingerprint);
-                if task.task_status == "active" && task.run_status == "running" {
+                if task.task_status == ConnectorTaskState::Active
+                    && task.run_status == ConnectorRunState::Running
+                {
                     return self
                         .continue_window_task(
                             task,
@@ -743,7 +746,9 @@ impl ConnectorRuntime {
                         )
                         .await;
                 }
-                if task.run_status == "interrupted" && task.task_status == "needs_attention" {
+                if task.run_status == ConnectorRunState::Interrupted
+                    && task.task_status == ConnectorTaskState::NeedsAttention
+                {
                     let window = window.expect("existing window context has a window");
                     let cursor = match self.db.append_interrupted_connector_instruction_and_bind(
                         &task.task_id,
@@ -1024,7 +1029,7 @@ impl ConnectorRuntime {
         now: i64,
     ) -> ConnectorCallOutcome {
         let event_cursor_before = task.event_cursor;
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Self::retired_inspect_task_outcome(&task);
         }
         if let Some(outcome) = Self::invalid_mode_transition_outcome(&task, mode) {
@@ -2288,7 +2293,7 @@ impl ConnectorRuntime {
                     "diff_preview": diff_preview
                 }),
             )
-        } else if task.task_status == "cancelled" {
+        } else if task.task_status == ConnectorTaskState::Cancelled {
             json!({
                 "source": "cancelled_task",
                 "changed_paths": [],
@@ -2416,9 +2421,9 @@ impl ConnectorRuntime {
             .and_then(|value| value["next_action"].as_str())
             .map(str::to_string)
             .unwrap_or_else(|| {
-                if task.task_status == "cancelled" {
+                if task.task_status == ConnectorTaskState::Cancelled {
                     "start_a_new_task"
-                } else if task.run_status == "interrupted" {
+                } else if task.run_status == ConnectorRunState::Interrupted {
                     "resume_or_reject_on_the_host"
                 } else {
                     "continue_or_finish"
@@ -2477,7 +2482,7 @@ impl ConnectorRuntime {
                     "updated_at": task.updated_at,
                     "execution_status": task.execution_status,
                     "validation_status": task.validation_status,
-                    "next_action": model_next_action(&task.task_status, &task.next_action),
+                    "next_action": model_next_action(task.task_status, &task.next_action),
                 })
             })
             .collect();
@@ -2506,7 +2511,7 @@ impl ConnectorRuntime {
             Ok(task) => task,
             Err(outcome) => return outcome,
         };
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Self::retired_inspect_task_outcome(&task);
         }
         let context_lock = window.map(|window| self.context_lock(subject_id, window.key()));
@@ -2544,16 +2549,14 @@ impl ConnectorRuntime {
             execution.map(|execution| execution::execution_projection(&execution, now, None));
         // A local decision outranks stale execution advice: an accepted or
         // rejected result decides the story, whatever the last run said.
-        let decision_action = result.as_ref().and_then(|result| {
-            match result.decision_status.as_str() {
-                "accepted" => {
-                    Some("the result was accepted locally; start the next piece of work with task_start")
-                }
-                "rejected" => Some(
-                    "the result was rejected; apply the guidance and start a corrected task with task_start",
-                ),
-                _ => None,
+        let decision_action = result.as_ref().and_then(|result| match result.decision_status {
+            ConnectorResultDecisionStatus::Accepted => {
+                Some("the result was accepted locally; start the next piece of work with task_start")
             }
+            ConnectorResultDecisionStatus::Rejected => Some(
+                "the result was rejected; apply the guidance and start a corrected task with task_start",
+            ),
+            ConnectorResultDecisionStatus::Pending => None,
         });
         let next_action = decision_action
             .map(str::to_string)
@@ -2566,9 +2569,9 @@ impl ConnectorRuntime {
             .unwrap_or_else(|| {
                 if result.is_some() {
                     "task_review, then ask the project owner to accept or reject locally"
-                } else if task.task_status == "cancelled" {
+                } else if task.task_status == ConnectorTaskState::Cancelled {
                     "start_a_new_task"
-                } else if task.run_status == "interrupted" {
+                } else if task.run_status == ConnectorRunState::Interrupted {
                     "ask the project owner to resume or reject this task on the host"
                 } else {
                     "continue with files_read/edits_apply, then task_review"
@@ -2667,7 +2670,9 @@ impl ConnectorRuntime {
         // Timeline visibility for the console; terminal tasks skip the
         // running-only event guard on purpose, and a failed advisory event
         // must not fail the bootstrap.
-        let cursor = if task.task_status == "active" && task.run_status == "running" {
+        let cursor = if task.task_status == ConnectorTaskState::Active
+            && task.run_status == ConnectorRunState::Running
+        {
             match self.record_event(
                 &task,
                 "task_resume",
@@ -2772,7 +2777,7 @@ impl ConnectorRuntime {
             Ok(task) => task,
             Err(outcome) => return outcome,
         };
-        if visible_task.mode == "inspect" {
+        if visible_task.mode == ConnectorTaskMode::InspectLegacy {
             return Self::retired_inspect_task_outcome(&visible_task);
         }
         if let Some(outcome) = Self::invalid_task_workspace_outcome(&visible_task) {
@@ -2793,8 +2798,8 @@ impl ConnectorRuntime {
                 "execution_not_terminal",
                 "task_finish is blocked until the active execution reaches a known terminal state",
                 true,
-                execution.state == "unknown",
-                Some(if execution.state == "unknown" {
+                execution.state == ConnectorExecutionState::Unknown,
+                Some(if execution.state == ConnectorExecutionState::Unknown {
                     "Inspect the executor state on the host before finishing this task."
                 } else {
                     "Use task_review to wait for completion or task_cancel to stop the execution."
@@ -2835,7 +2840,7 @@ impl ConnectorRuntime {
         }
         if let Some(check) = check_execution
             .as_ref()
-            .filter(|check| check.state == "succeeded")
+            .filter(|check| check.state == ConnectorExecutionState::Succeeded)
         {
             let Some(validated) = check.validated_workspace_sha256.as_deref() else {
                 return checks_stale_outcome(
@@ -3044,7 +3049,7 @@ impl ConnectorRuntime {
         task: &ConnectorTaskSnapshot,
         requested_mode: &str,
     ) -> Option<ConnectorCallOutcome> {
-        (task.mode == "normal" && requested_mode == "read_only").then(|| {
+        (task.mode == ConnectorTaskMode::Normal && requested_mode == "read_only").then(|| {
             ConnectorCallOutcome::error_for_task(
                 409,
                 "mode_transition_invalid",
@@ -3064,8 +3069,8 @@ impl ConnectorRuntime {
     fn invalid_task_workspace_outcome(
         task: &ConnectorTaskSnapshot,
     ) -> Option<ConnectorCallOutcome> {
-        let message = match task.mode.as_str() {
-            "normal"
+        let message = match task.mode {
+            ConnectorTaskMode::Normal
                 if !task.isolated
                     || task.execution_root == task.target_root
                     || task.baseline_commit.as_deref().is_none_or(str::is_empty)
@@ -3073,11 +3078,14 @@ impl ConnectorRuntime {
             {
                 "normal task has an invalid isolated writable-workspace state"
             }
-            "read_only" if task.isolated || task.execution_root != task.target_root => {
+            ConnectorTaskMode::ReadOnly
+                if task.isolated || task.execution_root != task.target_root =>
+            {
                 "read_only task has an invalid workspace state"
             }
-            "normal" | "read_only" | "inspect" => return None,
-            _ => "task mode is not part of the canonical Connector execution contract",
+            ConnectorTaskMode::Normal
+            | ConnectorTaskMode::ReadOnly
+            | ConnectorTaskMode::InspectLegacy => return None,
         };
         Some(ConnectorCallOutcome::error_for_task(
             409,
@@ -3100,12 +3108,12 @@ impl ConnectorRuntime {
         subject_id: &str,
     ) -> Result<ConnectorTaskSnapshot, ConnectorCallOutcome> {
         let task = self.task(task_id, subject_id)?;
-        if task.mode != "inspect" {
+        if task.mode != ConnectorTaskMode::InspectLegacy {
             if let Some(outcome) = Self::invalid_task_workspace_outcome(&task) {
                 return Err(outcome);
             }
         }
-        if task.run_status == "interrupted" {
+        if task.run_status == ConnectorRunState::Interrupted {
             return Err(ConnectorCallOutcome::error_for_task(
                 409,
                 "task_interrupted",
@@ -3119,7 +3127,9 @@ impl ConnectorRuntime {
                 }),
             ));
         }
-        if task.task_status != "active" || task.run_status != "running" {
+        if task.task_status != ConnectorTaskState::Active
+            || task.run_status != ConnectorRunState::Running
+        {
             return Err(ConnectorCallOutcome::error_for_task(
                 409,
                 "task_not_active",
@@ -3142,10 +3152,10 @@ impl ConnectorRuntime {
         now: i64,
     ) -> Result<ConnectorTaskSnapshot, ConnectorCallOutcome> {
         let task = self.active_task(task_id, subject_id)?;
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Err(Self::retired_inspect_task_outcome(&task));
         }
-        if task.mode == "read_only" {
+        if task.mode == ConnectorTaskMode::ReadOnly {
             let cursor = self.record_event(
                 &task,
                 capability,
@@ -3175,10 +3185,10 @@ impl ConnectorRuntime {
         now: i64,
     ) -> Result<ConnectorTaskSnapshot, ConnectorCallOutcome> {
         let task = self.active_task(task_id, subject_id)?;
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Err(Self::retired_inspect_task_outcome(&task));
         }
-        if task.mode == "read_only" {
+        if task.mode == ConnectorTaskMode::ReadOnly {
             let cursor = self.record_event(
                 &task,
                 capability,

--- a/crates/webcodex-connector-runtime/src/runtime_tests.rs
+++ b/crates/webcodex-connector-runtime/src/runtime_tests.rs
@@ -792,5 +792,5 @@ async fn missing_job_permission_blocks_cancel_without_mutating_task() {
             "project:wc_pgrant_1111111111111111",
         )
         .unwrap();
-    assert_eq!(task.task_status, "active");
+    assert_eq!(task.task_status, webcodex_store::ConnectorTaskState::Active);
 }

--- a/crates/webcodex-connector-runtime/src/workspace.rs
+++ b/crates/webcodex-connector-runtime/src/workspace.rs
@@ -16,8 +16,9 @@ use std::io::{ErrorKind, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output};
 use webcodex_store::{
-    ConnectorPreservedWorkspace, ConnectorTaskResult, ConnectorTaskSnapshot,
-    ConnectorTaskStoreError, Database,
+    ConnectorPreservedWorkspace, ConnectorResultDecision, ConnectorResultDecisionStatus,
+    ConnectorRunState, ConnectorTaskMode, ConnectorTaskResult, ConnectorTaskSnapshot,
+    ConnectorTaskState, ConnectorTaskStoreError, Database,
 };
 
 const MAX_RESULT_PATCH_BYTES: usize = 4 * 1024 * 1024;
@@ -878,14 +879,14 @@ impl WorkspaceManager {
         result: &ConnectorTaskResult,
         recovering: bool,
     ) -> Result<Option<String>, ConnectorTaskStoreError> {
-        match task.mode.as_str() {
-            "inspect" => {
+        match task.mode {
+            ConnectorTaskMode::InspectLegacy => {
                 return Err(ConnectorTaskStoreError::decision(
                     "inspect_mode_retired",
                     "a pre-0.4 inspect task cannot be accepted as writable work; reject it locally and start a new task",
                 ));
             }
-            "read_only" => {
+            ConnectorTaskMode::ReadOnly => {
                 if task.isolated || task.execution_root != task.target_root {
                     return Err(ConnectorTaskStoreError::decision(
                         "result_precondition_failed",
@@ -900,7 +901,7 @@ impl WorkspaceManager {
                 }
                 return Ok(None);
             }
-            "normal" => {
+            ConnectorTaskMode::Normal => {
                 if !task.isolated
                     || task.execution_root == task.target_root
                     || task.baseline_commit.as_deref().is_none_or(str::is_empty)
@@ -911,12 +912,6 @@ impl WorkspaceManager {
                         "normal task result is not backed by a canonical isolated writable workspace",
                     ));
                 }
-            }
-            _ => {
-                return Err(ConnectorTaskStoreError::decision(
-                    "result_precondition_failed",
-                    "task result mode is not part of the canonical Connector execution contract",
-                ));
             }
         }
         let baseline = task
@@ -1004,10 +999,12 @@ impl WorkspaceManager {
         runs_root: &Path,
         project_registry_dir: &Path,
     ) -> Result<(), String> {
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Err("inspect_mode_retired: this pre-0.4 inspect task can no longer execute; reject it locally and start a new read_only or normal task".to_string());
         }
-        if task.run_status != "interrupted" || task.task_status != "needs_attention" {
+        if task.run_status != ConnectorRunState::Interrupted
+            || task.task_status != ConnectorTaskState::NeedsAttention
+        {
             return Err("only an interrupted task can be resumed".to_string());
         }
         let execution_root = Path::new(&task.execution_root);
@@ -1050,7 +1047,8 @@ impl WorkspaceManager {
         now: i64,
     ) -> Result<ConnectorTaskResult, ConnectorTaskStoreError> {
         let task = local_decision_task(db, project_id, task_id, target_root)?;
-        if task.mode == "inspect" && decision == LocalResultDecision::Accept {
+        if task.mode == ConnectorTaskMode::InspectLegacy && decision == LocalResultDecision::Accept
+        {
             return Err(ConnectorTaskStoreError::decision(
                 "inspect_mode_retired",
                 "a pre-0.4 inspect task cannot be accepted as writable work; reject it locally and start a new task",
@@ -1059,7 +1057,7 @@ impl WorkspaceManager {
         let result = db.local_connector_task_result(task_id, project_id)?;
         if result.is_none()
             && decision == LocalResultDecision::Reject
-            && task.run_status == "interrupted"
+            && task.run_status == ConnectorRunState::Interrupted
         {
             if expected_result_id.is_some() {
                 return Err(result_changed());
@@ -1084,7 +1082,9 @@ impl WorkspaceManager {
         if expected_result_id != Some(result.result_id.as_str()) {
             return Err(result_changed());
         }
-        if decision == LocalResultDecision::Reject && result.decision_status == "rejected" {
+        if decision == LocalResultDecision::Reject
+            && result.decision_status == ConnectorResultDecisionStatus::Rejected
+        {
             if result.cleanup_warning.is_some() {
                 Self::release_and_record(db, project_id, &task, now)?;
                 return db
@@ -1093,7 +1093,7 @@ impl WorkspaceManager {
             }
             return Ok(result);
         }
-        if result.decision_status != "pending" {
+        if result.decision_status != ConnectorResultDecisionStatus::Pending {
             return Err(ConnectorTaskStoreError::decision(
                 "result_already_decided",
                 "task result was already decided",
@@ -1182,10 +1182,9 @@ impl WorkspaceManager {
         let intents = db.connector_result_decision_intents(project_id)?;
         let mut recovered = 0;
         for (task_id, result_id, decision) in &intents {
-            let decision = if decision == "accepted" {
-                LocalResultDecision::Accept
-            } else {
-                LocalResultDecision::Reject
+            let decision = match decision {
+                ConnectorResultDecision::Accepted => LocalResultDecision::Accept,
+                ConnectorResultDecision::Rejected => LocalResultDecision::Reject,
             };
             let outcome = (|| {
                 let task = local_decision_task(db, project_id, task_id, target_root)?;
@@ -1961,6 +1960,7 @@ fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use webcodex_store::{ConnectorRunLifecycle, ConnectorTaskLifecycle};
 
     fn git(root: &Path, args: &[&str]) {
         let output = Command::new("git")
@@ -2033,9 +2033,11 @@ mod tests {
             workspace_id: context.workspace_id.clone(),
             owner_subject_id: "user:owner".to_string(),
             goal: "edit the readme".to_string(),
-            mode: "normal".to_string(),
-            task_status: "ready_for_review".to_string(),
-            run_status: "completed".to_string(),
+            mode: ConnectorTaskMode::Normal,
+            task_lifecycle: ConnectorTaskLifecycle::ReadyForReview,
+            task_status: ConnectorTaskState::ReadyForReview,
+            run_lifecycle: ConnectorRunLifecycle::Completed,
+            run_status: ConnectorRunState::Completed,
             event_cursor: 2,
             target_executor_ref: context.executor_project.clone(),
             execution_executor_ref: prepared.execution_executor_ref.clone(),
@@ -2061,7 +2063,7 @@ mod tests {
             changed_paths: captured.changed_paths.clone(),
             validation: serde_json::json!({"status": "not_run"}),
             warnings: captured.warnings.clone(),
-            decision_status: "pending".to_string(),
+            decision_status: ConnectorResultDecisionStatus::Pending,
             decided_by: None,
             decided_at: None,
             cleanup_warning: None,

--- a/crates/webcodex-core/src/coding_agent.rs
+++ b/crates/webcodex-core/src/coding_agent.rs
@@ -64,6 +64,31 @@ impl CodingAgentRunState {
             Self::Completed | Self::Failed | Self::Cancelled | Self::Lost
         )
     }
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::WaitingPermission => "waiting_permission",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Lost => "lost",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        Some(match value {
+            "starting" => Self::Starting,
+            "running" => Self::Running,
+            "waiting_permission" => Self::WaitingPermission,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            "lost" => Self::Lost,
+            _ => return None,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,6 +98,27 @@ pub enum CodingAgentExecutionState {
     Started,
     OutcomeUnknown,
     Completed,
+}
+
+impl CodingAgentExecutionState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotStarted => "not_started",
+            Self::Started => "started",
+            Self::OutcomeUnknown => "outcome_unknown",
+            Self::Completed => "completed",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        Some(match value {
+            "not_started" => Self::NotStarted,
+            "started" => Self::Started,
+            "outcome_unknown" => Self::OutcomeUnknown,
+            "completed" => Self::Completed,
+            _ => return None,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -915,6 +961,36 @@ mod tests {
             assert_eq!(kind.as_str(), expected);
             assert_eq!(serde_json::to_value(&kind).unwrap(), expected);
         }
+    }
+
+    #[test]
+    fn run_and_execution_state_wire_vocabulary_is_exact_and_parseable() {
+        for (state, expected) in [
+            (CodingAgentRunState::Starting, "starting"),
+            (CodingAgentRunState::Running, "running"),
+            (CodingAgentRunState::WaitingPermission, "waiting_permission"),
+            (CodingAgentRunState::Completed, "completed"),
+            (CodingAgentRunState::Failed, "failed"),
+            (CodingAgentRunState::Cancelled, "cancelled"),
+            (CodingAgentRunState::Lost, "lost"),
+        ] {
+            assert_eq!(state.as_str(), expected);
+            assert_eq!(CodingAgentRunState::from_str(expected), Some(state.clone()));
+            assert_eq!(serde_json::to_value(&state).unwrap(), expected);
+        }
+        assert!(CodingAgentRunState::from_str("future_state").is_none());
+
+        for (state, expected) in [
+            (CodingAgentExecutionState::NotStarted, "not_started"),
+            (CodingAgentExecutionState::Started, "started"),
+            (CodingAgentExecutionState::OutcomeUnknown, "outcome_unknown"),
+            (CodingAgentExecutionState::Completed, "completed"),
+        ] {
+            assert_eq!(state.as_str(), expected);
+            assert_eq!(CodingAgentExecutionState::from_str(expected), Some(state));
+            assert_eq!(serde_json::to_value(state).unwrap(), expected);
+        }
+        assert!(CodingAgentExecutionState::from_str("future_state").is_none());
     }
 
     #[test]

--- a/crates/webcodex-store/src/agent_task.rs
+++ b/crates/webcodex-store/src/agent_task.rs
@@ -191,8 +191,8 @@ pub struct AgentTaskCodingRunObservation {
     pub provider_instance_id: String,
     pub authority_fingerprint: String,
     pub coding_agent_intent_fingerprint: String,
-    pub run_state: String,
-    pub execution_state: String,
+    pub run_state: CodingAgentRunState,
+    pub execution_state: CodingAgentExecutionState,
     pub observation_revision: i64,
     pub terminal_stop_reason: Option<String>,
     pub terminal_error_code: Option<String>,
@@ -212,8 +212,8 @@ pub struct AgentTaskCodingRunBindingRecord {
     pub coding_agent_intent_fingerprint: String,
     pub binding_intent_fingerprint: String,
     pub dispatch_state: AgentTaskCodingRunDispatchState,
-    pub last_observed_run_state: Option<String>,
-    pub last_observed_execution_state: Option<String>,
+    pub last_observed_run_state: Option<CodingAgentRunState>,
+    pub last_observed_execution_state: Option<CodingAgentExecutionState>,
     pub last_observation_revision: Option<i64>,
     pub terminal_stop_reason: Option<String>,
     pub terminal_error_code: Option<String>,
@@ -233,11 +233,16 @@ impl AgentTaskCodingRunBindingRecord {
                 AgentTaskExecutionStatus::OutcomeUnknown
             }
             AgentTaskCodingRunDispatchState::Terminal => AgentTaskExecutionStatus::Terminal,
-            AgentTaskCodingRunDispatchState::Bound => match self.last_observed_run_state.as_deref()
-            {
-                Some("waiting_permission") => AgentTaskExecutionStatus::WaitingPermission,
-                Some("lost") => AgentTaskExecutionStatus::OutcomeUnknown,
-                Some("completed" | "failed" | "cancelled") => AgentTaskExecutionStatus::Terminal,
+            AgentTaskCodingRunDispatchState::Bound => match self.last_observed_run_state.as_ref() {
+                Some(CodingAgentRunState::WaitingPermission) => {
+                    AgentTaskExecutionStatus::WaitingPermission
+                }
+                Some(CodingAgentRunState::Lost) => AgentTaskExecutionStatus::OutcomeUnknown,
+                Some(
+                    CodingAgentRunState::Completed
+                    | CodingAgentRunState::Failed
+                    | CodingAgentRunState::Cancelled,
+                ) => AgentTaskExecutionStatus::Terminal,
                 _ => AgentTaskExecutionStatus::Active,
             },
         }
@@ -2056,9 +2061,11 @@ impl Database {
                 "stale CodingAgentRun observation cannot terminalize AgentTask state",
             ));
         }
-        let desired_task_state = match binding.last_observed_run_state.as_deref() {
-            Some("completed") => AgentTaskState::Succeeded,
-            Some("failed" | "cancelled") => AgentTaskState::Failed,
+        let desired_task_state = match binding.last_observed_run_state.as_ref() {
+            Some(CodingAgentRunState::Completed) => AgentTaskState::Succeeded,
+            Some(CodingAgentRunState::Failed | CodingAgentRunState::Cancelled) => {
+                AgentTaskState::Failed
+            }
             _ => {
                 return Err(CommunicationStoreError::new(
                     "agent_task_coding_run_not_terminal",
@@ -2215,27 +2222,8 @@ fn canonical_coding_run_snapshot(
         }
     }
 
-    let state = match observation.run_state.as_str() {
-        "starting" => CodingAgentRunState::Starting,
-        "running" => CodingAgentRunState::Running,
-        "waiting_permission" => CodingAgentRunState::WaitingPermission,
-        "completed" => CodingAgentRunState::Completed,
-        "failed" => CodingAgentRunState::Failed,
-        "cancelled" => CodingAgentRunState::Cancelled,
-        "lost" => CodingAgentRunState::Lost,
-        _ => return Err("CodingAgentRun snapshot contains an unsupported run state".to_string()),
-    };
-    let execution_state = match observation.execution_state.as_str() {
-        "not_started" => CodingAgentExecutionState::NotStarted,
-        "started" => CodingAgentExecutionState::Started,
-        "outcome_unknown" => CodingAgentExecutionState::OutcomeUnknown,
-        "completed" => CodingAgentExecutionState::Completed,
-        _ => {
-            return Err(
-                "CodingAgentRun snapshot contains an unsupported execution state".to_string(),
-            )
-        }
-    };
+    let state = observation.run_state.clone();
+    let execution_state = observation.execution_state;
     let observation_revision = u64::try_from(observation.observation_revision).map_err(|_| {
         "CodingAgentRun snapshot contains a negative observation revision".to_string()
     })?;
@@ -2362,12 +2350,13 @@ fn merge_agent_task_coding_run_observation(
         return Ok((binding.clone(), disposition));
     }
 
-    let dispatch_state =
-        if observation.run_state == "lost" || observation.execution_state == "outcome_unknown" {
-            AgentTaskCodingRunDispatchState::OutcomeUnknown
-        } else {
-            AgentTaskCodingRunDispatchState::Bound
-        };
+    let dispatch_state = if observation.run_state == CodingAgentRunState::Lost
+        || observation.execution_state == CodingAgentExecutionState::OutcomeUnknown
+    {
+        AgentTaskCodingRunDispatchState::OutcomeUnknown
+    } else {
+        AgentTaskCodingRunDispatchState::Bound
+    };
     let updated = if let Some(expected_revision) = binding.last_observation_revision {
         transaction
             .execute(
@@ -2386,8 +2375,8 @@ fn merge_agent_task_coding_run_observation(
                     binding.task_id,
                     binding.attempt_id,
                     dispatch_state.as_str(),
-                    observation.run_state,
-                    observation.execution_state,
+                    observation.run_state.as_str(),
+                    observation.execution_state.as_str(),
                     observation.observation_revision,
                     observation.terminal_stop_reason,
                     observation.terminal_error_code,
@@ -2416,8 +2405,8 @@ fn merge_agent_task_coding_run_observation(
                     binding.task_id,
                     binding.attempt_id,
                     dispatch_state.as_str(),
-                    observation.run_state,
-                    observation.execution_state,
+                    observation.run_state.as_str(),
+                    observation.execution_state.as_str(),
                     observation.observation_revision,
                     observation.terminal_stop_reason,
                     observation.terminal_error_code,
@@ -2737,8 +2726,36 @@ fn load_coding_run_binding_for_attempt(
                     &row.get::<_, String>(9)?,
                     9,
                 )?,
-                last_observed_run_state: row.get(10)?,
-                last_observed_execution_state: row.get(11)?,
+                last_observed_run_state: row
+                    .get::<_, Option<String>>(10)?
+                    .as_deref()
+                    .map(|value| {
+                        CodingAgentRunState::from_str(value).ok_or_else(|| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                10,
+                                Type::Text,
+                                format!("unsupported observed CodingAgentRun state: {value}")
+                                    .into(),
+                            )
+                        })
+                    })
+                    .transpose()?,
+                last_observed_execution_state: row
+                    .get::<_, Option<String>>(11)?
+                    .as_deref()
+                    .map(|value| {
+                        CodingAgentExecutionState::from_str(value).ok_or_else(|| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                11,
+                                Type::Text,
+                                format!(
+                                    "unsupported observed CodingAgent execution state: {value}"
+                                )
+                                .into(),
+                            )
+                        })
+                    })
+                    .transpose()?,
                 last_observation_revision: row.get(12)?,
                 terminal_stop_reason: row.get(13)?,
                 terminal_error_code: row.get(14)?,
@@ -2759,7 +2776,7 @@ fn blocking_execution_error(
 ) -> Option<CommunicationStoreError> {
     let binding = binding.filter(|binding| binding.dispatch_state.blocks_replacement())?;
     if binding.dispatch_state == AgentTaskCodingRunDispatchState::OutcomeUnknown
-        || binding.last_observed_run_state.as_deref() == Some("lost")
+        || binding.last_observed_run_state.as_ref() == Some(&CodingAgentRunState::Lost)
     {
         Some(CommunicationStoreError::new(
             "agent_task_execution_outcome_unknown",

--- a/crates/webcodex-store/src/agent_task_tests.rs
+++ b/crates/webcodex-store/src/agent_task_tests.rs
@@ -7,6 +7,7 @@ use super::Database;
 use rusqlite::params;
 use std::sync::{mpsc, Arc, Barrier};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use webcodex_core::coding_agent::{CodingAgentExecutionState, CodingAgentRunState};
 
 const T0: i64 = 1_000_000;
 
@@ -108,8 +109,9 @@ fn coding_observation(
         provider_instance_id: intent.provider_instance_id.clone(),
         authority_fingerprint: intent.authority_fingerprint.clone(),
         coding_agent_intent_fingerprint: intent.coding_agent_intent_fingerprint.clone(),
-        run_state: run_state.to_string(),
-        execution_state: execution_state.to_string(),
+        run_state: CodingAgentRunState::from_str(run_state).expect("valid test run state"),
+        execution_state: CodingAgentExecutionState::from_str(execution_state)
+            .expect("valid test execution state"),
         observation_revision: revision,
         terminal_stop_reason: match (run_state, execution_state) {
             ("completed", _) => Some("end_turn".to_string()),
@@ -647,10 +649,13 @@ fn coding_run_observation_merge_preserves_newer_terminal_truth() {
         AgentTaskCodingRunDispatchState::Terminal
     );
     assert_eq!(stale.last_observation_revision, Some(2));
-    assert_eq!(stale.last_observed_run_state.as_deref(), Some("completed"));
     assert_eq!(
-        stale.last_observed_execution_state.as_deref(),
-        Some("completed")
+        stale.last_observed_run_state,
+        Some(CodingAgentRunState::Completed)
+    );
+    assert_eq!(
+        stale.last_observed_execution_state,
+        Some(CodingAgentExecutionState::Completed)
     );
     assert_eq!(stale.terminal_stop_reason.as_deref(), Some("end_turn"));
     assert_eq!(stale.terminal_error_code, None);
@@ -763,8 +768,8 @@ fn coding_run_observation_equal_revision_conflict_keeps_stored_truth() {
     assert_eq!(unchanged, stored);
     assert_eq!(unchanged.last_observation_revision, Some(2));
     assert_eq!(
-        unchanged.last_observed_run_state.as_deref(),
-        Some("running")
+        unchanged.last_observed_run_state,
+        Some(CodingAgentRunState::Running)
     );
     assert_eq!(unchanged.terminal_stop_reason, None);
     assert_eq!(unchanged.terminal_message, None);
@@ -844,7 +849,10 @@ fn coding_run_terminal_observation_stays_monotonic_after_restart() {
         AgentTaskCodingRunDispatchState::Terminal
     );
     assert_eq!(stale.last_observation_revision, Some(2));
-    assert_eq!(stale.last_observed_run_state.as_deref(), Some("completed"));
+    assert_eq!(
+        stale.last_observed_run_state,
+        Some(CodingAgentRunState::Completed)
+    );
     assert_eq!(
         stale.terminal_message.as_deref(),
         completed_rev2.terminal_message.as_deref()
@@ -1006,8 +1014,8 @@ fn failed_cancelled_and_lost_have_bounded_exact_terminal_semantics() {
     );
     assert_eq!(recovered.binding.last_observation_revision, Some(6));
     assert_eq!(
-        recovered.binding.last_observed_run_state.as_deref(),
-        Some("completed")
+        recovered.binding.last_observed_run_state,
+        Some(CodingAgentRunState::Completed)
     );
 }
 
@@ -1129,7 +1137,10 @@ fn coding_run_binding_survives_restart_without_endpoint_or_window_state() {
         binding.dispatch_state,
         AgentTaskCodingRunDispatchState::Bound
     );
-    assert_eq!(binding.last_observed_run_state.as_deref(), Some("running"));
+    assert_eq!(
+        binding.last_observed_run_state,
+        Some(CodingAgentRunState::Running)
+    );
     assert_eq!(binding.last_observation_revision, Some(11));
     let task = reopened.read_agent_task(&owner, &task_id).unwrap();
     assert!(task.summary.execution_bound);
@@ -1146,6 +1157,68 @@ fn coding_run_binding_survives_restart_without_endpoint_or_window_state() {
         .read_agent_task_coding_run_binding(&foreign, &task_id, &attempt_id)
         .unwrap_err();
     assert_eq!(foreign_error.code(), "agent_task_not_found");
+}
+
+#[test]
+fn corrupt_coding_run_observation_states_fail_closed_on_binding_load() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("agent-task-coding-corrupt-observation.db")).unwrap();
+    let owner = principal('0');
+    let assignee = agent(&db, &owner, "coding-corrupt-observation-agent");
+    let task_id = create_assigned_task(&db, &owner, &assignee, "coding-corrupt-observation-task");
+    let now = wall_now_ms();
+    let started = start(
+        &db,
+        &owner,
+        &task_id,
+        &assignee,
+        "coding-corrupt-observation-start",
+        now,
+    );
+    let intent = coding_binding_intent("corrupt-observation-run");
+    prepare_coding_binding(&db, &owner, &task_id, &assignee, &started, &intent, now + 1);
+    db.claim_agent_task_coding_run_dispatch(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &assignee,
+        &started.attempt_fence,
+        1,
+        &intent.binding_intent_fingerprint,
+    )
+    .unwrap();
+    db.record_agent_task_coding_run_observation(
+        &owner,
+        &task_id,
+        &started.attempt.attempt_id,
+        &coding_observation(&intent, "running", "started", 1),
+    )
+    .unwrap();
+
+    db.conn_for_tests()
+        .execute(
+            "UPDATE wc_agent_task_coding_runs
+             SET last_observed_run_state = 'future_state'
+             WHERE task_id = ?1 AND attempt_id = ?2",
+            params![task_id, started.attempt.attempt_id],
+        )
+        .unwrap();
+    assert!(db
+        .read_agent_task_coding_run_binding(&owner, &task_id, &started.attempt.attempt_id)
+        .is_err());
+
+    db.conn_for_tests()
+        .execute(
+            "UPDATE wc_agent_task_coding_runs
+             SET last_observed_run_state = 'running',
+                 last_observed_execution_state = 'future_state'
+             WHERE task_id = ?1 AND attempt_id = ?2",
+            params![task_id, started.attempt.attempt_id],
+        )
+        .unwrap();
+    assert!(db
+        .read_agent_task_coding_run_binding(&owner, &task_id, &started.attempt.attempt_id)
+        .is_err());
 }
 
 #[test]

--- a/crates/webcodex-store/src/agent_wake.rs
+++ b/crates/webcodex-store/src/agent_wake.rs
@@ -46,7 +46,7 @@ impl AgentWakeState {
         }
     }
 
-    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+    pub(crate) fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
         match value {
             "pending" => Ok(Self::Pending),
             "claimed" => Ok(Self::Claimed),

--- a/crates/webcodex-store/src/communication.rs
+++ b/crates/webcodex-store/src/communication.rs
@@ -1,4 +1,6 @@
-use super::agent_wake::{coalesce_agent_wake_for_delivery, reconcile_wakes_for_endpoint_loss};
+use super::agent_wake::{
+    coalesce_agent_wake_for_delivery, reconcile_wakes_for_endpoint_loss, AgentWakeState,
+};
 use super::Database;
 use rusqlite::{
     params, types::Type, Connection, OptionalExtension, Transaction, TransactionBehavior,
@@ -106,6 +108,99 @@ pub struct CommunicationPrincipal {
     pub digest: String,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentEndpointLifecycle {
+    Attached,
+    Detached,
+    Expired,
+}
+
+impl AgentEndpointLifecycle {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Attached => "attached",
+            Self::Detached => "detached",
+            Self::Expired => "expired",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "attached" => Ok(Self::Attached),
+            "detached" => Ok(Self::Detached),
+            "expired" => Ok(Self::Expired),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Agent Endpoint lifecycle: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for AgentEndpointLifecycle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_db())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationLifecycle {
+    Open,
+    Closed,
+}
+
+impl ConversationLifecycle {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "open" => Ok(Self::Open),
+            "closed" => Ok(Self::Closed),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Conversation lifecycle: {other}").into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageDeliveryState {
+    Queued,
+    Consumed,
+}
+
+impl MessageDeliveryState {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Consumed => "consumed",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "consumed" => Ok(Self::Consumed),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Message Delivery state: {other}").into(),
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct NewAgentIdentity {
     pub handle: String,
@@ -211,7 +306,7 @@ pub struct AgentEndpointRecord {
     pub client_attachment_id: Option<String>,
     pub wake_capable: bool,
     pub controller_generation: i64,
-    pub lifecycle: String,
+    pub lifecycle: AgentEndpointLifecycle,
     pub attached_at_unix_ms: i64,
     pub last_seen_at_unix_ms: i64,
     pub lease_expires_at_unix_ms: i64,
@@ -252,7 +347,7 @@ pub struct MessageDeliveryRecord {
     pub delivery_order: i64,
     pub delivery_id: String,
     pub recipient_agent_id: String,
-    pub state: String,
+    pub state: MessageDeliveryState,
     pub created_at_unix_ms: i64,
     pub consumed_at_unix_ms: Option<i64>,
 }
@@ -273,7 +368,7 @@ pub struct ConversationMessageRecord {
 pub struct ConversationSummaryRecord {
     pub conversation_id: String,
     pub title: Option<String>,
-    pub lifecycle: String,
+    pub lifecycle: ConversationLifecycle,
     pub created_at_unix_ms: i64,
     pub updated_at_unix_ms: i64,
     pub participant_count: i64,
@@ -319,7 +414,7 @@ pub struct ConversationMessageMutation {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AgentInboxItem {
     pub delivery_id: String,
-    pub state: String,
+    pub state: MessageDeliveryState,
     pub conversation_id: String,
     pub conversation_title: Option<String>,
     pub message: ConversationMessageRecord,
@@ -958,7 +1053,7 @@ impl Database {
             .ok_or_else(|| {
                 CommunicationStoreError::new("endpoint_not_found", "Agent Endpoint does not exist")
             })?;
-        if current.lifecycle != "attached" {
+        if current.lifecycle != AgentEndpointLifecycle::Attached {
             return Ok(AgentEndpointMutation {
                 endpoint: current,
                 created: false,
@@ -1520,13 +1615,20 @@ impl Database {
             else {
                 unreachable!("Wake reply identity requires Agent access");
             };
-            let wake_binding: Option<(String, Option<String>, Option<i64>)> = transaction
+            let wake_binding: Option<(AgentWakeState, Option<String>, Option<i64>)> = transaction
                 .query_row(
                     "SELECT state, claimed_endpoint_id, claimed_controller_generation
                      FROM wc_agent_wakes
                      WHERE wake_id = ?1 AND target_agent_id = ?2",
                     params![wake_id, agent_id],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    |row| {
+                        let state = row.get::<_, String>(0)?;
+                        Ok((
+                            AgentWakeState::from_db(&state, 0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                        ))
+                    },
                 )
                 .optional()
                 .map_err(store_error)?;
@@ -1536,8 +1638,10 @@ impl Database {
                     "Agent Wake does not exist",
                 ));
             };
-            match wake_state.as_str() {
-                "prepared" | "delivered" | "delivery_unknown" => {
+            match wake_state {
+                AgentWakeState::Prepared
+                | AgentWakeState::Delivered
+                | AgentWakeState::DeliveryUnknown => {
                     if claimed_endpoint_id.as_deref() != Some(endpoint_id.as_str())
                         || claimed_generation != Some(*expected_controller_generation)
                     {
@@ -1547,34 +1651,31 @@ impl Database {
                         ));
                     }
                 }
-                "pending" | "claimed" => {
+                AgentWakeState::Pending | AgentWakeState::Claimed => {
                     return Err(CommunicationStoreError::new(
                         "wake_not_dispatched",
                         "Agent Wake reply requires a dispatch or explicit-activation fence",
                     ));
                 }
-                "consumed" => {
+                AgentWakeState::Consumed => {
                     return Err(CommunicationStoreError::new(
                         "wake_already_consumed",
                         "Agent Wake was already consumed; re-read the Conversation before posting new work",
                     ));
                 }
-                _ => {
-                    return Err(CommunicationStoreError::new(
-                        "wake_state_invalid",
-                        "Agent Wake is in an unsupported state",
-                    ));
-                }
             }
         }
-        let lifecycle: String = transaction
+        let lifecycle = transaction
             .query_row(
                 "SELECT lifecycle FROM wc_conversations WHERE conversation_id = ?1",
                 params![input.conversation_id],
-                |row| row.get(0),
+                |row| {
+                    let lifecycle = row.get::<_, String>(0)?;
+                    ConversationLifecycle::from_db(&lifecycle, 0)
+                },
             )
             .map_err(store_error)?;
-        if lifecycle != "open" {
+        if lifecycle != ConversationLifecycle::Open {
             return Err(CommunicationStoreError::new(
                 "conversation_closed",
                 "Conversation is closed",
@@ -1844,7 +1945,7 @@ impl Database {
             })?;
             deliveries.push(AgentInboxItem {
                 delivery_id,
-                state: "queued".to_string(),
+                state: MessageDeliveryState::Queued,
                 conversation_id,
                 conversation_title,
                 message,
@@ -1892,12 +1993,15 @@ impl Database {
         let mut consumed_delivery_ids = Vec::new();
         let mut already_consumed_delivery_ids = Vec::new();
         for delivery_id in &delivery_ids {
-            let state: Option<String> = transaction
+            let state = transaction
                 .query_row(
                     "SELECT state FROM wc_agent_deliveries
                      WHERE delivery_id = ?1 AND recipient_agent_id = ?2",
                     params![delivery_id, agent_id],
-                    |row| row.get(0),
+                    |row| {
+                        let state = row.get::<_, String>(0)?;
+                        MessageDeliveryState::from_db(&state, 0)
+                    },
                 )
                 .optional()
                 .map_err(store_error)?;
@@ -1907,7 +2011,7 @@ impl Database {
                     "Agent delivery does not exist",
                 ));
             };
-            if state == "consumed" {
+            if state == MessageDeliveryState::Consumed {
                 already_consumed_delivery_ids.push(delivery_id.clone());
                 continue;
             }
@@ -2162,26 +2266,20 @@ pub(super) fn require_current_endpoint(
             "Agent Endpoint is attached to a different Agent",
         ));
     }
-    match row.lifecycle.as_str() {
-        "detached" => {
+    match row.lifecycle {
+        AgentEndpointLifecycle::Detached => {
             return Err(CommunicationStoreError::new(
                 "endpoint_detached",
                 "Agent Endpoint is detached",
             ));
         }
-        "expired" => {
+        AgentEndpointLifecycle::Expired => {
             return Err(CommunicationStoreError::new(
                 "endpoint_expired",
                 "Agent Endpoint is expired or stale",
             ));
         }
-        "attached" => {}
-        _ => {
-            return Err(CommunicationStoreError::new(
-                "endpoint_not_active",
-                "Agent Endpoint is not active",
-            ));
-        }
+        AgentEndpointLifecycle::Attached => {}
     }
     if row.lease_expires_at_unix_ms <= now_unix_ms() {
         return Err(CommunicationStoreError::new(
@@ -2307,7 +2405,7 @@ fn row_to_endpoint(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentEndpointRec
         client_attachment_id: row.get(3)?,
         wake_capable: row.get::<_, i64>(4)? != 0,
         controller_generation: row.get(5)?,
-        lifecycle: row.get(6)?,
+        lifecycle: AgentEndpointLifecycle::from_db(&row.get::<_, String>(6)?, 6)?,
         attached_at_unix_ms: row.get(7)?,
         last_seen_at_unix_ms: row.get(8)?,
         lease_expires_at_unix_ms: row.get(9)?,
@@ -2322,7 +2420,7 @@ fn row_to_conversation_summary(
     Ok(ConversationSummaryRecord {
         conversation_id: row.get(0)?,
         title: row.get(1)?,
-        lifecycle: row.get(2)?,
+        lifecycle: ConversationLifecycle::from_db(&row.get::<_, String>(2)?, 2)?,
         created_at_unix_ms: row.get(3)?,
         updated_at_unix_ms: row.get(4)?,
         participant_count: row.get(5)?,
@@ -2409,7 +2507,7 @@ fn load_message(
                 delivery_order: row.get(0)?,
                 delivery_id: row.get(1)?,
                 recipient_agent_id: row.get(2)?,
-                state: row.get(3)?,
+                state: MessageDeliveryState::from_db(&row.get::<_, String>(3)?, 3)?,
                 created_at_unix_ms: row.get(4)?,
                 consumed_at_unix_ms: row.get(5)?,
             })
@@ -2756,4 +2854,43 @@ pub(super) fn digest_text(domain: &str, value: &str) -> String {
 
 pub(super) fn now_unix_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
+}
+
+#[cfg(test)]
+mod lifecycle_contract_tests {
+    use super::*;
+
+    #[test]
+    fn durable_communication_lifecycle_encodings_are_closed_and_serde_stable() {
+        for (lifecycle, db) in [
+            (AgentEndpointLifecycle::Attached, "attached"),
+            (AgentEndpointLifecycle::Detached, "detached"),
+            (AgentEndpointLifecycle::Expired, "expired"),
+        ] {
+            assert_eq!(lifecycle.as_db(), db);
+            assert_eq!(AgentEndpointLifecycle::from_db(db, 0).unwrap(), lifecycle);
+            assert_eq!(serde_json::to_value(lifecycle).unwrap(), db);
+        }
+        assert!(AgentEndpointLifecycle::from_db("future_state", 0).is_err());
+
+        for (lifecycle, db) in [
+            (ConversationLifecycle::Open, "open"),
+            (ConversationLifecycle::Closed, "closed"),
+        ] {
+            assert_eq!(lifecycle.as_db(), db);
+            assert_eq!(ConversationLifecycle::from_db(db, 0).unwrap(), lifecycle);
+            assert_eq!(serde_json::to_value(lifecycle).unwrap(), db);
+        }
+        assert!(ConversationLifecycle::from_db("future_state", 0).is_err());
+
+        for (state, db) in [
+            (MessageDeliveryState::Queued, "queued"),
+            (MessageDeliveryState::Consumed, "consumed"),
+        ] {
+            assert_eq!(state.as_db(), db);
+            assert_eq!(MessageDeliveryState::from_db(db, 0).unwrap(), state);
+            assert_eq!(serde_json::to_value(state).unwrap(), db);
+        }
+        assert!(MessageDeliveryState::from_db("future_state", 0).is_err());
+    }
 }

--- a/crates/webcodex-store/src/communication_tests.rs
+++ b/crates/webcodex-store/src/communication_tests.rs
@@ -237,7 +237,14 @@ fn endpoint_attachment_is_principal_bound_and_detach_preserves_agent() {
         .endpoint_id
         .starts_with(AGENT_ENDPOINT_ID_PREFIX));
     assert_eq!(attached.endpoint.controller_generation, 1);
-    assert_eq!(attached.endpoint.lifecycle, "attached");
+    assert_eq!(
+        attached.endpoint.lifecycle,
+        AgentEndpointLifecycle::Attached
+    );
+    assert_eq!(
+        serde_json::to_value(&attached.endpoint).unwrap()["lifecycle"],
+        "attached"
+    );
     assert!(attached.endpoint.lease_expires_at_unix_ms > attached.endpoint.attached_at_unix_ms);
 
     let replay = db
@@ -256,7 +263,10 @@ fn endpoint_attachment_is_principal_bound_and_detach_preserves_agent() {
         .detach_agent_endpoint(&owner, &attached.endpoint.endpoint_id)
         .unwrap();
     assert!(detached.state_changed);
-    assert_eq!(detached.endpoint.lifecycle, "detached");
+    assert_eq!(
+        detached.endpoint.lifecycle,
+        AgentEndpointLifecycle::Detached
+    );
     assert!(detached.endpoint.detached_at_unix_ms.is_some());
     let desired_state_retry = db
         .detach_agent_endpoint(&owner, &attached.endpoint.endpoint_id)
@@ -281,7 +291,10 @@ fn endpoint_attachment_is_principal_bound_and_detach_preserves_agent() {
     );
     assert_eq!(replacement.endpoint.agent_id, agent.agent_id);
     assert_eq!(replacement.endpoint.controller_generation, 2);
-    assert_eq!(replacement.endpoint.lifecycle, "attached");
+    assert_eq!(
+        replacement.endpoint.lifecycle,
+        AgentEndpointLifecycle::Attached
+    );
     let after_replacement = db
         .list_agent_identities(&owner, Some(&agent.agent_id), 0, 10)
         .unwrap()
@@ -290,6 +303,36 @@ fn endpoint_attachment_is_principal_bound_and_detach_preserves_agent() {
         .unwrap();
     assert_eq!(after_replacement.current_controller_generation, 2);
     assert_eq!(after_replacement.active_endpoint_count, 1);
+}
+
+#[test]
+fn corrupt_endpoint_lifecycle_fails_closed_in_authority_load_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("corrupt-endpoint.db")).unwrap();
+    let owner = principal("user", '7');
+    let agent = db
+        .create_agent_identity(&owner, new_agent("corrupt", "Corrupt", "agent"))
+        .unwrap()
+        .agent;
+    let attached = db
+        .attach_agent_endpoint(&owner, endpoint(&agent.agent_id, "ChatGPT", "endpoint"))
+        .unwrap()
+        .endpoint;
+    let conn = db.conn_for_tests();
+    conn.execute_batch("PRAGMA ignore_check_constraints = ON;")
+        .unwrap();
+    conn.execute(
+        "UPDATE wc_agent_endpoints SET lifecycle = 'future_state' WHERE endpoint_id = ?1",
+        [&attached.endpoint_id],
+    )
+    .unwrap();
+    conn.execute_batch("PRAGMA ignore_check_constraints = OFF;")
+        .unwrap();
+    drop(conn);
+
+    assert!(db
+        .detach_agent_endpoint(&owner, &attached.endpoint_id)
+        .is_err());
 }
 
 #[test]
@@ -334,6 +377,14 @@ fn conversation_transcript_delivery_replay_offline_and_restart_are_durable() {
         .conversation_id
         .starts_with(CONVERSATION_ID_PREFIX));
     assert_eq!(created.conversation.participants.len(), 3);
+    assert_eq!(
+        created.conversation.conversation.lifecycle,
+        ConversationLifecycle::Open
+    );
+    assert_eq!(
+        serde_json::to_value(&created.conversation.conversation).unwrap()["lifecycle"],
+        "open"
+    );
     let conversation_id = created.conversation.conversation.conversation_id.clone();
 
     let room_replay = db
@@ -360,6 +411,15 @@ fn conversation_transcript_delivery_replay_offline_and_restart_are_durable() {
     assert_eq!(human.message.seq, 1);
     assert_eq!(human.message.author.participant_kind, "human");
     assert_eq!(human.message.deliveries.len(), 2);
+    assert!(human
+        .message
+        .deliveries
+        .iter()
+        .all(|delivery| delivery.state == MessageDeliveryState::Queued));
+    assert_eq!(
+        serde_json::to_value(&human.message.deliveries[0]).unwrap()["state"],
+        "queued"
+    );
 
     let exact_retry = db
         .post_conversation_message(
@@ -478,6 +538,10 @@ fn conversation_transcript_delivery_replay_offline_and_restart_are_durable() {
         vec![1, 2]
     );
     assert!(inbox_b.deliveries[0].message.deliveries[0].delivery_order > 0);
+    assert!(inbox_b
+        .deliveries
+        .iter()
+        .all(|item| item.state == MessageDeliveryState::Queued));
 
     let b_delivery_ids = inbox_b
         .deliveries
@@ -497,6 +561,15 @@ fn conversation_transcript_delivery_replay_offline_and_restart_are_durable() {
         .unwrap();
     assert!(consumed.state_changed);
     assert_eq!(consumed.consumed_delivery_ids, expected_b_delivery_ids);
+    let consumed_transcript = db
+        .read_conversation(&owner, &ConversationAccess::Human, &conversation_id, 0, 10)
+        .unwrap();
+    assert!(consumed_transcript.messages.iter().any(|message| {
+        message.deliveries.iter().any(|delivery| {
+            delivery.recipient_agent_id == agent_b.agent_id
+                && delivery.state == MessageDeliveryState::Consumed
+        })
+    }));
     let consume_retry = db
         .consume_agent_deliveries(
             &owner,

--- a/crates/webcodex-store/src/continuation_delivery_tests.rs
+++ b/crates/webcodex-store/src/continuation_delivery_tests.rs
@@ -415,7 +415,7 @@ fn startup_reconciliation_releases_claimed_but_quarantines_dispatching() {
     let safely_released = db
         .connector_execution(&claimed_execution.execution_id)
         .unwrap();
-    assert_eq!(safely_released.state, "succeeded");
+    assert_eq!(safely_released.state, ConnectorExecutionState::Succeeded);
     assert_eq!(
         safely_released.continuation_delivery_state,
         ConnectorTerminalContinuationDeliveryState::Unclaimed
@@ -425,7 +425,7 @@ fn startup_reconciliation_releases_claimed_but_quarantines_dispatching() {
     let uncertain = db
         .connector_execution(&dispatching_execution.execution_id)
         .unwrap();
-    assert_eq!(uncertain.state, "succeeded");
+    assert_eq!(uncertain.state, ConnectorExecutionState::Succeeded);
     assert_eq!(
         uncertain.continuation_delivery_state,
         ConnectorTerminalContinuationDeliveryState::DeliveryUnknown
@@ -495,7 +495,7 @@ fn inconsistent_delivery_state_and_fence_fail_closed() {
     assert!(db.claim_next_terminal_continuation().unwrap().is_none());
 
     let recovered_active = db.connector_execution(&active.execution_id).unwrap();
-    assert_eq!(recovered_active.state, "interrupted");
+    assert_eq!(recovered_active.state, ConnectorExecutionState::Interrupted);
     assert_eq!(
         recovered_active.continuation_delivery_state,
         ConnectorTerminalContinuationDeliveryState::Claimed

--- a/crates/webcodex-store/src/execution_intent_tests.rs
+++ b/crates/webcodex-store/src/execution_intent_tests.rs
@@ -181,7 +181,7 @@ fn mcp_task_materialization_and_terminal_result_finalize_durably_together() {
             },
         )
         .unwrap();
-    assert_eq!(terminal.state, "succeeded");
+    assert_eq!(terminal.state, ConnectorExecutionState::Succeeded);
     assert_eq!(terminal.mcp_task_result_finalized_at, Some(23));
     assert_eq!(terminal.mcp_task_output_tail.as_ref(), Some(&tail));
 
@@ -248,7 +248,7 @@ fn startup_reconciliation_preserves_armed_intent_and_makes_it_ready() {
         .unwrap();
     assert_eq!(recovery.1, 1);
     let interrupted = db.connector_execution(&execution.execution_id).unwrap();
-    assert_eq!(interrupted.state, "interrupted");
+    assert_eq!(interrupted.state, ConnectorExecutionState::Interrupted);
     assert_eq!(
         interrupted.continuation_intent,
         ConnectorExecutionContinuationIntent::ArmedForTerminal
@@ -265,4 +265,24 @@ fn startup_reconciliation_preserves_armed_intent_and_makes_it_ready() {
     assert!(events
         .iter()
         .any(|event| event.kind == "execution_interrupted"));
+}
+
+#[test]
+fn corrupt_execution_state_fails_closed_on_load() {
+    let (_temp, _path, db) = database();
+    let task = task(&db, "corrupt-state");
+    let execution = reserve(&db, &task, "op-corrupt-state");
+    let conn = db.conn_for_tests();
+    conn.execute_batch("PRAGMA ignore_check_constraints = ON;")
+        .unwrap();
+    conn.execute(
+        "UPDATE wc_executions SET state = 'future_state' WHERE id = ?1",
+        [&execution.execution_id],
+    )
+    .unwrap();
+    conn.execute_batch("PRAGMA ignore_check_constraints = OFF;")
+        .unwrap();
+    drop(conn);
+
+    assert!(db.connector_execution(&execution.execution_id).is_err());
 }

--- a/crates/webcodex-store/src/execution_model.rs
+++ b/crates/webcodex-store/src/execution_model.rs
@@ -1,4 +1,5 @@
 use rusqlite::{params, OptionalExtension};
+use serde::Serialize;
 use serde_json::Value;
 use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 
@@ -7,6 +8,119 @@ pub const MAX_ASSERTION_EVIDENCE_BYTES: usize = 16 * 1024;
 // JSON escaping. Keep the persisted MCP task snapshot hard-bounded while
 // allowing any ordinary Connector output-tail projection to serialize.
 pub(crate) const MAX_MCP_TASK_OUTPUT_TAIL_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorExecutionKind {
+    Command,
+    Check,
+}
+
+impl ConnectorExecutionKind {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Command => "command",
+            Self::Check => "check",
+        }
+    }
+
+    pub(crate) fn requested(value: &str) -> Option<Self> {
+        match value {
+            "command" => Some(Self::Command),
+            "check" => Some(Self::Check),
+            _ => None,
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        Self::requested(value).ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                index,
+                rusqlite::types::Type::Text,
+                format!("unsupported Connector Execution kind: {value}").into(),
+            )
+        })
+    }
+}
+
+impl std::fmt::Display for ConnectorExecutionKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_db())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorExecutionState {
+    Accepted,
+    Queued,
+    Starting,
+    Running,
+    CancelRequested,
+    Succeeded,
+    Failed,
+    Cancelled,
+    Interrupted,
+    Unknown,
+}
+
+impl ConnectorExecutionState {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Queued => "queued",
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::CancelRequested => "cancel_requested",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Interrupted => "interrupted",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub(crate) const fn is_active(self) -> bool {
+        matches!(
+            self,
+            Self::Accepted | Self::Queued | Self::Starting | Self::Running | Self::CancelRequested
+        )
+    }
+
+    pub(crate) const fn is_terminal(self) -> bool {
+        !self.is_active()
+    }
+
+    pub(crate) const fn blocks_finish(self) -> bool {
+        self.is_active() || matches!(self, Self::Unknown)
+    }
+
+    pub(crate) fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "accepted" => Ok(Self::Accepted),
+            "queued" => Ok(Self::Queued),
+            "starting" => Ok(Self::Starting),
+            "running" => Ok(Self::Running),
+            "cancel_requested" => Ok(Self::CancelRequested),
+            "succeeded" => Ok(Self::Succeeded),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            "interrupted" => Ok(Self::Interrupted),
+            "unknown" => Ok(Self::Unknown),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                rusqlite::types::Type::Text,
+                format!("unsupported Connector Execution state: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for ConnectorExecutionState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_db())
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnectorExecutionContinuationIntent {
@@ -83,10 +197,10 @@ pub struct ConnectorTerminalContinuationClaim {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectorExecution {
     pub execution_id: String,
-    pub kind: String,
+    pub kind: ConnectorExecutionKind,
     pub task_id: String,
     pub run_id: String,
-    pub state: String,
+    pub state: ConnectorExecutionState,
     pub submitted_at: i64,
     pub queued_at: Option<i64>,
     pub queue_deadline: i64,
@@ -121,19 +235,12 @@ pub struct ConnectorExecution {
 }
 
 impl ConnectorExecution {
-    pub fn state_is_active(state: &str) -> bool {
-        matches!(
-            state,
-            "accepted" | "queued" | "starting" | "running" | "cancel_requested"
-        )
-    }
-
     pub fn is_active(&self) -> bool {
-        Self::state_is_active(&self.state)
+        self.state.is_active()
     }
 
     pub fn is_terminal(&self) -> bool {
-        !self.is_active()
+        self.state.is_terminal()
     }
 
     pub fn terminal_continuation_is_armed(&self) -> bool {
@@ -150,7 +257,7 @@ impl ConnectorExecution {
     }
 
     pub fn blocks_finish(&self) -> bool {
-        self.is_active() || self.state == "unknown"
+        self.state.blocks_finish()
     }
 
     pub fn executor_status_recognized(status: &str) -> bool {
@@ -193,13 +300,13 @@ pub struct ConnectorExecutionObservation<'a> {
 }
 
 type Fact = Option<&'static str>;
-type StateOutcome = (&'static str, Fact, Fact, Fact);
+type StateOutcome = (ConnectorExecutionState, Fact, Fact, Fact);
 const EXECUTOR: Fact = Some("executor");
 const UNKNOWN_REASON: &str = "executor_terminal_unknown";
 
-fn active_state(execution: &ConnectorExecution, state: &'static str) -> StateOutcome {
-    let state = if execution.state == "cancel_requested" {
-        "cancel_requested"
+fn active_state(execution: &ConnectorExecution, state: ConnectorExecutionState) -> StateOutcome {
+    let state = if execution.state == ConnectorExecutionState::CancelRequested {
+        ConnectorExecutionState::CancelRequested
     } else {
         state
     };
@@ -207,11 +314,21 @@ fn active_state(execution: &ConnectorExecution, state: &'static str) -> StateOut
 }
 
 fn failed(source: &'static str, code: &'static str, reason: &'static str) -> StateOutcome {
-    ("failed", Some(source), Some(code), Some(reason))
+    (
+        ConnectorExecutionState::Failed,
+        Some(source),
+        Some(code),
+        Some(reason),
+    )
 }
 
 fn unknown(code: &'static str) -> StateOutcome {
-    ("unknown", EXECUTOR, Some(code), Some(UNKNOWN_REASON))
+    (
+        ConnectorExecutionState::Unknown,
+        EXECUTOR,
+        Some(code),
+        Some(UNKNOWN_REASON),
+    )
 }
 
 pub(super) fn observed_state(
@@ -224,35 +341,42 @@ pub(super) fn observed_state(
     if observation.executor_status == "recovering" {
         return active_state(
             execution,
-            if execution.state == "queued" {
-                "queued"
+            if execution.state == ConnectorExecutionState::Queued {
+                ConnectorExecutionState::Queued
             } else {
-                "running"
+                ConnectorExecutionState::Running
             },
         );
     }
     let Ok(lifecycle) = RunnerJobLifecycle::from_wire(observation.executor_status) else {
         // Callers reject unrecognized observation status before this projection.
         // Keep the historical conservative fallback for direct/internal callers.
-        return active_state(execution, "running");
+        return active_state(execution, ConnectorExecutionState::Running);
     };
     match lifecycle {
         RunnerJobLifecycle::Queued | RunnerJobLifecycle::RunnerQueued => {
-            active_state(execution, "queued")
+            active_state(execution, ConnectorExecutionState::Queued)
         }
         RunnerJobLifecycle::Running | RunnerJobLifecycle::StartedLegacy => {
-            active_state(execution, "running")
+            active_state(execution, ConnectorExecutionState::Running)
         }
-        RunnerJobLifecycle::StopRequested => active_state(execution, "running"),
+        RunnerJobLifecycle::StopRequested => {
+            active_state(execution, ConnectorExecutionState::Running)
+        }
         RunnerJobLifecycle::Completed
-            if execution.kind == "check"
+            if execution.kind == ConnectorExecutionKind::Check
                 && observation.exit_code == Some(0)
                 && observation.check_completed == Some(execution.check_plan.len())
                 && observation.failed_check.is_none() =>
         {
-            ("succeeded", None, None, Some("exit_zero"))
+            (
+                ConnectorExecutionState::Succeeded,
+                None,
+                None,
+                Some("exit_zero"),
+            )
         }
-        RunnerJobLifecycle::Completed if execution.kind == "check" => failed(
+        RunnerJobLifecycle::Completed if execution.kind == ConnectorExecutionKind::Check => failed(
             "executor",
             if observation.check_completed.is_none() {
                 "validation_progress_missing"
@@ -261,32 +385,40 @@ pub(super) fn observed_state(
             },
             "executor_protocol_violation",
         ),
-        RunnerJobLifecycle::Completed if observation.exit_code == Some(0) => {
-            ("succeeded", None, None, Some("exit_zero"))
-        }
+        RunnerJobLifecycle::Completed if observation.exit_code == Some(0) => (
+            ConnectorExecutionState::Succeeded,
+            None,
+            None,
+            Some("exit_zero"),
+        ),
         RunnerJobLifecycle::Completed if observation.exit_code.is_none() => {
             unknown("executor_exit_code_missing")
         }
         RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled
-            if execution.state == "cancel_requested"
+            if execution.state == ConnectorExecutionState::CancelRequested
                 && execution.failure_code.as_deref() == Some("queue_deadline") =>
         {
             failed("queue", "queue_deadline", "queue_timeout")
         }
         RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled
-            if execution.state == "cancel_requested" =>
+            if execution.state == ConnectorExecutionState::CancelRequested =>
         {
-            ("cancelled", None, None, Some("user_cancelled"))
+            (
+                ConnectorExecutionState::Cancelled,
+                None,
+                None,
+                Some("user_cancelled"),
+            )
         }
         RunnerJobLifecycle::Stopped | RunnerJobLifecycle::Cancelled => {
-            active_state(execution, "running")
+            active_state(execution, ConnectorExecutionState::Running)
         }
         RunnerJobLifecycle::Timeout | RunnerJobLifecycle::TimedOut => {
             failed("executor", "command_timeout", "timeout")
         }
         RunnerJobLifecycle::Lost => unknown("executor_lost"),
         RunnerJobLifecycle::Failed
-            if execution.kind == "check"
+            if execution.kind == ConnectorExecutionKind::Check
                 && observation.failed_check.is_some()
                 && observation
                     .check_completed
@@ -294,7 +426,7 @@ pub(super) fn observed_state(
         {
             failed("check", "assertion_failed", "nonzero_exit")
         }
-        RunnerJobLifecycle::Failed if execution.kind == "check" => failed(
+        RunnerJobLifecycle::Failed if execution.kind == ConnectorExecutionKind::Check => failed(
             "executor",
             if observation.check_completed.is_none() {
                 "validation_progress_missing"
@@ -334,7 +466,7 @@ pub(super) fn latest_execution(
 pub(super) fn latest_execution_by_kind(
     conn: &rusqlite::Connection,
     task_id: &str,
-    kind: &str,
+    kind: ConnectorExecutionKind,
 ) -> rusqlite::Result<Option<ConnectorExecution>> {
     query_execution(
         conn,
@@ -343,7 +475,7 @@ pub(super) fn latest_execution_by_kind(
              WHERE task_id = ?1 AND kind = ?2
              ORDER BY submitted_at DESC, rowid DESC LIMIT 1"
         ),
-        params![task_id, kind],
+        params![task_id, kind.as_db()],
     )
 }
 
@@ -392,10 +524,10 @@ pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<Connect
     };
     Ok(ConnectorExecution {
         execution_id: row.get(0)?,
-        kind: row.get(1)?,
+        kind: ConnectorExecutionKind::from_db(&row.get::<_, String>(1)?, 1)?,
         task_id: row.get(2)?,
         run_id: row.get(3)?,
-        state: row.get(4)?,
+        state: ConnectorExecutionState::from_db(&row.get::<_, String>(4)?, 4)?,
         submitted_at: row.get(5)?,
         queued_at: row.get(6)?,
         queue_deadline: row.get(7)?,
@@ -472,17 +604,17 @@ pub(super) fn map_execution(row: &rusqlite::Row<'_>) -> rusqlite::Result<Connect
     })
 }
 
-pub(super) fn execution_event_kind(state: &str) -> &'static str {
+pub(super) fn execution_event_kind(state: ConnectorExecutionState) -> &'static str {
     match state {
-        "accepted" => "execution_accepted",
-        "queued" => "execution_queued",
-        "starting" | "running" => "execution_started",
-        "cancel_requested" => "execution_cancel_requested",
-        "succeeded" => "execution_succeeded",
-        "cancelled" => "execution_cancelled",
-        "interrupted" => "execution_interrupted",
-        "unknown" => "execution_unknown",
-        _ => "execution_failed",
+        ConnectorExecutionState::Accepted => "execution_accepted",
+        ConnectorExecutionState::Queued => "execution_queued",
+        ConnectorExecutionState::Starting | ConnectorExecutionState::Running => "execution_started",
+        ConnectorExecutionState::CancelRequested => "execution_cancel_requested",
+        ConnectorExecutionState::Succeeded => "execution_succeeded",
+        ConnectorExecutionState::Failed => "execution_failed",
+        ConnectorExecutionState::Cancelled => "execution_cancelled",
+        ConnectorExecutionState::Interrupted => "execution_interrupted",
+        ConnectorExecutionState::Unknown => "execution_unknown",
     }
 }
 
@@ -490,13 +622,13 @@ pub(super) fn execution_event_kind(state: &str) -> &'static str {
 mod runner_job_lifecycle_projection_tests {
     use super::*;
 
-    fn execution(state: &str) -> ConnectorExecution {
+    fn execution(state: ConnectorExecutionState) -> ConnectorExecution {
         ConnectorExecution {
             execution_id: "execution".to_string(),
-            kind: "command".to_string(),
+            kind: ConnectorExecutionKind::Command,
             task_id: "task".to_string(),
             run_id: "run".to_string(),
-            state: state.to_string(),
+            state,
             submitted_at: 1,
             queued_at: None,
             queue_deadline: 10,
@@ -550,18 +682,89 @@ mod runner_job_lifecycle_projection_tests {
     }
 
     #[test]
+    fn execution_lifecycle_contract_is_closed_and_preserves_conservative_finish_blocking() {
+        let cases = [
+            (ConnectorExecutionState::Accepted, "accepted", true, true),
+            (ConnectorExecutionState::Queued, "queued", true, true),
+            (ConnectorExecutionState::Starting, "starting", true, true),
+            (ConnectorExecutionState::Running, "running", true, true),
+            (
+                ConnectorExecutionState::CancelRequested,
+                "cancel_requested",
+                true,
+                true,
+            ),
+            (
+                ConnectorExecutionState::Succeeded,
+                "succeeded",
+                false,
+                false,
+            ),
+            (ConnectorExecutionState::Failed, "failed", false, false),
+            (
+                ConnectorExecutionState::Cancelled,
+                "cancelled",
+                false,
+                false,
+            ),
+            (
+                ConnectorExecutionState::Interrupted,
+                "interrupted",
+                false,
+                false,
+            ),
+            (ConnectorExecutionState::Unknown, "unknown", false, true),
+        ];
+
+        for (state, db, active, blocks_finish) in cases {
+            assert_eq!(state.as_db(), db);
+            assert_eq!(ConnectorExecutionState::from_db(db, 0).unwrap(), state);
+            assert_eq!(state.is_active(), active, "{db}");
+            assert_eq!(state.is_terminal(), !active, "{db}");
+            assert_eq!(state.blocks_finish(), blocks_finish, "{db}");
+            assert_eq!(serde_json::to_value(state).unwrap(), db);
+        }
+        assert!(ConnectorExecutionState::from_db("future_state", 0).is_err());
+
+        for (kind, db) in [
+            (ConnectorExecutionKind::Command, "command"),
+            (ConnectorExecutionKind::Check, "check"),
+        ] {
+            assert_eq!(kind.as_db(), db);
+            assert_eq!(ConnectorExecutionKind::from_db(db, 0).unwrap(), kind);
+            assert_eq!(serde_json::to_value(kind).unwrap(), db);
+        }
+        assert!(ConnectorExecutionKind::from_db("future_kind", 0).is_err());
+    }
+
+    #[test]
     fn runner_job_lifecycle_projects_to_connector_execution_semantics() {
-        let execution = execution("accepted");
+        let execution = execution(ConnectorExecutionState::Accepted);
         let cases: [(&str, StateOutcome); 9] = [
-            ("queued", ("queued", None, None, None)),
-            ("agent_queued", ("queued", None, None, None)),
-            ("started", ("running", None, None, None)),
-            ("running", ("running", None, None, None)),
-            ("stop_requested", ("running", None, None, None)),
+            (
+                "queued",
+                (ConnectorExecutionState::Queued, None, None, None),
+            ),
+            (
+                "agent_queued",
+                (ConnectorExecutionState::Queued, None, None, None),
+            ),
+            (
+                "started",
+                (ConnectorExecutionState::Running, None, None, None),
+            ),
+            (
+                "running",
+                (ConnectorExecutionState::Running, None, None, None),
+            ),
+            (
+                "stop_requested",
+                (ConnectorExecutionState::Running, None, None, None),
+            ),
             (
                 "timeout",
                 (
-                    "failed",
+                    ConnectorExecutionState::Failed,
                     Some("executor"),
                     Some("command_timeout"),
                     Some("timeout"),
@@ -570,7 +773,7 @@ mod runner_job_lifecycle_projection_tests {
             (
                 "timed_out",
                 (
-                    "failed",
+                    ConnectorExecutionState::Failed,
                     Some("executor"),
                     Some("command_timeout"),
                     Some("timeout"),
@@ -579,13 +782,21 @@ mod runner_job_lifecycle_projection_tests {
             (
                 "lost",
                 (
-                    "unknown",
+                    ConnectorExecutionState::Unknown,
                     Some("executor"),
                     Some("executor_lost"),
                     Some("executor_terminal_unknown"),
                 ),
             ),
-            ("completed", ("succeeded", None, None, Some("exit_zero"))),
+            (
+                "completed",
+                (
+                    ConnectorExecutionState::Succeeded,
+                    None,
+                    None,
+                    Some("exit_zero"),
+                ),
+            ),
         ];
 
         for (status, expected) in cases {
@@ -603,16 +814,25 @@ mod runner_job_lifecycle_projection_tests {
         assert!(ConnectorExecution::executor_status_recognized("recovering"));
         assert!(!ConnectorExecution::executor_status_recognized("unknown"));
         assert_eq!(
-            observed_state(&execution("queued"), &observation("recovering", None)),
-            ("queued", None, None, None)
+            observed_state(
+                &execution(ConnectorExecutionState::Queued),
+                &observation("recovering", None)
+            ),
+            (ConnectorExecutionState::Queued, None, None, None)
         );
         assert_eq!(
-            observed_state(&execution("running"), &observation("recovering", None)),
-            ("running", None, None, None)
+            observed_state(
+                &execution(ConnectorExecutionState::Running),
+                &observation("recovering", None)
+            ),
+            (ConnectorExecutionState::Running, None, None, None)
         );
         assert_eq!(
-            observed_state(&execution("accepted"), &observation("unknown", None)),
-            ("running", None, None, None),
+            observed_state(
+                &execution(ConnectorExecutionState::Accepted),
+                &observation("unknown", None)
+            ),
+            (ConnectorExecutionState::Running, None, None, None),
             "direct/internal unknown fallback stays conservative; callers reject it before projection"
         );
     }

--- a/crates/webcodex-store/src/executions.rs
+++ b/crates/webcodex-store/src/executions.rs
@@ -4,14 +4,14 @@
 use super::execution_model::{
     execution_event_kind, latest_execution, latest_execution_by_kind, load_execution,
     load_execution_by_operation, observed_state, ConnectorExecution,
-    ConnectorExecutionContinuationIntent, ConnectorExecutionFailure, ConnectorExecutionObservation,
-    ConnectorExecutionReservation, ConnectorTerminalContinuationDeliveryState,
-    MAX_MCP_TASK_OUTPUT_TAIL_BYTES,
+    ConnectorExecutionContinuationIntent, ConnectorExecutionFailure, ConnectorExecutionKind,
+    ConnectorExecutionObservation, ConnectorExecutionReservation, ConnectorExecutionState,
+    ConnectorTerminalContinuationDeliveryState, MAX_MCP_TASK_OUTPUT_TAIL_BYTES,
 };
 #[cfg(any(test, feature = "root-test-support"))]
 use super::execution_model::{ConnectorTerminalContinuationClaim, EXECUTION_COLUMNS};
 use super::task_kernel::{
-    expire_task_approvals, insert_event, load_task, require_running, touch_task,
+    expire_task_approvals, insert_event, load_task, require_running, touch_task, ConnectorTaskState,
 };
 use super::{ConnectorTaskSnapshot, ConnectorTaskStoreError, Database};
 use rusqlite::{params, Transaction};
@@ -59,6 +59,11 @@ impl Database {
         queue_deadline: i64,
         now: i64,
     ) -> Result<ConnectorExecutionReservation, ConnectorTaskStoreError> {
+        let kind = ConnectorExecutionKind::requested(kind).ok_or_else(|| {
+            ConnectorTaskStoreError::InvalidState(
+                "execution kind and check plan do not match".to_string(),
+            )
+        })?;
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let current = load_task(&tx, &task.task_id, &task.project_id, &task.owner_subject_id)?
@@ -83,20 +88,19 @@ impl Database {
                 active.execution_id, active.state
             )));
         }
-        if !matches!(kind, "command" | "check")
-            || (kind == "command" && !check_plan.is_empty())
-            || (kind == "check" && check_plan.is_empty())
-            || (kind == "command" && check_workspace_sha256.is_some())
-            || (kind == "check" && check_workspace_sha256.is_none())
-            || (kind == "command" && check_recipe.is_some())
-            || (kind == "check" && check_recipe.is_none())
+        if (kind == ConnectorExecutionKind::Command && !check_plan.is_empty())
+            || (kind == ConnectorExecutionKind::Check && check_plan.is_empty())
+            || (kind == ConnectorExecutionKind::Command && check_workspace_sha256.is_some())
+            || (kind == ConnectorExecutionKind::Check && check_workspace_sha256.is_none())
+            || (kind == ConnectorExecutionKind::Command && check_recipe.is_some())
+            || (kind == ConnectorExecutionKind::Check && check_recipe.is_none())
         {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "execution kind and check plan do not match".to_string(),
             ));
         }
         let execution_id = format!("wc_exec_{}", uuid::Uuid::new_v4().simple());
-        let check_plan = (kind == "check").then(|| check_plan.join(","));
+        let check_plan = (kind == ConnectorExecutionKind::Check).then(|| check_plan.join(","));
         let check_recipe_json = check_recipe
             .map(serde_json::to_string)
             .transpose()
@@ -109,7 +113,7 @@ impl Database {
              VALUES (?1, ?2, ?3, ?4, 'accepted', ?5, ?6, 1, 1, ?7, ?8, ?9, ?10, ?11)",
             params![
                 execution_id,
-                kind,
+                kind.as_db(),
                 task.task_id,
                 task.run_id,
                 now,
@@ -123,7 +127,7 @@ impl Database {
         )?;
         let execution =
             load_execution(&tx, &execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
-        append_execution_event(&tx, &execution, "accepted", now)?;
+        append_execution_event(&tx, &execution, ConnectorExecutionState::Accepted, now)?;
         touch_task(&tx, &task.task_id, now)?;
         tx.commit()?;
         Ok(ConnectorExecutionReservation::Created(execution))
@@ -138,7 +142,7 @@ impl Database {
         let tx = conn.transaction()?;
         let execution =
             load_execution(&tx, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
-        if execution.state != "accepted" {
+        if execution.state != ConnectorExecutionState::Accepted {
             tx.commit()?;
             return Ok(execution);
         }
@@ -146,7 +150,7 @@ impl Database {
             "UPDATE wc_executions SET state = 'starting' WHERE id = ?1",
             params![execution_id],
         )?;
-        append_execution_event(&tx, &execution, "starting", now)?;
+        append_execution_event(&tx, &execution, ConnectorExecutionState::Starting, now)?;
         touch_task(&tx, &execution.task_id, now)?;
         commit_execution(tx, execution_id)
     }
@@ -502,6 +506,11 @@ impl Database {
         subject_id: &str,
         kind: &str,
     ) -> Result<Option<ConnectorExecution>, ConnectorTaskStoreError> {
+        let kind = ConnectorExecutionKind::requested(kind).ok_or_else(|| {
+            ConnectorTaskStoreError::InvalidState(
+                "execution kind must be command or check".to_string(),
+            )
+        })?;
         let conn = self.conn.lock().unwrap();
         load_task(&conn, task_id, project_id, subject_id)?
             .ok_or(ConnectorTaskStoreError::NotFound)?;
@@ -541,20 +550,20 @@ impl Database {
         }
         let lifecycle = RunnerJobLifecycle::from_wire(executor_status).ok();
         let recognized = ConnectorExecution::executor_status_recognized(executor_status);
-        let state = if execution.state == "cancel_requested" {
-            "cancel_requested"
+        let state = if execution.state == ConnectorExecutionState::CancelRequested {
+            ConnectorExecutionState::CancelRequested
         } else if matches!(
             lifecycle,
             Some(RunnerJobLifecycle::Queued | RunnerJobLifecycle::RunnerQueued)
         ) {
-            "queued"
+            ConnectorExecutionState::Queued
         } else if matches!(
             lifecycle,
             Some(RunnerJobLifecycle::Running | RunnerJobLifecycle::StartedLegacy)
         ) {
-            "running"
+            ConnectorExecutionState::Running
         } else {
-            execution.state.as_str()
+            execution.state
         };
         tx.execute(
             "UPDATE wc_executions SET executor_reference = ?1, state = ?2,
@@ -565,7 +574,7 @@ impl Database {
                     status_failure_code = CASE WHEN ?4 THEN status_failure_code
                         ELSE 'executor_status_unrecognized' END
              WHERE id = ?5",
-            params![executor_reference, state, now, recognized, execution_id],
+            params![executor_reference, state.as_db(), now, recognized, execution_id],
         )?;
         if execution.state != state {
             append_execution_event(&tx, &execution, state, now)?;
@@ -644,7 +653,7 @@ impl Database {
                 "validation progress cannot move backwards".to_string(),
             ));
         }
-        if execution.kind == "command"
+        if execution.kind == ConnectorExecutionKind::Command
             && (observation.check_completed.is_some()
                 || observation.failed_check.is_some()
                 || observation.validated_workspace_sha256.is_some())
@@ -684,14 +693,16 @@ impl Database {
             ));
         }
         if observation.assertion_evidence.is_some()
-            && (observation.failed_check.is_none() || state != "failed" || source != Some("check"))
+            && (observation.failed_check.is_none()
+                || state != ConnectorExecutionState::Failed
+                || source != Some("check"))
         {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "assertion evidence requires trusted failed-check progress".to_string(),
             ));
         }
-        if state == "succeeded"
-            && execution.kind == "check"
+        if state == ConnectorExecutionState::Succeeded
+            && execution.kind == ConnectorExecutionKind::Check
             && (observation.check_completed != Some(execution.check_plan.len())
                 || observation.failed_check.is_some()
                 || observation.validated_workspace_sha256.is_none()
@@ -704,7 +715,8 @@ impl Database {
             ));
         }
         if observation.validated_workspace_sha256.is_some()
-            && !(state == "succeeded" && execution.kind == "check")
+            && !(state == ConnectorExecutionState::Succeeded
+                && execution.kind == ConnectorExecutionKind::Check)
         {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "validated workspace provenance requires a successful check".to_string(),
@@ -712,7 +724,7 @@ impl Database {
         }
         let validated_workspace = observation.validated_workspace_sha256;
         let state_changed = state != execution.state;
-        let terminal = !ConnectorExecution::state_is_active(state);
+        let terminal = state.is_terminal();
         tx.execute(
             "UPDATE wc_executions SET state = ?1, stdout_cursor = ?2, stderr_cursor = ?3,
                     last_output_at = CASE WHEN ?4 THEN ?5 ELSE last_output_at END,
@@ -747,7 +759,7 @@ impl Database {
                     END
                     WHERE id = ?13",
             params![
-                state,
+                state.as_db(),
                 stdout_cursor as i64,
                 stderr_cursor as i64,
                 output_advanced,
@@ -770,7 +782,7 @@ impl Database {
         if state_changed {
             append_execution_event(&tx, &execution, state, observation.now)?;
         }
-        if state == "unknown" {
+        if state == ConnectorExecutionState::Unknown {
             interrupt_run(
                 &tx,
                 &execution.run_id,
@@ -778,7 +790,7 @@ impl Database {
                 "execution_terminal_unknown",
                 observation.now,
             )?;
-        } else if state == "cancelled" {
+        } else if state == ConnectorExecutionState::Cancelled {
             finalize_task_cancel(
                 &tx,
                 &execution.task_id,
@@ -801,7 +813,7 @@ impl Database {
         let tx = conn.transaction()?;
         let current = load_task(&tx, &task.task_id, &task.project_id, &task.owner_subject_id)?
             .ok_or(ConnectorTaskStoreError::NotFound)?;
-        if current.task_status == "cancelled" {
+        if current.task_status == ConnectorTaskState::Cancelled {
             let execution = latest_execution(&tx, &task.task_id)?;
             tx.commit()?;
             return Ok(execution);
@@ -819,11 +831,12 @@ impl Database {
                 tx.commit()?;
                 return Ok(Some(execution));
             }
-            let immediate = execution.state == "accepted" && execution.executor_reference.is_none();
+            let immediate = execution.state == ConnectorExecutionState::Accepted
+                && execution.executor_reference.is_none();
             let state = if immediate {
-                "cancelled"
+                ConnectorExecutionState::Cancelled
             } else {
-                "cancel_requested"
+                ConnectorExecutionState::CancelRequested
             };
             tx.execute(
                 "UPDATE wc_executions SET state = ?1,
@@ -836,9 +849,9 @@ impl Database {
                             ELSE mcp_task_result_finalized_at
                         END
                  WHERE id = ?4",
-                params![state, now, immediate, execution.execution_id],
+                params![state.as_db(), now, immediate, execution.execution_id],
             )?;
-            if execution.state != "cancel_requested" {
+            if execution.state != ConnectorExecutionState::CancelRequested {
                 append_execution_event(&tx, &execution, state, now)?;
             }
             if immediate {
@@ -849,7 +862,10 @@ impl Database {
                     &json!({ "execution_id": execution.execution_id }),
                     now,
                 )?;
-            } else if let (false, Some(reason)) = (execution.state == "cancel_requested", reason) {
+            } else if let (false, Some(reason)) = (
+                execution.state == ConnectorExecutionState::CancelRequested,
+                reason,
+            ) {
                 insert_event(
                     &tx,
                     &task.task_id,
@@ -883,7 +899,7 @@ impl Database {
         let tx = conn.transaction()?;
         let execution =
             load_execution(&tx, execution_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
-        if execution.state != "queued" {
+        if execution.state != ConnectorExecutionState::Queued {
             tx.commit()?;
             return Ok(execution);
         }
@@ -894,7 +910,12 @@ impl Database {
              WHERE id = ?2",
             params![now, execution_id],
         )?;
-        append_execution_event(&tx, &execution, "cancel_requested", now)?;
+        append_execution_event(
+            &tx,
+            &execution,
+            ConnectorExecutionState::CancelRequested,
+            now,
+        )?;
         touch_task(&tx, &execution.task_id, now)?;
         commit_execution(tx, execution_id)
     }
@@ -999,7 +1020,7 @@ impl Database {
                      WHERE id = ?2",
                     params![now, execution_id],
                 )?;
-                append_execution_event(&tx, &execution, "interrupted", now)?;
+                append_execution_event(&tx, &execution, ConnectorExecutionState::Interrupted, now)?;
                 executions_interrupted += 1;
             }
             interrupt_run(&tx, run_id, task_id, "runtime_restarted", now)?;
@@ -1039,21 +1060,34 @@ impl Database {
             _ => None,
         };
         let (state, source, code, reason) = match failure {
-            ConnectorExecutionFailure::Submission(_) if execution.state == "cancel_requested" => (
-                "cancelled",
-                "cancellation",
-                "cancelled_before_submission",
-                "user_cancelled",
+            ConnectorExecutionFailure::Submission(_)
+                if execution.state == ConnectorExecutionState::CancelRequested =>
+            {
+                (
+                    ConnectorExecutionState::Cancelled,
+                    "cancellation",
+                    "cancelled_before_submission",
+                    "user_cancelled",
+                )
+            }
+            ConnectorExecutionFailure::Submission(code) => (
+                ConnectorExecutionState::Failed,
+                "submission",
+                code,
+                "submission_failed",
             ),
-            ConnectorExecutionFailure::Submission(code) => {
-                ("failed", "submission", code, "submission_failed")
-            }
-            ConnectorExecutionFailure::Unknown(code) => {
-                ("unknown", "transport", code, "executor_terminal_unknown")
-            }
-            ConnectorExecutionFailure::Workspace { code, .. } => {
-                ("failed", "workspace", code, "workspace_invariant_failed")
-            }
+            ConnectorExecutionFailure::Unknown(code) => (
+                ConnectorExecutionState::Unknown,
+                "transport",
+                code,
+                "executor_terminal_unknown",
+            ),
+            ConnectorExecutionFailure::Workspace { code, .. } => (
+                ConnectorExecutionState::Failed,
+                "workspace",
+                code,
+                "workspace_invariant_failed",
+            ),
         };
         tx.execute(
             "UPDATE wc_executions SET state = ?1, finished_at = ?2, exit_code = ?3,
@@ -1066,7 +1100,7 @@ impl Database {
                         END
              WHERE id = ?8",
             params![
-                state,
+                state.as_db(),
                 now,
                 Option::<i32>::None,
                 source,
@@ -1077,7 +1111,7 @@ impl Database {
             ],
         )?;
         append_execution_event(&tx, &execution, state, now)?;
-        if state == "cancelled" {
+        if state == ConnectorExecutionState::Cancelled {
             finalize_task_cancel(
                 &tx,
                 &execution.task_id,
@@ -1085,7 +1119,7 @@ impl Database {
                 &json!({ "execution_id": execution.execution_id }),
                 now,
             )?;
-        } else if state == "unknown" {
+        } else if state == ConnectorExecutionState::Unknown {
             interrupt_run(
                 &tx,
                 &execution.run_id,
@@ -1153,7 +1187,7 @@ fn finalize_task_cancel(
 fn append_execution_event(
     tx: &Transaction<'_>,
     execution: &ConnectorExecution,
-    state: &str,
+    state: ConnectorExecutionState,
     now: i64,
 ) -> Result<(), ConnectorTaskStoreError> {
     insert_event(

--- a/crates/webcodex-store/src/lib.rs
+++ b/crates/webcodex-store/src/lib.rs
@@ -42,19 +42,19 @@ pub use self::agent_wake::{
     AgentWakeState, AGENT_WAKE_CONSUME_TOKEN_PREFIX, AGENT_WAKE_ID_PREFIX,
 };
 pub use self::communication::{
-    AgentEndpointMutation, AgentEndpointRecord, AgentIdentityMutation, AgentIdentityPage,
-    AgentInboxItem, AgentInboxPage, AgentProfilePatch, CommunicationPrincipal,
-    CommunicationStoreError, ConversationAccess, ConversationDetailRecord,
+    AgentEndpointLifecycle, AgentEndpointMutation, AgentEndpointRecord, AgentIdentityMutation,
+    AgentIdentityPage, AgentInboxItem, AgentInboxPage, AgentProfilePatch, CommunicationPrincipal,
+    CommunicationStoreError, ConversationAccess, ConversationDetailRecord, ConversationLifecycle,
     ConversationMessageMutation, ConversationMessageRecord, ConversationMutation, ConversationPage,
     ConversationParticipantRecord, ConversationSummaryRecord, DeliveryConsumeResult,
-    DurableAgentIdentity, MessageAuthorRecord, MessageDeliveryRecord, NewAgentEndpoint,
-    NewAgentIdentity, NewConversation, NewConversationMessage,
+    DurableAgentIdentity, MessageAuthorRecord, MessageDeliveryRecord, MessageDeliveryState,
+    NewAgentEndpoint, NewAgentIdentity, NewConversation, NewConversationMessage,
     COMMUNICATION_PRINCIPAL_DIGEST_PREFIX, MAX_DURABLE_AGENTS,
 };
 pub use self::execution_model::{
-    ConnectorExecution, ConnectorExecutionFailure, ConnectorExecutionObservation,
-    ConnectorExecutionReservation, ConnectorTerminalContinuationDeliveryState,
-    MAX_ASSERTION_EVIDENCE_BYTES,
+    ConnectorExecution, ConnectorExecutionFailure, ConnectorExecutionKind,
+    ConnectorExecutionObservation, ConnectorExecutionReservation, ConnectorExecutionState,
+    ConnectorTerminalContinuationDeliveryState, MAX_ASSERTION_EVIDENCE_BYTES,
 };
 #[cfg(any(test, feature = "root-test-support"))]
 pub use self::execution_model::{
@@ -80,12 +80,15 @@ pub use self::memory::{
 pub use self::oauth::RotateResult;
 pub use self::server_instance::ServerInstanceGuard;
 pub use self::task_kernel::{
-    AppliedPaths, ConnectorApproval, ConnectorApprovalGate, ConnectorBinding,
-    ConnectorEditOperationGate, ConnectorPreservedWorkspace, ConnectorResultDecisionRecovery,
-    ConnectorTaskContinuation, ConnectorTaskEvent, ConnectorTaskResult, ConnectorTaskSnapshot,
-    ConnectorTaskStoreError, ConnectorWindowBinding, ConnectorWindowContext,
-    ConnectorWorkspaceTransition, GuidanceReadState, LocalReviewableTask, NewConnectorResult,
-    NewConnectorTask, WindowProjectActivation,
+    AppliedPaths, ConnectorApproval, ConnectorApprovalGate, ConnectorApprovalState,
+    ConnectorBinding, ConnectorEditOperationGate, ConnectorPreservedWorkspace,
+    ConnectorResultDecision, ConnectorResultDecisionRecovery, ConnectorResultDecisionRecoveryState,
+    ConnectorResultDecisionStatus, ConnectorRunLifecycle, ConnectorRunState,
+    ConnectorTaskContinuation, ConnectorTaskEvent, ConnectorTaskLifecycle, ConnectorTaskMode,
+    ConnectorTaskResult, ConnectorTaskSnapshot, ConnectorTaskState, ConnectorTaskStoreError,
+    ConnectorWindowBinding, ConnectorWindowContext, ConnectorWorkspaceTransition,
+    GuidanceReadState, LocalReviewableTask, NewConnectorResult, NewConnectorTask,
+    WindowProjectActivation,
 };
 pub use self::window_activity::{MAX_WINDOW_ACTIVITY_LIMIT, MAX_WINDOW_LINK_LIMIT};
 pub struct Database {

--- a/crates/webcodex-store/src/task_kernel.rs
+++ b/crates/webcodex-store/src/task_kernel.rs
@@ -4,6 +4,7 @@
 //! session ledger. A connector task is the product-level unit of work; a run is
 //! one executor attempt; events are its bounded, ordered audit trail.
 
+use super::execution_model::ConnectorExecutionState;
 use super::Database;
 use rusqlite::types::Type;
 use rusqlite::{params, OptionalExtension, Transaction};
@@ -12,6 +13,389 @@ use serde_json::Value;
 use std::collections::HashSet;
 use uuid::Uuid;
 use webcodex_core::project_context_contract::ProjectContextFingerprint;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorTaskMode {
+    Normal,
+    ReadOnly,
+    #[serde(rename = "inspect")]
+    InspectLegacy,
+}
+
+impl ConnectorTaskMode {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::ReadOnly => "read_only",
+            Self::InspectLegacy => "inspect",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "normal" => Ok(Self::Normal),
+            "read_only" => Ok(Self::ReadOnly),
+            "inspect" => Ok(Self::InspectLegacy),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Task mode: {other}").into(),
+            )),
+        }
+    }
+
+    fn requested(value: &str) -> Result<Self, ConnectorTaskStoreError> {
+        match value {
+            "normal" => Ok(Self::Normal),
+            "read_only" => Ok(Self::ReadOnly),
+            _ => Err(ConnectorTaskStoreError::InvalidState(
+                "task mode must be normal or read_only".to_string(),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for ConnectorTaskMode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_db())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorTaskLifecycle {
+    Active,
+    ReadyForReview,
+    Accepted,
+    Rejected,
+}
+
+impl ConnectorTaskLifecycle {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::ReadyForReview => "ready_for_review",
+            Self::Accepted => "accepted",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "active" => Ok(Self::Active),
+            "ready_for_review" => Ok(Self::ReadyForReview),
+            "accepted" => Ok(Self::Accepted),
+            "rejected" => Ok(Self::Rejected),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Task lifecycle: {other}").into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorTaskState {
+    Active,
+    ReadyForReview,
+    Accepted,
+    Rejected,
+    Cancelled,
+    NeedsAttention,
+}
+
+impl ConnectorTaskState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::ReadyForReview => "ready_for_review",
+            Self::Accepted => "accepted",
+            Self::Rejected => "rejected",
+            Self::Cancelled => "cancelled",
+            Self::NeedsAttention => "needs_attention",
+        }
+    }
+
+    fn from_projection(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "active" => Ok(Self::Active),
+            "ready_for_review" => Ok(Self::ReadyForReview),
+            "accepted" => Ok(Self::Accepted),
+            "rejected" => Ok(Self::Rejected),
+            "cancelled" => Ok(Self::Cancelled),
+            "needs_attention" => Ok(Self::NeedsAttention),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported effective Connector Task state: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for ConnectorTaskState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorRunLifecycle {
+    Running,
+    Completed,
+    Interrupted,
+}
+
+impl ConnectorRunLifecycle {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Interrupted => "interrupted",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "interrupted" => Ok(Self::Interrupted),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Run lifecycle: {other}").into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorRunState {
+    Running,
+    Completed,
+    Interrupted,
+    Cancelled,
+}
+
+impl ConnectorRunState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Interrupted => "interrupted",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl std::fmt::Display for ConnectorRunState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorResultDecisionStatus {
+    Pending,
+    Accepted,
+    Rejected,
+}
+
+impl ConnectorResultDecisionStatus {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Accepted => "accepted",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "accepted" => Ok(Self::Accepted),
+            "rejected" => Ok(Self::Rejected),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Result decision status: {other}").into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorResultDecision {
+    Accepted,
+    Rejected,
+}
+
+impl ConnectorResultDecision {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    pub fn requested(value: &str) -> Result<Self, ConnectorTaskStoreError> {
+        match value {
+            "accepted" => Ok(Self::Accepted),
+            "rejected" => Ok(Self::Rejected),
+            _ => Err(ConnectorTaskStoreError::InvalidState(
+                "result decision must be accepted or rejected".to_string(),
+            )),
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "accepted" => Ok(Self::Accepted),
+            "rejected" => Ok(Self::Rejected),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Result decision: {other}").into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorResultDecisionRecoveryState {
+    Pending,
+    NeedsAttention,
+}
+
+impl ConnectorResultDecisionRecoveryState {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::NeedsAttention => "needs_attention",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "needs_attention" => Ok(Self::NeedsAttention),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Result decision recovery state: {other}").into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorApprovalState {
+    Pending,
+    Approved,
+    Denied,
+    Consumed,
+    Expired,
+}
+
+impl ConnectorApprovalState {
+    pub const fn as_db(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Denied => "denied",
+            Self::Consumed => "consumed",
+            Self::Expired => "expired",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "approved" => Ok(Self::Approved),
+            "denied" => Ok(Self::Denied),
+            "consumed" => Ok(Self::Consumed),
+            "expired" => Ok(Self::Expired),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Approval state: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for ConnectorApprovalState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_db())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectorEditOperationState {
+    Pending,
+    Completed,
+    Failed,
+}
+
+impl ConnectorEditOperationState {
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Connector Edit Operation state: {other}").into(),
+            )),
+        }
+    }
+}
+
+fn effective_task_state(
+    lifecycle: ConnectorTaskLifecycle,
+    run_lifecycle: ConnectorRunLifecycle,
+    result_decision: Option<ConnectorResultDecisionStatus>,
+    cancelled: bool,
+) -> ConnectorTaskState {
+    if cancelled {
+        return ConnectorTaskState::Cancelled;
+    }
+    match result_decision {
+        Some(ConnectorResultDecisionStatus::Accepted) => return ConnectorTaskState::Accepted,
+        Some(ConnectorResultDecisionStatus::Rejected) => return ConnectorTaskState::Rejected,
+        Some(ConnectorResultDecisionStatus::Pending) | None => {}
+    }
+    if run_lifecycle == ConnectorRunLifecycle::Interrupted {
+        return ConnectorTaskState::NeedsAttention;
+    }
+    match lifecycle {
+        ConnectorTaskLifecycle::Active => ConnectorTaskState::Active,
+        ConnectorTaskLifecycle::ReadyForReview => ConnectorTaskState::ReadyForReview,
+        ConnectorTaskLifecycle::Accepted => ConnectorTaskState::Accepted,
+        ConnectorTaskLifecycle::Rejected => ConnectorTaskState::Rejected,
+    }
+}
+
+fn effective_run_state(lifecycle: ConnectorRunLifecycle, cancelled: bool) -> ConnectorRunState {
+    if cancelled {
+        return ConnectorRunState::Cancelled;
+    }
+    match lifecycle {
+        ConnectorRunLifecycle::Running => ConnectorRunState::Running,
+        ConnectorRunLifecycle::Completed => ConnectorRunState::Completed,
+        ConnectorRunLifecycle::Interrupted => ConnectorRunState::Interrupted,
+    }
+}
 
 pub struct ConnectorBinding<'a> {
     pub project_id: &'a str,
@@ -114,9 +498,13 @@ pub struct ConnectorTaskSnapshot {
     #[serde(skip_serializing)]
     pub owner_subject_id: String,
     pub goal: String,
-    pub mode: String,
-    pub task_status: String,
-    pub run_status: String,
+    pub mode: ConnectorTaskMode,
+    #[serde(skip_serializing)]
+    pub task_lifecycle: ConnectorTaskLifecycle,
+    pub task_status: ConnectorTaskState,
+    #[serde(skip_serializing)]
+    pub run_lifecycle: ConnectorRunLifecycle,
+    pub run_status: ConnectorRunState,
     pub event_cursor: i64,
     #[serde(skip_serializing)]
     pub target_executor_ref: String,
@@ -139,9 +527,9 @@ pub struct ConnectorTaskSnapshot {
 pub struct LocalReviewableTask {
     pub task_id: String,
     pub goal: String,
-    pub task_status: String,
+    pub task_status: ConnectorTaskState,
     pub updated_at: i64,
-    pub execution_status: Option<String>,
+    pub execution_status: Option<ConnectorExecutionState>,
     pub validation_status: Option<String>,
     pub next_action: String,
     /// Count of `human_guidance` events the model has not yet claimed (above
@@ -163,7 +551,7 @@ pub struct ConnectorTaskResult {
     pub changed_paths: Vec<String>,
     pub validation: Value,
     pub warnings: Vec<String>,
-    pub decision_status: String,
+    pub decision_status: ConnectorResultDecisionStatus,
     pub decided_by: Option<String>,
     pub decided_at: Option<i64>,
     pub cleanup_warning: Option<String>,
@@ -174,8 +562,8 @@ pub struct ConnectorTaskResult {
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ConnectorResultDecisionRecovery {
-    pub state: String,
-    pub decision: String,
+    pub state: ConnectorResultDecisionRecoveryState,
+    pub decision: ConnectorResultDecision,
     pub error_code: Option<String>,
     pub error_message: Option<String>,
     pub last_attempt_at: Option<i64>,
@@ -189,7 +577,7 @@ pub struct ConnectorApproval {
     pub action_kind: String,
     pub action_hash: String,
     pub action_summary: String,
-    pub state: String,
+    pub state: ConnectorApprovalState,
     pub requested_at: i64,
     pub expires_at: i64,
     pub decided_by: Option<String>,
@@ -493,8 +881,9 @@ impl Database {
         task: NewConnectorTask<'_>,
         binding: Option<ConnectorWindowBinding<'_>>,
     ) -> Result<ConnectorTaskSnapshot, ConnectorTaskStoreError> {
+        let mode = ConnectorTaskMode::requested(task.mode)?;
         validate_connector_task_workspace_shape(
-            task.mode,
+            mode,
             task.isolated,
             task.target_root,
             task.execution_root,
@@ -525,7 +914,7 @@ impl Database {
                 task.project_id,
                 task.subject_id,
                 task.goal,
-                task.mode,
+                mode.as_db(),
                 task.now
             ],
         )?;
@@ -559,7 +948,7 @@ impl Database {
             "task_started",
             &serde_json::json!({
                 "goal": task.goal,
-                "mode": task.mode,
+                "mode": mode,
                 "isolated": task.isolated,
                 "baseline_commit": task.baseline_commit
             }),
@@ -577,9 +966,11 @@ impl Database {
             workspace_id: task.workspace_id.to_string(),
             owner_subject_id: task.subject_id.to_string(),
             goal: task.goal.to_string(),
-            mode: task.mode.to_string(),
-            task_status: "active".to_string(),
-            run_status: "running".to_string(),
+            mode,
+            task_lifecycle: ConnectorTaskLifecycle::Active,
+            task_status: ConnectorTaskState::Active,
+            run_lifecycle: ConnectorRunLifecycle::Running,
+            run_status: ConnectorRunState::Running,
             event_cursor: 1,
             target_executor_ref: task.target_executor_ref.to_string(),
             execution_executor_ref: task.execution_executor_ref.to_string(),
@@ -597,7 +988,7 @@ impl Database {
         &self,
         continuation: ConnectorTaskContinuation<'_>,
         binding: ConnectorWindowBinding<'_>,
-    ) -> Result<(ConnectorTaskSnapshot, i64, String), ConnectorTaskStoreError> {
+    ) -> Result<(ConnectorTaskSnapshot, i64, ConnectorTaskMode), ConnectorTaskStoreError> {
         self.continue_connector_task_transaction(continuation, Some(binding))
     }
 
@@ -605,12 +996,8 @@ impl Database {
         &self,
         continuation: ConnectorTaskContinuation<'_>,
         binding: Option<ConnectorWindowBinding<'_>>,
-    ) -> Result<(ConnectorTaskSnapshot, i64, String), ConnectorTaskStoreError> {
-        if !matches!(continuation.mode, "normal" | "read_only") {
-            return Err(ConnectorTaskStoreError::InvalidState(
-                "task mode must be normal or read_only".to_string(),
-            ));
-        }
+    ) -> Result<(ConnectorTaskSnapshot, i64, ConnectorTaskMode), ConnectorTaskStoreError> {
+        let requested_mode = ConnectorTaskMode::requested(continuation.mode)?;
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let task = load_task(
@@ -621,29 +1008,32 @@ impl Database {
         )?
         .ok_or(ConnectorTaskStoreError::NotFound)?;
         require_running(&task)?;
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "inspect_mode_retired: this pre-0.4 inspect task can no longer execute; start a new read_only task for analysis or a new normal task for writable work"
                     .to_string(),
             ));
         }
-        if task.task_status != "active" {
+        if task.task_status != ConnectorTaskState::Active {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "only an active task can continue".to_string(),
             ));
         }
-        if task.mode == "normal" && continuation.mode == "read_only" {
+        if task.mode == ConnectorTaskMode::Normal && requested_mode == ConnectorTaskMode::ReadOnly {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "normal tasks cannot transition to read_only; finish or reject the current writable task and start a new read_only task"
                     .to_string(),
             ));
         }
-        if continuation.mode == "normal" && !task.isolated && continuation.workspace.is_none() {
+        if requested_mode == ConnectorTaskMode::Normal
+            && !task.isolated
+            && continuation.workspace.is_none()
+        {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "read-only workspace must be upgraded before enabling writes".to_string(),
             ));
         }
-        let previous_mode = task.mode.clone();
+        let previous_mode = task.mode;
         let workspace_upgraded = continuation.workspace.is_some();
         let (
             final_isolated,
@@ -668,7 +1058,7 @@ impl Database {
             ),
         };
         validate_connector_task_workspace_shape(
-            continuation.mode,
+            requested_mode,
             final_isolated,
             final_target_root,
             final_execution_root,
@@ -695,7 +1085,11 @@ impl Database {
         }
         tx.execute(
             "UPDATE wc_tasks SET mode = ?1, updated_at = ?2 WHERE id = ?3",
-            params![continuation.mode, continuation.now, continuation.task_id],
+            params![
+                requested_mode.as_db(),
+                continuation.now,
+                continuation.task_id
+            ],
         )?;
         let sequence = task.event_cursor + 1;
         insert_event(
@@ -707,8 +1101,8 @@ impl Database {
             &serde_json::json!({
                 "instruction": continuation.instruction,
                 "previous_mode": previous_mode,
-                "mode": continuation.mode,
-                "capability_changed": previous_mode != continuation.mode,
+                "mode": requested_mode,
+                "capability_changed": previous_mode != requested_mode,
                 "workspace_upgraded": workspace_upgraded
             }),
             continuation.now,
@@ -769,36 +1163,34 @@ impl Database {
         now: i64,
         binding: Option<ConnectorWindowBinding<'_>>,
     ) -> Result<i64, ConnectorTaskStoreError> {
+        let requested_mode = ConnectorTaskMode::requested(requested_mode)?;
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let task = load_task(&tx, task_id, project_id, subject_id)?
             .ok_or(ConnectorTaskStoreError::NotFound)?;
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "inspect_mode_retired: this pre-0.4 inspect task can no longer execute; start a new read_only task for analysis or a new normal task for writable work"
                     .to_string(),
             ));
         }
-        if !matches!(requested_mode, "normal" | "read_only") {
-            return Err(ConnectorTaskStoreError::InvalidState(
-                "task mode must be normal or read_only".to_string(),
-            ));
-        }
-        if task.mode == "normal" && requested_mode == "read_only" {
+        if task.mode == ConnectorTaskMode::Normal && requested_mode == ConnectorTaskMode::ReadOnly {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "normal tasks cannot transition to read_only; finish or reject the current writable task and start a new read_only task"
                     .to_string(),
             ));
         }
         validate_connector_task_workspace_shape(
-            &task.mode,
+            task.mode,
             task.isolated,
             &task.target_root,
             &task.execution_root,
             task.baseline_commit.as_deref(),
             task.baseline_tree.as_deref(),
         )?;
-        if task.run_status != "interrupted" || task.task_status != "needs_attention" {
+        if task.run_status != ConnectorRunState::Interrupted
+            || task.task_status != ConnectorTaskState::NeedsAttention
+        {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "only an interrupted task accepts a blocked continuation instruction".to_string(),
             ));
@@ -919,9 +1311,10 @@ impl Database {
                  WHERE task_id = ?1 AND operation_id = ?2",
                 params![task_id, operation_id],
                 |row| {
+                    let state = row.get::<_, String>(1)?;
                     Ok((
                         row.get::<_, String>(0)?,
-                        row.get::<_, String>(1)?,
+                        ConnectorEditOperationState::from_db(&state, 1)?,
                         row.get::<_, Option<String>>(2)?,
                     ))
                 },
@@ -932,12 +1325,14 @@ impl Database {
             if stored_hash != request_sha256 {
                 return Ok(ConnectorEditOperationGate::Conflict);
             }
-            return match (state.as_str(), result_json) {
-                ("pending", None) => Ok(ConnectorEditOperationGate::Pending),
-                ("completed", Some(result_json)) => Ok(ConnectorEditOperationGate::Replay(
-                    serde_json::from_str(&result_json)?,
-                )),
-                ("failed", None) => {
+            return match (state, result_json) {
+                (ConnectorEditOperationState::Pending, None) => {
+                    Ok(ConnectorEditOperationGate::Pending)
+                }
+                (ConnectorEditOperationState::Completed, Some(result_json)) => Ok(
+                    ConnectorEditOperationGate::Replay(serde_json::from_str(&result_json)?),
+                ),
+                (ConnectorEditOperationState::Failed, None) => {
                     let updated = conn.execute(
                         "UPDATE wc_edit_operations SET state = 'pending', updated_at = ?1
                          WHERE task_id = ?2 AND operation_id = ?3 AND request_sha256 = ?4
@@ -1111,9 +1506,11 @@ impl Database {
         let task = load_task(&tx, task_id, project_id, subject_id)?
             .ok_or(ConnectorTaskStoreError::NotFound)?;
         if !matches!(
-            task.task_status.as_str(),
-            "ready_for_review" | "accepted" | "rejected"
-        ) || task.run_status != "completed"
+            task.task_status,
+            ConnectorTaskState::ReadyForReview
+                | ConnectorTaskState::Accepted
+                | ConnectorTaskState::Rejected
+        ) || task.run_status != ConnectorRunState::Completed
         {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "workspace release can only follow a completed task result".to_string(),
@@ -1493,25 +1890,25 @@ impl Database {
             approval = load_approval_by_hash(&tx, task_id, &task.run_id, action_hash)?;
         }
         let mut approval = approval.expect("approval inserted or loaded");
-        let gate = match approval.state.as_str() {
-            "pending" if approval.expires_at <= now => {
+        let gate = match approval.state {
+            ConnectorApprovalState::Pending if approval.expires_at <= now => {
                 tx.execute(
                     "UPDATE wc_approvals SET state = 'expired' WHERE id = ?1 AND state = 'pending'",
                     params![approval.approval_id],
                 )?;
-                approval.state = "expired".to_string();
+                approval.state = ConnectorApprovalState::Expired;
                 ConnectorApprovalGate::Expired(approval)
             }
-            "pending" => ConnectorApprovalGate::Pending(approval),
-            "approved" if approval.expires_at <= now => {
+            ConnectorApprovalState::Pending => ConnectorApprovalGate::Pending(approval),
+            ConnectorApprovalState::Approved if approval.expires_at <= now => {
                 tx.execute(
                     "UPDATE wc_approvals SET state = 'expired' WHERE id = ?1 AND state = 'approved'",
                     params![approval.approval_id],
                 )?;
-                approval.state = "expired".to_string();
+                approval.state = ConnectorApprovalState::Expired;
                 ConnectorApprovalGate::Expired(approval)
             }
-            "approved" => {
+            ConnectorApprovalState::Approved => {
                 let updated = tx.execute(
                     "UPDATE wc_approvals SET state = 'consumed', consumed_at = ?1
                      WHERE id = ?2 AND state = 'approved'",
@@ -1522,7 +1919,7 @@ impl Database {
                         "approval was already consumed".to_string(),
                     ));
                 }
-                approval.state = "consumed".to_string();
+                approval.state = ConnectorApprovalState::Consumed;
                 approval.consumed_at = Some(now);
                 insert_event(
                     &tx,
@@ -1539,8 +1936,8 @@ impl Database {
                 touch_task(&tx, task_id, now)?;
                 ConnectorApprovalGate::Authorized(approval)
             }
-            "denied" => ConnectorApprovalGate::Denied(approval),
-            "expired" => {
+            ConnectorApprovalState::Denied => ConnectorApprovalGate::Denied(approval),
+            ConnectorApprovalState::Expired => {
                 tx.execute(
                     "UPDATE wc_approvals
                      SET state = 'pending', requested_at = ?1, expires_at = ?2,
@@ -1564,7 +1961,7 @@ impl Database {
                     now,
                 )?;
                 touch_task(&tx, task_id, now)?;
-                approval.state = "pending".to_string();
+                approval.state = ConnectorApprovalState::Pending;
                 approval.requested_at = now;
                 approval.expires_at = expires_at;
                 approval.decided_by = None;
@@ -1572,12 +1969,7 @@ impl Database {
                 approval.consumed_at = None;
                 ConnectorApprovalGate::Pending(approval)
             }
-            "consumed" => ConnectorApprovalGate::Consumed(approval),
-            other => {
-                return Err(ConnectorTaskStoreError::InvalidState(format!(
-                    "unknown approval state {other}"
-                )))
-            }
+            ConnectorApprovalState::Consumed => ConnectorApprovalGate::Consumed(approval),
         };
         tx.commit()?;
         Ok(gate)
@@ -1625,7 +2017,8 @@ impl Database {
                         WHEN q.task_status = 'active' THEN 'in_progress'
                         ELSE 'review'
                     END,
-                    q.unread_guidance
+                    q.unread_guidance,
+                    q.task_lifecycle, q.run_lifecycle, q.result_decision_status, q.cancelled
              FROM (
                 SELECT t.id AS task_id, t.goal, t.updated_at,
                     CASE
@@ -1636,6 +2029,11 @@ impl Database {
                         WHEN r.status = 'interrupted' THEN 'needs_attention'
                         ELSE t.status
                     END AS task_status,
+                    t.status AS task_lifecycle,
+                    r.status AS run_lifecycle,
+                    res.decision_status AS result_decision_status,
+                    EXISTS (SELECT 1 FROM wc_task_events c
+                            WHERE c.task_id = t.id AND c.kind = 'task_cancelled') AS cancelled,
                     r.status AS run_status, res.id AS result_id, res.validation_json,
                     (SELECT ex.state FROM wc_executions ex WHERE ex.task_id = t.id
                      ORDER BY ex.submitted_at DESC, ex.rowid DESC LIMIT 1) AS execution_status,
@@ -1662,18 +2060,7 @@ impl Database {
         )?;
         let rows = statement.query_map(
             params![project_id, include_completed as i64, limit.max(1) as i64],
-            |row| {
-                Ok(LocalReviewableTask {
-                    task_id: row.get(0)?,
-                    goal: row.get(1)?,
-                    task_status: row.get(2)?,
-                    updated_at: row.get(3)?,
-                    execution_status: row.get(4)?,
-                    validation_status: row.get(5)?,
-                    next_action: row.get(6)?,
-                    unread_guidance: row.get(7)?,
-                })
-            },
+            map_reviewable_task,
         )?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
@@ -1699,7 +2086,8 @@ impl Database {
                         WHEN q.task_status = 'active' THEN 'in_progress'
                         ELSE 'review'
                     END,
-                    q.unread_guidance
+                    q.unread_guidance,
+                    q.task_lifecycle, q.run_lifecycle, q.result_decision_status, q.cancelled
              FROM (
                 SELECT t.id AS task_id, t.goal, t.updated_at,
                     CASE
@@ -1710,6 +2098,11 @@ impl Database {
                         WHEN r.status = 'interrupted' THEN 'needs_attention'
                         ELSE t.status
                     END AS task_status,
+                    t.status AS task_lifecycle,
+                    r.status AS run_lifecycle,
+                    res.decision_status AS result_decision_status,
+                    EXISTS (SELECT 1 FROM wc_task_events c
+                            WHERE c.task_id = t.id AND c.kind = 'task_cancelled') AS cancelled,
                     r.status AS run_status, res.id AS result_id, res.validation_json,
                     (SELECT ex.state FROM wc_executions ex WHERE ex.task_id = t.id
                      ORDER BY ex.submitted_at DESC, ex.rowid DESC LIMIT 1) AS execution_status,
@@ -1735,18 +2128,7 @@ impl Database {
         )?;
         let rows = statement.query_map(
             params![project_id, subject_id, limit.max(1) as i64],
-            |row| {
-                Ok(LocalReviewableTask {
-                    task_id: row.get(0)?,
-                    goal: row.get(1)?,
-                    task_status: row.get(2)?,
-                    updated_at: row.get(3)?,
-                    execution_status: row.get(4)?,
-                    validation_status: row.get(5)?,
-                    next_action: row.get(6)?,
-                    unread_guidance: row.get(7)?,
-                })
-            },
+            map_reviewable_task,
         )?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
@@ -1865,21 +2247,23 @@ impl Database {
             .ok_or(ConnectorTaskStoreError::NotFound)?;
         let task = load_task(&tx, task_id, project_id, &subject_id)?
             .ok_or(ConnectorTaskStoreError::NotFound)?;
-        if task.mode == "inspect" {
+        if task.mode == ConnectorTaskMode::InspectLegacy {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "inspect_mode_retired: this pre-0.4 inspect task can no longer execute; reject it locally and start a new read_only or normal task"
                     .to_string(),
             ));
         }
         validate_connector_task_workspace_shape(
-            &task.mode,
+            task.mode,
             task.isolated,
             &task.target_root,
             &task.execution_root,
             task.baseline_commit.as_deref(),
             task.baseline_tree.as_deref(),
         )?;
-        if task.run_status != "interrupted" || task.task_status != "needs_attention" {
+        if task.run_status != ConnectorRunState::Interrupted
+            || task.task_status != ConnectorTaskState::NeedsAttention
+        {
             return Err(ConnectorTaskStoreError::InvalidState(
                 "only an interrupted task can be resumed".to_string(),
             ));
@@ -1991,6 +2375,7 @@ impl Database {
         actor: &str,
         now: i64,
     ) -> Result<(), ConnectorTaskStoreError> {
+        let decision = ConnectorResultDecision::requested(decision)?;
         let conn = self.conn.lock().unwrap();
         let inserted = conn.execute(
             "INSERT INTO wc_result_decision_intents
@@ -2010,7 +2395,7 @@ impl Database {
              WHERE wc_result_decision_intents.result_id = excluded.result_id
                AND wc_result_decision_intents.state = 'needs_attention'
                AND excluded.decision = 'rejected'",
-            params![task_id, project_id, decision, actor, now, result_id],
+            params![task_id, project_id, decision.as_db(), actor, now, result_id],
         )?;
         if inserted == 1 {
             return Ok(());
@@ -2037,7 +2422,7 @@ impl Database {
     pub fn connector_result_decision_intents(
         &self,
         project_id: &str,
-    ) -> Result<Vec<(String, String, String)>, ConnectorTaskStoreError> {
+    ) -> Result<Vec<(String, String, ConnectorResultDecision)>, ConnectorTaskStoreError> {
         let conn = self.conn.lock().unwrap();
         let mut statement = conn.prepare(
             "SELECT i.task_id, i.result_id, i.decision
@@ -2047,7 +2432,12 @@ impl Database {
              ORDER BY i.started_at, i.task_id",
         )?;
         let rows = statement.query_map([project_id], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            let decision = row.get::<_, String>(2)?;
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                ConnectorResultDecision::from_db(&decision, 2)?,
+            ))
         })?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
@@ -2137,8 +2527,9 @@ impl Database {
                  ORDER BY r.started_at DESC LIMIT 1",
                 params![task_id, result_id, project_id],
                 |row| {
+                    let decision = row.get::<_, String>(0)?;
                     Ok((
-                        row.get::<_, String>(0)?,
+                        ConnectorResultDecision::from_db(&decision, 0)?,
                         row.get::<_, String>(1)?,
                         row.get::<_, String>(2)?,
                         row.get::<_, i64>(3)?,
@@ -2157,7 +2548,14 @@ impl Database {
              SET decision_status = ?1, decided_by = ?2, decided_at = ?3,
                  cleanup_warning = COALESCE(?4, cleanup_warning)
              WHERE task_id = ?5 AND id = ?6 AND decision_status = 'pending'",
-            params![decision, actor, now, cleanup_warning, task_id, result_id],
+            params![
+                decision.as_db(),
+                actor,
+                now,
+                cleanup_warning,
+                task_id,
+                result_id
+            ],
         )?;
         if updated != 1 {
             return Err(ConnectorTaskStoreError::decision(
@@ -2167,7 +2565,7 @@ impl Database {
         }
         tx.execute(
             "UPDATE wc_tasks SET status = ?1, updated_at = ?2 WHERE id = ?3",
-            params![decision, now, task_id],
+            params![decision.as_db(), now, task_id],
         )?;
         tx.execute(
             "UPDATE wc_runs
@@ -2180,10 +2578,9 @@ impl Database {
             task_id,
             &run_id,
             cursor + 1,
-            if decision == "accepted" {
-                "task_accepted"
-            } else {
-                "task_rejected"
+            match decision {
+                ConnectorResultDecision::Accepted => "task_accepted",
+                ConnectorResultDecision::Rejected => "task_rejected",
             },
             &serde_json::json!({
                 "decision": decision,
@@ -2226,7 +2623,7 @@ impl Database {
         require_running(&task)?;
         let approval =
             load_approval(&tx, approval_id, task_id)?.ok_or(ConnectorTaskStoreError::NotFound)?;
-        if approval.state != "pending" {
+        if approval.state != ConnectorApprovalState::Pending {
             return Err(ConnectorTaskStoreError::InvalidState(format!(
                 "approval is {}; only pending approvals can be decided",
                 approval.state
@@ -2243,13 +2640,17 @@ impl Database {
                     .to_string(),
             ));
         }
-        let state = if approve { "approved" } else { "denied" };
+        let state = if approve {
+            ConnectorApprovalState::Approved
+        } else {
+            ConnectorApprovalState::Denied
+        };
         let reason = reason.map(str::trim).filter(|reason| !reason.is_empty());
         tx.execute(
             "UPDATE wc_approvals SET state = ?1, decided_by = ?2, decided_at = ?3,
                     decision_reason = ?5
              WHERE id = ?4 AND state = 'pending'",
-            params![state, actor, now, approval_id, reason],
+            params![state.as_db(), actor, now, approval_id, reason],
         )?;
         let cursor: i64 = tx.query_row(
             "SELECT COALESCE(MAX(sequence), 0) FROM wc_task_events WHERE task_id = ?1",
@@ -2280,6 +2681,47 @@ impl Database {
     }
 }
 
+fn map_reviewable_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<LocalReviewableTask> {
+    let projected_raw = row.get::<_, String>(2)?;
+    let task_lifecycle_raw = row.get::<_, String>(8)?;
+    let run_lifecycle_raw = row.get::<_, String>(9)?;
+    let result_decision_raw = row.get::<_, Option<String>>(10)?;
+    let cancelled = row.get::<_, i64>(11)? != 0;
+    let task_lifecycle = ConnectorTaskLifecycle::from_db(&task_lifecycle_raw, 8)?;
+    let run_lifecycle = ConnectorRunLifecycle::from_db(&run_lifecycle_raw, 9)?;
+    let result_decision = result_decision_raw
+        .as_deref()
+        .map(|value| ConnectorResultDecisionStatus::from_db(value, 10))
+        .transpose()?;
+    let canonical = effective_task_state(task_lifecycle, run_lifecycle, result_decision, cancelled);
+    let projected = ConnectorTaskState::from_projection(&projected_raw, 2)?;
+    if projected != canonical {
+        return Err(rusqlite::Error::FromSqlConversionFailure(
+            2,
+            Type::Text,
+            format!(
+                "Connector Task SQL projection diverged from canonical Rust projection: SQL={projected}, Rust={canonical}"
+            )
+            .into(),
+        ));
+    }
+    let execution_status = row
+        .get::<_, Option<String>>(4)?
+        .as_deref()
+        .map(|value| ConnectorExecutionState::from_db(value, 4))
+        .transpose()?;
+    Ok(LocalReviewableTask {
+        task_id: row.get(0)?,
+        goal: row.get(1)?,
+        task_status: canonical,
+        updated_at: row.get(3)?,
+        execution_status,
+        validation_status: row.get(5)?,
+        next_action: row.get(6)?,
+        unread_guidance: row.get(7)?,
+    })
+}
+
 pub(super) fn load_task(
     conn: &rusqlite::Connection,
     task_id: &str,
@@ -2288,23 +2730,11 @@ pub(super) fn load_task(
 ) -> Result<Option<ConnectorTaskSnapshot>, rusqlite::Error> {
     conn.query_row(
         "SELECT t.id, r.id, t.project_id, r.workspace_id, t.owner_subject_id, t.goal, t.mode,
-                CASE
-                    WHEN EXISTS (
-                        SELECT 1 FROM wc_task_events cancelled
-                        WHERE cancelled.task_id = t.id AND cancelled.kind = 'task_cancelled'
-                    ) THEN 'cancelled'
-                    WHEN result.decision_status = 'accepted' THEN 'accepted'
-                    WHEN result.decision_status = 'rejected' THEN 'rejected'
-                    WHEN r.status = 'interrupted' THEN 'needs_attention'
-                    ELSE t.status
-                END,
-                CASE
-                    WHEN EXISTS (
-                        SELECT 1 FROM wc_task_events cancelled
-                        WHERE cancelled.task_id = t.id AND cancelled.kind = 'task_cancelled'
-                    ) THEN 'cancelled'
-                    ELSE r.status
-                END,
+                t.status, r.status, result.decision_status,
+                EXISTS (
+                    SELECT 1 FROM wc_task_events cancelled
+                    WHERE cancelled.task_id = t.id AND cancelled.kind = 'task_cancelled'
+                ),
                 COALESCE(MAX(e.sequence), 0),
                 ctx.target_executor_ref, ctx.execution_executor_ref,
                 ctx.target_root, ctx.execution_root,
@@ -2321,6 +2751,18 @@ pub(super) fn load_task(
          LIMIT 1",
         params![task_id, project_id, subject_id],
         |row| {
+            let mode_raw = row.get::<_, String>(6)?;
+            let task_lifecycle_raw = row.get::<_, String>(7)?;
+            let run_lifecycle_raw = row.get::<_, String>(8)?;
+            let result_decision_raw = row.get::<_, Option<String>>(9)?;
+            let cancelled = row.get::<_, i64>(10)? != 0;
+            let mode = ConnectorTaskMode::from_db(&mode_raw, 6)?;
+            let task_lifecycle = ConnectorTaskLifecycle::from_db(&task_lifecycle_raw, 7)?;
+            let run_lifecycle = ConnectorRunLifecycle::from_db(&run_lifecycle_raw, 8)?;
+            let result_decision = result_decision_raw
+                .as_deref()
+                .map(|value| ConnectorResultDecisionStatus::from_db(value, 9))
+                .transpose()?;
             Ok(ConnectorTaskSnapshot {
                 task_id: row.get(0)?,
                 run_id: row.get(1)?,
@@ -2328,19 +2770,26 @@ pub(super) fn load_task(
                 workspace_id: row.get(3)?,
                 owner_subject_id: row.get(4)?,
                 goal: row.get(5)?,
-                mode: row.get(6)?,
-                task_status: row.get(7)?,
-                run_status: row.get(8)?,
-                event_cursor: row.get(9)?,
-                target_executor_ref: row.get(10)?,
-                execution_executor_ref: row.get(11)?,
-                target_root: row.get(12)?,
-                execution_root: row.get(13)?,
-                baseline_commit: row.get(14)?,
-                baseline_tree: row.get(15)?,
-                isolated: row.get::<_, i64>(16)? != 0,
-                created_at: row.get(17)?,
-                updated_at: row.get(18)?,
+                mode,
+                task_lifecycle,
+                task_status: effective_task_state(
+                    task_lifecycle,
+                    run_lifecycle,
+                    result_decision,
+                    cancelled,
+                ),
+                run_lifecycle,
+                run_status: effective_run_state(run_lifecycle, cancelled),
+                event_cursor: row.get(11)?,
+                target_executor_ref: row.get(12)?,
+                execution_executor_ref: row.get(13)?,
+                target_root: row.get(14)?,
+                execution_root: row.get(15)?,
+                baseline_commit: row.get(16)?,
+                baseline_tree: row.get(17)?,
+                isolated: row.get::<_, i64>(18)? != 0,
+                created_at: row.get(19)?,
+                updated_at: row.get(20)?,
             })
         },
     )
@@ -2383,13 +2832,16 @@ fn map_result(row: &rusqlite::Row<'_>) -> Result<ConnectorTaskResult, rusqlite::
     let patch_bytes = usize::try_from(patch_bytes_raw)
         .map_err(|e| rusqlite::Error::FromSqlConversionFailure(6, Type::Integer, Box::new(e)))?;
     let recovery = match row.get::<_, Option<String>>(15)? {
-        Some(state) => Some(ConnectorResultDecisionRecovery {
-            state,
-            decision: row.get(16)?,
-            error_code: row.get(17)?,
-            error_message: row.get(18)?,
-            last_attempt_at: row.get(19)?,
-        }),
+        Some(state) => {
+            let decision = row.get::<_, String>(16)?;
+            Some(ConnectorResultDecisionRecovery {
+                state: ConnectorResultDecisionRecoveryState::from_db(&state, 15)?,
+                decision: ConnectorResultDecision::from_db(&decision, 16)?,
+                error_code: row.get(17)?,
+                error_message: row.get(18)?,
+                last_attempt_at: row.get(19)?,
+            })
+        }
         None => None,
     };
     Ok(ConnectorTaskResult {
@@ -2403,7 +2855,7 @@ fn map_result(row: &rusqlite::Row<'_>) -> Result<ConnectorTaskResult, rusqlite::
         changed_paths: json_col(row, 7)?,
         validation: json_col(row, 8)?,
         warnings: json_col(row, 9)?,
-        decision_status: row.get(10)?,
+        decision_status: ConnectorResultDecisionStatus::from_db(&row.get::<_, String>(10)?, 10)?,
         decided_by: row.get(11)?,
         decided_at: row.get(12)?,
         cleanup_warning: row.get(13)?,
@@ -2455,7 +2907,7 @@ fn map_approval(row: &rusqlite::Row<'_>) -> Result<ConnectorApproval, rusqlite::
         action_kind: row.get(3)?,
         action_hash: row.get(4)?,
         action_summary: row.get(5)?,
-        state: row.get(6)?,
+        state: ConnectorApprovalState::from_db(&row.get::<_, String>(6)?, 6)?,
         requested_at: row.get(7)?,
         expires_at: row.get(8)?,
         decided_by: row.get(9)?,
@@ -2492,7 +2944,7 @@ pub(super) fn expire_task_approvals(
 }
 
 fn validate_connector_task_workspace_shape(
-    mode: &str,
+    mode: ConnectorTaskMode,
     isolated: bool,
     target_root: &str,
     execution_root: &str,
@@ -2500,7 +2952,7 @@ fn validate_connector_task_workspace_shape(
     baseline_tree: Option<&str>,
 ) -> Result<(), ConnectorTaskStoreError> {
     match mode {
-        "normal"
+        ConnectorTaskMode::Normal
             if !isolated
                 || execution_root == target_root
                 || baseline_commit.is_none_or(str::is_empty)
@@ -2510,20 +2962,22 @@ fn validate_connector_task_workspace_shape(
                 "normal tasks require an isolated execution root and Git baseline".to_string(),
             ))
         }
-        "read_only" if isolated || execution_root != target_root => {
+        ConnectorTaskMode::ReadOnly if isolated || execution_root != target_root => {
             Err(ConnectorTaskStoreError::InvalidState(
                 "read_only tasks must use the target workspace without isolation".to_string(),
             ))
         }
-        "normal" | "read_only" => Ok(()),
-        _ => Err(ConnectorTaskStoreError::InvalidState(
+        ConnectorTaskMode::Normal | ConnectorTaskMode::ReadOnly => Ok(()),
+        ConnectorTaskMode::InspectLegacy => Err(ConnectorTaskStoreError::InvalidState(
             "task mode must be normal or read_only".to_string(),
         )),
     }
 }
 
 pub(super) fn require_running(task: &ConnectorTaskSnapshot) -> Result<(), ConnectorTaskStoreError> {
-    if task.task_status != "active" || task.run_status != "running" {
+    if task.task_status != ConnectorTaskState::Active
+        || task.run_status != ConnectorRunState::Running
+    {
         return Err(ConnectorTaskStoreError::InvalidState(format!(
             "task {} is {}, run is {}; start a new task for more work",
             task.task_id, task.task_status, task.run_status

--- a/crates/webcodex-store/src/task_kernel_tests.rs
+++ b/crates/webcodex-store/src/task_kernel_tests.rs
@@ -242,7 +242,7 @@ fn failed_continuation_binding_rolls_back_mode_workspace_and_instruction() {
     let restored = db
         .connector_task(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap();
-    assert_eq!(restored.mode, "read_only");
+    assert_eq!(restored.mode, ConnectorTaskMode::ReadOnly);
     assert!(!restored.isolated);
     assert_eq!(restored.execution_root, "/workspace/demo");
     assert_eq!(restored.event_cursor, 1);
@@ -294,7 +294,7 @@ fn normal_task_cannot_downgrade_to_read_only() {
     let restored = db
         .connector_task(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap();
-    assert_eq!(restored.mode, "normal");
+    assert_eq!(restored.mode, ConnectorTaskMode::Normal);
     assert!(restored.isolated);
     assert_eq!(restored.execution_root, task.execution_root);
     assert_eq!(restored.event_cursor, 1);
@@ -352,7 +352,7 @@ fn malformed_persisted_read_only_isolated_task_cannot_continue() {
     let restored = db
         .connector_task(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap();
-    assert_eq!(restored.mode, "read_only");
+    assert_eq!(restored.mode, ConnectorTaskMode::ReadOnly);
     assert!(restored.isolated);
     assert_eq!(restored.execution_root, task.execution_root);
     assert_eq!(restored.event_cursor, 1);
@@ -501,14 +501,17 @@ fn finish_is_atomic_and_prevents_more_events() {
     let snapshot = db
         .connector_task(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap();
-    assert_eq!(snapshot.task_status, "ready_for_review");
-    assert_eq!(snapshot.run_status, "completed");
+    assert_eq!(snapshot.task_status, ConnectorTaskState::ReadyForReview);
+    assert_eq!(snapshot.run_status, ConnectorRunState::Completed);
     let result = db
         .connector_task_result(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap()
         .unwrap();
     assert_eq!(result.changed_paths, changed_paths);
-    assert_eq!(result.decision_status, "pending");
+    assert_eq!(
+        result.decision_status,
+        ConnectorResultDecisionStatus::Pending
+    );
     assert!(matches!(
         db.append_connector_task_event(
             &task.task_id,
@@ -520,6 +523,278 @@ fn finish_is_atomic_and_prevents_more_events() {
         ),
         Err(ConnectorTaskStoreError::InvalidState(_))
     ));
+}
+
+#[test]
+fn task_and_run_lifecycle_contracts_are_distinct_from_effective_state() {
+    assert_eq!(
+        effective_task_state(
+            ConnectorTaskLifecycle::Active,
+            ConnectorRunLifecycle::Running,
+            None,
+            false,
+        ),
+        ConnectorTaskState::Active
+    );
+    assert_eq!(
+        effective_task_state(
+            ConnectorTaskLifecycle::ReadyForReview,
+            ConnectorRunLifecycle::Completed,
+            Some(ConnectorResultDecisionStatus::Pending),
+            false,
+        ),
+        ConnectorTaskState::ReadyForReview
+    );
+    assert_eq!(
+        effective_task_state(
+            ConnectorTaskLifecycle::ReadyForReview,
+            ConnectorRunLifecycle::Completed,
+            Some(ConnectorResultDecisionStatus::Accepted),
+            false,
+        ),
+        ConnectorTaskState::Accepted
+    );
+    assert_eq!(
+        effective_task_state(
+            ConnectorTaskLifecycle::ReadyForReview,
+            ConnectorRunLifecycle::Completed,
+            Some(ConnectorResultDecisionStatus::Rejected),
+            false,
+        ),
+        ConnectorTaskState::Rejected
+    );
+    assert_eq!(
+        effective_task_state(
+            ConnectorTaskLifecycle::Active,
+            ConnectorRunLifecycle::Interrupted,
+            None,
+            false,
+        ),
+        ConnectorTaskState::NeedsAttention
+    );
+    assert_eq!(
+        effective_task_state(
+            ConnectorTaskLifecycle::Rejected,
+            ConnectorRunLifecycle::Interrupted,
+            Some(ConnectorResultDecisionStatus::Accepted),
+            true,
+        ),
+        ConnectorTaskState::Cancelled,
+        "cancellation must retain precedence over result and interruption projections"
+    );
+    for (mode, db) in [
+        (ConnectorTaskMode::Normal, "normal"),
+        (ConnectorTaskMode::ReadOnly, "read_only"),
+        (ConnectorTaskMode::InspectLegacy, "inspect"),
+    ] {
+        assert_eq!(mode.as_db(), db);
+        assert_eq!(ConnectorTaskMode::from_db(db, 0).unwrap(), mode);
+    }
+    assert!(ConnectorTaskMode::from_db("future_mode", 0).is_err());
+    assert!(ConnectorTaskMode::requested("inspect").is_err());
+
+    assert_eq!(
+        effective_run_state(ConnectorRunLifecycle::Completed, true),
+        ConnectorRunState::Cancelled
+    );
+
+    for (lifecycle, db) in [
+        (ConnectorTaskLifecycle::Active, "active"),
+        (ConnectorTaskLifecycle::ReadyForReview, "ready_for_review"),
+        (ConnectorTaskLifecycle::Accepted, "accepted"),
+        (ConnectorTaskLifecycle::Rejected, "rejected"),
+    ] {
+        assert_eq!(lifecycle.as_db(), db);
+        assert_eq!(ConnectorTaskLifecycle::from_db(db, 0).unwrap(), lifecycle);
+    }
+    assert!(ConnectorTaskLifecycle::from_db("cancelled", 0).is_err());
+    assert!(ConnectorTaskLifecycle::from_db("needs_attention", 0).is_err());
+
+    for (lifecycle, db) in [
+        (ConnectorRunLifecycle::Running, "running"),
+        (ConnectorRunLifecycle::Completed, "completed"),
+        (ConnectorRunLifecycle::Interrupted, "interrupted"),
+    ] {
+        assert_eq!(lifecycle.as_db(), db);
+        assert_eq!(ConnectorRunLifecycle::from_db(db, 0).unwrap(), lifecycle);
+    }
+    assert!(ConnectorRunLifecycle::from_db("cancelled", 0).is_err());
+
+    for (status, db) in [
+        (ConnectorResultDecisionStatus::Pending, "pending"),
+        (ConnectorResultDecisionStatus::Accepted, "accepted"),
+        (ConnectorResultDecisionStatus::Rejected, "rejected"),
+    ] {
+        assert_eq!(status.as_db(), db);
+        assert_eq!(
+            ConnectorResultDecisionStatus::from_db(db, 0).unwrap(),
+            status
+        );
+    }
+    assert!(ConnectorResultDecisionStatus::from_db("future_state", 0).is_err());
+
+    for (decision, db) in [
+        (ConnectorResultDecision::Accepted, "accepted"),
+        (ConnectorResultDecision::Rejected, "rejected"),
+    ] {
+        assert_eq!(decision.as_db(), db);
+        assert_eq!(ConnectorResultDecision::from_db(db, 0).unwrap(), decision);
+    }
+    assert!(ConnectorResultDecision::from_db("pending", 0).is_err());
+
+    for (state, db) in [
+        (ConnectorResultDecisionRecoveryState::Pending, "pending"),
+        (
+            ConnectorResultDecisionRecoveryState::NeedsAttention,
+            "needs_attention",
+        ),
+    ] {
+        assert_eq!(state.as_db(), db);
+        assert_eq!(
+            ConnectorResultDecisionRecoveryState::from_db(db, 0).unwrap(),
+            state
+        );
+    }
+    assert!(ConnectorResultDecisionRecoveryState::from_db("future_state", 0).is_err());
+
+    for (state, db) in [
+        (ConnectorApprovalState::Pending, "pending"),
+        (ConnectorApprovalState::Approved, "approved"),
+        (ConnectorApprovalState::Denied, "denied"),
+        (ConnectorApprovalState::Consumed, "consumed"),
+        (ConnectorApprovalState::Expired, "expired"),
+    ] {
+        assert_eq!(state.as_db(), db);
+        assert_eq!(ConnectorApprovalState::from_db(db, 0).unwrap(), state);
+    }
+    assert!(ConnectorApprovalState::from_db("future_state", 0).is_err());
+
+    for (state, db) in [
+        (ConnectorEditOperationState::Pending, "pending"),
+        (ConnectorEditOperationState::Completed, "completed"),
+        (ConnectorEditOperationState::Failed, "failed"),
+    ] {
+        assert_eq!(ConnectorEditOperationState::from_db(db, 0).unwrap(), state);
+    }
+    assert!(ConnectorEditOperationState::from_db("future_state", 0).is_err());
+}
+
+#[test]
+fn cancellation_projection_does_not_pollute_persisted_task_or_run_lifecycle() {
+    let (_temp, db) = database();
+    bind(&db, "user:one");
+    let task = start(&db, "user:one", "project cancellation separately");
+    db.finish_connector_task(
+        &task.task_id,
+        "wc_proj_demo",
+        "user:one",
+        NewConnectorResult {
+            result_id: "wc_result_cancel_projection",
+            summary: "done",
+            patch_artifact: None,
+            patch_sha256: None,
+            patch_bytes: 0,
+            changed_paths: &[],
+            validation: &json!({"status": "recorded"}),
+            warnings: &[],
+        },
+        102,
+    )
+    .unwrap();
+    {
+        let conn = db.conn_for_tests();
+        conn.execute(
+            "UPDATE wc_tasks SET status = 'accepted' WHERE id = ?1",
+            [&task.task_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE wc_task_results SET decision_status = 'accepted' WHERE task_id = ?1",
+            [&task.task_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wc_task_events
+                 (id, task_id, run_id, sequence, kind, payload_json, created_at)
+             VALUES (?1, ?2, ?3, 3, 'task_cancelled', '{}', 103)",
+            rusqlite::params![new_id("wc_evt"), task.task_id, task.run_id],
+        )
+        .unwrap();
+    }
+
+    let projected = db
+        .connector_task(&task.task_id, "wc_proj_demo", "user:one")
+        .unwrap();
+    assert_eq!(projected.task_lifecycle, ConnectorTaskLifecycle::Accepted);
+    assert_eq!(projected.run_lifecycle, ConnectorRunLifecycle::Completed);
+    assert_eq!(projected.task_status, ConnectorTaskState::Cancelled);
+    assert_eq!(projected.run_status, ConnectorRunState::Cancelled);
+    let reviewable = db.local_reviewable_tasks("wc_proj_demo", true, 20).unwrap();
+    assert_eq!(reviewable.len(), 1);
+    assert_eq!(reviewable[0].task_status, ConnectorTaskState::Cancelled);
+    let mine = db
+        .connector_tasks_for_subject("wc_proj_demo", "user:one", 20)
+        .unwrap();
+    assert_eq!(mine.len(), 1);
+    assert_eq!(mine[0].task_status, ConnectorTaskState::Cancelled);
+}
+
+#[test]
+fn task_snapshot_json_preserves_legacy_strings_and_hides_persisted_lifecycle_fields() {
+    let (_temp, db) = database();
+    bind(&db, "user:one");
+    let task = start(&db, "user:one", "serialize compatibly");
+    let value = serde_json::to_value(&task).unwrap();
+    assert_eq!(value["mode"], "normal");
+    assert_eq!(value["task_status"], "active");
+    assert_eq!(value["run_status"], "running");
+    assert!(value.get("task_lifecycle").is_none());
+    assert!(value.get("run_lifecycle").is_none());
+    assert_eq!(
+        serde_json::to_value(ConnectorApprovalState::Pending).unwrap(),
+        "pending"
+    );
+    assert_eq!(
+        serde_json::to_value(ConnectorResultDecisionRecoveryState::NeedsAttention).unwrap(),
+        "needs_attention"
+    );
+}
+
+#[test]
+fn corrupt_persisted_task_and_run_lifecycles_fail_closed_on_load() {
+    for target in ["task", "run"] {
+        let (_temp, db) = database();
+        bind(&db, "user:one");
+        let task = start(&db, "user:one", "reject future state");
+        let conn = db.conn_for_tests();
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON;")
+            .unwrap();
+        match target {
+            "task" => {
+                conn.execute(
+                    "UPDATE wc_tasks SET status = 'future_state' WHERE id = ?1",
+                    [&task.task_id],
+                )
+                .unwrap();
+            }
+            "run" => {
+                conn.execute(
+                    "UPDATE wc_runs SET status = 'future_state' WHERE id = ?1",
+                    [&task.run_id],
+                )
+                .unwrap();
+            }
+            _ => unreachable!(),
+        }
+        conn.execute_batch("PRAGMA ignore_check_constraints = OFF;")
+            .unwrap();
+        drop(conn);
+        assert!(
+            db.connector_task(&task.task_id, "wc_proj_demo", "user:one")
+                .is_err(),
+            "{target} future state was accepted"
+        );
+    }
 }
 
 #[test]
@@ -553,7 +828,7 @@ fn raw_command_approval_is_exact_and_consumed_once() {
             103,
         )
         .unwrap();
-    assert_eq!(approved.state, "approved");
+    assert_eq!(approved.state, ConnectorApprovalState::Approved);
 
     let authorized = db
         .request_or_consume_connector_approval(
@@ -638,7 +913,7 @@ fn finishing_task_expires_unconsumed_command_approval() {
     let stored = db
         .local_connector_task_approvals(&task.task_id, "wc_proj_demo")
         .unwrap();
-    assert_eq!(stored[0].state, "expired");
+    assert_eq!(stored[0].state, ConnectorApprovalState::Expired);
     assert!(matches!(
         db.decide_connector_approval(
             &task.task_id,
@@ -665,8 +940,8 @@ fn restart_marks_unfinished_runs_for_attention() {
     let recovered = db
         .connector_task(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap();
-    assert_eq!(recovered.task_status, "needs_attention");
-    assert_eq!(recovered.run_status, "interrupted");
+    assert_eq!(recovered.task_status, ConnectorTaskState::NeedsAttention);
+    assert_eq!(recovered.run_status, ConnectorRunState::Interrupted);
     let preserved = db.connector_preserved_workspaces("wc_proj_demo").unwrap();
     assert_eq!(preserved.len(), 1);
     assert_eq!(preserved[0].task_id, task.task_id);
@@ -678,8 +953,8 @@ fn restart_marks_unfinished_runs_for_attention() {
     let resumed = db
         .resume_connector_task(&task.task_id, "wc_proj_demo", "local_cli", 103)
         .unwrap();
-    assert_eq!(resumed.task_status, "active");
-    assert_eq!(resumed.run_status, "running");
+    assert_eq!(resumed.task_status, ConnectorTaskState::Active);
+    assert_eq!(resumed.run_status, ConnectorRunState::Running);
     let events = db
         .connector_task_events(&task.task_id, "wc_proj_demo", "user:one", 20)
         .unwrap();
@@ -697,7 +972,10 @@ fn interrupted_task_can_be_abandoned_without_capturing_workspace_changes() {
     let result = db
         .abandon_interrupted_connector_task(&task.task_id, "wc_proj_demo", "local_cli", 103)
         .unwrap();
-    assert_eq!(result.decision_status, "rejected");
+    assert_eq!(
+        result.decision_status,
+        ConnectorResultDecisionStatus::Rejected
+    );
     assert_eq!(result.patch_bytes, 0);
     assert_eq!(result.validation["status"], "not_run");
     assert!(db
@@ -707,7 +985,7 @@ fn interrupted_task_can_be_abandoned_without_capturing_workspace_changes() {
     let decided = db
         .connector_task(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap();
-    assert_eq!(decided.task_status, "rejected");
+    assert_eq!(decided.task_status, ConnectorTaskState::Rejected);
     let cursor = db
         .record_connector_workspace_release(
             &task.task_id,
@@ -773,7 +1051,10 @@ fn local_result_decision_becomes_canonical_task_status() {
     let result = db
         .finalize_connector_result_decision(&task.task_id, "wc_proj_demo", result_id, None, 104)
         .unwrap();
-    assert_eq!(result.decision_status, "accepted");
+    assert_eq!(
+        result.decision_status,
+        ConnectorResultDecisionStatus::Accepted
+    );
     assert_eq!(
         result.cleanup_warning.as_deref(),
         Some("slot cleanup needs retry")
@@ -781,7 +1062,7 @@ fn local_result_decision_becomes_canonical_task_status() {
     let decided = db
         .connector_task(&task.task_id, "wc_proj_demo", "user:one")
         .unwrap();
-    assert_eq!(decided.task_status, "accepted");
+    assert_eq!(decided.task_status, ConnectorTaskState::Accepted);
 }
 // -----------------------------------------------------------------------
 // Guidance claim

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,6 +135,8 @@ The Server persists managed accounts, OAuth state, project/task history, and dur
 
 Runner Jobs are reconciled when the same live Runner process reconnects. Ordinary child processes cannot be adopted by an unrelated replacement Runner; specialized detached execution has its own explicit durable ownership path. The stable Runner `client_id` and the current process lease are separate, but the exact lease field is an internal wire detail.
 
+Durable Store aggregates use closed typed Rust lifecycle/state contracts for business authority. SQLite `TEXT` values and `CHECK` constraints remain the persistence encoding, not a second semantic registry. In particular, a Connector Task's persisted lifecycle is distinct from its derived/effective state: cancellation, result decision, and Run interruption are projected from typed durable facts before the existing public strings are serialized. Connector Execution, result/approval, and durable communication lifecycles likewise decode fail-closed from their unchanged SQLite vocabularies.
+
 ## Module map
 
 ```text

--- a/docs/architecture/durable-agent-conversation.md
+++ b/docs/architecture/durable-agent-conversation.md
@@ -32,6 +32,8 @@ The Control-owned SQLite database remains the standalone authoritative transacti
 
 This reuses the existing durable database lifecycle instead of adding another JSON truth or process-local registry. Generic `Database::open` is storage-only: it may run schema migration and owner-independent housekeeping, but it never declares a Wake worker dead or performs takeover recovery. The standalone Control Server holds an exclusive instance guard bound to its exact database state for its full lifetime; crash/takeover Wake reconciliation runs only after a successor acquires that ownership proof. This is deliberately standalone coordination, not a distributed lease or cluster protocol. The schema is concrete to the current communication/wake use case rather than a generic actor/event framework. It does not assume SQLite is process memory, and the domain can later be mapped to another transactional backend without changing its IDs or public semantics.
 
+Agent Endpoint lifecycle, Conversation lifecycle, and Agent Delivery state are closed typed Store contracts. Their existing SQLite strings remain storage encodings and public serialization values; unknown persisted lifecycle values fail closed before authorization or delivery authority is evaluated. This does not change the independently typed Wake or Agent Task/TaskAttempt state machines.
+
 A Message append, sequence allocation, all requested Agent Deliveries, required Wake Intent coalescing/creation, Conversation update, and idempotency record commit in one immediate transaction. A forced Wake insertion failure therefore leaves no Message, no partial Inbox state, no Wake, no consumed sequence, and no stale idempotency outcome.
 
 ## Identity and authorization

--- a/src/mcp/tasks.rs
+++ b/src/mcp/tasks.rs
@@ -9,6 +9,7 @@ use crate::db::ConnectorExecution;
 use crate::model_surface::RuntimeExposure;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use webcodex_store::ConnectorExecutionState;
 
 pub(super) const MCP_TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
 pub(super) const MCP_MISSING_REQUIRED_CLIENT_CAPABILITY: i64 = -32021;
@@ -82,7 +83,7 @@ fn mcp_task_id_is_valid(task_id: &str) -> bool {
 }
 
 fn mcp_task_status(execution: &ConnectorExecution) -> &'static str {
-    if execution.state == "cancelled" {
+    if execution.state == ConnectorExecutionState::Cancelled {
         "cancelled"
     } else if execution.is_terminal() {
         "completed"

--- a/src/mcp_tests/project_connector.rs
+++ b/src/mcp_tests/project_connector.rs
@@ -892,7 +892,7 @@ async fn http_project_connector_2026_tasks_poll_durable_execution_across_reopen(
             },
         )
         .unwrap();
-    assert_eq!(finalized.state, "failed");
+    assert_eq!(finalized.state, crate::db::ConnectorExecutionState::Failed);
     assert_eq!(finalized.mcp_task_result_finalized_at, Some(20));
     assert_eq!(finalized.mcp_task_output_tail.as_ref(), Some(&durable_tail));
     let mut completed = mcp_2026_task_request(
@@ -1075,7 +1075,7 @@ async fn http_project_connector_2026_tasks_cancel_reuses_execution_cancellation(
     );
     assert_eq!(
         db.connector_execution(&task_id).unwrap().state,
-        "cancel_requested"
+        crate::db::ConnectorExecutionState::CancelRequested
     );
 
     db.observe_connector_execution(

--- a/src/project_entry_tests.rs
+++ b/src/project_entry_tests.rs
@@ -2154,7 +2154,10 @@ async fn console_accept_requires_result_id_and_stale_identity_has_no_effect() {
         .db
         .local_connector_task(&task_id, &fixture.connector.context().project_id)
         .unwrap();
-    assert_eq!(task.task_status, "ready_for_review");
+    assert_eq!(
+        task.task_status,
+        webcodex_store::ConnectorTaskState::ReadyForReview
+    );
 }
 
 #[test]

--- a/src/task_cli.rs
+++ b/src/task_cli.rs
@@ -9,6 +9,7 @@ use crate::project_entry::{resolve_local_task_state, LocalTaskState};
 use crate::Database;
 use serde_json::json;
 use std::path::{Path, PathBuf};
+use webcodex_store::{ConnectorApprovalState, ConnectorResultDecisionStatus, ConnectorRunState};
 
 const DEFAULT_PROFILE: &str = "personal";
 const DEFAULT_LIST_LIMIT: usize = 20;
@@ -379,20 +380,19 @@ pub(crate) fn run(command: TaskCliCommand) -> Result<String, String> {
                 .local_connector_task_events(&task_id, &state.logical_project_id, EVENT_LIMIT)
                 .map_err(store_error)?;
             let mut available_actions = Vec::new();
-            if task.run_status == "interrupted" {
+            if task.run_status == ConnectorRunState::Interrupted {
                 available_actions.push(format!("webcodex task resume {task_id}"));
                 available_actions.push(format!("webcodex task reject {task_id}"));
             }
-            if result
-                .as_ref()
-                .is_some_and(|result| result.decision_status == "pending")
-            {
+            if result.as_ref().is_some_and(|result| {
+                result.decision_status == ConnectorResultDecisionStatus::Pending
+            }) {
                 available_actions.push(format!("webcodex task accept {task_id}"));
                 available_actions.push(format!("webcodex task reject {task_id}"));
             }
             for approval in approvals
                 .iter()
-                .filter(|approval| approval.state == "pending")
+                .filter(|approval| approval.state == ConnectorApprovalState::Pending)
             {
                 available_actions.push(format!(
                     "webcodex task approve {task_id} {}",
@@ -839,7 +839,10 @@ mod tests {
             .local_connector_task_result(task_id, &context.project_id)
             .unwrap()
             .unwrap();
-        assert_eq!(decided.decision_status, "accepted");
+        assert_eq!(
+            decided.decision_status,
+            ConnectorResultDecisionStatus::Accepted
+        );
 
         let abandoned_task_id = "wc_task_5123456789abcdef0123456789abcdef";
         let abandoned_run_id = "wc_run_5123456789abcdef0123456789abcdef";

--- a/src/tool_runtime/agent_task.rs
+++ b/src/tool_runtime/agent_task.rs
@@ -15,7 +15,7 @@ use serde_json::{json, to_value, Value};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use webcodex_core::coding_agent::{
-    CodingAgentConfigValue, CodingAgentExecutionState, CodingAgentRunSnapshot, CodingAgentRunState,
+    CodingAgentConfigValue, CodingAgentRunSnapshot, CodingAgentRunState,
 };
 
 const DEFAULT_AGENT_TASK_LIST_LIMIT: usize = 50;
@@ -61,6 +61,7 @@ fn agent_task_recovery_kind(
 #[cfg(test)]
 mod observation_tests {
     use super::*;
+    use webcodex_core::coding_agent::CodingAgentExecutionState;
 
     #[test]
     fn coding_run_observation_revision_overflow_fails_closed() {
@@ -114,27 +115,6 @@ fn serialized_task_success<T: Serialize>(value: T) -> ToolResult {
             }),
         )
         .with_recovery(RecoveryKind::NoAction, None),
-    }
-}
-
-fn coding_run_state_name(state: &CodingAgentRunState) -> &'static str {
-    match state {
-        CodingAgentRunState::Starting => "starting",
-        CodingAgentRunState::Running => "running",
-        CodingAgentRunState::WaitingPermission => "waiting_permission",
-        CodingAgentRunState::Completed => "completed",
-        CodingAgentRunState::Failed => "failed",
-        CodingAgentRunState::Cancelled => "cancelled",
-        CodingAgentRunState::Lost => "lost",
-    }
-}
-
-fn coding_execution_state_name(state: CodingAgentExecutionState) -> &'static str {
-    match state {
-        CodingAgentExecutionState::NotStarted => "not_started",
-        CodingAgentExecutionState::Started => "started",
-        CodingAgentExecutionState::OutcomeUnknown => "outcome_unknown",
-        CodingAgentExecutionState::Completed => "completed",
     }
 }
 
@@ -203,8 +183,8 @@ fn coding_run_observation(
         provider_instance_id: run.provider_instance_id.clone(),
         authority_fingerprint: run.authority_fingerprint.clone(),
         coding_agent_intent_fingerprint: run.intent_fingerprint.clone(),
-        run_state: coding_run_state_name(&run.state).to_string(),
-        execution_state: coding_execution_state_name(run.execution_state).to_string(),
+        run_state: run.state.clone(),
+        execution_state: run.execution_state,
         observation_revision,
         terminal_stop_reason: bounded_optional_terminal(
             run.terminal
@@ -232,14 +212,16 @@ fn binding_execution_status(binding: &AgentTaskCodingRunBindingRecord) -> &'stat
         }
         AgentTaskCodingRunDispatchState::OutcomeUnknown => "outcome_unknown",
         AgentTaskCodingRunDispatchState::Terminal => "terminal",
-        AgentTaskCodingRunDispatchState::Bound => {
-            match binding.last_observed_run_state.as_deref() {
-                Some("waiting_permission") => "waiting_permission",
-                Some("lost") => "outcome_unknown",
-                Some("completed" | "failed" | "cancelled") => "terminal",
-                _ => "active",
-            }
-        }
+        AgentTaskCodingRunDispatchState::Bound => match binding.last_observed_run_state.as_ref() {
+            Some(CodingAgentRunState::WaitingPermission) => "waiting_permission",
+            Some(CodingAgentRunState::Lost) => "outcome_unknown",
+            Some(
+                CodingAgentRunState::Completed
+                | CodingAgentRunState::Failed
+                | CodingAgentRunState::Cancelled,
+            ) => "terminal",
+            _ => "active",
+        },
     }
 }
 
@@ -249,12 +231,15 @@ fn binding_recovery_kind(binding: &AgentTaskCodingRunBindingRecord) -> &'static 
         | AgentTaskCodingRunDispatchState::NotStarted
         | AgentTaskCodingRunDispatchState::Terminal => "none",
         AgentTaskCodingRunDispatchState::OutcomeUnknown => "reconcile",
-        AgentTaskCodingRunDispatchState::Bound => {
-            match binding.last_observed_run_state.as_deref() {
-                Some("lost" | "completed" | "failed" | "cancelled") => "reconcile",
-                _ => "observe",
-            }
-        }
+        AgentTaskCodingRunDispatchState::Bound => match binding.last_observed_run_state.as_ref() {
+            Some(
+                CodingAgentRunState::Lost
+                | CodingAgentRunState::Completed
+                | CodingAgentRunState::Failed
+                | CodingAgentRunState::Cancelled,
+            ) => "reconcile",
+            _ => "observe",
+        },
     }
 }
 
@@ -270,7 +255,7 @@ fn coding_run_binding_projection(
         "project": binding.runtime_project_id,
         "provider_id": binding.provider_id,
         "dispatch_state": binding.dispatch_state.as_str(),
-        "run_state": binding.last_observed_run_state,
+        "run_state": binding.last_observed_run_state.as_ref(),
         "execution_state": binding.last_observed_execution_state,
         "execution_status": binding_execution_status(binding),
         "execution_recovery": binding_recovery_kind(binding),
@@ -310,11 +295,7 @@ fn coding_run_failure_result(
 }
 
 fn coding_run_terminal_result(run: &CodingAgentRunSnapshot) -> String {
-    let mut result = format!(
-        "CodingAgentRun {} {}",
-        run.run_id,
-        coding_run_state_name(&run.state)
-    );
+    let mut result = format!("CodingAgentRun {} {}", run.run_id, run.state.as_str());
     if let Some(terminal) = run.terminal.as_ref() {
         if let Some(message) = terminal.message.as_deref() {
             result.push_str(": ");
@@ -680,8 +661,12 @@ impl ToolRuntime {
         };
         if observed_binding.last_observation_revision != Some(observation.observation_revision)
             || !matches!(
-                observed_binding.last_observed_run_state.as_deref(),
-                Some("completed" | "failed" | "cancelled")
+                observed_binding.last_observed_run_state.as_ref(),
+                Some(
+                    CodingAgentRunState::Completed
+                        | CodingAgentRunState::Failed
+                        | CodingAgentRunState::Cancelled
+                )
             )
         {
             return ToolResult::ok(coding_run_binding_projection(

--- a/src/tool_runtime/communication.rs
+++ b/src/tool_runtime/communication.rs
@@ -1,9 +1,9 @@
 use super::{RecoveryKind, ToolResult, ToolRuntime};
 use crate::auth::{AuthContext, AuthKind};
 use crate::db::{
-    AgentProfilePatch, AgentWakeState, CommunicationPrincipal, CommunicationStoreError,
-    ConversationAccess, NewAgentEndpoint, NewAgentIdentity, NewConversation,
-    NewConversationMessage, COMMUNICATION_PRINCIPAL_DIGEST_PREFIX,
+    AgentEndpointLifecycle, AgentProfilePatch, AgentWakeState, CommunicationPrincipal,
+    CommunicationStoreError, ConversationAccess, NewAgentEndpoint, NewAgentIdentity,
+    NewConversation, NewConversationMessage, COMMUNICATION_PRINCIPAL_DIGEST_PREFIX,
 };
 use serde::Serialize;
 use serde_json::{json, to_value};
@@ -761,8 +761,8 @@ impl ToolRuntime {
             });
         // Visible capability is the conjunction of durable Endpoint state and
         // a current callable process-local registration.
-        bootstrap.endpoint.wake_capable &=
-            binding.adapter_registered && bootstrap.endpoint.lifecycle == "attached";
+        bootstrap.endpoint.wake_capable &= binding.adapter_registered
+            && bootstrap.endpoint.lifecycle == AgentEndpointLifecycle::Attached;
         let wake_reply = bootstrap
             .wake
             .as_ref()


### PR DESCRIPTION
## Summary

This is an authority/ownership closure, not a mechanical String-to-enum cleanup. Several durable Store aggregates had closed SQLite vocabularies while Rust business logic still interpreted arbitrary strings, and Connector Task/Run snapshots also mixed persisted lifecycle with derived/effective state in the same fields.

### Connector Task / Run

- Added closed typed `ConnectorTaskMode`, persisted `ConnectorTaskLifecycle`, effective `ConnectorTaskState`, persisted `ConnectorRunLifecycle`, and effective `ConnectorRunState` contracts.
- `load_task()` now reads durable source facts and computes effective Task/Run state in canonical Rust projection code.
- Preserved the existing effective Task precedence: cancellation > accepted/rejected result decision > interrupted Run > persisted Task lifecycle.
- `Cancelled` / `NeedsAttention` are no longer values of the persisted Task lifecycle, and effective Run `Cancelled` cannot enter `wc_runs.status`.
- Legacy pre-0.4 `inspect` tasks remain readable for recovery/rejection but cannot be newly created or resumed for execution; `inspect` is not silently mapped to `read_only`.
- Bounded list queries retain SQL CASE expressions only as query optimization for filtering/sorting. They also read the source facts and fail if the SQL projection diverges from the canonical Rust projection.

### Connector Execution

- Added typed `ConnectorExecutionKind` and `ConnectorExecutionState` and propagated them through Store and connector-runtime authority paths.
- Preserved the existing `RunnerJobLifecycle -> ConnectorExecutionState` observation mapping, queue deadline/cancellation behavior, validation-progress protocol, recovery semantics, and failure/event contracts.
- Active states remain Accepted/Queued/Starting/Running/CancelRequested.
- `Unknown` remains non-active but conservatively `blocks_finish = true`.

### Result / approval / edit operation

- Typed result decision status, decision intent, decision recovery state, and approval state while preserving existing transaction/CAS/idempotency boundaries.
- `wc_edit_operations.state` is also typed because it is authority-bearing: it controls pending/replay/retry behavior.
- Unknown persisted lifecycle values fail closed during DB row parsing.

### Durable communication

- Typed Agent Endpoint lifecycle, Conversation lifecycle, and Message Delivery state.
- Endpoint authority still requires Attached + live lease + current controller generation.
- Closed Conversations still reject new messages.
- Delivery remains exact queued -> consumed CAS with existing ordering/wake coupling.
- A Communication Wake-reply fence now reuses the already-existing typed `AgentWakeState` parser instead of dispatching on raw strings; the Agent Wake state machine itself was not redesigned.

### Compatibility / scope

- SQLite TEXT values and CHECK constraints are unchanged; no schema migration or version bump.
- Existing public JSON field names and string values are unchanged. Internal persisted Task/Run lifecycle fields are not serialized.
- SQL literals remain where they are the persistence vocabulary or indexed/CAS predicates; dynamic lifecycle binds use typed encodings.
- Existing Agent Task / TaskAttempt / Agent Wake lifecycle models were not refactored.
- Project Memory `identity_state` was intentionally not changed.
- Runner Project/Computer payloads, Runner protocol/registry/Job model, Runtime Console, RouteSpec/OpenAPI, ToolDefinition, ToolSessionEvidencePolicy, Tool Audit, ToolCall, and MCP surface design remain out of scope. Downstream files touched outside Store only consume the new typed Store contract without redesigning those surfaces.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p webcodex-store --all-targets` — pass, 0 warnings
- `cargo test --quiet -p webcodex-store` — 158 passed, 0 failed
- focused Store coverage:
  - execution lifecycle contract — 1/1
  - Task/Run persisted-vs-effective contract — 1/1
  - corrupt DB load-path tests — 3/3
  - approval — 2/2
  - decision — 1/1
  - continuation delivery — 8/8
  - communication — 9/9
- `cargo check -p webcodex-connector-runtime --all-targets` — pass, 0 warnings
- focused connector-runtime legacy inspect recovery/rejection — 1/1
- focused connector-runtime result finalization recovery/CAS — 1/1
- `cargo check -p webcodex --all-targets` — pass; one pre-existing unrelated unused-import warning in unchanged `src/tool_runtime/files.rs`
- focused root MCP execution cancellation — 1/1
- focused root local result accept — 1/1
- focused root durable communication continuation — 1/1
- `git diff --check`
- `crates/webcodex-store/src/schema.rs` is identical to base

## Architecture closeout

A repo-wide read-only sanity scan found no newly identified issue at the same P0/P1 architecture-debt level. Remaining raw strings in the reviewed areas are persistence/query literals, public/wire labels, audit/session metadata, or validated external observation encoding rather than a second durable business-state authority.

This closes the currently identified core architecture-debt program. Remaining cleanup is maintenance-level and should be performed opportunistically with feature work.