### PR TITLE
perf(projects): aggregate active job counts in one registry snapshot

### DIFF
--- a/crates/webcodex-runner-registry/src/job_updates.rs
+++ b/crates/webcodex-runner-registry/src/job_updates.rs
@@ -22,7 +22,7 @@ use super::{
 };
 use crate::DetachedInitiatorIdentity;
 use sha2::{Digest, Sha256};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::Ordering;
 use uuid::Uuid;
 use webcodex_core::runner_operation::{
@@ -1518,27 +1518,52 @@ impl RunnerRegistry {
         jobs
     }
 
-    /// Count active jobs for one exact runtime project without applying the
-    /// display-list pagination limit. Jobs without a runtime project id are
-    /// intentionally excluded.
+    /// Count caller-visible active Jobs for the requested exact Projects in one
+    /// registry snapshot. Refresh lifecycle once, then aggregate once: O(P + J),
+    /// with output bounded by requested Projects, not the complete Job inventory.
+    /// Private, projectless, terminal and unauthorized Jobs never contribute.
+    pub async fn count_active_jobs_for_projects(
+        &self,
+        auth: Option<&crate::RunnerAccess>,
+        runtime_project_ids: &[&str],
+    ) -> HashMap<String, usize> {
+        let mut counts: HashMap<String, usize> = runtime_project_ids
+            .iter()
+            .map(|id| ((*id).to_string(), 0))
+            .collect();
+        if counts.is_empty() {
+            return counts;
+        }
+        let mut inner = self.inner.lock().await;
+        #[cfg(any(test, feature = "root-test-support"))]
+        self.project_job_scan_count.fetch_add(1, Ordering::Relaxed);
+        let job_ids = inner.jobs_by_id.keys().cloned().collect::<Vec<_>>();
+        for job_id in job_ids {
+            refresh_job_status_locked(&mut inner, &job_id);
+        }
+        for job in inner.jobs_by_id.values().filter(|job| {
+            job.visibility == ShellJobVisibility::Public
+                && job.lifecycle.is_active()
+                && shell_job_visible_to_auth(auth, &inner, job)
+        }) {
+            if let Some(count) = job.project_id.as_deref().and_then(|id| counts.get_mut(id)) {
+                *count += 1;
+            }
+        }
+        counts
+    }
+
+    /// Single-Project observation shares the same unpaginated, authorized path.
     pub async fn count_active_jobs_for_project(
         &self,
         auth: Option<&crate::RunnerAccess>,
         runtime_project_id: &str,
     ) -> usize {
-        let mut inner = self.inner.lock().await;
-        let job_ids = inner.jobs_by_id.keys().cloned().collect::<Vec<_>>();
-        for job_id in job_ids {
-            refresh_job_status_locked(&mut inner, &job_id);
-        }
-        inner
-            .jobs_by_id
-            .values()
-            .filter(|job| job.visibility == ShellJobVisibility::Public)
-            .filter(|job| shell_job_visible_to_auth(auth, &inner, job))
-            .filter(|job| job.project_id.as_deref() == Some(runtime_project_id))
-            .filter(|job| job.lifecycle.is_active())
-            .count()
+        self.count_active_jobs_for_projects(auth, &[runtime_project_id])
+            .await
+            .get(runtime_project_id)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Atomically fence new job starts and count all currently active jobs for

--- a/crates/webcodex-runner-registry/src/registry.rs
+++ b/crates/webcodex-runner-registry/src/registry.rs
@@ -73,6 +73,8 @@ pub struct RunnerRegistry {
     pub(crate) shared_key_limits: SharedKeyRegistrationLimits,
     pub(crate) telemetry: Arc<dyn RunnerRegistryTelemetry>,
     pub(crate) cleanup_intents: Arc<StdMutex<HashMap<String, Option<RunnerAccess>>>>,
+    #[cfg(any(test, feature = "root-test-support"))]
+    pub(crate) project_job_scan_count: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl Default for RunnerRegistry {
@@ -89,7 +91,15 @@ impl RunnerRegistry {
             shared_key_limits: SharedKeyRegistrationLimits::default(),
             telemetry,
             cleanup_intents: Arc::new(StdMutex::new(HashMap::new())),
+            #[cfg(any(test, feature = "root-test-support"))]
+            project_job_scan_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
+    }
+
+    #[cfg(any(test, feature = "root-test-support"))]
+    pub fn project_job_scan_count_for_test(&self) -> usize {
+        self.project_job_scan_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     #[cfg(any(test, feature = "root-test-support"))]

--- a/crates/webcodex-runner-registry/src/tests/project_unregister.rs
+++ b/crates/webcodex-runner-registry/src/tests/project_unregister.rs
@@ -1,6 +1,110 @@
 use super::*;
 
 #[tokio::test]
+async fn project_active_job_batch_preserves_visibility_lifecycle_and_bounds() {
+    use crate::state::{JobLifecycleState, JobRecoveryPhase, JobRecoveryState, ShellJobVisibility};
+    let registry = RunnerRegistry::default();
+    register_with_instance(&registry, "oe", "batch-inst").await;
+    let target = "agent:oe:target";
+    let other = "agent:oe:other";
+    let empty = "agent:oe:empty";
+    let mut ids = Vec::new();
+    for index in 0..112 {
+        let job = registry
+            .start_job_with_metadata(
+                ShellJobOpRequest {
+                    op: "start".into(),
+                    client_id: Some("oe".into()),
+                    cwd: None,
+                    command: Some("echo fixture-only".into()),
+                    timeout_secs: Some(60),
+                    job_id: None,
+                    since_stdout_line: None,
+                    since_stderr_line: None,
+                    tail_lines: None,
+                    limit: None,
+                    codex: None,
+                },
+                "alice".into(),
+                ShellJobStartMetadata {
+                    project_id: Some(target.into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        ids.push(job.job_id);
+        let mut inner = registry.inner.lock().await;
+        let job = inner.jobs_by_id.get_mut(ids.last().unwrap()).unwrap();
+        match index {
+            0 => job.visibility = ShellJobVisibility::HiddenUntilHandoff,
+            1 => job.visibility = ShellJobVisibility::CleanupPending,
+            2 => job.lifecycle = JobLifecycleState::Completed,
+            3 => job.project_id = None,
+            4 => job.project_id = Some(other.into()),
+            5 => {
+                job.lifecycle = JobLifecycleState::Running;
+                job.recovery = JobRecoveryState {
+                    phase: Some(JobRecoveryPhase::Recovering),
+                    recovering_since: Some(now_ts() - job_recovery_grace_secs() - 1),
+                    ..Default::default()
+                };
+            }
+            6 => {
+                job.lifecycle = JobLifecycleState::Running;
+                job.recovery = JobRecoveryState {
+                    phase: Some(JobRecoveryPhase::Recovering),
+                    recovering_since: Some(now_ts()),
+                    ..Default::default()
+                };
+            }
+            7 => job.auth_group = shared_key_access("foreign").group,
+            _ => {}
+        }
+    }
+    let alice = auth_context(Some("alice"), false);
+    let bob = auth_context(Some("bob"), false);
+    assert_eq!(registry.project_job_scan_count_for_test(), 0);
+    let counts = registry
+        .count_active_jobs_for_projects(Some(&alice), &[target, other, empty, target])
+        .await;
+    assert_eq!(registry.project_job_scan_count_for_test(), 1);
+    assert_eq!(counts.len(), 3);
+    assert_eq!(counts[target], 105); // 104 queued + one still-recovering Job.
+    assert_eq!(counts[other], 1);
+    assert_eq!(counts[empty], 0);
+    assert_eq!(
+        registry.inner.lock().await.jobs_by_id[&ids[5]].lifecycle,
+        JobLifecycleState::Lost
+    );
+    let denied = registry
+        .count_active_jobs_for_projects(Some(&bob), &[target, other])
+        .await;
+    assert!(denied.values().all(|count| *count == 0));
+    let grouped = registry
+        .count_active_jobs_for_projects(Some(&shared_key_access("foreign")), &[target])
+        .await;
+    assert_eq!(grouped[target], 1);
+    let global = registry
+        .count_active_jobs_for_projects(None, &[target])
+        .await;
+    assert_eq!(global[target], 106);
+    assert!(!global.contains_key(other));
+    let scans = registry.project_job_scan_count_for_test();
+    assert!(registry
+        .count_active_jobs_for_projects(None, &[])
+        .await
+        .is_empty());
+    assert_eq!(registry.project_job_scan_count_for_test(), scans);
+    assert_eq!(
+        registry
+            .count_active_jobs_for_project(Some(&alice), target)
+            .await,
+        counts[target]
+    );
+}
+
+#[tokio::test]
 async fn project_active_job_query_is_not_truncated_and_unregister_fences_starts() {
     let registry = RunnerRegistry::default();
     register_with_instance(&registry, "oe", "inst-jobs").await;

--- a/crates/webcodex-tool-contracts/src/tool_catalog.rs
+++ b/crates/webcodex-tool-contracts/src/tool_catalog.rs
@@ -110,6 +110,7 @@ pub const TOOL_DISCOVERY_GROUPS: &[ToolDiscoveryGroup] = &[
             "list_agent_identities",
             "update_agent_identity",
             "attach_agent_endpoint",
+            "present_agent_continuation",
             "bootstrap_agent_conversation",
             "detach_agent_endpoint",
             "create_conversation",

--- a/src/db/agent_wake_tests.rs
+++ b/src/db/agent_wake_tests.rs
@@ -253,7 +253,7 @@ fn fake_adapter_recovers_same_wake_before_fence_and_exact_consume_is_idempotent(
     assert_eq!(envelope.controller_generation, 2);
     assert!(envelope
         .resume_hint
-        .contains("read the authoritative Agent Inbox"));
+        .contains("Re-read durable work from list_agent_inbox and read_conversation"));
     assert!(!envelope.resume_hint.contains(secret_body));
     assert!(!envelope
         .resume_hint

--- a/src/mcp_tests/model_surface.rs
+++ b/src/mcp_tests/model_surface.rs
@@ -517,6 +517,11 @@ async fn adaptive_runtime_tools_list_is_small_core_plus_gateway() {
     let tools = compact_tools;
     let names: Vec<&str> = tools
         .iter()
+        .filter(|tool| {
+            tool.pointer("/_meta/ui/visibility")
+                .and_then(Value::as_array)
+                .is_none_or(|visibility| !visibility.iter().any(|value| value == "app"))
+        })
         .map(|tool| tool["name"].as_str().unwrap())
         .collect();
     let direct_names = crate::model_surface::adaptive_runtime_direct_tool_specs()
@@ -526,7 +531,7 @@ async fn adaptive_runtime_tools_list_is_small_core_plus_gateway() {
     assert_eq!(
         names.len(),
         direct_names.len() + 1,
-        "adaptive surface should expose only the definition-derived direct set plus one gateway"
+        "adaptive model surface should expose only the definition-derived direct set plus one gateway"
     );
     assert_eq!(
         &names[..direct_names.len()],

--- a/src/model_surface.rs
+++ b/src/model_surface.rs
@@ -338,6 +338,8 @@ mod tests {
     const EXPECTED_ADAPTIVE_RUNTIME_DIRECT_TOOL_NAMES: &[&str] = &[
         "work_on_project",
         "session_discussion_summary",
+        "present_goal_plan",
+        "present_agent_continuation",
         "runtime_status",
         "plugin_tool",
         "tool_manifest",

--- a/src/tool_runtime/projects.rs
+++ b/src/tool_runtime/projects.rs
@@ -203,6 +203,14 @@ impl ToolRuntime {
             candidates.truncate(limit);
         }
         let truncated = candidates.len() < matched_count;
+        let project_ids: Vec<&str> = candidates
+            .iter()
+            .map(|candidate| candidate.runtime_id.as_str())
+            .collect();
+        let active_jobs_by_project = self
+            .runner_registry
+            .count_active_jobs_for_projects(access.as_ref(), &project_ids)
+            .await;
 
         let mut list = Vec::with_capacity(candidates.len());
         for ProjectCandidate {
@@ -211,10 +219,9 @@ impl ToolRuntime {
             project_index,
         } in candidates
         {
-            // Extract only one selected Project and the small Runner fields used by
-            // its projection before awaiting Job state. Candidate staging above
-            // never owns or clones a RunnerView (and therefore never clones
-            // the Runner's complete projects Vec per match).
+            // Extract only one selected Project and its small Runner projection.
+            // Candidate staging never clones a Runner's complete project inventory;
+            // Job counts above share one authorized registry snapshot.
             let (
                 client_id,
                 runner_status,
@@ -245,10 +252,10 @@ impl ToolRuntime {
                     smoke_project_capabilities(client, project),
                 )
             };
-            let active_jobs = self
-                .runner_registry
-                .count_active_jobs_for_project(access.as_ref(), &runtime_id)
-                .await;
+            let active_jobs = active_jobs_by_project
+                .get(&runtime_id)
+                .copied()
+                .unwrap_or(0);
             let value = if options.summary_only {
                 json!({
                     "id": runtime_id,

--- a/src/tool_runtime/tests/schema/definitions.rs
+++ b/src/tool_runtime/tests/schema/definitions.rs
@@ -86,6 +86,13 @@ fn tool_call_parser_name_gate_matches_tool_definitions() {
     let expected_hidden: BTreeSet<&str> = [
         "start_session",
         "job_tail",
+        "goal_plan_state",
+        "agent_continuation_bind",
+        "agent_continuation_state",
+        "agent_continuation_wake_acquire",
+        "agent_continuation_wake_prepare",
+        "agent_continuation_wake_finish",
+        "agent_continuation_unbind",
         "read_tool_trace",
         "skill_list",
         "skill_read_file",

--- a/src/tool_runtime/tests/schema/discovery.rs
+++ b/src/tool_runtime/tests/schema/discovery.rs
@@ -217,6 +217,7 @@ fn allowed_tool_definition_categories_for_discovery_group(group: &str) -> &'stat
         "edit" => &["artifact", "edit", "patch"],
         "file_transfer" => &["artifact"],
         "git" => &["checkpoint", "cleanup", "file", "git"],
+        "goal" => &["goal"],
         "inspect" => &[
             "checkpoint",
             "computer",

--- a/src/tool_runtime/tests/targeted_inventory.rs
+++ b/src/tool_runtime/tests/targeted_inventory.rs
@@ -205,6 +205,67 @@ fn project_candidate_staging_is_index_only() {
 }
 
 #[tokio::test]
+async fn list_projects_batch_job_counts_join_exact_projects_and_skip_empty_selection() {
+    let runtime = test_runtime();
+    register_target_agent(
+        &runtime,
+        "batch",
+        vec![
+            registered_project("a", "/tmp/batch-a"),
+            registered_project("b", "/tmp/batch-b"),
+        ],
+        None,
+    )
+    .await;
+    for id in ["a", "a", "b"] {
+        runtime
+            .runner_registry
+            .start_job_with_metadata(
+                crate::runner_protocol::ShellJobOpRequest {
+                    op: "start".into(),
+                    client_id: Some("batch".into()),
+                    cwd: None,
+                    command: Some("echo fixture".into()),
+                    timeout_secs: Some(60),
+                    job_id: None,
+                    since_stdout_line: None,
+                    since_stderr_line: None,
+                    tail_lines: None,
+                    limit: None,
+                    codex: None,
+                },
+                "fixture".into(),
+                webcodex_runner_registry::ShellJobStartMetadata {
+                    project_id: Some(format!("agent:batch:{id}")),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+    }
+    let listed = runtime
+        .dispatch_with_auth(
+            list_projects_call(Some("batch"), None, None, None, true),
+            None,
+        )
+        .await;
+    assert!(listed.success, "{:?}", listed.error);
+    assert_eq!(listed.output["projects"][0]["id"], "agent:batch:a");
+    assert_eq!(listed.output["projects"][0]["active_jobs"], 2);
+    assert_eq!(listed.output["projects"][1]["active_jobs"], 1);
+    assert_eq!(runtime.runner_registry.project_job_scan_count_for_test(), 1);
+    let empty = runtime
+        .dispatch_with_auth(
+            list_projects_call(Some("missing"), None, None, None, true),
+            None,
+        )
+        .await;
+    assert!(empty.success);
+    assert_eq!(empty.output["count"], 0);
+    assert_eq!(runtime.runner_registry.project_job_scan_count_for_test(), 1);
+}
+
+#[tokio::test]
 async fn list_projects_large_single_runner_inventory_preserves_linear_staging_contract() {
     for project_count in [256usize, 1024] {
         let runtime = test_runtime();
@@ -232,6 +293,7 @@ async fn list_projects_large_single_runner_inventory_preserves_linear_staging_co
         assert_eq!(exact.output["matched_count"], 1);
         assert_eq!(exact.output["truncated"], false);
         assert_eq!(exact.output["projects"][0]["id"], exact_id);
+        assert_eq!(runtime.runner_registry.project_job_scan_count_for_test(), 1);
 
         let broad = runtime
             .list_projects_with_visible_clients_for_test(
@@ -260,6 +322,7 @@ async fn list_projects_large_single_runner_inventory_preserves_linear_staging_co
             .map(|index| format!("agent:special:project-{index:04}"))
             .collect::<Vec<_>>();
         assert_eq!(broad_ids, expected_ids);
+        assert_eq!(runtime.runner_registry.project_job_scan_count_for_test(), 2);
 
         let full = runtime
             .list_projects_with_visible_clients_for_test(
@@ -272,6 +335,11 @@ async fn list_projects_large_single_runner_inventory_preserves_linear_staging_co
         assert_eq!(full.output["matched_count"], project_count);
         assert_eq!(full.output["count"], project_count);
         assert_eq!(full.output["truncated"], false);
+        assert_eq!(
+            runtime.runner_registry.project_job_scan_count_for_test(),
+            3,
+            "a full inventory must scan Jobs once, not once per Project"
+        );
         assert_eq!(
             full.output["projects"][0]["id"],
             "agent:special:project-0000"


### PR DESCRIPTION
Listing P projects currently refreshes and scans the entire Job registry once per selected project. Aggregate requested exact project IDs in one registry snapshot so lifecycle refresh and Job traversal happen once per listing.

Preserve caller authorization, public visibility, active lifecycle filtering, zero counts and the single-project API. Empty selections skip the scan; results are bounded by requested project IDs. The change reduces repeated registry traversal, without claiming measured production latency gains.

Tests cover exact counts, duplicate selections, user/shared-key isolation, hidden and terminal Jobs, recovery expiry, empty selections and one scan per listing for 256/1024-project inventories. This PR excludes local maintenance tooling.

Validation on macOS with an isolated target directory:

- Changed-file rustfmt and `git diff --check`: passed.
- `cargo test --locked --offline -j 1 -p webcodex-runner-registry --lib project_active_job -- --test-threads=1`: 2 passed.
- `cargo test --locked --offline -j 1 -p webcodex --lib targeted_inventory -- --test-threads=1`: 13 passed.

No full-workspace or production performance claim; cross-platform CI is separate.
