### PR TITLE
Add TypeScript Native Plugin SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,11 @@ jobs:
       needs_windows_desktop: ${{ steps.classify.outputs.needs_windows_desktop }}
       needs_macos: ${{ steps.classify.outputs.needs_macos }}
       needs_macos_desktop: ${{ steps.classify.outputs.needs_macos_desktop }}
-      # Older trusted PR bases do not expose the newer frontend/container outputs.
+      # Older trusted PR bases do not expose the newer frontend/container/Plugin SDK outputs.
       # A historical full-native result is the safe rollout fallback for those bases.
       needs_frontend: ${{ steps.classify.outputs.needs_frontend == 'true' || (steps.classify.outputs.needs_frontend == '' && steps.classify.outputs.needs_full_native == 'true') }}
       needs_desktop_frontend: ${{ steps.classify.outputs.needs_desktop_frontend == 'true' || (steps.classify.outputs.needs_desktop_frontend == '' && steps.classify.outputs.needs_full_native == 'true') }}
+      needs_plugin_sdk: ${{ steps.classify.outputs.needs_plugin_sdk == 'true' || (steps.classify.outputs.needs_plugin_sdk == '' && steps.classify.outputs.needs_full_native == 'true') }}
       needs_docker: ${{ steps.classify.outputs.needs_docker == 'true' || (steps.classify.outputs.needs_docker == '' && steps.classify.outputs.needs_full_native == 'true') }}
       needs_desktop_package: ${{ steps.classify.outputs.needs_desktop_package }}
       needs_full_native: ${{ steps.classify.outputs.needs_full_native }}
@@ -74,6 +75,7 @@ jobs:
                 needs_macos_desktop \
                 needs_frontend \
                 needs_desktop_frontend \
+                needs_plugin_sdk \
                 needs_docker \
                 needs_desktop_package \
                 needs_full_native; do
@@ -121,13 +123,14 @@ jobs:
         with:
           shared-key: linux-ci
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.needs_frontend == 'true' || needs.changes.outputs.needs_desktop_frontend == 'true'
+        if: needs.changes.outputs.needs_frontend == 'true' || needs.changes.outputs.needs_desktop_frontend == 'true' || needs.changes.outputs.needs_plugin_sdk == 'true'
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: |
             frontend/package-lock.json
             apps/desktop/package-lock.json
+            npm/plugin-sdk/package-lock.json
       - name: Install frontend dependencies
         if: needs.changes.outputs.needs_frontend == 'true'
         run: npm ci --prefix frontend
@@ -146,6 +149,16 @@ jobs:
           npm --prefix apps/desktop run typecheck
           npm --prefix apps/desktop test
           npm --prefix apps/desktop run build
+      - name: Install Plugin SDK dependencies
+        if: needs.changes.outputs.needs_plugin_sdk == 'true'
+        run: npm ci --prefix npm/plugin-sdk
+      - name: Check Plugin SDK contracts
+        if: needs.changes.outputs.needs_plugin_sdk == 'true'
+        run: |
+          npm --prefix npm/plugin-sdk run typecheck
+          npm --prefix npm/plugin-sdk run build
+          npm --prefix npm/plugin-sdk test
+          npm --prefix npm/plugin-sdk run pack:dry-run
       - name: Verify workspace boundaries
         run: |
           bash scripts/workspace_boundary_check.sh --self-test

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -229,6 +229,40 @@ restart-only fields without starting disposable Plugin processes. Use
 `plugin_tool check(runner, plugin)` when you need executable resolution plus the
 Plugin `initialize -> tools/list` protocol/admission preflight.
 
