### PR TITLE
fix(npm): wait for download streams to close before cleanup

### DIFF
--- a/npm/webcodex/install.js
+++ b/npm/webcodex/install.js
@@ -483,10 +483,19 @@ function fetchToFile(url, dest, options = {}, redirects = 0, deadlineAt = null) 
       settled = true;
       clearTimers();
       if (response) response.destroy();
-      if (file) file.destroy();
       if (request) request.destroy();
-      removePartial();
-      reject(message instanceof Error ? message : new Error(message));
+      const finishFailure = () => {
+        removePartial();
+        reject(message instanceof Error ? message : new Error(message));
+      };
+      if (file && !file.closed) {
+        // destroy() closes asynchronously, including a pending open. Callers
+        // must not remove the temporary directory until the handle is closed.
+        file.once("close", finishFailure);
+        file.destroy();
+      } else {
+        finishFailure();
+      }
     };
     const succeed = () => {
       if (settled) return;

--- a/npm/webcodex/package.json
+++ b/npm/webcodex/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "postinstall": "node install.js",
-    "test": "node test/self-test.js && node test/release-manifest-check-self-test.js",
+    "test": "node test/self-test.js && node test/release-manifest-check-self-test.js && node --test test/download-cleanup.test.js",
     "pack:release-dry-run": "npm pack --dry-run",
     "prepack": "node test/release-manifest-check.js --quiet",
     "prepublishOnly": "node test/release-manifest-check.js"

--- a/npm/webcodex/test/download-cleanup.test.js
+++ b/npm/webcodex/test/download-cleanup.test.js
@@ -1,0 +1,123 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { fetchToFile } = require("../install");
+
+async function checkFailureCleanup(kind, expectedError) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "webcodex-download-cleanup-"));
+  const destination = path.join(tempDir, "partial.bin");
+  const originalCreateWriteStream = fs.createWriteStream;
+  const sockets = new Set();
+  let response;
+  let stream;
+  let streamClosed = Promise.resolve();
+  let releaseClose;
+  let holdClose = true;
+  let settled = false;
+  let outcome;
+  let signalCloseAttempt;
+  const closeAttempted = new Promise((resolve) => { signalCloseAttempt = resolve; });
+  let timer;
+  const deadline = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error("Download cleanup fixture timed out")), 5000);
+  });
+
+  const server = http.createServer((_req, res) => {
+    response = res;
+    // Do not send Content-Length: the byte-limit failure must happen after
+    // the installer creates its output stream, not during header validation.
+    res.writeHead(200, { "Transfer-Encoding": "chunked" });
+    if (kind === "oversized") res.end("too large");
+    else res.write("partial");
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  try {
+    await Promise.race([
+      new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      }),
+      deadline
+    ]);
+
+    // Keep the real WriteStream and filesystem operations. Gate only the
+    // close callback so this race is deterministic on every supported OS.
+    // Tests in this file run serially; restore the shared method in finally.
+    fs.createWriteStream = (file, options) => {
+      stream = originalCreateWriteStream(file, {
+        ...options,
+        fs: {
+          open: fs.open,
+          write: fs.write,
+          writev: fs.writev,
+          close(fd, callback) {
+            if (!holdClose) return fs.close(fd, callback);
+            releaseClose = () => {
+              releaseClose = null;
+              fs.close(fd, callback);
+            };
+            signalCloseAttempt();
+          }
+        }
+      });
+      streamClosed = new Promise((resolve) => stream.once("close", resolve));
+      if (kind === "aborted") stream.once("open", () => response.destroy());
+      return stream;
+    };
+
+    outcome = fetchToFile(`http://127.0.0.1:${server.address().port}/artifact`, destination, {
+      label: "Artifact",
+      maxBytes: kind === "oversized" ? 1 : 1024,
+      firstByteTimeoutMs: 2000,
+      inactivityTimeoutMs: 2000,
+      totalTimeoutMs: 3000,
+      environment: {}
+    }).then(
+      () => { settled = true; return null; },
+      (error) => { settled = true; return error; }
+    );
+
+    await Promise.race([closeAttempted, deadline]);
+    assert.equal(stream.closed, false);
+    assert.equal(settled, false, "download must not reject while its output file is still open");
+    assert.equal(fs.existsSync(destination), true, "partial output must remain until close finishes");
+
+    releaseClose();
+    const error = await Promise.race([outcome, deadline]);
+    assert.ok(error instanceof Error, "the original download failure must still be reported");
+    assert.match(error.message, expectedError);
+    assert.equal(stream.closed, true);
+    assert.equal(fs.existsSync(destination), false, "failure must remove the closed partial output");
+    // Match the installer's caller: immediate synchronous directory cleanup
+    // must be safe once the download promise rejects, including on Windows.
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  } finally {
+    fs.createWriteStream = originalCreateWriteStream;
+    holdClose = false;
+    if (releaseClose) releaseClose();
+    if (stream) stream.destroy();
+    await streamClosed;
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+    if (outcome) await Promise.race([outcome, deadline]).catch(() => {});
+    clearTimeout(timer);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("chunked byte-limit failure waits for the output file to close", { concurrency: false }, async () => {
+  await checkFailureCleanup("oversized", /Artifact exceeds the 1-byte download limit/);
+});
+
+test("aborted response waits for the output file to close", { concurrency: false }, async () => {
+  await checkFailureCleanup("aborted", /Artifact download ended before completion/);
+});


### PR DESCRIPTION
## Summary

Wait for a failed download's output `WriteStream` to close before removing its partial file and rejecting the download promise. This prevents the installer's synchronous temporary-directory cleanup from racing an open file handle on Windows.

## Reproduction and cause

While exercising WebCodex's npm installer on Windows with Node.js v20.18.0 at `2a848ef432debba8af0fb223647a5857341d9278`, the existing installer self-test failed with `EPERM: operation not permitted, lstat` against a temporary `artifact.tar.gz`.

The failure path called `file.destroy()`, immediately removed the partial file, and rejected. Destruction closes the descriptor asynchronously, including when an open is still pending. The caller's `finally` cleanup could therefore run before the descriptor was closed and obscure the original download error.

## Changes

- Keep request/response cancellation immediate, but defer partial-file cleanup and rejection until the output stream emits `close`.
- Retain the immediate failure path when no output stream exists or it is already closed.
- Add two focused regression tests and wire them into the existing npm test entrypoint.

The regressions cover chunked byte-limit overflow and an aborted HTTP response. They use loopback HTTP and real filesystem streams, gating only the close callback to make the ordering deterministic. They assert that the promise remains pending until close, the original download failure is preserved, the partial output is removed, and immediate caller directory cleanup succeeds. No external network is used by these tests.

## Validation

On Windows / Node.js v20.18.0:

- Before the production fix: both new regressions failed at `download must not reject while its output file is still open`.
- After the fix: both regressions passed.
- `npm --prefix npm/webcodex test` passed, including the existing installer/wrapper suite, release-manifest self-test, and both new regressions. Rechecked before submission.
- `git diff --check` passed; final change is limited to three files.

Linux/macOS execution, Rust workspace tests, and the real-native-binary installation smoke were not run locally. No Rust, runtime configuration, release artifacts, or installed services are changed.

Prepared and validated using WebCodex itself.
