### PR TITLE
Add Runner-configured live Skill roots

### DIFF
--- a/crates/webcodex-core/src/configured_skills.rs
+++ b/crates/webcodex-core/src/configured_skills.rs
@@ -1,0 +1,267 @@
+//! Runner-configured live Skill root protocol.
+//!
+//! This contract deliberately carries no native filesystem path. Control may
+//! ask one exact Runner to list its configured live Skills or read a resource
+//! by opaque Skill identity; the Runner alone resolves that identity against
+//! its current trusted `[skills].roots` configuration.
+
+use crate::runtime_contract::{MAX_SKILL_READ_LINES, MAX_SKILL_RESOURCE_PATH_CHARS};
+use crate::skill_metadata::{
+    MAX_SKILL_DEFINITION_BYTES, MAX_SKILL_DESCRIPTION_CHARS, MAX_SKILL_NAME_CHARS,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Component, Path};
+
+pub const CONFIGURED_SKILL_ROOTS_REQUEST_KIND: &str = "configured_skill_roots";
+pub const CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT: &str = "webcodex.runner_configured_skills.v1";
+pub const CONFIGURED_SKILL_ROOTS_REQUEST_MAX_BYTES: usize = 4 * 1024;
+pub const CONFIGURED_SKILL_ROOTS_RESPONSE_MAX_BYTES: usize = 256 * 1024;
+pub const MAX_CONFIGURED_SKILL_PACKAGES: usize = 256;
+pub const MAX_CONFIGURED_SKILL_DIAGNOSTICS: usize = 8;
+pub const MAX_CONFIGURED_SKILL_ROOT_SCAN_ENTRIES: usize = 1024;
+pub const MAX_CONFIGURED_SKILL_RESOURCE_FILE_BYTES: usize = 512 * 1024;
+pub const MAX_CONFIGURED_SKILL_READ_TEXT_BYTES: usize = 48 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ConfiguredSkillRootsRequest {
+    List,
+    Read {
+        skill_id: String,
+        path: String,
+        start_line: usize,
+        limit: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_definition_revision: Option<String>,
+    },
+}
+
+impl ConfiguredSkillRootsRequest {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        match self {
+            Self::List => Ok(()),
+            Self::Read {
+                skill_id,
+                path,
+                start_line,
+                limit,
+                expected_definition_revision,
+            } => {
+                if !valid_configured_skill_id(skill_id) {
+                    return Err("invalid configured Skill id");
+                }
+                normalize_configured_skill_resource_path(path)?;
+                if *start_line == 0 || !(1..=MAX_SKILL_READ_LINES).contains(limit) {
+                    return Err("invalid configured Skill read range");
+                }
+                if expected_definition_revision
+                    .as_deref()
+                    .is_some_and(|revision| !valid_lower_sha256(revision))
+                {
+                    return Err("invalid configured Skill definition revision");
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConfiguredSkillDescriptor {
+    pub skill_id: String,
+    pub name: String,
+    pub description: String,
+    pub definition_revision: String,
+}
+
+impl ConfiguredSkillDescriptor {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if !valid_configured_skill_id(&self.skill_id)
+            || !valid_lower_sha256(&self.definition_revision)
+            || self.name.is_empty()
+            || self.name.chars().count() > MAX_SKILL_NAME_CHARS
+            || self.description.chars().count() > MAX_SKILL_DESCRIPTION_CHARS
+        {
+            return Err("invalid configured Skill descriptor");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConfiguredSkillRootsListResponse {
+    pub format: String,
+    pub skills: Vec<ConfiguredSkillDescriptor>,
+    pub invalid_count: usize,
+    pub diagnostics: Vec<String>,
+    pub discovery_truncated: bool,
+}
+
+impl ConfiguredSkillRootsListResponse {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.format != CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT
+            || self.skills.len() > MAX_CONFIGURED_SKILL_PACKAGES
+            || self.diagnostics.len() > MAX_CONFIGURED_SKILL_DIAGNOSTICS
+            || self
+                .diagnostics
+                .iter()
+                .any(|reason| !valid_diagnostic_reason(reason))
+        {
+            return Err("invalid configured Skill list response");
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for skill in &self.skills {
+            skill.validate()?;
+            if !seen.insert(skill.skill_id.as_str()) {
+                return Err("duplicate configured Skill id");
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConfiguredSkillRootsReadResponse {
+    pub format: String,
+    pub skill_id: String,
+    pub name: String,
+    pub definition_revision: String,
+    pub path: String,
+    pub sha256: String,
+    pub file_bytes: usize,
+    pub total_lines: usize,
+    pub text: String,
+    pub start_line: usize,
+    pub end_line: Option<usize>,
+    pub returned_lines: usize,
+    pub has_more: bool,
+    pub next_start_line: Option<usize>,
+}
+
+impl ConfiguredSkillRootsReadResponse {
+    pub fn validate_for_request(
+        &self,
+        request_skill_id: &str,
+        request_path: &str,
+        request_start_line: usize,
+        request_limit: usize,
+    ) -> Result<(), &'static str> {
+        let normalized_path = normalize_configured_skill_resource_path(request_path)?;
+        let max_file_bytes = if normalized_path == "SKILL.md" {
+            MAX_SKILL_DEFINITION_BYTES
+        } else {
+            MAX_CONFIGURED_SKILL_RESOURCE_FILE_BYTES
+        };
+        if self.format != CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT
+            || self.skill_id != request_skill_id
+            || self.path != normalized_path
+            || !valid_configured_skill_id(&self.skill_id)
+            || self.name.is_empty()
+            || self.name.chars().count() > MAX_SKILL_NAME_CHARS
+            || !valid_lower_sha256(&self.definition_revision)
+            || !valid_lower_sha256(&self.sha256)
+            || self.file_bytes > max_file_bytes
+            || self.text.len() > MAX_CONFIGURED_SKILL_READ_TEXT_BYTES
+            || self.start_line != request_start_line
+            || self.returned_lines > request_limit
+            || self.has_more != self.next_start_line.is_some()
+        {
+            return Err("invalid configured Skill read response");
+        }
+        Ok(())
+    }
+}
+
+pub fn valid_configured_skill_id(value: &str) -> bool {
+    value.len() == "wc_skill_".len() + 32
+        && value.starts_with("wc_skill_")
+        && value["wc_skill_".len()..]
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+pub fn valid_lower_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+pub fn normalize_configured_skill_resource_path(path: &str) -> Result<String, &'static str> {
+    let trimmed = path.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > MAX_SKILL_RESOURCE_PATH_CHARS
+        || trimmed.chars().any(char::is_control)
+        || trimmed.starts_with('/')
+        || trimmed.starts_with('\\')
+        || trimmed.as_bytes().get(1) == Some(&b':')
+    {
+        return Err("invalid configured Skill resource path");
+    }
+    let normalized = trimmed.replace('\\', "/");
+    if normalized
+        .split('/')
+        .any(|component| component.is_empty() || component == "." || component == "..")
+        || Path::new(&normalized)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err("invalid configured Skill resource path");
+    }
+    Ok(normalized)
+}
+
+fn valid_diagnostic_reason(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 80
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_response_uses_definition_file_size_bound() {
+        let response = ConfiguredSkillRootsReadResponse {
+            format: CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT.to_string(),
+            skill_id: format!("wc_skill_{}", "a".repeat(32)),
+            name: "demo".to_string(),
+            definition_revision: "b".repeat(64),
+            path: "SKILL.md".to_string(),
+            sha256: "c".repeat(64),
+            file_bytes: MAX_SKILL_DEFINITION_BYTES + 1,
+            total_lines: 1,
+            text: "x".to_string(),
+            start_line: 1,
+            end_line: Some(1),
+            returned_lines: 1,
+            has_more: false,
+            next_start_line: None,
+        };
+        assert!(response
+            .validate_for_request(&response.skill_id, "SKILL.md", 1, 1)
+            .is_err());
+    }
+
+    #[test]
+    fn resource_paths_are_relative_and_normalized() {
+        assert_eq!(
+            normalize_configured_skill_resource_path("references\\guide.md").unwrap(),
+            "references/guide.md"
+        );
+        for invalid in [
+            "../secret",
+            "references/../secret",
+            "/etc/passwd",
+            "C:\\secret",
+        ] {
+            assert!(normalize_configured_skill_resource_path(invalid).is_err());
+        }
+    }
+}

--- a/crates/webcodex-core/src/configured_skills.rs
+++ b/crates/webcodex-core/src/configured_skills.rs
@@ -192,6 +192,13 @@ pub fn valid_lower_sha256(value: &str) -> bool {
 
 pub fn normalize_configured_skill_resource_path(path: &str) -> Result<String, &'static str> {
     let trimmed = path.trim();
+    #[cfg(windows)]
+    if trimmed.contains(':') {
+        // A colon beyond a drive prefix is an NTFS alternate data stream
+        // selector. Configured Skill resources are ordinary package files; do
+        // not let an opaque resource path reach directory-invisible streams.
+        return Err("invalid configured Skill resource path");
+    }
     if trimmed.is_empty()
         || trimmed.chars().count() > MAX_SKILL_RESOURCE_PATH_CHARS
         || trimmed.chars().any(char::is_control)
@@ -263,5 +270,12 @@ mod tests {
         ] {
             assert!(normalize_configured_skill_resource_path(invalid).is_err());
         }
+        #[cfg(windows)]
+        assert!(normalize_configured_skill_resource_path("references/guide.md:secret").is_err());
+        #[cfg(not(windows))]
+        assert_eq!(
+            normalize_configured_skill_resource_path("references/guide.md:stream").unwrap(),
+            "references/guide.md:stream"
+        );
     }
 }

--- a/crates/webcodex-core/src/lib.rs
+++ b/crates/webcodex-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod audit_preview;
 pub mod authority;
 pub mod build_info;
 pub mod coding_agent;
+pub mod configured_skills;
 pub mod job_observation;
 pub mod lsp_bridge;
 pub mod mcp_gateway;

--- a/crates/webcodex-core/src/runner_operation.rs
+++ b/crates/webcodex-core/src/runner_operation.rs
@@ -6,6 +6,10 @@
 //! then operation identity and its required payload travel together.
 
 use crate::coding_agent::{validate_request as validate_coding_agent_request, CodingAgentRequest};
+use crate::configured_skills::{
+    ConfiguredSkillRootsRequest, CONFIGURED_SKILL_ROOTS_REQUEST_KIND,
+    CONFIGURED_SKILL_ROOTS_REQUEST_MAX_BYTES,
+};
 use crate::lsp_bridge::RunnerLspPayload;
 use crate::mcp_gateway::{validate_request as validate_mcp_gateway_request, McpGatewayRequest};
 use crate::plugin::{validate_request as validate_plugin_gateway_request, PluginGatewayRequest};
@@ -521,6 +525,7 @@ pub enum RunnerOperation {
     McpGateway(McpGatewayRequest),
     PluginGateway(PluginGatewayRequest),
     CodingAgent(CodingAgentRequest),
+    ConfiguredSkillRoots(ConfiguredSkillRootsRequest),
     SkillStore(SkillStoreRequest),
     SshResource(SshResourceRequest),
     RunnerConfig(RunnerConfigOperationRequest),
@@ -550,6 +555,7 @@ impl RunnerOperation {
             Self::McpGateway(_) => "mcp_gateway",
             Self::PluginGateway(_) => "plugin_gateway",
             Self::CodingAgent(_) => "coding_agent",
+            Self::ConfiguredSkillRoots(_) => CONFIGURED_SKILL_ROOTS_REQUEST_KIND,
             Self::SkillStore(_) => "skill_store",
             Self::SshResource(_) => "ssh_resource",
             Self::RunnerConfig(_) => RUNNER_CONFIG_REQUEST_KIND,
@@ -752,6 +758,19 @@ fn encode_operation(
                 .map_err(|error| format!("invalid CodingAgent request: {error}"))?;
             wire.timeout_secs = 120;
             wire.coding_agent = Some(operation);
+        }
+        RunnerOperation::ConfiguredSkillRoots(operation) => {
+            operation
+                .validate()
+                .map_err(|error| format!("invalid configured Skill roots request: {error}"))?;
+            let content = serde_json::to_string(&operation).map_err(|error| {
+                format!("could not encode configured Skill roots request: {error}")
+            })?;
+            if content.len() > CONFIGURED_SKILL_ROOTS_REQUEST_MAX_BYTES {
+                return Err("configured Skill roots request exceeds V2 payload bound".to_string());
+            }
+            wire.content = Some(content);
+            wire.timeout_secs = 30;
         }
         RunnerOperation::SkillStore(operation) => {
             let content = serde_json::to_string(&operation)
@@ -1093,6 +1112,21 @@ fn decode_operation(wire: &RunnerRequest) -> Result<RunnerOperation, String> {
             validate_coding_agent_request(&operation)
                 .map_err(|error| format!("invalid CodingAgent request: {error}"))?;
             Ok(RunnerOperation::CodingAgent(operation))
+        }
+        CONFIGURED_SKILL_ROOTS_REQUEST_KIND => {
+            ensure_special_payloads_absent(wire)?;
+            ensure_empty_generic_execution_fields(wire, true)?;
+            let content = bounded_content(
+                wire,
+                CONFIGURED_SKILL_ROOTS_REQUEST_MAX_BYTES,
+                CONFIGURED_SKILL_ROOTS_REQUEST_KIND,
+            )?;
+            let operation = serde_json::from_str::<ConfiguredSkillRootsRequest>(content)
+                .map_err(|error| format!("invalid configured Skill roots payload: {error}"))?;
+            operation
+                .validate()
+                .map_err(|error| format!("invalid configured Skill roots request: {error}"))?;
+            Ok(RunnerOperation::ConfiguredSkillRoots(operation))
         }
         "skill_store" => {
             ensure_special_payloads_absent(wire)?;
@@ -2028,6 +2062,9 @@ mod tests {
                     timeout_secs: 60,
                 },
             )),
+            RunnerOperation::ConfiguredSkillRoots(
+                crate::configured_skills::ConfiguredSkillRootsRequest::List,
+            ),
             RunnerOperation::SkillStore(crate::skill_store::SkillStoreRequest::ListActive),
             RunnerOperation::SshResource(crate::ssh_resource::SshResourceRequest::List),
             RunnerOperation::RunnerConfig(RunnerConfigOperationRequest {
@@ -2166,6 +2203,7 @@ mod tests {
             "mcp_gateway",
             "plugin_gateway",
             "coding_agent",
+            CONFIGURED_SKILL_ROOTS_REQUEST_KIND,
             "skill_store",
             "ssh_resource",
             RUNNER_CONFIG_REQUEST_KIND,

--- a/crates/webcodex-core/src/runner_protocol.rs
+++ b/crates/webcodex-core/src/runner_protocol.rs
@@ -264,6 +264,10 @@ pub const RUNNER_CAPABILITY_PROJECT_PATH_REGISTRATION: &str = "project_path_regi
 /// source/ref and owns the filesystem destination; missing on older Runners is
 /// false and is never inferred from generic Git or path-registration support.
 pub const RUNNER_CAPABILITY_MANAGED_WORKTREE: &str = "managed_worktree";
+/// Runner-global read-only discovery/read for operator-configured live Skill roots.
+/// Missing on older Runners is false and is never inferred from generic file_read,
+/// project lifecycle support, or managed Skill Store support.
+pub const RUNNER_CAPABILITY_CONFIGURED_SKILL_ROOTS_READ: &str = "configured_skill_roots_read";
 /// Runner-global read-only operator-installed Skill store discovery/read.
 /// Missing on older Runners is false and is never inferred from file_read or
 /// project lifecycle support.
@@ -437,6 +441,7 @@ pub const RUNNER_CAPABILITY_NAMES: &[&str] = &[
     RUNNER_CAPABILITY_PROJECT_LIFECYCLE,
     RUNNER_CAPABILITY_PROJECT_PATH_REGISTRATION,
     RUNNER_CAPABILITY_MANAGED_WORKTREE,
+    RUNNER_CAPABILITY_CONFIGURED_SKILL_ROOTS_READ,
     RUNNER_CAPABILITY_SKILL_STORE_READ,
     RUNNER_CAPABILITY_SKILL_STORE_MANAGE,
     RUNNER_CAPABILITY_COMPUTER_OBSERVE,
@@ -638,6 +643,10 @@ pub struct RunnerCapabilities {
     /// Runners fail closed instead of falling back to Server-side Git/path work.
     #[serde(default, skip_serializing_if = "is_false")]
     pub managed_worktree: bool,
+    /// Read-only operator-configured live Skill root support. Paths remain
+    /// Runner-local trusted configuration and are never accepted on this wire.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub configured_skill_roots_read: bool,
     /// Read-only operator-installed Skill store support. Missing on older
     /// Runners is false and never follows from generic file_read.
     #[serde(default, skip_serializing_if = "is_false")]
@@ -841,12 +850,14 @@ impl RunnerConfigOperationResponse {
                 if matches!(
                     field,
                     "max_concurrent_jobs"
+                        | "skills.roots"
                         | "shell.max_persistent_shells"
                         | "shell.persistent_shell_idle_timeout_secs"
                         | "acp.max_concurrent_runs"
                         | "acp.permission_timeout_secs"
                         | "mcp.request_timeout_secs"
                 ) => {}
+            (Some("skills.roots"), Some("invalid_path")) => {}
             _ => return Err("invalid config error diagnostic"),
         }
         if let Some(code) = self.error_code.as_deref() {
@@ -937,6 +948,7 @@ impl Default for RunnerCapabilities {
             project_lifecycle: false,
             project_path_registration: false,
             managed_worktree: false,
+            configured_skill_roots_read: false,
             skill_store_read: false,
             skill_store_manage: false,
             computer_observe: false,
@@ -3695,6 +3707,7 @@ mod envelope_tests {
                 project_lifecycle: false,
                 project_path_registration: false,
                 managed_worktree: false,
+                configured_skill_roots_read: false,
                 skill_store_read: false,
                 skill_store_manage: false,
                 computer_observe: false,
@@ -4873,6 +4886,7 @@ mod envelope_tests {
                 "project_lifecycle",
                 "project_path_registration",
                 "managed_worktree",
+                "configured_skill_roots_read",
                 "skill_store_read",
                 "skill_store_manage",
                 "computer_observe",

--- a/crates/webcodex-runner-config/src/lib.rs
+++ b/crates/webcodex-runner-config/src/lib.rs
@@ -278,6 +278,9 @@ pub fn generated_runner_config_toml(opts: &RunnerInitOptions) -> Result<String, 
             managed_worktree: false,
             // Runner-global Skill store support is runtime-only and never
             // inferred from project/file capabilities in generated config.
+            // Configured live Skill roots are Runner-owned runtime config and
+            // require an explicit running-binary capability.
+            configured_skill_roots_read: false,
             skill_store_read: false,
             skill_store_manage: false,
             // Desktop observation is a runtime/platform capability and is never

--- a/crates/webcodex-runner-registry/src/capabilities.rs
+++ b/crates/webcodex-runner-registry/src/capabilities.rs
@@ -43,6 +43,7 @@ pub enum RunnerFeature {
     ProjectLifecycle,
     ProjectPathRegistration,
     ManagedWorktree,
+    ConfiguredSkillRootsRead,
     SkillStoreRead,
     SkillStoreManage,
     ComputerObserve,
@@ -67,7 +68,7 @@ pub enum RunnerFeature {
     ComputerTextInput,
 }
 
-const ALL_RUNNER_FEATURES: [RunnerFeature; 57] = [
+const ALL_RUNNER_FEATURES: [RunnerFeature; 58] = [
     RunnerFeature::Shell,
     RunnerFeature::FileRead,
     RunnerFeature::FileWrite,
@@ -103,6 +104,7 @@ const ALL_RUNNER_FEATURES: [RunnerFeature; 57] = [
     RunnerFeature::ProjectLifecycle,
     RunnerFeature::ProjectPathRegistration,
     RunnerFeature::ManagedWorktree,
+    RunnerFeature::ConfiguredSkillRootsRead,
     RunnerFeature::SkillStoreRead,
     RunnerFeature::SkillStoreManage,
     RunnerFeature::ComputerObserve,
@@ -187,6 +189,7 @@ impl RunnerFeature {
             Self::ProjectLifecycle => wire::RUNNER_CAPABILITY_PROJECT_LIFECYCLE,
             Self::ProjectPathRegistration => wire::RUNNER_CAPABILITY_PROJECT_PATH_REGISTRATION,
             Self::ManagedWorktree => wire::RUNNER_CAPABILITY_MANAGED_WORKTREE,
+            Self::ConfiguredSkillRootsRead => wire::RUNNER_CAPABILITY_CONFIGURED_SKILL_ROOTS_READ,
             Self::SkillStoreRead => wire::RUNNER_CAPABILITY_SKILL_STORE_READ,
             Self::SkillStoreManage => wire::RUNNER_CAPABILITY_SKILL_STORE_MANAGE,
             Self::ComputerObserve => wire::RUNNER_CAPABILITY_COMPUTER_OBSERVE,
@@ -259,6 +262,7 @@ impl RunnerFeature {
             wire::RUNNER_CAPABILITY_PROJECT_LIFECYCLE => Self::ProjectLifecycle,
             wire::RUNNER_CAPABILITY_PROJECT_PATH_REGISTRATION => Self::ProjectPathRegistration,
             wire::RUNNER_CAPABILITY_MANAGED_WORKTREE => Self::ManagedWorktree,
+            wire::RUNNER_CAPABILITY_CONFIGURED_SKILL_ROOTS_READ => Self::ConfiguredSkillRootsRead,
             wire::RUNNER_CAPABILITY_SKILL_STORE_READ => Self::SkillStoreRead,
             wire::RUNNER_CAPABILITY_SKILL_STORE_MANAGE => Self::SkillStoreManage,
             wire::RUNNER_CAPABILITY_COMPUTER_OBSERVE => Self::ComputerObserve,
@@ -326,6 +330,7 @@ impl RunnerFeature {
             | Self::SshPersistentShell
             | Self::DetachedProcessJobs
             | Self::ManagedWorktree
+            | Self::ConfiguredSkillRootsRead
             | Self::SkillStoreRead
             | Self::SkillStoreManage
             | Self::ComputerObserve
@@ -394,6 +399,7 @@ impl RunnerFeature {
             Self::ProjectLifecycle => capabilities.project_lifecycle,
             Self::ProjectPathRegistration => capabilities.project_path_registration,
             Self::ManagedWorktree => capabilities.managed_worktree,
+            Self::ConfiguredSkillRootsRead => capabilities.configured_skill_roots_read,
             Self::SkillStoreRead => capabilities.skill_store_read,
             Self::SkillStoreManage => capabilities.skill_store_manage,
             Self::ComputerObserve => capabilities.computer_observe,

--- a/crates/webcodex-runner-registry/src/polling.rs
+++ b/crates/webcodex-runner-registry/src/polling.rs
@@ -399,7 +399,7 @@ impl RunnerRegistry {
             let stale_skill_store_error =
                 inner.pending_by_id.get(&request_id).and_then(|pending| {
                     match (&pending.operation, pending.skill_store_fence.as_ref()) {
-                        (RunnerOperation::SkillStore(_), Some(fence)) => {
+                        (RunnerOperation::SkillStore(_), Some(fence)) if !fence.configured_roots => {
                             let Some(runner) = inner.runners.get(&body.client_id) else {
                                 return Some(
                                     "stale_runner: Skill store target Runner disappeared before dispatch"
@@ -424,11 +424,38 @@ impl RunnerRegistry {
                                 )
                             })
                         }
-                        (RunnerOperation::SkillStore(_), None) => Some(
-                            "stale_runner: Skill store exact dispatch fence is missing".to_string(),
+                        (RunnerOperation::ConfiguredSkillRoots(_), Some(fence))
+                            if fence.configured_roots && !fence.management =>
+                        {
+                            let Some(runner) = inner.runners.get(&body.client_id) else {
+                                return Some(
+                                    "stale_runner: configured Skill roots target Runner disappeared before dispatch"
+                                        .to_string(),
+                                );
+                            };
+                            if runner.runner_instance_id != fence.runner_instance_id {
+                                return Some(
+                                    "stale_runner: configured Skill roots target Runner changed before dispatch"
+                                        .to_string(),
+                                );
+                            }
+                            (!runner
+                                .runner_features
+                                .supports(RunnerFeature::ConfiguredSkillRootsRead))
+                            .then(|| {
+                                "configured_skill_roots_capability_unavailable: exact Runner no longer advertises configured_skill_roots_read before dispatch"
+                                    .to_string()
+                            })
+                        }
+                        (RunnerOperation::SkillStore(_) | RunnerOperation::ConfiguredSkillRoots(_), None) => Some(
+                            "stale_runner: Skill source exact dispatch fence is missing".to_string(),
+                        ),
+                        (RunnerOperation::SkillStore(_) | RunnerOperation::ConfiguredSkillRoots(_), Some(_)) => Some(
+                            "stale_runner: Skill source dispatch fence mode does not match the request kind"
+                                .to_string(),
                         ),
                         (_, Some(_)) => Some(
-                            "stale_runner: Skill store dispatch fence is attached to the wrong request kind"
+                            "stale_runner: Skill source dispatch fence is attached to the wrong request kind"
                                 .to_string(),
                         ),
                         (_, None) => None,

--- a/crates/webcodex-runner-registry/src/requests.rs
+++ b/crates/webcodex-runner-registry/src/requests.rs
@@ -21,6 +21,7 @@ use webcodex_core::coding_agent::{
     validate_request as validate_coding_agent_request, CodingAgentDispatchState,
     CodingAgentRequest, CodingAgentResponse,
 };
+use webcodex_core::configured_skills::ConfiguredSkillRootsRequest;
 use webcodex_core::lsp_bridge::{RunnerLspPayload, RunnerLspRequest};
 use webcodex_core::mcp_gateway::{
     validate_request as validate_mcp_gateway_request, McpGatewayDispatchState, McpGatewayRequest,
@@ -1183,6 +1184,79 @@ impl RunnerRegistry {
         remove_pending_request_locked(&mut inner, request_id).map(|pending| pending.dispatched)
     }
 
+    /// Enqueue one read-only configured live Skill-root operation for one exact
+    /// Runner process. No native root path crosses this boundary: the Runner
+    /// resolves the opaque Skill identity against its own current hot config.
+    pub async fn enqueue_configured_skill_roots(
+        &self,
+        client_id: &str,
+        expected_runner_instance_id: &str,
+        operation: ConfiguredSkillRootsRequest,
+        auth: Option<&crate::RunnerAccess>,
+        requested_by: String,
+    ) -> Result<(String, oneshot::Receiver<ShellRunResponse>), String> {
+        operation
+            .validate()
+            .map_err(|_| "invalid configured Skill roots request".to_string())?;
+        let request_id = next_request_id();
+        let (tx, rx) = oneshot::channel();
+        let request = encode_runner_operation(
+            &request_id,
+            client_id,
+            requested_by,
+            RunnerOperation::ConfiguredSkillRoots(operation),
+        )
+        .map_err(|_| "invalid configured Skill roots request".to_string())?;
+        let mut inner = self.inner.lock().await;
+        let runner = inner
+            .runners
+            .get(client_id)
+            .ok_or_else(|| "exact Runner is unavailable".to_string())?;
+        assert_runner_access(auth, runner)
+            .map_err(|_| "exact Runner is unavailable".to_string())?;
+        if runner.runner_instance_id != expected_runner_instance_id {
+            return Err(
+                "stale Runner identity; configured Skill roots request was not dispatched"
+                    .to_string(),
+            );
+        }
+        if !runner
+            .runner_features
+            .supports(RunnerFeature::ConfiguredSkillRootsRead)
+        {
+            return Err(
+                "configured_skill_roots_capability_unavailable: exact Runner does not support configured_skill_roots_read"
+                    .to_string(),
+            );
+        }
+        if now_ts().saturating_sub(runner.last_seen) > RUNNER_ONLINE_WINDOW_SECS {
+            return Err(
+                "exact Runner is offline; configured Skill roots request was not dispatched"
+                    .to_string(),
+            );
+        }
+        enqueue_pending_request_locked(
+            self.telemetry.as_ref(),
+            &mut inner,
+            client_id,
+            request_id.clone(),
+            request,
+            Some(tx),
+            None,
+        )?;
+        let pending = inner
+            .pending_by_id
+            .get_mut(&request_id)
+            .expect("configured Skill roots request was just enqueued");
+        pending.skill_store_fence = Some(SkillStoreDispatchFence {
+            runner_instance_id: expected_runner_instance_id.to_string(),
+            management: false,
+            configured_roots: true,
+        });
+        notify_runner_locked(&inner, client_id);
+        Ok((request_id, rx))
+    }
+
     /// Enqueue one closed Runner-global Skill store operation for one exact
     /// live Runner process. Read and management capabilities are independent;
     /// the exact process lease and capability are revalidated again at dequeue.
@@ -1253,6 +1327,7 @@ impl RunnerRegistry {
         pending.skill_store_fence = Some(SkillStoreDispatchFence {
             runner_instance_id: expected_runner_instance_id.to_string(),
             management,
+            configured_roots: false,
         });
         notify_runner_locked(&inner, client_id);
         Ok((request_id, rx))

--- a/crates/webcodex-runner-registry/src/state.rs
+++ b/crates/webcodex-runner-registry/src/state.rs
@@ -205,6 +205,7 @@ impl RunnerRecord {
 pub(super) struct SkillStoreDispatchFence {
     pub(super) runner_instance_id: String,
     pub(super) management: bool,
+    pub(super) configured_roots: bool,
 }
 
 #[derive(Debug)]
@@ -239,9 +240,9 @@ pub(super) struct PendingShellRequest {
     /// Revalidated at dequeue so neither check nor reload can silently retarget
     /// a replacement process using the same client_id.
     pub(super) expected_runner_config_runner_instance_id: Option<String>,
-    /// Exact Runner process lease plus read/manage mode captured for a
-    /// Runner-global Skill store request. Revalidated at dequeue so a
-    /// replacement process using the same client_id cannot inherit authority.
+    /// Exact Runner process lease plus source/read/manage mode captured for a
+    /// Runner-global Skill request. Revalidated at dequeue so a replacement
+    /// process using the same client_id cannot inherit authority.
     pub(super) skill_store_fence: Option<SkillStoreDispatchFence>,
     pub(super) dispatched: bool,
 }

--- a/crates/webcodex-runner-registry/src/tests.rs
+++ b/crates/webcodex-runner-registry/src/tests.rs
@@ -311,6 +311,8 @@ mod computer_observe;
 mod computer_snapshot_artifact;
 #[path = "tests/computer_text_input.rs"]
 mod computer_text_input;
+#[path = "tests/configured_skills.rs"]
+mod configured_skills;
 #[path = "tests/connection_lease.rs"]
 mod connection_lease;
 #[path = "tests/disconnect_reconciliation.rs"]

--- a/crates/webcodex-runner-registry/src/tests/capabilities.rs
+++ b/crates/webcodex-runner-registry/src/tests/capabilities.rs
@@ -98,6 +98,7 @@ fn capability_classification_keeps_environment_dependent_features_registration_r
         RunnerFeature::ComputerTextInput,
         RunnerFeature::JobStateReconciliation,
         RunnerFeature::CodingAgentRuns,
+        RunnerFeature::ConfiguredSkillRootsRead,
         RunnerFeature::SkillStoreRead,
         RunnerFeature::SkillStoreManage,
         RunnerFeature::ManagedSshResources,

--- a/crates/webcodex-runner-registry/src/tests/configured_skills.rs
+++ b/crates/webcodex-runner-registry/src/tests/configured_skills.rs
@@ -1,0 +1,131 @@
+use super::*;
+use crate::runner_protocol::{
+    RunnerPollRequest, RunnerRegisterRequest, ShellCommandExecutionState,
+};
+use webcodex_core::configured_skills::ConfiguredSkillRootsRequest;
+
+fn configured_skills_registration(instance: &str, read: bool) -> RunnerRegisterRequest {
+    current_runner_registration(RunnerRegisterRequest {
+        client_id: "configured-skills-runner".to_string(),
+        runner_instance_id: instance.to_string(),
+        runner_protocol_generation: crate::runner_protocol::RUNNER_PROTOCOL_GENERATION_V2,
+        display_name: None,
+        owner: Some("alice".to_string()),
+        hostname: None,
+        capabilities: RunnerCapabilities {
+            configured_skill_roots_read: read,
+            ..Default::default()
+        },
+        host_context: None,
+        policy: None,
+        process_started_at: None,
+        build: None,
+        job_concurrency_limit: None,
+        job_inventory: None,
+        coding_agent_providers: None,
+        coding_agent_inventory: None,
+    })
+}
+
+fn alice() -> RunnerAccess {
+    auth_context(Some("alice"), false)
+}
+
+#[tokio::test]
+async fn configured_skill_roots_enqueue_requires_exact_instance_and_explicit_capability() {
+    let registry = RunnerRegistry::default();
+    registry
+        .register(configured_skills_registration("instance-a", false))
+        .await
+        .unwrap();
+    let auth = alice();
+
+    let capability_error = registry
+        .enqueue_configured_skill_roots(
+            "configured-skills-runner",
+            "instance-a",
+            ConfiguredSkillRootsRequest::List,
+            Some(&auth),
+            "test".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert!(capability_error.contains("configured_skill_roots_capability_unavailable"));
+    assert!(capability_error.contains("configured_skill_roots_read"));
+
+    registry
+        .register(configured_skills_registration("instance-a", true))
+        .await
+        .unwrap();
+    let stale_error = registry
+        .enqueue_configured_skill_roots(
+            "configured-skills-runner",
+            "replacement-instance",
+            ConfiguredSkillRootsRequest::List,
+            Some(&auth),
+            "test".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert!(stale_error.contains("stale Runner"));
+
+    let inner = registry.inner.lock().await;
+    assert!(inner.pending_by_id.is_empty());
+}
+
+#[tokio::test]
+async fn configured_skill_roots_dequeue_rejects_replacement_runner_before_dispatch() {
+    let registry = RunnerRegistry::default();
+    registry
+        .register(configured_skills_registration("instance-a", true))
+        .await
+        .unwrap();
+    let auth = alice();
+    let (_request_id, receiver) = registry
+        .enqueue_configured_skill_roots(
+            "configured-skills-runner",
+            "instance-a",
+            ConfiguredSkillRootsRequest::List,
+            Some(&auth),
+            "test".to_string(),
+        )
+        .await
+        .unwrap();
+
+    // Normal replacement registration drains stale synchronous work. Mutate
+    // only the exact process lease here to prove dequeue independently fences
+    // a later process that recycles the same stable client_id.
+    {
+        let mut inner = registry.inner.lock().await;
+        inner
+            .runners
+            .get_mut("configured-skills-runner")
+            .unwrap()
+            .runner_instance_id = "instance-b".to_string();
+    }
+    let polled = registry
+        .poll(RunnerPollRequest {
+            client_id: "configured-skills-runner".to_string(),
+            runner_instance_id: "instance-b".to_string(),
+        })
+        .await
+        .unwrap();
+    assert!(polled.is_none());
+    let response = receiver.await.unwrap();
+    assert!(!response.success);
+    assert_eq!(response.request_dispatched, Some(false));
+    assert_eq!(
+        response.command_execution_state,
+        Some(ShellCommandExecutionState::NotStarted)
+    );
+    assert!(response.error.as_deref().is_some_and(|error| {
+        error.contains("configured Skill roots target Runner changed before dispatch")
+    }));
+
+    let inner = registry.inner.lock().await;
+    assert!(inner.pending_by_id.is_empty());
+    assert!(inner
+        .queues_by_runner
+        .get("configured-skills-runner")
+        .is_none_or(|queue| queue.is_empty()));
+}

--- a/crates/webcodex-runner-registry/src/tests/file_validation.rs
+++ b/crates/webcodex-runner-registry/src/tests/file_validation.rs
@@ -63,6 +63,7 @@ fn validate_file_request_rejects_invalid_read_requests() {
 fn generic_file_request_cannot_inject_runner_skill_store_operations() {
     for op in [
         "skill_store",
+        "configured_skill_roots",
         "skill_install",
         "skill_activate",
         "skill_versions",

--- a/crates/webcodex-runner-registry/src/tests/protocol.rs
+++ b/crates/webcodex-runner-registry/src/tests/protocol.rs
@@ -480,6 +480,7 @@ async fn runner_supports_recognizes_all_protocol_capability_names() {
                 project_lifecycle: true,
                 project_path_registration: true,
                 managed_worktree: true,
+                configured_skill_roots_read: true,
                 skill_store_read: true,
                 skill_store_manage: true,
                 computer_observe: true,

--- a/crates/webcodex-runner/src/main.rs
+++ b/crates/webcodex-runner/src/main.rs
@@ -2011,6 +2011,10 @@ fn runner_register_capabilities(cfg: &RunnerConfig) -> RunnerCapabilities {
     // advertise a capability that the binary does not implement.
     capabilities.project_path_registration = true;
     capabilities.managed_worktree = true;
+    // Runner-configured live Skill root discovery/read is a separate read-only
+    // capability. It remains explicit even with no configured roots so Server
+    // rolling upgrades never infer this authority from file_read or Skill Store.
+    capabilities.configured_skill_roots_read = true;
     // Runner-global operator-installed Skill store read and management are
     // explicit rolling-upgrade capabilities implemented by this binary.
     capabilities.skill_store_read = true;

--- a/crates/webcodex-runner/src/main_tests.rs
+++ b/crates/webcodex-runner/src/main_tests.rs
@@ -83,6 +83,7 @@ fn test_config(project_registry_dir: PathBuf) -> RunnerConfig {
         max_concurrent_jobs: None,
         policy: unrestricted_test_policy(),
         shell: ShellConfig::default(),
+        skills: crate::webcodex_runner::config::SkillsConfig::default(),
         ssh: SshConfig::default(),
         transport: None,
         websocket_connect_timeout_secs: default_websocket_connect_timeout_secs(),

--- a/crates/webcodex-runner/src/main_tests/config_reload.rs
+++ b/crates/webcodex-runner/src/main_tests/config_reload.rs
@@ -72,6 +72,7 @@ fn reload_field_classification_is_exhaustive_and_allowlisted() {
     let mut hot_only = startup.clone();
     hot_only.policy.max_timeout_secs += 1;
     hot_only.shell.program = "bash".to_string();
+    hot_only.skills.roots.push(PathBuf::from("live-skill-root"));
     hot_only.plugins.request_timeout_secs += 1;
     hot_only.tool_providers.strategy =
         webcodex_runner::config::ToolProviderStrategy::ClaudeCodeThenNative;
@@ -101,6 +102,46 @@ fn reload_field_classification_is_exhaustive_and_allowlisted() {
             webcodex_runner::config::restart_required_fields(&startup, &changed).join(" "),
             "capabilities client_id display_name hostname host_context max_concurrent_jobs mcp_gateway owner poll_interval_ms project_registry_dir quic server_url token transport websocket_connect_timeout_secs"
         );
+}
+
+#[test]
+fn skill_roots_config_change_is_hot_reloadable_and_generation_fenced() {
+    let (tmp, path, runtime) = reload_fixture();
+    let old = runtime.snapshot();
+    assert!(old.skills.roots.is_empty());
+    let live_root = tmp.path().join("live-skills");
+    let candidate = format!(
+        "{}\n[skills]\nroots = [{:?}]\n",
+        reload_toml(
+            "oe",
+            None,
+            60,
+            1024,
+            "sh",
+            "native",
+            false,
+            "claude",
+            "project_search_generation_1",
+        ),
+        live_root.to_string_lossy().as_ref()
+    );
+    std::fs::write(&path, candidate).unwrap();
+
+    let checked = runtime.check_config();
+    assert_eq!(checked.valid, Some(true));
+    assert!(!checked.restart_required);
+    assert!(checked.restart_required_fields.is_empty());
+    assert_eq!(checked.current_generation, Some(1));
+    assert!(old.skills.roots.is_empty());
+
+    let reloaded = runtime.reload_config(1);
+    assert_eq!(reloaded.valid, Some(true));
+    assert!(!reloaded.restart_required);
+    assert_eq!(reloaded.current_generation, Some(2));
+    let active = runtime.snapshot();
+    assert_eq!(active.generation, 2);
+    assert_eq!(active.skills.roots, vec![live_root]);
+    assert!(old.skills.roots.is_empty());
 }
 
 #[test]

--- a/crates/webcodex-runner/src/main_tests/project_policy.rs
+++ b/crates/webcodex-runner/src/main_tests/project_policy.rs
@@ -125,6 +125,35 @@ fn default_policy_denies_paths_outside_allowed_roots() {
 }
 
 #[test]
+fn configured_skill_roots_do_not_expand_generic_file_authority() {
+    let project = tempfile::tempdir().unwrap();
+    let skills = tempfile::tempdir().unwrap();
+    let project_root = project.path().canonicalize().unwrap();
+    let skill_root = skills.path().canonicalize().unwrap();
+    let outside_file = skill_root.join("outside.txt");
+    std::fs::write(&outside_file, "must stay outside project authority").unwrap();
+
+    let config = RunnerConfig {
+        policy: RunnerPolicy {
+            allowed_roots: vec![project_root.clone()],
+            ..RunnerPolicy::default()
+        },
+        skills: crate::webcodex_runner::config::SkillsConfig {
+            roots: vec![skill_root.clone()],
+        },
+        ..test_config(project_root)
+    };
+    assert_eq!(config.skills.roots, vec![skill_root]);
+    let error = resolve_requested_path(
+        &config.policy,
+        None,
+        outside_file.to_string_lossy().as_ref(),
+    )
+    .expect_err("configured Skill roots must not grant generic file authority");
+    assert!(error.contains("outside allowed_roots"), "{error}");
+}
+
+#[test]
 fn load_config_explicit_allowed_roots_override_home_default() {
     let _guard = test_env_lock();
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/webcodex-runner/src/main_tests/runner_config.rs
+++ b/crates/webcodex-runner/src/main_tests/runner_config.rs
@@ -89,6 +89,67 @@ client_id = "oe"
 }
 
 #[test]
+fn runner_config_skill_roots_default_empty_and_accept_absolute_paths() {
+    let omitted: RunnerConfig = toml::from_str(
+        "server_url = \"http://127.0.0.1:8000\"\ntoken = \"t\"\nclient_id = \"oe\"\n",
+    )
+    .unwrap();
+    assert!(omitted.skills.roots.is_empty());
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("runner.toml");
+    let live_root = tmp.path().join("live-skills");
+    std::fs::write(
+        &config_path,
+        format!(
+            "server_url = \"http://127.0.0.1:8000\"\ntoken = \"t\"\nclient_id = \"oe\"\nproject_registry_dir = \"project-registry\"\n[skills]\nroots = [{:?}]\n[policy]\nallow_cwd_anywhere = true\n",
+            live_root.to_string_lossy().as_ref()
+        ),
+    )
+    .unwrap();
+    let configured = load_config(&config_path).unwrap();
+    assert_eq!(configured.skills.roots, vec![live_root]);
+}
+
+#[test]
+fn runner_config_skill_roots_validation_fails_closed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("runner.toml");
+    let render = |roots: &str| {
+        format!(
+            "server_url = \"http://127.0.0.1:8000\"\ntoken = \"t\"\nclient_id = \"oe\"\nproject_registry_dir = \"project-registry\"\n[skills]\nroots = [{roots}]\n[policy]\nallow_cwd_anywhere = true\n"
+        )
+    };
+
+    std::fs::write(&config_path, render("\"relative/skills\"")).unwrap();
+    let error = load_config(&config_path).unwrap_err();
+    assert!(
+        error.contains("absolute paths without parent traversal"),
+        "{error}"
+    );
+
+    let absolute = std::env::current_dir().unwrap().join("skill-root");
+    let encoded = format!("{:?}", absolute.to_string_lossy().as_ref());
+    let too_many = std::iter::repeat_n(encoded, 17)
+        .collect::<Vec<_>>()
+        .join(", ");
+    std::fs::write(&config_path, render(&too_many)).unwrap();
+    let error = load_config(&config_path).unwrap_err();
+    assert!(error.contains("at most 16 entries"), "{error}");
+
+    let too_long = std::env::current_dir()
+        .unwrap()
+        .join("x".repeat(crate::webcodex_runner::config::MAX_CONFIGURED_SKILL_ROOT_PATH_BYTES + 1));
+    std::fs::write(
+        &config_path,
+        render(&format!("{:?}", too_long.to_string_lossy().as_ref())),
+    )
+    .unwrap();
+    let error = load_config(&config_path).unwrap_err();
+    assert!(error.contains("at most 4096 bytes"), "{error}");
+}
+
+#[test]
 fn runner_config_rejects_zero_websocket_connect_timeout() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("agent.toml");

--- a/crates/webcodex-runner/src/webcodex_runner/config.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/config.rs
@@ -40,6 +40,15 @@ const DEFAULT_PERSISTENT_SHELL_IDLE_TIMEOUT_SECS: u64 = 30 * 60;
 const MIN_PERSISTENT_SHELL_IDLE_TIMEOUT_SECS: u64 = 1;
 const MAX_PERSISTENT_SHELL_IDLE_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 
+pub(crate) const MAX_CONFIGURED_SKILL_ROOTS: usize = 16;
+pub(crate) const MAX_CONFIGURED_SKILL_ROOT_PATH_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub(crate) struct SkillsConfig {
+    #[serde(default)]
+    pub(crate) roots: Vec<PathBuf>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct RunnerConfig {
     pub(crate) server_url: String,
@@ -72,6 +81,8 @@ pub(crate) struct RunnerConfig {
     pub(crate) max_concurrent_jobs: Option<usize>,
     #[serde(default)]
     pub(crate) policy: RunnerPolicy,
+    #[serde(default)]
+    pub(crate) skills: SkillsConfig,
     /// Transport selection: `"websocket"` (default), `"polling"`, `"quic"`,
     /// or explicit `"auto"` fallback mode.
     #[serde(default)]
@@ -494,6 +505,7 @@ pub(crate) struct HotRunnerConfig {
     pub(crate) generation: u64,
     pub(crate) policy: RunnerPolicy,
     pub(crate) shell: ShellConfig,
+    pub(crate) skills: SkillsConfig,
     /// Static/manual `[ssh.resources]` from the current runner.toml generation.
     pub(crate) static_ssh: SshConfig,
     /// Effective process-local resources: current static resources plus the
@@ -515,6 +527,7 @@ impl HotRunnerConfig {
             generation,
             policy: cfg.policy.clone(),
             shell: cfg.shell.clone(),
+            skills: cfg.skills.clone(),
             static_ssh: cfg.ssh.clone(),
             ssh,
             external_tools: Arc::new(ExternalToolRouter::new(&cfg.tool_providers)),
@@ -909,6 +922,11 @@ fn reload_error_code(error: &str) -> &'static str {
 
 fn reload_error_diagnostic(error: &str) -> (Option<&'static str>, Option<&'static str>) {
     const OUT_OF_RANGE_FIELDS: &[(&str, &str)] = &[
+        ("skills.roots may contain at most ", "skills.roots"),
+        (
+            "skills.roots entries must be non-empty paths of at most ",
+            "skills.roots",
+        ),
         (
             "max_concurrent_jobs must be between ",
             "max_concurrent_jobs",
@@ -934,6 +952,12 @@ fn reload_error_diagnostic(error: &str) -> (Option<&'static str>, Option<&'stati
             "mcp.request_timeout_secs",
         ),
     ];
+    if error.starts_with("skills.roots entries must be absolute paths")
+        || error.starts_with("skills.roots contains an unsupported Windows path namespace")
+        || error.starts_with("skills.roots contains duplicate path identities")
+    {
+        return (Some("skills.roots"), Some("invalid_path"));
+    }
     OUT_OF_RANGE_FIELDS
         .iter()
         .find_map(|(prefix, field)| {
@@ -988,7 +1012,7 @@ pub(crate) fn restart_required_fields(
     macro_rules! classify {
         ($($field:ident),+ $(,)?) => {{
             let RunnerConfig {
-                policy: _, shell: _, ssh: _, plugins: _, tool_providers: _, legacy_projects_dir: _,
+                policy: _, shell: _, skills: _, ssh: _, plugins: _, tool_providers: _, legacy_projects_dir: _,
                 $($field: _),+
             } = candidate;
             [$((stringify!($field), startup.$field != candidate.$field)),+]
@@ -1443,6 +1467,7 @@ pub(crate) fn load_config(path: &Path) -> Result<RunnerConfig, String> {
         return Err("websocket_connect_timeout_secs must be > 0".to_string());
     }
     validate_max_concurrent_jobs(cfg.max_concurrent_jobs)?;
+    validate_skills_config(&cfg.skills)?;
     if let Some(host_context) = cfg.host_context.take() {
         cfg.host_context = Some(host_context.normalized()?);
     }
@@ -1513,6 +1538,51 @@ pub(crate) fn load_config(path: &Path) -> Result<RunnerConfig, String> {
     validate_plugin_config(&cfg.plugins, &cfg.shell)?;
     validate_acp_config(&cfg.acp)?;
     Ok(cfg)
+}
+
+pub(crate) fn configured_skill_root_identity(root: &Path) -> String {
+    let lexical = root.components().collect::<PathBuf>();
+    crate::runner_config::paths::normalize_path_identity(&lexical)
+}
+
+fn validate_skills_config(config: &SkillsConfig) -> Result<(), String> {
+    use std::collections::HashSet;
+
+    if config.roots.len() > MAX_CONFIGURED_SKILL_ROOTS {
+        return Err(format!(
+            "skills.roots may contain at most {MAX_CONFIGURED_SKILL_ROOTS} entries"
+        ));
+    }
+    let mut identities = HashSet::with_capacity(config.roots.len());
+    for root in &config.roots {
+        let text = root.to_string_lossy();
+        if text.is_empty()
+            || text.len() > MAX_CONFIGURED_SKILL_ROOT_PATH_BYTES
+            || text.contains('\0')
+        {
+            return Err(format!(
+                "skills.roots entries must be non-empty paths of at most {MAX_CONFIGURED_SKILL_ROOT_PATH_BYTES} bytes"
+            ));
+        }
+        if !root.is_absolute()
+            || crate::runner_config::paths::project_path_has_parent_traversal(root)
+        {
+            return Err(
+                "skills.roots entries must be absolute paths without parent traversal".to_string(),
+            );
+        }
+        #[cfg(windows)]
+        if crate::runner_config::paths::windows_project_path_kind(root)
+            == Some(crate::runner_config::paths::WindowsProjectPathKind::UnsupportedNamespace)
+        {
+            return Err("skills.roots contains an unsupported Windows path namespace".to_string());
+        }
+        let identity = configured_skill_root_identity(root);
+        if !identities.insert(identity) {
+            return Err("skills.roots contains duplicate path identities".to_string());
+        }
+    }
+    Ok(())
 }
 
 fn validate_acp_env_name(value: &str) -> Result<(), ()> {

--- a/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
@@ -1,0 +1,700 @@
+use super::config::{configured_skill_root_identity, SkillsConfig};
+use super::CommandResult;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use webcodex_core::configured_skills::{
+    normalize_configured_skill_resource_path, ConfiguredSkillDescriptor,
+    ConfiguredSkillRootsListResponse, ConfiguredSkillRootsReadResponse,
+    ConfiguredSkillRootsRequest, CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT,
+    CONFIGURED_SKILL_ROOTS_RESPONSE_MAX_BYTES, MAX_CONFIGURED_SKILL_DIAGNOSTICS,
+    MAX_CONFIGURED_SKILL_PACKAGES, MAX_CONFIGURED_SKILL_READ_TEXT_BYTES,
+    MAX_CONFIGURED_SKILL_RESOURCE_FILE_BYTES, MAX_CONFIGURED_SKILL_ROOT_SCAN_ENTRIES,
+};
+use webcodex_core::skill_metadata::{parse_skill_metadata, MAX_SKILL_DEFINITION_BYTES};
+use webcodex_workspace::file_read_range;
+
+const SKILL_DEFINITION_FILE: &str = "SKILL.md";
+const MAX_SKILL_PACKAGE_NAME_BYTES: usize = 160;
+
+#[derive(Debug)]
+struct LiveSkill {
+    descriptor: ConfiguredSkillDescriptor,
+    package_root: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct LiveDiscovery {
+    skills: Vec<LiveSkill>,
+    invalid_count: usize,
+    diagnostics: Vec<String>,
+    discovery_truncated: bool,
+}
+
+pub(crate) fn handle_configured_skill_roots_request(
+    config: &SkillsConfig,
+    request: ConfiguredSkillRootsRequest,
+) -> CommandResult {
+    let start = Instant::now();
+    let result = match request {
+        ConfiguredSkillRootsRequest::List => discover(config).and_then(|discovery| {
+            let response = ConfiguredSkillRootsListResponse {
+                format: CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT.to_string(),
+                skills: discovery
+                    .skills
+                    .into_iter()
+                    .map(|skill| skill.descriptor)
+                    .collect(),
+                invalid_count: discovery.invalid_count,
+                diagnostics: discovery.diagnostics,
+                discovery_truncated: discovery.discovery_truncated,
+            };
+            response
+                .validate()
+                .map_err(|_| "configured_skill_response_invalid".to_string())?;
+            serialize_bounded(&response)
+        }),
+        ConfiguredSkillRootsRequest::Read {
+            skill_id,
+            path,
+            start_line,
+            limit,
+            expected_definition_revision,
+        } => read_resource(
+            config,
+            &skill_id,
+            &path,
+            start_line,
+            limit,
+            expected_definition_revision.as_deref(),
+        )
+        .and_then(|response| serialize_bounded(&response)),
+    };
+    match result {
+        Ok(stdout) => CommandResult {
+            exit_code: Some(0),
+            stdout: Some(stdout),
+            stderr: Some(String::new()),
+            duration_ms: Some(start.elapsed().as_millis() as u64),
+            error: None,
+        },
+        Err(code) => CommandResult {
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            duration_ms: Some(start.elapsed().as_millis() as u64),
+            error: Some(code),
+        },
+    }
+}
+
+fn discover(config: &SkillsConfig) -> Result<LiveDiscovery, String> {
+    let mut discovery = LiveDiscovery::default();
+    let mut seen_ids = BTreeSet::new();
+    for configured_root in &config.roots {
+        if discovery.skills.len() >= MAX_CONFIGURED_SKILL_PACKAGES {
+            discovery.discovery_truncated = true;
+            break;
+        }
+        let root_metadata = match fs::symlink_metadata(configured_root) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                push_diagnostic(
+                    &mut discovery.diagnostics,
+                    "configured_skill_root_not_found",
+                );
+                continue;
+            }
+            Err(_) => {
+                push_diagnostic(
+                    &mut discovery.diagnostics,
+                    "configured_skill_root_unavailable",
+                );
+                continue;
+            }
+        };
+        if metadata_is_link_like(&root_metadata) {
+            push_diagnostic(
+                &mut discovery.diagnostics,
+                "configured_skill_root_link_not_allowed",
+            );
+            continue;
+        }
+        if !root_metadata.is_dir() {
+            push_diagnostic(
+                &mut discovery.diagnostics,
+                "configured_skill_root_not_directory",
+            );
+            continue;
+        }
+        let root = match configured_root.canonicalize() {
+            Ok(root) if root.is_dir() => root,
+            _ => {
+                push_diagnostic(
+                    &mut discovery.diagnostics,
+                    "configured_skill_root_unavailable",
+                );
+                continue;
+            }
+        };
+        let entries = match bounded_root_entries(&root) {
+            Ok(entries) => entries,
+            Err(code) => {
+                if code == "configured_skill_root_scan_limit_exceeded" {
+                    discovery.discovery_truncated = true;
+                }
+                push_diagnostic(&mut discovery.diagnostics, code);
+                continue;
+            }
+        };
+        for package_name in entries {
+            if discovery.skills.len() >= MAX_CONFIGURED_SKILL_PACKAGES {
+                discovery.discovery_truncated = true;
+                break;
+            }
+            match load_live_skill(configured_root, &root, &package_name) {
+                Ok(skill) => {
+                    if !seen_ids.insert(skill.descriptor.skill_id.clone()) {
+                        return Err("configured_skill_identity_collision".to_string());
+                    }
+                    discovery.skills.push(skill);
+                }
+                Err(code) => {
+                    discovery.invalid_count = discovery.invalid_count.saturating_add(1);
+                    push_diagnostic(&mut discovery.diagnostics, code);
+                }
+            }
+        }
+    }
+    discovery
+        .skills
+        .sort_by(|left, right| left.descriptor.skill_id.cmp(&right.descriptor.skill_id));
+    Ok(discovery)
+}
+
+fn bounded_root_entries(root: &Path) -> Result<Vec<String>, &'static str> {
+    let read_dir = fs::read_dir(root).map_err(|_| "configured_skill_root_unavailable")?;
+    let mut candidates = Vec::new();
+    let mut scanned = 0usize;
+    for entry in read_dir {
+        scanned = scanned.saturating_add(1);
+        if scanned > MAX_CONFIGURED_SKILL_ROOT_SCAN_ENTRIES {
+            return Err("configured_skill_root_scan_limit_exceeded");
+        }
+        let entry = entry.map_err(|_| "configured_skill_root_unavailable")?;
+        let file_type = entry
+            .file_type()
+            .map_err(|_| "configured_skill_root_unavailable")?;
+        if !file_type.is_dir() && !file_type.is_symlink() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            candidates.push(String::new());
+            continue;
+        };
+        candidates.push(name);
+    }
+    candidates.sort();
+    Ok(candidates)
+}
+
+fn load_live_skill(
+    configured_root: &Path,
+    canonical_root: &Path,
+    package_name: &str,
+) -> Result<LiveSkill, &'static str> {
+    if !valid_package_name(package_name) {
+        return Err("invalid_skill_package");
+    }
+    if webcodex_core::sensitive_paths::is_secret_path(package_name) {
+        return Err("sensitive_skill_definition");
+    }
+    let package_path = canonical_root.join(package_name);
+    let metadata = fs::symlink_metadata(&package_path).map_err(|_| "invalid_skill_package")?;
+    if metadata_is_link_like(&metadata) || !metadata.is_dir() {
+        return Err("invalid_skill_package");
+    }
+    let package_root = package_path
+        .canonicalize()
+        .map_err(|_| "invalid_skill_package")?;
+    if !crate::runner_config::paths::path_is_within(&package_root, canonical_root) {
+        return Err("invalid_skill_package");
+    }
+    let definition = resolve_regular_package_file(
+        &package_root,
+        canonical_root,
+        SKILL_DEFINITION_FILE,
+        "missing_skill_definition",
+        "invalid_skill_package",
+    )?;
+    let bytes =
+        read_bounded(&definition, MAX_SKILL_DEFINITION_BYTES).map_err(|code| match code {
+            "too_large" => "skill_definition_too_large",
+            "invalid_utf8" => "invalid_utf8_skill_definition",
+            _ => "invalid_skill_package",
+        })?;
+    let text = std::str::from_utf8(&bytes).map_err(|_| "invalid_utf8_skill_definition")?;
+    let skill_metadata = parse_skill_metadata(text)?;
+    let definition_revision = sha256_hex(&bytes);
+    let skill_id = configured_skill_id(configured_root, package_name);
+    Ok(LiveSkill {
+        descriptor: ConfiguredSkillDescriptor {
+            skill_id,
+            name: skill_metadata.name,
+            description: skill_metadata.description,
+            definition_revision,
+        },
+        package_root,
+    })
+}
+
+fn read_resource(
+    config: &SkillsConfig,
+    skill_id: &str,
+    requested_path: &str,
+    start_line: usize,
+    limit: usize,
+    expected_definition_revision: Option<&str>,
+) -> Result<ConfiguredSkillRootsReadResponse, String> {
+    let path = normalize_configured_skill_resource_path(requested_path)
+        .map_err(|_| "skill_resource_path_invalid".to_string())?;
+    if webcodex_core::sensitive_paths::is_secret_path(&path) {
+        return Err("skill_sensitive_path".to_string());
+    }
+    let discovery = discover(config)?;
+    let skill = discovery
+        .skills
+        .into_iter()
+        .find(|skill| skill.descriptor.skill_id == skill_id)
+        .ok_or_else(|| "skill_not_found".to_string())?;
+    if expected_definition_revision
+        .is_some_and(|expected| expected != skill.descriptor.definition_revision)
+    {
+        return Err("skill_definition_changed".to_string());
+    }
+    let canonical_root = skill
+        .package_root
+        .parent()
+        .ok_or_else(|| "skill_resource_path_invalid".to_string())?;
+    let target = resolve_regular_package_file(
+        &skill.package_root,
+        canonical_root,
+        &path,
+        "skill_resource_not_found",
+        "skill_resource_path_invalid",
+    )
+    .map_err(str::to_string)?;
+    let relative = target
+        .strip_prefix(&skill.package_root)
+        .map_err(|_| "skill_resource_path_invalid".to_string())?
+        .to_string_lossy();
+    if webcodex_core::sensitive_paths::is_secret_path(relative.as_ref()) {
+        return Err("skill_sensitive_path".to_string());
+    }
+    let max_file_bytes = if path == SKILL_DEFINITION_FILE {
+        MAX_SKILL_DEFINITION_BYTES
+    } else {
+        MAX_CONFIGURED_SKILL_RESOURCE_FILE_BYTES
+    };
+    let file_bytes = target
+        .metadata()
+        .map_err(|_| "skill_resource_unavailable".to_string())?
+        .len();
+    if file_bytes > max_file_bytes as u64 {
+        return Err("skill_resource_too_large".to_string());
+    }
+    let range = file_read_range::EffectiveRange::new(Some(start_line), Some(limit));
+    let read = file_read_range::read_range_with_budget(
+        &target,
+        range,
+        MAX_CONFIGURED_SKILL_READ_TEXT_BYTES,
+    )
+    .map_err(|error| match error.reason {
+        file_read_range::ReadFileReason::InvalidUtf8 => {
+            "skill_resource_unsupported_encoding".to_string()
+        }
+        file_read_range::ReadFileReason::NotFound => "skill_resource_not_found".to_string(),
+        file_read_range::ReadFileReason::RangeTooLarge => "skill_read_result_too_large".to_string(),
+        _ => "skill_resource_unavailable".to_string(),
+    })?;
+    let definition_after = resolve_regular_package_file(
+        &skill.package_root,
+        canonical_root,
+        SKILL_DEFINITION_FILE,
+        "skill_definition_changed",
+        "skill_definition_changed",
+    )
+    .map_err(str::to_string)?;
+    let definition_after = read_bounded(&definition_after, MAX_SKILL_DEFINITION_BYTES)
+        .map_err(|_| "skill_definition_changed".to_string())?;
+    if sha256_hex(&definition_after) != skill.descriptor.definition_revision
+        || (path == SKILL_DEFINITION_FILE && read.sha256 != skill.descriptor.definition_revision)
+    {
+        return Err("skill_definition_changed".to_string());
+    }
+    let response = ConfiguredSkillRootsReadResponse {
+        format: CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT.to_string(),
+        skill_id: skill.descriptor.skill_id,
+        name: skill.descriptor.name,
+        definition_revision: skill.descriptor.definition_revision,
+        path: path.clone(),
+        sha256: read.sha256,
+        file_bytes: file_bytes.min(usize::MAX as u64) as usize,
+        total_lines: read.total_lines,
+        text: read.content,
+        start_line: read.start_line,
+        end_line: read.end_line,
+        returned_lines: read.returned_lines,
+        has_more: read.has_more,
+        next_start_line: read.next_start_line,
+    };
+    response
+        .validate_for_request(skill_id, &path, start_line, limit)
+        .map_err(|_| "configured_skill_response_invalid".to_string())?;
+    Ok(response)
+}
+
+fn resolve_regular_package_file(
+    package_root: &Path,
+    canonical_root: &Path,
+    relative: &str,
+    missing_code: &'static str,
+    invalid_code: &'static str,
+) -> Result<PathBuf, &'static str> {
+    let mut current = package_root.to_path_buf();
+    let components = relative.split('/').collect::<Vec<_>>();
+    for (index, component) in components.iter().enumerate() {
+        current.push(component);
+        let metadata = fs::symlink_metadata(&current).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                missing_code
+            } else {
+                invalid_code
+            }
+        })?;
+        let last = index + 1 == components.len();
+        if metadata_is_link_like(&metadata)
+            || (last && !metadata.is_file())
+            || (!last && !metadata.is_dir())
+        {
+            return Err(invalid_code);
+        }
+    }
+    let target = current.canonicalize().map_err(|_| invalid_code)?;
+    if !crate::runner_config::paths::path_is_within(&target, package_root)
+        || !crate::runner_config::paths::path_is_within(&target, canonical_root)
+    {
+        return Err(invalid_code);
+    }
+    Ok(target)
+}
+
+fn metadata_is_link_like(metadata: &fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+fn read_bounded(path: &Path, max_bytes: usize) -> Result<Vec<u8>, &'static str> {
+    let file = File::open(path).map_err(|_| "unavailable")?;
+    let mut bytes = Vec::with_capacity(max_bytes.min(64 * 1024));
+    file.take(max_bytes.saturating_add(1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "unavailable")?;
+    if bytes.len() > max_bytes {
+        return Err("too_large");
+    }
+    if std::str::from_utf8(&bytes).is_err() {
+        return Err("invalid_utf8");
+    }
+    Ok(bytes)
+}
+
+fn configured_skill_id(root: &Path, package_name: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"webcodex.configured-skill-id.v1\0");
+    hasher.update(configured_skill_root_identity(root).as_bytes());
+    hasher.update(b"\0");
+    hasher.update(package_name.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("wc_skill_{}", &digest[..32])
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn valid_package_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_SKILL_PACKAGE_NAME_BYTES
+        && !name.contains(['/', '\\'])
+        && name != "."
+        && name != ".."
+        && !name.chars().any(char::is_control)
+}
+
+fn push_diagnostic(diagnostics: &mut Vec<String>, code: &str) {
+    if diagnostics.len() < MAX_CONFIGURED_SKILL_DIAGNOSTICS {
+        diagnostics.push(code.to_string());
+    }
+}
+
+fn serialize_bounded<T: serde::Serialize>(value: &T) -> Result<String, String> {
+    let output = serde_json::to_string(value)
+        .map_err(|_| "configured_skill_response_invalid".to_string())?;
+    if output.len() > CONFIGURED_SKILL_ROOTS_RESPONSE_MAX_BYTES {
+        return Err("configured_skill_response_too_large".to_string());
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_skill(root: &Path, package: &str, name: &str, body: &str) {
+        let package = root.join(package);
+        fs::create_dir_all(package.join("references")).unwrap();
+        fs::write(
+            package.join(SKILL_DEFINITION_FILE),
+            format!("---\nname: {name}\ndescription: configured test skill\n---\n{body}"),
+        )
+        .unwrap();
+        fs::write(package.join("references/guide.md"), "line one\nline two\n").unwrap();
+    }
+
+    #[test]
+    fn empty_roots_preserve_empty_source() {
+        let result = handle_configured_skill_roots_request(
+            &SkillsConfig::default(),
+            ConfiguredSkillRootsRequest::List,
+        );
+        let response: ConfiguredSkillRootsListResponse =
+            serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
+        assert!(response.skills.is_empty());
+        assert!(response.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn live_discovery_and_resource_read_observe_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        write_skill(temp.path(), "demo", "demo", "version one");
+        let config = SkillsConfig {
+            roots: vec![temp.path().to_path_buf()],
+        };
+        let first = discover(&config).unwrap();
+        assert_eq!(first.skills.len(), 1);
+        let id = first.skills[0].descriptor.skill_id.clone();
+        let revision = first.skills[0].descriptor.definition_revision.clone();
+        let listed =
+            handle_configured_skill_roots_request(&config, ConfiguredSkillRootsRequest::List);
+        let listed_text = listed.stdout.as_deref().unwrap();
+        assert!(!listed_text.contains(temp.path().to_string_lossy().as_ref()));
+        let definition =
+            read_resource(&config, &id, SKILL_DEFINITION_FILE, 1, 20, Some(&revision)).unwrap();
+        assert!(definition.text.contains("version one"));
+        let resource =
+            read_resource(&config, &id, "references/guide.md", 1, 20, Some(&revision)).unwrap();
+        assert_eq!(resource.text, "line one\nline two");
+
+        write_skill(temp.path(), "demo", "demo", "version two");
+        let second = discover(&config).unwrap();
+        assert_eq!(second.skills[0].descriptor.skill_id, id);
+        assert_ne!(second.skills[0].descriptor.definition_revision, revision);
+        assert_eq!(
+            read_resource(&config, &id, SKILL_DEFINITION_FILE, 1, 20, Some(&revision)).unwrap_err(),
+            "skill_definition_changed"
+        );
+        let fresh_revision = &second.skills[0].descriptor.definition_revision;
+        let fresh = read_resource(
+            &config,
+            &id,
+            SKILL_DEFINITION_FILE,
+            1,
+            20,
+            Some(fresh_revision),
+        )
+        .unwrap();
+        assert!(fresh.text.contains("version two"));
+        let serialized = serde_json::to_string(&fresh).unwrap();
+        assert!(!serialized.contains(temp.path().to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn missing_root_is_a_bounded_path_free_diagnostic_not_an_empty_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing-live-skills");
+        let result = handle_configured_skill_roots_request(
+            &SkillsConfig {
+                roots: vec![missing.clone()],
+            },
+            ConfiguredSkillRootsRequest::List,
+        );
+        assert_eq!(result.exit_code, Some(0));
+        let stdout = result.stdout.as_deref().unwrap();
+        assert!(!stdout.contains(missing.to_string_lossy().as_ref()));
+        let response: ConfiguredSkillRootsListResponse = serde_json::from_str(stdout).unwrap();
+        assert!(response.skills.is_empty());
+        assert_eq!(
+            response.diagnostics,
+            vec!["configured_skill_root_not_found".to_string()]
+        );
+    }
+
+    #[test]
+    fn same_package_in_two_roots_has_distinct_opaque_identity() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        write_skill(first.path(), "same", "same", "first");
+        write_skill(second.path(), "same", "same", "second");
+        let discovery = discover(&SkillsConfig {
+            roots: vec![first.path().to_path_buf(), second.path().to_path_buf()],
+        })
+        .unwrap();
+        assert_eq!(discovery.skills.len(), 2);
+        assert_ne!(
+            discovery.skills[0].descriptor.skill_id,
+            discovery.skills[1].descriptor.skill_id
+        );
+        for skill in discovery.skills {
+            assert!(!skill
+                .descriptor
+                .skill_id
+                .contains(&first.path().to_string_lossy().as_ref()));
+            assert!(!skill
+                .descriptor
+                .skill_id
+                .contains(&second.path().to_string_lossy().as_ref()));
+        }
+    }
+
+    #[test]
+    fn configured_root_symlink_is_rejected() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let target = tempfile::tempdir().unwrap();
+            write_skill(target.path(), "demo", "demo", "body");
+            let holder = tempfile::tempdir().unwrap();
+            let link = holder.path().join("skills-link");
+            symlink(target.path(), &link).unwrap();
+            let discovery = discover(&SkillsConfig { roots: vec![link] }).unwrap();
+            assert!(discovery.skills.is_empty());
+            assert!(discovery
+                .diagnostics
+                .iter()
+                .any(|code| code == "configured_skill_root_link_not_allowed"));
+        }
+    }
+
+    #[test]
+    fn traversal_and_symlink_escape_are_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        write_skill(temp.path(), "demo", "demo", "body");
+        let config = SkillsConfig {
+            roots: vec![temp.path().to_path_buf()],
+        };
+        let skill = discover(&config).unwrap().skills.remove(0);
+        assert_eq!(
+            read_resource(
+                &config,
+                &skill.descriptor.skill_id,
+                "../secret",
+                1,
+                20,
+                None
+            )
+            .unwrap_err(),
+            "skill_resource_path_invalid"
+        );
+        assert_eq!(
+            read_resource(
+                &config,
+                &skill.descriptor.skill_id,
+                "/etc/passwd",
+                1,
+                20,
+                None
+            )
+            .unwrap_err(),
+            "skill_resource_path_invalid"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let outside = tempfile::tempdir().unwrap();
+            fs::write(outside.path().join("secret.md"), "secret").unwrap();
+            symlink(
+                outside.path().join("secret.md"),
+                temp.path().join("demo/references/escape.md"),
+            )
+            .unwrap();
+            assert_eq!(
+                read_resource(
+                    &config,
+                    &skill.descriptor.skill_id,
+                    "references/escape.md",
+                    1,
+                    20,
+                    None,
+                )
+                .unwrap_err(),
+                "skill_resource_path_invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn sensitive_package_names_are_not_discovered() {
+        let temp = tempfile::tempdir().unwrap();
+        write_skill(temp.path(), ".git", "hidden", "must stay hidden");
+        let discovery = discover(&SkillsConfig {
+            roots: vec![temp.path().to_path_buf()],
+        })
+        .unwrap();
+        assert!(discovery.skills.is_empty());
+        assert_eq!(discovery.invalid_count, 1);
+        assert!(discovery
+            .diagnostics
+            .iter()
+            .any(|code| code == "sensitive_skill_definition"));
+    }
+
+    #[test]
+    fn malformed_and_oversized_definitions_are_bounded_diagnostics() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(temp.path().join("bad")).unwrap();
+        fs::write(temp.path().join("bad/SKILL.md"), "not frontmatter").unwrap();
+        fs::create_dir_all(temp.path().join("huge")).unwrap();
+        fs::write(
+            temp.path().join("huge/SKILL.md"),
+            vec![b'x'; MAX_SKILL_DEFINITION_BYTES + 1],
+        )
+        .unwrap();
+        let discovery = discover(&SkillsConfig {
+            roots: vec![temp.path().to_path_buf()],
+        })
+        .unwrap();
+        assert_eq!(discovery.invalid_count, 2);
+        assert!(discovery.diagnostics.len() <= MAX_CONFIGURED_SKILL_DIAGNOSTICS);
+        assert!(discovery
+            .diagnostics
+            .iter()
+            .any(|code| code == "skill_definition_too_large"));
+    }
+}

--- a/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
@@ -296,16 +296,17 @@ fn read_resource(
     } else {
         MAX_CONFIGURED_SKILL_RESOURCE_FILE_BYTES
     };
-    let file_bytes = target
-        .metadata()
-        .map_err(|_| "skill_resource_unavailable".to_string())?
-        .len();
-    if file_bytes > max_file_bytes as u64 {
-        return Err("skill_resource_too_large".to_string());
-    }
+    // Enforce the file bound on the bytes actually read, not a metadata
+    // snapshot: configured resources can grow or be replaced between reads.
+    let bytes = read_bounded(&target, max_file_bytes).map_err(|code| match code {
+        "too_large" => "skill_resource_too_large".to_string(),
+        "invalid_utf8" => "skill_resource_unsupported_encoding".to_string(),
+        _ => "skill_resource_unavailable".to_string(),
+    })?;
+    let file_bytes = bytes.len();
     let range = file_read_range::EffectiveRange::new(Some(start_line), Some(limit));
-    let read = file_read_range::read_range_with_budget(
-        &target,
+    let read = file_read_range::read_range_from_with_budget(
+        bytes.as_slice(),
         range,
         MAX_CONFIGURED_SKILL_READ_TEXT_BYTES,
     )
@@ -339,7 +340,7 @@ fn read_resource(
         definition_revision: skill.descriptor.definition_revision,
         path: path.clone(),
         sha256: read.sha256,
-        file_bytes: file_bytes.min(usize::MAX as u64) as usize,
+        file_bytes,
         total_lines: read.total_lines,
         text: read.content,
         start_line: read.start_line,
@@ -479,268 +480,5 @@ fn serialize_bounded<T: serde::Serialize>(value: &T) -> Result<String, String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn write_skill(root: &Path, package: &str, name: &str, body: &str) {
-        let package = root.join(package);
-        fs::create_dir_all(package.join("references")).unwrap();
-        fs::write(
-            package.join(SKILL_DEFINITION_FILE),
-            format!("---\nname: {name}\ndescription: configured test skill\n---\n{body}"),
-        )
-        .unwrap();
-        fs::write(package.join("references/guide.md"), "line one\nline two\n").unwrap();
-    }
-
-    #[test]
-    fn empty_roots_preserve_empty_source() {
-        let result = handle_configured_skill_roots_request(
-            &SkillsConfig::default(),
-            ConfiguredSkillRootsRequest::List,
-        );
-        let response: ConfiguredSkillRootsListResponse =
-            serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
-        assert!(response.skills.is_empty());
-        assert!(response.diagnostics.is_empty());
-    }
-
-    #[test]
-    fn live_discovery_and_resource_read_observe_changes() {
-        let temp = tempfile::tempdir().unwrap();
-        write_skill(temp.path(), "demo", "demo", "version one");
-        let config = SkillsConfig {
-            roots: vec![temp.path().to_path_buf()],
-        };
-        let first = discover(&config).unwrap();
-        assert_eq!(first.skills.len(), 1);
-        let id = first.skills[0].descriptor.skill_id.clone();
-        let revision = first.skills[0].descriptor.definition_revision.clone();
-        let listed =
-            handle_configured_skill_roots_request(&config, ConfiguredSkillRootsRequest::List);
-        let listed_text = listed.stdout.as_deref().unwrap();
-        assert!(!listed_text.contains(temp.path().to_string_lossy().as_ref()));
-        let definition =
-            read_resource(&config, &id, SKILL_DEFINITION_FILE, 1, 20, Some(&revision)).unwrap();
-        assert!(definition.text.contains("version one"));
-        let resource =
-            read_resource(&config, &id, "references/guide.md", 1, 20, Some(&revision)).unwrap();
-        assert_eq!(resource.text, "line one\nline two");
-
-        write_skill(temp.path(), "demo", "demo", "version two");
-        let second = discover(&config).unwrap();
-        assert_eq!(second.skills[0].descriptor.skill_id, id);
-        assert_ne!(second.skills[0].descriptor.definition_revision, revision);
-        assert_eq!(
-            read_resource(&config, &id, SKILL_DEFINITION_FILE, 1, 20, Some(&revision)).unwrap_err(),
-            "skill_definition_changed"
-        );
-        let fresh_revision = &second.skills[0].descriptor.definition_revision;
-        let fresh = read_resource(
-            &config,
-            &id,
-            SKILL_DEFINITION_FILE,
-            1,
-            20,
-            Some(fresh_revision),
-        )
-        .unwrap();
-        assert!(fresh.text.contains("version two"));
-        let serialized = serde_json::to_string(&fresh).unwrap();
-        assert!(!serialized.contains(temp.path().to_string_lossy().as_ref()));
-    }
-
-    #[test]
-    fn missing_root_is_a_bounded_path_free_diagnostic_not_an_empty_fallback() {
-        let temp = tempfile::tempdir().unwrap();
-        let missing = temp.path().join("missing-live-skills");
-        let result = handle_configured_skill_roots_request(
-            &SkillsConfig {
-                roots: vec![missing.clone()],
-            },
-            ConfiguredSkillRootsRequest::List,
-        );
-        assert_eq!(result.exit_code, Some(0));
-        let stdout = result.stdout.as_deref().unwrap();
-        assert!(!stdout.contains(missing.to_string_lossy().as_ref()));
-        let response: ConfiguredSkillRootsListResponse = serde_json::from_str(stdout).unwrap();
-        assert!(response.skills.is_empty());
-        assert_eq!(
-            response.diagnostics,
-            vec!["configured_skill_root_not_found".to_string()]
-        );
-    }
-
-    #[test]
-    fn same_package_in_two_roots_has_distinct_opaque_identity() {
-        let first = tempfile::tempdir().unwrap();
-        let second = tempfile::tempdir().unwrap();
-        write_skill(first.path(), "same", "same", "first");
-        write_skill(second.path(), "same", "same", "second");
-        let discovery = discover(&SkillsConfig {
-            roots: vec![first.path().to_path_buf(), second.path().to_path_buf()],
-        })
-        .unwrap();
-        assert_eq!(discovery.skills.len(), 2);
-        assert_ne!(
-            discovery.skills[0].descriptor.skill_id,
-            discovery.skills[1].descriptor.skill_id
-        );
-        for skill in discovery.skills {
-            assert!(!skill
-                .descriptor
-                .skill_id
-                .contains(&first.path().to_string_lossy().as_ref()));
-            assert!(!skill
-                .descriptor
-                .skill_id
-                .contains(&second.path().to_string_lossy().as_ref()));
-        }
-    }
-
-    #[test]
-    fn list_response_truncates_valid_unicode_descriptors_to_wire_budget() {
-        let temp = tempfile::tempdir().unwrap();
-        let description = "界".repeat(webcodex_core::skill_metadata::MAX_SKILL_DESCRIPTION_CHARS);
-        for index in 0..MAX_CONFIGURED_SKILL_PACKAGES {
-            let package = temp.path().join(format!("skill-{index:03}"));
-            fs::create_dir_all(&package).unwrap();
-            fs::write(
-                package.join(SKILL_DEFINITION_FILE),
-                format!("---\nname: skill-{index:03}\ndescription: {description}\n---\nbody\n"),
-            )
-            .unwrap();
-        }
-
-        let result = handle_configured_skill_roots_request(
-            &SkillsConfig {
-                roots: vec![temp.path().to_path_buf()],
-            },
-            ConfiguredSkillRootsRequest::List,
-        );
-        assert_eq!(result.exit_code, Some(0));
-        let stdout = result.stdout.as_deref().unwrap();
-        assert!(stdout.len() <= CONFIGURED_SKILL_ROOTS_RESPONSE_MAX_BYTES);
-        let response: ConfiguredSkillRootsListResponse = serde_json::from_str(stdout).unwrap();
-        response.validate().unwrap();
-        assert!(response.discovery_truncated);
-        assert!(!response.skills.is_empty());
-        assert!(response.skills.len() < MAX_CONFIGURED_SKILL_PACKAGES);
-    }
-
-    #[test]
-    fn configured_root_symlink_is_rejected() {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::symlink;
-            let target = tempfile::tempdir().unwrap();
-            write_skill(target.path(), "demo", "demo", "body");
-            let holder = tempfile::tempdir().unwrap();
-            let link = holder.path().join("skills-link");
-            symlink(target.path(), &link).unwrap();
-            let discovery = discover(&SkillsConfig { roots: vec![link] }).unwrap();
-            assert!(discovery.skills.is_empty());
-            assert!(discovery
-                .diagnostics
-                .iter()
-                .any(|code| code == "configured_skill_root_link_not_allowed"));
-        }
-    }
-
-    #[test]
-    fn traversal_and_symlink_escape_are_rejected() {
-        let temp = tempfile::tempdir().unwrap();
-        write_skill(temp.path(), "demo", "demo", "body");
-        let config = SkillsConfig {
-            roots: vec![temp.path().to_path_buf()],
-        };
-        let skill = discover(&config).unwrap().skills.remove(0);
-        assert_eq!(
-            read_resource(
-                &config,
-                &skill.descriptor.skill_id,
-                "../secret",
-                1,
-                20,
-                None
-            )
-            .unwrap_err(),
-            "skill_resource_path_invalid"
-        );
-        assert_eq!(
-            read_resource(
-                &config,
-                &skill.descriptor.skill_id,
-                "/etc/passwd",
-                1,
-                20,
-                None
-            )
-            .unwrap_err(),
-            "skill_resource_path_invalid"
-        );
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::symlink;
-            let outside = tempfile::tempdir().unwrap();
-            fs::write(outside.path().join("secret.md"), "secret").unwrap();
-            symlink(
-                outside.path().join("secret.md"),
-                temp.path().join("demo/references/escape.md"),
-            )
-            .unwrap();
-            assert_eq!(
-                read_resource(
-                    &config,
-                    &skill.descriptor.skill_id,
-                    "references/escape.md",
-                    1,
-                    20,
-                    None,
-                )
-                .unwrap_err(),
-                "skill_resource_path_invalid"
-            );
-        }
-    }
-
-    #[test]
-    fn sensitive_package_names_are_not_discovered() {
-        let temp = tempfile::tempdir().unwrap();
-        write_skill(temp.path(), ".git", "hidden", "must stay hidden");
-        let discovery = discover(&SkillsConfig {
-            roots: vec![temp.path().to_path_buf()],
-        })
-        .unwrap();
-        assert!(discovery.skills.is_empty());
-        assert_eq!(discovery.invalid_count, 1);
-        assert!(discovery
-            .diagnostics
-            .iter()
-            .any(|code| code == "sensitive_skill_definition"));
-    }
-
-    #[test]
-    fn malformed_and_oversized_definitions_are_bounded_diagnostics() {
-        let temp = tempfile::tempdir().unwrap();
-        fs::create_dir_all(temp.path().join("bad")).unwrap();
-        fs::write(temp.path().join("bad/SKILL.md"), "not frontmatter").unwrap();
-        fs::create_dir_all(temp.path().join("huge")).unwrap();
-        fs::write(
-            temp.path().join("huge/SKILL.md"),
-            vec![b'x'; MAX_SKILL_DEFINITION_BYTES + 1],
-        )
-        .unwrap();
-        let discovery = discover(&SkillsConfig {
-            roots: vec![temp.path().to_path_buf()],
-        })
-        .unwrap();
-        assert_eq!(discovery.invalid_count, 2);
-        assert!(discovery.diagnostics.len() <= MAX_CONFIGURED_SKILL_DIAGNOSTICS);
-        assert!(discovery
-            .diagnostics
-            .iter()
-            .any(|code| code == "skill_definition_too_large"));
-    }
-}
+#[path = "configured_skills_tests.rs"]
+mod tests;

--- a/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
@@ -41,7 +41,7 @@ pub(crate) fn handle_configured_skill_roots_request(
     let start = Instant::now();
     let result = match request {
         ConfiguredSkillRootsRequest::List => discover(config).and_then(|discovery| {
-            let response = ConfiguredSkillRootsListResponse {
+            let mut response = ConfiguredSkillRootsListResponse {
                 format: CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT.to_string(),
                 skills: discovery
                     .skills
@@ -52,10 +52,7 @@ pub(crate) fn handle_configured_skill_roots_request(
                 diagnostics: discovery.diagnostics,
                 discovery_truncated: discovery.discovery_truncated,
             };
-            response
-                .validate()
-                .map_err(|_| "configured_skill_response_invalid".to_string())?;
-            serialize_bounded(&response)
+            serialize_list_bounded(&mut response)
         }),
         ConfiguredSkillRootsRequest::Read {
             skill_id,
@@ -453,6 +450,25 @@ fn push_diagnostic(diagnostics: &mut Vec<String>, code: &str) {
     }
 }
 
+fn serialize_list_bounded(
+    response: &mut ConfiguredSkillRootsListResponse,
+) -> Result<String, String> {
+    loop {
+        response
+            .validate()
+            .map_err(|_| "configured_skill_response_invalid".to_string())?;
+        let output = serde_json::to_string(response)
+            .map_err(|_| "configured_skill_response_invalid".to_string())?;
+        if output.len() <= CONFIGURED_SKILL_ROOTS_RESPONSE_MAX_BYTES {
+            return Ok(output);
+        }
+        if response.skills.pop().is_none() {
+            return Err("configured_skill_response_too_large".to_string());
+        }
+        response.discovery_truncated = true;
+    }
+}
+
 fn serialize_bounded<T: serde::Serialize>(value: &T) -> Result<String, String> {
     let output = serde_json::to_string(value)
         .map_err(|_| "configured_skill_response_invalid".to_string())?;
@@ -580,6 +596,36 @@ mod tests {
                 .skill_id
                 .contains(&second.path().to_string_lossy().as_ref()));
         }
+    }
+
+    #[test]
+    fn list_response_truncates_valid_unicode_descriptors_to_wire_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        let description = "界".repeat(webcodex_core::skill_metadata::MAX_SKILL_DESCRIPTION_CHARS);
+        for index in 0..MAX_CONFIGURED_SKILL_PACKAGES {
+            let package = temp.path().join(format!("skill-{index:03}"));
+            fs::create_dir_all(&package).unwrap();
+            fs::write(
+                package.join(SKILL_DEFINITION_FILE),
+                format!("---\nname: skill-{index:03}\ndescription: {description}\n---\nbody\n"),
+            )
+            .unwrap();
+        }
+
+        let result = handle_configured_skill_roots_request(
+            &SkillsConfig {
+                roots: vec![temp.path().to_path_buf()],
+            },
+            ConfiguredSkillRootsRequest::List,
+        );
+        assert_eq!(result.exit_code, Some(0));
+        let stdout = result.stdout.as_deref().unwrap();
+        assert!(stdout.len() <= CONFIGURED_SKILL_ROOTS_RESPONSE_MAX_BYTES);
+        let response: ConfiguredSkillRootsListResponse = serde_json::from_str(stdout).unwrap();
+        response.validate().unwrap();
+        assert!(response.discovery_truncated);
+        assert!(!response.skills.is_empty());
+        assert!(response.skills.len() < MAX_CONFIGURED_SKILL_PACKAGES);
     }
 
     #[test]

--- a/crates/webcodex-runner/src/webcodex_runner/configured_skills_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/configured_skills_tests.rs
@@ -1,0 +1,317 @@
+use super::*;
+
+fn write_skill(root: &Path, package: &str, name: &str, body: &str) {
+    let package = root.join(package);
+    fs::create_dir_all(package.join("references")).unwrap();
+    fs::write(
+        package.join(SKILL_DEFINITION_FILE),
+        format!("---\nname: {name}\ndescription: configured test skill\n---\n{body}"),
+    )
+    .unwrap();
+    fs::write(package.join("references/guide.md"), "line one\nline two\n").unwrap();
+}
+
+#[test]
+fn empty_roots_preserve_empty_source() {
+    let result = handle_configured_skill_roots_request(
+        &SkillsConfig::default(),
+        ConfiguredSkillRootsRequest::List,
+    );
+    let response: ConfiguredSkillRootsListResponse =
+        serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
+    assert!(response.skills.is_empty());
+    assert!(response.diagnostics.is_empty());
+}
+
+#[test]
+fn live_discovery_and_resource_read_observe_changes() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(temp.path(), "demo", "demo", "version one");
+    let config = SkillsConfig {
+        roots: vec![temp.path().to_path_buf()],
+    };
+    let first = discover(&config).unwrap();
+    assert_eq!(first.skills.len(), 1);
+    let id = first.skills[0].descriptor.skill_id.clone();
+    let revision = first.skills[0].descriptor.definition_revision.clone();
+    let listed = handle_configured_skill_roots_request(&config, ConfiguredSkillRootsRequest::List);
+    let listed_text = listed.stdout.as_deref().unwrap();
+    assert!(!listed_text.contains(temp.path().to_string_lossy().as_ref()));
+    let definition =
+        read_resource(&config, &id, SKILL_DEFINITION_FILE, 1, 20, Some(&revision)).unwrap();
+    assert!(definition.text.contains("version one"));
+    let resource =
+        read_resource(&config, &id, "references/guide.md", 1, 20, Some(&revision)).unwrap();
+    assert_eq!(resource.text, "line one\nline two");
+
+    write_skill(temp.path(), "demo", "demo", "version two");
+    let second = discover(&config).unwrap();
+    assert_eq!(second.skills[0].descriptor.skill_id, id);
+    assert_ne!(second.skills[0].descriptor.definition_revision, revision);
+    assert_eq!(
+        read_resource(&config, &id, SKILL_DEFINITION_FILE, 1, 20, Some(&revision)).unwrap_err(),
+        "skill_definition_changed"
+    );
+    let fresh_revision = &second.skills[0].descriptor.definition_revision;
+    let fresh = read_resource(
+        &config,
+        &id,
+        SKILL_DEFINITION_FILE,
+        1,
+        20,
+        Some(fresh_revision),
+    )
+    .unwrap();
+    assert!(fresh.text.contains("version two"));
+    let serialized = serde_json::to_string(&fresh).unwrap();
+    assert!(!serialized.contains(temp.path().to_string_lossy().as_ref()));
+}
+
+#[test]
+fn missing_root_is_a_bounded_path_free_diagnostic_not_an_empty_fallback() {
+    let temp = tempfile::tempdir().unwrap();
+    let missing = temp.path().join("missing-live-skills");
+    let result = handle_configured_skill_roots_request(
+        &SkillsConfig {
+            roots: vec![missing.clone()],
+        },
+        ConfiguredSkillRootsRequest::List,
+    );
+    assert_eq!(result.exit_code, Some(0));
+    let stdout = result.stdout.as_deref().unwrap();
+    assert!(!stdout.contains(missing.to_string_lossy().as_ref()));
+    let response: ConfiguredSkillRootsListResponse = serde_json::from_str(stdout).unwrap();
+    assert!(response.skills.is_empty());
+    assert_eq!(
+        response.diagnostics,
+        vec!["configured_skill_root_not_found".to_string()]
+    );
+}
+
+#[test]
+fn same_package_in_two_roots_has_distinct_opaque_identity() {
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    write_skill(first.path(), "same", "same", "first");
+    write_skill(second.path(), "same", "same", "second");
+    let discovery = discover(&SkillsConfig {
+        roots: vec![first.path().to_path_buf(), second.path().to_path_buf()],
+    })
+    .unwrap();
+    assert_eq!(discovery.skills.len(), 2);
+    assert_ne!(
+        discovery.skills[0].descriptor.skill_id,
+        discovery.skills[1].descriptor.skill_id
+    );
+    for skill in discovery.skills {
+        assert!(!skill
+            .descriptor
+            .skill_id
+            .contains(&first.path().to_string_lossy().as_ref()));
+        assert!(!skill
+            .descriptor
+            .skill_id
+            .contains(&second.path().to_string_lossy().as_ref()));
+    }
+}
+
+#[test]
+fn list_response_truncates_valid_unicode_descriptors_to_wire_budget() {
+    let temp = tempfile::tempdir().unwrap();
+    let description = "界".repeat(webcodex_core::skill_metadata::MAX_SKILL_DESCRIPTION_CHARS);
+    for index in 0..MAX_CONFIGURED_SKILL_PACKAGES {
+        let package = temp.path().join(format!("skill-{index:03}"));
+        fs::create_dir_all(&package).unwrap();
+        fs::write(
+            package.join(SKILL_DEFINITION_FILE),
+            format!("---\nname: skill-{index:03}\ndescription: {description}\n---\nbody\n"),
+        )
+        .unwrap();
+    }
+
+    let result = handle_configured_skill_roots_request(
+        &SkillsConfig {
+            roots: vec![temp.path().to_path_buf()],
+        },
+        ConfiguredSkillRootsRequest::List,
+    );
+    assert_eq!(result.exit_code, Some(0));
+    let stdout = result.stdout.as_deref().unwrap();
+    assert!(stdout.len() <= CONFIGURED_SKILL_ROOTS_RESPONSE_MAX_BYTES);
+    let response: ConfiguredSkillRootsListResponse = serde_json::from_str(stdout).unwrap();
+    response.validate().unwrap();
+    assert!(response.discovery_truncated);
+    assert!(!response.skills.is_empty());
+    assert!(response.skills.len() < MAX_CONFIGURED_SKILL_PACKAGES);
+}
+
+#[test]
+fn configured_root_symlink_is_rejected() {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        let target = tempfile::tempdir().unwrap();
+        write_skill(target.path(), "demo", "demo", "body");
+        let holder = tempfile::tempdir().unwrap();
+        let link = holder.path().join("skills-link");
+        symlink(target.path(), &link).unwrap();
+        let discovery = discover(&SkillsConfig { roots: vec![link] }).unwrap();
+        assert!(discovery.skills.is_empty());
+        assert!(discovery
+            .diagnostics
+            .iter()
+            .any(|code| code == "configured_skill_root_link_not_allowed"));
+    }
+}
+
+#[test]
+fn traversal_and_symlink_escape_are_rejected() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(temp.path(), "demo", "demo", "body");
+    let config = SkillsConfig {
+        roots: vec![temp.path().to_path_buf()],
+    };
+    let skill = discover(&config).unwrap().skills.remove(0);
+    assert_eq!(
+        read_resource(
+            &config,
+            &skill.descriptor.skill_id,
+            "../secret",
+            1,
+            20,
+            None
+        )
+        .unwrap_err(),
+        "skill_resource_path_invalid"
+    );
+    assert_eq!(
+        read_resource(
+            &config,
+            &skill.descriptor.skill_id,
+            "/etc/passwd",
+            1,
+            20,
+            None
+        )
+        .unwrap_err(),
+        "skill_resource_path_invalid"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("secret.md"), "secret").unwrap();
+        symlink(
+            outside.path().join("secret.md"),
+            temp.path().join("demo/references/escape.md"),
+        )
+        .unwrap();
+        assert_eq!(
+            read_resource(
+                &config,
+                &skill.descriptor.skill_id,
+                "references/escape.md",
+                1,
+                20,
+                None,
+            )
+            .unwrap_err(),
+            "skill_resource_path_invalid"
+        );
+    }
+}
+
+#[test]
+fn sensitive_package_names_are_not_discovered() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(temp.path(), ".git", "hidden", "must stay hidden");
+    let discovery = discover(&SkillsConfig {
+        roots: vec![temp.path().to_path_buf()],
+    })
+    .unwrap();
+    assert!(discovery.skills.is_empty());
+    assert_eq!(discovery.invalid_count, 1);
+    assert!(discovery
+        .diagnostics
+        .iter()
+        .any(|code| code == "sensitive_skill_definition"));
+}
+
+#[test]
+fn malformed_and_oversized_definitions_are_bounded_diagnostics() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(temp.path().join("bad")).unwrap();
+    fs::write(temp.path().join("bad/SKILL.md"), "not frontmatter").unwrap();
+    fs::create_dir_all(temp.path().join("huge")).unwrap();
+    fs::write(
+        temp.path().join("huge/SKILL.md"),
+        vec![b'x'; MAX_SKILL_DEFINITION_BYTES + 1],
+    )
+    .unwrap();
+    let discovery = discover(&SkillsConfig {
+        roots: vec![temp.path().to_path_buf()],
+    })
+    .unwrap();
+    assert_eq!(discovery.invalid_count, 2);
+    assert!(discovery.diagnostics.len() <= MAX_CONFIGURED_SKILL_DIAGNOSTICS);
+    assert!(discovery
+        .diagnostics
+        .iter()
+        .any(|code| code == "skill_definition_too_large"));
+}
+
+#[test]
+fn resource_reads_enforce_actual_byte_bound_and_preserve_range_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(temp.path(), "demo", "demo", "body");
+    let config = SkillsConfig {
+        roots: vec![temp.path().to_path_buf()],
+    };
+    let skill = discover(&config).unwrap().skills.remove(0);
+    let resource = temp.path().join("demo/references/guide.md");
+    // Selecting a tiny range must still reject an oversized complete file.
+    let mut bytes = vec![b'\n'; MAX_CONFIGURED_SKILL_RESOURCE_FILE_BYTES];
+    fs::write(&resource, &bytes).unwrap();
+    let read = read_resource(
+        &config,
+        &skill.descriptor.skill_id,
+        "references/guide.md",
+        2,
+        1,
+        None,
+    )
+    .unwrap();
+    assert_eq!(read.file_bytes, bytes.len());
+    assert_eq!(read.sha256, sha256_hex(&bytes));
+    assert_eq!(read.total_lines, bytes.len());
+    assert_eq!(read.returned_lines, 1);
+    assert_eq!(read.next_start_line, Some(3));
+    bytes.push(b'\n');
+    fs::write(&resource, &bytes).unwrap();
+    assert_eq!(
+        read_resource(
+            &config,
+            &skill.descriptor.skill_id,
+            "references/guide.md",
+            2,
+            1,
+            None
+        )
+        .unwrap_err(),
+        "skill_resource_too_large"
+    );
+    fs::write(&resource, [0xff]).unwrap();
+    assert_eq!(
+        read_resource(
+            &config,
+            &skill.descriptor.skill_id,
+            "references/guide.md",
+            1,
+            1,
+            None
+        )
+        .unwrap_err(),
+        "skill_resource_unsupported_encoding"
+    );
+}

--- a/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/dispatch.rs
@@ -3,10 +3,10 @@ use super::lsp::{handle_lsp_operation, LspSupervisor};
 use super::transport::ResultSubmission;
 use super::validation::handle_validation_request;
 use super::{
-    handle_computer_operation, handle_prepare_managed_worktree_operation,
-    handle_project_lifecycle_operation, handle_project_operation,
-    handle_resolve_or_register_project_operation, handle_skill_store_request,
-    run_internal_posix_script_with_profiles_and_execution_state,
+    handle_computer_operation, handle_configured_skill_roots_request,
+    handle_prepare_managed_worktree_operation, handle_project_lifecycle_operation,
+    handle_project_operation, handle_resolve_or_register_project_operation,
+    handle_skill_store_request, run_internal_posix_script_with_profiles_and_execution_state,
     run_internal_search_script_with_profiles_and_execution_state,
     run_process_with_profiles_and_execution_state, run_script_with_profiles_and_execution_state,
     run_shell_with_profiles_and_execution_state, run_ssh_shell_with_execution_state, CommandResult,
@@ -416,6 +416,11 @@ pub(crate) fn dispatch_request_with_outcome(
                 duration_ms: Some(0),
                 error: None,
             };
+            sink.submit_result_with_metadata(request_id, result, config, runtime)
+                .map(|_| true)
+        }
+        RunnerOperation::ConfiguredSkillRoots(operation) => {
+            let result = handle_configured_skill_roots_request(&config.skills, operation);
             sink.submit_result_with_metadata(request_id, result, config, runtime)
                 .map(|_| true)
         }

--- a/crates/webcodex-runner/src/webcodex_runner/mod.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod checkpoints;
 pub(crate) mod coding_agent;
 pub(crate) mod computer;
 pub(crate) mod config;
+pub(crate) mod configured_skills;
 pub(crate) mod detached_job;
 pub(crate) mod dispatch;
 #[cfg(windows)]
@@ -50,6 +51,7 @@ pub(crate) use config::{
     default_websocket_connect_timeout_secs, QuicClientConfig, ShellProfileConfig,
     CLIENT_PROFILE_ERROR, DEFAULT_MAX_CONCURRENT_JOBS,
 };
+pub(crate) use configured_skills::handle_configured_skill_roots_request;
 #[cfg(test)]
 pub(super) use dispatch::dispatch_request;
 pub(super) use dispatch::{dispatch_request_with_outcome, RunnerDispatchOutcome};

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -572,7 +572,7 @@ fn runner_config(
 ) -> RunnerConfig {
     use super::super::config::{
         default_websocket_connect_timeout_secs, AcpConfig, McpGatewayConfig, RunnerPolicy,
-        SshConfig, ToolProvidersConfig,
+        SkillsConfig, SshConfig, ToolProvidersConfig,
     };
     RunnerConfig {
         server_url: "http://127.0.0.1:8000".to_string(),
@@ -592,6 +592,7 @@ fn runner_config(
         websocket_connect_timeout_secs: default_websocket_connect_timeout_secs(),
         quic: None,
         shell,
+        skills: SkillsConfig::default(),
         ssh: SshConfig::default(),
         tool_providers: ToolProvidersConfig::default(),
         mcp_gateway: McpGatewayConfig::default(),

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_tests.rs
@@ -183,7 +183,7 @@ fn runner_config(
 ) -> RunnerConfig {
     use super::super::config::{
         default_websocket_connect_timeout_secs, AcpConfig, McpGatewayConfig, RunnerPolicy,
-        SshConfig, ToolProvidersConfig,
+        SkillsConfig, SshConfig, ToolProvidersConfig,
     };
     RunnerConfig {
         server_url: "http://127.0.0.1:8000".to_string(),
@@ -203,6 +203,7 @@ fn runner_config(
         websocket_connect_timeout_secs: default_websocket_connect_timeout_secs(),
         quic: None,
         shell,
+        skills: SkillsConfig::default(),
         ssh: SshConfig::default(),
         tool_providers: ToolProvidersConfig::default(),
         mcp_gateway: McpGatewayConfig::default(),

--- a/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/transport_tests.rs
@@ -42,6 +42,7 @@ fn test_runner_config(server_url: String) -> RunnerConfig {
             crate::webcodex_runner::default_websocket_connect_timeout_secs(),
         quic: None,
         shell: ShellConfig::default(),
+        skills: super::super::config::SkillsConfig::default(),
         ssh: Default::default(),
         tool_providers: Default::default(),
         mcp_gateway: Default::default(),

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/skills.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/skills.rs
@@ -87,7 +87,7 @@ pub fn skill_read_file_input_schema() -> Value {
         "type": "object",
         "properties": {
             "project": {"type": "string", "minLength": 1, "description": "Required authorized runtime Project id."},
-            "skill_id": {"type": "string", "pattern": "^wc_skill_[0-9a-f]{32}$", "description": "Opaque project-scoped Skill identity returned by skills.catalog or skill_list."},
+            "skill_id": {"type": "string", "pattern": "^wc_skill_[0-9a-f]{32}$", "description": "Opaque Skill identity returned by skills.catalog or skill_list; it selects one exact source/package without exposing native Runner paths."},
             "path": {"type": "string", "minLength": 1, "maxLength": MAX_SKILL_RESOURCE_PATH_CHARS, "description": "Skill-package-relative UTF-8 text resource path. Defaults to SKILL.md; absolute paths and traversal are forbidden."},
             "start_line": {"type": "integer", "minimum": 1},
             "limit": {"type": "integer", "minimum": 1, "maximum": MAX_SKILL_READ_LINES},

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/skills.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/skills.rs
@@ -12,13 +12,33 @@ fn descriptor_schema() -> Value {
             "description": {"type": "string", "maxLength": MAX_SKILL_DESCRIPTION_CHARS},
             "definition_revision": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
             "source_scope": {"type": "string", "enum": ["project", "runner"]},
-            "trust": {"type": "string", "enum": ["project_content", "operator_installed_guidance"]},
+            "trust": {"type": "string", "enum": ["project_content", "operator_configured_guidance", "operator_installed_guidance"]},
             "package_revision": {"anyOf": [{"type":"string","pattern":"^wc_skillpkg_[0-9a-f]{64}$"},{"type":"null"}]},
             "name_conflict": {"type": "boolean"}
         },
         "required": ["skill_id", "name", "description", "definition_revision", "source_scope", "trust", "package_revision", "name_conflict"],
         "additionalProperties": false
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn descriptor_trust_distinguishes_configured_and_managed_runner_guidance() {
+        let schema = descriptor_schema();
+        let values = schema["properties"]["trust"]["enum"]
+            .as_array()
+            .expect("trust enum");
+        assert!(values.iter().any(|value| value == "project_content"));
+        assert!(values
+            .iter()
+            .any(|value| value == "operator_configured_guidance"));
+        assert!(values
+            .iter()
+            .any(|value| value == "operator_installed_guidance"));
+    }
 }
 
 pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {

--- a/crates/webcodex-tool-contracts/src/registry/tool_specs/skills.rs
+++ b/crates/webcodex-tool-contracts/src/registry/tool_specs/skills.rs
@@ -17,12 +17,12 @@ pub(super) fn tool_specs() -> Vec<ToolSpec> {
     vec![
         tool_spec(
             "skill_list",
-            "Fresh, bounded discovery of project-scoped Skills plus active operator-installed Skills on the Project's exact owning Runner. Returns lightweight descriptors only; bodies require skill_read_file. Same names across sources remain independently selectable by opaque skill_id.",
+            "Fresh, bounded discovery of project-scoped Skills, configured live read-only Skills on the Project's exact owning Runner, and active operator-installed immutable Skills. Returns lightweight descriptors only; bodies require skill_read_file. trust and package_revision distinguish live configured content from managed installed revisions, and same names across sources remain independently selectable by opaque skill_id.",
             skill_list_input_schema(),
         ),
         tool_spec(
             "skill_read_file",
-            "Read one bounded UTF-8 text resource from a selected project or active operator-installed Skill. Operator reads support expected_package_revision in addition to the SKILL.md definition_revision guard. Scripts are text-only resources and are never executed by this tool.",
+            "Read one bounded UTF-8 text resource from a selected project, configured live Runner Skill, or active operator-installed immutable Skill. expected_definition_revision guards every source; expected_package_revision applies only to managed installed Skills. Configured live files are re-read from the Runner filesystem and carry no package revision. Scripts are text-only resources and are never executed by this tool.",
             skill_read_file_input_schema(),
         ),
         tool_spec(

--- a/deploy/webcodex-runner.toml.example
+++ b/deploy/webcodex-runner.toml.example
@@ -72,6 +72,15 @@ conda activate ml
 # host = "tmp"
 # default_cwd = "/opt/webcodex-edge"
 
+# Optional read-only live Skill roots on this Runner host. These paths do not
+# expand [policy].allowed_roots and are not copied into the managed Skill Store.
+# Editing files under a root is visible on the next Skill discovery/read; editing
+# this roots list is applied with runner config check/reload, without a restart.
+[skills]
+roots = []
+# roots = ["/home/webcodex/.codex/skills", "/opt/company/agent-skills"]
+# Windows TOML literal-string example: roots = ['C:\Users\alice\.codex\skills']
+
 [capabilities]
 file_read = true
 file_write = true

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -361,6 +361,7 @@ Client enrollment generates the Runner config. Important settings in
 | `transport` | Prefer `auto` with `[quic]` configured. |
 | `project_registry_dir` | Directory of project registry files. |
 | `[policy]` | Local execution boundary (`allowed_roots`, etc.). |
+| `[skills].roots` | Optional absolute Runner-local read-only Skill roots; live files are discovered without copying into the managed Skill Store. |
 | `[shell]` | Optional shell profile definitions and bounded persistent-shell limits. |
 | `[ssh.resources.<name>]` | Optional named SSH target for Session-bound `run_shell` / `run_job`. |
 

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -316,6 +316,7 @@ package 时默认将其设为 private；维护者
 | `transport` | 配置 `[quic]` 时优先用 `auto`。 |
 | `project_registry_dir` | 项目注册文件目录。 |
 | `[policy]` | 本地执行边界（`allowed_roots` 等）。 |
+| `[skills].roots` | 可选的 Runner 本机绝对只读 Skill roots；直接 live discovery，不复制进 managed Skill Store。 |
 | `[shell]` | 可选 shell profile 定义与有界 persistent-shell 限制。 |
 | `[ssh.resources.<name>]` | 可选命名 SSH 目标，用于 Session 绑定的 `run_shell` / `run_job`。 |
 

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -119,6 +119,59 @@ The runtime tools `register_project` and `create_project` let a client register
 an existing directory or create a new one on an online Runner, subject to the
 Runner's `allowed_roots` policy.
 
+## Skill sources
+
+`skill_list` presents one catalog while preserving three distinct ownership and
+lifecycle models:
+
+| Source | Location / owner | Trust | Version semantics |
+| --- | --- | --- | --- |
+| Project Skills | `<project>/.agents/skills/<package>/SKILL.md` | `project_content` | Live project content; no package revision. |
+| Configured live Runner Skill roots | Operator-selected absolute directories on the Runner host | `operator_configured_guidance` | Live read-only filesystem content; no install, activation, rollback, or package revision. |
+| Managed Runner Skill Store | Runner state under `runner-skills-v1` | `operator_installed_guidance` | Immutable package revisions with install, activation, removal, and rollback-oriented Store semantics. |
+
+Configured live roots are optional and have no implicit defaults. Each configured
+root contains normal Agent Skill packages directly:
+
+```toml
+[skills]
+roots = [
+    "/home/alice/.codex/skills",
+    "/home/alice/.agents/skills",
+    "/opt/company/agent-skills",
+]
+```
+
+On Windows, use absolute local paths; TOML literal strings are convenient for
+backslashes:
+
+```toml
+[skills]
+roots = [
+    'C:\Users\alice\.codex\skills',
+    'C:\Users\alice\.agents\skills',
+]
+```
+
+A root has the form `<root>/<package>/SKILL.md`, with optional package resources
+such as `references/`. These directories are read directly by the Runner. WebCodex
+does not copy them into the managed Store, and `skill_install`, `skill_activate`,
+and `skill_remove_revision` continue to mutate only that Store.
+
+The configured paths belong to the **Runner host**, even when the Server is on a
+different machine. They are not added to `[policy].allowed_roots`, do not grant
+ordinary Project file/shell/process tools access to those directories, and native
+root paths are not projected through the model-facing Skill catalog. Skill reads
+accept only an opaque `skill_id` plus a package-relative resource path; the Runner
+resolves the root from its trusted configuration and rejects traversal or link
+escapes.
+
+Skill files remain live: editing `SKILL.md` or a resource is visible to the next
+discovery/read without any reload. Changing the configured `roots` list is a
+hot-reloadable Runner configuration change: edit `runner.toml`, run
+`runner_config_check`, then `runner_config_reload` with the current generation.
+No Runner process restart is required.
+
 ## Local MCP providers
 
 The Runner can directly host persistent stdio MCP providers for WebCodex's built-in MCP gateway:
@@ -476,7 +529,7 @@ of finding its PID or sending signals manually:
 4. Inspect `runtime_status(client_id=...)` (or `list_runners`) after reload.
 
 `runner_config_reload` never writes `runner.toml`; it only activates the candidate
-already on disk. Hot-reloadable policy, shell, Native Plugin, and static SSH-resource changes can
+already on disk. Hot-reloadable policy, shell, configured Skill roots, Native Plugin, and static SSH-resource changes can
 become active immediately, while fields reported in `restart_required_fields`
 remain startup-only until the Runner restarts. Invalid candidates leave the active
 snapshot and generation unchanged. Managed `ssh_resource` mutations are different:

--- a/docs/RUNNER.zh-CN.md
+++ b/docs/RUNNER.zh-CN.md
@@ -108,6 +108,52 @@ allowed_roots = ["/root/git"]
 runtime 工具 `register_project` 与 `create_project` 让客户端在在线 Runner 上
 注册已有目录或创建新目录，受 Runner 的 `allowed_roots` policy 约束。
 
+## Skill 来源
+
+`skill_list` 继续只暴露一个 catalog，但其中保留三种彼此独立的 ownership / lifecycle：
+
+| 来源 | 位置 / owner | Trust | 版本语义 |
+| --- | --- | --- | --- |
+| Project Skills | `<project>/.agents/skills/<package>/SKILL.md` | `project_content` | Project live content；没有 package revision。 |
+| Configured live Runner Skill roots | Runner 主机上由 operator 配置的绝对目录 | `operator_configured_guidance` | 直接读取的只读 live filesystem content；没有 install、activation、rollback 或 package revision。 |
+| Managed Runner Skill Store | Runner state 下的 `runner-skills-v1` | `operator_installed_guidance` | immutable package revision，并保留 install、activation、remove 与 rollback-oriented Store 语义。 |
+
+Configured live roots 默认不存在，需要在 Runner 的 `runner.toml` 中显式配置：
+
+```toml
+[skills]
+roots = [
+    "/home/alice/.codex/skills",
+    "/home/alice/.agents/skills",
+    "/opt/company/agent-skills",
+]
+```
+
+Windows 使用等价的本机绝对路径；包含反斜杠时可以使用 TOML literal string：
+
+```toml
+[skills]
+roots = [
+    'C:\Users\alice\.codex\skills',
+    'C:\Users\alice\.agents\skills',
+]
+```
+
+每个 root 直接包含 `<root>/<package>/SKILL.md`，package 内可以有 `references/`
+等 resource。WebCodex 不会把它们复制到 managed Store；`skill_install`、
+`skill_activate` 与 `skill_remove_revision` 仍然只修改 managed Store。
+
+这些路径始终属于 **Runner 主机**；Server 与 Runner 不在同一台机器时也不会改用
+Server 的 filesystem。Configured roots 不会加入 `[policy].allowed_roots`，因此不会给普通
+Project file/shell/process 工具扩大文件系统 authority，native root path 也不会投影到
+model-facing Skill catalog。Skill read 只提交 opaque `skill_id` 与 package-relative resource
+path，由 Runner 根据 trusted config 解析 root，并拒绝 traversal 与 link escape。
+
+Skill 文件本身是 live 的：修改 `SKILL.md` 或 resource 后，下一次 discovery/read 会直接
+看到新内容，不需要 reload。只有修改 `roots` 配置列表时才需要按正式流程先执行
+`runner_config_check`，再携带当前 generation 执行 `runner_config_reload`；该字段支持 hot
+reload，不需要重启 Runner 进程。
+
 ## 本地 MCP provider
 
 Runner 可以直接托管供 WebCodex 内建 MCP gateway 使用的 persistent stdio MCP provider：
@@ -379,7 +425,7 @@ User scope 使用 `systemctl --user`；system scope 使用 `/etc/systemd/system`
 4. reload 后调用 `runtime_status(client_id=...)`（或 `list_runners`）检查当前运行状态。
 
 `runner_config_reload` 不写 `runner.toml`，只激活磁盘上已经存在的 candidate。policy、
-shell、Native Plugin 与静态 SSH resource 中可热加载的字段可以立即生效；`restart_required_fields`
+shell、configured Skill roots、Native Plugin 与静态 SSH resource 中可热加载的字段可以立即生效；`restart_required_fields`
 报告的字段仍保持 startup-only，重启前不会假装已在线生效。无效 candidate 保留旧 active
 snapshot 与 generation。`ssh_resource` managed mutation 不同：它使用 frozen startup
 snapshot，且只在工具返回 `restart_required=true` 时要求重启 Runner。

--- a/src/runner_quic.rs
+++ b/src/runner_quic.rs
@@ -598,6 +598,7 @@ mod tests {
             project_lifecycle: false,
             project_path_registration: false,
             managed_worktree: false,
+            configured_skill_roots_read: false,
             skill_store_read: false,
             skill_store_manage: false,
             computer_observe: false,

--- a/src/runner_ws.rs
+++ b/src/runner_ws.rs
@@ -403,6 +403,7 @@ mod tests {
                         project_lifecycle: false,
                         project_path_registration: false,
                         managed_worktree: false,
+                        configured_skill_roots_read: false,
                         skill_store_read: false,
                         skill_store_manage: false,
                         computer_observe: false,

--- a/src/tool_runtime/skills.rs
+++ b/src/tool_runtime/skills.rs
@@ -9,6 +9,9 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::path::Component;
 use std::time::Duration;
+use webcodex_core::configured_skills::{
+    ConfiguredSkillRootsListResponse, ConfiguredSkillRootsReadResponse, ConfiguredSkillRootsRequest,
+};
 use webcodex_core::skill_metadata::parse_skill_metadata;
 pub(crate) use webcodex_core::skill_metadata::{
     MAX_SKILL_DEFINITION_BYTES, MAX_SKILL_DESCRIPTION_CHARS, MAX_SKILL_NAME_CHARS,
@@ -67,7 +70,8 @@ pub(crate) struct SkillDescriptor {
 #[derive(Debug, Clone)]
 enum CatalogSkillLocator {
     Project { package_name: String },
-    Runner,
+    RunnerConfigured,
+    RunnerManaged,
 }
 
 #[derive(Debug, Clone)]
@@ -221,6 +225,89 @@ impl ToolRuntime {
         }
     }
 
+    async fn runner_configured_skill_roots_request(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+        operation: ConfiguredSkillRootsRequest,
+        optional_if_unsupported: bool,
+    ) -> Result<Option<ShellRunResponse>, String> {
+        let client_id = project.config.client_id.clone();
+        let access = crate::runner_http::runner_access_from_auth(auth);
+        let view = self
+            .runner_registry
+            .get_runner_semantic_view_checked_for_auth(&client_id, access.as_ref())
+            .await
+            .map_err(|_| "configured_skill_roots_runner_unavailable".to_string())?;
+        if !view.supports(RunnerFeature::ConfiguredSkillRootsRead) {
+            return if optional_if_unsupported {
+                Ok(None)
+            } else {
+                Err("configured_skill_roots_capability_unavailable".to_string())
+            };
+        }
+        if !view.view.connected {
+            return Err("configured_skill_roots_runner_unavailable".to_string());
+        }
+        let (request_id, rx) = self
+            .runner_registry
+            .enqueue_configured_skill_roots(
+                &client_id,
+                &view.view.runner_instance_id,
+                operation,
+                access.as_ref(),
+                "skill_runtime".to_string(),
+            )
+            .await
+            .map_err(|error| {
+                if error.contains("capability_unavailable") {
+                    "configured_skill_roots_capability_unavailable".to_string()
+                } else if error.contains("stale Runner") || error.contains("exact Runner") {
+                    "configured_skill_roots_runner_changed".to_string()
+                } else {
+                    "configured_skill_roots_runner_unavailable".to_string()
+                }
+            })?;
+        match tokio::time::timeout(Duration::from_secs(30), rx).await {
+            Ok(Ok(response)) => Ok(Some(response)),
+            Ok(Err(_)) => Err("configured_skill_roots_runner_unavailable".to_string()),
+            Err(_) => {
+                self.runner_registry
+                    .cancel_request_dispatch_state(&request_id)
+                    .await;
+                Err("configured_skill_roots_runner_unavailable".to_string())
+            }
+        }
+    }
+
+    async fn observe_configured_runner_skills(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+    ) -> Result<Option<ConfiguredSkillRootsListResponse>, String> {
+        let Some(response) = self
+            .runner_configured_skill_roots_request(
+                project,
+                auth,
+                ConfiguredSkillRootsRequest::List,
+                true,
+            )
+            .await?
+        else {
+            return Ok(None);
+        };
+        if response.exit_code != Some(0) || response.error.is_some() {
+            return Err("skills_catalog_unavailable".to_string());
+        }
+        let parsed: ConfiguredSkillRootsListResponse =
+            serde_json::from_str(response.stdout.as_deref().unwrap_or_default())
+                .map_err(|_| "skills_catalog_unavailable".to_string())?;
+        parsed
+            .validate()
+            .map_err(|_| "skills_catalog_unavailable".to_string())?;
+        Ok(Some(parsed))
+    }
+
     async fn observe_runner_skills(
         &self,
         project: &ResolvedProject,
@@ -366,13 +453,120 @@ impl ToolRuntime {
         ToolResult::ok(output)
     }
 
+    async fn read_configured_runner_skill(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+        skill_id: &str,
+        path: &str,
+        start_line: usize,
+        limit: usize,
+        definition_revision: &str,
+    ) -> ToolResult {
+        let response = match self
+            .runner_configured_skill_roots_request(
+                project,
+                auth,
+                ConfiguredSkillRootsRequest::Read {
+                    skill_id: skill_id.to_string(),
+                    path: path.to_string(),
+                    start_line,
+                    limit,
+                    expected_definition_revision: Some(definition_revision.to_string()),
+                },
+                false,
+            )
+            .await
+        {
+            Ok(Some(response)) => response,
+            Ok(None) => {
+                return skill_error(
+                    "configured_skill_roots_capability_unavailable",
+                    &project.resolved_id,
+                    Some(json!({"skill_id": skill_id})),
+                )
+            }
+            Err(kind) => {
+                return skill_error_dynamic(
+                    &kind,
+                    &project.resolved_id,
+                    Some(json!({"skill_id": skill_id})),
+                    false,
+                )
+            }
+        };
+        if response.exit_code != Some(0) || response.error.is_some() {
+            let kind = stable_configured_skill_error(response.error.as_deref());
+            return skill_error_dynamic(
+                &kind,
+                &project.resolved_id,
+                Some(json!({"skill_id": skill_id, "path": path})),
+                false,
+            );
+        }
+        let read: ConfiguredSkillRootsReadResponse =
+            match serde_json::from_str(response.stdout.as_deref().unwrap_or_default()) {
+                Ok(read) => read,
+                Err(_) => {
+                    return skill_error(
+                        "configured_skill_response_invalid",
+                        &project.resolved_id,
+                        Some(json!({"skill_id": skill_id})),
+                    )
+                }
+            };
+        if read
+            .validate_for_request(skill_id, path, start_line, limit)
+            .is_err()
+            || read.definition_revision != definition_revision
+        {
+            return skill_error(
+                "configured_skill_response_invalid",
+                &project.resolved_id,
+                Some(json!({"skill_id": skill_id})),
+            );
+        }
+        let output = json!({
+            "project": project.resolved_id,
+            "skill_id": read.skill_id,
+            "name": read.name,
+            "source_scope": "runner",
+            "trust": "operator_configured_guidance",
+            "package_revision": null,
+            "definition_revision": read.definition_revision,
+            "path": read.path,
+            "sha256": read.sha256,
+            "text": read.text,
+            "start_line": read.start_line,
+            "end_line": read.end_line,
+            "returned_lines": read.returned_lines,
+            "has_more": read.has_more,
+            "next_start_line": read.next_start_line,
+        });
+        if serde_json::to_vec(&output)
+            .map(|bytes| bytes.len() > MAX_SKILL_READ_RESULT_BYTES)
+            .unwrap_or(true)
+        {
+            return skill_error(
+                "skill_read_result_too_large",
+                &project.resolved_id,
+                Some(json!({"skill_id": skill_id, "path": path})),
+            );
+        }
+        ToolResult::ok(output)
+    }
+
     async fn discover_skills(
         &self,
         project: &ResolvedProject,
         auth: Option<&AuthContext>,
     ) -> Result<SkillCatalog, &'static str> {
         let mut catalog = self.discover_project_skills(project).await?;
-        let runner = self
+        let configured = self
+            .observe_configured_runner_skills(project, auth)
+            .await
+            .map_err(|_| "skills_catalog_unavailable")?;
+        let managed = self
             .observe_runner_skills(project, auth)
             .await
             .map_err(|_| "skills_catalog_unavailable")?;
@@ -381,9 +575,38 @@ impl ToolRuntime {
             .iter()
             .map(|skill| skill.descriptor.skill_id.clone())
             .collect::<std::collections::BTreeSet<_>>();
-        let mut runner = runner;
-        runner.sort_by(|left, right| left.skill_key.cmp(&right.skill_key));
-        for skill in runner {
+        if let Some(configured) = configured {
+            catalog.invalid_count = catalog
+                .invalid_count
+                .saturating_add(configured.invalid_count);
+            catalog.discovery_truncated |= configured.discovery_truncated;
+            for reason_code in configured.diagnostics {
+                push_diagnostic(&mut catalog.diagnostics, &reason_code);
+            }
+            for skill in configured.skills {
+                if !seen_ids.insert(skill.skill_id.clone()) {
+                    return Err("skills_catalog_unavailable");
+                }
+                let order_key = skill.skill_id.clone();
+                catalog.skills.push(CatalogSkill {
+                    descriptor: SkillDescriptor {
+                        skill_id: skill.skill_id,
+                        name: skill.name,
+                        description: skill.description,
+                        definition_revision: skill.definition_revision,
+                        package_revision: None,
+                        source_scope: "runner",
+                        trust: "operator_configured_guidance",
+                        name_conflict: false,
+                    },
+                    locator: CatalogSkillLocator::RunnerConfigured,
+                    order_key,
+                });
+            }
+        }
+        let mut managed = managed;
+        managed.sort_by(|left, right| left.skill_key.cmp(&right.skill_key));
+        for skill in managed {
             if !seen_ids.insert(skill.skill_id.clone()) {
                 return Err("skills_catalog_unavailable");
             }
@@ -398,7 +621,7 @@ impl ToolRuntime {
                     trust: "operator_installed_guidance",
                     name_conflict: false,
                 },
-                locator: CatalogSkillLocator::Runner,
+                locator: CatalogSkillLocator::RunnerManaged,
                 order_key: skill.skill_key,
             });
         }
@@ -546,19 +769,55 @@ impl ToolRuntime {
                 Some(json!({"skill_id": skill_id})),
             );
         };
-        if matches!(skill.locator, CatalogSkillLocator::Runner) {
-            return self
-                .read_runner_skill(
-                    project,
-                    auth,
-                    &skill_id,
-                    &resource_path,
-                    start_line,
-                    limit,
-                    expected_package_revision.as_deref(),
-                    expected_definition_revision.as_deref(),
-                )
-                .await;
+        match &skill.locator {
+            CatalogSkillLocator::RunnerManaged => {
+                return self
+                    .read_runner_skill(
+                        project,
+                        auth,
+                        &skill_id,
+                        &resource_path,
+                        start_line,
+                        limit,
+                        expected_package_revision.as_deref(),
+                        expected_definition_revision.as_deref(),
+                    )
+                    .await;
+            }
+            CatalogSkillLocator::RunnerConfigured => {
+                if expected_package_revision.is_some() {
+                    return skill_error(
+                        "skill_package_revision_not_supported",
+                        &project.resolved_id,
+                        Some(json!({"skill_id": skill_id})),
+                    );
+                }
+                if expected_definition_revision
+                    .as_deref()
+                    .is_some_and(|expected| expected != skill.descriptor.definition_revision)
+                {
+                    return skill_error(
+                        "skill_definition_changed",
+                        &project.resolved_id,
+                        Some(json!({
+                            "skill_id": skill_id,
+                            "definition_revision": skill.descriptor.definition_revision,
+                        })),
+                    );
+                }
+                return self
+                    .read_configured_runner_skill(
+                        project,
+                        auth,
+                        &skill_id,
+                        &resource_path,
+                        start_line,
+                        limit,
+                        &skill.descriptor.definition_revision,
+                    )
+                    .await;
+            }
+            CatalogSkillLocator::Project { .. } => {}
         }
         if expected_package_revision.is_some() {
             return skill_error(
@@ -582,7 +841,9 @@ impl ToolRuntime {
         }
         let package_name = match &skill.locator {
             CatalogSkillLocator::Project { package_name } => package_name,
-            CatalogSkillLocator::Runner => unreachable!("runner branch returned above"),
+            CatalogSkillLocator::RunnerConfigured | CatalogSkillLocator::RunnerManaged => {
+                unreachable!("runner branches returned above")
+            }
         };
         let package_root = format!("{}/{}", SKILL_ROOT, package_name);
         let full_path = format!("{package_root}/{resource_path}");
@@ -1461,6 +1722,25 @@ fn stable_skill_store_error(error: Option<&str>) -> String {
     }
 }
 
+fn stable_configured_skill_error(error: Option<&str>) -> String {
+    let base = error
+        .unwrap_or("configured_skill_roots_unavailable")
+        .split(':')
+        .next()
+        .unwrap_or("configured_skill_roots_unavailable")
+        .trim();
+    if (base.starts_with("skill_") || base.starts_with("configured_skill_"))
+        && base.len() <= 96
+        && base
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        base.to_string()
+    } else {
+        "configured_skill_roots_unavailable".to_string()
+    }
+}
+
 fn uncertain_skill_store_error(kind: &str) -> bool {
     matches!(
         kind,
@@ -1603,7 +1883,7 @@ fn catalog_revision(
     format!("wc_skillcat_{:x}", hasher.finalize())
 }
 
-fn push_diagnostic(diagnostics: &mut Vec<Value>, reason_code: &'static str) {
+fn push_diagnostic(diagnostics: &mut Vec<Value>, reason_code: &str) {
     if diagnostics.len() < MAX_SKILL_INVALID_DIAGNOSTICS {
         diagnostics.push(json!({"reason_code": reason_code}));
     }

--- a/src/tool_runtime/tests/metadata.rs
+++ b/src/tool_runtime/tests/metadata.rs
@@ -382,6 +382,7 @@ async fn register_agent_projects_for_auth(
                         project_lifecycle: false,
                         project_path_registration: false,
                         managed_worktree: false,
+                        configured_skill_roots_read: false,
                         skill_store_read: false,
                         skill_store_manage: false,
                         computer_observe: false,

--- a/src/tool_runtime/tests/skills.rs
+++ b/src/tool_runtime/tests/skills.rs
@@ -15,6 +15,10 @@ use std::fs;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use webcodex_core::configured_skills::{
+    ConfiguredSkillDescriptor, ConfiguredSkillRootsListResponse, ConfiguredSkillRootsReadResponse,
+    ConfiguredSkillRootsRequest, CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT,
+};
 use webcodex_core::skill_store::{
     RunnerSkillDescriptor, SkillStoreListActiveResponse, SkillStoreReadResponse, SkillStoreRequest,
     SKILL_STORE_RESPONSE_FORMAT,
@@ -150,6 +154,16 @@ fn skill_by_name<'a>(result: &'a ToolResult, name: &str) -> &'a Value {
 }
 
 #[derive(Debug, Clone)]
+struct FakeConfiguredSkillState {
+    skill_id: String,
+    name: String,
+    description: String,
+    definition_revision: String,
+    definition_text: String,
+    resource_text: String,
+}
+
+#[derive(Debug, Clone)]
 struct FakeOperatorSkillState {
     skill_id: String,
     skill_key: String,
@@ -157,6 +171,7 @@ struct FakeOperatorSkillState {
     description: String,
     package_revision: String,
     definition_revision: String,
+    configured: Option<FakeConfiguredSkillState>,
     resource_text: String,
 }
 
@@ -199,7 +214,113 @@ async fn call_kernel_with_fake_operator_store(
             "operator Skill fixture timed out"
         );
         if let Some(request) = probe_patch_agent_request(runtime, client_id).await {
-            if request.kind == "skill_store" {
+            if request.kind == "configured_skill_roots" {
+                let operation: ConfiguredSkillRootsRequest = serde_json::from_str(
+                    request
+                        .content
+                        .as_deref()
+                        .expect("typed configured Skill roots request"),
+                )
+                .unwrap();
+                let state = operator
+                    .lock()
+                    .unwrap()
+                    .configured
+                    .clone()
+                    .expect("configured Skill fixture state");
+                let (exit_code, stdout, error) = match operation {
+                    ConfiguredSkillRootsRequest::List => (
+                        Some(0),
+                        Some(
+                            serde_json::to_string(&ConfiguredSkillRootsListResponse {
+                                format: CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT.to_string(),
+                                skills: vec![ConfiguredSkillDescriptor {
+                                    skill_id: state.skill_id,
+                                    name: state.name,
+                                    description: state.description,
+                                    definition_revision: state.definition_revision,
+                                }],
+                                invalid_count: 0,
+                                diagnostics: Vec::new(),
+                                discovery_truncated: false,
+                            })
+                            .unwrap(),
+                        ),
+                        None,
+                    ),
+                    ConfiguredSkillRootsRequest::Read {
+                        skill_id,
+                        path,
+                        start_line,
+                        limit,
+                        expected_definition_revision,
+                    } => {
+                        let error = if skill_id != state.skill_id {
+                            Some("skill_not_found".to_string())
+                        } else if expected_definition_revision
+                            .as_deref()
+                            .is_some_and(|expected| expected != state.definition_revision)
+                        {
+                            Some("skill_definition_changed".to_string())
+                        } else {
+                            None
+                        };
+                        if let Some(error) = error {
+                            (None, None, Some(error))
+                        } else {
+                            let text = if path == "SKILL.md" {
+                                state.definition_text
+                            } else {
+                                state.resource_text
+                            };
+                            assert!(limit >= 1);
+                            let sha256 = if path == "SKILL.md" {
+                                state.definition_revision.clone()
+                            } else {
+                                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                                    .to_string()
+                            };
+                            (
+                                Some(0),
+                                Some(
+                                    serde_json::to_string(&ConfiguredSkillRootsReadResponse {
+                                        format: CONFIGURED_SKILL_ROOTS_RESPONSE_FORMAT.to_string(),
+                                        skill_id: state.skill_id,
+                                        name: state.name,
+                                        definition_revision: state.definition_revision,
+                                        path,
+                                        sha256,
+                                        file_bytes: text.len(),
+                                        total_lines: 1,
+                                        text,
+                                        start_line,
+                                        end_line: Some(start_line),
+                                        returned_lines: 1,
+                                        has_more: false,
+                                        next_start_line: None,
+                                    })
+                                    .unwrap(),
+                                ),
+                                None,
+                            )
+                        }
+                    }
+                };
+                runtime
+                    .runner_registry
+                    .complete(RunnerResultRequest {
+                        client_id: client_id.to_string(),
+                        runner_instance_id: "inst".to_string(),
+                        request_id: request.request_id,
+                        exit_code,
+                        stdout,
+                        stderr: Some(String::new()),
+                        duration_ms: Some(1),
+                        error,
+                    })
+                    .await
+                    .unwrap();
+            } else if request.kind == "skill_store" {
                 let operation: SkillStoreRequest = serde_json::from_str(
                     request
                         .content
@@ -360,6 +481,7 @@ async fn project_and_operator_skill_catalog_union_is_fresh_conflict_safe_and_pac
         description: "Operator-installed guidance".to_string(),
         package_revision: package_a.clone(),
         definition_revision: definition.clone(),
+        configured: None,
         resource_text: "resource-a".to_string(),
     }));
 
@@ -456,6 +578,129 @@ async fn project_and_operator_skill_catalog_union_is_fresh_conflict_safe_and_pac
     assert_eq!(pinned_read.output["trust"], "operator_installed_guidance");
     assert_eq!(pinned_read.output["package_revision"], package_b);
     assert_eq!(pinned_read.output["definition_revision"], definition);
+}
+
+#[tokio::test]
+async fn project_configured_and_managed_skills_share_one_conflict_safe_catalog() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_skill(
+        project_root.path(),
+        "project-duplicate",
+        "duplicate",
+        "Project guidance",
+        "project body\n",
+    );
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "skill-three-source-union";
+    register_agent_with_projects(
+        &runtime,
+        client_id,
+        None,
+        RunnerCapabilities {
+            file_read: true,
+            configured_skill_roots_read: true,
+            skill_store_read: true,
+            ..Default::default()
+        },
+        vec![registered_project(
+            "project",
+            project_root.path().to_string_lossy().as_ref(),
+        )],
+    )
+    .await;
+    let project = crate::tool_runtime::runner_project_runtime_id(client_id, "project");
+    let configured_id = format!("wc_skill_{}", "2".repeat(32));
+    let managed_id = format!("wc_skill_{}", "3".repeat(32));
+    let configured_revision = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    let managed_revision = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    let managed_package = format!("wc_skillpkg_{}", "a".repeat(64));
+    let sources = Arc::new(Mutex::new(FakeOperatorSkillState {
+        skill_id: managed_id.clone(),
+        skill_key: "managed-duplicate".to_string(),
+        name: "duplicate".to_string(),
+        description: "Managed guidance".to_string(),
+        package_revision: managed_package.clone(),
+        definition_revision: managed_revision.to_string(),
+        configured: Some(FakeConfiguredSkillState {
+            skill_id: configured_id.clone(),
+            name: "duplicate".to_string(),
+            description: "Configured guidance".to_string(),
+            definition_revision: configured_revision.to_string(),
+            definition_text: "configured definition".to_string(),
+            resource_text: "configured resource".to_string(),
+        }),
+        resource_text: "managed resource".to_string(),
+    }));
+
+    let listed = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_list",
+        json!({"project": project, "limit": 10}),
+        sources.clone(),
+    )
+    .await;
+    assert!(listed.success, "{:?}", listed.error);
+    assert_eq!(listed.output["total_count"], 3);
+    let skills = listed.output["skills"].as_array().unwrap();
+    assert!(skills.iter().all(|skill| skill["name_conflict"] == true));
+    let configured = skills
+        .iter()
+        .find(|skill| skill["skill_id"] == configured_id)
+        .unwrap();
+    assert_eq!(configured["source_scope"], "runner");
+    assert_eq!(configured["trust"], "operator_configured_guidance");
+    assert!(configured["package_revision"].is_null());
+    let managed = skills
+        .iter()
+        .find(|skill| skill["skill_id"] == managed_id)
+        .unwrap();
+    assert_eq!(managed["trust"], "operator_installed_guidance");
+    assert_eq!(managed["package_revision"], managed_package);
+    let project_skill = skills
+        .iter()
+        .find(|skill| skill["source_scope"] == "project")
+        .unwrap();
+    assert_eq!(project_skill["trust"], "project_content");
+
+    let configured_read = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_read_file",
+        json!({
+            "project": project,
+            "skill_id": configured_id,
+            "path": "references/guide.md",
+            "expected_definition_revision": configured_revision
+        }),
+        sources.clone(),
+    )
+    .await;
+    assert!(configured_read.success, "{:?}", configured_read.error);
+    assert_eq!(configured_read.output["text"], "configured resource");
+    assert_eq!(
+        configured_read.output["trust"],
+        "operator_configured_guidance"
+    );
+    assert!(configured_read.output["package_revision"].is_null());
+
+    let managed_read = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_read_file",
+        json!({
+            "project": project,
+            "skill_id": managed_id,
+            "path": "references/guide.md",
+            "expected_package_revision": managed_package,
+            "expected_definition_revision": managed_revision
+        }),
+        sources,
+    )
+    .await;
+    assert!(managed_read.success, "{:?}", managed_read.error);
+    assert_eq!(managed_read.output["text"], "managed resource");
+    assert_eq!(managed_read.output["trust"], "operator_installed_guidance");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add hot-reloadable `[skills].roots` for Runner-owned live Skill directories outside a project
- expose configured Skills through the existing unified `skill_list` / `skill_read_file` catalog using opaque IDs, without extending generic filesystem authority
- preserve exact Runner capability/lease fencing and managed Skill Store semantics
- harden configured-source discovery and reads with bounded diagnostics, symlink/reparse containment, response-size truncation, Windows ADS rejection, and actual-byte file-size enforcement
- document Linux/macOS/Windows configuration and reload behavior

## Security / authority

Configured roots remain Runner-local configuration. Native root paths are never sent in Server-to-Runner requests or returned in model-facing descriptors, and `[skills].roots` does not extend `policy.allowed_roots` or generic file/shell/process authority.

## Validation

- `webcodex-core` configured Skill protocol tests
- `webcodex-runner` configured live-source tests: 10/10
- Runner config/hot-reload and registry capability/lease regressions
- project + configured + managed three-source catalog/read integration
- Windows native path/UNC/reparse checks and ADS regression
- macOS native symlink/resource containment checks
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`

Closes #374