### PR TITLE
fix(cli): validate tool inventory without a fixed release count

### DIFF
--- a/crates/webcodex-cli/src/webcodex_cli/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/ops.rs
@@ -5,7 +5,6 @@ use webcodex_admin::ServerHttpOptions;
 
 use super::{call_runtime_tool_status, http_post_json_status, resolve_user_api_token};
 
-const DEFAULT_EXPECTED_TOOL_COUNT: u64 = 66;
 pub(crate) const DEFAULT_RUNNER_REQUEST_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -633,15 +632,26 @@ pub(crate) fn ops_status_report(server_url: &str, runtime: &Option<Value>) -> Op
     }
 
     let tools_count = runtime.pointer("/tools/count").and_then(Value::as_u64);
-    if tools_count != Some(DEFAULT_EXPECTED_TOOL_COUNT) {
-        verdict.warn_reason(
-            format!(
-                "tools_count_unexpected:{}",
-                tools_count
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "unknown".to_string())
-            ),
-            "confirm runtime tool registry count before deployment",
+    // This is the Server's internal registry, not the caller's MCP surface.
+    // Its size changes across releases; validate self-consistency instead of
+    // comparing it to a historical constant. Older compact reports omit names.
+    let inventory_valid = tools_count.is_some_and(|count| count > 0)
+        && match runtime.pointer("/tools/names") {
+            None => true,
+            Some(Value::Array(names)) => {
+                let mut seen = std::collections::HashSet::new();
+                Some(names.len() as u64) == tools_count
+                    && names.iter().all(|name| {
+                        name.as_str()
+                            .is_some_and(|name| !name.trim().is_empty() && seen.insert(name))
+                    })
+            }
+            Some(_) => false,
+        };
+    if !inventory_valid {
+        verdict.fail_reason(
+            "malformed_tool_inventory",
+            "inspect the runtime tool count and optional names; verify required MCP capabilities separately",
         );
     }
 

--- a/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
+++ b/crates/webcodex-cli/src/webcodex_cli/tests/ops.rs
@@ -881,6 +881,51 @@ fn ops_status_runtime_ok_passes() {
 }
 
 #[test]
+fn ops_status_tool_inventory_accepts_different_release_sizes() {
+    for count in [1_u64, 47, 66, 135, 200] {
+        let mut runtime = runtime_status_fixture();
+        runtime["tools"] = json!({"count": count});
+        let report = ops_status_report("https://ops.example.test", &Some(runtime.clone()));
+        assert_eq!(report.verdict.status, "pass", "compact count {count}");
+        runtime["tools"]["names"] =
+            json!((0..count).map(|i| format!("tool_{i}")).collect::<Vec<_>>());
+        let report = ops_status_report("https://ops.example.test", &Some(runtime));
+        assert_eq!(report.verdict.status, "pass", "full count {count}");
+        assert!(report.verdict.warning_reasons.is_empty());
+    }
+}
+
+#[test]
+fn ops_status_tool_inventory_rejects_missing_empty_or_inconsistent_data() {
+    for tools in [
+        Value::Null,
+        json!({}),
+        json!({"count": 0}),
+        json!({"count": -1}),
+        json!({"count": "135"}),
+        json!({"count": 1.5}),
+        json!({"count": 2, "names": ["one"]}),
+        json!({"count": 2, "names": ["one", "one"]}),
+        json!({"count": 1, "names": [""]}),
+        json!({"count": 1, "names": [" "]}),
+        json!({"count": 1, "names": [42]}),
+        json!({"count": 1, "names": null}),
+        json!({"count": 1, "names": "one"}),
+    ] {
+        let mut runtime = runtime_status_fixture();
+        runtime["tools"] = tools;
+        let report = ops_status_report("https://ops.example.test", &Some(runtime));
+        assert_eq!(report.verdict.status, "fail");
+        assert!(report.verdict.blocking);
+        assert!(report
+            .verdict
+            .blocking_reasons
+            .contains(&"malformed_tool_inventory".to_string()));
+        assert_eq!(ops_exit_code(true, report.verdict.status), 2);
+    }
+}
+
+#[test]
 fn ops_status_no_online_agents_fails() {
     let mut runtime = runtime_status_fixture();
     runtime["agents"]["online_count"] = json!(0);


### PR DESCRIPTION
`ops status` compares the Server's internal tool registry with a historical count of 66, so a valid registry with a different size produces an unexpected-count warning.

Validate a positive count and, when names are provided, matching length, non-empty names and uniqueness. Compact count-only reports remain supported; malformed inventories fail explicitly. Required caller-visible MCP capabilities still need separate verification.

Regression cases cover valid release sizes and malformed or inconsistent inventories. This PR contains only CLI reporting and its tests; it does not change tool registration, MCP schemas or authorization.

Validation: changed-file rustfmt and `git diff --check` passed. `cargo test --locked --offline -j 1 -p webcodex-cli --lib tests::ops:: -- --test-threads=1` passed all 39 tests on macOS using an isolated target directory.

The initial legacy `ops_` substring filter also selected three unrelated `stops_` process tests; that broader run had 41 passes and 3 failures because this host could not capture process identity. Those tests were not retried or weakened. The exact ops-module run above includes both new inventory regressions. Full cross-platform CI remains separate.
