### PR TITLE
Stabilize runtime console window authority test stack

### DIFF
--- a/src/runtime_console_http.rs
+++ b/src/runtime_console_http.rs
@@ -4579,8 +4579,30 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn window_activity_lookup_is_principal_and_current_project_authority_bounded() {
+    #[test]
+    fn window_activity_lookup_is_principal_and_current_project_authority_bounded() {
+        // This multi-principal integration fixture overflows the default libtest
+        // stack in workspace builds, even when selected alone with one test thread.
+        // Match the bounded stack isolation used by the large MCP fixtures without
+        // changing production runtime stacks or weakening any authority assertions.
+        std::thread::Builder::new()
+            .name("runtime-console-window-authority".to_string())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build window authority test runtime")
+                    .block_on(
+                        window_activity_lookup_is_principal_and_current_project_authority_bounded_body(),
+                    );
+            })
+            .expect("spawn window authority test thread")
+            .join()
+            .expect("window authority test thread panicked");
+    }
+
+    async fn window_activity_lookup_is_principal_and_current_project_authority_bounded_body() {
         let (_tmp, db, runtime) = test_runtime_with_window_db();
         let auth_a = crate::auth::shared_key_context("window-group-a");
         let auth_b = crate::auth::shared_key_context("window-group-b");


### PR DESCRIPTION
## Summary

Closes #393.

Run the demonstrated large runtime-console window-authority integration fixture on a dedicated, bounded 8 MiB test thread with a current-thread Tokio runtime, following the existing pattern from #174.

- Only `src/runtime_console_http.rs` changes, inside `#[cfg(test)]` (+24/-2).
- Keep the original test name, body, and all authority assertions. The body was compared byte-for-byte with the base source.
- Propagate child-thread panics through `join().expect(...)`, so assertion failures still fail the test.
- No production runtime stack, permission, HTTP/MCP behavior, global `RUST_MIN_STACK`, CI gate, or dependency changes.

## Reproduction / control

On clean upstream `04e8135f852a75b572c9a575db0182b07b534eea`, macOS arm64, rustc 1.93.0, with `RUST_MIN_STACK` unset:

```sh
cargo test --locked --workspace --lib \
  runtime_console_http::tests::window_activity_lookup_is_principal_and_current_project_authority_bounded \
  -- --exact --test-threads=1
```

The **single selected test** aborts with stack overflow / SIGABRT. Running the same unmodified source with diagnostic `RUST_MIN_STACK=8388608` passes. Thus concurrent tests are not required to reproduce it. A package-only rerun previously passed but generated a different test executable and is not an equivalent reproduction.

## Validation

- `cargo fmt -- --check`: passed.
- `git diff --check`: passed.
- Original test body and all remaining file content verified unchanged; only the wrapper/test-body split is new.
- Exact workspace reproduction above after the fix, with `RUST_MIN_STACK` explicitly unset: **1 passed**.
- Final-commit targeted workspace rerun selecting this test and the port test mentioned below, with `RUST_MIN_STACK` unset and `--test-threads=1`: **2 passed**.

### Full-suite result — not all green

```sh
env -u RUST_MIN_STACK cargo test --locked --workspace --lib --quiet
```

The root `webcodex` test binary completed **without the previous stack overflow**:

```text
2518 passed; 1 failed; 2 ignored
```

The other failure was in an unchanged test:

```text
project_entry::tests::setup_does_not_replace_persisted_port_when_temporarily_occupied
src/project_entry_tests.rs:1395
TcpListener::bind(...).unwrap(): AddrInUse (os error 48)
```

That test passed in the targeted final-commit rerun, alongside the fixed stack test. This rerun does not erase the full-suite failure. Cargo stopped after the root-package failure, so the command does **not** establish that all remaining workspace library suites passed. No port-test changes or skipped assertions are included in this PR.

## Scope limitation

This is test-harness stabilization only. It does not claim to fix or establish the cause of live ChatGPT connector unavailability. Native Plugin reload/replay policy and the existing macOS production worker-stack behavior from #163 are unchanged.