+## TypeScript Plugin SDK
+
+`@yyjeqhc/webcodex-plugin-sdk` is an optional TypeScript authoring layer for Native
+Tool Plugins:
+
+```text
+raw executable protocol
+    -> @yyjeqhc/webcodex-plugin-sdk
+    -> still webcodex-plugin-v1
+    -> Runner-authoritative check / reload / call
+```
+
+The SDK supplies the small v1 schema builder, `defineTool`, `definePlugin`, result
+helpers, and serial newline-delimited JSON-RPC stdio runtime so Plugin authors do
+not need to hand-write framing and dispatch boilerplate. It is **not** an MCP SDK,
+does not change Plugin authority, and does not sandbox the trusted executable.
+The Server and Runner do not need Node because the SDK exists; only a Plugin that
+chooses this SDK needs Node on its Runner machine. TypeScript is an authoring/build
+dependency: production executes the compiled ESM JavaScript, with no TypeScript
+runtime requirement.
+
+SDK types are authoring assistance, not a second admission authority. The Rust
+Runner still owns protocol/schema admission, frozen catalog semantics, bounds,
+timeout/process lifecycle, output validation, and `OutcomeUnknown`. In particular,
+`plugin_tool check` remains the authoritative admission check. An explicit SDK
+`errorResult(...)` is a known completed application result; an unhandled handler
+throw/rejection stops the provider without fabricating a ToolResult so the Runner
+can retain send ambiguity for effectful calls.
+
+See [`../npm/plugin-sdk/README.md`](../npm/plugin-sdk/README.md) and the TypeScript
+[`echo-plugin.ts`](../npm/plugin-sdk/examples/echo-plugin.ts) example. The raw,
+zero-dependency [`native-tool-plugin.mjs`](../examples/native-tool-plugin.mjs)
+remains the protocol reference and does not depend on the SDK.
+
 ## WebCodex Plugin Protocol v1
 
 The native protocol is newline-delimited JSON-RPC 2.0 framing with the protocol

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -202,6 +202,36 @@ reload` 则提供更窄、只需要 `plugin:manage` 的专门入口。Plugin man
 需要检查 executable resolution 以及 Plugin `initialize -> tools/list` protocol/admission 时，
 使用 `plugin_tool check(runner, plugin)`。
 
+## TypeScript Plugin SDK
+
+`@yyjeqhc/webcodex-plugin-sdk` 是 Native Tool Plugin 的可选 TypeScript authoring layer：
+
+```text
+raw executable protocol
+    -> @yyjeqhc/webcodex-plugin-sdk
+    -> 仍然是 webcodex-plugin-v1
+    -> Runner-authoritative check / reload / call
+```
+
+SDK 提供小型 v1 schema builder、`defineTool`、`definePlugin`、result helper，以及严格
+串行的 newline-delimited JSON-RPC stdio runtime，让 Plugin 作者不用重复手写 framing 和
+dispatch 样板代码。它**不是** MCP SDK，不会改变 Plugin authority，也不会 sandbox 受信任
+executable。WebCodex Server / Runner 不会因为 SDK 而要求 Node；只有主动选择这个 SDK 的
+Plugin 自己需要 Runner 机器提供 Node。TypeScript 只用于 authoring/build，生产环境执行编译
+后的 ESM JavaScript，不要求 TypeScript runtime。
+
+SDK 类型只是 authoring assistance，并不是第二套 admission authority。Rust Runner 继续权威
+拥有 protocol/schema admission、frozen catalog、bounds、timeout/process lifecycle、output
+validation 与 `OutcomeUnknown`。`plugin_tool check` 仍然是 authoritative admission check。
+其中显式 `errorResult(...)` 表示确定的 completed application result；未处理的 handler
+throw/rejection 会终止 provider，并且不会伪造 ToolResult，因此 effectful call 的 send
+ambiguity 仍可由 Runner 正确保留。
+
+完整 SDK 说明见 [`../npm/plugin-sdk/README.zh-CN.md`](../npm/plugin-sdk/README.zh-CN.md)，
+TypeScript 示例见 [`echo-plugin.ts`](../npm/plugin-sdk/examples/echo-plugin.ts)。原有无 SDK
+依赖的 raw [`native-tool-plugin.mjs`](../examples/native-tool-plugin.mjs) 继续作为 protocol
+reference 保留。
+
 ## WebCodex Plugin Protocol v1
 
 Native protocol 使用 newline-delimited JSON-RPC 2.0 framing，protocol version 是

--- a/npm/plugin-sdk/.gitignore
+++ b/npm/plugin-sdk/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tgz

--- a/npm/plugin-sdk/LICENSE
+++ b/npm/plugin-sdk/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/npm/plugin-sdk/README.md
+++ b/npm/plugin-sdk/README.md
@@ -1,0 +1,84 @@
+# @yyjeqhc/webcodex-plugin-sdk
+
+TypeScript authoring helpers for WebCodex Native Tool Plugins. The SDK removes JSON-RPC, stdio framing, and dispatch boilerplate while keeping the existing `webcodex-plugin-v1` protocol unchanged.
+
+The Rust Runner remains authoritative for Plugin admission, schema validation, authority, timeout, process lifecycle, frozen catalog identity, response bounds, and `OutcomeUnknown` semantics. TypeScript types and SDK helpers improve authoring; `plugin_tool check` remains the authoritative WebCodex Plugin admission check.
+
+## Requirements
+
+- Node.js 18 or newer to run a Plugin built with this SDK.
+- TypeScript is an authoring/build dependency only. Production Plugin execution uses compiled ESM JavaScript and does not require a TypeScript runtime or compiler.
+- The SDK has zero runtime package dependencies and uses Node built-ins only.
+
+Using this SDK does not make a Plugin an MCP server, grant new WebCodex permissions, or sandbox the executable. Native Plugins are trusted local processes. WebCodex Server and Runner themselves do not require Node because of this SDK; only a Plugin that chooses this SDK needs a Node runtime on its Runner machine.
+
+## Example
+
+```ts
+import {
+  definePlugin,
+  defineTool,
+  runPlugin,
+  schema,
+  textResult,
+} from "@yyjeqhc/webcodex-plugin-sdk";
+
+const echo = defineTool({
+  name: "echo",
+  description: "Echo one string",
+  inputSchema: schema.object({
+    text: schema.string({ minLength: 1, maxLength: 4096 }),
+    uppercase: schema.optional(schema.boolean()),
+  }),
+  outputSchema: schema.object({
+    text: schema.string({ maxLength: 4096 }),
+  }),
+  async execute({ text, uppercase }) {
+    const value = uppercase ? text.toUpperCase() : text;
+    return textResult(value, { text: value });
+  },
+});
+
+runPlugin(definePlugin({ tools: [echo] }));
+```
+
+Compile authoring source with TypeScript, then configure the Runner to execute the generated JavaScript:
+
+```text
+plugin.ts
+   -> tsc/build
+ dist/plugin.js
+   -> node dist/plugin.js
+```
+
+`stdout` is protocol-only. Plugin diagnostics belong on `stderr`; ordinary application logging must not use `console.log` or otherwise write to stdout.
+
+## Schema builder
+
+`schema` intentionally models only the Native Plugin Schema Profile v1, not general JSON Schema. It provides:
+
+- `schema.object`, `schema.array`, `schema.string`, `schema.number`, `schema.integer`, `schema.boolean`, and `schema.null`;
+- `schema.optional` for object properties;
+- `title`, `description`, `enum`, and `const` where applicable;
+- string `minLength` / `maxLength` and array `minItems` / `maxItems`;
+- boolean `additionalProperties`, defaulting to `false` for `schema.object`.
+
+Object properties not wrapped with `schema.optional(...)` are emitted in `required`. Input and output roots accepted by `defineTool` are object schemas. Enum and const literals are preserved in ordinary TypeScript inference where practical.
+
+The builder deliberately does not implement `$ref`, `$defs`, recursive references, `pattern`, `format`, numeric ranges, schema-valued `additionalProperties`, union types, `anyOf`, `oneOf`, `allOf`, `not`, or draft-specific keywords. It also does not copy WebCodex's byte, depth, node-count, or catalog admission limits. Run `plugin_tool check` against the configured provider for the authoritative result.
+
+## Results and failure semantics
+
+`textResult(text, structuredContent?)` returns a normal result with `isError: false`. `errorResult(text, structuredContent?)` returns a **known application result** with `isError: true`. Both emit v1 text content only and use the protocol fields `structuredContent` and `isError`.
+
+A handler throw or rejected Promise has deliberately different semantics. The SDK does **not** turn it into `errorResult`. It emits only a generic diagnostic to stderr, stops the provider runtime, and sends no fabricated ToolResult for that request. If the Runner may already have sent an effectful `tools/call`, the existing Runner lifecycle can therefore preserve `OutcomeUnknown` instead of misreporting a known application failure. Plugin authors should return `errorResult(...)` only when the failure is known and safe to represent as a completed application result.
+
+The SDK does not truncate or rewrite results to fit Runner limits. When an `outputSchema` is declared, its TypeScript generic constrains normal authoring, but the Runner remains the authoritative runtime validator for `structuredContent`.
+
+## Runtime model
+
+`runPlugin(plugin)` serves newline-delimited JSON-RPC 2.0 over process stdin/stdout. Requests are handled strictly one at a time; async handlers are awaited before the next input line is dispatched. Only `initialize`, `tools/list`, and `tools/call` are supported. Notifications and arbitrary methods fail closed.
+
+`definePlugin` rejects duplicate provider-local tool names before serving and freezes the authoring catalog. `tools/list` exposes only protocol definitions; executable handlers and local closures never enter the wire representation. Declaration order is preserved by the SDK; the WebCodex Runner independently admits and freezes its authoritative catalog.
+
+For the minimal protocol without any SDK dependency, see [`../../examples/native-tool-plugin.mjs`](../../examples/native-tool-plugin.mjs). The repository example [`examples/echo-plugin.ts`](examples/echo-plugin.ts) demonstrates SDK authoring.

--- a/npm/plugin-sdk/README.zh-CN.md
+++ b/npm/plugin-sdk/README.zh-CN.md
@@ -1,0 +1,84 @@
+# @yyjeqhc/webcodex-plugin-sdk
+
+WebCodex Native Tool Plugin 的 TypeScript authoring SDK。它只负责消除 JSON-RPC、stdio framing 与 dispatch 样板代码，底层协议仍然是现有的 `webcodex-plugin-v1`。
+
+Rust Runner 继续权威拥有 Plugin admission、schema validation、authority、timeout、process lifecycle、frozen catalog identity、response bounds 与 `OutcomeUnknown` 语义。TypeScript 类型和 SDK helper 只改善作者体验；`plugin_tool check` 仍然是 WebCodex Plugin 的 authoritative admission check。
+
+## 运行要求
+
+- 使用本 SDK 构建的 Plugin 在生产运行时需要 Node.js 18 或更高版本。
+- TypeScript 只属于 authoring/build dependency。生产 Plugin 执行编译后的 ESM JavaScript，不要求 TypeScript runtime 或 compiler。
+- SDK runtime package dependency 为 0，只使用 Node built-ins。
+
+使用这个 SDK 不会把 Plugin 变成 MCP Server，不会增加 WebCodex 权限，也不会 sandbox executable。Native Plugin 仍然是受信任的本地进程。WebCodex Server / Runner 不会因为 SDK 而要求 Node；只有选择这个 SDK 的 Plugin 自己需要 Runner 机器提供 Node runtime。
+
+## 示例
+
+```ts
+import {
+  definePlugin,
+  defineTool,
+  runPlugin,
+  schema,
+  textResult,
+} from "@yyjeqhc/webcodex-plugin-sdk";
+
+const echo = defineTool({
+  name: "echo",
+  description: "Echo one string",
+  inputSchema: schema.object({
+    text: schema.string({ minLength: 1, maxLength: 4096 }),
+    uppercase: schema.optional(schema.boolean()),
+  }),
+  outputSchema: schema.object({
+    text: schema.string({ maxLength: 4096 }),
+  }),
+  async execute({ text, uppercase }) {
+    const value = uppercase ? text.toUpperCase() : text;
+    return textResult(value, { text: value });
+  },
+});
+
+runPlugin(definePlugin({ tools: [echo] }));
+```
+
+正常发布/部署 Plugin 时先编译 TypeScript，再让 Runner 执行生成的 JavaScript：
+
+```text
+plugin.ts
+   -> tsc/build
+ dist/plugin.js
+   -> node dist/plugin.js
+```
+
+`stdout` 只能用于 protocol。Plugin diagnostics 应写入 `stderr`；普通应用日志不能通过 `console.log` 或其他方式污染 stdout。
+
+## Schema builder
+
+`schema` 只建模 Native Plugin Schema Profile v1，并不是通用 JSON Schema framework。它提供：
+
+- `schema.object`、`schema.array`、`schema.string`、`schema.number`、`schema.integer`、`schema.boolean`、`schema.null`；
+- object property 使用 `schema.optional` 表示非 required；
+- profile 允许的 `title`、`description`、`enum`、`const`；
+- string 的 `minLength` / `maxLength` 与 array 的 `minItems` / `maxItems`；
+- boolean `additionalProperties`，`schema.object` 默认是 `false`。
+
+没有包裹 `schema.optional(...)` 的 property 会进入 `required`。`defineTool` 的 input/output root 在 TypeScript API 上必须是 object schema。普通场景下 enum / const 会尽可能保留 literal inference。
+
+Builder 明确不支持 `$ref`、`$defs`、recursive refs、`pattern`、`format`、numeric range、schema-valued `additionalProperties`、union type、`anyOf`、`oneOf`、`allOf`、`not` 或 draft-specific keyword。它也不会复制 WebCodex 的 byte/depth/node-count/catalog admission 上限。请对真实配置 provider 运行 `plugin_tool check`，以 Runner 的结果为准。
+
+## Result 与失败语义
+
+`textResult(text, structuredContent?)` 表示正常完成结果，`isError: false`；`errorResult(text, structuredContent?)` 表示**确定的应用层完成结果**，`isError: true`。两者都只产生 v1 text content，并使用 wire 字段 `structuredContent` / `isError`。
+
+handler throw 或 Promise rejection 的语义刻意不同。SDK **不会**自动将异常转换成 `errorResult`。它只向 stderr 输出 generic diagnostic，停止 provider runtime，并且不会为当前 request 伪造 ToolResult。这样在 Runner 已经可能发送 effectful `tools/call` 的情况下，Runner 现有 lifecycle 可以继续得到 `OutcomeUnknown`，而不是把不确定副作用误报成已知 application failure。只有当 Plugin 作者明确知道失败已经确定且可安全表示时，才应显式返回 `errorResult(...)`。
+
+SDK 不会为了通过 Runner bounds 而截断或改写结果。声明 `outputSchema` 时 TypeScript generic 会约束常规 authoring，但 `structuredContent` 的 runtime validation 仍由 Runner 权威执行。
+
+## Runtime 模型
+
+`runPlugin(plugin)` 在 process stdin/stdout 上提供 newline-delimited JSON-RPC 2.0。请求严格串行：async handler 完成以前不会 dispatch 下一行。只支持 `initialize`、`tools/list`、`tools/call`；notification 与 arbitrary method fail closed。
+
+`definePlugin` 会在 serve 前拒绝 provider-local duplicate tool name，并冻结 authoring catalog。`tools/list` 只暴露 protocol definition；execute handler、function source、closure/local state 不会进入 wire。SDK 保留声明顺序，WebCodex Runner 会独立 admission 并冻结自己的 authoritative catalog。
+
+完全不依赖 SDK 的最小 raw protocol reference 仍然是 [`../../examples/native-tool-plugin.mjs`](../../examples/native-tool-plugin.mjs)。仓库中的 [`examples/echo-plugin.ts`](examples/echo-plugin.ts) 展示 TypeScript SDK authoring。

--- a/npm/plugin-sdk/examples/echo-plugin.ts
+++ b/npm/plugin-sdk/examples/echo-plugin.ts
@@ -1,0 +1,24 @@
+import {
+  definePlugin,
+  defineTool,
+  runPlugin,
+  schema,
+  textResult,
+} from "@yyjeqhc/webcodex-plugin-sdk";
+
+const echo = defineTool({
+  name: "echo",
+  description: "Echo one string",
+  inputSchema: schema.object({
+    text: schema.string({ minLength: 1, maxLength: 4096 }),
+  }),
+  outputSchema: schema.object({
+    text: schema.string({ maxLength: 4096 }),
+  }),
+  async execute({ text }) {
+    await Promise.resolve();
+    return textResult(text, { text });
+  },
+});
+
+runPlugin(definePlugin({ tools: [echo] }));

--- a/npm/plugin-sdk/package-lock.json
+++ b/npm/plugin-sdk/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@yyjeqhc/webcodex-plugin-sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@yyjeqhc/webcodex-plugin-sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^18.19.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/npm/plugin-sdk/package.json
+++ b/npm/plugin-sdk/package.json
@@ -19,8 +19,9 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build --silent",
     "test": "npm run build --silent && node --test test/*.test.mjs",
-    "pack:dry-run": "npm run build --silent && npm pack --dry-run"
+    "pack:dry-run": "npm pack --dry-run"
   },
   "engines": {
     "node": ">=18"

--- a/npm/plugin-sdk/package.json
+++ b/npm/plugin-sdk/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@yyjeqhc/webcodex-plugin-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript authoring SDK for the WebCodex Native Tool Plugin Protocol v1.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "README.zh-CN.md"
+  ],
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build --silent && node --test test/*.test.mjs",
+    "pack:dry-run": "npm run build --silent && npm pack --dry-run"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yyjeqhc/webcodex.git",
+    "directory": "npm/plugin-sdk"
+  },
+  "keywords": [
+    "webcodex",
+    "plugin",
+    "typescript",
+    "developer-tools"
+  ],
+  "devDependencies": {
+    "@types/node": "^18.19.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/npm/plugin-sdk/src/index.ts
+++ b/npm/plugin-sdk/src/index.ts
@@ -1,0 +1,11 @@
+export { schema } from "./schema.js";
+export { runPlugin } from "./runtime.js";
+export { definePlugin, defineTool, errorResult, textResult } from "./types.js";
+export type {
+  InferSchema,
+  JsonObject,
+  JsonValue,
+  ObjectSchema,
+  Plugin,
+  ToolResult,
+} from "./types.js";

--- a/npm/plugin-sdk/src/protocol.ts
+++ b/npm/plugin-sdk/src/protocol.ts
@@ -1,0 +1,76 @@
+export const PLUGIN_PROTOCOL_VERSION = "webcodex-plugin-v1" as const;
+
+export type JsonRpcId = string | number;
+
+export interface JsonRpcRequest {
+  readonly jsonrpc: "2.0";
+  readonly id: JsonRpcId;
+  readonly method: string;
+  readonly params?: unknown;
+}
+
+export interface JsonRpcErrorObject {
+  readonly code: number;
+  readonly message: string;
+}
+
+export type JsonRpcResponse =
+  | {
+      readonly jsonrpc: "2.0";
+      readonly id: JsonRpcId | null;
+      readonly result: unknown;
+    }
+  | {
+      readonly jsonrpc: "2.0";
+      readonly id: JsonRpcId | null;
+      readonly error: JsonRpcErrorObject;
+    };
+
+export type ParsedRequest =
+  | { readonly ok: true; readonly request: JsonRpcRequest }
+  | { readonly ok: false; readonly response: JsonRpcResponse };
+
+export function rpcResult(id: JsonRpcId, result: unknown): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, result };
+}
+
+export function rpcError(
+  id: JsonRpcId | null,
+  code: number,
+  message: string,
+): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+export function parseRequestLine(line: string): ParsedRequest {
+  let value: unknown;
+  try {
+    value = JSON.parse(line) as unknown;
+  } catch {
+    return { ok: false, response: rpcError(null, -32700, "parse error") };
+  }
+
+  if (!isRecord(value) || value.jsonrpc !== "2.0" || !isJsonRpcId(value.id)) {
+    return { ok: false, response: rpcError(null, -32600, "invalid request") };
+  }
+  if (typeof value.method !== "string" || value.method.length === 0) {
+    return { ok: false, response: rpcError(value.id, -32600, "invalid request") };
+  }
+  return {
+    ok: true,
+    request: {
+      jsonrpc: "2.0",
+      id: value.id,
+      method: value.method,
+      ...(Object.prototype.hasOwnProperty.call(value, "params") ? { params: value.params } : {}),
+    },
+  };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+  return typeof value === "string" || (typeof value === "number" && Number.isFinite(value));
+}

--- a/npm/plugin-sdk/src/runtime.ts
+++ b/npm/plugin-sdk/src/runtime.ts
@@ -1,0 +1,147 @@
+import { once } from "node:events";
+import process from "node:process";
+import readline from "node:readline";
+import type { Readable, Writable } from "node:stream";
+
+import {
+  PLUGIN_PROTOCOL_VERSION,
+  isRecord,
+  parseRequestLine,
+  rpcError,
+  rpcResult,
+  type JsonRpcResponse,
+} from "./protocol.js";
+import {
+  getPluginDefinitions,
+  getPluginExecutor,
+  type Plugin,
+  type ToolResult,
+} from "./types.js";
+
+const HANDLER_FAILURE_DIAGNOSTIC = "webcodex plugin handler failed; provider will stop\n";
+const RUNTIME_FAILURE_DIAGNOSTIC = "webcodex plugin runtime failed; provider will stop\n";
+
+export interface PluginStreams {
+  readonly input: Readable;
+  readonly output: Writable;
+  readonly error: Writable;
+}
+
+class PluginHandlerFailure extends Error {
+  constructor() {
+    super("plugin handler failed");
+    this.name = "PluginHandlerFailure";
+  }
+}
+
+async function writeResponse(output: Writable, response: JsonRpcResponse): Promise<void> {
+  const line = `${JSON.stringify(response)}\n`;
+  if (!output.write(line)) {
+    await once(output, "drain");
+  }
+}
+
+function writeDiagnostic(error: Writable, message: string): void {
+  try {
+    error.write(message);
+  } catch {
+    // Diagnostics are best-effort. Never redirect them onto protocol stdout.
+  }
+}
+
+async function handleCall(
+  plugin: Plugin,
+  id: string | number,
+  params: unknown,
+  streams: Pick<PluginStreams, "output" | "error">,
+): Promise<void> {
+  if (!isRecord(params) || typeof params.name !== "string" || !isRecord(params.arguments)) {
+    await writeResponse(streams.output, rpcError(id, -32602, "invalid params"));
+    return;
+  }
+
+  const execute = getPluginExecutor(plugin, params.name);
+  if (execute === undefined) {
+    await writeResponse(streams.output, rpcError(id, -32602, "unknown tool"));
+    return;
+  }
+
+  let result: ToolResult<object>;
+  try {
+    result = await execute(params.arguments);
+  } catch {
+    writeDiagnostic(streams.error, HANDLER_FAILURE_DIAGNOSTIC);
+    throw new PluginHandlerFailure();
+  }
+  await writeResponse(streams.output, rpcResult(id, result));
+}
+
+async function handleOne(
+  plugin: Plugin,
+  line: string,
+  streams: Pick<PluginStreams, "output" | "error">,
+): Promise<void> {
+  const parsed = parseRequestLine(line);
+  if (!parsed.ok) {
+    await writeResponse(streams.output, parsed.response);
+    return;
+  }
+
+  const { id, method, params } = parsed.request;
+  if (method === "initialize") {
+    if (!isRecord(params) || params.protocolVersion !== PLUGIN_PROTOCOL_VERSION) {
+      await writeResponse(streams.output, rpcError(id, -32602, "unsupported protocol version"));
+      return;
+    }
+    await writeResponse(
+      streams.output,
+      rpcResult(id, { protocolVersion: PLUGIN_PROTOCOL_VERSION }),
+    );
+    return;
+  }
+
+  if (method === "tools/list") {
+    if (params !== undefined && !isRecord(params)) {
+      await writeResponse(streams.output, rpcError(id, -32602, "invalid params"));
+      return;
+    }
+    await writeResponse(streams.output, rpcResult(id, { tools: getPluginDefinitions(plugin) }));
+    return;
+  }
+
+  if (method === "tools/call") {
+    await handleCall(plugin, id, params, streams);
+    return;
+  }
+
+  await writeResponse(streams.output, rpcError(id, -32601, "method not found"));
+}
+
+export async function servePlugin(plugin: Plugin, streams: PluginStreams): Promise<void> {
+  const lines = readline.createInterface({
+    input: streams.input,
+    crlfDelay: Infinity,
+    terminal: false,
+  });
+  try {
+    for await (const line of lines) {
+      await handleOne(plugin, line, streams);
+    }
+  } finally {
+    lines.close();
+  }
+}
+
+export function runPlugin(plugin: Plugin): void {
+  void servePlugin(plugin, {
+    input: process.stdin,
+    output: process.stdout,
+    error: process.stderr,
+  }).catch((error: unknown) => {
+    if (!(error instanceof PluginHandlerFailure)) {
+      writeDiagnostic(process.stderr, RUNTIME_FAILURE_DIAGNOSTIC);
+    }
+    process.exitCode = 1;
+    process.stdin.destroy();
+  });
+}

--- a/npm/plugin-sdk/src/schema.ts
+++ b/npm/plugin-sdk/src/schema.ts
@@ -1,0 +1,225 @@
+import type {
+  AnySchema,
+  ArraySchemaShape,
+  BooleanSchemaShape,
+  InferSchema,
+  JsonObject,
+  JsonValue,
+  NullSchemaShape,
+  NumberSchemaShape,
+  ObjectSchema,
+  ObjectSchemaShape,
+  OptionalSchema,
+  PropertyMap,
+  PropertySchema,
+  Schema,
+  SchemaNode,
+  StringSchemaShape,
+} from "./types.js";
+
+type CommonOptions<TValue extends JsonValue> = {
+  readonly title?: string;
+  readonly description?: string;
+  readonly enum?: readonly TValue[];
+  readonly const?: TValue;
+};
+
+type StringOptions = CommonOptions<string> & {
+  readonly minLength?: number;
+  readonly maxLength?: number;
+};
+
+type NumberOptions = CommonOptions<number>;
+type BooleanOptions = CommonOptions<boolean>;
+type NullOptions = CommonOptions<null>;
+
+type ArrayValue = readonly JsonValue[];
+type ArrayOptions = CommonOptions<ArrayValue> & {
+  readonly minItems?: number;
+  readonly maxItems?: number;
+};
+
+type ObjectOptions = CommonOptions<JsonObject> & {
+  readonly additionalProperties?: boolean;
+};
+
+type NarrowValue<TOptions, TFallback> = TOptions extends { readonly const: infer TValue }
+  ? TValue
+  : TOptions extends { readonly enum: readonly (infer TValue)[] }
+    ? TValue
+    : TFallback;
+
+type OptionalKeys<TProperties extends PropertyMap> = {
+  [K in keyof TProperties]-?: TProperties[K] extends OptionalSchema<AnySchema> ? K : never;
+}[keyof TProperties];
+
+type RequiredKeys<TProperties extends PropertyMap> = Exclude<
+  keyof TProperties,
+  OptionalKeys<TProperties>
+>;
+
+type PropertyValue<TProperty extends PropertySchema> =
+  TProperty extends OptionalSchema<infer TSchema>
+    ? InferSchema<TSchema>
+    : TProperty extends AnySchema
+      ? InferSchema<TProperty>
+      : never;
+
+type KnownObjectValue<TProperties extends PropertyMap> = {
+  [K in RequiredKeys<TProperties>]: PropertyValue<TProperties[K]>;
+} & {
+  [K in OptionalKeys<TProperties>]?: PropertyValue<TProperties[K]>;
+};
+
+type Simplify<T> = { [K in keyof T]: T[K] };
+
+type ObjectValue<TProperties extends PropertyMap, TOptions> = Simplify<
+  KnownObjectValue<TProperties>
+> &
+  (TOptions extends { readonly additionalProperties: true } ? Record<string, unknown> : unknown);
+
+type ArrayItemValue<TItem extends AnySchema> = InferSchema<TItem>[];
+
+type StringValue<TOptions> = NarrowValue<TOptions, string>;
+type NumberValue<TOptions> = NarrowValue<TOptions, number>;
+type BooleanValue<TOptions> = NarrowValue<TOptions, boolean>;
+type NullValue<TOptions> = NarrowValue<TOptions, null>;
+type ArraySchemaValue<TItem extends AnySchema, TOptions> = NarrowValue<
+  TOptions,
+  ArrayItemValue<TItem>
+>;
+type ObjectSchemaValue<TProperties extends PropertyMap, TOptions> = NarrowValue<
+  TOptions,
+  ObjectValue<TProperties, TOptions>
+>;
+
+function cloneAndFreezeJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map((item) => cloneAndFreezeJson(item)));
+  }
+  if (value !== null && typeof value === "object") {
+    const clone: Record<string, JsonValue> = {};
+    for (const [key, child] of Object.entries(value)) {
+      clone[key] = cloneAndFreezeJson(child);
+    }
+    return Object.freeze(clone);
+  }
+  return value;
+}
+
+function applyCommonOptions(
+  target: Record<string, JsonValue>,
+  options: CommonOptions<JsonValue> | undefined,
+): void {
+  if (options?.title !== undefined) target.title = options.title;
+  if (options?.description !== undefined) target.description = options.description;
+  if (options?.enum !== undefined) target.enum = options.enum;
+  if (options?.const !== undefined) target.const = options.const;
+}
+
+function finish<TValue, TShape extends SchemaNode>(shape: TShape): Schema<TValue, TShape> {
+  return cloneAndFreezeJson(shape as unknown as JsonValue) as Schema<TValue, TShape>;
+}
+
+function string<const TOptions extends StringOptions = {}>(
+  options?: TOptions,
+): Schema<StringValue<TOptions>, StringSchemaShape> {
+  const shape: Record<string, JsonValue> = { type: "string" };
+  applyCommonOptions(shape, options);
+  if (options?.minLength !== undefined) shape.minLength = options.minLength;
+  if (options?.maxLength !== undefined) shape.maxLength = options.maxLength;
+  return finish(shape as unknown as StringSchemaShape);
+}
+
+function number<const TOptions extends NumberOptions = {}>(
+  options?: TOptions,
+): Schema<NumberValue<TOptions>, NumberSchemaShape> {
+  const shape: Record<string, JsonValue> = { type: "number" };
+  applyCommonOptions(shape, options);
+  return finish(shape as unknown as NumberSchemaShape);
+}
+
+function integer<const TOptions extends NumberOptions = {}>(
+  options?: TOptions,
+): Schema<NumberValue<TOptions>, NumberSchemaShape> {
+  const shape: Record<string, JsonValue> = { type: "integer" };
+  applyCommonOptions(shape, options);
+  return finish(shape as unknown as NumberSchemaShape);
+}
+
+function boolean<const TOptions extends BooleanOptions = {}>(
+  options?: TOptions,
+): Schema<BooleanValue<TOptions>, BooleanSchemaShape> {
+  const shape: Record<string, JsonValue> = { type: "boolean" };
+  applyCommonOptions(shape, options);
+  return finish(shape as unknown as BooleanSchemaShape);
+}
+
+function nullSchema<const TOptions extends NullOptions = {}>(
+  options?: TOptions,
+): Schema<NullValue<TOptions>, NullSchemaShape> {
+  const shape: Record<string, JsonValue> = { type: "null" };
+  applyCommonOptions(shape, options);
+  return finish(shape as unknown as NullSchemaShape);
+}
+
+function array<const TItem extends AnySchema, const TOptions extends ArrayOptions = {}>(
+  item: TItem,
+  options?: TOptions,
+): Schema<ArraySchemaValue<TItem, TOptions>, ArraySchemaShape> {
+  const shape: Record<string, JsonValue> = {
+    type: "array",
+    items: item as unknown as JsonValue,
+  };
+  applyCommonOptions(shape, options);
+  if (options?.minItems !== undefined) shape.minItems = options.minItems;
+  if (options?.maxItems !== undefined) shape.maxItems = options.maxItems;
+  return finish(shape as unknown as ArraySchemaShape);
+}
+
+function optional<const TSchema extends AnySchema>(schema: TSchema): OptionalSchema<TSchema> {
+  return Object.freeze({ optional: true, schema });
+}
+
+function object<
+  const TProperties extends PropertyMap,
+  const TOptions extends ObjectOptions = {},
+>(
+  properties: TProperties,
+  options?: TOptions,
+): ObjectSchema<ObjectSchemaValue<TProperties, TOptions> & object> {
+  const wireProperties: Record<string, SchemaNode> = {};
+  const required: string[] = [];
+  for (const [name, property] of Object.entries(properties)) {
+    if (isOptional(property)) {
+      wireProperties[name] = property.schema;
+    } else {
+      wireProperties[name] = property;
+      required.push(name);
+    }
+  }
+
+  const shape: Record<string, JsonValue> = {
+    type: "object",
+    properties: wireProperties as unknown as JsonValue,
+    required,
+    additionalProperties: options?.additionalProperties ?? false,
+  };
+  applyCommonOptions(shape, options);
+  return finish(shape as unknown as ObjectSchemaShape);
+}
+
+function isOptional(value: PropertySchema): value is OptionalSchema<AnySchema> {
+  return "optional" in value && value.optional === true;
+}
+
+export const schema = Object.freeze({
+  object,
+  array,
+  string,
+  number,
+  integer,
+  boolean,
+  null: nullSchema,
+  optional,
+});

--- a/npm/plugin-sdk/src/schema.ts
+++ b/npm/plugin-sdk/src/schema.ts
@@ -98,10 +98,9 @@ function cloneAndFreezeJson(value: JsonValue): JsonValue {
     return Object.freeze(value.map((item) => cloneAndFreezeJson(item)));
   }
   if (value !== null && typeof value === "object") {
-    const clone: Record<string, JsonValue> = {};
-    for (const [key, child] of Object.entries(value)) {
-      clone[key] = cloneAndFreezeJson(child);
-    }
+    const clone = Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, cloneAndFreezeJson(child)]),
+    ) as Record<string, JsonValue>;
     return Object.freeze(clone);
   }
   return value;
@@ -188,7 +187,7 @@ function object<
   properties: TProperties,
   options?: TOptions,
 ): ObjectSchema<ObjectSchemaValue<TProperties, TOptions> & object> {
-  const wireProperties: Record<string, SchemaNode> = {};
+  const wireProperties = Object.create(null) as Record<string, SchemaNode>;
   const required: string[] = [];
   for (const [name, property] of Object.entries(properties)) {
     if (isOptional(property)) {

--- a/npm/plugin-sdk/src/types.ts
+++ b/npm/plugin-sdk/src/types.ts
@@ -161,10 +161,9 @@ function cloneAndFreezeJson(value: JsonValue): JsonValue {
     return Object.freeze(value.map((item) => cloneAndFreezeJson(item)));
   }
   if (value !== null && typeof value === "object") {
-    const clone: Record<string, JsonValue> = {};
-    for (const [key, child] of Object.entries(value)) {
-      clone[key] = cloneAndFreezeJson(child);
-    }
+    const clone = Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, cloneAndFreezeJson(child)]),
+    ) as Record<string, JsonValue>;
     return Object.freeze(clone);
   }
   return value;

--- a/npm/plugin-sdk/src/types.ts
+++ b/npm/plugin-sdk/src/types.ts
@@ -1,0 +1,281 @@
+export type JsonPrimitive = null | boolean | number | string;
+export type JsonValue =
+  | JsonPrimitive
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+export type JsonObject = { readonly [key: string]: JsonValue };
+
+export type SchemaTypeName =
+  | "object"
+  | "array"
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "null";
+
+export interface SchemaAnnotations {
+  readonly title?: string;
+  readonly description?: string;
+  readonly enum?: readonly JsonValue[];
+  readonly const?: JsonValue;
+}
+
+export interface ObjectSchemaShape extends SchemaAnnotations {
+  readonly type: "object";
+  readonly properties: Readonly<Record<string, SchemaNode>>;
+  readonly required: readonly string[];
+  readonly additionalProperties: boolean;
+}
+
+export interface ArraySchemaShape extends SchemaAnnotations {
+  readonly type: "array";
+  readonly items: SchemaNode;
+  readonly minItems?: number;
+  readonly maxItems?: number;
+}
+
+export interface StringSchemaShape extends SchemaAnnotations {
+  readonly type: "string";
+  readonly minLength?: number;
+  readonly maxLength?: number;
+}
+
+export interface NumberSchemaShape extends SchemaAnnotations {
+  readonly type: "number" | "integer";
+}
+
+export interface BooleanSchemaShape extends SchemaAnnotations {
+  readonly type: "boolean";
+}
+
+export interface NullSchemaShape extends SchemaAnnotations {
+  readonly type: "null";
+}
+
+export type SchemaNode =
+  | ObjectSchemaShape
+  | ArraySchemaShape
+  | StringSchemaShape
+  | NumberSchemaShape
+  | BooleanSchemaShape
+  | NullSchemaShape;
+
+declare const schemaValue: unique symbol;
+
+export type Schema<T, Shape extends SchemaNode = SchemaNode> = Readonly<Shape> & {
+  readonly [schemaValue]?: T;
+};
+
+export type AnySchema = Schema<any, SchemaNode>;
+export type ObjectSchema<T extends object = Record<string, unknown>> = Schema<T, ObjectSchemaShape>;
+
+export type InferSchema<S> = S extends { readonly [schemaValue]?: infer T } ? T : never;
+
+export interface OptionalSchema<S extends AnySchema> {
+  readonly optional: true;
+  readonly schema: S;
+}
+
+export type PropertySchema = AnySchema | OptionalSchema<AnySchema>;
+export type PropertyMap = Readonly<Record<string, PropertySchema>>;
+
+export interface PluginToolDefinition {
+  readonly name: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly inputSchema: ObjectSchemaShape;
+  readonly outputSchema?: ObjectSchemaShape;
+  readonly annotations?: JsonObject;
+}
+
+export interface TextContent {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export interface ToolResult<TStructured extends object = object, TError extends boolean = boolean> {
+  readonly content: readonly TextContent[];
+  readonly structuredContent: TStructured;
+  readonly isError: TError;
+}
+
+export type MaybePromise<T> = T | Promise<T>;
+
+declare const definedToolBrand: unique symbol;
+declare const pluginBrand: unique symbol;
+
+export interface DefinedTool<
+  TInput extends ObjectSchema<any> = ObjectSchema<any>,
+  TOutput extends ObjectSchema<any> | undefined = ObjectSchema<any> | undefined,
+> {
+  readonly [definedToolBrand]: {
+    readonly input: TInput;
+    readonly output: TOutput;
+  };
+}
+
+export interface Plugin {
+  readonly [pluginBrand]: true;
+}
+
+export interface DefinePluginOptions<TTools extends readonly DefinedTool[]> {
+  readonly tools: TTools;
+}
+
+type OutputValue<TOutput extends ObjectSchema<any> | undefined> =
+  TOutput extends ObjectSchema<infer T> ? T : object;
+
+export interface DefineToolOptions<
+  TInput extends ObjectSchema<any>,
+  TOutput extends ObjectSchema<any> | undefined,
+> {
+  readonly name: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly inputSchema: TInput;
+  readonly outputSchema?: TOutput;
+  readonly annotations?: JsonObject;
+  readonly execute: (
+    args: InferSchema<TInput>,
+  ) => MaybePromise<ToolResult<NoInfer<OutputValue<TOutput>>>>;
+}
+
+const TOOL_DEFINITION = Symbol("webcodex.plugin.tool-definition");
+const TOOL_EXECUTE = Symbol("webcodex.plugin.tool-execute");
+const PLUGIN_DEFINITIONS = Symbol("webcodex.plugin.definitions");
+const PLUGIN_DISPATCH = Symbol("webcodex.plugin.dispatch");
+
+interface InternalDefinedTool {
+  readonly [TOOL_DEFINITION]: PluginToolDefinition;
+  readonly [TOOL_EXECUTE]: (args: object) => MaybePromise<ToolResult<object>>;
+}
+
+interface InternalPlugin {
+  readonly [PLUGIN_DEFINITIONS]: readonly PluginToolDefinition[];
+  readonly [PLUGIN_DISPATCH]: Readonly<Record<string, InternalDefinedTool>>;
+}
+
+function cloneAndFreezeJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map((item) => cloneAndFreezeJson(item)));
+  }
+  if (value !== null && typeof value === "object") {
+    const clone: Record<string, JsonValue> = {};
+    for (const [key, child] of Object.entries(value)) {
+      clone[key] = cloneAndFreezeJson(child);
+    }
+    return Object.freeze(clone);
+  }
+  return value;
+}
+
+function cloneDefinition(
+  options: DefineToolOptions<ObjectSchema<any>, ObjectSchema<any> | undefined>,
+): PluginToolDefinition {
+  const definition: {
+    name: string;
+    title?: string;
+    description?: string;
+    inputSchema: ObjectSchemaShape;
+    outputSchema?: ObjectSchemaShape;
+    annotations?: JsonObject;
+  } = {
+    name: options.name,
+    inputSchema: cloneAndFreezeJson(options.inputSchema as unknown as JsonValue) as unknown as ObjectSchemaShape,
+  };
+  if (options.title !== undefined) definition.title = options.title;
+  if (options.description !== undefined) definition.description = options.description;
+  if (options.outputSchema !== undefined) {
+    definition.outputSchema = cloneAndFreezeJson(
+      options.outputSchema as unknown as JsonValue,
+    ) as unknown as ObjectSchemaShape;
+  }
+  if (options.annotations !== undefined) {
+    definition.annotations = cloneAndFreezeJson(options.annotations) as JsonObject;
+  }
+  return Object.freeze(definition);
+}
+
+export function textResult(text: string): ToolResult<Record<string, never>, false>;
+export function textResult<const TStructured extends object>(
+  text: string,
+  structuredContent: TStructured,
+): ToolResult<TStructured, false>;
+export function textResult(
+  text: string,
+  structuredContent: object = {},
+): ToolResult<object, false> {
+  return {
+    content: [{ type: "text", text }],
+    structuredContent,
+    isError: false,
+  };
+}
+
+export function errorResult(text: string): ToolResult<Record<string, never>, true>;
+export function errorResult<const TStructured extends object>(
+  text: string,
+  structuredContent: TStructured,
+): ToolResult<TStructured, true>;
+export function errorResult(
+  text: string,
+  structuredContent: object = {},
+): ToolResult<object, true> {
+  return {
+    content: [{ type: "text", text }],
+    structuredContent,
+    isError: true,
+  };
+}
+
+export function defineTool<
+  const TInput extends ObjectSchema<any>,
+  const TOutput extends ObjectSchema<any> | undefined = undefined,
+>(options: DefineToolOptions<TInput, TOutput>): DefinedTool<TInput, TOutput> {
+  const internal: InternalDefinedTool = Object.freeze({
+    [TOOL_DEFINITION]: cloneDefinition(
+      options as DefineToolOptions<ObjectSchema<any>, ObjectSchema<any> | undefined>,
+    ),
+    [TOOL_EXECUTE]: options.execute as unknown as (
+      args: object,
+    ) => MaybePromise<ToolResult<object>>,
+  });
+  return internal as unknown as DefinedTool<TInput, TOutput>;
+}
+
+export function definePlugin<const TTools extends readonly DefinedTool[]>(
+  options: DefinePluginOptions<TTools>,
+): Plugin {
+  const definitions: PluginToolDefinition[] = [];
+  const dispatch = Object.create(null) as Record<string, InternalDefinedTool>;
+  for (const tool of options.tools) {
+    const internal = tool as unknown as InternalDefinedTool;
+    const definition = internal[TOOL_DEFINITION];
+    if (definition === undefined || internal[TOOL_EXECUTE] === undefined) {
+      throw new TypeError("definePlugin received a tool not created by defineTool");
+    }
+    if (Object.hasOwn(dispatch, definition.name)) {
+      throw new Error(`duplicate plugin tool name: ${definition.name}`);
+    }
+    definitions.push(definition);
+    dispatch[definition.name] = internal;
+  }
+
+  const plugin: InternalPlugin = Object.freeze({
+    [PLUGIN_DEFINITIONS]: Object.freeze(definitions),
+    [PLUGIN_DISPATCH]: Object.freeze(dispatch),
+  });
+  return plugin as unknown as Plugin;
+}
+
+export function getPluginDefinitions(plugin: Plugin): readonly PluginToolDefinition[] {
+  return (plugin as unknown as InternalPlugin)[PLUGIN_DEFINITIONS];
+}
+
+export function getPluginExecutor(
+  plugin: Plugin,
+  name: string,
+): ((args: object) => MaybePromise<ToolResult<object>>) | undefined {
+  return (plugin as unknown as InternalPlugin)[PLUGIN_DISPATCH][name]?.[TOOL_EXECUTE];
+}

--- a/npm/plugin-sdk/test/protocol.test.mjs
+++ b/npm/plugin-sdk/test/protocol.test.mjs
@@ -107,6 +107,29 @@ test("definePlugin snapshots its catalog independently of the caller tools array
   assert.equal(JSON.stringify(first), "{}");
 });
 
+test("schema and catalog snapshots preserve special JSON property names", async () => {
+  const key = "__proto__";
+  const inputSchema = schema.object({ [key]: schema.string() });
+  assert.equal(Object.hasOwn(inputSchema.properties, key), true);
+  assert.deepEqual(inputSchema.required, [key]);
+
+  const tool = defineTool({
+    name: "special_key",
+    inputSchema,
+    execute(args) {
+      return textResult(String(args[key]));
+    },
+  });
+  const result = await exchange(
+    [JSON.stringify({ jsonrpc: "2.0", id: 5, method: "tools/list", params: {} })],
+    definePlugin({ tools: [tool] }),
+  );
+  const listed = result.lines[0].result.tools[0].inputSchema;
+  assert.equal(Object.hasOwn(listed.properties, key), true);
+  assert.equal(listed.properties[key].type, "string");
+  assert.deepEqual(listed.required, [key]);
+});
+
 test("duplicate tool names fail before serving", () => {
   const make = () => defineTool({
     name: "same",

--- a/npm/plugin-sdk/test/protocol.test.mjs
+++ b/npm/plugin-sdk/test/protocol.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { PassThrough, Readable } from "node:stream";
+import test from "node:test";
+
+import { definePlugin, defineTool, schema, textResult } from "../dist/index.js";
+import { servePlugin } from "../dist/runtime.js";
+
+function captureStream() {
+  const stream = new PassThrough();
+  let text = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => {
+    text += chunk;
+  });
+  return { stream, read: () => text };
+}
+
+async function exchange(lines, plugin = definePlugin({ tools: [] })) {
+  const output = captureStream();
+  const error = captureStream();
+  await servePlugin(plugin, {
+    input: Readable.from(lines.map((line) => `${line}\n`)),
+    output: output.stream,
+    error: error.stream,
+  });
+  return {
+    lines: output.read().trimEnd().split("\n").filter(Boolean).map((line) => JSON.parse(line)),
+    raw: output.read(),
+    stderr: error.read(),
+  };
+}
+
+test("initialize requires the exact webcodex-plugin-v1 version", async () => {
+  const ok = await exchange([
+    JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "webcodex-plugin-v1" } }),
+  ]);
+  assert.deepEqual(ok.lines, [
+    { jsonrpc: "2.0", id: 1, result: { protocolVersion: "webcodex-plugin-v1" } },
+  ]);
+
+  const wrong = await exchange([
+    JSON.stringify({ jsonrpc: "2.0", id: 2, method: "initialize", params: { protocolVersion: "webcodex-plugin-v2" } }),
+  ]);
+  assert.deepEqual(wrong.lines, [
+    { jsonrpc: "2.0", id: 2, error: { code: -32602, message: "unsupported protocol version" } },
+  ]);
+});
+
+test("tools/list exposes only protocol definitions and preserves authoring order", async () => {
+  const second = defineTool({
+    name: "second",
+    inputSchema: schema.object({ value: schema.string() }),
+    execute({ value }) {
+      return textResult(value);
+    },
+  });
+  const first = defineTool({
+    name: "first",
+    title: "First",
+    description: "First tool",
+    inputSchema: schema.object({}),
+    annotations: { readOnlyHint: true },
+    execute() {
+      return textResult("first");
+    },
+  });
+  const result = await exchange(
+    [JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} })],
+    definePlugin({ tools: [second, first] }),
+  );
+  const tools = result.lines[0].result.tools;
+  assert.deepEqual(tools.map((tool) => tool.name), ["second", "first"]);
+  assert.equal("execute" in tools[0], false);
+  assert.equal(JSON.stringify(tools).includes("function"), false);
+  assert.deepEqual(Object.keys(tools[1]).sort(), [
+    "annotations",
+    "description",
+    "inputSchema",
+    "name",
+    "title",
+  ]);
+});
+
+test("definePlugin snapshots its catalog independently of the caller tools array", async () => {
+  const first = defineTool({
+    name: "first",
+    inputSchema: schema.object({}),
+    execute() {
+      return textResult("first");
+    },
+  });
+  const second = defineTool({
+    name: "second",
+    inputSchema: schema.object({}),
+    execute() {
+      return textResult("second");
+    },
+  });
+  const tools = [first];
+  const plugin = definePlugin({ tools });
+  tools.push(second);
+  const result = await exchange(
+    [JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/list", params: {} })],
+    plugin,
+  );
+  assert.deepEqual(result.lines[0].result.tools.map((tool) => tool.name), ["first"]);
+  assert.equal(JSON.stringify(first), "{}");
+});
+
+test("duplicate tool names fail before serving", () => {
+  const make = () => defineTool({
+    name: "same",
+    inputSchema: schema.object({}),
+    execute() {
+      return textResult("ok");
+    },
+  });
+  assert.throws(() => definePlugin({ tools: [make(), make()] }), /duplicate plugin tool name/);
+});
+
+test("unknown methods and malformed JSON fail closed without ToolResult", async () => {
+  const result = await exchange([
+    JSON.stringify({ jsonrpc: "2.0", id: "x", method: "other/method", params: {} }),
+    "{broken-json",
+    JSON.stringify({ jsonrpc: "1.0", id: 5, method: "tools/list", params: {} }),
+  ]);
+  assert.equal(result.lines.length, 3);
+  assert.deepEqual(result.lines[0], {
+    jsonrpc: "2.0",
+    id: "x",
+    error: { code: -32601, message: "method not found" },
+  });
+  assert.equal(result.lines[1].error.code, -32700);
+  assert.equal(result.lines[2].error.code, -32600);
+  for (const response of result.lines) assert.equal("result" in response, false);
+});
+
+test("stdout framing is exactly one JSON response per line", async () => {
+  const result = await exchange([
+    JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+  ]);
+  assert.equal(result.raw.endsWith("\n"), true);
+  assert.equal(result.raw.split("\n").filter(Boolean).length, 2);
+  for (const line of result.raw.trimEnd().split("\n")) assert.doesNotThrow(() => JSON.parse(line));
+  assert.equal(result.stderr, "");
+});

--- a/npm/plugin-sdk/test/runtime.test.mjs
+++ b/npm/plugin-sdk/test/runtime.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { PassThrough, Readable } from "node:stream";
+import test from "node:test";
+
+import {
+  definePlugin,
+  defineTool,
+  errorResult,
+  schema,
+  textResult,
+} from "../dist/index.js";
+import { servePlugin } from "../dist/runtime.js";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function captureStream() {
+  const stream = new PassThrough();
+  let text = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => {
+    text += chunk;
+  });
+  return { stream, read: () => text };
+}
+
+function callLine(id, name, args) {
+  return `${JSON.stringify({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } })}\n`;
+}
+
+async function serveLines(plugin, lines) {
+  const output = captureStream();
+  const error = captureStream();
+  await servePlugin(plugin, {
+    input: Readable.from(lines),
+    output: output.stream,
+    error: error.stream,
+  });
+  return {
+    responses: output.read().trimEnd().split("\n").filter(Boolean).map((line) => JSON.parse(line)),
+    stdout: output.read(),
+    stderr: error.read(),
+  };
+}
+
+test("tools/call supports synchronous and asynchronous handlers", async () => {
+  const sync = defineTool({
+    name: "sync",
+    inputSchema: schema.object({ text: schema.string() }),
+    outputSchema: schema.object({ text: schema.string() }),
+    execute({ text }) {
+      return textResult(text, { text });
+    },
+  });
+  const asyncTool = defineTool({
+    name: "async",
+    inputSchema: schema.object({ value: schema.integer() }),
+    outputSchema: schema.object({ doubled: schema.integer() }),
+    async execute({ value }) {
+      await Promise.resolve();
+      return textResult(String(value * 2), { doubled: value * 2 });
+    },
+  });
+  const result = await serveLines(definePlugin({ tools: [sync, asyncTool] }), [
+    callLine(1, "sync", { text: "hello" }),
+    callLine(2, "async", { value: 4 }),
+  ]);
+  assert.deepEqual(result.responses, [
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        content: [{ type: "text", text: "hello" }],
+        structuredContent: { text: "hello" },
+        isError: false,
+      },
+    },
+    {
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        content: [{ type: "text", text: "8" }],
+        structuredContent: { doubled: 8 },
+        isError: false,
+      },
+    },
+  ]);
+  assert.equal(result.stderr, "");
+});
+
+test("async calls are strictly serialized without timing assumptions", async () => {
+  const firstStarted = deferred();
+  const releaseFirst = deferred();
+  const order = [];
+  const tool = defineTool({
+    name: "serial",
+    inputSchema: schema.object({ sequence: schema.integer() }),
+    async execute({ sequence }) {
+      order.push(`start-${sequence}`);
+      if (sequence === 1) {
+        firstStarted.resolve();
+        await releaseFirst.promise;
+      }
+      order.push(`end-${sequence}`);
+      return textResult(String(sequence), { sequence });
+    },
+  });
+
+  const output = captureStream();
+  const error = captureStream();
+  const serving = servePlugin(definePlugin({ tools: [tool] }), {
+    input: Readable.from([
+      callLine(1, "serial", { sequence: 1 }),
+      callLine(2, "serial", { sequence: 2 }),
+    ]),
+    output: output.stream,
+    error: error.stream,
+  });
+
+  await firstStarted.promise;
+  assert.deepEqual(order, ["start-1"]);
+  releaseFirst.resolve();
+  await serving;
+  assert.deepEqual(order, ["start-1", "end-1", "start-2", "end-2"]);
+  assert.equal(output.read().trimEnd().split("\n").length, 2);
+});
+
+test("explicit errorResult is a normal completed application result", async () => {
+  const tool = defineTool({
+    name: "known_failure",
+    inputSchema: schema.object({}),
+    outputSchema: schema.object({ code: schema.string() }),
+    execute() {
+      return errorResult("known application failure", { code: "rejected" });
+    },
+  });
+  const result = await serveLines(definePlugin({ tools: [tool] }), [
+    callLine(9, "known_failure", {}),
+  ]);
+  assert.equal(result.responses.length, 1);
+  assert.equal(result.responses[0].result.isError, true);
+  assert.deepEqual(result.responses[0].result.structuredContent, { code: "rejected" });
+  assert.deepEqual(result.responses[0].result.content, [
+    { type: "text", text: "known application failure" },
+  ]);
+});
+
+test("handler rejection returns no ToolResult and emits only a bounded generic diagnostic", async () => {
+  let secondRan = false;
+  const tool = defineTool({
+    name: "uncertain",
+    inputSchema: schema.object({ secretArgument: schema.string() }),
+    async execute({ secretArgument }) {
+      if (secretArgument === "second") secondRan = true;
+      throw new Error(`secret-exception-body:${secretArgument}`);
+    },
+  });
+  const output = captureStream();
+  const error = captureStream();
+  await assert.rejects(
+    servePlugin(definePlugin({ tools: [tool] }), {
+      input: Readable.from([
+        callLine(1, "uncertain", { secretArgument: "secret-argument" }),
+        callLine(2, "uncertain", { secretArgument: "second" }),
+      ]),
+      output: output.stream,
+      error: error.stream,
+    }),
+    /plugin handler failed/,
+  );
+  assert.equal(output.read(), "");
+  assert.equal(secondRan, false);
+  assert.equal(error.read(), "webcodex plugin handler failed; provider will stop\n");
+  assert.equal(error.read().includes("secret-argument"), false);
+  assert.equal(error.read().includes("secret-exception-body"), false);
+  assert.equal(error.read().includes(" at "), false);
+});
+
+test("result helpers use only text content and camelCase v1 result fields", () => {
+  const ok = textResult("ok", { value: 1 });
+  const error = errorResult("bad", { value: 2 });
+  assert.deepEqual(Object.keys(ok), ["content", "structuredContent", "isError"]);
+  assert.deepEqual(Object.keys(error), ["content", "structuredContent", "isError"]);
+  assert.deepEqual(ok.content, [{ type: "text", text: "ok" }]);
+  assert.deepEqual(error.content, [{ type: "text", text: "bad" }]);
+  assert.equal(ok.isError, false);
+  assert.equal(error.isError, true);
+});

--- a/npm/plugin-sdk/test/schema.test.mjs
+++ b/npm/plugin-sdk/test/schema.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { schema } from "../dist/index.js";
+
+const PROFILE_KEYS = new Set([
+  "type",
+  "title",
+  "description",
+  "properties",
+  "required",
+  "additionalProperties",
+  "enum",
+  "const",
+  "minLength",
+  "maxLength",
+  "minItems",
+  "maxItems",
+  "items",
+]);
+
+function assertProfileOnly(value) {
+  assert.equal(typeof value, "object");
+  assert.notEqual(value, null);
+  assert.equal(Array.isArray(value), false);
+  for (const key of Object.keys(value)) {
+    assert.equal(PROFILE_KEYS.has(key), true, `unexpected schema keyword: ${key}`);
+  }
+  if (value.properties) {
+    for (const child of Object.values(value.properties)) assertProfileOnly(child);
+  }
+  if (value.items) assertProfileOnly(value.items);
+}
+
+test("schema builders emit the Native Plugin Schema Profile v1 shapes", () => {
+  const value = schema.object({
+    text: schema.string({ minLength: 1, maxLength: 12, enum: ["a", "b"], const: "a" }),
+    ratio: schema.number({ title: "Ratio" }),
+    count: schema.integer({ description: "Count" }),
+    enabled: schema.boolean(),
+    empty: schema.null(),
+    tags: schema.array(schema.string(), { minItems: 1, maxItems: 3 }),
+  });
+
+  assert.deepEqual(value, {
+    type: "object",
+    properties: {
+      text: { type: "string", minLength: 1, maxLength: 12, enum: ["a", "b"], const: "a" },
+      ratio: { type: "number", title: "Ratio" },
+      count: { type: "integer", description: "Count" },
+      enabled: { type: "boolean" },
+      empty: { type: "null" },
+      tags: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 3 },
+    },
+    required: ["text", "ratio", "count", "enabled", "empty", "tags"],
+    additionalProperties: false,
+  });
+  assertProfileOnly(value);
+});
+
+test("optional properties are omitted from required and object defaults closed", () => {
+  const value = schema.object({
+    requiredValue: schema.string(),
+    optionalValue: schema.optional(schema.boolean()),
+  });
+  assert.deepEqual(value.required, ["requiredValue"]);
+  assert.equal(value.additionalProperties, false);
+  assert.deepEqual(value.properties.optionalValue, { type: "boolean" });
+  assert.equal("optional" in value.properties.optionalValue, false);
+});
+
+test("additionalProperties true is explicit and enum/const literals stay on wire", () => {
+  const value = schema.object(
+    {
+      mode: schema.string({ enum: ["fast", "safe"] }),
+      exact: schema.integer({ const: 2 }),
+    },
+    { additionalProperties: true },
+  );
+  assert.equal(value.additionalProperties, true);
+  assert.deepEqual(value.properties.mode.enum, ["fast", "safe"]);
+  assert.equal(value.properties.exact.const, 2);
+  assertProfileOnly(value);
+});
+
+test("schemas are immutable snapshots of authoring input", () => {
+  const values = ["first", "second"];
+  const value = schema.string({ enum: values });
+  values.push("later");
+  assert.deepEqual(value.enum, ["first", "second"]);
+  assert.equal(Object.isFrozen(value), true);
+  assert.equal(Object.isFrozen(value.enum), true);
+});

--- a/npm/plugin-sdk/test/types.test.ts
+++ b/npm/plugin-sdk/test/types.test.ts
@@ -1,0 +1,96 @@
+import {
+  defineTool,
+  schema,
+  textResult,
+  type InferSchema,
+} from "../src/index.js";
+
+const input = schema.object({
+  text: schema.string(),
+  count: schema.optional(schema.integer()),
+});
+
+defineTool({
+  name: "inference",
+  inputSchema: input,
+  execute(args) {
+    const text: string = args.text;
+    const count: number | undefined = args.count;
+    void text;
+    void count;
+    // @ts-expect-error unknown properties are rejected for closed object schemas.
+    void args.missing;
+    return textResult(args.text, { text: args.text });
+  },
+});
+
+const modeSchema = schema.string({ enum: ["fast", "safe"] });
+type Mode = InferSchema<typeof modeSchema>;
+const mode: Mode = "fast";
+void mode;
+// @ts-expect-error enum literal inference excludes other strings.
+const invalidMode: Mode = "other";
+void invalidMode;
+
+const exactSchema = schema.integer({ const: 2 });
+type Exact = InferSchema<typeof exactSchema>;
+const exact: Exact = 2;
+void exact;
+// @ts-expect-error const literal inference keeps the exact numeric value.
+const invalidExact: Exact = 3;
+void invalidExact;
+
+const output = schema.object({ text: schema.string() });
+defineTool({
+  name: "typed-output",
+  inputSchema: schema.object({}),
+  outputSchema: output,
+  execute() {
+    return textResult("ok", { text: "ok" });
+  },
+});
+
+defineTool({
+  name: "bad-output",
+  inputSchema: schema.object({}),
+  outputSchema: output,
+  // @ts-expect-error structuredContent must match the declared output schema at authoring time.
+  execute() {
+    return textResult("bad", { text: 42 });
+  },
+});
+
+defineTool({
+  name: "bad-input-root",
+  // @ts-expect-error Plugin inputSchema roots must be object schemas.
+  inputSchema: schema.string(),
+  execute() {
+    return textResult("bad");
+  },
+});
+
+defineTool({
+  name: "bad-output-root",
+  inputSchema: schema.object({}),
+  // @ts-expect-error Plugin outputSchema roots must be object schemas.
+  outputSchema: schema.array(schema.string()),
+  execute() {
+    return textResult("bad", {});
+  },
+});
+
+const openInput = schema.object(
+  { known: schema.string() },
+  { additionalProperties: true },
+);
+defineTool({
+  name: "open-input",
+  inputSchema: openInput,
+  execute(args) {
+    const known: string = args.known;
+    const extra: unknown = args.other;
+    void known;
+    void extra;
+    return textResult("ok");
+  },
+});

--- a/npm/plugin-sdk/tsconfig.json
+++ b/npm/plugin-sdk/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/npm/plugin-sdk/tsconfig.typecheck.json
+++ b/npm/plugin-sdk/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@yyjeqhc/webcodex-plugin-sdk": ["./src/index.ts"]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "examples/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/scripts/ci_path_risk.py
+++ b/scripts/ci_path_risk.py
@@ -55,6 +55,7 @@ class Risk:
     needs_docker: bool = False
     needs_frontend: bool = False
     needs_desktop_frontend: bool = False
+    needs_plugin_sdk: bool = False
     needs_full_native: bool = False
     categories: set[str] = field(default_factory=set)
     changed_count: int = 0
@@ -76,6 +77,7 @@ class Risk:
             self.needs_docker = True
             self.needs_frontend = True
             self.needs_desktop_frontend = True
+            self.needs_plugin_sdk = True
         return self
 
     def outputs(self) -> dict[str, str]:
@@ -102,6 +104,7 @@ class Risk:
             "needs_docker": _bool(self.needs_docker),
             "needs_frontend": _bool(self.needs_frontend),
             "needs_desktop_frontend": _bool(self.needs_desktop_frontend),
+            "needs_plugin_sdk": _bool(self.needs_plugin_sdk),
             "needs_desktop_package": _bool(needs_desktop_package),
             "needs_full_native": _bool(self.needs_full_native),
             "categories": categories,
@@ -204,6 +207,10 @@ def _classify_path(risk: Risk, path: str) -> None:
 
     if _is_docs_or_text(path):
         risk.categories.add("docs")
+        return
+    if path.startswith("npm/plugin-sdk/"):
+        risk.needs_plugin_sdk = True
+        risk.categories.add("plugin-sdk")
         return
     if _is_main_frontend(path):
         risk.needs_frontend = True

--- a/scripts/ci_path_risk.py
+++ b/scripts/ci_path_risk.py
@@ -205,12 +205,12 @@ def _classify_path(risk: Risk, path: str) -> None:
     name = PurePosixPath(lower).name
     tokens = {token for token in re.split(r"[/_.-]+", lower) if token}
 
-    if _is_docs_or_text(path):
-        risk.categories.add("docs")
-        return
     if path.startswith("npm/plugin-sdk/"):
         risk.needs_plugin_sdk = True
         risk.categories.add("plugin-sdk")
+        return
+    if _is_docs_or_text(path):
+        risk.categories.add("docs")
         return
     if _is_main_frontend(path):
         risk.needs_frontend = True

--- a/scripts/tests/test_ci_path_risk.py
+++ b/scripts/tests/test_ci_path_risk.py
@@ -73,15 +73,21 @@ class PathRiskFixtureTests(unittest.TestCase):
         self.assertEqual(result["needs_macos_desktop"], "true")
 
     def test_plugin_sdk_isolated_from_native_frontend_desktop_and_docker(self) -> None:
-        result = classify("npm/plugin-sdk/src/runtime.ts")
-        self.assertEqual(result["needs_plugin_sdk"], "true")
-        self.assertEqual(result["needs_full_native"], "false")
-        self.assertEqual(result["needs_windows"], "false")
-        self.assertEqual(result["needs_macos"], "false")
-        self.assertEqual(result["needs_docker"], "false")
-        self.assertEqual(result["needs_frontend"], "false")
-        self.assertEqual(result["needs_desktop_frontend"], "false")
-        self.assertIn("plugin-sdk", result["categories"])
+        for path in (
+            "npm/plugin-sdk/src/runtime.ts",
+            "npm/plugin-sdk/README.md",
+            "npm/plugin-sdk/LICENSE",
+        ):
+            with self.subTest(path=path):
+                result = classify(path)
+                self.assertEqual(result["needs_plugin_sdk"], "true")
+                self.assertEqual(result["needs_full_native"], "false")
+                self.assertEqual(result["needs_windows"], "false")
+                self.assertEqual(result["needs_macos"], "false")
+                self.assertEqual(result["needs_docker"], "false")
+                self.assertEqual(result["needs_frontend"], "false")
+                self.assertEqual(result["needs_desktop_frontend"], "false")
+                self.assertIn("plugin-sdk", result["categories"])
 
     def test_npm_installer_change_requires_native_windows_package_lane(self) -> None:
         result = classify("npm/webcodex/install.js")

--- a/scripts/tests/test_ci_path_risk.py
+++ b/scripts/tests/test_ci_path_risk.py
@@ -30,6 +30,7 @@ class PathRiskFixtureTests(unittest.TestCase):
         self.assertEqual(result["needs_docker"], "false")
         self.assertEqual(result["needs_frontend"], "false")
         self.assertEqual(result["needs_desktop_frontend"], "false")
+        self.assertEqual(result["needs_plugin_sdk"], "false")
 
     def test_main_frontend_isolated_from_native_and_desktop_frontend(self) -> None:
         result = classify("frontend/src/runtime.ts")
@@ -70,6 +71,17 @@ class PathRiskFixtureTests(unittest.TestCase):
         self.assertEqual(result["needs_frontend"], "false")
         self.assertEqual(result["needs_windows_desktop"], "true")
         self.assertEqual(result["needs_macos_desktop"], "true")
+
+    def test_plugin_sdk_isolated_from_native_frontend_desktop_and_docker(self) -> None:
+        result = classify("npm/plugin-sdk/src/runtime.ts")
+        self.assertEqual(result["needs_plugin_sdk"], "true")
+        self.assertEqual(result["needs_full_native"], "false")
+        self.assertEqual(result["needs_windows"], "false")
+        self.assertEqual(result["needs_macos"], "false")
+        self.assertEqual(result["needs_docker"], "false")
+        self.assertEqual(result["needs_frontend"], "false")
+        self.assertEqual(result["needs_desktop_frontend"], "false")
+        self.assertIn("plugin-sdk", result["categories"])
 
     def test_npm_installer_change_requires_native_windows_package_lane(self) -> None:
         result = classify("npm/webcodex/install.js")
@@ -211,6 +223,7 @@ class InvocationOverrideFixtureTests(unittest.TestCase):
         self.assertIn("override-run-ci", result["reason"])
         self.assertEqual(result["needs_frontend"], "true")
         self.assertEqual(result["needs_desktop_frontend"], "true")
+        self.assertEqual(result["needs_plugin_sdk"], "true")
 
     def test_push_main_uses_path_classifier(self) -> None:
         forced = risk.forced_risk_for_invocation(

--- a/scripts/tests/test_release_readiness.py
+++ b/scripts/tests/test_release_readiness.py
@@ -280,6 +280,16 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("needs: changes", contract)
         self.assertIn("if: needs.changes.outputs.needs_frontend == 'true'", contract)
         self.assertIn("if: needs.changes.outputs.needs_desktop_frontend == 'true'", contract)
+        self.assertIn("needs.changes.outputs.needs_plugin_sdk == 'true'", contract)
+        self.assertIn("npm/plugin-sdk/package-lock.json", contract)
+        for command in (
+            "npm ci --prefix npm/plugin-sdk",
+            "npm --prefix npm/plugin-sdk run typecheck",
+            "npm --prefix npm/plugin-sdk run build",
+            "npm --prefix npm/plugin-sdk test",
+            "npm --prefix npm/plugin-sdk run pack:dry-run",
+        ):
+            self.assertIn(command, contract)
         self.assertIn("github.event.before", changes)
         self.assertIn("persist-credentials: false", changes)
         self.assertIn('classifier="scripts/ci_path_risk.py"', changes)
@@ -369,7 +379,12 @@ class WorkflowContractTests(unittest.TestCase):
             "reason",
         ):
             self.assertIn(f"{output}: ${{{{ steps.classify.outputs.{output} }}}}", changes)
-        for rollout_output in ("needs_frontend", "needs_desktop_frontend", "needs_docker"):
+        for rollout_output in (
+            "needs_frontend",
+            "needs_desktop_frontend",
+            "needs_plugin_sdk",
+            "needs_docker",
+        ):
             self.assertIn(f"{rollout_output}: ${{{{ steps.classify.outputs.{rollout_output} == 'true'", changes)
             self.assertIn(f"steps.classify.outputs.{rollout_output} == '' && steps.classify.outputs.needs_full_native == 'true'", changes)
         self.assertNotIn("needs_windows_arm64", workflow)


### PR DESCRIPTION
## Summary

- add `@yyjeqhc/webcodex-plugin-sdk` as a zero-runtime-dependency TypeScript authoring SDK for the existing `webcodex-plugin-v1` Native Tool Plugin protocol
- provide a bounded v1 schema builder, typed `defineTool` / `definePlugin`, result helpers, and strictly serial stdio JSON-RPC runtime while keeping Rust Runner admission, lifecycle, bounds, and `OutcomeUnknown` semantics authoritative
- add TypeScript authoring docs/example plus path-aware CI coverage without adding a new heavyweight CI job
- preserve raw protocol examples and leave `plugins/safe-delete` unchanged for a later dogfood migration

## Review fix

Independent review found that ordinary object assignment could silently lose a valid schema property named `__proto__`. The branch now uses safe JSON snapshot construction and includes an end-to-end regression test so special JSON property names survive schema building and `tools/list` projection.

## Validation

- `npm ci --prefix npm/plugin-sdk`
- `npm --prefix npm/plugin-sdk run typecheck`
- `npm --prefix npm/plugin-sdk test` — 16 passed
- `npm --prefix npm/plugin-sdk run pack:dry-run` — 14 expected files, 13.8 kB package
- `python3 -m unittest scripts.tests.test_ci_path_risk scripts.tests.test_release_readiness.WorkflowContractTests` — 36 passed
- `python3 -m py_compile scripts/ci_path_risk.py scripts/tests/test_ci_path_risk.py scripts/tests/test_release_readiness.py`
- `git diff --check 7250997e81c558463da6d78a0ff80b9694d51c2a..HEAD`

No Rust Plugin protocol changes, publication, deployment, or service restart are included.