### PR TITLE
Add repo-context Plugin composition dogfood

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
             npm/plugin-sdk/package-lock.json
             plugins/safe-delete/package-lock.json
             plugins/repo-info/package-lock.json
+            plugins/repo-context/package-lock.json
       - name: Install frontend dependencies
         if: needs.changes.outputs.needs_frontend == 'true'
         run: npm ci --prefix frontend
@@ -157,6 +158,7 @@ jobs:
           npm ci --prefix npm/plugin-sdk
           npm ci --prefix plugins/safe-delete
           npm ci --prefix plugins/repo-info
+          npm ci --prefix plugins/repo-context
       - name: Check Plugin SDK contracts and first-party dogfood
         if: needs.changes.outputs.needs_plugin_sdk == 'true'
         run: |
@@ -168,6 +170,8 @@ jobs:
           npm --prefix plugins/safe-delete test
           npm --prefix plugins/repo-info run typecheck
           npm --prefix plugins/repo-info test
+          npm --prefix plugins/repo-context run typecheck
+          npm --prefix plugins/repo-context test
       - name: Verify workspace boundaries
         run: |
           bash scripts/workspace_boundary_check.sh --self-test

--- a/plugins/repo-context/.gitignore
+++ b/plugins/repo-context/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/plugins/repo-context/README.md
+++ b/plugins/repo-context/README.md
@@ -1,0 +1,55 @@
+# repo-context Native Tool Plugin
+
+`repo-context` is a small read-only first-party experiment for Native Plugin composition. It was created with the real `webcodex plugin init plugins/repo-context --id repo-context` authoring flow, then its repository dependency was switched to `file:../../npm/plugin-sdk` so CI validates the current checkout without changing the public `@yyjeqhc/webcodex-plugin-sdk@0.1.0` contract.
+
+It exposes exactly one tool, `repo_context`, with an empty input object. The provider's configured `cwd` is the only repository authority boundary; callers cannot supply a path, project, repository, Runner, command, or environment override.
+
+## Output
+
+The bounded structured result contains Git branch/HEAD/detached/dirty state, staged/unstaged/untracked counts, up to 128 changed paths, Cargo availability, up to 128 workspace member names, up to 128 advisory affected package names, at most 16 warnings, and `elapsedMs`.
+
+`affectedPackages` is deliberately advisory, not dependency-impact or validation evidence. Files under a concrete workspace package root map to the deepest package root. Root/shared files such as `Cargo.toml` conservatively mark all observed workspace packages affected. Paths outside Cargo package roots remain unmapped rather than being attributed to the root crate merely because its manifest lives at `.`.
+
+The Plugin never returns a Git diff, complete manifests, raw `cargo metadata`, absolute provider paths, remote URLs, credentials, validation verdicts, or merge/safety claims.
+
+## Local execution boundary
+
+Git uses `execFile` with literal argv, `shell: false`, `windowsHide: true`, timeouts, and bounded buffers. It uses only local read-only observations (`rev-parse` and porcelain `status`) and never fetches or mutates the repository.
+
+Cargo uses `cargo metadata --offline --no-deps --format-version 1`. `--offline` makes the no-network experiment boundary explicit. If Cargo is missing, the root is not a Cargo workspace, metadata is malformed, or the command times out/fails, Git context is still returned and the Cargo portion becomes unavailable with a bounded warning.
+
+## Install, build, and test
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+npm test
+```
+
+Node.js 18 or newer is required. Production execution uses the compiled ESM `dist/plugin.js`.
+
+## Configure one Runner
+
+```toml
+[[plugins.providers]]
+id = "repo-context"
+name = "Repo Context"
+command = "node"
+args = ["/absolute/path/to/webcodex/plugins/repo-context/dist/plugin.js"]
+cwd = "/absolute/path/to/repository"
+timeout_secs = 30
+```
+
+`cwd` is the repository being observed and is intentionally distinct from the Plugin source directory when necessary.
+
+## Author loop
+
+```text
+webcodex plugin check --runner <runner> --plugin repo-context
+webcodex plugin reload --runner <runner>
+webcodex plugin list --runner <runner> --plugin repo-context
+webcodex plugin describe --runner <runner> --plugin repo-context --tool repo_context
+```
+
+Invocation remains on the canonical `plugin_tool describe -> call` binding path. There is intentionally no `webcodex plugin call` command and no outer MCP tool is added for `repo_context`.

--- a/plugins/repo-context/README.md
+++ b/plugins/repo-context/README.md
@@ -16,7 +16,7 @@ The Plugin never returns a Git diff, complete manifests, raw `cargo metadata`, a
 
 Git uses `execFile` with literal argv, `shell: false`, `windowsHide: true`, timeouts, and bounded buffers. It uses only local read-only observations (`rev-parse` and porcelain `status`) and never fetches or mutates the repository.
 
-Cargo uses `cargo metadata --offline --no-deps --format-version 1`. `--offline` makes the no-network experiment boundary explicit. If Cargo is missing, the root is not a Cargo workspace, metadata is malformed, or the command times out/fails, Git context is still returned and the Cargo portion becomes unavailable with a bounded warning.
+Cargo uses `cargo metadata --frozen --no-deps --format-version 1`. `--frozen` makes both the no-network and no-lockfile-update read-only experiment boundaries explicit. If Cargo is missing, the root is not a Cargo workspace, metadata is malformed, or the command times out/fails, Git context is still returned and the Cargo portion becomes unavailable with a bounded warning.
 
 ## Install, build, and test
 

--- a/plugins/repo-context/README.md
+++ b/plugins/repo-context/README.md
@@ -6,9 +6,9 @@ It exposes exactly one tool, `repo_context`, with an empty input object. The pro
 
 ## Output
 
-The bounded structured result contains Git branch/HEAD/detached/dirty state, staged/unstaged/untracked counts, up to 128 changed paths, Cargo availability, up to 128 workspace member names, up to 128 advisory affected package names, at most 16 warnings, and `elapsedMs`.
+The bounded structured result contains Git branch/HEAD/detached/dirty state, staged/unstaged/untracked counts, up to 128 changed paths, Cargo availability, up to 128 workspace member names, up to 128 advisory affected package names, `globalChange`, at most 16 warnings, and `elapsedMs`.
 
-`affectedPackages` is deliberately advisory, not dependency-impact or validation evidence. Files under a concrete workspace package root map to the deepest package root. Root/shared files such as `Cargo.toml` conservatively mark all observed workspace packages affected. Paths outside Cargo package roots remain unmapped rather than being attributed to the root crate merely because its manifest lives at `.`.
+`affectedPackages` is deliberately advisory, not dependency-impact or validation evidence. Files under a concrete workspace package root map to the deepest package root. Root/shared files such as `Cargo.toml` conservatively mark all observed workspace packages affected and set `globalChange=true`. Paths outside Cargo package roots remain unmapped rather than being attributed to the root crate merely because its manifest lives at `.`.
 
 The Plugin never returns a Git diff, complete manifests, raw `cargo metadata`, absolute provider paths, remote URLs, credentials, validation verdicts, or merge/safety claims.
 

--- a/plugins/repo-context/README.zh-CN.md
+++ b/plugins/repo-context/README.zh-CN.md
@@ -6,9 +6,9 @@
 
 ## 输出
 
-bounded structured result 包含 Git branch/HEAD/detached/dirty 状态、staged/unstaged/untracked 计数、最多 128 个 changed paths、Cargo availability、最多 128 个 workspace member 名称、最多 128 个 advisory affected package 名称、最多 16 条 warning，以及 `elapsedMs`。
+bounded structured result 包含 Git branch/HEAD/detached/dirty 状态、staged/unstaged/untracked 计数、最多 128 个 changed paths、Cargo availability、最多 128 个 workspace member 名称、最多 128 个 advisory affected package 名称、`globalChange`、最多 16 条 warning，以及 `elapsedMs`。
 
-`affectedPackages` 明确只是 advisory context，不是 dependency impact analysis，也不是 validation evidence。位于明确 workspace package root 下的文件映射到最深 package root；`Cargo.toml` 等 root/shared change 会保守地标记全部已观察 workspace packages；位于 Cargo package roots 之外的路径不会因为 root crate 的 manifest 位于 `.` 就被误归到 root crate。
+`affectedPackages` 明确只是 advisory context，不是 dependency impact analysis，也不是 validation evidence。位于明确 workspace package root 下的文件映射到最深 package root；`Cargo.toml` 等 root/shared change 会保守地标记全部已观察 workspace packages，并令 `globalChange=true`；位于 Cargo package roots 之外的路径不会因为 root crate 的 manifest 位于 `.` 就被误归到 root crate。
 
 Plugin 不返回 Git diff、完整 manifest、raw `cargo metadata`、provider 绝对路径、remote URL、credential、validation verdict，也不会给出 verified/safe-to-merge 之类结论。
 

--- a/plugins/repo-context/README.zh-CN.md
+++ b/plugins/repo-context/README.zh-CN.md
@@ -16,7 +16,7 @@ Plugin 不返回 Git diff、完整 manifest、raw `cargo metadata`、provider �
 
 Git 通过 `execFile` 和 literal argv 执行，固定 `shell: false`、`windowsHide: true`，并设置 timeout 与 bounded buffer。它只做本地只读的 `rev-parse` 和 porcelain `status`，不会 fetch，也不会修改 repository。
 
-Cargo 使用 `cargo metadata --offline --no-deps --format-version 1`，其中 `--offline` 明确保证本实验不访问网络。如果 Cargo 不存在、provider cwd 不是 Cargo workspace、metadata malformed、timeout 或失败，Git context 仍会返回，Cargo 部分则通过 bounded warning 表示 unavailable。
+Cargo 使用 `cargo metadata --frozen --no-deps --format-version 1`，其中 `--frozen` 同时明确保证本实验不访问网络、也不生成或更新 lockfile。如果 Cargo 不存在、provider cwd 不是 Cargo workspace、metadata malformed、timeout 或失败，Git context 仍会返回，Cargo 部分则通过 bounded warning 表示 unavailable。
 
 ## 安装、构建与测试
 

--- a/plugins/repo-context/README.zh-CN.md
+++ b/plugins/repo-context/README.zh-CN.md
@@ -1,0 +1,55 @@
+# repo-context Native Tool Plugin
+
+`repo-context` 是一个很小的只读 first-party Native Plugin composition 实验。它先通过真实的 `webcodex plugin init plugins/repo-context --id repo-context` authoring flow 创建，再把仓库内 dependency 调整为 `file:../../npm/plugin-sdk`，从而让 CI 验证当前 checkout，同时不改变公开的 `@yyjeqhc/webcodex-plugin-sdk@0.1.0` contract。
+
+它只暴露一个 `repo_context` 工具，input 是空对象。provider 配置中的 `cwd` 是唯一 repository authority boundary；调用者不能传入 path、project、repository、Runner、command 或 environment override。
+
+## 输出
+
+bounded structured result 包含 Git branch/HEAD/detached/dirty 状态、staged/unstaged/untracked 计数、最多 128 个 changed paths、Cargo availability、最多 128 个 workspace member 名称、最多 128 个 advisory affected package 名称、最多 16 条 warning，以及 `elapsedMs`。
+
+`affectedPackages` 明确只是 advisory context，不是 dependency impact analysis，也不是 validation evidence。位于明确 workspace package root 下的文件映射到最深 package root；`Cargo.toml` 等 root/shared change 会保守地标记全部已观察 workspace packages；位于 Cargo package roots 之外的路径不会因为 root crate 的 manifest 位于 `.` 就被误归到 root crate。
+
+Plugin 不返回 Git diff、完整 manifest、raw `cargo metadata`、provider 绝对路径、remote URL、credential、validation verdict，也不会给出 verified/safe-to-merge 之类结论。
+
+## 本地执行边界
+
+Git 通过 `execFile` 和 literal argv 执行，固定 `shell: false`、`windowsHide: true`，并设置 timeout 与 bounded buffer。它只做本地只读的 `rev-parse` 和 porcelain `status`，不会 fetch，也不会修改 repository。
+
+Cargo 使用 `cargo metadata --offline --no-deps --format-version 1`，其中 `--offline` 明确保证本实验不访问网络。如果 Cargo 不存在、provider cwd 不是 Cargo workspace、metadata malformed、timeout 或失败，Git context 仍会返回，Cargo 部分则通过 bounded warning 表示 unavailable。
+
+## 安装、构建与测试
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+npm test
+```
+
+需要 Node.js 18 或更新版本；实际 provider 运行编译后的 ESM `dist/plugin.js`。
+
+## 配置一个 Runner
+
+```toml
+[[plugins.providers]]
+id = "repo-context"
+name = "Repo Context"
+command = "node"
+args = ["/absolute/path/to/webcodex/plugins/repo-context/dist/plugin.js"]
+cwd = "/absolute/path/to/repository"
+timeout_secs = 30
+```
+
+`cwd` 就是被观察的 repository；必要时它与 Plugin source directory 完全不同。
+
+## Author loop
+
+```text
+webcodex plugin check --runner <runner> --plugin repo-context
+webcodex plugin reload --runner <runner>
+webcodex plugin list --runner <runner> --plugin repo-context
+webcodex plugin describe --runner <runner> --plugin repo-context --tool repo_context
+```
+
+实际 invocation 继续使用 canonical `plugin_tool describe -> call` opaque binding 路径；这里不会新增 `webcodex plugin call`，也不会把 `repo_context` 暴露成 outer MCP root tool。

