### PR TITLE
Add durable Goal foundation

### DIFF
--- a/crates/webcodex-store/src/goal.rs
+++ b/crates/webcodex-store/src/goal.rs
@@ -1,0 +1,1145 @@
+use super::agent_task::AGENT_TASK_ID_PREFIX;
+use super::communication::{
+    digest_text, new_id, now_unix_ms, validate_communication_principal, validate_id,
+    CommunicationPrincipal,
+};
+use super::Database;
+use rusqlite::{
+    params, types::Type, Connection, OptionalExtension, Transaction, TransactionBehavior,
+};
+use serde::Serialize;
+use serde_json::json;
+
+pub const GOAL_ID_PREFIX: &str = "wc_goal_";
+pub const MAX_GOAL_TITLE_CHARS: usize = 200;
+pub const MAX_GOAL_OBJECTIVE_BYTES: usize = 8_192;
+pub const MAX_GOAL_TERMINAL_REASON_BYTES: usize = 4_096;
+pub const MAX_GOAL_LIST_LIMIT: usize = 100;
+pub const MAX_GOAL_CORRELATIONS: i64 = 64;
+pub const WORKFLOW_SESSION_ID_PREFIX: &str = "wc_sess_";
+const MAX_GOAL_IDEMPOTENCY_KEY_CHARS: usize = 128;
+
+const OP_CREATE_GOAL: &str = "create_goal";
+const OP_UPDATE_GOAL: &str = "update_goal";
+const OP_ASSOCIATE_GOAL_AGENT_TASK: &str = "associate_goal_agent_task";
+const OP_ASSOCIATE_GOAL_WORKFLOW_SESSION: &str = "associate_goal_workflow_session";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoalStoreError {
+    code: &'static str,
+    message: String,
+    current_revision: Option<i64>,
+}
+
+impl GoalStoreError {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            current_revision: None,
+        }
+    }
+
+    fn revision_changed(current_revision: i64) -> Self {
+        Self {
+            code: "goal_revision_changed",
+            message: format!("Goal changed; current authoritative revision is {current_revision}"),
+            current_revision: Some(current_revision),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn current_revision(&self) -> Option<i64> {
+        self.current_revision
+    }
+}
+
+impl std::fmt::Display for GoalStoreError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GoalStoreError {}
+
+fn goal_store_error(error: rusqlite::Error) -> GoalStoreError {
+    tracing::warn!(error = %error, "durable Goal store operation failed");
+    GoalStoreError::new(
+        "goal_store_unavailable",
+        "Durable Goal store is unavailable",
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct NewGoal {
+    pub title: String,
+    pub objective: String,
+    pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GoalPatch {
+    pub title: Option<String>,
+    pub objective: Option<String>,
+    pub lifecycle: Option<GoalLifecycle>,
+    pub terminal_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalLifecycle {
+    Active,
+    Completed,
+    Cancelled,
+}
+
+impl GoalLifecycle {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn from_input(value: &str) -> Result<Self, GoalStoreError> {
+        match value {
+            "active" => Ok(Self::Active),
+            "completed" => Ok(Self::Completed),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(GoalStoreError::new(
+                "invalid_goal_lifecycle",
+                "Goal lifecycle must be one of: active, completed, cancelled",
+            )),
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "active" => Ok(Self::Active),
+            "completed" => Ok(Self::Completed),
+            "cancelled" => Ok(Self::Cancelled),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Goal lifecycle: {other}").into(),
+            )),
+        }
+    }
+
+    pub const fn terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Cancelled)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalCorrelationKind {
+    AgentTask,
+    WorkflowSession,
+}
+
+impl GoalCorrelationKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::AgentTask => "agent_task",
+            Self::WorkflowSession => "workflow_session",
+        }
+    }
+
+    fn from_db(value: &str, index: usize) -> rusqlite::Result<Self> {
+        match value {
+            "agent_task" => Ok(Self::AgentTask),
+            "workflow_session" => Ok(Self::WorkflowSession),
+            other => Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                Type::Text,
+                format!("unsupported Goal correlation kind: {other}").into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GoalCorrelation {
+    pub kind: GoalCorrelationKind,
+    pub reference_id: String,
+    pub created_at_unix_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GoalSummary {
+    pub goal_id: String,
+    pub title: String,
+    pub lifecycle: GoalLifecycle,
+    pub revision: i64,
+    pub created_at_unix_ms: i64,
+    pub updated_at_unix_ms: i64,
+    pub terminal_at_unix_ms: Option<i64>,
+    pub agent_task_count: i64,
+    pub workflow_session_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GoalDetail {
+    pub summary: GoalSummary,
+    pub objective: String,
+    pub terminal_reason: Option<String>,
+    pub correlations: Vec<GoalCorrelation>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GoalMutation {
+    pub goal: GoalDetail,
+    pub created: bool,
+    pub replayed: bool,
+    pub state_changed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GoalPage {
+    pub total_count: i64,
+    pub offset: usize,
+    pub next_offset: Option<usize>,
+    pub truncated: bool,
+    pub goals: Vec<GoalSummary>,
+}
+
+impl Database {
+    pub(super) fn ensure_goal_schema(conn: &mut Connection) -> anyhow::Result<()> {
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS wc_goals (
+                goal_id TEXT PRIMARY KEY,
+                owner_principal_kind TEXT NOT NULL,
+                owner_principal_digest TEXT NOT NULL,
+                title TEXT NOT NULL,
+                objective TEXT NOT NULL,
+                lifecycle TEXT NOT NULL CHECK(lifecycle IN ('active', 'completed', 'cancelled')),
+                revision INTEGER NOT NULL CHECK(revision >= 1),
+                created_at_unix_ms INTEGER NOT NULL,
+                updated_at_unix_ms INTEGER NOT NULL,
+                terminal_at_unix_ms INTEGER,
+                terminal_reason TEXT,
+                CHECK(
+                    (lifecycle = 'active' AND terminal_at_unix_ms IS NULL AND terminal_reason IS NULL)
+                    OR (lifecycle IN ('completed', 'cancelled') AND terminal_at_unix_ms IS NOT NULL)
+                )
+            );
+            CREATE INDEX IF NOT EXISTS idx_wc_goals_owner_updated
+                ON wc_goals(owner_principal_digest, updated_at_unix_ms DESC, goal_id);
+            CREATE INDEX IF NOT EXISTS idx_wc_goals_owner_lifecycle
+                ON wc_goals(owner_principal_digest, lifecycle, updated_at_unix_ms DESC, goal_id);
+
+            CREATE TABLE IF NOT EXISTS wc_goal_correlations (
+                goal_id TEXT NOT NULL,
+                kind TEXT NOT NULL CHECK(kind IN ('agent_task', 'workflow_session')),
+                reference_id TEXT NOT NULL,
+                created_at_unix_ms INTEGER NOT NULL,
+                PRIMARY KEY(goal_id, kind, reference_id),
+                FOREIGN KEY(goal_id) REFERENCES wc_goals(goal_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_wc_goal_correlations_reference
+                ON wc_goal_correlations(kind, reference_id, goal_id);
+
+            CREATE TABLE IF NOT EXISTS wc_goal_idempotency (
+                principal_digest TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                key_hash TEXT NOT NULL,
+                request_hash TEXT NOT NULL,
+                goal_id TEXT NOT NULL,
+                created_at_unix_ms INTEGER NOT NULL,
+                PRIMARY KEY(principal_digest, operation, key_hash)
+            );
+            CREATE INDEX IF NOT EXISTS idx_wc_goal_idempotency_created
+                ON wc_goal_idempotency(created_at_unix_ms DESC);
+            ",
+        )?;
+        Ok(())
+    }
+
+    pub fn create_goal(
+        &self,
+        principal: &CommunicationPrincipal,
+        input: NewGoal,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        self.create_goal_at(principal, input, now_unix_ms())
+    }
+
+    pub(crate) fn create_goal_at(
+        &self,
+        principal: &CommunicationPrincipal,
+        input: NewGoal,
+        now: i64,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        validate_goal_principal(principal)?;
+        let title = validate_title(&input.title)?;
+        let objective = validate_objective(&input.objective)?;
+        let idempotency_key = validate_idempotency_key(&input.idempotency_key)?;
+        let request_hash = goal_request_hash(&json!({
+            "title": title,
+            "objective": objective,
+        }));
+
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(goal_store_error)?;
+        if let Some(goal_id) = lookup_idempotent_goal(
+            &transaction,
+            principal,
+            OP_CREATE_GOAL,
+            &idempotency_key,
+            &request_hash,
+        )? {
+            let goal = load_owned_goal(&transaction, principal, &goal_id)?;
+            transaction.commit().map_err(goal_store_error)?;
+            return Ok(GoalMutation {
+                goal,
+                created: false,
+                replayed: true,
+                state_changed: false,
+            });
+        }
+
+        let goal_id = new_id(GOAL_ID_PREFIX);
+        transaction
+            .execute(
+                "INSERT INTO wc_goals (
+                    goal_id, owner_principal_kind, owner_principal_digest,
+                    title, objective, lifecycle, revision, created_at_unix_ms,
+                    updated_at_unix_ms, terminal_at_unix_ms, terminal_reason
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, 'active', 1, ?6, ?6, NULL, NULL)",
+                params![
+                    goal_id,
+                    principal.kind,
+                    principal.digest,
+                    title,
+                    objective,
+                    now,
+                ],
+            )
+            .map_err(goal_store_error)?;
+        record_idempotent_goal(
+            &transaction,
+            principal,
+            OP_CREATE_GOAL,
+            &idempotency_key,
+            &request_hash,
+            &goal_id,
+            now,
+        )?;
+        let goal = load_owned_goal(&transaction, principal, &goal_id)?;
+        transaction.commit().map_err(goal_store_error)?;
+        Ok(GoalMutation {
+            goal,
+            created: true,
+            replayed: false,
+            state_changed: true,
+        })
+    }
+
+    pub fn read_goal(
+        &self,
+        principal: &CommunicationPrincipal,
+        goal_id: &str,
+    ) -> Result<GoalDetail, GoalStoreError> {
+        validate_goal_principal(principal)?;
+        validate_goal_id(goal_id)?;
+        let conn = self.conn.lock().unwrap();
+        load_owned_goal(&conn, principal, goal_id)
+    }
+
+    pub fn list_goals(
+        &self,
+        principal: &CommunicationPrincipal,
+        lifecycle: Option<GoalLifecycle>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<GoalPage, GoalStoreError> {
+        validate_goal_principal(principal)?;
+        if limit == 0 || limit > MAX_GOAL_LIST_LIMIT {
+            return Err(GoalStoreError::new(
+                "invalid_goal_list_limit",
+                format!("limit must be within 1..={MAX_GOAL_LIST_LIMIT}"),
+            ));
+        }
+        let offset_i64 = i64::try_from(offset).map_err(|_| {
+            GoalStoreError::new(
+                "invalid_goal_list_offset",
+                "offset exceeds the durable Goal store range",
+            )
+        })?;
+        let conn = self.conn.lock().unwrap();
+        let (total_count, goal_ids) = match lifecycle {
+            Some(lifecycle) => {
+                let total_count = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM wc_goals
+                         WHERE owner_principal_kind = ?1 AND owner_principal_digest = ?2
+                           AND lifecycle = ?3",
+                        params![principal.kind, principal.digest, lifecycle.as_str()],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(goal_store_error)?;
+                let mut statement = conn
+                    .prepare(
+                        "SELECT goal_id FROM wc_goals
+                         WHERE owner_principal_kind = ?1 AND owner_principal_digest = ?2
+                           AND lifecycle = ?3
+                         ORDER BY updated_at_unix_ms DESC, goal_id
+                         LIMIT ?4 OFFSET ?5",
+                    )
+                    .map_err(goal_store_error)?;
+                let ids = statement
+                    .query_map(
+                        params![
+                            principal.kind,
+                            principal.digest,
+                            lifecycle.as_str(),
+                            limit as i64,
+                            offset_i64,
+                        ],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .map_err(goal_store_error)?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(goal_store_error)?;
+                (total_count, ids)
+            }
+            None => {
+                let total_count = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM wc_goals
+                         WHERE owner_principal_kind = ?1 AND owner_principal_digest = ?2",
+                        params![principal.kind, principal.digest],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(goal_store_error)?;
+                let mut statement = conn
+                    .prepare(
+                        "SELECT goal_id FROM wc_goals
+                         WHERE owner_principal_kind = ?1 AND owner_principal_digest = ?2
+                         ORDER BY updated_at_unix_ms DESC, goal_id
+                         LIMIT ?3 OFFSET ?4",
+                    )
+                    .map_err(goal_store_error)?;
+                let ids = statement
+                    .query_map(
+                        params![principal.kind, principal.digest, limit as i64, offset_i64,],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .map_err(goal_store_error)?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(goal_store_error)?;
+                (total_count, ids)
+            }
+        };
+        let goals = goal_ids
+            .iter()
+            .map(|goal_id| load_owned_goal_summary(&conn, principal, goal_id))
+            .collect::<Result<Vec<_>, _>>()?;
+        let next_offset = if offset.saturating_add(goals.len()) < total_count as usize {
+            Some(offset.saturating_add(goals.len()))
+        } else {
+            None
+        };
+        Ok(GoalPage {
+            total_count,
+            offset,
+            truncated: next_offset.is_some(),
+            next_offset,
+            goals,
+        })
+    }
+
+    pub fn update_goal(
+        &self,
+        principal: &CommunicationPrincipal,
+        goal_id: &str,
+        expected_revision: i64,
+        patch: GoalPatch,
+        idempotency_key: &str,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        self.update_goal_at(
+            principal,
+            goal_id,
+            expected_revision,
+            patch,
+            idempotency_key,
+            now_unix_ms(),
+        )
+    }
+
+    pub(crate) fn update_goal_at(
+        &self,
+        principal: &CommunicationPrincipal,
+        goal_id: &str,
+        expected_revision: i64,
+        patch: GoalPatch,
+        idempotency_key: &str,
+        now: i64,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        validate_goal_principal(principal)?;
+        validate_goal_id(goal_id)?;
+        if expected_revision < 1 {
+            return Err(GoalStoreError::new(
+                "invalid_goal_revision",
+                "expected_revision must be at least 1",
+            ));
+        }
+        let title = patch.title.as_deref().map(validate_title).transpose()?;
+        let objective = patch
+            .objective
+            .as_deref()
+            .map(validate_objective)
+            .transpose()?;
+        let terminal_reason = patch
+            .terminal_reason
+            .as_deref()
+            .map(validate_terminal_reason)
+            .transpose()?;
+        if title.is_none()
+            && objective.is_none()
+            && patch.lifecycle.is_none()
+            && terminal_reason.is_none()
+        {
+            return Err(GoalStoreError::new(
+                "goal_update_empty",
+                "Goal update must change bounded metadata or lifecycle",
+            ));
+        }
+        if terminal_reason.is_some() && !patch.lifecycle.is_some_and(GoalLifecycle::terminal) {
+            return Err(GoalStoreError::new(
+                "goal_terminal_reason_requires_terminal_lifecycle",
+                "terminal_reason requires an explicit completed or cancelled lifecycle transition",
+            ));
+        }
+        let idempotency_key = validate_idempotency_key(idempotency_key)?;
+        let request_hash = goal_request_hash(&json!({
+            "goal_id": goal_id,
+            "expected_revision": expected_revision,
+            "title": title,
+            "objective": objective,
+            "lifecycle": patch.lifecycle,
+            "terminal_reason": terminal_reason,
+        }));
+
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(goal_store_error)?;
+        if let Some(replayed_goal_id) = lookup_idempotent_goal(
+            &transaction,
+            principal,
+            OP_UPDATE_GOAL,
+            &idempotency_key,
+            &request_hash,
+        )? {
+            if replayed_goal_id != goal_id {
+                return Err(GoalStoreError::new(
+                    "goal_idempotency_conflict",
+                    "Goal update idempotency replay points at a different Goal",
+                ));
+            }
+            let goal = load_owned_goal(&transaction, principal, goal_id)?;
+            transaction.commit().map_err(goal_store_error)?;
+            return Ok(GoalMutation {
+                goal,
+                created: false,
+                replayed: true,
+                state_changed: false,
+            });
+        }
+
+        let current = load_owned_goal(&transaction, principal, goal_id)?;
+        if current.summary.revision != expected_revision {
+            return Err(GoalStoreError::revision_changed(current.summary.revision));
+        }
+        if current.summary.lifecycle.terminal() {
+            return Err(GoalStoreError::new(
+                "goal_terminal",
+                "Terminal Goal state is immutable",
+            ));
+        }
+        let target_lifecycle = patch.lifecycle.unwrap_or(GoalLifecycle::Active);
+        let target_title = title.unwrap_or_else(|| current.summary.title.clone());
+        let target_objective = objective.unwrap_or_else(|| current.objective.clone());
+        let state_changed = target_title != current.summary.title
+            || target_objective != current.objective
+            || target_lifecycle != current.summary.lifecycle
+            || terminal_reason != current.terminal_reason;
+
+        if state_changed {
+            let (terminal_at, terminal_reason) = if target_lifecycle.terminal() {
+                (Some(now), terminal_reason)
+            } else {
+                (None, None)
+            };
+            transaction
+                .execute(
+                    "UPDATE wc_goals
+                     SET title = ?2, objective = ?3, lifecycle = ?4,
+                         revision = revision + 1, updated_at_unix_ms = ?5,
+                         terminal_at_unix_ms = ?6, terminal_reason = ?7
+                     WHERE goal_id = ?1",
+                    params![
+                        goal_id,
+                        target_title,
+                        target_objective,
+                        target_lifecycle.as_str(),
+                        now,
+                        terminal_at,
+                        terminal_reason,
+                    ],
+                )
+                .map_err(goal_store_error)?;
+        }
+        record_idempotent_goal(
+            &transaction,
+            principal,
+            OP_UPDATE_GOAL,
+            &idempotency_key,
+            &request_hash,
+            goal_id,
+            now,
+        )?;
+        let goal = load_owned_goal(&transaction, principal, goal_id)?;
+        transaction.commit().map_err(goal_store_error)?;
+        Ok(GoalMutation {
+            goal,
+            created: false,
+            replayed: false,
+            state_changed,
+        })
+    }
+
+    pub fn associate_goal_agent_task(
+        &self,
+        principal: &CommunicationPrincipal,
+        goal_id: &str,
+        task_id: &str,
+        idempotency_key: &str,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        validate_id(task_id, AGENT_TASK_ID_PREFIX, "invalid_agent_task_id")
+            .map_err(map_communication_validation_error)?;
+        self.associate_goal_reference(
+            principal,
+            goal_id,
+            GoalCorrelationKind::AgentTask,
+            task_id,
+            idempotency_key,
+            now_unix_ms(),
+        )
+    }
+
+    pub fn associate_goal_workflow_session(
+        &self,
+        principal: &CommunicationPrincipal,
+        goal_id: &str,
+        session_id: &str,
+        idempotency_key: &str,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        validate_id(
+            session_id,
+            WORKFLOW_SESSION_ID_PREFIX,
+            "invalid_workflow_session_id",
+        )
+        .map_err(map_communication_validation_error)?;
+        self.associate_goal_reference(
+            principal,
+            goal_id,
+            GoalCorrelationKind::WorkflowSession,
+            session_id,
+            idempotency_key,
+            now_unix_ms(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn associate_goal_reference_at(
+        &self,
+        principal: &CommunicationPrincipal,
+        goal_id: &str,
+        kind: GoalCorrelationKind,
+        reference_id: &str,
+        idempotency_key: &str,
+        now: i64,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        match kind {
+            GoalCorrelationKind::AgentTask => {
+                validate_id(reference_id, AGENT_TASK_ID_PREFIX, "invalid_agent_task_id")
+                    .map_err(map_communication_validation_error)?
+            }
+            GoalCorrelationKind::WorkflowSession => validate_id(
+                reference_id,
+                WORKFLOW_SESSION_ID_PREFIX,
+                "invalid_workflow_session_id",
+            )
+            .map_err(map_communication_validation_error)?,
+        }
+        self.associate_goal_reference(principal, goal_id, kind, reference_id, idempotency_key, now)
+    }
+
+    fn associate_goal_reference(
+        &self,
+        principal: &CommunicationPrincipal,
+        goal_id: &str,
+        kind: GoalCorrelationKind,
+        reference_id: &str,
+        idempotency_key: &str,
+        now: i64,
+    ) -> Result<GoalMutation, GoalStoreError> {
+        validate_goal_principal(principal)?;
+        validate_goal_id(goal_id)?;
+        let idempotency_key = validate_idempotency_key(idempotency_key)?;
+        let operation = match kind {
+            GoalCorrelationKind::AgentTask => OP_ASSOCIATE_GOAL_AGENT_TASK,
+            GoalCorrelationKind::WorkflowSession => OP_ASSOCIATE_GOAL_WORKFLOW_SESSION,
+        };
+        let request_hash = goal_request_hash(&json!({
+            "goal_id": goal_id,
+            "kind": kind,
+            "reference_id": reference_id,
+        }));
+        let mut conn = self.conn.lock().unwrap();
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(goal_store_error)?;
+        if let Some(replayed_goal_id) = lookup_idempotent_goal(
+            &transaction,
+            principal,
+            operation,
+            &idempotency_key,
+            &request_hash,
+        )? {
+            if replayed_goal_id != goal_id {
+                return Err(GoalStoreError::new(
+                    "goal_idempotency_conflict",
+                    "Goal association idempotency replay points at a different Goal",
+                ));
+            }
+            let goal = load_owned_goal(&transaction, principal, goal_id)?;
+            transaction.commit().map_err(goal_store_error)?;
+            return Ok(GoalMutation {
+                goal,
+                created: false,
+                replayed: true,
+                state_changed: false,
+            });
+        }
+        let current = load_owned_goal(&transaction, principal, goal_id)?;
+        if current.summary.lifecycle.terminal() {
+            return Err(GoalStoreError::new(
+                "goal_terminal",
+                "Terminal Goal state is immutable",
+            ));
+        }
+        let exists = transaction
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM wc_goal_correlations
+                    WHERE goal_id = ?1 AND kind = ?2 AND reference_id = ?3
+                 )",
+                params![goal_id, kind.as_str(), reference_id],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(goal_store_error)?;
+        let state_changed = if exists {
+            false
+        } else {
+            let count = transaction
+                .query_row(
+                    "SELECT COUNT(*) FROM wc_goal_correlations WHERE goal_id = ?1",
+                    [goal_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(goal_store_error)?;
+            if count >= MAX_GOAL_CORRELATIONS {
+                return Err(GoalStoreError::new(
+                    "goal_correlation_capacity_exceeded",
+                    format!("Goal correlation count is limited to {MAX_GOAL_CORRELATIONS}"),
+                ));
+            }
+            transaction
+                .execute(
+                    "INSERT INTO wc_goal_correlations (
+                        goal_id, kind, reference_id, created_at_unix_ms
+                     ) VALUES (?1, ?2, ?3, ?4)",
+                    params![goal_id, kind.as_str(), reference_id, now],
+                )
+                .map_err(goal_store_error)?;
+            transaction
+                .execute(
+                    "UPDATE wc_goals
+                     SET revision = revision + 1, updated_at_unix_ms = ?2
+                     WHERE goal_id = ?1",
+                    params![goal_id, now],
+                )
+                .map_err(goal_store_error)?;
+            true
+        };
+        record_idempotent_goal(
+            &transaction,
+            principal,
+            operation,
+            &idempotency_key,
+            &request_hash,
+            goal_id,
+            now,
+        )?;
+        let goal = load_owned_goal(&transaction, principal, goal_id)?;
+        transaction.commit().map_err(goal_store_error)?;
+        Ok(GoalMutation {
+            goal,
+            created: false,
+            replayed: false,
+            state_changed,
+        })
+    }
+}
+
+fn validate_goal_principal(principal: &CommunicationPrincipal) -> Result<(), GoalStoreError> {
+    validate_communication_principal(principal).map_err(map_communication_validation_error)
+}
+
+fn map_communication_validation_error(
+    error: super::communication::CommunicationStoreError,
+) -> GoalStoreError {
+    GoalStoreError::new(error.code(), error.message())
+}
+
+fn validate_goal_id(goal_id: &str) -> Result<(), GoalStoreError> {
+    validate_id(goal_id, GOAL_ID_PREFIX, "invalid_goal_id")
+        .map_err(map_communication_validation_error)
+}
+
+fn validate_title(value: &str) -> Result<String, GoalStoreError> {
+    let value = value.trim();
+    if value.is_empty() || value.chars().count() > MAX_GOAL_TITLE_CHARS {
+        return Err(GoalStoreError::new(
+            "invalid_goal_title",
+            format!("Goal title must contain 1..={MAX_GOAL_TITLE_CHARS} characters"),
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn validate_objective(value: &str) -> Result<String, GoalStoreError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > MAX_GOAL_OBJECTIVE_BYTES {
+        return Err(GoalStoreError::new(
+            "invalid_goal_objective",
+            format!("Goal objective must contain 1..={MAX_GOAL_OBJECTIVE_BYTES} UTF-8 bytes"),
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn validate_terminal_reason(value: &str) -> Result<String, GoalStoreError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > MAX_GOAL_TERMINAL_REASON_BYTES {
+        return Err(GoalStoreError::new(
+            "invalid_goal_terminal_reason",
+            format!(
+                "Goal terminal_reason must contain 1..={MAX_GOAL_TERMINAL_REASON_BYTES} UTF-8 bytes"
+            ),
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn validate_idempotency_key(value: &str) -> Result<String, GoalStoreError> {
+    let value = value.trim();
+    if value.is_empty() || value.chars().count() > MAX_GOAL_IDEMPOTENCY_KEY_CHARS {
+        return Err(GoalStoreError::new(
+            "invalid_goal_idempotency_key",
+            format!("idempotency_key must contain 1..={MAX_GOAL_IDEMPOTENCY_KEY_CHARS} characters"),
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn goal_request_hash(value: &serde_json::Value) -> String {
+    digest_text(
+        "webcodex.goal.request.v1",
+        &serde_json::to_string(value).expect("Goal request serializes"),
+    )
+}
+
+fn lookup_idempotent_goal(
+    transaction: &Transaction<'_>,
+    principal: &CommunicationPrincipal,
+    operation: &str,
+    idempotency_key: &str,
+    request_hash: &str,
+) -> Result<Option<String>, GoalStoreError> {
+    let key_hash = digest_text("webcodex.goal.idempotency-key.v1", idempotency_key);
+    let existing: Option<(String, String)> = transaction
+        .query_row(
+            "SELECT request_hash, goal_id FROM wc_goal_idempotency
+             WHERE principal_digest = ?1 AND operation = ?2 AND key_hash = ?3",
+            params![principal.digest, operation, key_hash],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(goal_store_error)?;
+    match existing {
+        None => Ok(None),
+        Some((existing_request_hash, goal_id)) if existing_request_hash == request_hash => {
+            Ok(Some(goal_id))
+        }
+        Some(_) => Err(GoalStoreError::new(
+            "goal_idempotency_conflict",
+            "Idempotency key was already used with a different Goal request",
+        )),
+    }
+}
+
+fn record_idempotent_goal(
+    transaction: &Transaction<'_>,
+    principal: &CommunicationPrincipal,
+    operation: &str,
+    idempotency_key: &str,
+    request_hash: &str,
+    goal_id: &str,
+    now: i64,
+) -> Result<(), GoalStoreError> {
+    let key_hash = digest_text("webcodex.goal.idempotency-key.v1", idempotency_key);
+    transaction
+        .execute(
+            "INSERT INTO wc_goal_idempotency (
+                principal_digest, operation, key_hash, request_hash, goal_id, created_at_unix_ms
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                principal.digest,
+                operation,
+                key_hash,
+                request_hash,
+                goal_id,
+                now,
+            ],
+        )
+        .map_err(goal_store_error)?;
+    Ok(())
+}
+
+fn persisted_goal_state_error() -> GoalStoreError {
+    tracing::warn!("durable Goal store contains invalid persisted bounded state");
+    GoalStoreError::new(
+        "goal_store_unavailable",
+        "Durable Goal store contains invalid persisted state",
+    )
+}
+
+fn validate_loaded_goal_summary(summary: &GoalSummary) -> Result<(), GoalStoreError> {
+    let normalized_title =
+        validate_title(&summary.title).map_err(|_| persisted_goal_state_error())?;
+    if normalized_title != summary.title
+        || summary.revision < 1
+        || summary.agent_task_count < 0
+        || summary.workflow_session_count < 0
+        || summary
+            .agent_task_count
+            .saturating_add(summary.workflow_session_count)
+            > MAX_GOAL_CORRELATIONS
+        || (summary.lifecycle == GoalLifecycle::Active && summary.terminal_at_unix_ms.is_some())
+        || (summary.lifecycle.terminal() && summary.terminal_at_unix_ms.is_none())
+    {
+        return Err(persisted_goal_state_error());
+    }
+    Ok(())
+}
+
+fn validate_loaded_goal_detail(detail: &GoalDetail) -> Result<(), GoalStoreError> {
+    validate_loaded_goal_summary(&detail.summary)?;
+    let normalized_objective =
+        validate_objective(&detail.objective).map_err(|_| persisted_goal_state_error())?;
+    if normalized_objective != detail.objective
+        || (detail.summary.lifecycle == GoalLifecycle::Active && detail.terminal_reason.is_some())
+    {
+        return Err(persisted_goal_state_error());
+    }
+    if let Some(reason) = detail.terminal_reason.as_deref() {
+        let normalized_reason =
+            validate_terminal_reason(reason).map_err(|_| persisted_goal_state_error())?;
+        if normalized_reason != reason {
+            return Err(persisted_goal_state_error());
+        }
+    }
+    if detail.correlations.len() > MAX_GOAL_CORRELATIONS as usize {
+        return Err(persisted_goal_state_error());
+    }
+    for correlation in &detail.correlations {
+        let validation = match correlation.kind {
+            GoalCorrelationKind::AgentTask => validate_id(
+                &correlation.reference_id,
+                AGENT_TASK_ID_PREFIX,
+                "invalid_agent_task_id",
+            ),
+            GoalCorrelationKind::WorkflowSession => validate_id(
+                &correlation.reference_id,
+                WORKFLOW_SESSION_ID_PREFIX,
+                "invalid_workflow_session_id",
+            ),
+        };
+        if validation.is_err() {
+            return Err(persisted_goal_state_error());
+        }
+    }
+    Ok(())
+}
+
+fn load_owned_goal_summary(
+    conn: &Connection,
+    principal: &CommunicationPrincipal,
+    goal_id: &str,
+) -> Result<GoalSummary, GoalStoreError> {
+    validate_goal_id(goal_id)?;
+    let summary = conn
+        .query_row(
+            "SELECT goal_id, title, lifecycle, revision, created_at_unix_ms,
+                    updated_at_unix_ms, terminal_at_unix_ms,
+                    (SELECT COUNT(*) FROM wc_goal_correlations c
+                     WHERE c.goal_id = g.goal_id AND c.kind = 'agent_task'),
+                    (SELECT COUNT(*) FROM wc_goal_correlations c
+                     WHERE c.goal_id = g.goal_id AND c.kind = 'workflow_session')
+             FROM wc_goals g
+             WHERE goal_id = ?1 AND owner_principal_kind = ?2 AND owner_principal_digest = ?3",
+            params![goal_id, principal.kind, principal.digest],
+            |row| {
+                Ok(GoalSummary {
+                    goal_id: row.get(0)?,
+                    title: row.get(1)?,
+                    lifecycle: GoalLifecycle::from_db(&row.get::<_, String>(2)?, 2)?,
+                    revision: row.get(3)?,
+                    created_at_unix_ms: row.get(4)?,
+                    updated_at_unix_ms: row.get(5)?,
+                    terminal_at_unix_ms: row.get(6)?,
+                    agent_task_count: row.get(7)?,
+                    workflow_session_count: row.get(8)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(goal_store_error)?
+        .ok_or_else(|| GoalStoreError::new("goal_not_found", "Goal does not exist"))?;
+    validate_loaded_goal_summary(&summary)?;
+    Ok(summary)
+}
+
+fn load_owned_goal(
+    conn: &Connection,
+    principal: &CommunicationPrincipal,
+    goal_id: &str,
+) -> Result<GoalDetail, GoalStoreError> {
+    validate_goal_id(goal_id)?;
+    let row = conn
+        .query_row(
+            "SELECT goal_id, title, objective, lifecycle, revision,
+                    created_at_unix_ms, updated_at_unix_ms, terminal_at_unix_ms,
+                    terminal_reason,
+                    (SELECT COUNT(*) FROM wc_goal_correlations c
+                     WHERE c.goal_id = g.goal_id AND c.kind = 'agent_task'),
+                    (SELECT COUNT(*) FROM wc_goal_correlations c
+                     WHERE c.goal_id = g.goal_id AND c.kind = 'workflow_session')
+             FROM wc_goals g
+             WHERE goal_id = ?1 AND owner_principal_kind = ?2 AND owner_principal_digest = ?3",
+            params![goal_id, principal.kind, principal.digest],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    GoalLifecycle::from_db(&row.get::<_, String>(3)?, 3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, i64>(6)?,
+                    row.get::<_, Option<i64>>(7)?,
+                    row.get::<_, Option<String>>(8)?,
+                    row.get::<_, i64>(9)?,
+                    row.get::<_, i64>(10)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(goal_store_error)?
+        .ok_or_else(|| GoalStoreError::new("goal_not_found", "Goal does not exist"))?;
+    if row.9.saturating_add(row.10) > MAX_GOAL_CORRELATIONS {
+        return Err(persisted_goal_state_error());
+    }
+    let mut statement = conn
+        .prepare(
+            "SELECT kind, reference_id, created_at_unix_ms
+             FROM wc_goal_correlations
+             WHERE goal_id = ?1
+             ORDER BY created_at_unix_ms, kind, reference_id
+             LIMIT ?2",
+        )
+        .map_err(goal_store_error)?;
+    let correlations = statement
+        .query_map(params![goal_id, MAX_GOAL_CORRELATIONS + 1], |row| {
+            Ok(GoalCorrelation {
+                kind: GoalCorrelationKind::from_db(&row.get::<_, String>(0)?, 0)?,
+                reference_id: row.get(1)?,
+                created_at_unix_ms: row.get(2)?,
+            })
+        })
+        .map_err(goal_store_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(goal_store_error)?;
+    let detail = GoalDetail {
+        summary: GoalSummary {
+            goal_id: row.0,
+            title: row.1,
+            lifecycle: row.3,
+            revision: row.4,
+            created_at_unix_ms: row.5,
+            updated_at_unix_ms: row.6,
+            terminal_at_unix_ms: row.7,
+            agent_task_count: row.9,
+            workflow_session_count: row.10,
+        },
+        objective: row.2,
+        terminal_reason: row.8,
+        correlations,
+    };
+    validate_loaded_goal_detail(&detail)?;
+    Ok(detail)
+}
+
+#[cfg(test)]
+mod lifecycle_contract_tests {
+    use super::*;
+
+    #[test]
+    fn goal_lifecycle_and_correlation_encodings_are_closed() {
+        for (lifecycle, db) in [
+            (GoalLifecycle::Active, "active"),
+            (GoalLifecycle::Completed, "completed"),
+            (GoalLifecycle::Cancelled, "cancelled"),
+        ] {
+            assert_eq!(lifecycle.as_str(), db);
+            assert_eq!(GoalLifecycle::from_db(db, 0).unwrap(), lifecycle);
+            assert_eq!(serde_json::to_value(lifecycle).unwrap(), db);
+        }
+        assert!(GoalLifecycle::from_db("waiting_validation", 0).is_err());
+
+        for (kind, db) in [
+            (GoalCorrelationKind::AgentTask, "agent_task"),
+            (GoalCorrelationKind::WorkflowSession, "workflow_session"),
+        ] {
+            assert_eq!(kind.as_str(), db);
+            assert_eq!(GoalCorrelationKind::from_db(db, 0).unwrap(), kind);
+            assert_eq!(serde_json::to_value(kind).unwrap(), db);
+        }
+        assert!(GoalCorrelationKind::from_db("job", 0).is_err());
+    }
+}

--- a/crates/webcodex-store/src/goal_tests.rs
+++ b/crates/webcodex-store/src/goal_tests.rs
@@ -1,0 +1,398 @@
+use super::communication::{CommunicationPrincipal, COMMUNICATION_PRINCIPAL_DIGEST_PREFIX};
+use super::goal::*;
+use super::Database;
+
+const T0: i64 = 10_000;
+
+fn principal(hex: char) -> CommunicationPrincipal {
+    CommunicationPrincipal {
+        kind: "user".to_string(),
+        digest: format!(
+            "{COMMUNICATION_PRINCIPAL_DIGEST_PREFIX}{}",
+            hex.to_string().repeat(64)
+        ),
+    }
+}
+
+fn input(key: &str) -> NewGoal {
+    NewGoal {
+        title: "Ship durable Goal foundation".to_string(),
+        objective: "Preserve high-level durable intent without granting execution authority."
+            .to_string(),
+        idempotency_key: key.to_string(),
+    }
+}
+
+#[test]
+fn create_read_list_update_and_terminal_replay_are_durable_and_revisioned() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("goals.db");
+    let owner = principal('a');
+    let goal_id = {
+        let db = Database::open(&path).unwrap();
+        let created = db.create_goal_at(&owner, input("create-goal"), T0).unwrap();
+        assert!(created.created);
+        assert!(!created.replayed);
+        assert!(created.state_changed);
+        assert!(created.goal.summary.goal_id.starts_with(GOAL_ID_PREFIX));
+        assert_eq!(created.goal.summary.lifecycle, GoalLifecycle::Active);
+        assert_eq!(created.goal.summary.revision, 1);
+        assert!(created.goal.correlations.is_empty());
+
+        let replay = db
+            .create_goal_at(&owner, input("create-goal"), T0 + 1)
+            .unwrap();
+        assert!(replay.replayed);
+        assert!(!replay.state_changed);
+        assert_eq!(replay.goal.summary.goal_id, created.goal.summary.goal_id);
+
+        let mut changed_create = input("create-goal");
+        changed_create.objective.push_str(" Changed.");
+        let conflict = db
+            .create_goal_at(&owner, changed_create, T0 + 2)
+            .unwrap_err();
+        assert_eq!(conflict.code(), "goal_idempotency_conflict");
+
+        let updated = db
+            .update_goal_at(
+                &owner,
+                &created.goal.summary.goal_id,
+                1,
+                GoalPatch {
+                    title: Some("Ship Goal foundation".to_string()),
+                    objective: None,
+                    lifecycle: None,
+                    terminal_reason: None,
+                },
+                "update-title",
+                T0 + 3,
+            )
+            .unwrap();
+        assert!(updated.state_changed);
+        assert_eq!(updated.goal.summary.revision, 2);
+        assert_eq!(updated.goal.summary.lifecycle, GoalLifecycle::Active);
+
+        let changed_update_reuse = db
+            .update_goal_at(
+                &owner,
+                &created.goal.summary.goal_id,
+                1,
+                GoalPatch {
+                    title: Some("Different title under same key".to_string()),
+                    objective: None,
+                    lifecycle: None,
+                    terminal_reason: None,
+                },
+                "update-title",
+                T0 + 3,
+            )
+            .unwrap_err();
+        assert_eq!(changed_update_reuse.code(), "goal_idempotency_conflict");
+
+        let terminal = db
+            .update_goal_at(
+                &owner,
+                &created.goal.summary.goal_id,
+                2,
+                GoalPatch {
+                    title: None,
+                    objective: None,
+                    lifecycle: Some(GoalLifecycle::Completed),
+                    terminal_reason: Some("Phase 1 accepted".to_string()),
+                },
+                "complete-goal",
+                T0 + 4,
+            )
+            .unwrap();
+        assert_eq!(terminal.goal.summary.lifecycle, GoalLifecycle::Completed);
+        assert_eq!(terminal.goal.summary.revision, 3);
+        assert_eq!(terminal.goal.summary.terminal_at_unix_ms, Some(T0 + 4));
+        assert_eq!(
+            terminal.goal.terminal_reason.as_deref(),
+            Some("Phase 1 accepted")
+        );
+
+        let terminal_replay = db
+            .update_goal_at(
+                &owner,
+                &created.goal.summary.goal_id,
+                2,
+                GoalPatch {
+                    title: None,
+                    objective: None,
+                    lifecycle: Some(GoalLifecycle::Completed),
+                    terminal_reason: Some("Phase 1 accepted".to_string()),
+                },
+                "complete-goal",
+                T0 + 5,
+            )
+            .unwrap();
+        assert!(terminal_replay.replayed);
+        assert!(!terminal_replay.state_changed);
+        assert_eq!(terminal_replay.goal.summary.revision, 3);
+
+        let page = db
+            .list_goals(&owner, Some(GoalLifecycle::Completed), 0, 10)
+            .unwrap();
+        assert_eq!(page.total_count, 1);
+        assert_eq!(page.goals[0].goal_id, created.goal.summary.goal_id);
+        assert_eq!(page.goals[0].agent_task_count, 0);
+        assert_eq!(page.goals[0].workflow_session_count, 0);
+        created.goal.summary.goal_id
+    };
+
+    let reopened = Database::open(&path).unwrap();
+    let goal = reopened.read_goal(&owner, &goal_id).unwrap();
+    assert_eq!(goal.summary.lifecycle, GoalLifecycle::Completed);
+    assert_eq!(goal.summary.revision, 3);
+    assert_eq!(goal.terminal_reason.as_deref(), Some("Phase 1 accepted"));
+}
+
+#[test]
+fn exact_read_hides_foreign_existence_and_updates_fail_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("goal-auth.db")).unwrap();
+    let owner = principal('b');
+    let foreign = principal('c');
+    let created = db
+        .create_goal_at(&owner, input("owner-create"), T0)
+        .unwrap();
+    let goal_id = created.goal.summary.goal_id;
+
+    let foreign_error = db.read_goal(&foreign, &goal_id).unwrap_err();
+    assert_eq!(foreign_error.code(), "goal_not_found");
+    let missing = format!("{GOAL_ID_PREFIX}{}", "f".repeat(32));
+    let missing_error = db.read_goal(&foreign, &missing).unwrap_err();
+    assert_eq!(missing_error.code(), "goal_not_found");
+
+    let stale = db
+        .update_goal_at(
+            &owner,
+            &goal_id,
+            99,
+            GoalPatch {
+                title: Some("stale".to_string()),
+                ..GoalPatch::default()
+            },
+            "stale-update",
+            T0 + 1,
+        )
+        .unwrap_err();
+    assert_eq!(stale.code(), "goal_revision_changed");
+    assert_eq!(stale.current_revision(), Some(1));
+
+    let terminal = db
+        .update_goal_at(
+            &owner,
+            &goal_id,
+            1,
+            GoalPatch {
+                lifecycle: Some(GoalLifecycle::Cancelled),
+                ..GoalPatch::default()
+            },
+            "cancel-goal",
+            T0 + 2,
+        )
+        .unwrap();
+    assert_eq!(terminal.goal.summary.lifecycle, GoalLifecycle::Cancelled);
+    let immutable = db
+        .update_goal_at(
+            &owner,
+            &goal_id,
+            2,
+            GoalPatch {
+                title: Some("cannot mutate".to_string()),
+                ..GoalPatch::default()
+            },
+            "terminal-mutate",
+            T0 + 3,
+        )
+        .unwrap_err();
+    assert_eq!(immutable.code(), "goal_terminal");
+}
+
+#[test]
+fn correlations_are_bounded_explicit_identity_only_and_replayed() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("goal-correlations.db")).unwrap();
+    let owner = principal('d');
+    let created = db.create_goal_at(&owner, input("corr-create"), T0).unwrap();
+    let goal_id = created.goal.summary.goal_id;
+    let task_id = format!("wc_agent_task_{}", "1".repeat(32));
+    let session_id = format!("wc_sess_{}", "2".repeat(32));
+
+    let task_link = db
+        .associate_goal_reference_at(
+            &owner,
+            &goal_id,
+            GoalCorrelationKind::AgentTask,
+            &task_id,
+            "task-link",
+            T0 + 1,
+        )
+        .unwrap();
+    assert!(task_link.state_changed);
+    assert_eq!(task_link.goal.summary.revision, 2);
+    assert_eq!(task_link.goal.summary.agent_task_count, 1);
+
+    let task_replay = db
+        .associate_goal_reference_at(
+            &owner,
+            &goal_id,
+            GoalCorrelationKind::AgentTask,
+            &task_id,
+            "task-link",
+            T0 + 2,
+        )
+        .unwrap();
+    assert!(task_replay.replayed);
+    assert!(!task_replay.state_changed);
+
+    let session_link = db
+        .associate_goal_reference_at(
+            &owner,
+            &goal_id,
+            GoalCorrelationKind::WorkflowSession,
+            &session_id,
+            "session-link",
+            T0 + 3,
+        )
+        .unwrap();
+    assert_eq!(session_link.goal.summary.revision, 3);
+    assert_eq!(session_link.goal.summary.workflow_session_count, 1);
+    assert_eq!(session_link.goal.correlations.len(), 2);
+
+    let changed_reuse = db
+        .associate_goal_reference_at(
+            &owner,
+            &goal_id,
+            GoalCorrelationKind::WorkflowSession,
+            &format!("wc_sess_{}", "3".repeat(32)),
+            "session-link",
+            T0 + 4,
+        )
+        .unwrap_err();
+    assert_eq!(changed_reuse.code(), "goal_idempotency_conflict");
+
+    for ordinal in 0..(MAX_GOAL_CORRELATIONS - 2) {
+        let reference_id = format!("wc_agent_task_{ordinal:032x}");
+        let key = format!("capacity-link-{ordinal}");
+        db.associate_goal_reference_at(
+            &owner,
+            &goal_id,
+            GoalCorrelationKind::AgentTask,
+            &reference_id,
+            &key,
+            T0 + 10 + ordinal,
+        )
+        .unwrap();
+    }
+    let full = db.read_goal(&owner, &goal_id).unwrap();
+    assert_eq!(full.correlations.len(), MAX_GOAL_CORRELATIONS as usize);
+    let overflow = db
+        .associate_goal_reference_at(
+            &owner,
+            &goal_id,
+            GoalCorrelationKind::AgentTask,
+            &format!("wc_agent_task_{}", "f".repeat(32)),
+            "capacity-overflow",
+            T0 + 100,
+        )
+        .unwrap_err();
+    assert_eq!(overflow.code(), "goal_correlation_capacity_exceeded");
+}
+
+#[test]
+fn bounds_and_unknown_persisted_lifecycle_fail_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open(&temp.path().join("goal-bounds.db")).unwrap();
+    let owner = principal('e');
+
+    let mut oversized = input("oversized-title");
+    oversized.title = "x".repeat(MAX_GOAL_TITLE_CHARS + 1);
+    assert_eq!(
+        db.create_goal_at(&owner, oversized, T0).unwrap_err().code(),
+        "invalid_goal_title"
+    );
+    let mut oversized = input("oversized-objective");
+    oversized.objective = "x".repeat(MAX_GOAL_OBJECTIVE_BYTES + 1);
+    assert_eq!(
+        db.create_goal_at(&owner, oversized, T0).unwrap_err().code(),
+        "invalid_goal_objective"
+    );
+    assert_eq!(
+        db.list_goals(&owner, None, 0, MAX_GOAL_LIST_LIMIT + 1)
+            .unwrap_err()
+            .code(),
+        "invalid_goal_list_limit"
+    );
+    #[cfg(target_pointer_width = "64")]
+    assert_eq!(
+        db.list_goals(&owner, None, (i64::MAX as usize) + 1, 1)
+            .unwrap_err()
+            .code(),
+        "invalid_goal_list_offset"
+    );
+
+    let oversized_persisted = db
+        .create_goal_at(&owner, input("corrupt-objective-create"), T0)
+        .unwrap();
+    {
+        let conn = db.conn_for_tests();
+        conn.execute(
+            "UPDATE wc_goals SET objective = ?2 WHERE goal_id = ?1",
+            rusqlite::params![
+                oversized_persisted.goal.summary.goal_id,
+                "x".repeat(MAX_GOAL_OBJECTIVE_BYTES + 1)
+            ],
+        )
+        .unwrap();
+    }
+    let error = db
+        .read_goal(&owner, &oversized_persisted.goal.summary.goal_id)
+        .unwrap_err();
+    assert_eq!(error.code(), "goal_store_unavailable");
+
+    let overlinked = db
+        .create_goal_at(&owner, input("corrupt-correlations-create"), T0)
+        .unwrap();
+    {
+        let conn = db.conn_for_tests();
+        for ordinal in 0..=MAX_GOAL_CORRELATIONS {
+            conn.execute(
+                "INSERT INTO wc_goal_correlations (
+                    goal_id, kind, reference_id, created_at_unix_ms
+                 ) VALUES (?1, 'agent_task', ?2, ?3)",
+                rusqlite::params![
+                    overlinked.goal.summary.goal_id,
+                    format!("wc_agent_task_{ordinal:032x}"),
+                    T0 + ordinal,
+                ],
+            )
+            .unwrap();
+        }
+    }
+    let error = db
+        .read_goal(&owner, &overlinked.goal.summary.goal_id)
+        .unwrap_err();
+    assert_eq!(error.code(), "goal_store_unavailable");
+
+    let created = db
+        .create_goal_at(&owner, input("corrupt-create"), T0)
+        .unwrap();
+    let goal_id = created.goal.summary.goal_id;
+    {
+        let conn = db.conn_for_tests();
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON;")
+            .unwrap();
+        conn.execute(
+            "UPDATE wc_goals SET lifecycle = 'waiting_validation' WHERE goal_id = ?1",
+            [goal_id.as_str()],
+        )
+        .unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = OFF;")
+            .unwrap();
+    }
+    let error = db.read_goal(&owner, &goal_id).unwrap_err();
+    assert_eq!(error.code(), "goal_store_unavailable");
+}

--- a/crates/webcodex-store/src/lib.rs
+++ b/crates/webcodex-store/src/lib.rs
@@ -15,6 +15,7 @@ mod audit;
 mod communication;
 mod execution_model;
 mod executions;
+mod goal;
 mod memory;
 pub mod models;
 mod oauth;
@@ -59,6 +60,12 @@ pub use self::execution_model::{
 #[cfg(any(test, feature = "root-test-support"))]
 pub use self::execution_model::{
     ConnectorExecutionContinuationIntent, ConnectorTerminalContinuationClaim,
+};
+pub use self::goal::{
+    GoalCorrelation, GoalCorrelationKind, GoalDetail, GoalLifecycle, GoalMutation, GoalPage,
+    GoalPatch, GoalStoreError, GoalSummary, NewGoal, GOAL_ID_PREFIX, MAX_GOAL_CORRELATIONS,
+    MAX_GOAL_LIST_LIMIT, MAX_GOAL_OBJECTIVE_BYTES, MAX_GOAL_TERMINAL_REASON_BYTES,
+    MAX_GOAL_TITLE_CHARS, WORKFLOW_SESSION_ID_PREFIX,
 };
 #[allow(unused_imports)]
 pub use self::memory::{
@@ -138,5 +145,7 @@ mod continuation_delivery_tests;
 mod db_tests;
 #[cfg(test)]
 mod execution_intent_tests;
+#[cfg(test)]
+mod goal_tests;
 #[cfg(test)]
 mod memory_tests;

--- a/crates/webcodex-store/src/schema.rs
+++ b/crates/webcodex-store/src/schema.rs
@@ -642,6 +642,10 @@ impl Database {
         // and deliberately do not bind any execution backend in A3.
         Self::ensure_agent_task_schema(&mut conn)?;
 
+        // Goal is independent high-level durable intent/control state. It may
+        // correlate AgentTasks and Workflow Sessions, but owns no execution authority.
+        Self::ensure_goal_schema(&mut conn)?;
+
         // Project Memory was introduced after v0.3.9. Only the current schema is
         // supported; development-only intermediate shapes are rejected.
         Self::ensure_project_memory_schema(&mut conn)?;

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas.rs
@@ -11,6 +11,7 @@ mod computer;
 mod discovery;
 mod files;
 mod git;
+mod goals;
 mod hygiene;
 mod jobs;
 mod line_edits;
@@ -91,6 +92,11 @@ pub use files::{
 pub use git::{
     git_commit_paths_input_schema, git_diff_hunks_input_schema, git_log_input_schema,
     git_review_summary_input_schema, git_status_input_schema, show_changes_input_schema,
+};
+pub use goals::{
+    associate_goal_agent_task_input_schema, associate_goal_workflow_session_input_schema,
+    create_goal_input_schema, get_goal_input_schema, list_goals_input_schema,
+    update_goal_input_schema,
 };
 pub use hygiene::workspace_hygiene_check_input_schema;
 pub use jobs::{

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/goals.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/goals.rs
@@ -1,0 +1,159 @@
+use serde_json::{json, Value};
+
+const GOAL_ID_PATTERN: &str = "^wc_goal_[0-9a-f]{32}$";
+const TASK_ID_PATTERN: &str = "^wc_agent_task_[0-9a-f]{32}$";
+const SESSION_ID_PATTERN: &str = "^wc_sess_[0-9a-f]{32}$";
+
+fn canonical_id(pattern: &str, description: &str) -> Value {
+    json!({"type": "string", "pattern": pattern, "description": description})
+}
+
+fn goal_id() -> Value {
+    canonical_id(
+        GOAL_ID_PATTERN,
+        "Canonical durable Goal id. It is exact identity only and is never a bearer credential or execution selector.",
+    )
+}
+
+fn idempotency_key(description: &str) -> Value {
+    json!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128,
+        "description": description
+    })
+}
+
+fn lifecycle() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["active", "completed", "cancelled"],
+        "description": "Closed authoritative Goal lifecycle. Execution/presentation states such as implementing, blocked, or waiting_validation are not Goal lifecycle values."
+    })
+}
+
+pub fn create_goal_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Bounded human-readable Goal title."
+            },
+            "objective": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 8192,
+                "description": "Bounded authoritative high-level objective/instruction. The Server additionally enforces an 8192-byte UTF-8 bound."
+            },
+            "idempotency_key": idempotency_key("Caller-generated Goal creation key. Exact retry returns the same Goal; changed reuse fails closed.")
+        },
+        "required": ["title", "objective", "idempotency_key"],
+        "additionalProperties": false
+    })
+}
+
+pub fn get_goal_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {"goal_id": goal_id()},
+        "required": ["goal_id"],
+        "additionalProperties": false
+    })
+}
+
+pub fn list_goals_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "lifecycle": lifecycle(),
+            "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9223372036854775807i64,
+                "default": 0,
+                "description": "Bounded SQLite-compatible page offset."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 50,
+                "description": "Maximum number of caller-visible Goal summaries returned."
+            }
+        },
+        "required": [],
+        "additionalProperties": false
+    })
+}
+
+pub fn update_goal_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "goal_id": goal_id(),
+            "expected_revision": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Exact observed Goal revision. Stale mutation fails closed and returns the current revision only."
+            },
+            "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Optional replacement Goal title."
+            },
+            "objective": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 8192,
+                "description": "Optional replacement objective. The Server additionally enforces an 8192-byte UTF-8 bound."
+            },
+            "lifecycle": lifecycle(),
+            "terminal_reason": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 4096,
+                "description": "Optional bounded terminal reason; valid only with an explicit completed or cancelled transition."
+            },
+            "idempotency_key": idempotency_key("Caller-generated Goal update key. Exact retry replays; changed reuse fails closed.")
+        },
+        "required": ["goal_id", "expected_revision", "idempotency_key"],
+        "dependentRequired": {"terminal_reason": ["lifecycle"]},
+        "anyOf": [
+            {"required": ["title"]},
+            {"required": ["objective"]},
+            {"required": ["lifecycle"]},
+            {"required": ["terminal_reason"]}
+        ],
+        "additionalProperties": false
+    })
+}
+
+pub fn associate_goal_agent_task_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "goal_id": goal_id(),
+            "task_id": canonical_id(TASK_ID_PATTERN, "Exact durable AgentTask id. Association is correlation only and never grants TaskAttempt, Project, Runner, or execution authority."),
+            "idempotency_key": idempotency_key("Caller-generated Goal-to-AgentTask association key. Exact retry replays; changed reuse fails closed.")
+        },
+        "required": ["goal_id", "task_id", "idempotency_key"],
+        "additionalProperties": false
+    })
+}
+
+pub fn associate_goal_workflow_session_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "goal_id": goal_id(),
+            "session_id": canonical_id(SESSION_ID_PATTERN, "Exact Workflow Session id. The target Session is independently re-authorized before association; the correlation never grants Session or Project authority."),
+            "idempotency_key": idempotency_key("Caller-generated Goal-to-Workflow-Session association key. Exact retry replays; changed reuse fails closed.")
+        },
+        "required": ["goal_id", "session_id", "idempotency_key"],
+        "additionalProperties": false
+    })
+}

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas.rs
@@ -13,6 +13,7 @@ mod discovery;
 mod edits;
 mod files;
 mod git;
