### PR TITLE
Add Git MCP App presentation

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -64,8 +64,10 @@ For a regular independent Windows Server + Runner reached through OpenAI Tunnel,
 
 On operator surfaces, clients advertising MCP Apps HTML support can display
 read-only result cards for `list_jobs`, `observe_jobs`, `cargo_check`, `cargo_test`,
-`go_test`, and `validation_summary`. Validation cards show execution outcomes,
-bounded diagnostics, and current versus historical validation evidence.
+`go_test`, `validation_summary`, `show_changes`, and `git_review_summary`.
+Validation cards show execution outcomes, bounded diagnostics, and current versus
+historical validation evidence; Git cards show bounded worktree or committed-range
+metadata without embedding raw diffs or hunks.
 Cards do not poll, retry, or invoke tools; the canonical tool result remains
 available independently. `WEBCODEX_MCP_APPS_ENABLED=false` disables App metadata
 and resources without disabling the underlying tools.

--- a/src/mcp/presentation.rs
+++ b/src/mcp/presentation.rs
@@ -712,10 +712,13 @@ fn review_file_presentation(file: &Value) -> Option<Value> {
         .get("path_omitted")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let path = match file.get("path") {
-        Some(value) if value.is_string() => Some(safe_repo_relative_path(value)?),
-        _ if path_omitted => None,
-        _ => return None,
+    let path = if path_omitted {
+        None
+    } else {
+        match file.get("path") {
+            Some(value) if value.is_string() => Some(safe_repo_relative_path(value)?),
+            _ => return None,
+        }
     };
     let mut item = Map::new();
     if let Some(path) = path {

--- a/src/mcp/presentation.rs
+++ b/src/mcp/presentation.rs
@@ -17,6 +17,8 @@ pub(super) fn tool_supports_result_app(tool_name: &str) -> bool {
             | "cargo_test"
             | "go_test"
             | "validation_summary"
+            | "show_changes"
+            | "git_review_summary"
     )
 }
 
@@ -511,6 +513,361 @@ fn validation_summary_presentation(output: &Value) -> Option<Value> {
     }))
 }
 
