### PR TITLE
Add MCP Job result presentation foundation

### DIFF
--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -372,20 +372,26 @@ The standing direction for model-facing execution is defined in
 3. **One execution may outlive one tool/model turn.** When work exceeds a short
    synchronous grace window, the same execution should continue as a durable Job;
    handoff must not be implemented as cancel-and-retry.
-4. **Job/observation is the continuation API.** Durable Job identity, lifecycle,
-   bounded logs, observation token, cancellation, ownership, and recovery/lost
-   semantics remain OS-, transport-, and presentation-neutral. Batch observation
-   should reuse this model rather than create a second scheduler or revision
-   system.
+4. **Job/observation is the execution continuation and observation API.** Durable
+   Job identity, lifecycle, bounded logs, observation token, cancellation,
+   ownership, and recovery/lost semantics remain OS-, transport-, and
+   presentation-neutral. This does not itself mean model/Host continuation; batch
+   observation should reuse this model rather than create a second scheduler or
+   revision system.
 5. **Optional host UI is an adapter, not an owner.** MCP Apps or another host may
    observe Jobs and later resume a model, but core execution cannot depend on
-   Apps, MCP Tasks, MRTR, elicitation, progress extensions, or iframe state. If
-   automatic model resume is provided, exactly one durable continuation domain
-   owns each logical resume event; independent Job Views, cards, or Host views do
-   not race to resume the model. For Agent-bound continuation, the Agent Wake /
-   Wake Delivery Attempt domain owns that logical continuation; Host/controller
-   state is adapter-local delivery state rather than a second WebCodex
-   continuation truth.
+   Apps, MCP Tasks, MRTR, elicitation, progress extensions, or iframe state. MCP
+   App presentation is a Server-level optional adapter: `WEBCODEX_MCP_APPS_ENABLED`
+   defaults on and may disable App capability advertisement, descriptor linkage,
+   presentation metadata, and static App resources without disabling canonical
+   MCP tools/results or non-App resource delivery. If automatic model resume is
+   provided, exactly one durable continuation domain owns each logical resume
+   event; independent Job Views, cards, or Host views do not race to resume the
+   model. A long build/watch reaching terminal state may be an explicit input to
+   Goal/AgentTask orchestration, but the card is never the trigger or continuation
+   owner. For Agent-bound continuation, the Agent Wake / Wake Delivery Attempt
+   domain owns that logical continuation; Host/controller state is adapter-local
+   delivery state rather than a second WebCodex continuation truth.
 6. **Transport fallback must preserve execution semantics.** Polling, WebSocket,
    and QUIC may differ in delivery behavior, but none may silently duplicate a
    command or turn a transport stall into a false pre-start rejection.

--- a/src/config.rs
+++ b/src/config.rs
@@ -324,6 +324,21 @@ pub(crate) fn mcp_compact_schemas_enabled() -> bool {
     env_flag("WEBCODEX_MCP_COMPACT_SCHEMAS").unwrap_or(false)
 }
 
