### PR TITLE
Fix canonical target validation for structured file edits

### DIFF
--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -176,6 +176,9 @@ mod shell_job_tree;
 mod shell_profiles;
 #[path = "main_tests/structured_delete.rs"]
 mod structured_delete;
+#[cfg(unix)]
+#[path = "main_tests/structured_write_paths.rs"]
+mod structured_write_paths;
 #[path = "main_tests/write_project_file.rs"]
 mod write_project_file;
 

--- a/crates/webcodex-runner/src/main_tests/structured_write_paths.rs
+++ b/crates/webcodex-runner/src/main_tests/structured_write_paths.rs
@@ -1,0 +1,130 @@
+use super::*;
+
+#[test]
+fn file_structured_edits_reject_canonical_boundary_escapes() {
+    for (alias, expected_error) in [("external", "escapes project"), ("protected", "sensitive")] {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(project.join(".git")).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("existing.txt"), "original\n").unwrap();
+        std::fs::write(project.join(".git/existing.txt"), "original\n").unwrap();
+        std::fs::write(project.join("source.txt"), "original\n").unwrap();
+        std::os::unix::fs::symlink(&outside, project.join("external")).unwrap();
+        std::os::unix::fs::symlink(".git", project.join("protected")).unwrap();
+        // Both projects are allowed to the Runner; each request must still stay
+        // inside its own project and outside that project's protected paths.
+        let policy = project_policy(temp.path());
+        let target = format!("{alias}/nested/new.txt");
+        let existing = format!("{alias}/existing.txt");
+        let hash = sha256_hex_bytes(b"original\n");
+        let cases = vec![
+            (
+                "file_write_project_file",
+                target.clone(),
+                serde_json::json!({"content": "replacement\n"}),
+            ),
+            (
+                "file_write_project_file",
+                existing.clone(),
+                serde_json::json!({"content": "replacement\n", "overwrite": true, "expected_sha256": hash}),
+            ),
+            (
+                "file_apply_text_edits",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"changes": [
+                    {"kind": "create", "path": "would-create.txt", "content": "first\n"},
+                    {"kind": "create", "path": target, "content": "replacement\n"}
+                ]}),
+            ),
+            (
+                "file_apply_text_edits",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"changes": [{"kind": "edit", "path": existing, "expected_sha256": hash,
+                    "edits": [{"kind": "replace_exact", "old_text": "original", "new_text": "replacement"}]}]}),
+            ),
+            (
+                "file_apply_text_edits",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"changes": [{"kind": "delete", "path": existing, "expected_sha256": hash}]}),
+            ),
+            (
+                "file_apply_text_edits",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"changes": [{"kind": "rename", "path": "source.txt", "to_path": target, "expected_sha256": hash}]}),
+            ),
+            (
+                "file_apply_patch",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"patch": format!("*** Begin Patch\n*** Add File: would-create.txt\n+first\n*** Add File: {target}\n+replacement\n*** End Patch")}),
+            ),
+            (
+                "file_apply_patch",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"patch": format!("*** Begin Patch\n*** Update File: {existing}\n-original\n+replacement\n*** End Patch")}),
+            ),
+            (
+                "file_apply_patch",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"patch": format!("*** Begin Patch\n*** Delete File: {existing}\n*** End Patch")}),
+            ),
+            (
+                "file_apply_patch",
+                "routing-placeholder".to_string(),
+                serde_json::json!({"patch": format!("*** Begin Patch\n*** Update File: source.txt\n*** Move to: {target}\n-original\n+replacement\n*** End Patch")}),
+            ),
+        ];
+
+        for (kind, path, payload) in cases {
+            let output = line_edit_json(handle_file_request(
+                &policy,
+                &json_file_op_request(&project, kind, &path, payload),
+            ));
+            assert!(
+                output["error"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains(expected_error),
+                "{kind} accepted {alias}: {output}"
+            );
+            assert_eq!(output["state_changed"], false);
+            assert_eq!(
+                std::fs::read(outside.join("existing.txt")).unwrap(),
+                b"original\n"
+            );
+            assert_eq!(
+                std::fs::read(project.join(".git/existing.txt")).unwrap(),
+                b"original\n"
+            );
+            assert_eq!(
+                std::fs::read(project.join("source.txt")).unwrap(),
+                b"original\n"
+            );
+            assert!(!outside.join("nested").exists());
+            assert!(!project.join(".git/nested").exists());
+            assert!(!project.join("would-create.txt").exists());
+        }
+    }
+}
+
+#[test]
+fn file_structured_edits_allow_internal_directory_aliases() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir(root.path().join("src")).unwrap();
+    std::os::unix::fs::symlink("src", root.path().join("alias")).unwrap();
+    let output = line_edit_json(handle_file_request(
+        &project_policy(root.path()),
+        &json_file_op_request(
+            root.path(),
+            "file_write_project_file",
+            "alias/nested/new.txt",
+            serde_json::json!({"content": "created\n"}),
+        ),
+    ));
+    assert_eq!(output["created"], true, "{output}");
+    assert_eq!(
+        std::fs::read(root.path().join("src/nested/new.txt")).unwrap(),
+        b"created\n"
+    );
+}

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -39,6 +39,34 @@ pub(crate) fn validate_structured_edit_runner_path(path: &str) -> Result<(), Str
     Ok(())
 }
 
