### PR TITLE
Improve coding tool ergonomics and recovery

### DIFF
--- a/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
+++ b/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
@@ -251,6 +251,33 @@ fn file_apply_text_edits_ignores_empty_insert_noop_and_applies_remaining_edit() 
 }
 
 #[test]
+fn file_apply_text_edits_empty_insert_noop_still_validates_anchor_text() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let file = tmp.path().join("target.txt");
+    std::fs::write(&file, "old\n").unwrap();
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_text_edits_request(
+            tmp.path(),
+            "target.txt",
+            serde_json::json!({
+                "edits": [
+                    {"kind": "insert_before", "anchor_text": "bad\u{0}anchor", "new_text": ""},
+                    {"kind": "replace_exact", "old_text": "old", "new_text": "new"}
+                ]
+            }),
+        ),
+    ));
+    let msg = out["error"].as_str().unwrap();
+    assert!(msg.contains("NUL"), "{msg}");
+    assert!(msg.contains("No files were modified"), "{msg}");
+    assert_eq!(out["changed"], false);
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "old\n");
+}
+
+#[test]
 fn file_apply_text_edits_dry_run_does_not_write() {
     let tmp = tempfile::tempdir().unwrap();
     let policy = project_policy(tmp.path());

--- a/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
+++ b/crates/webcodex-runner/src/main_tests/apply_text_edits.rs
@@ -225,6 +225,32 @@ fn file_apply_text_edits_replace_exact_writes_atomically() {
 }
 
 #[test]
+fn file_apply_text_edits_ignores_empty_insert_noop_and_applies_remaining_edit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let policy = project_policy(tmp.path());
+    let file = tmp.path().join("target.txt");
+    std::fs::write(&file, "old\n").unwrap();
+
+    let out = line_edit_json(handle_file_request(
+        &policy,
+        &apply_text_edits_request(
+            tmp.path(),
+            "target.txt",
+            serde_json::json!({
+                "edits": [
+                    {"kind": "insert_before", "anchor_text": "missing", "new_text": ""},
+                    {"kind": "replace_exact", "old_text": "old", "new_text": "new"}
+                ]
+            }),
+        ),
+    ));
+    assert_eq!(out["changed"], true);
+    assert_eq!(out["ignored_noop_count"], 1);
+    assert_eq!(out["files"][0]["edits"].as_array().unwrap().len(), 1);
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "new\n");
+}
+
+#[test]
 fn file_apply_text_edits_dry_run_does_not_write() {
     let tmp = tempfile::tempdir().unwrap();
     let policy = project_policy(tmp.path());

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -551,19 +551,18 @@ fn edit_plan(
                     .ok_or_else(|| {
                         EditPlanError::plain(index, kind.as_str(), "anchor_text must be non-empty")
                     })?;
-                let new_text = edit
-                    .new_text
-                    .as_deref()
-                    .filter(|value| !value.is_empty())
-                    .ok_or_else(|| {
-                        EditPlanError::plain(index, kind.as_str(), "new_text must be non-empty")
-                    })?;
+                let new_text = edit.new_text.as_deref().ok_or_else(|| {
+                    EditPlanError::plain(index, kind.as_str(), "new_text is required")
+                })?;
                 if edit.old_text.is_some() {
                     return Err(EditPlanError::plain(
                         index,
                         kind.as_str(),
                         "old_text is not allowed",
                     ));
+                }
+                if new_text.is_empty() {
+                    continue;
                 }
                 (anchor, new_text.to_string())
             }
@@ -1128,6 +1127,7 @@ fn execute_planned_file_changes(
     plans: Vec<PlannedFileChange>,
     dry_run: bool,
     requested_matching_mode: Option<ApplyPatchMatchingMode>,
+    ignored_noop_count: usize,
     start: Instant,
 ) -> CommandResult {
     let mut changed_paths = Vec::new();
@@ -1205,6 +1205,7 @@ fn execute_planned_file_changes(
     let mut output = serde_json::json!({
         "dry_run": dry_run,
         "applied_count": plans.len(),
+        "ignored_noop_count": ignored_noop_count,
         "changed": !dry_run && would_change,
         "state_changed": !dry_run && would_change,
         "execution_state": "completed",
@@ -1635,7 +1636,7 @@ pub(crate) fn handle_apply_patch_file_request(
         plans.push(planned);
     }
 
-    execute_planned_file_changes(plans, dry_run, Some(matching_mode), start)
+    execute_planned_file_changes(plans, dry_run, Some(matching_mode), 0, start)
 }
 
 pub(crate) fn handle_apply_text_edits_file_request(
@@ -1668,6 +1669,17 @@ pub(crate) fn handle_apply_text_edits_file_request(
         );
     }
     let dry_run = payload.dry_run.unwrap_or(false);
+    let ignored_noop_count = payload
+        .changes
+        .iter()
+        .flat_map(|change| change.edits.iter())
+        .filter(|edit| {
+            matches!(
+                edit.kind,
+                ApplyTextEditKind::InsertBefore | ApplyTextEditKind::InsertAfter
+            ) && edit.new_text.as_deref() == Some("")
+        })
+        .count();
     let mut touched = HashSet::new();
     let mut plans = Vec::with_capacity(payload.changes.len());
     for (index, change) in payload.changes.iter().enumerate() {
@@ -2030,7 +2042,7 @@ pub(crate) fn handle_apply_text_edits_file_request(
         plans.push(planned);
     }
 
-    execute_planned_file_changes(plans, dry_run, None, start)
+    execute_planned_file_changes(plans, dry_run, None, ignored_noop_count, start)
 }
 
 #[cfg(test)]

--- a/crates/webcodex-runner/src/webcodex_runner/patches.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/patches.rs
@@ -561,9 +561,6 @@ fn edit_plan(
                         "old_text is not allowed",
                     ));
                 }
-                if new_text.is_empty() {
-                    continue;
-                }
                 (anchor, new_text.to_string())
             }
         };
