### PR TITLE
Add Native Plugin authoring CLI

### DIFF
--- a/crates/webcodex-cli/src/lib.rs
+++ b/crates/webcodex-cli/src/lib.rs
@@ -40,21 +40,24 @@ use webcodex_cli::{
     default_device_name, default_server_paths, disconnect_usage, discover_internal_binary,
     is_effective_root, login_usage, logout_usage, ops_projects_usage, ops_runner_usage,
     ops_runners_usage, ops_smoke_preflight_usage, ops_status_usage, ops_usage, ops_windows_usage,
-    pairing_create_usage, pairing_usage, project_activate_usage, project_register_usage,
-    read_env_file_value, render_token_generate, run_connect, run_disconnect, run_hosted_log_writer,
-    run_internal_binary, run_login, run_logout, run_ops_command, run_pairing_create,
-    run_project_activate, run_project_register, run_runner_install_service, run_runner_service,
-    run_runner_status, run_runner_token_create_local, run_server_init, run_server_install_service,
-    run_server_service, run_server_status, run_server_tunnel, run_status, run_token_create_local,
+    pairing_create_usage, pairing_usage, parse_plugin_command, plugin_check_usage,
+    plugin_describe_usage, plugin_list_usage, plugin_reload_usage, plugin_usage,
+    project_activate_usage, project_register_usage, read_env_file_value, render_token_generate,
+    run_connect, run_disconnect, run_hosted_log_writer, run_internal_binary, run_login, run_logout,
+    run_ops_command, run_pairing_create, run_plugin_command, run_project_activate,
+    run_project_register, run_runner_install_service, run_runner_service, run_runner_status,
+    run_runner_token_create_local, run_server_init, run_server_install_service, run_server_service,
+    run_server_status, run_server_tunnel, run_status, run_token_create_local,
     runner_config_for_scope, runner_init_usage, runner_install_service_usage,
     runner_service_file_for_scope, runner_status_usage, runner_usage, server_init_usage,
     server_install_service_usage, server_status_usage, server_tunnel_usage, server_usage,
     service_unit_name, status_usage, system_user_home, system_user_is_root, usage,
     validate_client_profile, validate_service_file_scope, write_connect_result, ConnectAuth,
     ConnectOptions, DisconnectOptions, LoginOptions, LogoutOptions, OpsCommand, OpsCommonOptions,
-    OpsRunnerOptions, OpsSmokePreflightOptions, OpsWindowsOptions, ProjectActivateOptions,
-    ProjectRegisterOptions, ServerStatusOptions, ServiceControl, StatusOptions, DEFAULT_LOG_LINES,
-    RUNNER_SERVICE_UNIT, SERVER_SERVICE_FILE, SERVER_SERVICE_UNIT,
+    OpsRunnerOptions, OpsSmokePreflightOptions, OpsWindowsOptions, PluginCommand,
+    ProjectActivateOptions, ProjectRegisterOptions, ServerStatusOptions, ServiceControl,
+    StatusOptions, DEFAULT_LOG_LINES, RUNNER_SERVICE_UNIT, SERVER_SERVICE_FILE,
+    SERVER_SERVICE_UNIT,
 };
 const SETUP_GPT_SCOPES: &[&str] = &[
     "runtime:read",
@@ -119,6 +122,7 @@ enum CliAction {
     Logout(LogoutOptions),
     Status(StatusOptions),
     Ops(OpsCommand),
+    Plugin(PluginCommand),
     RunnerInstall(RunnerInstallServiceOptions),
     RunnerStatus(RunnerStatusOptions),
     RunnerRun(InternalRunOptions),
@@ -348,6 +352,7 @@ where
         "logout" => parse_logout(&args[1..]),
         "auth" => parse_auth_subcommand(&args[1..]),
         "ops" => parse_ops_subcommand(&args[1..]),
+        "plugin" => parse_plugin_subcommand(&args[1..]),
         "runner" => parse_runner_subcommand(&args[1..]),
         "agent-token" => cli_parse_error(
             "`webcodex agent-token` was removed; use `webcodex runner-tokens ...`".to_string(),
@@ -1359,6 +1364,55 @@ fn parse_pairing_subcommand(args: &[String]) -> CliAction {
             code: 2,
             stdout: String::new(),
             stderr: format!("unknown pairing subcommand: {}\n", other),
+        },
+    }
+}
+
+fn parse_plugin_subcommand(args: &[String]) -> CliAction {
+    if args.is_empty() {
+        return CliAction::Exit {
+            code: 2,
+            stdout: String::new(),
+            stderr: format!("{}\n", plugin_usage()),
+        };
+    }
+    if matches!(args[0].as_str(), "--help" | "-h") {
+        return CliAction::Exit {
+            code: 0,
+            stdout: plugin_usage().to_string(),
+            stderr: String::new(),
+        };
+    }
+    let command = args[0].as_str();
+    let usage = match command {
+        "list" => plugin_list_usage(),
+        "describe" => plugin_describe_usage(),
+        "check" => plugin_check_usage(),
+        "reload" => plugin_reload_usage(),
+        other => {
+            return CliAction::Exit {
+                code: 2,
+                stdout: String::new(),
+                stderr: format!("unknown plugin subcommand: {other}\n"),
+            }
+        }
+    };
+    if args
+        .get(1)
+        .is_some_and(|arg| arg == "--help" || arg == "-h")
+    {
+        return CliAction::Exit {
+            code: 0,
+            stdout: usage,
+            stderr: String::new(),
+        };
+    }
+    match parse_plugin_command(command, &args[1..]) {
+        Ok(command) => CliAction::Plugin(command),
+        Err(error) => CliAction::Exit {
+            code: 2,
+            stdout: String::new(),
+            stderr: format!("{error}\n"),
         },
     }
 }
@@ -2763,6 +2817,19 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
+        CliAction::Plugin(command) => match run_plugin_command(command).await {
+            Ok(output) => {
+                print!("{}", output.stdout);
+                if !output.stdout.ends_with('\n') {
+                    println!();
+                }
+                std::process::exit(output.exit_code);
+            }
+            Err(stderr) => {
+                eprintln!("{}", stderr);
+                std::process::exit(1);
+            }
+        },
         CliAction::RunnerInstall(opts) => match run_runner_install_service(opts) {
             Ok(stdout) => {
                 print!("{}", stdout);

--- a/crates/webcodex-cli/src/webcodex_cli/http.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/http.rs
@@ -128,10 +128,10 @@ pub(crate) async fn http_post_json_status(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("unknown")
         .to_string();
-    let text = resp
-        .text()
-        .await
-        .map_err(|e| format!("failed to read response: {}", e))?;
+    let text = resp.text().await.map_err(|e| {
+        let error = format!("failed to read response: {}", e);
+        token.map_or_else(|| error.clone(), |token| error.replace(token, "[redacted]"))
+    })?;
     let json = if content_type
         .split(';')
         .next()
@@ -142,6 +142,23 @@ pub(crate) async fn http_post_json_status(
         None
     };
     Ok((status, content_type, json))
+}
+
+pub(crate) async fn call_runtime_tool_status(
+    server_url: &str,
+    server_http: &ServerHttpOptions,
+    token: Option<&str>,
+    tool: &str,
+    params: Value,
+) -> Result<(u16, String, Option<Value>), String> {
+    http_post_json_status(
+        server_url,
+        server_http,
+        "/api/tools/call",
+        token,
+        json!({"tool": tool, "params": params}),
+    )
+    .await
 }
 
 #[derive(Debug, Clone)]

--- a/crates/webcodex-cli/src/webcodex_cli/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod login;
 pub(crate) mod ops;
 pub(crate) mod output;
 pub(crate) mod pairing;
+pub(crate) mod plugin;
 pub(crate) mod profiles;
 pub(crate) mod project;
 pub(crate) mod runner_service;
@@ -63,7 +64,10 @@ pub(crate) use env::{
 pub(crate) use http::format_error_body;
 #[cfg(test)]
 pub(crate) use http::post_json_unauthed;
-pub(crate) use http::{fetch_runtime_status, http_post_json_status, post_json_authed, ApiCall};
+pub(crate) use http::{
+    call_runtime_tool_status, fetch_runtime_status, http_post_json_status, post_json_authed,
+    ApiCall,
+};
 pub(crate) use login::{
     base_dir_or_default, default_device_name, run_login, run_logout, run_status, LoginOptions,
     LogoutOptions, StatusOptions,
@@ -79,6 +83,7 @@ pub(crate) use output::{
     runtime_build_metadata, server_status_revision_check,
 };
 pub(crate) use pairing::run_pairing_create;
+pub(crate) use plugin::{parse_plugin_command, run_plugin_command, PluginCommand};
 #[cfg(test)]
 pub(crate) use profiles::{client_output_dir_for_profile, CLIENT_PROFILE_ERROR};
 pub(crate) use profiles::{
@@ -113,8 +118,8 @@ pub(crate) use service::{
 };
 pub(crate) use system::{
     discover_internal_binary, read_optional_token, read_optional_user_api_token,
-    system_group_exists, system_user_exists, system_user_home, system_user_is_root,
-    validate_user_api_token,
+    resolve_user_api_token, system_group_exists, system_user_exists, system_user_home,
+    system_user_is_root, validate_user_api_token,
 };
 #[cfg(test)]
 pub(crate) use token_commands::resolve_account_credential;
@@ -126,10 +131,12 @@ pub(crate) use tokens::{
 pub(crate) use usage::{
     connect_usage, disconnect_usage, login_usage, logout_usage, ops_projects_usage,
     ops_runner_usage, ops_runners_usage, ops_smoke_preflight_usage, ops_status_usage, ops_usage,
-    ops_windows_usage, pairing_create_usage, pairing_usage, project_activate_usage,
-    project_register_usage, runner_init_usage, runner_install_service_usage, runner_status_usage,
-    runner_usage, server_init_usage, server_install_service_usage, server_status_usage,
-    server_tunnel_usage, server_usage, status_usage, usage,
+    ops_windows_usage, pairing_create_usage, pairing_usage, plugin_check_usage,
+    plugin_describe_usage, plugin_list_usage, plugin_reload_usage, plugin_usage,
+    project_activate_usage, project_register_usage, runner_init_usage,
+    runner_install_service_usage, runner_status_usage, runner_usage, server_init_usage,
+    server_install_service_usage, server_status_usage, server_tunnel_usage, server_usage,
+    status_usage, usage,
 };
 
 #[cfg(test)]

--- a/crates/webcodex-cli/src/webcodex_cli/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/ops.rs
@@ -3,9 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use webcodex_admin::ServerHttpOptions;
 
-use super::{
-    http_post_json_status, read_env_file_value, read_optional_token, validate_user_api_token,
-};
+use super::{call_runtime_tool_status, http_post_json_status, resolve_user_api_token};
 
 const DEFAULT_EXPECTED_TOOL_COUNT: u64 = 66;
 pub(crate) const DEFAULT_RUNNER_REQUEST_TIMEOUT_MS: u64 = 5_000;
@@ -359,35 +357,7 @@ fn render_ops_command_output(
 }
 
 fn resolve_ops_token(opts: &OpsCommonOptions) -> Result<Option<String>, String> {
-    if let Some(token) = &opts.token {
-        let token = token.trim().to_string();
-        if token.is_empty() {
-            return Err("--token cannot be empty".to_string());
-        }
-        validate_user_api_token(&token)?;
-        return Ok(Some(token));
-    }
-    if let Some(token) = read_optional_token(&opts.token_file, "--token-file")? {
-        validate_user_api_token(&token)?;
-        return Ok(Some(token));
-    }
-    if let Some(path) = &opts.env_file {
-        if let Some(token) = read_env_file_value(path, "WEBCODEX_TOKEN")? {
-            let token = token.trim().to_string();
-            if !token.is_empty() {
-                validate_user_api_token(&token)?;
-                return Ok(Some(token));
-            }
-        }
-    }
-    if let Ok(token) = std::env::var("WEBCODEX_TOKEN") {
-        let token = token.trim().to_string();
-        if !token.is_empty() {
-            validate_user_api_token(&token)?;
-            return Ok(Some(token));
-        }
-    }
-    Ok(None)
+    resolve_user_api_token(&opts.token, &opts.token_file, &opts.env_file)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -561,15 +531,17 @@ async fn call_runtime_tool(
     tool: &str,
     params: Value,
 ) -> Result<Option<Value>, OpsHttpFailure> {
-    fetch_ops_json_output(
-        server_url,
-        server_http,
-        "/api/tools/call",
-        token,
-        json!({"tool": tool, "params": params}),
-    )
-    .await
-    .map(Some)
+    match call_runtime_tool_status(server_url, server_http, token, tool, params).await {
+        Ok((status, _content_type, Some(value))) if (200..300).contains(&status) => {
+            Ok(Some(output_payload(value)))
+        }
+        Ok((status, content_type, value)) => Err(OpsHttpFailure::from_response(
+            status,
+            content_type,
+            value.is_some(),
+        )),
+        Err(error) => Err(OpsHttpFailure::from_transport_error(error)),
+    }
 }
 
 fn output_payload(value: Value) -> Value {

--- a/crates/webcodex-cli/src/webcodex_cli/plugin.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/plugin.rs
@@ -1,0 +1,767 @@
+use serde_json::{json, Value};
+use std::path::PathBuf;
+use webcodex_admin::ServerHttpOptions;
+
+use super::{call_runtime_tool_status, resolve_user_api_token};
+
+const DEFAULT_SERVER_URL: &str = "http://127.0.0.1:8080";
+const PLUGIN_TOOL_NAME: &str = "plugin_tool";
+const MAX_HUMAN_TEXT_CHARS: usize = 4096;
+const MAX_HUMAN_SCHEMA_CHARS: usize = 16 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginCommonOptions {
+    pub(crate) server_url: String,
+    pub(crate) server_http: ServerHttpOptions,
+    pub(crate) env_file: Option<PathBuf>,
+    pub(crate) token_file: Option<PathBuf>,
+    pub(crate) token: Option<String>,
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginListOptions {
+    pub(crate) common: PluginCommonOptions,
+    pub(crate) runner: Option<String>,
+    pub(crate) plugin: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginDescribeOptions {
+    pub(crate) common: PluginCommonOptions,
+    pub(crate) runner: String,
+    pub(crate) plugin: String,
+    pub(crate) tool: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginCheckOptions {
+    pub(crate) common: PluginCommonOptions,
+    pub(crate) runner: String,
+    pub(crate) plugin: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginReloadOptions {
+    pub(crate) common: PluginCommonOptions,
+    pub(crate) runner: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PluginCommand {
+    List(PluginListOptions),
+    Describe(PluginDescribeOptions),
+    Check(PluginCheckOptions),
+    Reload(PluginReloadOptions),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginCommandOutput {
+    pub(crate) stdout: String,
+    pub(crate) exit_code: i32,
+}
+
+impl PluginCommand {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List(_) => "list",
+            Self::Describe(_) => "describe",
+            Self::Check(_) => "check",
+            Self::Reload(_) => "reload",
+        }
+    }
+
+    fn common(&self) -> &PluginCommonOptions {
+        match self {
+            Self::List(opts) => &opts.common,
+            Self::Describe(opts) => &opts.common,
+            Self::Check(opts) => &opts.common,
+            Self::Reload(opts) => &opts.common,
+        }
+    }
+
+    fn params(&self) -> Value {
+        match self {
+            Self::List(opts) => {
+                let mut params = json!({"action": "list"});
+                if let Some(runner) = opts.runner.as_ref() {
+                    params["runner"] = Value::String(runner.clone());
+                }
+                if let Some(plugin) = opts.plugin.as_ref() {
+                    params["plugin"] = Value::String(plugin.clone());
+                }
+                params
+            }
+            Self::Describe(opts) => json!({
+                "action": "describe",
+                "runner": opts.runner,
+                "plugin": opts.plugin,
+                "tool": opts.tool,
+            }),
+            Self::Check(opts) => json!({
+                "action": "check",
+                "runner": opts.runner,
+                "plugin": opts.plugin,
+            }),
+            Self::Reload(opts) => json!({
+                "action": "reload",
+                "runner": opts.runner,
+            }),
+        }
+    }
+
+    fn is_consequential_management(&self) -> bool {
+        matches!(self, Self::Check(_) | Self::Reload(_))
+    }
+}
+
+#[derive(Debug, Default)]
+struct ParsedFlags {
+    server_url: Option<String>,
+    proxy: Option<String>,
+    no_system_proxy: bool,
+    no_system_proxy_seen: bool,
+    env_file: Option<PathBuf>,
+    token_file: Option<PathBuf>,
+    token: Option<String>,
+    json: bool,
+    json_seen: bool,
+    runner: Option<String>,
+    plugin: Option<String>,
+    tool: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AllowedIdentityFlags {
+    runner: bool,
+    plugin: bool,
+    tool: bool,
+}
+
+pub(crate) fn parse_plugin_command(
+    command: &str,
+    args: &[String],
+) -> Result<PluginCommand, String> {
+    let allowed = match command {
+        "list" => AllowedIdentityFlags {
+            runner: true,
+            plugin: true,
+            tool: false,
+        },
+        "describe" => AllowedIdentityFlags {
+            runner: true,
+            plugin: true,
+            tool: true,
+        },
+        "check" => AllowedIdentityFlags {
+            runner: true,
+            plugin: true,
+            tool: false,
+        },
+        "reload" => AllowedIdentityFlags {
+            runner: true,
+            plugin: false,
+            tool: false,
+        },
+        other => return Err(format!("unknown plugin subcommand: {other}")),
+    };
+    let flags = parse_flags(command, args, allowed)?;
+    let common = flags.common()?;
+    match command {
+        "list" => {
+            if flags.plugin.is_some() && flags.runner.is_none() {
+                return Err("plugin list requires --runner when --plugin is provided".to_string());
+            }
+            Ok(PluginCommand::List(PluginListOptions {
+                common,
+                runner: flags.runner,
+                plugin: flags.plugin,
+            }))
+        }
+        "describe" => Ok(PluginCommand::Describe(PluginDescribeOptions {
+            common,
+            runner: required_identity(flags.runner, "--runner", command)?,
+            plugin: required_identity(flags.plugin, "--plugin", command)?,
+            tool: required_identity(flags.tool, "--tool", command)?,
+        })),
+        "check" => Ok(PluginCommand::Check(PluginCheckOptions {
+            common,
+            runner: required_identity(flags.runner, "--runner", command)?,
+            plugin: required_identity(flags.plugin, "--plugin", command)?,
+        })),
+        "reload" => Ok(PluginCommand::Reload(PluginReloadOptions {
+            common,
+            runner: required_identity(flags.runner, "--runner", command)?,
+        })),
+        _ => unreachable!("closed plugin command vocabulary"),
+    }
+}
+
+fn parse_flags(
+    command: &str,
+    args: &[String],
+    allowed: AllowedIdentityFlags,
+) -> Result<ParsedFlags, String> {
+    let mut flags = ParsedFlags::default();
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        match arg.as_str() {
+            "--server-url" => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_once(&mut flags.server_url, value, arg)?;
+            }
+            "--proxy" => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_once(&mut flags.proxy, value, arg)?;
+            }
+            "--no-system-proxy" => {
+                if flags.no_system_proxy_seen {
+                    return Err("--no-system-proxy may be specified only once".to_string());
+                }
+                flags.no_system_proxy_seen = true;
+                flags.no_system_proxy = true;
+            }
+            "--env-file" => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_path_once(&mut flags.env_file, value, arg)?;
+            }
+            "--token-file" => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_path_once(&mut flags.token_file, value, arg)?;
+            }
+            "--token" => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_once(&mut flags.token, value, arg)?;
+            }
+            "--json" => {
+                if flags.json_seen {
+                    return Err("--json may be specified only once".to_string());
+                }
+                flags.json_seen = true;
+                flags.json = true;
+            }
+            "--runner" if allowed.runner => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_once(&mut flags.runner, value, arg)?;
+            }
+            "--plugin" if allowed.plugin => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_once(&mut flags.plugin, value, arg)?;
+            }
+            "--tool" if allowed.tool => {
+                let value = flag_value(args, &mut index, arg)?;
+                set_once(&mut flags.tool, value, arg)?;
+            }
+            other => return Err(format!("unknown plugin {command} flag: {other}")),
+        }
+        index += 1;
+    }
+    Ok(flags)
+}
+
+impl ParsedFlags {
+    fn common(&self) -> Result<PluginCommonOptions, String> {
+        let server_http = ServerHttpOptions {
+            proxy: self.proxy.clone(),
+            no_system_proxy: self.no_system_proxy,
+        };
+        server_http.validate()?;
+        let server_url = self
+            .server_url
+            .clone()
+            .unwrap_or_else(|| DEFAULT_SERVER_URL.to_string());
+        if server_url.trim().is_empty() {
+            return Err("--server-url cannot be empty".to_string());
+        }
+        Ok(PluginCommonOptions {
+            server_url,
+            server_http,
+            env_file: self.env_file.clone(),
+            token_file: self.token_file.clone(),
+            token: self.token.clone(),
+            json: self.json,
+        })
+    }
+}
+
+fn flag_value(args: &[String], index: &mut usize, flag: &str) -> Result<String, String> {
+    *index += 1;
+    let value = args
+        .get(*index)
+        .ok_or_else(|| format!("{flag} requires a value"))?;
+    if value.is_empty() {
+        return Err(format!("{flag} cannot be empty"));
+    }
+    Ok(value.clone())
+}
+
+fn set_once(target: &mut Option<String>, value: String, flag: &str) -> Result<(), String> {
+    if target.is_some() {
+        return Err(format!("{flag} may be specified only once"));
+    }
+    *target = Some(value);
+    Ok(())
+}
+
+fn set_path_once(target: &mut Option<PathBuf>, value: String, flag: &str) -> Result<(), String> {
+    if target.is_some() {
+        return Err(format!("{flag} may be specified only once"));
+    }
+    let path = PathBuf::from(value);
+    if path.as_os_str().is_empty() {
+        return Err(format!("{flag} cannot be empty"));
+    }
+    *target = Some(path);
+    Ok(())
+}
+
+fn required_identity(value: Option<String>, flag: &str, command: &str) -> Result<String, String> {
+    let value = value.ok_or_else(|| format!("plugin {command} requires {flag}"))?;
+    if value.trim().is_empty() {
+        return Err(format!("{flag} cannot be empty"));
+    }
+    Ok(value)
+}
+
+pub(crate) async fn run_plugin_command(
+    command: PluginCommand,
+) -> Result<PluginCommandOutput, String> {
+    let common = command.common();
+    let token = resolve_user_api_token(&common.token, &common.token_file, &common.env_file)?;
+    let action = command.action();
+    let response = call_runtime_tool_status(
+        &common.server_url,
+        &common.server_http,
+        token.as_deref(),
+        PLUGIN_TOOL_NAME,
+        command.params(),
+    )
+    .await;
+
+    let (status, content_type, value) = match response {
+        Ok(response) => response,
+        Err(error) => return Err(transport_error(&command, &error)),
+    };
+
+    if status == 401 {
+        return Err("plugin request was rejected with HTTP 401; provide a user/API bearer credential accepted by this WebCodex Server".to_string());
+    }
+    if status == 403 {
+        let scope = if matches!(command, PluginCommand::List(_) | PluginCommand::Describe(_)) {
+            "plugin:inspect"
+        } else {
+            "plugin:manage"
+        };
+        let extra = if scope == "plugin:manage" {
+            "; --oauth-local-plugins grants inspect/invoke only and does not grant plugin:manage"
+        } else {
+            ""
+        };
+        return Err(format!(
+            "plugin request was rejected with HTTP 403; use a credential explicitly granted {scope}{extra}"
+        ));
+    }
+
+    let Some(value) = value else {
+        return Err(response_shape_error(
+            &command,
+            format!("HTTP {status} returned non-JSON content ({content_type})"),
+        ));
+    };
+
+    let Some(success) = value.get("success").and_then(Value::as_bool) else {
+        return Err(response_shape_error(
+            &command,
+            format!("HTTP {status} returned a malformed runtime tool response"),
+        ));
+    };
+    let output = value.get("output").cloned();
+
+    if !success {
+        if let Some(output) = output {
+            let stdout = render_tool_failure(action, &output, common.json)?;
+            return Ok(PluginCommandOutput {
+                stdout,
+                exit_code: 1,
+            });
+        }
+        let error = value
+            .get("error")
+            .and_then(Value::as_str)
+            .map(|text| bounded_line(text, MAX_HUMAN_TEXT_CHARS))
+            .unwrap_or_else(|| format!("HTTP {status} runtime tool failure"));
+        return Err(response_shape_error(&command, error));
+    }
+
+    if !(200..300).contains(&status) {
+        return Err(response_shape_error(
+            &command,
+            format!("runtime tool reported success with unexpected HTTP {status}"),
+        ));
+    }
+    let output = output.ok_or_else(|| {
+        response_shape_error(
+            &command,
+            "runtime tool response is missing output".to_string(),
+        )
+    })?;
+
+    let exit_code = command_exit_code(&command, &output)?;
+    let stdout = if common.json {
+        render_json(&output)?
+    } else {
+        render_human(&command, &output)?
+    };
+    Ok(PluginCommandOutput { stdout, exit_code })
+}
+
+fn command_exit_code(command: &PluginCommand, output: &Value) -> Result<i32, String> {
+    match command {
+        PluginCommand::Check(_) => output
+            .get("ready")
+            .and_then(Value::as_bool)
+            .map(|ready| if ready { 0 } else { 2 })
+            .ok_or_else(|| "malformed plugin check output: missing boolean ready".to_string()),
+        PluginCommand::Reload(_) => output
+            .get("failures")
+            .and_then(Value::as_array)
+            .map(|failures| if failures.is_empty() { 0 } else { 2 })
+            .ok_or_else(|| "malformed plugin reload output: missing failures array".to_string()),
+        PluginCommand::List(_) | PluginCommand::Describe(_) => Ok(0),
+    }
+}
+
+fn transport_error(command: &PluginCommand, error: &str) -> String {
+    let error = bounded_line(error, MAX_HUMAN_TEXT_CHARS);
+    if command.is_consequential_management() {
+        format!(
+            "plugin {} request failed after the Server request began; outcome may be unknown. Do not retry automatically; observe current Plugin state before retrying. {}",
+            command.action(),
+            error
+        )
+    } else {
+        format!("plugin {} request failed: {}", command.action(), error)
+    }
+}
+
+fn response_shape_error(command: &PluginCommand, detail: String) -> String {
+    let detail = bounded_line(&detail, MAX_HUMAN_TEXT_CHARS);
+    if command.is_consequential_management() {
+        format!(
+            "plugin {} response could not be confirmed; outcome may be unknown. Do not retry automatically; observe current Plugin state before retrying. {}",
+            command.action(),
+            detail
+        )
+    } else {
+        format!(
+            "plugin {} response could not be read: {}",
+            command.action(),
+            detail
+        )
+    }
+}
+
+fn render_tool_failure(action: &str, output: &Value, json_output: bool) -> Result<String, String> {
+    if json_output {
+        return render_json(output);
+    }
+    let mut lines = vec![format!("Plugin {action}: failed")];
+    if let Some(code) = output
+        .pointer("/error/code")
+        .and_then(Value::as_str)
+        .or_else(|| output.get("failure_kind").and_then(Value::as_str))
+    {
+        lines.push(format!(
+            "Code: {}",
+            bounded_line(code, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(message) = output.pointer("/error/message").and_then(Value::as_str) {
+        lines.push(format!(
+            "Message: {}",
+            bounded_line(message, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(certainty) = output.get("dispatch_certainty").and_then(Value::as_str) {
+        lines.push(format!(
+            "Dispatch certainty: {}",
+            bounded_line(certainty, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(recovery) = output.get("recovery").and_then(Value::as_str) {
+        lines.push(format!(
+            "Recovery: {}",
+            bounded_line(recovery, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
+fn render_human(command: &PluginCommand, output: &Value) -> Result<String, String> {
+    match command {
+        PluginCommand::List(opts) => render_list(opts, output),
+        PluginCommand::Describe(_) => render_describe(output),
+        PluginCommand::Check(_) => render_check(output),
+        PluginCommand::Reload(_) => render_reload(output),
+    }
+}
+
+fn render_list(opts: &PluginListOptions, output: &Value) -> Result<String, String> {
+    if opts.runner.is_none() {
+        let runners = array_field(output, "runners", "plugin list")?;
+        let mut lines = vec![format!("Runners: {}", runners.len())];
+        for runner in runners {
+            let id = string_field(runner, "runner", "plugin list runner")?;
+            let name = runner.get("name").and_then(Value::as_str);
+            lines.push(match name {
+                Some(name) => format!(
+                    "  {}  {}",
+                    bounded_line(id, MAX_HUMAN_TEXT_CHARS),
+                    bounded_line(name, MAX_HUMAN_TEXT_CHARS)
+                ),
+                None => format!("  {}", bounded_line(id, MAX_HUMAN_TEXT_CHARS)),
+            });
+        }
+        return Ok(format!("{}\n", lines.join("\n")));
+    }
+
+    if opts.plugin.is_none() {
+        let runner = string_field(output, "runner", "plugin list")?;
+        let plugins = array_field(output, "plugins", "plugin list")?;
+        let mut lines = vec![
+            format!("Runner: {}", bounded_line(runner, MAX_HUMAN_TEXT_CHARS)),
+            format!("Plugins: {}", plugins.len()),
+        ];
+        for plugin in plugins {
+            lines.push(render_provider_line(plugin)?);
+        }
+        return Ok(format!("{}\n", lines.join("\n")));
+    }
+
+    let runner = string_field(output, "runner", "plugin list")?;
+    let plugin = string_field(output, "plugin", "plugin list")?;
+    let status = string_field(output, "status", "plugin list")?;
+    let tools = array_field(output, "tools", "plugin list")?;
+    let mut lines = vec![
+        format!("Plugin: {}", bounded_line(plugin, MAX_HUMAN_TEXT_CHARS)),
+        format!("Runner: {}", bounded_line(runner, MAX_HUMAN_TEXT_CHARS)),
+        format!("Status: {}", bounded_line(status, MAX_HUMAN_TEXT_CHARS)),
+        format!("Tools: {}", tools.len()),
+    ];
+    for tool in tools {
+        lines.push(render_tool_line(tool)?);
+    }
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
+fn render_describe(output: &Value) -> Result<String, String> {
+    let runner = string_field(output, "runner", "plugin describe")?;
+    let plugin = string_field(output, "plugin", "plugin describe")?;
+    let tool = output
+        .get("tool")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "malformed plugin describe output: missing tool object".to_string())?;
+    let name = tool
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "malformed plugin describe output: missing tool.name".to_string())?;
+    let binding = string_field(output, "binding", "plugin describe")?;
+    let mut lines = vec![
+        format!("Plugin: {}", bounded_line(plugin, MAX_HUMAN_TEXT_CHARS)),
+        format!("Runner: {}", bounded_line(runner, MAX_HUMAN_TEXT_CHARS)),
+        format!("Tool: {}", bounded_line(name, MAX_HUMAN_TEXT_CHARS)),
+    ];
+    if let Some(title) = tool.get("title").and_then(Value::as_str) {
+        lines.push(format!(
+            "Title: {}",
+            bounded_line(title, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(description) = tool.get("description").and_then(Value::as_str) {
+        lines.push(format!(
+            "Description: {}",
+            bounded_line(description, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(annotations) = tool.get("annotations") {
+        lines.push(format!(
+            "Annotations: {}",
+            bounded_json(annotations, MAX_HUMAN_SCHEMA_CHARS)?
+        ));
+    }
+    let input = tool
+        .get("inputSchema")
+        .ok_or_else(|| "malformed plugin describe output: missing tool.inputSchema".to_string())?;
+    lines.push(format!(
+        "Input schema: {}",
+        bounded_json(input, MAX_HUMAN_SCHEMA_CHARS)?
+    ));
+    if let Some(output_schema) = tool.get("outputSchema") {
+        lines.push(format!(
+            "Output schema: {}",
+            bounded_json(output_schema, MAX_HUMAN_SCHEMA_CHARS)?
+        ));
+    }
+    lines.push(format!(
+        "Binding: {}",
+        bounded_line(binding, MAX_HUMAN_TEXT_CHARS)
+    ));
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
+fn render_check(output: &Value) -> Result<String, String> {
+    let runner = string_field(output, "runner", "plugin check")?;
+    let plugin = string_field(output, "plugin", "plugin check")?;
+    let ready = output
+        .get("ready")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| "malformed plugin check output: missing boolean ready".to_string())?;
+    let tools = array_field(output, "tools", "plugin check")?;
+    let mut lines = vec![
+        format!("Plugin: {}", bounded_line(plugin, MAX_HUMAN_TEXT_CHARS)),
+        format!("Runner: {}", bounded_line(runner, MAX_HUMAN_TEXT_CHARS)),
+        format!("Status: {}", if ready { "ready" } else { "not ready" }),
+    ];
+    if let Some(phase) = output.get("phase").and_then(Value::as_str) {
+        lines.push(format!(
+            "Phase: {}",
+            bounded_line(phase, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(code) = output.get("code").and_then(Value::as_str) {
+        lines.push(format!(
+            "Code: {}",
+            bounded_line(code, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(detail) = output.get("detail").and_then(Value::as_str) {
+        lines.push(format!(
+            "Detail: {}",
+            bounded_line(detail, MAX_HUMAN_TEXT_CHARS)
+        ));
+    }
+    if let Some(diagnostic) = output.get("diagnostic") {
+        lines.push(format!(
+            "Diagnostic: {}",
+            bounded_json(diagnostic, MAX_HUMAN_TEXT_CHARS)?
+        ));
+    }
+    lines.push(format!("Tools: {}", tools.len()));
+    for tool in tools {
+        lines.push(render_tool_line(tool)?);
+    }
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
+fn render_reload(output: &Value) -> Result<String, String> {
+    let runner = string_field(output, "runner", "plugin reload")?;
+    let plugins = array_field(output, "plugins", "plugin reload")?;
+    let failures = array_field(output, "failures", "plugin reload")?;
+    let mut lines = vec![
+        format!("Runner: {}", bounded_line(runner, MAX_HUMAN_TEXT_CHARS)),
+        format!(
+            "Status: {}",
+            if failures.is_empty() {
+                "ready"
+            } else {
+                "rejected"
+            }
+        ),
+        format!("Plugins: {}", plugins.len()),
+    ];
+    for plugin in plugins {
+        lines.push(render_provider_line(plugin)?);
+    }
+    if !failures.is_empty() {
+        lines.push(format!("Failures: {}", failures.len()));
+        for failure in failures {
+            let provider = failure
+                .get("provider_id")
+                .and_then(Value::as_str)
+                .unwrap_or("[unknown]");
+            let code = failure
+                .get("code")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            lines.push(format!(
+                "  {}  {}",
+                bounded_line(provider, MAX_HUMAN_TEXT_CHARS),
+                bounded_line(code, MAX_HUMAN_TEXT_CHARS)
+            ));
+        }
+    }
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
+fn render_provider_line(provider: &Value) -> Result<String, String> {
+    let id = string_field(provider, "plugin", "Plugin provider")?;
+    let status = string_field(provider, "status", "Plugin provider")?;
+    let name = provider.get("name").and_then(Value::as_str).unwrap_or("");
+    let error_code = provider.get("errorCode").and_then(Value::as_str);
+    let mut line = format!(
+        "  {}  {}",
+        bounded_line(id, MAX_HUMAN_TEXT_CHARS),
+        bounded_line(status, MAX_HUMAN_TEXT_CHARS)
+    );
+    if !name.is_empty() {
+        line.push_str("  ");
+        line.push_str(&bounded_line(name, MAX_HUMAN_TEXT_CHARS));
+    }
+    if let Some(code) = error_code.filter(|code| !code.is_empty()) {
+        line.push_str("  code=");
+        line.push_str(&bounded_line(code, MAX_HUMAN_TEXT_CHARS));
+    }
+    Ok(line)
+}
+
+fn render_tool_line(tool: &Value) -> Result<String, String> {
+    let name = string_field(tool, "name", "Plugin tool")?;
+    let title = tool.get("title").and_then(Value::as_str).unwrap_or("");
+    Ok(if title.is_empty() {
+        format!("  {}", bounded_line(name, MAX_HUMAN_TEXT_CHARS))
+    } else {
+        format!(
+            "  {}  {}",
+            bounded_line(name, MAX_HUMAN_TEXT_CHARS),
+            bounded_line(title, MAX_HUMAN_TEXT_CHARS)
+        )
+    })
+}
+
+fn array_field<'a>(value: &'a Value, field: &str, context: &str) -> Result<&'a Vec<Value>, String> {
+    value
+        .get(field)
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("malformed {context} output: missing {field} array"))
+}
+
+fn string_field<'a>(value: &'a Value, field: &str, context: &str) -> Result<&'a str, String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("malformed {context} output: missing {field}"))
+}
+
+fn render_json(value: &Value) -> Result<String, String> {
+    serde_json::to_string_pretty(value)
+        .map(|text| format!("{text}\n"))
+        .map_err(|error| format!("failed to encode Plugin JSON output: {error}"))
+}
+
+fn bounded_line(value: &str, max_chars: usize) -> String {
+    let mut output = String::new();
+    for ch in value.chars().take(max_chars) {
+        output.push(if ch.is_control() { ' ' } else { ch });
+    }
+    if value.chars().count() > max_chars {
+        output.push('…');
+    }
+    output
+}
+
+fn bounded_json(value: &Value, max_chars: usize) -> Result<String, String> {
+    let encoded = serde_json::to_string(value)
+        .map_err(|error| format!("failed to encode Plugin metadata: {error}"))?;
+    Ok(bounded_line(&encoded, max_chars))
+}

--- a/crates/webcodex-cli/src/webcodex_cli/system.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/system.rs
@@ -1,3 +1,4 @@
+use super::env::read_env_file_value;
 use std::path::{Path, PathBuf};
 
 pub(crate) fn write_text_file(
@@ -599,6 +600,42 @@ pub(crate) fn validate_user_api_token(token: &str) -> Result<(), String> {
         );
     }
     Ok(())
+}
+
+pub(crate) fn resolve_user_api_token(
+    token: &Option<String>,
+    token_file: &Option<PathBuf>,
+    env_file: &Option<PathBuf>,
+) -> Result<Option<String>, String> {
+    if let Some(token) = token {
+        let token = token.trim().to_string();
+        if token.is_empty() {
+            return Err("--token cannot be empty".to_string());
+        }
+        validate_user_api_token(&token)?;
+        return Ok(Some(token));
+    }
+    if let Some(token) = read_optional_token(token_file, "--token-file")? {
+        validate_user_api_token(&token)?;
+        return Ok(Some(token));
+    }
+    if let Some(path) = env_file {
+        if let Some(token) = read_env_file_value(path, "WEBCODEX_TOKEN")? {
+            let token = token.trim().to_string();
+            if !token.is_empty() {
+                validate_user_api_token(&token)?;
+                return Ok(Some(token));
+            }
+        }
+    }
+    if let Ok(token) = std::env::var("WEBCODEX_TOKEN") {
+        let token = token.trim().to_string();
+        if !token.is_empty() {
+            validate_user_api_token(&token)?;
+            return Ok(Some(token));
+        }
+    }
+    Ok(None)
 }
 
 pub(crate) fn read_optional_user_api_token(

--- a/crates/webcodex-cli/src/webcodex_cli/tests/mod.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/mod.rs
@@ -3,6 +3,7 @@ mod support;
 mod connect;
 mod ops;
 mod platform;
+mod plugin;
 mod profiles;
 mod server;
 mod usage;

--- a/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
@@ -1,0 +1,765 @@
+use super::support::*;
+use crate::webcodex_cli::plugin::{parse_plugin_command, run_plugin_command, PluginCommand};
+use std::net::TcpStream;
+use std::sync::mpsc;
+
+#[derive(Clone)]
+enum TestResponse {
+    Json(u16, Value),
+    Raw(u16, &'static str, &'static str),
+    Drop,
+}
+
+fn status_reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        500 => "Internal Server Error",
+        _ => "Response",
+    }
+}
+
+fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = stream.read(&mut chunk).unwrap();
+        assert!(
+            n > 0,
+            "client closed before sending a complete HTTP request"
+        );
+        bytes.extend_from_slice(&chunk[..n]);
+        let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let header_end = header_end + 4;
+        let headers = String::from_utf8_lossy(&bytes[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().unwrap())
+            })
+            .unwrap_or(0);
+        if bytes.len() >= header_end + content_length {
+            return String::from_utf8(bytes).unwrap();
+        }
+    }
+}
+
+fn spawn_plugin_server(
+    response: TestResponse,
+) -> (String, mpsc::Sender<()>, thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (stop_tx, stop_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let mut requests = Vec::new();
+        loop {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream.set_nonblocking(false).unwrap();
+                    let request = read_http_request(&mut stream);
+                    requests.push(request);
+                    match &response {
+                        TestResponse::Json(status, value) => {
+                            let body = serde_json::to_string(value).unwrap();
+                            write!(
+                                stream,
+                                "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                                status,
+                                status_reason(*status),
+                                body.len(),
+                                body
+                            )
+                            .unwrap();
+                        }
+                        TestResponse::Raw(status, content_type, body) => {
+                            write!(
+                                stream,
+                                "HTTP/1.1 {} {}\r\ncontent-type: {}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                                status,
+                                status_reason(*status),
+                                content_type,
+                                body.len(),
+                                body
+                            )
+                            .unwrap();
+                        }
+                        TestResponse::Drop => {}
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if stop_rx.try_recv().is_ok() {
+                        break;
+                    }
+                    thread::yield_now();
+                }
+                Err(error) => panic!("plugin test server accept failed: {error}"),
+            }
+        }
+        requests
+    });
+    (format!("http://{addr}"), stop_tx, handle)
+}
+
+fn request_body(request: &str) -> Value {
+    let (_, body) = request
+        .split_once("\r\n\r\n")
+        .expect("HTTP request should contain a body separator");
+    serde_json::from_str(body).unwrap()
+}
+
+fn request_authorization(request: &str) -> Option<&str> {
+    request.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("authorization")
+            .then(|| value.trim())
+    })
+}
+
+fn runtime_success(output: Value) -> TestResponse {
+    TestResponse::Json(
+        200,
+        json!({
+            "success": true,
+            "error": null,
+            "output": output,
+        }),
+    )
+}
+
+fn safe_delete_tool() -> Value {
+    json!({
+        "name": "safe_delete",
+        "title": "Safe delete",
+        "description": "Move one path to Trash.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+            "additionalProperties": false
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {"outcome": {"type": "string"}},
+            "required": ["outcome"],
+            "additionalProperties": false
+        },
+        "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true
+        }
+    })
+}
+
+fn parse_for_server(
+    command: &str,
+    server_url: &str,
+    identity: &[&str],
+    json_output: bool,
+) -> PluginCommand {
+    let mut args = identity
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect::<Vec<_>>();
+    args.extend([
+        "--server-url".to_string(),
+        server_url.to_string(),
+        "--no-system-proxy".to_string(),
+    ]);
+    if json_output {
+        args.push("--json".to_string());
+    }
+    parse_plugin_command(command, &args).unwrap()
+}
+
+async fn run_once(
+    command: &str,
+    identity: &[&str],
+    response: TestResponse,
+    json_output: bool,
+) -> (
+    Result<crate::webcodex_cli::plugin::PluginCommandOutput, String>,
+    Vec<String>,
+) {
+    let (server_url, stop_tx, handle) = spawn_plugin_server(response);
+    let command = parse_for_server(command, &server_url, identity, json_output);
+    let output = run_plugin_command(command).await;
+    stop_tx.send(()).unwrap();
+    let requests = handle.join().unwrap();
+    (output, requests)
+}
+
+#[test]
+fn plugin_help_and_root_usage_expose_only_phase_one_surface() {
+    let root = cli_exit(["--help"]).unwrap();
+    assert!(root
+        .lines()
+        .any(|line| line.trim_start().starts_with("plugin ")));
+
+    let help = cli_exit(["plugin", "--help"]).unwrap();
+    for command in ["list", "describe", "check", "reload"] {
+        assert!(
+            help.lines()
+                .any(|line| line.trim_start().starts_with(command)),
+            "{help}"
+        );
+    }
+    assert!(
+        !help
+            .lines()
+            .any(|line| line.trim_start().starts_with("call ")),
+        "{help}"
+    );
+    assert!(
+        !help
+            .lines()
+            .any(|line| line.trim_start().starts_with("init ")),
+        "{help}"
+    );
+    assert!(help.contains("plugin:inspect"), "{help}");
+    assert!(help.contains("plugin:manage"), "{help}");
+}
+
+#[test]
+fn plugin_command_help_documents_exact_identity_and_reload_scope() {
+    let cases: &[(&[&str], &[&str])] = &[
+        (
+            &["plugin", "list", "--help"],
+            &["--runner RUNNER", "--plugin PLUGIN", "plugin:inspect"],
+        ),
+        (
+            &["plugin", "describe", "--help"],
+            &[
+                "--runner RUNNER",
+                "--plugin PLUGIN",
+                "--tool TOOL",
+                "plugin:inspect",
+            ],
+        ),
+        (
+            &["plugin", "check", "--help"],
+            &[
+                "--runner RUNNER",
+                "--plugin PLUGIN",
+                "disposable",
+                "plugin:manage",
+            ],
+        ),
+        (
+            &["plugin", "reload", "--help"],
+            &[
+                "--runner RUNNER",
+                "complete provider",
+                "no per-provider",
+                "plugin:manage",
+            ],
+        ),
+    ];
+    for (args, expected) in cases {
+        let help = cli_exit(args.iter().copied()).unwrap();
+        for needle in *expected {
+            assert!(
+                help.contains(needle),
+                "help for {args:?} missing {needle:?}: {help}"
+            );
+        }
+    }
+}
+
+#[test]
+fn plugin_parser_accepts_only_canonical_identity_shapes() {
+    match cli_action(["plugin", "list", "--json"]) {
+        CliAction::Plugin(PluginCommand::List(opts)) => {
+            assert!(opts.runner.is_none());
+            assert!(opts.plugin.is_none());
+            assert!(opts.common.json);
+        }
+        other => panic!("unexpected plugin list parse: {other:?}"),
+    }
+    match cli_action([
+        "plugin",
+        "list",
+        "--runner",
+        "special",
+        "--plugin",
+        "safe-delete",
+    ]) {
+        CliAction::Plugin(PluginCommand::List(opts)) => {
+            assert_eq!(opts.runner.as_deref(), Some("special"));
+            assert_eq!(opts.plugin.as_deref(), Some("safe-delete"));
+        }
+        other => panic!("unexpected scoped plugin list parse: {other:?}"),
+    }
+    match cli_action([
+        "plugin",
+        "describe",
+        "--runner",
+        "special",
+        "--plugin",
+        "safe-delete",
+        "--tool",
+        "safe_delete",
+    ]) {
+        CliAction::Plugin(PluginCommand::Describe(opts)) => {
+            assert_eq!(opts.runner, "special");
+            assert_eq!(opts.plugin, "safe-delete");
+            assert_eq!(opts.tool, "safe_delete");
+        }
+        other => panic!("unexpected plugin describe parse: {other:?}"),
+    }
+}
+
+#[test]
+fn plugin_parser_requires_exact_targets_and_rejects_invented_surfaces() {
+    let failures: &[(&[&str], &str)] = &[
+        (
+            &["plugin", "list", "--plugin", "safe-delete"],
+            "requires --runner",
+        ),
+        (
+            &[
+                "plugin",
+                "describe",
+                "--plugin",
+                "safe-delete",
+                "--tool",
+                "safe_delete",
+            ],
+            "requires --runner",
+        ),
+        (
+            &["plugin", "check", "--runner", "special"],
+            "requires --plugin",
+        ),
+        (&["plugin", "reload"], "requires --runner"),
+        (
+            &[
+                "plugin",
+                "reload",
+                "--runner",
+                "special",
+                "--plugin",
+                "safe-delete",
+            ],
+            "unknown plugin reload flag: --plugin",
+        ),
+        (&["plugin", "call"], "unknown plugin subcommand: call"),
+        (&["plugin", "init"], "unknown plugin subcommand: init"),
+        (&["plugin", "unknown"], "unknown plugin subcommand: unknown"),
+    ];
+    for (args, expected) in failures {
+        match cli_action(args.iter().copied()) {
+            CliAction::Exit {
+                code,
+                stdout,
+                stderr,
+            } => {
+                assert_eq!(code, 2, "{args:?}: {stderr}");
+                assert!(stdout.is_empty());
+                assert!(stderr.contains(expected), "{args:?}: {stderr}");
+            }
+            other => panic!("{args:?} unexpectedly parsed: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn plugin_parser_rejects_duplicate_and_invalid_flags_without_echoing_token() {
+    let secret = "wc_pat_plugin_parser_secret_0123456789";
+    for args in [
+        vec!["plugin", "list", "--runner", "special", "--runner", "other"],
+        vec!["plugin", "list", "--json", "--json"],
+        vec!["plugin", "list", "--tool", "safe_delete"],
+        vec![
+            "plugin",
+            "check",
+            "--runner",
+            "special",
+            "--plugin",
+            "safe-delete",
+            "--oauth-local-plugins",
+        ],
+        vec![
+            "plugin",
+            "check",
+            "--runner",
+            "special",
+            "--plugin",
+            "safe-delete",
+            "--token",
+            secret,
+            "--bad",
+        ],
+    ] {
+        match cli_action(args.iter().copied()) {
+            CliAction::Exit { code, stderr, .. } => {
+                assert_eq!(code, 2, "{args:?}: {stderr}");
+                assert!(!stderr.contains(secret), "{stderr}");
+            }
+            other => panic!("invalid plugin args unexpectedly parsed: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn plugin_list_request_mapping_is_exact_for_all_three_scopes() {
+    let cases = [
+        (vec![], json!({"action": "list"}), json!({"runners": []})),
+        (
+            vec!["--runner", "special"],
+            json!({"action": "list", "runner": "special"}),
+            json!({"runner": "special", "plugins": []}),
+        ),
+        (
+            vec!["--runner", "special", "--plugin", "safe-delete"],
+            json!({"action": "list", "runner": "special", "plugin": "safe-delete"}),
+            json!({
+                "runner": "special",
+                "plugin": "safe-delete",
+                "name": "Safe Delete",
+                "status": "ready",
+                "errorCode": null,
+                "toolCount": 0,
+                "tools": []
+            }),
+        ),
+    ];
+    for (identity, expected_params, output) in cases {
+        let (result, requests) = run_once("list", &identity, runtime_success(output), false).await;
+        assert_eq!(result.unwrap().exit_code, 0);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            request_body(&requests[0]),
+            json!({"tool": "plugin_tool", "params": expected_params})
+        );
+    }
+}
+
+#[tokio::test]
+async fn plugin_describe_check_and_reload_map_to_one_canonical_runtime_call() {
+    let cases = [
+        (
+            "describe",
+            vec![
+                "--runner",
+                "special",
+                "--plugin",
+                "safe-delete",
+                "--tool",
+                "safe_delete",
+            ],
+            json!({"action": "describe", "runner": "special", "plugin": "safe-delete", "tool": "safe_delete"}),
+            json!({
+                "runner": "special",
+                "plugin": "safe-delete",
+                "pluginName": "Safe Delete",
+                "tool": safe_delete_tool(),
+                "binding": "wc_pbind_test"
+            }),
+        ),
+        (
+            "check",
+            vec!["--runner", "special", "--plugin", "safe-delete"],
+            json!({"action": "check", "runner": "special", "plugin": "safe-delete"}),
+            json!({
+                "runner": "special", "plugin": "safe-delete", "ready": true, "phase": "ready",
+                "toolCount": 1, "tools": [{"name":"safe_delete","title":"Safe delete"}]
+            }),
+        ),
+        (
+            "reload",
+            vec!["--runner", "special"],
+            json!({"action": "reload", "runner": "special"}),
+            json!({"runner":"special","plugins":[],"failures":[]}),
+        ),
+    ];
+    for (command, identity, params, output) in cases {
+        let (result, requests) = run_once(command, &identity, runtime_success(output), false).await;
+        assert_eq!(result.unwrap().exit_code, 0);
+        assert_eq!(requests.len(), 1, "{command}");
+        assert_eq!(
+            request_body(&requests[0]),
+            json!({"tool": "plugin_tool", "params": params}),
+            "{command}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn plugin_bearer_token_is_header_only_and_never_rendered() {
+    let secret = "wc_pat_plugin_header_secret_0123456789";
+    let (server_url, stop_tx, handle) =
+        spawn_plugin_server(runtime_success(json!({"runners": []})));
+    let args = vec![
+        "--server-url".to_string(),
+        server_url,
+        "--no-system-proxy".to_string(),
+        "--token".to_string(),
+        secret.to_string(),
+        "--json".to_string(),
+    ];
+    let output = run_plugin_command(parse_plugin_command("list", &args).unwrap())
+        .await
+        .unwrap();
+    stop_tx.send(()).unwrap();
+    let requests = handle.join().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        request_authorization(&requests[0]),
+        Some(&format!("Bearer {secret}")[..])
+    );
+    assert_eq!(
+        request_body(&requests[0]),
+        json!({"tool":"plugin_tool","params":{"action":"list"}})
+    );
+    assert!(!requests[0]
+        .split_once("\r\n\r\n")
+        .unwrap()
+        .1
+        .contains(secret));
+    assert!(!output.stdout.contains(secret));
+}
+
+#[tokio::test]
+async fn plugin_rejects_runner_transport_token_before_any_request() {
+    let secret = "wc_agent_plugin_wrong_credential_0123456789";
+    let (server_url, stop_tx, handle) =
+        spawn_plugin_server(runtime_success(json!({"runners": []})));
+    let args = vec![
+        "--server-url".to_string(),
+        server_url,
+        "--no-system-proxy".to_string(),
+        "--token".to_string(),
+        secret.to_string(),
+    ];
+    let error = run_plugin_command(parse_plugin_command("list", &args).unwrap())
+        .await
+        .unwrap_err();
+    stop_tx.send(()).unwrap();
+    let requests = handle.join().unwrap();
+    assert!(requests.is_empty());
+    assert!(error.contains("Runner transport token"), "{error}");
+    assert!(!error.contains(secret), "{error}");
+}
+
+#[tokio::test]
+async fn plugin_http_401_and_403_fail_with_command_specific_scope_guidance() {
+    let cases = [
+        ("list", vec![], 401, "user/API bearer credential"),
+        (
+            "describe",
+            vec![
+                "--runner",
+                "special",
+                "--plugin",
+                "safe-delete",
+                "--tool",
+                "safe_delete",
+            ],
+            403,
+            "plugin:inspect",
+        ),
+        (
+            "check",
+            vec!["--runner", "special", "--plugin", "safe-delete"],
+            403,
+            "plugin:manage",
+        ),
+        ("reload", vec!["--runner", "special"], 403, "plugin:manage"),
+    ];
+    for (command, identity, status, expected) in cases {
+        let response = TestResponse::Json(status, json!({"error":"scope rejected"}));
+        let (result, requests) = run_once(command, &identity, response, false).await;
+        assert_eq!(requests.len(), 1);
+        let error = result.unwrap_err();
+        assert!(error.contains(expected), "{command}: {error}");
+        if status == 403 && matches!(command, "check" | "reload") {
+            assert!(error.contains("--oauth-local-plugins"), "{error}");
+            assert!(error.contains("does not grant plugin:manage"), "{error}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn plugin_json_output_preserves_canonical_output_without_wrapper() {
+    let canonical = json!({
+        "runner": "special",
+        "plugin": "safe-delete",
+        "pluginName": "Safe Delete",
+        "tool": safe_delete_tool(),
+        "binding": "wc_pbind_exact"
+    });
+    let (result, requests) = run_once(
+        "describe",
+        &[
+            "--runner",
+            "special",
+            "--plugin",
+            "safe-delete",
+            "--tool",
+            "safe_delete",
+        ],
+        runtime_success(canonical.clone()),
+        true,
+    )
+    .await;
+    assert_eq!(requests.len(), 1);
+    let output = result.unwrap();
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(
+        serde_json::from_str::<Value>(&output.stdout).unwrap(),
+        canonical
+    );
+}
+
+#[tokio::test]
+async fn plugin_human_rendering_is_bounded_and_ignores_unknown_raw_stderr_field() {
+    let long_name = format!("{}\nINJECTED", "x".repeat(5000));
+    let output = json!({
+        "runner":"special",
+        "plugin":"safe-delete",
+        "ready":false,
+        "phase":"tools_list",
+        "code":"plugin_schema_invalid",
+        "detail": long_name,
+        "diagnostic":{"code":"schema_invalid","field":"inputSchema"},
+        "toolCount":0,
+        "tools":[],
+        "stderr":"RAW_PROVIDER_SECRET"
+    });
+    let (result, _) = run_once(
+        "check",
+        &["--runner", "special", "--plugin", "safe-delete"],
+        runtime_success(output),
+        false,
+    )
+    .await;
+    let result = result.unwrap();
+    assert_eq!(result.exit_code, 2);
+    assert!(result.stdout.contains("Status: not ready"));
+    assert!(result.stdout.contains("Code: plugin_schema_invalid"));
+    assert!(!result.stdout.contains("\nINJECTED"));
+    assert!(!result.stdout.contains("RAW_PROVIDER_SECRET"));
+    assert!(
+        result.stdout.chars().count() < 5000,
+        "output was not bounded"
+    );
+}
+
+#[tokio::test]
+async fn plugin_check_and_reload_known_rejections_have_deterministic_nonzero_exit() {
+    let (check, _) = run_once(
+        "check",
+        &["--runner", "special", "--plugin", "broken"],
+        runtime_success(json!({
+            "runner":"special","plugin":"broken","ready":false,"phase":"validation",
+            "code":"plugin_schema_invalid","detail":"schema rejected","toolCount":0,"tools":[]
+        })),
+        false,
+    )
+    .await;
+    assert_eq!(check.unwrap().exit_code, 2);
+
+    let (reload, _) = run_once(
+        "reload",
+        &["--runner", "special"],
+        runtime_success(json!({
+            "runner":"special",
+            "plugins":[{"plugin":"safe-delete","name":"Safe Delete","status":"ready","errorCode":null}],
+            "failures":[{"provider_id":"broken","code":"plugin_schema_invalid"}]
+        })),
+        false,
+    )
+    .await;
+    let reload = reload.unwrap();
+    assert_eq!(reload.exit_code, 2);
+    assert!(
+        reload.stdout.contains("Status: rejected"),
+        "{}",
+        reload.stdout
+    );
+    assert!(
+        reload.stdout.contains("plugin_schema_invalid"),
+        "{}",
+        reload.stdout
+    );
+}
+
+#[tokio::test]
+async fn plugin_runtime_tool_failure_preserves_canonical_failure_for_json_scripts() {
+    let canonical_failure = json!({
+        "error": {"code":"runner_not_found","message":"Runner is not available"},
+        "failure_kind":"runner_not_found",
+        "dispatch_certainty":"not_started",
+        "recovery":"Re-list caller-visible Plugin Runners."
+    });
+    let response = TestResponse::Json(
+        400,
+        json!({"success":false,"error":"Runner is not available","output":canonical_failure.clone()}),
+    );
+    let (result, requests) = run_once("list", &["--runner", "missing"], response, true).await;
+    assert_eq!(requests.len(), 1);
+    let result = result.unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(
+        serde_json::from_str::<Value>(&result.stdout).unwrap(),
+        canonical_failure
+    );
+}
+
+#[tokio::test]
+async fn plugin_check_transport_failure_posts_once_and_reports_uncertainty() {
+    let (result, requests) = run_once(
+        "check",
+        &["--runner", "special", "--plugin", "safe-delete"],
+        TestResponse::Drop,
+        false,
+    )
+    .await;
+    assert_eq!(
+        requests.len(),
+        1,
+        "check transport failure must not be retried"
+    );
+    let error = result.unwrap_err();
+    assert!(error.contains("outcome may be unknown"), "{error}");
+    assert!(error.contains("Do not retry automatically"), "{error}");
+    assert!(error.contains("observe current Plugin state"), "{error}");
+}
+
+#[tokio::test]
+async fn plugin_reload_malformed_post_send_response_posts_once_and_reports_uncertainty() {
+    let (result, requests) = run_once(
+        "reload",
+        &["--runner", "special"],
+        TestResponse::Raw(200, "application/json", "{"),
+        false,
+    )
+    .await;
+    assert_eq!(
+        requests.len(),
+        1,
+        "reload ambiguous response must not be retried"
+    );
+    let error = result.unwrap_err();
+    assert!(error.contains("outcome may be unknown"), "{error}");
+    assert!(error.contains("Do not retry automatically"), "{error}");
+    assert!(!error.contains("definitely not applied"), "{error}");
+}
+
+#[tokio::test]
+async fn plugin_observation_transport_failure_is_not_misrepresented_as_management_uncertainty() {
+    let (result, requests) = run_once("list", &[], TestResponse::Drop, false).await;
+    assert_eq!(requests.len(), 1);
+    let error = result.unwrap_err();
+    assert!(error.contains("plugin list request failed"), "{error}");
+    assert!(!error.contains("outcome may be unknown"), "{error}");
+}

--- a/crates/webcodex-cli/src/webcodex_cli/usage.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/usage.rs
@@ -26,6 +26,7 @@ Account:\n\
   logout                        Remove this device's credentials\n\n\
 Advanced / operator:\n\
   ops                           Read-only operator workflow checks\n\
+  plugin                        Inspect, check, and reload Native Tool Plugins\n\
   users                         Manage users\n\
   tokens                        Manage personal API credentials\n\
   runner-tokens                 Manage Runner transport credentials\n\n\
@@ -263,6 +264,93 @@ pub(crate) fn ops_smoke_preflight_usage() -> &'static str {
        --strict                Exit 2 when the ops report status is FAIL\n\
        -h, --help              Print help and exit\n\n\
      This command calls only read-only status/project/workspace inspection APIs.\n"
+}
+
+pub(crate) fn plugin_usage() -> &'static str {
+    "Usage: webcodex plugin <COMMAND>\n\n\
+Native Tool Plugin authoring/operator commands. These are thin authenticated adapters\n\
+over the canonical Server plugin_tool runtime; the CLI never starts Plugin executables\n\
+or implements Runner admission/lifecycle itself.\n\n\
+Commands:\n\
+  list        List visible Plugin-capable Runners, committed providers, or provider tools\n\
+  describe    Describe one exact provider-local tool and return its opaque binding observation\n\
+  check       Ask one exact Runner to perform the disposable Plugin admission preflight\n\
+  reload      Ask one exact Runner to atomically replace its complete configured provider set\n\n\
+Use `webcodex plugin <COMMAND> --help` for command-specific options.\n\
+list/describe require plugin:inspect. check/reload require plugin:manage.\n\
+--oauth-local-plugins grants plugin:inspect + plugin:invoke only; it never grants plugin:manage.\n\
+There is intentionally no plugin call command in this authoring phase. plugin init is deferred\n\
+until @yyjeqhc/webcodex-plugin-sdk has a real external distribution contract.\n"
+}
+
+fn plugin_common_usage() -> &'static str {
+    "  --server-url URL         WebCodex Server URL [default: http://127.0.0.1:8080]\n\
+  --proxy http://HOST:PORT  Explicit proxy override for this Server request\n\
+  --no-system-proxy         Ignore proxy environment and connect directly\n\
+  --env-file PATH           Read WEBCODEX_TOKEN from env file\n\
+  --token-file PATH         Read bearer token from file\n\
+  --token TOKEN             Bearer token input; never printed\n\
+  --json                    Print the canonical plugin_tool output object as JSON\n\
+  -h, --help                Print help and exit\n"
+}
+
+pub(crate) fn plugin_list_usage() -> String {
+    format!(
+        "Usage: webcodex plugin list [--runner RUNNER [--plugin PLUGIN]] [OPTIONS]\n\n\
+Mirror plugin_tool action=list without starting, checking, or reloading providers.\n\
+Without --runner, list caller-visible Plugin-capable Runners. With --runner, list\n\
+that exact Runner's committed providers. With --runner + --plugin, list the provider's\n\
+current frozen tool catalog. Requires plugin:inspect.\n\n\
+Identity options:\n\
+  --runner RUNNER            Exact caller-visible Runner client_id\n\
+  --plugin PLUGIN            Exact provider id; requires --runner\n\n\
+Common options:\n{}",
+        plugin_common_usage()
+    )
+}
+
+pub(crate) fn plugin_describe_usage() -> String {
+    format!(
+        "Usage: webcodex plugin describe --runner RUNNER --plugin PLUGIN --tool TOOL [OPTIONS]\n\n\
+Mirror plugin_tool action=describe for one exact Runner/provider/tool. The Server returns\n\
+the current tool metadata and an opaque binding observation; the CLI does not cache it or\n\
+treat it as authorization. Requires plugin:inspect and does not perform an extra list.\n\n\
+Identity options:\n\
+  --runner RUNNER            Exact caller-visible Runner client_id (required)\n\
+  --plugin PLUGIN            Exact provider id (required)\n\
+  --tool TOOL                Exact provider-local tool name (required)\n\n\
+Common options:\n{}",
+        plugin_common_usage()
+    )
+}
+
+pub(crate) fn plugin_check_usage() -> String {
+    format!(
+        "Usage: webcodex plugin check --runner RUNNER --plugin PLUGIN [OPTIONS]\n\n\
+Mirror plugin_tool action=check. The exact Runner resolves its real provider configuration,\n\
+starts a disposable candidate, performs initialize/tools-list admission, and disposes it.\n\
+The candidate is never committed, but startup itself may have side effects. Requires\n\
+plugin:manage. The CLI does not spawn or validate the Plugin itself and never auto-retries.\n\n\
+Identity options:\n\
+  --runner RUNNER            Exact caller-visible Runner client_id (required)\n\
+  --plugin PLUGIN            Exact provider id (required)\n\n\
+Common options:\n{}",
+        plugin_common_usage()
+    )
+}
+
+pub(crate) fn plugin_reload_usage() -> String {
+    format!(
+        "Usage: webcodex plugin reload --runner RUNNER [OPTIONS]\n\n\
+Mirror plugin_tool action=reload for one exact Runner. The Runner rereads runner.toml,\n\
+prepares every configured provider candidate, and atomically replaces the complete provider\n\
+set only when all candidates are admitted; otherwise the committed set is unchanged.\n\
+There is no per-provider reload option. Requires plugin:manage and never auto-retries.\n\n\
+Identity options:\n\
+  --runner RUNNER            Exact caller-visible Runner client_id (required)\n\n\
+Common options:\n{}",
+        plugin_common_usage()
+    )
 }
 
 pub(crate) fn server_usage() -> &'static str {

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -229,6 +229,86 @@ restart-only fields without starting disposable Plugin processes. Use
 `plugin_tool check(runner, plugin)` when you need executable resolution plus the
 Plugin `initialize -> tools/list` protocol/admission preflight.
 
+## Plugin authoring/operator CLI
+
+`webcodex plugin` is the operator-friendly adapter over the same canonical
+`plugin_tool` path. It does not add a Plugin endpoint, Runtime, supervisor, or
+admission implementation. All four network commands issue one authenticated
+`POST /api/tools/call` with `tool="plugin_tool"` and the corresponding canonical
+`params`:
+
+```text
+webcodex plugin list
+    -> {"action":"list"}
+webcodex plugin list --runner special
+    -> {"action":"list","runner":"special"}
+webcodex plugin list --runner special --plugin safe-delete
+    -> {"action":"list","runner":"special","plugin":"safe-delete"}
+webcodex plugin describe --runner special --plugin safe-delete --tool safe_delete
+    -> {"action":"describe","runner":"special","plugin":"safe-delete","tool":"safe_delete"}
+webcodex plugin check --runner special --plugin safe-delete
+    -> {"action":"check","runner":"special","plugin":"safe-delete"}
+webcodex plugin reload --runner special
+    -> {"action":"reload","runner":"special"}
+```
+
+A practical author loop is therefore:
+
+```text
+edit/build Plugin
+    -> webcodex plugin check --runner special --plugin safe-delete
+    -> webcodex plugin reload --runner special
+    -> webcodex plugin list --runner special --plugin safe-delete
+    -> webcodex plugin describe --runner special --plugin safe-delete --tool safe_delete
+```
+
+The identity and lifecycle rules are unchanged. Runner ids are exact; the CLI does
+not fuzzy-match or infer one from a provider/project. `list` never checks/reloads a
+provider, and `describe` consumes the canonical describe response without an extra
+list. `check` still starts and disposes the Runner-owned candidate without commit.
+`reload` still rereads that exact Runner's `runner.toml` and atomically replaces the
+**complete** configured provider set; there is intentionally no `reload --plugin`.
+Bindings returned by describe are printed as opaque observations and are never
+cached or promoted into credentials. Bindings created before a successful reload
+still fail closed when their provider instance is retired.
+
+Network options follow the existing CLI Server conventions: `--server-url`,
+`--proxy`, `--no-system-proxy`, `--env-file`, `--token-file`, `--token`, and
+`--json`. Bearer-token precedence is explicit token, token file,
+`WEBCODEX_TOKEN` from the selected env file, then process `WEBCODEX_TOKEN`.
+Runner transport tokens are rejected for this user/API path. `list`/`describe`
+require `plugin:inspect`; `check`/`reload` require an explicitly granted
+`plugin:manage`. The existing `--oauth-local-plugins` setup option still grants
+only `plugin:inspect + plugin:invoke` and **does not** grant management authority.
+A 401/403 is a normal CLI failure; the CLI never mints, upgrades, or mutates a
+credential to make the request pass.
+
+`--json` prints the canonical `plugin_tool` output object rather than a second CLI
+Plugin schema. Human output renders only bounded canonical fields. A completed
+`check` exits 0 only for `ready=true`; `ready=false` exits non-zero while retaining
+its phase/code/detail/diagnostic. Reload exits 0 only when its canonical `failures`
+array is empty; known rejection is non-zero.
+
+The CLI never auto-retries `check` or `reload`. Once a request has begun, an HTTP
+timeout, connection reset, malformed post-send response, or lost response cannot
+prove the management operation did not reach the Server/Runner. The CLI therefore
+reports that the outcome may be unknown and directs the operator to observe current
+Plugin state before retrying. This is intentionally conservative even for `check`,
+because arbitrary Plugin startup/initialize/list behavior may itself have side
+effects.
+
+There is deliberately no `webcodex plugin call` in this authoring phase. The raw
+`plugin_tool describe -> call` contract remains the canonical invocation path with
+its existing binding, effect, retry, and `OutcomeUnknown` semantics.
+
+`webcodex plugin init` is also deferred for now. The TypeScript SDK is currently a
+repository-local development package used by first-party dogfood; it does not yet
+have a published/repeatable external distribution contract, and WebCodex binary/npm
+distribution does not bundle it as scaffoldable assets. The CLI will not generate
+a deceptively standalone project that depends on the current repository checkout,
+a build-machine path, vendored SDK source, or temporary `--sdk-path`. See the
+architecture roadmap for the distribution prerequisite.
+
 ## TypeScript Plugin SDK
 
 `@yyjeqhc/webcodex-plugin-sdk` is an optional TypeScript authoring layer for Native

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -202,6 +202,74 @@ reload` 则提供更窄、只需要 `plugin:manage` 的专门入口。Plugin man
 需要检查 executable resolution 以及 Plugin `initialize -> tools/list` protocol/admission 时，
 使用 `plugin_tool check(runner, plugin)`。
 
+## Plugin authoring/operator CLI
+
+`webcodex plugin` 是同一条 canonical `plugin_tool` 链路的 operator-friendly adapter；它不会
+新增 Plugin endpoint、Runtime、supervisor 或 admission implementation。四个网络命令都只向
+现有 `POST /api/tools/call` 发一次 authenticated request，外层固定为
+`tool="plugin_tool"`，`params` 严格映射已有 action：
+
+```text
+webcodex plugin list
+    -> {"action":"list"}
+webcodex plugin list --runner special
+    -> {"action":"list","runner":"special"}
+webcodex plugin list --runner special --plugin safe-delete
+    -> {"action":"list","runner":"special","plugin":"safe-delete"}
+webcodex plugin describe --runner special --plugin safe-delete --tool safe_delete
+    -> {"action":"describe","runner":"special","plugin":"safe-delete","tool":"safe_delete"}
+webcodex plugin check --runner special --plugin safe-delete
+    -> {"action":"check","runner":"special","plugin":"safe-delete"}
+webcodex plugin reload --runner special
+    -> {"action":"reload","runner":"special"}
+```
+
+实际 author loop 可以直接写成：
+
+```text
+编辑/构建 Plugin
+    -> webcodex plugin check --runner special --plugin safe-delete
+    -> webcodex plugin reload --runner special
+    -> webcodex plugin list --runner special --plugin safe-delete
+    -> webcodex plugin describe --runner special --plugin safe-delete --tool safe_delete
+```
+
+identity/lifecycle 语义没有变化。Runner id 必须精确提供，CLI 不做 fuzzy match，也不会从
+provider/project 推断 Runner。`list` 不会偷偷 check/reload；`describe` 直接消费 canonical
+describe response，不额外 list。`check` 仍由 Runner 启动并销毁 disposable candidate，且不
+commit。`reload` 仍由 exact Runner 重新读取自己的 `runner.toml`，准备**完整 provider set**，
+只有全部 admission 成功才原子替换；因此刻意不存在 `reload --plugin`。describe 返回的
+binding 只作为 opaque observation 输出，不缓存、不提升为 credential；reload retire provider
+后，旧 binding 仍按原 contract fail closed。
+
+网络参数沿用现有 CLI Server conventions：`--server-url`、`--proxy`、
+`--no-system-proxy`、`--env-file`、`--token-file`、`--token`、`--json`。Bearer token
+优先级依次为显式 `--token`、token file、指定 env file 中的 `WEBCODEX_TOKEN`、当前进程
+`WEBCODEX_TOKEN`；Runner transport token 会在 user/API 路径前被拒绝。`list`/`describe`
+要求 `plugin:inspect`；`check`/`reload` 必须由用户显式提供具有 `plugin:manage` 的 credential。
+现有 `--oauth-local-plugins` 仍然只表示 `plugin:inspect + plugin:invoke`，**不会**授予 manage。
+401/403 会正常 non-zero 失败；CLI 不会为了通过请求自动 mint、升级或修改 credential。
+
+`--json` 直接打印 canonical `plugin_tool` output object，不再设计第二套 CLI Plugin JSON
+模型；human output 只渲染有界 canonical fields。`check` 只有在 `ready=true` 时 exit 0；
+`ready=false` non-zero，但仍保留 phase/code/detail/diagnostic。reload 只有 canonical
+`failures` 为空时 exit 0；known rejection non-zero。
+
+CLI 不会自动 retry `check` 或 `reload`。请求开始后如果遇到 HTTP timeout、connection reset、
+post-send malformed response 或 response lost，CLI 无法证明 management operation 没有到达
+Server/Runner，因此会保守报告 outcome may be unknown，并要求先观察当前 Plugin state 再决定
+是否 retry。`check` 也遵循这一点，因为 arbitrary Plugin startup/initialize/list 本身仍可能
+有外部副作用。
+
+本阶段刻意没有 `webcodex plugin call`。raw `plugin_tool describe -> call` 仍是 canonical
+invocation path，并继续拥有原有 binding、effect、retry 和 `OutcomeUnknown` 语义。
+
+当前也暂缓 `webcodex plugin init`。TypeScript SDK 目前仍是仓库内 first-party dogfood 使用的
+development package；尚未建立 published/repeatable external distribution contract，而且正常
+WebCodex binary/npm distribution 也不携带可 scaffold 的 SDK assets。CLI 不会生成一个表面
+standalone、实际依赖当前源码 checkout、build-machine path、vendored SDK 或临时 `--sdk-path`
+的项目。distribution 前置条件见 architecture roadmap。
+
 ## TypeScript Plugin SDK
 
 `@yyjeqhc/webcodex-plugin-sdk` 是 Native Tool Plugin 的可选 TypeScript authoring layer：

--- a/docs/architecture/native-tool-plugins.md
+++ b/docs/architecture/native-tool-plugins.md
@@ -129,78 +129,98 @@ When the project later declares an SDK/CLI/package surface stable, that decision
 should add an explicit compatibility policy at that boundary rather than carrying
 pre-stability migration code indefinitely.
 
-## Next phase: Plugin authoring CLI
+## Phase 1: Plugin authoring/operator CLI
 
-The next implementation phase should reduce the manual author loop without
-creating another Plugin runtime. The target experience is conceptually:
+The first CLI phase reduces the manual author loop without creating another Plugin
+runtime. Its canonical public surface is intentionally limited to:
 
 ```text
-webcodex plugin init ./my-plugin
-    -> edit/build/test locally
-    -> configure the provider on an exact Runner
+webcodex plugin list [--runner <runner> [--plugin <provider>]]
+webcodex plugin describe --runner <runner> --plugin <provider> --tool <tool>
 webcodex plugin check --runner <runner> --plugin <provider>
-    -> fix bounded admission diagnostics
 webcodex plugin reload --runner <runner>
-webcodex plugin list/describe ...
-    -> verify the committed catalog
-    -> exercise the tool through the normal model/operator path
 ```
 
-Exact command spelling can follow the current CLI conventions during
-implementation, but the architectural split should remain as follows.
-
-### `plugin init`: local authoring only
-
-`init` should be a deterministic scaffold generator. It may create a minimal
-TypeScript Plugin project containing, for example:
+The normal author loop is:
 
 ```text
-package.json
-tsconfig.json
-src/plugin.ts
-README.md
+edit/build Plugin
+    -> webcodex plugin check --runner special --plugin safe-delete
+    -> fix bounded Runner admission diagnostics until ready
+    -> webcodex plugin reload --runner special
+    -> webcodex plugin list --runner special --plugin safe-delete
+    -> webcodex plugin describe --runner special --plugin safe-delete --tool safe_delete
 ```
 
-The generated Plugin should use the current SDK, build to ordinary ESM JavaScript,
-and contain one small example tool plus a documented `runner.toml` provider
-snippet. It should not edit a Runner config automatically, start a provider, make
-network calls, install packages implicitly, or execute repository code as part of
-project discovery.
+`list` and `describe` mirror the existing `plugin_tool` inspection semantics and
+require `plugin:inspect`. `check` and `reload` mirror the existing management
+semantics and require `plugin:manage`. The CLI does not widen credentials;
+`--oauth-local-plugins` continues to mean only `plugin:inspect + plugin:invoke` and
+never supplies `plugin:manage`.
 
-Template generation is convenience, not authority. A raw protocol Plugin remains
-a fully supported peer of an SDK-authored Plugin.
+### Thin adapter boundary
 
-### `plugin check/reload`: thin adapters over current authority
-
-Authoring CLI management commands should call the existing WebCodex management
-path rather than reimplementing Plugin admission in the CLI or SDK.
-
-Conceptually:
+Every network command goes through the existing authenticated Server runtime path:
 
 ```text
-webcodex plugin check
-    -> authenticated Server request
-    -> existing plugin_tool/check semantics
-    -> exact Runner
-    -> disposable Runner-owned candidate
-
-webcodex plugin reload
-    -> authenticated Server request
-    -> existing plugin_tool/reload semantics
-    -> exact Runner
-    -> atomic candidate-set replacement
+webcodex plugin ...
+    -> POST /api/tools/call
+    -> {"tool":"plugin_tool","params":{...canonical action arguments...}}
+    -> existing Server permission/audit gateway
+    -> exact caller-selected Runner
 ```
 
-The CLI must not directly spawn the configured provider as a substitute for
-Runner `check`, because doing so would use a different environment, process-tree,
-bounds, and admission path. It also must not silently widen credentials. Management
-operations continue to require the existing `plugin:manage` authority; inspect and
-invoke scopes remain distinct.
+The CLI reuses the existing Server HTTP client, proxy behavior, bearer-token
+resolution, and token redaction. It does not connect directly to Runner transport,
+read `runner.toml` to resolve executables, spawn Plugin processes, validate Plugin
+schemas, inspect provider stderr, create bindings itself, or implement provider
+lifecycle. `describe` consumes the one canonical describe result rather than
+performing an extra list, and bindings are displayed only as opaque observations;
+they are not cached or treated as authorization credentials.
 
-The CLI should reuse existing WebCodex HTTP/auth/profile primitives and provide a
-bounded human-readable view plus machine-readable JSON where current CLI
-conventions support it. Runner-generated diagnostic codes remain canonical; the
-CLI should not parse raw provider stderr into a new public error contract.
+`reload` remains an exact-Runner **complete provider-set** operation. There is no
+per-provider reload flag: the Runner rereads its own `runner.toml`, prepares every
+candidate, and atomically replaces the committed set only if all candidates are
+admitted. `check` likewise remains Runner-owned disposable admission and never
+commits its candidate.
+
+The CLI performs exactly one Server request per command and adds no hidden retry.
+This matters especially for `check` and `reload`: after an HTTP timeout, connection
+reset, malformed post-send response, or lost response, the CLI cannot prove the
+request was not processed. It therefore reports that the outcome may be unknown
+and instructs the operator to observe current Plugin state before retrying rather
+than inventing retry authority.
+
+Machine output (`--json`) is the canonical `plugin_tool` output object with no
+parallel Plugin domain model. Human output is a bounded rendering of the same safe
+fields. A completed `check` exits successfully only when `ready=true`; a known
+`ready=false` result is non-zero. Reload succeeds only when the canonical
+`failures` array is empty. HTTP/auth/runtime failures remain non-zero without
+flattening canonical failure codes or exposing credentials.
+
+There is intentionally no `webcodex plugin call` in this phase. Effectful
+invocation, binding/retry behavior, and `OutcomeUnknown` remain on the normal
+model/operator `plugin_tool describe -> call` path.
+
+### `plugin init` is deferred until SDK distribution is real
+
+A public `webcodex plugin init` is **not** part of Phase 1. Today
+`@yyjeqhc/webcodex-plugin-sdk` is a repository development package used by
+first-party dogfood through a local `file:` dependency. It has no established npm
+publication/versioning contract, and normal WebCodex binary/npm distribution does
+not carry reusable SDK template/package assets. Generating a project that appears
+standalone but depends on the current source checkout or a build-machine absolute
+path would therefore be misleading.
+
+Do not paper over that boundary with embedded SDK source, per-project vendoring,
+an npm workspace, automatic pack/install, temporary `--sdk-path`, or generated
+absolute paths. Once the SDK has a truthful repeatable external dependency source,
+`plugin init` can be added as a deterministic local scaffold generator. At that
+point it may create a minimal TypeScript/ESM project and documented `runner.toml`
+snippet, but it still must not install packages implicitly, edit Runner config,
+register/reload a provider, create credentials, or execute generated code.
+
+A raw protocol Plugin remains a fully supported peer of an SDK-authored Plugin.
 
 ### Why this phase matters
 
@@ -221,9 +241,9 @@ less JSON/tool-call ceremony
 - no second Plugin runtime
 ```
 
-This is the highest-value next step because the SDK has already proved it can
-carry a real effectful Plugin; the remaining obvious cost is the author/operator
-workflow around that Plugin.
+This phase addresses the highest-value remaining authoring cost after the SDK
+proved it can carry a real effectful Plugin: repeated operator ceremony around the
+same authoritative runtime path.
 
 ## Follow-up phases
 
@@ -239,12 +259,14 @@ shows a concrete need. A future `dev` convenience command should only compose
 existing build/check/reload primitives; it must not invent a separate hot-reload
 runtime.
 
-### Phase 3: package/distribution contract
+### Phase 3: SDK distribution contract and `plugin init`
 
-After the SDK and authoring loop have real consumers, decide the publication and
-versioning contract for the SDK and any scaffolding templates. At that point the
-project can define which package names, generated layouts, Node versions, and CLI
-flags become compatibility commitments.
+After the SDK and authoring loop have real consumers, establish the publication
+and versioning contract for the SDK first. Only once a generated project has a
+truthful, repeatable dependency source should `webcodex plugin init` become a
+public command and scaffolding templates become a compatibility surface. At that
+point the project can define which package names, generated layouts, Node versions,
+and CLI flags become compatibility commitments.
 
 Do not make WebCodex product releases depend on SDK version equality unless a
 concrete distribution requirement appears. Native Plugin protocol versioning and
@@ -262,7 +284,7 @@ Memory, orchestration, or integrations, is also a separate architectural layer.
 It may consume canonical WebCodex primitives, but Native Tool Plugins should not
 silently evolve into that runtime.
 
-## Explicit non-goals for the next phase
+## Explicit non-goals for the authoring workflow
 
 The authoring CLI should not introduce:
 
@@ -279,27 +301,31 @@ The authoring CLI should not introduce:
 - automatic npm/pnpm/yarn dependency installation;
 - compatibility shims for unpublished development layouts.
 
-## Acceptance criteria for the authoring CLI phase
+## Acceptance criteria for the Phase 1 authoring CLI
 
-The phase is complete when all of the following are true:
+Phase 1 is complete when all of the following are true:
 
-1. A new TypeScript Plugin can be scaffolded without hand-writing protocol
-   boilerplate.
-2. The generated Plugin builds to ordinary JavaScript and passes SDK tests without
-   requiring the Runner to understand TypeScript.
-3. An operator can perform authoritative check and reload for one exact Runner
-   without manually constructing `plugin_tool` JSON.
-4. Failed admission preserves the bounded Runner diagnostic and does not replace
-   the currently committed provider set.
-5. A successful reload produces the same frozen catalog and binding behavior as
-   direct `plugin_tool` use.
-6. CLI credentials do not gain Plugin management scope implicitly.
-7. No CLI/SDK code becomes a second provider supervisor, schema authority, or
-   effect-lifecycle owner.
-8. `safe-delete` can use the workflow without reintroducing legacy entrypoint or
+1. An operator can list visible Plugin Runners, inspect committed providers/tools,
+   and describe one exact tool without manually constructing `plugin_tool` JSON.
+2. Authoritative check and reload target one exact caller-provided Runner through
+   the existing authenticated Server `/api/tools/call` path.
+3. Failed admission preserves the bounded Runner diagnostic and does not replace
+   the currently committed provider set; reload remains whole-set atomic.
+4. A successful reload produces the same frozen catalog and binding behavior as
+   direct `plugin_tool` use, and describe does not secretly re-list the provider.
+5. CLI credentials do not gain Plugin management scope implicitly; inspect and
+   manage remain distinct.
+6. Check/reload transport ambiguity never becomes automatic retry authority.
+7. JSON output preserves canonical Plugin gateway fields while human output is
+   bounded and never projects raw provider stderr or credentials.
+8. No CLI/SDK code becomes a second provider supervisor, schema authority, or
+   effect-lifecycle owner, and no `plugin call` surface is introduced.
+9. `safe-delete` can use the workflow without reintroducing legacy entrypoint or
    source compatibility shims.
-9. Default CI remains deterministic and path-aware; authoring-only changes do not
-   trigger unrelated Desktop/native/release lanes.
+10. Default CI remains deterministic and path-aware; authoring-only changes do not
+    trigger unrelated Desktop/native/release lanes.
+11. `plugin init` remains absent until the SDK has a truthful external distribution
+    contract; its later acceptance criteria belong to the distribution phase.
 
 Once these conditions hold, the project will have a coherent extension path:
 Runner-authoritative executable Plugins, a typed authoring SDK, a real first-party

--- a/npm/plugin-sdk/README.md
+++ b/npm/plugin-sdk/README.md
@@ -12,6 +12,10 @@ The Rust Runner remains authoritative for Plugin admission, schema validation, a
 
 Using this SDK does not make a Plugin an MCP server, grant new WebCodex permissions, or sandbox the executable. Native Plugins are trusted local processes. WebCodex Server and Runner themselves do not require Node because of this SDK; only a Plugin that chooses this SDK needs a Node runtime on its Runner machine.
 
+## Stability
+
+The SDK is experimental while it is pre-1.0. Minor `0.x` releases may contain breaking authoring API changes; pin an exact version when a Plugin needs a stable build input. Native Plugin protocol versioning and SDK package versioning remain separate concerns.
+
 ## Example
 
 ```ts
@@ -81,4 +85,4 @@ The SDK does not truncate or rewrite results to fit Runner limits. When an `outp
 
 `definePlugin` rejects duplicate provider-local tool names before serving and freezes the authoring catalog. `tools/list` exposes only protocol definitions; executable handlers and local closures never enter the wire representation. Declaration order is preserved by the SDK; the WebCodex Runner independently admits and freezes its authoritative catalog.
 
-For the minimal protocol without any SDK dependency, see [`../../examples/native-tool-plugin.mjs`](../../examples/native-tool-plugin.mjs). The repository example [`examples/echo-plugin.ts`](examples/echo-plugin.ts) demonstrates SDK authoring.
+The published package includes [`examples/echo-plugin.ts`](examples/echo-plugin.ts) as a minimal SDK authoring example. For the raw protocol without any SDK dependency, see [`examples/native-tool-plugin.mjs`](https://github.com/yyjeqhc/webcodex/blob/main/examples/native-tool-plugin.mjs) in the WebCodex repository.

--- a/npm/plugin-sdk/README.zh-CN.md
+++ b/npm/plugin-sdk/README.zh-CN.md
@@ -12,6 +12,10 @@ Rust Runner 继续权威拥有 Plugin admission、schema validation、authority�
 
 使用这个 SDK 不会把 Plugin 变成 MCP Server，不会增加 WebCodex 权限，也不会 sandbox executable。Native Plugin 仍然是受信任的本地进程。WebCodex Server / Runner 不会因为 SDK 而要求 Node；只有选择这个 SDK 的 Plugin 自己需要 Runner 机器提供 Node runtime。
 
+## 稳定性
+
+SDK 在 1.0 之前仍属于实验阶段。`0.x` 的 minor release 可能包含破坏性的 authoring API 调整；如果 Plugin 需要稳定的构建输入，应固定到精确版本。Native Plugin protocol version 与 SDK package version 仍然是两个独立概念。
+
 ## 示例
 
 ```ts
@@ -81,4 +85,4 @@ SDK 不会为了通过 Runner bounds 而截断或改写结果。声明 `outputSc
 
 `definePlugin` 会在 serve 前拒绝 provider-local duplicate tool name，并冻结 authoring catalog。`tools/list` 只暴露 protocol definition；execute handler、function source、closure/local state 不会进入 wire。SDK 保留声明顺序，WebCodex Runner 会独立 admission 并冻结自己的 authoritative catalog。
 
-完全不依赖 SDK 的最小 raw protocol reference 仍然是 [`../../examples/native-tool-plugin.mjs`](../../examples/native-tool-plugin.mjs)。仓库中的 [`examples/echo-plugin.ts`](examples/echo-plugin.ts) 展示 TypeScript SDK authoring。
+发布后的 package 会包含 [`examples/echo-plugin.ts`](examples/echo-plugin.ts) 作为最小 TypeScript SDK authoring 示例。完全不依赖 SDK 的 raw protocol reference 仍然位于 WebCodex 仓库的 [`examples/native-tool-plugin.mjs`](https://github.com/yyjeqhc/webcodex/blob/main/examples/native-tool-plugin.mjs)。

--- a/npm/plugin-sdk/package.json
+++ b/npm/plugin-sdk/package.json
@@ -13,9 +13,13 @@
   },
   "files": [
     "dist",
+    "examples",
     "README.md",
     "README.zh-CN.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary

- add `webcodex plugin list`, `describe`, `check`, and `reload` as thin operator adapters over the existing authenticated `/api/tools/call -> plugin_tool` path
- preserve exact Runner targeting, `plugin:inspect` vs `plugin:manage` scope separation, whole-provider-set atomic reload semantics, canonical JSON output, and conservative no-retry handling for ambiguous management outcomes
- reuse existing CLI HTTP/token infrastructure without adding a second Plugin runtime, direct Runner transport path, `plugin call`, or speculative compatibility aliases
- defer `webcodex plugin init` until the SDK has a truthful external distribution source
- prepare `@yyjeqhc/webcodex-plugin-sdk@0.1.0` for public npm distribution by setting public publish metadata, including the SDK authoring example in the package, fixing package-vs-repository README links, and documenting pre-1.0 stability expectations

## Validation

- `cargo test -p webcodex-cli plugin_ --lib` — 17 passed
- prior complete `cargo test -p webcodex-cli --lib` on the CLI commit — 385 passed, 0 failed
- `npm ci --prefix npm/plugin-sdk`
- `npm --prefix npm/plugin-sdk run typecheck`
- `npm --prefix npm/plugin-sdk test` — 16 passed
- `npm --prefix npm/plugin-sdk run pack:dry-run -- --json` — 15 expected files, including `examples/echo-plugin.ts`
- `npm publish --dry-run --json` from `npm/plugin-sdk` — public access, dry-run only
- `git diff --check`
- final worktree clean

No Server or Runner production changes, Plugin protocol changes, npm publication, deployment, restart, merge, tag, or release are included.