+mod goals;
 mod hygiene;
 mod jobs;
 mod lsp;
@@ -28,6 +29,9 @@ use common::default_output_schema;
 
 pub fn output_schema_for_tool(name: &str) -> Value {
     if let Some(schema) = agent_tasks::output_schema_for_tool(name) {
+        return schema;
+    }
+    if let Some(schema) = goals::output_schema_for_tool(name) {
         return schema;
     }
     if let Some(schema) = coding_agents::output_schema_for_tool(name) {

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/goals.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/goals.rs
@@ -1,0 +1,135 @@
+use super::common::{schema_type, wrapped_output_schema};
+use serde_json::{json, Value};
+
+fn nullable_integer(description: &str) -> Value {
+    json!({
+        "anyOf": [{"type": "integer"}, {"type": "null"}],
+        "description": description
+    })
+}
+
+fn lifecycle_schema() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["active", "completed", "cancelled"],
+        "description": "Authoritative durable Goal lifecycle."
+    })
+}
+
+fn goal_summary_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "goal_id": {"type": "string", "pattern": "^wc_goal_[0-9a-f]{32}$", "description": "Canonical durable Goal id; identity only, never authority."},
+            "title": {"type": "string", "minLength": 1, "maxLength": 200, "description": "Bounded Goal title."},
+            "lifecycle": lifecycle_schema(),
+            "revision": {"type": "integer", "minimum": 1, "description": "Monotonic authoritative Goal revision."},
+            "created_at_unix_ms": schema_type("integer", "Goal creation time."),
+            "updated_at_unix_ms": schema_type("integer", "Latest durable Goal mutation time."),
+            "terminal_at_unix_ms": nullable_integer("Terminal transition time, or null while active."),
+            "agent_task_count": {"type": "integer", "minimum": 0, "maximum": 64, "description": "Count of explicit AgentTask correlations; correlation grants no Task or execution authority."},
+            "workflow_session_count": {"type": "integer", "minimum": 0, "maximum": 64, "description": "Count of explicit Workflow Session correlations; correlation grants no Session or Project authority."}
+        },
+        "required": [
+            "goal_id", "title", "lifecycle", "revision", "created_at_unix_ms",
+            "updated_at_unix_ms", "terminal_at_unix_ms", "agent_task_count",
+            "workflow_session_count"
+        ]
+    })
+}
+
+fn correlation_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "kind": {"type": "string", "enum": ["agent_task", "workflow_session"]},
+            "reference_id": {"type": "string", "pattern": "^(wc_agent_task_[0-9a-f]{32}|wc_sess_[0-9a-f]{32})$", "maxLength": 46, "description": "Exact correlated durable identity. It is not a credential and cannot be dereferenced without that domain's normal authorization."},
+            "created_at_unix_ms": schema_type("integer", "Correlation creation time.")
+        },
+        "required": ["kind", "reference_id", "created_at_unix_ms"]
+    })
+}
+
+fn goal_detail_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "summary": goal_summary_schema(),
+            "objective": {"type": "string", "minLength": 1, "maxLength": 8192, "description": "Bounded authoritative high-level objective/instruction; the Store enforces the same 8192-byte UTF-8 ceiling."},
+            "terminal_reason": {
+                "anyOf": [
+                    {"type": "string", "minLength": 1, "maxLength": 4096},
+                    {"type": "null"}
+                ],
+                "description": "Bounded terminal reason, if one was explicitly supplied."
+            },
+            "correlations": {
+                "type": "array",
+                "maxItems": 64,
+                "items": correlation_schema(),
+                "description": "Bounded explicit AgentTask and Workflow Session correlations only. No target-domain authority or private target state is projected."
+            }
+        },
+        "required": ["summary", "objective", "terminal_reason", "correlations"]
+    })
+}
+
+fn goal_mutation_schema() -> Value {
+    wrapped_output_schema(vec![
+        ("goal", goal_detail_schema()),
+        (
+            "created",
+            schema_type("boolean", "True only for first Goal creation."),
+        ),
+        (
+            "replayed",
+            schema_type("boolean", "True only for exact keyed replay."),
+        ),
+        (
+            "state_changed",
+            schema_type("boolean", "Whether authoritative Goal state changed."),
+        ),
+    ])
+}
+
+pub fn output_schema_for_tool(name: &str) -> Option<Value> {
+    let schema = match name {
+        "create_goal"
+        | "update_goal"
+        | "associate_goal_agent_task"
+        | "associate_goal_workflow_session" => goal_mutation_schema(),
+        "get_goal" => wrapped_output_schema(vec![("goal", goal_detail_schema())]),
+        "list_goals" => wrapped_output_schema(vec![
+            (
+                "total_count",
+                schema_type(
+                    "integer",
+                    "Total Goals visible to the current owner principal.",
+                ),
+            ),
+            ("offset", schema_type("integer", "Returned page offset.")),
+            (
+                "next_offset",
+                nullable_integer("Next page offset when truncated."),
+            ),
+            (
+                "truncated",
+                schema_type("boolean", "True when more caller-visible Goals remain."),
+            ),
+            (
+                "goals",
+                json!({
+                    "type": "array",
+                    "maxItems": 100,
+                    "items": goal_summary_schema(),
+                    "description": "Bounded Goal summaries. Objective, terminal reason, and correlation identities are omitted from list projection."
+                }),
+            ),
+        ]),
+        _ => return None,
+    };
+    Some(schema)
+}

