### PR TITLE
fix(build): refresh dirty dogfood identity

### DIFF
--- a/crates/webcodex-core/build.rs
+++ b/crates/webcodex-core/build.rs
@@ -127,6 +127,7 @@ fn watch_git_dirty_inputs(repo_root: &Path, git_dirty: &str) {
     if !output.status.success() {
         return;
     }
+    let mut watched_paths = std::collections::HashSet::new();
     for path in output.stdout.split(|byte| *byte == 0) {
         if path.is_empty() || path.contains(&b'\n') || path.contains(&b'\r') {
             continue;
@@ -134,7 +135,18 @@ fn watch_git_dirty_inputs(repo_root: &Path, git_dirty: &str) {
         let Ok(path) = std::str::from_utf8(path) else {
             continue;
         };
-        println!("cargo:rerun-if-changed={}", repo_root.join(path).display());
+        let path = repo_root.join(path);
+        // Deleted tracked files are valid dirty inputs, but a missing
+        // rerun-if-changed path makes Cargo rerun the build script forever.
+        // Watch the nearest existing ancestor instead; recreating the missing
+        // entry changes that directory and refreshes dirty state without
+        // sacrificing no-op caching while the deletion remains.
+        let Some(existing_path) = path.ancestors().find(|candidate| candidate.exists()) else {
+            continue;
+        };
+        if watched_paths.insert(existing_path.to_path_buf()) {
+            println!("cargo:rerun-if-changed={}", existing_path.display());
+        }
     }
 }
 

--- a/crates/webcodex-core/build.rs
+++ b/crates/webcodex-core/build.rs
@@ -34,10 +34,21 @@ fn main() {
         println!("cargo:rerun-if-changed={}", packed_refs.display());
     }
 
+    // Git metadata does not change for ordinary unstaged worktree edits. When
+    // dirty state is derived locally, make those tracked files explicit Cargo
+    // inputs so a same-HEAD rebuild cannot reuse stale build-script output.
+    // CI/release callers that pin WEBCODEX_GIT_DIRTY intentionally skip these
+    // worktree dependencies and keep their deterministic identity contract.
+    let git_dirty_override = env_value("WEBCODEX_GIT_DIRTY");
+    let git_dirty = git_dirty_override
+        .clone()
+        .unwrap_or_else(|| git_dirty_from_git(&repo_root));
+    if git_dirty_override.is_none() {
+        watch_git_dirty_inputs(&repo_root, &git_dirty);
+    }
+
     let git_commit =
         env_value("WEBCODEX_GIT_COMMIT").unwrap_or_else(|| git_commit_from_git(&repo_root));
-    let git_dirty =
-        env_value("WEBCODEX_GIT_DIRTY").unwrap_or_else(|| git_dirty_from_git(&repo_root));
     // Release workflows pin WEBCODEX_BUILT_AT explicitly. For ordinary Git
     // worktrees, prefer stable inputs so the same commit does not invalidate
     // compiler caches merely because it was built at a different wall-clock
@@ -92,6 +103,39 @@ fn git_metadata_path(repo_root: &Path, name: &str) -> Option<PathBuf> {
     } else {
         repo_root.join(path)
     })
+}
+
+fn watch_git_dirty_inputs(repo_root: &Path, git_dirty: &str) {
+    if let Some(index_path) = git_metadata_path(repo_root, "index").filter(|path| path.exists()) {
+        println!("cargo:rerun-if-changed={}", index_path.display());
+    }
+
+    let mut command = Command::new("git");
+    command.current_dir(repo_root);
+    if git_dirty == "true" {
+        // Once already dirty, only the paths keeping us dirty need watching.
+        // Newly dirtied files cannot change the boolean identity; if a watched
+        // dirty path becomes clean, the next run re-evaluates and rotates this set.
+        command.args(["diff-index", "--name-only", "-z", "HEAD", "--"]);
+    } else {
+        // A clean tree can become dirty through any tracked worktree path.
+        command.args(["ls-files", "-z"]);
+    }
+    let Ok(output) = command.output() else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    for path in output.stdout.split(|byte| *byte == 0) {
+        if path.is_empty() || path.contains(&b'\n') || path.contains(&b'\r') {
+            continue;
+        }
+        let Ok(path) = std::str::from_utf8(path) else {
+            continue;
+        };
+        println!("cargo:rerun-if-changed={}", repo_root.join(path).display());
+    }
 }
 
 fn git_dirty_from_git(repo_root: &Path) -> String {

--- a/scripts/tests/test_build_identity.py
+++ b/scripts/tests/test_build_identity.py
@@ -141,6 +141,14 @@ class BuildIdentityTests(unittest.TestCase):
                 self.assertEqual(run(repo, "git", "rev-parse", "HEAD"), head)
                 self.assertEqual(build(), "false")
 
+                (repo / "tracked.txt").unlink()
+                self.assertEqual(build(), "true")
+                deleted_stamp = outputs[0].stat().st_mtime_ns
+                self.assertEqual(build(), "true")
+                self.assertEqual(outputs[0].stat().st_mtime_ns, deleted_stamp)
+                run(repo, "git", "restore", "tracked.txt")
+                self.assertEqual(build(), "false")
+
                 env["WEBCODEX_GIT_DIRTY"] = "false"
                 self.assertEqual(build(), "false")
                 outputs = list((root / "target/debug/build").glob("identity-fixture-*/output"))

--- a/scripts/tests/test_build_identity.py
+++ b/scripts/tests/test_build_identity.py
@@ -75,6 +75,81 @@ class BuildIdentityTests(unittest.TestCase):
                 self.assertEqual(build(), expected)
                 self.assertEqual(outputs[0].stat().st_mtime_ns, stamp)
 
+    def test_tracked_dirty_state_refreshes_at_same_head(self):
+        for linked_worktree in (False, True):
+            with self.subTest(linked_worktree=linked_worktree), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                env = os.environ.copy()
+                for key in (
+                    "WEBCODEX_GIT_COMMIT", "WEBCODEX_GIT_DIRTY", "WEBCODEX_BUILT_AT",
+                    "SOURCE_DATE_EPOCH", "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+                ):
+                    env.pop(key, None)
+                env["CARGO_TARGET_DIR"] = str(root / "target")
+
+                def run(cwd, *args):
+                    return subprocess.run(
+                        args, cwd=cwd, env=env, check=True, capture_output=True,
+                        text=True, timeout=60,
+                    ).stdout.strip()
+
+                repo = root / "repo"
+                repo.mkdir()
+                run(repo, "git", "init", "-b", "review/dirty")
+                run(repo, "git", "config", "user.name", "Build fixture")
+                run(repo, "git", "config", "user.email", "fixture@example.invalid")
+                (repo / "tracked.txt").write_text("clean\n", encoding="utf-8")
+                (repo / "other.txt").write_text("clean\n", encoding="utf-8")
+                package = repo / "crates/fixture"
+                (package / "src").mkdir(parents=True)
+                (package / "Cargo.toml").write_text(
+                    '[package]\nname = "identity-fixture"\nversion = "0.0.0"\n'
+                    'edition = "2021"\n', encoding="utf-8",
+                )
+                shutil.copyfile(BUILD_SCRIPT, package / "build.rs")
+                (package / "src/main.rs").write_text(
+                    'fn main() { println!("{}", env!("WEBCODEX_BUILD_GIT_DIRTY")); }\n',
+                    encoding="utf-8",
+                )
+                run(repo, "git", "add", ".")
+                run(repo, "git", "commit", "-m", "fixture")
+                if linked_worktree:
+                    checkout = root / "checkout"
+                    run(repo, "git", "worktree", "add", "-b", "review/linked", str(checkout))
+                    repo = checkout
+                    package = repo / "crates/fixture"
+
+                def build():
+                    return run(package, "cargo", "run", "--offline", "--quiet")
+
+                head = run(repo, "git", "rev-parse", "HEAD")
+                self.assertEqual(build(), "false")
+                (repo / "tracked.txt").write_text("dirty\n", encoding="utf-8")
+                self.assertEqual(run(repo, "git", "rev-parse", "HEAD"), head)
+                self.assertEqual(build(), "true")
+                outputs = list((root / "target/debug/build").glob("identity-fixture-*/output"))
+                self.assertEqual(len(outputs), 1)
+                dirty_stamp = outputs[0].stat().st_mtime_ns
+                (repo / "other.txt").write_text("also dirty\n", encoding="utf-8")
+                self.assertEqual(build(), "true")
+                self.assertEqual(outputs[0].stat().st_mtime_ns, dirty_stamp)
+
+                run(repo, "git", "restore", "tracked.txt")
+                self.assertEqual(run(repo, "git", "rev-parse", "HEAD"), head)
+                self.assertEqual(build(), "true")
+                run(repo, "git", "restore", "other.txt")
+                self.assertEqual(run(repo, "git", "rev-parse", "HEAD"), head)
+                self.assertEqual(build(), "false")
+
+                env["WEBCODEX_GIT_DIRTY"] = "false"
+                self.assertEqual(build(), "false")
+                outputs = list((root / "target/debug/build").glob("identity-fixture-*/output"))
+                self.assertEqual(len(outputs), 1)
+                stamp = outputs[0].stat().st_mtime_ns
+                (repo / "tracked.txt").write_text("dirty with pinned identity\n", encoding="utf-8")
+                self.assertEqual(build(), "false")
+                self.assertEqual(outputs[0].stat().st_mtime_ns, stamp)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- refresh `webcodex-core` build identity when tracked worktree dirty state changes without a HEAD change
- keep clean builds sensitive to tracked-file changes, then narrow dirty-state watchers to the paths that currently keep the worktree dirty
- watch the nearest existing ancestor for deleted tracked paths so Cargo can detect restoration without permanently rerunning the build script on a missing path
- preserve pinned CI/release behavior when `WEBCODEX_GIT_DIRTY` is explicitly supplied
- cover ordinary and linked worktrees, clean → dirty → clean transitions, dirty-state cache stability, tracked deletion/restoration, and pinned identity behavior

Closes #403.

## Validation

- `python3 scripts/tests/test_build_identity.py` — 2/2 passed
- `cargo fmt --all -- --check`
- `cargo check --all-targets -p webcodex-core`
- `git diff --check`
- final clean dogfood build for `webcodex`, `webcodex-cli`, and `webcodex-runner` succeeded
- immediate no-op dogfood rebuild completed in 0.59s
- all three runtime binaries report the same final identity: `commit e67132be4cd2, dirty=false`

No deploy, restart, merge, tag, or release was performed.