+fn safe_label(value: &Value) -> Option<String> {
+    let value = value.as_str()?;
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-'))
+    {
+        return None;
+    }
+    bounded_text(&Value::String(value.to_string()))
+}
+
+fn safe_repo_relative_path(value: &Value) -> Option<String> {
+    let path = value.as_str()?;
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.starts_with('\\')
+        || path.contains("://")
+        || path.chars().any(char::is_control)
+        || path
+            .split(|ch| ch == '/' || ch == '\\')
+            .any(|component| component == "..")
+    {
+        return None;
+    }
+    let bytes = path.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+    {
+        return None;
+    }
+    bounded_text(value)
+}
+
+fn short_git_commit(value: &Value) -> Option<String> {
+    let value = value.as_str()?;
+    if !(4..=40).contains(&value.len()) || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(value[..value.len().min(8)].to_ascii_lowercase())
+}
+
+fn bounded_safe_labels(source: &Value) -> (Vec<Value>, bool) {
+    let Some(source) = source.as_array() else {
+        return (Vec::new(), false);
+    };
+    let mut values = Vec::new();
+    let mut truncated = false;
+    for value in source {
+        if values.len() == MAX_MCP_PRESENTATION_ITEMS {
+            truncated = true;
+            break;
+        }
+        if let Some(value) = safe_label(value) {
+            values.push(Value::String(value));
+        } else {
+            truncated = true;
+        }
+    }
+    (
+        values,
+        truncated || source.len() > MAX_MCP_PRESENTATION_ITEMS,
+    )
+}
+
+fn show_changes_file_presentation(file: &Value) -> Option<Value> {
+    file.as_object()?;
+    let path = file.get("path").and_then(safe_repo_relative_path)?;
+    let mut item = Map::new();
+    item.insert("path".to_string(), Value::String(path));
+    if let Some(status) = file.get("status").and_then(safe_label) {
+        item.insert("status".to_string(), Value::String(status));
+    }
+    if let Some(kind) = file.get("kind").and_then(safe_label) {
+        item.insert("kind".to_string(), Value::String(kind));
+    }
+    for key in ["staged", "unstaged"] {
+        copy_scalar(file, &mut item, key);
+    }
+    if let Some(old_path) = file.get("old_path").and_then(safe_repo_relative_path) {
+        item.insert("old_path".to_string(), Value::String(old_path));
+    }
+    Some(Value::Object(item))
+}
+
+fn show_changes_status_observation(output: &Value) -> Option<Value> {
+    let observation = output.get("status_observation")?;
+    observation.as_object()?;
+    let mut result = Map::new();
+    for key in ["status", "reason_code"] {
+        if let Some(value) = observation.get(key).and_then(safe_label) {
+            result.insert(key.to_string(), Value::String(value));
+        }
+    }
+    copy_scalar(observation, &mut result, "exit_code");
+    (!result.is_empty()).then_some(Value::Object(result))
+}
+
+fn show_changes_presentation(output: &Value) -> Option<Value> {
+    output.as_object()?;
+    let mut presentation = Map::new();
+    presentation.insert("version".to_string(), Value::from(MCP_PRESENTATION_VERSION));
+    presentation.insert("kind".to_string(), Value::String("git_changes".to_string()));
+    for key in ["branch"] {
+        copy_bounded_text(output, &mut presentation, key);
+    }
+    for key in ["upstream_status", "upstream_reason_code"] {
+        if let Some(value) = output.get(key).and_then(safe_label) {
+            presentation.insert(key.to_string(), Value::String(value));
+        }
+    }
+    for key in [
+        "git_available",
+        "non_git_project",
+        "ahead",
+        "behind",
+        "clean",
+        "files_total",
+        "files_returned",
+        "files_truncated",
+        "files_limit",
+        "transport_safe",
+        "output_truncated",
+    ] {
+        copy_scalar(output, &mut presentation, key);
+    }
+    if let Some(observation) = show_changes_status_observation(output) {
+        presentation.insert("status_observation".to_string(), observation);
+    }
+    if let Some(short) = output.pointer("/head/short").and_then(short_git_commit) {
+        presentation.insert("head".to_string(), json!({"short": short}));
+    }
+    if let Some(counts) = output.get("counts") {
+        if counts.is_object() {
+            let mut bounded_counts = Map::new();
+            for key in [
+                "modified",
+                "added",
+                "deleted",
+                "renamed",
+                "copied",
+                "untracked",
+                "conflicted",
+                "staged",
+                "unstaged",
+            ] {
+                copy_scalar(counts, &mut bounded_counts, key);
+            }
+            presentation.insert("counts".to_string(), Value::Object(bounded_counts));
+        }
+    }
+    let (truncation_reasons, reasons_truncated) = output
+        .get("truncation_reasons")
+        .map(bounded_safe_labels)
+        .unwrap_or_default();
+    if !truncation_reasons.is_empty() {
+        presentation.insert(
+            "truncation_reasons".to_string(),
+            Value::Array(truncation_reasons),
+        );
+    }
+    if reasons_truncated {
+        presentation.insert(
+            "truncation_reasons_truncated".to_string(),
+            Value::Bool(true),
+        );
+    }
+
+    if let Some(source_files) = output.get("files").and_then(Value::as_array) {
+        let mut files = Vec::new();
+        let mut items_truncated = false;
+        for file in source_files {
+            if files.len() == MAX_MCP_PRESENTATION_ITEMS {
+                items_truncated = true;
+                break;
+            }
+            if let Some(file) = show_changes_file_presentation(file) {
+                files.push(file);
+            } else {
+                items_truncated = true;
+            }
+        }
+        presentation.insert("files".to_string(), Value::Array(files));
+        presentation.insert(
+            "items_truncated".to_string(),
+            Value::Bool(items_truncated || source_files.len() > MAX_MCP_PRESENTATION_ITEMS),
+        );
+    }
+    Some(Value::Object(presentation))
+}
+
+fn review_file_presentation(file: &Value) -> Option<Value> {
+    file.as_object()?;
+    let path_omitted = file
+        .get("path_omitted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let path = match file.get("path") {
+        Some(value) if value.is_string() => Some(safe_repo_relative_path(value)?),
+        _ if path_omitted => None,
+        _ => return None,
+    };
+    let mut item = Map::new();
+    if let Some(path) = path {
+        item.insert("path".to_string(), Value::String(path));
+    }
+    item.insert("path_omitted".to_string(), Value::Bool(path_omitted));
+    if let Some(previous_path) = file.get("previous_path").and_then(safe_repo_relative_path) {
+        item.insert("previous_path".to_string(), Value::String(previous_path));
+    }
+    if let Some(status) = file.get("status").and_then(safe_label) {
+        item.insert("status".to_string(), Value::String(status));
+    }
+    for key in ["additions", "deletions", "binary", "gitlink"] {
+        copy_scalar(file, &mut item, key);
+    }
+    let (classes, classes_truncated) = file
+        .get("classes")
+        .map(bounded_safe_labels)
+        .unwrap_or_default();
+    if !classes.is_empty() {
+        item.insert("classes".to_string(), Value::Array(classes));
+    }
+    if classes_truncated {
+        item.insert("classes_truncated".to_string(), Value::Bool(true));
+    }
+    Some(Value::Object(item))
+}
+
+fn git_review_file_classes_presentation(output: &Value) -> Option<Value> {
+    let classes = output.get("file_classes")?;
+    classes.as_object()?;
+    let mut result = Map::new();
+    copy_scalar(classes, &mut result, "partial");
+    if let Some(counts) = classes.get("counts_observed").and_then(Value::as_object) {
+        let mut bounded_counts = Map::new();
+        let mut truncated = false;
+        for (key, value) in counts {
+            if bounded_counts.len() == MAX_MCP_PRESENTATION_ITEMS {
+                truncated = true;
+                break;
+            }
+            let label = safe_label(&Value::String(key.clone()));
+            if let Some(label) = label.filter(|_| value.is_number()) {
+                bounded_counts.insert(label, value.clone());
+            } else {
+                truncated = true;
+            }
+        }
+        result.insert("counts_observed".to_string(), Value::Object(bounded_counts));
+        result.insert(
+            "counts_truncated".to_string(),
+            Value::Bool(truncated || counts.len() > MAX_MCP_PRESENTATION_ITEMS),
+        );
+    }
+    Some(Value::Object(result))
+}
+
+fn git_review_presentation(output: &Value) -> Option<Value> {
+    output.as_object()?;
+    let mut presentation = Map::new();
+    presentation.insert("version".to_string(), Value::from(MCP_PRESENTATION_VERSION));
+    presentation.insert("kind".to_string(), Value::String("git_review".to_string()));
+    for key in ["deterministic", "truncated"] {
+        copy_scalar(output, &mut presentation, key);
+    }
+    if let Some(reason_code) = output.get("reason_code").and_then(safe_label) {
+        presentation.insert("reason_code".to_string(), Value::String(reason_code));
+    }
+    if let Some(scope) = output.get("scope") {
+        if scope.is_object() {
+            let mut bounded_scope = Map::new();
+            for (source, target) in [
+                ("requested_base", "base"),
+                ("requested_head", "head"),
+                ("merge_base", "merge_base"),
+            ] {
+                if let Some(value) = scope.get(source).and_then(short_git_commit) {
+                    bounded_scope.insert(target.to_string(), Value::String(value));
+                }
+            }
+            for key in ["base_is_ancestor", "commit_count"] {
+                copy_scalar(scope, &mut bounded_scope, key);
+            }
+            presentation.insert("scope".to_string(), Value::Object(bounded_scope));
+        }
+    }
+    for (source_key, target_key, fields) in [
+        (
+            "stats",
+            "stats",
+            &["files_changed", "insertions", "deletions", "binary_files"][..],
+        ),
+        (
+            "coverage",
+            "coverage",
+            &[
+                "production_changed",
+                "tests_changed",
+                "docs_changed",
+                "partial",
+            ][..],
+        ),
+        (
+            "truncation",
+            "truncation",
+            &[
+                "files_total",
+                "files_returned",
+                "files_truncated",
+                "classification_partial",
+                "file_stats_partial",
+                "file_modes_partial",
+                "symbols_partial",
+                "subsystems_partial",
+                "signals_partial",
+            ][..],
+        ),
+    ] {
+        if let Some(source) = output.get(source_key).filter(|value| value.is_object()) {
+            let mut target = Map::new();
+            for key in fields {
+                copy_scalar(source, &mut target, key);
+            }
+            presentation.insert(target_key.to_string(), Value::Object(target));
+        }
+    }
+    if let Some(classes) = git_review_file_classes_presentation(output) {
+        presentation.insert("file_classes".to_string(), classes);
+    }
+    if let Some(source_files) = output.get("files").and_then(Value::as_array) {
+        let mut files = Vec::new();
+        let mut items_truncated = false;
+        for file in source_files {
+            if files.len() == MAX_MCP_PRESENTATION_ITEMS {
+                items_truncated = true;
+                break;
+            }
+            if let Some(file) = review_file_presentation(file) {
+                files.push(file);
+            } else {
+                items_truncated = true;
+            }
+        }
+        presentation.insert("files".to_string(), Value::Array(files));
+        presentation.insert(
+            "items_truncated".to_string(),
+            Value::Bool(items_truncated || source_files.len() > MAX_MCP_PRESENTATION_ITEMS),
+        );
+    }
+    Some(Value::Object(presentation))
+}
+
 fn presentation_from_call_result(tool_name: &str, call_result: &Value) -> Option<Value> {
     if !tool_supports_result_app(tool_name) {
         return None;
@@ -522,6 +879,8 @@ fn presentation_from_call_result(tool_name: &str, call_result: &Value) -> Option
         "observe_jobs" => observe_jobs_presentation(output),
         "cargo_check" | "cargo_test" | "go_test" => validation_run_presentation(tool_name, output),
         "validation_summary" => validation_summary_presentation(output),
+        "show_changes" => show_changes_presentation(output),
+        "git_review_summary" => git_review_presentation(output),
         _ => None,
     }
 }