+/// Global Server switch for optional MCP App presentation resources and metadata.
+///
+/// Apps are enabled by default. Setting `WEBCODEX_MCP_APPS_ENABLED=false` keeps
+/// canonical MCP tools/results and non-App resources available while suppressing
+/// App capability advertisement, tool linkage, presentation metadata, and static
+/// App resource reads. Invalid values follow `env_flag` and fall back to the
+/// default enabled behavior.
+fn mcp_apps_enabled_from_flag(flag: Option<bool>) -> bool {
+    flag.unwrap_or(true)
+}
+
+pub(crate) fn mcp_apps_enabled() -> bool {
+    mcp_apps_enabled_from_flag(env_flag("WEBCODEX_MCP_APPS_ENABLED"))
+}
+
 pub(crate) fn load_startup_env_files() -> Result<Vec<EnvFileLoad>, String> {
     if let Ok(path) = std::env::var("WEBCODEX_ENV_FILE") {
         return Ok(vec![load_env_file(Path::new(&path))?]);
@@ -777,6 +792,13 @@ mod tests {
         // Invalid values are treated as unset by env_flag -> default false.
         assert!(!mcp_compact_schemas_enabled());
         env.remove("WEBCODEX_MCP_COMPACT_SCHEMAS");
+    }
+
+    #[test]
+    fn mcp_apps_default_on_and_can_be_disabled() {
+        assert!(mcp_apps_enabled_from_flag(None));
+        assert!(mcp_apps_enabled_from_flag(Some(true)));
+        assert!(!mcp_apps_enabled_from_flag(Some(false)));
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,4 +1,5 @@
 mod http_metadata;
+mod presentation;
 mod protocol;
 mod resources;
 mod response;
@@ -1086,7 +1087,15 @@ async fn handle_mcp_request_with_lifecycle(
         ),
         "ping" if !stateless_2026 => rpc_result(id, json!({})),
         "tools/list" => {
-            return tools::handle_list(runtime, id, auth, stateless_2026, compact_schemas).await;
+            return tools::handle_list(
+                runtime,
+                id,
+                auth,
+                stateless_2026,
+                compact_schemas,
+                mcp_app_enabled,
+            )
+            .await;
         }
         "resources/list" if stateless_2026 && runtime_resource_method => {
             return resources::handle_list(id, mcp_app_enabled);
@@ -1117,6 +1126,7 @@ async fn handle_mcp_request_with_lifecycle(
                 id,
                 auth,
                 stateless_2026,
+                mcp_app_enabled,
                 host_file_import_trust,
                 window,
                 lifecycle.as_deref_mut(),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -576,6 +576,7 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
         None
     };
     let compact_schemas = crate::config::mcp_compact_schemas_enabled();
+    let server_mcp_apps_enabled = crate::config::mcp_apps_enabled();
 
     let config = crate::auth::get_config(depot);
     let db = crate::auth::get_db(depot);
@@ -623,6 +624,7 @@ pub async fn mcp_post(req: &mut Request, depot: &mut Depot, res: &mut Response) 
                 Some(&mut guard),
                 Some(&mut model_ergonomics),
                 compact_schemas,
+                server_mcp_apps_enabled,
                 Some(&mut tool_correlation),
             )),
         ),
@@ -947,6 +949,7 @@ async fn handle_mcp_request(
 ) -> McpOutcome {
     let protocol_era = inferred_protocol_era(&request);
     let compact_schemas = crate::config::mcp_compact_schemas_enabled();
+    let server_mcp_apps_enabled = crate::config::mcp_apps_enabled();
     let outcome = handle_mcp_request_with_lifecycle(
         runtime,
         None,
@@ -958,6 +961,7 @@ async fn handle_mcp_request(
         None,
         None,
         compact_schemas,
+        server_mcp_apps_enabled,
         None,
     )
     .await;
@@ -987,6 +991,7 @@ async fn handle_mcp_request_with_lifecycle(
     mut lifecycle: Option<&mut ToolRequestLifecycle>,
     mut model_ergonomics_out: Option<&mut Option<ModelErgonomicsRecord>>,
     compact_schemas: bool,
+    server_mcp_apps_enabled: bool,
     mut correlation_out: Option<&mut crate::tool_runtime::ToolCallCorrelation>,
 ) -> McpOutcome {
     let stateless_2026 = protocol_era == McpProtocolEra::Stateless2026;
@@ -997,9 +1002,12 @@ async fn handle_mcp_request_with_lifecycle(
             && request.method == "resources/read"
             && resources::resource_read_bypasses_runtime_read(&request.params);
     let mcp_app_enabled = match runtime_exposure {
-        RuntimeExposure::Runtime(model_surface) => {
-            resources::mcp_app_enabled(stateless_2026, model_surface, &request.params)
-        }
+        RuntimeExposure::Runtime(model_surface) => resources::mcp_app_enabled(
+            server_mcp_apps_enabled,
+            stateless_2026,
+            model_surface,
+            &request.params,
+        ),
         RuntimeExposure::ProjectConnector => false,
     };
     let runtime_resource_method = matches!(runtime_exposure, RuntimeExposure::Runtime(_))
@@ -1072,7 +1080,7 @@ async fn handle_mcp_request_with_lifecycle(
                 RuntimeExposure::Runtime(model_surface)
                     if resources::model_surface_supports_computer_app(model_surface) =>
                 {
-                    resources::server_capabilities()
+                    resources::server_capabilities(server_mcp_apps_enabled)
                 }
                 RuntimeExposure::Runtime(_) => json!({ "tools": { "listChanged": false } }),
             };
@@ -1104,7 +1112,15 @@ async fn handle_mcp_request_with_lifecycle(
             let RuntimeExposure::Runtime(model_surface) = runtime_exposure else {
                 unreachable!("runtime_resource_method requires a runtime ModelSurface");
             };
-            return resources::handle_read(runtime, request.params, id, auth, model_surface).await;
+            return resources::handle_read(
+                runtime,
+                request.params,
+                id,
+                auth,
+                model_surface,
+                server_mcp_apps_enabled,
+            )
+            .await;
         }
         method @ ("tasks/get" | "tasks/update" | "tasks/cancel")
             if stateless_2026 && tasks::runtime_exposure_supports_tasks(runtime_exposure) =>

--- a/src/mcp/presentation.rs
+++ b/src/mcp/presentation.rs
@@ -1,5 +1,4 @@
 use serde_json::{json, Map, Value};
-use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
 
 pub(super) const MCP_PRESENTATION_META_KEY: &str = "webcodex/presentation";
 pub(super) const MCP_PRESENTATION_VERSION: u64 = 1;
@@ -77,11 +76,16 @@ fn job_summary_presentation(job: &Value) -> Option<Value> {
     copy_bounded_text(job, &mut item, "recovery_state");
     copy_bounded_text(job, &mut item, "recovery_reason_code");
     copy_bounded_text(job, &mut item, "recovery_reason");
-    copy_scalar(job, &mut item, "duration_ms");
-    copy_scalar(job, &mut item, "elapsed_secs");
-    copy_scalar(job, &mut item, "exit_code");
-    if let Ok(lifecycle) = RunnerJobLifecycle::from_wire(&status) {
-        item.insert("terminal".to_string(), Value::Bool(lifecycle.is_terminal()));
+    for key in [
+        "active",
+        "blocking_active",
+        "terminal",
+        "terminal_pending",
+        "duration_ms",
+        "elapsed_secs",
+        "exit_code",
+    ] {
+        copy_scalar(job, &mut item, key);
     }
     let execution_state = job.get("command_execution_state").and_then(Value::as_str);
     let recovery_state = job.get("recovery_state").and_then(Value::as_str);

--- a/src/mcp/presentation.rs
+++ b/src/mcp/presentation.rs
@@ -1,0 +1,260 @@
+use serde_json::{json, Map, Value};
+use webcodex_core::runner_job_lifecycle::RunnerJobLifecycle;
+
+pub(super) const MCP_PRESENTATION_META_KEY: &str = "webcodex/presentation";
+pub(super) const MCP_PRESENTATION_VERSION: u64 = 1;
+pub(super) const MAX_MCP_PRESENTATION_ITEMS: usize = 8;
+pub(super) const MAX_MCP_PRESENTATION_TEXT_CHARS: usize = 256;
+
+fn bounded_text(value: &Value) -> Option<String> {
+    let value = value.as_str()?;
+    let mut chars = value.chars();
+    let bounded = chars
+        .by_ref()
+        .take(MAX_MCP_PRESENTATION_TEXT_CHARS)
+        .collect::<String>();
+    if chars.next().is_some() {
+        let mut truncated = bounded
+            .chars()
+            .take(MAX_MCP_PRESENTATION_TEXT_CHARS.saturating_sub(1))
+            .collect::<String>();
+        truncated.push('…');
+        Some(truncated)
+    } else {
+        Some(bounded)
+    }
+}
+
+fn copy_bounded_text(source: &Value, target: &mut Map<String, Value>, key: &str) {
+    if let Some(value) = source.get(key).and_then(bounded_text) {
+        target.insert(key.to_string(), Value::String(value));
+    }
+}
+
+fn copy_scalar(source: &Value, target: &mut Map<String, Value>, key: &str) {
+    if let Some(value) = source.get(key) {
+        if value.is_boolean() || value.is_number() {
+            target.insert(key.to_string(), value.clone());
+        }
+    }
+}
+
+fn static_guidance(
+    status: Option<&str>,
+    execution_state: Option<&str>,
+    recovery: Option<&str>,
+) -> Option<&'static str> {
+    if execution_state == Some("outcome_unknown") {
+        return Some("Outcome is uncertain. Observe current Job state before retrying.");
+    }
+    if status == Some("lost") {
+        return Some(
+            "Job state is lost. Re-observe runtime state before deciding whether retry is safe.",
+        );
+    }
+    match recovery {
+        Some("recovering") => {
+            Some("Job recovery is in progress; this card does not poll or retry automatically.")
+        }
+        Some("reconciled") => {
+            Some("Job state was reconciled from the canonical runtime record.")
+        }
+        Some("lost_after_reconcile") => Some(
+            "Job remained lost after reconciliation; inspect current runtime state before retrying.",
+        ),
+        _ => None,
+    }
+}
+
+fn job_summary_presentation(job: &Value) -> Option<Value> {
+    let job_id = job.get("job_id").and_then(bounded_text)?;
+    let status = job.get("status").and_then(bounded_text)?;
+    let mut item = Map::new();
+    item.insert("job_id".to_string(), Value::String(job_id));
+    item.insert("status".to_string(), Value::String(status.clone()));
+    copy_bounded_text(job, &mut item, "project");
+    copy_bounded_text(job, &mut item, "command_execution_state");
+    copy_bounded_text(job, &mut item, "recovery_state");
+    copy_bounded_text(job, &mut item, "recovery_reason_code");
+    copy_bounded_text(job, &mut item, "recovery_reason");
+    copy_scalar(job, &mut item, "duration_ms");
+    copy_scalar(job, &mut item, "elapsed_secs");
+    copy_scalar(job, &mut item, "exit_code");
+    if let Ok(lifecycle) = RunnerJobLifecycle::from_wire(&status) {
+        item.insert("terminal".to_string(), Value::Bool(lifecycle.is_terminal()));
+    }
+    let execution_state = job.get("command_execution_state").and_then(Value::as_str);
+    let recovery_state = job.get("recovery_state").and_then(Value::as_str);
+    if let Some(guidance) = static_guidance(Some(&status), execution_state, recovery_state) {
+        item.insert("guidance".to_string(), Value::String(guidance.to_string()));
+    }
+    Some(Value::Object(item))
+}
+
+fn list_jobs_presentation(output: &Value) -> Option<Value> {
+    let jobs = output.get("jobs")?.as_array()?;
+    let items = jobs
+        .iter()
+        .take(MAX_MCP_PRESENTATION_ITEMS)
+        .filter_map(job_summary_presentation)
+        .collect::<Vec<_>>();
+    Some(json!({
+        "version": MCP_PRESENTATION_VERSION,
+        "kind": "job_list",
+        "count": output.get("count").and_then(Value::as_u64)?,
+        "matched_count": output.get("matched_count").and_then(Value::as_u64)?,
+        "truncated": output.get("truncated").and_then(Value::as_bool)?,
+        "items_truncated": jobs.len() > MAX_MCP_PRESENTATION_ITEMS,
+        "items": items,
+    }))
+}
+
+fn observation_guidance(item: &Value) -> Option<&'static str> {
+    let status = item.get("status").and_then(Value::as_str);
+    let execution_state = item.get("command_execution_state").and_then(Value::as_str);
+    let recovery_state = item.get("recovery_state").and_then(Value::as_str);
+    static_guidance(status, execution_state, recovery_state)
+}
+
+fn observed_success_presentation(observation: &Value) -> Option<Value> {
+    let job_id = observation.get("job_id").and_then(bounded_text)?;
+    let status = observation.get("status").and_then(bounded_text)?;
+    let mut item = Map::new();
+    item.insert("job_id".to_string(), Value::String(job_id));
+    item.insert("status".to_string(), Value::String(status));
+    for key in [
+        "command_execution_state",
+        "recovery_state",
+        "recovery_reason_code",
+        "recovery_reason",
+        "log_delta_status",
+    ] {
+        copy_bounded_text(observation, &mut item, key);
+    }
+    for key in [
+        "terminal",
+        "changed",
+        "exit_code",
+        "stdout_lines",
+        "stderr_lines",
+        "stdout_returned_lines",
+        "stderr_returned_lines",
+        "stdout_truncated",
+        "stderr_truncated",
+        "stdout_delta_reset",
+        "stderr_delta_reset",
+        "earlier_stdout_unavailable",
+        "earlier_stderr_unavailable",
+    ] {
+        copy_scalar(observation, &mut item, key);
+    }
+    if let Some(guidance) = observation_guidance(observation) {
+        item.insert("guidance".to_string(), Value::String(guidance.to_string()));
+    }
+    Some(Value::Object(item))
+}
+
+fn observed_failure_presentation(item: &Value) -> Option<Value> {
+    let job_id = item.get("job_id").and_then(bounded_text)?;
+    let mut output = Map::new();
+    output.insert("job_id".to_string(), Value::String(job_id));
+    for key in ["error_kind", "recovery_kind", "recovery_tool"] {
+        copy_bounded_text(item, &mut output, key);
+    }
+    if item.get("error_kind").and_then(Value::as_str) == Some("unknown_job") {
+        output.insert(
+            "guidance".to_string(),
+            Value::String(
+                "Job is not directly observable here. Re-observe caller-visible Jobs before retrying."
+                    .to_string(),
+            ),
+        );
+    }
+    Some(Value::Object(output))
+}
+
+fn observe_jobs_presentation(output: &Value) -> Option<Value> {
+    let source_items = output.get("items")?.as_array()?;
+    let items = source_items
+        .iter()
+        .take(MAX_MCP_PRESENTATION_ITEMS)
+        .filter_map(|item| {
+            if item.get("success").is_some() {
+                if item.get("success").and_then(Value::as_bool) == Some(true) {
+                    item.get("output").and_then(observed_success_presentation)
+                } else {
+                    observed_failure_presentation(item)
+                }
+            } else {
+                observed_success_presentation(item)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut presentation = Map::new();
+    presentation.insert("version".to_string(), Value::from(MCP_PRESENTATION_VERSION));
+    presentation.insert(
+        "kind".to_string(),
+        Value::String("job_observation".to_string()),
+    );
+    presentation.insert("items".to_string(), Value::Array(items));
+    presentation.insert(
+        "items_truncated".to_string(),
+        Value::Bool(source_items.len() > MAX_MCP_PRESENTATION_ITEMS),
+    );
+    if let Some(wait) = output.get("wait").and_then(Value::as_object) {
+        let mut bounded_wait = Map::new();
+        if let Some(outcome) = wait.get("outcome").and_then(bounded_text) {
+            bounded_wait.insert("outcome".to_string(), Value::String(outcome));
+        }
+        if let Some(waited_ms) = wait.get("waited_ms").filter(|value| value.is_number()) {
+            bounded_wait.insert("waited_ms".to_string(), waited_ms.clone());
+        }
+        if !bounded_wait.is_empty() {
+            presentation.insert("wait".to_string(), Value::Object(bounded_wait));
+        }
+    }
+    for key in [
+        "requested_count",
+        "returned_count",
+        "succeeded_count",
+        "failed_count",
+        "changed_count",
+        "terminal_count",
+        "output_truncated",
+        "next_index",
+    ] {
+        if let Some(value) = output.get(key) {
+            if value.is_boolean() || value.is_number() || value.is_null() {
+                presentation.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+    Some(Value::Object(presentation))
+}
+
+fn presentation_from_call_result(tool_name: &str, call_result: &Value) -> Option<Value> {
+    let structured = call_result.get("structuredContent")?;
+    let output = structured.get("output")?;
+    match tool_name {
+        "list_jobs" => list_jobs_presentation(output),
+        "observe_jobs" => observe_jobs_presentation(output),
+        _ => None,
+    }
+}
+
+pub(super) fn attach_result_app_presentation(tool_name: &str, call_result: &mut Value) {
+    let Some(presentation) = presentation_from_call_result(tool_name, call_result) else {
+        return;
+    };
+    let Some(result) = call_result.as_object_mut() else {
+        return;
+    };
+    let meta = result
+        .entry("_meta".to_string())
+        .or_insert_with(|| json!({}));
+    let Some(meta) = meta.as_object_mut() else {
+        return;
+    };
+    meta.insert(MCP_PRESENTATION_META_KEY.to_string(), presentation);
+}

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -53,8 +53,10 @@ pub(super) const MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS: &[&str] = &[
 // resource for every card so resource reuse/cache is not an unobserved variable.
 pub(super) const MCP_COMPUTER_UI_RESOURCE_TTL_MS: u64 = 0;
 pub(super) const MCP_COMPUTER_UI_DOMAIN: &str = "https://sg4.yyjeqhc.cn";
+pub(super) const MCP_RESULT_UI_RESOURCE_URI: &str = "ui://webcodex/result/v1";
 pub(super) const MCP_UI_RESOURCE_MIME_TYPE: &str = "text/html;profile=mcp-app";
 pub(super) const MCP_COMPUTER_APP_HTML: &str = include_str!("../mcp_computer_app.html");
+pub(super) const MCP_RESULT_APP_HTML: &str = include_str!("../mcp_result_app.html");
 
 pub(super) fn request_supports_mcp_apps(params: &Value) -> bool {
     let Some(extension) = request_client_capabilities(params)
@@ -72,8 +74,12 @@ pub(super) fn request_supports_mcp_apps(params: &Value) -> bool {
     }
 }
 
-pub(super) fn model_surface_supports_computer_app(model_surface: ModelSurface) -> bool {
+pub(super) fn model_surface_supports_mcp_apps(model_surface: ModelSurface) -> bool {
     model_surface.supports_operator_extensions()
+}
+
+pub(super) fn model_surface_supports_computer_app(model_surface: ModelSurface) -> bool {
+    model_surface_supports_mcp_apps(model_surface)
 }
 
 pub(super) fn mcp_computer_app_resource_meta() -> Value {
@@ -101,6 +107,33 @@ pub(super) fn mcp_computer_app_resources_list() -> Value {
     })
 }
 
+pub(super) fn mcp_result_app_resource_meta() -> Value {
+    json!({
+        "ui": {
+            "prefersBorder": true,
+            "csp": {
+                "connectDomains": [],
+                "resourceDomains": []
+            }
+        }
+    })
+}
+
+pub(super) fn mcp_app_resources_list() -> Value {
+    let mut result = mcp_computer_app_resources_list();
+    result["resources"]
+        .as_array_mut()
+        .expect("computer App resource list must be an array")
+        .push(json!({
+            "uri": MCP_RESULT_UI_RESOURCE_URI,
+            "name": "WebCodex Result",
+            "description": "Read-only WebCodex structured result presentation for supported Job tools. The App renders bounded presentation metadata and never performs tool calls or owns runtime state.",
+            "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
+            "_meta": mcp_result_app_resource_meta()
+        }));
+    result
+}
+
 pub(super) fn is_mcp_computer_app_resource_uri(uri: &str) -> bool {
     uri == MCP_COMPUTER_UI_RESOURCE_URI || MCP_COMPUTER_UI_RESOURCE_LEGACY_URIS.contains(&uri)
 }
@@ -121,6 +154,23 @@ pub(super) fn mcp_computer_app_resource_read(uri: &str) -> Option<Value> {
             }]
         })
     })
+}
+
+pub(super) fn mcp_result_app_resource_read(uri: &str) -> Option<Value> {
+    (uri == MCP_RESULT_UI_RESOURCE_URI).then(|| {
+        json!({
+            "contents": [{
+                "uri": uri,
+                "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
+                "text": MCP_RESULT_APP_HTML,
+                "_meta": mcp_result_app_resource_meta()
+            }]
+        })
+    })
+}
+
+fn mcp_static_app_resource_read(uri: &str) -> Option<Value> {
+    mcp_computer_app_resource_read(uri).or_else(|| mcp_result_app_resource_read(uri))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1321,7 +1371,7 @@ pub(super) fn mcp_app_enabled(
     params: &Value,
 ) -> bool {
     stateless_2026
-        && model_surface_supports_computer_app(model_surface)
+        && model_surface_supports_mcp_apps(model_surface)
         && request_supports_mcp_apps(params)
 }
 
@@ -1342,7 +1392,7 @@ pub(super) fn resource_read_bypasses_runtime_read(params: &Value) -> bool {
 
 pub(super) fn handle_list(id: Option<Value>, app_enabled: bool) -> McpOutcome {
     let result = if app_enabled {
-        mcp_computer_app_resources_list()
+        mcp_app_resources_list()
     } else {
         json!({ "resources": [] })
     };
@@ -1421,14 +1471,14 @@ pub(super) async fn handle_read(
 
     // Tool descriptors advertise the App resource independently of whether a
     // later resource fetch repeats UI client-capability metadata.
-    if !model_surface_supports_computer_app(model_surface) {
+    if !model_surface_supports_mcp_apps(model_surface) {
         return McpOutcome::BadRequest(rpc_error(
             id,
             -32602,
             "MCP App resource is unavailable on this model surface",
         ));
     }
-    let Some(result) = mcp_computer_app_resource_read(uri) else {
+    let Some(result) = mcp_static_app_resource_read(uri) else {
         return McpOutcome::BadRequest(rpc_error(id, -32602, format!("Resource not found: {uri}")));
     };
     let mut result = mcp_stateless_result(result, true);

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -1353,24 +1353,29 @@ pub(super) fn mcp_artifact_export_read_error_outcome(
     }
 }
 
-pub(super) fn server_capabilities() -> Value {
-    json!({
+pub(super) fn server_capabilities(apps_enabled: bool) -> Value {
+    let mut capabilities = json!({
         "tools": { "listChanged": false },
-        "resources": { "listChanged": false, "subscribe": false },
-        "extensions": {
+        "resources": { "listChanged": false, "subscribe": false }
+    });
+    if apps_enabled {
+        capabilities["extensions"] = json!({
             MCP_UI_EXTENSION: {
                 "mimeTypes": [MCP_UI_RESOURCE_MIME_TYPE]
             }
-        }
-    })
+        });
+    }
+    capabilities
 }
 
 pub(super) fn mcp_app_enabled(
+    server_apps_enabled: bool,
     stateless_2026: bool,
     model_surface: ModelSurface,
     params: &Value,
 ) -> bool {
-    stateless_2026
+    server_apps_enabled
+        && stateless_2026
         && model_surface_supports_mcp_apps(model_surface)
         && request_supports_mcp_apps(params)
 }
@@ -1405,6 +1410,7 @@ pub(super) async fn handle_read(
     id: Option<Value>,
     auth: Option<&AuthContext>,
     model_surface: ModelSurface,
+    apps_enabled: bool,
 ) -> McpOutcome {
     let Some(uri) = params.get("uri").and_then(Value::as_str) else {
         return McpOutcome::BadRequest(rpc_error(id, -32602, "Invalid params: uri is required"));
@@ -1467,6 +1473,16 @@ pub(super) async fn handle_read(
             }]
         });
         return McpOutcome::Ok(rpc_result(id, mcp_stateless_result(result, true)));
+    }
+
+    // Artifact/snapshot resources above remain available independently. The
+    // global switch controls only optional static MCP App presentation.
+    if !apps_enabled {
+        return McpOutcome::BadRequest(rpc_error(
+            id,
+            -32602,
+            "MCP App resources are disabled by Server configuration",
+        ));
     }
 
     // Tool descriptors advertise the App resource independently of whether a

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,3 +1,4 @@
+use super::presentation;
 use super::resources;
 use super::response::{
     connector_call_tool_result, mcp_runtime_tool_result_fallback, mcp_stateless_result, rpc_error,
@@ -514,7 +515,29 @@ pub(super) fn add_stateless_workflow_recorder_metadata(
     }
 }
 
-fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, _app_enabled: bool) -> Value {
+fn tool_meta_object(value: &mut Value) -> Option<&mut serde_json::Map<String, Value>> {
+    let object = value.as_object_mut()?;
+    let meta = object
+        .entry("_meta".to_string())
+        .or_insert_with(|| json!({}));
+    meta.as_object_mut()
+}
+
+pub(super) fn attach_app_metadata(value: &mut Value, resource_uri: &str) {
+    let Some(meta) = tool_meta_object(value) else {
+        return;
+    };
+    let ui = meta.entry("ui".to_string()).or_insert_with(|| json!({}));
+    let Some(ui) = ui.as_object_mut() else {
+        return;
+    };
+    ui.insert(
+        "resourceUri".to_string(),
+        Value::String(resource_uri.to_string()),
+    );
+}
+
+fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, app_enabled: bool) -> Value {
     let tool_name = spec.name.clone();
     if matches!(
         tool_name.as_str(),
@@ -556,12 +579,12 @@ fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, _app_enabled: bool) -> 
         }
     }
     if tool_name == "import_conversation_files_to_project" {
-        if let Some(object) = value.as_object_mut() {
-            object.insert(
-                "_meta".to_string(),
-                json!({"openai/fileParams": ["openaiFileIdRefs"]}),
-            );
+        if let Some(meta) = tool_meta_object(&mut value) {
+            meta.insert("openai/fileParams".to_string(), json!(["openaiFileIdRefs"]));
         }
+    }
+    if app_enabled && matches!(tool_name.as_str(), "list_jobs" | "observe_jobs") {
+        attach_app_metadata(&mut value, resources::MCP_RESULT_UI_RESOURCE_URI);
     }
     value
 }
@@ -594,6 +617,7 @@ pub(super) async fn handle_list(
     auth: Option<&AuthContext>,
     stateless_2026: bool,
     compact_schemas: bool,
+    app_enabled: bool,
 ) -> McpOutcome {
     let result = match runtime.runtime_exposure() {
         RuntimeExposure::ProjectConnector => {
@@ -603,7 +627,7 @@ pub(super) async fn handle_list(
             let mut result = mcp_tools_list_payload_with_features_for_auth(
                 model_surface,
                 compact_schemas,
-                stateless_2026 && resources::model_surface_supports_computer_app(model_surface),
+                app_enabled,
                 stateless_2026,
                 stateless_2026,
                 auth,
@@ -1118,6 +1142,7 @@ pub(super) async fn handle_call(
     id: Option<Value>,
     auth: Option<&AuthContext>,
     stateless_2026: bool,
+    app_enabled: bool,
     host_file_import_trust: HostFileImportTrust,
     window: Option<&crate::client_window::ClientWindow>,
     mut lifecycle: Option<&mut ToolRequestLifecycle>,
@@ -1807,7 +1832,7 @@ pub(super) async fn handle_call(
             lc.dispatch_finished(true, Some(false), category);
         }
     }
-    let result = match resources::adapt_tool_result(
+    let mut result = match resources::adapt_tool_result(
         &params.name,
         as_image_requested,
         result,
@@ -1818,6 +1843,9 @@ pub(super) async fn handle_call(
             mcp_runtime_tool_result_fallback(result)
         }
     };
+    if app_enabled {
+        presentation::attach_result_app_presentation(&params.name, &mut result);
+    }
     let model_ergonomics = model_ergonomics_completion.as_ref().and_then(|completion| {
         result
             .get("structuredContent")

--- a/src/mcp_result_app.html
+++ b/src/mcp_result_app.html
@@ -78,6 +78,9 @@
     addRow(card, "Status", boundedString(item.status));
     addRow(card, "Project", boundedString(item.project));
     addRow(card, "Terminal", typeof item.terminal === "boolean" ? (item.terminal ? "yes" : "no") : null);
+    addRow(card, "Active", typeof item.active === "boolean" ? (item.active ? "yes" : "no") : null);
+    addRow(card, "Blocking", typeof item.blocking_active === "boolean" ? (item.blocking_active ? "yes" : "no") : null);
+    addRow(card, "Stop pending", typeof item.terminal_pending === "boolean" ? (item.terminal_pending ? "yes" : "no") : null);
     addRow(card, "Execution", boundedString(item.command_execution_state));
     addRow(card, "Duration", Number.isFinite(item.duration_ms) ? String(item.duration_ms) + " ms" : null);
     addRow(card, "Elapsed", Number.isFinite(item.elapsed_secs) ? String(item.elapsed_secs) + " s" : null);

--- a/src/mcp_result_app.html
+++ b/src/mcp_result_app.html
@@ -21,7 +21,8 @@
 
   function boundedString(value) {
     if (typeof value !== "string") return null;
-    return value.length <= MAX_TEXT ? value : value.slice(0, MAX_TEXT - 1) + "…";
+    const chars = Array.from(value);
+    return chars.length <= MAX_TEXT ? value : chars.slice(0, MAX_TEXT - 1).join("") + "…";
   }
 
   function request(method, params, timeoutMs = 10000) {

--- a/src/mcp_result_app.html
+++ b/src/mcp_result_app.html
@@ -1,0 +1,172 @@
+<div id="app" style="font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;padding:16px;border:1px solid var(--color-border-primary,rgba(127,127,127,.35));border-radius:12px;max-width:760px;color:var(--color-text-primary,inherit);background:var(--color-background-primary,transparent)">
+  <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+    <strong id="title" style="font-size:17px">WebCodex Job</strong>
+    <span id="state" style="font-size:12px">HTML loaded</span>
+  </div>
+  <div id="summary" style="margin-top:8px;font-size:13px">Minimal MCP Apps handshake · waiting for a supported Job result</div>
+  <div id="cards" style="display:grid;gap:10px;margin-top:12px"></div>
+</div>
+<script>
+(() => {
+  const APP_PROTOCOL = "2026-01-26";
+  const PRESENTATION_KEY = "webcodex/presentation";
+  const MAX_ITEMS = 8;
+  const MAX_TEXT = 256;
+  const stateEl = document.getElementById("state");
+  const titleEl = document.getElementById("title");
+  const summaryEl = document.getElementById("summary");
+  const cardsEl = document.getElementById("cards");
+  const pending = new Map();
+  let nextId = 1;
+
+  function boundedString(value) {
+    if (typeof value !== "string") return null;
+    return value.length <= MAX_TEXT ? value : value.slice(0, MAX_TEXT - 1) + "…";
+  }
+
+  function request(method, params, timeoutMs = 10000) {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(method + " timed out"));
+      }, timeoutMs);
+      pending.set(id, { resolve, reject, timeout });
+      try {
+        window.parent.postMessage({ jsonrpc: "2.0", id, method, params: params || {} }, "*");
+      } catch (error) {
+        pending.delete(id);
+        clearTimeout(timeout);
+        reject(error);
+      }
+    });
+  }
+
+  function notify(method, params) {
+    window.parent.postMessage({ jsonrpc: "2.0", method, ...(params === undefined ? {} : { params }) }, "*");
+  }
+
+  function clearCards() {
+    while (cardsEl.firstChild) cardsEl.removeChild(cardsEl.firstChild);
+  }
+
+  function addRow(card, label, value) {
+    if (value === undefined || value === null || value === "") return;
+    const row = document.createElement("div");
+    row.style.display = "grid";
+    row.style.gridTemplateColumns = "minmax(100px, 140px) 1fr";
+    row.style.gap = "10px";
+    row.style.fontSize = "13px";
+    const key = document.createElement("span");
+    key.style.opacity = ".68";
+    key.textContent = label;
+    const text = document.createElement("span");
+    text.style.overflowWrap = "anywhere";
+    text.textContent = typeof value === "string" ? (boundedString(value) || "") : String(value);
+    row.appendChild(key);
+    row.appendChild(text);
+    card.appendChild(row);
+  }
+
+  function renderItem(item) {
+    if (!item || typeof item !== "object") return;
+    const card = document.createElement("div");
+    card.style.border = "1px solid var(--color-border-secondary,rgba(127,127,127,.25))";
+    card.style.borderRadius = "10px";
+    card.style.padding = "12px";
+    addRow(card, "Job", boundedString(item.job_id));
+    addRow(card, "Status", boundedString(item.status));
+    addRow(card, "Project", boundedString(item.project));
+    addRow(card, "Terminal", typeof item.terminal === "boolean" ? (item.terminal ? "yes" : "no") : null);
+    addRow(card, "Execution", boundedString(item.command_execution_state));
+    addRow(card, "Duration", Number.isFinite(item.duration_ms) ? String(item.duration_ms) + " ms" : null);
+    addRow(card, "Elapsed", Number.isFinite(item.elapsed_secs) ? String(item.elapsed_secs) + " s" : null);
+    addRow(card, "Recovery", boundedString(item.recovery_state));
+    addRow(card, "Recovery reason", boundedString(item.recovery_reason));
+    addRow(card, "Wait/log update", boundedString(item.log_delta_status));
+    addRow(card, "stdout lines", Number.isInteger(item.stdout_lines) ? item.stdout_lines : null);
+    addRow(card, "stderr lines", Number.isInteger(item.stderr_lines) ? item.stderr_lines : null);
+    addRow(card, "Error", boundedString(item.error_kind));
+    addRow(card, "Recovery action", boundedString(item.recovery_kind));
+    addRow(card, "Re-observe with", boundedString(item.recovery_tool));
+    addRow(card, "Guidance", boundedString(item.guidance));
+    cardsEl.appendChild(card);
+  }
+
+  function renderPresentation(presentation) {
+    if (!presentation || typeof presentation !== "object" || presentation.version !== 1) {
+      stateEl.textContent = "result unavailable";
+      summaryEl.textContent = "No bounded WebCodex Job presentation metadata was attached.";
+      clearCards();
+      return;
+    }
+    const items = Array.isArray(presentation.items) ? presentation.items.slice(0, MAX_ITEMS) : [];
+    clearCards();
+    if (presentation.kind === "job_list") {
+      titleEl.textContent = "WebCodex Jobs";
+      const count = Number.isInteger(presentation.count) ? presentation.count : items.length;
+      const matched = Number.isInteger(presentation.matched_count) ? presentation.matched_count : count;
+      summaryEl.textContent = String(count) + " shown · " + String(matched) + " matched"
+        + (presentation.truncated === true ? " · canonical result truncated" : "")
+        + (presentation.items_truncated === true ? " · card subset bounded" : "");
+    } else if (presentation.kind === "job_observation") {
+      titleEl.textContent = items.length === 1 ? "WebCodex Job" : "WebCodex Jobs";
+      const wait = presentation.wait && typeof presentation.wait === "object" ? boundedString(presentation.wait.outcome) : null;
+      const terminal = Number.isInteger(presentation.terminal_count) ? presentation.terminal_count : null;
+      summaryEl.textContent = (wait ? "Observation: " + wait : "Job observation")
+        + (terminal === null ? "" : " · " + String(terminal) + " terminal")
+        + (presentation.output_truncated === true ? " · canonical result truncated" : "")
+        + (presentation.items_truncated === true ? " · card subset bounded" : "");
+    } else {
+      stateEl.textContent = "result rejected";
+      summaryEl.textContent = "Unsupported WebCodex presentation kind.";
+      return;
+    }
+    items.forEach(renderItem);
+    stateEl.textContent = "result received";
+  }
+
+  function renderToolResult(result) {
+    const meta = result && typeof result === "object" && result._meta && typeof result._meta === "object"
+      ? result._meta
+      : null;
+    renderPresentation(meta ? meta[PRESENTATION_KEY] : null);
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.source !== window.parent) return;
+    const message = event.data;
+    if (!message || typeof message !== "object" || message.jsonrpc !== "2.0") return;
+    if (message.id !== undefined && pending.has(message.id)) {
+      const item = pending.get(message.id);
+      pending.delete(message.id);
+      clearTimeout(item.timeout);
+      if (message.error !== undefined) item.reject(message.error);
+      else item.resolve(message.result);
+      return;
+    }
+    if (message.method === "ui/notifications/tool-result") renderToolResult(message.params);
+  }, { passive: true });
+
+  async function initialize() {
+    try {
+      const result = await request("ui/initialize", {
+        protocolVersion: APP_PROTOCOL,
+        appInfo: { name: "webcodex-result-app", title: "WebCodex Result", version: "1.0.0" },
+        appCapabilities: {}
+      });
+      const protocol = result && typeof result === "object" ? boundedString(result.protocolVersion) : null;
+      notify("ui/notifications/initialized", {});
+      if (stateEl.textContent !== "result received") {
+        stateEl.textContent = "initialized";
+        summaryEl.textContent = "MCP Apps initialized" + (protocol ? " · " + protocol : "") + " · waiting for a supported Job result";
+      }
+    } catch (error) {
+      stateEl.textContent = "init failed";
+      summaryEl.textContent = "ui/initialize failed: " + boundedString(String(error && error.message ? error.message : error));
+    }
+  }
+
+  void initialize();
+})();
+</script>

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -215,6 +215,8 @@ mod plugin_tools;
 mod project_connector;
 #[path = "mcp_tests/protocol.rs"]
 mod protocol;
+#[path = "mcp_tests/result_app.rs"]
+mod result_app;
 #[path = "mcp_tests/runtime_tools.rs"]
 mod runtime_tools;
 #[path = "mcp_tests/ssh_resource.rs"]

--- a/src/mcp_tests/result_app.rs
+++ b/src/mcp_tests/result_app.rs
@@ -1,0 +1,658 @@
+use super::*;
+use crate::runner_protocol::{
+    RunnerCapabilities, RunnerJobUpdateRequest, RunnerPollRequest, RunnerProjectSummary,
+    RunnerRegisterRequest,
+};
+use crate::tool_runtime::{ObserveJobsItem, ToolCall};
+
+fn tool<'a>(payload: &'a Value, name: &str) -> &'a Value {
+    payload["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tool| tool["name"] == name)
+        .unwrap_or_else(|| panic!("missing {name} descriptor"))
+}
+
+fn presentation<'a>(call_result: &'a Value) -> &'a Value {
+    &call_result["_meta"][super::super::presentation::MCP_PRESENTATION_META_KEY]
+}
+
+#[test]
+fn job_tool_app_metadata_is_capability_scoped_compact_safe_and_merge_safe() {
+    for compact in [false, true] {
+        let enabled = mcp_tools_list_payload_with_compact_and_app(
+            ModelSurface::FullOperatorRuntime,
+            compact,
+            true,
+        );
+        for name in ["list_jobs", "observe_jobs"] {
+            assert_eq!(
+                tool(&enabled, name)["_meta"]["ui"]["resourceUri"],
+                MCP_RESULT_UI_RESOURCE_URI
+            );
+            assert!(tool(&enabled, name)["_meta"]
+                .get("ui/resourceUri")
+                .is_none());
+        }
+
+        let disabled = mcp_tools_list_payload_with_compact_and_app(
+            ModelSurface::FullOperatorRuntime,
+            compact,
+            false,
+        );
+        for name in ["list_jobs", "observe_jobs"] {
+            assert!(tool(&disabled, name).get("_meta").is_none());
+        }
+    }
+
+    let mut existing = json!({
+        "name": "future_job_tool",
+        "_meta": {
+            "openai/fileParams": ["file"],
+            "ui": {"other": true}
+        }
+    });
+    super::super::tools::attach_app_metadata(&mut existing, MCP_RESULT_UI_RESOURCE_URI);
+    assert_eq!(existing["_meta"]["openai/fileParams"], json!(["file"]));
+    assert_eq!(existing["_meta"]["ui"]["other"], true);
+    assert_eq!(
+        existing["_meta"]["ui"]["resourceUri"],
+        MCP_RESULT_UI_RESOURCE_URI
+    );
+}
+
+#[tokio::test]
+async fn job_app_descriptor_and_resource_exposure_require_ui_operator_capability() {
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
+    let ui_tools = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/list",
+            Some(json!(3201)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(ui_tools) = ui_tools else {
+        panic!("expected UI-capable tools/list");
+    };
+    for name in ["list_jobs", "observe_jobs"] {
+        assert_eq!(
+            tool(&ui_tools["result"], name)["_meta"]["ui"]["resourceUri"],
+            MCP_RESULT_UI_RESOURCE_URI
+        );
+    }
+
+    let plain_tools = handle_mcp_request(
+        &runtime,
+        rpc("tools/list", Some(json!(3202)), mcp_2026_params(json!({}))),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(plain_tools) = plain_tools else {
+        panic!("expected ordinary tools/list");
+    };
+    for name in ["list_jobs", "observe_jobs"] {
+        assert!(tool(&plain_tools["result"], name).get("_meta").is_none());
+    }
+
+    let resources = handle_mcp_request(
+        &runtime,
+        rpc(
+            "resources/list",
+            Some(json!(3203)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(resources) = resources else {
+        panic!("expected UI resources/list");
+    };
+    let resources = resources["result"]["resources"].as_array().unwrap();
+    assert!(resources
+        .iter()
+        .any(|resource| resource["uri"] == MCP_COMPUTER_UI_RESOURCE_URI));
+    let result_resource = resources
+        .iter()
+        .find(|resource| resource["uri"] == MCP_RESULT_UI_RESOURCE_URI)
+        .expect("Result App resource");
+    assert_eq!(result_resource["mimeType"], MCP_UI_RESOURCE_MIME_TYPE);
+    assert_eq!(
+        result_resource["_meta"],
+        json!({
+            "ui": {
+                "prefersBorder": true,
+                "csp": {"connectDomains": [], "resourceDomains": []}
+            }
+        })
+    );
+
+    let read = handle_mcp_request(
+        &runtime,
+        rpc(
+            "resources/read",
+            Some(json!(3204)),
+            mcp_2026_params(json!({"uri": MCP_RESULT_UI_RESOURCE_URI})),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(read) = read else {
+        panic!("expected Result App resource read");
+    };
+    assert_eq!(
+        read["result"]["contents"][0]["uri"],
+        MCP_RESULT_UI_RESOURCE_URI
+    );
+    assert_eq!(
+        read["result"]["contents"][0]["mimeType"],
+        MCP_UI_RESOURCE_MIME_TYPE
+    );
+    assert_eq!(read["result"]["contents"][0]["text"], MCP_RESULT_APP_HTML);
+
+    let no_ui_resources = handle_mcp_request(
+        &runtime,
+        rpc(
+            "resources/list",
+            Some(json!(3205)),
+            mcp_2026_params(json!({})),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(no_ui_resources) = no_ui_resources else {
+        panic!("expected non-UI resources/list");
+    };
+    assert!(no_ui_resources["result"]["resources"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    let local_runtime = test_runtime_with_surface(ModelSurface::LocalCoding);
+    let local_tools = handle_mcp_request(
+        &local_runtime,
+        rpc(
+            "tools/list",
+            Some(json!(3206)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        None,
+    )
+    .await;
+    let McpOutcome::Ok(local_tools) = local_tools else {
+        panic!("expected LocalCoding tools/list");
+    };
+    assert!(local_tools["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|tool| tool
+            .pointer("/_meta/ui/resourceUri")
+            .and_then(Value::as_str)
+            != Some(MCP_RESULT_UI_RESOURCE_URI)));
+
+    assert!(!mcp_app_enabled(
+        true,
+        ModelSurface::LocalCoding,
+        &mcp_2026_ui_params(json!({}))
+    ));
+}
+
+#[test]
+fn job_presentation_is_post_result_bounded_and_private() {
+    let secret = "SECRET-SHOULD-NOT-REACH-PRESENTATION";
+    let jobs = (0..12)
+        .map(|index| {
+            json!({
+                "job_id": format!("job-{index}"),
+                "status": if index == 0 { "lost" } else { "running" },
+                "project": "p".repeat(400),
+                "duration_ms": 25,
+                "elapsed_secs": 1,
+                "command_execution_state": if index == 0 { "outcome_unknown" } else { "completed" },
+                "recovery_state": if index == 0 { "recovering" } else { "reconciled" },
+                "recovery_reason": "r".repeat(400),
+                "stdout_tail": secret,
+                "stderr_tail": secret,
+                "command_summary": secret,
+                "cwd": format!("/private/{secret}"),
+                "observation_token": secret,
+            })
+        })
+        .collect::<Vec<_>>();
+    let canonical = ToolResult::ok(json!({
+        "jobs": jobs,
+        "count": 12,
+        "matched_count": 12,
+        "truncated": true
+    }));
+    let mut framed = super::super::tools::mcp_runtime_tool_result("list_jobs", false, canonical);
+    let structured_before = framed["structuredContent"].clone();
+    super::super::presentation::attach_result_app_presentation("list_jobs", &mut framed);
+    assert_eq!(framed["structuredContent"], structured_before);
+
+    let meta = presentation(&framed);
+    assert_eq!(meta["kind"], "job_list");
+    assert_eq!(meta["items"].as_array().unwrap().len(), 8);
+    assert_eq!(meta["items_truncated"], true);
+    assert_eq!(meta["truncated"], true);
+    assert_eq!(meta["items"][0]["status"], "lost");
+    assert_eq!(
+        meta["items"][0]["command_execution_state"],
+        "outcome_unknown"
+    );
+    assert_eq!(meta["items"][0]["recovery_state"], "recovering");
+    assert_eq!(meta["items"][0]["terminal"], true);
+    assert!(meta["items"][0]["guidance"]
+        .as_str()
+        .unwrap()
+        .contains("uncertain"));
+
+    fn assert_bounded_strings(value: &Value) {
+        match value {
+            Value::String(text) => assert!(
+                text.chars().count() <= super::super::presentation::MAX_MCP_PRESENTATION_TEXT_CHARS,
+                "presentation text exceeded bound: {}",
+                text.chars().count()
+            ),
+            Value::Array(values) => values.iter().for_each(assert_bounded_strings),
+            Value::Object(values) => values.values().for_each(assert_bounded_strings),
+            _ => {}
+        }
+    }
+    assert_bounded_strings(meta);
+    let serialized = serde_json::to_string(meta).unwrap();
+    assert!(!serialized.contains(secret));
+    for forbidden in [
+        "stdout_tail",
+        "stderr_tail",
+        "command_summary",
+        "observation_token",
+        "cwd",
+    ] {
+        assert!(!serialized.contains(forbidden));
+    }
+}
+
+#[test]
+fn observe_presentation_preserves_wait_uncertainty_and_unknown_job_without_log_bodies() {
+    let canonical = ToolResult::ok(json!({
+        "requested_count": 2,
+        "returned_count": 2,
+        "succeeded_count": 1,
+        "failed_count": 1,
+        "items": [
+            {
+                "job_id": "job-uncertain",
+                "success": true,
+                "output": {
+                    "job_id": "job-uncertain",
+                    "status": "lost",
+                    "terminal": true,
+                    "changed": true,
+                    "command_execution_state": "outcome_unknown",
+                    "recovery_state": "lost_after_reconcile",
+                    "log_delta_status": "delta",
+                    "stdout_lines": 500,
+                    "stderr_lines": 2,
+                    "stdout_tail": "SECRET-STDOUT",
+                    "stderr_tail": "SECRET-STDERR",
+                    "observation_token": "opaque-secret-token"
+                }
+            },
+            {
+                "job_id": "missing-job",
+                "success": false,
+                "error_kind": "unknown_job",
+                "recovery_kind": "reobserve",
+                "recovery_tool": "list_jobs",
+                "error": "unbounded internal error text"
+            }
+        ],
+        "wait": {"outcome": "item_error", "waited_ms": 7},
+        "changed_count": 1,
+        "terminal_count": 1,
+        "output_truncated": false,
+        "next_index": null
+    }));
+    let mut framed = super::super::tools::mcp_runtime_tool_result("observe_jobs", false, canonical);
+    let structured_before = framed["structuredContent"].clone();
+    super::super::presentation::attach_result_app_presentation("observe_jobs", &mut framed);
+    assert_eq!(framed["structuredContent"], structured_before);
+    let meta = presentation(&framed);
+    assert_eq!(meta["wait"]["outcome"], "item_error");
+    assert_eq!(meta["items"][0]["status"], "lost");
+    assert_eq!(
+        meta["items"][0]["command_execution_state"],
+        "outcome_unknown"
+    );
+    assert_eq!(meta["items"][1]["error_kind"], "unknown_job");
+    assert_eq!(meta["items"][1]["recovery_tool"], "list_jobs");
+    let serialized = serde_json::to_string(meta).unwrap();
+    for forbidden in [
+        "SECRET-STDOUT",
+        "SECRET-STDERR",
+        "opaque-secret-token",
+        "unbounded internal error text",
+        "stdout_tail",
+        "stderr_tail",
+        "observation_token",
+    ] {
+        assert!(!serialized.contains(forbidden));
+    }
+}
+
+#[test]
+fn result_app_html_is_display_only_and_uses_safe_dom_rendering() {
+    let html = MCP_RESULT_APP_HTML;
+    for expected in [
+        "ui/initialize",
+        "ui/notifications/initialized",
+        "ui/notifications/tool-result",
+        "webcodex/presentation",
+        "textContent",
+        "document.createElement",
+    ] {
+        assert!(html.contains(expected), "missing {expected}");
+    }
+    for forbidden in [
+        "innerHTML",
+        "eval(",
+        "new Function",
+        "localStorage",
+        "indexedDB",
+        "fetch(",
+        "WebSocket",
+        "tools/call",
+        "callServerTool",
+        "ui/update-model-context",
+        "ui/message",
+        "<button",
+    ] {
+        assert!(
+            !html.contains(forbidden),
+            "Result App must not contain {forbidden}"
+        );
+    }
+}
+
+fn result_app_auth() -> crate::auth::AuthContext {
+    crate::auth::AuthContext {
+        kind: crate::auth::AuthKind::Bootstrap,
+        user_id: Some("user-result-app-owner".to_string()),
+        username: Some("result-app-owner".to_string()),
+        api_key_id: Some("key-result-app-owner".to_string()),
+        role: Some("admin".to_string()),
+        scopes: vec!["admin".to_string()],
+        is_bootstrap: true,
+        token_kind: None,
+        allowed_client_id: None,
+        shared_key_hash: None,
+        project_grant_id: None,
+    }
+}
+
+async fn register_job_runner(runtime: &ToolRuntime, auth: &crate::auth::AuthContext) {
+    let capabilities = RunnerCapabilities {
+        async_jobs: true,
+        async_shell_jobs: true,
+        ..Default::default()
+    };
+    runtime
+        .runner_registry
+        .register_with_auth(
+            crate::test_support::current_runner_registration(RunnerRegisterRequest {
+                process_started_at: None,
+                build: None,
+                job_concurrency_limit: None,
+                job_inventory: None,
+                coding_agent_providers: None,
+                coding_agent_inventory: None,
+                client_id: "result-app-runner".to_string(),
+                runner_instance_id: "inst-result-app".to_string(),
+                display_name: None,
+                owner: None,
+                hostname: None,
+                host_context: None,
+                capabilities: crate::test_support::current_runner_capabilities(capabilities),
+                policy: None,
+                runner_protocol_generation: crate::runner_protocol::RUNNER_PROTOCOL_GENERATION_V2,
+            }),
+            Some(&crate::test_support::runner_access(auth)),
+        )
+        .await
+        .unwrap();
+    crate::test_support::apply_project_inventory_snapshot(
+        &runtime.runner_registry,
+        "result-app-runner",
+        "inst-result-app",
+        vec![RunnerProjectSummary {
+            id: "demo".to_string(),
+            name: Some("Result App Demo".to_string()),
+            path: "/tmp/result-app-demo".to_string(),
+            allow_patch: true,
+            kind: Some("repo".to_string()),
+            registration_source: None,
+            description: None,
+            hooks: Vec::new(),
+            disabled: false,
+            revision: None,
+            git_branch: None,
+            git_head: None,
+            git_dirty: None,
+            updated_at: 1,
+            shell_profile: None,
+        }],
+    )
+    .await;
+}
+
+async fn set_job_state(
+    runtime: &ToolRuntime,
+    request: &crate::runner_protocol::RunnerRequest,
+    status: &str,
+    finished: bool,
+) {
+    runtime
+        .runner_registry
+        .update_job(RunnerJobUpdateRequest {
+            client_id: "result-app-runner".to_string(),
+            runner_instance_id: "inst-result-app".to_string(),
+            update_seq: None,
+            job_id: request.job_id.clone().expect("Job id"),
+            request_id: Some(request.request_id.clone()),
+            status: status.to_string(),
+            stdout_chunk: Some("secret log body that presentation must not copy\n".to_string()),
+            stderr_chunk: None,
+            stdout_tail: None,
+            stderr_tail: None,
+            log_snapshot: None,
+            exit_code: finished.then_some(0),
+            duration_ms: finished.then_some(25),
+            error: None,
+            command_execution_state: finished
+                .then_some(crate::runner_protocol::ShellCommandExecutionState::Completed),
+            validation_progress: None,
+            activity: None,
+            finished,
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn mcp_job_presentation_tracks_real_running_to_terminal_transition() {
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
+    let auth = result_app_auth();
+    register_job_runner(&runtime, &auth).await;
+    let started = runtime
+        .dispatch_with_auth(
+            ToolCall::RunJob {
+                project: "agent:result-app-runner:demo".to_string(),
+                command: "echo result-app".to_string(),
+                session_id: None,
+                timeout_secs: Some(60),
+                cwd: None,
+                purpose: None,
+                shell: None,
+            },
+            Some(&auth),
+        )
+        .await;
+    assert!(started.success, "{:?}", started.error);
+    let job_id = started.output["job_id"].as_str().unwrap().to_string();
+    let request = runtime
+        .runner_registry
+        .poll(RunnerPollRequest {
+            client_id: "result-app-runner".to_string(),
+            runner_instance_id: "inst-result-app".to_string(),
+        })
+        .await
+        .unwrap()
+        .expect("queued Job request");
+    set_job_state(&runtime, &request, "running", false).await;
+
+    async fn observe(
+        runtime: &ToolRuntime,
+        auth: &crate::auth::AuthContext,
+        job_id: &str,
+        id: i64,
+    ) -> Value {
+        let outcome = handle_mcp_request(
+            runtime,
+            rpc(
+                "tools/call",
+                Some(json!(id)),
+                mcp_2026_ui_params(json!({
+                    "name": "observe_jobs",
+                    "arguments": {"items": [{"job_id": job_id}]}
+                })),
+            ),
+            Some(auth),
+        )
+        .await;
+        let McpOutcome::Ok(body) = outcome else {
+            panic!("expected observe_jobs MCP result");
+        };
+        body["result"].clone()
+    }
+
+    let running = observe(&runtime, &auth, &job_id, 3210).await;
+    assert_eq!(presentation(&running)["items"][0]["status"], "running");
+    assert_eq!(presentation(&running)["items"][0]["terminal"], false);
+    assert!(serde_json::to_string(presentation(&running))
+        .unwrap()
+        .find("secret log body")
+        .is_none());
+
+    let listed = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(32101)),
+            mcp_2026_ui_params(json!({
+                "name": "list_jobs",
+                "arguments": {"project": "agent:result-app-runner:demo", "limit": 10}
+            })),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Ok(listed) = listed else {
+        panic!("expected list_jobs MCP result");
+    };
+    assert_eq!(presentation(&listed["result"])["kind"], "job_list");
+    assert!(presentation(&listed["result"])["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["job_id"] == job_id && item["status"] == "running"));
+
+    let plain_listed = handle_mcp_request(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(32102)),
+            mcp_2026_params(json!({
+                "name": "list_jobs",
+                "arguments": {"project": "agent:result-app-runner:demo", "limit": 10}
+            })),
+        ),
+        Some(&auth),
+    )
+    .await;
+    let McpOutcome::Ok(plain_listed) = plain_listed else {
+        panic!("expected non-UI list_jobs MCP result");
+    };
+    assert!(plain_listed["result"]["_meta"]
+        .get(super::super::presentation::MCP_PRESENTATION_META_KEY)
+        .is_none());
+    assert_eq!(
+        plain_listed["result"]["structuredContent"]["output"]["jobs"][0]["job_id"],
+        job_id
+    );
+
+    set_job_state(&runtime, &request, "completed", true).await;
+    let completed = observe(&runtime, &auth, &job_id, 3211).await;
+    assert_eq!(presentation(&completed)["items"][0]["status"], "completed");
+    assert_eq!(presentation(&completed)["items"][0]["terminal"], true);
+    assert_eq!(
+        completed["structuredContent"]["output"]["items"][0]["status"],
+        "completed"
+    );
+
+    let unknown = observe(&runtime, &auth, "unknown-result-app-job", 3212).await;
+    assert_eq!(
+        presentation(&unknown)["items"][0]["error_kind"],
+        "unknown_job"
+    );
+    assert_eq!(
+        presentation(&unknown)["items"][0]["recovery_tool"],
+        "list_jobs"
+    );
+
+    assert!(runtime.runner_registry.remove_job_record(&job_id).await);
+}
+
+#[test]
+fn observation_token_remains_only_in_canonical_result() {
+    let canonical = ToolResult::ok(json!({
+        "items": [{
+            "job_id": "job-token",
+            "status": "running",
+            "terminal": false,
+            "changed": false,
+            "log_delta_status": "unchanged",
+            "observation_token": "opaque-continuation-token"
+        }],
+        "wait": {"outcome": "immediate"}
+    }));
+    let mut framed = super::super::tools::mcp_runtime_tool_result("observe_jobs", false, canonical);
+    super::super::presentation::attach_result_app_presentation("observe_jobs", &mut framed);
+    assert_eq!(
+        framed["structuredContent"]["output"]["items"][0]["observation_token"],
+        "opaque-continuation-token"
+    );
+    assert!(!serde_json::to_string(presentation(&framed))
+        .unwrap()
+        .contains("opaque-continuation-token"));
+}
+
+#[test]
+fn observe_jobs_item_limit_matches_presentation_bound() {
+    assert_eq!(super::super::presentation::MAX_MCP_PRESENTATION_ITEMS, 8);
+    let parsed = ToolCall::ObserveJobs {
+        items: (0..8)
+            .map(|index| ObserveJobsItem {
+                job_id: format!("job-{index}"),
+                after_observation_token: None,
+            })
+            .collect(),
+        tail_lines: 40,
+        wait_secs: None,
+    };
+    assert!(matches!(parsed, ToolCall::ObserveJobs { .. }));
+}

--- a/src/mcp_tests/result_app.rs
+++ b/src/mcp_tests/result_app.rs
@@ -210,6 +210,10 @@ fn job_presentation_is_post_result_bounded_and_private() {
                 "job_id": format!("job-{index}"),
                 "status": if index == 0 { "lost" } else { "running" },
                 "project": "p".repeat(400),
+                "active": index != 0,
+                "blocking_active": index != 0,
+                "terminal": index == 0,
+                "terminal_pending": false,
                 "duration_ms": 25,
                 "elapsed_secs": 1,
                 "command_execution_state": if index == 0 { "outcome_unknown" } else { "completed" },
@@ -246,6 +250,9 @@ fn job_presentation_is_post_result_bounded_and_private() {
     );
     assert_eq!(meta["items"][0]["recovery_state"], "recovering");
     assert_eq!(meta["items"][0]["terminal"], true);
+    assert_eq!(meta["items"][0]["active"], false);
+    assert_eq!(meta["items"][0]["blocking_active"], false);
+    assert_eq!(meta["items"][0]["terminal_pending"], false);
     assert!(meta["items"][0]["guidance"]
         .as_str()
         .unwrap()

--- a/src/mcp_tests/result_app.rs
+++ b/src/mcp_tests/result_app.rs
@@ -18,6 +18,30 @@ fn presentation<'a>(call_result: &'a Value) -> &'a Value {
     &call_result["_meta"][super::super::presentation::MCP_PRESENTATION_META_KEY]
 }
 
+async fn handle_with_server_apps_enabled(
+    runtime: &ToolRuntime,
+    request: JsonRpcRequest,
+    auth: Option<&crate::auth::AuthContext>,
+    server_mcp_apps_enabled: bool,
+) -> McpOutcome {
+    let protocol_era = super::super::inferred_protocol_era(&request);
+    super::super::handle_mcp_request_with_lifecycle(
+        runtime,
+        None,
+        request,
+        auth,
+        protocol_era,
+        super::super::HostFileImportTrust::Untrusted,
+        None,
+        None,
+        None,
+        crate::config::mcp_compact_schemas_enabled(),
+        server_mcp_apps_enabled,
+        None,
+    )
+    .await
+}
+
 #[test]
 fn job_tool_app_metadata_is_capability_scoped_compact_safe_and_merge_safe() {
     for compact in [false, true] {
@@ -196,9 +220,160 @@ async fn job_app_descriptor_and_resource_exposure_require_ui_operator_capability
 
     assert!(!mcp_app_enabled(
         true,
+        true,
         ModelSurface::LocalCoding,
         &mcp_2026_ui_params(json!({}))
     ));
+    assert!(!mcp_app_enabled(
+        false,
+        true,
+        ModelSurface::FullOperatorRuntime,
+        &mcp_2026_ui_params(json!({}))
+    ));
+}
+
+#[tokio::test]
+async fn server_mcp_apps_setting_disables_only_app_presentation() {
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
+
+    let enabled = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/list",
+            Some(json!(3207)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        None,
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(enabled) = enabled else {
+        panic!("enabled MCP Apps tools/list failed");
+    };
+    assert_eq!(
+        tool(&enabled["result"], "list_jobs")["_meta"]["ui"]["resourceUri"],
+        MCP_RESULT_UI_RESOURCE_URI
+    );
+
+    let discover = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "server/discover",
+            Some(json!(3208)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        None,
+        false,
+    )
+    .await;
+    let McpOutcome::Ok(discover) = discover else {
+        panic!("MCP discovery with Apps disabled failed");
+    };
+    let capabilities = &discover["result"]["capabilities"];
+    assert_eq!(capabilities["resources"]["listChanged"], false);
+    assert!(capabilities["extensions"].get(MCP_UI_EXTENSION).is_none());
+
+    let tools = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/list",
+            Some(json!(3209)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        None,
+        false,
+    )
+    .await;
+    let McpOutcome::Ok(tools) = tools else {
+        panic!("tools/list with Apps disabled failed");
+    };
+    for name in ["list_jobs", "observe_jobs"] {
+        assert!(tool(&tools["result"], name)
+            .pointer("/_meta/ui/resourceUri")
+            .is_none());
+    }
+
+    let resources = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "resources/list",
+            Some(json!(3213)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        None,
+        false,
+    )
+    .await;
+    let McpOutcome::Ok(resources) = resources else {
+        panic!("resources/list with Apps disabled failed");
+    };
+    assert!(resources["result"]["resources"]
+        .as_array()
+        .is_some_and(Vec::is_empty));
+
+    let read = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "resources/read",
+            Some(json!(3214)),
+            mcp_2026_ui_params(json!({"uri": MCP_RESULT_UI_RESOURCE_URI})),
+        ),
+        None,
+        false,
+    )
+    .await;
+    match read {
+        McpOutcome::BadRequest(value) => {
+            assert_eq!(value["error"]["code"], -32602);
+            assert!(value["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("disabled by Server configuration")));
+        }
+        other => panic!("disabled static App resource must fail closed: {other:?}"),
+    }
+
+    let computer_read = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "resources/read",
+            Some(json!(3216)),
+            mcp_2026_ui_params(json!({"uri": MCP_COMPUTER_UI_RESOURCE_URI})),
+        ),
+        None,
+        false,
+    )
+    .await;
+    match computer_read {
+        McpOutcome::BadRequest(value) => {
+            assert_eq!(value["error"]["code"], -32602);
+            assert!(value["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("disabled by Server configuration")));
+        }
+        other => panic!("disabled Computer App resource must fail closed: {other:?}"),
+    }
+
+    let call = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(3215)),
+            mcp_2026_ui_params(json!({
+                "name": "list_jobs",
+                "arguments": {"limit": 1}
+            })),
+        ),
+        None,
+        false,
+    )
+    .await;
+    let McpOutcome::Ok(call) = call else {
+        panic!("canonical list_jobs call with Apps disabled failed");
+    };
+    assert!(call["result"]["structuredContent"].is_object());
+    assert!(call["result"]["_meta"]
+        .get(super::super::presentation::MCP_PRESENTATION_META_KEY)
+        .is_none());
 }
 
 #[test]
@@ -362,6 +537,7 @@ fn result_app_html_is_display_only_and_uses_safe_dom_rendering() {
         "webcodex/presentation",
         "textContent",
         "document.createElement",
+        "Array.from",
     ] {
         assert!(html.contains(expected), "missing {expected}");
     }


### PR DESCRIPTION
Part of #91

## Summary
- add a shared read-only MCP Result App and link only `list_jobs` / `observe_jobs` on UI-capable stateless operator surfaces
- derive bounded MCP-only Job presentation metadata after canonical `structuredContent`; preserve Job lifecycle, recovery, uncertainty, authority, and non-UI fallback semantics
- add `WEBCODEX_MCP_APPS_ENABLED` as a Server-level switch that defaults on and disables App advertisement/linkage/presentation/static App resources without disabling canonical MCP tools/results or non-App resources
- keep Computer App specialized and independent; make Result App text bounds Unicode-safe
- document that cards are presentation only: future long build/watch completion may feed Goal/AgentTask orchestration, while model/Host continuation remains owned by an explicit durable continuation domain such as Agent Wake / Wake Delivery Attempt

## Validation
- `cargo test -p webcodex mcp::tests::result_app` — 9 passed
- `cargo test -p webcodex mcp_apps` — 2 passed
- `cargo test -p webcodex mcp::tests::computer_app` — 4 passed
- `cargo check -p webcodex` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check origin/main...HEAD` — passed

This is only the Job-family foundation. Validation and Git/changes presentation remain separate follow-up work for #91.