### PR TITLE
Check canonical sensitive paths before reading artifacts

### DIFF
--- a/crates/webcodex-runner/src/main_tests/artifact_read.rs
+++ b/crates/webcodex-runner/src/main_tests/artifact_read.rs
@@ -1,5 +1,72 @@
 use super::*;
 
+#[cfg(unix)]
+#[test]
+fn file_project_artifact_reads_reject_canonical_sensitive_paths() {
+    let root = tempfile::tempdir().unwrap();
+    let policy = project_policy(root.path());
+    let content = b"fixture content";
+    std::fs::write(root.path().join(".env"), content).unwrap();
+    std::fs::create_dir(root.path().join(".git")).unwrap();
+    std::fs::write(root.path().join(".git/config"), content).unwrap();
+    std::os::unix::fs::symlink(".env", root.path().join("report.txt")).unwrap();
+    std::os::unix::fs::symlink(".git", root.path().join("reports")).unwrap();
+
+    for path in ["report.txt", "reports/config"] {
+        for kind in [
+            "file_read_project_artifact",
+            "file_read_project_artifact_metadata",
+            "file_read_project_artifact_export_chunk",
+        ] {
+            let output = line_edit_json(handle_file_request(
+                &policy,
+                &json_file_op_request(
+                    root.path(),
+                    kind,
+                    path,
+                    serde_json::json!({
+                        "expected_file_bytes": content.len(),
+                        "offset": 0,
+                        "length": content.len(),
+                    }),
+                ),
+            ));
+            assert!(
+                output["error"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("sensitive"),
+                "{kind} accepted {path}: {output}"
+            );
+            assert!(output["content_base64"]
+                .as_str()
+                .unwrap_or_default()
+                .is_empty());
+            assert!(output["sha256"].is_null());
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn file_project_artifact_reads_allow_non_sensitive_internal_aliases() {
+    let root = tempfile::tempdir().unwrap();
+    let policy = project_policy(root.path());
+    std::fs::write(root.path().join("report.txt"), b"fixture content").unwrap();
+    std::os::unix::fs::symlink("report.txt", root.path().join("alias.txt")).unwrap();
+    let output = line_edit_json(handle_file_request(
+        &policy,
+        &json_file_op_request(
+            root.path(),
+            "file_read_project_artifact",
+            "alias.txt",
+            serde_json::json!({}),
+        ),
+    ));
+    assert!(output.get("error").is_none(), "{output}");
+    assert_eq!(output["content_base64"], "Zml4dHVyZSBjb250ZW50");
+}
+
 fn fake_zip_eocd_with_entries(entries: u16) -> Vec<u8> {
     let mut bytes = b"PK\x05\x06".to_vec();
     bytes.extend_from_slice(&[0, 0]); // disk number

--- a/crates/webcodex-runner/src/webcodex_runner/artifacts.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/artifacts.rs
@@ -184,12 +184,18 @@ fn project_root(request: &RunnerFilePayload) -> Result<std::path::PathBuf, Strin
     std::fs::canonicalize(cwd).map_err(|e| format!("project root does not exist: {}", e))
 }
 
-fn ensure_existing_target_in_project_root(resolved: &Path, root: &Path) -> Result<(), String> {
+fn resolve_existing_target_in_project_root(
+    resolved: &Path,
+    root: &Path,
+) -> Result<PathBuf, String> {
     let target = std::fs::canonicalize(resolved).map_err(|e| format!("read failed: {}", e))?;
-    if target != root && !target.starts_with(root) {
-        return Err("artifact path escapes project root".to_string());
+    let relative = target
+        .strip_prefix(root)
+        .map_err(|_| "artifact path escapes project root".to_string())?;
+    if is_sensitive_artifact_path(&relative.to_string_lossy()) {
+        return Err("refusing sensitive artifact target".to_string());
     }
-    Ok(())
+    Ok(target)
 }
 
 fn ensure_parent_in_project_root(resolved: &Path, root: &Path) -> Result<(), String> {
@@ -2213,23 +2219,27 @@ fn handle_read_project_artifact_metadata(
         Ok(value) => value,
         Err(e) => return line_edit_stdout(metadata_error(Some(path), e), start),
     };
-    if let Err(e) = ensure_existing_target_in_project_root(resolved, &root) {
-        let target_missing = matches!(
-            std::fs::symlink_metadata(resolved),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound
-        );
-        if allow_missing && target_missing {
-            return line_edit_stdout(
-                json!({
-                    "path": path,
-                    "exists": false,
-                    "missing": true,
-                }),
-                start,
+    let target = match resolve_existing_target_in_project_root(resolved, &root) {
+        Ok(target) => target,
+        Err(e) => {
+            let target_missing = matches!(
+                std::fs::symlink_metadata(resolved),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound
             );
+            if allow_missing && target_missing {
+                return line_edit_stdout(
+                    json!({
+                        "path": path,
+                        "exists": false,
+                        "missing": true,
+                    }),
+                    start,
+                );
+            }
+            return line_edit_stdout(metadata_error(Some(path), e), start);
         }
-        return line_edit_stdout(metadata_error(Some(path), e), start);
-    }
+    };
+    let resolved = target.as_path();
     let max_bytes = match parse_usize_field(&payload, "max_bytes", DEFAULT_MAX_ARTIFACT_BYTES) {
         Ok(value) => value,
         Err(e) => return line_edit_stdout(metadata_error(Some(path), e), start),
@@ -2361,10 +2371,14 @@ fn handle_read_project_artifact_export_chunk(
         Ok(root) => root,
         Err(e) => return line_edit_stdout(read_error(Some(path), e), start),
     };
-    if let Err(e) = ensure_existing_target_in_project_root(resolved, &root) {
-        let msg = e.replacen("read failed", "stat failed", 1);
-        return line_edit_stdout(read_error(Some(path), msg), start);
-    }
+    let target = match resolve_existing_target_in_project_root(resolved, &root) {
+        Ok(target) => target,
+        Err(e) => {
+            let msg = e.replacen("read failed", "stat failed", 1);
+            return line_edit_stdout(read_error(Some(path), msg), start);
+        }
+    };
+    let resolved = target.as_path();
     if payload.get("expected_file_bytes").is_none() {
         return line_edit_stdout(
             read_error(Some(path), "expected_file_bytes is required"),
@@ -2502,10 +2516,14 @@ fn handle_read_project_artifact(
         Ok(root) => root,
         Err(e) => return line_edit_stdout(read_error(Some(path), e), start),
     };
-    if let Err(e) = ensure_existing_target_in_project_root(resolved, &root) {
-        let msg = e.replacen("read failed", "stat failed", 1);
-        return line_edit_stdout(read_error(Some(path), msg), start);
-    }
+    let target = match resolve_existing_target_in_project_root(resolved, &root) {
+        Ok(target) => target,
+        Err(e) => {
+            let msg = e.replacen("read failed", "stat failed", 1);
+            return line_edit_stdout(read_error(Some(path), msg), start);
+        }
+    };
+    let resolved = target.as_path();
     let offset = match parse_usize_field(&payload, "offset", 0) {
         Ok(value) => value,
         Err(e) => return line_edit_stdout(read_error(Some(path), e), start),


### PR DESCRIPTION
Fixes #364.

Artifact read, metadata, and export-chunk handlers now validate the canonical target's project-relative path against the shared sensitive-artifact policy. They use that resolved path for subsequent I/O instead of resolving the submitted alias again.

Adds Runner-dispatch regression tests for protected targets reached through file and directory aliases across all three read surfaces, plus a permitted internal alias. Existing missing-file metadata behavior and output schemas are preserved.

Validation: the new negative test failed on the base implementation; `cargo test --offline --locked -p webcodex-runner --bin webcodex-runner artifact` passes in an isolated target directory (43 passed). `cargo fmt --all -- --check` and `git diff --check` pass. Symlink fixtures ran on macOS/Unix; no live artifact transport or Windows execution was performed.