--- a/plugins/repo-context/package-lock.json
+++ b/plugins/repo-context/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "@yyjeqhc/webcodex-repo-context-plugin",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@yyjeqhc/webcodex-repo-context-plugin",
+      "version": "0.0.0",
+      "dependencies": {
+        "@yyjeqhc/webcodex-plugin-sdk": "file:../../npm/plugin-sdk"
+      },
+      "devDependencies": {
+        "@types/node": "^18.19.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../npm/plugin-sdk": {
+      "name": "@yyjeqhc/webcodex-plugin-sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^18.19.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@yyjeqhc/webcodex-plugin-sdk": {
+      "resolved": "../../npm/plugin-sdk",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/plugins/repo-context/package.json
+++ b/plugins/repo-context/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build --silent && node --test plugin.test.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/plugins/repo-context/package.json
+++ b/plugins/repo-context/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@yyjeqhc/webcodex-repo-context-plugin",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@yyjeqhc/webcodex-plugin-sdk": "file:../../npm/plugin-sdk"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/plugins/repo-context/plugin.test.mjs
+++ b/plugins/repo-context/plugin.test.mjs
@@ -243,6 +243,26 @@ test("untracked file is counted and maps to its workspace package", async () => 
   }
 });
 
+
+test("cross-package rename marks both source and destination packages affected", async () => {
+  const root = initWorkspace();
+  try {
+    fs.writeFileSync(path.join(root, "crates", "a", "rename-me.txt"), "fixture\n");
+    git(root, ["add", "crates/a/rename-me.txt"]);
+    git(root, ["-c", "commit.gpgSign=false", "commit", "-qm", "rename fixture"]);
+    git(root, ["mv", "crates/a/rename-me.txt", "crates/b/moved-from-a.txt"]);
+    const result = await callRepoContext(root);
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.cargoAvailable, true);
+    assert.equal(result.structuredContent.stagedCount, 1);
+    assert.equal(result.structuredContent.totalChangedPaths, 1);
+    assert.deepEqual(result.structuredContent.changedPaths, ["crates/b/moved-from-a.txt"]);
+    assert.deepEqual(result.structuredContent.affectedPackages, ["pkg-a", "pkg-b"]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("detached HEAD is reported without inventing a branch", async () => {
   const root = initWorkspace();
   try {

--- a/plugins/repo-context/plugin.test.mjs
+++ b/plugins/repo-context/plugin.test.mjs
@@ -195,6 +195,7 @@ test("clean Git repository returns HEAD, branch, and Cargo workspace members", a
     assert.equal(result.structuredContent.workspaceMemberCount, 2);
     assert.deepEqual(result.structuredContent.workspaceMembers, ["pkg-a", "pkg-b"]);
     assert.deepEqual(result.structuredContent.affectedPackages, []);
+    assert.equal(result.structuredContent.globalChange, false);
     assert.equal(JSON.stringify(result).includes(root), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -252,6 +253,7 @@ test("root shared change conservatively affects all observed workspace packages"
     const result = await callRepoContext(root);
     assert.deepEqual(result.structuredContent.changedPaths, ["Cargo.toml"]);
     assert.deepEqual(result.structuredContent.affectedPackages, ["pkg-a", "pkg-b"]);
+    assert.equal(result.structuredContent.globalChange, true);
     assert.match(result.structuredContent.warnings.join("\n"), /conservatively mark all/u);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/plugins/repo-context/plugin.test.mjs
+++ b/plugins/repo-context/plugin.test.mjs
@@ -56,6 +56,14 @@ function initWorkspace() {
   );
   writePackage(root, "crates/a", "pkg-a");
   writePackage(root, "crates/b", "pkg-b");
+  const lock = spawnSync("cargo", ["generate-lockfile", "--offline"], {
+    cwd: root,
+    encoding: "utf8",
+    shell: false,
+    windowsHide: true,
+  });
+  assert.equal(lock.error, undefined, lock.error?.message);
+  assert.equal(lock.status, 0, `cargo generate-lockfile failed: ${lock.stderr}`);
   git(root, ["add", "."]);
   git(root, [
     "-c",
@@ -132,7 +140,10 @@ function fakeGitAndCargo(cwd, cargoResult, status = "") {
       if (args.includes("status")) return { ok: true, stdout: status };
       return { ok: false, kind: "failed" };
     }
-    if (executable === "cargo") return cargoResult;
+    if (executable === "cargo") {
+      assert.deepEqual(args, ["metadata", "--frozen", "--no-deps", "--format-version", "1"]);
+      return cargoResult;
+    }
     throw new Error(`unexpected executable ${executable} in ${cwd}`);
   };
 }

--- a/plugins/repo-context/plugin.test.mjs
+++ b/plugins/repo-context/plugin.test.mjs
@@ -249,7 +249,17 @@ test("cross-package rename marks both source and destination packages affected",
   try {
     fs.writeFileSync(path.join(root, "crates", "a", "rename-me.txt"), "fixture\n");
     git(root, ["add", "crates/a/rename-me.txt"]);
-    git(root, ["-c", "commit.gpgSign=false", "commit", "-qm", "rename fixture"]);
+    git(root, [
+      "-c",
+      "user.name=WebCodex Test",
+      "-c",
+      "user.email=webcodex-test@example.invalid",
+      "-c",
+      "commit.gpgSign=false",
+      "commit",
+      "-qm",
+      "rename fixture",
+    ]);
     git(root, ["mv", "crates/a/rename-me.txt", "crates/b/moved-from-a.txt"]);
     const result = await callRepoContext(root);
     assert.equal(result.isError, false);

--- a/plugins/repo-context/plugin.test.mjs
+++ b/plugins/repo-context/plugin.test.mjs
@@ -1,0 +1,326 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  AFFECTED_PACKAGE_LIMIT,
+  CHANGED_PATH_LIMIT,
+  WARNING_LIMIT,
+  WORKSPACE_MEMBER_LIMIT,
+  observeRepoContext,
+} from "./dist/context.js";
+
+const PROTOCOL_VERSION = "webcodex-plugin-v1";
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pluginPath = path.join(here, "dist", "plugin.js");
+const HEAD = "a".repeat(40);
+
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "webcodex-repo-context-"));
+}
+
+function git(cwd, args) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    shell: false,
+    windowsHide: true,
+  });
+  assert.equal(result.error, undefined, result.error?.message);
+  assert.equal(result.status, 0, `git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout;
+}
+
+function writePackage(root, relative, name) {
+  const packageRoot = path.join(root, relative);
+  fs.mkdirSync(path.join(packageRoot, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "Cargo.toml"),
+    `[package]\nname = "${name}"\nversion = "0.1.0"\nedition = "2021"\n`,
+  );
+  fs.writeFileSync(path.join(packageRoot, "src", "lib.rs"), `pub const NAME: &str = "${name}";\n`);
+}
+
+function initWorkspace() {
+  const root = tempRoot();
+  const hooks = path.join(root, "empty-hooks");
+  fs.mkdirSync(hooks);
+  git(root, ["init", "-q"]);
+  fs.writeFileSync(
+    path.join(root, "Cargo.toml"),
+    '[workspace]\nmembers = ["crates/a", "crates/b"]\nresolver = "2"\n',
+  );
+  writePackage(root, "crates/a", "pkg-a");
+  writePackage(root, "crates/b", "pkg-b");
+  git(root, ["add", "."]);
+  git(root, [
+    "-c",
+    "user.name=WebCodex Test",
+    "-c",
+    "user.email=webcodex-test@example.invalid",
+    "-c",
+    "commit.gpgSign=false",
+    "-c",
+    `core.hooksPath=${hooks}`,
+    "commit",
+    "-qm",
+    "initial",
+  ]);
+  return root;
+}
+
+async function runProtocol(cwd, requests) {
+  const child = spawn(process.execPath, [pluginPath], {
+    cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+    shell: false,
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  for (const request of requests) child.stdin.write(`${JSON.stringify(request)}\n`);
+  child.stdin.end();
+
+  const exitCode = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error("repo-context protocol test timed out"));
+    }, 15_000);
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+  assert.equal(exitCode, 0, stderr);
+  assert.equal(stderr, "");
+  const lines = stdout.split(/\r?\n/u).filter((line) => line.length > 0);
+  assert.equal(lines.length, requests.length, `unexpected stdout framing: ${stdout}`);
+  return lines.map((line) => JSON.parse(line));
+}
+
+function initializeRequest(id = 1) {
+  return { jsonrpc: "2.0", id, method: "initialize", params: { protocolVersion: PROTOCOL_VERSION } };
+}
+
+function callRequest(id = 2) {
+  return { jsonrpc: "2.0", id, method: "tools/call", params: { name: "repo_context", arguments: {} } };
+}
+
+async function callRepoContext(cwd) {
+  const responses = await runProtocol(cwd, [initializeRequest(), callRequest()]);
+  assert.equal(responses[0].result.protocolVersion, PROTOCOL_VERSION);
+  return responses[1].result;
+}
+
+function fakeGitAndCargo(cwd, cargoResult, status = "") {
+  return async (executable, args) => {
+    if (executable === "git") {
+      if (args.includes("--verify")) return { ok: true, stdout: `${HEAD}\n` };
+      if (args.includes("--abbrev-ref")) return { ok: true, stdout: "main\n" };
+      if (args.includes("status")) return { ok: true, stdout: status };
+      return { ok: false, kind: "failed" };
+    }
+    if (executable === "cargo") return cargoResult;
+    throw new Error(`unexpected executable ${executable} in ${cwd}`);
+  };
+}
+
+function fakeMetadata(cwd, count) {
+  const packages = [];
+  const workspaceMembers = [];
+  for (let index = 0; index < count; index += 1) {
+    const suffix = String(index).padStart(3, "0");
+    const id = `workspace-pkg-${suffix}`;
+    workspaceMembers.push(id);
+    packages.push({
+      id,
+      name: `pkg-${suffix}`,
+      manifest_path: path.join(cwd, "crates", `pkg-${suffix}`, "Cargo.toml"),
+    });
+  }
+  return JSON.stringify({ packages, workspace_members: workspaceMembers });
+}
+
+test("compiled Plugin lists the bounded read-only repo_context contract", async () => {
+  const root = initWorkspace();
+  try {
+    const responses = await runProtocol(root, [
+      initializeRequest(1),
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+    ]);
+    const tools = responses[1].result.tools;
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].name, "repo_context");
+    assert.deepEqual(tools[0].inputSchema, {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+    assert.deepEqual(tools[0].annotations, {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("clean Git repository returns HEAD, branch, and Cargo workspace members", async () => {
+  const root = initWorkspace();
+  try {
+    const branch = git(root, ["branch", "--show-current"]).trim();
+    const head = git(root, ["rev-parse", "HEAD"]).trim();
+    const result = await callRepoContext(root);
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.branch, branch);
+    assert.equal(result.structuredContent.head, head);
+    assert.equal(result.structuredContent.detached, false);
+    assert.equal(result.structuredContent.dirty, false);
+    assert.equal(result.structuredContent.cargoAvailable, true);
+    assert.equal(result.structuredContent.workspaceMemberCount, 2);
+    assert.deepEqual(result.structuredContent.workspaceMembers, ["pkg-a", "pkg-b"]);
+    assert.deepEqual(result.structuredContent.affectedPackages, []);
+    assert.equal(JSON.stringify(result).includes(root), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("dirty tracked file maps to its deepest workspace package", async () => {
+  const root = initWorkspace();
+  try {
+    fs.writeFileSync(path.join(root, "crates", "a", "src", "lib.rs"), "pub const CHANGED: bool = true;\n");
+    const result = await callRepoContext(root);
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.dirty, true);
+    assert.equal(result.structuredContent.stagedCount, 0);
+    assert.equal(result.structuredContent.unstagedCount, 1);
+    assert.equal(result.structuredContent.untrackedCount, 0);
+    assert.deepEqual(result.structuredContent.changedPaths, ["crates/a/src/lib.rs"]);
+    assert.deepEqual(result.structuredContent.affectedPackages, ["pkg-a"]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("untracked file is counted and maps to its workspace package", async () => {
+  const root = initWorkspace();
+  try {
+    fs.writeFileSync(path.join(root, "crates", "b", "new.txt"), "new\n");
+    const result = await callRepoContext(root);
+    assert.equal(result.structuredContent.untrackedCount, 1);
+    assert.deepEqual(result.structuredContent.changedPaths, ["crates/b/new.txt"]);
+    assert.deepEqual(result.structuredContent.affectedPackages, ["pkg-b"]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("detached HEAD is reported without inventing a branch", async () => {
+  const root = initWorkspace();
+  try {
+    git(root, ["checkout", "--detach", "-q"]);
+    const result = await callRepoContext(root);
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.detached, true);
+    assert.equal(result.structuredContent.branch, "");
+    assert.equal(result.structuredContent.head, git(root, ["rev-parse", "HEAD"]).trim());
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("root shared change conservatively affects all observed workspace packages", async () => {
+  const root = initWorkspace();
+  try {
+    fs.appendFileSync(path.join(root, "Cargo.toml"), "\n# shared workspace change\n");
+    const result = await callRepoContext(root);
+    assert.deepEqual(result.structuredContent.changedPaths, ["Cargo.toml"]);
+    assert.deepEqual(result.structuredContent.affectedPackages, ["pkg-a", "pkg-b"]);
+    assert.match(result.structuredContent.warnings.join("\n"), /conservatively mark all/u);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Git command failure produces a bounded partial error without leaking cwd", async () => {
+  const root = tempRoot();
+  try {
+    const observation = await observeRepoContext(root, async (executable) => {
+      if (executable === "git") return { ok: false, kind: "failed" };
+      throw new Error("cargo should not run without a root Cargo.toml");
+    });
+    assert.equal(observation.gitAvailable, false);
+    assert.equal(observation.structured.head, "");
+    assert.match(observation.structured.warnings.join("\n"), /git observation failed/u);
+    assert.equal(JSON.stringify(observation).includes(root), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Cargo unavailable, malformed metadata, and timeout preserve Git context", async (t) => {
+  for (const [name, cargoResult, warning] of [
+    ["unavailable", { ok: false, kind: "not_found" }, /cargo executable is unavailable/u],
+    ["malformed", { ok: true, stdout: "{not-json" }, /malformed JSON/u],
+    ["timeout", { ok: false, kind: "timeout" }, /cargo observation timed out/u],
+  ]) {
+    await t.test(name, async () => {
+      const root = tempRoot();
+      try {
+        fs.writeFileSync(path.join(root, "Cargo.toml"), "[workspace]\nmembers = []\n");
+        const observation = await observeRepoContext(root, fakeGitAndCargo(root, cargoResult));
+        assert.equal(observation.gitAvailable, true);
+        assert.equal(observation.structured.head, HEAD);
+        assert.equal(observation.structured.cargoAvailable, false);
+        assert.match(observation.structured.warnings.join("\n"), warning);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("bounded projections truncate changed paths, members, affected packages, and warnings", async () => {
+  const root = tempRoot();
+  try {
+    fs.writeFileSync(path.join(root, "Cargo.toml"), "[workspace]\nmembers = []\n");
+    const status = Array.from({ length: 150 }, (_, index) => {
+      const suffix = String(index).padStart(3, "0");
+      return `?? ${index < 140 ? `crates/pkg-${suffix}/src/new.rs` : `misc-${suffix}.txt`}\0`;
+    }).join("");
+    const metadata = fakeMetadata(root, 140);
+    const observation = await observeRepoContext(
+      root,
+      fakeGitAndCargo(root, { ok: true, stdout: metadata }, status),
+    );
+    const value = observation.structured;
+    assert.equal(value.totalChangedPaths, 150);
+    assert.equal(value.changedPaths.length, CHANGED_PATH_LIMIT);
+    assert.equal(value.changedPathsTruncated, true);
+    assert.equal(value.workspaceMemberCount, 140);
+    assert.equal(value.workspaceMembers.length, WORKSPACE_MEMBER_LIMIT);
+    assert.equal(value.workspaceMembersTruncated, true);
+    assert.equal(value.affectedPackages.length, AFFECTED_PACKAGE_LIMIT);
+    assert.equal(value.affectedPackagesTruncated, true);
+    assert.ok(value.warnings.length <= WARNING_LIMIT);
+    assert.equal(JSON.stringify(value).includes(root), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/plugins/repo-context/src/context.ts
+++ b/plugins/repo-context/src/context.ts
@@ -52,6 +52,7 @@ export interface RepoContextStructured {
   readonly workspaceMembersTruncated: boolean;
   readonly affectedPackages: string[];
   readonly affectedPackagesTruncated: boolean;
+  readonly globalChange: boolean;
   readonly warnings: string[];
   readonly elapsedMs: number;
 }
@@ -360,17 +361,21 @@ function mapAffectedPackages(
   changedPaths: readonly string[],
   members: readonly WorkspaceMember[],
   warnings: string[],
-): readonly string[] {
-  if (members.length === 0 || changedPaths.length === 0) return [];
+): { packages: string[]; globalChange: boolean } {
+  if (members.length === 0 || changedPaths.length === 0) {
+    return { packages: [], globalChange: false };
+  }
   const affected = new Set<string>();
   const rootMember = members.find((member) => member.root === ".");
   const byDepth = members
     .filter((member) => member.root !== ".")
     .sort((left, right) => right.root.split("/").length - left.root.split("/").length);
   let sharedWarningAdded = false;
+  let globalChange = false;
 
   for (const changedPath of changedPaths) {
     if (isSharedWorkspacePath(changedPath)) {
+      globalChange = true;
       for (const member of members) affected.add(member.name);
       if (!sharedWarningAdded) {
         pushWarning(
@@ -396,7 +401,7 @@ function mapAffectedPackages(
       affected.add(rootMember.name);
     }
   }
-  return [...affected].sort();
+  return { packages: [...affected].sort(), globalChange };
 }
 
 export async function observeRepoContext(
@@ -409,7 +414,7 @@ export async function observeRepoContext(
   const cargo = await observeCargo(cwd, run, warnings);
   const affected = mapAffectedPackages(git.mappingPaths, cargo.members, warnings);
   const visibleMembers = cargo.members.slice(0, WORKSPACE_MEMBER_LIMIT);
-  const visibleAffected = affected.slice(0, AFFECTED_PACKAGE_LIMIT);
+  const visibleAffected = affected.packages.slice(0, AFFECTED_PACKAGE_LIMIT);
 
   return {
     gitAvailable: git.available,
@@ -429,7 +434,8 @@ export async function observeRepoContext(
       workspaceMembers: visibleMembers.map((member) => member.name),
       workspaceMembersTruncated: cargo.members.length > visibleMembers.length,
       affectedPackages: [...visibleAffected],
-      affectedPackagesTruncated: affected.length > visibleAffected.length,
+      affectedPackagesTruncated: affected.packages.length > visibleAffected.length,
+      globalChange: affected.globalChange,
       warnings: [...warnings],
       elapsedMs: Math.max(0, Date.now() - started),
     },

--- a/plugins/repo-context/src/context.ts
+++ b/plugins/repo-context/src/context.ts
@@ -343,7 +343,7 @@ async function observeCargo(cwd: string, run: CommandRunner, warnings: string[])
   }
   const result = await run(
     "cargo",
-    ["metadata", "--offline", "--no-deps", "--format-version", "1"],
+    ["metadata", "--frozen", "--no-deps", "--format-version", "1"],
     { cwd, timeoutMs: CARGO_TIMEOUT_MS, maxBuffer: CARGO_MAX_BUFFER },
   );
   if (!result.ok) {

--- a/plugins/repo-context/src/context.ts
+++ b/plugins/repo-context/src/context.ts
@@ -1,0 +1,437 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+export const CHANGED_PATH_LIMIT = 128;
+export const WORKSPACE_MEMBER_LIMIT = 128;
+export const AFFECTED_PACKAGE_LIMIT = 128;
+export const WARNING_LIMIT = 16;
+export const PATH_MAX_CHARS = 512;
+export const PACKAGE_NAME_MAX_CHARS = 256;
+export const WARNING_MAX_CHARS = 512;
+
+const GIT_TIMEOUT_MS = 5_000;
+const CARGO_TIMEOUT_MS = 10_000;
+const GIT_MAX_BUFFER = 256 * 1024;
+const CARGO_MAX_BUFFER = 8 * 1024 * 1024;
+const HEAD_MAX_CHARS = 64;
+const BRANCH_MAX_CHARS = 512;
+
+type CommandFailureKind = "not_found" | "timeout" | "too_large" | "failed";
+
+export interface CommandOptions {
+  readonly cwd: string;
+  readonly timeoutMs: number;
+  readonly maxBuffer: number;
+}
+
+export type CommandResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly kind: CommandFailureKind };
+
+export type CommandRunner = (
+  executable: string,
+  args: readonly string[],
+  options: CommandOptions,
+) => Promise<CommandResult>;
+
+export interface RepoContextStructured {
+  readonly branch: string;
+  readonly head: string;
+  readonly detached: boolean;
+  readonly dirty: boolean;
+  readonly stagedCount: number;
+  readonly unstagedCount: number;
+  readonly untrackedCount: number;
+  readonly changedPaths: string[];
+  readonly totalChangedPaths: number;
+  readonly changedPathsTruncated: boolean;
+  readonly cargoAvailable: boolean;
+  readonly workspaceMemberCount: number;
+  readonly workspaceMembers: string[];
+  readonly workspaceMembersTruncated: boolean;
+  readonly affectedPackages: string[];
+  readonly affectedPackagesTruncated: boolean;
+  readonly warnings: string[];
+  readonly elapsedMs: number;
+}
+
+export interface RepoContextObservation {
+  readonly structured: RepoContextStructured;
+  readonly gitAvailable: boolean;
+}
+
+interface GitObservation {
+  readonly available: boolean;
+  readonly branch: string;
+  readonly head: string;
+  readonly detached: boolean;
+  readonly dirty: boolean;
+  readonly stagedCount: number;
+  readonly unstagedCount: number;
+  readonly untrackedCount: number;
+  readonly changedPaths: readonly string[];
+  readonly mappingPaths: readonly string[];
+  readonly totalChangedPaths: number;
+  readonly changedPathsTruncated: boolean;
+}
+
+interface WorkspaceMember {
+  readonly name: string;
+  readonly root: string;
+}
+
+interface CargoObservation {
+  readonly available: boolean;
+  readonly members: readonly WorkspaceMember[];
+}
+
+interface CargoMetadataPackage {
+  readonly id?: unknown;
+  readonly name?: unknown;
+  readonly manifest_path?: unknown;
+}
+
+interface CargoMetadata {
+  readonly packages?: unknown;
+  readonly workspace_members?: unknown;
+}
+
+export function nativeCommandRunner(
+  executable: string,
+  args: readonly string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    execFile(
+      executable,
+      [...args],
+      {
+        cwd: options.cwd,
+        encoding: "utf8",
+        maxBuffer: options.maxBuffer,
+        shell: false,
+        timeout: options.timeoutMs,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error === null) {
+          resolve({ ok: true, stdout: String(stdout) });
+          return;
+        }
+        const details = error as {
+          readonly code?: unknown;
+          readonly killed?: unknown;
+          readonly message?: unknown;
+        };
+        let kind: CommandFailureKind = "failed";
+        if (details.code === "ENOENT") kind = "not_found";
+        else if (details.killed === true || details.code === "ETIMEDOUT") kind = "timeout";
+        else if (
+          details.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" ||
+          String(details.message ?? "").includes("maxBuffer")
+        ) {
+          kind = "too_large";
+        }
+        resolve({ ok: false, kind });
+      },
+    );
+  });
+}
+
+function boundedString(value: string, maxChars: number): string | undefined {
+  const text = value.trim();
+  if (text.length === 0 || text.length > maxChars || Buffer.byteLength(text, "utf8") > maxChars) {
+    return undefined;
+  }
+  return text;
+}
+
+function pushWarning(warnings: string[], warning: string): void {
+  if (warnings.length >= WARNING_LIMIT) return;
+  const flattened = warning.replace(/\s+/gu, " ").trim();
+  warnings.push(flattened.slice(0, WARNING_MAX_CHARS));
+}
+
+function commandWarning(scope: "git" | "cargo", kind: CommandFailureKind): string {
+  switch (kind) {
+    case "not_found":
+      return `${scope} executable is unavailable`;
+    case "timeout":
+      return `${scope} observation timed out`;
+    case "too_large":
+      return `${scope} observation exceeded the local process output bound`;
+    case "failed":
+      return `${scope} observation failed`;
+  }
+}
+
+function emptyGitObservation(): GitObservation {
+  return {
+    available: false,
+    branch: "",
+    head: "",
+    detached: false,
+    dirty: false,
+    stagedCount: 0,
+    unstagedCount: 0,
+    untrackedCount: 0,
+    changedPaths: [],
+    mappingPaths: [],
+    totalChangedPaths: 0,
+    changedPathsTruncated: false,
+  };
+}
+
+function parsePorcelainStatus(
+  stdout: string,
+  warnings: string[],
+): Omit<GitObservation, "available" | "branch" | "head" | "detached"> {
+  const fields = stdout.split("\0");
+  const visiblePaths: string[] = [];
+  const mappingPaths: string[] = [];
+  let stagedCount = 0;
+  let unstagedCount = 0;
+  let untrackedCount = 0;
+  let totalChangedPaths = 0;
+
+  for (let index = 0; index < fields.length; index += 1) {
+    const field = fields[index];
+    if (field === undefined || field.length === 0) continue;
+    if (field.length < 4 || field[2] !== " ") {
+      pushWarning(warnings, "git status returned a malformed porcelain record");
+      continue;
+    }
+    const x = field[0] ?? " ";
+    const y = field[1] ?? " ";
+    const normalized = field.slice(3).replaceAll("\\", "/");
+    const renameOrCopy = x === "R" || x === "C" || y === "R" || y === "C";
+    if (renameOrCopy && index + 1 < fields.length) index += 1;
+
+    if (x === "?" && y === "?") {
+      untrackedCount += 1;
+    } else {
+      if (x !== " " && x !== "?") stagedCount += 1;
+      if (y !== " " && y !== "?") unstagedCount += 1;
+    }
+
+    totalChangedPaths += 1;
+    mappingPaths.push(normalized);
+    if (visiblePaths.length >= CHANGED_PATH_LIMIT) continue;
+    if (normalized.length <= PATH_MAX_CHARS && Buffer.byteLength(normalized, "utf8") <= PATH_MAX_CHARS) {
+      visiblePaths.push(normalized);
+    } else {
+      pushWarning(warnings, "a changed path exceeded the per-string output bound and was omitted");
+    }
+  }
+
+  return {
+    dirty: totalChangedPaths > 0,
+    stagedCount,
+    unstagedCount,
+    untrackedCount,
+    changedPaths: visiblePaths,
+    mappingPaths,
+    totalChangedPaths,
+    changedPathsTruncated: totalChangedPaths > visiblePaths.length,
+  };
+}
+
+async function observeGit(cwd: string, run: CommandRunner, warnings: string[]): Promise<GitObservation> {
+  const headResult = await run("git", ["--no-optional-locks", "rev-parse", "--verify", "HEAD"], {
+    cwd,
+    timeoutMs: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_MAX_BUFFER,
+  });
+  if (!headResult.ok) {
+    pushWarning(warnings, commandWarning("git", headResult.kind));
+    return emptyGitObservation();
+  }
+  const head = boundedString(headResult.stdout, HEAD_MAX_CHARS);
+  if (head === undefined || !/^[0-9a-f]{40,64}$/u.test(head)) {
+    pushWarning(warnings, "git returned a malformed HEAD object id");
+    return emptyGitObservation();
+  }
+
+  const branchResult = await run("git", ["--no-optional-locks", "rev-parse", "--abbrev-ref", "HEAD"], {
+    cwd,
+    timeoutMs: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_MAX_BUFFER,
+  });
+  if (!branchResult.ok) {
+    pushWarning(warnings, commandWarning("git", branchResult.kind));
+    return emptyGitObservation();
+  }
+  const branchValue = boundedString(branchResult.stdout, BRANCH_MAX_CHARS);
+  if (branchValue === undefined) {
+    pushWarning(warnings, "git returned a malformed branch name");
+    return emptyGitObservation();
+  }
+  const detached = branchValue === "HEAD";
+
+  const statusResult = await run(
+    "git",
+    ["--no-optional-locks", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    { cwd, timeoutMs: GIT_TIMEOUT_MS, maxBuffer: GIT_MAX_BUFFER },
+  );
+  if (!statusResult.ok) {
+    pushWarning(warnings, commandWarning("git", statusResult.kind));
+    return emptyGitObservation();
+  }
+
+  return {
+    available: true,
+    branch: detached ? "" : branchValue,
+    head,
+    detached,
+    ...parsePorcelainStatus(statusResult.stdout, warnings),
+  };
+}
+
+function parseCargoMetadata(cwd: string, stdout: string, warnings: string[]): CargoObservation {
+  let parsed: CargoMetadata;
+  try {
+    parsed = JSON.parse(stdout) as CargoMetadata;
+  } catch {
+    pushWarning(warnings, "cargo metadata returned malformed JSON");
+    return { available: false, members: [] };
+  }
+  if (!Array.isArray(parsed.packages) || !Array.isArray(parsed.workspace_members)) {
+    pushWarning(warnings, "cargo metadata omitted packages or workspace_members");
+    return { available: false, members: [] };
+  }
+
+  const workspaceIds = new Set(
+    parsed.workspace_members.filter((value): value is string => typeof value === "string"),
+  );
+  const members: WorkspaceMember[] = [];
+  for (const value of parsed.packages) {
+    if (value === null || typeof value !== "object") continue;
+    const pkg = value as CargoMetadataPackage;
+    if (typeof pkg.id !== "string" || !workspaceIds.has(pkg.id)) continue;
+    if (typeof pkg.name !== "string" || typeof pkg.manifest_path !== "string") {
+      pushWarning(warnings, "cargo metadata contained a malformed workspace package");
+      continue;
+    }
+    const name = boundedString(pkg.name, PACKAGE_NAME_MAX_CHARS);
+    if (name === undefined) {
+      pushWarning(warnings, "a Cargo package name exceeded the per-string bound and was omitted");
+      continue;
+    }
+    const relative = path.relative(cwd, path.dirname(pkg.manifest_path));
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      pushWarning(warnings, `workspace package ${name} is outside provider cwd and was omitted`);
+      continue;
+    }
+    members.push({
+      name,
+      root: relative === "" ? "." : relative.replaceAll(path.sep, "/"),
+    });
+  }
+  members.sort((left, right) => left.name.localeCompare(right.name) || left.root.localeCompare(right.root));
+  if (members.length !== workspaceIds.size) {
+    pushWarning(warnings, "some Cargo workspace members could not be projected inside provider cwd");
+  }
+  return { available: true, members };
+}
+
+async function observeCargo(cwd: string, run: CommandRunner, warnings: string[]): Promise<CargoObservation> {
+  if (!fs.existsSync(path.join(cwd, "Cargo.toml"))) {
+    pushWarning(warnings, "provider cwd has no root Cargo.toml; Cargo workspace context is unavailable");
+    return { available: false, members: [] };
+  }
+  const result = await run(
+    "cargo",
+    ["metadata", "--offline", "--no-deps", "--format-version", "1"],
+    { cwd, timeoutMs: CARGO_TIMEOUT_MS, maxBuffer: CARGO_MAX_BUFFER },
+  );
+  if (!result.ok) {
+    pushWarning(warnings, commandWarning("cargo", result.kind));
+    return { available: false, members: [] };
+  }
+  return parseCargoMetadata(cwd, result.stdout, warnings);
+}
+
+function isSharedWorkspacePath(changedPath: string): boolean {
+  return !changedPath.includes("/") || changedPath.startsWith(".cargo/");
+}
+
+function mapAffectedPackages(
+  changedPaths: readonly string[],
+  members: readonly WorkspaceMember[],
+  warnings: string[],
+): readonly string[] {
+  if (members.length === 0 || changedPaths.length === 0) return [];
+  const affected = new Set<string>();
+  const rootMember = members.find((member) => member.root === ".");
+  const byDepth = members
+    .filter((member) => member.root !== ".")
+    .sort((left, right) => right.root.split("/").length - left.root.split("/").length);
+  let sharedWarningAdded = false;
+
+  for (const changedPath of changedPaths) {
+    if (isSharedWorkspacePath(changedPath)) {
+      for (const member of members) affected.add(member.name);
+      if (!sharedWarningAdded) {
+        pushWarning(
+          warnings,
+          "root/shared changes conservatively mark all observed workspace packages affected",
+        );
+        sharedWarningAdded = true;
+      }
+      continue;
+    }
+    const member = byDepth.find(
+      (candidate) =>
+        changedPath === candidate.root || changedPath.startsWith(`${candidate.root}/`),
+    );
+    if (member !== undefined) {
+      affected.add(member.name);
+      continue;
+    }
+    if (
+      rootMember !== undefined &&
+      ["src/", "tests/", "benches/", "examples/"].some((prefix) => changedPath.startsWith(prefix))
+    ) {
+      affected.add(rootMember.name);
+    }
+  }
+  return [...affected].sort();
+}
+
+export async function observeRepoContext(
+  cwd: string,
+  run: CommandRunner = nativeCommandRunner,
+): Promise<RepoContextObservation> {
+  const started = Date.now();
+  const warnings: string[] = [];
+  const git = await observeGit(cwd, run, warnings);
+  const cargo = await observeCargo(cwd, run, warnings);
+  const affected = mapAffectedPackages(git.mappingPaths, cargo.members, warnings);
+  const visibleMembers = cargo.members.slice(0, WORKSPACE_MEMBER_LIMIT);
+  const visibleAffected = affected.slice(0, AFFECTED_PACKAGE_LIMIT);
+
+  return {
+    gitAvailable: git.available,
+    structured: {
+      branch: git.branch,
+      head: git.head,
+      detached: git.detached,
+      dirty: git.dirty,
+      stagedCount: git.stagedCount,
+      unstagedCount: git.unstagedCount,
+      untrackedCount: git.untrackedCount,
+      changedPaths: [...git.changedPaths],
+      totalChangedPaths: git.totalChangedPaths,
+      changedPathsTruncated: git.changedPathsTruncated,
+      cargoAvailable: cargo.available,
+      workspaceMemberCount: cargo.members.length,
+      workspaceMembers: visibleMembers.map((member) => member.name),
+      workspaceMembersTruncated: cargo.members.length > visibleMembers.length,
+      affectedPackages: [...visibleAffected],
+      affectedPackagesTruncated: affected.length > visibleAffected.length,
+      warnings: [...warnings],
+      elapsedMs: Math.max(0, Date.now() - started),
+    },
+  };
+}

--- a/plugins/repo-context/src/context.ts
+++ b/plugins/repo-context/src/context.ts
@@ -206,8 +206,18 @@ function parsePorcelainStatus(
     const x = field[0] ?? " ";
     const y = field[1] ?? " ";
     const normalized = field.slice(3).replaceAll("\\", "/");
-    const renameOrCopy = x === "R" || x === "C" || y === "R" || y === "C";
-    if (renameOrCopy && index + 1 < fields.length) index += 1;
+    const rename = x === "R" || y === "R";
+    const copy = x === "C" || y === "C";
+    let renameSource: string | undefined;
+    if (rename || copy) {
+      const source = fields[index + 1];
+      if (source === undefined || source.length === 0) {
+        pushWarning(warnings, "git status returned a rename/copy record without a source path");
+      } else {
+        if (rename) renameSource = source.replaceAll("\\", "/");
+        index += 1;
+      }
+    }
 
     if (x === "?" && y === "?") {
       untrackedCount += 1;
@@ -218,6 +228,11 @@ function parsePorcelainStatus(
 
     totalChangedPaths += 1;
     mappingPaths.push(normalized);
+    // A cross-package rename changes both the source and destination package.
+    // Copy sources remain unchanged, so only rename source paths participate in
+    // advisory affected-package mapping. changedPaths/totalChangedPaths still
+    // represent one Git status record rather than double-counting the rename.
+    if (renameSource !== undefined) mappingPaths.push(renameSource);
     if (visiblePaths.length >= CHANGED_PATH_LIMIT) continue;
     if (normalized.length <= PATH_MAX_CHARS && Buffer.byteLength(normalized, "utf8") <= PATH_MAX_CHARS) {
       visiblePaths.push(normalized);

--- a/plugins/repo-context/src/plugin.ts
+++ b/plugins/repo-context/src/plugin.ts
@@ -47,6 +47,7 @@ const repoContextTool = defineTool({
       maxItems: AFFECTED_PACKAGE_LIMIT,
     }),
     affectedPackagesTruncated: schema.boolean(),
+    globalChange: schema.boolean(),
     warnings: schema.array(schema.string({ maxLength: WARNING_MAX_CHARS }), {
       maxItems: WARNING_LIMIT,
     }),

--- a/plugins/repo-context/src/plugin.ts
+++ b/plugins/repo-context/src/plugin.ts
@@ -1,0 +1,76 @@
+import {
+  definePlugin,
+  defineTool,
+  errorResult,
+  runPlugin,
+  schema,
+  textResult,
+} from "@yyjeqhc/webcodex-plugin-sdk";
+
+import {
+  AFFECTED_PACKAGE_LIMIT,
+  CHANGED_PATH_LIMIT,
+  PACKAGE_NAME_MAX_CHARS,
+  PATH_MAX_CHARS,
+  WARNING_LIMIT,
+  WARNING_MAX_CHARS,
+  WORKSPACE_MEMBER_LIMIT,
+  observeRepoContext,
+} from "./context.js";
+
+const repoContextTool = defineTool({
+  name: "repo_context",
+  title: "Repository context",
+  description:
+    "Observe only this Plugin provider's configured cwd and return compact bounded Git status plus advisory Cargo workspace/package context. The tool accepts no path or repository input, performs local read-only Git/Cargo process calls without a shell or network access, and does not return raw cargo metadata, Git diffs, validation verdicts, or absolute provider paths.",
+  inputSchema: schema.object({}),
+  outputSchema: schema.object({
+    branch: schema.string({ maxLength: 512 }),
+    head: schema.string({ maxLength: 64 }),
+    detached: schema.boolean(),
+    dirty: schema.boolean(),
+    stagedCount: schema.integer(),
+    unstagedCount: schema.integer(),
+    untrackedCount: schema.integer(),
+    changedPaths: schema.array(schema.string({ maxLength: PATH_MAX_CHARS }), {
+      maxItems: CHANGED_PATH_LIMIT,
+    }),
+    totalChangedPaths: schema.integer(),
+    changedPathsTruncated: schema.boolean(),
+    cargoAvailable: schema.boolean(),
+    workspaceMemberCount: schema.integer(),
+    workspaceMembers: schema.array(schema.string({ maxLength: PACKAGE_NAME_MAX_CHARS }), {
+      maxItems: WORKSPACE_MEMBER_LIMIT,
+    }),
+    workspaceMembersTruncated: schema.boolean(),
+    affectedPackages: schema.array(schema.string({ maxLength: PACKAGE_NAME_MAX_CHARS }), {
+      maxItems: AFFECTED_PACKAGE_LIMIT,
+    }),
+    affectedPackagesTruncated: schema.boolean(),
+    warnings: schema.array(schema.string({ maxLength: WARNING_MAX_CHARS }), {
+      maxItems: WARNING_LIMIT,
+    }),
+    elapsedMs: schema.integer(),
+  }),
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  async execute() {
+    const observation = await observeRepoContext(process.cwd());
+    const value = observation.structured;
+    if (!observation.gitAvailable) {
+      return errorResult("Git context is unavailable for the configured provider cwd.", value);
+    }
+    const location = value.detached ? "detached HEAD" : `branch ${value.branch}`;
+    const affected = value.affectedPackages.length === 0 ? "none" : value.affectedPackages.join(", ");
+    return textResult(
+      `Repository ${location} at ${value.head.slice(0, 12)}; ${value.totalChangedPaths} changed path(s), ${value.workspaceMemberCount} Cargo workspace member(s), advisory affected packages: ${affected}.`,
+      value,
+    );
+  },
+});
+
+runPlugin(definePlugin({ tools: [repoContextTool] }));

--- a/plugins/repo-context/tsconfig.json
+++ b/plugins/repo-context/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": false,
+    "sourceMap": false,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/ci_path_risk.py
+++ b/scripts/ci_path_risk.py
@@ -209,6 +209,7 @@ def _classify_path(risk: Risk, path: str) -> None:
         path.startswith("npm/plugin-sdk/")
         or path.startswith("plugins/safe-delete/")
         or path.startswith("plugins/repo-info/")
+        or path.startswith("plugins/repo-context/")
     ):
         risk.needs_plugin_sdk = True
         risk.categories.add(

--- a/scripts/tests/test_ci_path_risk.py
+++ b/scripts/tests/test_ci_path_risk.py
@@ -97,6 +97,9 @@ class PathRiskFixtureTests(unittest.TestCase):
             "plugins/repo-info/src/plugin.ts",
             "plugins/repo-info/plugin.test.mjs",
             "plugins/repo-info/package-lock.json",
+            "plugins/repo-context/src/plugin.ts",
+            "plugins/repo-context/plugin.test.mjs",
+            "plugins/repo-context/package-lock.json",
         ):
             with self.subTest(path=path):
                 result = classify(path)


### PR DESCRIPTION
## Summary
- add the read-only `repo-context` first-party Native Plugin dogfood
- aggregate bounded Git status and Cargo workspace/package context behind one Plugin call
- keep provider cwd as the only repository boundary and use `cargo metadata --frozen --no-deps`
- add plugin-sdk dogfood CI coverage and cross-package rename advisory mapping

## What the experiment showed
- warm Plugin path reduced the fixed context question from 2 model-facing calls to 1
- local parsing reduced raw Cargo metadata (~64.6 KiB) to a bounded structured payload under 1 KiB (~77x smaller)
- cold Plugin discovery was not better than the simple 2-call baseline, so the result supports local composition/compact projection more strongly than protocol-level speed claims
- TypeScript-only changes were build/check/reload-able without rebuilding or restarting WebCodex Server/Runner or changing the outer MCP schema

## Validation
- `npm --prefix plugins/repo-context run typecheck`
- `npm --prefix plugins/repo-context test` — 13/13 passing
- `python3 -m unittest scripts.tests.test_ci_path_risk` — 33/33 passing
- `plugin_tool check` on mini — ready=true, toolCount=1
- committed-range review `f7a0b267..28c7c63b` — no deterministic signals or truncation

No protocol, product, or public SDK version bump.