--- a/crates/webcodex-tool-contracts/src/tool_catalog.rs
+++ b/crates/webcodex-tool-contracts/src/tool_catalog.rs
@@ -10,6 +10,7 @@ pub const TOOL_DISCOVERY_GROUP_AGENT_TASK: &str = "agent_task";
 pub const TOOL_DISCOVERY_GROUP_EDIT: &str = "edit";
 pub const TOOL_DISCOVERY_GROUP_FILE_TRANSFER: &str = "file_transfer";
 pub const TOOL_DISCOVERY_GROUP_GIT: &str = "git";
+pub const TOOL_DISCOVERY_GROUP_GOAL: &str = "goal";
 pub const TOOL_DISCOVERY_GROUP_INSPECT: &str = "inspect";
 pub const TOOL_DISCOVERY_GROUP_JOBS: &str = "jobs";
 pub const TOOL_DISCOVERY_GROUP_PATCH: &str = "patch";
@@ -88,6 +89,17 @@ pub const TOOL_DISCOVERY_GROUPS: &[ToolDiscoveryGroup] = &[
             "reconcile_agent_task_coding_run",
             "heartbeat_agent_task_attempt",
             "complete_agent_task_attempt",
+        ],
+    },
+    ToolDiscoveryGroup {
+        name: TOOL_DISCOVERY_GROUP_GOAL,
+        tools: &[
+            "create_goal",
+            "get_goal",
+            "list_goals",
+            "update_goal",
+            "associate_goal_agent_task",
+            "associate_goal_workflow_session",
         ],
     },
     ToolDiscoveryGroup {

--- a/crates/webcodex-tool-contracts/src/tool_definition.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition.rs
@@ -17,6 +17,7 @@ mod discovery;
 mod edits;
 mod files;
 mod git;
+mod goals;
 mod hygiene;
 mod jobs;
 mod lsp;
@@ -721,6 +722,7 @@ pub const TOOL_CATEGORY_CLEANUP: &str = "cleanup";
 pub const TOOL_CATEGORY_EDIT: &str = "edit";
 pub const TOOL_CATEGORY_FILE: &str = "file";
 pub const TOOL_CATEGORY_GIT: &str = "git";
+pub const TOOL_CATEGORY_GOAL: &str = "goal";
 pub const TOOL_CATEGORY_JOB: &str = "job";
 pub const TOOL_CATEGORY_LSP: &str = "lsp";
 pub const TOOL_CATEGORY_PATCH: &str = "patch";
@@ -987,6 +989,7 @@ const TOOL_DEFINITION_GROUPS: &[&[ToolDefinition]] = &[
     TOOL_DEFINITION_HEAD,
     sessions::DEFINITIONS,
     communication::DEFINITIONS,
+    goals::DEFINITIONS,
     agent_tasks::DEFINITIONS,
     memory::DEFINITIONS,
     skills::DEFINITIONS,

--- a/crates/webcodex-tool-contracts/src/tool_definition/goals.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/goals.rs
@@ -1,0 +1,227 @@
+use super::ToolVisibility::ModelVisible;
+use super::{def, model_spec, require_all_scopes, ToolDefinition, TOOL_CATEGORY_GOAL};
+use crate::metadata::{
+    ToolPathHint::None as NoPath,
+    ToolRisk::{Read, WorkflowManage},
+    COMMUNICATION_MANAGE, COMMUNICATION_READ, TOOL_PROVIDER_CONTROL,
+};
+use crate::registry::input_schemas::{
+    associate_goal_agent_task_input_schema, associate_goal_workflow_session_input_schema,
+    create_goal_input_schema, get_goal_input_schema, list_goals_input_schema,
+    update_goal_input_schema,
+};
+use webcodex_core::authority::{
+    COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES, SCOPE_COMMUNICATION_MANAGE,
+    SCOPE_COMMUNICATION_READ, SCOPE_SESSION_COLLABORATE,
+};
+
+const GOAL_SESSION_ASSOCIATE_SCOPES: &[&str] = &[
+    SCOPE_COMMUNICATION_READ,
+    SCOPE_COMMUNICATION_MANAGE,
+    SCOPE_SESSION_COLLABORATE,
+];
+
+pub(super) const DEFINITIONS: &[ToolDefinition] = &[
+    require_all_scopes(
+        model_spec(
+            def(
+                "create_goal",
+                super::ToolAuditPolicy::typed_fields(&[
+                    super::ToolAuditResultField::pointer("goal_id", "/goal/summary/goal_id"),
+                    super::ToolAuditResultField::pointer("lifecycle", "/goal/summary/lifecycle"),
+                    super::ToolAuditResultField::pointer("revision", "/goal/summary/revision"),
+                    super::ToolAuditResultField::value("created"),
+                    super::ToolAuditResultField::value("replayed"),
+                    super::ToolAuditResultField::value("state_changed"),
+                    super::ToolAuditResultField::value("error_kind"),
+                ]),
+                ModelVisible,
+                TOOL_CATEGORY_GOAL,
+                None,
+                TOOL_PROVIDER_CONTROL,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Mutate,
+                    risk: WorkflowManage,
+                    approval: super::ToolApprovalPolicy::Standard,
+                    idempotency: super::ToolIdempotency::Keyed,
+                },
+                Some(COMMUNICATION_MANAGE),
+                false,
+                NoPath,
+                false,
+                false,
+                super::ToolSessionEvidencePolicy::NONE,
+            ),
+            "Create one explicit durable high-level Goal owned by the current management principal. Goal is intent/control state only: creation never selects a Project, starts a Workflow Session, claims an AgentTaskAttempt, reaches a Runner, or dispatches a Job.",
+            create_goal_input_schema,
+        ),
+        COMMUNICATION_MANAGE_SCOPES,
+    ),
+    require_all_scopes(
+        model_spec(
+            def(
+                "get_goal",
+                super::ToolAuditPolicy::typed_fields(&[
+                    super::ToolAuditResultField::pointer("goal_id", "/goal/summary/goal_id"),
+                    super::ToolAuditResultField::pointer("lifecycle", "/goal/summary/lifecycle"),
+                    super::ToolAuditResultField::pointer("revision", "/goal/summary/revision"),
+                    super::ToolAuditResultField::value("error_kind"),
+                ]),
+                ModelVisible,
+                TOOL_CATEGORY_GOAL,
+                None,
+                TOOL_PROVIDER_CONTROL,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Observe,
+                    risk: Read,
+                    approval: super::ToolApprovalPolicy::None,
+                    idempotency: super::ToolIdempotency::PureRead,
+                },
+                Some(COMMUNICATION_READ),
+                false,
+                NoPath,
+                false,
+                false,
+                super::ToolSessionEvidencePolicy::NONE,
+            ),
+            "Read one exact caller-owned durable Goal. Unauthorized and nonexistent ids are existence-hidden. Correlations expose only bounded identities and never target-domain authority, fences, tokens, credentials, Job state, or Workflow Session ledgers.",
+            get_goal_input_schema,
+        ),
+        COMMUNICATION_READ_SCOPES,
+    ),
+    require_all_scopes(
+        model_spec(
+            def(
+                "list_goals",
+                super::ToolAuditPolicy::typed_fields(&[
+                    super::ToolAuditResultField::value("total_count"),
+                    super::ToolAuditResultField::array_len("returned_count", "goals"),
+                    super::ToolAuditResultField::value("offset"),
+                    super::ToolAuditResultField::value("next_offset"),
+                    super::ToolAuditResultField::value("truncated"),
+                    super::ToolAuditResultField::value("error_kind"),
+                ]),
+                ModelVisible,
+                TOOL_CATEGORY_GOAL,
+                None,
+                TOOL_PROVIDER_CONTROL,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Observe,
+                    risk: Read,
+                    approval: super::ToolApprovalPolicy::None,
+                    idempotency: super::ToolIdempotency::PureRead,
+                },
+                Some(COMMUNICATION_READ),
+                false,
+                NoPath,
+                false,
+                false,
+                super::ToolSessionEvidencePolicy::NONE,
+            ),
+            "List bounded Goals visible to the current owner principal, optionally filtered by authoritative lifecycle. List projection omits objective, terminal reason, and exact correlation identities.",
+            list_goals_input_schema,
+        ),
+        COMMUNICATION_READ_SCOPES,
+    ),
+    require_all_scopes(
+        model_spec(
+            def(
+                "update_goal",
+                super::ToolAuditPolicy::typed_fields(&[
+                    super::ToolAuditResultField::pointer("goal_id", "/goal/summary/goal_id"),
+                    super::ToolAuditResultField::pointer("lifecycle", "/goal/summary/lifecycle"),
+                    super::ToolAuditResultField::pointer("revision", "/goal/summary/revision"),
+                    super::ToolAuditResultField::value("created"),
+                    super::ToolAuditResultField::value("replayed"),
+                    super::ToolAuditResultField::value("state_changed"),
+                    super::ToolAuditResultField::value("error_kind"),
+                ]),
+                ModelVisible,
+                TOOL_CATEGORY_GOAL,
+                None,
+                TOOL_PROVIDER_CONTROL,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Mutate,
+                    risk: WorkflowManage,
+                    approval: super::ToolApprovalPolicy::Standard,
+                    idempotency: super::ToolIdempotency::Keyed,
+                },
+                Some(COMMUNICATION_MANAGE),
+                false,
+                NoPath,
+                false,
+                false,
+                super::ToolSessionEvidencePolicy::NONE,
+            ),
+            "Update bounded Goal metadata or explicitly transition active to completed/cancelled using an exact revision and idempotency key. Terminal Goal state is immutable. No execution domain is mutated or inferred from this transition.",
+            update_goal_input_schema,
+        ),
+        COMMUNICATION_MANAGE_SCOPES,
+    ),
+    require_all_scopes(
+        model_spec(
+            def(
+                "associate_goal_agent_task",
+                super::ToolAuditPolicy::typed_fields(&[
+                    super::ToolAuditResultField::pointer("goal_id", "/goal/summary/goal_id"),
+                    super::ToolAuditResultField::pointer("revision", "/goal/summary/revision"),
+                    super::ToolAuditResultField::value("replayed"),
+                    super::ToolAuditResultField::value("state_changed"),
+                    super::ToolAuditResultField::value("error_kind"),
+                ]),
+                ModelVisible,
+                TOOL_CATEGORY_GOAL,
+                None,
+                TOOL_PROVIDER_CONTROL,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Mutate,
+                    risk: WorkflowManage,
+                    approval: super::ToolApprovalPolicy::Standard,
+                    idempotency: super::ToolIdempotency::Keyed,
+                },
+                Some(COMMUNICATION_MANAGE),
+                false,
+                NoPath,
+                false,
+                false,
+                super::ToolSessionEvidencePolicy::NONE,
+            ),
+            "Explicitly correlate one owned active Goal with one exact owned AgentTask after independently re-authorizing that AgentTask. The link is identity-only and grants no TaskAttempt, CodingAgentRun, Project, Runner, filesystem, or Job authority.",
+            associate_goal_agent_task_input_schema,
+        ),
+        COMMUNICATION_MANAGE_SCOPES,
+    ),
+    require_all_scopes(
+        model_spec(
+            def(
+                "associate_goal_workflow_session",
+                super::ToolAuditPolicy::typed_fields(&[
+                    super::ToolAuditResultField::pointer("goal_id", "/goal/summary/goal_id"),
+                    super::ToolAuditResultField::pointer("revision", "/goal/summary/revision"),
+                    super::ToolAuditResultField::value("replayed"),
+                    super::ToolAuditResultField::value("state_changed"),
+                    super::ToolAuditResultField::value("error_kind"),
+                ]),
+                ModelVisible,
+                TOOL_CATEGORY_GOAL,
+                None,
+                TOOL_PROVIDER_CONTROL,
+                super::ToolSemanticContract {
+                    effect: super::ToolEffect::Mutate,
+                    risk: WorkflowManage,
+                    approval: super::ToolApprovalPolicy::Standard,
+                    idempotency: super::ToolIdempotency::Keyed,
+                },
+                Some(COMMUNICATION_MANAGE),
+                false,
+                NoPath,
+                false,
+                false,
+                super::ToolSessionEvidencePolicy::NONE,
+            ),
+            "Explicitly correlate one owned active Goal with one exact Workflow Session after independently re-authorizing the Session through its existing authority fingerprint and any bound Project authorization. The Goal link is never a Session or Project credential.",
+            associate_goal_workflow_session_input_schema,
+        ),
+        GOAL_SESSION_ASSOCIATE_SCOPES,
+    ),
+];

