### PR TITLE
Split Skill catalog observation from exact resolution

### DIFF
--- a/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/configured_skills.rs
@@ -236,6 +236,109 @@ fn discover_with_trigger(
     Ok(discovery)
 }
 
+fn resolve_live_skill_by_id(
+    config: &SkillsConfig,
+    target_skill_id: &str,
+) -> Result<(Option<LiveSkill>, ConfiguredSkillScanStats), String> {
+    let mut discovery = LiveDiscovery::default();
+    let started = Instant::now();
+    let mut stats = ConfiguredSkillScanStats::default();
+    for configured_root in &config.roots {
+        stats.roots_examined = stats.roots_examined.saturating_add(1);
+        let root_metadata = match fs::symlink_metadata(configured_root) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                push_diagnostic(
+                    &mut discovery.diagnostics,
+                    "configured_skill_root_not_found",
+                );
+                continue;
+            }
+            Err(_) => {
+                push_diagnostic(
+                    &mut discovery.diagnostics,
+                    "configured_skill_root_unavailable",
+                );
+                continue;
+            }
+        };
+        if metadata_is_link_like(&root_metadata) {
+            push_diagnostic(
+                &mut discovery.diagnostics,
+                "configured_skill_root_link_not_allowed",
+            );
+            continue;
+        }
+        if !root_metadata.is_dir() {
+            push_diagnostic(
+                &mut discovery.diagnostics,
+                "configured_skill_root_not_directory",
+            );
+            continue;
+        }
+        let root = match configured_root.canonicalize() {
+            Ok(root) if root.is_dir() => root,
+            _ => {
+                push_diagnostic(
+                    &mut discovery.diagnostics,
+                    "configured_skill_root_unavailable",
+                );
+                continue;
+            }
+        };
+        let entries = match bounded_root_entries(&root, &mut stats) {
+            Ok(entries) => entries,
+            Err(code) => {
+                if code == "configured_skill_root_scan_limit_exceeded" {
+                    discovery.discovery_truncated = true;
+                }
+                push_diagnostic(&mut discovery.diagnostics, code);
+                continue;
+            }
+        };
+        for package_name in entries {
+            if !valid_package_name(&package_name) {
+                discovery.invalid_count = discovery.invalid_count.saturating_add(1);
+                continue;
+            }
+            if webcodex_core::sensitive_paths::is_secret_path(&package_name) {
+                discovery.invalid_count = discovery.invalid_count.saturating_add(1);
+                continue;
+            }
+            if configured_skill_id(configured_root, &package_name) != target_skill_id {
+                continue;
+            }
+            match load_live_skill(configured_root, &root, &package_name, &mut stats) {
+                Ok(skill) => {
+                    if !discovery.skills.is_empty() {
+                        observe_configured_skill_scan(
+                            &stats,
+                            &discovery,
+                            started,
+                            ConfiguredSkillScanTrigger::ExactReadResolution,
+                            "error",
+                        );
+                        return Err("configured_skill_identity_collision".to_string());
+                    }
+                    discovery.skills.push(skill);
+                }
+                Err(code) => {
+                    discovery.invalid_count = discovery.invalid_count.saturating_add(1);
+                    push_diagnostic(&mut discovery.diagnostics, code);
+                }
+            }
+        }
+    }
+    observe_configured_skill_scan(
+        &stats,
+        &discovery,
+        started,
+        ConfiguredSkillScanTrigger::ExactReadResolution,
+        "success",
+    );
+    Ok((discovery.skills.pop(), stats))
+}
+
 fn bounded_root_entries(
     root: &Path,
     stats: &mut ConfiguredSkillScanStats,
@@ -333,12 +436,8 @@ fn read_resource(
     if webcodex_core::sensitive_paths::is_secret_path(&path) {
         return Err("skill_sensitive_path".to_string());
     }
-    let discovery = discover_with_trigger(config, ConfiguredSkillScanTrigger::ExactReadResolution)?;
-    let skill = discovery
-        .skills
-        .into_iter()
-        .find(|skill| skill.descriptor.skill_id == skill_id)
-        .ok_or_else(|| "skill_not_found".to_string())?;
+    let (skill, _scan_stats) = resolve_live_skill_by_id(config, skill_id)?;
+    let skill = skill.ok_or_else(|| "skill_not_found".to_string())?;
     if expected_definition_revision
         .is_some_and(|expected| expected != skill.descriptor.definition_revision)
     {

--- a/crates/webcodex-runner/src/webcodex_runner/configured_skills_tests.rs
+++ b/crates/webcodex-runner/src/webcodex_runner/configured_skills_tests.rs
@@ -24,6 +24,62 @@ fn configured_skill_scan_triggers_are_closed_and_identity_free() {
 }
 
 #[test]
+fn exact_resolution_scans_identities_but_reads_only_target_definition() {
+    let temp = tempfile::tempdir().unwrap();
+    for index in 0..24 {
+        write_skill(
+            temp.path(),
+            &format!("skill-{index:02}"),
+            &format!("skill-{index:02}"),
+            "body",
+        );
+    }
+    fs::write(temp.path().join("skill-03/SKILL.md"), "not frontmatter").unwrap();
+    fs::write(
+        temp.path().join("skill-04/SKILL.md"),
+        vec![b'x'; MAX_SKILL_DEFINITION_BYTES + 1],
+    )
+    .unwrap();
+    let config = SkillsConfig {
+        roots: vec![temp.path().to_path_buf()],
+    };
+    let target_id = configured_skill_id(temp.path(), "skill-23");
+
+    let (resolved, stats) = resolve_live_skill_by_id(&config, &target_id).unwrap();
+    let resolved = resolved.expect("target configured Skill should resolve");
+    assert_eq!(resolved.descriptor.skill_id, target_id);
+    assert_eq!(resolved.descriptor.name, "skill-23");
+    assert_eq!(stats.roots_examined, 1);
+    assert_eq!(stats.directory_entries_scanned, 24);
+    assert_eq!(stats.definitions_attempted, 1);
+    assert_eq!(stats.definitions_read, 1);
+    assert!(stats.definition_bytes_read > 0);
+
+    let resource = read_resource(
+        &config,
+        &target_id,
+        "references/guide.md",
+        1,
+        20,
+        Some(&resolved.descriptor.definition_revision),
+    )
+    .unwrap();
+    assert_eq!(resource.text, "line one\nline two");
+
+    let malformed_id = configured_skill_id(temp.path(), "skill-03");
+    let (malformed, malformed_stats) = resolve_live_skill_by_id(&config, &malformed_id).unwrap();
+    assert!(malformed.is_none());
+    assert_eq!(malformed_stats.definitions_attempted, 1);
+    assert_eq!(malformed_stats.definitions_read, 1);
+
+    let oversized_id = configured_skill_id(temp.path(), "skill-04");
+    let (oversized, oversized_stats) = resolve_live_skill_by_id(&config, &oversized_id).unwrap();
+    assert!(oversized.is_none());
+    assert_eq!(oversized_stats.definitions_attempted, 1);
+    assert_eq!(oversized_stats.definitions_read, 0);
+}
+
+#[test]
 fn empty_roots_preserve_empty_source() {
     let result = handle_configured_skill_roots_request(
         &SkillsConfig::default(),

--- a/docs/architecture/resource-model-and-quality-review.md
+++ b/docs/architecture/resource-model-and-quality-review.md
@@ -98,9 +98,9 @@ Memory provider    Skill providers    Plugin provider
 
 这个收敛没有把 authorization 混入 family：Skill Management 的 admin 要求、Memory conjunctive scopes、Project/Runner authority、permission 与 Session evidence 仍由原 canonical policy 所有；Goal Plan、Work Result、Agent Continuation 的 MCP App/Host capability 也保持独立。Definition invariant 还要求 operator-extension family 必须保持 `ModelHidden`，避免普通 model-visible 工具因误标 family 同时进入通用 registry 与 extension projection。
 
-### B. Skill 发现与精确读取耦合过紧（P1 设计风险；延迟尚未量化）
+### B. Skill 目录观察与精确读取（P1 风险已进入 observer/resolver split）
 
-`discover_project_skills` 逐个读取包定义；`discover_skills` 依次观察项目、configured、managed 来源；`skill_read_file` 也先重建全部目录再按 id 定位。某可选来源观察失败会让整体目录不可用。证据：[skills.rs](../../src/tool_runtime/skills.rs)，562–575、788–803、1376–1416。
+#420 建立 baseline 时，`discover_project_skills` 会逐个读取包定义，`discover_skills` 依次观察 Project、configured、managed 来源，而 `skill_read_file` 也先重建完整目录再按 id 定位。Stage 2 后续实现已把 known-id read 从这个完整 catalog observer 中分离；`skill_list`、startup/context catalog 仍保留完整 `discover_skills` 语义。证据：[skills.rs](../../src/tool_runtime/skills.rs)、[configured_skills.rs](../../crates/webcodex-runner/src/webcodex_runner/configured_skills.rs)。
 
 注意：启动层的 Skill 和 Plugin 已经并行等待，见 [coding_task.rs](../../src/tool_runtime/coding_task.rs)，1232–1269；不能把它描述为整个启动串行。
 
@@ -114,16 +114,23 @@ Memory provider    Skill providers    Plugin provider
 
 Runner configured / managed 的 Server 协议请求虽然携带精确 `skill_id`，`skill_read_file` 目前仍先观察完整跨来源 catalog。仅启用 configured capability 且 Project 为空时，实测 sequence 是 `Project package list -> Configured List -> Configured Read`；仅启用 managed capability 时是 `Project package list -> Managed ListActive -> Managed Read`。mixed project + configured + managed、且 Project 有 1 个 Skill 时，读取 configured target 的 sequence 是 `Project list -> Project definition -> Configured List -> Managed ListActive -> Configured Read`，读取 managed target 只把最后一步换成 `Managed Read`。这明确证明 known-id read 仍观察非目标来源。
 
-Server 侧现已增加 fail-open、低基数的 Skill source observation。固定 `source` 只有 `project / runner_configured / runner_managed`；固定 `operation` 只有 `catalog_list / catalog_definition_read / resource_read / definition_recheck`。Project 层能可靠区分四种操作；configured/managed 在 Server 只声称 `catalog_list` 或 `resource_read`，不伪造 Runner 内部扫描细节。每个已发出的 source request 可观察 request count=1、Server elapsed、Runner response 中已有的 `duration_ms`、stdout response bytes、catalog item count（仅当前层有 authoritative count 时）以及 bounded outcome class。metric sink 仍由 `runtime_metrics` 的 panic guard fail-open；没有 Project/Skill/package/root/resource/query/error body/content/绝对路径/principal 作为 label，也没有修改 ToolResult、Skill JSON、MCP tools/list、Session、Memory、数据库或 Runner wire schema。
+Server 侧的 fail-open、低基数 Skill source observation 继续保留。固定 `source` 只有 `project / runner_configured / runner_managed`；固定 `operation` 现在是 `catalog_list / catalog_definition_read / exact_resolve / resource_read / definition_recheck`。`exact_resolve` 专门标记 known-id membership probe，不把 resolver 流量伪装成 catalog observation 或用户 resource read。每个已发出的 source request 仍可观察 request count=1、Server elapsed、Runner response 中已有的 `duration_ms`、stdout response bytes、catalog item count（仅当前层有 authoritative count 时）以及 bounded outcome class。metric sink 仍由 `runtime_metrics` 的 panic guard fail-open；没有 Project/Skill/package/root/resource/query/error body/content/绝对路径/principal 作为 label，也没有修改 ToolResult、Skill JSON、MCP tools/list、Session、Memory、数据库或 Runner wire schema。
 
-Runner-local blind spot 也用纯 structured tracing 补齐，不新增跨进程 telemetry protocol。configured `discover` 现在记录 `roots_examined`、`directory_entries_scanned`、`definitions_attempted`、`definitions_read`、`definition_bytes_read`、valid/invalid count、truncated、elapsed，并用封闭 `trigger = catalog_list / exact_read_resolution` 区分 catalog observation 与 exact Read 内部重新执行的完整 `discover(config)`；因此两次扫描即使连续发生也不会在 Runner 日志里混成同一种事件。managed exact read 记录 `skill_keys_listed`、为了 opaque-id 匹配实际比较的 `skill_keys_examined`、hit 与 elapsed；其中 `list_skill_keys()` 仍先枚举完整 installed-key 集合，而后续 id 比较在命中时可以提前结束。Server 仍只看到一次 typed Read 的 duration/bytes/outcome，Runner-local scan counters 不会回传或写入业务结果，因此跨进程集中关联这些内部计数仍是明确 blind spot。
+Runner-local tracing 同样继续使用原有事件。configured source 仍记录 `roots_examined`、`directory_entries_scanned`、`definitions_attempted`、`definitions_read`、`definition_bytes_read`、valid/invalid count、truncated、elapsed，并用封闭 `trigger = catalog_list / exact_read_resolution` 区分 use case；区别是 exact Read 已不再内部执行完整 `discover(config)`，而是枚举 bounded package identities、计算既有 opaque id，只对 target-id match 调用 definition loader。managed exact read 仍记录 `skill_keys_listed`、`skill_keys_examined`、hit 与 elapsed；`list_skill_keys()` 的 O(number of keys) 解析仍存在，本阶段没有 reverse index。Runner-local scan counters 仍不回传业务结果，因此跨进程集中关联内部扫描量依旧是 observability blind spot，而不是新 authority。
 
-下一轮 observer/resolver split 必须保持以下前提：
+#### B.2 Stage 2：catalog observer 与 known-id exact resolver 已分离
 
-- **Project**：opaque `skill_id` 不能反推出 package name。可以评估“有界枚举 package names -> 本地计算 candidate opaque ids -> 只读取命中的 package definition/resource”，但删除、重命名、definition revision race、resource 后置 recheck 与 sensitive-path boundary 都必须继续 fail closed。
-- **Configured**：当前 exact `Read` 内部仍完整 `discover(config)`。真正的优化应提供与 configured-root lifecycle 一致的 exact identity resolution/index，而不是让 Server 按错误码盲试来源。
-- **Managed**：协议是 exact `skill_id` Read，但实现仍通过 `list_skill_keys()` 解析 opaque id。可以评估 stable reverse mapping/index，但必须与 Skill store lock、active state、revision install/remove lifecycle 一致；删除后旧 id 绝不能因缓存或索引残留复活。
-- **Cross-source**：不能从 opaque id 前缀猜 source；完整 catalog 当前承担 duplicate `skill_id` fail-closed、name conflict、catalog revision 和 optional-provider failure 语义。optional source unavailable 时是否允许其它 source exact resolution 继续属于外部语义变更，本阶段不改。减少扫描与 partial catalog 必须保持为两个独立改动。
+Stage 2 的 use-case 边界现在是：`skill_list`、startup Skill catalog 与需要完整 descriptor/conflict/revision/diagnostics 的 context catalog 继续调用完整 `discover_skills`；`skill_read_file` 改为内部 typed exact resolver，不再构造完整 `SkillCatalog`。resolver 对 Project、configured、managed 三类 source 分别得到 `Absent / Candidate / NotApplicable / SourceUnavailable` 等封闭状态；opaque id 不携带 source routing 语义，不能按 `wc_skill_...` 前缀猜来源。
+
+Exact resolution 必须证明**requested target id 在所有 applicable sources 中唯一**。Project source 始终适用；Runner 不支持 configured/managed read capability 时该 source 为 `NotApplicable` 并跳过。若 capability 表明 source 适用，但 transport、provider/store 或 response validation 无法可靠回答 membership，则整个 exact resolution fail closed 为既有 `skill_catalog_unavailable`。0 个 valid candidate 是 `skill_not_found`；2 个及以上 valid candidates 同样以 `skill_catalog_unavailable` fail closed。这样只放弃了与当前 target 无关的全局 catalog 完整性检查，没有把 source failure 变成 partial success；`skill_list` 的全局 duplicate-id、name conflict、catalog revision、diagnostics/truncation 语义完全不变。
+
+Project exact resolution 先复用 bounded package-name enumeration，再以 `skill_id(project.resolved_id, package_name)` 本地比较 opaque id，只读取匹配 package 的 `SKILL.md`。7 个 Project Skills 的 characterization 中，`skill_list` 仍是 `1 package list + 7 definition reads = 8 requests`；同一目录的 exact `SKILL.md` read 从旧 `1 + N + 1 = 9` 降为固定的 `package list + target definition probe + actual definition = 3`，普通 resource read 从旧 `1 + N + 1 + 1 = 10` 降为 `package list + target definition probe + resource + definition recheck = 4`。因此 unrelated definition I/O 从 6 次降为 0；post-resource definition recheck、sensitive-path boundary、byte/range bounds 和 revision race 检测均保留。若 Runner-configured/managed capability 不支持，不会额外发 probe 请求。
+
+Configured / managed 的 Server membership probe 直接复用现有 wire-compatible `Read(skill_id, SKILL.md, ...)`，probe 不携带用户 revision expectation。configured-only exact resource read 现在是 `Project package list -> Configured Read probe -> Configured Read actual`，不再需要 `Configured List`；managed-only 对应 `Project package list -> Managed Read probe -> Managed Read actual`，不再需要 `ListActive`。mixed source 下读取 configured 或 managed target 时仍会 probe 另一个 applicable source 来证明唯一性，但不再完整观察其 catalog：当前 sequence 为 `Project package list -> Configured Read probe -> Managed Read probe -> target Read actual`，且 unrelated Project definition 不被读取。
+
+新的 configured Runner identity-first helper 在 24 个 package 的 focused test 中仍扫描 24 个 directory identities，但 valid target resolve 的 `definitions_attempted=1 / definitions_read=1`；两个 unrelated malformed/oversized definitions完全未读取。若 target 自身 malformed，则只 attempt/read target definition 后不产生 valid candidate；target oversized 则只 attempt target，bounded read 在计入 `definitions_read` 前失败。configured resolver继续扫描其它 roots/package identities以检测 target-id ambiguity；没有为性能引入新 request variant、capability bit 或 Server/Runner lockstep requirement。旧兼容 Runner 仍可处理相同 `ConfiguredSkillRootsRequest::Read`，只是其内部实现可能继续较慢。
+
+Revision semantics 保持 source-specific：Project probe revision是该次 snapshot identity，普通 resource 后继续 definition recheck；Configured probe revision会作为实际 resource Read 的 `expected_definition_revision`，因此 probe→read 间变化返回 `skill_definition_changed`；Managed probe只证明 source membership，**不会**把 probe 观察到的 package/definition revision升级为隐式 CAS，最终 managed Read仍只传用户显式 expected revisions。Project/Configured 的 `expected_package_revision` 仍在 target uniqueness 建立后返回 `skill_package_revision_not_supported`。本阶段没有 cache、persistent reverse index、数据库表、background refresh、source priority/shadowing或 partial-success semantics。
 
 ### C. 区分仓库知识身份与执行 worktree 身份（P1 产品设计）
 
@@ -212,13 +219,13 @@ Plugin 已有 `NotStarted / OutcomeUnknown / Completed`，见 [plugin.rs](../../
 |---|---|---|---|
 | 0，本轮 | 启动目录投影的小型复用、基线表征测试、本文 | JSON 形状、顺序、hint、预算、来源发现和权限均不改 | 新旧 JSON oracle 对照，空/不可用/上游截断、Unicode/转义、超大条目；既有 startup 测试 |
 | 1，后续已完成 | 扩展家族 admission 声明归 ToolDefinition；Runner Skill provider enqueue typed error 小切片 | 外部错误、scope、surface、direct/gateway 语义不改 | family/registry invariant、ModelHidden invariant、surface/principal focused tests、typed-to-legacy error-kind 对照 |
-| 2 | Skill observer/resolver 分离；增加来源级诊断与测量 | opaque identity 和请求时授权不改 | 读取触发扫描次数、cold/warm latency、删除/重配/断线/换实例测试 |
+| 2，后续已完成 | Skill catalog observer / known-id exact resolver 分离；来源级诊断与测量 | opaque identity、请求时授权、catalog 完整语义、revision/race 语义不改 | before/after request fanout、duplicate target、source unavailable、revision race、configured identity-first scan tests |
 | 3 | 实测需要的缓存、有界并发、DB worker 隔离 | 未知结果/事务/重放语义不改 | 与基线比较 p50/p95、锁等待、内存/字节上限、故障注入 |
 | 4，独立功能设计 | 用户私有命名空间、显式仓库知识复用、统一资源浏览界面 | 不隐式继承权限，不改变执行 cwd | principal 隔离、分享撤销、worktree 来源、冲突展示与迁移方案 |
 
 区分纯重构和新增功能很重要：共同描述结构可以先不改变任何用户功能；跨 worktree 共享或 user namespace 一定要另行定义产品行为。阶段 4 不应成为阶段 1/2 的前提。
 
-后续复查也进一步收紧了阶段 2 的前置条件：managed Skill 的 wire request 已是 opaque `skill_id` 精确 Read，但 Runner 内部仍扫描 `list_skill_keys()` 来解析该 id；configured Skill 的 Runner read 当前仍会在来源内部执行完整 `discover(config)`；Project Skill 的 opaque id 又不能反推出 package name，只能从有界包名集合计算匹配；完整 catalog 还承担跨来源 duplicate-id fail-closed 检查。因此不要简单把 `skill_read_file` 的 `discover_skills` 删除后按来源盲试。当前已完成来源级 fanout characterization、Server metrics 与不改 wire 的 Runner-local scan tracing；下一步应在这些事实基础上先定义 exact resolution 的失败、重复身份和 lifecycle 一致性语义，再做 observer/resolver 分离。
+阶段 2 已按这些前置条件落地：`skill_read_file` 不再调用完整 `discover_skills`，而是对 bounded Project identities和现有 configured/managed exact Read primitives 做 target-only resolution；所有 applicable source 都参与 target uniqueness 证明，unsupported capability跳过，source uncertainty与 target ambiguity fail closed。configured Runner Read 已改为 identity-first，因此不再为 unrelated packages读取定义；managed Runner 仍通过 `list_skill_keys()` 扫描 opaque id，尚未声称 O(1)。完整 catalog observer继续独立承担全局 duplicate-id、name conflict、catalog revision、diagnostics/truncation。后续若实测需要优化 managed key scan，应另行设计与 store lifecycle一致的 reverse mapping，而不是在本阶段偷加 cache/index。
 
 建议持续关注的指标不是抽象数量，而是：新增一个工具需要改多少个独立分类点；精确 Skill 读取触发多少次 Runner 请求；为了做一个简单选择要给模型多少 schema 字节；失败是否直接给出可执行的下一步；核心改动需要编译和运行哪些无关测试。
 

--- a/src/tool_runtime/runtime_metrics.rs
+++ b/src/tool_runtime/runtime_metrics.rs
@@ -42,6 +42,7 @@ impl SkillSourceMetricSource {
 pub(crate) enum SkillSourceMetricOperation {
     CatalogList,
     CatalogDefinitionRead,
+    ExactResolve,
     ResourceRead,
     DefinitionRecheck,
 }
@@ -51,6 +52,7 @@ impl SkillSourceMetricOperation {
         match self {
             Self::CatalogList => "catalog_list",
             Self::CatalogDefinitionRead => "catalog_definition_read",
+            Self::ExactResolve => "exact_resolve",
             Self::ResourceRead => "resource_read",
             Self::DefinitionRecheck => "definition_recheck",
         }
@@ -322,6 +324,7 @@ mod tests {
         let operations = [
             SkillSourceMetricOperation::CatalogList.as_str(),
             SkillSourceMetricOperation::CatalogDefinitionRead.as_str(),
+            SkillSourceMetricOperation::ExactResolve.as_str(),
             SkillSourceMetricOperation::ResourceRead.as_str(),
             SkillSourceMetricOperation::DefinitionRecheck.as_str(),
         ];
@@ -330,6 +333,7 @@ mod tests {
             [
                 "catalog_list",
                 "catalog_definition_read",
+                "exact_resolve",
                 "resource_read",
                 "definition_recheck",
             ]
@@ -369,7 +373,7 @@ mod tests {
             &sink,
             SkillSourceMetricObservation {
                 source: SkillSourceMetricSource::Project,
-                operation: SkillSourceMetricOperation::ResourceRead,
+                operation: SkillSourceMetricOperation::ExactResolve,
                 outcome_class: SkillSourceMetricOutcomeClass::RunnerError,
                 elapsed_ms: 10,
                 runner_duration_ms: Some(8),

--- a/src/tool_runtime/skills.rs
+++ b/src/tool_runtime/skills.rs
@@ -167,6 +167,22 @@ enum ExactSkillProbeOutcome {
     SourceUnavailable,
 }
 
+fn merge_exact_skill_probe(
+    candidate: &mut Option<ExactSkillCandidate>,
+    outcome: ExactSkillProbeOutcome,
+) -> Result<(), &'static str> {
+    match outcome {
+        ExactSkillProbeOutcome::NotApplicable | ExactSkillProbeOutcome::Absent => Ok(()),
+        ExactSkillProbeOutcome::Candidate(next) if candidate.is_none() => {
+            *candidate = Some(next);
+            Ok(())
+        }
+        ExactSkillProbeOutcome::Candidate(_)
+        | ExactSkillProbeOutcome::Ambiguous
+        | ExactSkillProbeOutcome::SourceUnavailable => Err("skills_catalog_unavailable"),
+    }
+}
+
 fn observe_skill_source_request(
     metrics: &dyn RuntimeMetrics,
     source: SkillSourceMetricSource,
@@ -808,33 +824,22 @@ impl ToolRuntime {
         auth: Option<&AuthContext>,
         skill_id: &str,
     ) -> Result<Option<ExactSkillCandidate>, &'static str> {
-        let outcomes = [
+        let mut candidate = None;
+        merge_exact_skill_probe(
+            &mut candidate,
             self.probe_project_skill_exact(project, skill_id).await,
+        )?;
+        merge_exact_skill_probe(
+            &mut candidate,
             self.probe_configured_skill_exact(project, auth, skill_id)
                 .await,
+        )?;
+        merge_exact_skill_probe(
+            &mut candidate,
             self.probe_managed_skill_exact(project, auth, skill_id)
                 .await,
-        ];
-        let mut candidate = None;
-        let mut uncertain = false;
-        for outcome in outcomes {
-            match outcome {
-                ExactSkillProbeOutcome::NotApplicable | ExactSkillProbeOutcome::Absent => {}
-                ExactSkillProbeOutcome::Candidate(next) => {
-                    if candidate.replace(next).is_some() {
-                        uncertain = true;
-                    }
-                }
-                ExactSkillProbeOutcome::Ambiguous | ExactSkillProbeOutcome::SourceUnavailable => {
-                    uncertain = true;
-                }
-            }
-        }
-        if uncertain {
-            Err("skills_catalog_unavailable")
-        } else {
-            Ok(candidate)
-        }
+        )?;
+        Ok(candidate)
     }
 
     async fn read_runner_skill(

--- a/src/tool_runtime/skills.rs
+++ b/src/tool_runtime/skills.rs
@@ -64,16 +64,8 @@ pub(crate) struct SkillDescriptor {
 }
 
 #[derive(Debug, Clone)]
-enum CatalogSkillLocator {
-    Project { package_name: String },
-    RunnerConfigured,
-    RunnerManaged,
-}
-
-#[derive(Debug, Clone)]
 struct CatalogSkill {
     descriptor: SkillDescriptor,
-    locator: CatalogSkillLocator,
     order_key: String,
 }
 
@@ -148,6 +140,33 @@ struct AgentSkillFileRead {
     next_start_line: Option<usize>,
 }
 
+#[derive(Debug, Clone)]
+enum ExactSkillCandidate {
+    Project {
+        package_name: String,
+        name: String,
+        definition_revision: String,
+    },
+    RunnerConfigured {
+        name: String,
+        definition_revision: String,
+    },
+    RunnerManaged {
+        name: String,
+        package_revision: String,
+        definition_revision: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum ExactSkillProbeOutcome {
+    NotApplicable,
+    Absent,
+    Candidate(ExactSkillCandidate),
+    Ambiguous,
+    SourceUnavailable,
+}
+
 fn observe_skill_source_request(
     metrics: &dyn RuntimeMetrics,
     source: SkillSourceMetricSource,
@@ -186,6 +205,29 @@ impl ToolRuntime {
         operation: SkillStoreRequest,
         optional_if_unsupported: bool,
     ) -> Result<Option<ShellRunResponse>, String> {
+        let metric_operation = match &operation {
+            SkillStoreRequest::ListActive => Some(SkillSourceMetricOperation::CatalogList),
+            SkillStoreRequest::Read { .. } => Some(SkillSourceMetricOperation::ResourceRead),
+            _ => None,
+        };
+        self.runner_skill_store_request_with_metric(
+            project,
+            auth,
+            operation,
+            optional_if_unsupported,
+            metric_operation,
+        )
+        .await
+    }
+
+    async fn runner_skill_store_request_with_metric(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+        operation: SkillStoreRequest,
+        optional_if_unsupported: bool,
+        metric_operation: Option<SkillSourceMetricOperation>,
+    ) -> Result<Option<ShellRunResponse>, String> {
         let client_id = project.config.client_id.clone();
         let access = crate::runner_http::runner_access_from_auth(auth);
         let view = self
@@ -194,11 +236,6 @@ impl ToolRuntime {
             .await
             .map_err(|_| "skill_store_runner_unavailable".to_string())?;
         let management = operation.requires_management_capability();
-        let metric_operation = match &operation {
-            SkillStoreRequest::ListActive => Some(SkillSourceMetricOperation::CatalogList),
-            SkillStoreRequest::Read { .. } => Some(SkillSourceMetricOperation::ResourceRead),
-            _ => None,
-        };
         let required = if management {
             RunnerFeature::SkillStoreManage
         } else {
@@ -280,12 +317,30 @@ impl ToolRuntime {
         operation: ConfiguredSkillRootsRequest,
         optional_if_unsupported: bool,
     ) -> Result<Option<ShellRunResponse>, String> {
-        let client_id = project.config.client_id.clone();
-        let access = crate::runner_http::runner_access_from_auth(auth);
         let metric_operation = match &operation {
             ConfiguredSkillRootsRequest::List => SkillSourceMetricOperation::CatalogList,
             ConfiguredSkillRootsRequest::Read { .. } => SkillSourceMetricOperation::ResourceRead,
         };
+        self.runner_configured_skill_roots_request_with_metric(
+            project,
+            auth,
+            operation,
+            optional_if_unsupported,
+            metric_operation,
+        )
+        .await
+    }
+
+    async fn runner_configured_skill_roots_request_with_metric(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+        operation: ConfiguredSkillRootsRequest,
+        optional_if_unsupported: bool,
+        metric_operation: SkillSourceMetricOperation,
+    ) -> Result<Option<ShellRunResponse>, String> {
+        let client_id = project.config.client_id.clone();
+        let access = crate::runner_http::runner_access_from_auth(auth);
         let view = self
             .runner_registry
             .get_runner_semantic_view_checked_for_auth(&client_id, access.as_ref())
@@ -496,6 +551,290 @@ impl ToolRuntime {
             Some(parsed.skills.len()),
         );
         Ok(parsed.skills)
+    }
+
+    async fn probe_project_skill_exact(
+        &self,
+        project: &ResolvedProject,
+        target_skill_id: &str,
+    ) -> ExactSkillProbeOutcome {
+        let packages = match self
+            .list_agent_skill_packages(project, SkillSourceMetricOperation::ExactResolve)
+            .await
+        {
+            Ok(packages) => packages,
+            Err(_) => return ExactSkillProbeOutcome::SourceUnavailable,
+        };
+        let mut candidate = None;
+        for package in packages.entries {
+            if !valid_package_name(&package.name) || package.kind != "dir" {
+                continue;
+            }
+            if skill_id(&project.resolved_id, &package.name) != target_skill_id {
+                continue;
+            }
+            let package_root = format!("{}/{}", SKILL_ROOT, package.name);
+            let definition_path = format!("{package_root}/{SKILL_DEFINITION_FILE}");
+            let read = match self
+                .read_agent_skill_file(
+                    project,
+                    SkillSourceMetricOperation::ExactResolve,
+                    &package_root,
+                    &definition_path,
+                    1,
+                    MAX_SKILL_DISCOVERY_READ_LINES,
+                    MAX_SKILL_DEFINITION_BYTES,
+                    MAX_SKILL_DEFINITION_BYTES,
+                )
+                .await
+            {
+                Ok(read) => read,
+                Err(SkillIoError::Unavailable) => return ExactSkillProbeOutcome::SourceUnavailable,
+                Err(_) => continue,
+            };
+            let metadata = match parse_skill_metadata(&read.content) {
+                Ok(metadata) => metadata,
+                Err(_) => continue,
+            };
+            let next = ExactSkillCandidate::Project {
+                package_name: package.name,
+                name: metadata.name,
+                definition_revision: read.sha256,
+            };
+            if candidate.replace(next).is_some() {
+                return ExactSkillProbeOutcome::Ambiguous;
+            }
+        }
+        candidate
+            .map(ExactSkillProbeOutcome::Candidate)
+            .unwrap_or(ExactSkillProbeOutcome::Absent)
+    }
+
+    async fn probe_configured_skill_exact(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+        skill_id: &str,
+    ) -> ExactSkillProbeOutcome {
+        let observation_started = Instant::now();
+        let response = match self
+            .runner_configured_skill_roots_request_with_metric(
+                project,
+                auth,
+                ConfiguredSkillRootsRequest::Read {
+                    skill_id: skill_id.to_string(),
+                    path: SKILL_DEFINITION_FILE.to_string(),
+                    start_line: 1,
+                    limit: 1,
+                    expected_definition_revision: None,
+                },
+                true,
+                SkillSourceMetricOperation::ExactResolve,
+            )
+            .await
+        {
+            Ok(Some(response)) => response,
+            Ok(None) => return ExactSkillProbeOutcome::NotApplicable,
+            Err(_) => return ExactSkillProbeOutcome::SourceUnavailable,
+        };
+        if response.exit_code != Some(0) || response.error.is_some() {
+            observe_skill_source_request(
+                self.metrics.as_ref(),
+                SkillSourceMetricSource::RunnerConfigured,
+                SkillSourceMetricOperation::ExactResolve,
+                observation_started,
+                Some(&response),
+                SkillSourceMetricOutcomeClass::RunnerError,
+                None,
+            );
+            return if response.error.as_deref() == Some("skill_not_found") {
+                ExactSkillProbeOutcome::Absent
+            } else {
+                ExactSkillProbeOutcome::SourceUnavailable
+            };
+        }
+        let read: ConfiguredSkillRootsReadResponse =
+            match serde_json::from_str(response.stdout.as_deref().unwrap_or_default()) {
+                Ok(read) => read,
+                Err(_) => {
+                    observe_skill_source_request(
+                        self.metrics.as_ref(),
+                        SkillSourceMetricSource::RunnerConfigured,
+                        SkillSourceMetricOperation::ExactResolve,
+                        observation_started,
+                        Some(&response),
+                        SkillSourceMetricOutcomeClass::InvalidResponse,
+                        None,
+                    );
+                    return ExactSkillProbeOutcome::SourceUnavailable;
+                }
+            };
+        if read
+            .validate_for_request(skill_id, SKILL_DEFINITION_FILE, 1, 1)
+            .is_err()
+            || read.sha256 != read.definition_revision
+        {
+            observe_skill_source_request(
+                self.metrics.as_ref(),
+                SkillSourceMetricSource::RunnerConfigured,
+                SkillSourceMetricOperation::ExactResolve,
+                observation_started,
+                Some(&response),
+                SkillSourceMetricOutcomeClass::InvalidResponse,
+                None,
+            );
+            return ExactSkillProbeOutcome::SourceUnavailable;
+        }
+        observe_skill_source_request(
+            self.metrics.as_ref(),
+            SkillSourceMetricSource::RunnerConfigured,
+            SkillSourceMetricOperation::ExactResolve,
+            observation_started,
+            Some(&response),
+            SkillSourceMetricOutcomeClass::Success,
+            None,
+        );
+        ExactSkillProbeOutcome::Candidate(ExactSkillCandidate::RunnerConfigured {
+            name: read.name,
+            definition_revision: read.definition_revision,
+        })
+    }
+
+    async fn probe_managed_skill_exact(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+        skill_id: &str,
+    ) -> ExactSkillProbeOutcome {
+        let observation_started = Instant::now();
+        let response = match self
+            .runner_skill_store_request_with_metric(
+                project,
+                auth,
+                SkillStoreRequest::Read {
+                    skill_id: skill_id.to_string(),
+                    path: SKILL_DEFINITION_FILE.to_string(),
+                    start_line: 1,
+                    limit: 1,
+                    expected_package_revision: None,
+                    expected_definition_revision: None,
+                },
+                true,
+                Some(SkillSourceMetricOperation::ExactResolve),
+            )
+            .await
+        {
+            Ok(Some(response)) => response,
+            Ok(None) => return ExactSkillProbeOutcome::NotApplicable,
+            Err(_) => return ExactSkillProbeOutcome::SourceUnavailable,
+        };
+        if response.exit_code != Some(0) || response.error.is_some() {
+            observe_skill_source_request(
+                self.metrics.as_ref(),
+                SkillSourceMetricSource::RunnerManaged,
+                SkillSourceMetricOperation::ExactResolve,
+                observation_started,
+                Some(&response),
+                SkillSourceMetricOutcomeClass::RunnerError,
+                None,
+            );
+            return if response.error.as_deref() == Some("skill_not_found") {
+                ExactSkillProbeOutcome::Absent
+            } else {
+                ExactSkillProbeOutcome::SourceUnavailable
+            };
+        }
+        let read: SkillStoreReadResponse =
+            match serde_json::from_str(response.stdout.as_deref().unwrap_or_default()) {
+                Ok(read) => read,
+                Err(_) => {
+                    observe_skill_source_request(
+                        self.metrics.as_ref(),
+                        SkillSourceMetricSource::RunnerManaged,
+                        SkillSourceMetricOperation::ExactResolve,
+                        observation_started,
+                        Some(&response),
+                        SkillSourceMetricOutcomeClass::InvalidResponse,
+                        None,
+                    );
+                    return ExactSkillProbeOutcome::SourceUnavailable;
+                }
+            };
+        if read.format != SKILL_STORE_RESPONSE_FORMAT
+            || read.skill_id != skill_id
+            || read.path != SKILL_DEFINITION_FILE
+            || !valid_skill_key(&read.skill_key)
+            || !valid_package_revision(&read.package_revision)
+            || !is_lower_sha256(&read.definition_revision)
+            || !is_lower_sha256(&read.sha256)
+            || read.sha256 != read.definition_revision
+            || read.name.chars().count() > MAX_SKILL_NAME_CHARS
+            || read.description.chars().count() > MAX_SKILL_DESCRIPTION_CHARS
+            || read.start_line != 1
+            || read.returned_lines > 1
+            || read.text.len() > MAX_SKILL_READ_TEXT_BYTES
+            || read.has_more != read.next_start_line.is_some()
+        {
+            observe_skill_source_request(
+                self.metrics.as_ref(),
+                SkillSourceMetricSource::RunnerManaged,
+                SkillSourceMetricOperation::ExactResolve,
+                observation_started,
+                Some(&response),
+                SkillSourceMetricOutcomeClass::InvalidResponse,
+                None,
+            );
+            return ExactSkillProbeOutcome::SourceUnavailable;
+        }
+        observe_skill_source_request(
+            self.metrics.as_ref(),
+            SkillSourceMetricSource::RunnerManaged,
+            SkillSourceMetricOperation::ExactResolve,
+            observation_started,
+            Some(&response),
+            SkillSourceMetricOutcomeClass::Success,
+            None,
+        );
+        ExactSkillProbeOutcome::Candidate(ExactSkillCandidate::RunnerManaged {
+            name: read.name,
+            package_revision: read.package_revision,
+            definition_revision: read.definition_revision,
+        })
+    }
+
+    async fn resolve_exact_skill(
+        &self,
+        project: &ResolvedProject,
+        auth: Option<&AuthContext>,
+        skill_id: &str,
+    ) -> Result<Option<ExactSkillCandidate>, &'static str> {
+        let outcomes = [
+            self.probe_project_skill_exact(project, skill_id).await,
+            self.probe_configured_skill_exact(project, auth, skill_id)
+                .await,
+            self.probe_managed_skill_exact(project, auth, skill_id)
+                .await,
+        ];
+        let mut candidate = None;
+        let mut uncertain = false;
+        for outcome in outcomes {
+            match outcome {
+                ExactSkillProbeOutcome::NotApplicable | ExactSkillProbeOutcome::Absent => {}
+                ExactSkillProbeOutcome::Candidate(next) => {
+                    if candidate.replace(next).is_some() {
+                        uncertain = true;
+                    }
+                }
+                ExactSkillProbeOutcome::Ambiguous | ExactSkillProbeOutcome::SourceUnavailable => {
+                    uncertain = true;
+                }
+            }
+        }
+        if uncertain {
+            Err("skills_catalog_unavailable")
+        } else {
+            Ok(candidate)
+        }
     }
 
     async fn read_runner_skill(
@@ -829,7 +1168,6 @@ impl ToolRuntime {
                         trust: "operator_configured_guidance",
                         name_conflict: false,
                     },
-                    locator: CatalogSkillLocator::RunnerConfigured,
                     order_key,
                 });
             }
@@ -851,7 +1189,6 @@ impl ToolRuntime {
                     trust: "operator_installed_guidance",
                     name_conflict: false,
                 },
-                locator: CatalogSkillLocator::RunnerManaged,
                 order_key: skill.skill_key,
             });
         }
@@ -1012,23 +1349,25 @@ impl ToolRuntime {
                 Some(json!({"skill_id": skill_id})),
             );
         }
-        let catalog = match self.discover_skills(project, auth).await {
-            Ok(catalog) => catalog,
+        let candidate = match self.resolve_exact_skill(project, auth, &skill_id).await {
+            Ok(Some(candidate)) => candidate,
+            Ok(None) => {
+                return skill_error(
+                    "skill_not_found",
+                    &project.resolved_id,
+                    Some(json!({"skill_id": skill_id})),
+                )
+            }
             Err(_) => return skill_error("skill_catalog_unavailable", &project.resolved_id, None),
         };
-        let Some(skill) = catalog
-            .skills
-            .iter()
-            .find(|skill| skill.descriptor.skill_id == skill_id)
-        else {
-            return skill_error(
-                "skill_not_found",
-                &project.resolved_id,
-                Some(json!({"skill_id": skill_id})),
-            );
-        };
-        match &skill.locator {
-            CatalogSkillLocator::RunnerManaged => {
+        let (package_name, name, definition_revision) = match candidate {
+            ExactSkillCandidate::RunnerManaged {
+                name: _resolved_name,
+                package_revision: _resolved_package_revision,
+                definition_revision: _resolved_definition_revision,
+            } => {
+                // The probe snapshot proves source membership only. Managed package and
+                // definition revisions remain pinned exclusively by user-supplied expectations.
                 return self
                     .read_runner_skill(
                         project,
@@ -1042,7 +1381,10 @@ impl ToolRuntime {
                     )
                     .await;
             }
-            CatalogSkillLocator::RunnerConfigured => {
+            ExactSkillCandidate::RunnerConfigured {
+                name: _resolved_name,
+                definition_revision,
+            } => {
                 if expected_package_revision.is_some() {
                     return skill_error(
                         "skill_package_revision_not_supported",
@@ -1052,14 +1394,14 @@ impl ToolRuntime {
                 }
                 if expected_definition_revision
                     .as_deref()
-                    .is_some_and(|expected| expected != skill.descriptor.definition_revision)
+                    .is_some_and(|expected| expected != definition_revision)
                 {
                     return skill_error(
                         "skill_definition_changed",
                         &project.resolved_id,
                         Some(json!({
                             "skill_id": skill_id,
-                            "definition_revision": skill.descriptor.definition_revision,
+                            "definition_revision": definition_revision,
                         })),
                     );
                 }
@@ -1071,12 +1413,16 @@ impl ToolRuntime {
                         &resource_path,
                         start_line,
                         limit,
-                        &skill.descriptor.definition_revision,
+                        &definition_revision,
                     )
                     .await;
             }
-            CatalogSkillLocator::Project { .. } => {}
-        }
+            ExactSkillCandidate::Project {
+                package_name,
+                name,
+                definition_revision,
+            } => (package_name, name, definition_revision),
+        };
         if expected_package_revision.is_some() {
             return skill_error(
                 "skill_package_revision_not_supported",
@@ -1086,23 +1432,17 @@ impl ToolRuntime {
         }
         if expected_definition_revision
             .as_deref()
-            .is_some_and(|expected| expected != skill.descriptor.definition_revision)
+            .is_some_and(|expected| expected != definition_revision)
         {
             return skill_error(
                 "skill_definition_changed",
                 &project.resolved_id,
                 Some(json!({
                     "skill_id": skill_id,
-                    "definition_revision": skill.descriptor.definition_revision,
+                    "definition_revision": definition_revision,
                 })),
             );
         }
-        let package_name = match &skill.locator {
-            CatalogSkillLocator::Project { package_name } => package_name,
-            CatalogSkillLocator::RunnerConfigured | CatalogSkillLocator::RunnerManaged => {
-                unreachable!("runner branches returned above")
-            }
-        };
         let package_root = format!("{}/{}", SKILL_ROOT, package_name);
         let full_path = format!("{package_root}/{resource_path}");
         if crate::sensitive_paths::is_secret_path(&full_path) {
@@ -1145,7 +1485,7 @@ impl ToolRuntime {
         // read itself cannot prove that the selected Skill definition is still
         // the one the caller/discovery observed.
         if resource_path == SKILL_DEFINITION_FILE {
-            if read.sha256 != skill.descriptor.definition_revision {
+            if read.sha256 != definition_revision {
                 return skill_error(
                     "skill_definition_changed",
                     &project.resolved_id,
@@ -1179,7 +1519,7 @@ impl ToolRuntime {
                     )
                 }
             };
-            if current_definition.sha256 != skill.descriptor.definition_revision {
+            if current_definition.sha256 != definition_revision {
                 return skill_error(
                     "skill_definition_changed",
                     &project.resolved_id,
@@ -1192,12 +1532,12 @@ impl ToolRuntime {
         }
         let output = json!({
             "project": project.resolved_id,
-            "skill_id": skill.descriptor.skill_id,
-            "name": skill.descriptor.name,
+            "skill_id": skill_id,
+            "name": name,
             "source_scope": "project",
             "trust": "project_content",
             "package_revision": null,
-            "definition_revision": skill.descriptor.definition_revision,
+            "definition_revision": definition_revision,
             "path": resource_path,
             "sha256": read.sha256,
             "text": read.content,
@@ -1606,7 +1946,9 @@ impl ToolRuntime {
         &self,
         project: &ResolvedProject,
     ) -> Result<SkillCatalog, &'static str> {
-        let packages = self.list_agent_skill_packages(project).await?;
+        let packages = self
+            .list_agent_skill_packages(project, SkillSourceMetricOperation::CatalogList)
+            .await?;
         let discovery_truncated = packages.truncated;
         let mut invalid_count = 0usize;
         let mut diagnostics = Vec::new();
@@ -1665,9 +2007,6 @@ impl ToolRuntime {
                     trust: "project_content",
                     name_conflict: false,
                 },
-                locator: CatalogSkillLocator::Project {
-                    package_name: package.name.clone(),
-                },
                 order_key: package.name,
             });
         }
@@ -1697,6 +2036,7 @@ impl ToolRuntime {
     async fn list_agent_skill_packages(
         &self,
         project: &ResolvedProject,
+        operation: SkillSourceMetricOperation,
     ) -> Result<AgentSkillPackageList, &'static str> {
         let client_id = project.config.client_id.clone();
         let payload = json!({"limit": MAX_SKILL_DISCOVERY_PACKAGES + 1}).to_string();
@@ -1732,7 +2072,7 @@ impl ToolRuntime {
                 observe_skill_source_request(
                     self.metrics.as_ref(),
                     SkillSourceMetricSource::Project,
-                    SkillSourceMetricOperation::CatalogList,
+                    operation,
                     request_started,
                     None,
                     SkillSourceMetricOutcomeClass::Unavailable,
@@ -1745,7 +2085,7 @@ impl ToolRuntime {
             observe_skill_source_request(
                 self.metrics.as_ref(),
                 SkillSourceMetricSource::Project,
-                SkillSourceMetricOperation::CatalogList,
+                operation,
                 request_started,
                 Some(&response),
                 SkillSourceMetricOutcomeClass::RunnerError,
@@ -1761,7 +2101,7 @@ impl ToolRuntime {
                     observe_skill_source_request(
                         self.metrics.as_ref(),
                         SkillSourceMetricSource::Project,
-                        SkillSourceMetricOperation::CatalogList,
+                        operation,
                         request_started,
                         Some(&response),
                         SkillSourceMetricOutcomeClass::InvalidResponse,
@@ -1776,7 +2116,7 @@ impl ToolRuntime {
             observe_skill_source_request(
                 self.metrics.as_ref(),
                 SkillSourceMetricSource::Project,
-                SkillSourceMetricOperation::CatalogList,
+                operation,
                 request_started,
                 Some(&response),
                 SkillSourceMetricOutcomeClass::InvalidResponse,
@@ -1788,7 +2128,7 @@ impl ToolRuntime {
         observe_skill_source_request(
             self.metrics.as_ref(),
             SkillSourceMetricSource::Project,
-            SkillSourceMetricOperation::CatalogList,
+            operation,
             request_started,
             Some(&response),
             SkillSourceMetricOutcomeClass::Success,
@@ -2342,9 +2682,6 @@ mod tests {
                     source_scope: "project",
                     trust: "project_content",
                     name_conflict: false,
-                },
-                locator: CatalogSkillLocator::Project {
-                    package_name: format!("package-{index:02}"),
                 },
                 order_key: format!("package-{index:02}"),
             });

--- a/src/tool_runtime/tests/skills.rs
+++ b/src/tool_runtime/tests/skills.rs
@@ -161,6 +161,8 @@ struct FakeConfiguredSkillState {
     definition_revision: String,
     definition_text: String,
     resource_text: String,
+    read_error: Option<String>,
+    next_definition_revision_after_probe: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -215,7 +217,6 @@ async fn call_kernel_with_fake_operator_store(
             "operator Skill fixture timed out"
         );
         if let Some(request) = probe_patch_agent_request(runtime, client_id).await {
-            kinds.push(request.kind.clone());
             if request.kind == "configured_skill_roots" {
                 let operation: ConfiguredSkillRootsRequest = serde_json::from_str(
                     request
@@ -224,6 +225,13 @@ async fn call_kernel_with_fake_operator_store(
                         .expect("typed configured Skill roots request"),
                 )
                 .unwrap();
+                kinds.push(
+                    match &operation {
+                        ConfiguredSkillRootsRequest::List => "configured_skill_roots:list",
+                        ConfiguredSkillRootsRequest::Read { .. } => "configured_skill_roots:read",
+                    }
+                    .to_string(),
+                );
                 let state = operator
                     .lock()
                     .unwrap()
@@ -257,17 +265,24 @@ async fn call_kernel_with_fake_operator_store(
                         limit,
                         expected_definition_revision,
                     } => {
-                        let error = if skill_id != state.skill_id {
-                            Some("skill_not_found".to_string())
-                        } else if expected_definition_revision
-                            .as_deref()
-                            .is_some_and(|expected| expected != state.definition_revision)
-                        {
-                            Some("skill_definition_changed".to_string())
-                        } else {
-                            None
-                        };
-                        if let Some(error) = error {
+                        let is_identity_probe =
+                            path == "SKILL.md" && expected_definition_revision.is_none();
+                        let next_definition_revision = is_identity_probe
+                            .then(|| state.next_definition_revision_after_probe.clone())
+                            .flatten();
+                        let error = state.read_error.clone().or_else(|| {
+                            if skill_id != state.skill_id {
+                                Some("skill_not_found".to_string())
+                            } else if expected_definition_revision
+                                .as_deref()
+                                .is_some_and(|expected| expected != state.definition_revision)
+                            {
+                                Some("skill_definition_changed".to_string())
+                            } else {
+                                None
+                            }
+                        });
+                        let result = if let Some(error) = error {
                             (None, None, Some(error))
                         } else {
                             let text = if path == "SKILL.md" {
@@ -305,7 +320,17 @@ async fn call_kernel_with_fake_operator_store(
                                 ),
                                 None,
                             )
+                        };
+                        if result.2.is_none() {
+                            if let Some(next_revision) = next_definition_revision {
+                                if let Some(configured) =
+                                    operator.lock().unwrap().configured.as_mut()
+                                {
+                                    configured.definition_revision = next_revision;
+                                }
+                            }
                         }
+                        result
                     }
                 };
                 runtime
@@ -331,6 +356,14 @@ async fn call_kernel_with_fake_operator_store(
                 )
                 .unwrap();
                 let state = operator.lock().unwrap().clone();
+                kinds.push(
+                    match &operation {
+                        SkillStoreRequest::ListActive => "skill_store:list_active",
+                        SkillStoreRequest::Read { .. } => "skill_store:read",
+                        _ => "skill_store:other",
+                    }
+                    .to_string(),
+                );
                 let (exit_code, stdout, error) = match operation {
                     SkillStoreRequest::ListActive => (
                         Some(0),
@@ -377,7 +410,21 @@ async fn call_kernel_with_fake_operator_store(
                         if let Some(error) = error {
                             (None, None, Some(error))
                         } else {
-                            let text = state.resource_text;
+                            let definition_read = path == "SKILL.md";
+                            let text = if definition_read {
+                                format!(
+                                    "---\nname: {}\ndescription: {}\n---\nmanaged definition\n",
+                                    state.name, state.description
+                                )
+                            } else {
+                                state.resource_text
+                            };
+                            let sha256 = if definition_read {
+                                state.definition_revision.clone()
+                            } else {
+                                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                                    .to_string()
+                            };
                             (
                                 Some(0),
                                 Some(
@@ -390,8 +437,7 @@ async fn call_kernel_with_fake_operator_store(
                                         package_revision: state.package_revision,
                                         definition_revision: state.definition_revision,
                                         path,
-                                        sha256: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                                            .to_string(),
+                                        sha256,
                                         text,
                                         start_line,
                                         end_line: Some(start_line),
@@ -422,6 +468,7 @@ async fn call_kernel_with_fake_operator_store(
                     .await
                     .unwrap();
             } else {
+                kinds.push(request.kind.clone());
                 let (exit_code, stdout, stderr) = run_runner_shell_request_locally(&request);
                 complete_patch_agent_request(
                     runtime,
@@ -632,6 +679,8 @@ async fn project_configured_and_managed_skills_share_one_conflict_safe_catalog()
             definition_revision: configured_revision.to_string(),
             definition_text: "configured definition".to_string(),
             resource_text: "configured resource".to_string(),
+            read_error: None,
+            next_definition_revision_after_probe: None,
         }),
         resource_text: "managed resource".to_string(),
     }));
@@ -691,10 +740,9 @@ async fn project_configured_and_managed_skills_share_one_conflict_safe_catalog()
         configured_read_kinds,
         vec![
             "file_skill_list_packages",
-            "file_skill_read_file",
-            "configured_skill_roots",
-            "skill_store",
-            "configured_skill_roots",
+            "configured_skill_roots:read",
+            "skill_store:read",
+            "configured_skill_roots:read",
         ]
     );
 
@@ -719,16 +767,15 @@ async fn project_configured_and_managed_skills_share_one_conflict_safe_catalog()
         managed_read_kinds,
         vec![
             "file_skill_list_packages",
-            "file_skill_read_file",
-            "configured_skill_roots",
-            "skill_store",
-            "skill_store",
+            "configured_skill_roots:read",
+            "skill_store:read",
+            "skill_store:read",
         ]
     );
 }
 
 #[tokio::test]
-async fn configured_skill_exact_read_observes_project_and_configured_catalog_first() {
+async fn configured_skill_exact_read_uses_read_probe_without_catalog_list() {
     let root = tempfile::tempdir().unwrap();
     let runtime = ToolRuntime::new_for_tests();
     let client_id = "configured-skill-read-fanout";
@@ -765,6 +812,8 @@ async fn configured_skill_exact_read_observes_project_and_configured_catalog_fir
             definition_revision: configured_revision.to_string(),
             definition_text: "configured definition".to_string(),
             resource_text: "configured resource".to_string(),
+            read_error: None,
+            next_definition_revision_after_probe: None,
         }),
         resource_text: "unused managed resource".to_string(),
     }));
@@ -779,7 +828,7 @@ async fn configured_skill_exact_read_observes_project_and_configured_catalog_fir
             "path": "references/guide.md",
             "expected_definition_revision": configured_revision,
         }),
-        sources,
+        sources.clone(),
     )
     .await;
     assert!(read.success, "{:?}", read.error);
@@ -788,14 +837,36 @@ async fn configured_skill_exact_read_observes_project_and_configured_catalog_fir
         kinds,
         vec![
             "file_skill_list_packages",
-            "configured_skill_roots",
-            "configured_skill_roots",
+            "configured_skill_roots:read",
+            "configured_skill_roots:read",
         ]
+    );
+
+    let (unsupported_package, unsupported_kinds) = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_read_file",
+        json!({
+            "project": project,
+            "skill_id": configured_id,
+            "expected_package_revision": format!("wc_skillpkg_{}", "f".repeat(64)),
+        }),
+        sources,
+    )
+    .await;
+    assert!(!unsupported_package.success);
+    assert_eq!(
+        unsupported_package.output["error_kind"],
+        "skill_package_revision_not_supported"
+    );
+    assert_eq!(
+        unsupported_kinds,
+        vec!["file_skill_list_packages", "configured_skill_roots:read"]
     );
 }
 
 #[tokio::test]
-async fn managed_skill_exact_read_observes_project_and_managed_catalog_first() {
+async fn managed_skill_exact_read_uses_read_probe_without_list_active() {
     let root = tempfile::tempdir().unwrap();
     let runtime = ToolRuntime::new_for_tests();
     let client_id = "managed-skill-read-fanout";
@@ -847,7 +918,234 @@ async fn managed_skill_exact_read_observes_project_and_managed_catalog_first() {
     assert_eq!(read.output["text"], "managed resource");
     assert_eq!(
         kinds,
-        vec!["file_skill_list_packages", "skill_store", "skill_store"]
+        vec![
+            "file_skill_list_packages",
+            "skill_store:read",
+            "skill_store:read",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn exact_skill_resolution_fails_closed_on_duplicate_target_across_sources() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "skill-exact-duplicate";
+    register_agent_with_projects(
+        &runtime,
+        client_id,
+        None,
+        RunnerCapabilities {
+            file_read: true,
+            configured_skill_roots_read: true,
+            skill_store_read: true,
+            ..Default::default()
+        },
+        vec![registered_project(
+            "project",
+            root.path().to_string_lossy().as_ref(),
+        )],
+    )
+    .await;
+    let project = crate::tool_runtime::runner_project_runtime_id(client_id, "project");
+    let duplicate_id = format!("wc_skill_{}", "7".repeat(32));
+    let configured_revision = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    let managed_revision = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    let managed_package = format!("wc_skillpkg_{}", "a".repeat(64));
+    let sources = Arc::new(Mutex::new(FakeOperatorSkillState {
+        skill_id: duplicate_id.clone(),
+        skill_key: "managed-duplicate-id".to_string(),
+        name: "managed".to_string(),
+        description: "Managed guidance".to_string(),
+        package_revision: managed_package.clone(),
+        definition_revision: managed_revision.to_string(),
+        configured: Some(FakeConfiguredSkillState {
+            skill_id: duplicate_id.clone(),
+            name: "configured".to_string(),
+            description: "Configured guidance".to_string(),
+            definition_revision: configured_revision.to_string(),
+            definition_text: "configured definition".to_string(),
+            resource_text: "configured resource".to_string(),
+            read_error: None,
+            next_definition_revision_after_probe: None,
+        }),
+        resource_text: "managed resource".to_string(),
+    }));
+
+    let (read, kinds) = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_read_file",
+        json!({
+            "project": project,
+            "skill_id": duplicate_id,
+            "path": "references/guide.md",
+            "expected_package_revision": managed_package,
+        }),
+        sources,
+    )
+    .await;
+    assert!(!read.success);
+    assert_eq!(read.output["error_kind"], "skill_catalog_unavailable");
+    assert_eq!(
+        kinds,
+        vec![
+            "file_skill_list_packages",
+            "configured_skill_roots:read",
+            "skill_store:read",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn exact_skill_resolution_fails_closed_when_applicable_source_is_unavailable() {
+    let root = tempfile::tempdir().unwrap();
+    write_skill(
+        root.path(),
+        "alpha",
+        "project-target",
+        "Project target guidance",
+        "project body\n",
+    );
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "skill-exact-source-unavailable";
+    register_agent_with_projects(
+        &runtime,
+        client_id,
+        None,
+        RunnerCapabilities {
+            file_read: true,
+            configured_skill_roots_read: true,
+            ..Default::default()
+        },
+        vec![registered_project(
+            "project",
+            root.path().to_string_lossy().as_ref(),
+        )],
+    )
+    .await;
+    let project = crate::tool_runtime::runner_project_runtime_id(client_id, "project");
+    let configured_revision = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    let sources = Arc::new(Mutex::new(FakeOperatorSkillState {
+        skill_id: format!("wc_skill_{}", "8".repeat(32)),
+        skill_key: "unused-managed".to_string(),
+        name: "unused-managed".to_string(),
+        description: "Unused managed guidance".to_string(),
+        package_revision: format!("wc_skillpkg_{}", "b".repeat(64)),
+        definition_revision: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            .to_string(),
+        configured: Some(FakeConfiguredSkillState {
+            skill_id: format!("wc_skill_{}", "9".repeat(32)),
+            name: "configured-unavailable".to_string(),
+            description: "Configured unavailable".to_string(),
+            definition_revision: configured_revision.to_string(),
+            definition_text: "configured definition".to_string(),
+            resource_text: "configured resource".to_string(),
+            read_error: Some("configured_skill_roots_unavailable".to_string()),
+            next_definition_revision_after_probe: None,
+        }),
+        resource_text: "unused managed resource".to_string(),
+    }));
+    let (listed, _) = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_list",
+        json!({"project": project}),
+        sources.clone(),
+    )
+    .await;
+    assert!(listed.success, "{:?}", listed.error);
+    let project_skill_id = skill_by_name(&listed, "project-target")["skill_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let (read, kinds) = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_read_file",
+        json!({"project": project, "skill_id": project_skill_id}),
+        sources,
+    )
+    .await;
+    assert!(!read.success);
+    assert_eq!(read.output["error_kind"], "skill_catalog_unavailable");
+    assert_eq!(
+        kinds,
+        vec![
+            "file_skill_list_packages",
+            "file_skill_read_file",
+            "configured_skill_roots:read",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn configured_exact_read_pins_probe_revision_across_resource_read() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = ToolRuntime::new_for_tests();
+    let client_id = "configured-skill-exact-race";
+    register_agent_with_projects(
+        &runtime,
+        client_id,
+        None,
+        RunnerCapabilities {
+            file_read: true,
+            configured_skill_roots_read: true,
+            ..Default::default()
+        },
+        vec![registered_project(
+            "project",
+            root.path().to_string_lossy().as_ref(),
+        )],
+    )
+    .await;
+    let project = crate::tool_runtime::runner_project_runtime_id(client_id, "project");
+    let configured_id = format!("wc_skill_{}", "2".repeat(32));
+    let revision_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let revision_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let sources = Arc::new(Mutex::new(FakeOperatorSkillState {
+        skill_id: format!("wc_skill_{}", "3".repeat(32)),
+        skill_key: "unused-managed".to_string(),
+        name: "unused-managed".to_string(),
+        description: "Unused managed guidance".to_string(),
+        package_revision: format!("wc_skillpkg_{}", "c".repeat(64)),
+        definition_revision: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            .to_string(),
+        configured: Some(FakeConfiguredSkillState {
+            skill_id: configured_id.clone(),
+            name: "configured".to_string(),
+            description: "Configured guidance".to_string(),
+            definition_revision: revision_a.to_string(),
+            definition_text: "configured definition".to_string(),
+            resource_text: "configured resource".to_string(),
+            read_error: None,
+            next_definition_revision_after_probe: Some(revision_b.to_string()),
+        }),
+        resource_text: "unused managed resource".to_string(),
+    }));
+
+    let (read, kinds) = call_kernel_with_fake_operator_store(
+        &runtime,
+        client_id,
+        "skill_read_file",
+        json!({
+            "project": project,
+            "skill_id": configured_id,
+            "path": "references/guide.md",
+        }),
+        sources,
+    )
+    .await;
+    assert!(!read.success);
+    assert_eq!(read.output["error_kind"], "skill_definition_changed");
+    assert_eq!(
+        kinds,
+        vec![
+            "file_skill_list_packages",
+            "configured_skill_roots:read",
+            "configured_skill_roots:read",
+        ]
     );
 }
 
@@ -1023,7 +1321,15 @@ async fn project_skill_exact_read_request_fanout_is_characterized() {
         "Alpha guidance",
         "alpha body\n",
     );
-    write_skill(root.path(), "beta", "beta", "Beta guidance", "beta body\n");
+    for index in 0..6 {
+        write_skill(
+            root.path(),
+            &format!("other-{index}"),
+            &format!("other-{index}"),
+            "Unrelated guidance",
+            "unrelated body\n",
+        );
+    }
     let refs = root.path().join(".agents/skills/alpha/references");
     fs::create_dir_all(&refs).unwrap();
     fs::write(refs.join("guide.md"), "resource body\n").unwrap();
@@ -1032,7 +1338,7 @@ async fn project_skill_exact_read_request_fanout_is_characterized() {
     let project =
         register_runner_project_at_path(&runtime, "project-skill-read-fanout", "demo", root.path())
             .await;
-    let (listed, _) = call_kernel_with_local_agent(
+    let (listed, listed_kinds) = call_kernel_with_local_agent(
         &runtime,
         "project-skill-read-fanout",
         "skill_list",
@@ -1041,10 +1347,37 @@ async fn project_skill_exact_read_request_fanout_is_characterized() {
     )
     .await;
     assert!(listed.success, "{:?}", listed.error);
-    assert_eq!(listed.output["total_count"], 2);
+    assert_eq!(listed.output["total_count"], 7);
+    assert_eq!(listed_kinds.len(), 8);
+    assert_eq!(listed_kinds[0], "file_skill_list_packages");
+    assert!(listed_kinds[1..]
+        .iter()
+        .all(|kind| kind == "file_skill_read_file"));
     let alpha = skill_by_name(&listed, "alpha");
     let skill_id = alpha["skill_id"].as_str().unwrap().to_string();
     let definition_revision = alpha["definition_revision"].as_str().unwrap().to_string();
+
+    let (unsupported_package, unsupported_kinds) = call_kernel_with_local_agent(
+        &runtime,
+        "project-skill-read-fanout",
+        "skill_read_file",
+        json!({
+            "project": project,
+            "skill_id": skill_id,
+            "expected_package_revision": format!("wc_skillpkg_{}", "f".repeat(64)),
+        }),
+        true,
+    )
+    .await;
+    assert!(!unsupported_package.success);
+    assert_eq!(
+        unsupported_package.output["error_kind"],
+        "skill_package_revision_not_supported"
+    );
+    assert_eq!(
+        unsupported_kinds,
+        vec!["file_skill_list_packages", "file_skill_read_file"]
+    );
 
     let (definition, definition_kinds) = call_kernel_with_local_agent(
         &runtime,
@@ -1060,7 +1393,6 @@ async fn project_skill_exact_read_request_fanout_is_characterized() {
         definition_kinds,
         vec![
             "file_skill_list_packages",
-            "file_skill_read_file",
             "file_skill_read_file",
             "file_skill_read_file",
         ]
@@ -1085,7 +1417,6 @@ async fn project_skill_exact_read_request_fanout_is_characterized() {
         resource_kinds,
         vec![
             "file_skill_list_packages",
-            "file_skill_read_file",
             "file_skill_read_file",
             "file_skill_read_file",
             "file_skill_read_file",

--- a/src/tool_runtime/tests/skills.rs
+++ b/src/tool_runtime/tests/skills.rs
@@ -1016,6 +1016,7 @@ async fn exact_skill_resolution_fails_closed_when_applicable_source_is_unavailab
         RunnerCapabilities {
             file_read: true,
             configured_skill_roots_read: true,
+            skill_store_read: true,
             ..Default::default()
         },
         vec![registered_project(


### PR DESCRIPTION
## Summary

- separate full Skill catalog observation from known-id exact resolution
- keep `skill_list`, startup, and context catalogs on the complete `discover_skills` path
- resolve Project Skills by bounded package identity matching without reading unrelated definitions
- make configured Runner exact reads identity-first while preserving the existing wire protocol
- keep managed Skill reads on the existing opaque-id scan without adding a reverse index or cache
- fail closed on target ambiguity and applicable-source uncertainty
- preserve Project/Configured revision race protection and existing Managed explicit revision semantics
- add `exact_resolve` low-cardinality source observability and before/after fanout characterization
- short-circuit later source probes once exact resolution is already uncertain

## Behavior

- Project exact `SKILL.md` read with 7 Project Skills: 9 Runner requests -> 3
- Project ordinary resource read with 7 Project Skills: 10 -> 4
- Configured exact reads no longer require a preceding Configured List/full discovery
- Managed exact reads no longer require a preceding `ListActive`
- Configured Runner exact resolution scans package identities but reads only matching definitions
- full catalog duplicate-id, name-conflict, revision, diagnostics, and truncation semantics remain on observer paths

No new Runner request/response variant, capability bit, cache, reverse index, database table, source priority, or partial-success behavior is introduced.

## Validation

- root Skill runtime tests: 13/13
- runtime metrics: 3/3
- configured Runner Skill tests: 12/12
- managed Skill store tests: 23/23
- review-fix exact-resolution focused tests: 2/2
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`