### PR TITLE
Improve Plugin initialize EOF diagnostics

### DIFF
--- a/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
@@ -348,7 +348,7 @@ fn plugin_init_creates_exact_public_sdk_scaffold_without_executing_dependencies(
         .unwrap();
     assert_eq!(
         rendered_entrypoint,
-        destination.join("dist/plugin.js").to_str().unwrap()
+        destination.join("dist").join("plugin.js").to_str().unwrap()
     );
     let root_entries = std::fs::read_dir(&destination)
         .unwrap()

--- a/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
@@ -971,7 +971,7 @@ async fn plugin_human_rendering_is_bounded_and_ignores_unknown_raw_stderr_field(
 
 #[tokio::test]
 async fn plugin_check_renders_canonical_initialize_eof_guidance_without_a_second_error_model() {
-    let detail = "Plugin process exited before initialize completed; verify the configured command and arguments. For a generated TypeScript Plugin, run npm run build and ensure dist/plugin.js exists on the Runner host before retrying.";
+    let detail = "Plugin protocol output ended before initialize completed; the process may have exited or closed stdout. Verify the configured command and arguments. For a generated TypeScript Plugin, run npm run build and ensure dist/plugin.js exists on the Runner host before retrying.";
     let canonical = json!({
         "runner":"special",
         "plugin":"my-plugin",

--- a/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/plugin.rs
@@ -970,6 +970,52 @@ async fn plugin_human_rendering_is_bounded_and_ignores_unknown_raw_stderr_field(
 }
 
 #[tokio::test]
+async fn plugin_check_renders_canonical_initialize_eof_guidance_without_a_second_error_model() {
+    let detail = "Plugin process exited before initialize completed; verify the configured command and arguments. For a generated TypeScript Plugin, run npm run build and ensure dist/plugin.js exists on the Runner host before retrying.";
+    let canonical = json!({
+        "runner":"special",
+        "plugin":"my-plugin",
+        "ready":false,
+        "phase":"initialize",
+        "code":"plugin_eof",
+        "detail":detail,
+        "diagnostic":null,
+        "toolCount":0,
+        "tools":[]
+    });
+
+    let (human, human_requests) = run_once(
+        "check",
+        &["--runner", "special", "--plugin", "my-plugin"],
+        runtime_success(canonical.clone()),
+        false,
+    )
+    .await;
+    assert_eq!(human_requests.len(), 1);
+    let human = human.unwrap();
+    assert_eq!(human.exit_code, 2);
+    assert!(human.stdout.contains("Phase: initialize"));
+    assert!(human.stdout.contains("Code: plugin_eof"));
+    assert!(human.stdout.contains(&format!("Detail: {detail}")));
+    assert!(human.stdout.contains("Tools: 0"));
+
+    let (json_output, json_requests) = run_once(
+        "check",
+        &["--runner", "special", "--plugin", "my-plugin"],
+        runtime_success(canonical.clone()),
+        true,
+    )
+    .await;
+    assert_eq!(json_requests.len(), 1);
+    let json_output = json_output.unwrap();
+    assert_eq!(json_output.exit_code, 2);
+    assert_eq!(
+        serde_json::from_str::<Value>(&json_output.stdout).unwrap(),
+        canonical
+    );
+}
+
+#[tokio::test]
 async fn plugin_check_and_reload_known_rejections_have_deterministic_nonzero_exit() {
     let (check, _) = run_once(
         "check",

--- a/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/fake_plugin.rs
@@ -81,7 +81,13 @@ fn main() -> io::Result<()> {
         match method.as_str() {
             "initialize" => {
                 append(marker, "initialize\n")?;
-                if scenario == "init_crash" || scenario == "check_init_crash" {
+                if matches!(
+                    scenario,
+                    "init_crash" | "check_init_crash" | "check_init_crash_stderr"
+                ) {
+                    if scenario == "check_init_crash_stderr" {
+                        eprintln!("diagnostic-only-secret-looking-initialize-stderr");
+                    }
                     return Ok(());
                 }
                 if scenario == "check_init_timeout" {

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -242,7 +242,7 @@ fn initialize_failure_detail(code: &str) -> &'static str {
         }
         "plugin_initialize_invalid" => "Plugin initialize result violates protocol bounds",
         "plugin_timeout" => "Plugin initialize did not complete within the provider timeout",
-        "plugin_eof" => "Plugin process ended during initialize",
+        "plugin_eof" => "Plugin process exited before initialize completed; verify the configured command and arguments. For a generated TypeScript Plugin, run npm run build and ensure dist/plugin.js exists on the Runner host before retrying.",
         _ => "Plugin initialize did not complete successfully",
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/plugin.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin.rs
@@ -242,7 +242,7 @@ fn initialize_failure_detail(code: &str) -> &'static str {
         }
         "plugin_initialize_invalid" => "Plugin initialize result violates protocol bounds",
         "plugin_timeout" => "Plugin initialize did not complete within the provider timeout",
-        "plugin_eof" => "Plugin process exited before initialize completed; verify the configured command and arguments. For a generated TypeScript Plugin, run npm run build and ensure dist/plugin.js exists on the Runner host before retrying.",
+        "plugin_eof" => "Plugin protocol output ended before initialize completed; the process may have exited or closed stdout. Verify the configured command and arguments. For a generated TypeScript Plugin, run npm run build and ensure dist/plugin.js exists on the Runner host before retrying.",
         _ => "Plugin initialize did not complete successfully",
     }
 }

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -273,7 +273,8 @@ fn check_observes_edited_v2_without_replacing_current_v1() {
 #[test]
 fn initialize_eof_detail_is_actionable_without_inventing_a_root_cause() {
     let detail = initialize_failure_detail("plugin_eof");
-    assert!(detail.contains("Plugin process exited before initialize completed"));
+    assert!(detail.contains("Plugin protocol output ended before initialize completed"));
+    assert!(detail.contains("process may have exited or closed stdout"));
     assert!(detail.contains("configured command and arguments"));
     assert!(detail.contains("For a generated TypeScript Plugin"));
     assert!(detail.contains("npm run build"));

--- a/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/plugin_check_tests.rs
@@ -271,6 +271,46 @@ fn check_observes_edited_v2_without_replacing_current_v1() {
 }
 
 #[test]
+fn initialize_eof_detail_is_actionable_without_inventing_a_root_cause() {
+    let detail = initialize_failure_detail("plugin_eof");
+    assert!(detail.contains("Plugin process exited before initialize completed"));
+    assert!(detail.contains("configured command and arguments"));
+    assert!(detail.contains("For a generated TypeScript Plugin"));
+    assert!(detail.contains("npm run build"));
+    assert!(detail.contains("dist/plugin.js"));
+    assert!(!detail.contains("entrypoint_missing"));
+    assert!(!detail.contains("Cannot find module"));
+}
+
+#[test]
+fn initialize_eof_keeps_raw_stderr_runner_local() {
+    let fixture = CheckFixture::new("check_init_crash_stderr", 2);
+    let response = fixture.check();
+    let encoded = serde_json::to_string(&response).unwrap();
+    assert!(!encoded.contains("diagnostic-only-secret-looking-initialize-stderr"));
+    assert!(!encoded.contains(fixture._temp.path().to_string_lossy().as_ref()));
+
+    let report = checked_report(response);
+    assert!(!report.ready);
+    assert_eq!(report.phase, PluginCheckPhase::Initialize);
+    assert_eq!(report.code.as_deref(), Some("plugin_eof"));
+    assert_eq!(
+        report.detail.as_deref(),
+        Some(initialize_failure_detail("plugin_eof"))
+    );
+    assert!(report.diagnostic.is_none());
+
+    let local = fixture
+        .manager
+        .local_check_stderr_diagnostics("fake")
+        .expect("initialize failure should retain bounded Runner-local stderr");
+    assert!(local
+        .lines
+        .iter()
+        .any(|line| line.text == "diagnostic-only-secret-looking-initialize-stderr"));
+}
+
+#[test]
 #[ignore = "runner real-process lane: disposable plugin checks clean up failed candidate process trees"]
 fn runner_real_process_plugin_check_failures_are_structured_diagnostic_results_and_cleanup_process_trees(
 ) {

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -330,13 +330,14 @@ Plugin schema. Human output renders only bounded canonical fields. A completed
 its phase/code/detail/diagnostic. Reload exits 0 only when its canonical `failures`
 array is empty; known rejection is non-zero.
 
-If `check` returns `phase=initialize` with `code=plugin_eof`, the provider process
-exited before initialize completed. Verify the configured command and arguments. For
-a Plugin created by `webcodex plugin init`, ensure `npm run build` has produced
-`dist/plugin.js` on the Runner host before retrying. This is conditional author
-guidance, not a root-cause classification: any provider that exits during initialize
-can produce `plugin_eof`, and WebCodex does not infer the cause from raw stderr or
-opaque argv.
+If `check` returns `phase=initialize` with `code=plugin_eof`, the provider's protocol
+output ended before initialize completed; the process may have exited or closed
+stdout. Verify the configured command and arguments. For a Plugin created by
+`webcodex plugin init`, ensure `npm run build` has produced `dist/plugin.js` on the
+Runner host before retrying. This is conditional author guidance, not a root-cause
+classification: any provider whose protocol output ends during initialize can
+produce `plugin_eof`, and WebCodex does not infer the cause from raw stderr or opaque
+argv.
 
 The CLI never auto-retries `check` or `reload`. Once a request has begun, an HTTP
 timeout, connection reset, malformed post-send response, or lost response cannot

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -330,6 +330,14 @@ Plugin schema. Human output renders only bounded canonical fields. A completed
 its phase/code/detail/diagnostic. Reload exits 0 only when its canonical `failures`
 array is empty; known rejection is non-zero.
 
+If `check` returns `phase=initialize` with `code=plugin_eof`, the provider process
+exited before initialize completed. Verify the configured command and arguments. For
+a Plugin created by `webcodex plugin init`, ensure `npm run build` has produced
+`dist/plugin.js` on the Runner host before retrying. This is conditional author
+guidance, not a root-cause classification: any provider that exits during initialize
+can produce `plugin_eof`, and WebCodex does not infer the cause from raw stderr or
+opaque argv.
+
 The CLI never auto-retries `check` or `reload`. Once a request has begun, an HTTP
 timeout, connection reset, malformed post-send response, or lost response cannot
 prove the management operation did not reach the Server/Runner. The CLI therefore

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -291,6 +291,13 @@ Runner transport token 会在发起 user/API HTTP request 前被拒绝。`list` 
 `ready=false` non-zero，但仍保留 phase/code/detail/diagnostic。reload 只有 canonical
 `failures` 为空时 exit 0；known rejection non-zero。
 
+如果 `check` 返回 `phase=initialize`、`code=plugin_eof`，表示 provider process 在
+initialize 完成前已经退出。应先检查配置的 command 与 arguments。对于由
+`webcodex plugin init` 创建的 Plugin，还应确认已执行 `npm run build`，并且 Runner 主机上
+已经生成 `dist/plugin.js`，再重试。这里是条件性的 author guidance，不是 root-cause 分类：
+任何在 initialize 阶段提前退出的 provider 都可能产生 `plugin_eof`，WebCodex 不会根据 raw
+stderr 或 opaque argv 推断具体原因。
+
 CLI 不会自动 retry `check` 或 `reload`。请求开始后如果遇到 HTTP timeout、connection reset、
 post-send malformed response 或 response lost，CLI 无法证明 management operation 没有到达
 Server/Runner，因此会保守报告 outcome may be unknown，并要求先观察当前 Plugin state 再决定

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -291,12 +291,12 @@ Runner transport token 会在发起 user/API HTTP request 前被拒绝。`list` 
 `ready=false` non-zero，但仍保留 phase/code/detail/diagnostic。reload 只有 canonical
 `failures` 为空时 exit 0；known rejection non-zero。
 
-如果 `check` 返回 `phase=initialize`、`code=plugin_eof`，表示 provider process 在
-initialize 完成前已经退出。应先检查配置的 command 与 arguments。对于由
-`webcodex plugin init` 创建的 Plugin，还应确认已执行 `npm run build`，并且 Runner 主机上
-已经生成 `dist/plugin.js`，再重试。这里是条件性的 author guidance，不是 root-cause 分类：
-任何在 initialize 阶段提前退出的 provider 都可能产生 `plugin_eof`，WebCodex 不会根据 raw
-stderr 或 opaque argv 推断具体原因。
+如果 `check` 返回 `phase=initialize`、`code=plugin_eof`，表示 provider 的 protocol
+output 在 initialize 完成前已经结束；进程可能已经退出，也可能只是关闭了 stdout。应先检查
+配置的 command 与 arguments。对于由 `webcodex plugin init` 创建的 Plugin，还应确认已执行
+`npm run build`，并且 Runner 主机上已经生成 `dist/plugin.js`，再重试。这里是条件性的 author
+guidance，不是 root-cause 分类：任何在 initialize 阶段结束 protocol output 的 provider 都
+可能产生 `plugin_eof`，WebCodex 不会根据 raw stderr 或 opaque argv 推断具体原因。
 
 CLI 不会自动 retry `check` 或 `reload`。请求开始后如果遇到 HTTP timeout、connection reset、
 post-send malformed response 或 response lost，CLI 无法证明 management operation 没有到达


### PR DESCRIPTION
## Summary
- make `plugin_eof` initialize guidance actionable without inventing a root cause
- keep raw provider stderr Runner-local and preserve canonical Plugin failure semantics
- cover CLI canonical rendering and Windows Plugin init path assertion behavior

## Validation
- focused Runner initialize EOF tests
- focused CLI canonical rendering test
- Plugin init scaffold/path test
- cargo fmt --all -- --check
- git diff --check

This PR intentionally does not add Node-specific stderr parsing, new Plugin error codes, protocol changes, config-path inference, or Phase 4 Plugin surfaces.