--- a/src/mcp_result_app.html
+++ b/src/mcp_result_app.html
@@ -346,8 +346,9 @@
       if (scope) {
         const base = boundedString(scope.base);
         const head = boundedString(scope.head);
-        addRow(body, "Range", base && head ? base + " → " + head : base || head);
-        addRow(body, "Merge base", boundedString(scope.merge_base));
+        const mergeBase = boundedString(scope.merge_base);
+        addRow(body, "Requested range", base && head ? base + " → " + head : base || head);
+        addRow(body, "Diff range", mergeBase && head ? mergeBase + " → " + head : null);
         addRow(body, "Base is ancestor", typeof scope.base_is_ancestor === "boolean" ? (scope.base_is_ancestor ? "yes" : "no") : null);
       }
       addRow(body, "Deterministic", typeof presentation.deterministic === "boolean" ? (presentation.deterministic ? "yes" : "no") : null);

--- a/src/mcp_result_app.html
+++ b/src/mcp_result_app.html
@@ -252,6 +252,136 @@
     });
   }
 
+  function addGitFile(body, item, reviewMode) {
+    if (!item || typeof item !== "object") return;
+    const path = boundedString(item.path);
+    const status = boundedString(item.status);
+    const oldPath = boundedString(reviewMode ? item.previous_path : item.old_path);
+    const line = document.createElement("div");
+    line.style.fontSize = "12px";
+    line.style.overflowWrap = "anywhere";
+    const facts = [];
+    if (status) facts.push(status);
+    if (reviewMode) {
+      if (Number.isInteger(item.additions)) facts.push("+" + String(item.additions));
+      if (Number.isInteger(item.deletions)) facts.push("−" + String(item.deletions));
+      if (item.binary === true) facts.push("binary");
+      if (item.gitlink === true) facts.push("gitlink");
+      const classes = Array.isArray(item.classes) ? item.classes.slice(0, MAX_ITEMS).map(boundedString).filter(Boolean) : [];
+      if (classes.length) facts.push(classes.join(", "));
+    } else {
+      if (item.staged === true) facts.push("staged");
+      if (item.unstaged === true) facts.push("unstaged");
+    }
+    line.textContent = (path || (item.path_omitted === true ? "path omitted" : "changed file"))
+      + (oldPath ? " ← " + oldPath : "")
+      + (facts.length ? " · " + facts.join(" · ") : "");
+    body.appendChild(line);
+  }
+
+  function renderGitChanges(presentation) {
+    const state = presentation.git_available === false
+      ? (presentation.non_git_project === true ? "Non-Git" : "Git unavailable")
+      : presentation.clean === true
+        ? "Clean"
+        : presentation.clean === false ? "Changes" : "Status unavailable";
+    titleEl.textContent = "Git changes";
+    stateEl.textContent = state;
+    const parts = [];
+    const branch = boundedString(presentation.branch);
+    if (branch) parts.push(branch);
+    if (Number.isInteger(presentation.files_total)) parts.push(String(presentation.files_total) + " changed files");
+    const upstream = boundedString(presentation.upstream_status);
+    if (upstream) parts.push("upstream: " + upstream);
+    if (Number.isInteger(presentation.ahead) && presentation.ahead > 0) parts.push(String(presentation.ahead) + " ahead");
+    if (Number.isInteger(presentation.behind) && presentation.behind > 0) parts.push(String(presentation.behind) + " behind");
+    if (presentation.files_truncated === true || presentation.output_truncated === true || presentation.items_truncated === true) parts.push("bounded view");
+    summaryEl.textContent = parts.length ? parts.join(" · ") : state;
+
+    appendDetailsCard((body) => {
+      addRow(body, "Git available", typeof presentation.git_available === "boolean" ? (presentation.git_available ? "yes" : "no") : null);
+      addRow(body, "Non-Git project", typeof presentation.non_git_project === "boolean" ? (presentation.non_git_project ? "yes" : "no") : null);
+      addRow(body, "Branch", branch);
+      addRow(body, "Head", presentation.head && typeof presentation.head === "object" ? boundedString(presentation.head.short) : null);
+      addRow(body, "Upstream", upstream);
+      addRow(body, "Upstream reason", boundedString(presentation.upstream_reason_code));
+      addRow(body, "Ahead", Number.isInteger(presentation.ahead) ? presentation.ahead : null);
+      addRow(body, "Behind", Number.isInteger(presentation.behind) ? presentation.behind : null);
+      const observation = presentation.status_observation && typeof presentation.status_observation === "object" ? presentation.status_observation : null;
+      if (observation) {
+        addRow(body, "Status observation", boundedString(observation.status));
+        addRow(body, "Status reason", boundedString(observation.reason_code));
+      }
+      const counts = presentation.counts && typeof presentation.counts === "object" ? presentation.counts : null;
+      if (counts) {
+        for (const [key, label] of [["modified", "Modified"], ["added", "Added"], ["deleted", "Deleted"], ["renamed", "Renamed"], ["copied", "Copied"], ["untracked", "Untracked"], ["conflicted", "Conflicted"], ["staged", "Staged"], ["unstaged", "Unstaged"]]) {
+          addRow(body, label, Number.isInteger(counts[key]) ? counts[key] : null);
+        }
+      }
+      const files = Array.isArray(presentation.files) ? presentation.files.slice(0, MAX_ITEMS) : [];
+      files.forEach((item) => addGitFile(body, item, false));
+      if (presentation.files_truncated === true || presentation.items_truncated === true) addRow(body, "Changed files", "bounded/truncated");
+      if (presentation.output_truncated === true) addRow(body, "Canonical output", "truncated");
+    });
+  }
+
+  function renderGitReview(presentation) {
+    titleEl.textContent = "Committed review";
+    stateEl.textContent = boundedString(presentation.reason_code)
+      ? "Unavailable"
+      : presentation.truncated === true
+        ? "Partial"
+        : presentation.deterministic === true ? "Mapped" : "Review metadata";
+    const scope = presentation.scope && typeof presentation.scope === "object" ? presentation.scope : null;
+    const stats = presentation.stats && typeof presentation.stats === "object" ? presentation.stats : null;
+    const parts = [];
+    if (scope && Number.isInteger(scope.commit_count)) parts.push(String(scope.commit_count) + " commits");
+    if (stats && Number.isInteger(stats.files_changed)) parts.push(String(stats.files_changed) + " files");
+    if (stats && Number.isInteger(stats.insertions)) parts.push("+" + String(stats.insertions));
+    if (stats && Number.isInteger(stats.deletions)) parts.push("−" + String(stats.deletions));
+    if (presentation.truncated === true || presentation.items_truncated === true) parts.push("bounded view");
+    summaryEl.textContent = parts.length ? parts.join(" · ") : "Committed-range metadata";
+
+    appendDetailsCard((body) => {
+      if (scope) {
+        const base = boundedString(scope.base);
+        const head = boundedString(scope.head);
+        addRow(body, "Range", base && head ? base + " → " + head : base || head);
+        addRow(body, "Merge base", boundedString(scope.merge_base));
+        addRow(body, "Base is ancestor", typeof scope.base_is_ancestor === "boolean" ? (scope.base_is_ancestor ? "yes" : "no") : null);
+      }
+      addRow(body, "Deterministic", typeof presentation.deterministic === "boolean" ? (presentation.deterministic ? "yes" : "no") : null);
+      addRow(body, "Reason", boundedString(presentation.reason_code));
+      if (stats) {
+        addRow(body, "Files changed", Number.isInteger(stats.files_changed) ? stats.files_changed : null);
+        addRow(body, "Insertions", Number.isInteger(stats.insertions) ? stats.insertions : null);
+        addRow(body, "Deletions", Number.isInteger(stats.deletions) ? stats.deletions : null);
+        addRow(body, "Binary files", Number.isInteger(stats.binary_files) ? stats.binary_files : null);
+      }
+      const coverage = presentation.coverage && typeof presentation.coverage === "object" ? presentation.coverage : null;
+      if (coverage) {
+        addRow(body, "Production changed", typeof coverage.production_changed === "boolean" ? (coverage.production_changed ? "yes" : "no") : null);
+        addRow(body, "Tests changed", typeof coverage.tests_changed === "boolean" ? (coverage.tests_changed ? "yes" : "no") : null);
+        addRow(body, "Docs changed", typeof coverage.docs_changed === "boolean" ? (coverage.docs_changed ? "yes" : "no") : null);
+        addRow(body, "Coverage partial", typeof coverage.partial === "boolean" ? (coverage.partial ? "yes" : "no") : null);
+      }
+      const classes = presentation.file_classes && typeof presentation.file_classes === "object" ? presentation.file_classes : null;
+      if (classes && classes.counts_observed && typeof classes.counts_observed === "object") {
+        Object.entries(classes.counts_observed).slice(0, MAX_ITEMS).forEach(([name, count]) => addRow(body, "Class " + boundedString(name), Number.isInteger(count) ? count : null));
+        if (classes.counts_truncated === true) addRow(body, "File classes", "bounded/truncated");
+      }
+      const truncation = presentation.truncation && typeof presentation.truncation === "object" ? presentation.truncation : null;
+      if (truncation) {
+        addRow(body, "Files returned", Number.isInteger(truncation.files_returned) ? truncation.files_returned : null);
+        addRow(body, "Files total", Number.isInteger(truncation.files_total) ? truncation.files_total : null);
+        addRow(body, "Files truncated", typeof truncation.files_truncated === "boolean" ? (truncation.files_truncated ? "yes" : "no") : null);
+      }
+      const files = Array.isArray(presentation.files) ? presentation.files.slice(0, MAX_ITEMS) : [];
+      files.forEach((item) => addGitFile(body, item, true));
+      if (presentation.items_truncated === true) addRow(body, "Review files", "bounded/truncated");
+    });
+  }
+
   function renderItem(item) {
     if (!item || typeof item !== "object") return;
     const card = document.createElement("div");
@@ -294,6 +424,14 @@
     }
     if (presentation.kind === "validation_summary") {
       renderValidationSummary(presentation);
+      return;
+    }
+    if (presentation.kind === "git_changes") {
+      renderGitChanges(presentation);
+      return;
+    }
+    if (presentation.kind === "git_review") {
+      renderGitReview(presentation);
       return;
     }
     const items = Array.isArray(presentation.items) ? presentation.items.slice(0, MAX_ITEMS) : [];