@@ -588,6 +585,13 @@ fn edit_plan(
         let replacement = canonicalize_apply_text_line_endings(&replacement, line_ending)
             .map_err(|error| EditPlanError::plain(index, kind.as_str(), error))?
             .into_owned();
+        if matches!(
+            kind,
+            ApplyTextEditKind::InsertBefore | ApplyTextEditKind::InsertAfter
+        ) && replacement.is_empty()
+        {
+            continue;
+        }
         let needle = needle.as_ref();
         let (start, end) =
             resolve_apply_text_match(original, needle, edit.occurrence, edit.line_scope.as_ref())

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/git.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/git.rs
@@ -56,7 +56,7 @@ pub fn show_changes_input_schema() -> Value {
         (
             "session_event_limit",
             "integer",
-            "Maximum recent session events to include (clamped).",
+            "Optional recent session-event diagnostic projection (clamped). Omit or use 0 for the compact default, which keeps review signals and changed paths without event history.",
             false,
         ),
     ]))

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/line_edits.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/line_edits.rs
@@ -72,8 +72,7 @@ fn apply_text_edit_schema() -> Value {
                     },
                     "new_text": {
                         "type": "string",
-                        "minLength": 1,
-                        "description": "Non-empty text inserted before anchor_text."
+                        "description": "Text inserted before anchor_text. Empty text is accepted as a provable no-op and ignored without invalidating other edits in the transaction."
                     },
                     "occurrence": {
                         "type": "integer",
@@ -96,8 +95,7 @@ fn apply_text_edit_schema() -> Value {
                     },
                     "new_text": {
                         "type": "string",
-                        "minLength": 1,
-                        "description": "Non-empty text inserted after anchor_text."
+                        "description": "Text inserted after anchor_text. Empty text is accepted as a provable no-op and ignored without invalidating other edits in the transaction."
                     },
                     "occurrence": {
                         "type": "integer",

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/validation.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/validation.rs
@@ -160,7 +160,12 @@ pub fn cargo_test_input_schema() -> Value {
                 "Optional project-relative working directory.",
                 false,
             ),
-            ("filter", "string", "Optional cargo test filter.", false),
+            (
+                "filter",
+                "string",
+                "Optional Rust test substring passed as `cargo test FILTER`. This is not a CLI-argument field: do not include `--exact`, `--nocapture`, or other Cargo/libtest flags. Omit it to run the selected Cargo test target normally; if zero tests run, broaden or remove the filter, or use the test's full qualified name.",
+                false,
+            ),
             ("all_targets", "boolean", "Include --all-targets.", false),
             ("all_features", "boolean", "Include --all-features.", false),
             (

--- a/crates/webcodex-tool-contracts/src/registry/input_schemas/validation.rs
+++ b/crates/webcodex-tool-contracts/src/registry/input_schemas/validation.rs
@@ -41,10 +41,9 @@ fn with_optional_result_expectation(mut schema: Value) -> Value {
 }
 
 pub fn cargo_fmt_input_schema() -> Value {
-    // `cargo_fmt(check=false)` mutates source and keeps the existing explicit
-    // synchronous semantics: it never auto-promotes to a Job, so its
-    // `timeout_secs` stays a synchronous command timeout. Only `check=true`
-    // accepts the long read-only budget.
+    // `cargo_fmt(check=false)` synchronously ensures formatting: a read-only
+    // precheck avoids mutation when already formatted, and a proven rustfmt diff
+    // triggers `cargo fmt`. Only `check=true` accepts the long read-only budget.
     let mut schema = object_schema(with_optional_session_id(vec![
         ("project", "string", "Runner-registered project id.", true),
         (
@@ -56,13 +55,13 @@ pub fn cargo_fmt_input_schema() -> Value {
         (
             "check",
             "boolean",
-            "Run cargo fmt -- --check instead of formatting.",
+            "When true, perform pure read-only `cargo fmt -- --check` validation. Omit or use false during coding to ensure formatting: WebCodex first checks, then runs mutating `cargo fmt` only when a stable rustfmt diff is proven.",
             false,
         ),
         (
             "timeout_secs",
             "integer",
-            "For mutating format, synchronous timeout has minimum 1 and defaults to 120; values above 120 are accepted and clamped to 120. With check=true, values above the 3600-second total validation budget are accepted and clamped to 3600, and a long check keeps the same execution and returns job_id.",
+            "For check=false ensure-format, this is the shared synchronous budget for precheck plus any required mutation; minimum 1, default 120, values above 120 clamp to 120. With check=true, values above the 3600-second read-only validation budget clamp to 3600 and a long check may return job_id.",
             false,
         ),
         (
@@ -104,7 +103,7 @@ pub fn cargo_fmt_input_schema() -> Value {
     }]);
     let mut schema = with_optional_result_expectation(schema);
     schema["properties"][TOOL_RESULT_EXPECTATION_FIELD]["description"] = json!(
-        "Optional pre-execution validation-result expectation, available only with check=true. Mutating cargo fmt never accepts result_expectation. The real ToolResult and process outcome remain unchanged."
+        "Optional pre-execution validation-result expectation, available only with check=true. Ensure-format mode (check=false) never accepts result_expectation. The real ToolResult and process outcome remain unchanged."
     );
     schema
 }

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/edits.rs
@@ -382,6 +382,10 @@ pub(super) fn output_schema_for_tool(name: &str) -> Option<Value> {
                 schema_type("integer", "Number of file changes applied in the batch."),
             ),
             (
+                "ignored_noop_count",
+                schema_type("integer", "Number of provable empty insert operations ignored without invalidating the transactional batch."),
+            ),
+            (
                 "changed",
                 schema_type("boolean", "Whether the worktree was changed."),
             ),

--- a/crates/webcodex-tool-contracts/src/registry/output_schemas/testing.rs
+++ b/crates/webcodex-tool-contracts/src/registry/output_schemas/testing.rs
@@ -133,6 +133,24 @@ fn cargo_output_schema(tool_name: &str) -> Value {
             ("session_hint", session_hint_schema()),
             ("permission", permission_decision_schema()),
     ];
+    if tool_name == "cargo_fmt" {
+        fields.extend([
+            (
+                "changed",
+                nullable_schema(
+                    "boolean",
+                    "For check=false ensure-format: true when precheck proved formatting was needed and the mutating cargo fmt completed successfully, false when no mutation was needed or mutation definitely did not start, null when mutation may have changed source but the final effect is uncertain. Absent for check=true validation.",
+                ),
+            ),
+            (
+                "state_changed",
+                nullable_schema(
+                    "boolean",
+                    "Effect-state projection for check=false ensure-format. Mirrors changed on known outcomes and is null when post-dispatch mutation state is uncertain. Absent for check=true validation.",
+                ),
+            ),
+        ]);
+    }
     if matches!(tool_name, "cargo_check" | "cargo_test" | "go_test") {
         fields.push((
             "diagnostics",

--- a/crates/webcodex-tool-contracts/src/tests/edit_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/edit_schemas.rs
@@ -71,7 +71,11 @@ fn apply_text_edits_input_schema_encodes_file_and_edit_kind_contracts() {
     assert!(remove["properties"].get("anchor_text").is_none());
     for insert in [insert_before, insert_after] {
         assert_eq!(insert["properties"]["anchor_text"]["minLength"], 1);
-        assert_eq!(insert["properties"]["new_text"]["minLength"], 1);
+        assert!(insert["properties"]["new_text"].get("minLength").is_none());
+        assert!(insert["properties"]["new_text"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("no-op"));
         assert!(insert["properties"].get("old_text").is_none());
     }
     assert!(replace["properties"]["new_text"].get("minLength").is_none());
@@ -94,6 +98,8 @@ fn apply_text_edits_input_schema_encodes_file_and_edit_kind_contracts() {
         json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"delete_exact","old_text":"old"}]}]}),
         json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"insert_before","anchor_text":"anchor","new_text":"new"}]}]}),
         json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"insert_after","anchor_text":"anchor","new_text":"new"}]}]}),
+        json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"insert_before","anchor_text":"anchor","new_text":""}]}]}),
+        json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"insert_after","anchor_text":"anchor","new_text":""}]}]}),
         json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"replace_exact","old_text":"old","line_scope":{"start_line":10,"end_line":20}}]}]}),
         json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"delete_exact","old_text":"old","line_scope":{"start_line":10,"end_line":20}}]}]}),
         json!({"project":"demo","changes":[{"kind":"edit","path":"a.rs","expected_sha256":hash,"edits":[{"kind":"insert_before","anchor_text":"anchor","new_text":"new","line_scope":{"start_line":10,"end_line":20}}]}]}),