--- a/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
@@ -186,6 +186,106 @@ fn typed_structured_validation_request_audit(
 }
 
 #[derive(Debug, Clone, Copy)]
+enum GoalRequestAudit {
+    Create,
+    Get,
+    List,
+    Update,
+    AssociateAgentTask,
+    AssociateWorkflowSession,
+}
+
+fn typed_goal_request_audit(kind: GoalRequestAudit, arguments: &Value) -> Value {
+    let Some(obj) = arguments.as_object() else {
+        return empty_audit_projection();
+    };
+    let mut out = serde_json::Map::new();
+    match kind {
+        GoalRequestAudit::Create => {
+            out.insert(
+                "title_chars".to_string(),
+                Value::from(
+                    obj.get("title")
+                        .and_then(Value::as_str)
+                        .map(str::chars)
+                        .map(Iterator::count)
+                        .unwrap_or_default(),
+                ),
+            );
+            out.insert(
+                "objective_bytes".to_string(),
+                Value::from(
+                    obj.get("objective")
+                        .and_then(Value::as_str)
+                        .map(str::len)
+                        .unwrap_or_default(),
+                ),
+            );
+            out.insert(
+                "idempotency_key_present".to_string(),
+                Value::Bool(obj.get("idempotency_key").and_then(Value::as_str).is_some()),
+            );
+        }
+        GoalRequestAudit::Get => copy_keys(obj, &mut out, &["goal_id"]),
+        GoalRequestAudit::List => copy_keys(obj, &mut out, &["lifecycle", "offset", "limit"]),
+        GoalRequestAudit::Update => {
+            copy_keys(
+                obj,
+                &mut out,
+                &["goal_id", "expected_revision", "lifecycle"],
+            );
+            out.insert(
+                "title_chars".to_string(),
+                Value::from(
+                    obj.get("title")
+                        .and_then(Value::as_str)
+                        .map(str::chars)
+                        .map(Iterator::count)
+                        .unwrap_or_default(),
+                ),
+            );
+            out.insert(
+                "objective_bytes".to_string(),
+                Value::from(
+                    obj.get("objective")
+                        .and_then(Value::as_str)
+                        .map(str::len)
+                        .unwrap_or_default(),
+                ),
+            );
+            out.insert(
+                "terminal_reason_bytes".to_string(),
+                Value::from(
+                    obj.get("terminal_reason")
+                        .and_then(Value::as_str)
+                        .map(str::len)
+                        .unwrap_or_default(),
+                ),
+            );
+            out.insert(
+                "idempotency_key_present".to_string(),
+                Value::Bool(obj.get("idempotency_key").and_then(Value::as_str).is_some()),
+            );
+        }
+        GoalRequestAudit::AssociateAgentTask => {
+            copy_keys(obj, &mut out, &["goal_id", "task_id"]);
+            out.insert(
+                "idempotency_key_present".to_string(),
+                Value::Bool(obj.get("idempotency_key").and_then(Value::as_str).is_some()),
+            );
+        }
+        GoalRequestAudit::AssociateWorkflowSession => {
+            copy_keys(obj, &mut out, &["goal_id", "session_id"]);
+            out.insert(
+                "idempotency_key_present".to_string(),
+                Value::Bool(obj.get("idempotency_key").and_then(Value::as_str).is_some()),
+            );
+        }
+    }
+    Value::Object(out)
+}
+
+#[derive(Debug, Clone, Copy)]
 enum AgentTaskRequestAudit {
     Create,
     List,
@@ -3368,6 +3468,78 @@ impl ToolCall {
                 "items": items,
                 "with_line_numbers": with_line_numbers,
             }),