--- a/src/mcp_tests/result_app.rs
+++ b/src/mcp_tests/result_app.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::runner_protocol::{
     RunnerCapabilities, RunnerJobUpdateRequest, RunnerPollRequest, RunnerProjectSummary,
-    RunnerRegisterRequest,
+    RunnerRegisterRequest, RunnerResultRequest,
 };
 use crate::tool_runtime::{ObserveJobsItem, ToolCall};
 
@@ -18,20 +18,28 @@ fn presentation<'a>(call_result: &'a Value) -> &'a Value {
     &call_result["_meta"][super::super::presentation::MCP_PRESENTATION_META_KEY]
 }
 
-const RESULT_APP_TOOLS: [&str; 6] = [
+const RESULT_APP_TOOLS: [&str; 8] = [
     "list_jobs",
     "observe_jobs",
     "cargo_check",
     "cargo_test",
     "go_test",
     "validation_summary",
+    "show_changes",
+    "git_review_summary",
 ];
-const UNBOUND_RESULT_APP_TOOLS: [&str; 5] = [
+const UNBOUND_RESULT_APP_TOOLS: [&str; 11] = [
     "cargo_fmt",
     "run_shell",
     "run_process",
     "run_job",
     "finish_coding_task",
+    "git_diff_summary",
+    "git_diff",
+    "git_diff_hunks",
+    "git_status",
+    "git_commit_paths",
+    "git_restore_paths",
 ];
 
 fn assert_presentation_strings_bounded(value: &Value) {
@@ -966,6 +974,409 @@ fn validation_summary_presentation_bounds_events_and_excludes_private_event_fiel
 }
 
 #[test]
+fn git_changes_presentation_preserves_canonical_workspace_states() {
+    let clean = projected_result(
+        "show_changes",
+        true,
+        json!({
+            "git_available": true,
+            "non_git_project": false,
+            "branch": "main",
+            "upstream_status": "absent",
+            "upstream_reason_code": "no_upstream",
+            "ahead": null,
+            "behind": null,
+            "head": {"commit": "a".repeat(40), "short": "aaaaaaaa", "summary": "canonical subject"},
+            "status_observation": {"status": "observed", "reason_code": null, "exit_code": 0},
+            "clean": true,
+            "counts": {"modified": 0, "added": 0, "deleted": 0, "renamed": 0, "copied": 0, "untracked": 0, "conflicted": 0, "staged": 0, "unstaged": 0},
+            "files": [],
+            "files_total": 0,
+            "files_returned": 0,
+            "files_truncated": false,
+            "files_limit": 200,
+            "transport_safe": true,
+            "output_truncated": false,
+            "truncation_reasons": []
+        }),
+    );
+    let clean_meta = presentation(&clean);
+    assert_eq!(clean_meta["kind"], "git_changes");
+    assert_eq!(clean_meta["git_available"], true);
+    assert_eq!(clean_meta["clean"], true);
+    assert_eq!(clean_meta["branch"], "main");
+    assert_eq!(clean_meta["upstream_status"], "absent");
+    assert_eq!(clean_meta["head"]["short"], "aaaaaaaa");
+    assert_eq!(clean_meta["files_total"], 0);
+
+    let dirty = projected_result(
+        "show_changes",
+        true,
+        json!({
+            "git_available": true,
+            "non_git_project": false,
+            "branch": "feature/git-card",
+            "upstream_status": "unobserved",
+            "upstream_reason_code": "git_status_unobserved",
+            "ahead": 2,
+            "behind": 1,
+            "head": {"short": "12345678"},
+            "status_observation": {"status": "observed", "reason_code": null, "exit_code": 0},
+            "clean": false,
+            "counts": {"modified": 2, "added": 1, "deleted": 1, "renamed": 1, "copied": 0, "untracked": 1, "conflicted": 1, "staged": 2, "unstaged": 3},
+            "files": [
+                {"path": "src/lib.rs", "status": "modified", "staged": true, "unstaged": true, "kind": "tracked"},
+                {"path": "src/new.rs", "old_path": "src/old.rs", "status": "renamed", "staged": true, "unstaged": false, "kind": "tracked"},
+                {"path": "notes.txt", "status": "untracked", "staged": false, "unstaged": false, "kind": "untracked"},
+                {"path": "src/conflict.rs", "status": "conflicted", "staged": false, "unstaged": false, "kind": "conflicted"}
+            ],
+            "files_total": 4,
+            "files_returned": 4,
+            "files_truncated": false,
+            "files_limit": 200,
+            "transport_safe": true,
+            "output_truncated": false,
+            "truncation_reasons": []
+        }),
+    );
+    let dirty_meta = presentation(&dirty);
+    assert_eq!(dirty_meta["clean"], false);
+    assert_eq!(dirty_meta["ahead"], 2);
+    assert_eq!(dirty_meta["behind"], 1);
+    assert_eq!(dirty_meta["counts"]["staged"], 2);
+    assert_eq!(dirty_meta["counts"]["unstaged"], 3);
+    assert_eq!(dirty_meta["counts"]["untracked"], 1);
+    assert_eq!(dirty_meta["counts"]["conflicted"], 1);
+    assert_eq!(dirty_meta["counts"]["renamed"], 1);
+    assert_eq!(dirty_meta["files"][1]["old_path"], "src/old.rs");
+
+    let non_git = projected_result(
+        "show_changes",
+        true,
+        json!({
+            "git_available": false,
+            "non_git_project": true,
+            "branch": null,
+            "upstream_status": "unobserved",
+            "upstream_reason_code": "git_unavailable",
+            "ahead": null,
+            "behind": null,
+            "head": {"short": null},
+            "status_observation": {"status": "non_git", "reason_code": "not_a_git_repository", "exit_code": 128},
+            "clean": null,
+            "counts": {"modified": 0, "added": 0, "deleted": 0, "renamed": 0, "copied": 0, "untracked": 0, "conflicted": null, "staged": 0, "unstaged": 0},
+            "files": [],
+            "files_total": null,
+            "files_returned": 0,
+            "files_truncated": false,
+            "transport_safe": false,
+            "output_truncated": false,
+            "truncation_reasons": []
+        }),
+    );
+    let non_git_meta = presentation(&non_git);
+    assert_eq!(non_git_meta["git_available"], false);
+    assert_eq!(non_git_meta["non_git_project"], true);
+    assert!(
+        non_git_meta.get("clean").is_none(),
+        "unavailable Git status must not become clean"
+    );
+    assert_eq!(non_git_meta["status_observation"]["status"], "non_git");
+    assert_eq!(non_git_meta["upstream_status"], "unobserved");
+}
+
+#[test]
+fn git_changes_presentation_bounds_paths_and_excludes_raw_private_fields() {
+    let secret = "GIT_PRESENTATION_SECRET_MARKER";
+    let mut files = vec![
+        json!({"path": format!("/private/{secret}"), "status": "modified", "kind": "tracked"}),
+        json!({"path": format!("https://example.invalid/{secret}"), "status": "modified", "kind": "tracked"}),
+        json!({"path": format!("../{secret}"), "status": "modified", "kind": "tracked"}),
+        json!({"path": format!("C:\\private\\{secret}"), "status": "modified", "kind": "tracked"}),
+        json!({"path": format!("src/{}{}", "x".repeat(320), secret), "status": "modified", "staged": false, "unstaged": true, "kind": "tracked"}),
+    ];
+    files.extend((0..12).map(|index| {
+        json!({
+            "path": format!("src/safe-{index}.rs"),
+            "status": if index == 0 { "renamed" } else { "modified" },
+            "old_path": (index == 0).then(|| format!("old/safe-{index}.rs")),
+            "staged": index % 2 == 0,
+            "unstaged": index % 2 == 1,
+            "kind": "tracked"
+        })
+    }));
+    let framed = projected_result(
+        "show_changes",
+        true,
+        json!({
+            "git_available": true,
+            "non_git_project": false,
+            "branch": "feature/git-card",
+            "upstream_status": "ahead",
+            "upstream_reason_code": "tracking_branch_observed",
+            "upstream": format!("https://user:{secret}@example.invalid/repo.git"),
+            "ahead": 1,
+            "behind": 0,
+            "head": {"short": "abcdef12", "summary": secret},
+            "status_observation": {"status": "observed", "reason_code": null, "exit_code": 0, "repository_probe": format!("/{secret}")},
+            "clean": false,
+            "counts": {"modified": 16, "added": 0, "deleted": 0, "renamed": 1, "copied": 0, "untracked": 0, "conflicted": 0, "staged": 6, "unstaged": 7},
+            "files": files,
+            "files_total": 17,
+            "files_returned": 17,
+            "files_truncated": true,
+            "files_limit": 200,
+            "transport_safe": true,
+            "output_truncated": true,
+            "truncation_reasons": ["status_file_count_limit"],
+            "diff_stat": format!("src/{secret}.rs | 99 +++++"),
+            "diff": format!("RAW_DIFF_{secret}"),
+            "hunks": [{"diff": format!("RAW_HUNK_{secret}")}],
+            "untracked_previews": [{"body": format!("PREVIEW_{secret}")}],
+            "porcelain": format!(" M /private/{secret}"),
+            "stdout": format!("STDOUT_{secret}"),
+            "stderr": format!("STDERR_{secret}"),
+            "command": format!("git status {secret}"),
+            "argv": [secret],
+            "cwd": format!("/absolute/{secret}"),
+            "remote_url": format!("https://{secret}@example.invalid"),
+            "Authorization": format!("Bearer {secret}"),
+            "credential": secret,
+            "token": secret,
+            "suggested_next_actions": [format!("do something with {secret}")]
+        }),
+    );
+    let meta = presentation(&framed);
+    assert_eq!(meta["kind"], "git_changes");
+    assert!(meta["files"].as_array().unwrap().len() <= 8);
+    assert_eq!(meta["items_truncated"], true);
+    assert_eq!(meta["files_truncated"], true);
+    assert_eq!(meta["output_truncated"], true);
+    assert!(meta["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["path"] == "src/safe-0.rs"));
+    let oversized = meta["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find_map(|item| {
+            item["path"]
+                .as_str()
+                .filter(|path| path.starts_with("src/xxx"))
+        })
+        .expect("bounded oversized repository-relative path");
+    assert!(oversized.chars().count() <= 256);
+    assert!(!oversized.contains(secret));
+    assert_presentation_strings_bounded(meta);
+    let serialized = serde_json::to_string(meta).unwrap();
+    for forbidden in [
+        secret,
+        "RAW_DIFF_",
+        "RAW_HUNK_",
+        "PREVIEW_",
+        "\"diff_stat\"",
+        "\"hunks\"",
+        "\"untracked_previews\"",
+        "\"porcelain\"",
+        "\"stdout\"",
+        "\"stderr\"",
+        "\"command\"",
+        "\"argv\"",
+        "\"cwd\"",
+        "\"remote_url\"",
+        "\"Authorization\"",
+        "\"credential\"",
+        "\"token\"",
+        "\"suggested_next_actions\"",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "leaked {forbidden}: {serialized}"
+        );
+    }
+}
+
+#[test]
+fn git_review_presentation_preserves_scope_stats_files_and_partial_state() {
+    let base = "a".repeat(40);
+    let head = "b".repeat(40);
+    let complete = projected_result(
+        "git_review_summary",
+        true,
+        json!({
+            "scope": {"requested_base": base, "requested_head": head, "merge_base": "a".repeat(40), "base_is_ancestor": true, "commit_count": 3, "diff_range": "raw range"},
+            "stats": {"files_changed": 4, "insertions": 12, "deletions": 7, "binary_files": 1},
+            "file_classes": {"counts_observed": {"production": 2, "test": 1, "docs": 1}, "partial": false},
+            "coverage": {"production_changed": true, "tests_changed": true, "docs_changed": true, "partial": false},
+            "truncation": {"files_total": 4, "files_returned": 4, "files_truncated": false, "classification_partial": false, "file_stats_partial": false, "file_modes_partial": false, "symbols_partial": false, "subsystems_partial": false, "signals_partial": false},
+            "files": [
+                {"path": "src/new.rs", "previous_path": "src/old.rs", "path_omitted": false, "status": "renamed", "additions": 5, "deletions": 2, "binary": false, "gitlink": false, "classes": ["production"], "symbols": ["ignored"]},
+                {"path": "src/added.rs", "previous_path": null, "path_omitted": false, "status": "added", "additions": 4, "deletions": 0, "binary": false, "gitlink": false, "classes": ["production"]},
+                {"path": "tests/deleted.rs", "previous_path": null, "path_omitted": false, "status": "deleted", "additions": 0, "deletions": 5, "binary": false, "gitlink": false, "classes": ["test"]},
+                {"path": "docs/blob.bin", "previous_path": null, "path_omitted": false, "status": "modified", "additions": null, "deletions": null, "binary": true, "gitlink": false, "classes": ["docs"]}
+            ],
+            "deterministic": true,
+            "llm_summary": false,
+            "truncated": false,
+            "reason_code": null
+        }),
+    );
+    let meta = presentation(&complete);
+    assert_eq!(meta["kind"], "git_review");
+    assert_eq!(meta["scope"]["base"], "aaaaaaaa");
+    assert_eq!(meta["scope"]["head"], "bbbbbbbb");
+    assert_eq!(meta["scope"]["base_is_ancestor"], true);
+    assert_eq!(meta["scope"]["commit_count"], 3);
+    assert_eq!(meta["stats"]["files_changed"], 4);
+    assert_eq!(meta["stats"]["insertions"], 12);
+    assert_eq!(meta["stats"]["deletions"], 7);
+    assert_eq!(meta["stats"]["binary_files"], 1);
+    assert_eq!(meta["coverage"]["production_changed"], true);
+    assert_eq!(meta["coverage"]["tests_changed"], true);
+    assert_eq!(meta["coverage"]["docs_changed"], true);
+    assert_eq!(meta["files"][0]["status"], "renamed");
+    assert_eq!(meta["files"][0]["previous_path"], "src/old.rs");
+    assert_eq!(meta["files"][3]["binary"], true);
+    assert_eq!(meta["truncated"], false);
+
+    let partial = projected_result(
+        "git_review_summary",
+        true,
+        json!({
+            "scope": {"requested_base": "c".repeat(40), "requested_head": "d".repeat(40), "merge_base": "c".repeat(40), "base_is_ancestor": true, "commit_count": 9},
+            "stats": {"files_changed": 120, "insertions": 500, "deletions": 250, "binary_files": 2},
+            "file_classes": {"counts_observed": {"production": 70}, "partial": true},
+            "coverage": {"production_changed": true, "tests_changed": null, "docs_changed": null, "partial": true},
+            "truncation": {"files_total": 120, "files_returned": 80, "files_truncated": true, "classification_partial": true, "file_stats_partial": true, "file_modes_partial": false, "symbols_partial": true, "subsystems_partial": true, "signals_partial": true},
+            "files": [{"path": null, "previous_path": null, "path_omitted": true, "status": "modified", "additions": null, "deletions": null, "binary": null, "gitlink": null, "classes": []}],
+            "deterministic": true,
+            "truncated": true
+        }),
+    );
+    let partial_meta = presentation(&partial);
+    assert_eq!(partial_meta["truncated"], true);
+    assert_eq!(partial_meta["coverage"]["partial"], true);
+    assert_eq!(partial_meta["file_classes"]["partial"], true);
+    assert_eq!(partial_meta["truncation"]["files_total"], 120);
+    assert_eq!(partial_meta["truncation"]["files_returned"], 80);
+    assert_eq!(partial_meta["truncation"]["files_truncated"], true);
+    assert_eq!(partial_meta["truncation"]["classification_partial"], true);
+    assert_eq!(partial_meta["files"][0]["path_omitted"], true);
+}
+
+#[test]
+fn git_review_presentation_bounds_file_metadata_and_excludes_raw_diff_context() {
+    let secret = "GIT_REVIEW_PRESENTATION_SECRET";
+    let base = "e".repeat(40);
+    let head = "f".repeat(40);
+    let class_counts = (0..12)
+        .map(|index| (format!("class_{index}"), Value::from(index + 1)))
+        .collect::<serde_json::Map<_, _>>();
+    let mut files = vec![json!({
+        "path": format!("/absolute/{secret}"), "previous_path": null, "path_omitted": false,
+        "status": "modified", "additions": 1, "deletions": 1, "binary": false, "gitlink": false,
+        "classes": ["production"], "symbols": [secret]
+    })];
+    files.extend((0..12).map(|index| {
+        json!({
+            "path": format!("src/review-{index}.rs"),
+            "previous_path": (index == 0).then(|| format!("/private/{secret}")),
+            "path_omitted": false,
+            "status": if index == 0 { "renamed" } else { "modified" },
+            "additions": index + 1,
+            "deletions": index,
+            "binary": index == 3,
+            "gitlink": index == 4,
+            "classes": (0..12).map(|class| format!("class_{class}")).collect::<Vec<_>>(),
+            "symbols": [format!("fn {secret}_{index}()")],
+            "symbol_inspection": secret
+        })
+    }));
+    let framed = projected_result(
+        "git_review_summary",
+        true,
+        json!({
+            "scope": {"requested_base": base, "requested_head": head, "merge_base": "e".repeat(40), "base_is_ancestor": true, "commit_count": 2, "diff_range": format!("{}..{}", "e".repeat(40), "f".repeat(40))},
+            "stats": {"files_changed": 13, "insertions": 91, "deletions": 78, "binary_files": 1},
+            "file_classes": {"counts_observed": class_counts, "partial": false},
+            "coverage": {"production_changed": true, "tests_changed": false, "docs_changed": false, "partial": false},
+            "truncation": {"files_total": 13, "files_returned": 13, "files_truncated": false, "classification_partial": false, "file_stats_partial": false, "file_modes_partial": false, "symbols_partial": true, "subsystems_partial": false, "signals_partial": false},
+            "files": files,
+            "subsystems": [{"name": secret, "paths": [format!("/private/{secret}")]}],
+            "signals": [{"name": secret, "reason": secret, "paths": [format!("/private/{secret}")]}],
+            "warnings": [secret],
+            "raw_diff": format!("@@ -1 +1 @@ {secret}"),
+            "raw_hunk": format!("HUNK_{secret}"),
+            "stdout": secret,
+            "stderr": secret,
+            "command": secret,
+            "argv": [secret],
+            "cwd": format!("/private/{secret}"),
+            "remote_url": format!("https://{secret}@example.invalid"),
+            "Authorization": format!("Bearer {secret}"),
+            "credential": secret,
+            "token": secret,
+            "deterministic": true,
+            "llm_summary": false,
+            "truncated": true,
+            "reason_code": null
+        }),
+    );
+    let meta = presentation(&framed);
+    assert_eq!(meta["kind"], "git_review");
+    assert!(meta["files"].as_array().unwrap().len() <= 8);
+    assert_eq!(meta["items_truncated"], true);
+    assert_eq!(
+        meta["file_classes"]["counts_observed"]
+            .as_object()
+            .unwrap()
+            .len(),
+        8
+    );
+    assert_eq!(meta["file_classes"]["counts_truncated"], true);
+    assert!(meta["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|item| item["classes"].as_array().unwrap().len() <= 8));
+    assert_eq!(meta["files"][0]["path"], "src/review-0.rs");
+    assert!(meta["files"][0].get("previous_path").is_none());
+    assert_eq!(meta["stats"]["files_changed"], 13);
+    assert_presentation_strings_bounded(meta);
+    let serialized = serde_json::to_string(meta).unwrap();
+    for forbidden in [
+        secret,
+        &"e".repeat(40),
+        &"f".repeat(40),
+        "@@ -1 +1 @@",
+        "HUNK_",
+        "\"subsystems\"",
+        "\"signals\"",
+        "\"symbols\"",
+        "\"warnings\"",
+        "\"raw_diff\"",
+        "\"raw_hunk\"",
+        "\"stdout\"",
+        "\"stderr\"",
+        "\"command\"",
+        "\"argv\"",
+        "\"cwd\"",
+        "\"remote_url\"",
+        "\"Authorization\"",
+        "\"credential\"",
+        "\"token\"",
+        "\"diff_range\"",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "leaked {forbidden}: {serialized}"
+        );
+    }
+}
+
+#[test]
 fn validation_presentation_is_fail_open_for_unknown_shapes_and_unbound_tools() {
     let canonical = ToolResult::ok(json!({"future_validation_shape": [1, 2, 3]}));
     let mut framed = super::super::tools::mcp_runtime_tool_result("cargo_check", false, canonical);
@@ -998,6 +1409,10 @@ fn result_app_html_is_display_only_and_uses_safe_dom_rendering() {
         "document.createElement(\"details\")",
         "validation_run",
         "validation_summary",
+        "git_changes",
+        "git_review",
+        "Git changes",
+        "Committed review",
         "Cargo Test",
         "Array.from",
         "Cargo test zero tests",
@@ -1043,6 +1458,9 @@ fn result_app_auth() -> crate::auth::AuthContext {
 
 async fn register_job_runner(runtime: &ToolRuntime, auth: &crate::auth::AuthContext) {
     let capabilities = RunnerCapabilities {
+        shell: true,
+        git: true,
+        internal_posix_script: true,
         async_jobs: true,
         async_shell_jobs: true,
         structured_validation_argv: true,
@@ -1185,6 +1603,64 @@ async fn complete_result_app_validation_job(
         })
         .await
         .unwrap();
+}
+
+async fn complete_result_app_show_changes(
+    runtime: &ToolRuntime,
+    request: &crate::runner_protocol::RunnerRequest,
+) {
+    assert_eq!(request.kind, "run_internal_posix_script");
+    let stdout = crate::tool_runtime::framed_clean_show_changes_test_stdout(
+        "secret canonical subject not projected",
+        false,
+    );
+    runtime
+        .runner_registry
+        .complete(RunnerResultRequest {
+            client_id: "result-app-runner".to_string(),
+            runner_instance_id: "inst-result-app".to_string(),
+            request_id: request.request_id.clone(),
+            exit_code: Some(0),
+            stdout: Some(stdout),
+            stderr: Some(String::new()),
+            duration_ms: Some(1),
+            error: None,
+        })
+        .await
+        .unwrap();
+}
+
+async fn mcp_show_changes_result(
+    runtime: &ToolRuntime,
+    auth: &crate::auth::AuthContext,
+    id: i64,
+    ui: bool,
+    server_apps_enabled: bool,
+) -> Value {
+    let params = json!({
+        "name": "show_changes",
+        "arguments": {"project": "agent:result-app-runner:demo", "include_diff": false}
+    });
+    let params = if ui {
+        mcp_2026_ui_params(params)
+    } else {
+        mcp_2026_params(params)
+    };
+    let call = handle_with_server_apps_enabled(
+        runtime,
+        rpc("tools/call", Some(json!(id)), params),
+        Some(auth),
+        server_apps_enabled,
+    );
+    let complete = async {
+        let request = wait_for_result_app_runner_request(runtime).await;
+        complete_result_app_show_changes(runtime, &request).await;
+    };
+    let (outcome, _) = tokio::join!(call, complete);
+    let McpOutcome::Ok(body) = outcome else {
+        panic!("expected show_changes MCP result");
+    };
+    body["result"].clone()
 }
 
 #[tokio::test]
@@ -1462,6 +1938,36 @@ async fn mcp_validation_run_and_summary_use_real_canonical_contracts() {
         summary_result["structuredContent"]
     );
     assert!(plain["result"]["_meta"]
+        .get(super::super::presentation::MCP_PRESENTATION_META_KEY)
+        .is_none());
+}
+
+#[tokio::test]
+async fn mcp_show_changes_uses_real_canonical_framing_and_app_gating() {
+    let runtime = test_runtime_with_surface(ModelSurface::FullOperatorRuntime);
+    let auth = result_app_auth();
+    register_job_runner(&runtime, &auth).await;
+
+    let ui = mcp_show_changes_result(&runtime, &auth, 3230, true, true).await;
+    let canonical = ui["structuredContent"].clone();
+    assert_eq!(canonical["output"]["git_available"], true);
+    assert_eq!(canonical["output"]["clean"], true);
+    assert_eq!(canonical["output"]["branch"], "main");
+    let meta = presentation(&ui);
+    assert_eq!(meta["kind"], "git_changes");
+    assert_eq!(meta["git_available"], true);
+    assert_eq!(meta["clean"], true);
+    assert_eq!(meta["branch"], "main");
+
+    let disabled = mcp_show_changes_result(&runtime, &auth, 3231, true, false).await;
+    assert_eq!(disabled["structuredContent"], canonical);
+    assert!(disabled["_meta"]
+        .get(super::super::presentation::MCP_PRESENTATION_META_KEY)
+        .is_none());
+
+    let plain = mcp_show_changes_result(&runtime, &auth, 3232, false, true).await;
+    assert_eq!(plain["structuredContent"], canonical);
+    assert!(plain["_meta"]
         .get(super::super::presentation::MCP_PRESENTATION_META_KEY)
         .is_none());
 }

--- a/src/mcp_tests/result_app.rs
+++ b/src/mcp_tests/result_app.rs
@@ -1250,7 +1250,7 @@ fn git_review_presentation_preserves_scope_stats_files_and_partial_state() {
             "file_classes": {"counts_observed": {"production": 70}, "partial": true},
             "coverage": {"production_changed": true, "tests_changed": null, "docs_changed": null, "partial": true},
             "truncation": {"files_total": 120, "files_returned": 80, "files_truncated": true, "classification_partial": true, "file_stats_partial": true, "file_modes_partial": false, "symbols_partial": true, "subsystems_partial": true, "signals_partial": true},
-            "files": [{"path": null, "previous_path": null, "path_omitted": true, "status": "modified", "additions": null, "deletions": null, "binary": null, "gitlink": null, "classes": []}],
+            "files": [{"path": "/private/must-not-render", "previous_path": null, "path_omitted": true, "status": "modified", "additions": null, "deletions": null, "binary": null, "gitlink": null, "classes": []}],
             "deterministic": true,
             "truncated": true
         }),
@@ -1264,6 +1264,10 @@ fn git_review_presentation_preserves_scope_stats_files_and_partial_state() {
     assert_eq!(partial_meta["truncation"]["files_truncated"], true);
     assert_eq!(partial_meta["truncation"]["classification_partial"], true);
     assert_eq!(partial_meta["files"][0]["path_omitted"], true);
+    assert!(
+        partial_meta["files"][0].get("path").is_none(),
+        "canonical path_omitted must suppress a contradictory path value"
+    );
 }
 
 #[test]

--- a/src/mcp_tests/result_app.test.mjs
+++ b/src/mcp_tests/result_app.test.mjs
@@ -98,6 +98,32 @@ test("git review renders bounded committed-range metadata", () => {
   assert.equal(view.nodes.cards.children.length, 1);
 });
 
+test("git review distinguishes requested commits from the actual merge-base diff", () => {
+  const view = app();
+  view.result({
+    ...partialReview,
+    scope: { base: "aaaaaaaa", head: "bbbbbbbb", merge_base: "cccccccc", base_is_ancestor: false, commit_count: 1 },
+  });
+  const text = node => [node.textContent, ...node.children.map(text)].join(" ");
+  const details = text(view.nodes.cards);
+  assert.match(details, /Requested range aaaaaaaa → bbbbbbbb/);
+  assert.match(details, /Diff range cccccccc → bbbbbbbb/);
+  assert.match(details, /Base is ancestor no/);
+});
+
+test("git review does not infer a diff range when merge-base observation failed", () => {
+  const view = app();
+  view.result({
+    version: 1, kind: "git_review", reason_code: "no_merge_base", deterministic: true,
+    scope: { base: "aaaaaaaa", head: "bbbbbbbb" },
+  });
+  const text = node => [node.textContent, ...node.children.map(text)].join(" ");
+  const details = text(view.nodes.cards);
+  assert.equal(view.nodes.state.textContent, "Unavailable");
+  assert.match(details, /Requested range aaaaaaaa → bbbbbbbb/);
+  assert.doesNotMatch(details, /Diff range/);
+});
+
 test("untrusted messages are ignored and later results replace earlier cards", () => {
   const view = app();
   view.result(passed, {});

--- a/src/mcp_tests/result_app.test.mjs
+++ b/src/mcp_tests/result_app.test.mjs
@@ -43,6 +43,20 @@ function app() {
 }
 
 const passed = { version: 1, kind: "validation_run", tool: "cargo_test", execution_state: "completed", passed: true, tests_run_count: 2, tests_passed: 2 };
+const cleanGit = {
+  version: 1, kind: "git_changes",
+  branch: "main", upstream_status: "absent", clean: true,
+  files_total: 0, files_truncated: false, output_truncated: false, items_truncated: false,
+  counts: { modified: 0, added: 0, deleted: 0, renamed: 0, copied: 0, untracked: 0, conflicted: 0, staged: 0, unstaged: 0 },
+  files: [],
+};
+const partialReview = {
+  version: 1, kind: "git_review", deterministic: true, truncated: true, items_truncated: true,
+  scope: { base: "aaaaaaaa", head: "bbbbbbbb", base_is_ancestor: true, commit_count: 1 },
+  stats: { files_changed: 2, insertions: 3, deletions: 1, binary_files: 0 },
+  coverage: { production_changed: true, tests_changed: false, docs_changed: false, partial: true },
+  files: [{ path: "src/lib.rs", path_omitted: false, status: "modified", additions: 3, deletions: 1, binary: false, gitlink: false, classes: ["production"] }],
+};
 
 for (const outcome of ["success", "error", "timeout"]) {
   for (const early of [true, false]) {
@@ -60,6 +74,29 @@ for (const outcome of ["success", "error", "timeout"]) {
     });
   }
 }
+
+for (const outcome of ["success", "error", "timeout"]) {
+  for (const early of [true, false]) {
+    test(`git changes survives initialize ${outcome}, result ${early ? "before" : "after"}`, async () => {
+      const view = app();
+      if (early) view.result(cleanGit);
+      view.initialize(outcome);
+      await Promise.resolve();
+      if (!early) view.result(cleanGit);
+      assert.equal(view.nodes.state.textContent, "Clean");
+      assert.equal(view.nodes.summary.textContent, "main · 0 changed files · upstream: absent");
+      assert.equal(view.nodes.cards.children.length, 1);
+    });
+  }
+}
+
+test("git review renders bounded committed-range metadata", () => {
+  const view = app();
+  view.result(partialReview);
+  assert.equal(view.nodes.state.textContent, "Partial");
+  assert.equal(view.nodes.summary.textContent, "1 commits · 2 files · +3 · −1 · bounded view");
+  assert.equal(view.nodes.cards.children.length, 1);
+});
 
 test("untrusted messages are ignored and later results replace earlier cards", () => {
   const view = app();


### PR DESCRIPTION
## Summary

Final initial-scope slice for #91. This extends the shared read-only MCP Result App to bounded Git/change presentation without changing canonical Git execution or structured results.

- bind only `show_changes` and `git_review_summary` to the existing `ui://webcodex/result/v1` resource
- project bounded `git_changes` and `git_review` metadata from final MCP `structuredContent`
- keep raw diffs/hunks, porcelain, commands, absolute paths, credentials, remote URLs, and other private/raw fields out of App metadata
- preserve Apps-disabled/non-UI fallbacks and existing Job/Validation/Computer presentation behavior
- add DOM/message-order and real `show_changes` MCP contract coverage
- honor canonical `path_omitted` even if a contradictory path value is present

## Validation

- `cargo test --locked -p webcodex --lib result_app` — 20 passed
- `node --test src/mcp_tests/result_app.test.mjs` — 14 passed
- `cargo check -p webcodex` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check origin/main...HEAD` — passed
- workspace hygiene — clean

#91 remains open while this final slice is under review; after this PR lands, the initial Job + Validation + Git/changes scope is complete.