### PR TITLE
Preserve caller authorization in REST job cancellation

### DIFF
--- a/src/runtime_http/jobs.rs
+++ b/src/runtime_http/jobs.rs
@@ -142,7 +142,8 @@ pub async fn job_stop(req: &mut Request, depot: &mut Depot, res: &mut Response) 
     let Some(body) = parse_json_body::<JobStopRequest>(req, res).await else {
         return;
     };
-    let result = runtime.stop_job(body.job_id).await;
+    let auth = depot.obtain::<crate::auth::AuthContext>().ok().cloned();
+    let result = runtime.stop_job(body.job_id, auth.as_ref()).await;
     render_result(res, &audit, "job_stop", None, result);
 }
 

--- a/src/runtime_http/tests/jobs_tests.rs
+++ b/src/runtime_http/tests/jobs_tests.rs
@@ -4,6 +4,159 @@ use salvo::Service;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
+#[tokio::test]
+async fn http_job_stop_preserves_owner_and_scope_boundaries() {
+    use crate::runner_protocol::{
+        RunnerCapabilities, RunnerJobUpdateRequest, RunnerPollRequest, RunnerRegisterRequest,
+        ShellJobOpRequest,
+    };
+
+    let _env = crate::auth::AuthEnvGuard::auth_required();
+    let config = super::test_config_oauth2(Some("secret"));
+    let (_temp, db) = super::test_db();
+    let alice = super::seed_user(&db, "alice");
+    let bob = super::seed_user(&db, "bob");
+    let alice_client = super::seed_oauth_client(&db, &alice);
+    let bob_client = super::seed_oauth_client(&db, &bob);
+    let alice_token = super::seed_oauth_access_token_with_shared_key_hash(
+        &db,
+        &alice_client,
+        &alice,
+        "job:run",
+        None,
+    );
+    let bob_token = super::seed_oauth_access_token_with_shared_key_hash(
+        &db,
+        &bob_client,
+        &bob,
+        "job:run",
+        None,
+    );
+    let read_token = super::seed_oauth_access_token_with_shared_key_hash(
+        &db,
+        &alice_client,
+        &alice,
+        "runtime:read",
+        None,
+    );
+    let registry = Arc::new(super::RunnerRegistry::default());
+    registry
+        .register(crate::test_support::current_runner_registration(
+            RunnerRegisterRequest {
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: None,
+                job_inventory: None,
+                coding_agent_providers: None,
+                coding_agent_inventory: None,
+                client_id: "owner-runner".to_string(),
+                runner_instance_id: "owner-instance".to_string(),
+                runner_protocol_generation: crate::runner_protocol::RUNNER_PROTOCOL_GENERATION_V2,
+                display_name: None,
+                owner: Some("alice".to_string()),
+                hostname: None,
+                host_context: None,
+                capabilities: RunnerCapabilities::default(),
+                policy: None,
+            },
+        ))
+        .await
+        .unwrap();
+    let runtime = Arc::new(
+        crate::tool_runtime::ToolRuntime::new_for_tests_with_runner_registry(registry.clone()),
+    );
+    let service = Service::new(super::build_projects_router(config, db, runtime));
+    let poll = RunnerPollRequest {
+        client_id: "owner-runner".to_string(),
+        runner_instance_id: "owner-instance".to_string(),
+    };
+
+    for running in [false, true] {
+        let job = registry
+            .start_job(
+                serde_json::from_value::<ShellJobOpRequest>(json!({
+                    "op": "start",
+                    "client_id": "owner-runner",
+                    "command": "fixture-only",
+                    "timeout_secs": 30
+                }))
+                .unwrap(),
+                "alice".to_string(),
+            )
+            .await
+            .unwrap();
+        if running {
+            let request = registry.poll(poll.clone()).await.unwrap().unwrap();
+            registry
+                .update_job(
+                    serde_json::from_value::<RunnerJobUpdateRequest>(json!({
+                        "client_id": "owner-runner",
+                        "agent_instance_id": "owner-instance",
+                        "job_id": job.job_id,
+                        "request_id": request.request_id,
+                        "status": "running",
+                        "update_seq": 1,
+                        "finished": false
+                    }))
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+        }
+        let status_before = registry.get_job(&job.job_id).await.unwrap().status;
+        let body = json!({"job_id": job.job_id});
+
+        let response = TestClient::post("http://localhost/api/jobs/stop")
+            .json(&body)
+            .send(&service)
+            .await;
+        assert_eq!(super::effective_status(&response), StatusCode::UNAUTHORIZED);
+
+        let response = TestClient::post("http://localhost/api/jobs/stop")
+            .bearer_auth(&read_token)
+            .json(&body)
+            .send(&service)
+            .await;
+        assert_eq!(super::effective_status(&response), StatusCode::FORBIDDEN);
+
+        let mut response = TestClient::post("http://localhost/api/jobs/stop")
+            .bearer_auth(&bob_token)
+            .json(&body)
+            .send(&service)
+            .await;
+        let output: Value = response.take_json().await.unwrap();
+        assert_eq!(output["success"], false, "{output}");
+        assert!(output["error"].as_str().unwrap().contains("unknown job"));
+        assert_eq!(
+            registry.get_job(&job.job_id).await.unwrap().status,
+            status_before
+        );
+        if running {
+            assert!(registry.poll(poll.clone()).await.unwrap().is_none());
+        }
+
+        let mut response = TestClient::post("http://localhost/api/jobs/stop")
+            .bearer_auth(&alice_token)
+            .json(&body)
+            .send(&service)
+            .await;
+        assert_eq!(super::effective_status(&response), StatusCode::OK);
+        let output: Value = response.take_json().await.unwrap();
+        assert_eq!(output["success"], true, "{output}");
+        if running {
+            let stop = registry.poll(poll.clone()).await.unwrap().unwrap();
+            assert_eq!(stop.kind, "stop_job");
+            assert_eq!(stop.job_id.as_deref(), Some(job.job_id.as_str()));
+        } else {
+            assert_eq!(
+                registry.get_job(&job.job_id).await.unwrap().status,
+                "stopped"
+            );
+            assert!(registry.poll(poll.clone()).await.unwrap().is_none());
+        }
+    }
+}
+
 // =========================================================================
 // runProjectShellCommand
 // =========================================================================

--- a/src/runtime_http_tests.rs
+++ b/src/runtime_http_tests.rs
@@ -251,6 +251,7 @@ fn build_projects_router(
                     Router::with_path("projects/git_diff_summary").post(projects_git_diff_summary),
                 )
                 .push(Router::with_path("jobs/list").post(jobs_list))
+                .push(Router::with_path("jobs/stop").post(job_stop))
                 .push(Router::with_path("jobs/tail").post(job_tail))
                 .push(Router::with_path("runtime/status").post(runtime_status)),
         )