+            Self::CreateGoal {
+                title,
+                objective,
+                idempotency_key,
+            } => typed_goal_request_audit(
+                GoalRequestAudit::Create,
+                &serde_json::json!({
+                    "title": title,
+                    "objective": objective,
+                    "idempotency_key": idempotency_key,
+                }),
+            ),
+            Self::GetGoal { goal_id } => typed_goal_request_audit(
+                GoalRequestAudit::Get,
+                &serde_json::json!({"goal_id": goal_id}),
+            ),
+            Self::ListGoals {
+                lifecycle,
+                offset,
+                limit,
+            } => typed_goal_request_audit(
+                GoalRequestAudit::List,
+                &serde_json::json!({
+                    "lifecycle": lifecycle,
+                    "offset": offset,
+                    "limit": limit,
+                }),
+            ),
+            Self::UpdateGoal {
+                goal_id,
+                expected_revision,
+                title,
+                objective,
+                lifecycle,
+                terminal_reason,
+                idempotency_key,
+            } => typed_goal_request_audit(
+                GoalRequestAudit::Update,
+                &serde_json::json!({
+                    "goal_id": goal_id,
+                    "expected_revision": expected_revision,
+                    "title": title,
+                    "objective": objective,
+                    "lifecycle": lifecycle,
+                    "terminal_reason": terminal_reason,
+                    "idempotency_key": idempotency_key,
+                }),
+            ),
+            Self::AssociateGoalAgentTask {
+                goal_id,
+                task_id,
+                idempotency_key,
+            } => typed_goal_request_audit(
+                GoalRequestAudit::AssociateAgentTask,
+                &serde_json::json!({
+                    "goal_id": goal_id,
+                    "task_id": task_id,
+                    "idempotency_key": idempotency_key,
+                }),
+            ),
+            Self::AssociateGoalWorkflowSession {
+                goal_id,
+                session_id,
+                idempotency_key,
+            } => typed_goal_request_audit(
+                GoalRequestAudit::AssociateWorkflowSession,
+                &serde_json::json!({
+                    "goal_id": goal_id,
+                    "session_id": session_id,
+                    "idempotency_key": idempotency_key,
+                }),
+            ),
             Self::CreateAgentTask {
                 title,
                 instruction,

--- a/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
@@ -1142,6 +1142,57 @@ pub enum ToolCall {
         session_id: Option<String>,
     },
 
+    /// Create explicit high-level durable intent/control state without execution authority.
+    CreateGoal {
+        title: String,
+        objective: String,
+        idempotency_key: String,
+    },
+
+    /// Read one exact caller-owned durable Goal.
+    GetGoal {
+        goal_id: String,
+    },
+
+    /// List caller-visible durable Goals with an optional authoritative lifecycle filter.
+    ListGoals {
+        #[serde(default)]
+        lifecycle: Option<String>,
+        #[serde(default)]
+        offset: Option<usize>,
+        #[serde(default)]
+        limit: Option<usize>,
+    },
+
+    /// CAS-update bounded Goal metadata or its closed lifecycle.
+    UpdateGoal {
+        goal_id: String,
+        expected_revision: i64,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        objective: Option<String>,
+        #[serde(default)]
+        lifecycle: Option<String>,
+        #[serde(default)]
+        terminal_reason: Option<String>,
+        idempotency_key: String,
+    },
+
+    /// Explicitly correlate an owned Goal with an independently authorized AgentTask.
+    AssociateGoalAgentTask {
+        goal_id: String,
+        task_id: String,
+        idempotency_key: String,
+    },
+
+    /// Explicitly correlate an owned Goal with an independently authorized Workflow Session.
+    AssociateGoalWorkflowSession {
+        goal_id: String,
+        session_id: String,
+        idempotency_key: String,
+    },
+
     /// Create explicit durable Agent work independent from communication messages and execution backends.
     CreateAgentTask {
         title: String,
@@ -2711,6 +2762,12 @@ impl ToolCall {
             Self::SkillInstall { .. } => "skill_install",
             Self::SkillActivate { .. } => "skill_activate",
             Self::SkillRemoveRevision { .. } => "skill_remove_revision",
+            Self::CreateGoal { .. } => "create_goal",
+            Self::GetGoal { .. } => "get_goal",
+            Self::ListGoals { .. } => "list_goals",
+            Self::UpdateGoal { .. } => "update_goal",
+            Self::AssociateGoalAgentTask { .. } => "associate_goal_agent_task",
+            Self::AssociateGoalWorkflowSession { .. } => "associate_goal_workflow_session",
             Self::CreateAgentTask { .. } => "create_agent_task",
             Self::ListAgentTasks { .. } => "list_agent_tasks",
             Self::ReadAgentTask { .. } => "read_agent_task",

--- a/crates/webcodex-tool-runtime-contracts/src/tool_call_test_support.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_call_test_support.rs
@@ -38,6 +38,9 @@ fn sample_tool_args_for_spec(spec: &ToolSpec) -> Value {
         "work_on_project" => {
             args.insert("project".to_string(), json!(SAMPLE_PROJECT));
         }
+        "update_goal" => {
+            args.insert("expected_revision".to_string(), json!(1));
+        }
         "observe_jobs" => {
             args.insert("items".to_string(), json!([{"job_id": "job_123"}]));
         }
@@ -71,6 +74,7 @@ fn sample_field_value(field: &str) -> Value {
         "text" => json!("// hi\n"),
         "content" => json!("fn main() {}\n"),
         "instruction" => json!("implement the requested change"),
+        "objective" => json!("Preserve durable high-level intent without execution authority."),
         "title" => json!("Durable agent work"),
         "include_project_instructions" | "include_workflow_guidance" => json!(false),
         "content_base64" => json!("AA=="),
@@ -97,6 +101,7 @@ fn sample_field_value(field: &str) -> Value {
         "agent_id" => json!(format!("wc_dagent_{}", "a".repeat(32))),
         "assignee_agent_id" => json!(format!("wc_dagent_{}", "a".repeat(32))),
         "task_id" => json!(format!("wc_agent_task_{}", "1".repeat(32))),
+        "goal_id" => json!(format!("wc_goal_{}", "0".repeat(32))),
         "attempt_id" => json!(format!("wc_agent_task_attempt_{}", "2".repeat(32))),
         "attempt_fence" => json!(format!("wc_agent_task_fence_{}", "3".repeat(32))),
         "attempt_controller_generation" => json!(1),
@@ -114,7 +119,7 @@ fn sample_field_value(field: &str) -> Value {
         "provider_id" => json!("codex"),
         "run_id" => json!("wc_agent_run_sample_1234"),
         "shell_id" => json!("wc_shell_123"),
-        "session_id" => json!("wc_sess_existing"),
+        "session_id" => json!(format!("wc_sess_{}", "1".repeat(32))),
         "checkpoint_id" => json!("wc_ckpt_1234"),
         "confirm" => json!(true),
         "client_id" => json!("oe"),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,8 +78,11 @@ Conversation membership and Durable Agent identity grant only the communication/
 
 Maintainer-level lifecycle and Agent Task/TaskAttempt details live in [Durable Agent runtime and asynchronous work](architecture/durable-agent-runtime.md) and [Durable Agent/Conversation/Wake contract](architecture/durable-agent-conversation.md).
 
+The Server also owns an independent durable **Goal** domain for high-level intent/control state. A Goal answers what the user ultimately wants and the authoritative high-level lifecycle of that intent. It is not a Workflow Session, Agent Task, Job, Project selector, credential, or execution authority. Goal references to Agent Tasks and Workflow Sessions are explicit correlation only; dereferencing those ids always re-runs the referenced domain's normal authorization.
+
 ## Task, Job, and Workflow Session continuity
 
+- **Goal** — high-level durable intent/control state (`wc_goal_*`). It can correlate multiple work/execution records, but it does not run them and is never inferred from the current Project, window, credential, or Workflow Session.
 - **Connector Task** — project-first work created by the task-oriented Connector. It can be explicitly resumed by its task handle.
 - **Job** — a long-running command or validation that continues after the initiating call returns. Observe the same Job instead of starting another copy.
 - **Workflow Session** — bounded coding evidence/continuity used by the regular runtime for review, validation, collaboration, and closeout. It is not a credential.
@@ -133,7 +136,7 @@ See [SECURITY.md](../SECURITY.md) and [AUTH_MODEL.md](AUTH_MODEL.md).
 
 ## Persistence and recovery
 
-The Server persists managed accounts, OAuth state, project/task history, and durable Agent/Conversation state. Workflow/task continuity is restored from its own durable identifiers; WebCodex does not invent continuity from a credential or current browser window.
+The Server persists managed accounts, OAuth state, project/task history, durable Agent/Conversation state, and durable Goal state. Workflow/task/Goal continuity is restored from each domain's own durable identifiers; WebCodex does not invent continuity from a credential, current browser window, Project, or neighboring domain identity.
 
 Runner Jobs are reconciled when the same live Runner process reconnects. Ordinary child processes cannot be adopted by an unrelated replacement Runner; specialized detached execution has its own explicit durable ownership path. The stable Runner `client_id` and the current process lease are separate, but the exact lease field is an internal wire detail.
 
@@ -146,6 +149,7 @@ MCP / OpenAPI / Runtime HTTP --> ToolRuntime --+--> Project resolution --> Runne
                                                |      |--> File/Edit/Git/Validation/Job tools
                                                |      +--> Workflow Session / Handoff / Hygiene
                                                +--> Durable Agent / Conversation / Delivery / Wake
+                                               +--> Goal (high-level durable intent/control; no execution dispatch)
 Runtime Console -----------------------> canonical Server HTTP/kernel paths above
 ```
 

--- a/docs/agent/architecture-decisions.md
+++ b/docs/agent/architecture-decisions.md
@@ -59,7 +59,10 @@ this concrete Agent/Conversation model. Standing rules are:
 - the planned asynchronous work object is an independent **Agent Task** with an
   exact fenced **Agent TaskAttempt**. It is not the existing Connector Task and is
   not inferred merely because a Conversation Message exists;
-- references among Conversation, Agent Task, Workflow Session, Job, CodingAgentRun,
+- **Goal** is an independent `wc_goal_*` high-level durable intent/control domain. It is not an Agent Task, Workflow Session, Job, Project selector, execution primitive, or scheduler; Goal identity/status/revision/correlation is never a bearer credential;
+- Goal selection is exact durable identity or explicit creation only. Never infer the current Goal from Project, ClientWindow, credential, MCP/OpenAI session data, Conversation membership, Workflow Session, or shared timing;
+- Goal lifecycle is currently closed to `active | completed | cancelled`. `finish_coding_task`, AgentTask/TaskAttempt completion, Job terminal state, or validation evidence do not automatically transition a Goal;
+- references among Goal, Conversation, Agent Task, Workflow Session, Job, CodingAgentRun,
   commit, PR, or Artifact provide correlation only. Dereferencing always re-runs
   the referenced object's normal authorization;
 - automatic worker spawning, runnable-frontier scheduling, capacity management,

--- a/docs/agent/session-model.md
+++ b/docs/agent/session-model.md
@@ -98,6 +98,8 @@ handoff, and finish can reason about the same unit of work.
 - Validation evidence and closeout summaries
 - Handoff / finish tooling (`session_handoff_summary`, `finish_coding_task`, …)
 
+Workflow Session lifecycle is independent from the durable `wc_goal_*` Goal domain. A Session may be explicitly correlated to a Goal, but that correlation grants no Session/Project authority and does not make the Session the Goal's lifecycle owner. In particular, `finish_coding_task` does not transition a Goal to `completed`; any Goal transition is a separate explicit Goal-domain mutation.
+
 ### Identity
 
 | Aspect | Contract |

--- a/docs/architecture/durable-agent-runtime.md
+++ b/docs/architecture/durable-agent-runtime.md
@@ -53,6 +53,7 @@ domains and must remain explicit in code, schemas, documentation, and reviews.
 | Workflow Session | Existing execution/provenance/validation/handoff evidence context | Agent, Conversation, Agent Task |
 | Job | Concrete long-running process/validation execution | Agent Task or TaskAttempt |
 | CodingAgentRun | Existing ACP delegated coding execution | Agent Task itself |
+| Goal | Server-owned high-level durable intent/control state (`wc_goal_*`) | Agent Task, Workflow Session, Job, Project authority, scheduler |
 
 The `agent:` prefix in a runtime Project id is historical Runner-address syntax. It
 is unrelated to the durable `wc_dagent_*` Agent identity domain.
@@ -129,6 +130,7 @@ Important current invariants:
   and the same logical Wake remain durable until a new exact Endpoint generation
   registers a callable adapter.
 - project-scoped Memory is unchanged; Agent-scoped Memory is only a future boundary.
+- durable Goals are independent high-level intent/control truth; Goal identity, ownership, lifecycle, revision, and correlations grant no Project, Runner, filesystem, Workflow Session, AgentTaskAttempt, CodingAgentRun, or Job authority.
 
 No production ChatGPT auto-resume adapter currently exists in the repository. A
 September 2026 temporary MCP App probe did demonstrate that ChatGPT can accept an
@@ -145,6 +147,55 @@ dispatch semantics rather than production Host wake delivery.
 
 These invariants, the natural-conversation slice, and the durable A3 ownership
 substrate support asynchronous Agent work without introducing a scheduler.
+
+## Durable Goal Phase 1
+
+Phase 1 adds a deliberately small, Control-owned Goal domain. A Goal answers:
+
+> What does the user ultimately want completed, and what is the authoritative high-level durable state of that intent?
+
+It does **not** answer who owns the next execution attempt, which repository operation should run, or whether a concrete coding Session/Job succeeded. Those remain owned by AgentTask/TaskAttempt, Workflow Session, Project/Runner, and Job domains respectively.
+
+The authoritative model is persisted in the existing Server SQLite database using independent `wc_goals`, `wc_goal_correlations`, and `wc_goal_idempotency` tables. The first model is intentionally bounded:
+
+```text
+Goal
+  goal_id                 # Server-minted wc_goal_*
+  owner principal         # stable authorized communication-management principal
+  title                   # <= 200 characters
+  objective               # <= 8192 UTF-8 bytes
+  lifecycle               # active | completed | cancelled
+  revision                # monotonic, starts at 1
+  created_at / updated_at
+  terminal_at?
+  terminal_reason?        # <= 4096 UTF-8 bytes
+  correlations[]          # <= 64 explicit AgentTask / Workflow Session identities
+```
+
+`active`, `completed`, and `cancelled` are the complete Phase 1 authoritative lifecycle. Terminal state is immutable. Presentation phases such as `implementing`, `blocked`, or `waiting_validation` are not stored as Goal lifecycle. Unknown persisted lifecycle/correlation values fail closed rather than becoming a new state implicitly.
+
+Goal tools are Control-side only: `create_goal`, `get_goal`, `list_goals`, `update_goal`, `associate_goal_agent_task`, and `associate_goal_workflow_session`. They do not declare Project requirements or Runner capabilities. Reads use the existing stable communication-read principal model; mutations use communication management. Exact Goal reads combine id and owner in the durable lookup so a foreign id is indistinguishable from a nonexistent id. Create/update/association use durable keyed replay; exact duplicate retries replay, while changed reuse of the same key fails closed. `list_goals` returns bounded summaries rather than objective text or correlation identities.
+
+Correlation is explicit durable identity only:
+
+- Goal → AgentTask association first re-authorizes the exact AgentTask under its existing owner-principal rules.
+- Goal → Workflow Session association first runs the existing exact Session authority fence, including creation-time authority fingerprint validation and normal authorization for any bound Project.
+- the Goal store then persists only the target identity and timestamp; it never persists the target's fence, token, authority, ledger, Job state, or other private execution data;
+- Jobs remain traceable through their existing Workflow Session/AgentTask provenance. Phase 1 intentionally does not duplicate a Goal → Job truth.
+
+A Goal reference never becomes inherited authority. A Goal that references a Project indirectly through an AgentTask still has no Project authority; a Goal that references a Session is not a Session credential; a Goal linked to an AgentTask does not own that TaskAttempt. Any later dereference must run the target domain's normal checks again.
+
+No current execution path accepts or requires `goal_id`: `work_on_project`, read/edit/search, shell/process, Job handoff/observation, validation, Git, and `finish_coding_task` retain their existing semantics. Goal is not selected from ClientWindow, OpenAI/MCP session data, Project identity, credential, Conversation, or Workflow Session. The historical Runner/Codex metadata field named `goal_id` remains compatibility metadata and is **not** the `wc_goal_*` durable identity.
+
+Lifecycle is independent across domains. `finish_coding_task` reports/finishes one Workflow Session concern and does not complete a Goal. AgentTask/TaskAttempt terminal completion likewise does not transition a Goal without a future explicit contract. Phase 1 creates no Goal scheduler, Wake/controller, automatic AgentTask, TaskAttempt, Workflow Session, CodingAgentRun, Runner request, process, or Job.
+
+### Follow-on boundaries
+
+**G2 — bounded Plan presentation.** Project one exact Goal into a bounded Plan view, create at most one App-bound presentation for that presentation identity, and let the App poll exact bounded state through an App-only read path. Presentation phases may derive from Goal plus existing work/evidence, but they must not expand the authoritative Goal lifecycle. G2 has no wake or model-turn continuation.
+
+**G3 — production Host continuation adapter.** Add Host continuation only after presentation identity is stable. Reuse the existing durable Agent Endpoint / Wake / Wake Delivery Attempt controller generation, lease/dispatch fence, and exact consume semantics; do not invent a second continuation truth owned by Goal, App, iframe, or Job view.
+
+These phase boundaries intentionally follow the [September 11–12, 2026 MCP App continuation findings](../agent/mcp-app-continuation-experiments.md): one persistent presentation should converge from server-owned state through bounded App-only refresh; Host dispatch acceptance is not the same as model resumption; and the temporary probe's in-memory timer/map state machine must not be copied into production.
 
 ## Asynchronous Agent work
 

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -1799,6 +1799,54 @@ impl ToolRuntime {
                 .await
             }
 
+            ToolCall::CreateGoal {
+                title,
+                objective,
+                idempotency_key,
+            } => self.create_goal(auth, title, objective, idempotency_key),
+
+            ToolCall::GetGoal { goal_id } => self.get_goal(auth, goal_id),
+
+            ToolCall::ListGoals {
+                lifecycle,
+                offset,
+                limit,
+            } => self.list_goals(auth, lifecycle, offset, limit),
+
+            ToolCall::UpdateGoal {
+                goal_id,
+                expected_revision,
+                title,
+                objective,
+                lifecycle,
+                terminal_reason,
+                idempotency_key,
+            } => self.update_goal(
+                auth,
+                goal_id,
+                expected_revision,
+                title,
+                objective,
+                lifecycle,
+                terminal_reason,
+                idempotency_key,
+            ),
+
+            ToolCall::AssociateGoalAgentTask {
+                goal_id,
+                task_id,
+                idempotency_key,
+            } => self.associate_goal_agent_task(auth, goal_id, task_id, idempotency_key),
+
+            ToolCall::AssociateGoalWorkflowSession {
+                goal_id,
+                session_id,
+                idempotency_key,
+            } => {
+                self.associate_goal_workflow_session(auth, goal_id, session_id, idempotency_key)
+                    .await
+            }
+
             ToolCall::CreateAgentTask {
                 title,
                 instruction,

--- a/src/tool_runtime/goal.rs
+++ b/src/tool_runtime/goal.rs
@@ -1,0 +1,260 @@
+use super::{RecoveryKind, ToolResult, ToolRuntime};
+use crate::auth::AuthContext;
+use crate::db::{GoalLifecycle, GoalPatch, GoalStoreError, NewGoal, MAX_GOAL_LIST_LIMIT};
+use serde::Serialize;
+use serde_json::{json, to_value};
+
+const DEFAULT_GOAL_LIST_LIMIT: usize = 50;
+
+fn goal_principal(
+    auth: Option<&AuthContext>,
+) -> Result<crate::db::CommunicationPrincipal, ToolResult> {
+    super::communication::communication_principal(auth)
+}
+
+fn goal_store_unavailable() -> ToolResult {
+    ToolResult::err_with_output(
+        "Durable Goal storage is unavailable in this runtime",
+        json!({
+            "error_kind": "goal_store_unavailable",
+            "state_changed": false,
+        }),
+    )
+    .with_recovery(RecoveryKind::UserAction, None)
+}
+
+fn goal_error(error: GoalStoreError, store_failure_recovery: RecoveryKind) -> ToolResult {
+    let recovery = match error.code() {
+        "goal_store_unavailable" => store_failure_recovery,
+        "goal_not_found" | "goal_revision_changed" | "goal_terminal" => RecoveryKind::Reobserve,
+        "goal_idempotency_conflict" => RecoveryKind::Reobserve,
+        _ => RecoveryKind::FixInput,
+    };
+    ToolResult::err_with_output(
+        error.message(),
+        json!({
+            "error_kind": error.code(),
+            "message": error.message(),
+            "current_revision": error.current_revision(),
+            "state_changed": false,
+        }),
+    )
+    .with_recovery(recovery, None)
+}
+
+fn target_authorization_error(error: crate::db::CommunicationStoreError) -> ToolResult {
+    ToolResult::err_with_output(
+        error.message(),
+        json!({
+            "error_kind": error.code(),
+            "message": error.message(),
+            "state_changed": false,
+        }),
+    )
+    .with_recovery(RecoveryKind::Reobserve, None)
+}
+
+fn serialized_goal_success<T: Serialize>(value: T) -> ToolResult {
+    match to_value(value) {
+        Ok(value) => ToolResult::ok(value),
+        Err(error) => ToolResult::err_with_output(
+            format!("Failed to serialize durable Goal result: {error}"),
+            json!({
+                "error_kind": "goal_result_serialization_failed",
+                "state_changed": false,
+            }),
+        )
+        .with_recovery(RecoveryKind::NoAction, None),
+    }
+}
+
+impl ToolRuntime {
+    pub(crate) fn create_goal(
+        &self,
+        auth: Option<&AuthContext>,
+        title: String,
+        objective: String,
+        idempotency_key: String,
+    ) -> ToolResult {
+        let principal = match goal_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return goal_store_unavailable();
+        };
+        match db.create_goal(
+            &principal,
+            NewGoal {
+                title,
+                objective,
+                idempotency_key,
+            },
+        ) {
+            Ok(result) => serialized_goal_success(result),
+            Err(error) => goal_error(error, RecoveryKind::RetrySame),
+        }
+    }
+
+    pub(crate) fn get_goal(&self, auth: Option<&AuthContext>, goal_id: String) -> ToolResult {
+        let principal = match goal_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return goal_store_unavailable();
+        };
+        match db.read_goal(&principal, &goal_id) {
+            Ok(goal) => serialized_goal_success(json!({"goal": goal})),
+            Err(error) => goal_error(error, RecoveryKind::Reobserve),
+        }
+    }
+
+    pub(crate) fn list_goals(
+        &self,
+        auth: Option<&AuthContext>,
+        lifecycle: Option<String>,
+        offset: Option<usize>,
+        limit: Option<usize>,
+    ) -> ToolResult {
+        let principal = match goal_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let lifecycle = match lifecycle
+            .as_deref()
+            .map(GoalLifecycle::from_input)
+            .transpose()
+        {
+            Ok(lifecycle) => lifecycle,
+            Err(error) => return goal_error(error, RecoveryKind::FixInput),
+        };
+        let limit = limit.unwrap_or(DEFAULT_GOAL_LIST_LIMIT);
+        if limit == 0 || limit > MAX_GOAL_LIST_LIMIT {
+            return goal_error(
+                GoalStoreError::new(
+                    "invalid_goal_list_limit",
+                    format!("limit must be within 1..={MAX_GOAL_LIST_LIMIT}"),
+                ),
+                RecoveryKind::FixInput,
+            );
+        }
+        let Some(db) = self.communication_db.as_ref() else {
+            return goal_store_unavailable();
+        };
+        match db.list_goals(&principal, lifecycle, offset.unwrap_or(0), limit) {
+            Ok(page) => serialized_goal_success(page),
+            Err(error) => goal_error(error, RecoveryKind::Reobserve),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn update_goal(
+        &self,
+        auth: Option<&AuthContext>,
+        goal_id: String,
+        expected_revision: i64,
+        title: Option<String>,
+        objective: Option<String>,
+        lifecycle: Option<String>,
+        terminal_reason: Option<String>,
+        idempotency_key: String,
+    ) -> ToolResult {
+        let principal = match goal_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let lifecycle = match lifecycle
+            .as_deref()
+            .map(GoalLifecycle::from_input)
+            .transpose()
+        {
+            Ok(lifecycle) => lifecycle,
+            Err(error) => return goal_error(error, RecoveryKind::FixInput),
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return goal_store_unavailable();
+        };
+        match db.update_goal(
+            &principal,
+            &goal_id,
+            expected_revision,
+            GoalPatch {
+                title,
+                objective,
+                lifecycle,
+                terminal_reason,
+            },
+            &idempotency_key,
+        ) {
+            Ok(result) => serialized_goal_success(result),
+            Err(error) => goal_error(error, RecoveryKind::RetrySame),
+        }
+    }
+
+    pub(crate) fn associate_goal_agent_task(
+        &self,
+        auth: Option<&AuthContext>,
+        goal_id: String,
+        task_id: String,
+        idempotency_key: String,
+    ) -> ToolResult {
+        let principal = match goal_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return goal_store_unavailable();
+        };
+        // Authorize the Goal first so a foreign Goal cannot be used to probe target ids.
+        if let Err(error) = db.read_goal(&principal, &goal_id) {
+            return goal_error(error, RecoveryKind::Reobserve);
+        }
+        // Re-authorize the AgentTask in its own domain. The subsequent Goal record stores
+        // only the exact identity; this check is never converted into inherited authority.
+        if let Err(error) = db.read_agent_task(&principal, &task_id) {
+            return target_authorization_error(error);
+        }
+        match db.associate_goal_agent_task(&principal, &goal_id, &task_id, &idempotency_key) {
+            Ok(result) => serialized_goal_success(result),
+            Err(error) => goal_error(error, RecoveryKind::RetrySame),
+        }
+    }
+
+    pub(crate) async fn associate_goal_workflow_session(
+        &self,
+        auth: Option<&AuthContext>,
+        goal_id: String,
+        session_id: String,
+        idempotency_key: String,
+    ) -> ToolResult {
+        let principal = match goal_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return goal_store_unavailable();
+        };
+        // Check Goal ownership before looking at the target Session to preserve existence hiding.
+        if let Err(error) = db.read_goal(&principal, &goal_id) {
+            return goal_error(error, RecoveryKind::Reobserve);
+        }
+        // This is the existing authoritative Session fence: it verifies the immutable
+        // creation-time authority fingerprint and independently re-authorizes a bound Project.
+        if let Err(result) = self
+            .authorize_session_target(&session_id, "associate_goal_workflow_session", auth)
+            .await
+        {
+            return result;
+        }
+        match db.associate_goal_workflow_session(
+            &principal,
+            &goal_id,
+            &session_id,
+            &idempotency_key,
+        ) {
+            Ok(result) => serialized_goal_success(result),
+            Err(error) => goal_error(error, RecoveryKind::RetrySame),
+        }
+    }
+}

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -31,6 +31,7 @@ pub(crate) use git::{framed_clean_show_changes_test_stdout, framed_show_changes_
 mod git_committed;
 mod git_review;
 mod git_tools;
+mod goal;
 mod handoff;
 mod handoff_brief;
 mod handoff_tools;

--- a/src/tool_runtime/runtime.rs
+++ b/src/tool_runtime/runtime.rs
@@ -167,8 +167,9 @@ pub struct ToolRuntime {
     /// the server from the existing webcodex.db handle; Runner-native project
     /// filesystems never own Memory v1 persistence.
     pub(crate) memory_db: Option<Arc<crate::Database>>,
-    /// Optional Control-owned durable Agent and Conversation store. It shares
-    /// the Server SQLite handle with other durable domains but owns independent tables.
+    /// Optional Control-owned durable user-domain store. Durable Agent, Conversation,
+    /// AgentTask, and Goal state share this Server SQLite handle while remaining
+    /// independent tables, lifecycles, and authority domains.
     pub(crate) communication_db: Option<Arc<crate::Database>>,
     /// Optional process-local Host continuation registry/controller. It is
     /// created only when the durable communication database is injected and is

--- a/src/tool_runtime/tests/goals.rs
+++ b/src/tool_runtime/tests/goals.rs
@@ -1,0 +1,568 @@
+use super::support::*;
+use crate::auth::scopes::{
+    COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES, SCOPE_COMMUNICATION_MANAGE,
+    SCOPE_COMMUNICATION_READ, SCOPE_SESSION_COLLABORATE,
+};
+use crate::tool_runtime::metadata::{
+    ToolApprovalPolicy, ToolAuthorityPolicy, ToolEffect, ToolIdempotency, ToolRisk,
+};
+use crate::tool_runtime::tool_definition::{lookup_tool_definition, RunnerCapabilityRequirement};
+use crate::tool_runtime::{registered_tool_specs, ToolCall, ToolRuntime};
+use serde_json::json;
+use std::sync::Arc;
+
+fn runtime_with_goal_db() -> (tempfile::TempDir, Arc<crate::db::Database>, ToolRuntime) {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Arc::new(crate::db::Database::open(&temp.path().join("goals.db")).unwrap());
+    let runtime = ToolRuntime::new_for_tests().with_communication_database(db.clone());
+    (temp, db, runtime)
+}
+
+fn create_goal(
+    runtime: &ToolRuntime,
+    auth: Option<&crate::auth::AuthContext>,
+    key: &str,
+) -> String {
+    let created = runtime.create_goal(
+        auth,
+        "Durable Goal Phase 1".to_string(),
+        "Keep high-level durable intent authoritative and independent from execution domains."
+            .to_string(),
+        key.to_string(),
+    );
+    assert!(created.success, "{:?}", created.output);
+    created.output["goal"]["summary"]["goal_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn goal_tools_are_control_only_and_never_declare_execution_authority() {
+    for name in [
+        "create_goal",
+        "get_goal",
+        "list_goals",
+        "update_goal",
+        "associate_goal_agent_task",
+        "associate_goal_workflow_session",
+    ] {
+        let definition = lookup_tool_definition(name).unwrap_or_else(|| panic!("missing {name}"));
+        assert!(
+            definition.model_spec.is_some(),
+            "{name} must be model-visible"
+        );
+        assert_eq!(definition.category, "goal");
+        assert_eq!(definition.metadata.provider_id, "control");
+        assert!(!definition.metadata.requires_project, "{name}");
+        assert_eq!(
+            definition.runner_capability, None::<RunnerCapabilityRequirement>,
+            "{name}"
+        );
+        assert!(!definition.metadata.shell_like, "{name}");
+        assert!(!matches!(
+            definition.metadata.risk,
+            ToolRisk::ProjectWrite | ToolRisk::JobRun
+        ));
+    }
+
+    for name in ["get_goal", "list_goals"] {
+        let definition = lookup_tool_definition(name).unwrap();
+        assert_eq!(definition.metadata.effect, ToolEffect::Observe);
+        assert_eq!(definition.metadata.risk, ToolRisk::Read);
+        assert_eq!(definition.metadata.approval, ToolApprovalPolicy::None);
+        assert_eq!(definition.metadata.idempotency, ToolIdempotency::PureRead);
+        assert_eq!(
+            definition.metadata.authority,
+            ToolAuthorityPolicy::RequireAll(COMMUNICATION_READ_SCOPES)
+        );
+    }
+
+    for name in ["create_goal", "update_goal", "associate_goal_agent_task"] {
+        let definition = lookup_tool_definition(name).unwrap();
+        assert_eq!(definition.metadata.effect, ToolEffect::Mutate);
+        assert_eq!(definition.metadata.risk, ToolRisk::WorkflowManage);
+        assert_eq!(definition.metadata.approval, ToolApprovalPolicy::Standard);
+        assert_eq!(definition.metadata.idempotency, ToolIdempotency::Keyed);
+        assert_eq!(
+            definition.metadata.authority,
+            ToolAuthorityPolicy::RequireAll(COMMUNICATION_MANAGE_SCOPES)
+        );
+    }
+
+    let session_link = lookup_tool_definition("associate_goal_workflow_session").unwrap();
+    assert_eq!(session_link.metadata.idempotency, ToolIdempotency::Keyed);
+    assert_eq!(
+        session_link.metadata.authority,
+        ToolAuthorityPolicy::RequireAll(&[
+            SCOPE_COMMUNICATION_READ,
+            SCOPE_COMMUNICATION_MANAGE,
+            SCOPE_SESSION_COLLABORATE,
+        ])
+    );
+}
+
+#[test]
+fn goal_schemas_are_bounded_private_and_existing_coding_tools_do_not_accept_goal_id() {
+    let specs = registered_tool_specs();
+    let spec = |name: &str| spec_named(&specs, name);
+
+    let create = spec("create_goal");
+    assert_eq!(create.input_schema["properties"]["title"]["maxLength"], 200);
+    assert_eq!(
+        create.input_schema["properties"]["objective"]["maxLength"],
+        8192
+    );
+    assert_eq!(
+        create.input_schema["properties"]["idempotency_key"]["maxLength"],
+        128
+    );
+
+    let update = spec("update_goal");
+    assert_eq!(
+        update.input_schema["properties"]["lifecycle"]["enum"],
+        json!(["active", "completed", "cancelled"])
+    );
+    assert_eq!(
+        update.input_schema["properties"]["terminal_reason"]["maxLength"],
+        4096
+    );
+
+    let list_summary =
+        &spec("list_goals").output_schema["properties"]["output"]["properties"]["goals"]["items"];
+    for field in [
+        "goal_id",
+        "title",
+        "lifecycle",
+        "revision",
+        "created_at_unix_ms",
+        "updated_at_unix_ms",
+        "terminal_at_unix_ms",
+        "agent_task_count",
+        "workflow_session_count",
+    ] {
+        assert!(list_summary["properties"].get(field).is_some(), "{field}");
+    }
+    for private in ["objective", "terminal_reason", "correlations"] {
+        assert!(
+            list_summary["properties"].get(private).is_none(),
+            "{private}"
+        );
+    }
+
+    let detail = &spec("get_goal").output_schema["properties"]["output"]["properties"]["goal"];
+    let correlation = &detail["properties"]["correlations"]["items"];
+    assert_eq!(
+        correlation["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec![
+            "created_at_unix_ms".to_string(),
+            "kind".to_string(),
+            "reference_id".to_string(),
+        ]
+    );
+    let serialized_detail = serde_json::to_string(detail).unwrap();
+    for forbidden in [
+        "attempt_fence",
+        "authority_fingerprint",
+        "consume_token",
+        "wake_token",
+        "session_ledger",
+        "stdout",
+        "stderr",
+    ] {
+        assert!(
+            !serialized_detail.contains(forbidden),
+            "Goal detail schema leaked execution/private field {forbidden}"
+        );
+    }
+
+    for existing in [
+        "work_on_project",
+        "read_files",
+        "apply_text_edits",
+        "run_process",
+        "run_shell",
+        "finish_coding_task",
+    ] {
+        let properties = spec(existing).input_schema["properties"]
+            .as_object()
+            .unwrap();
+        assert!(
+            !properties.contains_key("goal_id"),
+            "{existing} must not gain Goal as an implicit selector or required execution context"
+        );
+    }
+}
+
+#[test]
+fn goal_tool_calls_and_audit_keep_goal_identity_distinct_and_private_text_out_of_logs() {
+    let goal_id = format!("wc_goal_{}", "0".repeat(32));
+    let call = ToolCall::from_tool_name(
+        "update_goal",
+        json!({
+            "goal_id": goal_id,
+            "expected_revision": 4,
+            "objective": "PRIVATE_GOAL_OBJECTIVE_DO_NOT_LOG",
+            "lifecycle": "completed",
+            "terminal_reason": "PRIVATE_GOAL_REASON_DO_NOT_LOG",
+            "idempotency_key": "PRIVATE_GOAL_KEY_DO_NOT_LOG"
+        }),
+    )
+    .unwrap();
+    assert_eq!(call.tool_name(), "update_goal");
+
+    let audit = crate::tool_runtime::tool_audit::session_log_arguments_for_tool_request(
+        "update_goal",
+        &json!({
+            "goal_id": goal_id,
+            "expected_revision": 4,
+            "objective": "PRIVATE_GOAL_OBJECTIVE_DO_NOT_LOG",
+            "lifecycle": "completed",
+            "terminal_reason": "PRIVATE_GOAL_REASON_DO_NOT_LOG",
+            "idempotency_key": "PRIVATE_GOAL_KEY_DO_NOT_LOG"
+        }),
+    );
+    assert_eq!(audit["goal_id"], goal_id);
+    assert_eq!(audit["expected_revision"], 4);
+    assert_eq!(
+        audit["objective_bytes"],
+        "PRIVATE_GOAL_OBJECTIVE_DO_NOT_LOG".len()
+    );
+    assert_eq!(
+        audit["terminal_reason_bytes"],
+        "PRIVATE_GOAL_REASON_DO_NOT_LOG".len()
+    );
+    assert_eq!(audit["idempotency_key_present"], true);
+    let serialized = serde_json::to_string(&audit).unwrap();
+    for private in [
+        "PRIVATE_GOAL_OBJECTIVE_DO_NOT_LOG",
+        "PRIVATE_GOAL_REASON_DO_NOT_LOG",
+        "PRIVATE_GOAL_KEY_DO_NOT_LOG",
+    ] {
+        assert!(!serialized.contains(private), "Goal audit leaked {private}");
+    }
+
+    assert!(ToolCall::from_tool_name(
+        "associate_goal_agent_task",
+        json!({
+            "goal_id": format!("wc_goal_{}", "1".repeat(32)),
+            "task_id": format!("wc_agent_task_{}", "2".repeat(32)),
+            "idempotency_key": "link"
+        })
+    )
+    .is_ok());
+}
+
+#[test]
+fn goal_runtime_crud_replay_and_exact_read_hide_foreign_existence() {
+    let (_temp, _db, runtime) = runtime_with_goal_db();
+    let bob = auth_context(Some("bob-goal"), false);
+    let alice = auth_context(Some("alice-goal"), false);
+
+    let first = runtime.create_goal(
+        Some(&bob),
+        "Private Bob Goal".to_string(),
+        "Private objective".to_string(),
+        "bob-create-goal".to_string(),
+    );
+    assert!(first.success, "{:?}", first.output);
+    let goal_id = first.output["goal"]["summary"]["goal_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(first.output["goal"]["summary"]["revision"], 1);
+    assert_eq!(first.output["goal"]["summary"]["lifecycle"], "active");
+
+    let replay = runtime.create_goal(
+        Some(&bob),
+        "Private Bob Goal".to_string(),
+        "Private objective".to_string(),
+        "bob-create-goal".to_string(),
+    );
+    assert!(replay.success);
+    assert_eq!(replay.output["replayed"], true);
+    assert_eq!(replay.output["goal"]["summary"]["goal_id"], goal_id);
+
+    let changed = runtime.create_goal(
+        Some(&bob),
+        "Private Bob Goal".to_string(),
+        "Changed objective".to_string(),
+        "bob-create-goal".to_string(),
+    );
+    assert!(!changed.success);
+    assert_eq!(changed.output["error_kind"], "goal_idempotency_conflict");
+
+    let foreign = runtime.get_goal(Some(&alice), goal_id.clone());
+    let missing = runtime.get_goal(Some(&alice), format!("wc_goal_{}", "f".repeat(32)));
+    assert!(!foreign.success);
+    assert!(!missing.success);
+    assert_eq!(foreign.output["error_kind"], "goal_not_found");
+    assert_eq!(foreign.output["error_kind"], missing.output["error_kind"]);
+    assert_eq!(foreign.error, missing.error);
+
+    let updated = runtime.update_goal(
+        Some(&bob),
+        goal_id.clone(),
+        1,
+        Some("Updated Bob Goal".to_string()),
+        None,
+        None,
+        None,
+        "bob-update-goal".to_string(),
+    );
+    assert!(updated.success, "{:?}", updated.output);
+    assert_eq!(updated.output["goal"]["summary"]["revision"], 2);
+
+    let update_replay = runtime.update_goal(
+        Some(&bob),
+        goal_id,
+        1,
+        Some("Updated Bob Goal".to_string()),
+        None,
+        None,
+        None,
+        "bob-update-goal".to_string(),
+    );
+    assert!(update_replay.success);
+    assert_eq!(update_replay.output["replayed"], true);
+    assert_eq!(update_replay.output["goal"]["summary"]["revision"], 2);
+}
+
+#[test]
+fn goal_agent_task_link_reauthorizes_task_and_task_completion_never_completes_goal() {
+    let (_temp, db, runtime) = runtime_with_goal_db();
+    let bob = auth_context(Some("bob-task-goal"), false);
+    let alice = auth_context(Some("alice-task-goal"), false);
+    let goal_id = create_goal(&runtime, Some(&bob), "bob-task-goal-create");
+
+    let bob_agent = runtime.create_agent_identity(
+        Some(&bob),
+        "bob-goal-worker".to_string(),
+        "Bob Goal Worker".to_string(),
+        None,
+        Vec::new(),
+        "bob-goal-worker-create".to_string(),
+    );
+    assert!(bob_agent.success);
+    let bob_agent_id = bob_agent.output["agent"]["agent_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let bob_task = runtime.create_agent_task(
+        Some(&bob),
+        "Goal-correlated task".to_string(),
+        "Complete one explicit durable work chunk.".to_string(),
+        Some(bob_agent_id.clone()),
+        None,
+        None,
+        Some("agent:special:reference-is-not-authority".to_string()),
+        "bob-goal-task-create".to_string(),
+    );
+    assert!(bob_task.success, "{:?}", bob_task.output);
+    let bob_task_id = bob_task.output["task"]["summary"]["task_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let linked = runtime.associate_goal_agent_task(
+        Some(&bob),
+        goal_id.clone(),
+        bob_task_id.clone(),
+        "bob-goal-task-link".to_string(),
+    );
+    assert!(linked.success, "{:?}", linked.output);
+    assert_eq!(linked.output["goal"]["summary"]["revision"], 2);
+    assert_eq!(linked.output["goal"]["summary"]["agent_task_count"], 1);
+    assert_eq!(
+        db.conn_for_tests()
+            .query_row(
+                "SELECT COUNT(*) FROM wc_agent_task_coding_runs",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        0,
+        "Goal correlation must not dispatch an AgentTask CodingAgentRun"
+    );
+
+    let alice_agent = runtime.create_agent_identity(
+        Some(&alice),
+        "alice-goal-worker".to_string(),
+        "Alice Goal Worker".to_string(),
+        None,
+        Vec::new(),
+        "alice-goal-worker-create".to_string(),
+    );
+    assert!(alice_agent.success);
+    let alice_agent_id = alice_agent.output["agent"]["agent_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let alice_task = runtime.create_agent_task(
+        Some(&alice),
+        "Alice private task".to_string(),
+        "Private Alice work".to_string(),
+        Some(alice_agent_id),
+        None,
+        None,
+        None,
+        "alice-private-task-create".to_string(),
+    );
+    assert!(alice_task.success);
+    let alice_task_id = alice_task.output["task"]["summary"]["task_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let foreign_link = runtime.associate_goal_agent_task(
+        Some(&bob),
+        goal_id.clone(),
+        alice_task_id,
+        "foreign-task-link".to_string(),
+    );
+    assert!(!foreign_link.success);
+    assert_eq!(foreign_link.output["error_kind"], "agent_task_not_found");
+
+    let attempt = runtime.start_agent_task_attempt(
+        Some(&bob),
+        bob_task_id.clone(),
+        bob_agent_id.clone(),
+        "bob-goal-task-attempt".to_string(),
+    );
+    assert!(attempt.success, "{:?}", attempt.output);
+    let attempt_id = attempt.output["attempt"]["attempt_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let fence = attempt.output["attempt_fence"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let completed = runtime.complete_agent_task_attempt(
+        Some(&bob),
+        bob_task_id,
+        attempt_id,
+        bob_agent_id,
+        fence,
+        1,
+        "succeeded".to_string(),
+        Some("Task work finished".to_string()),
+        None,
+        "bob-goal-task-complete".to_string(),
+    );
+    assert!(completed.success, "{:?}", completed.output);
+    assert_eq!(completed.output["task"]["state"], "succeeded");
+
+    let goal = runtime.get_goal(Some(&bob), goal_id);
+    assert!(goal.success, "{:?}", goal.output);
+    assert_eq!(goal.output["goal"]["summary"]["lifecycle"], "active");
+    assert_eq!(goal.output["goal"]["summary"]["revision"], 2);
+    assert!(goal.output["goal"]["summary"]["terminal_at_unix_ms"].is_null());
+}
+
+#[tokio::test]
+async fn workflow_session_link_is_identity_only_and_finish_coding_task_does_not_complete_goal() {
+    let temp = tempfile::tempdir().unwrap();
+    init_git_repo(temp.path());
+    commit_file(temp.path(), "README.md", "hello\n", "add readme");
+    let db = Arc::new(crate::db::Database::open(&temp.path().join("goal-session.db")).unwrap());
+    let runtime = ToolRuntime::new_for_tests().with_communication_database(db);
+    let project =
+        register_runner_project_at_path(&runtime, "goal-session-finish", "demo", temp.path()).await;
+    let auth = auth_context(None, true);
+    let session = runtime.sessions.start_session(
+        Some(project.clone()),
+        Some("Goal-correlated coding work".to_string()),
+    );
+    let mut limited = auth_context(Some("goal-session-limited"), false);
+    limited.scopes = vec![
+        SCOPE_COMMUNICATION_READ.to_string(),
+        SCOPE_COMMUNICATION_MANAGE.to_string(),
+        SCOPE_SESSION_COLLABORATE.to_string(),
+    ];
+    let limited_goal_id = create_goal(&runtime, Some(&limited), "limited-session-goal-create");
+    let unauthorized_link = runtime
+        .associate_goal_workflow_session(
+            Some(&limited),
+            limited_goal_id.clone(),
+            session.session_id.clone(),
+            "limited-session-goal-link".to_string(),
+        )
+        .await;
+    assert!(
+        !unauthorized_link.success,
+        "Goal ownership and session:collaborate must not grant bound Project authority"
+    );
+    let limited_goal = runtime.get_goal(Some(&limited), limited_goal_id);
+    assert!(limited_goal.success, "{:?}", limited_goal.output);
+    assert_eq!(limited_goal.output["goal"]["summary"]["revision"], 1);
+    assert_eq!(
+        limited_goal.output["goal"]["summary"]["workflow_session_count"],
+        0
+    );
+
+    let goal_id = create_goal(&runtime, Some(&auth), "session-goal-create");
+
+    let linked = runtime
+        .associate_goal_workflow_session(
+            Some(&auth),
+            goal_id.clone(),
+            session.session_id.clone(),
+            "session-goal-link".to_string(),
+        )
+        .await;
+    assert!(linked.success, "{:?}", linked.output);
+    assert_eq!(linked.output["goal"]["summary"]["revision"], 2);
+    assert_eq!(
+        linked.output["goal"]["summary"]["workflow_session_count"],
+        1
+    );
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        let project = project.clone();
+        let session_id = session.session_id.clone();
+        let auth = auth.clone();
+        async move {
+            runtime
+                .dispatch_with_auth(
+                    ToolCall::FinishCodingTask {
+                        project,
+                        session_id,
+                        summary_only: true,
+                        include_diff: Some(false),
+                        include_workspace: Some(true),
+                        include_hygiene: Some(false),
+                        include_handoff: Some(false),
+                        include_validation_summary: Some(false),
+                    },
+                    Some(&auth),
+                )
+                .await
+        }
+    });
+    let request = wait_for_patch_agent_request(&runtime, "goal-session-finish").await;
+    let show_changes_stdout =
+        crate::tool_runtime::framed_clean_show_changes_test_stdout("add readme", false);
+    complete_patch_agent_request(
+        &runtime,
+        "goal-session-finish",
+        &request.request_id,
+        0,
+        &show_changes_stdout,
+        "",
+    )
+    .await;
+    let finish = task.await.unwrap();
+    assert!(finish.success, "{:?}", finish.error);
+
+    let goal = runtime.get_goal(Some(&auth), goal_id);
+    assert!(goal.success, "{:?}", goal.output);
+    assert_eq!(goal.output["goal"]["summary"]["lifecycle"], "active");
+    assert_eq!(goal.output["goal"]["summary"]["revision"], 2);
+    assert!(goal.output["goal"]["summary"]["terminal_at_unix_ms"].is_null());
+}

--- a/src/tool_runtime/tests/mod.rs
+++ b/src/tool_runtime/tests/mod.rs
@@ -20,6 +20,7 @@ mod execution_context;
 mod files;
 mod files_helpers;
 mod git;
+mod goals;
 mod handoff;
 mod handoff_brief;
 mod hygiene;

--- a/src/tool_runtime/tests/support/runtime.rs
+++ b/src/tool_runtime/tests/support/runtime.rs
@@ -56,6 +56,9 @@ pub(in crate::tool_runtime::tests) fn sample_tool_args_for_spec(spec: &ToolSpec)
         "work_on_project" => {
             args.insert("project".to_string(), json!(SAMPLE_PROJECT));
         }
+        "update_goal" => {
+            args.insert("expected_revision".to_string(), json!(1));
+        }
         "observe_jobs" => {
             args.insert("items".to_string(), json!([{"job_id": "job_123"}]));
         }
@@ -89,6 +92,7 @@ pub(in crate::tool_runtime::tests) fn sample_field_value(field: &str) -> Value {
         "text" => json!("// hi\n"),
         "content" => json!("fn main() {}\n"),
         "instruction" => json!("implement the requested change"),
+        "objective" => json!("Preserve durable high-level intent without execution authority."),
         "title" => json!("Durable agent work"),
         "include_project_instructions"
         | "include_workflow_guidance"
@@ -117,6 +121,7 @@ pub(in crate::tool_runtime::tests) fn sample_field_value(field: &str) -> Value {
         "agent_id" => json!(format!("wc_dagent_{}", "a".repeat(32))),
         "assignee_agent_id" => json!(format!("wc_dagent_{}", "a".repeat(32))),
         "task_id" => json!(format!("wc_agent_task_{}", "1".repeat(32))),
+        "goal_id" => json!(format!("wc_goal_{}", "0".repeat(32))),
         "attempt_id" => json!(format!("wc_agent_task_attempt_{}", "2".repeat(32))),
         "attempt_fence" => json!(format!("wc_agent_task_fence_{}", "3".repeat(32))),
         "attempt_controller_generation" | "expected_generation" => json!(1),
@@ -134,7 +139,7 @@ pub(in crate::tool_runtime::tests) fn sample_field_value(field: &str) -> Value {
         "provider_id" => json!("codex"),
         "run_id" => json!("wc_agent_run_sample_1234"),
         "shell_id" => json!("wc_shell_123"),
-        "session_id" => json!("wc_sess_existing"),
+        "session_id" => json!(format!("wc_sess_{}", "1".repeat(32))),
         "checkpoint_id" => json!("wc_ckpt_1234"),
         "confirm" => json!(true),
         "client_id" => json!("oe"),


### PR DESCRIPTION
## Summary
- add Control-owned durable Goal state backed by the existing Server SQLite database
- expose bounded create/get/list/update and explicit AgentTask/Workflow Session correlation tools
- preserve independent authorization boundaries and keep Goal outside Runner/Job/coding execution authority
- define Phase 1 lifecycle and follow-on G2/G3 boundaries in architecture docs

## Validation
- Goal Store tests: 5/5
- Goal ToolRuntime tests: 6/6
- webcodex-tool-contracts: 106/106
- webcodex-tool-runtime-contracts: 73/73
- existing builtin coding workflow: 4/4
- finish_coding_task non-auto-close regression: 1/1
- cargo check --all-targets
- cargo fmt --all -- --check
- git diff --check

Independent committed-range review found no remaining authority inheritance, replay/idempotency, restart durability, boundedness/privacy, or execution-path regression findings.