--- a/crates/webcodex-tool-contracts/src/tests/input_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/input_schemas.rs
@@ -416,6 +416,15 @@ fn cargo_fmt_conditional_timeout_schema_matches_contract() {
     let specs = registered_tool_specs();
     let schema = &spec_named(&specs, "cargo_fmt").input_schema;
     let validates = |value: &Value| test_support::validate_schema_instance(value, schema).is_ok();
+    let check_description = schema["properties"]["check"]["description"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(check_description.contains("pure read-only"));
+    assert!(check_description.contains("ensure formatting"));
+    let timeout_description = schema["properties"]["timeout_secs"]["description"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(timeout_description.contains("precheck plus any required mutation"));
 
     assert!(validates(
         &json!({"project": "demo", "check": true, "timeout_secs": 3600})

--- a/crates/webcodex-tool-contracts/src/tests/input_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/input_schemas.rs
@@ -273,6 +273,13 @@ fn cargo_test_schema_explains_execution_proof_policy() {
     let specs = registered_tool_specs();
     let spec = spec_named(&specs, "cargo_test");
     let properties = spec.input_schema["properties"].as_object().unwrap();
+    let filter = properties["filter"]["description"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(filter.contains("substring"), "{filter}");
+    assert!(filter.contains("cargo test FILTER"), "{filter}");
+    assert!(filter.contains("--exact"), "{filter}");
+    assert!(filter.contains("full qualified name"), "{filter}");
     let require_tests = properties["require_tests"]["description"]
         .as_str()
         .unwrap_or_default();
@@ -300,6 +307,11 @@ fn cargo_test_schema_explains_execution_proof_policy() {
         .contains("Normal execution requires non-zero"));
     assert!(spec.description.contains("require_tests=false opts out"));
     assert!(spec.description.contains("no_run=true is compile-only"));
+    assert!(spec.description.contains("Rust substring"));
+    assert!(spec.description.contains("--exact"));
+    assert!(spec
+        .description
+        .contains("zero-test results are not validation proof"));
 }
 
 #[test]

--- a/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
+++ b/crates/webcodex-tool-contracts/src/tests/output_schemas.rs
@@ -167,6 +167,20 @@ fn git_log_and_directory_listing_expose_parser_ready_next_pages() {
 }
 
 #[test]
+fn cargo_fmt_output_schema_exposes_bounded_ensure_format_effect_state() {
+    let specs = registered_tool_specs();
+    let output = output_schema_properties(&specs, "cargo_fmt");
+    for field in ["changed", "state_changed"] {
+        assert!(output[field]["anyOf"].is_array(), "cargo_fmt.{field}");
+        let description = output[field]["description"].as_str().unwrap_or_default();
+        assert!(
+            description.contains("check=false"),
+            "{field}: {description}"
+        );
+    }
+}
+
+#[test]
 fn tracked_listing_schema_separates_source_incomplete_from_safe_page_truncation() {
     let specs = registered_tool_specs();
     let properties = output_schema_properties(&specs, "list_project_tracked_files");

--- a/crates/webcodex-tool-contracts/src/tool_definition/edits.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/edits.rs
@@ -64,7 +64,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 super::ToolSessionEvidencePolicy::NONE,
                 ),
-                "Canonical default guarded edit path after read_files for ordinary model-generated changes on the current worktree. Transactional and SHA-guarded: pass each existing file's current read SHA as expected_sha256; exact matches are unique by default, occurrence remains global source order, and optional line_scope fences matches. Supports transactional multi-file edits. Many changed lines alone are not a reason to choose apply_patch; use apply_patch only when contextual or large multi-hunk patch form is materially clearer. Use apply_unified_diff only for an external raw diff.",
+                "Canonical default guarded edit path after read_files for ordinary model-generated changes on the current worktree. Transactional and SHA-guarded: pass each existing file's current read SHA as expected_sha256; exact matches are unique by default, occurrence stays global source order, and line_scope optionally fences matches. Supports transactional multi-file edits; empty insert_before/insert_after text is a provable no-op that does not invalidate the batch. Many changed lines alone are not a reason to choose apply_patch. On conflict_recovery.direct_retry_safe=true, use the returned candidate occurrence/range without rereading; reread only when reread_required=true. Use apply_patch only when contextual or large multi-hunk form is materially clearer; external raw diffs use apply_unified_diff.",
                 apply_text_edits_input_schema,
             ),
             PERMISSION_RISK_WRITE,

--- a/crates/webcodex-tool-contracts/src/tool_definition/git.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/git.rs
@@ -88,7 +88,7 @@ pub(super) const SUMMARY_DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 super::ToolSessionEvidencePolicy::NONE.review(super::ToolReviewEvidence::WorkspaceReview).diff_review(super::ToolDiffReviewEvidence::ArgumentBool("include_diff")),
             ),
-            "Default inspect/review tool before final response. Read-only worktree overview with bounded hunks. If hunks truncate, diff_review_handoff classifies page/line/mixed truncation and provides a parser-ready git_diff_hunks recovery call.",
+            "Default inspect/review tool before final response. Read-only worktree overview with bounded hunks and compact Session signals; recent Session event history is omitted unless session_event_limit is explicitly positive. If hunks truncate, diff_review_handoff classifies page/line/mixed truncation and provides a parser-ready git_diff_hunks recovery call.",
             show_changes_input_schema,
         )))),
         130,

--- a/crates/webcodex-tool-contracts/src/tool_definition/testing.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/testing.rs
@@ -88,7 +88,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
                 false,
                 super::ToolSessionEvidencePolicy::NONE.validation_identity(super::ToolValidationIdentityKind::CargoTest),
             ),
-            "Preferred structured cargo test with scoped args and bounded output. Normal execution requires non-zero executed-test evidence; explicit require_tests=false opts out when no min_tests minimum is requested, while require_tests=true/min_tests enforce a proven minimum. no_run=true is compile-only and does not require executed-test-count proof. Optional sync_wait_secs controls only synchronous grace before the same execution Job is returned; it never changes total timeout, test proof, or retry semantics.",
+            "Preferred structured cargo test with scoped args and bounded output. filter is one Rust substring passed as `cargo test FILTER`, not a place for `--exact`, `--nocapture`, or other CLI flags; zero-test results are not validation proof and return recovery guidance. Normal execution requires non-zero executed-test evidence; explicit require_tests=false opts out when no min_tests minimum is requested, while require_tests=true/min_tests enforce a proven minimum. no_run=true is compile-only and does not require executed-test-count proof. sync_wait_secs only controls same execution Job handoff grace.",
             cargo_test_input_schema,
         )),
         100,

--- a/crates/webcodex-tool-contracts/src/tool_definition/testing.rs
+++ b/crates/webcodex-tool-contracts/src/tool_definition/testing.rs
@@ -34,7 +34,7 @@ pub(super) const DEFINITIONS: &[ToolDefinition] = &[
             false,
             super::ToolSessionEvidencePolicy::NONE.validation_identity(super::ToolValidationIdentityKind::CargoFmt),
         ),