--- a/src/tool_runtime/jobs.rs
+++ b/src/tool_runtime/jobs.rs
@@ -1829,13 +1829,17 @@ impl ToolRuntime {
     /// Hidden REST compatibility wrapper for stopping a runtime Job by id.
     /// Registered Project Jobs are Runner-owned, so this delegates directly to
     /// the Runner Job registry and never attempts Server-local process control.
-    pub async fn stop_job(&self, job_id: String) -> ToolResult {
+    pub async fn stop_job(&self, job_id: String, auth: Option<&AuthContext>) -> ToolResult {
         if !is_safe_job_id(&job_id) {
             return ToolResult::err("invalid job id");
         }
         match self
             .runner_registry
-            .stop_job(&job_id, "runtime_http".to_string())
+            .stop_job_for_auth(
+                crate::runner_http::runner_access_from_auth(auth).as_ref(),
+                &job_id,
+                crate::runner_http::requested_by_from_auth(auth),
+            )
             .await
         {
             Ok(job) => ToolResult::ok(json!({

--- a/src/tool_runtime/tests/jobs.rs
+++ b/src/tool_runtime/tests/jobs.rs
@@ -1166,7 +1166,7 @@ async fn run_job_rejects_server_configured_project_without_local_spawn() {
 #[tokio::test]
 async fn stop_job_rejects_unsafe_job_id() {
     let runtime = test_runtime();
-    let result = runtime.stop_job("../escape".to_string()).await;
+    let result = runtime.stop_job("../escape".to_string(), None).await;
     assert!(!result.success);
     assert!(result.error.unwrap().contains("invalid job id"));
 }
@@ -1175,7 +1175,7 @@ async fn stop_job_rejects_unsafe_job_id() {
 async fn stop_job_unknown_job_returns_error() {
     let runtime = test_runtime();
     let result = runtime
-        .stop_job("55555555-6666-7777-8888-999999999999".to_string())
+        .stop_job("55555555-6666-7777-8888-999999999999".to_string(), None)
         .await;
     assert!(!result.success);
     assert!(result.error.unwrap().contains("unknown job"));


### PR DESCRIPTION
Fixes #365.

The `/api/jobs/stop` handler now forwards its `AuthContext` to `ToolRuntime::stop_job`, which projects it to `RunnerAccess` and calls `stop_job_for_auth`. Stop-request attribution also uses the authenticated caller. The endpoint's scope requirement and request/response shapes are unchanged.

Adds an in-process HTTP regression using the real auth middleware and two isolated OAuth users. It covers unauthorized requests, insufficient scope, a different owner's requests against queued/running Jobs without state/queue effects, and successful owner cancellation. Existing direct wrapper tests are updated for the explicit auth parameter.

Validation: the HTTP regression failed on the base implementation and passes after the fix. `cargo test --offline --locked -p webcodex --lib job_stop` passes (4 tests); the focused `stop_job` test group, `cargo fmt --all -- --check`, and `git diff --check` also pass. These are in-process Registry/HTTP fixtures, not real OS process cancellation or a production deployment.
