### PR TITLE
Add durable Goal Plan MCP App presentation

### DIFF
--- a/crates/webcodex-tool-contracts/src/registry/input_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas.rs
@@ -95,8 +95,8 @@ pub use git::{
 };
 pub use goals::{
     associate_goal_agent_task_input_schema, associate_goal_workflow_session_input_schema,
-    create_goal_input_schema, get_goal_input_schema, list_goals_input_schema,
-    update_goal_input_schema,
+    create_goal_input_schema, get_goal_input_schema, goal_plan_state_input_schema,
+    list_goals_input_schema, present_goal_plan_input_schema, update_goal_input_schema,
 };
 pub use hygiene::workspace_hygiene_check_input_schema;
 pub use jobs::{

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/goals.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/goals.rs
@@ -64,6 +64,14 @@ pub fn get_goal_input_schema() -> Value {
     })
 }
 
+pub fn present_goal_plan_input_schema() -> Value {
+    get_goal_input_schema()
+}
+
+pub fn goal_plan_state_input_schema() -> Value {
+    get_goal_input_schema()
+}
+
 pub fn list_goals_input_schema() -> Value {
     json!({
         "type": "object",

--- a/crates/webcodex-tool-contracts/src/registry/mod.rs
+++ b/crates/webcodex-tool-contracts/src/registry/mod.rs
@@ -13,7 +13,7 @@ pub use input_schemas::{
 pub use output_schemas::coding_workflow_diagnostic_output_schema_for_test;
 pub use output_schemas::output_schema_for_tool;
 pub use tool_specs::{
-    memory_management_tool_specs, memory_runtime_tool_specs, operator_diagnostic_tool_specs,
-    registered_tool_specs, skill_management_tool_specs, skill_runtime_tool_specs,
-    stateless_operator_extension_tool_specs,
+    goal_plan_app_tool_specs, memory_management_tool_specs, memory_runtime_tool_specs,
+    operator_diagnostic_tool_specs, registered_tool_specs, skill_management_tool_specs,
+    skill_runtime_tool_specs, stateless_operator_extension_tool_specs,
 };

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/goals.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/goals.rs
@@ -77,6 +77,31 @@ fn goal_detail_schema() -> Value {
     })
 }
 
+fn goal_plan_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "version": {"type": "integer", "const": 1, "description": "Goal Plan presentation projection version."},
+            "goal_id": {"type": "string", "pattern": "^wc_goal_[0-9a-f]{32}$", "description": "Exact durable Goal identity used for refresh/rehydration and app-only polling. Identity is never authority."},
+            "title": {"type": "string", "minLength": 1, "maxLength": 200, "description": "Bounded Goal title."},
+            "objective": {"type": "string", "minLength": 1, "maxLength": 8192, "description": "Bounded authoritative Goal objective; the Store enforces the same 8192-byte UTF-8 ceiling."},
+            "lifecycle": lifecycle_schema(),
+            "revision": {"type": "integer", "minimum": 1, "description": "Monotonic authoritative Goal revision."},
+            "updated_at_unix_ms": schema_type("integer", "Latest authoritative Goal mutation time."),
+            "terminal_at_unix_ms": nullable_integer("Terminal transition time, or null while active."),
+            "agent_task_count": {"type": "integer", "minimum": 0, "maximum": 64, "description": "Count of explicit AgentTask correlations; no target-domain state or authority is projected."},
+            "workflow_session_count": {"type": "integer", "minimum": 0, "maximum": 64, "description": "Count of explicit Workflow Session correlations; no Session ledger, Project state, or authority is projected."}
+        },
+        "required": [
+            "version", "goal_id", "title", "objective", "lifecycle", "revision",
+            "updated_at_unix_ms", "terminal_at_unix_ms", "agent_task_count",
+            "workflow_session_count"
+        ],
+        "description": "Read-only bounded Goal Plan presentation projection. It contains no execution authority, fences, tokens, credentials, Session ledger, Job logs, stdout, or stderr."
+    })
+}
+
 fn goal_mutation_schema() -> Value {
     wrapped_output_schema(vec![
         ("goal", goal_detail_schema()),
@@ -102,6 +127,9 @@ pub fn output_schema_for_tool(name: &str) -> Option<Value> {
         | "associate_goal_agent_task"
         | "associate_goal_workflow_session" => goal_mutation_schema(),
         "get_goal" => wrapped_output_schema(vec![("goal", goal_detail_schema())]),
+        "present_goal_plan" | "goal_plan_state" => {
+            wrapped_output_schema(vec![("goal_plan", goal_plan_schema())])
+        }
         "list_goals" => wrapped_output_schema(vec![
             (
                 "total_count",

--- a/crates/webcodex-tool-contracts/src/registry/tool_specs.rs
+++ b/crates/webcodex-tool-contracts/src/registry/tool_specs.rs
@@ -14,6 +14,17 @@ pub fn registered_tool_specs() -> Vec<ToolSpec> {
     resolve_tool_specs(model_visible_tool_definitions())
 }
 
+/// Fixed read-only Goal Plan polling contract for MCP App Views. The canonical
+/// ToolDefinition remains globally ModelHidden; only a UI-capable MCP adapter may
+/// project this spec with app-only visibility.
+pub fn goal_plan_app_tool_specs() -> Vec<ToolSpec> {
+    vec![tool_spec(
+        "goal_plan_state",
+        "App-only exact read of the current bounded Goal Plan projection. Requires explicit goal_id, re-authorizes the Goal on every call, grants no execution authority, and never mutates Goal state.",
+        super::input_schemas::goal_plan_state_input_schema(),
+    )]
+}
+
 /// Fixed admin-only forensic trace reader. It remains globally ModelHidden and
 /// is projected only by capable Stateless MCP 2026 operator adapters.
 pub fn operator_diagnostic_tool_specs() -> Vec<ToolSpec> {

--- a/crates/webcodex-tool-contracts/src/tool_catalog.rs
+++ b/crates/webcodex-tool-contracts/src/tool_catalog.rs
@@ -96,6 +96,7 @@ pub const TOOL_DISCOVERY_GROUPS: &[ToolDiscoveryGroup] = &[
         tools: &[
             "create_goal",
             "get_goal",
+            "present_goal_plan",
             "list_goals",
             "update_goal",
             "associate_goal_agent_task",

--- a/crates/webcodex-tool-contracts/src/tool_definition/goals.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/goals.rs
@@ -1,5 +1,8 @@
-use super::ToolVisibility::ModelVisible;
-use super::{def, model_spec, require_all_scopes, ToolDefinition, TOOL_CATEGORY_GOAL};
+use super::ToolVisibility::{ModelHidden, ModelVisible};
+use super::{
+    adaptive_runtime_direct, def, model_spec, require_all_scopes, ToolDefinition,
+    TOOL_CATEGORY_GOAL,
+};
 use crate::metadata::{
     ToolPathHint::None as NoPath,
     ToolRisk::{Read, WorkflowManage},
@@ -8,7 +11,7 @@ use crate::metadata::{
 use crate::registry::input_schemas::{
     associate_goal_agent_task_input_schema, associate_goal_workflow_session_input_schema,
     create_goal_input_schema, get_goal_input_schema, list_goals_input_schema,
-    update_goal_input_schema,
+    present_goal_plan_input_schema, update_goal_input_schema,
 };
 use webcodex_core::authority::{
     COMMUNICATION_MANAGE_SCOPES, COMMUNICATION_READ_SCOPES, SCOPE_COMMUNICATION_MANAGE,
@@ -86,6 +89,85 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             ),
             "Read one exact caller-owned durable Goal. Unauthorized and nonexistent ids are existence-hidden. Correlations expose only bounded identities and never target-domain authority, fences, tokens, credentials, Job state, or Workflow Session ledgers.",
             get_goal_input_schema,
+        ),
+        COMMUNICATION_READ_SCOPES,
+    ),
+    require_all_scopes(
+        adaptive_runtime_direct(
+            model_spec(
+                def(
+                    "present_goal_plan",
+                    super::ToolAuditPolicy::typed_fields(&[
+                        super::ToolAuditResultField::pointer("goal_id", "/goal_plan/goal_id"),
+                        super::ToolAuditResultField::pointer("lifecycle", "/goal_plan/lifecycle"),
+                        super::ToolAuditResultField::pointer("revision", "/goal_plan/revision"),
+                        super::ToolAuditResultField::pointer(
+                            "agent_task_count",
+                            "/goal_plan/agent_task_count",
+                        ),
+                        super::ToolAuditResultField::pointer(
+                            "workflow_session_count",
+                            "/goal_plan/workflow_session_count",
+                        ),
+                        super::ToolAuditResultField::value("error_kind"),
+                    ]),
+                    ModelVisible,
+                    TOOL_CATEGORY_GOAL,
+                    None,
+                    TOOL_PROVIDER_CONTROL,
+                    super::ToolSemanticContract {
+                        effect: super::ToolEffect::Observe,
+                        risk: Read,
+                        approval: super::ToolApprovalPolicy::None,
+                        idempotency: super::ToolIdempotency::PureRead,
+                    },
+                    Some(COMMUNICATION_READ),
+                    false,
+                    NoPath,
+                    false,
+                    false,
+                    super::ToolSessionEvidencePolicy::NONE,
+                ),
+                "Present one exact caller-owned durable Goal as a sparse read-only Goal Plan MCP App card. Requires explicit goal_id and never infers Goal identity from Project, Workflow Session, Conversation, credential, ClientWindow, or recent activity. Presentation creates no work, grants no execution authority, and does not modify Goal lifecycle.",
+                present_goal_plan_input_schema,
+            ),
+            17,
+        ),
+        COMMUNICATION_READ_SCOPES,
+    ),
+    require_all_scopes(
+        def(
+            "goal_plan_state",
+            super::ToolAuditPolicy::typed_fields(&[
+                super::ToolAuditResultField::pointer("goal_id", "/goal_plan/goal_id"),
+                super::ToolAuditResultField::pointer("lifecycle", "/goal_plan/lifecycle"),
+                super::ToolAuditResultField::pointer("revision", "/goal_plan/revision"),
+                super::ToolAuditResultField::pointer(
+                    "agent_task_count",
+                    "/goal_plan/agent_task_count",
+                ),
+                super::ToolAuditResultField::pointer(
+                    "workflow_session_count",
+                    "/goal_plan/workflow_session_count",
+                ),
+                super::ToolAuditResultField::value("error_kind"),
+            ]),
+            ModelHidden,
+            TOOL_CATEGORY_GOAL,
+            None,
+            TOOL_PROVIDER_CONTROL,
+            super::ToolSemanticContract {
+                effect: super::ToolEffect::Observe,
+                risk: Read,
+                approval: super::ToolApprovalPolicy::None,
+                idempotency: super::ToolIdempotency::PureRead,
+            },
+            Some(COMMUNICATION_READ),
+            false,
+            NoPath,
+            false,
+            false,
+            super::ToolSessionEvidencePolicy::NONE,
         ),
         COMMUNICATION_READ_SCOPES,
     ),

--- a/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_audit.rs
@@ -3484,6 +3484,12 @@ impl ToolCall {
                 GoalRequestAudit::Get,
                 &serde_json::json!({"goal_id": goal_id}),
             ),
+            Self::PresentGoalPlan { goal_id } | Self::GoalPlanState { goal_id } => {
+                typed_goal_request_audit(
+                    GoalRequestAudit::Get,
+                    &serde_json::json!({"goal_id": goal_id}),
+                )
+            }
             Self::ListGoals {
                 lifecycle,
                 offset,

--- a/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
+++ b/crates/webcodex-tool-runtime-contracts/src/tool_call.rs
@@ -1154,6 +1154,16 @@ pub enum ToolCall {
         goal_id: String,
     },
 
+    /// Build the bounded read-only Goal Plan projection for one explicit App presentation.
+    PresentGoalPlan {
+        goal_id: String,
+    },
+
+    /// App-only exact read of the same bounded Goal Plan projection.
+    GoalPlanState {
+        goal_id: String,
+    },
+
     /// List caller-visible durable Goals with an optional authoritative lifecycle filter.
     ListGoals {
         #[serde(default)]
@@ -2764,6 +2774,8 @@ impl ToolCall {
             Self::SkillRemoveRevision { .. } => "skill_remove_revision",
             Self::CreateGoal { .. } => "create_goal",
             Self::GetGoal { .. } => "get_goal",
+            Self::PresentGoalPlan { .. } => "present_goal_plan",
+            Self::GoalPlanState { .. } => "goal_plan_state",
             Self::ListGoals { .. } => "list_goals",
             Self::UpdateGoal { .. } => "update_goal",
             Self::AssociateGoalAgentTask { .. } => "associate_goal_agent_task",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,6 +80,8 @@ Maintainer-level lifecycle and Agent Task/TaskAttempt details live in [Durable A
 
 The Server also owns an independent durable **Goal** domain for high-level intent/control state. A Goal answers what the user ultimately wants and the authoritative high-level lifecycle of that intent. It is not a Workflow Session, Agent Task, Job, Project selector, credential, or execution authority. Goal references to Agent Tasks and Workflow Sessions are explicit correlation only; dereferencing those ids always re-runs the referenced domain's normal authorization.
 
+Stateless MCP 2026 can optionally present one exact Goal through the sparse Goal Plan App. `present_goal_plan(goal_id)` is the sole model-visible App-bound entry; the View converges through the ModelHidden/app-only `goal_plan_state(goal_id)` read. Both are bounded observations over the same SQLite Goal truth and carry no Project, Runner, Job, Workflow Session mutation, or Host-continuation authority. Existing coding tools do not require Goal identity and keep their normal/native presentation.
+
 ## Task, Job, and Workflow Session continuity
 
 - **Goal** — high-level durable intent/control state (`wc_goal_*`). It can correlate multiple work/execution records, but it does not run them and is never inferred from the current Project, window, credential, or Workflow Session.

--- a/docs/agent/mcp-app-continuation-experiments.md
+++ b/docs/agent/mcp-app-continuation-experiments.md
@@ -139,6 +139,8 @@ Do not copy the temporary timer/map implementation into production. Reuse the au
 
 The static Result App follows the same sparsity rule: current tool descriptors bind it only to `list_jobs`, `validation_summary`, and `git_review_summary`. High-frequency observation, validation-run, and worktree-review calls keep native Host presentation; bounded legacy projections remain available only so already-cached older descriptors fail gracefully rather than forcing a compatibility break.
 
+The production Durable Goal G2 implementation now applies the same findings to a server-owned Goal: one explicit `present_goal_plan(goal_id)` binds `ui://webcodex/goal-plan/v1`, while the existing View uses the ModelHidden/app-only `goal_plan_state(goal_id)` exact read to converge on SQLite Goal revision. It deliberately adds no Wake, `ui/message`, model resume, timer-owned server state, or execution transition; those remain G3 concerns.
+
 ## Recommended implementation order
 
 The Host mechanism is no longer the main unknown. The lowest-risk implementation sequence is:

--- a/docs/architecture/durable-agent-runtime.md
+++ b/docs/architecture/durable-agent-runtime.md
@@ -189,11 +189,35 @@ No current execution path accepts or requires `goal_id`: `work_on_project`, read
 
 Lifecycle is independent across domains. `finish_coding_task` reports/finishes one Workflow Session concern and does not complete a Goal. AgentTask/TaskAttempt terminal completion likewise does not transition a Goal without a future explicit contract. Phase 1 creates no Goal scheduler, Wake/controller, automatic AgentTask, TaskAttempt, Workflow Session, CodingAgentRun, Runner request, process, or Job.
 
-### Follow-on boundaries
+### G2 — Goal Plan MCP App presentation
 
-**G2 — bounded Plan presentation.** Project one exact Goal into a bounded Plan view, create at most one App-bound presentation for that presentation identity, and let the App poll exact bounded state through an App-only read path. Presentation phases may derive from Goal plus existing work/evidence, but they must not expand the authoritative Goal lifecycle. G2 has no wake or model-turn continuation.
+G2 is implemented as a projection over the exact durable Goal rather than a second state machine:
 
-**G3 — production Host continuation adapter.** Add Host continuation only after presentation identity is stable. Reuse the existing durable Agent Endpoint / Wake / Wake Delivery Attempt controller generation, lease/dispatch fence, and exact consume semantics; do not invent a second continuation truth owned by Goal, App, iframe, or Job view.
+```text
+authoritative Goal Store
+        ↓
+exact owner-authorized Goal read
+        ↓
+bounded Goal Plan projection
+        ↓
+present_goal_plan(goal_id)   # model-visible, App-bound, read-only
+        ↓
+ui://webcodex/goal-plan/v1
+        ↓
+goal_plan_state(goal_id)     # ModelHidden, App-only exact polling read
+```
+
+`present_goal_plan` is the only Goal tool bound to the Goal Plan App resource. Each explicit presentation call may create a new Host card; Goal mutations, AgentTask changes, Workflow Session changes, validation, Jobs, and `finish_coding_task` do not create or refresh cards. Ordinary coding/execution tools keep their native Host presentation.
+
+The projection is intentionally sparse: exact `goal_id`, bounded title/objective, authoritative `active | completed | cancelled` lifecycle, monotonic revision, `updated_at`, optional terminal timestamp, and bounded AgentTask/Workflow Session correlation counts. It exposes no correlation identities, Session ledger, TaskAttempt fence, authority fingerprint, Wake/consume token, credential, Job log, stdout, or stderr. G2 does not synthesize `implementing`, `blocked`, `validating`, `reviewing`, or any other durable/presentation phase when the current durable facts do not prove one.
+
+`goal_plan_state` is globally ModelHidden. A UI-capable Stateless MCP 2026 operator surface advertises it to the Host with MCP Apps `ui.visibility = ["app"]`; it is not part of the ordinary model tool universe, Adaptive gateway targets, REST runtime surface, or legacy MCP surface. The protocol-surface gate is not Goal authority: every polling call still derives the existing stable communication principal and independently performs the exact owner-scoped Goal read. App/iframe possession, ClientWindow, Project, Workflow Session, Conversation, credential transport state, and correlation do not select or authorize a Goal.
+
+The App receives exact `goal_id` and revision in the initial presentation result, polls the authoritative Store by that id, and avoids full DOM updates while revision is unchanged. Active cards converge again after foreground/visibility changes; terminal Goals stop periodic polling and retain a stable terminal presentation. Teardown/page unload stops timers. Refresh/reopen requires no localStorage or Server process-local Goal map: the rebuilt View can recover current state from the exact durable identity and SQLite truth. Multiple Views observing the same Goal are safe because both presentation tools are pure reads.
+
+There is no stable Goal page in the Web UI yet, so G2 deliberately omits an `Open in WebCodex` link rather than emitting a dead or semantically incorrect URL.
+
+**G3 — production Host continuation adapter.** Add Host continuation only after this presentation identity/read path is stable. Reuse the existing durable Agent Endpoint / Wake / Wake Delivery Attempt controller generation, lease/dispatch fence, and exact consume semantics; do not invent a second continuation truth owned by Goal, App, iframe, or Job view. G2 contains no Wake, `ui/message`, model resume, dispatch fence, consume token, background model scheduler, or automatic Goal/work execution transition.
 
 These phase boundaries intentionally follow the [September 11–12, 2026 MCP App continuation findings](../agent/mcp-app-continuation-experiments.md): one persistent presentation should converge from server-owned state through bounded App-only refresh; Host dispatch acceptance is not the same as model resumption; and the temporary probe's in-memory timer/map state machine must not be copied into production.
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1149,6 +1149,7 @@ async fn handle_mcp_request_with_lifecycle(
                 auth,
                 stateless_2026,
                 mcp_app_enabled,
+                server_mcp_apps_enabled,
                 host_file_import_trust,
                 window,
                 lifecycle.as_deref_mut(),

--- a/src/mcp/presentation.rs
+++ b/src/mcp/presentation.rs
@@ -16,6 +16,13 @@ pub(super) fn tool_supports_result_app(tool_name: &str) -> bool {
     )
 }
 
+/// Dedicated sparse Goal Plan App binding. Only the explicit presentation entry
+/// gets a resource; Goal mutations, execution tools, and app-only polling never
+/// create additional Host cards.
+pub(super) fn tool_supports_goal_plan_app(tool_name: &str) -> bool {
+    tool_name == "present_goal_plan"
+}
+
 /// Bounded presentation projections retained for current milestone cards and for
 /// already-cached older tool descriptors. Projection support does not itself bind
 /// a new App card in tools/list.

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -56,9 +56,11 @@ pub(super) const MCP_COMPUTER_UI_RESOURCE_TTL_MS: u64 = 0;
 pub(super) const MCP_RESULT_UI_RESOURCE_URI: &str = "ui://webcodex/result/v3";
 pub(super) const MCP_RESULT_UI_RESOURCE_LEGACY_URIS: &[&str] =
     &["ui://webcodex/result/v1", "ui://webcodex/result/v2"];
+pub(super) const MCP_GOAL_PLAN_UI_RESOURCE_URI: &str = "ui://webcodex/goal-plan/v1";
 pub(super) const MCP_UI_RESOURCE_MIME_TYPE: &str = "text/html;profile=mcp-app";
 pub(super) const MCP_COMPUTER_APP_HTML: &str = include_str!("../mcp_computer_app.html");
 pub(super) const MCP_RESULT_APP_HTML: &str = include_str!("../mcp_result_app.html");
+pub(super) const MCP_GOAL_PLAN_APP_HTML: &str = include_str!("../mcp_goal_plan_app.html");
 
 pub(super) fn request_supports_mcp_apps(params: &Value) -> bool {
     let Some(extension) = request_client_capabilities(params)
@@ -130,6 +132,16 @@ pub(super) fn mcp_app_resources_list(domain: Option<&str>) -> Value {
             "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
             "_meta": mcp_result_app_resource_meta(domain)
         }));
+    result["resources"]
+        .as_array_mut()
+        .expect("App resource list must be an array")
+        .push(json!({
+            "uri": MCP_GOAL_PLAN_UI_RESOURCE_URI,
+            "name": "WebCodex Goal Plan",
+            "description": "Sparse read-only durable Goal presentation. One explicit present_goal_plan call creates the card; the View converges by app-only exact polling of authoritative Goal state and never owns execution or lifecycle state.",
+            "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
+            "_meta": mcp_app_resource_meta(domain)
+        }));
     result
 }
 
@@ -172,9 +184,27 @@ pub(super) fn mcp_result_app_resource_read(uri: &str, domain: Option<&str>) -> O
     })
 }
 
+pub(super) fn is_mcp_goal_plan_app_resource_uri(uri: &str) -> bool {
+    uri == MCP_GOAL_PLAN_UI_RESOURCE_URI
+}
+
+pub(super) fn mcp_goal_plan_app_resource_read(uri: &str, domain: Option<&str>) -> Option<Value> {
+    is_mcp_goal_plan_app_resource_uri(uri).then(|| {
+        json!({
+            "contents": [{
+                "uri": uri,
+                "mimeType": MCP_UI_RESOURCE_MIME_TYPE,
+                "text": MCP_GOAL_PLAN_APP_HTML,
+                "_meta": mcp_app_resource_meta(domain)
+            }]
+        })
+    })
+}
+
 fn mcp_static_app_resource_read(uri: &str, domain: Option<&str>) -> Option<Value> {
     mcp_computer_app_resource_read(uri, domain)
         .or_else(|| mcp_result_app_resource_read(uri, domain))
+        .or_else(|| mcp_goal_plan_app_resource_read(uri, domain))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -319,11 +319,23 @@ pub(super) fn mcp_tools_list_payload_with_features_for_auth(
         }
     };
 
-    let tools = specs
+    let mut tools = specs
         .into_iter()
         .filter(|spec| artifact_export_enabled || spec.name != "export_project_artifact")
         .map(|spec| mcp_tool_spec_json(spec, compact, app_enabled))
         .collect::<Vec<_>>();
+    if app_enabled && stateless_2026 && model_surface.supports_operator_extensions() {
+        let mut app_specs =
+            filter_specs_for_oauth(crate::tool_runtime::goal_plan_app_tool_specs(), auth)
+                .into_iter()
+                .map(|spec| {
+                    let mut value = mcp_tool_spec_json(spec, compact, false);
+                    attach_app_visibility(&mut value);
+                    value
+                })
+                .collect::<Vec<_>>();
+        tools.append(&mut app_specs);
+    }
     json!({ "tools": tools })
 }
 
@@ -433,6 +445,9 @@ pub(super) fn add_stateless_workflow_recorder_metadata(
         return;
     };
     for tool in tools {
+        if tool.get("name").and_then(Value::as_str) == Some("goal_plan_state") {
+            continue;
+        }
         let accepts_context_ack = tool
             .get("name")
             .and_then(Value::as_str)
@@ -537,6 +552,17 @@ pub(super) fn attach_app_metadata(value: &mut Value, resource_uri: &str) {
     );
 }
 
+fn attach_app_visibility(value: &mut Value) {
+    let Some(meta) = tool_meta_object(value) else {
+        return;
+    };
+    let ui = meta.entry("ui".to_string()).or_insert_with(|| json!({}));
+    let Some(ui) = ui.as_object_mut() else {
+        return;
+    };
+    ui.insert("visibility".to_string(), json!(["app"]));
+}
+
 fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, app_enabled: bool) -> Value {
     let tool_name = spec.name.clone();
     if matches!(
@@ -585,6 +611,9 @@ fn mcp_tool_spec_json(mut spec: ToolSpec, compact: bool, app_enabled: bool) -> V
     }
     if app_enabled && presentation::tool_supports_result_app(&tool_name) {
         attach_app_metadata(&mut value, resources::MCP_RESULT_UI_RESOURCE_URI);
+    }
+    if app_enabled && presentation::tool_supports_goal_plan_app(&tool_name) {
+        attach_app_metadata(&mut value, resources::MCP_GOAL_PLAN_UI_RESOURCE_URI);
     }
     value
 }
@@ -1143,6 +1172,7 @@ pub(super) async fn handle_call(
     auth: Option<&AuthContext>,
     stateless_2026: bool,
     app_enabled: bool,
+    server_mcp_apps_enabled: bool,
     host_file_import_trust: HostFileImportTrust,
     window: Option<&crate::client_window::ClientWindow>,
     mut lifecycle: Option<&mut ToolRequestLifecycle>,
@@ -1571,10 +1601,15 @@ pub(super) async fn handle_call(
     // MCP boundary. Adaptive gateway calls are already reduced to an admitted
     // target and continue through the same normal runtime checks, whether that
     // target's preferred exposure is gateway or direct.
+    let goal_plan_app_surface =
+        server_mcp_apps_enabled && stateless_2026 && model_surface.supports_operator_extensions();
+    let app_only_goal_plan_state = goal_plan_app_surface && params.name == "goal_plan_state";
     let surface_denied = match model_surface {
         ModelSurface::LocalCoding => !LOCAL_CODING_TOOL_NAMES.contains(&params.name.as_str()),
         ModelSurface::AdaptiveRuntime => {
-            !via_adaptive_runtime_gateway && !is_adaptive_runtime_direct_tool(&params.name)
+            !app_only_goal_plan_state
+                && !via_adaptive_runtime_gateway
+                && !is_adaptive_runtime_direct_tool(&params.name)
         }
         ModelSurface::FullOperatorRuntime => false,
     };
@@ -1708,6 +1743,7 @@ pub(super) async fn handle_call(
     let skill_management_capable = stateless_2026 && model_surface.supports_operator_extensions();
     let memory_surface_capable = stateless_2026 && model_surface.supports_operator_extensions();
     let trace_diagnostics_capable = stateless_2026 && model_surface.supports_operator_extensions();
+    let goal_plan_app_capable = goal_plan_app_surface;
     let context_request = if context_sidecar_capable {
         match strip_stateless_context_request(&mut params.arguments) {
             Ok(keys) => keys,
@@ -1776,6 +1812,7 @@ pub(super) async fn handle_call(
                 skill_management: skill_management_capable,
                 memory_surface: memory_surface_capable,
                 trace_diagnostics: trace_diagnostics_capable,
+                goal_plan_app: goal_plan_app_capable,
             },
         )
         .await;

--- a/src/mcp_goal_plan_app.html
+++ b/src/mcp_goal_plan_app.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>WebCodex Goal Plan</title>
+<style>
+:root { color-scheme: light dark; font: 13px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+* { box-sizing: border-box; }
+body { margin: 0; padding: 12px; color: CanvasText; background: Canvas; }
+.card { display: grid; gap: 10px; }
+.header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+h1 { margin: 0; font-size: 15px; font-weight: 650; overflow-wrap: anywhere; }
+.badge { padding: 2px 7px; border: 1px solid color-mix(in srgb, CanvasText 22%, transparent); border-radius: 999px; font-size: 11px; white-space: nowrap; }
+.objective { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 11em; overflow: auto; }
+.meta { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 6px 14px; font-size: 12px; color: color-mix(in srgb, CanvasText 72%, transparent); }
+.meta b { color: CanvasText; font-weight: 600; }
+.status { min-height: 1.4em; font-size: 11px; color: color-mix(in srgb, CanvasText 60%, transparent); }
+[hidden] { display: none !important; }
+</style>
+</head>
+<body>
+<main class="card" aria-live="polite">
+  <div class="header"><h1 id="title">Goal</h1><span id="lifecycle" class="badge">Loading</span></div>
+  <p id="objective" class="objective">Waiting for Goal state…</p>
+  <div id="meta" class="meta" hidden>
+    <span>Agent Tasks <b id="tasks">0</b></span>
+    <span>Workflow Sessions <b id="sessions">0</b></span>
+    <span>Revision <b id="revision">—</b></span>
+    <span>Updated <b id="updated">—</b></span>
+  </div>
+  <div id="status" class="status">Initializing…</div>
+</main>
+<script>
+(() => {
+  "use strict";
+  const GOAL_ID = /^wc_goal_[0-9a-f]{32}$/;
+  const APP_PROTOCOL = "2026-01-26";
+  const LIFECYCLES = new Set(["active", "completed", "cancelled"]);
+  const POLL_MS = 3000;
+  const CALL_TIMEOUT_MS = 10000;
+  let nextId = 1;
+  let goalId = null;
+  let lastRevision = 0;
+  let pollTimer = null;
+  let pollInFlight = false;
+  let tornDown = false;
+  const pending = new Map();
+  const utf8Encoder = new TextEncoder();
+  const el = id => document.getElementById(id);
+
+  function send(method, params) {
+    if (tornDown) return Promise.reject(new Error("App torn down"));
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error("Host request timed out"));
+      }, CALL_TIMEOUT_MS);
+      pending.set(id, { resolve, reject, timer });
+      parent.postMessage({ jsonrpc: "2.0", id, method, params }, "*");
+    });
+  }
+
+  function notify(method, params) {
+    if (!tornDown) parent.postMessage({ jsonrpc: "2.0", method, params }, "*");
+  }
+
+  function validPlan(value) {
+    if (!value || typeof value !== "object") return null;
+    if (value.version !== 1 || !GOAL_ID.test(value.goal_id || "")) return null;
+    if (typeof value.title !== "string" || Array.from(value.title).length < 1 || Array.from(value.title).length > 200) return null;
+    if (typeof value.objective !== "string" || utf8Encoder.encode(value.objective).length < 1 || utf8Encoder.encode(value.objective).length > 8192) return null;
+    if (!LIFECYCLES.has(value.lifecycle) || !Number.isSafeInteger(value.revision) || value.revision < 1) return null;
+    if (!Number.isSafeInteger(value.updated_at_unix_ms)) return null;
+    if (!(value.terminal_at_unix_ms === null || Number.isSafeInteger(value.terminal_at_unix_ms))) return null;
+    for (const key of ["agent_task_count", "workflow_session_count"]) {
+      if (!Number.isSafeInteger(value[key]) || value[key] < 0 || value[key] > 64) return null;
+    }
+    return value;
+  }
+
+  function extractPlan(result) {
+    const structured = result && (result.structuredContent || result.structured_content || result);
+    const output = structured && (structured.output || structured);
+    return validPlan(output && output.goal_plan);
+  }
+
+  function labelLifecycle(value) {
+    return value === "active" ? "Active" : value === "completed" ? "Completed" : "Cancelled";
+  }
+
+  function render(plan) {
+    el("title").textContent = plan.title;
+    el("lifecycle").textContent = labelLifecycle(plan.lifecycle);
+    el("objective").textContent = plan.objective;
+    el("tasks").textContent = String(plan.agent_task_count);
+    el("sessions").textContent = String(plan.workflow_session_count);
+    el("revision").textContent = String(plan.revision);
+    const date = new Date(plan.updated_at_unix_ms);
+    el("updated").textContent = Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+    el("meta").hidden = false;
+    el("status").textContent = plan.lifecycle === "active" ? "Tracking authoritative Goal state" : "Terminal Goal state";
+  }
+
+  function stopPolling() {
+    if (pollTimer !== null) clearInterval(pollTimer);
+    pollTimer = null;
+  }
+
+  async function poll() {
+    if (tornDown || !goalId || pollInFlight) return;
+    pollInFlight = true;
+    try {
+      const response = await send("tools/call", { name: "goal_plan_state", arguments: { goal_id: goalId } });
+      const plan = extractPlan(response);
+      if (!plan || plan.goal_id !== goalId) throw new Error("Invalid Goal Plan state");
+      if (plan.revision > lastRevision) {
+        lastRevision = plan.revision;
+        render(plan);
+      } else if (plan.revision === lastRevision && plan.lifecycle === "active" && el("status").textContent === "State refresh pending") {
+        el("status").textContent = "Tracking authoritative Goal state";
+      }
+      if (plan.lifecycle !== "active") stopPolling();
+    } catch (_) {
+      if (!tornDown) el("status").textContent = "State refresh pending";
+    } finally {
+      pollInFlight = false;
+    }
+  }
+
+  function ensurePolling(plan) {
+    if (plan.lifecycle !== "active" || tornDown) return stopPolling();
+    if (pollTimer === null) pollTimer = setInterval(poll, POLL_MS);
+  }
+
+  function acceptInitial(result) {
+    const plan = extractPlan(result);
+    if (!plan) return;
+    if (goalId && goalId !== plan.goal_id) return;
+    goalId = plan.goal_id;
+    if (plan.revision >= lastRevision) {
+      lastRevision = plan.revision;
+      render(plan);
+    }
+    ensurePolling(plan);
+  }
+
+  function teardown() {
+    tornDown = true;
+    stopPolling();
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error("App torn down"));
+    }
+    pending.clear();
+  }
+
+  addEventListener("message", event => {
+    if (event.source !== parent) return;
+    const msg = event.data;
+    if (!msg || msg.jsonrpc !== "2.0") return;
+    if (Object.prototype.hasOwnProperty.call(msg, "id") && pending.has(msg.id)) {
+      const entry = pending.get(msg.id);
+      pending.delete(msg.id);
+      clearTimeout(entry.timer);
+      if (msg.error) entry.reject(new Error(String(msg.error.message || "Host error")));
+      else entry.resolve(msg.result);
+      return;
+    }
+    if (msg.method === "ui/notifications/tool-result") {
+      acceptInitial(msg.params);
+      return;
+    }
+    if (msg.method === "ui/resource-teardown") {
+      teardown();
+      if (Object.prototype.hasOwnProperty.call(msg, "id")) {
+        parent.postMessage({ jsonrpc: "2.0", id: msg.id, result: {} }, "*");
+      }
+    }
+  });
+
+  addEventListener("visibilitychange", () => {
+    if (!document.hidden) void poll();
+  });
+  addEventListener("pagehide", teardown, { once: true });
+  addEventListener("beforeunload", teardown, { once: true });
+
+  send("ui/initialize", { protocolVersion: APP_PROTOCOL, appInfo: { name: "webcodex-goal-plan-app", title: "WebCodex Goal Plan", version: "1.0.0" }, appCapabilities: {} })
+    .then(() => notify("ui/notifications/initialized", {}))
+    .catch(() => { if (!tornDown) el("status").textContent = "Host initialization unavailable"; });
+})();
+</script>
+</body>
+</html>

--- a/src/mcp_tests.rs
+++ b/src/mcp_tests.rs
@@ -214,6 +214,8 @@ mod artifact_export;
 mod computer_app;
 #[path = "mcp_tests/file_import.rs"]
 mod file_import;
+#[path = "mcp_tests/goal_plan_app.rs"]
+mod goal_plan_app;
 #[path = "mcp_tests/http_transport.rs"]
 mod http_transport;
 #[path = "mcp_tests/model_ergonomics.rs"]

--- a/src/mcp_tests/goal_plan_app.rs
+++ b/src/mcp_tests/goal_plan_app.rs
@@ -1,0 +1,409 @@
+use super::*;
+use std::sync::Arc;
+
+fn tool<'a>(payload: &'a Value, name: &str) -> Option<&'a Value> {
+    payload["tools"]
+        .as_array()?
+        .iter()
+        .find(|tool| tool["name"] == name)
+}
+
+fn goal_auth(username: &str) -> crate::auth::AuthContext {
+    let mut auth = crate::auth::AuthContext::new(crate::auth::AuthKind::ApiToken);
+    auth.user_id = Some(format!("user-{username}"));
+    auth.username = Some(username.to_string());
+    auth.api_key_id = Some(format!("key-{username}"));
+    auth.role = Some("user".to_string());
+    auth.scopes = vec![
+        crate::auth::SCOPE_RUNTIME_READ.to_string(),
+        crate::auth::SCOPE_COMMUNICATION_READ.to_string(),
+        crate::auth::SCOPE_COMMUNICATION_MANAGE.to_string(),
+    ];
+    auth.token_kind = Some("user".to_string());
+    auth
+}
+
+fn goal_runtime(
+    surface: ModelSurface,
+) -> (tempfile::TempDir, Arc<crate::db::Database>, ToolRuntime) {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Arc::new(crate::db::Database::open(&temp.path().join("goal-plan.db")).unwrap());
+    let runtime = ToolRuntime::new_for_tests()
+        .with_model_surface(surface)
+        .with_communication_database(db.clone());
+    (temp, db, runtime)
+}
+
+fn create_goal(runtime: &ToolRuntime, auth: &crate::auth::AuthContext, key: &str) -> String {
+    let created = runtime.create_goal(
+        Some(auth),
+        "Ship Goal Plan presentation".to_string(),
+        "Expose one bounded read-only durable Goal card with exact-state polling.".to_string(),
+        key.to_string(),
+    );
+    assert!(created.success, "{:?}", created.output);
+    created.output["goal"]["summary"]["goal_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn handle_with_server_apps_enabled(
+    runtime: &ToolRuntime,
+    request: JsonRpcRequest,
+    auth: Option<&crate::auth::AuthContext>,
+    enabled: bool,
+) -> McpOutcome {
+    let protocol_era = super::super::inferred_protocol_era(&request);
+    super::super::handle_mcp_request_with_lifecycle(
+        runtime,
+        None,
+        request,
+        auth,
+        protocol_era,
+        super::super::HostFileImportTrust::Untrusted,
+        None,
+        None,
+        None,
+        crate::model_surface::effective_mcp_compact_schemas(
+            runtime.runtime_exposure(),
+            crate::config::mcp_compact_schemas_override(),
+        ),
+        enabled,
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn goal_plan_app_descriptor_is_sparse_app_only_resource_backed_and_adaptive_direct() {
+    let (_temp, _db, adaptive) = goal_runtime(ModelSurface::AdaptiveRuntime);
+    let auth = goal_auth("goal-plan-descriptor");
+
+    let ui = handle_with_server_apps_enabled(
+        &adaptive,
+        rpc(
+            "tools/list",
+            Some(json!(4101)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        Some(&auth),
+        true,
+    )
+    .await;
+    let ui = match ui {
+        McpOutcome::Ok(value) => value,
+        other => panic!("expected UI-capable adaptive tools/list: {other:?}"),
+    };
+    let present = tool(&ui["result"], "present_goal_plan").expect("adaptive present_goal_plan");
+    assert_eq!(
+        present.pointer("/_meta/ui/resourceUri"),
+        Some(&json!(MCP_GOAL_PLAN_UI_RESOURCE_URI))
+    );
+    assert!(present.pointer("/_meta/ui/visibility").is_none());
+    let state = tool(&ui["result"], "goal_plan_state").expect("app-only goal_plan_state");
+    assert_eq!(state.pointer("/_meta/ui/visibility"), Some(&json!(["app"])));
+    assert!(state.pointer("/_meta/ui/resourceUri").is_none());
+    assert_eq!(state["inputSchema"]["required"], json!(["goal_id"]));
+    assert_eq!(
+        state["inputSchema"]["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec!["goal_id".to_string()]
+    );
+
+    let plain = handle_with_server_apps_enabled(
+        &adaptive,
+        rpc("tools/list", Some(json!(4102)), mcp_2026_params(json!({}))),
+        Some(&auth),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(plain) = plain else {
+        panic!("expected ordinary adaptive tools/list");
+    };
+    assert!(tool(&plain["result"], "present_goal_plan").is_some());
+    assert!(tool(&plain["result"], "present_goal_plan")
+        .unwrap()
+        .pointer("/_meta/ui/resourceUri")
+        .is_none());
+    assert!(tool(&plain["result"], "goal_plan_state").is_none());
+
+    let disabled_ui = handle_with_server_apps_enabled(
+        &adaptive,
+        rpc(
+            "tools/list",
+            Some(json!(4106)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        Some(&auth),
+        false,
+    )
+    .await;
+    let McpOutcome::Ok(disabled_ui) = disabled_ui else {
+        panic!("expected tools/list with Server Apps disabled");
+    };
+    let disabled_present = tool(&disabled_ui["result"], "present_goal_plan")
+        .expect("present_goal_plan remains a normal read tool");
+    assert!(disabled_present.pointer("/_meta/ui/resourceUri").is_none());
+    assert!(tool(&disabled_ui["result"], "goal_plan_state").is_none());
+
+    let (_full_temp, _full_db, full) = goal_runtime(ModelSurface::FullOperatorRuntime);
+    let full_ui = handle_with_server_apps_enabled(
+        &full,
+        rpc(
+            "tools/list",
+            Some(json!(4103)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        Some(&auth),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(full_ui) = full_ui else {
+        panic!("expected UI-capable Full Operator tools/list");
+    };
+    for name in [
+        "create_goal",
+        "get_goal",
+        "list_goals",
+        "update_goal",
+        "associate_goal_agent_task",
+        "associate_goal_workflow_session",
+        "work_on_project",
+        "run_process",
+        "run_shell",
+        "finish_coding_task",
+    ] {
+        let descriptor = tool(&full_ui["result"], name).unwrap_or_else(|| panic!("missing {name}"));
+        assert_ne!(
+            descriptor
+                .pointer("/_meta/ui/resourceUri")
+                .and_then(Value::as_str),
+            Some(MCP_GOAL_PLAN_UI_RESOURCE_URI),
+            "{name} must not create another Goal Plan card"
+        );
+    }
+
+    let resources = handle_with_server_apps_enabled(
+        &full,
+        rpc(
+            "resources/list",
+            Some(json!(4104)),
+            mcp_2026_ui_params(json!({})),
+        ),
+        Some(&auth),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(resources) = resources else {
+        panic!("expected Goal Plan resources/list");
+    };
+    let resource = resources["result"]["resources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|resource| resource["uri"] == MCP_GOAL_PLAN_UI_RESOURCE_URI)
+        .expect("Goal Plan App resource");
+    assert_eq!(resource["mimeType"], MCP_UI_RESOURCE_MIME_TYPE);
+    assert_eq!(
+        resource["_meta"]["ui"]["csp"],
+        json!({"connectDomains": [], "resourceDomains": []})
+    );
+
+    let read = handle_with_server_apps_enabled(
+        &full,
+        rpc(
+            "resources/read",
+            Some(json!(4105)),
+            mcp_2026_ui_params(json!({"uri": MCP_GOAL_PLAN_UI_RESOURCE_URI})),
+        ),
+        Some(&auth),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(read) = read else {
+        panic!("expected Goal Plan resource read");
+    };
+    assert_eq!(
+        read["result"]["contents"][0]["uri"],
+        MCP_GOAL_PLAN_UI_RESOURCE_URI
+    );
+    assert_eq!(
+        read["result"]["contents"][0]["text"],
+        MCP_GOAL_PLAN_APP_HTML
+    );
+    for required in [
+        "goal_plan_state",
+        "visibilitychange",
+        "ui/resource-teardown",
+        "lastRevision",
+        "setInterval",
+        "pagehide",
+    ] {
+        assert!(
+            MCP_GOAL_PLAN_APP_HTML.contains(required),
+            "missing App behavior {required}"
+        );
+    }
+    for forbidden in [
+        "localStorage",
+        "ui/message",
+        "consume_token",
+        "wake_token",
+        "attempt_fence",
+        "authority_fingerprint",
+    ] {
+        assert!(
+            !MCP_GOAL_PLAN_APP_HTML.contains(forbidden),
+            "Goal Plan App contains forbidden G3/private marker {forbidden}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn goal_plan_poll_reads_authoritative_revision_without_ui_request_identity_or_mutation() {
+    let (_temp, _db, runtime) = goal_runtime(ModelSurface::AdaptiveRuntime);
+    let bob = goal_auth("goal-plan-bob");
+    let alice = goal_auth("goal-plan-alice");
+    let goal_id = create_goal(&runtime, &bob, "goal-plan-bob-create");
+
+    let present = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(4201)),
+            mcp_2026_ui_params(json!({
+                "name": "present_goal_plan",
+                "arguments": {"goal_id": goal_id}
+            })),
+        ),
+        Some(&bob),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(present) = present else {
+        panic!("present_goal_plan failed");
+    };
+    assert_eq!(present["result"]["structuredContent"]["success"], true);
+    assert_eq!(
+        present["result"]["structuredContent"]["output"]["goal_plan"]["goal_id"],
+        goal_id
+    );
+    assert_eq!(
+        present["result"]["structuredContent"]["output"]["goal_plan"]["revision"],
+        1
+    );
+
+    // App polling must not rely on the initiating tools/list/call carrying UI capability
+    // metadata. Exact Goal identity plus the caller's normal Goal authority is sufficient.
+    let poll = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(4202)),
+            mcp_2026_params(json!({
+                "name": "goal_plan_state",
+                "arguments": {"goal_id": goal_id}
+            })),
+        ),
+        Some(&bob),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(poll) = poll else {
+        panic!("app-only Goal polling failed");
+    };
+    assert_eq!(poll["result"]["structuredContent"]["success"], true);
+    assert_eq!(
+        poll["result"]["structuredContent"]["output"]["goal_plan"]["revision"],
+        1
+    );
+    assert_eq!(
+        runtime.get_goal(Some(&bob), goal_id.clone()).output["goal"]["summary"]["revision"],
+        1
+    );
+
+    let update = runtime.update_goal(
+        Some(&bob),
+        goal_id.clone(),
+        1,
+        None,
+        Some("Revision two objective".to_string()),
+        None,
+        None,
+        "goal-plan-revision-two".to_string(),
+    );
+    assert!(update.success, "{:?}", update.output);
+    let poll2 = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(4203)),
+            mcp_2026_params(json!({
+                "name": "goal_plan_state",
+                "arguments": {"goal_id": goal_id}
+            })),
+        ),
+        Some(&bob),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(poll2) = poll2 else {
+        panic!("second app-only Goal polling failed");
+    };
+    assert_eq!(
+        poll2["result"]["structuredContent"]["output"]["goal_plan"]["revision"],
+        2
+    );
+    assert_eq!(
+        poll2["result"]["structuredContent"]["output"]["goal_plan"]["objective"],
+        "Revision two objective"
+    );
+    assert_eq!(
+        runtime.get_goal(Some(&bob), goal_id.clone()).output["goal"]["summary"]["revision"],
+        2
+    );
+
+    let foreign = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(4204)),
+            mcp_2026_params(json!({
+                "name": "goal_plan_state",
+                "arguments": {"goal_id": goal_id}
+            })),
+        ),
+        Some(&alice),
+        true,
+    )
+    .await;
+    let McpOutcome::Ok(foreign) = foreign else {
+        panic!("foreign exact lookup must return an existence-hidden tool result");
+    };
+    assert_eq!(foreign["result"]["structuredContent"]["success"], false);
+    assert_eq!(
+        foreign["result"]["structuredContent"]["output"]["error_kind"],
+        "goal_not_found"
+    );
+
+    let disabled = handle_with_server_apps_enabled(
+        &runtime,
+        rpc(
+            "tools/call",
+            Some(json!(4205)),
+            mcp_2026_params(json!({
+                "name": "goal_plan_state",
+                "arguments": {"goal_id": goal_id}
+            })),
+        ),
+        Some(&bob),
+        false,
+    )
+    .await;
+    assert!(matches!(disabled, McpOutcome::BadRequest(_)));
+}

--- a/src/tool_runtime/dispatch.rs
+++ b/src/tool_runtime/dispatch.rs
@@ -1807,6 +1807,10 @@ impl ToolRuntime {
 
             ToolCall::GetGoal { goal_id } => self.get_goal(auth, goal_id),
 
+            ToolCall::PresentGoalPlan { goal_id } => self.present_goal_plan(auth, goal_id),
+
+            ToolCall::GoalPlanState { goal_id } => self.goal_plan_state(auth, goal_id),
+
             ToolCall::ListGoals {
                 lifecycle,
                 offset,

--- a/src/tool_runtime/goal.rs
+++ b/src/tool_runtime/goal.rs
@@ -1,10 +1,41 @@
 use super::{RecoveryKind, ToolResult, ToolRuntime};
 use crate::auth::AuthContext;
-use crate::db::{GoalLifecycle, GoalPatch, GoalStoreError, NewGoal, MAX_GOAL_LIST_LIMIT};
+use crate::db::{
+    GoalDetail, GoalLifecycle, GoalPatch, GoalStoreError, NewGoal, MAX_GOAL_LIST_LIMIT,
+};
 use serde::Serialize;
 use serde_json::{json, to_value};
 
 const DEFAULT_GOAL_LIST_LIMIT: usize = 50;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct GoalPlanProjection {
+    pub version: u8,
+    pub goal_id: String,
+    pub title: String,
+    pub objective: String,
+    pub lifecycle: GoalLifecycle,
+    pub revision: i64,
+    pub updated_at_unix_ms: i64,
+    pub terminal_at_unix_ms: Option<i64>,
+    pub agent_task_count: i64,
+    pub workflow_session_count: i64,
+}
+
+fn goal_plan_projection(goal: GoalDetail) -> GoalPlanProjection {
+    GoalPlanProjection {
+        version: 1,
+        goal_id: goal.summary.goal_id,
+        title: goal.summary.title,
+        objective: goal.objective,
+        lifecycle: goal.summary.lifecycle,
+        revision: goal.summary.revision,
+        updated_at_unix_ms: goal.summary.updated_at_unix_ms,
+        terminal_at_unix_ms: goal.summary.terminal_at_unix_ms,
+        agent_task_count: goal.summary.agent_task_count,
+        workflow_session_count: goal.summary.workflow_session_count,
+    }
+}
 
 fn goal_principal(
     auth: Option<&AuthContext>,
@@ -108,6 +139,38 @@ impl ToolRuntime {
             Ok(goal) => serialized_goal_success(json!({"goal": goal})),
             Err(error) => goal_error(error, RecoveryKind::Reobserve),
         }
+    }
+
+    fn exact_goal_plan(&self, auth: Option<&AuthContext>, goal_id: String) -> ToolResult {
+        let principal = match goal_principal(auth) {
+            Ok(principal) => principal,
+            Err(result) => return result,
+        };
+        let Some(db) = self.communication_db.as_ref() else {
+            return goal_store_unavailable();
+        };
+        match db.read_goal(&principal, &goal_id) {
+            Ok(goal) => serialized_goal_success(json!({
+                "goal_plan": goal_plan_projection(goal),
+            })),
+            Err(error) => goal_error(error, RecoveryKind::Reobserve),
+        }
+    }
+
+    pub(crate) fn present_goal_plan(
+        &self,
+        auth: Option<&AuthContext>,
+        goal_id: String,
+    ) -> ToolResult {
+        self.exact_goal_plan(auth, goal_id)
+    }
+
+    pub(crate) fn goal_plan_state(
+        &self,
+        auth: Option<&AuthContext>,
+        goal_id: String,
+    ) -> ToolResult {
+        self.exact_goal_plan(auth, goal_id)
     }
 
     pub(crate) fn list_goals(

--- a/src/tool_runtime/kernel.rs
+++ b/src/tool_runtime/kernel.rs
@@ -106,6 +106,9 @@ pub(crate) struct ToolProtocolCapabilities {
     /// Protocol-surface support for privileged forensic trace retrieval. Caller
     /// authority is still derived only from the canonical ToolDefinition.
     pub(crate) trace_diagnostics: bool,
+    /// Protocol-surface support for the ModelHidden Goal Plan App polling read.
+    /// This never replaces canonical communication/Goal authorization.
+    pub(crate) goal_plan_app: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -273,6 +276,7 @@ impl ToolRuntime {
                 skill_management: false,
                 memory_surface: false,
                 trace_diagnostics: false,
+                goal_plan_app: false,
             },
         )
         .await
@@ -341,6 +345,19 @@ impl ToolRuntime {
                 result: None,
                 error_status: Some(ToolCallErrorStatus::InvalidArguments {
                     message: "Tool trace diagnostics are available only on Stateless MCP 2026 operator surfaces"
+                        .to_string(),
+                }),
+                project: None,
+                model_ergonomics: None,
+                correlation: Default::default(),
+            };
+        }
+        if request.tool_name == "goal_plan_state" && !capabilities.goal_plan_app {
+            return ToolCallOutcome {
+                success: false,
+                result: None,
+                error_status: Some(ToolCallErrorStatus::InvalidArguments {
+                    message: "Goal Plan App state is available only on Stateless MCP 2026 App-enabled operator surfaces"
                         .to_string(),
                 }),
                 project: None,

--- a/src/tool_runtime/mod.rs
+++ b/src/tool_runtime/mod.rs
@@ -155,7 +155,7 @@ pub(crate) use project_resolution::{runner_project_runtime_id, ProjectResolverEr
 #[cfg(test)]
 pub(crate) use registry::accepted_flattened_args_for_spec;
 pub(crate) use registry::{
-    generic_tool_call_flattened_args_for_spec, registered_tool_specs,
+    generic_tool_call_flattened_args_for_spec, goal_plan_app_tool_specs, registered_tool_specs,
     stateless_operator_extension_tool_specs,
 };
 #[cfg(test)]

--- a/src/tool_runtime/registry/mod.rs
+++ b/src/tool_runtime/registry/mod.rs
@@ -8,9 +8,10 @@ pub(super) mod input_schemas {
 #[allow(unused_imports)]
 pub(crate) use webcodex_tool_contracts::registry::{
     accepted_flattened_args_for_spec, generic_tool_call_flattened_args_for_spec,
-    memory_management_tool_specs, memory_runtime_tool_specs, operator_diagnostic_tool_specs,
-    output_schema_for_tool, registered_tool_specs, skill_management_tool_specs,
-    skill_runtime_tool_specs, stateless_operator_extension_tool_specs, tool_annotations,
+    goal_plan_app_tool_specs, memory_management_tool_specs, memory_runtime_tool_specs,
+    operator_diagnostic_tool_specs, output_schema_for_tool, registered_tool_specs,
+    skill_management_tool_specs, skill_runtime_tool_specs, stateless_operator_extension_tool_specs,
+    tool_annotations,
 };
 
 #[cfg(test)]

--- a/src/tool_runtime/tests/goals.rs
+++ b/src/tool_runtime/tests/goals.rs
@@ -42,6 +42,7 @@ fn goal_tools_are_control_only_and_never_declare_execution_authority() {
     for name in [
         "create_goal",
         "get_goal",
+        "present_goal_plan",
         "list_goals",
         "update_goal",
         "associate_goal_agent_task",
@@ -66,7 +67,7 @@ fn goal_tools_are_control_only_and_never_declare_execution_authority() {
         ));
     }
 
-    for name in ["get_goal", "list_goals"] {
+    for name in ["get_goal", "list_goals", "present_goal_plan"] {
         let definition = lookup_tool_definition(name).unwrap();
         assert_eq!(definition.metadata.effect, ToolEffect::Observe);
         assert_eq!(definition.metadata.risk, ToolRisk::Read);
@@ -89,6 +90,25 @@ fn goal_tools_are_control_only_and_never_declare_execution_authority() {
             ToolAuthorityPolicy::RequireAll(COMMUNICATION_MANAGE_SCOPES)
         );
     }
+
+    let app_state = lookup_tool_definition("goal_plan_state").unwrap();
+    assert!(app_state.model_spec.is_none());
+    assert_eq!(app_state.category, "goal");
+    assert_eq!(app_state.metadata.provider_id, "control");
+    assert!(!app_state.metadata.requires_project);
+    assert_eq!(
+        app_state.runner_capability,
+        None::<RunnerCapabilityRequirement>
+    );
+    assert!(!app_state.metadata.shell_like);
+    assert_eq!(app_state.metadata.effect, ToolEffect::Observe);
+    assert_eq!(app_state.metadata.risk, ToolRisk::Read);
+    assert_eq!(app_state.metadata.approval, ToolApprovalPolicy::None);
+    assert_eq!(app_state.metadata.idempotency, ToolIdempotency::PureRead);
+    assert_eq!(
+        app_state.metadata.authority,
+        ToolAuthorityPolicy::RequireAll(COMMUNICATION_READ_SCOPES)
+    );
 
     let session_link = lookup_tool_definition("associate_goal_workflow_session").unwrap();
     assert_eq!(session_link.metadata.idempotency, ToolIdempotency::Keyed);
@@ -127,6 +147,44 @@ fn goal_schemas_are_bounded_private_and_existing_coding_tools_do_not_accept_goal
         update.input_schema["properties"]["terminal_reason"]["maxLength"],
         4096
     );
+
+    let present = spec("present_goal_plan");
+    assert_eq!(present.input_schema["required"], json!(["goal_id"]));
+    let plan = &present.output_schema["properties"]["output"]["properties"]["goal_plan"];
+    assert_eq!(plan["properties"]["version"]["const"], 1);
+    assert_eq!(plan["properties"]["title"]["maxLength"], 200);
+    assert_eq!(plan["properties"]["objective"]["maxLength"], 8192);
+    assert_eq!(
+        plan["properties"]["lifecycle"]["enum"],
+        json!(["active", "completed", "cancelled"])
+    );
+    assert_eq!(plan["properties"]["agent_task_count"]["maximum"], 64);
+    assert_eq!(plan["properties"]["workflow_session_count"]["maximum"], 64);
+    let plan_properties = plan["properties"].as_object().unwrap();
+    for forbidden_property in [
+        "correlations",
+        "terminal_reason",
+        "attempt_fence",
+        "authority_fingerprint",
+        "consume_token",
+        "wake_token",
+        "session_ledger",
+        "stdout",
+        "stderr",
+        "job_log",
+    ] {
+        assert!(
+            !plan_properties.contains_key(forbidden_property),
+            "Goal Plan schema exposed private property {forbidden_property}"
+        );
+    }
+    let app_specs = crate::tool_runtime::goal_plan_app_tool_specs();
+    assert_eq!(app_specs.len(), 1);
+    assert_eq!(app_specs[0].name, "goal_plan_state");
+    assert_eq!(app_specs[0].input_schema["required"], json!(["goal_id"]));
+    assert!(!registered_tool_names()
+        .iter()
+        .any(|name| name == "goal_plan_state"));
 
     let list_summary =
         &spec("list_goals").output_schema["properties"]["output"]["properties"]["goals"]["items"];
@@ -247,6 +305,36 @@ fn goal_tool_calls_and_audit_keep_goal_identity_distinct_and_private_text_out_of
         assert!(!serialized.contains(private), "Goal audit leaked {private}");
     }
 
+    let plan_audit = crate::tool_runtime::tool_audit::session_log_arguments_for_tool_request(
+        "present_goal_plan",
+        &json!({"goal_id": goal_id}),
+    );
+    assert_eq!(plan_audit, json!({"goal_id": goal_id}));
+    let private_objective = "PRIVATE_GOAL_PLAN_OBJECTIVE_DO_NOT_AUDIT";
+    let result_audit = crate::tool_runtime::tool_audit::session_log_result_for_tool(
+        "present_goal_plan",
+        &json!({
+            "goal_plan": {
+                "goal_id": goal_id,
+                "title": "Private title",
+                "objective": private_objective,
+                "lifecycle": "active",
+                "revision": 7,
+                "updated_at_unix_ms": 1,
+                "terminal_at_unix_ms": null,
+                "agent_task_count": 2,
+                "workflow_session_count": 3
+            }
+        }),
+    );
+    assert_eq!(result_audit["goal_id"], goal_id);
+    assert_eq!(result_audit["revision"], 7);
+    assert_eq!(result_audit["agent_task_count"], 2);
+    assert_eq!(result_audit["workflow_session_count"], 3);
+    assert!(!serde_json::to_string(&result_audit)
+        .unwrap()
+        .contains(private_objective));
+
     assert!(ToolCall::from_tool_name(
         "associate_goal_agent_task",
         json!({
@@ -331,6 +419,127 @@ fn goal_runtime_crud_replay_and_exact_read_hide_foreign_existence() {
     assert!(update_replay.success);
     assert_eq!(update_replay.output["replayed"], true);
     assert_eq!(update_replay.output["goal"]["summary"]["revision"], 2);
+}
+
+#[test]
+fn goal_plan_projection_is_exact_pure_revisioned_terminal_and_existence_hidden() {
+    let (_temp, _db, runtime) = runtime_with_goal_db();
+    let bob = auth_context(Some("bob-plan"), false);
+    let alice = auth_context(Some("alice-plan"), false);
+    let goal_id = create_goal(&runtime, Some(&bob), "bob-plan-create");
+
+    let initial = runtime.present_goal_plan(Some(&bob), goal_id.clone());
+    assert!(initial.success, "{:?}", initial.output);
+    let plan = &initial.output["goal_plan"];
+    assert_eq!(plan["version"], 1);
+    assert_eq!(plan["goal_id"], goal_id);
+    assert_eq!(plan["lifecycle"], "active");
+    assert_eq!(plan["revision"], 1);
+    assert_eq!(plan["agent_task_count"], 0);
+    assert_eq!(plan["workflow_session_count"], 0);
+    assert!(plan["terminal_at_unix_ms"].is_null());
+    assert_eq!(
+        plan.as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>(),
+        [
+            "agent_task_count",
+            "goal_id",
+            "lifecycle",
+            "objective",
+            "revision",
+            "terminal_at_unix_ms",
+            "title",
+            "updated_at_unix_ms",
+            "version",
+            "workflow_session_count"
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    );
+
+    let polled = runtime.goal_plan_state(Some(&bob), goal_id.clone());
+    assert!(polled.success);
+    assert_eq!(polled.output["goal_plan"]["revision"], 1);
+    assert_eq!(
+        runtime.get_goal(Some(&bob), goal_id.clone()).output["goal"]["summary"]["revision"],
+        1
+    );
+
+    let foreign = runtime.goal_plan_state(Some(&alice), goal_id.clone());
+    let missing = runtime.goal_plan_state(Some(&alice), format!("wc_goal_{}", "f".repeat(32)));
+    assert!(!foreign.success);
+    assert!(!missing.success);
+    assert_eq!(foreign.output["error_kind"], "goal_not_found");
+    assert_eq!(foreign.error, missing.error);
+
+    let updated = runtime.update_goal(
+        Some(&bob),
+        goal_id.clone(),
+        1,
+        None,
+        Some("Updated durable plan objective".to_string()),
+        None,
+        None,
+        "bob-plan-update".to_string(),
+    );
+    assert!(updated.success, "{:?}", updated.output);
+    let after_update = runtime.goal_plan_state(Some(&bob), goal_id.clone());
+    assert!(after_update.success);
+    assert_eq!(after_update.output["goal_plan"]["revision"], 2);
+    assert_eq!(
+        after_update.output["goal_plan"]["objective"],
+        "Updated durable plan objective"
+    );
+
+    let completed = runtime.update_goal(
+        Some(&bob),
+        goal_id.clone(),
+        2,
+        None,
+        None,
+        Some("completed".to_string()),
+        Some("done".to_string()),
+        "bob-plan-complete".to_string(),
+    );
+    assert!(completed.success, "{:?}", completed.output);
+    let terminal = runtime.goal_plan_state(Some(&bob), goal_id.clone());
+    assert!(terminal.success);
+    assert_eq!(terminal.output["goal_plan"]["lifecycle"], "completed");
+    assert_eq!(terminal.output["goal_plan"]["revision"], 3);
+    assert!(terminal.output["goal_plan"]["terminal_at_unix_ms"].is_i64());
+    assert_eq!(
+        runtime.get_goal(Some(&bob), goal_id).output["goal"]["summary"]["revision"],
+        3
+    );
+}
+
+#[test]
+fn goal_plan_projection_fails_closed_on_malformed_persisted_goal() {
+    let (_temp, db, runtime) = runtime_with_goal_db();
+    let bob = auth_context(Some("bob-plan-corrupt"), false);
+    let goal_id = create_goal(&runtime, Some(&bob), "bob-plan-corrupt-create");
+    {
+        let conn = db.conn_for_tests();
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON;")
+            .unwrap();
+        conn.execute(
+            "UPDATE wc_goals SET lifecycle = 'waiting_validation' WHERE goal_id = ?1",
+            [goal_id.as_str()],
+        )
+        .unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = OFF;")
+            .unwrap();
+    }
+    let presented = runtime.present_goal_plan(Some(&bob), goal_id.clone());
+    let polled = runtime.goal_plan_state(Some(&bob), goal_id);
+    assert!(!presented.success);
+    assert!(!polled.success);
+    assert_eq!(presented.output["error_kind"], "goal_store_unavailable");
+    assert_eq!(polled.output["error_kind"], "goal_store_unavailable");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a bounded read-only GoalPlanProjection over the authoritative durable Goal store
- add `present_goal_plan` as the explicit Adaptive Runtime direct/App-bound presentation entry
- add `goal_plan_state` as a ModelHidden app-only exact polling read, gated to Stateless MCP 2026 App-enabled operator surfaces
- add `ui://webcodex/goal-plan/v1` with revision-driven polling, rehydration, terminal convergence, and teardown handling
- preserve Goal lifecycle (`active | completed | cancelled`), owner authorization, execution authority boundaries, and existing coding workflow semantics
- intentionally do not add Wake, `ui/message`, model resume, controller generation, dispatch fences, or other G3 behavior

## Review
Independent committed-range review found no remaining authority, protocol-gating, boundedness/privacy, rehydration, multi-iframe, or execution-path findings.

## Validation
- `cargo test -p webcodex goal_plan --lib`: 4 passed / 0 failed
- `cargo test -p webcodex tool_runtime::tests::goals --lib`: 8 passed / 0 failed
- `cargo fmt --all -- --check`: pass
- `git diff --check d454d5fd888704dd74293b8f5b33dfe0996b82ab..3f2c71e784f9383620a3ab7da249a20793e75b59`: pass
- Goal Plan App inline JavaScript syntax check: pass