-        "Run cargo fmt. With check=true it is read-only validation; optional sync_wait_secs shortens only the synchronous grace before the same execution is returned as a Job. Mutating format stays synchronous and rejects sync_wait_secs.",
+        "After source edits, use check=false (default) to ensure formatting: precheck first, mutate only for a proven rustfmt diff, and use changed/state_changed instead of reproducing rustfmt diffs with edit tools. Use check=true for pure read-only final validation; only that mode may hand off the same execution as a Job via sync_wait_secs. Ensure-format stays synchronous.",
         cargo_fmt_input_schema,
     )),
     adaptive_runtime_direct(

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -30,6 +30,18 @@ const CARGO_VALIDATION_FAILURE_KIND: &str = "validation_failed";
 const VALIDATION_FAILURE_GUIDANCE: &str =
     "command was started; inspect bounded validation evidence, fix the reported issue, then rerun the same structured validation tool.";
 
+fn test_count_assertion_failure_message(tool_name: &str, payload: &Value) -> String {
+    if tool_name == "cargo_test"
+        && payload.get("zero_tests_run").and_then(Value::as_bool) == Some(true)
+    {
+        return "cargo_test completed but 0 tests executed; broaden or remove the substring filter, use the test's full qualified name if needed, or verify the selected package/target. Do not put --exact, --nocapture, or other Cargo/libtest flags in filter, and do not treat this result as validation success.".to_string();
+    }
+    if tool_name == "cargo_test" {
+        return "cargo_test test-count assertion was not proven; inspect test_count_assertion and rerun with a scope that executes enough tests.".to_string();
+    }
+    "structured test-count assertion was not proven; inspect test_count_assertion and rerun with a scope that executes enough tests.".to_string()
+}
+
 fn validate_cwd(cwd: Option<String>) -> Result<Option<String>, String> {
     match cwd {
         Some(raw) => {
@@ -1233,24 +1245,17 @@ impl ToolRuntime {
                 CARGO_VALIDATION_FAILURE_KIND
             };
             payload["failure_kind"] = json!(failure_kind);
+            let error = if timed_out {
+                command_timeout_message(handoff.effective_timeout_secs, &stdout_tail, &stderr_tail)
+            } else if process_passed {
+                test_count_assertion_failure_message(adapter.tool_identity(), &payload)
+            } else {
+                format!("structured validation command failed; {VALIDATION_FAILURE_GUIDANCE}")
+            };
             let result = ToolResult {
                 success: false,
                 output: payload,
-                error: Some(if timed_out {
-                    command_timeout_message(
-                        handoff.effective_timeout_secs,
-                        &stdout_tail,
-                        &stderr_tail,
-                    )
-                } else {
-                    if process_passed {
-                        "cargo_test test-count assertion was not proven; inspect test_count_assertion and rerun with a scope that executes enough tests.".to_string()
-                    } else {
-                        format!(
-                            "structured validation command failed; {VALIDATION_FAILURE_GUIDANCE}"
-                        )
-                    }
-                }),
+                error: Some(error),
             };
             self.runner_registry
                 .remove_projected_hidden_terminal_job_record(&job_id)
@@ -1399,16 +1404,15 @@ impl ToolRuntime {
                 } else {
                     "process_exit"
                 });
+                let error = if process_passed {
+                    test_count_assertion_failure_message(adapter.tool_identity(), &payload)
+                } else {
+                    format!("structured validation command failed; {VALIDATION_FAILURE_GUIDANCE}")
+                };
                 ToolResult {
                     success: false,
                     output: payload,
-                    error: Some(if process_passed {
-                        "cargo_test test-count assertion was not proven; inspect test_count_assertion and rerun with a scope that executes enough tests.".to_string()
-                    } else {
-                        format!(
-                            "structured validation command failed; {VALIDATION_FAILURE_GUIDANCE}"
-                        )
-                    }),
+                    error: Some(error),
                 }
             }
         }

--- a/src/tool_runtime/cargo.rs
+++ b/src/tool_runtime/cargo.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use std::time::{Duration, Instant};
 
 use super::helpers::{
     bounded_tail, command_outcome_unknown_message, command_rejected_message,
@@ -13,6 +14,7 @@ use super::structured_execution::structured_job_observation;
 use super::tool_result::ToolResult;
 use super::validation_profile::{
     validation_adapter_for_tool, ValidationAdapter, ValidationCommandOptions,
+    ValidationFailureEvidence,
 };
 use super::{ExecutionPurpose, ToolRuntime};
 use crate::auth::AuthContext;
@@ -40,6 +42,43 @@ fn test_count_assertion_failure_message(tool_name: &str, payload: &Value) -> Str
         return "cargo_test test-count assertion was not proven; inspect test_count_assertion and rerun with a scope that executes enough tests.".to_string();
     }
     "structured test-count assertion was not proven; inspect test_count_assertion and rerun with a scope that executes enough tests.".to_string()
+}
+
+fn cargo_fmt_check_is_stable_diff(
+    adapter: &'static dyn ValidationAdapter,
+    output: &ProjectCommandOutput,
+) -> bool {
+    if output.execution_state != ShellCommandExecutionState::Completed
+        || output.exit_code == Some(0)
+    {
+        return false;
+    }
+    adapter.map_failure_kind(ValidationFailureEvidence {
+        success: false,
+        reported_failure_kind: None,
+        exit_code: output.exit_code.map(i64::from),
+        diagnostics: None,
+        stdout_excerpt: &output.stdout,
+        stderr_excerpt: &output.stderr,
+    }) == "format_diff"
+}
+
+fn annotate_cargo_fmt_effect(
+    result: &mut ToolResult,
+    changed: Option<bool>,
+    state_changed: Option<bool>,
+) {
+    result.output["changed"] = changed.map(Value::Bool).unwrap_or(Value::Null);
+    result.output["state_changed"] = state_changed.map(Value::Bool).unwrap_or(Value::Null);
+}
+
+fn append_cargo_fmt_uncertainty_guidance(result: &mut ToolResult) {
+    let guidance =
+        "cargo fmt mutation may have changed source; inspect the worktree before retrying.";
+    result.error = Some(match result.error.take() {
+        Some(error) => format!("{error} {guidance}"),
+        None => guidance.to_string(),
+    });
 }
 
 fn validate_cwd(cwd: Option<String>) -> Result<Option<String>, String> {
@@ -339,9 +378,10 @@ impl ToolRuntime {
         if let Some(result) = reject_structured_validation_ssh_resource(ssh_resource) {
             return result;
         }
-        // Non-check `cargo fmt` mutates source and keeps the existing explicit
-        // synchronous semantics: it never auto-promotes to a Job after the
-        // tool has returned. Only `check=true` gets the read-only handoff path.
+        // Non-check `cargo_fmt` is an ensure-formatted operation. It first runs
+        // the read-only rustfmt check, mutating only when that check proves a
+        // stable formatting diff. The mutation stays synchronous and never
+        // continues after this ToolResult returns.
         if !check {
             let timeout =
                 match resolve_sync_timeout_secs(timeout_secs, DEFAULT_CARGO_FMT_TIMEOUT_SECS) {
@@ -362,17 +402,173 @@ impl ToolRuntime {
                     ))
                 }
             };
+            let config = match self.resolve_project(&project).await {
+                Ok(config) => config,
+                Err(e) => {
+                    return ToolResult::err(command_rejected_message(
+                        e.to_message(),
+                        "verify the project id/cwd and agent connectivity, then retry.",
+                    ))
+                }
+            };
             let adapter = validation_adapter_for_tool("cargo_fmt")
                 .expect("Rust validation profile must register cargo_fmt");
+            let check_command = adapter
+                .build_command(ValidationCommandOptions {
+                    check: true,
+                    ..ValidationCommandOptions::default()
+                })
+                .expect("cargo_fmt check command builder is infallible");
+            let started = Instant::now();
+            let check_output = match self
+                .run_project_command_capture(&project, check_command.clone(), timeout, cwd.clone())
+                .await
+            {
+                Ok(output) => output,
+                Err(e) => {
+                    return ToolResult::err(command_rejected_message(
+                        e,
+                        "verify the project id/cwd and agent connectivity, then retry.",
+                    ))
+                }
+            };
+            let already_formatted = check_output.execution_state
+                == ShellCommandExecutionState::Completed
+                && check_output.exit_code == Some(0);
+            if already_formatted {
+                let mut result = self
+                    .build_cargo_result(
+                        &project,
+                        &check_command,
+                        cwd.as_deref(),
+                        &config,
+                        adapter,
+                        check_output,
+                        timeout,
+                        0,
+                        false,
+                        false,
+                        false,
+                        None,
+                        None,
+                        None,
+                    )
+                    .await;
+                annotate_cargo_fmt_effect(&mut result, Some(false), Some(false));
+                return result;
+            }
+            if !cargo_fmt_check_is_stable_diff(adapter, &check_output) {
+                let mut result = self
+                    .build_cargo_result(
+                        &project,
+                        &check_command,
+                        cwd.as_deref(),
+                        &config,
+                        adapter,
+                        check_output,
+                        timeout,
+                        0,
+                        false,
+                        false,
+                        false,
+                        None,
+                        None,
+                        None,
+                    )
+                    .await;
+                annotate_cargo_fmt_effect(&mut result, Some(false), Some(false));
+                if let Some(error) = result.error.take() {
+                    result.error = Some(format!(
+                        "{error} No source formatting was attempted because the precheck did not prove a stable rustfmt diff."
+                    ));
+                }
+                return result;
+            }
+
+            let total_budget = Duration::from_secs(timeout);
+            let elapsed = started.elapsed();
+            let remaining_budget = total_budget.saturating_sub(elapsed);
+            if remaining_budget < Duration::from_secs(1) {
+                let mut result = self
+                    .build_cargo_result(
+                        &project,
+                        &check_command,
+                        cwd.as_deref(),
+                        &config,
+                        adapter,
+                        check_output,
+                        timeout,
+                        0,
+                        false,
+                        false,
+                        false,
+                        None,
+                        None,
+                        None,
+                    )
+                    .await;
+                annotate_cargo_fmt_effect(&mut result, Some(false), Some(false));
+                result.output["failure_kind"] = json!("timeout");
+                result.error = Some(
+                    "cargo_fmt found formatting differences but exhausted its synchronous timeout before mutation; no source formatting was attempted."
+                        .to_string(),
+                );
+                return result;
+            }
+            let remaining = remaining_budget.as_secs();
             let command = adapter
                 .build_command(ValidationCommandOptions {
                     check: false,
                     ..ValidationCommandOptions::default()
                 })
                 .expect("cargo_fmt command builder is infallible");
-            // `cargo fmt` (mutating) uses the plain sync path.
-            self.run_cargo_command_sync(project, cwd, command, timeout, adapter)
+            let mutation_output = match self
+                .run_project_command_capture(&project, command.clone(), remaining, cwd.clone())
                 .await
+            {
+                Ok(output) => output,
+                Err(e) => {
+                    return ToolResult::err(command_rejected_message(
+                        e,
+                        "the formatting precheck proved a diff but the mutation command could not be dispatched; inspect the worktree before retrying.",
+                    ))
+                }
+            };
+            let mutation_state = mutation_output.execution_state;
+            let mutation_exit_code = mutation_output.exit_code;
+            let mut result = self
+                .build_cargo_result(
+                    &project,
+                    &command,
+                    cwd.as_deref(),
+                    &config,
+                    adapter,
+                    mutation_output,
+                    remaining,
+                    0,
+                    false,
+                    false,
+                    false,
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+            result.output["effective_timeout_secs"] = json!(timeout);
+            result.output["duration_ms"] = json!(started.elapsed().as_millis() as u64);
+            match (mutation_state, mutation_exit_code) {
+                (ShellCommandExecutionState::Completed, Some(0)) => {
+                    annotate_cargo_fmt_effect(&mut result, Some(true), Some(true));
+                }
+                (ShellCommandExecutionState::NotStarted, _) => {
+                    annotate_cargo_fmt_effect(&mut result, Some(false), Some(false));
+                }
+                _ => {
+                    annotate_cargo_fmt_effect(&mut result, None, None);
+                    append_cargo_fmt_uncertainty_guidance(&mut result);
+                }
+            }
+            result
         } else {
             self.run_readonly_validation(
                 "cargo_fmt",
@@ -1416,62 +1612,6 @@ impl ToolRuntime {
                 }
             }
         }
-    }
-
-    /// The previous synchronous cargo path, used by mutating `cargo fmt` (and
-    /// the old `run_cargo_command`). Kept separate so the read-only tools go
-    /// through the shared exactly-once validation path.
-    async fn run_cargo_command_sync(
-        &self,
-        project: String,
-        cwd: Option<String>,
-        command: String,
-        timeout_secs: u64,
-        adapter: &'static dyn ValidationAdapter,
-    ) -> ToolResult {
-        let config = match self.resolve_project(&project).await {
-            Ok(config) => config,
-            Err(e) => {
-                return ToolResult::err(command_rejected_message(
-                    e.to_message(),
-                    "verify the project id/cwd and agent connectivity, then retry or use run_shell for custom diagnostics.",
-                ))
-            }
-        };
-        let output = match self
-            .run_project_command_capture(
-                &project,
-                command.clone(),
-                timeout_secs,
-                cwd.clone(),
-            )
-            .await
-        {
-            Ok(output) => output,
-            Err(e) => {
-                return ToolResult::err(command_rejected_message(
-                    e,
-                    "verify the project id/cwd and agent connectivity, then retry or use run_shell for custom diagnostics.",
-                ))
-            }
-        };
-        self.build_cargo_result(
-            &project,
-            &command,
-            cwd.as_deref(),
-            &config,
-            adapter,
-            output,
-            timeout_secs,
-            0,
-            false,
-            false,
-            false,
-            None,
-            None,
-            None,
-        )
-        .await
     }
 }
 