+fn checked_structured_edit_target(cwd: Option<&str>, resolved: &Path) -> Result<PathBuf, String> {
+    let root = cwd.ok_or_else(|| "structured edit request missing project root".to_string())?;
+    let root = std::fs::canonicalize(root)
+        .map_err(|error| format!("project root does not exist: {error}"))?;
+    let parent = resolved
+        .parent()
+        .ok_or_else(|| "target path has no parent directory".to_string())?;
+    let name = resolved
+        .file_name()
+        .ok_or_else(|| "target path has no file name".to_string())?;
+    // Resolve parent aliases before planning or creating directories, including
+    // any not-yet-created suffix. Keep the final component so batch operations
+    // retain their existing rejection of symlink files.
+    let target = canonical_batch_identity(parent)?.join(name);
+    let identity = canonical_batch_identity(&target)?;
+    // Check both the directory entry that will be changed and the target that
+    // a content/hash read would follow if the final component is a symlink.
+    for candidate in [&target, &identity] {
+        let relative = candidate
+            .strip_prefix(&root)
+            .map_err(|_| "structured edit path escapes project root".to_string())?;
+        if is_sensitive_edit_path(&relative.to_string_lossy()) {
+            return Err("refusing to edit sensitive path".to_string());
+        }
+    }
+    Ok(target)
+}
+
 fn write_file_atomic_strict(path: &Path, content: &str, tmp_prefix: &str) -> Result<(), String> {
     let parent = path
         .parent()
@@ -222,6 +250,16 @@ pub(crate) fn handle_write_project_file_request(
             )
         }
     };
+    let target = match checked_structured_edit_target(request.cwd.as_deref(), resolved) {
+        Ok(target) => target,
+        Err(error) => {
+            return line_edit_stdout(
+                write_project_file_error(serde_json::json!(path), error),
+                start,
+            )
+        }
+    };
+    let resolved = target.as_path();
     let exists = std::fs::symlink_metadata(resolved).is_ok();
     if exists && !overwrite {
         return line_edit_stdout(
@@ -1184,8 +1222,9 @@ fn resolve_unique_patch_path(
             start,
         ));
     }
-    let resolved =
-        resolve_requested_path(policy, request.cwd.as_deref(), path).map_err(|error| {
+    let resolved = resolve_requested_path(policy, request.cwd.as_deref(), path)
+        .and_then(|resolved| checked_structured_edit_target(request.cwd.as_deref(), &resolved))
+        .map_err(|error| {
             batch_error(
                 Some(index),
                 Some(kind),
@@ -1627,7 +1666,9 @@ pub(crate) fn handle_apply_text_edits_file_request(
                 start,
             );
         }
-        let resolved = match resolve_requested_path(policy, request.cwd.as_deref(), &change.path) {
+        let resolved = match resolve_requested_path(policy, request.cwd.as_deref(), &change.path)
+            .and_then(|resolved| checked_structured_edit_target(request.cwd.as_deref(), &resolved))
+        {
             Ok(path) => path,
             Err(error) => {
                 return batch_error(
@@ -1674,7 +1715,9 @@ pub(crate) fn handle_apply_text_edits_file_request(
                     start,
                 );
             }
-            match resolve_requested_path(policy, request.cwd.as_deref(), to_path) {
+            match resolve_requested_path(policy, request.cwd.as_deref(), to_path).and_then(
+                |resolved| checked_structured_edit_target(request.cwd.as_deref(), &resolved),
+            ) {
                 Ok(path) => {
                     let identity = match canonical_batch_identity(&path) {
                         Ok(identity) => identity,


### PR DESCRIPTION
Fixes #363.

Structured edit paths are now checked against the canonical project root and protected-path policy before planning or writing. The check covers the directory entry being changed and the target followed by content/hash reads. Subsequent I/O uses the resolved parent path while retaining existing final-component symlink handling.

Applies to `write_project_file` and all source/destination paths in `apply_patch` and `apply_text_edits`. Regression fixtures cover rejected creates, guarded overwrites, edits, deletes, and moves, transaction preflight with no partial effects, and a permitted internal directory alias.

Validation: the new boundary test failed on the base implementation; `cargo test --offline --locked -p webcodex-runner --bin webcodex-runner file_` passes in an isolated target directory (124 passed, 1 existing ignored test). `cargo fmt --all -- --check` and `git diff --check` pass. Symlink regression fixtures ran on macOS/Unix; Windows execution is left to native CI. This is canonical path validation, not a new OS sandbox or a claim of race-free filesystem transactions.