--- a/src/tool_runtime/files/mutations.rs
+++ b/src/tool_runtime/files/mutations.rs
@@ -348,14 +348,9 @@ fn validate_apply_text_edit(
                     edit.kind.as_str()
                 ));
             }
-            if edit
-                .new_text
-                .as_deref()
-                .filter(|value| !value.is_empty())
-                .is_none()
-            {
+            if edit.new_text.is_none() {
                 return Err(format!(
-                    "change {change_index} edit {edit_index} ({}): new_text must be non-empty",
+                    "change {change_index} edit {edit_index} ({}): new_text is required",
                     edit.kind.as_str()
                 ));
             }
@@ -1681,6 +1676,15 @@ pub(crate) fn apply_text_edits_to_string(
     // Resolve each edit to a (start, end, replacement, index) op against the
     // original content. start/end are byte offsets; inserts are zero-width.
     let mut ops: Vec<(usize, usize, String, usize)> = Vec::with_capacity(edits.len());
+    let ignored_noop_count = edits
+        .iter()
+        .filter(|edit| {
+            matches!(
+                edit.kind,
+                ApplyTextEditKind::InsertBefore | ApplyTextEditKind::InsertAfter
+            ) && edit.new_text.as_deref() == Some("")
+        })
+        .count();
     for (index, edit) in edits.iter().enumerate() {
         let kind = edit.kind;
         if edit.occurrence == Some(0) {
@@ -1724,8 +1728,10 @@ pub(crate) fn apply_text_edits_to_string(
                 let new = edit
                     .new_text
                     .as_deref()
-                    .filter(|v| !v.is_empty())
-                    .ok_or_else(|| edit_field_error(index, kind, "new_text must be non-empty"))?;
+                    .ok_or_else(|| edit_field_error(index, kind, "new_text is required"))?;
+                if new.is_empty() {
+                    continue;
+                }
                 (anchor, new.to_string())
             }
         };
@@ -1850,6 +1856,7 @@ pub(crate) fn apply_text_edits_to_string(
         "path": path,
         "dry_run": dry_run,
         "applied_count": edits.len(),
+        "ignored_noop_count": ignored_noop_count,
         "old_sha256": old_sha256,
         "new_sha256": new_sha256,
         "changed": changed,

--- a/src/tool_runtime/git.rs
+++ b/src/tool_runtime/git.rs
@@ -51,7 +51,7 @@ const SHOW_CHANGES_MAX_HUNK_LINES: usize = 240;
 // Keep overview context materially below the default per-hunk line ceiling so
 // ordinary small mid-file edits remain decision-complete in show_changes.
 const SHOW_CHANGES_DIFF_CONTEXT_LINES: usize = 20;
-const SHOW_CHANGES_DEFAULT_SESSION_EVENT_LIMIT: usize = 30;
+const SHOW_CHANGES_SESSION_SIGNAL_EVENT_LIMIT: usize = 30;
 const SHOW_CHANGES_MAX_SESSION_EVENT_LIMIT: usize = 200;
 /// Maximum number of changed-file records `show_changes` emits on the
 /// production side. The total count stays exact (all entries are counted); only
@@ -1923,6 +1923,7 @@ pub(crate) fn apply_show_changes_session(
     output: &mut Value,
     session_id: Option<&str>,
     summary: Option<SessionSummary>,
+    recent_events_limit: Option<usize>,
 ) {
     let Some(session_id) = session_id else {
         output["session"] = Value::Null;
@@ -1932,11 +1933,13 @@ pub(crate) fn apply_show_changes_session(
     let session_signals = match summary {
         Some(summary) => {
             let changed_paths = session_changed_paths(&summary.events);
-            let recent_events: Vec<Value> = summary
-                .events
-                .iter()
-                .map(show_changes_session_event)
-                .collect();
+            let recent_events = recent_events_limit.filter(|limit| *limit > 0).map(|limit| {
+                let start = summary.events.len().saturating_sub(limit);
+                summary.events[start..]
+                    .iter()
+                    .map(show_changes_session_event)
+                    .collect::<Vec<_>>()
+            });
             let signals = SessionActionSignals {
                 failed: summary.counts.failed > 0,
                 write_like: summary.counts.write_like > 0,
@@ -1951,8 +1954,15 @@ pub(crate) fn apply_show_changes_session(
                 "updated_at": summary.updated_at,
                 "counts": summary.counts,
                 "changed_paths": changed_paths,
-                "recent_events": recent_events,
+                "signals": {
+                    "failed": signals.failed,
+                    "write_like": signals.write_like,
+                    "shell_like": signals.shell_like,
+                },
             });
+            if let Some(recent_events) = recent_events {
+                output["session"]["recent_events"] = json!(recent_events);
+            }
             Some(signals)
         }
         None => {
@@ -4706,9 +4716,11 @@ impl ToolRuntime {
             .filter(|n| *n > 0)
             .unwrap_or(SHOW_CHANGES_DEFAULT_MAX_HUNK_LINES)
             .min(SHOW_CHANGES_MAX_HUNK_LINES);
-        let session_event_limit = session_event_limit
-            .filter(|n| *n > 0)
-            .unwrap_or(SHOW_CHANGES_DEFAULT_SESSION_EVENT_LIMIT)
+        let recent_events_limit = session_event_limit
+            .unwrap_or(0)
+            .min(SHOW_CHANGES_MAX_SESSION_EVENT_LIMIT);
+        let session_summary_limit = recent_events_limit
+            .max(SHOW_CHANGES_SESSION_SIGNAL_EVENT_LIMIT)
             .min(SHOW_CHANGES_MAX_SESSION_EVENT_LIMIT);
         let command = show_changes_command(include_diff, max_hunks, max_hunk_lines);
         let output = match self
@@ -4740,8 +4752,13 @@ impl ToolRuntime {
             );
             let session_summary = session_id
                 .as_deref()
-                .and_then(|id| self.sessions.summary(id, Some(session_event_limit)));
-            apply_show_changes_session(&mut payload, session_id.as_deref(), session_summary);
+                .and_then(|id| self.sessions.summary(id, Some(session_summary_limit)));
+            apply_show_changes_session(
+                &mut payload,
+                session_id.as_deref(),
+                session_summary,
+                (recent_events_limit > 0).then_some(recent_events_limit),
+            );
             return ToolResult::ok(payload);
         }
         let status_observed = status_observation.status_observed();
@@ -4768,8 +4785,13 @@ impl ToolRuntime {
         }
         let session_summary = session_id
             .as_deref()
-            .and_then(|id| self.sessions.summary(id, Some(session_event_limit)));
-        apply_show_changes_session(&mut payload, session_id.as_deref(), session_summary);
+            .and_then(|id| self.sessions.summary(id, Some(session_summary_limit)));
+        apply_show_changes_session(
+            &mut payload,
+            session_id.as_deref(),
+            session_summary,
+            (recent_events_limit > 0).then_some(recent_events_limit),
+        );
         // Success requires the command/result envelope, status, diff-stat, and
         // (when requested) full diff inspections all to be proven successful.
         // `transport_safe` is a legacy field name: it describes bounded

--- a/src/tool_runtime/tests/apply_text_edits.rs
+++ b/src/tool_runtime/tests/apply_text_edits.rs
@@ -43,6 +43,13 @@ fn apply_text_edits_occurrence_and_recovery_schemas_are_model_visible() {
             .unwrap()
             .contains(&serde_json::json!("occurrence")));
     }
+    for variant in &edit_variants[2..] {
+        assert!(variant["properties"]["new_text"].get("minLength").is_none());
+        assert!(variant["properties"]["new_text"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("no-op"));
+    }
     let output = &spec.output_schema["properties"]["output"]["properties"]["conflict_recovery"];
     assert_eq!(output["properties"]["schema_version"]["const"], 1);
     assert_eq!(output["properties"]["candidate_ranges"]["maxItems"], 8);
@@ -65,6 +72,7 @@ fn apply_text_edits_occurrence_and_recovery_schemas_are_model_visible() {
         serde_json::json!(["not_started", "completed", "outcome_unknown"])
     );
     assert_eq!(output_properties["retry_guidance"]["type"], "string");
+    assert_eq!(output_properties["ignored_noop_count"]["type"], "integer");
     assert!(output["properties"]["conflict_kind"]["enum"]
         .as_array()
         .unwrap()
@@ -139,6 +147,8 @@ fn apply_text_edits_occurrence_and_recovery_schemas_are_model_visible() {
     assert!(spec.description.contains("occurrence"));
     assert!(spec.description.contains("line_scope"));
     assert!(spec.description.contains("global source order"));
+    assert!(spec.description.contains("direct_retry_safe"));
+    assert!(spec.description.contains("reread_required"));
     assert!(
         spec.description.chars().count() <= crate::tool_runtime::MODEL_TOOL_DESCRIPTION_MAX_CHARS
     );
@@ -193,6 +203,31 @@ fn apply_text_edits_multiple_edits_atomic() {
     assert_eq!(updated, "alpha\nBETA\ngamma\nDELTA\n");
     assert_eq!(out["applied_count"], 2);
     assert_eq!(out["edits"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn apply_text_edits_ignores_empty_insert_noop_without_blocking_other_edits() {
+    let original = "alpha\nbeta\n";
+    let edits = vec![
+        text_edit(
+            ApplyTextEditKind::InsertBefore,
+            None,
+            Some(""),
+            Some("anchor-that-does-not-exist"),
+        ),
+        text_edit(
+            ApplyTextEditKind::ReplaceExact,
+            Some("beta"),
+            Some("BETA"),
+            None,
+        ),
+    ];
+    let (updated, out) =
+        files::apply_text_edits_to_string(original, "src/x.rs", &edits, None, false).unwrap();
+    assert_eq!(updated, "alpha\nBETA\n");
+    assert_eq!(out["applied_count"], 2);
+    assert_eq!(out["ignored_noop_count"], 1);
+    assert_eq!(out["edits"].as_array().unwrap().len(), 1);
 }
 
 #[test]

--- a/src/tool_runtime/tests/git.rs
+++ b/src/tool_runtime/tests/git.rs
@@ -4322,7 +4322,7 @@ fn show_changes_without_session_id_treats_dirty_workspace_as_advisory() {
         Some(0),
         "",
     );
-    apply_show_changes_session(&mut output, None, None);
+    apply_show_changes_session(&mut output, None, None, None);
     assert_eq!(output["clean"], false);
     assert_eq!(output["counts"]["modified"], 1);
     assert_review_verdict_shape(&output["verdict"]);
@@ -4338,7 +4338,7 @@ fn show_changes_without_session_id_treats_dirty_workspace_as_advisory() {
 }
 
 #[test]
-fn show_changes_with_session_id_includes_session_summary() {
+fn show_changes_with_session_id_defaults_to_compact_session_summary() {
     let runtime = test_runtime();
     let session = runtime.sessions.start_session(
         Some("agent:oe:webcodex".to_string()),
@@ -4379,7 +4379,7 @@ fn show_changes_with_session_id_includes_session_summary() {
         "",
     );
     let summary = runtime.sessions.summary(&session.session_id, Some(30));
-    apply_show_changes_session(&mut output, Some(&session.session_id), summary);
+    apply_show_changes_session(&mut output, Some(&session.session_id), summary, None);
 
     assert_eq!(output["session"]["found"], true);
     assert_eq!(output["session"]["session_id"], session.session_id);
@@ -4388,7 +4388,10 @@ fn show_changes_with_session_id_includes_session_summary() {
     assert_eq!(output["session"]["counts"]["write_like"], 1);
     assert_eq!(output["session"]["counts"]["shell_like"], 1);
     assert_eq!(output["session"]["changed_paths"], json!(["src/foo.rs"]));
-    assert!(output["session"]["recent_events"].as_array().unwrap().len() >= 2);
+    assert_eq!(output["session"]["signals"]["failed"], false);
+    assert_eq!(output["session"]["signals"]["write_like"], true);
+    assert_eq!(output["session"]["signals"]["shell_like"], true);
+    assert!(output["session"].get("recent_events").is_none());
     let actions = output["suggested_next_actions"].as_array().unwrap();
     assert!(actions
         .iter()
@@ -4411,7 +4414,7 @@ fn show_changes_with_missing_session_id_returns_warning_not_panic() {
         Some(0),
         "",
     );
-    apply_show_changes_session(&mut output, Some("wc_sess_missing"), None);
+    apply_show_changes_session(&mut output, Some("wc_sess_missing"), None, None);
     assert_eq!(output["session"]["found"], false);
     assert_eq!(output["session"]["session_id"], "wc_sess_missing");
     assert!(output["warnings"]
@@ -4451,7 +4454,7 @@ fn show_changes_session_changed_paths_are_deduped() {
         "",
     );
     let summary = runtime.sessions.summary(&session.session_id, Some(30));
-    apply_show_changes_session(&mut output, Some(&session.session_id), summary);
+    apply_show_changes_session(&mut output, Some(&session.session_id), summary, None);
     assert_eq!(
         output["session"]["changed_paths"],
         json!(["src/foo.rs", "src/bar.rs"])
@@ -4459,7 +4462,7 @@ fn show_changes_session_changed_paths_are_deduped() {
 }
 
 #[tokio::test]
-async fn show_changes_session_event_limit_is_bounded() {
+async fn show_changes_explicit_session_event_limit_is_bounded() {
     let runtime = runtime_with_agent_project("show");
     let caps = RunnerCapabilities {
         shell: true,
@@ -6471,10 +6474,8 @@ async fn show_changes_non_git_project_still_returns_session_summary() {
     assert_eq!(result.output["git_available"], false);
     assert_eq!(result.output["session"]["found"], true);
     assert_eq!(result.output["session"]["session_id"], session.session_id);
-    assert!(!result.output["session"]["recent_events"]
-        .as_array()
-        .unwrap()
-        .is_empty());
+    assert!(result.output["session"].get("recent_events").is_none());
+    assert_eq!(result.output["session"]["signals"]["write_like"], true);
     assert_eq!(
         result.output["session"]["changed_paths"],
         json!(["src/foo.rs"])

--- a/src/tool_runtime/tests/validation_handoff.rs
+++ b/src/tool_runtime/tests/validation_handoff.rs
@@ -2545,11 +2545,10 @@ async fn terminal_validation_result_fields_are_consistent_between_executors() {
     assert_eq!(result.output["execution_state"], "completed");
     assert_eq!(result.output["passed"], true);
 }
-/// `cargo_fmt(check=false)` never auto-promotes: it keeps the existing
-/// synchronous execution semantics and must not modify source after the tool
-/// returns.
+/// `cargo_fmt(check=false)` first checks formatting and avoids a mutating
+/// subprocess entirely when the workspace is already formatted.
 #[tokio::test]
-async fn cargo_fmt_mutating_never_auto_promotes() {
+async fn cargo_fmt_ensure_formatted_skips_mutation_when_already_formatted() {
     let client_id = "vhandoff-fmt-mutate";
     let runtime = runtime_with_agent_project(client_id);
     let caps = RunnerCapabilities {
@@ -2570,6 +2569,7 @@ async fn cargo_fmt_mutating_never_auto_promotes() {
     });
     let request = wait_for_patch_agent_request(&runtime, client_id).await;
     assert_ne!(request.kind, "start_validation_job");
+    assert_eq!(request.command, "cargo fmt -- --check");
     runtime
         .runner_registry
         .complete(crate::runner_protocol::RunnerResultRequest {
@@ -2588,12 +2588,97 @@ async fn cargo_fmt_mutating_never_auto_promotes() {
     assert!(result.success, "{:?}", result.error);
     assert_ne!(result.output["promoted_to_job"], true);
     assert_eq!(result.output["command_completed"], true);
+    assert_eq!(result.output["changed"], false);
+    assert_eq!(result.output["state_changed"], false);
     // No job was created.
     assert!(runtime.runner_registry.list_jobs(Some(10)).await.is_empty());
 }
 
 #[tokio::test]
-async fn cargo_fmt_mutating_post_spawn_uncertainty_forbids_blind_retry() {
+async fn cargo_fmt_ensure_formatted_mutates_only_after_stable_format_diff() {
+    let client_id = "vhandoff-fmt-ensure-diff";
+    let runtime = runtime_with_agent_project(client_id);
+    register_agent(&runtime, client_id, None, RunnerCapabilities::default()).await;
+    let project = agent_test_project_id(client_id);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .cargo_fmt(project, None, Some(false), Some(120))
+                .await
+        }
+    });
+    let precheck = wait_for_patch_agent_request(&runtime, client_id).await;
+    assert_eq!(precheck.command, "cargo fmt -- --check");
+    complete_patch_agent_request(
+        &runtime,
+        client_id,
+        &precheck.request_id,
+        1,
+        "Diff in src/lib.rs:1:\n-old\n+new\n",
+        "",
+    )
+    .await;
+
+    let mutation = wait_for_patch_agent_request(&runtime, client_id).await;
+    assert_eq!(mutation.command, "cargo fmt");
+    complete_patch_agent_request(&runtime, client_id, &mutation.request_id, 0, "", "").await;
+
+    let result = task.await.unwrap();
+    assert!(result.success, "{:?}", result.error);
+    assert_eq!(result.output["changed"], true);
+    assert_eq!(result.output["state_changed"], true);
+    assert_eq!(result.output["command_summary"], "cargo fmt");
+    assert_ne!(result.output["promoted_to_job"], true);
+    assert!(runtime.runner_registry.list_jobs(Some(10)).await.is_empty());
+    assert_cargo_result_matches_schema("cargo_fmt", &result);
+}
+
+#[tokio::test]
+async fn cargo_fmt_ensure_formatted_non_format_precheck_failure_never_mutates() {
+    let client_id = "vhandoff-fmt-precheck-error";
+    let runtime = runtime_with_agent_project(client_id);
+    register_agent(&runtime, client_id, None, RunnerCapabilities::default()).await;
+    let project = agent_test_project_id(client_id);
+
+    let task = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .cargo_fmt(project, None, Some(false), Some(120))
+                .await
+        }
+    });
+    let precheck = wait_for_patch_agent_request(&runtime, client_id).await;
+    assert_eq!(precheck.command, "cargo fmt -- --check");
+    complete_patch_agent_request(
+        &runtime,
+        client_id,
+        &precheck.request_id,
+        1,
+        "",
+        "error: rustfmt component is unavailable",
+    )
+    .await;
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), task)
+        .await
+        .expect("non-format precheck failure must return without waiting for mutation")
+        .unwrap();
+    assert!(!result.success);
+    assert_eq!(result.output["changed"], false);
+    assert_eq!(result.output["state_changed"], false);
+    assert!(result
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("No source formatting was attempted")));
+    assert!(runtime.runner_registry.list_jobs(Some(10)).await.is_empty());
+    assert_cargo_result_matches_schema("cargo_fmt", &result);
+}
+
+#[tokio::test]
+async fn cargo_fmt_ensure_formatted_mutation_uncertainty_forbids_blind_retry() {
     let client_id = "vhandoff-fmt-mutate-unknown";
     let runtime = runtime_with_agent_project(client_id);
     let caps = RunnerCapabilities {
@@ -2611,7 +2696,22 @@ async fn cargo_fmt_mutating_post_spawn_uncertainty_forbids_blind_retry() {
                 .await
         }
     });
+    let precheck = wait_for_runner_request(&runtime, client_id).await;
+    assert_eq!(precheck.command, "cargo fmt -- --check");
+    complete_sync_shell_lifecycle(
+        &runtime,
+        client_id,
+        precheck.request_id,
+        ShellCommandExecutionState::Completed,
+        Some(1),
+        "Diff in src/lib.rs:1:\n-old\n+new\n",
+        "",
+        None,
+    )
+    .await;
+
     let request = wait_for_runner_request(&runtime, client_id).await;
+    assert_eq!(request.command, "cargo fmt");
     complete_sync_shell_lifecycle(
         &runtime,
         client_id,
@@ -2633,8 +2733,14 @@ async fn cargo_fmt_mutating_post_spawn_uncertainty_forbids_blind_retry() {
     assert_eq!(result.output["terminal"], false);
     assert_eq!(result.output["promoted_to_job"], false);
     assert!(result.output.get("job_id").is_none());
+    assert!(result.output["changed"].is_null());
+    assert!(result.output["state_changed"].is_null());
     let error = result.error.as_deref().unwrap_or_default();
     assert!(error.contains("Do not automatically retry"), "{error}");
+    assert!(
+        error.contains("mutation may have changed source"),
+        "{error}"
+    );
     assert!(error.contains("inspect the actual Job, process, service, or target state"));
     assert_cargo_result_matches_schema("cargo_fmt", &result);
     assert!(runtime.runner_registry.list_jobs(Some(10)).await.is_empty());

--- a/src/tool_runtime/tests/validation_handoff/cargo_test_assertions.rs
+++ b/src/tool_runtime/tests/validation_handoff/cargo_test_assertions.rs
@@ -88,6 +88,11 @@ async fn fast_cargo_test_require_tests_rejects_ignored_only_and_records_failed_s
     );
     assert_eq!(result.output["tests_run_count"], 0);
     assert_eq!(result.output["zero_tests_run"], true);
+    let error = result.error.as_deref().expect("zero-test recovery message");
+    assert!(error.contains("0 tests executed"), "{error}");
+    assert!(error.contains("substring filter"), "{error}");
+    assert!(error.contains("full qualified name"), "{error}");
+    assert!(error.contains("--exact"), "{error}");
     assert_eq!(result.output["test_count_assertion"]["actual_tests_run"], 0);
     assert_cargo_result_matches_schema("cargo_test", &result);
     assert!(

--- a/src/tool_runtime/validation_profile/mod.rs
+++ b/src/tool_runtime/validation_profile/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) use webcodex_validation::{
     validation_adapter_for_tool, ValidationAdapter, ValidationCommandOptions,
+    ValidationFailureEvidence,
 };


### PR DESCRIPTION
## Summary

- let `apply_text_edits` ignore provable empty insert no-ops without weakening transactional failure for real conflicts, and expose bounded no-op/recovery metadata
- clarify `cargo_test` substring filtering and return actionable zero-test recovery instead of encouraging CLI flags in `filter`
- make `show_changes` Session context compact by default while keeping bounded event history as an explicit opt-in
- make `cargo_fmt(check=false)` an effect-aware ensure-format operation: read-only precheck first, mutate only for a proven rustfmt diff, and report known/unknown effect state
- keep Runner-side empty-insert no-ops subject to basic field validation before match resolution is skipped

## Validation

On the latest `main` base (`13e9d66a`):

- `cargo test -p webcodex` — 2551 passed, 0 failed, 2 ignored
- `cargo test -p webcodex-tool-contracts --quiet` — 109 passed, 0 failed
- `cargo test -p webcodex-runner apply_text_edits --quiet` — 31 passed, 0 failed
- `cargo fmt -- --check`
- `git diff --check`
- deterministic committed-range review over all 5 commits and 21 changed files

Additional pre-final-rebase evidence: full `webcodex-runner` suite completed with 888 passed, 0 failed, 71 ignored. The later `main` updates did not overlap the Runner edit implementation.